### PR TITLE
RUE-1827: make machine-code generation cooperatively cancelable

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -75,6 +75,8 @@ const _: () = {
 pub struct CfgLower<'a> {
     /// Shared context with type helpers and chain tracing.
     ctx: CfgLowerContext<'a>,
+    /// Cooperative cancellation authority for this lowering (RUE-1827).
+    cancellation: crate::GenerationCancellation<'a>,
     /// Interner for resolving Spur to string
     interner: &'a ThreadedRodeo,
     symbols: crate::MachineSymbolResolver<'a>,
@@ -219,6 +221,15 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Install the pipeline's local frame-slot decision (RUE-768).
+    /// Install the caller's cooperative cancellation authority (RUE-1827).
+    pub(crate) fn with_cancellation(
+        mut self,
+        cancellation: crate::GenerationCancellation<'a>,
+    ) -> Self {
+        self.cancellation = cancellation;
+        self
+    }
+
     pub(crate) fn with_local_storage(
         mut self,
         local_storage: &'a crate::local_storage::LocalSlotPlan,
@@ -264,6 +275,7 @@ impl<'a> CfgLower<'a> {
 
         Self {
             ctx: CfgLowerContext::new(cfg, type_pool),
+            cancellation: crate::GenerationCancellation::NONE,
             interner,
             symbols,
             target,
@@ -544,7 +556,14 @@ impl<'a> CfgLower<'a> {
             self.interner,
         )?;
         let ctx = self.ctx;
-        crate::terminator_plan::lower_cfg(&ctx, &mut self, None, RET_REGS.len() as u32);
+        let cancellation = self.cancellation;
+        crate::terminator_plan::lower_cfg(
+            &ctx,
+            &mut self,
+            None,
+            RET_REGS.len() as u32,
+            cancellation,
+        )?;
         Ok(self.mir)
     }
 
@@ -565,12 +584,14 @@ impl<'a> CfgLower<'a> {
         };
 
         let ctx = self.ctx;
+        let cancellation = self.cancellation;
         crate::terminator_plan::lower_cfg(
             &ctx,
             &mut self,
             Some(&mut debug_info),
             RET_REGS.len() as u32,
-        );
+            cancellation,
+        )?;
         Ok((self.mir, debug_info))
     }
 

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -385,6 +385,8 @@ impl LabelOffsets {
 /// The emitter converts MIR instructions to machine code, producing both
 /// raw bytes and human-readable assembly text for each instruction.
 pub struct Emitter<'a> {
+    /// Cooperative cancellation authority for this emission (RUE-1827).
+    cancellation: crate::GenerationCancellation<'a>,
     mir: &'a Aarch64Mir,
     /// Raw machine code bytes being emitted.
     code: Vec<u8>,
@@ -470,6 +472,7 @@ impl<'a> Emitter<'a> {
         let estimated_block_labels = num_instructions / 10;
 
         Self {
+            cancellation: crate::GenerationCancellation::NONE,
             mir,
             code: Vec::with_capacity(estimated_code_size),
             instructions: Vec::with_capacity(num_instructions),
@@ -640,6 +643,12 @@ impl<'a> Emitter<'a> {
     /// Emit machine code for all instructions.
     ///
     /// Returns (code bytes, relocations). This does not generate assembly text.
+    /// Install the caller's cooperative cancellation authority (RUE-1827).
+    pub fn with_cancellation(mut self, cancellation: crate::GenerationCancellation<'a>) -> Self {
+        self.cancellation = cancellation;
+        self
+    }
+
     pub fn emit(mut self) -> CompileResult<(Vec<u8>, Vec<EmittedRelocation>)> {
         // emit_asm is already false by default
         self.emit_internal()?;
@@ -702,6 +711,10 @@ impl<'a> Emitter<'a> {
         }
 
         for inst in self.mir.iter() {
+            // The per-instruction check bounds a stale attempt's residual
+            // work to one encoding (RUE-1827); without an authority it is a
+            // single branch.
+            self.cancellation.check()?;
             self.emit_inst(inst)?;
         }
 

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -55,6 +55,7 @@ pub(crate) fn prepare_backend(
         target,
         symbols,
         crate::BackendArtifactRequest::default(),
+        crate::GenerationCancellation::NONE,
     )
     .map(|(prepared, _)| prepared)
 }
@@ -79,12 +80,14 @@ impl Backend for Aarch64CodegenBackend {
         request: crate::BackendArtifactRequest,
         param_storage: &crate::param_storage::ParamStoragePlan,
         local_storage: &crate::local_storage::LocalSlotPlan,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<(Self::Mir, crate::BackendArtifacts)> {
         let (mir, lowering) = if request.lowering {
             let (mir, debug) =
                 CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
                     .with_param_storage(param_storage)
                     .with_local_storage(local_storage)
+                    .with_cancellation(cancellation)
                     .lower_with_debug()?;
             (mir, Some(debug))
         } else {
@@ -92,6 +95,7 @@ impl Backend for Aarch64CodegenBackend {
                 CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
                     .with_param_storage(param_storage)
                     .with_local_storage(local_storage)
+                    .with_cancellation(cancellation)
                     .lower()?,
                 None,
             )
@@ -112,10 +116,11 @@ impl Backend for Aarch64CodegenBackend {
         existing_slots: u32,
         artifacts: &mut crate::BackendArtifacts,
         request: crate::BackendArtifactRequest,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<(Self::Mir, u32, Vec<Self::Reg>)> {
         let (mir, spills, used, liveness, regalloc) =
             RegAlloc::new_with_artifacts(mir, existing_slots, request.liveness)
-                .allocate_with_artifacts(request.regalloc)?;
+                .allocate_with_artifacts(request.regalloc, cancellation)?;
         artifacts.liveness = liveness.map(|debug| debug.to_string());
         artifacts.regalloc = regalloc.map(|debug| debug.to_string());
         Ok((mir, spills, used))
@@ -163,6 +168,7 @@ impl Backend for Aarch64CodegenBackend {
         local_strings: &[String],
         request: crate::BackendArtifactRequest,
         artifacts: &mut crate::BackendArtifacts,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<MachineCode> {
         let emitter = Emitter::new(
             &prepared.mir,
@@ -174,7 +180,8 @@ impl Backend for Aarch64CodegenBackend {
         )
         .with_sret(prepared.has_sret)
         .with_frame_layout(prepared.frame_layout)
-        .with_param_homing(prepared.param_homing.clone());
+        .with_param_homing(prepared.param_homing.clone())
+        .with_cancellation(cancellation);
         if request.asm {
             let emitted = emitter.emit_all()?;
             artifacts.asm = Some(emitted.to_asm());
@@ -215,6 +222,7 @@ pub fn generate(
             &[],
             false,
             crate::BackendArtifactRequest::default(),
+            crate::GenerationCancellation::NONE,
         )?
         .machine_code,
     )
@@ -239,6 +247,7 @@ pub fn generate_with_symbols(
             &[],
             false,
             crate::BackendArtifactRequest::default(),
+            crate::GenerationCancellation::NONE,
         )?
         .machine_code,
     )
@@ -264,6 +273,7 @@ pub fn generate_with_symbols_and_atoms(
             atoms,
             true,
             crate::BackendArtifactRequest::default(),
+            crate::GenerationCancellation::NONE,
         )?
         .machine_code,
     )
@@ -280,7 +290,42 @@ pub fn generate_product_with_symbols_and_atoms(
     atoms: &[crate::LocalAtomProjection<'_>],
     request: crate::BackendArtifactRequest,
 ) -> CompileResult<crate::BackendProduct> {
+    generate_product_with_symbols_atoms_and_cancellation(
+        cfg,
+        type_pool,
+        strings,
+        interner,
+        target,
+        symbols,
+        atoms,
+        request,
+        crate::GenerationCancellation::NONE,
+    )
+}
+
+/// [`generate_product_with_symbols_and_atoms`] under a caller-owned
+/// cooperative cancellation authority (RUE-1827).
+pub fn generate_product_with_symbols_atoms_and_cancellation(
+    cfg: &ValidatedCfg,
+    type_pool: &FrozenTypeInternPool,
+    strings: &[String],
+    interner: &ThreadedRodeo,
+    target: Target,
+    symbols: crate::MachineSymbolResolver<'_>,
+    atoms: &[crate::LocalAtomProjection<'_>],
+    request: crate::BackendArtifactRequest,
+    cancellation: crate::GenerationCancellation<'_>,
+) -> CompileResult<crate::BackendProduct> {
     crate::codegen_pipeline::generate_with_backend::<Aarch64CodegenBackend>(
-        cfg, type_pool, strings, interner, target, symbols, atoms, true, request,
+        cfg,
+        type_pool,
+        strings,
+        interner,
+        target,
+        symbols,
+        atoms,
+        true,
+        request,
+        cancellation,
     )
 }

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -147,6 +147,7 @@ impl RegAlloc {
     pub(crate) fn allocate_with_artifacts(
         self,
         capture_regalloc: bool,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<(
         Aarch64Mir,
         u32,
@@ -154,7 +155,8 @@ impl RegAlloc {
         Option<crate::LivenessDebugInfo>,
         Option<RegAllocDebugInfo<Reg>>,
     )> {
-        self.driver.allocate_with_artifacts(capture_regalloc)
+        self.driver
+            .allocate_with_artifacts(capture_regalloc, cancellation)
     }
 
     fn rewrite_inst(

--- a/crates/rue-codegen/src/backend.rs
+++ b/crates/rue-codegen/src/backend.rs
@@ -46,6 +46,7 @@ pub(crate) trait Backend {
         request: BackendArtifactRequest,
         param_storage: &crate::param_storage::ParamStoragePlan,
         local_storage: &crate::local_storage::LocalSlotPlan,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<(Self::Mir, BackendArtifacts)>;
 
     fn allocate(
@@ -53,6 +54,7 @@ pub(crate) trait Backend {
         existing_slots: u32,
         artifacts: &mut BackendArtifacts,
         request: BackendArtifactRequest,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<(Self::Mir, u32, Vec<Self::Reg>)>;
 
     fn peephole(mir: &mut Self::Mir);
@@ -74,5 +76,6 @@ pub(crate) trait Backend {
         local_strings: &[String],
         request: BackendArtifactRequest,
         artifacts: &mut BackendArtifacts,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<MachineCode>;
 }

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -203,7 +203,9 @@ pub(crate) fn prepare_mir_with_backend<B: crate::backend::Backend>(
     target: rue_target::Target,
     symbols: crate::MachineSymbolResolver<'_>,
     request: crate::BackendArtifactRequest,
+    cancellation: crate::GenerationCancellation<'_>,
 ) -> CompileResult<(PreparedMir<B::Mir, B::Reg>, crate::BackendArtifacts)> {
+    cancellation.check()?;
     assert_eq!(
         target.arch(),
         B::ARCH,
@@ -238,27 +240,33 @@ pub(crate) fn prepare_mir_with_backend<B: crate::backend::Backend>(
             request,
             &param_storage,
             &local_storage,
+            cancellation,
         )?
     };
+    cancellation.check()?;
     let existing_slots =
         checked_slot_sum([frame_local_slots, homed_param_slots, u32::from(has_sret)])
             .ok_or_else(|| frame_budget_error(cfg, None))?;
     let (mut mir, num_spills, used_callee_saved) = {
         let _span = info_span!("register_allocation").entered();
-        B::allocate(mir, existing_slots, &mut artifacts, request)?
+        B::allocate(mir, existing_slots, &mut artifacts, request, cancellation)?
     };
+    cancellation.check()?;
     {
         let _span = info_span!("mir_peephole").entered();
         B::peephole(&mut mir);
     }
+    cancellation.check()?;
     {
         let _span = info_span!("mir_scheduling").entered();
         B::schedule(&mut mir);
     }
+    cancellation.check()?;
     {
         let _span = info_span!("mir_verification").entered();
         B::verify(&mir)?;
     }
+    cancellation.check()?;
 
     let total_locals = frame_local_slots
         .checked_add(num_spills)
@@ -302,9 +310,17 @@ pub(crate) fn generate_with_backend<B: crate::backend::Backend>(
     atoms: &[crate::LocalAtomProjection<'_>],
     require_complete_atoms: bool,
     request: crate::BackendArtifactRequest,
+    cancellation: crate::GenerationCancellation<'_>,
 ) -> CompileResult<crate::BackendProduct> {
-    let (mut prepared, mut artifacts) =
-        prepare_mir_with_backend::<B>(cfg, type_pool, interner, target, symbols, request)?;
+    let (mut prepared, mut artifacts) = prepare_mir_with_backend::<B>(
+        cfg,
+        type_pool,
+        interner,
+        target,
+        symbols,
+        request,
+        cancellation,
+    )?;
     let local_strings = {
         let _span = info_span!("string_table_compaction").entered();
         let (local_strings, remap) = crate::compact_string_table(
@@ -316,8 +332,15 @@ pub(crate) fn generate_with_backend<B: crate::backend::Backend>(
         B::remap_string_ids(&mut prepared.mir, &remap);
         local_strings
     };
+    cancellation.check()?;
     let _emission_span = info_span!("machine_emission").entered();
-    let machine_code = B::emit(&prepared, &local_strings, request, &mut artifacts)?;
+    let machine_code = B::emit(
+        &prepared,
+        &local_strings,
+        request,
+        &mut artifacts,
+        cancellation,
+    )?;
     Ok(crate::BackendProduct {
         machine_code,
         artifacts,
@@ -370,6 +393,7 @@ mod tests {
             _request: crate::BackendArtifactRequest,
             _param_storage: &crate::param_storage::ParamStoragePlan,
             local_storage: &crate::local_storage::LocalSlotPlan,
+            _cancellation: crate::GenerationCancellation<'_>,
         ) -> rue_error::CompileResult<(Self::Mir, crate::BackendArtifacts)> {
             record("lower");
             assert_eq!(local_storage.frame_local_slots(), 3);
@@ -381,6 +405,7 @@ mod tests {
             existing_slots: u32,
             _artifacts: &mut crate::BackendArtifacts,
             _request: crate::BackendArtifactRequest,
+            _cancellation: crate::GenerationCancellation<'_>,
         ) -> rue_error::CompileResult<(Self::Mir, u32, Vec<Self::Reg>)> {
             record("allocate");
             assert_eq!(existing_slots, 6);
@@ -420,6 +445,7 @@ mod tests {
             _local_strings: &[String],
             _request: crate::BackendArtifactRequest,
             _artifacts: &mut crate::BackendArtifacts,
+            _cancellation: crate::GenerationCancellation<'_>,
         ) -> rue_error::CompileResult<crate::MachineCode> {
             panic!("synthetic backend emitter is not part of this preparation test")
         }
@@ -487,6 +513,7 @@ mod tests {
             Target::X86_64Linux,
             crate::MachineSymbolResolver::default(),
             crate::BackendArtifactRequest::default(),
+            crate::GenerationCancellation::NONE,
         )
         .expect("synthetic pipeline should succeed");
 
@@ -516,6 +543,7 @@ mod tests {
             Target::Aarch64Linux,
             crate::MachineSymbolResolver::default(),
             crate::BackendArtifactRequest::default(),
+            crate::GenerationCancellation::NONE,
         );
     }
 

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -283,6 +283,55 @@ pub struct BackendProduct {
     pub artifacts: BackendArtifacts,
 }
 
+/// Cooperative cancellation authority for one backend generation call
+/// (RUE-1827).
+///
+/// This crate has no query-runtime dependency, so cancellation arrives as a
+/// caller-owned probe; the query layer builds one from its cancellation
+/// token. [`GenerationCancellation::NONE`] makes every check a no-op branch,
+/// keeping callers without an authority — tests, drivers, tools — ergonomic
+/// and free of overhead. The shared pipeline checks at stage boundaries, and
+/// the per-block lowering walk, the per-instruction allocation rewrite, and
+/// the per-instruction emission loops check inside their unbounded work, so
+/// both architectures share one cancellation contract.
+#[derive(Clone, Copy, Default)]
+pub struct GenerationCancellation<'a> {
+    probe: Option<&'a dyn Fn() -> bool>,
+}
+
+/// Exact marker carried by a cancellation rejection. The message never
+/// reaches users: the query layer converts it to its own abort before the
+/// error can surface, via [`is_generation_canceled`].
+const GENERATION_CANCELED: &str = "backend generation canceled";
+
+impl<'a> GenerationCancellation<'a> {
+    /// No cancellation authority: every check is a no-op.
+    pub const NONE: GenerationCancellation<'static> = GenerationCancellation { probe: None };
+
+    /// A cancellation authority backed by `probe`; generation stops at the
+    /// next check once the probe returns true.
+    pub fn from_probe(probe: &'a dyn Fn() -> bool) -> Self {
+        Self { probe: Some(probe) }
+    }
+
+    /// Fail cooperatively when the caller's authority reports cancellation.
+    pub fn check(self) -> rue_error::CompileResult<()> {
+        match self.probe {
+            Some(probe) if probe() => Err(rue_error::CompileError::without_span(
+                rue_error::ErrorKind::InternalError(GENERATION_CANCELED.to_owned()),
+            )),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Whether `error` is this crate's cooperative-cancellation rejection.
+/// Callers with a cancellation authority use this to convert the rejection
+/// into their own abort channel instead of recording a codegen failure.
+pub fn is_generation_canceled(error: &rue_error::CompileError) -> bool {
+    matches!(&error.kind, rue_error::ErrorKind::InternalError(message) if message == GENERATION_CANCELED)
+}
+
 /// Stable local-data identity projected onto the current program string table.
 ///
 /// Multiple occurrence identities may intentionally share one dense ID when
@@ -793,6 +842,88 @@ mod tests {
             ),
         }
         .expect("production backend generation should succeed")
+    }
+
+    /// Both backends share one cooperative cancellation contract (RUE-1827):
+    /// a probe that trips mid-pipeline stops generation with the crate's
+    /// cancellation rejection, a counting probe proves the pipeline actually
+    /// consults the authority repeatedly (block/instruction-level checks),
+    /// and a live-but-quiet authority leaves the product identical to an
+    /// uncancellable run.
+    #[test]
+    fn generation_cancels_promptly_and_quiet_probes_change_nothing() {
+        use std::cell::Cell;
+
+        let (cfg, type_pool, interner) = test_cfg();
+        for target in [
+            rue_target::Target::X86_64Linux,
+            rue_target::Target::Aarch64Linux,
+        ] {
+            let generate = |cancellation: GenerationCancellation<'_>| match target.arch() {
+                rue_target::Arch::X86_64 => {
+                    x86_64::generate_product_with_symbols_atoms_and_cancellation(
+                        &cfg,
+                        &type_pool,
+                        &[],
+                        &interner,
+                        target,
+                        MachineSymbolResolver::default(),
+                        &[],
+                        BackendArtifactRequest::default(),
+                        cancellation,
+                    )
+                }
+                rue_target::Arch::Aarch64 => {
+                    aarch64::generate_product_with_symbols_atoms_and_cancellation(
+                        &cfg,
+                        &type_pool,
+                        &[],
+                        &interner,
+                        target,
+                        MachineSymbolResolver::default(),
+                        &[],
+                        BackendArtifactRequest::default(),
+                        cancellation,
+                    )
+                }
+            };
+
+            // An authority canceled from the first probe stops at entry.
+            let tripped = || true;
+            let error = generate(GenerationCancellation::from_probe(&tripped))
+                .expect_err("a tripped authority must stop generation");
+            assert!(is_generation_canceled(&error), "{error:?}");
+
+            // A counting authority that trips after a few checks stops
+            // mid-pipeline; the check count proves the pipeline consulted
+            // the authority more than once before tripping.
+            let remaining = Cell::new(3_u32);
+            let counting = || {
+                if remaining.get() == 0 {
+                    true
+                } else {
+                    remaining.set(remaining.get() - 1);
+                    false
+                }
+            };
+            let error = generate(GenerationCancellation::from_probe(&counting))
+                .expect_err("a counting authority must stop generation mid-pipeline");
+            assert!(is_generation_canceled(&error), "{error:?}");
+            assert_eq!(remaining.get(), 0);
+
+            // A quiet authority changes nothing relative to NONE.
+            let quiet = || false;
+            let with_authority = generate(GenerationCancellation::from_probe(&quiet)).unwrap();
+            let without_authority = generate(GenerationCancellation::NONE).unwrap();
+            assert_eq!(
+                with_authority.machine_code.code,
+                without_authority.machine_code.code
+            );
+            assert_eq!(
+                with_authority.machine_code.relocations.len(),
+                without_authority.machine_code.relocations.len()
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -1530,7 +1530,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
     pub fn allocate(mut self) -> CompileResult<B::Mir> {
         self.assign_registers();
         self.validate_spill_budget()?;
-        self.rewrite_instructions()?;
+        self.rewrite_instructions(crate::GenerationCancellation::NONE)?;
         Ok(self.mir)
     }
 
@@ -1538,7 +1538,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
     pub fn allocate_with_spills(mut self) -> CompileResult<(B::Mir, u32, Vec<B::Reg>)> {
         self.assign_registers();
         self.validate_spill_budget()?;
-        self.rewrite_instructions()?;
+        self.rewrite_instructions(crate::GenerationCancellation::NONE)?;
         Ok((self.mir, self.num_spills, self.used_callee_saved))
     }
 
@@ -1547,6 +1547,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
     pub fn allocate_with_artifacts(
         mut self,
         capture_regalloc: bool,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<(
         B::Mir,
         u32,
@@ -1554,14 +1555,16 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         Option<LivenessDebugInfo>,
         Option<RegAllocDebugInfo<B::Reg>>,
     )> {
+        cancellation.check()?;
         let regalloc_debug = if capture_regalloc {
             Some(self.assign_registers_with_debug())
         } else {
             self.assign_registers();
             None
         };
+        cancellation.check()?;
         self.validate_spill_budget()?;
-        self.rewrite_instructions()?;
+        self.rewrite_instructions(cancellation)?;
         Ok((
             self.mir,
             self.num_spills,
@@ -1577,7 +1580,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
     ) -> CompileResult<(B::Mir, u32, Vec<B::Reg>, RegAllocDebugInfo<B::Reg>)> {
         let debug_info = self.assign_registers_with_debug();
         self.validate_spill_budget()?;
-        self.rewrite_instructions()?;
+        self.rewrite_instructions(crate::GenerationCancellation::NONE)?;
         Ok((
             self.mir,
             self.num_spills,
@@ -1629,7 +1632,10 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
             })
     }
 
-    fn rewrite_instructions(&mut self) -> CompileResult<()> {
+    fn rewrite_instructions(
+        &mut self,
+        cancellation: crate::GenerationCancellation<'_>,
+    ) -> CompileResult<()> {
         // The source instruction order is the canonical rewrite order. The
         // target hook classifies generated instructions into before/main/after
         // queues, and this driver drains them identically on both targets.
@@ -1647,6 +1653,10 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         // empty, and `into_ordered` allocated a fourth to concatenate them.
         let mut buffer = RewriteBuffer::new();
         for (idx, inst) in old_instructions.into_iter().enumerate() {
+            // The per-instruction check bounds a stale attempt's residual
+            // work to one rewrite (RUE-1827); without an authority it is a
+            // single branch.
+            cancellation.check()?;
             if self.coalesce_result.is_eliminated(idx) {
                 continue;
             }

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -528,7 +528,8 @@ pub(crate) fn lower_cfg<A: CfgLowerAdapter>(
     adapter: &mut A,
     mut debug_info: Option<&mut crate::LoweringDebugInfo>,
     ret_reg_budget: u32,
-) {
+    cancellation: crate::GenerationCancellation<'_>,
+) -> rue_error::CompileResult<()> {
     adapter.preload_by_ref_params();
     let order = BlockOrder::of(ctx);
 
@@ -539,6 +540,9 @@ pub(crate) fn lower_cfg<A: CfgLowerAdapter>(
     }
 
     for &block_id in order.blocks() {
+        // The per-block check bounds a stale attempt's residual work to one
+        // block of lowering (RUE-1827).
+        cancellation.check()?;
         let block = ctx.cfg.get_block(block_id);
         let mut block_info = debug_info.as_deref_mut().map(|_| crate::BlockLoweringInfo {
             block_id: block.id,
@@ -610,6 +614,7 @@ pub(crate) fn lower_cfg<A: CfgLowerAdapter>(
             debug.blocks.push(info);
         }
     }
+    Ok(())
 }
 
 /// Stable, target-independent debug rendering of a normalized terminator.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -80,6 +80,8 @@ const _: () = {
 pub struct CfgLower<'a> {
     /// Shared context with type helpers and chain tracing.
     ctx: CfgLowerContext<'a>,
+    /// Cooperative cancellation authority for this lowering (RUE-1827).
+    cancellation: crate::GenerationCancellation<'a>,
     /// Interner for resolving Spur to string
     interner: &'a ThreadedRodeo,
     symbols: crate::MachineSymbolResolver<'a>,
@@ -221,6 +223,15 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Install the pipeline's local frame-slot decision (RUE-768).
+    /// Install the caller's cooperative cancellation authority (RUE-1827).
+    pub(crate) fn with_cancellation(
+        mut self,
+        cancellation: crate::GenerationCancellation<'a>,
+    ) -> Self {
+        self.cancellation = cancellation;
+        self
+    }
+
     pub(crate) fn with_local_storage(
         mut self,
         local_storage: &'a crate::local_storage::LocalSlotPlan,
@@ -263,6 +274,7 @@ impl<'a> CfgLower<'a> {
 
         Self {
             ctx: CfgLowerContext::new(cfg, type_pool),
+            cancellation: crate::GenerationCancellation::NONE,
             interner,
             symbols,
             mir: X86Mir::new(),
@@ -701,7 +713,14 @@ impl<'a> CfgLower<'a> {
             self.interner,
         )?;
         let ctx = self.ctx;
-        crate::terminator_plan::lower_cfg(&ctx, &mut self, None, RET_REGS.len() as u32);
+        let cancellation = self.cancellation;
+        crate::terminator_plan::lower_cfg(
+            &ctx,
+            &mut self,
+            None,
+            RET_REGS.len() as u32,
+            cancellation,
+        )?;
         Ok(self.mir)
     }
 
@@ -722,12 +741,14 @@ impl<'a> CfgLower<'a> {
         };
 
         let ctx = self.ctx;
+        let cancellation = self.cancellation;
         crate::terminator_plan::lower_cfg(
             &ctx,
             &mut self,
             Some(&mut debug_info),
             RET_REGS.len() as u32,
-        );
+            cancellation,
+        )?;
         Ok((self.mir, debug_info))
     }
 

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -233,6 +233,8 @@ impl LabelOffsets {
 /// The emitter converts MIR instructions to machine code, producing both
 /// raw bytes and human-readable assembly text for each instruction.
 pub struct Emitter<'a> {
+    /// Cooperative cancellation authority for this emission (RUE-1827).
+    cancellation: crate::GenerationCancellation<'a>,
     mir: &'a X86Mir,
     /// Raw machine code bytes being emitted.
     code: Vec<u8>,
@@ -321,6 +323,7 @@ impl<'a> Emitter<'a> {
         let estimated_block_labels = num_instructions / 10;
 
         Self {
+            cancellation: crate::GenerationCancellation::NONE,
             mir,
             code: Vec::with_capacity(estimated_code_size),
             instructions: Vec::with_capacity(num_instructions),
@@ -463,6 +466,12 @@ impl<'a> Emitter<'a> {
     /// Emit machine code for all instructions.
     ///
     /// Returns (code bytes, relocations). This does not generate assembly text.
+    /// Install the caller's cooperative cancellation authority (RUE-1827).
+    pub fn with_cancellation(mut self, cancellation: crate::GenerationCancellation<'a>) -> Self {
+        self.cancellation = cancellation;
+        self
+    }
+
     pub fn emit(mut self) -> CompileResult<(Vec<u8>, Vec<EmittedRelocation>)> {
         // emit_asm is already false by default
         self.emit_internal()?;
@@ -527,6 +536,10 @@ impl<'a> Emitter<'a> {
         }
 
         for inst in self.mir.iter() {
+            // The per-instruction check bounds a stale attempt's residual
+            // work to one encoding (RUE-1827); without an authority it is a
+            // single branch.
+            self.cancellation.check()?;
             self.emit_inst(inst)?;
         }
         if self.frameless_frame_reference {

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -52,6 +52,7 @@ pub(crate) fn prepare_backend(
         target,
         symbols,
         crate::BackendArtifactRequest::default(),
+        crate::GenerationCancellation::NONE,
     )
     .map(|(prepared, _)| prepared)
 }
@@ -76,11 +77,13 @@ impl Backend for X86CodegenBackend {
         request: crate::BackendArtifactRequest,
         param_storage: &crate::param_storage::ParamStoragePlan,
         local_storage: &crate::local_storage::LocalSlotPlan,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<(Self::Mir, crate::BackendArtifacts)> {
         let (mir, lowering) = if request.lowering {
             let (mir, debug) = CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)
                 .with_param_storage(param_storage)
                 .with_local_storage(local_storage)
+                .with_cancellation(cancellation)
                 .lower_with_debug()?;
             (mir, Some(debug))
         } else {
@@ -88,6 +91,7 @@ impl Backend for X86CodegenBackend {
                 CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)
                     .with_param_storage(param_storage)
                     .with_local_storage(local_storage)
+                    .with_cancellation(cancellation)
                     .lower()?,
                 None,
             )
@@ -108,10 +112,11 @@ impl Backend for X86CodegenBackend {
         existing_slots: u32,
         artifacts: &mut crate::BackendArtifacts,
         request: crate::BackendArtifactRequest,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<(Self::Mir, u32, Vec<Self::Reg>)> {
         let (mir, spills, used, liveness, regalloc) =
             RegAlloc::new_with_artifacts(mir, existing_slots, request.liveness)
-                .allocate_with_artifacts(request.regalloc)?;
+                .allocate_with_artifacts(request.regalloc, cancellation)?;
         artifacts.liveness = liveness.map(|debug| debug.to_string());
         artifacts.regalloc = regalloc.map(|debug| debug.to_string());
         Ok((mir, spills, used))
@@ -159,6 +164,7 @@ impl Backend for X86CodegenBackend {
         local_strings: &[String],
         request: crate::BackendArtifactRequest,
         artifacts: &mut crate::BackendArtifacts,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<MachineCode> {
         let emitter = Emitter::new(
             &prepared.mir,
@@ -170,7 +176,8 @@ impl Backend for X86CodegenBackend {
         )
         .with_sret(prepared.has_sret)
         .with_frame_layout(prepared.frame_layout)
-        .with_param_homing(prepared.param_homing.clone());
+        .with_param_homing(prepared.param_homing.clone())
+        .with_cancellation(cancellation);
         if request.asm {
             let emitted = emitter.emit_all()?;
             artifacts.asm = Some(emitted.to_asm());
@@ -212,6 +219,7 @@ pub fn generate(
             &[],
             false,
             crate::BackendArtifactRequest::default(),
+            crate::GenerationCancellation::NONE,
         )?
         .machine_code,
     )
@@ -236,6 +244,7 @@ pub fn generate_with_symbols(
             &[],
             false,
             crate::BackendArtifactRequest::default(),
+            crate::GenerationCancellation::NONE,
         )?
         .machine_code,
     )
@@ -261,6 +270,7 @@ pub fn generate_with_symbols_and_atoms(
             atoms,
             true,
             crate::BackendArtifactRequest::default(),
+            crate::GenerationCancellation::NONE,
         )?
         .machine_code,
     )
@@ -277,7 +287,42 @@ pub fn generate_product_with_symbols_and_atoms(
     atoms: &[crate::LocalAtomProjection<'_>],
     request: crate::BackendArtifactRequest,
 ) -> CompileResult<crate::BackendProduct> {
+    generate_product_with_symbols_atoms_and_cancellation(
+        cfg,
+        type_pool,
+        strings,
+        interner,
+        target,
+        symbols,
+        atoms,
+        request,
+        crate::GenerationCancellation::NONE,
+    )
+}
+
+/// [`generate_product_with_symbols_and_atoms`] under a caller-owned
+/// cooperative cancellation authority (RUE-1827).
+pub fn generate_product_with_symbols_atoms_and_cancellation(
+    cfg: &ValidatedCfg,
+    type_pool: &FrozenTypeInternPool,
+    strings: &[String],
+    interner: &ThreadedRodeo,
+    target: rue_target::Target,
+    symbols: crate::MachineSymbolResolver<'_>,
+    atoms: &[crate::LocalAtomProjection<'_>],
+    request: crate::BackendArtifactRequest,
+    cancellation: crate::GenerationCancellation<'_>,
+) -> CompileResult<crate::BackendProduct> {
     crate::codegen_pipeline::generate_with_backend::<X86CodegenBackend>(
-        cfg, type_pool, strings, interner, target, symbols, atoms, true, request,
+        cfg,
+        type_pool,
+        strings,
+        interner,
+        target,
+        symbols,
+        atoms,
+        true,
+        request,
+        cancellation,
     )
 }

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -178,6 +178,7 @@ impl RegAlloc {
     pub(crate) fn allocate_with_artifacts(
         self,
         capture_regalloc: bool,
+        cancellation: crate::GenerationCancellation<'_>,
     ) -> CompileResult<(
         X86Mir,
         u32,
@@ -185,7 +186,8 @@ impl RegAlloc {
         Option<crate::LivenessDebugInfo>,
         Option<RegAllocDebugInfo<Reg>>,
     )> {
-        self.driver.allocate_with_artifacts(capture_regalloc)
+        self.driver
+            .allocate_with_artifacts(capture_regalloc, cancellation)
     }
 
     fn rewrite_inst(

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -34,6 +34,41 @@ thread_local! {
     static INJECT_CODEGEN_FAILURE: Cell<bool> = const { Cell::new(false) };
 }
 
+/// Deterministic mid-backend cancellation for tests. Codegen units evaluate
+/// on query worker threads, so unlike the linker's thread-local tripwire this
+/// one is a process-global slot.
+#[cfg(test)]
+static CODEGEN_CANCELLATION_TRIPWIRE: std::sync::Mutex<
+    Option<(rue_query::CancellationToken, usize)>,
+> = std::sync::Mutex::new(None);
+
+/// Arm a deterministic mid-backend cancellation: the Nth cooperative probe
+/// inside machine-code generation cancels `token`, so the stale attempt must
+/// exit through the cancellation contract rather than completing the unit
+/// (RUE-1827). Mirrors `linking::set_link_cancellation_tripwire`.
+#[cfg(test)]
+pub(crate) fn set_codegen_cancellation_tripwire(
+    cancellation: Option<(rue_query::CancellationToken, usize)>,
+) {
+    *CODEGEN_CANCELLATION_TRIPWIRE.lock().unwrap() = cancellation;
+}
+
+/// One cooperative cancellation probe evaluation for the backend kernel.
+fn generation_probe_is_canceled(context: &QueryContext) -> bool {
+    #[cfg(test)]
+    {
+        let mut slot = CODEGEN_CANCELLATION_TRIPWIRE.lock().unwrap();
+        if let Some((token, remaining)) = slot.as_mut() {
+            *remaining = remaining.saturating_sub(1);
+            if *remaining == 0 {
+                token.cancel();
+                *slot = None;
+            }
+        }
+    }
+    context.cancellation().is_canceled()
+}
+
 #[cfg(test)]
 pub(crate) fn with_test_codegen_failure_injection<T>(run: impl FnOnce() -> T) -> T {
     struct Reset;
@@ -551,30 +586,47 @@ pub(crate) fn evaluate_codegen_unit(
         &record.codegen.foreign_symbols,
     );
     context.record_work(rue_query::WorkItem::new("codegen.lowering.local", 1));
+    // The backend kernel has no query-runtime dependency; hand it this
+    // task's cancellation authority as a probe so a stale watch revision
+    // stops lowering/allocation/emission promptly instead of completing the
+    // unit (RUE-1827).
+    let probe = || generation_probe_is_canceled(context);
+    let cancellation = rue_codegen::GenerationCancellation::from_probe(&probe);
     let generated = match key.target.arch() {
-        rue_target::Arch::X86_64 => rue_codegen::x86_64::generate_product_with_symbols_and_atoms(
-            &record.cfg,
-            &record.type_pool,
-            &record.strings,
-            &record.interner,
-            key.target,
-            symbols,
-            &atoms,
-            key.request,
-        ),
-        rue_target::Arch::Aarch64 => rue_codegen::aarch64::generate_product_with_symbols_and_atoms(
-            &record.cfg,
-            &record.type_pool,
-            &record.strings,
-            &record.interner,
-            key.target,
-            symbols,
-            &atoms,
-            key.request,
-        ),
+        rue_target::Arch::X86_64 => {
+            rue_codegen::x86_64::generate_product_with_symbols_atoms_and_cancellation(
+                &record.cfg,
+                &record.type_pool,
+                &record.strings,
+                &record.interner,
+                key.target,
+                symbols,
+                &atoms,
+                key.request,
+                cancellation,
+            )
+        }
+        rue_target::Arch::Aarch64 => {
+            rue_codegen::aarch64::generate_product_with_symbols_atoms_and_cancellation(
+                &record.cfg,
+                &record.type_pool,
+                &record.strings,
+                &record.interner,
+                key.target,
+                symbols,
+                &atoms,
+                key.request,
+                cancellation,
+            )
+        }
     };
     let mut product = match generated {
         Ok(product) => product,
+        // A cooperative cancellation rejection is this task's own abort, not
+        // a codegen failure: it must not record a failure terminal.
+        Err(error) if rue_codegen::is_generation_canceled(&error) => {
+            return Err(QueryAbort::Canceled);
+        }
         Err(error) => return Ok(codegen_failure(error.into())),
     };
     if let Some(lowering) = &mut product.artifacts.lowering {

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -1221,6 +1221,44 @@ mod tests {
         assert!(!recovered.elf.is_empty());
     }
 
+    /// RUE-1827: canceling the revision while machine-code generation is in
+    /// flight aborts the rooted backend request through the cooperative
+    /// cancellation contract — the tripwire cancels the token from INSIDE the
+    /// backend kernel's own probe, so the stale attempt exits before
+    /// completing its unit — and the canceled attempt records no failure
+    /// terminal: the same session recompiles cleanly afterward.
+    #[test]
+    fn in_progress_codegen_cancellation_aborts_without_poisoning_reuse() {
+        let snapshot = wide_reached_program(64, 7);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let cancellation = rue_query::CancellationToken::new();
+        crate::codegen_query::set_codegen_cancellation_tripwire(Some((cancellation.clone(), 40)));
+
+        let canceled = session.rooted_codegen_internal_with_cancellation(
+            &options,
+            rue_codegen::BackendArtifactRequest::default(),
+            cancellation.clone(),
+        );
+
+        crate::codegen_query::set_codegen_cancellation_tripwire(None);
+        assert!(matches!(
+            canceled,
+            Err(crate::session::PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled
+            ))
+        ));
+        assert!(cancellation.is_canceled());
+
+        let recovered = crate::queries::compile_with_session(&mut session, &snapshot, &options)
+            .expect("a canceled backend kernel must not poison retained compiler terminals");
+        assert!(!recovered.elf.is_empty());
+    }
+
     #[test]
     fn failed_wide_batches_release_their_unpublished_child_cones_under_pressure() {
         const CHAIN_FUNCTIONS: usize = 33;

--- a/crates/rue-query/src/context.rs
+++ b/crates/rue-query/src/context.rs
@@ -245,6 +245,13 @@ impl QueryContext {
         }
     }
 
+    /// Borrowed cancellation authority of this task, for threading
+    /// cooperative checks into crates that do not depend on the query
+    /// runtime (RUE-1827).
+    pub fn cancellation(&self) -> &CancellationToken {
+        &self.task.cancellation
+    }
+
     /// Reads and records one exact leaf from this task's pinned revision.
     pub fn input(&self, input: InputIdentity) -> Result<u64, QueryAbort> {
         let stamp = self

--- a/scripts/planted-miscompile-study.py
+++ b/scripts/planted-miscompile-study.py
@@ -30,7 +30,7 @@ PATCH_TARGETS = {
 PATCH_PREIMAGE_SHA256 = {
     "RUE-348": "5ee3154a1c860db866743d1e8a7a59123ad153e3b4f97888f8fef8d0cf1eb6d0",
     "RUE-914": "29be4acc44becb5df841089d0bfd7af545cec69da08d08ded392f35df7bde2bd",
-    "RUE-1758": "eddde415113e38eb02cc77b61045a6da5d3fe07f49e4d927bdc54bcd245106c0",
+    "RUE-1758": "cdb907ba09b8f17243aa6671d249f4f72b24cec00ac33854d3b0e07a83ad13cf",
 }
 FOCUSED_CLI = {
     "RUE-348": "enum_payload_equality_across_opt_levels",


### PR DESCRIPTION
Fixes RUE-1827.

## Problem

`evaluate_codegen_unit` checked query cancellation at entry and again only after `generate_product_with_symbols_and_atoms` returned. Everything between — CFG-to-MIR lowering, register allocation, liveness, scheduling, peephole work, verification, and machine-code emission — ran to completion on stale watch revisions, so watch-mode latency and wasted CPU scaled with the largest canceled codegen unit. RUE-1810 covered object generation and linking; this covers the earlier codegen kernel.

## Fix

- **rue-codegen** gains `GenerationCancellation<'_>`: a caller-owned probe (`&dyn Fn() -> bool`) since the crate has no query-runtime dependency, with a `NONE` constant that makes every check a single no-op branch for callers without an authority (tests, drivers, tools keep their signatures via the unchanged wrapper entry points).
- Checks at **every stage boundary** in the shared pipeline (`prepare_mir_with_backend` / `generate_with_backend`), plus inside the three unbounded loops: the **shared per-block lowering walk** (`terminator_plan::lower_cfg`), the **shared per-instruction allocation rewrite** (`RegAllocDriver::rewrite_instructions`), and each architecture's **per-instruction emission loop** — one contract for x86-64 and AArch64, threaded through the `Backend` trait's `lower`/`allocate`/`emit`.
- A rejection carries a crate-recognized marker (`is_generation_canceled`). The codegen query builds its probe from the task's token via the new `QueryContext::cancellation` accessor and converts the rejection to `QueryAbort::Canceled`, so a canceled attempt records **no failure terminal**.
- The RUE-1758 planted-miscompile preimage pin is refreshed for the `terminator_plan.rs` change; the planted patch targets `BlockOrder::of`, which this diff does not touch, and still applies cleanly (`--verify-layout` green).

## Tests

- `generation_cancels_promptly_and_quiet_probes_change_nothing` (rue-codegen, both arches): a tripped authority stops at entry; a counting authority stops mid-pipeline after the probe is consulted repeatedly; a quiet authority leaves machine code byte-identical to `NONE`.
- `in_progress_codegen_cancellation_aborts_without_poisoning_reuse` (rue-compiler): a process-global tripwire (codegen units evaluate on worker threads, unlike the linker's thread-local one) cancels the revision from inside the kernel's own probe mid-backend; the rooted request aborts as `Canceled` and the same session recompiles cleanly afterward — the deterministic block-inside/cancel/prove-exit case from the acceptance list.

## Validation

- `buck2 test` on rue-codegen (790), rue-query, rue-compiler (1130) + clippy/debug-assert gates — all green
- `scripts/rue quick` and full `scripts/rue premerge` — pass, exit 0 (including the planted-miscompile isolation validation)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLu5tyWdwrL8RywUZqaQc)_