### PR TITLE
RUE-1732: memoize body-local comptime reductions

### DIFF
--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -221,9 +221,11 @@ pub enum ComptimeMemoInsertError {
     AlreadyMemoized,
 }
 
-/// Completed call facts retained only for the lifetime of one evaluation.
-/// A missing key is intentionally distinct from a memoized not-ready or
-/// runtime-dependent outcome, so callers can turn misses into `Enter` frames.
+/// Completed call facts retained for the lifetime chosen by the host.
+/// The ordinary body host owns one instance per body analysis, so its entries
+/// are dropped at that boundary. A missing key is intentionally distinct from
+/// a memoized not-ready or runtime-dependent outcome, so callers can turn
+/// misses into `Enter` frames.
 #[derive(Debug)]
 pub struct ComptimeCompletedCallMemo<D, C, T, V, R> {
     outcomes: AHashMap<ComptimeCallKey<D, C, T, V>, ComptimeMemoizedOutcome<R>>,
@@ -738,6 +740,9 @@ mod value_domain_tests {
         static CALL_ARGUMENTS: RefCell<Vec<(FakeValue, bool)>> = const { RefCell::new(Vec::new()) };
         static BINDING_FINISHES: Cell<usize> = const { Cell::new(0) };
         static PREPARE_CALLS: Cell<usize> = const { Cell::new(0) };
+        static PREPARE_CANONICAL_PROBE: Cell<bool> = const { Cell::new(false) };
+        static CANONICAL_FAILURE_AFTER: Cell<Option<usize>> = const { Cell::new(None) };
+        static DEPTH_FAILURE_VARIANT: Cell<bool> = const { Cell::new(false) };
         static ALLOW_MODULE_CALLS: Cell<bool> = const { Cell::new(false) };
         static EVALUATED_METHOD_RECEIVER_MODE: Cell<u8> = const { Cell::new(0) };
         static EVALUATED_METHOD_RECEIVERS: RefCell<Vec<FakeValue>> = const { RefCell::new(Vec::new()) };
@@ -1421,6 +1426,7 @@ mod value_domain_tests {
     enum FakeFailure {
         Generic,
         Canceled,
+        DepthExceeded,
         NonFunctionMethod,
         OwnComptimeTypeParameter,
     }
@@ -1997,7 +2003,11 @@ mod value_domain_tests {
                     .borrow_mut()
                     .push((*site.program(), site.span().start, site.span().end))
             });
-            FAKE_FAILURE
+            if DEPTH_FAILURE_VARIANT.with(Cell::get) {
+                FakeFailure::DepthExceeded
+            } else {
+                FAKE_FAILURE
+            }
         }
         fn literal_out_of_range(
             &self,
@@ -2408,20 +2418,34 @@ mod value_domain_tests {
                 } else {
                     call_body
                 };
+                let frame = ComptimeFrame {
+                    program: 1,
+                    body,
+                    name: Some(admission.name.clone()),
+                    context: Some(FakeFile { index: 0 }),
+                    span: Span::new(0, 0),
+                    function_span: Span::new(0, 0),
+                    type_bindings: AHashMap::new(),
+                    value_bindings: AHashMap::new(),
+                    name_bindings: AHashMap::new(),
+                    call_identity: None,
+                    expected_result: expected,
+                };
+                if PREPARE_CANONICAL_PROBE.with(Cell::get) {
+                    // Model the ordinary host's pre-lookup identity probe. A
+                    // failure here must remain deferrable until `run_frame`
+                    // has performed its depth admission check.
+                    let _ = self.canonical_function_producer(
+                        &frame.program,
+                        &self.enter_count,
+                        admission.name,
+                        &frame.type_bindings,
+                        &frame.value_bindings,
+                        frame.span,
+                    );
+                }
                 return Ok(Some(ComptimeCallPreparation::Enter {
-                    frame: ComptimeFrame {
-                        program: 1,
-                        body,
-                        name: Some(admission.name),
-                        context: Some(FakeFile { index: 0 }),
-                        span: Span::new(0, 0),
-                        function_span: Span::new(0, 0),
-                        type_bindings: AHashMap::new(),
-                        value_bindings: AHashMap::new(),
-                        name_bindings: AHashMap::new(),
-                        call_identity: None,
-                        expected_result: expected,
-                    },
+                    frame,
                     ticket: self.enter_count,
                 }));
             }
@@ -2542,7 +2566,10 @@ mod value_domain_tests {
             PRODUCER_CALLS.with(|calls| {
                 calls.borrow_mut().push((*program, *ticket, name.ordinal));
             });
-            if matches!(self.finish_outcome, FakeFinishOutcome::CanonicalFailure) {
+            if matches!(self.finish_outcome, FakeFinishOutcome::CanonicalFailure)
+                || CANONICAL_FAILURE_AFTER
+                    .with(|after| after.get().is_some_and(|after| self.enter_count >= after))
+            {
                 return Err(FAKE_FAILURE.into());
             }
             Ok(FakeIdentity {
@@ -5716,7 +5743,7 @@ mod value_domain_tests {
     }
 
     #[test]
-    fn entered_frames_use_the_real_64_frame_budget_and_memoized_bypasses_it() {
+    fn entered_frames_use_the_real_64_frame_budget_and_prepared_outcomes_remain_ticket_free() {
         let mut editor = rue_rir::RirEditor::new();
         let interner = lasso::ThreadedRodeo::new();
         let symbol = interner.get_or_intern("loop");
@@ -5953,6 +5980,49 @@ mod value_domain_tests {
         TICKET_EVENTS.with(|events| assert!(events.borrow().is_empty()));
         PRODUCER_CALLS.with(|calls| {
             assert_eq!(calls.borrow().as_slice(), &[(1, 1, base)]);
+        });
+    }
+
+    #[test]
+    fn depth_rejection_precedes_prelookup_canonicalization_failure() {
+        let interner = lasso::ThreadedRodeo::new();
+        let symbol = interner.get_or_intern("deep");
+        let mut root = rue_rir::RirEditor::new();
+        let root_call = root.add_call(symbol, &[], Span::new(13, 19)).unwrap();
+        let mut child = rue_rir::RirEditor::new();
+        let child_call = child.add_call(symbol, &[], Span::new(23, 29)).unwrap();
+        let mut host = FakeHost {
+            programs: vec![root.finish(), child.finish()],
+            type_symbol: SymbolHandle::new(symbol),
+            constant: None,
+            dependencies: Vec::new(),
+            call_plans: AHashMap::new(),
+            recursive: Some((MAX_COMPTIME_CALL_DEPTH + 2, child_call, child_call, None)),
+            enter_count: 0,
+            finish_outcome: FakeFinishOutcome::Identity,
+            finished: Vec::new(),
+            float_evaluations: Cell::new(0),
+        };
+        PREPARE_CANONICAL_PROBE.with(|enabled| enabled.set(true));
+        CANONICAL_FAILURE_AFTER.with(|after| after.set(Some(MAX_COMPTIME_CALL_DEPTH + 2)));
+        DEPTH_FAILURE_VARIANT.with(|enabled| enabled.set(true));
+        DIAGNOSTIC_SITES.with(|sites| sites.borrow_mut().clear());
+        PRODUCER_CALLS.with(|calls| calls.borrow_mut().clear());
+        let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        let result = ComptimeEngine::new(&mut host)
+            .evaluate(ComptimeFrame::expression(0, root_call), &mut env);
+        PREPARE_CANONICAL_PROBE.with(|enabled| enabled.set(false));
+        CANONICAL_FAILURE_AFTER.with(|after| after.set(None));
+        DEPTH_FAILURE_VARIANT.with(|enabled| enabled.set(false));
+        assert!(matches!(
+            result,
+            ComptimeOutcome::HostFailure(FakeFailure::DepthExceeded)
+        ));
+        DIAGNOSTIC_SITES.with(|sites| {
+            assert_eq!(sites.borrow().as_slice(), &[(1, 0, 0)]);
+        });
+        PRODUCER_CALLS.with(|calls| {
+            assert!(calls.borrow().len() >= MAX_COMPTIME_CALL_DEPTH);
         });
     }
 
@@ -6455,8 +6525,12 @@ mod value_domain_tests {
     }
 
     #[test]
-    fn completed_memo_distinguishes_ordered_args_and_miss() {
-        type Memo = ComptimeCompletedCallMemo<u8, u8, u8, u8, u8>;
+    fn completed_memo_distinguishes_callable_target_and_ordered_args() {
+        // The declaration tuple stands in for the real producer's callable,
+        // imported-module, and generic-identity components. Keeping those
+        // components in one exact field catches counterfeit near-collision
+        // keys without depending on a particular issuer's token numbers.
+        type Memo = ComptimeCompletedCallMemo<(u8, u8, u8), u8, u8, u8, u8>;
         let key = |declaration, configuration, types: &[u8], values: &[u8]| ComptimeCallKey {
             declaration,
             configuration,
@@ -6464,7 +6538,7 @@ mod value_domain_tests {
             value_arguments: Arc::from(values),
         };
         let mut memo = Memo::new();
-        let base = key(7, 3, &[1, 2], &[3, 4]);
+        let base = key((7, 11, 13), 3, &[1, 2], &[3, 4]);
         assert!(matches!(memo.lookup(&base), ComptimeCallMemoLookup::Miss));
         memo.insert(base.clone(), ComptimeMemoizedOutcome::NotReady)
             .unwrap();
@@ -6473,19 +6547,23 @@ mod value_domain_tests {
             ComptimeCallMemoLookup::Memoized(ComptimeMemoizedOutcome::NotReady)
         ));
         assert!(matches!(
-            memo.lookup(&key(8, 3, &[1, 2], &[3, 4])),
+            memo.lookup(&key((8, 11, 13), 3, &[1, 2], &[3, 4])),
             ComptimeCallMemoLookup::Miss
         ));
         assert!(matches!(
-            memo.lookup(&key(7, 4, &[1, 2], &[3, 4])),
+            memo.lookup(&key((7, 11, 14), 3, &[1, 2], &[3, 4])),
             ComptimeCallMemoLookup::Miss
         ));
         assert!(matches!(
-            memo.lookup(&key(7, 3, &[2, 1], &[3, 4])),
+            memo.lookup(&key((7, 11, 13), 4, &[1, 2], &[3, 4])),
             ComptimeCallMemoLookup::Miss
         ));
         assert!(matches!(
-            memo.lookup(&key(7, 3, &[1, 2], &[4, 3])),
+            memo.lookup(&key((7, 11, 13), 3, &[2, 1], &[3, 4])),
+            ComptimeCallMemoLookup::Miss
+        ));
+        assert!(matches!(
+            memo.lookup(&key((7, 11, 13), 3, &[1, 2], &[4, 3])),
             ComptimeCallMemoLookup::Miss
         ));
         assert_eq!(memo.len(), 1);
@@ -6494,7 +6572,7 @@ mod value_domain_tests {
             memo.insert(base, ComptimeMemoizedOutcome::Known(9)),
             Err(ComptimeMemoInsertError::AlreadyMemoized)
         );
-        let trap_key = key(7, 3, &[1, 2], &[5]);
+        let trap_key = key((7, 11, 13), 3, &[1, 2], &[5]);
         let trap = ComptimeTrap {
             operation: "division by zero",
             span: Span::new(0, 0),
@@ -7147,6 +7225,24 @@ pub trait ComptimeHost {
         >,
         Self::Failure,
     >;
+    /// Look up a successful result in the host's evaluation-local completed
+    /// memo after the engine has admitted this frame's depth and canonical
+    /// identity. A hit returns directly without activating or finishing the
+    /// completion ticket. Durable hosts retain the default miss behavior;
+    /// ordinary body hosts may use this hook for their body-local memo.
+    fn lookup_completed_comptime_call(
+        &mut self,
+        _frame: &ComptimeFrame<
+            Self::Value,
+            Self::Type,
+            Self::Name,
+            Self::File,
+            Self::ProgramKey,
+            Self::CanonicalIdentity,
+        >,
+    ) -> ComptimeHostResult<Option<Self::Value>, Self::Failure> {
+        Ok(None)
+    }
     fn finish_comptime_call(
         &mut self,
         frame: &ComptimeFrame<
@@ -7161,7 +7257,9 @@ pub trait ComptimeHost {
         result: ComptimeOutcome<Self::Value, Self::Failure>,
     ) -> ComptimeOutcome<Self::Value, Self::Failure>;
     /// Activate a prepared completion ticket only after the engine has
-    /// admitted depth and issued the canonical producer identity.
+    /// admitted depth and has a canonical producer identity. A host may issue
+    /// that identity during preparation when it also needs it for admission;
+    /// the engine then carries it into the entered frame.
     fn enter_comptime_call(
         &mut self,
         _frame: &ComptimeFrame<
@@ -8057,15 +8155,22 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             ));
         }
         if let Some(name) = frame.name.clone() {
-            let canonical_identity = host_value!(self.host.canonical_function_producer(
-                &frame.program,
-                &ticket,
-                name,
-                &frame.type_bindings,
-                &frame.value_bindings,
-                frame.span,
-            ));
+            let canonical_identity = if let Some(identity) = frame.call_identity.clone() {
+                identity
+            } else {
+                host_value!(self.host.canonical_function_producer(
+                    &frame.program,
+                    &ticket,
+                    name,
+                    &frame.type_bindings,
+                    &frame.value_bindings,
+                    frame.span,
+                ))
+            };
             frame.call_identity = Some(canonical_identity);
+            if let Some(value) = host_value!(self.host.lookup_completed_comptime_call(&frame)) {
+                return ComptimeOutcome::Known(value);
+            }
             // Admission and canonical producer issuance are complete. Only
             // now may a host activate the opaque completion ticket carried by
             // this frame; depth/producer failures above never activate it.

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -56,8 +56,8 @@ use rue_span::{FileId, Span};
 
 use super::comptime::{
     ComptimeAnonymousKind, ComptimeArgMode, ComptimeArrayLengthBinding, ComptimeCallAdmission,
-    ComptimeCallArgument, ComptimeCallPreparation, ComptimeDiagnosticSite, ComptimeEngine,
-    ComptimeEnv as GenericComptimeEnv, ComptimeFile, ComptimeFrame, ComptimeHost,
+    ComptimeCallArgument, ComptimeCallKey, ComptimeCallPreparation, ComptimeDiagnosticSite,
+    ComptimeEngine, ComptimeEnv as GenericComptimeEnv, ComptimeFile, ComptimeFrame, ComptimeHost,
     ComptimeHostError, ComptimeHostResult, ComptimeIdentity, ComptimeMatchPattern,
     ComptimeMethodDescriptor, ComptimeName, ComptimeNamedValueResolution, ComptimeOutcome,
     ComptimeSelection, ComptimeSemanticRejection, ComptimeStructuredTypeResolution, ComptimeTrap,
@@ -595,6 +595,52 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         )
     }
 
+    /// Build the exact body-local key for one admitted callable. Parameter
+    /// order is part of the key's representation: the maps are convenient
+    /// binding state, but their hash iteration order is intentionally not a
+    /// semantic identity. The stable producer distinguishes callable and
+    /// imported/generic identities; the target distinguishes target-sensitive
+    /// intrinsic results; the concrete substitutions distinguish each state.
+    fn comptime_reduction_key(
+        &self,
+        name: Spur,
+        identity: super::anon_structs::IssuedStableProducerId,
+        type_bindings: &AHashMap<Spur, Type>,
+        value_bindings: &AHashMap<Spur, ConstValue>,
+    ) -> Option<
+        ComptimeCallKey<
+            super::anon_structs::IssuedStableProducerId,
+            rue_target::Target,
+            Type,
+            ConstValue,
+        >,
+    > {
+        let info = self.function_info(name)?;
+        let param_data = self.body_param_data(info.params);
+        let type_flags = self.comptime_type_param_flags(&info);
+        let mut type_arguments = Vec::new();
+        let mut value_arguments = Vec::new();
+        for (index, (parameter, _, _, is_comptime)) in param_data.iter().enumerate() {
+            if !*is_comptime {
+                continue;
+            }
+            if type_flags[index] {
+                type_arguments.push(*type_bindings.get(parameter)?);
+            } else {
+                value_arguments.push(*value_bindings.get(parameter)?);
+            }
+        }
+        let key = ComptimeCallKey {
+            declaration: identity,
+            configuration: self.target(),
+            type_arguments: type_arguments.into(),
+            value_arguments: value_arguments.into(),
+        };
+        #[cfg(test)]
+        self.record_comptime_reduction_key(&key);
+        Some(key)
+    }
+
     /// Complete a child call after the engine has evaluated its body. This
     /// hook owns only semantic bookkeeping; it never walks RIR or starts a
     /// second evaluator.
@@ -611,8 +657,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         _ticket: (),
         result: ComptimeOutcome<ConstValue, CompileError>,
     ) -> ComptimeOutcome<ConstValue, CompileError> {
+        #[cfg(test)]
+        if !matches!(result, ComptimeOutcome::Known(_)) {
+            self.record_non_successful_comptime_completion();
+        }
         if let (Some(name), ComptimeOutcome::Known(ConstValue::Type(ty))) = (frame.name, &result) {
             self.record_ctor_type_display(name, *ty, &frame.type_bindings, &frame.value_bindings);
+        }
+        if let (Some(identity), ComptimeOutcome::Known(value)) =
+            (frame.call_identity.clone(), &result)
+        {
+            if let Some(name) = frame.name
+                && let Some(key) = self.comptime_reduction_key(
+                    name,
+                    identity,
+                    &frame.type_bindings,
+                    &frame.value_bindings,
+                )
+            {
+                self.memoize_comptime_reduction(key, *value);
+            }
         }
         result
     }
@@ -2410,14 +2474,66 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
                 })
                 .map_err(Into::into);
         }
-        OrdinaryBodyEngine::prepare_comptime_call(
+        let name = admission.name;
+        let preparation = OrdinaryBodyEngine::prepare_comptime_call(
             self,
             admission,
             bound.callee_types,
             bound.callee_values,
             span,
         )
-        .map_err(Into::into)
+        .map_err(ComptimeHostError::HostFailure)?;
+        let Some(ComptimeCallPreparation::Enter { mut frame, ticket }) = preparation else {
+            return Ok(preparation);
+        };
+        // Canonicalization is an optimization input to the local lookup, not
+        // an admission gate. If it cannot issue an identity yet, leave the
+        // frame identity-less so `run_frame` preserves its established
+        // depth-first ordering: an over-limit call reports depth before the
+        // original canonicalization failure. A successful issuance is carried
+        // into the frame so a normal miss does not mint the same identity a
+        // second time after the depth check.
+        let identity = match self.canonical_function_producer(
+            name,
+            &frame.type_bindings,
+            &frame.value_bindings,
+        ) {
+            Ok(identity) => identity,
+            Err(_) => return Ok(Some(ComptimeCallPreparation::Enter { frame, ticket })),
+        };
+        // Admission already issued the exact identity used by the local
+        // lookup. Carry it into the frame so `run_frame` does not mint the
+        // same producer a second time after the depth check. The lookup itself
+        // happens in the engine only after that depth check.
+        frame.call_identity = Some(identity);
+        Ok(Some(ComptimeCallPreparation::Enter { frame, ticket }))
+    }
+    fn lookup_completed_comptime_call(
+        &mut self,
+        frame: &ComptimeFrame<ConstValue, Type, Spur, FileId, (), Self::CanonicalIdentity>,
+    ) -> ComptimeHostResult<Option<ConstValue>, Self::Failure> {
+        let Some(name) = frame.name else {
+            return Ok(None);
+        };
+        let Some(identity) = frame.call_identity.clone() else {
+            return Ok(None);
+        };
+        let Some(key) = self.comptime_reduction_key(
+            name,
+            identity,
+            &frame.type_bindings,
+            &frame.value_bindings,
+        ) else {
+            return Ok(None);
+        };
+        let Some(value) = self.lookup_comptime_reduction(&key) else {
+            #[cfg(test)]
+            self.record_comptime_reduction_miss();
+            return Ok(None);
+        };
+        self.check_canceled()
+            .map_err(ComptimeHostError::HostFailure)?;
+        Ok(Some(value))
     }
     fn finish_comptime_call(
         &mut self,

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -3,7 +3,9 @@
 //! [`OrdinaryBodyAnalysisHost`] names the state the algorithm actually needs;
 //! the query-backed provider host is its one production implementation. [`OrdinaryBodyEngine`] only gives that one generic algorithm an
 //! inherent-method receiver, which stable Rust cannot define on a trait. It
-//! owns no state, representation conversion, cache, or alternative policy.
+//! owns only a body-analysis-local successful comptime reduction memo in
+//! addition to the borrowed storage handle; it has no alternate semantic
+//! policy or representation conversion.
 
 use crate::Node;
 use ahash::{AHashMap, AHashSet};
@@ -19,6 +21,9 @@ use super::aggregate_resolution::is_accessible as aggregate_is_accessible;
 use super::analysis::FirstClassStrSite;
 use super::anon_structs::{
     IssuedCanonicalArguments, IssuedFunctionInstanceKey, IssuedStableProducerId,
+};
+use super::comptime::{
+    ComptimeCallKey, ComptimeCallMemoLookup, ComptimeCompletedCallMemo, ComptimeMemoizedOutcome,
 };
 use super::context::{AnalysisContext, DivergenceKinds, ParamIndex, ParamInfo};
 use super::fact_mode::{
@@ -447,15 +452,141 @@ pub(crate) trait OrdinaryBodyAnalysisHost:
 
 /// Inherent-method receiver for the generic ordinary-body algorithm.
 ///
-/// The engine owns no analyzer representation and has no alternate semantic
-/// algorithm. Both concrete hosts enter the same methods through this receiver.
+/// The engine owns no analyzer representation or alternate semantic algorithm.
+/// It carries only the host-owned body-analysis-local successful reduction
+/// memo needed by the ordinary comptime path. Both concrete hosts enter the
+/// same methods through this receiver.
 pub(crate) struct OrdinaryBodyEngine<'h, H: OrdinaryBodyAnalysisHost> {
     storage: &'h mut H,
+    comptime_reduction_memo:
+        ComptimeCompletedCallMemo<IssuedStableProducerId, Target, Type, ConstValue, ConstValue>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ComptimeReductionTestStats {
+    pub(crate) misses: usize,
+    pub(crate) hits: usize,
+    pub(crate) publications: usize,
+    pub(crate) canonical_issuances: usize,
+    pub(crate) non_successful_completions: usize,
+    pub(crate) last_known_integer: Option<i128>,
+    pub(crate) max_entries: usize,
+    pub(crate) body_instances_dropped: usize,
+    pub(crate) last_dropped_entries: usize,
+}
+
+#[cfg(test)]
+thread_local! {
+    static COMPTIME_REDUCTION_TEST_STATS: std::cell::Cell<ComptimeReductionTestStats> =
+        const { std::cell::Cell::new(ComptimeReductionTestStats {
+            misses: 0,
+            hits: 0,
+            publications: 0,
+            canonical_issuances: 0,
+            non_successful_completions: 0,
+            last_known_integer: None,
+            max_entries: 0,
+            body_instances_dropped: 0,
+            last_dropped_entries: 0,
+        }) };
+    static COMPTIME_REDUCTION_TEST_KEYS: std::cell::RefCell<Vec<ComptimeCallKey<IssuedStableProducerId, Target, Type, ConstValue>>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_comptime_reduction_test_stats() {
+    COMPTIME_REDUCTION_TEST_STATS.with(|stats| stats.set(ComptimeReductionTestStats::default()));
+    COMPTIME_REDUCTION_TEST_KEYS.with(|keys| keys.borrow_mut().clear());
+}
+
+#[cfg(test)]
+pub(crate) fn comptime_reduction_test_keys()
+-> Vec<ComptimeCallKey<IssuedStableProducerId, Target, Type, ConstValue>> {
+    COMPTIME_REDUCTION_TEST_KEYS.with(|keys| keys.borrow().clone())
+}
+
+#[cfg(test)]
+pub(crate) fn comptime_reduction_test_stats() -> ComptimeReductionTestStats {
+    COMPTIME_REDUCTION_TEST_STATS.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+fn update_comptime_reduction_test_stats(update: impl FnOnce(&mut ComptimeReductionTestStats)) {
+    COMPTIME_REDUCTION_TEST_STATS.with(|stats| {
+        let mut current = stats.get();
+        update(&mut current);
+        stats.set(current);
+    });
 }
 
 impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn new(storage: &'h mut H) -> Self {
-        Self { storage }
+        Self {
+            storage,
+            comptime_reduction_memo: ComptimeCompletedCallMemo::new(),
+        }
+    }
+
+    pub(crate) fn lookup_comptime_reduction(
+        &self,
+        key: &ComptimeCallKey<IssuedStableProducerId, Target, Type, ConstValue>,
+    ) -> Option<ConstValue> {
+        match self.comptime_reduction_memo.lookup(key) {
+            ComptimeCallMemoLookup::Memoized(ComptimeMemoizedOutcome::Known(value)) => {
+                #[cfg(test)]
+                update_comptime_reduction_test_stats(|stats| stats.hits += 1);
+                Some(*value)
+            }
+            ComptimeCallMemoLookup::Memoized(_) | ComptimeCallMemoLookup::Miss => None,
+        }
+    }
+
+    pub(crate) fn memoize_comptime_reduction(
+        &mut self,
+        key: ComptimeCallKey<IssuedStableProducerId, Target, Type, ConstValue>,
+        value: ConstValue,
+    ) {
+        // The key is admitted only after a completed call has been evaluated.
+        // A duplicate would indicate an impossible second completion of the
+        // same frame, so retain the first successful result deterministically.
+        let insertion = self
+            .comptime_reduction_memo
+            .insert(key, ComptimeMemoizedOutcome::Known(value))
+            .is_ok();
+        #[cfg(test)]
+        if insertion {
+            update_comptime_reduction_test_stats(|stats| {
+                stats.publications += 1;
+                stats.last_known_integer = value.as_int_value();
+                stats.max_entries = stats.max_entries.max(self.comptime_reduction_memo.len());
+            });
+        }
+        #[cfg(not(test))]
+        let _ = insertion;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_comptime_reduction_miss(&self) {
+        update_comptime_reduction_test_stats(|stats| stats.misses += 1);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_comptime_reduction_key(
+        &self,
+        key: &ComptimeCallKey<IssuedStableProducerId, Target, Type, ConstValue>,
+    ) {
+        COMPTIME_REDUCTION_TEST_KEYS.with(|keys| keys.borrow_mut().push(key.clone()));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_comptime_canonical_issuance(&self) {
+        update_comptime_reduction_test_stats(|stats| stats.canonical_issuances += 1);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_non_successful_comptime_completion(&self) {
+        update_comptime_reduction_test_stats(|stats| stats.non_successful_completions += 1);
     }
 
     pub(crate) fn check_canceled(&self) -> CompileResult<()> {
@@ -1124,6 +1255,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         tys: &AHashMap<Spur, Type>,
         vals: &AHashMap<Spur, ConstValue>,
     ) -> Result<IssuedStableProducerId, crate::SemanticBodyExportFailure> {
+        #[cfg(test)]
+        self.record_comptime_canonical_issuance();
         use crate::SemanticBodyExportFailure as F;
         let function =
             DeclarationFacts::function_info(self.storage, name).ok_or(F::MissingStableIdentity)?;
@@ -2359,5 +2492,15 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             ctx.referenced_functions,
             ctx.referenced_methods,
         ))
+    }
+}
+
+#[cfg(test)]
+impl<H: OrdinaryBodyAnalysisHost> Drop for OrdinaryBodyEngine<'_, H> {
+    fn drop(&mut self) {
+        update_comptime_reduction_test_stats(|stats| {
+            stats.body_instances_dropped += 1;
+            stats.last_dropped_entries = self.comptime_reduction_memo.len();
+        });
     }
 }

--- a/crates/rue-air/src/sema/provider_fixture.rs
+++ b/crates/rue-air/src/sema/provider_fixture.rs
@@ -23,6 +23,8 @@
 //!   this path, fixture tests fail loudly instead of silently absorbing it.
 
 use ahash::AHashMap;
+#[cfg(test)]
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -39,15 +41,17 @@ use super::provider::{
 };
 use super::{
     BodyFactProvider, BodyRirBundle, DurableAnonymousShape, DurableAnonymousSource,
-    DurableBodyLookupSource, DurableCallableSource, DurableConst, DurableConstSource,
-    DurableFunction, DurableMethod, DurableNominal, DurableNominalBody, DurableNominalSource,
-    DurableSignatureParameter, ProviderOrdinaryBody, ProviderWellKnownOptionFacts,
-    analyze_provider_ordinary_body,
+    DurableBodyLookupSource, DurableCallableSource, DurableComptimeCallOutcome, DurableConst,
+    DurableConstSource, DurableFunction, DurableMethod, DurableNominal, DurableNominalBody,
+    DurableNominalSource, DurableReducedComptimeCall, DurableSignatureParameter,
+    ProviderOrdinaryBody, ProviderWellKnownOptionFacts, analyze_provider_ordinary_body,
+    analyze_provider_specialized_body,
 };
 use crate::types::LangItem;
 use crate::{
-    AnonymousNominalKey, SemanticImportConstValue, SemanticImportType, SemanticParameterMode,
-    StableDefinitionKind, stable_digest,
+    AnonymousNominalKey, CanonicalArgumentValue, CanonicalArguments, ProviderSpecializedBody,
+    SemanticComptimeCallResult, SemanticImportConstValue, SemanticImportType,
+    SemanticParameterMode, StableDefinitionKind, TypeInstanceKey, stable_digest,
 };
 
 /// The one durable definition key vocabulary of the fixture: a name, an
@@ -108,6 +112,7 @@ pub(crate) type FixtureModule = Arc<str>;
 pub(crate) type FixtureType = SemanticImportType<FixtureKey, FixtureModule>;
 pub(crate) type FixtureConstValue = SemanticImportConstValue<FixtureKey, FixtureModule>;
 pub(crate) type FixtureBody = ProviderOrdinaryBody<FixtureKey, FixtureModule>;
+pub(crate) type FixtureSpecializedBody = ProviderSpecializedBody<FixtureKey, FixtureModule>;
 
 /// Explicit in-memory declaration facts for one single-module program.
 #[derive(Clone, Default)]
@@ -277,6 +282,30 @@ impl DurableBodyLookupSource<FixtureKey, FixtureModule> for FixtureFactSource {
     fn definition_owner_name(&self, definition: &FixtureKey) -> Option<Arc<str>> {
         definition.owner.clone()
     }
+
+    #[cfg(test)]
+    fn reduce_comptime_call(
+        &self,
+        definition: &FixtureKey,
+        _type_arguments: &[(Arc<str>, FixtureType)],
+        _value_arguments: &[(Arc<str>, FixtureConstValue)],
+    ) -> DurableComptimeCallOutcome<FixtureKey, FixtureModule> {
+        FIXTURE_DURABLE_REDUCTION.with(|configured| {
+            let configured = configured.borrow();
+            let Some((expected, value)) = configured.as_ref() else {
+                return DurableComptimeCallOutcome::NotReduced;
+            };
+            if expected != definition {
+                return DurableComptimeCallOutcome::NotReduced;
+            }
+            FIXTURE_DURABLE_REDUCTION_CALLS.with(|calls| calls.set(calls.get() + 1));
+            DurableComptimeCallOutcome::Reduced(DurableReducedComptimeCall {
+                result: SemanticComptimeCallResult::Value(SemanticImportConstValue::Integer(
+                    *value,
+                )),
+            })
+        })
+    }
 }
 
 /// Guard stub for the exact-fact provider boundary. The ordinary provider body
@@ -285,6 +314,43 @@ impl DurableBodyLookupSource<FixtureKey, FixtureModule> for FixtureFactSource {
 /// fixture (and the production wiring in `revisioned_query_database.rs`) must
 /// learn about.
 pub(crate) struct UnconsultedFactProvider;
+
+#[cfg(test)]
+thread_local! {
+    static FIXTURE_CANCELLATION_AFTER: Cell<Option<usize>> = const { Cell::new(None) };
+    static FIXTURE_CANCELLATION_CHECKS: Cell<usize> = const { Cell::new(0) };
+    static FIXTURE_DURABLE_REDUCTION: RefCell<Option<(FixtureKey, i128)>> = const { RefCell::new(None) };
+    static FIXTURE_DURABLE_REDUCTION_CALLS: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn with_fixture_durable_integer<R>(
+    function: &str,
+    value: i128,
+    action: impl FnOnce() -> R,
+) -> (R, usize) {
+    FIXTURE_DURABLE_REDUCTION.with(|configured| {
+        let previous = configured.replace(Some((FixtureKey::function(function), value)));
+        FIXTURE_DURABLE_REDUCTION_CALLS.with(|calls| calls.set(0));
+        let result = action();
+        let calls = FIXTURE_DURABLE_REDUCTION_CALLS.with(Cell::get);
+        configured.replace(previous);
+        FIXTURE_DURABLE_REDUCTION_CALLS.with(|count| count.set(0));
+        (result, calls)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn with_fixture_cancellation_after<R>(checks: usize, action: impl FnOnce() -> R) -> R {
+    FIXTURE_CANCELLATION_AFTER.with(|configured| {
+        let previous = configured.replace(Some(checks));
+        FIXTURE_CANCELLATION_CHECKS.with(|count| count.set(0));
+        let result = action();
+        configured.set(previous);
+        FIXTURE_CANCELLATION_CHECKS.with(|count| count.set(0));
+        result
+    })
+}
 
 macro_rules! unconsulted {
     () => {
@@ -309,6 +375,17 @@ impl BodyFactProvider for UnconsultedFactProvider {
     type ToolchainFacts = ();
 
     fn is_canceled(&self) -> bool {
+        #[cfg(test)]
+        {
+            return FIXTURE_CANCELLATION_AFTER.with(|configured| {
+                FIXTURE_CANCELLATION_CHECKS.with(|count| {
+                    let checks = count.get() + 1;
+                    count.set(checks);
+                    configured.get().is_some_and(|after| checks >= after)
+                })
+            });
+        }
+        #[cfg(not(test))]
         false
     }
 
@@ -419,6 +496,29 @@ pub(crate) fn value_param(
         ty,
         mode: SemanticParameterMode::Value,
         is_comptime: false,
+    }
+}
+
+pub(crate) fn comptime_value_param(
+    name: &str,
+    ty: FixtureType,
+) -> DurableSignatureParameter<FixtureKey, FixtureModule> {
+    DurableSignatureParameter {
+        name: Arc::from(name),
+        ty,
+        mode: SemanticParameterMode::Value,
+        is_comptime: true,
+    }
+}
+
+pub(crate) fn comptime_type_param(
+    name: &str,
+) -> DurableSignatureParameter<FixtureKey, FixtureModule> {
+    DurableSignatureParameter {
+        name: Arc::from(name),
+        ty: SemanticImportType::ComptimeType,
+        mode: SemanticParameterMode::Value,
+        is_comptime: true,
     }
 }
 
@@ -655,6 +755,107 @@ impl ProviderFixture {
             StableDefinitionKind::Function,
             None,
             |_| {},
+        )
+    }
+
+    /// Run one exact comptime specialization through the production provider
+    /// body host. This is the fixture equivalent of the compiler's
+    /// specialization query and lets tests exercise recursive body evaluation
+    /// with concrete substitutions while retaining the real host boundary.
+    pub(crate) fn analyze_specialized(
+        &self,
+        source: &str,
+        function: &str,
+        values: &[i128],
+    ) -> CompileResult<FixtureSpecializedBody> {
+        self.analyze_specialized_arguments(
+            source,
+            function,
+            Arc::from([]),
+            values
+                .iter()
+                .copied()
+                .map(CanonicalArgumentValue::Integer)
+                .collect::<Vec<_>>()
+                .into(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn analyze_specialized_with_types(
+        &self,
+        source: &str,
+        function: &str,
+        types: &[FixtureType],
+        values: &[i128],
+    ) -> CompileResult<FixtureSpecializedBody> {
+        let types = types
+            .iter()
+            .map(|ty| match ty {
+                SemanticImportType::Nominal(key) => {
+                    TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(key.clone()))
+                }
+                other => panic!("fixture type specialization expects a nominal, got {other:?}"),
+            })
+            .collect::<Vec<_>>()
+            .into();
+        self.analyze_specialized_arguments(
+            source,
+            function,
+            types,
+            values
+                .iter()
+                .copied()
+                .map(CanonicalArgumentValue::Integer)
+                .collect::<Vec<_>>()
+                .into(),
+        )
+    }
+
+    fn analyze_specialized_arguments(
+        &self,
+        source: &str,
+        function: &str,
+        types: Arc<[TypeInstanceKey<FixtureKey, FixtureModule>]>,
+        values: Arc<[CanonicalArgumentValue<FixtureKey, FixtureModule>]>,
+    ) -> CompileResult<FixtureSpecializedBody> {
+        let (tokens, interner) = Lexer::new(source).tokenize().expect("fixture source lexes");
+        let (ast, interner) = Parser::new(tokens, interner)
+            .parse()
+            .expect("fixture source parses");
+        assert_eq!(
+            ast.items.len(),
+            1,
+            "the analyzed body plan carries exactly one declaration"
+        );
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let editor = astgen.finish_editor();
+        let source_lengths = [(self.facts.file, source.len() as u32)];
+        let rir = ValidatedRir::finish(
+            editor,
+            &RirValidationContext {
+                symbol_count: interner.len(),
+                source_lengths: &source_lengths,
+            },
+        )
+        .expect("fixture RIR validates");
+        let bundle = BodyRirBundle::new(
+            rir,
+            rue_rir::SharedSymbolSpace::adopt(std::sync::Arc::new(interner)),
+        );
+        let arguments = CanonicalArguments { types, values };
+        let facts = FixtureFactSource(Rc::new(self.facts.clone()));
+        analyze_provider_specialized_body(
+            &UnconsultedFactProvider,
+            facts,
+            &bundle,
+            FixtureKey::function(function),
+            function,
+            &arguments,
+            Target::host().expect("host target resolves"),
+            self.preview.clone(),
+            &self.well_known,
         )
     }
 

--- a/crates/rue-air/src/sema/provider_fixture_tests.rs
+++ b/crates/rue-air/src/sema/provider_fixture_tests.rs
@@ -10,12 +10,25 @@
 use rue_error::ErrorKind;
 use std::sync::Arc;
 
+use super::comptime::MAX_COMPTIME_CALL_DEPTH;
+use super::ordinary_engine::{
+    comptime_reduction_test_keys, comptime_reduction_test_stats,
+    reset_comptime_reduction_test_stats,
+};
 use super::provider_fixture::{
-    MethodShape, ProviderFixture, StructShape, error_source_slice, mode_param, value_param,
+    MethodShape, ProviderFixture, StructShape, comptime_type_param, comptime_value_param,
+    error_source_slice, mode_param, value_param, with_fixture_cancellation_after,
+    with_fixture_durable_integer,
+};
+use super::{
+    ComptimeCallKey, ComptimeCallMemoLookup, ComptimeCompletedCallMemo, ComptimeMemoizedOutcome,
 };
 use crate::{
-    SemanticImportConstValue, SemanticImportNominalKind, SemanticImportType, StableDefinitionKind,
+    ConstValue, SemanticDefinitionToken, SemanticImportConstValue, SemanticImportNominalKind,
+    SemanticImportType, SemanticModuleToken, StableDefinitionKind, StableProducerId, Type,
 };
+use rue_rir::SymbolHandle;
+use rue_target::Target;
 
 // Migrated from `tests::test_analyze_addition`: ordinary expression typing on
 // the production provider path.
@@ -34,6 +47,404 @@ fn provider_body_types_integer_addition() {
     let add = air.get(crate::AirRef::from_raw(2));
     assert!(matches!(add.data, crate::AirInstData::Add(_, _)));
     assert_eq!(add.ty, crate::types::Type::I32);
+}
+
+#[test]
+fn provider_specialized_body_uses_local_comptime_memo_for_branching_recursion() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function(
+        "recur",
+        vec![comptime_value_param("n", SemanticImportType::I32)],
+        SemanticImportType::I32,
+    );
+    reset_comptime_reduction_test_stats();
+    let first = fixture.analyze_specialized(
+        "fn recur(comptime n: i32) -> i32 { comptime { if n <= 0 { 1 } else { recur(n - 1) + recur(n - 1) } } }",
+        "recur",
+        &[8],
+    )
+    .expect("branching comptime recursion analyzes");
+    let first_stats = comptime_reduction_test_stats();
+    assert_eq!(first.function.air.return_type(), crate::types::Type::I32);
+    assert_eq!(
+        first_stats.last_known_integer,
+        Some(128),
+        "the largest memoized child reduction is the exact 2^7 result"
+    );
+    assert!(
+        first
+            .function
+            .air
+            .iter()
+            .any(|(_, instruction)| matches!(instruction.data, crate::AirInstData::Const(256))),
+        "the specialized root must retain the exact 2^8 branch result"
+    );
+    assert_eq!(first_stats.misses, 8, "one miss per unique recursive state");
+    assert_eq!(
+        first_stats.hits, 8,
+        "the repeated branch hits the body memo"
+    );
+    assert_eq!(first_stats.publications, 8, "only completed states publish");
+    assert_eq!(
+        first_stats.canonical_issuances,
+        first_stats.misses + first_stats.hits,
+        "each local call issues its producer identity once without run-frame duplication"
+    );
+    assert_eq!(first_stats.non_successful_completions, 0);
+    assert!(first_stats.body_instances_dropped > 0);
+    assert_eq!(first_stats.max_entries, 8);
+    assert_eq!(first_stats.last_dropped_entries, 8);
+
+    // A second request gets a fresh body-local memo, yet the durable export
+    // remains deterministic byte-for-byte.
+    reset_comptime_reduction_test_stats();
+    let second = fixture
+        .analyze_specialized(
+            "fn recur(comptime n: i32) -> i32 { comptime { if n <= 0 { 1 } else { recur(n - 1) + recur(n - 1) } } }",
+            "recur",
+            &[8],
+        )
+        .expect("retained recursion analyzes");
+    let second_stats = comptime_reduction_test_stats();
+    assert_eq!(first.export.body, second.export.body);
+    assert_eq!(first_stats, second_stats);
+}
+
+#[test]
+fn provider_local_memo_hit_still_obeys_depth_before_lookup() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function(
+        "recur",
+        vec![comptime_value_param("n", SemanticImportType::I32)],
+        SemanticImportType::I32,
+    );
+    let source = "fn recur(comptime n: i32) -> i32 { comptime { if n == 66 { recur(0) + recur(65) } else if n <= 0 { 1 } else { recur(n - 1) } } }";
+    reset_comptime_reduction_test_stats();
+    let error = match fixture.analyze_specialized(
+        source,
+        "recur",
+        &[MAX_COMPTIME_CALL_DEPTH as i128 + 2],
+    ) {
+        Ok(_) => panic!("the cached zero state cannot bypass the depth gate"),
+        Err(error) => error,
+    };
+    let stats = comptime_reduction_test_stats();
+    assert_eq!(
+        stats.publications, 1,
+        "the shallow zero state was cached first"
+    );
+    assert_eq!(
+        stats.hits, 0,
+        "the only over-limit frame is rejected before lookup"
+    );
+    assert!(matches!(
+        &error.kind,
+        ErrorKind::ComptimeEvaluationFailed { reason }
+            if reason == "specialization of 'recur' exceeded the maximum nesting depth (64); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?"
+    ));
+    assert_eq!(error_source_slice(source, &error), source);
+}
+
+#[test]
+fn provider_specialized_body_failed_reduction_is_not_cached_and_retries() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function(
+        "looping",
+        vec![comptime_value_param("n", SemanticImportType::I32)],
+        SemanticImportType::I32,
+    );
+    let source = "fn looping(comptime n: i32) -> i32 { comptime { looping(n) } }";
+    reset_comptime_reduction_test_stats();
+    let first_error = match fixture.analyze_specialized(source, "looping", &[0]) {
+        Ok(_) => panic!("non-terminating comptime recursion is rejected"),
+        Err(error) => error,
+    };
+    let first_stats = comptime_reduction_test_stats();
+    assert!(matches!(
+        &first_error.kind,
+        ErrorKind::ComptimeEvaluationFailed { reason }
+            if reason == "specialization of 'looping' exceeded the maximum nesting depth (64); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?"
+    ));
+    assert_eq!(error_source_slice(source, &first_error), source);
+    assert_eq!(first_stats.publications, 0);
+    assert_eq!(first_stats.hits, 0);
+    assert!(first_stats.non_successful_completions > 0);
+    assert!(first_stats.misses > 0);
+
+    reset_comptime_reduction_test_stats();
+    let second_error = match fixture.analyze_specialized(source, "looping", &[0]) {
+        Ok(_) => panic!("a failed reduction must be retried"),
+        Err(error) => error,
+    };
+    let second_stats = comptime_reduction_test_stats();
+    assert_eq!(first_error.kind, second_error.kind);
+    assert_eq!(first_error.span(), second_error.span());
+    assert_eq!(first_stats, second_stats);
+}
+
+#[test]
+fn provider_specialized_body_canceled_reduction_is_not_cached() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function(
+        "recur",
+        vec![comptime_value_param("n", SemanticImportType::I32)],
+        SemanticImportType::I32,
+    );
+    reset_comptime_reduction_test_stats();
+    let canceled_error = match with_fixture_cancellation_after(100, || {
+        fixture.analyze_specialized(
+            "fn recur(comptime n: i32) -> i32 { comptime { if n <= 0 { 1 } else { recur(n - 1) + recur(n - 1) } } }",
+            "recur",
+            &[8],
+        )
+    }) {
+        Ok(_) => panic!("canceled reduction must not complete"),
+        Err(error) => error,
+    };
+    let canceled_stats = comptime_reduction_test_stats();
+    assert!(
+        matches!(canceled_error.kind, ErrorKind::InternalError(ref reason) if reason == "body analysis query canceled")
+    );
+    assert_eq!(canceled_stats.publications, 0);
+    assert_eq!(canceled_stats.hits, 0);
+    assert!(canceled_stats.non_successful_completions > 0);
+
+    reset_comptime_reduction_test_stats();
+    let retry = fixture
+        .analyze_specialized(
+            "fn recur(comptime n: i32) -> i32 { comptime { if n <= 0 { 1 } else { recur(n - 1) + recur(n - 1) } } }",
+            "recur",
+            &[8],
+        )
+        .expect("canceled reduction is retried in a fresh body");
+    let retry_stats = comptime_reduction_test_stats();
+    assert_eq!(retry.function.air.return_type(), crate::types::Type::I32);
+    assert_eq!(retry_stats.publications, 8);
+    assert_eq!(retry_stats.hits, 8);
+}
+
+#[test]
+fn provider_durable_first_comptime_query_bypasses_local_body_memo() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function(
+        "external",
+        vec![comptime_value_param("n", SemanticImportType::I32)],
+        SemanticImportType::I32,
+    );
+    fixture.declare_function("caller", Vec::new(), SemanticImportType::I32);
+    reset_comptime_reduction_test_stats();
+    let (body, durable_calls) = with_fixture_durable_integer("external", 77, || {
+        fixture
+            .analyze("fn caller() -> i32 { comptime { external(1) } }", "caller")
+            .expect("the durable comptime query produces its configured result")
+    });
+    let stats = comptime_reduction_test_stats();
+    assert_eq!(body.function.air.return_type(), crate::types::Type::I32);
+    assert_eq!(
+        durable_calls, 1,
+        "the durable result was actually consulted"
+    );
+    assert!(
+        body.function
+            .air
+            .iter()
+            .any(|(_, instruction)| matches!(instruction.data, crate::AirInstData::Const(77))),
+        "the AIR contains the exact durable reduction result"
+    );
+    assert_eq!(stats.misses, 0);
+    assert_eq!(stats.hits, 0);
+    assert_eq!(stats.publications, 0);
+}
+
+#[test]
+fn production_comptime_key_separates_real_identity_target_type_and_value() {
+    let mut fixture = ProviderFixture::new();
+    let marker = fixture.declare_struct("Marker", vec![("value", SemanticImportType::I32)], true);
+    fixture.declare_function(
+        "recur",
+        vec![
+            comptime_type_param("T"),
+            comptime_value_param("n", SemanticImportType::I32),
+            comptime_value_param("step", SemanticImportType::I32),
+        ],
+        SemanticImportType::I32,
+    );
+    reset_comptime_reduction_test_stats();
+    fixture
+        .analyze_specialized_with_types(
+            "fn recur(comptime T: type, comptime n: i32, comptime step: i32) -> i32 { comptime { if n <= 0 { step } else { recur(T, n - 1, step) } } }",
+            "recur",
+            &[SemanticImportType::Nominal(marker.clone())],
+            &[2, 7],
+        )
+        .expect("the production builder emits keys for real recursive calls");
+    let observed = comptime_reduction_test_keys();
+    assert!(
+        !observed.is_empty(),
+        "the test uses keys issued by the production path"
+    );
+    assert!(
+        observed.iter().any(|key| {
+            key.type_arguments.len() == 1
+                && key.type_arguments[0] == observed[0].type_arguments[0]
+                && key.value_arguments.as_ref() == [ConstValue::Integer(1), ConstValue::Integer(7)]
+        }),
+        "production keys retain the declared T, n, step order"
+    );
+    assert!(
+        observed.iter().any(|key| {
+            key.type_arguments.len() == 1
+                && key.type_arguments[0] == observed[0].type_arguments[0]
+                && key.value_arguments.as_ref() == [ConstValue::Integer(0), ConstValue::Integer(7)]
+        }),
+        "recursive production keys carry a distinct real value substitution"
+    );
+    let mut identity_fixture = ProviderFixture::new();
+    identity_fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
+    let identity_body = identity_fixture
+        .analyze(
+            "fn main() -> i32 { let A = struct { value: i32, fn helper() -> i32 { 0 } }; let B = struct { value: i32 }; 0 }",
+            "main",
+        )
+        .expect("the identity source produces real anonymous and symbol identities");
+    let mut anonymous_types = identity_body
+        .type_pool
+        .all_struct_ids()
+        .into_iter()
+        .filter(|id| identity_body.type_pool.is_anonymous_struct(*id))
+        .map(Type::new_struct);
+    let anonymous_a = anonymous_types.next().expect("first anonymous type");
+    let anonymous_b = anonymous_types.next().expect("second anonymous type");
+    let function_a = SymbolHandle::new(identity_body.interner.get("main").expect("main symbol"));
+    let function_b = SymbolHandle::new(
+        identity_body
+            .interner
+            .get("helper")
+            .expect("anonymous method symbol"),
+    );
+
+    type Producer = StableProducerId<SemanticDefinitionToken, SemanticModuleToken>;
+    type Memo = ComptimeCompletedCallMemo<Producer, Target, Type, ConstValue, ConstValue>;
+    let key = |producer, target, ty, value| ComptimeCallKey {
+        declaration: producer,
+        configuration: target,
+        type_arguments: Arc::from([ty]),
+        value_arguments: Arc::from([value, ConstValue::Integer(7)]),
+    };
+    let base = observed
+        .iter()
+        .find(|key| {
+            key.value_arguments.as_ref() == [ConstValue::Integer(1), ConstValue::Integer(7)]
+        })
+        .expect("production key is available")
+        .clone();
+    let mut memo = Memo::new();
+    memo.insert(
+        base.clone(),
+        ComptimeMemoizedOutcome::Known(ConstValue::Integer(17)),
+    )
+    .unwrap();
+    assert!(matches!(
+        memo.lookup(&base),
+        ComptimeCallMemoLookup::Memoized(ComptimeMemoizedOutcome::Known(ConstValue::Integer(17)))
+    ));
+    let function_base = key(
+        base.declaration.clone(),
+        base.configuration,
+        anonymous_a,
+        ConstValue::Function(function_a),
+    );
+    memo.insert(
+        function_base.clone(),
+        ComptimeMemoizedOutcome::Known(ConstValue::Integer(18)),
+    )
+    .unwrap();
+    assert!(matches!(
+        memo.lookup(&function_base),
+        ComptimeCallMemoLookup::Memoized(ComptimeMemoizedOutcome::Known(ConstValue::Integer(18)))
+    ));
+    let generic_specialization = observed
+        .iter()
+        .find(|candidate| candidate.declaration != base.declaration)
+        .expect("recursive states issue distinct generic specializations")
+        .declaration
+        .clone();
+    let mut other_fixture = ProviderFixture::new();
+    other_fixture.declare_function(
+        "other",
+        vec![
+            comptime_type_param("T"),
+            comptime_value_param("n", SemanticImportType::I32),
+            comptime_value_param("step", SemanticImportType::I32),
+        ],
+        SemanticImportType::I32,
+    );
+    reset_comptime_reduction_test_stats();
+    let other_marker =
+        other_fixture.declare_struct("Marker", vec![("value", SemanticImportType::I32)], true);
+    other_fixture
+        .analyze_specialized_with_types(
+            "fn other(comptime T: type, comptime n: i32, comptime step: i32) -> i32 { comptime { if n <= 0 { step } else { other(T, n - 1, step) } } }",
+            "other",
+            &[SemanticImportType::Nominal(other_marker)],
+            &[2, 7],
+        )
+        .expect("a second production callable issues a real identity");
+    // Each provider run owns request-local Type handles, so use the second
+    // production-issued declaration only after the memo's base substitutions
+    // have been fixed. The explicit key below isolates callable identity while
+    // preserving those substitutions.
+    let callable_issuer = comptime_reduction_test_keys()
+        .into_iter()
+        .find(|candidate| candidate.declaration != base.declaration)
+        .expect("the second callable has a distinct producer identity")
+        .declaration;
+    let callable_counterfeit = key(
+        callable_issuer,
+        base.configuration,
+        base.type_arguments[0],
+        base.value_arguments[0],
+    );
+    let generic_counterfeit = key(
+        generic_specialization,
+        base.configuration,
+        base.type_arguments[0],
+        base.value_arguments[0],
+    );
+    let target_counterfeit = key(
+        observed[0].declaration.clone(),
+        if base.configuration == Target::X86_64Linux {
+            Target::Aarch64Linux
+        } else {
+            Target::X86_64Linux
+        },
+        base.type_arguments[0],
+        base.value_arguments[0],
+    );
+    let type_counterfeit = key(
+        function_base.declaration.clone(),
+        function_base.configuration,
+        anonymous_b,
+        function_base.value_arguments[0],
+    );
+    let value_counterfeit = key(
+        function_base.declaration.clone(),
+        function_base.configuration,
+        function_base.type_arguments[0],
+        ConstValue::Function(function_b),
+    );
+    for counterfeit in [
+        callable_counterfeit,
+        generic_counterfeit,
+        target_counterfeit,
+        type_counterfeit,
+        value_counterfeit,
+    ] {
+        assert!(matches!(
+            memo.lookup(&counterfeit),
+            ComptimeCallMemoLookup::Miss
+        ));
+    }
 }
 
 // Migrated from `tests::test_undefined_variable`: the diagnostic keeps its
@@ -58,6 +469,73 @@ fn provider_body_reports_undefined_variable_with_exact_span() {
 // Migrated from `tests::test_use_after_move_error`: ownership diagnostics on
 // the production provider path, with the callee crossing the boundary as an
 // explicit durable signature fact.
+#[test]
+fn memoized_comptime_result_keeps_linear_ownership_diagnostic_on_production_path() {
+    let mut fixture = ProviderFixture::new();
+    let token = fixture.declare_struct_with(
+        "Token",
+        vec![("id", SemanticImportType::I32)],
+        false,
+        StructShape {
+            is_linear: true,
+            ..StructShape::default()
+        },
+    );
+    fixture.declare_function(
+        "recur",
+        vec![
+            comptime_type_param("T"),
+            comptime_value_param("n", SemanticImportType::I32),
+        ],
+        SemanticImportType::I32,
+    );
+    fixture.declare_function(
+        "consume",
+        vec![value_param("n", SemanticImportType::Nominal(token.clone()))],
+        SemanticImportType::I32,
+    );
+    reset_comptime_reduction_test_stats();
+    let source = "fn recur(comptime T: type, comptime n: i32) -> i32 {
+    let result = comptime { if n <= 0 { 1 } else { recur(T, n - 1) + recur(T, n - 1) } };
+    if n > 1 {
+        let TokenType = Token;
+        let token: TokenType = Token { id: 42 };
+        let consumed = consume(token);
+        consumed + token.id
+    } else {
+        result
+    }
+}";
+    let error = fixture
+        .analyze_specialized_with_types(
+            source,
+            "recur",
+            &[SemanticImportType::Nominal(token.clone())],
+            &[2],
+        )
+        .map(|_| ())
+        .expect_err("the move/use check still runs after a memoized child reduction");
+    let stats = comptime_reduction_test_stats();
+    assert!(
+        stats.publications > 0,
+        "the local memo published the successful child result"
+    );
+    assert!(
+        stats.hits > 0,
+        "the duplicate recursive child reaches the local memo"
+    );
+    assert!(
+        comptime_reduction_test_keys()
+            .iter()
+            .any(|key| key.type_arguments.len() == 1),
+        "the memoized child key retains the linear nominal type substitution"
+    );
+    assert!(
+        matches!(&error.kind, ErrorKind::UseAfterMove(..)),
+        "unexpected diagnostic after a memoized result: {error:?}"
+    );
+}
+
 #[test]
 fn provider_body_reports_use_after_move() {
     let mut fixture = ProviderFixture::new();

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -3506,6 +3506,50 @@ mod tests {
     }
 
     #[test]
+    fn comptime_body_warm_session_matches_fresh_artifacts_and_executable() {
+        let prior = SourceSnapshot::single("<comptime-warm>", "fn main() -> i32 { 0 }").unwrap();
+        let snapshot = SourceSnapshot::single(
+            "<comptime-warm>",
+            "fn recur(comptime n: i32) -> i32 { comptime { if n <= 0 { 1 } else { recur(n - 1) + recur(n - 1) } } } fn main() -> i32 { recur(8) }",
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+
+        let mut warm_session = CompilerSession::new();
+        warm_session
+            .update_for_presentation(&prior)
+            .into_result()
+            .unwrap();
+        warm_session.rooted_cfg(&options).unwrap();
+        warm_session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let warm = warm_session.rooted_cfg(&options).unwrap();
+
+        let mut fresh_session = CompilerSession::new();
+        fresh_session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let fresh = fresh_session.rooted_cfg(&options).unwrap();
+
+        crate::test_support::assert_rooted_cfg_value_parity(
+            "comptime body warm/fresh",
+            &warm,
+            &fresh,
+        );
+        assert_eq!(warm.warnings(), fresh.warnings());
+
+        let warm_output =
+            crate::queries::compile_with_session(&mut warm_session, &snapshot, &options).unwrap();
+        let fresh_output =
+            crate::queries::compile_with_session(&mut fresh_session, &snapshot, &options).unwrap();
+        assert_eq!(warm_output.warnings, fresh_output.warnings);
+        assert_eq!(warm_output.elf, fresh_output.elf);
+    }
+
+    #[test]
     fn phase2_free_function_inlining_is_structural_and_request_local() {
         let snapshot = SourceSnapshot::single(
             "<phase2-inline-structure>",


### PR DESCRIPTION
## Summary
- cache successful local comptime reductions for one body analysis using exact callable, target, and ordered substitution identity
- preserve depth, cycle, cancellation, and durable-query boundaries by consulting the memo only after admission
- add structural scaling, failure lifecycle, identity separation, retention, ownership, and warm/fresh parity coverage

## Validation
- scripts/rue unit air comptime
- scripts/rue unit air provider_specialized_body
- scripts/rue unit compiler comptime_body_warm_session
- scripts/rue quick
- scripts/rue fmt
- git diff --check
- scripts/rue premerge
- scripts/rue test (corpus actions host-blocked by EAGAIN worker-thread exhaustion; CI is the platform-wide authority)

Fixes RUE-1732