### PR TITLE
RUE-1836: box the AST nodes that set every node's size

### DIFF
--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -1147,7 +1147,7 @@ fn statement_record(
                 rue_parser::LetPattern::Ident(ident) => (Some(resolved_ident(owner, ident)), "let"),
                 rue_parser::LetPattern::Wildcard(_) => (None, "let_wildcard"),
             };
-            let mut children = directive_records(owner, &statement.directives).collect::<Vec<_>>();
+            let mut children = directive_records(owner, statement.directives()).collect::<Vec<_>>();
             children.push(modifier_record(
                 statement.span,
                 "mutable",

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -122,8 +122,17 @@ fn pattern_charge(pattern: &ast::Pattern) -> u64 {
 
 fn statement_charge(statement: &ast::Statement) -> u64 {
     match statement {
-        ast::Statement::Let(statement) => directives_charge(&statement.directives)
-            .saturating_add(statement.ty.as_ref().map_or(0, type_charge))
+        ast::Statement::Let(statement) => statement
+            .directives
+            .as_ref()
+            .map_or(0, |directives| boxed_charge(directives, directives_charge))
+            // RUE-1836 boxed the annotation, so its own bytes are now heap.
+            .saturating_add(
+                statement
+                    .ty
+                    .as_ref()
+                    .map_or(0, |ty| boxed_charge(ty, type_charge)),
+            )
             .saturating_add(boxed_charge(&statement.init, expr_charge)),
         ast::Statement::Assign(statement) => {
             let target = match &statement.target {
@@ -156,9 +165,12 @@ fn expr_charge(expr: &ast::Expr) -> u64 {
         Expr::Unary(unary) => boxed_charge(&unary.operand, expr_charge),
         Expr::Paren(paren) => boxed_charge(&paren.inner, expr_charge),
         Expr::Block(block) => block_charge(block),
-        Expr::If(value) => boxed_charge(&value.cond, expr_charge)
-            .saturating_add(block_charge(&value.then_block))
-            .saturating_add(value.else_block.as_ref().map_or(0, block_charge)),
+        // RUE-1836 boxed the `IfExpr` itself, so charge its bytes as heap too.
+        Expr::If(value) => boxed_charge(value, |if_expr| {
+            boxed_charge(&if_expr.cond, expr_charge)
+                .saturating_add(block_charge(&if_expr.then_block))
+                .saturating_add(if_expr.else_block.as_ref().map_or(0, block_charge))
+        }),
         Expr::Match(value) => boxed_charge(&value.scrutinee, expr_charge).saturating_add(
             owned_slice_charge(&value.arms, |arm| {
                 pattern_charge(&arm.pattern).saturating_add(boxed_charge(&arm.body, expr_charge))

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -814,8 +814,8 @@ impl Shapes<'_> {
                             LetPattern::Wildcard(_) => UNDERSCORE * 256,
                         }
                 ),
-                self.directives(&v.directives),
-                v.ty.as_ref().map_or("_".into(), |t| self.ty(t)),
+                self.directives(v.directives()),
+                v.ty.as_deref().map_or("_".into(), |t| self.ty(t)),
                 self.expr(&v.init),
                 "_".into(),
             ),

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -694,7 +694,10 @@ pub enum Expr {
     /// Blocks without an explicit final expression store implicit unit.
     Block(BlockExpr),
     /// If expression (e.g., `if cond { a } else { b }`)
-    If(IfExpr),
+    ///
+    /// Boxed: `IfExpr` embeds both branch blocks inline, and at 120 bytes it
+    /// was the variant that set `Expr`'s size for every other node (RUE-1836).
+    If(Box<IfExpr>),
     /// Match expression (e.g., `match x { 1 => a, _ => b }`)
     Match(MatchExpr),
     /// While expression (e.g., `while cond { body }`)
@@ -1155,17 +1158,32 @@ impl LetPattern {
 /// A let binding statement.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LetStatement {
-    /// Directives applied to this let binding
-    pub directives: Directives,
+    /// Directives applied to this let binding.
+    ///
+    /// Boxed and optional: `Directives` is a `SmallVec` with one inline
+    /// `Directive`, so it costs 72 bytes on every `let` whether or not any
+    /// directive is present — and almost none are (RUE-1836). `None` is the
+    /// empty case; use [`LetStatement::directives`] to read either as a slice.
+    pub directives: Option<Box<Directives>>,
     /// Whether the binding is mutable
     pub is_mut: bool,
     /// The binding pattern (identifier or wildcard)
     pub pattern: LetPattern,
-    /// Optional type annotation
-    pub ty: Option<TypeExpr>,
+    /// Optional type annotation.
+    ///
+    /// Boxed: an inline `TypeExpr` costs 64 bytes on every `let`, annotated or
+    /// not, and a `Vec<Statement>` block body pays it per statement (RUE-1836).
+    pub ty: Option<Box<TypeExpr>>,
     /// Initializer expression
     pub init: Box<Expr>,
     pub span: Span,
+}
+
+impl LetStatement {
+    /// The directives on this binding, empty when there are none.
+    pub fn directives(&self) -> &[Directive] {
+        self.directives.as_ref().map_or(&[], |d| d.as_slice())
+    }
 }
 
 /// An assignment statement.
@@ -1914,7 +1932,9 @@ fn rebind_let_pattern(pattern: &mut LetPattern, file_id: FileId) {
 fn rebind_statement(statement: &mut Statement, file_id: FileId) {
     match statement {
         Statement::Let(binding) => {
-            rebind_directives(&mut binding.directives, file_id);
+            if let Some(directives) = binding.directives.as_deref_mut() {
+                rebind_directives(directives, file_id);
+            }
             rebind_let_pattern(&mut binding.pattern, file_id);
             if let Some(ty) = &mut binding.ty {
                 rebind_type(ty, file_id);
@@ -2406,5 +2426,59 @@ fn fmt_stmt(f: &mut fmt::Formatter<'_>, stmt: &Statement, level: usize) -> fmt::
             writeln!(f, "ExprStmt")?;
             fmt_expr(f, expr, level + 1)
         }
+    }
+}
+
+#[cfg(test)]
+mod size_guards {
+    use super::*;
+
+    /// RUE-1836. The AST is retained for the life of a module revision
+    /// (`ParsedModule` holds `ast: Arc<Ast>`, and `retained_charge()` bills its
+    /// bytes as session memory), and during parsing every `PResult<Expr>` return
+    /// and `Vec` push memcpys these values. Both costs scale with the *largest*
+    /// variant, so the common nodes pay for the rare shapes.
+    ///
+    /// Upper bounds rather than equalities: shrinking further is always welcome,
+    /// and these are 64-bit figures. Nothing else in the repo guarded AST sizes,
+    /// so any new variant could silently widen every node — these are the tests
+    /// the issue asked for, beside `rue-span`'s `test_span_size`.
+    #[test]
+    fn ast_nodes_stay_small() {
+        // Was 128: `Expr::If` inlined a 120-byte `IfExpr` holding both blocks.
+        assert!(
+            size_of::<Expr>() <= 96,
+            "Expr grew to {} bytes; the cap is StructLitExpr at {}",
+            size_of::<Expr>(),
+            size_of::<StructLitExpr>(),
+        );
+        // Was 192, driven by LetStatement.
+        assert!(
+            size_of::<Statement>() <= 96,
+            "Statement grew to {} bytes",
+            size_of::<Statement>(),
+        );
+        // Was 176: an inline `Directives` SmallVec plus an inline `TypeExpr`.
+        assert!(
+            size_of::<LetStatement>() <= 56,
+            "LetStatement grew to {} bytes",
+            size_of::<LetStatement>(),
+        );
+        // Was 144; inlines one `Expr`, so it tracks `Expr` above.
+        assert!(
+            size_of::<CallArg>() <= 112,
+            "CallArg grew to {} bytes",
+            size_of::<CallArg>(),
+        );
+    }
+
+    /// The boxes above only pay off while the nodes they point at stay off the
+    /// hot inline path. If `IfExpr` were ever inlined back into `Expr`, the
+    /// bound above would fail — but so would the intent, so state it directly.
+    #[test]
+    fn oversized_nodes_stay_behind_a_pointer() {
+        assert!(size_of::<IfExpr>() > size_of::<Expr>());
+        assert_eq!(size_of::<Option<Box<Directives>>>(), size_of::<usize>());
+        assert_eq!(size_of::<Option<Box<TypeExpr>>>(), size_of::<usize>());
     }
 }

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -362,9 +362,9 @@ mod tests {
         let Statement::Let(statement) = &body.statements[0] else {
             panic!("expected directed let statement");
         };
-        assert_eq!(statement.directives.len(), 2);
-        assert_eq!(statement.directives[0].args.len(), 2);
-        assert_eq!(statement.directives[1].args.len(), 1);
+        assert_eq!(statement.directives().len(), 2);
+        assert_eq!(statement.directives()[0].args.len(), 2);
+        assert_eq!(statement.directives()[1].args.len(), 1);
     }
 
     #[test]

--- a/crates/rue-parser/src/parser/statements.rs
+++ b/crates/rue-parser/src/parser/statements.rs
@@ -24,12 +24,12 @@ impl Parser {
         } else {
             None
         };
-        Ok(Expr::If(IfExpr {
+        Ok(Expr::If(Box::new(IfExpr {
             cond: Box::new(cond),
             then_block,
             else_block,
             span: self.span_from(start),
-        }))
+        })))
     }
     pub(super) fn while_expr(&mut self) -> PResult<Expr> {
         let start = self.start();
@@ -479,10 +479,12 @@ impl Parser {
         }
         self.bump();
         Ok(Statement::Let(LetStatement {
-            directives,
+            // Empty stays `None`: allocating for the common undirected `let`
+            // would trade the inline bytes for a heap trip (RUE-1836).
+            directives: (!directives.is_empty()).then(|| Box::new(directives)),
             is_mut,
             pattern,
-            ty,
+            ty: ty.map(Box::new),
             init,
             span: self.span_from(start),
         }))

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -254,7 +254,7 @@ impl Validator<'_> {
     fn check_statement(&mut self, statement: &Statement) {
         match statement {
             Statement::Let(l) => {
-                self.check_directives(&l.directives, DirectiveSite::Let);
+                self.check_directives(l.directives(), DirectiveSite::Let);
                 self.check_expr(&l.init);
             }
             Statement::Assign(a) => self.check_expr(&a.value),

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -2066,7 +2066,7 @@ impl<'a> AstGen<'a> {
     fn gen_statement(&mut self, stmt: &Statement) -> InstRef {
         match stmt {
             Statement::Let(let_stmt) => {
-                let directives = self.convert_directives(&let_stmt.directives);
+                let directives = self.convert_directives(let_stmt.directives());
                 let name = match &let_stmt.pattern {
                     LetPattern::Ident(ident) => Some(self.symbol(ident.name)),
                     LetPattern::Wildcard(_) => None,


### PR DESCRIPTION
Fixes RUE-1836.

## Problem

Measured on x86-64 (rustc 1.92.0), matching the issue exactly: `Expr` 128 B,
`Statement` 192 B, `CallArg` 144 B, `LetStatement` 176 B.

The AST is not transient — `ParsedModule` holds `ast: Arc<Ast>` for the life of a
module revision and `retained_charge()` already bills its bytes as session memory
— and during parsing every `PResult<Expr>` return and `Vec` push memcpys these
values. Both costs scale with the *largest* variant, so the common nodes (`Ident`,
`Int`, `Field`, `Call`) paid for the rare `If` and `Let` shapes.

## Change

Three outliers set those sizes. Box them:

| | before | after |
|---|---|---|
| `Expr` | 128 | **96** |
| `Statement` | 192 | **96** |
| `LetStatement` | 176 | **56** |
| `CallArg` | 144 | **112** |

- `Expr::If(IfExpr)` → `Expr::If(Box<IfExpr>)`. `IfExpr` embeds *both* branch
  blocks inline, making it 120 B and capping `Expr`.
- `LetStatement.ty` → `Option<Box<TypeExpr>>`. An inline `TypeExpr` cost 64 B on
  every `let`, annotated or not.
- `LetStatement.directives` → `Option<Box<Directives>>`. `Directives` is a
  `SmallVec` with one inline `Directive`, so it cost 72 B on every `let` whether
  or not a directive was present. `None` is the common undirected case, so it
  costs a pointer and no allocation. `LetStatement::directives()` reads either
  form as a `&[Directive]`.

`CallArg` follows `Expr` down without needing its own box, as the issue expected.

Mechanical throughout: one construction site each, and most `Expr::If(..)` match
arms auto-deref unchanged. No grammar or semantic change — the parser produces the
same tree.

## Retained-charge accounting

`retained_charge` is updated to match the new layout rather than just to compile.
The boxed `IfExpr`, type annotation and directives are now charged through
`boxed_charge`, which bills the pointee's own bytes — so the session's memory model
still reflects what is actually on the heap, which matters because this issue's
impact claim is about AST retention.

## Guard

The repo asserts sizes for `Span`, `rue-cfg`/`rue-air` instructions and MIR, but
nothing guarded the AST — any new variant could silently widen every node. Two
tests beside `rue-span`'s `test_span_size`:

- `ast_nodes_stay_small` — upper bounds on all four types above, with failure
  messages naming the new size and the capping variant.
- `oversized_nodes_stay_behind_a_pointer` — `IfExpr` must stay larger than `Expr`
  (i.e. still boxed), and the two `Option<Box<..>>` fields must each be one word.

## Validation

- `scripts/rue unit rue-parser` — 63 passed; `rue-rir` — 137 passed;
  `rue-compiler` — 1129 passed, 0 failed.
- `rue-parser-clippy`, `rue-parser-fmt-check`, `rue-rir-clippy`,
  `rue-compiler-clippy` green.
- `//crates/rue:rue` and `//crates/rue-frontend-diff:rue-frontend-diff` both build
  (the latter is outside the `rue` graph and needed its own two call-site updates).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nmb41AiKasPE74Vm3BFd8n)_