### PR TITLE
RUE-1660: make validated RIR views lazy

### DIFF
--- a/crates/rue-rir/src/api_inventory.rs
+++ b/crates/rue-rir/src/api_inventory.rs
@@ -201,3 +201,95 @@ fn rir_structural_anchor_storage_is_tied_to_retained_charge() {
         "retained charge omits the structured type-syntax arena"
     );
 }
+
+#[test]
+fn fixed_payload_views_keep_the_validated_boundary_and_direct_indexing() {
+    let owner = include_str!("inst.rs");
+    let packed = include_str!("inst/packed.rs");
+
+    let slice = owner
+        .split("impl<'a, T: 'a> RirSlice<'a, T> {")
+        .nth(1)
+        .and_then(|rest| rest.split("impl<'a, T> IntoIterator for RirSlice").next())
+        .expect("RirSlice implementation");
+    let get = slice
+        .split("pub fn get(&self, index: usize) -> Option<T> {")
+        .nth(1)
+        .and_then(|rest| rest.split("\n    }").next())
+        .expect("RirSlice::get implementation");
+    assert!(get.contains("checked_mul"));
+    assert!(get.contains("checked_add"));
+    assert!(!get.contains("nth"));
+
+    for accessor in [
+        "fn ref_view<R>(",
+        "fn call_arg_view<R>(",
+        "pub fn params(",
+        "pub fn field_inits(",
+        "fn field_decl_view<R>(",
+        "fn symbol_view<R>(",
+    ] {
+        let body = owner
+            .split(accessor)
+            .nth(1)
+            .and_then(|rest| rest.split("\n    }").next())
+            .unwrap_or_else(|| panic!("missing fixed accessor {accessor}"));
+        assert!(
+            body.contains("fixed_view"),
+            "{accessor} bypasses fixed_view"
+        );
+    }
+
+    let match_decoder = owner
+        .split("fn decode_match_record(")
+        .nth(1)
+        .and_then(|rest| rest.split("fn decode_directive_record(").next())
+        .expect("match decoder");
+    let match_bindings = match_decoder
+        .split("x if x == PatternKind::Path")
+        .nth(1)
+        .expect("path-pattern binding decoder");
+    assert!(match_bindings.contains("validated"));
+    assert!(match_bindings.contains("RirSlice::new_validated"));
+    assert!(match_bindings.contains("RirSlice::new_unvalidated"));
+
+    let directive_decoder = owner
+        .split("fn decode_directive_record(")
+        .nth(1)
+        .and_then(|rest| rest.split("/// Stored representation of directive").next())
+        .expect("directive decoder");
+    assert!(directive_decoder.contains("validated"));
+    assert!(directive_decoder.contains("RirSlice::new_validated"));
+    assert!(directive_decoder.contains("RirSlice::new_unvalidated"));
+
+    let enum_decoder = owner
+        .split("impl<'a> Iterator for RirEnumPayloads")
+        .nth(1)
+        .and_then(|rest| rest.split("impl ExactSizeIterator").next())
+        .expect("enum payload decoder");
+    assert!(enum_decoder.contains("validated"));
+    assert!(enum_decoder.contains("RirSlice::new_validated"));
+    assert!(enum_decoder.contains("RirSlice::new_unvalidated"));
+
+    for accessor in ["pub fn match_arms(", "pub fn directives("] {
+        let body = owner
+            .split(accessor)
+            .nth(1)
+            .and_then(|rest| rest.split("\n    }\n\n    pub fn").next())
+            .unwrap_or_else(|| panic!("missing variable accessor {accessor}"));
+        assert!(
+            body.contains("validated: self.views_validated"),
+            "{accessor} does not propagate validation state"
+        );
+    }
+
+    let enum_view = owner
+        .split("fn enum_payload_view<'a, R>(")
+        .nth(1)
+        .and_then(|rest| rest.split("    pub fn enum_payloads(").next())
+        .expect("enum payload view");
+    assert!(enum_view.contains("validated: self.views_validated"));
+
+    assert_eq!(owner.matches("views_validated = true").count(), 1);
+    assert_eq!(packed.matches("views_validated = true").count(), 1);
+}

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -84,6 +84,11 @@ pub struct AstGen<'a> {
     /// inside an anonymous type are independent producers and obtain their
     /// anchors from the shared frontend walk when their root is entered.
     producer_root_depth: usize,
+    /// Fixed compiler spellings are interned on first use and cached for the
+    /// rest of this lowering session. Names carrying a counter remain
+    /// dynamically interned at their call sites.
+    self_symbol: Option<Spur>,
+    u64_symbol: Option<Spur>,
     normalize_symbol: Box<dyn Fn(Spur) -> Spur + 'a>,
     cancellation_check: Option<Box<dyn FnMut() -> bool + 'a>>,
     canceled: bool,
@@ -167,6 +172,8 @@ impl<'a> AstGen<'a> {
             anonymous_anchors: AHashMap::new(),
             authoritative_anonymous_anchors: false,
             producer_root_depth: 0,
+            self_symbol: None,
+            u64_symbol: None,
             normalize_symbol: Box::new(normalize_symbol),
             cancellation_check: None,
             canceled: false,
@@ -378,6 +385,24 @@ impl<'a> AstGen<'a> {
                 Spur::default()
             }
         }
+    }
+
+    fn intern_fixed_self(&mut self) -> Spur {
+        if let Some(symbol) = self.self_symbol {
+            return symbol;
+        }
+        let symbol = self.intern("self");
+        self.self_symbol = Some(symbol);
+        symbol
+    }
+
+    fn intern_fixed_u64(&mut self) -> Spur {
+        if let Some(symbol) = self.u64_symbol {
+            return symbol;
+        }
+        let symbol = self.intern("u64");
+        self.u64_symbol = Some(symbol);
+        symbol
     }
 
     fn with_structural_segment<T>(
@@ -1475,7 +1500,7 @@ impl<'a> AstGen<'a> {
             }
             Expr::SelfExpr(self_expr) => {
                 // `self` in method bodies is just a variable reference to the implicit self parameter
-                let name = self.intern("self");
+                let name = self.intern_fixed_self();
                 self.rir.add_inst(Inst {
                     data: InstData::VarRef { name, anchor: None },
                     span: self_expr.span,
@@ -1807,8 +1832,8 @@ impl<'a> AstGen<'a> {
 
         // let mut __p: u64 = 0;   (position — usize is u64)
         let p_name = self.intern(format!("@rue:for:pos:{n}"));
-        let u64_sym = self.intern("u64");
-        let u64_type = self.rir.add_named_type(u64_sym).unwrap_or_else(|error| {
+        let u64_symbol = self.intern_fixed_u64();
+        let u64_type = self.rir.add_named_type(u64_symbol).unwrap_or_else(|error| {
             if self.payload_error.is_none() {
                 self.payload_error = Some(type_syntax_build_error(error));
             }
@@ -3661,6 +3686,71 @@ mod tests {
             _ => false,
         });
         assert!(self_ref.is_some(), "Expected self VarRef instruction");
+        let self_symbol = interner.get("self").expect("self was interned once");
+        assert!(matches!(
+            self_ref.map(|(_, inst)| &inst.data),
+            Some(InstData::VarRef { name, .. }) if *name == self_symbol
+        ));
+    }
+
+    #[test]
+    fn fixed_generated_spellings_keep_the_interner_identity() {
+        let (rir, interner) = gen_rir("fn main() { for _ in [1] {} }");
+        let u64_symbol = interner.get("u64").expect("u64 was interned once");
+        assert!(rir.type_syntax().nodes().iter().any(|node| {
+            matches!(
+                node,
+                crate::RirTypeSyntaxNode::Named(symbol)
+                    if rir.type_syntax().symbol(*symbol) == Some(&u64_symbol)
+            )
+        }));
+    }
+
+    #[test]
+    fn fixed_generated_spellings_are_not_interned_when_unused() {
+        let (tokens, source_interner) = Lexer::new("fn main() -> i32 { 0 }").tokenize().unwrap();
+        let (ast, interner) = Parser::new(tokens, source_interner).parse().unwrap();
+        let before_len = interner.len();
+        let before_self = interner.get("self");
+        let before_u64 = interner.get("u64");
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let _rir = astgen.finish();
+        assert_eq!(interner.len(), before_len);
+        assert_eq!(interner.get("self"), before_self);
+        assert_eq!(interner.get("u64"), before_u64);
+    }
+
+    #[test]
+    fn fixed_generated_spellings_are_cached_after_first_use() {
+        let source = r#"
+            struct Point {
+                x: i32,
+                fn get_x(self) -> i32 { self + self }
+            }
+            fn main() { for _ in [1] {} for _ in [2] {} }
+        "#;
+        let (rir, interner) = gen_rir(source);
+        let self_symbol = interner.get("self").expect("self was interned once");
+        let self_refs: Vec<_> = rir
+            .iter()
+            .filter_map(|(_, inst)| match inst.data {
+                InstData::VarRef { name, .. } if name == self_symbol => Some(name),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(self_refs.len(), 2);
+        assert_eq!(self_refs[0], self_refs[1]);
+
+        let u64_symbol = interner.get("u64").expect("u64 was interned once");
+        assert_eq!(
+            rir.type_syntax()
+                .symbols()
+                .iter()
+                .filter(|symbol| **symbol == u64_symbol)
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -579,11 +579,22 @@ impl<T> Clone for RirSlice<'_, T> {
 }
 
 impl<'a, T: 'a> RirSlice<'a, T> {
-    fn new(words: &'a [u32], width: usize, decode: fn(&[u32]) -> T) -> Self {
+    /// Construct a view over words that have not passed publication
+    /// validation. Decoding every record here keeps this boundary fail-closed:
+    /// callers cannot expose a slice whose decoder rejects one of its records.
+    fn new_unvalidated(words: &'a [u32], width: usize, decode: fn(&[u32]) -> T) -> Self {
         assert!(width != 0 && words.len().is_multiple_of(width));
         for record in words.chunks_exact(width) {
             decode(record);
         }
+        Self::new_validated(words, width, decode)
+    }
+
+    /// Construct a view after the owning RIR has passed publication
+    /// validation. Only fixed-width range invariants are checked here; records
+    /// remain borrowed and are decoded on iteration or indexed access.
+    fn new_validated(words: &'a [u32], width: usize, decode: fn(&[u32]) -> T) -> Self {
+        assert!(width != 0 && words.len().is_multiple_of(width));
         Self {
             words,
             width,
@@ -611,7 +622,9 @@ impl<'a, T: 'a> RirSlice<'a, T> {
     }
 
     pub fn get(&self, index: usize) -> Option<T> {
-        self.values().nth(index)
+        let start = index.checked_mul(self.width)?;
+        let end = start.checked_add(self.width)?;
+        Some((self.decode)(self.words.get(start..end)?))
     }
 
     pub fn to_vec(&self) -> Vec<T> {
@@ -1023,6 +1036,7 @@ fn encoded_enum_payload_record_extent<T>(payload: &[T]) -> Option<usize> {
 fn decode_match_record(
     words: &[u32],
     position: usize,
+    validated: bool,
 ) -> Option<(RirPatternView<'_>, InstRef, usize)> {
     let kind = *words.get(position + RECORD_KIND)?;
     let span = embedded_span(words, position)?;
@@ -1076,11 +1090,19 @@ fn decode_match_record(
                         words[position + MATCH_INT_NEGATIVE_OR_PATH_TYPE],
                     )?,
                     variant: decode_symbol_word(words[position + MATCH_INT_BODY_OR_PATH_VARIANT])?,
-                    bindings: RirSlice::new(
-                        &words[binding_start..binding_start + count],
-                        SYMBOL_SCHEMA.width,
-                        |record| validated_symbol_word(record[0]),
-                    ),
+                    bindings: if validated {
+                        RirSlice::new_validated(
+                            &words[binding_start..binding_start + count],
+                            SYMBOL_SCHEMA.width,
+                            |record| validated_symbol_word(record[0]),
+                        )
+                    } else {
+                        RirSlice::new_unvalidated(
+                            &words[binding_start..binding_start + count],
+                            SYMBOL_SCHEMA.width,
+                            |record| validated_symbol_word(record[0]),
+                        )
+                    },
                     span,
                 },
                 InstRef::from_raw(words[end - 1]),
@@ -1094,6 +1116,7 @@ fn decode_match_record(
 fn decode_directive_record(
     words: &[u32],
     position: usize,
+    validated: bool,
 ) -> Option<(RirDirectiveView<'_>, usize)> {
     let extent = decoded_directive_record_extent(words, position)?;
     let end = position.checked_add(extent)?;
@@ -1104,9 +1127,15 @@ fn decode_directive_record(
     Some((
         RirDirectiveView {
             name: decode_symbol_word(words[position + DIRECTIVE_NAME])?,
-            args: RirSlice::new(&words[args_start..end], SYMBOL_SCHEMA.width, |record| {
-                validated_symbol_word(record[0])
-            }),
+            args: if validated {
+                RirSlice::new_validated(&words[args_start..end], SYMBOL_SCHEMA.width, |record| {
+                    validated_symbol_word(record[0])
+                })
+            } else {
+                RirSlice::new_unvalidated(&words[args_start..end], SYMBOL_SCHEMA.width, |record| {
+                    validated_symbol_word(record[0])
+                })
+            },
             span: embedded_span(words, position)?,
         },
         extent,
@@ -1118,7 +1147,7 @@ fn decode_directive_record(
 /// Variable size due to args.
 
 /// The complete canonical RIR for one source revision.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct Rir {
     /// All instructions across the canonical module sequence.
     instructions: Vec<Inst>,
@@ -1137,7 +1166,22 @@ pub struct Rir {
     /// wrapping an `InstRef` onto the reserved null payload. Spec C.1:2
     /// requires a diagnostic, not a wrapped index.
     instruction_limit_exceeded: bool,
+    /// Set only after the complete owner passes publication validation. This
+    /// lets the same accessor API retain fail-closed construction for raw RIR
+    /// while giving published owners lazy fixed-record views.
+    views_validated: bool,
 }
+
+impl PartialEq for Rir {
+    fn eq(&self, other: &Self) -> bool {
+        self.instructions == other.instructions
+            && self.extra == other.extra
+            && self.type_syntax == other.type_syntax
+            && self.instruction_limit_exceeded == other.instruction_limit_exceeded
+    }
+}
+
+impl Eq for Rir {}
 
 /// Mutable construction-phase owner. Payload descriptors never leave this
 /// owner through the public API; callers add or replace complete nodes.
@@ -2642,6 +2686,8 @@ impl ValidatedRir {
         let rir = editor.into_unvalidated();
         rir.validate_payloads()?;
         rir.validate_context(context)?;
+        let mut rir = rir;
+        rir.views_validated = true;
         Ok(Self(rir))
     }
 
@@ -3604,7 +3650,7 @@ impl Rir {
                     });
                 }
             }
-            let (_, _, width) = decode_match_record(words, position).ok_or_else(|| {
+            let (_, _, width) = decode_match_record(words, position, false).ok_or_else(|| {
                 rir_payload_error! {
                     family: RirMatchArmsRange::FAMILY,
                     start: range.start(),
@@ -4196,17 +4242,18 @@ impl Rir {
                     reason: "symbol word is not representable",
                 });
             }
-            let (_, record_extent) = decode_directive_record(words, position).ok_or_else(|| {
-                rir_payload_error! {
-                    family: RirDirectivesRange::FAMILY,
-                    start: range.start(),
-                    extent: range.extent(),
-                    record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
-                    expected: record_width,
-                    actual: record_width,
-                    reason: "directive record failed schema decoding",
-                }
-            })?;
+            let (_, record_extent) =
+                decode_directive_record(words, position, false).ok_or_else(|| {
+                    rir_payload_error! {
+                        family: RirDirectivesRange::FAMILY,
+                        start: range.start(),
+                        extent: range.extent(),
+                        record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                        expected: record_width,
+                        actual: record_width,
+                        reason: "directive record failed schema decoding",
+                    }
+                })?;
             let end = position + record_extent;
             position = end;
         }
@@ -4362,12 +4409,25 @@ impl Rir {
         )
     }
 
+    fn fixed_view<'a, T: 'a>(
+        &self,
+        words: &'a [u32],
+        width: usize,
+        decode: fn(&[u32]) -> T,
+    ) -> RirSlice<'a, T> {
+        if self.views_validated {
+            RirSlice::new_validated(words, width, decode)
+        } else {
+            RirSlice::new_unvalidated(words, width, decode)
+        }
+    }
+
     fn ref_view<R>(
         &self,
         range: &R,
         parts: impl FnOnce(&R) -> (u32, u32, &'static str),
     ) -> RirSlice<'_, InstRef> {
-        RirSlice::new(
+        self.fixed_view(
             self.payload_words(range, parts)
                 .expect("validated RIR range"),
             REF_SCHEMA.width,
@@ -4475,7 +4535,7 @@ impl Rir {
         let data = self
             .payload_words(range, parts)
             .expect("validated RIR range");
-        RirSlice::new(data, CALL_ARG_SCHEMA.width, |chunk| RirCallArg {
+        self.fixed_view(data, CALL_ARG_SCHEMA.width, |chunk| RirCallArg {
             value: InstRef::from_raw(chunk[CALL_ARG_VALUE]),
             mode: RirArgMode::from_u32(chunk[CALL_ARG_MODE]),
         })
@@ -4521,7 +4581,7 @@ impl Rir {
         let data = self
             .payload_words(range, |r| (r.start(), r.extent(), RirParamsRange::FAMILY))
             .expect("validated RIR range");
-        RirSlice::new(data, PARAM_SCHEMA.width, |chunk| RirParam {
+        self.fixed_view(data, PARAM_SCHEMA.width, |chunk| RirParam {
             name: validated_symbol_word(chunk[PARAM_NAME]),
             ty: RirTypeSyntaxRef::from_u32(chunk[PARAM_TYPE]),
             mode: RirParamMode::from_u32(chunk[PARAM_MODE]),
@@ -4675,14 +4735,19 @@ impl Rir {
                 extra: words,
                 start: 0,
                 len: 0,
+                validated: self.views_validated,
             };
         }
         let view = RirMatchArms {
             extra: words,
             start: 1,
             len: words[0] as usize,
+            validated: self.views_validated,
         };
-        view.iter().for_each(drop);
+        if !view.validated {
+            let mut records = view.iter();
+            while records.next().is_some() {}
+        }
         view
     }
 
@@ -4719,7 +4784,7 @@ impl Rir {
                 (r.start(), r.extent(), RirFieldInitsRange::FAMILY)
             })
             .expect("validated RIR range");
-        RirSlice::new(data, FIELD_INIT_SCHEMA.width, |chunk| {
+        self.fixed_view(data, FIELD_INIT_SCHEMA.width, |chunk| {
             (
                 validated_symbol_word(chunk[FIELD_INIT_NAME]),
                 InstRef::from_raw(chunk[FIELD_INIT_VALUE]),
@@ -4782,7 +4847,7 @@ impl Rir {
         let data = self
             .payload_words(range, parts)
             .expect("validated RIR range");
-        RirSlice::new(data, FIELD_DECL_SCHEMA.width, |chunk| {
+        self.fixed_view(data, FIELD_DECL_SCHEMA.width, |chunk| {
             (
                 validated_symbol_word(chunk[FIELD_DECL_NAME]),
                 RirTypeSyntaxRef::from_u32(chunk[FIELD_DECL_TYPE]),
@@ -4876,14 +4941,19 @@ impl Rir {
                 extra: words,
                 start: 0,
                 len: 0,
+                validated: self.views_validated,
             };
         }
         let view = RirDirectives {
             extra: words,
             start: 1,
             len: words[0] as usize,
+            validated: self.views_validated,
         };
-        view.iter().for_each(drop);
+        if !view.validated {
+            let mut records = view.iter();
+            while records.next().is_some() {}
+        }
         view
     }
 
@@ -4937,7 +5007,7 @@ impl Rir {
         let words = self
             .payload_words(range, parts)
             .expect("validated RIR range");
-        RirSlice::new(words, SYMBOL_SCHEMA.width, |record| {
+        self.fixed_view(words, SYMBOL_SCHEMA.width, |record| {
             validated_symbol_word(record[0])
         })
     }
@@ -5017,6 +5087,7 @@ impl Rir {
                 .expect("validated RIR range"),
             position: 0,
             remaining: variant_count,
+            validated: self.views_validated,
         }
     }
 
@@ -5047,6 +5118,7 @@ pub struct RirEnumPayloads<'a> {
     words: &'a [u32],
     position: usize,
     remaining: usize,
+    validated: bool,
 }
 
 impl<'a> Iterator for RirEnumPayloads<'a> {
@@ -5058,16 +5130,24 @@ impl<'a> Iterator for RirEnumPayloads<'a> {
         }
         self.remaining -= 1;
         if self.words.is_empty() {
-            return Some(RirSlice::new(&[], SYMBOL_SCHEMA.width, |_| unreachable!()));
+            return Some(if self.validated {
+                RirSlice::new_validated(&[], SYMBOL_SCHEMA.width, |_| unreachable!())
+            } else {
+                RirSlice::new_unvalidated(&[], SYMBOL_SCHEMA.width, |_| unreachable!())
+            });
         }
         let (start, end) = enum_payload_record(self.words, self.position)
             .expect("validated enum payload descriptor");
         self.position = end;
-        Some(RirSlice::new(
-            &self.words[start..end],
-            SYMBOL_SCHEMA.width,
-            |record| RirTypeSyntaxRef::from_u32(record[0]),
-        ))
+        Some(if self.validated {
+            RirSlice::new_validated(&self.words[start..end], SYMBOL_SCHEMA.width, |record| {
+                RirTypeSyntaxRef::from_u32(record[0])
+            })
+        } else {
+            RirSlice::new_unvalidated(&self.words[start..end], SYMBOL_SCHEMA.width, |record| {
+                RirTypeSyntaxRef::from_u32(record[0])
+            })
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -5083,6 +5163,7 @@ pub struct RirMatchArms<'a> {
     extra: &'a [u32],
     start: usize,
     len: usize,
+    validated: bool,
 }
 
 impl<'a> RirMatchArms<'a> {
@@ -5101,11 +5182,16 @@ impl<'a> RirMatchArms<'a> {
             extra: self.extra,
             pos: self.start,
             remaining: self.len,
+            validated: self.validated,
         }
     }
 
     pub fn get(&self, index: usize) -> Option<(RirPatternView<'a>, InstRef)> {
-        self.iter().nth(index)
+        let mut records = self.iter();
+        for _ in 0..index {
+            records.next()?;
+        }
+        records.next()
     }
 
     pub fn to_vec(&self) -> Vec<(RirPatternView<'a>, InstRef)> {
@@ -5118,6 +5204,7 @@ struct RirMatchArmsIter<'a> {
     extra: &'a [u32],
     pos: usize,
     remaining: usize,
+    validated: bool,
 }
 
 impl<'a> Iterator for RirMatchArmsIter<'a> {
@@ -5127,10 +5214,11 @@ impl<'a> Iterator for RirMatchArmsIter<'a> {
         if self.remaining == 0 {
             return None;
         }
-        let (pattern, body, extent) = match decode_match_record(self.extra, self.pos) {
-            Some(record) => record,
-            None => unreachable!("match record passed schema validation"),
-        };
+        let (pattern, body, extent) =
+            match decode_match_record(self.extra, self.pos, self.validated) {
+                Some(record) => record,
+                None => unreachable!("match record passed schema validation"),
+            };
         self.pos += extent;
         self.remaining -= 1;
         Some((pattern, body))
@@ -5149,6 +5237,7 @@ pub struct RirDirectives<'a> {
     extra: &'a [u32],
     start: usize,
     len: usize,
+    validated: bool,
 }
 
 impl<'a> RirDirectives<'a> {
@@ -5165,11 +5254,16 @@ impl<'a> RirDirectives<'a> {
             extra: self.extra,
             pos: self.start,
             remaining: self.len,
+            validated: self.validated,
         }
     }
 
     pub fn get(&self, index: usize) -> Option<RirDirectiveView<'a>> {
-        self.iter().nth(index)
+        let mut records = self.iter();
+        for _ in 0..index {
+            records.next()?;
+        }
+        records.next()
     }
 
     pub fn to_vec(&self) -> Vec<RirDirectiveView<'a>> {
@@ -5182,6 +5276,7 @@ struct RirDirectivesIter<'a> {
     extra: &'a [u32],
     pos: usize,
     remaining: usize,
+    validated: bool,
 }
 
 impl<'a> Iterator for RirDirectivesIter<'a> {
@@ -5191,10 +5286,11 @@ impl<'a> Iterator for RirDirectivesIter<'a> {
         if self.remaining == 0 {
             return None;
         }
-        let (directive, extent) = match decode_directive_record(self.extra, self.pos) {
-            Some(record) => record,
-            None => unreachable!("directive record passed schema validation"),
-        };
+        let (directive, extent) =
+            match decode_directive_record(self.extra, self.pos, self.validated) {
+                Some(record) => record,
+                None => unreachable!("directive record passed schema validation"),
+            };
         self.pos += extent;
         self.remaining -= 1;
         Some(directive)
@@ -6785,6 +6881,22 @@ mod typed_payload_tests {
     use lasso::ThreadedRodeo;
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::cell::Cell;
+    thread_local! {
+        static SLICE_DECODE_COUNT: Cell<usize> = const { Cell::new(0) };
+    }
+
+    fn counted_word(record: &[u32]) -> u32 {
+        SLICE_DECODE_COUNT.with(|count| count.set(count.get() + 1));
+        record[0]
+    }
+
+    fn reset_decode_count() {
+        SLICE_DECODE_COUNT.with(|count| count.set(0));
+    }
+
+    fn decode_count() -> usize {
+        SLICE_DECODE_COUNT.with(Cell::get)
+    }
 
     struct CountingAllocator;
 
@@ -6833,6 +6945,47 @@ mod typed_payload_tests {
             ALLOCATION_COUNT.with(Cell::get),
             ALLOCATION_BYTES.with(Cell::get),
         )
+    }
+
+    #[test]
+    fn validated_fixed_slice_decodes_only_requested_records() {
+        let words: Vec<u32> = (0..128).collect();
+        reset_decode_count();
+        let view = RirSlice::new_validated(&words, 1, counted_word);
+        assert_eq!(decode_count(), 0);
+        assert_eq!(view.get(97), Some(97));
+        assert_eq!(decode_count(), 1);
+        assert_eq!(view.get(13), Some(13));
+        assert_eq!(decode_count(), 2);
+        assert_eq!(view.get(usize::MAX), None);
+        assert_eq!(view.get(view.len()), None);
+        assert_eq!(decode_count(), 2);
+
+        let wide = RirSlice::new_validated(&[], 2, counted_word);
+        assert_eq!(wide.get(usize::MAX / 2), None); // checked start + width overflow
+        assert_eq!(wide.get(usize::MAX), None); // checked index * width overflow
+    }
+
+    #[test]
+    fn unvalidated_fixed_slice_sweeps_before_exposing_values() {
+        let words: Vec<u32> = (0..128).collect();
+        reset_decode_count();
+        let view = RirSlice::new_unvalidated(&words, 1, counted_word);
+        assert_eq!(decode_count(), words.len());
+        assert_eq!(view.get(0), Some(0));
+        assert_eq!(decode_count(), words.len() + 1);
+    }
+
+    #[test]
+    fn validated_fixed_slice_construction_has_no_record_scaled_allocations() {
+        let small = [0u32; 8];
+        let large = [0u32; 1024];
+        let (small_allocations, small_bytes) =
+            allocation_evidence(|| drop(RirSlice::new_validated(&small, 1, counted_word)));
+        let (large_allocations, large_bytes) =
+            allocation_evidence(|| drop(RirSlice::new_validated(&large, 1, counted_word)));
+        assert_eq!((small_allocations, small_bytes), (0, 0));
+        assert_eq!((large_allocations, large_bytes), (0, 0));
     }
 
     fn span() -> Span {

--- a/crates/rue-rir/src/inst/packed.rs
+++ b/crates/rue-rir/src/inst/packed.rs
@@ -376,7 +376,11 @@ impl PackedValidatedRir {
                 )
                 .map_err(PackedRirAppendError::Build)?;
         }
-        Ok((ValidatedRir(editor.into_unvalidated()), appended.metadata))
+        let mut rir = editor.into_unvalidated();
+        // The packed envelope and append traversal have already checked the
+        // complete payload graph, so published consumers may use lazy views.
+        rir.views_validated = true;
+        Ok((ValidatedRir(rir), appended.metadata))
     }
 
     fn try_append_remapped_internal<E>(


### PR DESCRIPTION
## Summary
- separate validated and unvalidated RIR slice construction while keeping publication fail-closed
- decode fixed-width records lazily with checked direct indexing and propagate validation state through nested views
- lazily cache only fixed AstGen spellings while preserving interner identity and failure behavior
- add malformed-payload, indexing, repeated-access, allocation/scaling, symbol-identity, and structural regression evidence

## Validation
- `scripts/rue unit rir` (137 passed)
- `scripts/rue unit compiler candidate_` (36 passed)
- `scripts/rue quick` (33 targets passed)
- `scripts/rue premerge` (203 targets passed)
- `scripts/rue fmt`
- full standard suite: 235 targets passed; six oracle-diff corpus actions were blocked by macOS host thread exhaustion (`WouldBlock`) with no semantic disagreement

Fixes RUE-1660