### PR TITLE
RUE-1735: use indexed module source projection

### DIFF
--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -125,18 +125,18 @@ struct SourceRecord {
     text: Arc<String>,
 }
 
-/// Deterministic work counters for the two identity questions a build asks once
-/// per module: "which file in this snapshot is bound to this module?" and
-/// "which accepted-read entry names this physical file?".
+/// Deterministic work counters for identity questions measured on the compiler's
+/// canonical query path: "which file in this snapshot is bound to this module?"
+/// and "which accepted-read entry names this physical file?".
 ///
-/// Both questions used to be answered by scanning the whole set, so each cost
-/// one pass over a set that grows with the program — quadratic in the depth of
-/// an import chain, and invisible to every counter the compiler published,
-/// because a scan dispatches nothing. These counters make the *examinations*
-/// countable, not just the dispatches: a question is one `*_lookups`, and each
-/// position examined while answering it is one `*_visits`. An index-answered
-/// question examines a bounded number of positions; a scan-answered one
-/// examines the whole set, so `visits / lookups` is the shape under test.
+/// The compiler query entry points use the counters to make their
+/// *examinations* countable, not just their dispatches: a question is one
+/// `*_lookups`, and each position examined while answering it is one
+/// `*_visits`. An index-answered question examines a bounded number of
+/// positions; a scan-answered one examines the whole set, so
+/// `visits / lookups` is the shape under test. The public source projection
+/// shares the same indexed resolver but intentionally does not meter its
+/// host-side reads.
 ///
 /// Determinism: every field counts work actually performed on the canonical
 /// query path, exactly like `parse_sources_materialized` and
@@ -488,6 +488,18 @@ impl SourceSnapshot {
         self.record(file_id).map(|record| record.text.clone())
     }
 
+    /// Share ownership of the source text bound to `module`.
+    ///
+    /// Module identity resolution remains owned by this snapshot, including
+    /// its segmented inverse index and origin checks. Callers that only need
+    /// the source payload do not need to reconstruct that mapping by scanning
+    /// diagnostic files.
+    pub fn shared_source_for_module(&self, module: &ModuleId) -> Option<Arc<String>> {
+        self.resolve_file_id_for_module(module)
+            .0
+            .and_then(|file_id| self.shared_source_text(file_id))
+    }
+
     /// Stable exact content identity for a request-local file.
     pub fn source_id(&self, file_id: FileId) -> Option<&SourceId> {
         self.record(file_id).map(|record| &record.source_id)
@@ -498,7 +510,27 @@ impl SourceSnapshot {
         self.record(file_id).map(|record| &record.module_id)
     }
 
-    /// The file this snapshot binds `module` to.
+    /// Resolve a module through the snapshot-owned segmented inverse.
+    ///
+    /// The visit count is returned to the metered compiler entry point, while
+    /// the public source projection consumes only the file identity. Keeping
+    /// both callers on this helper prevents the projection from growing a
+    /// second lookup implementation or manufacturing discarded measurements.
+    fn resolve_file_id_for_module(&self, module: &ModuleId) -> (Option<FileId>, u64) {
+        let mut visited = 0;
+        let found = self.data.segments.iter().find_map(|segment| {
+            // One hash probe per segment, then one record read for the hit.
+            visited += 1;
+            segment.module_index.get(module).map(|&position| {
+                visited += 1;
+                segment.contents[position].file_id
+            })
+        });
+        (found, visited)
+    }
+
+    /// The file this snapshot binds `module` to on the metered compiler query
+    /// path.
     ///
     /// A snapshot's [`SourceRevision`] rejects duplicate module identities, so
     /// this inverse is a function. Segments hold disjoint ascending file-id
@@ -517,15 +549,7 @@ impl SourceSnapshot {
         module: &ModuleId,
         meter: &IdentityResolutionMeter,
     ) -> Option<FileId> {
-        let mut visited = 0;
-        let found = self.data.segments.iter().find_map(|segment| {
-            // One hash probe per segment, then one record read for the hit.
-            visited += 1;
-            segment.module_index.get(module).map(|&position| {
-                visited += 1;
-                segment.contents[position].file_id
-            })
-        });
+        let (found, visited) = self.resolve_file_id_for_module(module);
         meter.record_module_resolution(visited);
         found
     }
@@ -825,6 +849,25 @@ mod tests {
     }
 
     #[test]
+    fn module_source_projection_delegates_to_the_indexed_resolver() {
+        let production = include_str!("source_snapshot.rs")
+            .split("\n#[cfg(test)]\nmod tests")
+            .next()
+            .expect("the production source precedes this test module");
+        let compact: String = production.split_whitespace().collect();
+
+        assert_eq!(
+            compact
+                .matches("resolve_file_id_for_module(module)")
+                .count(),
+            2,
+            "metered and public paths must share the one canonical resolver"
+        );
+        assert!(!compact.contains("files().find"));
+        assert!(!compact.contains("files().find_map"));
+    }
+
+    #[test]
     fn requires_exact_metadata_membership() {
         let descriptor = metadata(&[(2, "two.rue"), (4, "four.rue"), (8, "eight.rue")]);
         assert_eq!(
@@ -908,6 +951,59 @@ mod tests {
         assert_eq!(file.path, "src/main.rue");
         assert_eq!(file.source, "fn main() {}");
         assert!(snapshot.source(FileId::new(8)).is_none());
+    }
+
+    #[test]
+    fn module_source_projection_preserves_source_identity_and_rejects_foreign_modules() {
+        let file_id = FileId::new(7);
+        let source = Arc::new("fn main() {}".to_owned());
+        let snapshot = SourceSnapshot::new(
+            metadata(&[(7, "src/main.rue")]),
+            vec![(file_id, Arc::clone(&source))],
+        )
+        .unwrap();
+        let module = ModuleId::from_logical_path("src/main.rue").unwrap();
+
+        let projected = snapshot
+            .shared_source_for_module(&module)
+            .expect("the canonical module is present");
+        let indexed = snapshot.shared_source_text(file_id).unwrap();
+        assert!(Arc::ptr_eq(&projected, &indexed));
+        assert!(Arc::ptr_eq(&projected, &source));
+        assert!(
+            snapshot
+                .shared_source_for_module(&ModuleId::from_logical_path("stale.rue").unwrap())
+                .is_none()
+        );
+
+        let trusted_file = FileId::new(8);
+        let trusted_path = "\0rue-std/option.rue";
+        let physical_paths = [(trusted_file, "/toolchain/option.rue")]
+            .into_iter()
+            .map(|(file_id, path)| (file_id, path.to_owned()))
+            .collect();
+        let logical_paths = [(trusted_file, trusted_path.to_owned())]
+            .into_iter()
+            .collect();
+        let trusted_metadata = SourceMetadata::new_with_trusted_standard_library(
+            trusted_file,
+            physical_paths,
+            logical_paths,
+            [trusted_file].into_iter().collect(),
+        )
+        .unwrap();
+        let trusted_snapshot = SourceSnapshot::new(
+            trusted_metadata,
+            vec![(trusted_file, Arc::new("pub fn option() {}".to_owned()))],
+        )
+        .unwrap();
+        let counterfeit = ModuleId::from_logical_path(trusted_path).unwrap();
+        assert!(!counterfeit.is_trusted_standard_library());
+        assert!(
+            trusted_snapshot
+                .shared_source_for_module(&counterfeit)
+                .is_none()
+        );
     }
 
     #[test]
@@ -1043,6 +1139,13 @@ mod tests {
                 .expect("every snapshot file has a module identity")
                 .clone();
             assert_eq!(snapshot.file_id_for_module(&module, &meter), Some(file_id));
+            let projected = snapshot
+                .shared_source_for_module(&module)
+                .expect("the canonical module projection is present");
+            assert!(Arc::ptr_eq(
+                &projected,
+                &snapshot.shared_source_text(file_id).unwrap()
+            ));
             // The scan this replaces is quadratic, so compare against it on a
             // sample rather than on every module.
             if position % 64 == 0 {

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -443,17 +443,6 @@ fn metadata_requires_content_hash(
     }
 }
 
-fn cached_source_for_module(
-    snapshot: &SourceSnapshot,
-    module: &rue_compiler::ModuleId,
-) -> Option<Arc<String>> {
-    snapshot.files().find_map(|source| {
-        (snapshot.module_id(source.file_id) == Some(module))
-            .then(|| snapshot.shared_source_text(source.file_id))
-            .flatten()
-    })
-}
-
 /// Capture the ordered physical identities of symlink components traversed
 /// below a spelling's logical boundary. Ancestors shared by the host's path
 /// layout (for example `/var -> /private/var`) are deliberately outside the
@@ -538,8 +527,9 @@ fn reobserve_accepted_reads(
     let now = SystemTime::now();
     let mut observed = AHashMap::with_capacity(manifest.len());
     for entry in manifest.iter() {
-        let cached_source =
-            cached_source_for_module(snapshot, entry.module()).ok_or_else(|| {
+        let cached_source = snapshot
+            .shared_source_for_module(entry.module())
+            .ok_or_else(|| {
                 SourceLoadError::Message(format!(
                     "Error: accepted read for {} has no cached source",
                     entry.module()
@@ -852,12 +842,9 @@ impl ImportDiscoveryResult {
         for entry in self.read_manifest.iter() {
             let source = self
                 .source_snapshot
-                .files()
-                .find(|source| {
-                    self.source_snapshot.module_id(source.file_id) == Some(entry.module())
-                })
+                .shared_source_for_module(entry.module())
                 .expect("an accepted read has source bytes in the committed snapshot");
-            let fingerprint = WatchFingerprint::from_bytes(source.source.as_bytes());
+            let fingerprint = WatchFingerprint::from_bytes(source.as_bytes());
             paths.push(WatchInput::new(
                 PathBuf::from(entry.requested_path()),
                 PathBuf::from(entry.canonical_path()),
@@ -2250,6 +2237,21 @@ mod architecture_tests {
                 "host boundary must have exactly one call: {required_boundary}"
             );
         }
+    }
+
+    #[test]
+    fn accepted_read_module_sources_use_the_snapshot_projection() {
+        let production = production_before_tests(include_str!("source_loader.rs"));
+        let compact: String = production.split_whitespace().collect();
+        assert_eq!(
+            compact
+                .matches("shared_source_for_module(entry.module())")
+                .count(),
+            2,
+            "reobservation and watch-input construction must use the canonical projection"
+        );
+        assert!(!compact.contains("snapshot.files().find_map"));
+        assert!(!compact.contains("source_snapshot.files().find"));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- expose a narrow snapshot-owned module-to-shared-source projection
- use the canonical segmented inverse for retained reobservation and watch inputs
- pin source identity, trusted-origin rejection, shared resolver ownership, and deep multi-segment scaling

Validation:
- focused SourceSnapshot projection tests
- full rue-driver test target (53 tests)
- scripts/rue quick
- scripts/rue fmt
- git diff --check
- local premerge reached 202/203 targets; the unrelated wrapper signal-name assertion also fails in isolation
- broad local run reached the host thread/process ceiling in oracle corpus worker spawning; focused oracle unit tests and all changed-area tests are green

Fixes RUE-1735