### PR TITLE
RUE-1846: derive loop info from the liveness successor table

### DIFF
--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -78,9 +78,17 @@ pub fn analyze_debug(mir: &Aarch64Mir) -> LivenessDebugInfo {
     crate::liveness::analyze_debug_adapter(&Aarch64LivenessAdapter { mir })
 }
 
-/// Compute allocator liveness and its diagnostic projection together.
-pub(crate) fn analyze_with_debug(mir: &Aarch64Mir) -> (LivenessInfo, LivenessDebugInfo) {
-    crate::liveness::analyze_with_debug_adapter(&Aarch64LivenessAdapter { mir })
+/// Compute allocator liveness and loop information in one walk (RUE-1846).
+pub(crate) fn analyze_with_loops(mir: &Aarch64Mir) -> (LivenessInfo, LoopInfo) {
+    crate::liveness::analyze_with_loops_adapter(&Aarch64LivenessAdapter { mir })
+}
+
+/// Compute allocator liveness, its diagnostic projection, and loop information
+/// in one walk (RUE-1846).
+pub(crate) fn analyze_with_debug_and_loops(
+    mir: &Aarch64Mir,
+) -> (LivenessInfo, LivenessDebugInfo, LoopInfo) {
+    crate::liveness::analyze_with_debug_and_loops_adapter(&Aarch64LivenessAdapter { mir })
 }
 
 /// Compute loop information for Aarch64Mir.

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -1316,18 +1316,18 @@ impl RegAllocBackend for Aarch64Backend {
         }
     }
 
-    fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg> {
-        liveness::analyze(mir)
+    fn analyze_with_loops(mir: &Self::Mir) -> (LivenessInfo<Self::Reg>, LoopInfo) {
+        liveness::analyze_with_loops(mir)
     }
 
-    fn analyze_with_debug(
+    fn analyze_with_debug_and_loops(
         mir: &Self::Mir,
-    ) -> (LivenessInfo<Self::Reg>, crate::regalloc::LivenessDebugInfo) {
-        liveness::analyze_with_debug(mir)
-    }
-
-    fn analyze_loops(mir: &Self::Mir) -> LoopInfo {
-        liveness::analyze_loops(mir)
+    ) -> (
+        LivenessInfo<Self::Reg>,
+        crate::regalloc::LivenessDebugInfo,
+        LoopInfo,
+    ) {
+        liveness::analyze_with_debug_and_loops(mir)
     }
 
     fn coalesce_candidates(instructions: &[Self::Inst]) -> Vec<CoalesceCandidate> {

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -252,6 +252,45 @@ where
     )
 }
 
+/// Compute liveness and loop information together for a target adapter.
+pub fn analyze_with_loops_adapter<A>(adapter: &A) -> (LivenessInfo<A::Reg>, LoopInfo)
+where
+    A: LivenessAdapter,
+{
+    analyze_with_loops(
+        adapter.instructions(),
+        adapter.vreg_count(),
+        adapter.vreg_classes().clone(),
+        |inst| adapter.label(inst),
+        |idx, inst, label_to_idx| adapter.successors(idx, inst, label_to_idx),
+        |inst| adapter.uses(inst),
+        |inst| adapter.defs(inst),
+        |inst| adapter.clobbers(inst),
+        |inst| adapter.is_non_returning(inst),
+    )
+}
+
+/// Compute liveness, its diagnostic projection, and loop information together
+/// for a target adapter.
+pub fn analyze_with_debug_and_loops_adapter<A>(
+    adapter: &A,
+) -> (LivenessInfo<A::Reg>, LivenessDebugInfo, LoopInfo)
+where
+    A: LivenessAdapter,
+{
+    analyze_with_debug_and_loops(
+        adapter.instructions(),
+        adapter.vreg_count(),
+        adapter.vreg_classes().clone(),
+        |inst| adapter.label(inst),
+        |idx, inst, label_to_idx| adapter.successors(idx, inst, label_to_idx),
+        |inst| adapter.uses(inst),
+        |inst| adapter.defs(inst),
+        |inst| adapter.clobbers(inst),
+        |inst| adapter.is_non_returning(inst),
+    )
+}
+
 /// Compute loop information for any backend implementing [`LivenessAdapter`].
 pub fn analyze_loops_adapter<A>(adapter: &A) -> LoopInfo
 where
@@ -350,6 +389,7 @@ where
         get_clobbers,
         get_non_returning,
         false,
+        false,
     )
     .0
 }
@@ -371,7 +411,7 @@ pub fn analyze_with_debug<I, R>(
 where
     R: Copy + Eq + std::hash::Hash + 'static,
 {
-    let (liveness, debug) = analyze_inner(
+    let (liveness, debug, _) = analyze_inner(
         instructions,
         vreg_count,
         vreg_classes,
@@ -382,10 +422,87 @@ where
         get_clobbers,
         get_non_returning,
         true,
+        false,
     );
     (
         liveness,
         debug.expect("debug liveness requested from the canonical analysis"),
+    )
+}
+
+/// Compute production liveness and loop information in one walk of the MIR.
+///
+/// The register allocator needs both, and both derive from the same label map
+/// and successor lists. Computing them through separate entry points walked the
+/// instruction stream twice to rebuild byte-identical tables (RUE-1846).
+#[allow(clippy::too_many_arguments)]
+pub fn analyze_with_loops<I, R>(
+    instructions: &[I],
+    vreg_count: u32,
+    vreg_classes: VRegClasses,
+    get_label: impl Fn(&I) -> Option<LabelId>,
+    get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
+    get_uses: impl Fn(&I) -> VRegList,
+    get_defs: impl Fn(&I) -> VRegList,
+    get_clobbers: impl Fn(&I) -> &'static [R],
+    get_non_returning: impl Fn(&I) -> bool,
+) -> (LivenessInfo<R>, LoopInfo)
+where
+    R: Copy + Eq + std::hash::Hash + 'static,
+{
+    let (liveness, _, loops) = analyze_inner(
+        instructions,
+        vreg_count,
+        vreg_classes,
+        get_label,
+        get_successors,
+        get_uses,
+        get_defs,
+        get_clobbers,
+        get_non_returning,
+        false,
+        true,
+    );
+    (
+        liveness,
+        loops.expect("loop info requested from the canonical analysis"),
+    )
+}
+
+/// As [`analyze_with_loops`], additionally retaining the diagnostic projection
+/// of the same dataflow.
+#[allow(clippy::too_many_arguments)]
+pub fn analyze_with_debug_and_loops<I, R>(
+    instructions: &[I],
+    vreg_count: u32,
+    vreg_classes: VRegClasses,
+    get_label: impl Fn(&I) -> Option<LabelId>,
+    get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
+    get_uses: impl Fn(&I) -> VRegList,
+    get_defs: impl Fn(&I) -> VRegList,
+    get_clobbers: impl Fn(&I) -> &'static [R],
+    get_non_returning: impl Fn(&I) -> bool,
+) -> (LivenessInfo<R>, LivenessDebugInfo, LoopInfo)
+where
+    R: Copy + Eq + std::hash::Hash + 'static,
+{
+    let (liveness, debug, loops) = analyze_inner(
+        instructions,
+        vreg_count,
+        vreg_classes,
+        get_label,
+        get_successors,
+        get_uses,
+        get_defs,
+        get_clobbers,
+        get_non_returning,
+        true,
+        true,
+    );
+    (
+        liveness,
+        debug.expect("debug liveness requested from the canonical analysis"),
+        loops.expect("loop info requested from the canonical analysis"),
     )
 }
 
@@ -401,7 +518,8 @@ fn analyze_inner<I, R>(
     get_clobbers: impl Fn(&I) -> &'static [R],
     get_non_returning: impl Fn(&I) -> bool,
     collect_debug: bool,
-) -> (LivenessInfo<R>, Option<LivenessDebugInfo>)
+    collect_loops: bool,
+) -> (LivenessInfo<R>, Option<LivenessDebugInfo>, Option<LoopInfo>)
 where
     R: Copy + Eq + std::hash::Hash + 'static,
 {
@@ -420,6 +538,7 @@ where
                 live_ranges: IndexMap::new(),
                 vreg_count,
             }),
+            collect_loops.then(|| LoopInfo::no_loops(0)),
         );
     }
 
@@ -428,6 +547,12 @@ where
 
     // Step 2: Build successor lists for each instruction
     let successors = build_successor_lists(instructions, &label_to_idx, &get_successors);
+
+    // Loop info is a pure function of that successor table (RUE-1846). Deriving
+    // it here lets the allocator's two analyses share one label-map and
+    // successor-list construction; previously `analyze_loops` walked the
+    // instruction stream again to rebuild byte-identical tables.
+    let loop_info = collect_loops.then(|| compute_loop_info(num_insts, &successors));
 
     // Step 3: Pre-compute uses and defs for each instruction
     let inst_uses: Vec<VRegList> = instructions.iter().map(&get_uses).collect();
@@ -513,6 +638,7 @@ where
             vreg_classes,
         },
         debug,
+        loop_info,
     )
 }
 
@@ -1596,6 +1722,67 @@ mod tests {
         assert_eq!(loop_info.depth(2), 1, "Loop body");
         assert_eq!(loop_info.depth(3), 1, "Loop back-edge");
         assert_eq!(loop_info.depth(4), 0, "After loop");
+    }
+
+    #[test]
+    fn test_analyze_with_loops_matches_the_separate_analyses() {
+        // RUE-1846: the allocator now takes liveness and loop info from one
+        // walk of the MIR, sharing the label map and successor lists it used to
+        // build twice. That combined path must agree exactly with the two
+        // standalone analyses it replaced.
+        let loop_label = LabelId::new(0);
+        let instructions = vec![
+            TestInst::Def { dst: 0 },
+            TestInst::Label { id: loop_label },
+            TestInst::Use { src: 0 },
+            TestInst::Branch { label: loop_label },
+            TestInst::Ret,
+        ];
+        let num_insts = instructions.len();
+
+        let separate_liveness: LivenessInfo<u32> = analyze(
+            &instructions,
+            1,
+            VRegClasses::all_gp(1),
+            test_get_label,
+            |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
+            test_get_uses,
+            test_get_defs,
+            test_get_clobbers,
+            |_| false,
+        );
+        let separate_loops =
+            analyze_loops(&instructions, test_get_label, |idx, inst, label_to_idx| {
+                test_get_successors(idx, inst, label_to_idx, num_insts)
+            });
+
+        let (combined_liveness, combined_loops): (LivenessInfo<u32>, _) = analyze_with_loops(
+            &instructions,
+            1,
+            VRegClasses::all_gp(1),
+            test_get_label,
+            |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
+            test_get_uses,
+            test_get_defs,
+            test_get_clobbers,
+            |_| false,
+        );
+
+        for idx in 0..num_insts {
+            assert_eq!(
+                combined_loops.depth(idx),
+                separate_loops.depth(idx),
+                "loop depth diverged at instruction {idx}"
+            );
+        }
+        assert_eq!(
+            combined_liveness.range(VReg::new(0)),
+            separate_liveness.range(VReg::new(0)),
+            "live range diverged from the standalone analysis"
+        );
+        // The fixture really does contain a back-edge, so the comparison above
+        // is not vacuously over an all-zero depth vector.
+        assert_eq!(separate_loops.depth(2), 1, "fixture must contain a loop");
     }
 
     // ========================================

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -1257,9 +1257,15 @@ pub trait RegAllocBackend {
     fn instructions(mir: &Self::Mir) -> &[Self::Inst];
     fn defs(inst: &Self::Inst) -> crate::liveness::VRegList;
     fn rematerialization(inst: &Self::Inst) -> Option<(VReg, RematerializeOp)>;
-    fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg>;
-    fn analyze_with_debug(mir: &Self::Mir) -> (LivenessInfo<Self::Reg>, LivenessDebugInfo);
-    fn analyze_loops(mir: &Self::Mir) -> LoopInfo;
+    /// Allocator liveness and loop information from one walk of the MIR. Both
+    /// derive from the same label map and successor lists, so they are produced
+    /// together rather than by two hooks that each rebuild them (RUE-1846).
+    fn analyze_with_loops(mir: &Self::Mir) -> (LivenessInfo<Self::Reg>, LoopInfo);
+    /// As [`RegAllocBackend::analyze_with_loops`], additionally retaining the
+    /// diagnostic projection of the same dataflow.
+    fn analyze_with_debug_and_loops(
+        mir: &Self::Mir,
+    ) -> (LivenessInfo<Self::Reg>, LivenessDebugInfo, LoopInfo);
     fn coalesce_candidates(instructions: &[Self::Inst]) -> Vec<CoalesceCandidate>;
     /// The allocatable registers of every [`RegClass`], each split by who is
     /// responsible for preserving them. Allocation prefers the caller-saved
@@ -1487,11 +1493,12 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
     pub fn new_with_artifacts(mir: B::Mir, existing_locals: u32, capture_liveness: bool) -> Self {
         assert_no_allocatable_physical_operands::<B>(&mir);
         let vreg_count = B::vreg_count(&mir) as usize;
-        let (mut liveness, liveness_debug) = if capture_liveness {
-            let (liveness, debug) = B::analyze_with_debug(&mir);
-            (liveness, Some(debug))
+        let (mut liveness, liveness_debug, loop_info) = if capture_liveness {
+            let (liveness, debug, loops) = B::analyze_with_debug_and_loops(&mir);
+            (liveness, Some(debug), loops)
         } else {
-            (B::analyze(&mir), None)
+            let (liveness, loops) = B::analyze_with_loops(&mir);
+            (liveness, None, loops)
         };
         assert_eq!(
             liveness.vreg_classes.len(),
@@ -1499,7 +1506,6 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
             "the MIR's virtual-register class table does not cover its virtual registers; \
              a mint site skipped recording a register class"
         );
-        let loop_info = B::analyze_loops(&mir);
         let candidates = B::coalesce_candidates(B::instructions(&mir));
         let coalesce_result = coalesce(&candidates, &mut liveness);
         let vreg_info = rematerialization_info::<B>(&mir, &coalesce_result);

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -78,9 +78,17 @@ pub fn analyze_debug(mir: &X86Mir) -> LivenessDebugInfo {
     crate::liveness::analyze_debug_adapter(&X86LivenessAdapter { mir })
 }
 
-/// Compute allocator liveness and its diagnostic projection together.
-pub(crate) fn analyze_with_debug(mir: &X86Mir) -> (LivenessInfo, LivenessDebugInfo) {
-    crate::liveness::analyze_with_debug_adapter(&X86LivenessAdapter { mir })
+/// Compute allocator liveness and loop information in one walk (RUE-1846).
+pub(crate) fn analyze_with_loops(mir: &X86Mir) -> (LivenessInfo, LoopInfo) {
+    crate::liveness::analyze_with_loops_adapter(&X86LivenessAdapter { mir })
+}
+
+/// Compute allocator liveness, its diagnostic projection, and loop information
+/// in one walk (RUE-1846).
+pub(crate) fn analyze_with_debug_and_loops(
+    mir: &X86Mir,
+) -> (LivenessInfo, LivenessDebugInfo, LoopInfo) {
+    crate::liveness::analyze_with_debug_and_loops_adapter(&X86LivenessAdapter { mir })
 }
 
 /// Compute loop information for X86Mir.

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -1357,18 +1357,18 @@ impl RegAllocBackend for X86Backend {
         }
     }
 
-    fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg> {
-        liveness::analyze(mir)
+    fn analyze_with_loops(mir: &Self::Mir) -> (LivenessInfo<Self::Reg>, LoopInfo) {
+        liveness::analyze_with_loops(mir)
     }
 
-    fn analyze_with_debug(
+    fn analyze_with_debug_and_loops(
         mir: &Self::Mir,
-    ) -> (LivenessInfo<Self::Reg>, crate::regalloc::LivenessDebugInfo) {
-        liveness::analyze_with_debug(mir)
-    }
-
-    fn analyze_loops(mir: &Self::Mir) -> LoopInfo {
-        liveness::analyze_loops(mir)
+    ) -> (
+        LivenessInfo<Self::Reg>,
+        crate::regalloc::LivenessDebugInfo,
+        LoopInfo,
+    ) {
+        liveness::analyze_with_debug_and_loops(mir)
     }
 
     fn coalesce_candidates(instructions: &[Self::Inst]) -> Vec<CoalesceCandidate> {


### PR DESCRIPTION
Fixes RUE-1846.

## Problem

`RegAllocDriver::new_with_artifacts` called `B::analyze` (or `analyze_with_debug`)
and then `B::analyze_loops` as two independent target hooks.

Both funnel to the same shared helpers. `analyze_inner` builds the label map and
successor lists but retains neither in the `LivenessInfo` it returns, so
`analyze_loops` rebuilt byte-identical tables from scratch before calling
`compute_loop_info` — which depends only on the successor table.

Every compiled function therefore paid two full O(instructions) matcher walks, each
allocating an `AHashMap<LabelId, usize>` and a `Vec<SuccessorList>` of instruction
length, to derive the same tables twice. Both backends delegated both hooks
identically, so this was paid on x86-64 and AArch64 alike.

## Change

Compute the loop info inside the analysis that already holds the successor table.

- `analyze_inner` gains a `collect_loops` flag and returns `Option<LoopInfo>`
  alongside the liveness and debug projections. The loop info is derived right
  after the successor lists are built, from those same lists.
- `analyze_with_loops` and `analyze_with_debug_and_loops` expose the combined
  result, with `..._adapter` forms for the two backends.
- The backend trait's `analyze`, `analyze_with_debug` and `analyze_loops` hooks had
  no callers outside the driver, so they collapse into `analyze_with_loops` and
  `analyze_with_debug_and_loops`.

The standalone `liveness::analyze` and `liveness::analyze_loops` free functions are
unchanged and still serve their existing test and diagnostic callers — including
the allocator's own baseline-spill tests, which keep exercising them independently
of the combined path.

## Guard

`test_analyze_with_loops_matches_the_separate_analyses`: on an instruction stream
containing a back-edge, the combined path must produce the same loop depths at
every index and the same live ranges as the two analyses it replaced. The test
also asserts the fixture really contains a loop, so the comparison is not
vacuously over an all-zero depth vector.

## Validation

- `scripts/rue unit rue-codegen` — 790 passed, 0 failed.
- `rue-codegen-clippy`, `rue-codegen-fmt-check`, `rue-codegen-debug-assert-check`
  all green.

No change to allocation results: the same liveness and the same loop depths reach
the allocator, from one walk instead of two.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nmb41AiKasPE74Vm3BFd8n)_