### PR TITLE
RUE-1339: add canonical 32-bit zero-extension moves

### DIFF
--- a/crates/rue-cli-tests/cases/std_net_tcp.toml
+++ b/crates/rue-cli-tests/cases/std_net_tcp.toml
@@ -403,10 +403,11 @@ stdout = "1\n"
 # Darwin's orderly FIN semantics may allow sends after a peer EOF. Shut down
 # the peer's receive direction, close it, and shut down the client's send
 # direction before making bounded sends until Darwin reports EPIPE/ECONNRESET;
-# MSG_NOSIGNAL proves that error is returned safely.
+# MSG_NOSIGNAL proves that error is returned safely. Once the peer is already
+# gone, Darwin may report ENOTCONN or ECONNRESET from the shutdown itself.
 [[case]]
 name = "tcp_macos_write_after_peer_read_shutdown"
-description = "Darwin reports a bounded post-peer-close write as ConnectionReset without SIGPIPE."
+description = "Darwin reports a bounded post-peer-close write as ConnectionReset without SIGPIPE, allowing NotConnected or ConnectionReset from the prior shutdown."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
 only_on = ["aarch64-macos"]
@@ -461,10 +462,18 @@ fn main() -> i32 {
     }
 
     // Closing the local send direction makes the EPIPE result deterministic
-    // after the peer has gone away, while still exercising MSG_NOSIGNAL.
+    // after the peer has gone away, while still exercising MSG_NOSIGNAL. On
+    // Darwin, shutdown may instead report ENOTCONN/ECONNRESET once the peer is
+    // already gone; either is an expected peer-gone outcome.
     match client.shutdown(std.net.Shutdown.Write) {
         RUnit.Ok(u) => {},
-        RUnit.Err(e) => { return fail(108); },
+        RUnit.Err(e) => {
+            match e {
+                std.net.NetworkError.NotConnected => {},
+                std.net.NetworkError.ConnectionReset => {},
+                _ => { return fail(108); },
+            }
+        },
     }
 
     let mut attempts: u64 = 0;

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1036,14 +1036,7 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(Aarch64Inst::Uxth { dst, src })
             }
             ScalarAbiExtension::Unsigned { from_bits: 32 } => {
-                // AAPCS64 has no single `uxtw` instruction; a 64-bit left/right
-                // logical-shift pair zero-extends the low 32 bits.
-                self.mir.push(Aarch64Inst::LslImm { dst, src, imm: 32 });
-                self.mir.push(Aarch64Inst::Lsr64Imm {
-                    dst,
-                    src: dst,
-                    imm: 32,
-                });
+                self.mir.push(Aarch64Inst::Uxtw { dst, src });
             }
             ScalarAbiExtension::Signed { from_bits }
             | ScalarAbiExtension::Unsigned { from_bits } => {
@@ -1820,18 +1813,10 @@ impl<'a> CfgLower<'a> {
                         dst: operand,
                         src: operand,
                     }),
-                    // The 64-bit shift pair clears bits 32..63 without needing a
-                    // `uxtw`-shaped instruction in this instruction set.
                     BitCastForm::Zero32 => {
-                        self.mir.push(Aarch64Inst::LslImm {
+                        self.mir.push(Aarch64Inst::Uxtw {
                             dst: operand,
                             src: operand,
-                            imm: 32,
-                        });
-                        self.mir.push(Aarch64Inst::Lsr64Imm {
-                            dst: operand,
-                            src: operand,
-                            imm: 32,
                         });
                     }
                 }
@@ -3832,6 +3817,31 @@ mod tests {
     };
     use rue_cfg::{CfgArgMode, CfgCallArg, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_span::{FileId, Span};
+
+    #[test]
+    fn zero32_consumers_use_canonical_uxtw_not_shift_pair() {
+        let source = include_str!("cfg_lower.rs");
+        let foreign = source
+            .split("ScalarAbiExtension::Unsigned { from_bits: 32 } => {")
+            .nth(1)
+            .expect("foreign u32 return extension must remain present")
+            .split("ScalarAbiExtension::Signed { from_bits }")
+            .next()
+            .expect("foreign extension match arm must have a following arm");
+        assert!(foreign.contains("Aarch64Inst::Uxtw"));
+        assert!(!foreign.contains("Aarch64Inst::LslImm"));
+        assert!(!foreign.contains("Aarch64Inst::Lsr64Imm"));
+        let bitcast = source
+            .split("BitCastForm::Zero32 => {")
+            .nth(1)
+            .expect("BitCastForm::Zero32 consumer must remain present")
+            .split("\n                    }\n                }")
+            .next()
+            .expect("BitCastForm::Zero32 arm must be bounded");
+        assert!(bitcast.contains("Aarch64Inst::Uxtw"));
+        assert!(!bitcast.contains("Aarch64Inst::LslImm"));
+        assert!(!bitcast.contains("Aarch64Inst::Lsr64Imm"));
+    }
 
     #[test]
     fn marshal_tag_cmp_imm_covers_aarch64_boundaries() {

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -1388,6 +1388,14 @@ impl<'a> Emitter<'a> {
                 end_inst!(self, "sxtw {}, {}", rd, rn.as_w());
             }
 
+            Aarch64Inst::Uxtw { dst, src } => {
+                let rd = dst.as_physical();
+                let rn = src.as_physical();
+                self.begin_inst();
+                self.emit_ubfm(rd, rn, 0, 31);
+                end_inst!(self, "uxtw {}, {}", rd, rn.as_w());
+            }
+
             Aarch64Inst::Uxtb { dst, src } => {
                 let rd = dst.as_physical();
                 let rn = src.as_physical();
@@ -3502,6 +3510,19 @@ mod tests {
         // SBFM 64-bit: sf=1, opc=00, N=1 -> 0x93400000
         assert_eq!(inst & 0xFFC00000, 0x93400000, "Should be SBFM 64-bit");
         // imms should be 31
+        assert_eq!((inst >> 10) & 0x3F, 31, "imms should be 31");
+    }
+
+    #[test]
+    fn test_uxtw() {
+        let code = emit_single(Aarch64Inst::Uxtw {
+            dst: Operand::Physical(Reg::X0),
+            src: Operand::Physical(Reg::X1),
+        });
+        // uxtw x0, w1 -> ubfm x0, x1, #0, #31
+        let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
+        assert_eq!(inst, 0xD3407C20, "uxtw x0, w1 exact encoding");
+        assert_eq!(inst & 0xFFC00000, 0xD3400000, "Should be UBFM 64-bit");
         assert_eq!((inst >> 10) & 0x3F, 31, "imms should be 31");
     }
 

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -229,6 +229,7 @@ fn uses(inst: &Aarch64Inst) -> VRegList {
         Aarch64Inst::Sxtb { src, .. }
         | Aarch64Inst::Sxth { src, .. }
         | Aarch64Inst::Sxtw { src, .. }
+        | Aarch64Inst::Uxtw { src, .. }
         | Aarch64Inst::Uxtb { src, .. }
         | Aarch64Inst::Uxth { src, .. } => {
             add_if_virtual(src, &mut result);
@@ -359,6 +360,7 @@ pub(crate) fn defs(inst: &Aarch64Inst) -> VRegList {
         Aarch64Inst::Sxtb { dst, .. }
         | Aarch64Inst::Sxth { dst, .. }
         | Aarch64Inst::Sxtw { dst, .. }
+        | Aarch64Inst::Uxtw { dst, .. }
         | Aarch64Inst::Uxtb { dst, .. }
         | Aarch64Inst::Uxth { dst, .. } => {
             add_if_virtual(dst, &mut result);

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -418,6 +418,16 @@ impl fmt::Display for Operand {
     }
 }
 
+/// Display an operand in the 32-bit W-register view used by `Uxtw`.
+/// Virtual registers have no physical width name; the `uxtw` mnemonic keeps
+/// the normalization width explicit until register allocation assigns one.
+fn fmt_operand_w(operand: &Operand, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match operand {
+        Operand::Virtual(vreg) => write!(f, "{}", vreg),
+        Operand::Physical(reg) => write!(f, "{}", reg.as_w()),
+    }
+}
+
 impl From<VReg> for Operand {
     fn from(vreg: VReg) -> Self {
         Operand::Virtual(vreg)
@@ -885,13 +895,17 @@ pub enum Aarch64Inst {
     /// `sxtw dst, src` - Sign-extend word to 64-bit.
     Sxtw { dst: Operand, src: Operand },
 
+    /// `uxtw dst, src` - Zero-extend word to 64-bit.
+    ///
+    /// This is the canonical UBFM alias for normalizing a 32-bit register
+    /// value into the 64-bit scalar representation.
+    Uxtw { dst: Operand, src: Operand },
+
     /// `uxtb dst, src` - Zero-extend byte to 64-bit.
     Uxtb { dst: Operand, src: Operand },
 
     /// `uxth dst, src` - Zero-extend halfword to 64-bit.
     Uxth { dst: Operand, src: Operand },
-
-    // Note: UXTW is implicit in W-register operations; no separate instruction needed.
 
     // === Control flow ===
     /// `b label` - Unconditional branch.
@@ -1297,6 +1311,10 @@ impl fmt::Display for Aarch64Inst {
             Aarch64Inst::Sxtb { dst, src } => write!(f, "sxtb {}, {}", dst, src),
             Aarch64Inst::Sxth { dst, src } => write!(f, "sxth {}, {}", dst, src),
             Aarch64Inst::Sxtw { dst, src } => write!(f, "sxtw {}, {}", dst, src),
+            Aarch64Inst::Uxtw { dst, src } => {
+                write!(f, "uxtw {}, ", dst)?;
+                fmt_operand_w(src, f)
+            }
             Aarch64Inst::Uxtb { dst, src } => write!(f, "uxtb {}, {}", dst, src),
             Aarch64Inst::Uxth { dst, src } => write!(f, "uxth {}, {}", dst, src),
             Aarch64Inst::B { label } => write!(f, "b {}", label),
@@ -1625,6 +1643,21 @@ mod tests {
             src2: Operand::Physical(Reg::X1),
         };
         assert_eq!(format!("{}", inst), "add x2, x0, x1");
+    }
+
+    #[test]
+    fn test_uxtw_display_uses_w_source() {
+        let inst = Aarch64Inst::Uxtw {
+            dst: Operand::Physical(Reg::X0),
+            src: Operand::Physical(Reg::X1),
+        };
+        assert_eq!(format!("{}", inst), "uxtw x0, w1");
+
+        let inst = Aarch64Inst::Uxtw {
+            dst: Operand::Virtual(VReg::new(2)),
+            src: Operand::Virtual(VReg::new(3)),
+        };
+        assert_eq!(format!("{}", inst), "uxtw v2, v3");
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -695,6 +695,13 @@ impl RegAlloc {
                 })?;
             }
 
+            Aarch64Inst::Uxtw { dst, src } => {
+                Self::emit_binop(context, mir, dst, src, |d, s| Aarch64Inst::Uxtw {
+                    dst: d,
+                    src: s,
+                })?;
+            }
+
             Aarch64Inst::Uxtb { dst, src } => {
                 Self::emit_binop(context, mir, dst, src, |d, s| Aarch64Inst::Uxtb {
                     dst: d,
@@ -1411,7 +1418,7 @@ mod tests {
     use super::liveness;
     use super::{
         ALLOCATABLE_REGS, Aarch64Inst, Aarch64Mir, CALLEE_SAVED_REGS, CALLER_SAVED_REGS, Operand,
-        Reg, RegAlloc, VReg,
+        Reg, RegAlloc, SCRATCH_SOURCE_A, SCRATCH_VALUE, VReg,
     };
     use crate::reg_class::RegClass;
     use crate::regalloc::{Allocation, RegAllocBackend, RematerializeOp};
@@ -2488,6 +2495,169 @@ mod tests {
                 if dst.is_physical() && src1.is_physical() && src2.is_physical())
         });
         assert!(has_add, "AddRR should be rewritten with physical registers");
+    }
+
+    #[test]
+    fn test_uxtw_spilled_source_reloads_before_move() {
+        let mut mir = Aarch64Mir::new();
+        let count = ALLOCATABLE_REGS.len() + 2;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
+        define_loaded_values(&mut mir, &vregs);
+        mir.push(Aarch64Inst::Uxtw {
+            dst: Operand::Virtual(vregs[0]),
+            src: Operand::Virtual(vregs[count - 1]),
+        });
+        for &vreg in &vregs[1..] {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+        assert_eq!(num_spills, 2);
+        let index = mir
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, Aarch64Inst::Uxtw { .. }))
+            .expect("rewritten Uxtw should be present");
+        assert!(matches!(
+            mir.instructions().get(index.checked_sub(1).unwrap()),
+            Some(Aarch64Inst::Ldr {
+                dst: Operand::Physical(dst),
+                base: Reg::Fp,
+                ..
+            }) if *dst == SCRATCH_SOURCE_A
+        ));
+        assert!(matches!(
+            mir.instructions().get(index),
+            Some(Aarch64Inst::Uxtw {
+                dst: Operand::Physical(dst),
+                src: Operand::Physical(src),
+            }) if *src == SCRATCH_SOURCE_A && *dst != *src
+        ));
+        assert!(!matches!(
+            mir.instructions().get(index + 1),
+            Some(Aarch64Inst::Str { .. })
+        ));
+    }
+
+    #[test]
+    fn test_uxtw_spilled_destination_stores_after_move() {
+        let mut mir = Aarch64Mir::new();
+        let count = ALLOCATABLE_REGS.len() + 2;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
+        define_loaded_values(&mut mir, &vregs);
+        mir.push(Aarch64Inst::Uxtw {
+            dst: Operand::Virtual(vregs[count - 1]),
+            src: Operand::Virtual(vregs[count - 2]),
+        });
+        for &vreg in &vregs[1..] {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+        assert_eq!(num_spills, 1);
+        let index = mir
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, Aarch64Inst::Uxtw { .. }))
+            .expect("rewritten Uxtw should be present");
+        assert!(matches!(
+            mir.instructions().get(index),
+            Some(Aarch64Inst::Uxtw {
+                dst: Operand::Physical(dst),
+                src: Operand::Physical(src),
+            }) if *dst == SCRATCH_VALUE && *src != *dst
+        ));
+        assert!(matches!(
+            mir.instructions().get(index + 1),
+            Some(Aarch64Inst::Str {
+                base: Reg::Fp,
+                src: Operand::Physical(src),
+                ..
+            }) if *src == SCRATCH_VALUE
+        ));
+    }
+
+    #[test]
+    fn test_uxtw_both_spilled_reloads_then_stores() {
+        let mut mir = Aarch64Mir::new();
+        let count = ALLOCATABLE_REGS.len() + 3;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
+        define_loaded_values(&mut mir, &vregs);
+        mir.push(Aarch64Inst::Uxtw {
+            dst: Operand::Virtual(vregs[count - 1]),
+            src: Operand::Virtual(vregs[count - 2]),
+        });
+        for &vreg in &vregs[1..] {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+        assert_eq!(num_spills, 2);
+        let index = mir
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, Aarch64Inst::Uxtw { .. }))
+            .expect("rewritten Uxtw should be present");
+        assert!(matches!(
+            mir.instructions().get(index.checked_sub(1).unwrap()),
+            Some(Aarch64Inst::Ldr {
+                dst: Operand::Physical(dst),
+                base: Reg::Fp,
+                ..
+            }) if *dst == SCRATCH_SOURCE_A
+        ));
+        assert!(matches!(
+            mir.instructions().get(index),
+            Some(Aarch64Inst::Uxtw {
+                dst: Operand::Physical(dst),
+                src: Operand::Physical(src),
+            }) if *dst == SCRATCH_VALUE && *src == SCRATCH_SOURCE_A
+        ));
+        assert!(matches!(
+            mir.instructions().get(index + 1),
+            Some(Aarch64Inst::Str {
+                base: Reg::Fp,
+                src: Operand::Physical(src),
+                ..
+            }) if *src == SCRATCH_VALUE
+        ));
+    }
+
+    #[test]
+    fn test_uxtw_preserves_src_dst_identity() {
+        let mut mir = Aarch64Mir::new();
+        let vreg = mir.alloc_vreg();
+        mir.push(Aarch64Inst::Ldr {
+            dst: Operand::Virtual(vreg),
+            base: Reg::X1,
+            offset: 0,
+        });
+        mir.push(Aarch64Inst::Uxtw {
+            dst: Operand::Virtual(vreg),
+            src: Operand::Virtual(vreg),
+        });
+        mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Physical(Reg::X0),
+            src: Operand::Virtual(vreg),
+        });
+        let mir = RegAlloc::new(mir, 0).allocate().unwrap();
+        let inst = mir
+            .instructions()
+            .iter()
+            .find_map(|inst| match inst {
+                Aarch64Inst::Uxtw { dst, src } => Some((dst, src)),
+                _ => None,
+            })
+            .expect("identity Uxtw should be preserved");
+        assert!(
+            matches!((inst.0, inst.1), (Operand::Physical(dst), Operand::Physical(src)) if dst == src)
+        );
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -167,6 +167,7 @@ fn get_latency(inst: &Aarch64Inst) -> u32 {
         Aarch64Inst::Sxtb { .. }
         | Aarch64Inst::Sxth { .. }
         | Aarch64Inst::Sxtw { .. }
+        | Aarch64Inst::Uxtw { .. }
         | Aarch64Inst::Uxtb { .. }
         | Aarch64Inst::Uxth { .. } => 1,
 
@@ -317,6 +318,7 @@ pub(super) fn regs_read(inst: &Aarch64Inst) -> RegList<Reg> {
         | Aarch64Inst::Sxtb { src, .. }
         | Aarch64Inst::Sxth { src, .. }
         | Aarch64Inst::Sxtw { src, .. }
+        | Aarch64Inst::Uxtw { src, .. }
         | Aarch64Inst::Uxtb { src, .. }
         | Aarch64Inst::Uxth { src, .. } => {
             add_if_phys(src, &mut result);
@@ -430,6 +432,7 @@ pub(super) fn regs_written(inst: &Aarch64Inst) -> RegList<Reg> {
         | Aarch64Inst::Sxtb { dst, .. }
         | Aarch64Inst::Sxth { dst, .. }
         | Aarch64Inst::Sxtw { dst, .. }
+        | Aarch64Inst::Uxtw { dst, .. }
         | Aarch64Inst::Uxtb { dst, .. }
         | Aarch64Inst::Uxth { dst, .. }
         | Aarch64Inst::LdrIndexed { dst, .. }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -3166,6 +3166,72 @@ mod tests {
     }
 
     #[test]
+    fn both_target_adapters_lower_production_zero32_to_one_canonical_instruction() {
+        let pool = TypeInternPool::new().freeze();
+        let interner = ThreadedRodeo::new();
+        let bit_cast = interner.get_or_intern("bitCast");
+        let mut cfg = Cfg::new(Type::U32, 0, 0, "zero32_cross_target".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let input = cfg.append_inst(entry, inst(CfgInstData::Const(0xFFFF_FFFF), Type::U32));
+        let result = cfg
+            .append_intrinsic(entry, None, bit_cast, [input], Type::U32, Span::new(0, 0))
+            .expect("synthetic bitCast should append");
+        cfg.set_return(entry, Some(result));
+
+        let x86 = X86CfgLower::new_unchecked(&cfg, &pool, &interner)
+            .lower()
+            .expect("x86 production Zero32 fixture should lower");
+        let x86_zero32 = x86
+            .instructions()
+            .iter()
+            .find_map(|inst| match inst {
+                X86Inst::Movzx32To64 { dst, src } => Some((dst, src)),
+                _ => None,
+            })
+            .expect("x86 production Zero32 consumer should lower canonically");
+        assert_eq!(x86_zero32.0, x86_zero32.1);
+        assert_eq!(
+            x86.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, X86Inst::Movzx32To64 { .. }))
+                .count(),
+            1
+        );
+        assert!(
+            !x86.instructions()
+                .iter()
+                .any(|inst| { matches!(inst, X86Inst::ShlRI { .. } | X86Inst::ShrRI { .. }) })
+        );
+
+        let arm = Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux)
+            .lower()
+            .expect("AArch64 production Zero32 fixture should lower");
+        let arm_zero32 = arm
+            .instructions()
+            .iter()
+            .find_map(|inst| match inst {
+                Aarch64Inst::Uxtw { dst, src } => Some((dst, src)),
+                _ => None,
+            })
+            .expect("AArch64 production Zero32 consumer should lower canonically");
+        assert_eq!(arm_zero32.0, arm_zero32.1);
+        assert_eq!(
+            arm.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, Aarch64Inst::Uxtw { .. }))
+                .count(),
+            1
+        );
+        assert!(!arm.instructions().iter().any(|inst| {
+            matches!(
+                inst,
+                Aarch64Inst::LslImm { .. } | Aarch64Inst::Lsr64Imm { .. }
+            )
+        }));
+    }
+
+    #[test]
     fn zero_slot_aggregate_parameter_emits_no_frame_load_on_either_target() {
         let pool = TypeInternPool::new();
         let array_id = pool.intern_array_from_type(Type::UNIT, 2);

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1238,11 +1238,7 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(X86Inst::Movzx16To64 { dst, src })
             }
             ScalarAbiExtension::Unsigned { from_bits: 32 } => {
-                // x86-64 has no `movzxd`; a 64-bit `shl`/`shr` pair zero-extends
-                // the low 32 bits (the low half survives, the high half is
-                // cleared by the logical right shift).
-                self.mir.push(X86Inst::ShlRI { dst, imm: 32 });
-                self.mir.push(X86Inst::ShrRI { dst, imm: 32 });
+                self.mir.push(X86Inst::Movzx32To64 { dst, src });
             }
             ScalarAbiExtension::Signed { from_bits }
             | ScalarAbiExtension::Unsigned { from_bits } => {
@@ -2074,17 +2070,10 @@ impl<'a> CfgLower<'a> {
                         dst: operand,
                         src: operand,
                     }),
-                    // x86-64 has no register-to-register 32-bit zero extension
-                    // in this instruction set, so clear bits 32..63 with the
-                    // 64-bit shift pair.
                     BitCastForm::Zero32 => {
-                        self.mir.push(X86Inst::ShlRI {
+                        self.mir.push(X86Inst::Movzx32To64 {
                             dst: operand,
-                            imm: 32,
-                        });
-                        self.mir.push(X86Inst::ShrRI {
-                            dst: operand,
-                            imm: 32,
+                            src: operand,
                         });
                     }
                 }
@@ -3610,6 +3599,31 @@ mod tests {
     };
     use rue_cfg::{CfgArgMode, CfgCallArg, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_span::{FileId, Span};
+
+    #[test]
+    fn zero32_consumers_use_canonical_move_not_shift_pair() {
+        let source = include_str!("cfg_lower.rs");
+        let foreign = source
+            .split("ScalarAbiExtension::Unsigned { from_bits: 32 } => {")
+            .nth(1)
+            .expect("foreign u32 return extension must remain present")
+            .split("ScalarAbiExtension::Signed { from_bits }")
+            .next()
+            .expect("foreign extension match arm must have a following arm");
+        assert!(foreign.contains("X86Inst::Movzx32To64"));
+        assert!(!foreign.contains("X86Inst::ShlRI"));
+        assert!(!foreign.contains("X86Inst::ShrRI"));
+        let bitcast = source
+            .split("BitCastForm::Zero32 => {")
+            .nth(1)
+            .expect("BitCastForm::Zero32 consumer must remain present")
+            .split("\n                    }\n                }")
+            .next()
+            .expect("BitCastForm::Zero32 arm must be bounded");
+        assert!(bitcast.contains("X86Inst::Movzx32To64"));
+        assert!(!bitcast.contains("X86Inst::ShlRI"));
+        assert!(!bitcast.contains("X86Inst::ShrRI"));
+    }
 
     #[test]
     fn marshal_tag_cmp_imm_covers_i32_boundary() {

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -1159,6 +1159,16 @@ impl<'a> Emitter<'a> {
                 self.emit_movsxd(dst.as_physical(), src.as_physical());
                 end_inst!(self, "movsxd {}, {}", dst.as_physical(), src.as_physical());
             }
+            X86Inst::Movzx32To64 { dst, src } => {
+                self.begin_inst();
+                self.emit_movzx32_to64(dst.as_physical(), src.as_physical());
+                end_inst!(
+                    self,
+                    "mov {}, {}",
+                    dst.as_physical().name32(),
+                    src.as_physical().name32()
+                );
+            }
             X86Inst::Movzx8To64 { dst, src } => {
                 self.begin_inst();
                 self.emit_movzx8_to64(dst.as_physical(), src.as_physical());
@@ -2891,6 +2901,25 @@ impl<'a> Emitter<'a> {
         self.code.push(modrm);
     }
 
+    /// Emit a 32-bit register move whose architectural zero-extension clears
+    /// the destination's upper half in 64-bit mode.
+    fn emit_movzx32_to64(&mut self, dst: Reg, src: Reg) {
+        let dst_enc = dst.encoding();
+        let src_enc = src.encoding();
+
+        // No REX.W: this is the 32-bit MOV r/m32, r32 form. REX.R/B extend
+        // the register fields for r8d-r15d while retaining 32-bit width.
+        if dst.needs_rex() || src.needs_rex() {
+            let rex = 0x40
+                | if src.needs_rex() { 0x04 } else { 0x00 }
+                | if dst.needs_rex() { 0x01 } else { 0x00 };
+            self.code.push(rex);
+        }
+        self.code.push(0x89);
+        let modrm = 0xC0 | ((src_enc & 7) << 3) | (dst_enc & 7);
+        self.code.push(modrm);
+    }
+
     /// Emit `movzx r64, r8` - Zero-extend 8-bit to 64-bit.
     ///
     /// Encoding: REX.W 0F B6 /r (movzx r64, r/m8)
@@ -4087,6 +4116,46 @@ mod tests {
         });
         // movsxd rax, ecx -> 48 63 C1 (REX.W 63 /r)
         assert_eq!(code, vec![0x48, 0x63, 0xC1]);
+    }
+
+    #[test]
+    fn test_movzx32_to64() {
+        let code = emit_single(X86Inst::Movzx32To64 {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Physical(Reg::Rcx),
+        });
+        // mov eax, ecx -> 89 C8 (32-bit write zeroes rax's high half)
+        assert_eq!(code, vec![0x89, 0xC8]);
+    }
+
+    #[test]
+    fn test_movzx32_to64_high_registers() {
+        let code = emit_single(X86Inst::Movzx32To64 {
+            dst: Operand::Physical(Reg::R8),
+            src: Operand::Physical(Reg::R9),
+        });
+        // mov r8d, r9d -> 45 89 C8
+        assert_eq!(code, vec![0x45, 0x89, 0xC8]);
+    }
+
+    #[test]
+    fn test_movzx32_to64_high_destination_rex_b() {
+        let code = emit_single(X86Inst::Movzx32To64 {
+            dst: Operand::Physical(Reg::R8),
+            src: Operand::Physical(Reg::Rcx),
+        });
+        // mov r8d, ecx -> REX.B 89 /r
+        assert_eq!(code, vec![0x41, 0x89, 0xC8]);
+    }
+
+    #[test]
+    fn test_movzx32_to64_high_source_rex_r() {
+        let code = emit_single(X86Inst::Movzx32To64 {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Physical(Reg::R9),
+        });
+        // mov eax, r9d -> REX.R 89 /r
+        assert_eq!(code, vec![0x44, 0x89, 0xC8]);
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -250,6 +250,7 @@ pub fn uses(inst: &X86Inst) -> VRegList {
         | X86Inst::Movsx8To64 { src, .. }
         | X86Inst::Movsx16To64 { src, .. }
         | X86Inst::Movsx32To64 { src, .. }
+        | X86Inst::Movzx32To64 { src, .. }
         | X86Inst::Movzx8To64 { src, .. }
         | X86Inst::Movzx16To64 { src, .. } => {
             add_if_virtual(src, &mut result);
@@ -408,6 +409,7 @@ pub fn defs(inst: &X86Inst) -> VRegList {
         | X86Inst::Movsx8To64 { dst, .. }
         | X86Inst::Movsx16To64 { dst, .. }
         | X86Inst::Movsx32To64 { dst, .. }
+        | X86Inst::Movzx32To64 { dst, .. }
         | X86Inst::Movzx8To64 { dst, .. }
         | X86Inst::Movzx16To64 { dst, .. } => {
             add_if_virtual(dst, &mut result);

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -254,6 +254,16 @@ impl fmt::Display for Operand {
     }
 }
 
+/// Display an operand in the 32-bit register view used by `Movzx32To64`.
+/// Virtual registers have no physical width name, so the `movl` mnemonic on
+/// the instruction remains the width authority before register allocation.
+fn fmt_operand32(operand: &Operand, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match operand {
+        Operand::Virtual(vreg) => write!(f, "{}", vreg),
+        Operand::Physical(reg) => write!(f, "{}", reg.name32()),
+    }
+}
+
 impl From<VReg> for Operand {
     fn from(vreg: VReg) -> Self {
         Operand::Virtual(vreg)
@@ -480,6 +490,13 @@ pub enum X86Inst {
 
     /// `movsxd dst, src` - Sign-extend 32-bit to 64-bit.
     Movsx32To64 { dst: Operand, src: Operand },
+
+    /// `mov dst32, src32` - Zero-extend 32-bit to 64-bit via a 32-bit write.
+    ///
+    /// In 64-bit mode, any write to a 32-bit general-purpose register clears
+    /// the destination's upper half. This is the canonical register-to-register
+    /// u32-to-u64 normalization instruction.
+    Movzx32To64 { dst: Operand, src: Operand },
 
     /// `movzx dst, src` - Zero-extend 8-bit to 64-bit.
     Movzx8To64 { dst: Operand, src: Operand },
@@ -830,6 +847,12 @@ impl fmt::Display for X86Inst {
             X86Inst::Movsx8To64 { dst, src } => write!(f, "movsx {}, byte {}", dst, src),
             X86Inst::Movsx16To64 { dst, src } => write!(f, "movsx {}, word {}", dst, src),
             X86Inst::Movsx32To64 { dst, src } => write!(f, "movsxd {}, {}", dst, src),
+            X86Inst::Movzx32To64 { dst, src } => {
+                write!(f, "movl ")?;
+                fmt_operand32(dst, f)?;
+                write!(f, ", ")?;
+                fmt_operand32(src, f)
+            }
             X86Inst::Movzx8To64 { dst, src } => write!(f, "movzx {}, byte {}", dst, src),
             X86Inst::Movzx16To64 { dst, src } => write!(f, "movzx {}, word {}", dst, src),
             X86Inst::TestRR { src1, src2 } => write!(f, "test {}, {}", src1, src2),
@@ -1257,5 +1280,20 @@ mod tests {
             imm: 42,
         };
         assert_eq!(format!("{}", inst), "mov rdi, 42");
+    }
+
+    #[test]
+    fn test_movzx32_to64_display_uses_32_bit_operands() {
+        let inst = X86Inst::Movzx32To64 {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Physical(Reg::R9),
+        };
+        assert_eq!(format!("{}", inst), "movl eax, r9d");
+
+        let inst = X86Inst::Movzx32To64 {
+            dst: Operand::Virtual(VReg::new(2)),
+            src: Operand::Virtual(VReg::new(3)),
+        };
+        assert_eq!(format!("{}", inst), "movl v2, v3");
     }
 }

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -642,6 +642,22 @@ impl RegAlloc {
                 );
             }
 
+            X86Inst::Movzx32To64 { dst, src } => {
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::Movzx32To64 { dst: dst_op, src: src_op });
+                    },
+                    store |offset| {
+                        mir.push_after(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset,
+                            src: Operand::Physical(SCRATCH_VALUE),
+                        });
+                    },
+                );
+            }
+
             X86Inst::Movzx8To64 { dst, src } => {
                 let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
@@ -1447,7 +1463,7 @@ mod tests {
     use super::liveness;
     use super::{
         ALLOCATABLE_REGS, CALLEE_SAVED_REGS, CALLER_SAVED_REGS, COMPACT_CALLEE_SAVED_REGS, Operand,
-        Reg, RegAlloc, VReg, X86Inst, X86Mir,
+        Reg, RegAlloc, SCRATCH_VALUE, VReg, X86Inst, X86Mir,
     };
     use crate::reg_class::RegClass;
     use crate::regalloc::{Allocation, RegAllocBackend, RematerializeOp};
@@ -2676,6 +2692,169 @@ mod tests {
             .iter()
             .any(|inst| matches!(inst, X86Inst::AddRR { dst, src } if dst.is_physical() && src.is_physical()));
         assert!(has_add, "AddRR should be rewritten with physical registers");
+    }
+
+    #[test]
+    fn test_movzx32_to64_spilled_source_reloads_before_move() {
+        let mut mir = X86Mir::new();
+        let count = ALLOCATABLE_REGS.len() + 2;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
+        define_loaded_values(&mut mir, &vregs);
+        mir.push(X86Inst::Movzx32To64 {
+            dst: Operand::Virtual(vregs[0]),
+            src: Operand::Virtual(vregs[count - 1]),
+        });
+        for &vreg in &vregs[1..] {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+        assert_eq!(num_spills, 2);
+        let index = mir
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, X86Inst::Movzx32To64 { .. }))
+            .expect("rewritten Movzx32To64 should be present");
+        assert!(matches!(
+            mir.instructions().get(index.checked_sub(1).unwrap()),
+            Some(X86Inst::MovRM {
+                dst: Operand::Physical(dst),
+                base: Reg::Rbp,
+                ..
+            }) if *dst == SCRATCH_VALUE
+        ));
+        assert!(matches!(
+            mir.instructions().get(index),
+            Some(X86Inst::Movzx32To64 {
+                dst: Operand::Physical(dst),
+                src: Operand::Physical(src),
+            }) if *src == SCRATCH_VALUE && *dst != *src
+        ));
+        assert!(!matches!(
+            mir.instructions().get(index + 1),
+            Some(X86Inst::MovMR { .. })
+        ));
+    }
+
+    #[test]
+    fn test_movzx32_to64_spilled_destination_stores_after_move() {
+        let mut mir = X86Mir::new();
+        let count = ALLOCATABLE_REGS.len() + 2;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
+        define_loaded_values(&mut mir, &vregs);
+        mir.push(X86Inst::Movzx32To64 {
+            dst: Operand::Virtual(vregs[count - 1]),
+            src: Operand::Virtual(vregs[count - 2]),
+        });
+        for &vreg in &vregs[1..] {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+        assert_eq!(num_spills, 1);
+        let index = mir
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, X86Inst::Movzx32To64 { .. }))
+            .expect("rewritten Movzx32To64 should be present");
+        assert!(matches!(
+            mir.instructions().get(index),
+            Some(X86Inst::Movzx32To64 {
+                dst: Operand::Physical(dst),
+                src: Operand::Physical(src),
+            }) if *dst == SCRATCH_VALUE && *src != *dst
+        ));
+        assert!(matches!(
+            mir.instructions().get(index + 1),
+            Some(X86Inst::MovMR {
+                base: Reg::Rbp,
+                src: Operand::Physical(src),
+                ..
+            }) if *src == SCRATCH_VALUE
+        ));
+    }
+
+    #[test]
+    fn test_movzx32_to64_both_spilled_reloads_then_stores() {
+        let mut mir = X86Mir::new();
+        let count = ALLOCATABLE_REGS.len() + 3;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
+        define_loaded_values(&mut mir, &vregs);
+        mir.push(X86Inst::Movzx32To64 {
+            dst: Operand::Virtual(vregs[count - 1]),
+            src: Operand::Virtual(vregs[count - 2]),
+        });
+        for &vreg in &vregs[1..] {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+        assert_eq!(num_spills, 2);
+        let index = mir
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, X86Inst::Movzx32To64 { .. }))
+            .expect("rewritten Movzx32To64 should be present");
+        assert!(matches!(
+            mir.instructions().get(index.checked_sub(1).unwrap()),
+            Some(X86Inst::MovRM {
+                dst: Operand::Physical(dst),
+                base: Reg::Rbp,
+                ..
+            }) if *dst == SCRATCH_VALUE
+        ));
+        assert!(matches!(
+            mir.instructions().get(index),
+            Some(X86Inst::Movzx32To64 {
+                dst: Operand::Physical(dst),
+                src: Operand::Physical(src),
+            }) if *dst == SCRATCH_VALUE && *src == SCRATCH_VALUE
+        ));
+        assert!(matches!(
+            mir.instructions().get(index + 1),
+            Some(X86Inst::MovMR {
+                base: Reg::Rbp,
+                src: Operand::Physical(src),
+                ..
+            }) if *src == SCRATCH_VALUE
+        ));
+    }
+
+    #[test]
+    fn test_movzx32_to64_preserves_src_dst_identity() {
+        let mut mir = X86Mir::new();
+        let vreg = mir.alloc_vreg();
+        mir.push(X86Inst::MovRM {
+            dst: Operand::Virtual(vreg),
+            base: Reg::Rsi,
+            offset: 0,
+        });
+        mir.push(X86Inst::Movzx32To64 {
+            dst: Operand::Virtual(vreg),
+            src: Operand::Virtual(vreg),
+        });
+        mir.push(X86Inst::MovRR {
+            dst: Operand::Physical(Reg::Rdi),
+            src: Operand::Virtual(vreg),
+        });
+        let mir = RegAlloc::new(mir, 0).allocate().unwrap();
+        let inst = mir
+            .instructions()
+            .iter()
+            .find_map(|inst| match inst {
+                X86Inst::Movzx32To64 { dst, src } => Some((dst, src)),
+                _ => None,
+            })
+            .expect("identity Movzx32To64 should be preserved");
+        assert!(
+            matches!((inst.0, inst.1), (Operand::Physical(dst), Operand::Physical(src)) if dst == src)
+        );
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -177,6 +177,7 @@ fn get_latency(inst: &X86Inst) -> u32 {
         | X86Inst::Movsx8To64 { .. }
         | X86Inst::Movsx16To64 { .. }
         | X86Inst::Movsx32To64 { .. }
+        | X86Inst::Movzx32To64 { .. }
         | X86Inst::Movzx8To64 { .. }
         | X86Inst::Movzx16To64 { .. } => 1,
 
@@ -360,6 +361,7 @@ pub(super) fn regs_read(inst: &X86Inst) -> RegList<Reg> {
         | X86Inst::Movsx8To64 { src, .. }
         | X86Inst::Movsx16To64 { src, .. }
         | X86Inst::Movsx32To64 { src, .. }
+        | X86Inst::Movzx32To64 { src, .. }
         | X86Inst::Movzx8To64 { src, .. }
         | X86Inst::Movzx16To64 { src, .. } => {
             add_if_phys(src, &mut result);
@@ -500,6 +502,7 @@ pub(super) fn regs_written(inst: &X86Inst) -> RegList<Reg> {
         | X86Inst::Movsx8To64 { dst, .. }
         | X86Inst::Movsx16To64 { dst, .. }
         | X86Inst::Movsx32To64 { dst, .. }
+        | X86Inst::Movzx32To64 { dst, .. }
         | X86Inst::Movzx8To64 { dst, .. }
         | X86Inst::Movzx16To64 { dst, .. } => {
             add_if_phys(dst, &mut result);

--- a/crates/rue-fuzz/src/codegen_generators.rs
+++ b/crates/rue-fuzz/src/codegen_generators.rs
@@ -187,6 +187,8 @@ pub fn arb_x86_inst_physical() -> BoxedStrategy<X86Inst> {
         (arb_physical_operand(), arb_physical_operand())
             .prop_map(|(dst, src)| X86Inst::Movsx32To64 { dst, src }),
         (arb_physical_operand(), arb_physical_operand())
+            .prop_map(|(dst, src)| X86Inst::Movzx32To64 { dst, src }),
+        (arb_physical_operand(), arb_physical_operand())
             .prop_map(|(dst, src)| X86Inst::Movzx8To64 { dst, src }),
         (arb_physical_operand(), arb_physical_operand())
             .prop_map(|(dst, src)| X86Inst::Movzx16To64 { dst, src }),
@@ -429,6 +431,11 @@ pub fn arb_aarch64_inst_physical() -> BoxedStrategy<Aarch64Inst> {
             arb_aarch64_physical_operand(),
         )
             .prop_map(|(dst, src)| Aarch64Inst::MvnRR { dst, src }),
+        (
+            arb_aarch64_physical_operand(),
+            arb_aarch64_physical_operand(),
+        )
+            .prop_map(|(dst, src)| Aarch64Inst::Uxtw { dst, src }),
         (
             arb_aarch64_physical_operand(),
             arb_aarch64_physical_operand(),


### PR DESCRIPTION
## Summary
- add canonical 32-bit zero-extension MIR operations for x86-64 and AArch64
- replace shift-pair lowering in bitcast and foreign-return consumers
- cover encoding, liveness, scheduling, register allocation, spills, and production lowering
- stabilize Darwin peer-shutdown CLI setup while preserving the MSG_NOSIGNAL write assertion

## Validation
- scripts/rue fmt
- ./buck2 test //crates/rue-codegen/... (809 tests)
- scripts/rue quick (33 suites)
- scripts/rue premerge (203 targets)
- scripts/rue cli bitcast (9 cases)
- scripts/rue cli tcp_macos_write_after_peer_read_shutdown
- ./buck2 build //crates/rue-fuzz:rue-fuzz

Closes RUE-1339