### PR TITLE
RUE-1714: bulk-copy byte buffer ranges

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -215,6 +215,41 @@ genrule(
     visibility = ["PUBLIC"],
 )
 
+# The CLI harness also pins the source shape of the byte-range bridge and trim
+# implementations. Keep these production inputs separate so that the unit
+# guard remains hermetic and only rebuilds when one of the relevant files does.
+genrule(
+    name = "std-rawbuf-source",
+    out = "std_rawbuf.rue",
+    srcs = ["std/rawbuf.rue"],
+    cmd = "cp $SRCS $OUT",
+    visibility = ["PUBLIC"],
+)
+
+genrule(
+    name = "std-arraybuf-source",
+    out = "std_arraybuf.rue",
+    srcs = ["std/arraybuf.rue"],
+    cmd = "cp $SRCS $OUT",
+    visibility = ["PUBLIC"],
+)
+
+genrule(
+    name = "std-strbuf-source",
+    out = "std_strbuf.rue",
+    srcs = ["std/strbuf.rue"],
+    cmd = "cp $SRCS $OUT",
+    visibility = ["PUBLIC"],
+)
+
+genrule(
+    name = "std-strings-source",
+    out = "std_strings.rue",
+    srcs = ["std/strings.rue"],
+    cmd = "cp $SRCS $OUT",
+    visibility = ["PUBLIC"],
+)
+
 # The example programs are runtime inputs to the CLI integration tests: the
 # suite compiles+runs every examples/*.rue through the real driver (RUE-48),
 # so an edit under examples/ MUST re-run the CLI suite (declared here as an

--- a/crates/rue-cli-tests/BUCK
+++ b/crates/rue-cli-tests/BUCK
@@ -12,6 +12,10 @@ rue_binary(
         "cases/execution_contracts.toml": "src/execution_contracts.toml",
         "cases/examples_mosaic.toml": "src/examples_mosaic.toml",
         "//:std-sort-source": "src/std_sort.rue",
+        "//:std-rawbuf-source": "src/std_rawbuf.rue",
+        "//:std-arraybuf-source": "src/std_arraybuf.rue",
+        "//:std-strbuf-source": "src/std_strbuf.rue",
+        "//:std-strings-source": "src/std_strings.rue",
     },
     deps = [
         "//crates/rue-linker:rue-linker",

--- a/crates/rue-cli-tests/cases/std_byte_bridges.toml
+++ b/crates/rue-cli-tests/cases/std_byte_bridges.toml
@@ -52,6 +52,78 @@ args = ["main.rue", "-o", "prog"]
 exit_code = 0
 
 [[case]]
+name = "raw_byte_copy_helper_is_not_importable"
+description = "The RawBuf bulk-copy implementation remains container-internal and cannot be reached through ordinary std imports."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let zero: u64 = 0;
+    let p: ptr mut u8 = checked { @int_to_ptr(zero) };
+    std.rawbuf.copy_nonoverlapping_bytes(p, 0, p, 0, 0, 1);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["no member", "rawbuf"]
+
+[[case]]
+name = "arraybuf_copy_shims_are_not_receiver_methods"
+description = "ArrayBuf copy shims cannot be reached through a public receiver with a forged logical source bound."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+
+fn main() -> i32 {
+    let mut bytes = Bytes.with_capacity(1);
+    let source: S = "a";
+    bytes.copy_from_rawbuf(borrow source.core, 100, 101, 0, 1);
+    bytes.len = 1;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["copy_from_rawbuf"]
+
+[[case]]
+name = "rawbuf_copy_shims_are_not_receiver_methods"
+description = "RawBuf same-owner copying cannot be reached through a StrBuf core receiver to read spare capacity."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mut source: S = "a";
+    source.core.copy_range_within(0, 1, 1);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["copy_range_within"]
+
+[[case]]
+name = "rawbuf_range_copy_is_not_a_receiver_method"
+description = "The former RawBuf range-copy receiver surface cannot be used to supply an arbitrary logical source bound."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mut destination: S = "a";
+    let source: S = "b";
+    destination.core.copy_range_from(borrow source.core, 0, 1, 0, 1);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["copy_range_from"]
+
+[[case]]
 name = "byte_range_bridges_reject_out_of_bounds_ranges"
 description = "The checked ArrayBuf(u8)-to-StrBuf range bridge traps before reading beyond the borrowed source."
 env = { RUE_STD_PATH = "${REAL_STD}" }
@@ -98,6 +170,44 @@ fn main() -> i32 {
     bytes.extend_from(borrow empty_bytes);
     bytes.extend_str(borrow empty_view);
     if !bytes.is_empty() || bytes.capacity() != bytes_cap { return 3; }
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "byte_range_bridges_cover_boundaries_and_large_ranges"
+description = "Both bridge directions copy boundary-aligned and large ranges in one ownership-independent result, including append into spare capacity."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+
+fn main() -> i32 {
+    let mut source = Bytes.with_capacity(128);
+    let mut i: u64 = 0;
+    while i < 128 {
+        source.push(@intCast(i));
+        i += 1;
+    }
+
+    let middle = S.from_byte_range(borrow source, 1, 126);
+    if middle.len() != 126 || middle[0] != 1 || middle[125] != 126 { return 1; }
+    let mut round_trip = middle.to_bytes();
+    if round_trip.len() != 126 || round_trip.get_or(0, 0) != 1 || round_trip.get_or(125, 0) != 126 { return 2; }
+
+    let mut target = S.with_capacity(160);
+    let target_cap = target.capacity();
+    target.append_byte_range(borrow source, 0, 128);
+    if target.len() != 128 || target.capacity() != target_cap { return 3; }
+    if target[0] != 0 || target[127] != 127 { return 4; }
+
+    // Mutating the copied ArrayBuf proves neither bridge aliases its source.
+    round_trip.set(0, 255);
+    if middle[0] != 1 || source.get_or(1, 0) != 1 { return 5; }
+    if source.len() != 128 || target.len() != 128 { return 6; }
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/std_m3.toml
+++ b/crates/rue-cli-tests/cases/std_m3.toml
@@ -49,6 +49,43 @@ fn main() -> i32 {
 """ }]
 
 [[case]]
+name = "std_strings_trim_returns_independent_capacity_sized_ranges"
+description = "trim, trim_start, and trim_end preserve exact contents while empty results stay empty and retained slices use their own capacity."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 68
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let empty: S = "";
+    let blank: S = " \\t\\n";
+    let empty_trimmed = std.strings.trim(empty);
+    let blank_start = std.strings.trim_start(blank);
+    let blank_end = std.strings.trim_end(" \\t\\n");
+    if empty_trimmed.len() != 0 || empty_trimmed.capacity() != 0 { return 1; }
+    if blank_start.len() != 0 || blank_start.capacity() != 0 { return 2; }
+    if blank_end.len() != 0 || blank_end.capacity() != 0 { return 3; }
+
+    let start = std.strings.trim_start("  abc  ");
+    let end = std.strings.trim_end("  abc  ");
+    let both = std.strings.trim("  abc  ");
+    if start != "abc  " || end != "  abc" || both != "abc" { return 4; }
+    if start.capacity() != 16 || end.capacity() != 16 || both.capacity() != 16 { return 5; }
+
+    let large: S = "    abcdefghijklmnopqrstuvwxyz0123456789    ";
+    let source_copy = large.copy();
+    let mut retained = std.strings.trim(large);
+    if retained != "abcdefghijklmnopqrstuvwxyz0123456789" { return 6; }
+    if retained.len() != 36 || retained.capacity() != 36 { return 7; }
+    retained.push(90);
+    if source_copy != "    abcdefghijklmnopqrstuvwxyz0123456789    " { return 8; }
+    68
+}
+""" }]
+
+[[case]]
 name = "std_strings_m3"
 description = "bounds-checked bytes plus byte- and character-oriented string helpers (22 checks -> exit 62)."
 env = { RUE_STD_PATH = "${REAL_STD}" }

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -236,13 +236,14 @@ fn main() -> i32 {
 args = ["--emit", "mir", "main.rue"]
 compile_only = true
 # Backend views expose production machine symbols. These are the stable-symbol
-# hex payloads for duplicate, byte_range, concat_borrowed, and
-# copy_packed_bytes respectively.
+# hex payloads for duplicate, byte_range, concat_borrowed, and the RawBuf bulk
+# copy helper respectively.
 compile_stdout_contains = [
     "6475706c6963617465",
     "627974655f72616e6765",
     "636f6e6361745f626f72726f776564",
-    "636f70795f7061636b65645f6279746573",
+    "636f70795f7261776275665f72616e6765",
+    "636f70795f7261776275665f72616e67655f77697468696e",
 ]
 
 [[case]]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -4528,6 +4528,94 @@ mod tests {
         );
     }
 
+    fn rue_function_body<'a>(source: &'a str, marker: &str) -> &'a str {
+        let marker_start = source
+            .find(marker)
+            .unwrap_or_else(|| panic!("Rue source must contain {marker:?}"));
+        let open = source[marker_start..]
+            .find('{')
+            .map(|offset| marker_start + offset)
+            .expect("Rue function must have a body");
+        let mut depth = 0usize;
+        for (offset, byte) in source[open..].bytes().enumerate() {
+            match byte {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[open + 1..open + offset];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("Rue function {marker:?} has an unterminated body");
+    }
+
+    #[test]
+    fn byte_range_source_inventory_pins_one_bulk_copy_path() {
+        let rawbuf = include_str!("std_rawbuf.rue");
+        let arraybuf = include_str!("std_arraybuf.rue");
+        let strbuf = include_str!("std_strbuf.rue");
+        let strings = include_str!("std_strings.rue");
+
+        let from_byte_range = rue_function_body(strbuf, "fn from_byte_range(");
+        let append_byte_range = rue_function_body(strbuf, "fn append_byte_range(");
+        let to_bytes = rue_function_body(strbuf, "fn to_bytes(");
+        assert!(from_byte_range.contains("copy_arraybuf_range("));
+        assert!(append_byte_range.contains("copy_arraybuf_range("));
+        assert!(to_bytes.contains("copy_rawbuf_range("));
+        for (name, body) in [
+            ("from_byte_range", from_byte_range),
+            ("append_byte_range", append_byte_range),
+            ("to_bytes", to_bytes),
+        ] {
+            assert!(!body.contains("while"), "{name} must remain one bulk call");
+            assert!(
+                !body.contains(".push("),
+                "{name} must not rebuild byte-by-byte"
+            );
+            assert!(
+                !body.contains("get_or("),
+                "{name} must not use per-byte lookup"
+            );
+        }
+
+        for marker in ["pub fn trim_start(", "pub fn trim_end(", "pub fn trim("] {
+            let body = rue_function_body(strings, marker);
+            assert!(
+                body.contains(".byte_range("),
+                "{marker} must return byte_range"
+            );
+            assert!(
+                !body.contains(".push("),
+                "{marker} must not rebuild byte-by-byte"
+            );
+            assert!(
+                !body.contains("get_or("),
+                "{marker} must not use per-byte lookup"
+            );
+            // The scan's while is intentional; the returned range must be the
+            // sole post-scan construction path rather than another loop.
+            let range = body.find(".byte_range(").expect("range call above");
+            assert!(!body[range..].contains("while"));
+        }
+
+        assert!(arraybuf.contains("\nfn copy_arraybuf_range("));
+        assert!(rawbuf.contains("\nfn copy_rawbuf_range("));
+        assert!(rawbuf.contains("\nfn copy_rawbuf_range_within("));
+        assert_eq!(rawbuf.matches("@byte_copy").count(), 1);
+        assert!(rawbuf.contains("fn copy_nonoverlapping_bytes("));
+        assert_eq!(
+            rawbuf.matches("copy_nonoverlapping_bytes(").count(),
+            3,
+            "one raw implementation plus the two thin RawBuf callers"
+        );
+        assert!(!strbuf.contains("@byte_copy"));
+        assert!(!arraybuf.contains("@byte_copy"));
+        assert!(!strings.contains("@byte_copy"));
+    }
+
     fn corpus_from_toml(source: &str) -> LoadedCorpus {
         let profiles = r#"
             [timeout_profile.ordinary]

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -421,3 +421,29 @@ pub fn ArrayBuf(comptime T: type) -> type {
         }
     }
 }
+
+// Directory-private bridge owned by ArrayBuf. Keeping this outside the public
+// type prevents user code from invoking a copy shim through an ArrayBuf
+// receiver. The source range is checked against this container's initialized
+// length; RawBuf separately checks the destination's real allocation capacity.
+fn copy_arraybuf_range(
+    comptime T: type,
+    borrow source: ArrayBuf(T),
+    inout destination: rawbuf.RawBuf(T),
+    start: u64,
+    destination_start: u64,
+    count: u64,
+) {
+    if start > source.len || count > source.len - start {
+        @panic("index out of bounds");
+    }
+    rawbuf.copy_rawbuf_range(
+        T,
+        inout destination,
+        borrow source.core,
+        start,
+        source.len,
+        destination_start,
+        count,
+    );
+}

--- a/std/rawbuf.rue
+++ b/std/rawbuf.rue
@@ -36,6 +36,59 @@
 // string literal, §6.13.4) belongs here too, as a third case of the same
 // invariant, so both containers can share it; it is not modeled yet.
 
+// The sole raw byte-copy implementation. Callers pass validated logical
+// ranges; this private function performs the shared byte-size, address,
+// overlap, and intrinsic checks for both distinct-buffer bridges and
+// same-buffer non-overlap copies. It is deliberately not exported through the
+// std facade and accepts no user-visible pointer API.
+fn copy_nonoverlapping_bytes(
+    source: ptr mut u8,
+    source_start: u64,
+    destination: ptr mut u8,
+    destination_start: u64,
+    count: u64,
+    element_size: u64,
+) {
+    if count == 0 || element_size == 0 {
+        return;
+    }
+    if count > 18446744073709551615 / element_size {
+        @panic("out of memory");
+    }
+    if source_start > 18446744073709551615 / element_size
+        || destination_start > 18446744073709551615 / element_size {
+        @panic("index out of bounds");
+    }
+    let source_offset = source_start * element_size;
+    let destination_offset = destination_start * element_size;
+    let bytes = count * element_size;
+    let source_address = checked { @ptr_to_int(source) };
+    let destination_address = checked { @ptr_to_int(destination) };
+    if source_address == 0 || destination_address == 0 {
+        @panic("index out of bounds");
+    }
+    if source_address > 18446744073709551615 - source_offset
+        || destination_address > 18446744073709551615 - destination_offset {
+        @panic("index out of bounds");
+    }
+    let source_begin = source_address + source_offset;
+    let destination_begin = destination_address + destination_offset;
+    if source_begin > 18446744073709551615 - bytes
+        || destination_begin > 18446744073709551615 - bytes {
+        @panic("index out of bounds");
+    }
+    let source_end = source_begin + bytes;
+    let destination_end = destination_begin + bytes;
+    if source_begin < destination_end && destination_begin < source_end {
+        @panic("overlapping byte ranges");
+    }
+    checked {
+        let source_ptr: ptr mut u8 = @int_to_ptr(source_begin);
+        let destination_ptr: ptr mut u8 = @int_to_ptr(destination_begin);
+        @byte_copy(destination_ptr, source_ptr, bytes);
+    };
+}
+
 pub fn RawBuf(comptime T: type) -> type {
     struct {
         buf: ptr mut T,
@@ -131,4 +184,75 @@ pub fn RawBuf(comptime T: type) -> type {
             self.release();
         }
     }
+}
+
+// Copy a checked range between RawBuf allocations. This is module-private
+// rather than an associated method: RawBuf is a public type, and associated
+// methods would become callable through a user's `value.core` projection.
+// `source_bound` is supplied only by the owning container's logical length;
+// the destination bound is always the destination RawBuf's actual capacity.
+// The ranges must not overlap. A zero count is validated, then returns before
+// either pointer is inspected.
+fn copy_rawbuf_range(
+    comptime T: type,
+    inout destination: RawBuf(T),
+    borrow source: RawBuf(T),
+    source_start: u64,
+    source_bound: u64,
+    destination_start: u64,
+    count: u64,
+) {
+    @require_trivially_droppable(T);
+    if source_start > source_bound || count > source_bound - source_start {
+        @panic("index out of bounds");
+    }
+    if destination_start > destination.cap || count > destination.cap - destination_start {
+        @panic("index out of bounds");
+    }
+    let element_size: u64 = @intCast(@size_of(T));
+    if count == 0 || element_size == 0 {
+        return;
+    }
+    let source_ptr: ptr mut u8 = checked { @int_to_ptr(@ptr_to_int(source.buf)) };
+    let destination_ptr: ptr mut u8 = checked { @int_to_ptr(@ptr_to_int(destination.buf)) };
+    copy_nonoverlapping_bytes(
+        source_ptr,
+        source_start,
+        destination_ptr,
+        destination_start,
+        count,
+        element_size,
+    );
+}
+
+// Same-owner form used by StrBuf.duplicate. Its logical source bound is still
+// explicit because RawBuf owns spare capacity but has no initialized length.
+fn copy_rawbuf_range_within(
+    comptime T: type,
+    inout buffer: RawBuf(T),
+    source_start: u64,
+    source_bound: u64,
+    destination_start: u64,
+    count: u64,
+) {
+    @require_trivially_droppable(T);
+    if source_start > source_bound || count > source_bound - source_start {
+        @panic("index out of bounds");
+    }
+    if destination_start > buffer.cap || count > buffer.cap - destination_start {
+        @panic("index out of bounds");
+    }
+    let element_size: u64 = @intCast(@size_of(T));
+    if count == 0 || element_size == 0 {
+        return;
+    }
+    let base_ptr: ptr mut u8 = checked { @int_to_ptr(@ptr_to_int(buffer.buf)) };
+    copy_nonoverlapping_bytes(
+        base_ptr,
+        source_start,
+        base_ptr,
+        destination_start,
+        count,
+        element_size,
+    );
 }

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -10,9 +10,10 @@
 // growable containers own their heap through one primitive. StrBuf adds the
 // length and the byte-string algorithms on top. The packed bytes are still
 // read/written one at a time through `@ptr_read`/`@ptr_write` over a
-// `@ptr_offset` walk of the `ptr u8`, and in bulk through `@byte_copy`; only
-// the raw `{buf, cap}` ownership (allocate / grow / free / teardown) is
-// delegated to the core.
+// `@ptr_offset` walk of the `ptr u8`; bounded bulk copies are delegated to
+// `RawBuf`, which is the only owner of the byte-copy intrinsic. The raw
+// `{buf, cap}` ownership (allocate / grow / free / teardown) is delegated to
+// the same core.
 //
 // Interoperability with core `str` and `ArrayBuf(u8)` is explicit and copying:
 // `from_str`, `from_bytes`, and `to_bytes` create independent owners, while
@@ -32,27 +33,6 @@ fn read_packed_byte(source: ptr mut u8, index: u64) -> u8 {
 
 fn write_packed_byte(destination: ptr mut u8, index: u64, byte: u8) {
     checked { @ptr_write(@ptr_offset(destination, index), byte); };
-}
-
-fn copy_packed_bytes(
-    source: ptr mut u8,
-    source_start: u64,
-    destination: ptr mut u8,
-    destination_start: u64,
-    count: u64,
-) {
-    // A memcpy-shaped bulk copy (ADR-0058). Every StrBuf caller copies between
-    // two distinct allocations (a fresh block during grow/duplicate, a foreign
-    // buffer during append/concat), so the source and destination ranges never
-    // overlap — the non-overlapping `@byte_copy` contract holds. `@ptr_offset`
-    // cannot form the sub-range pointers because it strides by the typed-pointer
-    // slot size, so the byte offsets are folded into the addresses directly.
-    checked {
-        let source_ptr: ptr mut u8 = @int_to_ptr(@ptr_to_int(source) + source_start);
-        let destination_ptr: ptr mut u8 =
-            @int_to_ptr(@ptr_to_int(destination) + destination_start);
-        @byte_copy(destination_ptr, source_ptr, count);
-    };
 }
 
 pub struct StrBuf {
@@ -98,11 +78,7 @@ pub struct StrBuf {
             @panic("index out of bounds");
         }
         let mut out = Self.allocate(count);
-        let mut i: u64 = 0;
-        while i < count {
-            write_packed_byte(out.core.buf, i, source.get_or(start + i, 0));
-            i += 1;
-        }
+        arraybuf.copy_arraybuf_range(u8, borrow source, inout out.core, start, 0, count);
         out.len = count;
         out
     }
@@ -180,9 +156,24 @@ pub struct StrBuf {
             if checked { @ptr_to_int(replacement) } == 0 {
                 @panic("out of memory");
             }
-            copy_packed_bytes(self.core.buf, 0, replacement, 0, self.len);
-            self.core.buf = replacement;
-            self.core.cap = new_cap;
+            let R = rawbuf.RawBuf(u8);
+            let mut replacement_core = R.new();
+            replacement_core.buf = replacement;
+            replacement_core.cap = new_cap;
+            rawbuf.copy_rawbuf_range(
+                u8,
+                inout replacement_core,
+                borrow self.core,
+                0,
+                self.len,
+                0,
+                self.len,
+            );
+            self.core.buf = replacement_core.buf;
+            self.core.cap = replacement_core.cap;
+            let zero: u64 = 0;
+            replacement_core.buf = checked { @int_to_ptr(zero) };
+            replacement_core.cap = 0;
         } else {
             self.core.grow_to(new_cap);
         }
@@ -212,7 +203,15 @@ pub struct StrBuf {
         if source_len == 0 {
             return;
         }
-        copy_packed_bytes(other.core.buf, 0, self.core.buf, destination_start, source_len);
+        rawbuf.copy_rawbuf_range(
+            u8,
+            inout self.core,
+            borrow other.core,
+            0,
+            source_len,
+            destination_start,
+            source_len,
+        );
         self.len = destination_start + source_len;
     }
 
@@ -248,11 +247,14 @@ pub struct StrBuf {
         }
         self.grow(count);
         let destination_start = self.len;
-        let mut i: u64 = 0;
-        while i < count {
-            write_packed_byte(self.core.buf, destination_start + i, source.get_or(start + i, 0));
-            i += 1;
-        }
+        arraybuf.copy_arraybuf_range(
+            u8,
+            borrow source,
+            inout self.core,
+            start,
+            destination_start,
+            count,
+        );
         self.len = destination_start + count;
     }
 
@@ -266,7 +268,15 @@ pub struct StrBuf {
         if source_len == 0 {
             return;
         }
-        copy_packed_bytes(other.core.buf, 0, target.core.buf, destination_start, source_len);
+        rawbuf.copy_rawbuf_range(
+            u8,
+            inout target.core,
+            borrow other.core,
+            0,
+            source_len,
+            destination_start,
+            source_len,
+        );
         target.len = destination_start + source_len;
     }
 
@@ -276,7 +286,7 @@ pub struct StrBuf {
     fn duplicate(inout self) {
         let old_len = self.len;
         self.grow(old_len);
-        copy_packed_bytes(self.core.buf, 0, self.core.buf, old_len, old_len);
+        rawbuf.copy_rawbuf_range_within(u8, inout self.core, 0, old_len, old_len, old_len);
         self.len = old_len + old_len;
     }
 
@@ -291,7 +301,15 @@ pub struct StrBuf {
     // Clone always allocates, including for an empty or literal-backed value.
     fn copy(borrow self) -> Self {
         let mut result = Self.allocate(Self.initial_capacity(self.len));
-        copy_packed_bytes(self.core.buf, 0, result.core.buf, 0, self.len);
+        rawbuf.copy_rawbuf_range(
+            u8,
+            inout result.core,
+            borrow self.core,
+            0,
+            self.len,
+            0,
+            self.len,
+        );
         result.len = self.len;
         result
     }
@@ -301,11 +319,16 @@ pub struct StrBuf {
     fn to_bytes(borrow self) -> arraybuf.ArrayBuf(u8) {
         let Bytes = arraybuf.ArrayBuf(u8);
         let mut out = Bytes.with_capacity(self.len);
-        let mut i: u64 = 0;
-        while i < self.len {
-            out.push(read_packed_byte(self.core.buf, i));
-            i += 1;
-        }
+        rawbuf.copy_rawbuf_range(
+            u8,
+            inout out.core,
+            borrow self.core,
+            0,
+            self.len,
+            0,
+            self.len,
+        );
+        out.len = self.len;
         out
     }
 
@@ -456,7 +479,15 @@ pub struct StrBuf {
             return Self.new();
         }
         let mut result = Self.allocate(count);
-        copy_packed_bytes(self.core.buf, start, result.core.buf, 0, count);
+        rawbuf.copy_rawbuf_range(
+            u8,
+            inout result.core,
+            borrow self.core,
+            start,
+            self.len,
+            0,
+            count,
+        );
         result.len = count;
         result
     }
@@ -489,8 +520,24 @@ pub struct StrBuf {
             return Self.new();
         }
         let mut result = Self.allocate(total);
-        copy_packed_bytes(first.core.buf, 0, result.core.buf, 0, first.len);
-        copy_packed_bytes(second.core.buf, 0, result.core.buf, first.len, second.len);
+        rawbuf.copy_rawbuf_range(
+            u8,
+            inout result.core,
+            borrow first.core,
+            0,
+            first.len,
+            0,
+            first.len,
+        );
+        rawbuf.copy_rawbuf_range(
+            u8,
+            inout result.core,
+            borrow second.core,
+            0,
+            second.len,
+            first.len,
+            second.len,
+        );
         result.len = total;
         result
     }

--- a/std/strings.rue
+++ b/std/strings.rue
@@ -228,14 +228,7 @@ pub fn trim_start(s: StrBuf) -> StrBuf {
             scanning = false;
         }
     }
-    let mut out = StrBuf.new();
-    let mut i = start;
-    while i < n {
-        let c = bounded_byte_at(borrow s, i);
-        out.push(c);
-        i += 1;
-    }
-    out
+    s.byte_range(start, n - start)
 }
 
 // Copy of `s` with trailing ASCII whitespace removed.
@@ -251,14 +244,7 @@ pub fn trim_end(s: StrBuf) -> StrBuf {
             scanning = false;
         }
     }
-    let mut out = StrBuf.new();
-    let mut i: u64 = 0;
-    while i < end {
-        let c = bounded_byte_at(borrow s, i);
-        out.push(c);
-        i += 1;
-    }
-    out
+    s.byte_range(0, end)
 }
 
 // Copy of `s` with both leading and trailing ASCII whitespace removed.
@@ -284,14 +270,7 @@ pub fn trim(s: StrBuf) -> StrBuf {
             ec = false;
         }
     }
-    let mut out = StrBuf.new();
-    let mut i = start;
-    while i < end {
-        let c = bounded_byte_at(borrow s, i);
-        out.push(c);
-        i += 1;
-    }
-    out
+    s.byte_range(start, end - start)
 }
 
 // `s` concatenated `n` times (empty string when `n == 0`).


### PR DESCRIPTION
Summary:
- centralize bounded non-overlapping byte copies under the RawBuf container authority
- route StrBuf/ArrayBuf bridges and trim results through bulk range copies
- pin bounds, privacy, ownership, empty-range, alias, capacity, source-shape, and scaling behavior with regressions

Validation:
- scripts/rue cli std_byte_bridges
- scripts/rue cli std_strbuf
- scripts/rue cli std_m3
- scripts/rue spec 3.7
- scripts/rue spec 3.10
- scripts/rue quick
- scripts/rue premerge
- scripts/rue fmt
- tutorial-snippet-tests (isolated)

The broad local run completed its ordinary unit/compiler/scaling/fuzz coverage, but the host was already above its soft process limit and macOS refused oracle corpus worker creation with Resource temporarily unavailable. CI remains the clean corpus and cross-platform authority.

Fixes RUE-1714