### PR TITLE
RUE-986: add macOS socket ABI support

### DIFF
--- a/crates/rue-cli-tests/cases/std_net.toml
+++ b/crates/rue-cli-tests/cases/std_net.toml
@@ -1,16 +1,15 @@
-# std.net address model + Linux sockaddr_in marshalling (RUE-982, ADR-0060).
+# std.net address model + target sockaddr_in marshalling (RUE-982/RUE-986,
+# ADR-0060).
 #
 # The marshaller is the ONE place that knows the kernel byte layout, so these
-# cases pin it byte-for-byte: AF_INET family (native/little-endian), big-endian
-# port, four address octets in network order, zero padding, 16 bytes total.
-# Running on both CI Linux platforms is the x86-64/aarch64 layout-equivalence
-# check: the encoding is defined by std.binary, not by host byte order, so the
-# same exact stdout must hold on both.
+# cases pin it byte-for-byte: Linux native/little-endian family or Darwin
+# sin_len/family, big-endian port, four address octets in network order, zero
+# padding, 16 bytes total. Each target family is pinned independently.
 
 [section]
 id = "cli.std_net"
 name = "Standard library v1 — std.net addresses (RUE-982)"
-description = "Ipv4Addr/IpAddr/SockAddr and byte-exact Linux sockaddr_in marshalling."
+description = "Ipv4Addr/IpAddr/SockAddr and byte-exact target sockaddr_in marshalling."
 
 # Every byte of the marshalled sockaddr_in, plus octets() and the named
 # constructors. Port 0x1f90 (8080) has distinct hi/lo bytes, and the address
@@ -20,6 +19,7 @@ name = "net_sockaddr_in_exact_layout"
 description = "SockAddr.to_sockaddr_in emits AF_INET, be port, octets, zero padding."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
+only_on = ["x86-64-linux", "aarch64-linux"]
 files = [{ path = "main.rue", source = """
 const std = @import("std");
 
@@ -53,6 +53,34 @@ fn main() -> i32 {
 """ }]
 stdout = "2\n0\n31\n144\n10\n20\n30\n40\n8\n16\n127\n1\n0\n0\n"
 
+[[case]]
+name = "net_sockaddr_in_darwin_exact_layout"
+description = "Darwin sockaddr_in emits sin_len=16, AF_INET, be port, octets, zero padding."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["aarch64-macos"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let addr = std.net.SockAddr.v4(std.net.Ipv4Addr.new(10, 20, 30, 40), 0x1f90);
+    let b = addr.to_sockaddr_in();
+    @dbg(b[0]); @dbg(b[1]);
+    @dbg(b[2]); @dbg(b[3]);
+    @dbg(b[4]); @dbg(b[5]); @dbg(b[6]); @dbg(b[7]);
+    let mut zeros: i32 = 0;
+    let mut i: u64 = 8;
+    while i < 16 {
+        if b[i] == 0 { zeros = zeros + 1; }
+        i = i + 1;
+    }
+    @dbg(zeros);
+    @dbg(std.net.sockaddr_in_len());
+    0
+}
+""" }]
+stdout = "16\n2\n31\n144\n10\n20\n30\n40\n8\n16\n"
+
 # Kernel-filled decode: a valid buffer round-trips through from_sockaddr_in,
 # and a wrong family field is rejected as None instead of misread.
 [[case]]
@@ -60,6 +88,7 @@ name = "net_sockaddr_in_decode"
 description = "from_sockaddr_in validates AF_INET and reconstructs ip:port."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
+only_on = ["x86-64-linux", "aarch64-linux"]
 files = [{ path = "main.rue", source = """
 const std = @import("std");
 
@@ -86,3 +115,33 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "443\n192\n2\n1\n"
+
+[[case]]
+name = "net_sockaddr_in_darwin_decode"
+description = "Darwin from_sockaddr_in validates sin_len/family and reconstructs ip:port."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["aarch64-macos"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let O = std.option.Option(std.net.SockAddr);
+    let addr = std.net.SockAddr.v4(std.net.Ipv4Addr.new(192, 168, 1, 2), 443);
+    match std.net.SockAddr.from_sockaddr_in(addr.to_sockaddr_in()) {
+        O.Some(back) => {
+            @dbg(back.port);
+            let rb = back.to_sockaddr_in();
+            @dbg(rb[0]); @dbg(rb[1]); @dbg(rb[4]); @dbg(rb[7]);
+        },
+        O.None => { @dbg(0 - 1); },
+    }
+    let wrong_len: [u8; 16] = [15, 2, 0x01, 0xbb, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0];
+    match std.net.SockAddr.from_sockaddr_in(wrong_len) {
+        O.Some(x) => { @dbg(0 - 1); },
+        O.None => { @dbg(1); },
+    }
+    0
+}
+""" }]
+stdout = "443\n16\n2\n192\n2\n1\n"

--- a/crates/rue-cli-tests/cases/std_net_tcp.toml
+++ b/crates/rue-cli-tests/cases/std_net_tcp.toml
@@ -1,18 +1,17 @@
 # std.net blocking TCP v1 (RUE-983, ADR-0060) — real sockets over loopback.
 #
-# The Linux cases run the whole blocking client/server surface in one process:
+# The loopback case runs the whole blocking client/server surface in one process:
 # bind on an ephemeral port (port 0 + local_addr, so no fixed port is
 # assumed), connect against the listen backlog, accept, byte round trip,
 # shutdown(Write) observed as EOF by the peer, and explicit consuming closes.
 # Deterministic RUE-984 multi-process loopback coverage extends this.
 #
-# macOS is the fail-closed unsupported platform until RUE-986: constructors
-# return NetworkError.Unsupported before any socket syscall, asserted by the
-# macOS-only case.
+# AArch64 macOS uses Darwin's socket syscall table and sin_len sockaddr layout;
+# the same loopback case runs natively there to cover the complete surface.
 
 [section]
 id = "cli.std_net_tcp"
-name = "Standard library v1 — std.net blocking TCP (RUE-983)"
+name = "Standard library v1 — std.net blocking TCP (RUE-983/RUE-986)"
 description = "TcpListener/TcpStream over loopback: connect/accept/read/write/shutdown/close."
 
 [[case]]
@@ -20,7 +19,7 @@ name = "tcp_loopback_round_trip"
 description = "bind(0)+local_addr, connect, accept, write_all->read, shutdown->EOF, closes."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
-only_on = ["x86-64-linux", "aarch64-linux"]
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 files = [{ path = "main.rue", source = """
 const std = @import("std");
 
@@ -401,41 +400,153 @@ fn main() -> i32 {
 """ }]
 stdout = "1\n"
 
-# The fail-closed platform boundary: macOS constructors report Unsupported
-# without issuing a socket syscall (ADR-0060 §7, real Darwin ABI is RUE-986).
+# Darwin's orderly FIN semantics may allow sends after a peer EOF. Shut down
+# the peer's receive direction, close it, and shut down the client's send
+# direction before making bounded sends until Darwin reports EPIPE/ECONNRESET;
+# MSG_NOSIGNAL proves that error is returned safely.
 [[case]]
-name = "tcp_macos_unsupported"
-description = "bind and connect return NetworkError.Unsupported on macOS."
+name = "tcp_macos_write_after_peer_read_shutdown"
+description = "Darwin reports a bounded post-peer-close write as ConnectionReset without SIGPIPE."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
 only_on = ["aarch64-macos"]
 files = [{ path = "main.rue", source = """
 const std = @import("std");
 
+fn fail(code: i32) -> i32 {
+    @dbg(code);
+    1
+}
+
 fn main() -> i32 {
     let RL = std.result.Result(std.net.TcpListener, std.net.NetworkError);
     let RS = std.result.Result(std.net.TcpStream, std.net.NetworkError);
-    let addr = std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 0);
-    match std.net.TcpListener.bind(addr) {
-        RL.Ok(l) => { let ignored = l.close(); @dbg(0); },
-        RL.Err(e) => {
-            match e {
-                std.net.NetworkError.Unsupported => { @dbg(1); },
-                _ => { @dbg(0); },
-            }
-        },
+    let RA = std.result.Result(std.net.SockAddr, std.net.NetworkError);
+    let RU = std.result.Result(u64, std.net.NetworkError);
+    let RUnit = std.result.Result((), std.net.NetworkError);
+
+    let mut listener = match std.net.TcpListener.bind(
+        std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 0)
+    ) {
+        RL.Ok(l) => l,
+        RL.Err(e) => { return fail(101); },
+    };
+    let port: u16 = match listener.local_addr() {
+        RA.Ok(a) => a.port,
+        RA.Err(e) => { return fail(102); },
+    };
+    let mut client = match std.net.TcpStream.connect(
+        std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), port)
+    ) {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(103); },
+    };
+    let mut server = match listener.accept() {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(104); },
+    };
+    let mut payload = std.arraybuf.ArrayBuf(u8).new();
+    payload.push(170);
+    match client.write(borrow payload) {
+        RU.Ok(n) => {},
+        RU.Err(e) => { return fail(105); },
     }
-    let addr2 = std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 1);
-    match std.net.TcpStream.connect(addr2) {
-        RS.Ok(s) => { let ignored = s.close(); @dbg(0); },
-        RS.Err(e) => {
-            match e {
-                std.net.NetworkError.Unsupported => { @dbg(2); },
-                _ => { @dbg(0); },
-            }
-        },
+    match server.shutdown(std.net.Shutdown.Read) {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(106); },
+    }
+    match server.close() {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(107); },
+    }
+
+    // Closing the local send direction makes the EPIPE result deterministic
+    // after the peer has gone away, while still exercising MSG_NOSIGNAL.
+    match client.shutdown(std.net.Shutdown.Write) {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(108); },
+    }
+
+    let mut attempts: u64 = 0;
+    let mut reset = false;
+    while attempts < 8 {
+        if reset { break; }
+        match client.write(borrow payload) {
+            RU.Ok(n) => {},
+            RU.Err(e) => {
+                match e {
+                    std.net.NetworkError.ConnectionReset => { reset = true; },
+                    _ => { return fail(109); },
+                }
+            },
+        }
+        attempts = attempts + 1;
+    }
+    if !reset { return fail(110); }
+    @dbg(1);
+    match client.close() {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(111); },
+    }
+    match listener.close() {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(112); },
     }
     0
 }
 """ }]
-stdout = "1\n2\n"
+stdout = "1\n"
+
+# Darwin errno values differ from Linux. Binding the same loopback port twice
+# deterministically exercises EADDRINUSE=48 -> AddressInUse without relying on
+# a vacant external service or a raw syscall test.
+[[case]]
+name = "tcp_macos_address_in_use_mapping"
+description = "Darwin EADDRINUSE is normalized to NetworkError.AddressInUse."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["aarch64-macos"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn fail(code: i32) -> i32 {
+    @dbg(code);
+    1
+}
+
+fn main() -> i32 {
+    let RL = std.result.Result(std.net.TcpListener, std.net.NetworkError);
+    let RA = std.result.Result(std.net.SockAddr, std.net.NetworkError);
+    let RUnit = std.result.Result((), std.net.NetworkError);
+    let mut first = match std.net.TcpListener.bind(
+        std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 0)
+    ) {
+        RL.Ok(l) => l,
+        RL.Err(e) => { return fail(101); },
+    };
+    let port: u16 = match first.local_addr() {
+        RA.Ok(a) => a.port,
+        RA.Err(e) => { return fail(102); },
+    };
+    match std.net.TcpListener.bind(
+        std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), port)
+    ) {
+        RL.Ok(second) => {
+            let ignored = second.close();
+            return fail(103);
+        },
+        RL.Err(e) => {
+            match e {
+                std.net.NetworkError.AddressInUse => { @dbg(1); },
+                _ => { return fail(104); },
+            }
+        },
+    }
+    match first.close() {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(105); },
+    }
+    0
+}
+""" }]
+stdout = "1\n"

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -412,7 +412,19 @@ const ENTRIES: &[Entry] = &[
         "cli.std_net_tcp",
         "tcp_loopback_round_trip",
         external(ExternalDependencyKind::SystemCall),
-        &["aarch64-linux", "x86-64-linux"],
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.std_net_tcp",
+        "tcp_macos_address_in_use_mapping",
+        external(ExternalDependencyKind::SystemCall),
+        &["aarch64-macos"],
+    ),
+    Entry::new(
+        "cli.std_net_tcp",
+        "tcp_macos_write_after_peer_read_shutdown",
+        external(ExternalDependencyKind::SystemCall),
+        &["aarch64-macos"],
     ),
     Entry::new(
         "cli.std_net_tcp",

--- a/docs/designs/0060-network-io-v1.md
+++ b/docs/designs/0060-network-io-v1.md
@@ -28,12 +28,13 @@ order conversion in reusable Rue library code rather than compiler intrinsics.
 
 ## Summary
 
-`std.net` v1 provides blocking TCP clients and servers on Linux x86-64 and
-aarch64. It supports IPv4 addresses through an extensible public address enum,
+`std.net` v1 provides blocking TCP clients and servers on Linux x86-64,
+aarch64, and AArch64 macOS. It supports IPv4 addresses through an extensible
+public address enum,
 marshals kernel socket addresses explicitly through a `SockAddr` abstraction,
 and exposes separate owned `TcpListener` and `TcpStream` descriptor types.
 Errors are normalized from errno into a target-independent network error enum.
-UDP, IPv6, DNS, TLS, macOS, and nonblocking/readiness APIs are outside v1.
+UDP, IPv6, DNS, TLS, and nonblocking/readiness APIs are outside v1.
 
 ## Context
 
@@ -51,17 +52,18 @@ design history may still describe the old carry-flag gap; they are historical,
 not evidence that the generic Darwin normalization bug remains. Current source,
 tests, and tracker state are authoritative.
 
-That generic fix does not make macOS networking ready. The network syscall ABI,
-constants, `sockaddr` layout (including Darwin's `sin_len`), errno mapping, and
-native loopback coverage still require target-specific work. RUE-986 owns that
-work.
+RUE-986 supplies the target-aware network syscall ABI, constants, `sockaddr`
+layout (including Darwin's `sin_len`), errno mapping, and native loopback
+coverage. The socket ABI remains isolated in `std.net`; generic syscall
+normalization is unchanged.
 
 ## Decision
 
-### 1. v1 is pure Rue, blocking TCP, on Linux
+### 1. v1 is pure Rue, blocking TCP, on Linux and AArch64 macOS
 
 `std.net` is Rue source over `@syscall`, following ADR-0057 and ADR-0034. v1
-targets Linux x86-64 and aarch64 only and provides the syscall operations needed
+targets Linux x86-64/aarch64 and AArch64 macOS and provides the syscall
+operations needed
 for a blocking TCP client and server:
 
 - `socket` and `connect` for clients;
@@ -110,11 +112,11 @@ C layout. It centralizes conversion between the public address value and the
 byte buffer passed to the kernel. Rue struct layout is not part of the C ABI and
 must not accidentally become a socket ABI promise.
 
-On the two v1 targets, Linux `sockaddr_in` is exactly 16 bytes:
+On every supported target, `sockaddr_in` is exactly 16 bytes:
 
 | Bytes | Encoding |
 | --- | --- |
-| 0..2 | native `AF_INET` family field; `02 00` on the supported little-endian Linux targets |
+| 0..2 | Linux native `AF_INET` (`02 00`), or Darwin `sin_len=16` and one-byte `AF_INET` (`10 02`) |
 | 2..4 | port as a big-endian `u16` |
 | 4..8 | the four IPv4 octets in network order |
 | 8..16 | eight zero bytes |
@@ -128,9 +130,8 @@ does not cast a `SockAddr` or `Ipv4Addr` value to a raw pointer and hope its
 physical representation matches the kernel.
 
 This boundary is deliberate isolation. IPv6 has a different structure and
-size; macOS IPv4 adds `sin_len` and has different ABI details. Adding either
-extends the `SockAddr` marshaller without exposing those kernel layouts through
-the public API.
+size; adding it extends the `SockAddr` marshaller without exposing kernel
+layouts through the public API.
 
 ### 4. Byte order is explicit, reusable Rue library code
 
@@ -141,9 +142,8 @@ targets. The helpers are not compiler intrinsics, and they do not use
 host-dependent C names such as `htons` that obscure which order is requested.
 
 This follows ADR-0059's rule that endianness policy remains source-defined over
-byte primitives. RUE-970, now Todo, owns the reusable helper surface. RUE-982 is
-blocked on it so `SockAddr` consumes the canonical helpers rather than growing a
-private competing conversion path.
+byte primitives. RUE-970 owns the reusable helper surface, and `SockAddr`
+consumes those helpers while selecting only the target-specific family prefix.
 
 ### 5. Listener and stream are distinct owned descriptor types
 
@@ -193,23 +193,23 @@ enum NetworkError {
 This list is an ADR-level contract, not a demand for speculative errno coverage:
 implementation should map useful, stable logical cases and route all remaining
 errors to `Other(i64)`. Raw errno values do not become the public matching API.
-For Linux socket sends, `sendto(2)` uses `MSG_NOSIGNAL` so a broken peer is
-reported to Rue instead of terminating the process with `SIGPIPE`; both
+For socket sends, `sendto(2)` uses the target-specific `MSG_NOSIGNAL` value
+(`0x4000` on Linux and `0x80000` on Darwin), so a broken peer is reported to
+Rue instead of terminating the process with `SIGPIPE`; both
 `ECONNRESET` and `EPIPE` map to `ConnectionReset`.
 `WouldBlock` remains available for unusual kernel/configuration behavior and
 future evolution even though v1 itself creates blocking sockets.
 
-Linux-only is a fail-closed platform boundary, not permission to issue guessed
-Darwin syscalls. On macOS, v1 network constructors return `Unsupported` without
-invoking a socket syscall. RUE-986 replaces that branch with the real Darwin
-ABI and execution coverage.
+The network ABI is a fail-closed target boundary: supported Linux and AArch64
+macOS select their explicit syscall tables, constants, and layouts; any other
+target returns `Unsupported` before issuing a socket syscall.
 
 ## Implementation Phases
 
 The implementation dependency chain is exact:
 
 - [x] **Reusable explicit-endian helpers** — RUE-970
-- [x] **IPv4 and `SockAddr` types plus Linux marshalling** — RUE-982, blocked by RUE-970
+- [x] **IPv4 and `SockAddr` types plus target marshalling** — RUE-982/RUE-986, blocked by RUE-970
 - [x] **Blocking `TcpListener`/`TcpStream` operations** — RUE-983, blocked by RUE-982
 - [ ] **Deterministic real-binary Linux loopback coverage** — RUE-984, blocked by RUE-983
 
@@ -219,8 +219,8 @@ port, impose bounded timeouts, and clean up both processes and descriptors on
 success or failure. This is real compiled-binary coverage, not only unit tests
 of marshalling helpers.
 
-RUE-985 (IPv6) and RUE-986 (macOS network ABI and coverage) are deferred bugs
-related to RUE-713; neither is in the v1 dependency chain.
+RUE-985 (IPv6) remains deferred work related to RUE-713; it is not in the v1
+dependency chain.
 
 ## Consequences
 
@@ -229,7 +229,7 @@ related to RUE-713; neither is in the v1 dependency chain.
 - Rue programs gain a minimal, useful TCP client and server facility without
   expanding the Rust runtime or its cross-target archive surface.
 - Explicit marshalling prevents accidental dependence on Rue struct layout and
-  gives IPv6 and macOS one well-defined extension point.
+  gives future IPv6 support one well-defined extension point.
 - Address and error APIs are portable shapes rather than Linux integer/layout
   details leaking into user code.
 - Separate affine listener and stream types make descriptor ownership and valid
@@ -237,7 +237,7 @@ related to RUE-713; neither is in the v1 dependency chain.
 
 ### Negative
 
-- v1 is Linux-only and IPv4-only.
+- v1 is IPv4-only.
 - Syscall numbers, socket constants, errno mappings, and ABI marshalling remain
   target-maintained library data.
 - Without traits, `File` and `TcpStream` have deliberately duplicated method
@@ -248,14 +248,13 @@ related to RUE-713; neither is in the v1 dependency chain.
 
 - The design adds no language feature, preview gate, compiler intrinsic, or
   runtime Rust helper.
-- DNS, TLS, UDP, IPv6, macOS, and readiness remain separable library work.
+- DNS, TLS, UDP, IPv6, and readiness remain separable library work.
 
 ## Alternatives Considered
 
-- **Support every current OS first.** Rejected: generic Darwin `@syscall` error
-  normalization is fixed by RUE-945, but network-specific constants, layouts,
-  errno details, and loopback validation remain substantial. RUE-986 owns that
-  work without blocking a coherent Linux v1.
+- **Support every current OS first.** Rejected: the target-aware table remains
+  deliberately limited to the three supported Rue targets; other OSes need
+  their own ABI review and fail closed.
 - **Pass Rue structs as C `sockaddr` structures.** Rejected: Rue does not promise
   that source structs have C layout. Explicit byte-buffer marshalling is checked,
   reviewable, and isolates target ABI differences.
@@ -275,8 +274,6 @@ related to RUE-713; neither is in the v1 dependency chain.
 ## Future Work
 
 - RUE-985: IPv6 address variants and kernel marshalling.
-- RUE-986: macOS socket ABI, constants, errno/layout details, `sin_len`, and
-  deterministic loopback coverage.
 - UDP, nonblocking/readiness, DNS, and TLS after their requirements are settled.
 
 ## References
@@ -287,4 +284,4 @@ related to RUE-713; neither is in the v1 dependency chain.
 - ADR-0059 — endianness remains explicit source-defined library policy
 - RUE-945 — implemented Darwin `@syscall` error normalization
 - RUE-970, RUE-982, RUE-983, RUE-984 — v1 implementation chain
-- RUE-985, RUE-986 — deferred IPv6 and macOS bugs
+- RUE-985 — deferred IPv6 work

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -24,7 +24,7 @@
 //   remove_dir/metadata, and directory enumeration via fs.read_dir/fs.walk
 //   (deterministically ordered `DirEntries`)
 // - std.binary: endianness-explicit integer<->byte conversions
-// - std.net: network IO v1 address model + Linux sockaddr marshalling
+// - std.net: network IO v1 address model + target sockaddr marshalling
 // - std.c: transparent C scalar-type aliases for the FFI boundary
 //   (c_int/c_long/c_size_t/wchar_t/...) sized per the target psABI
 
@@ -47,7 +47,8 @@ pub const fs = @import("fs.rue");
 // Endianness-explicit integer<->byte conversions (RUE-970, ADR-0059/0060).
 pub const binary = @import("binary.rue");
 
-// Network IO v1: address model + Linux sockaddr marshalling (RUE-982, ADR-0060).
+// Network IO v1: address model + target sockaddr marshalling (RUE-982/RUE-986,
+// ADR-0060).
 pub const net = @import("net.rue");
 
 // C FFI transparent scalar aliases (RUE-742, ADR-0064 Amendment 1 / P1.5):

--- a/std/net.rue
+++ b/std/net.rue
@@ -13,24 +13,23 @@
 //
 //     const std = @import("std");
 //     let addr = std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 8080);
-//     let bytes = addr.to_sockaddr_in();     // Linux sockaddr_in, 16 bytes
+//     let bytes = addr.to_sockaddr_in();     // target sockaddr_in, 16 bytes
 //
-// PLATFORM SCOPE (ADR-0060 §7): the marshalled layout is Linux `sockaddr_in`,
-// identical on the two v1 targets (x86-64 Linux and aarch64 Linux). macOS
-// IPv4 differs (`sin_len` first byte, different ABI details) and is an
-// explicit unsupported case until RUE-986; socket constructors on macOS
-// return `Unsupported` rather than guessing Darwin layouts (RUE-983).
+// PLATFORM SCOPE (ADR-0060 §7): the marshalled layout is the target's IPv4
+// `sockaddr_in`. Linux uses a native/little-endian family field; Darwin uses
+// `sin_len` followed by the one-byte family field. Both supported layouts are
+// exactly 16 bytes and are selected by the target-aware ABI helpers below.
 
 const binary = @import("binary.rue");
 const option = @import("option.rue");
 const result = @import("result.rue");
 
-// The AF_INET address-family value shared by both v1 Linux targets.
+// The AF_INET address-family value shared by the supported targets.
 fn _af_inet() -> u16 {
     2
 }
 
-// Byte size of the marshalled Linux `sockaddr_in`. Callers pass this as the
+// Byte size of the marshalled target `sockaddr_in`. Callers pass this as the
 // address length at the syscall boundary and validate kernel-returned lengths
 // against it before decoding.
 pub fn sockaddr_in_len() -> u64 {
@@ -84,11 +83,12 @@ pub struct SockAddr {
         SockAddr { ip: IpAddr.V4(ip), port: port }
     }
 
-    // Encode this address as the Linux `sockaddr_in` byte layout (ADR-0060
-    // §3), 16 bytes:
+    // Encode this address as the target `sockaddr_in` byte layout (ADR-0060
+    // §3), 16 bytes. Linux starts with the native/little-endian AF_INET
+    // family; Darwin starts with sin_len=16 and AF_INET in byte 1:
     //
     //   | bytes  | encoding                                            |
-    //   | 0..2   | AF_INET family, native/little-endian on v1 targets  |
+    //   | 0..2   | Linux family, or Darwin sin_len and one-byte family   |
     //   | 2..4   | port, big-endian (network order)                    |
     //   | 4..8   | the four IPv4 octets in network order               |
     //   | 8..16  | zero padding                                        |
@@ -96,27 +96,42 @@ pub struct SockAddr {
     // Every multi-byte field states its order through std.binary; nothing
     // here depends on Rue struct layout matching C.
     fn to_sockaddr_in(self) -> [u8; 16] {
-        let fam = binary.u16_to_le_bytes(_af_inet());
         let pb = binary.u16_to_be_bytes(self.port);
         match self.ip {
-            IpAddr.V4(v4) => [
-                fam[0], fam[1],
-                pb[0], pb[1],
-                v4.a, v4.b, v4.c, v4.d,
-                0, 0, 0, 0, 0, 0, 0, 0,
-            ],
+            IpAddr.V4(v4) => match @target_os() {
+                Os.Linux => {
+                    let fam = binary.u16_to_le_bytes(_af_inet());
+                    [
+                        fam[0], fam[1],
+                        pb[0], pb[1],
+                        v4.a, v4.b, v4.c, v4.d,
+                        0, 0, 0, 0, 0, 0, 0, 0,
+                    ]
+                },
+                Os.Macos => [
+                    16, @intCast(_af_inet()),
+                    pb[0], pb[1],
+                    v4.a, v4.b, v4.c, v4.d,
+                    0, 0, 0, 0, 0, 0, 0, 0,
+                ],
+            },
         }
     }
 
-    // Decode a kernel-filled Linux `sockaddr_in`. Returns `None` unless the
-    // family field is AF_INET; the caller has already validated the returned
-    // address length against `sockaddr_in_len()` at the syscall boundary
-    // (ADR-0060 §3). The trailing padding bytes are ignored.
+    // Decode a kernel-filled target `sockaddr_in`. Returns `None` unless the
+    // target's family (and Darwin sin_len) is valid; the caller has already
+    // validated the returned address length at the syscall boundary (ADR-0060
+    // §3). The trailing padding bytes are ignored.
     fn from_sockaddr_in(b: [u8; 16]) -> option.Option(SockAddr) {
         let O = option.Option(SockAddr);
-        let fam = binary.u16_from_le_bytes([b[0], b[1]]);
-        if fam != _af_inet() {
-            return O.None;
+        match @target_os() {
+            Os.Linux => {
+                let fam = binary.u16_from_le_bytes([b[0], b[1]]);
+                if fam != _af_inet() { return O.None; }
+            },
+            Os.Macos => {
+                if b[0] != 16 || b[1] != @intCast(_af_inet()) { return O.None; }
+            },
         }
         let port = binary.u16_from_be_bytes([b[2], b[3]]);
         let ip = Ipv4Addr.new(b[4], b[5], b[6], b[7]);
@@ -125,14 +140,12 @@ pub struct SockAddr {
 }
 
 // ===========================================================================
-// Blocking TCP v1 (RUE-983, ADR-0060 §1/§5/§6/§7).
+// Blocking TCP v1 (RUE-983/RUE-986, ADR-0060 §1/§5/§6/§7).
 //
-// Pure Rue over `@syscall`, Linux x86-64 and aarch64 only. Constructors are
-// the fail-closed platform boundary: on macOS they return
-// `NetworkError.Unsupported` BEFORE any socket syscall (no guessed Darwin
-// numbers; real Darwin support is RUE-986). Because no constructor succeeds
-// off-Linux, every method and drop below runs only over Linux descriptors,
-// so the syscall tables carry Linux numbers keyed by architecture alone.
+// Pure Rue over `@syscall`, with one target-aware socket ABI authority. The
+// helpers below select syscall numbers, constants, errno values, and
+// sockaddr bytes; constructors use the same selections on every supported
+// target and fail closed for any unsupported target.
 //
 // Descriptor ownership follows ADR-0057 §4 exactly as std.fs.File: scope exit
 // closes a live fd via `drop fn`; consuming `close(self)` first swaps in the
@@ -147,7 +160,7 @@ const arraybuf = @import("arraybuf.rue");
 // categories are mapped; everything else falls through to `Other(i64)` with
 // the raw errno, so no error is ever lost.
 pub enum NetworkError {
-    Unsupported,          // not a v1 platform (macOS until RUE-986)
+    Unsupported,          // target has no supported socket ABI
     PermissionDenied,     // EACCES, EPERM
     AddressInUse,         // EADDRINUSE
     AddressNotAvailable,  // EADDRNOTAVAIL
@@ -169,103 +182,226 @@ pub enum Shutdown {
     Both,   // SHUT_RDWR
 }
 
-// Whether this target runs real v1 network syscalls. The single fail-closed
-// platform gate (ADR-0060 §7): macOS waits for RUE-986.
+// Whether this target runs real v1 network syscalls. Keep this gate next to the
+// ABI tables so a future target cannot issue a table row accidentally.
 fn _net_supported() -> bool {
-    match @target_os() {
-        Os.Linux => true,
-        Os.Macos => false,
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => true,
+                Os.Macos => false,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => true,
+                Os.Macos => true,
+            }
+        },
     }
 }
 
 // ---------------------------------------------------------------------------
-// Linux socket syscall numbers, keyed by architecture. These are only issued
-// behind `_net_supported()` (see the section comment), so no Darwin numbers
-// appear here.
+// Target-aware socket ABI authority. Darwin syscall numbers are the BSD trap
+// numbers used by the AArch64 macOS target; Linux rows preserve the original
+// x86-64/AArch64 behavior byte-for-byte.
 // ---------------------------------------------------------------------------
 
 fn _sys_socket() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 41,
-        Arch.Aarch64 => 198,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 41,
+                Os.Macos => 97,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 198,
+                Os.Macos => 97,
+            }
+        },
     }
 }
 
 fn _sys_connect() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 42,
-        Arch.Aarch64 => 203,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 42,
+                Os.Macos => 98,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 203,
+                Os.Macos => 98,
+            }
+        },
     }
 }
 
 fn _sys_accept() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 43,
-        Arch.Aarch64 => 202,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 43,
+                Os.Macos => 30,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 202,
+                Os.Macos => 30,
+            }
+        },
     }
 }
 
 fn _sys_bind() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 49,
-        Arch.Aarch64 => 200,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 49,
+                Os.Macos => 104,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 200,
+                Os.Macos => 104,
+            }
+        },
     }
 }
 
 fn _sys_listen() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 50,
-        Arch.Aarch64 => 201,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 50,
+                Os.Macos => 106,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 201,
+                Os.Macos => 106,
+            }
+        },
     }
 }
 
 fn _sys_getsockname() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 51,
-        Arch.Aarch64 => 204,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 51,
+                Os.Macos => 32,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 204,
+                Os.Macos => 32,
+            }
+        },
     }
 }
 
 fn _sys_shutdown() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 48,
-        Arch.Aarch64 => 210,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 48,
+                Os.Macos => 134,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 210,
+                Os.Macos => 134,
+            }
+        },
     }
 }
 
 fn _sys_net_read() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 0,
-        Arch.Aarch64 => 63,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 0,
+                Os.Macos => 3,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 63,
+                Os.Macos => 3,
+            }
+        },
     }
 }
 
-// Linux `sendto(2)` with MSG_NOSIGNAL is the socket-specific write path. The
-// null destination and zero address length use the already-connected peer;
-// unlike `write(2)`, MSG_NOSIGNAL suppresses SIGPIPE for these sends only.
+// `sendto(2)` is the socket-specific write path. The null destination and zero
+// address length use the already-connected peer; per-target MSG_NOSIGNAL
+// suppresses SIGPIPE without changing the public write result.
 fn _sys_net_sendto() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 44,
-        Arch.Aarch64 => 206,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 44,
+                Os.Macos => 133,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 206,
+                Os.Macos => 133,
+            }
+        },
     }
 }
 
-fn _msg_nosignal() -> u64 { 0x4000 }
+// Darwin's SDK defines MSG_NOSIGNAL as 0x80000; Linux defines it as 0x4000.
+fn _msg_nosignal() -> u64 {
+    match @target_os() {
+        Os.Linux => 0x4000,
+        Os.Macos => 0x80000,
+    }
+}
 
 fn _sys_net_close() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 3,
-        Arch.Aarch64 => 57,
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 3,
+                Os.Macos => 6,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 57,
+                Os.Macos => 6,
+            }
+        },
     }
 }
 
-// Linux socket constants, identical on both v1 architectures.
+// Socket constants are shared by the supported kernels.
 fn _sock_stream() -> u64 { 1 }
 fn _default_backlog() -> u64 { 128 }
 
-// Normalize a POSITIVE Linux errno into `NetworkError` (asm-generic values,
-// same on x86-64 and aarch64).
+// Normalize a POSITIVE target errno into `NetworkError`. Darwin's errno values
+// differ from Linux (notably EAGAIN=35, EADDRINUSE=48, and ECONNREFUSED=61).
 fn _normalize_net_errno(e: i64) -> NetworkError {
+    match @target_os() {
+        Os.Linux => _normalize_linux_errno(e),
+        Os.Macos => _normalize_macos_errno(e),
+    }
+}
+
+fn _normalize_linux_errno(e: i64) -> NetworkError {
     // EPERM=1 EINTR=4 EBADF=9 EAGAIN=11 EACCES=13 EINVAL=22 EADDRINUSE=98
     // EADDRNOTAVAIL=99 ECONNABORTED=103 ECONNRESET=104 EPIPE=32 ENOTCONN=107
     // ETIMEDOUT=110 ECONNREFUSED=111
@@ -292,6 +428,43 @@ fn _normalize_net_errno(e: i64) -> NetworkError {
     } else if e == 4 {
         NetworkError.Interrupted
     } else if e == 11 {
+        NetworkError.WouldBlock
+    } else if e == 22 {
+        NetworkError.InvalidInput
+    } else if e == 9 {
+        NetworkError.InvalidInput
+    } else {
+        NetworkError.Other(e)
+    }
+}
+
+fn _normalize_macos_errno(e: i64) -> NetworkError {
+    // EPERM=1 EINTR=4 EBADF=9 EAGAIN=35 EACCES=13 EINVAL=22 EADDRINUSE=48
+    // EADDRNOTAVAIL=49 ECONNABORTED=53 ECONNRESET=54 EPIPE=32 ENOTCONN=57
+    // ETIMEDOUT=60 ECONNREFUSED=61.
+    if e == 1 {
+        NetworkError.PermissionDenied
+    } else if e == 13 {
+        NetworkError.PermissionDenied
+    } else if e == 48 {
+        NetworkError.AddressInUse
+    } else if e == 49 {
+        NetworkError.AddressNotAvailable
+    } else if e == 61 {
+        NetworkError.ConnectionRefused
+    } else if e == 54 {
+        NetworkError.ConnectionReset
+    } else if e == 32 {
+        NetworkError.ConnectionReset
+    } else if e == 53 {
+        NetworkError.ConnectionAborted
+    } else if e == 57 {
+        NetworkError.NotConnected
+    } else if e == 60 {
+        NetworkError.TimedOut
+    } else if e == 4 {
+        NetworkError.Interrupted
+    } else if e == 35 {
         NetworkError.WouldBlock
     } else if e == 22 {
         NetworkError.InvalidInput
@@ -410,8 +583,8 @@ pub struct TcpStream {
     // Send the bytes of `buf` in a single `sendto(2)` with MSG_NOSIGNAL;
     // the null destination uses the connected peer and suppresses SIGPIPE
     // for this socket send. It may send fewer than `buf.len()` (the count is
-    // returned). Use `write_all` for the whole-buffer guarantee. Linux EPIPE
-    // is normalized to ConnectionReset, like ECONNRESET.
+    // returned). Use `write_all` for the whole-buffer guarantee. EPIPE is
+    // normalized to ConnectionReset, like ECONNRESET, on every supported OS.
     fn write(inout self, borrow buf: arraybuf.ArrayBuf(u8)) -> result.Result(u64, NetworkError) {
         let R = result.Result(u64, NetworkError);
         let n = buf.len();


### PR DESCRIPTION
## Summary

- centralize target-aware socket ABI details for supported Linux and AArch64 macOS targets
- add Darwin syscall numbers, errno mapping, MSG_NOSIGNAL, and exact sockaddr_in encoding/decoding with sin_len
- add target-filtered source guards plus native macOS loopback, address-in-use, shutdown, peer-close, and SIGPIPE-safe write coverage

## Validation

- scripts/rue cli std_net
- scripts/rue cli std_net_tcp
- explicit x86-64 Linux and AArch64 Linux compile checks
- scripts/rue quick
- scripts/rue premerge
- scripts/rue fmt
- git diff --check
- broad standard suite attempted; oracle corpus actions could not spawn worker threads because the host was already above its process thread limit, before semantic execution

Fixes RUE-986