### PR TITLE
RUE-1352: publish concrete pointer intrinsic types

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -772,17 +772,141 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     /// The pointee of a pointer operand whose type is *already* concrete at
-    /// constraint-generation time — an annotated binding, a parameter, a
-    /// pointer-returning intrinsic with a fixed result type. Returns `None` for
-    /// anything still standing on a type variable (`@raw`, `@ptr_offset`,
-    /// `@int_to_ptr`), because this pass has no substitution to consult: the
-    /// unifier has not run yet, so an unresolved operand carries no pointee to
-    /// read and must be left free rather than guessed (RUE-1341).
+    /// constraint-generation time — an annotated binding, a parameter, or a
+    /// pointer-returning intrinsic whose result was published by this pass.
+    /// Returns `None` for anything still standing on a type variable (such as
+    /// an unresolved `@raw`, `@ptr_offset`, or context-driven `@int_to_ptr`),
+    /// because the unifier has not run yet and this pass must leave the
+    /// genuinely unresolved pointee free rather than guess it (RUE-1341).
     fn concrete_pointee_type(&self, ty: &InferType) -> Option<Type> {
         match ty.as_concrete()?.kind() {
             TypeKind::PtrConst(ptr_id) => Some(self.type_pool.ptr_const_def(ptr_id)),
             TypeKind::PtrMut(ptr_id) => Some(self.type_pool.ptr_mut_def(ptr_id)),
             _ => None,
+        }
+    }
+
+    /// Convert a fully concrete inference type to its interned semantic type.
+    /// Array literals remain structural during constraint generation, so they
+    /// need the same canonicalization as annotated array types before they can
+    /// be used as a raw-pointer pointee. Unresolved elements stay unresolved.
+    fn concrete_type(&self, ty: &InferType) -> Option<Type> {
+        match ty {
+            InferType::Concrete(ty)
+                if !ty.is_error()
+                    && !ty.is_never()
+                    && !ty.is_comptime_type()
+                    && !ty.is_module() =>
+            {
+                Some(*ty)
+            }
+            InferType::Concrete(_) => None,
+            InferType::Array { element, length } => {
+                let element = self.concrete_type(element)?;
+                Some(Type::new_array(
+                    self.type_pool.intern_array_from_type(element, *length),
+                ))
+            }
+            InferType::Var(_) | InferType::IntLiteral => None,
+        }
+    }
+
+    /// Whether a RIR operand can name local/parameter storage. Sema remains
+    /// authoritative for place validity (including resolved field/index
+    /// types), but avoiding computed/module/constant operands here prevents a
+    /// speculative pointer result from masking its targeted diagnostic.
+    fn is_inference_place(&self, inst_ref: InstRef, ctx: &ConstraintContext) -> bool {
+        match self.rir.get(inst_ref).data {
+            InstData::VarRef { name, .. } => {
+                match ctx.locals.get(&name) {
+                    Some(local) => {
+                        // Comptime aliases and module values are represented
+                        // in inference as locals, but sema materializes their
+                        // uses as TypeConst rather than addressable runtime
+                        // storage. Keep those uses on sema's targeted place
+                        // diagnostic. A local shadows a parameter here, so
+                        // do not fall through to the parameter predicate.
+                        !matches!(
+                            local.ty,
+                            InferType::Concrete(ty)
+                                if ty.is_comptime_type() || ty.is_module()
+                        )
+                    }
+                    None => {
+                        // Captured comptime values are materialized by sema
+                        // as Const/TypeConst rather than Param AIR. Keep
+                        // those names free as well; ordinary parameters (and
+                        // their comptime modes when not captured) remain
+                        // addressable Param values.
+                        !self
+                            .comptime_values
+                            .is_some_and(|values| values.contains_key(&name))
+                            && ctx.contains_param(name)
+                    }
+                }
+            }
+            InstData::FieldGet { base, .. } => self.is_inference_place(base, ctx),
+            InstData::IndexGet { base, index } => {
+                // Only fixed-array indexing names addressable storage. String
+                // and slice indexing is a computed runtime read, even when
+                // the base and index are concrete; publishing a pointer for
+                // it would steal sema's E0485 place diagnostic.
+                let base_is_fixed_array = self.expr_types.get(&base).is_some_and(|ty| match ty {
+                    InferType::Array { .. } => true,
+                    InferType::Concrete(ty) => ty.as_array().is_some(),
+                    InferType::Var(_) | InferType::IntLiteral => false,
+                });
+                // Keep an invalid index owned by sema. An exact pointer
+                // result for `@raw(a[true])` could otherwise make a separate
+                // pointer annotation fail first with E0206.
+                let index_is_integer = self.expr_types.get(&index).is_some_and(|ty| match ty {
+                    InferType::Concrete(ty) => ty.is_integer(),
+                    InferType::Var(id) => self.int_literal_vars.contains(id),
+                    InferType::IntLiteral => true,
+                    InferType::Array { .. } => false,
+                });
+                // Sema diagnoses a direct constant index outside a fixed
+                // array as E0902 before it can form a PlaceRead. The
+                // inference pass has no authoritative constant evaluator, so
+                // only direct literals proven in bounds and runtime local/
+                // parameter indices may publish a pointer; folded constants
+                // and other computed expressions stay free for sema.
+                let index_is_publishable = match self.rir.get(index).data {
+                    InstData::IntConst(value) => {
+                        index_is_integer
+                            && self
+                                .expr_types
+                                .get(&base)
+                                .and_then(|ty| match ty {
+                                    InferType::Array { length, .. } => Some(*length),
+                                    InferType::Concrete(ty) => ty
+                                        .as_array()
+                                        .map(|array_id| self.type_pool.array_def(array_id).1),
+                                    InferType::Var(_) | InferType::IntLiteral => None,
+                                })
+                                .is_some_and(|length| value < length)
+                    }
+                    InstData::VarRef { name, .. } => {
+                        index_is_integer
+                            && match ctx.locals.get(&name) {
+                                Some(local) => !matches!(
+                                    local.ty,
+                                    InferType::Concrete(ty)
+                                        if ty.is_comptime_type() || ty.is_module()
+                                ),
+                                None => {
+                                    !self
+                                        .comptime_values
+                                        .is_some_and(|values| values.contains_key(&name))
+                                        && ctx.contains_param(name)
+                                }
+                            }
+                    }
+                    _ => false,
+                };
+                self.is_inference_place(base, ctx) && base_is_fixed_array && index_is_publishable
+            }
+            _ => false,
         }
     }
 
@@ -1692,7 +1816,7 @@ impl<'a> ConstraintGenerator<'a> {
                         && value_info.continues
                         && !Self::is_never_concrete(&value_info.ty)
                     {
-                        // Constrain value to match variable type
+                        // Assignment stores the value with its semantic type.
                         self.add_constraint(Constraint::equal(value_info.ty, target_ty, span));
                     }
                 }
@@ -2291,12 +2415,33 @@ impl<'a> ConstraintGenerator<'a> {
                 } else if intrinsic_name == "ptr_offset" {
                     // @ptr_offset: takes (ptr T, i64), returns ptr T
                     // The return type is the same as the input pointer type.
-                    // We create a fresh type variable for proper inference.
-                    for arg_ref in args.iter() {
-                        generate_intrinsic_arg!(*arg_ref);
+                    // Publish that identity when a well-formed call already
+                    // has a concrete pointer operand; unresolved pointers and
+                    // wrong-arity calls remain free so sema owns diagnostics.
+                    let typed_shape = args.len() == 2;
+                    let mut pointer_ty = None;
+                    let mut offset_is_integer = false;
+                    for (index, arg_ref) in args.iter().enumerate() {
+                        let info = generate_intrinsic_arg!(*arg_ref);
+                        if typed_shape {
+                            match index {
+                                0 => pointer_ty = self.concrete_type(&info.ty).filter(Type::is_ptr),
+                                1 => {
+                                    offset_is_integer = match info.ty {
+                                        InferType::Concrete(ty) => ty.is_integer(),
+                                        InferType::Var(id) => self.int_literal_vars.contains(&id),
+                                        InferType::IntLiteral => true,
+                                        InferType::Array { .. } => false,
+                                    };
+                                }
+                                _ => {}
+                            }
+                        }
                     }
-                    let result_var = self.fresh_var();
-                    InferType::Var(result_var)
+                    if !offset_is_integer {
+                        pointer_ty = None;
+                    }
+                    pointer_ty.map_or_else(|| InferType::Var(self.fresh_var()), InferType::Concrete)
                 } else if intrinsic_name == "place" {
                     // The trusted `@place(ptr)` bridge is represented as a
                     // pointer-shaped expression until accessor-yield analysis
@@ -2311,15 +2456,33 @@ impl<'a> ConstraintGenerator<'a> {
                     || intrinsic_name == "field_ptr"
                 {
                     // @raw / @raw_mut / @field_ptr: takes a place, returns a
-                    // pointer to it (RUE-301). The return type is a pointer
-                    // whose pointee is only known once the operand is analyzed,
-                    // so we create a fresh type variable for proper inference
-                    // (Sema fixes it to `ptr const T`/`ptr mut T`).
-                    for arg_ref in args.iter() {
-                        generate_intrinsic_arg!(*arg_ref);
+                    // pointer to it (RUE-301). If the operand is a concrete
+                    // local/parameter place, publish the exact interned
+                    // pointee now. Computed and module/constant operands stay
+                    // free so sema retains ownership of its place diagnostic.
+                    let typed_shape = args.len() == 1;
+                    let mut pointee = None;
+                    for (index, arg_ref) in args.iter().enumerate() {
+                        let info = generate_intrinsic_arg!(*arg_ref);
+                        let is_field_place =
+                            matches!(self.rir.get(*arg_ref).data, InstData::FieldGet { .. });
+                        if typed_shape
+                            && index == 0
+                            && self.is_inference_place(*arg_ref, ctx)
+                            && (intrinsic_name != "field_ptr" || is_field_place)
+                        {
+                            pointee = self.concrete_type(&info.ty);
+                        }
                     }
-                    let result_var = self.fresh_var();
-                    InferType::Var(result_var)
+                    match pointee {
+                        Some(pointee) if intrinsic_name == "raw" => InferType::Concrete(
+                            Type::new_ptr_const(self.type_pool.intern_ptr_const_from_type(pointee)),
+                        ),
+                        Some(pointee) => InferType::Concrete(Type::new_ptr_mut(
+                            self.type_pool.intern_ptr_mut_from_type(pointee),
+                        )),
+                        None => InferType::Var(self.fresh_var()),
+                    }
                 } else if intrinsic_name == "alloc" || intrinsic_name == "alloc_zeroed" {
                     // @alloc(size: u64, align: u64) -> ptr mut u8 and its
                     // zeroing twin (ADR-0059 Phase 3, RUE-961/RUE-968). Both
@@ -4837,6 +5000,59 @@ mod tests {
 
         assert_eq!(info.ty, InferType::Concrete(Type::BOOL));
         assert_eq!(cgen.constraints().len(), 0);
+    }
+
+    #[test]
+    fn pointer_intrinsics_publish_concrete_operand_types() {
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
+        let value_name = interner.get_or_intern("value");
+        let value = rir.add_inst(rue_rir::Inst {
+            data: InstData::VarRef {
+                name: value_name,
+                anchor: None,
+            },
+            span: Span::new(1, 6),
+        });
+        let raw = rir
+            .add_intrinsic(interner.get_or_intern("raw"), &[value], Span::new(0, 10))
+            .unwrap();
+        let offset = rir.add_inst(rue_rir::Inst {
+            data: InstData::IntConst(0),
+            span: Span::new(11, 12),
+        });
+        let moved = rir
+            .add_intrinsic(
+                interner.get_or_intern("ptr_offset"),
+                &[raw, offset],
+                Span::new(0, 20),
+            )
+            .unwrap();
+
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
+        let params = AHashMap::new();
+        let mut ctx = ConstraintContext::new(&params, Type::UNIT);
+        ctx.locals.insert(
+            value_name,
+            LocalVarInfo {
+                ty: InferType::Concrete(Type::U16),
+                is_mut: false,
+                span: Span::new(1, 6),
+            },
+        );
+
+        let raw_ty = cgen.generate(raw, &mut ctx).ty;
+        let expected = Type::new_ptr_const(type_pool.intern_ptr_const_from_type(Type::U16));
+        assert_eq!(raw_ty, InferType::Concrete(expected));
+        assert_eq!(
+            cgen.generate(moved, &mut ctx).ty,
+            InferType::Concrete(expected)
+        );
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -479,7 +479,7 @@ fn main() -> i32 {
         @dbg(v);
         let q: ptr mut i32 = @raw_mut(y);
         @ptr_write(q, 35);
-        let f: ptr const i32 = @field_ptr(s.a);
+        let f: ptr mut i32 = @field_ptr(s.a);
         let w: i32 = @ptr_read(f);
         @dbg(w);
     };

--- a/crates/rue-cli-tests/cases/ptr_pointee_inference.toml
+++ b/crates/rue-cli-tests/cases/ptr_pointee_inference.toml
@@ -15,9 +15,10 @@
 # is already concrete in the same pass (annotated binding, parameter, struct
 # field). Both aligned and unaligned variants share the machinery, so both are
 # covered here. When the pointer operand is NOT resolvable during constraint
-# generation — `@raw`/`@raw_mut`/`@ptr_offset` are themselves fresh variables —
-# the types stay free exactly as before and the old diagnostics are unchanged;
-# those pins live at the bottom of this file.
+# generation — for example an address-of operation over an inferred local, or
+# a pointer result whose type is context-dependent — the types stay free
+# exactly as before and the old diagnostics are unchanged; those pins live at
+# the bottom of this file.
 
 [section]
 id = "cli.ptr_pointee_inference"
@@ -39,6 +40,34 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "true\n"
+
+[[case]]
+name = "ptr_offset_wrong_arity_keeps_intrinsic_diagnostic"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let value: i64 = 7;
+    let p: ptr const i64 = checked { @raw(value) };
+    checked { @ptr_offset(p) };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0701", "ptr_offset", "expects 2 arguments"]
+compile_stderr_contains = ["main.rue:4:15"]
+
+[[case]]
+name = "ptr_offset_bad_offset_keeps_type_diagnostic"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let value: i64 = 7;
+    let p: ptr const i64 = checked { @raw(value) };
+    checked { @ptr_offset(p, true) };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0702", "ptr_offset", "integer offset"]
+compile_stderr_contains = ["main.rue:4:15"]
 
 # --- RUE-1341 repro 2: @intCast target comes from the pointee ---------------
 [[case]]
@@ -198,16 +227,15 @@ fn main() -> i32 {
 stdout = "200\n"
 
 # --- PIN: an unresolvable pointer operand keeps today's behavior ------------
-# `@raw_mut(b)` is itself a fresh inference variable, so the value operand has
-# no expectation to read and @intCast still cannot name a target. Inference
-# never guesses a pointee it cannot see, and this diagnostic is deliberately
-# unchanged by RUE-1341. Widening @raw/@raw_mut/@ptr_offset to publish their
-# own concrete types would retire this pin.
+# An inferred local has no concrete type while constraint generation visits its
+# address, so `@raw_mut(b)` remains free and the value operand has no
+# expectation to read. Inference never guesses a pointee it cannot see, and
+# this diagnostic is deliberately unchanged by RUE-1352.
 [[case]]
 name = "ptr_write_unresolved_pointer_operand_still_e0709"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut b: u8 = 0;
+    let mut b = 0;
     let x: i32 = 30;
     checked {
         @ptr_write(@raw_mut(b), @intCast(x));
@@ -234,3 +262,306 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0206"]
+
+# --- RUE-1352: address-of results publish their concrete pointee ------------
+[[case]]
+name = "raw_const_direct_read_infers_pointee"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let value: u16 = 4097;
+    let hit: bool = checked { @ptr_read(@raw(value)) == 4097 };
+    @dbg(hit);
+    0
+}
+""" }]
+stdout = "true\n"
+
+[[case]]
+name = "raw_mut_direct_write_infers_pointee"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut value: u8 = 0;
+    let source: i64 = 200;
+    checked { @ptr_write(@raw_mut(value), @intCast(source)); };
+    @dbg(value);
+    0
+}
+""" }]
+stdout = "200\n"
+
+[[case]]
+name = "field_ptr_direct_write_preserves_field_type"
+files = [{ path = "main.rue", source = """
+struct Pair { narrow: u8, wide: i64 }
+fn main() -> i32 {
+    let mut pair = Pair { narrow: 0, wide: 0 };
+    let source: i64 = 200;
+    checked { @ptr_write(@field_ptr(pair.narrow), @intCast(source)); };
+    @dbg(pair.narrow);
+    0
+}
+""" }]
+stdout = "200\n"
+
+[[case]]
+name = "const_pointer_cannot_assign_to_mutable_accessor_place"
+files = [{ path = "main.rue", source = """
+struct Holder {
+    slot: ptr mut u8,
+    fn slot_mut(inout self) -> inout ptr mut u8 { yield self.slot; }
+}
+fn main() -> i32 {
+    let mut value: u8 = 1;
+    let mut holder = Holder { slot: @raw_mut(value) };
+    holder.slot_mut() = @raw(value);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "ptr mut u8", "ptr const u8"]
+
+[[case]]
+name = "mutable_intrinsic_cannot_assign_to_const_local"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut value: u8 = 1;
+    let mut slot: ptr const u8 = checked { @raw(value) };
+    slot = @raw_mut(value);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "ptr const u8", "ptr mut u8"]
+
+[[case]]
+name = "raw_mut_cannot_be_annotated_as_const_pointer"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut value: u8 = 1;
+    let view: ptr const u8 = checked { @raw_mut(value) };
+    @ptr_to_int(view);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "ptr const u8", "ptr mut u8"]
+
+[[case]]
+name = "field_ptr_cannot_be_annotated_as_const_pointer"
+files = [{ path = "main.rue", source = """
+struct Pair { value: u8 }
+fn main() -> i32 {
+    let mut pair = Pair { value: 1 };
+    let view: ptr const u8 = checked { @field_ptr(pair.value) };
+    @ptr_to_int(view);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "ptr const u8", "ptr mut u8"]
+
+[[case]]
+name = "mutable_intrinsic_cannot_assign_to_const_accessor_place"
+files = [{ path = "main.rue", source = """
+struct Holder {
+    slot: ptr const u8,
+    fn slot_const(inout self) -> inout ptr const u8 { yield self.slot; }
+}
+fn main() -> i32 {
+    let mut value: u8 = 1;
+    let mut holder = Holder { slot: @raw(value) };
+    holder.slot_const() = @raw_mut(value);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "ptr const u8", "ptr mut u8"]
+
+[[case]]
+name = "indirect_mutable_pointer_does_not_coerce_to_const"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut value: u8 = 1;
+    let mutable: ptr mut u8 = checked { @raw_mut(value) };
+    let immutable: ptr const u8 = mutable;
+    @ptr_to_int(immutable);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "expected ptr const u8", "found ptr mut u8"]
+
+[[case]]
+name = "nested_pointer_arrays_do_not_coerce_mutability"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut value: u8 = 1;
+    let mutable: [ptr mut u8; 1] = checked { [@raw_mut(value)] };
+    let immutable: [ptr const u8; 1] = mutable;
+    @ptr_to_int(immutable[0]);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206"]
+
+[[case]]
+name = "ptr_offset_preserves_const_and_mut_pointer_types"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let value: i64 = 4097;
+    let mut changed: u16 = 0;
+    let hit: bool = checked { @ptr_read(@ptr_offset(@raw(value), 0)) == 4097 };
+    let source: i64 = 4095;
+    checked { @ptr_write(@ptr_offset(@raw_mut(changed), 0), @intCast(source)); };
+    @dbg(hit);
+    @dbg(changed);
+    0
+}
+""" }]
+stdout = "true\n4095\n"
+
+[[case]]
+name = "raw_fixed_array_element_infers_pointee"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut values: [i64; 1] = [0];
+    let source: i32 = 4095;
+    checked { @ptr_write(@raw_mut(values[0]), @intCast(source)); };
+    @dbg(values[0]);
+    0
+}
+""" }]
+stdout = "4095\n"
+
+# A non-place operand remains sema-owned even when its value is concrete.
+[[case]]
+name = "raw_counterfeit_mismatch_keeps_place_diagnostic"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let p: ptr const u8 = checked { @raw(42) };
+    @ptr_to_int(p);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0485", "addressable place"]
+
+[[case]]
+name = "field_ptr_local_counterfeit_keeps_field_diagnostic"
+files = [{ path = "main.rue", source = """
+struct Pair { value: i64 }
+fn main() -> i32 {
+    let pair = Pair { value: 7 };
+    let fp: ptr mut u8 = checked { @field_ptr(pair) };
+    @ptr_to_int(fp);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0490", "field access"]
+
+[[case]]
+name = "field_ptr_index_counterfeit_keeps_field_diagnostic"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let values: [i64; 1] = [7];
+    let fp: ptr mut u8 = checked { @field_ptr(values[0]) };
+    @ptr_to_int(fp);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0490", "field access"]
+
+[[case]]
+name = "raw_string_index_counterfeit_keeps_place_diagnostic"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let text: str = "x";
+    let p: ptr const i64 = checked { @raw(text[0]) };
+    @ptr_to_int(p);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0485", "addressable place"]
+
+[[case]]
+name = "raw_comptime_alias_counterfeit_keeps_place_diagnostic"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let T = i64;
+    let p: ptr const u8 = checked { @raw(T) };
+    checked { @ptr_to_int(p); };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0485", "addressable place"]
+
+[[case]]
+name = "raw_fixed_array_out_of_bounds_keeps_bounds_diagnostic"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let values: [i64; 1] = [7];
+    let p: ptr const u8 = checked { @raw(values[2]) };
+    checked { @ptr_to_int(p); };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0902", "out of bounds"]
+compile_stderr_contains = ["main.rue:3:49"]
+
+[[case]]
+name = "raw_and_field_ptr_imported_types"
+files = [
+    { path = "main.rue", source = """
+const lib = @import("pointer_types.rue");
+fn main() -> i32 {
+    let mut pair = lib.Pair { value: 0 };
+    let source: i64 = 200;
+    checked { @ptr_write(@field_ptr(pair.value), @intCast(source)); };
+    @dbg(pair.value);
+    0
+}
+""" },
+    { path = "pointer_types.rue", source = """
+pub struct Pair { value: u8 }
+""" },
+]
+stdout = "200\n"
+
+[[case]]
+name = "generic_pointer_pointee_inference"
+files = [{ path = "main.rue", source = """
+fn round_trip(comptime T: type, value: T, source: i64) -> T {
+    let mut local = value;
+    checked {
+        let p = @raw_mut(local);
+        @ptr_write(p, @intCast(source));
+        @ptr_read(p)
+    }
+}
+fn main() -> i32 {
+    let result = checked { round_trip(u16, 0, 4095) };
+    @dbg(result);
+    0
+}
+""" }]
+stdout = "4095\n"
+
+[[case]]
+name = "int_to_ptr_remains_context_driven"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let addr: u64 = 0;
+    checked {
+        let p: ptr mut u8 = @int_to_ptr(addr);
+        @dbg(@ptr_to_int(p) == 0);
+    };
+    0
+}
+""" }]
+stdout = "true\n"


### PR DESCRIPTION
Summary
- Publish exact `@raw`, `@raw_mut`, and `@field_ptr` pointer result types when the operand is already a concrete addressable place.
- Preserve the concrete input pointer type through `@ptr_offset` while leaving unresolved and context-driven cases free.
- Add production-path coverage for mutability, fields, imports, generics, diagnostic ownership, bounds, and context controls.

Validation
- `scripts/rue unit air inference`
- `scripts/rue cli ptr_pointee_inference`
- `scripts/rue cli differential_opt`
- `scripts/rue cli pointers`
- `scripts/rue spec runtime.pointers`
- `scripts/rue spec items.unchecked`
- `scripts/rue quick`
- cache-disabled canonical premerge selection
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-1352