### PR TITLE
RUE-1824: reject session/snapshot mismatches before pipeline work

### DIFF
--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -5690,4 +5690,108 @@ mod tests {
             "every fixture struct must be observed in some body-local pool"
         );
     }
+    /// RUE-1824: a session/snapshot mismatch is an API precondition, rejected
+    /// before any semantic, CFG, or backend work runs or is recorded.
+    #[test]
+    fn session_snapshot_mismatch_is_rejected_before_any_pipeline_work() {
+        let published = snapshot_with_file_id(1, "fn main() -> i32 { 0 }");
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&published)
+            .into_result()
+            .unwrap();
+        let work_before = format!("{:?}", session.work());
+
+        let assert_rejected = |session: &mut CompilerSession, snapshot: &SourceSnapshot| {
+            let errors =
+                crate::queries::compile_with_session(session, snapshot, &CompileOptions::default())
+                    .unwrap_err();
+            assert!(
+                matches!(
+                    &errors.as_slice()[0].kind,
+                    ErrorKind::InvalidCompilerInput(reason)
+                        if reason.contains("differs from the published parsed program")
+                ),
+                "{errors:?}"
+            );
+        };
+
+        // Byte-different content under the same identity.
+        let different = snapshot_with_file_id(1, "fn main() -> i32 { 1 }");
+        assert_rejected(&mut session, &different);
+
+        // Byte-identical content relocated to a new physical path: the
+        // source revision is shared, so only exact physical membership can
+        // reject it.
+        let file_id = FileId::new(1);
+        let relocated_metadata = SourceMetadata::new(
+            file_id,
+            [(file_id, "/moved/main.rue".to_owned())]
+                .into_iter()
+                .collect(),
+            [(file_id, "main.rue".to_owned())].into_iter().collect(),
+        )
+        .unwrap();
+        let relocated = SourceSnapshot::new(
+            relocated_metadata,
+            vec![(file_id, Arc::new("fn main() -> i32 { 0 }".to_owned()))],
+        )
+        .unwrap();
+        assert_eq!(published.source_revision(), relocated.source_revision());
+        assert_rejected(&mut session, &relocated);
+
+        // Neither rejection performed or recorded any pipeline work.
+        assert_eq!(work_before, format!("{:?}", session.work()));
+
+        // The exact published snapshot still compiles.
+        crate::queries::compile_with_session(&mut session, &published, &CompileOptions::default())
+            .unwrap();
+    }
+
+    /// RUE-1824: the cancellation-aware entry point aborts an already
+    /// canceled request before judging its inputs, and rejects a mismatched
+    /// live request before any pipeline work.
+    #[test]
+    fn cancellation_takes_precedence_over_snapshot_mismatch() {
+        let published = snapshot_with_file_id(1, "fn main() -> i32 { 0 }");
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&published)
+            .into_result()
+            .unwrap();
+        let different = snapshot_with_file_id(1, "fn main() -> i32 { 1 }");
+
+        let canceled = rue_query::CancellationToken::new();
+        canceled.cancel();
+        let control = crate::queries::compile_with_session_with_cancellation(
+            &mut session,
+            &different,
+            &CompileOptions::default(),
+            canceled,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            control,
+            crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)
+        ));
+
+        let work_before = format!("{:?}", session.work());
+        let control = crate::queries::compile_with_session_with_cancellation(
+            &mut session,
+            &different,
+            &CompileOptions::default(),
+            rue_query::CancellationToken::new(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            &control,
+            crate::session::PipelineRequestControl::Compile(errors)
+                if matches!(
+                    &errors.as_slice()[0].kind,
+                    ErrorKind::InvalidCompilerInput(reason)
+                        if reason.contains("differs from the published parsed program")
+                )
+        ));
+        assert_eq!(work_before, format!("{:?}", session.work()));
+    }
 }

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -234,12 +234,36 @@ fn compile_snapshot_impl(
     compile_with_session(&mut session, snapshot, options)
 }
 
+/// Reject a session/snapshot pairing whose published parsed program does not
+/// belong to this EXACT snapshot, returning the program's token count on a
+/// match. Snapshot membership is physical, not merely source-revision-deep: a
+/// relocated byte-identical snapshot must be rejected. Both compile entry
+/// points run this as a preflight so an invalid request pays for no semantic,
+/// CFG, or backend work and records no metrics or retained terminals, and
+/// finalization reuses the same helper so the two checks cannot drift
+/// (RUE-1824).
+fn require_published_snapshot_membership(
+    session: &CompilerSession,
+    snapshot: &SourceSnapshot,
+) -> Result<usize, CompileErrors> {
+    session
+        .published_owner()
+        .filter(|program| program.belongs_to_exact_snapshot(snapshot))
+        .map(|program| program.token_count())
+        .ok_or_else(|| {
+            CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "compilation snapshot differs from the published parsed program".into(),
+            )))
+        })
+}
+
 pub(crate) fn compile_with_session(
     session: &mut CompilerSession,
     snapshot: &SourceSnapshot,
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!("compile_pipeline").entered();
+    require_published_snapshot_membership(session, snapshot)?;
     let rooted = if matches!(options.linker, LinkerMode::Internal) {
         session
             .rooted_codegen_internal_with_cancellation(
@@ -269,11 +293,15 @@ pub(crate) fn compile_with_session_with_cancellation(
     cancellation: rue_query::CancellationToken,
 ) -> Result<CompileOutput, crate::session::PipelineRequestControl> {
     let _span = info_span!("compile_pipeline").entered();
+    // Cancellation takes precedence over precondition validation: an already
+    // canceled request aborts before its inputs are judged.
     if cancellation.is_canceled() {
         return Err(crate::session::PipelineRequestControl::Abort(
             rue_query::QueryAbort::Canceled,
         ));
     }
+    require_published_snapshot_membership(session, snapshot)
+        .map_err(crate::session::PipelineRequestControl::Compile)?;
     let rooted = if matches!(options.linker, LinkerMode::Internal) {
         session.rooted_codegen_internal_with_cancellation(
             options,
@@ -352,15 +380,10 @@ pub(crate) fn compile_rooted_with_session_with_cancellation(
         }
     };
     check_cancellation()?;
-    let source_tokens = session
-        .published_owner()
-        .filter(|program| program.belongs_to_exact_snapshot(snapshot))
-        .map(|program| program.token_count())
-        .ok_or_else(|| {
-            CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
-                "compilation snapshot differs from the published parsed program".into(),
-            )))
-        })
+    // The entry points already ran this preflight; repeating it here keeps
+    // the unstable objects-ready continuation endpoint honest and defends
+    // against a session whose published program changed mid-pipeline.
+    let source_tokens = require_published_snapshot_membership(session, snapshot)
         .map_err(crate::session::PipelineRequestControl::Compile)?;
     let mut total_source_bytes = 0_usize;
     let mut total_source_lines = 0_usize;


### PR DESCRIPTION
Fixes RUE-1824.

## Problem

`compile_with_session` accepted a retained `CompilerSession` and a `SourceSnapshot` but validated that they describe the same exact snapshot only during finalization (`compile_rooted_with_session_with_cancellation`), after semantic, CFG, and backend work had completed. A mismatched request got the right `InvalidCompilerInput` — but only after paying for the whole pipeline, contaminating work/phase metrics, and populating retained backend terminals.

## Fix

- One shared helper, `require_published_snapshot_membership`, owns the check: the published program must `belongs_to_exact_snapshot(snapshot)` (physical membership — a byte-identical relocated snapshot is rejected), returning the token count on a match.
- `compile_with_session` and `compile_with_session_with_cancellation` run it as a preflight before requesting rooted codegen. The cancellation-aware entry point checks cancellation first, with the precedence now documented in-source.
- Finalization reuses the same helper (no drift possible), retained as defense for the unstable objects-ready continuation endpoint and against a mid-pipeline republication.

## Tests

`pipeline_tests.rs`:
- `session_snapshot_mismatch_is_rejected_before_any_pipeline_work` — byte-different and byte-identical-relocated mismatches (the latter proven to share the source revision) both reject with `session.work()` unchanged, and the exact published snapshot still compiles afterward.
- `cancellation_takes_precedence_over_snapshot_mismatch` — an already-canceled request aborts with `QueryAbort::Canceled` before the mismatch is judged; a live mismatched request rejects with no recorded work.

The work-unchanged assertion is the proof of the preflight: under the old code the mismatch surfaced only after rooted codegen mutated the session's work record.

## Validation

- `buck2 test //crates/rue-compiler:rue-compiler-test` — all green including the two new tests
- `scripts/rue quick` and full `scripts/rue premerge` — pass, exit 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLu5tyWdwrL8RywUZqaQc)_