### PR TITLE
RUE-1847: compact peephole add/sub chains once instead of per removal

### DIFF
--- a/crates/rue-codegen/src/aarch64/peephole.rs
+++ b/crates/rue-codegen/src/aarch64/peephole.rs
@@ -141,91 +141,111 @@ fn transform_single(instructions: &[Aarch64Inst], idx: usize) -> Option<Aarch64I
 /// - `sub r, r, #a` followed by `sub r, r, #b` → `sub r, r, #(a+b)`
 ///
 /// Returns the number of combinations made.
+/// Fold `later` into `earlier` when both are the same `op r, r, #imm` form on
+/// the same register and the combined immediate stays in the ordinary AArch64
+/// immediate range. Larger values use emitter materialization and must not be
+/// synthesized here.
+fn fold_pair(earlier: &Aarch64Inst, later: &Aarch64Inst) -> Option<Aarch64Inst> {
+    match (earlier, later) {
+        (
+            Aarch64Inst::AddImm {
+                dst: dst1,
+                src: src1,
+                imm: imm1,
+            },
+            Aarch64Inst::AddImm {
+                dst: dst2,
+                src: src2,
+                imm: imm2,
+            },
+        ) => {
+            // Only combine `add r, r, #imm` forms, both on the same register.
+            if !(operands_equal(dst1, src1)
+                && operands_equal(dst2, src2)
+                && operands_equal(dst1, dst2))
+            {
+                return None;
+            }
+            let combined = imm1.checked_add(*imm2).filter(|combined| {
+                (-MAX_ADD_SUB_IMMEDIATE..=MAX_ADD_SUB_IMMEDIATE).contains(combined)
+            })?;
+            Some(Aarch64Inst::AddImm {
+                dst: *dst1,
+                src: *src1,
+                imm: combined,
+            })
+        }
+        (
+            Aarch64Inst::SubImm {
+                dst: dst1,
+                src: src1,
+                imm: imm1,
+            },
+            Aarch64Inst::SubImm {
+                dst: dst2,
+                src: src2,
+                imm: imm2,
+            },
+        ) => {
+            if !(operands_equal(dst1, src1)
+                && operands_equal(dst2, src2)
+                && operands_equal(dst1, dst2))
+            {
+                return None;
+            }
+            let combined = imm1
+                .checked_add(*imm2)
+                .filter(|combined| (0..=MAX_ADD_SUB_IMMEDIATE).contains(combined))?;
+            Some(Aarch64Inst::SubImm {
+                dst: *dst1,
+                src: *src1,
+                imm: combined,
+            })
+        }
+        _ => None,
+    }
+}
+
 fn combine_adjacent(instructions: &mut Vec<Aarch64Inst>) -> usize {
     if instructions.len() < 2 {
         return 0;
     }
 
+    // Mark, then compact once (RUE-1847). Deleting in place with `Vec::remove`
+    // shifts the whole tail per removal, so a long add or sub chain cost
+    // O(chain × n); pass 3 below already compacts with `retain`.
+    let mut doomed = vec![false; instructions.len()];
     let mut changes = 0;
     let mut i = 0;
 
     while i + 1 < instructions.len() {
-        // Try to combine add chains: add r, r, #a; add r, r, #b → add r, r, #(a+b)
-        if let (
-            Aarch64Inst::AddImm {
-                dst: dst1,
-                src: src1,
-                imm: imm1,
-            },
-            Aarch64Inst::AddImm {
-                dst: dst2,
-                src: src2,
-                imm: imm2,
-            },
-        ) = (&instructions[i], &instructions[i + 1])
-        {
-            // Only combine if dst == src for both (i.e., add r, r, #imm pattern)
-            // and both operations are on the same register
-            if operands_equal(dst1, src1)
-                && operands_equal(dst2, src2)
-                && operands_equal(dst1, dst2)
-            {
-                // Keep the combined MIR immediate within the ordinary
-                // AArch64 immediate sequence; larger values use emitter
-                // materialization and should not be synthesized here.
-                if let Some(combined) = imm1.checked_add(*imm2).filter(|combined| {
-                    (-MAX_ADD_SUB_IMMEDIATE..=MAX_ADD_SUB_IMMEDIATE).contains(combined)
-                }) {
-                    // Replace first instruction with combined add
-                    instructions[i] = Aarch64Inst::AddImm {
-                        dst: *dst1,
-                        src: *src1,
-                        imm: combined,
-                    };
-                    // Remove second instruction
-                    instructions.remove(i + 1);
-                    changes += 1;
-                    // Don't increment i - there might be more adds to combine
-                    continue;
-                }
-            }
+        // Combine add chains (add r, r, #a; add r, r, #b → add r, r, #(a+b))
+        // and the matching sub chains. `i` is the accumulator; `j` walks the
+        // run folded into it, exactly as the previous
+        // `continue`-without-incrementing-`i` loop did.
+        let mut j = i + 1;
+        while j < instructions.len() {
+            let Some(folded) = fold_pair(&instructions[i], &instructions[j]) else {
+                break;
+            };
+            instructions[i] = folded;
+            doomed[j] = true;
+            changes += 1;
+            j += 1;
         }
+        // `j` is the first instruction not folded into the accumulator, i.e.
+        // the next survivor — what `i + 1` denoted after the old in-place
+        // removals.
+        i = j;
+    }
 
-        // Try to combine sub chains: sub r, r, #a; sub r, r, #b → sub r, r, #(a+b)
-        if let (
-            Aarch64Inst::SubImm {
-                dst: dst1,
-                src: src1,
-                imm: imm1,
-            },
-            Aarch64Inst::SubImm {
-                dst: dst2,
-                src: src2,
-                imm: imm2,
-            },
-        ) = (&instructions[i], &instructions[i + 1])
-        {
-            if operands_equal(dst1, src1)
-                && operands_equal(dst2, src2)
-                && operands_equal(dst1, dst2)
-            {
-                if let Some(combined) = imm1
-                    .checked_add(*imm2)
-                    .filter(|combined| (0..=MAX_ADD_SUB_IMMEDIATE).contains(combined))
-                {
-                    instructions[i] = Aarch64Inst::SubImm {
-                        dst: *dst1,
-                        src: *src1,
-                        imm: combined,
-                    };
-                    instructions.remove(i + 1);
-                    changes += 1;
-                    continue;
-                }
-            }
-        }
-
-        i += 1;
+    if changes > 0 {
+        let mut k = 0;
+        instructions.retain(|_| {
+            let keep = !doomed[k];
+            k += 1;
+            keep
+        });
     }
 
     changes
@@ -638,6 +658,51 @@ mod tests {
             instructions[0],
             Aarch64Inst::AddImm { imm: 35, .. }
         ));
+    }
+
+    #[test]
+    fn test_combine_two_separate_chains() {
+        // RUE-1847: after a chain ends, the accumulator must advance to the
+        // next *survivor*, not to the instruction just folded away. With the
+        // old in-place removals `i + 1` named that survivor implicitly; with
+        // mark-and-compact it is the index the inner walk stopped on.
+        let mut instructions = vec![
+            Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::X0),
+                imm: 10,
+            },
+            Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::X0),
+                imm: 20,
+            },
+            Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::X1),
+                src: Operand::Physical(Reg::X1),
+                imm: 1,
+            },
+            Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::X1),
+                src: Operand::Physical(Reg::X1),
+                imm: 2,
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 2);
+        assert_eq!(instructions.len(), 3);
+        assert!(matches!(
+            instructions[0],
+            Aarch64Inst::AddImm { imm: 30, .. }
+        ));
+        assert!(matches!(
+            instructions[1],
+            Aarch64Inst::AddImm { imm: 3, .. }
+        ));
+        assert!(matches!(instructions[2], Aarch64Inst::Ret));
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/peephole.rs
+++ b/crates/rue-codegen/src/x86_64/peephole.rs
@@ -251,40 +251,59 @@ fn combine_adjacent(instructions: &mut Vec<X86Inst>) -> usize {
         return 0;
     }
 
+    // Mark, then compact once (RUE-1847). Deleting in place with `Vec::remove`
+    // shifts the whole tail per removal, so a long add chain cost
+    // O(chain × n) — the same pattern pass 3 above was already cured of.
+    //
+    // Leaving folded instructions in place until the final compaction is
+    // invisible to `flags_dead_after`: it scans strictly forward from the
+    // instruction being folded, while every index doomed so far lies behind it.
+    let mut doomed = vec![false; instructions.len()];
     let mut changes = 0;
     let mut i = 0;
 
     while i + 1 < instructions.len() {
-        // Try to combine add chains: add r, a; add r, b → add r, a+b
-        if let (
-            X86Inst::AddRI {
-                dst: dst1,
-                imm: imm1,
-            },
-            X86Inst::AddRI {
-                dst: dst2,
-                imm: imm2,
-            },
-        ) = (&instructions[i], &instructions[i + 1])
-        {
-            if operands_equal(dst1, dst2) && flags_dead_after(instructions, i + 1) {
-                // Check for overflow when combining immediates
-                if let Some(combined) = imm1.checked_add(*imm2) {
-                    // Replace first instruction with combined add
-                    instructions[i] = X86Inst::AddRI {
-                        dst: *dst1,
-                        imm: combined,
-                    };
-                    // Remove second instruction
-                    instructions.remove(i + 1);
-                    changes += 1;
-                    // Don't increment i - there might be more adds to combine
-                    continue;
-                }
+        // Combine add chains: add r, a; add r, b → add r, a+b. `i` is the
+        // accumulator; `j` walks the run of adds folded into it, exactly as
+        // the previous `continue`-without-incrementing-`i` loop did.
+        let mut j = i + 1;
+        while j < instructions.len() {
+            let (dst1, imm1) = match &instructions[i] {
+                X86Inst::AddRI { dst, imm } => (*dst, *imm),
+                _ => break,
+            };
+            let (dst2, imm2) = match &instructions[j] {
+                X86Inst::AddRI { dst, imm } => (*dst, *imm),
+                _ => break,
+            };
+            if !operands_equal(&dst1, &dst2) || !flags_dead_after(instructions, j) {
+                break;
             }
+            // Stop the run on overflow rather than dropping the instruction.
+            let Some(combined) = imm1.checked_add(imm2) else {
+                break;
+            };
+            instructions[i] = X86Inst::AddRI {
+                dst: dst1,
+                imm: combined,
+            };
+            doomed[j] = true;
+            changes += 1;
+            j += 1;
         }
+        // `j` is the first instruction not folded into the accumulator, i.e.
+        // the next survivor — what `i + 1` denoted after the old in-place
+        // removals.
+        i = j;
+    }
 
-        i += 1;
+    if changes > 0 {
+        let mut k = 0;
+        instructions.retain(|_| {
+            let keep = !doomed[k];
+            k += 1;
+            keep
+        });
     }
 
     changes
@@ -671,6 +690,41 @@ mod tests {
         assert_eq!(changes, 2);
         assert_eq!(instructions.len(), 2);
         assert!(matches!(instructions[0], X86Inst::AddRI { imm: 35, .. }));
+    }
+
+    #[test]
+    fn test_combine_two_separate_chains() {
+        // RUE-1847: after a chain ends, the accumulator must advance to the
+        // next *survivor*, not to the instruction just folded away. With the
+        // old in-place removals `i + 1` named that survivor implicitly; with
+        // mark-and-compact it is the index the inner walk stopped on.
+        let mut instructions = vec![
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 10,
+            },
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 20,
+            },
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rbx),
+                imm: 1,
+            },
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rbx),
+                imm: 2,
+            },
+            X86Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 2);
+        assert_eq!(instructions.len(), 3);
+        assert!(matches!(instructions[0], X86Inst::AddRI { imm: 30, .. }));
+        assert!(matches!(instructions[1], X86Inst::AddRI { imm: 3, .. }));
+        assert!(matches!(instructions[2], X86Inst::Ret));
     }
 
     #[test]


### PR DESCRIPTION
Fixes RUE-1847.

## Problem

Peephole pass 2 (`combine_adjacent`) folded an add chain by rewriting the
accumulator and calling `Vec::remove` on each follower, shifting the whole
instruction tail per removal — so a chain of n adds cost O(chain × n).

This is the same tail-shift pattern pass 3 was already cured of. Pass 3's own
comment in `x86_64/peephole.rs` says so explicitly, and notes that AArch64's
pass 3 already compacts with `retain` — but pass 2 on both backends still used
`Vec::remove`.

## Change

Mark folded instructions in a `doomed` table and compact once with `retain`, on
both backends.

The accumulator walk is unchanged in effect. An inner loop folds the run of
followers into the accumulator at `i`, then resumes from `j`, the first
instruction not folded — which is exactly what `i + 1` denoted after the old
in-place removals. Overflow and out-of-range immediates still stop the run
rather than dropping an instruction.

Leaving folded instructions in place until the final compaction is invisible to
the x86-64 FLAGS gate: `flags_dead_after` scans strictly forward from the
instruction being folded, while every index doomed so far lies behind it. The
instructions it would scan past are identical either way.

The AArch64 add and sub arms were byte-identical apart from the immediate range
check, so they collapse into one `fold_pair` helper.

## Guard

Both backends gain `test_combine_two_separate_chains`: two independent add
chains on different registers, separated by nothing. It covers the accumulator
advancing across a chain boundary to the next *survivor* rather than to an
instruction that was folded away — the one behavior the restructure could get
wrong that the existing single-chain tests would not catch.

## Validation

- `scripts/rue unit rue-codegen peephole` — 66 passed, 0 failed (64 before, plus
  the two new ones). Existing chain, overflow, encoding-limit, different-register
  and FLAGS-gate tests all still pass unchanged on both backends.
- `scripts/rue premerge` — 203 pass, 0 fail.
- `rue-codegen-clippy`, `rue-codegen-fmt-check`, `rue-codegen-debug-assert-check`
  all green.

No change to emitted machine code: the same instructions are folded to the same
immediates, only the compaction strategy differs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nmb41AiKasPE74Vm3BFd8n)_