### PR TITLE
RUE-1665: resolve relocations by symbol index and precompute Mach-O anchors

### DIFF
--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -1102,6 +1102,22 @@ impl ObjectFile {
             }
         }
 
+        // The anchor a non-extern relocation resolves to: the first named
+        // symbol at offset 0 of each section. Precomputed once so each
+        // relocation probes a map instead of rescanning the whole symbol
+        // table — that scan was O(nreloc × nsyms) per object, and
+        // rustc-produced Mach-O objects use non-extern relocations heavily
+        // (RUE-1665). Synthesized anchors register here as they are minted.
+        let mut section_anchors: AHashMap<usize, usize> = AHashMap::new();
+        for (index, symbol) in symbols.iter().enumerate() {
+            if let Some(section) = symbol.section_index
+                && symbol.value == 0
+                && !symbol.name.is_empty()
+            {
+                section_anchors.entry(section).or_insert(index);
+            }
+        }
+
         // Parse relocations for each section
         for (section_index, nreloc, reloff) in section_reloc_info {
             check_parse_cancellation(cancellation)?;
@@ -1194,24 +1210,17 @@ impl ObjectFile {
                     // otherwise — real objects routinely have only local
                     // symbols, or none at all, at a section start.
                     // RUE-131 item 5c)
-                    symbols
-                        .iter()
-                        .position(|s| {
-                            s.section_index == Some(target_section)
-                                && s.value == 0
-                                && !s.name.is_empty()
-                        })
-                        .unwrap_or_else(|| {
-                            symbols.push(Symbol {
-                                name: sections[target_section].name.clone(),
-                                section_index: Some(target_section),
-                                value: 0,
-                                size: 0,
-                                binding: SymbolBinding::Local,
-                                sym_type: SymbolType::Section,
-                            });
-                            symbols.len() - 1
-                        })
+                    *section_anchors.entry(target_section).or_insert_with(|| {
+                        symbols.push(Symbol {
+                            name: sections[target_section].name.clone(),
+                            section_index: Some(target_section),
+                            value: 0,
+                            size: 0,
+                            binding: SymbolBinding::Local,
+                            sym_type: SymbolType::Section,
+                        });
+                        symbols.len() - 1
+                    })
                 };
 
                 // Convert Mach-O relocation type to our type
@@ -2214,6 +2223,75 @@ mod tests {
             relocs[0].addend, 3,
             "embedded target address must be re-based onto the section anchor"
         );
+    }
+
+    /// Non-extern relocations reuse an existing named symbol at offset 0 of
+    /// the target section rather than synthesizing a duplicate anchor, and
+    /// every relocation against the same section shares that one anchor. This
+    /// pins the semantics of the precomputed section→anchor index that
+    /// replaced the per-relocation symbol-table scan (RUE-1665).
+    #[test]
+    fn test_macho_non_extern_reuses_existing_section_anchor() {
+        let mut first_slot = vec![0u8; 8];
+        first_slot[0] = 0x13; // address of byte 3 within __cstring (addr 0x10)
+        let mut second_slot = vec![0u8; 8];
+        second_slot[0] = 0x15; // address of byte 5 within __cstring
+        let mut data = first_slot;
+        data.extend_from_slice(&second_slot);
+        let obj_bytes = build_test_macho(
+            &[
+                TestMachoSection {
+                    sectname: "__const",
+                    segname: "__TEXT",
+                    addr: 0,
+                    data,
+                    // Two non-extern UNSIGNED relocations against section 2.
+                    relocs: vec![
+                        (0, macho_r_info(2, false, 3, false, ARM64_RELOC_UNSIGNED)),
+                        (8, macho_r_info(2, false, 3, false, ARM64_RELOC_UNSIGNED)),
+                    ],
+                },
+                TestMachoSection {
+                    sectname: "__cstring",
+                    segname: "__TEXT",
+                    addr: 0x10,
+                    data: b"hi there".to_vec(),
+                    relocs: vec![],
+                },
+            ],
+            &[
+                TestMachoSymbol {
+                    name: "_main",
+                    n_type: N_EXT | N_SECT,
+                    n_sect: 1,
+                    n_value: 0,
+                },
+                // A LOCAL symbol at offset 0 of __cstring (n_value is the
+                // section's VM-layout address).
+                TestMachoSymbol {
+                    name: "l_str",
+                    n_type: N_SECT,
+                    n_sect: 2,
+                    n_value: 0x10,
+                },
+            ],
+        );
+
+        let obj = ObjectFile::parse(&obj_bytes).expect("parse");
+        assert_eq!(
+            obj.symbols.len(),
+            2,
+            "an existing offset-0 symbol must be reused, not duplicated"
+        );
+        let relocs = &obj.sections[0].relocations;
+        assert_eq!(relocs.len(), 2);
+        assert_eq!(obj.symbols[relocs[0].symbol_index].name, "l_str");
+        assert_eq!(
+            relocs[0].symbol_index, relocs[1].symbol_index,
+            "relocations against one section share one anchor"
+        );
+        assert_eq!(relocs[0].addend, 3);
+        assert_eq!(relocs[1].addend, 5);
     }
 
     /// Mach-O n_value is an address in the object's VM layout, not a

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -689,15 +689,15 @@ fn apply_relocation(
 struct PendingRelocation {
     /// Patch offset within the home buffer.
     offset: u64,
-    /// Name of the referenced symbol.
-    sym_name: String,
-    /// Section the referenced symbol is defined in (None if undefined).
-    sym_section: Option<usize>,
-    /// Binding of the referenced symbol. LOCAL symbols must resolve within
-    /// their own object — resolving them by name across all objects lets
-    /// same-named locals in different objects shadow each other.
-    /// (RUE-131 item 2)
-    sym_binding: SymbolBinding,
+    /// Index of the referenced symbol in its object's symbol table. The
+    /// object table is immutable for the whole link, so the index stays
+    /// valid and the symbol's name, section, and binding are read through
+    /// it at apply time — cloning the name into every relocation allocated
+    /// thousands of Strings per link (RUE-1665). Validated against the
+    /// table by [`collect_section_relocations`]. LOCAL symbols must still
+    /// resolve within their own object (RUE-131 item 2); `obj_idx` scopes
+    /// that.
+    symbol_index: usize,
     /// Index of the object the relocation (and any local symbol) lives in.
     obj_idx: usize,
     rel_type: RelocationType,
@@ -776,9 +776,7 @@ fn collect_section_relocations(
 
         pending.push(PendingRelocation {
             offset,
-            sym_name: sym.name.clone(),
-            sym_section: sym.section_index,
-            sym_binding: sym.binding,
+            symbol_index: reloc.symbol_index,
             obj_idx,
             rel_type: reloc.rel_type,
             addend: reloc.addend,
@@ -800,7 +798,10 @@ fn collect_section_relocations(
 #[derive(Default)]
 struct SymbolAddresses {
     globals: AHashMap<String, u64>,
-    locals: AHashMap<(usize, String), u64>,
+    /// Nested per-object so a resolve probes with the borrowed symbol name;
+    /// a flat `(usize, String)`-keyed map forced an owned String key
+    /// allocation for every local lookup (RUE-1665).
+    locals: AHashMap<usize, AHashMap<String, u64>>,
 }
 
 impl SymbolAddresses {
@@ -808,7 +809,7 @@ impl SymbolAddresses {
     /// object only, globals/weaks by name.
     fn resolve(&self, obj_idx: usize, name: &str, binding: SymbolBinding) -> Option<u64> {
         match binding {
-            SymbolBinding::Local => self.locals.get(&(obj_idx, name.to_string())).copied(),
+            SymbolBinding::Local => self.locals.get(&obj_idx)?.get(name).copied(),
             SymbolBinding::Global | SymbolBinding::Weak => self.globals.get(name).copied(),
         }
     }
@@ -1691,7 +1692,9 @@ impl Linker {
                             SymbolBinding::Local => {
                                 symbol_addresses
                                     .locals
-                                    .insert((obj_idx, sym.name.clone()), addr);
+                                    .entry(obj_idx)
+                                    .or_default()
+                                    .insert(sym.name.clone(), addr);
                             }
                             SymbolBinding::Global | SymbolBinding::Weak => {
                                 // Honor the winner chosen in add_object for
@@ -1738,9 +1741,7 @@ impl Linker {
         // Apply relocations
         for PendingRelocation {
             offset: patch_offset,
-            sym_name,
-            sym_section,
-            sym_binding,
+            symbol_index,
             obj_idx,
             rel_type,
             addend,
@@ -1748,6 +1749,12 @@ impl Linker {
         } in pending_relocations
         {
             check_cancellation(cancellation)?;
+            // The referenced symbol, read through its validated index; the
+            // object table is immutable during the link (RUE-1665).
+            let sym = &self.objects[obj_idx].symbols[symbol_index];
+            let sym_name = sym.name.as_str();
+            let sym_section = sym.section_index;
+            let sym_binding = sym.binding;
             // Pick the buffer the patch site lives in and its base vaddr.
             // (PatchHome::Rodata is unused here: Mach-O merges rodata into
             // the text buffer.)
@@ -1764,14 +1771,14 @@ impl Linker {
             // leaving its relocation unpatched would produce invalid code.
             // (RUE-131 item 7)
             let target_vaddr =
-                if let Some(addr) = symbol_addresses.resolve(obj_idx, &sym_name, sym_binding) {
+                if let Some(addr) = symbol_addresses.resolve(obj_idx, sym_name, sym_binding) {
                     addr
                 } else if let Some(sec_idx) = sym_section {
                     // Section-relative symbol - resolve via the section's address
                     let obj = &self.objects[obj_idx];
                     if sec_idx >= obj.sections.len() {
                         return Err(LinkError::InvalidSectionIndex {
-                            symbol: sym_name.clone(),
+                            symbol: sym_name.to_string(),
                             section_index: sec_idx,
                             section_count: obj.sections.len(),
                         });
@@ -1828,7 +1835,7 @@ impl Linker {
                 target_vaddr,
                 addend,
                 rel_type,
-                &sym_name,
+                sym_name,
             )?;
         }
 
@@ -2132,7 +2139,9 @@ impl Linker {
                             SymbolBinding::Local => {
                                 symbol_addresses
                                     .locals
-                                    .insert((obj_idx, sym.name.clone()), addr);
+                                    .entry(obj_idx)
+                                    .or_default()
+                                    .insert(sym.name.clone(), addr);
                             }
                             SymbolBinding::Global | SymbolBinding::Weak => {
                                 // For duplicate weak definitions the winner was
@@ -2171,7 +2180,9 @@ impl Linker {
                     // Use section name as fallback
                     symbol_addresses
                         .locals
-                        .entry((obj_idx, section.name.clone()))
+                        .entry(obj_idx)
+                        .or_default()
+                        .entry(section.name.clone())
                         .or_insert(addr);
                 }
             }
@@ -2189,9 +2200,7 @@ impl Linker {
         // Apply relocations
         for PendingRelocation {
             offset,
-            sym_name,
-            sym_section,
-            sym_binding,
+            symbol_index,
             obj_idx,
             rel_type,
             addend,
@@ -2199,6 +2208,12 @@ impl Linker {
         } in pending_relocations
         {
             check_cancellation(cancellation)?;
+            // The referenced symbol, read through its validated index; the
+            // object table is immutable during the link (RUE-1665).
+            let sym = &self.objects[obj_idx].symbols[symbol_index];
+            let sym_name = sym.name.as_str();
+            let sym_section = sym.section_index;
+            let sym_binding = sym.binding;
             // Pick the buffer the patch site lives in and its base vaddr.
             // PC-relative relocations in rodata/data measure from their own
             // section's address, not the code segment's.
@@ -2209,14 +2224,14 @@ impl Linker {
             };
             // Try to resolve the symbol (locals only within their own object)
             let target_addr =
-                if let Some(addr) = symbol_addresses.resolve(obj_idx, &sym_name, sym_binding) {
+                if let Some(addr) = symbol_addresses.resolve(obj_idx, sym_name, sym_binding) {
                     addr
                 } else if let Some(sec_idx) = sym_section {
                     // Section-relative symbol - look up the section's address
                     let obj = &self.objects[obj_idx];
                     if sec_idx >= obj.sections.len() {
                         return Err(LinkError::InvalidSectionIndex {
-                            symbol: sym_name.clone(),
+                            symbol: sym_name.to_string(),
                             section_index: sec_idx,
                             section_count: obj.sections.len(),
                         });
@@ -2253,7 +2268,7 @@ impl Linker {
                         if sym_name.is_empty() {
                             "<empty>"
                         } else {
-                            &sym_name
+                            sym_name
                         },
                         rel_type
                     )));
@@ -2263,7 +2278,7 @@ impl Linker {
 
             // Patch the site; the per-kind encoding is shared with the
             // Mach-O path via `apply_relocation` (RUE-335).
-            apply_relocation(buf, offset, pc, target_addr, addend, rel_type, &sym_name)?;
+            apply_relocation(buf, offset, pc, target_addr, addend, rel_type, sym_name)?;
         }
 
         drop(relocate_span);


### PR DESCRIPTION
Fixes RUE-1665.

Three allocation/scan hot spots in the linker, per the issue's fix direction:

1. **Per-relocation symbol-name clones.** `PendingRelocation` now stores the validated `(obj_idx, symbol_index)` pair instead of `sym_name: String` (plus the section/binding copies). The object table is immutable for the whole link, so both relocation-apply loops read the symbol's name, section, and binding through the index at apply time; owned `String`s are built only on error paths. With ~1,280 objects and several relocations each, this removes thousands of allocations per link on the instrumented `link_layout`/`link_relocate` spans.

2. **Per-local-resolve `String` key allocation.** `SymbolAddresses::locals` is now nested per object (`AHashMap<usize, AHashMap<String, u64>>`), so `resolve` probes with the borrowed symbol name instead of building an owned `(usize, String)` key for every local lookup. The RUE-131 item 2 semantics — locals resolve only within their defining object, section-name fallbacks stay per object — are unchanged, and the existing `test_local_symbols_resolve_within_object_{elf,macho}` and `test_macho_full_cycle_same_named_string_locals` tests still pin them.

3. **Quadratic Mach-O anchor search.** The non-extern relocation path scanned the whole symbol table per relocation (`O(nreloc × nsyms)` per object). The parser now precomputes each section's anchor — the first named symbol at offset 0 — once per object and consults the map per relocation; synthesized anchors register in the map as they are minted, preserving the exact first-match-or-synthesize semantics. A new `test_macho_non_extern_reuses_existing_section_anchor` pins anchor reuse and that all relocations against one section share one anchor, alongside the existing synthesis test.

Validation: all 182 `rue-linker` unit tests (including the new one), the quick unit tier across the workspace, a real end-to-end compile+link+run through the internal linker, and the full local premerge tier.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLu5tyWdwrL8RywUZqaQc)_