### PR TITLE
RUE-1857: deduplicate package-wide build gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,11 @@ jobs:
             dotslash-linux-x64-
 
       - name: Check formatting
-        # Every crate emits its own `<name>-fmt-check` test from the
-        # rue_crate/rue_binary macros (RUE-1153), so coverage follows the
-        # build graph. The target list comes from a query over that graph
+        # Every crate package emits one directory-named `<crate>-fmt-check`
+        # test from the rue_crate/rue_binary macros (RUE-1153, RUE-1857), so
+        # coverage follows the build graph without repeating byte-identical
+        # work when a package declares several binary/library targets. The
+        # target list comes from a query over that graph
         # rather than filesystem discovery: the original `//:fmt-check` took
         # its list from a root-package `glob(["crates/**/*.rs"])`, and a Buck
         # glob does not descend into subpackages, so it checked 1 file of 281
@@ -62,6 +64,45 @@ jobs:
             echo "fmt: no -fmt-check targets found; the query or the macros are broken" >&2
             exit 1
           fi
+
+          # The package-directory owner rule must not fail open. Prove that
+          # every package using the crate macros has exactly one canonical
+          # formatting gate and sources filegroup, and that no secondary
+          # target in the package emitted a duplicate. This complements the
+          # root ASan exception above, which is deliberately outside crates/.
+          mapfile -t PACKAGE_BUCKS < <(grep -l -E '^[[:space:]]*rue_(crate|binary)\(' crates/*/BUCK | sort)
+          if [ "${#PACKAGE_BUCKS[@]}" -eq 0 ]; then
+            echo "fmt: no rue_crate/rue_binary packages found; package-gate discovery is broken" >&2
+            exit 1
+          fi
+          mapfile -t SOURCE_TARGETS < <(./buck2 uquery "kind('filegroup', 'root//crates/...')" | grep -- '-sources$')
+          FMT_TARGET_SET="$(printf '%s\n' "${TARGETS[@]}")"
+          SOURCE_TARGET_SET="$(printf '%s\n' "${SOURCE_TARGETS[@]}")"
+          for buck in "${PACKAGE_BUCKS[@]}"; do
+            package="${buck%/BUCK}"
+            crate="${package##*/}"
+            expected_fmt="root//$package:$crate-fmt-check"
+            expected_sources="root//$package:$crate-sources"
+            if ! grep -Fqx -- "$expected_fmt" <<<"$FMT_TARGET_SET"; then
+              echo "fmt: missing canonical package gate $expected_fmt" >&2
+              exit 1
+            fi
+            if ! grep -Fqx -- "$expected_sources" <<<"$SOURCE_TARGET_SET"; then
+              echo "fmt: missing canonical package sources $expected_sources" >&2
+              exit 1
+            fi
+          done
+          crate_fmt_count=0
+          for target in "${TARGETS[@]}"; do
+            case "$target" in
+              root//crates/*) crate_fmt_count=$((crate_fmt_count + 1)) ;;
+            esac
+          done
+          if [ "$crate_fmt_count" -ne "${#PACKAGE_BUCKS[@]}" ] || [ "${#SOURCE_TARGETS[@]}" -ne "${#PACKAGE_BUCKS[@]}" ]; then
+            echo "fmt: package gate inventory is not one-to-one (packages=${#PACKAGE_BUCKS[@]}, fmt=$crate_fmt_count, sources=${#SOURCE_TARGETS[@]})" >&2
+            exit 1
+          fi
+
           echo "Checking formatting across ${#TARGETS[@]} crates..."
           ./buck2 test "${TARGETS[@]}"
 

--- a/crates/defs.bzl
+++ b/crates/defs.bzl
@@ -25,8 +25,12 @@ load("//:test_defs.bzl", "rue_test_labels")
 
 _RUSTFMT_CONFIG = "//:rustfmt-config"
 
+def _canonical_package_target_name():
+    """Returns the target name that owns package-wide structural gates."""
+    return package_name().split("/")[-1]
+
 def _sources_filegroup(name, srcs):
-    """Emits `<name>-sources`: this crate's compiled sources as a PUBLIC filegroup.
+    """Emits one `<package>-sources` PUBLIC filegroup for compiled sources.
 
     Structural gates that live outside this package (the root-BUCK inventory
     validators, RUE-1525) take a crate's sources as a `$(location ...)` input.
@@ -35,7 +39,13 @@ def _sources_filegroup(name, srcs):
     `glob(["src/**/*.rs"])` copy per gate per crate — with a single sources
     target that exists because the crate declares itself, and that new gates
     can reuse without touching the crate's BUCK file.
+
+    A package may declare several library or binary targets over the same
+    sources. The target matching the package directory owns this package-wide
+    filegroup, just as it owns the formatting and debug-assertion gates.
     """
+    if name != _canonical_package_target_name():
+        return
     native.filegroup(
         name = name + "-sources",
         srcs = srcs,
@@ -43,7 +53,7 @@ def _sources_filegroup(name, srcs):
     )
 
 def _fmt_check(name, srcs):
-    """Emits `<name>-fmt-check`: rustfmt --check over this crate's own sources.
+    """Emits one `<package>-fmt-check` over this package's compiled sources.
 
     Coverage is structural (RUE-1153). The gate this replaces took its file
     list from filesystem discovery — and before that from a root-package
@@ -56,8 +66,11 @@ def _fmt_check(name, srcs):
     sh_test runs from the project root, so each path is prefixed with the
     package to address the file from there. Declaring `srcs` as resources is
     what makes Buck re-run the check when a source changes rather than
-    serving a stale pass.
+    serving a stale pass. A package with several macro targets still emits one
+    byte-identical formatting action, owned by its directory-named target.
     """
+    if name != _canonical_package_target_name():
+        return
     native.sh_test(
         name = name + "-fmt-check",
         test = "toolchains//rust:rustfmt",
@@ -100,7 +113,7 @@ def _debug_assert_check(name, srcs):
     matches the directory. Orphaned ledger entries for a crate that stopped
     emitting a check entirely are caught by //:debug-assert-ledger-check.
     """
-    crate = package_name().split("/")[-1]
+    crate = _canonical_package_target_name()
     if name != crate:
         return
     native.sh_test(


### PR DESCRIPTION
## Summary

- emit package-wide formatting and source-file gates only from the directory-named canonical target
- retain per-target clippy checks and the existing canonical debug-assert owner
- add a CI graph guard requiring an exact one-to-one package, formatting-gate, and source-filegroup inventory

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (33/33)
- `scripts/rue premerge` (200 passed; the sole failure was two fixed two-second timing assertions under host load above 10)
- isolated `//crates/rue-compiler:rue-compiler-platform-native-test` (36/36)
- exact rebased Buck graph inventory: 28 packages, 28 formatting gates, 28 source filegroups, and all three `crates/rue` clippy targets
- `git diff --check`

Fixes RUE-1857