### PR TITLE
RUE-1856: surface rue-bench build in premerge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,9 +557,10 @@ jobs:
 
       # RUE-1258's two performance gates deliberately live in different jobs,
       # because they cost two orders of magnitude apart. This one is decidable
-      # from the tree alone and is about a second of hashing next to a compiler
-      # this lane has already built, so it belongs where the build is. Its
-      # sibling reads the published series, costs minutes, and shares nothing
+      # from the tree alone and its pin computation is cheap. The explicit
+      # `rue-bench` build below may nevertheless be the first/cold build on a
+      # narrowed or cacheless run, so `ci-timed` owns that cost and its errors.
+      # Its sibling reads the published series, costs minutes, and shares nothing
       # with this lane but `rue-bench`; it is the `performance-staleness` job.
       #
       # Neither gate has a bypass. The remedy for either is declaring the next
@@ -573,6 +574,7 @@ jobs:
         run: |
           set -euo pipefail
           RUE="$(scripts/rue-bin)"
+          scripts/ci-timed "rue-bench build" -- ./buck2 build //crates/rue-bench:rue-bench
           BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
           "$BENCH" check-pins \
             --manifest performance/manifest.toml \

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -194,6 +194,386 @@ class GateValidatorTests(unittest.TestCase):
             errors,
         )
 
+    def test_performance_pin_build_is_visible_and_timed(self):
+        changed = SOURCE.read_text().replace(
+            '          scripts/ci-timed "rue-bench build" -- ./buck2 build //crates/rue-bench:rue-bench\n',
+            "          # build moved to an untracked location\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("no executable ci-timed rue-bench build", errors)
+
+    def test_performance_pin_build_must_precede_warm_capture(self):
+        source = SOURCE.read_text()
+        visible = (
+            '          scripts/ci-timed "rue-bench build" -- ./buck2 build '
+            '//crates/rue-bench:rue-bench\n'
+        )
+        warm = (
+            '          BENCH="$(./buck2 build //crates/rue-bench:rue-bench '
+            '--show-simple-output 2>/dev/null | tail -1)"\n'
+        )
+        changed = source.replace(visible + warm, warm + visible, 1)
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("must precede the warm path-only capture", errors)
+
+    def test_performance_pin_build_cannot_follow_a_true_or_continuation(self):
+        source = SOURCE.read_text()
+        visible = (
+            '          scripts/ci-timed "rue-bench build" -- ./buck2 build '
+            '//crates/rue-bench:rue-bench\n'
+        )
+        changed = source.replace(
+            visible,
+            "          true || \\\n"
+            + visible,
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("exact straight-line command sequence", errors)
+
+    def test_performance_pin_build_cannot_follow_a_bang_continuation(self):
+        source = SOURCE.read_text()
+        visible = (
+            '          scripts/ci-timed "rue-bench build" -- ./buck2 build '
+            '//crates/rue-bench:rue-bench\n'
+        )
+        changed = source.replace(
+            visible,
+            "          ! \\\n"
+            + visible,
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("exact straight-line command sequence", errors)
+
+    def test_performance_pin_rejects_adjacent_hash_on_visible_target(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            "//crates/rue-bench:rue-bench\n",
+            "//crates/rue-bench:rue-bench# || true\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("no executable ci-timed rue-bench build", errors)
+
+    def test_performance_pin_rejects_adjacent_hash_on_final_argument(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            '          --compiler "$RUE"\n',
+            '          --compiler "$RUE"# || true\n',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("exact straight-line command sequence", errors)
+
+    def test_performance_pin_rejects_a_gap_inside_the_backslash_chain(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            '          "$BENCH" check-pins \\\n',
+            '          "$BENCH" check-pins \\\n\n',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("exact straight-line command sequence", errors)
+
+    def test_performance_pin_rejects_spaces_after_a_backslash(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            '          "$BENCH" check-pins \\\n',
+            '          "$BENCH" check-pins \\  \n',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("exact straight-line command sequence", errors)
+
+    def test_performance_pin_build_cannot_be_disabled_by_a_branch(self):
+        source = SOURCE.read_text()
+        visible = (
+            '          scripts/ci-timed "rue-bench build" -- ./buck2 build '
+            '//crates/rue-bench:rue-bench\n'
+        )
+        changed = source.replace(
+            visible,
+            "          if false; then\n"
+            + visible
+            + "          fi\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("without an intervening command or control line", errors)
+
+    def test_performance_pin_build_cannot_be_hidden_in_a_heredoc(self):
+        source = SOURCE.read_text()
+        visible = (
+            '          scripts/ci-timed "rue-bench build" -- ./buck2 build '
+            '//crates/rue-bench:rue-bench\n'
+        )
+        changed = source.replace(
+            visible,
+            "          cat <<'RUE_BUILD'\n"
+            + visible
+            + "          RUE_BUILD\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("without an intervening command or control line", errors)
+
+    def test_performance_pin_step_cannot_be_conditionally_disabled(self):
+        source = SOURCE.read_text()
+        marker = "      - name: Check the performance pins still match the tree\n"
+        changed = source.replace(
+            marker,
+            marker + "        if: ${{ false }}\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("disabling or custom execution metadata", errors)
+
+    def test_performance_pin_step_cannot_ignore_failure(self):
+        source = SOURCE.read_text()
+        marker = "      - name: Check the performance pins still match the tree\n"
+        changed = source.replace(
+            marker,
+            marker + "        continue-on-error: true\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("disabling or custom execution metadata", errors)
+
+    def test_performance_pin_step_cannot_use_custom_shell_execution(self):
+        source = SOURCE.read_text()
+        marker = "      - name: Check the performance pins still match the tree\n"
+        changed = source.replace(
+            marker,
+            marker + "        shell: true {0}\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("disabling or custom execution metadata", errors)
+
+    def test_performance_pin_step_rejects_quoted_metadata_keys(self):
+        source = SOURCE.read_text()
+        marker = "      - name: Check the performance pins still match the tree\n"
+        changed = source.replace(
+            marker,
+            marker + "        'if': false\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("only comments or blanks may precede", errors)
+
+    def test_linux_premerge_cannot_ignore_performance_pin_failure(self):
+        source = SOURCE.read_text()
+        marker = "  linux-premerge:\n    runs-on: ubuntu-latest\n"
+        changed = source.replace(
+            marker,
+            marker + "    continue-on-error: true\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("job-level continue-on-error", errors)
+
+        changed = source.replace(
+            marker,
+            marker + "    'continue-on-error': true\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("job-level continue-on-error", errors)
+
+    def test_linux_premerge_execution_condition_is_pinned(self):
+        source = SOURCE.read_text()
+        marker = (
+            "  linux-premerge:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    name: premerge (linux-x64)\n"
+            "    if: ${{ always() }}\n"
+        )
+        changed = source.replace(
+            marker,
+            marker.replace("if: ${{ always() }}", "if: ${{ false }}"),
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("must contain exactly one direct job if", errors)
+
+    def test_linux_premerge_cannot_override_job_shell_defaults(self):
+        source = SOURCE.read_text()
+        marker = "  linux-premerge:\n    runs-on: ubuntu-latest\n"
+        changed = source.replace(
+            marker,
+            marker
+            + "    defaults:\n"
+            + "      run:\n"
+            + "        shell: true {0}\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("defaults overrides", errors)
+
+    def test_workflow_cannot_override_run_shell_defaults(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            "jobs:\n",
+            'defaults: {run: {shell: "true {0}"}}\n\n'
+            "jobs:\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("workflow must not define top-level defaults", errors)
+
+    def test_performance_pin_failure_uploader_cannot_be_deleted(self):
+        source = SOURCE.read_text()
+        uploader = (
+            "      - name: Upload failing-suite output\n"
+            "        if: failure()\n"
+            "        uses: actions/upload-artifact@v6\n"
+            "        with:\n"
+            "          name: premerge-linux-x64-failure-logs\n"
+            "          path: ${{ runner.temp }}/rue-ci-failed-logs\n"
+            "          if-no-files-found: ignore\n"
+        )
+        changed = source.replace(uploader, "", 1)
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("failure-artifact uploader", errors)
+
+    def test_performance_pin_failure_uploader_must_follow_pin_step(self):
+        source = SOURCE.read_text()
+        uploader = (
+            "      - name: Upload failing-suite output\n"
+            "        if: failure()\n"
+            "        uses: actions/upload-artifact@v6\n"
+            "        with:\n"
+            "          name: premerge-linux-x64-failure-logs\n"
+            "          path: ${{ runner.temp }}/rue-ci-failed-logs\n"
+            "          if-no-files-found: ignore\n"
+        )
+        marker = "      - name: Check the performance pins still match the tree\n"
+        changed = source.replace(uploader, "", 1).replace(
+            marker,
+            uploader + marker,
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("must upload failing-suite output after", errors)
+
+    def test_performance_pin_failure_uploader_condition_is_pinned(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            "      - name: Upload failing-suite output\n"
+            "        if: failure()\n",
+            "      - name: Upload failing-suite output\n"
+            "        if: always()\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("exact raw metadata mapping", errors)
+
+    def test_performance_pin_failure_uploader_path_is_pinned(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            "          path: ${{ runner.temp }}/rue-ci-failed-logs\n",
+            "          path: ${{ runner.temp }}/other-logs\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("runner.temp", errors)
+
+    def test_performance_pin_failure_uploader_rejects_extra_metadata(self):
+        source = SOURCE.read_text()
+        marker = (
+            "      - name: Upload failing-suite output\n"
+            "        if: failure()\n"
+            "        uses: actions/upload-artifact@v6\n"
+        )
+        for extra in ("        continue-on-error: true\n", "        if: failure()\n"):
+            changed = source.replace(
+                marker,
+                marker.replace(
+                    "        uses: actions/upload-artifact@v6\n", extra
+                    + "        uses: actions/upload-artifact@v6\n"
+                ),
+                1,
+            )
+            errors = "\n".join(self.validate_text(changed))
+            self.assertIn("exact raw metadata mapping", errors)
+
+    def test_performance_pin_cannot_exit_after_path_capture(self):
+        source = SOURCE.read_text()
+        warm = (
+            '          BENCH="$(./buck2 build //crates/rue-bench:rue-bench '
+            '--show-simple-output 2>/dev/null | tail -1)"\n'
+        )
+        changed = source.replace(warm, warm + "          exit 0\n", 1)
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("exact straight-line command sequence", errors)
+
+    def test_performance_pin_step_cannot_ignore_failure_after_run_block(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            '          --compiler "$RUE"\n',
+            '          --compiler "$RUE"\n'
+            "        continue-on-error: true\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("disabling or custom execution metadata", errors)
+
+    def test_performance_pin_cannot_ignore_check_pins_failure(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            '          "$BENCH" check-pins \\\n',
+            '          # "$BENCH" check-pins \\\n',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("exact straight-line command sequence", errors)
+
+    def test_performance_pin_cannot_ignore_check_pins_with_or_true(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            '          --compiler "$RUE"\n',
+            '          --compiler "$RUE" || true\n',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("exact straight-line command sequence", errors)
+
+    def test_performance_pin_build_cannot_be_satisfied_by_comment_or_other_step(self):
+        source = SOURCE.read_text()
+        visible = (
+            '          scripts/ci-timed "rue-bench build" -- ./buck2 build '
+            '//crates/rue-bench:rue-bench\n'
+        )
+        changed = source.replace(visible, "", 1).replace(
+            "          # Would this change stop runs entering their series? Decidable from this\n",
+            "          # " + visible.strip() + "\n"
+            "          # Would this change stop runs entering their series? Decidable from this\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("no executable ci-timed rue-bench build", errors)
+
+        changed = source.replace(visible, "", 1).replace(
+            "      - name: Check the performance pins still match the tree\n",
+            "      - name: Unrelated rue-bench build\n"
+            "        run: " + visible + "\n"
+            "      - name: Check the performance pins still match the tree\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("no executable ci-timed rue-bench build", errors)
+
+    def test_performance_pin_build_must_target_rue_bench_exactly(self):
+        changed = SOURCE.read_text().replace(
+            "//crates/rue-bench:rue-bench\n",
+            "//crates/rue:rue\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("targeting //crates/rue-bench:rue-bench", errors)
+
     def test_dedicated_lane_corpus_without_a_job_fails(self):
         # spec-tests is skipped by the premerge suite because it carries the
         # label, so dropping its platform-corpus entry would drop it entirely.

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -357,6 +357,209 @@ def lane_targets(lane: str, script: Path = AFFECTED_TARGETS_SCRIPT) -> set[str]:
     return set(result.stdout.split())
 
 
+PERFORMANCE_PINS_STEP = "Check the performance pins still match the tree"
+VISIBLE_RUE_BENCH_BUILD = (
+    'scripts/ci-timed "rue-bench build" -- ./buck2 build '
+    "//crates/rue-bench:rue-bench"
+)
+WARM_RUE_BENCH_CAPTURE = (
+    'BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output '
+    '2>/dev/null | tail -1)"'
+)
+PERFORMANCE_PINS_COMMANDS = (
+    "set -euo pipefail",
+    'RUE="$(scripts/rue-bin)"',
+    VISIBLE_RUE_BENCH_BUILD,
+    WARM_RUE_BENCH_CAPTURE,
+    '"$BENCH" check-pins \\',
+    "  --manifest performance/manifest.toml \\",
+    "  --repo-root . \\",
+    '  --compiler "$RUE"',
+)
+PERFORMANCE_FAILURE_UPLOADER = (
+    "        if: failure()",
+    "        uses: actions/upload-artifact@v6",
+    "        with:",
+    "          name: premerge-linux-x64-failure-logs",
+    "          path: ${{ runner.temp }}/rue-ci-failed-logs",
+    "          if-no-files-found: ignore",
+)
+
+
+def performance_pin_step_errors(workflow: str) -> list[str]:
+    """Keep the first rue-bench build visible and timed in the pin step.
+
+    The warm path lookup intentionally remains a separate command: it names
+    the binary after the visible build has completed. Restricting the check to
+    the named step prevents a copy in another linux-premerge step (or a
+    comment) from satisfying this failure-artifact and timing contract.
+    """
+    linux = job_blocks(workflow).get("linux-premerge", "")
+    step_matches = list(
+        re.finditer(
+            rf"^      - name: {re.escape(PERFORMANCE_PINS_STEP)}\n"
+            rf"(?P<body>.*?)(?=^      - |\Z)",
+            linux,
+            re.MULTILINE | re.DOTALL,
+        )
+    )
+    if not step_matches:
+        return [f"linux-premerge is missing the {PERFORMANCE_PINS_STEP!r} step"]
+    if len(step_matches) != 1:
+        return [
+            f"linux-premerge must contain exactly one {PERFORMANCE_PINS_STEP!r} step"
+        ]
+    step_match = step_matches[0]
+
+    job_if_lines = [
+        line.strip()
+        for line in linux.splitlines()
+        if not line.lstrip().startswith("#")
+        and re.match(r"^    (?:['\"]?if['\"]?)\s*:", line)
+    ]
+    if job_if_lines != ["if: ${{ always() }}"]:
+        return [
+            "linux-premerge must contain exactly one direct job if: "
+            "if: ${{ always() }}"
+        ]
+
+    linux_has_job_policy_override = any(
+        not line.lstrip().startswith("#")
+        and (
+            re.match(r"^    (?:['\"]?continue-on-error['\"]?)\s*:", line)
+            or re.match(r"^    (?:['\"]?defaults['\"]?|<<)\s*:", line)
+        )
+        for line in linux.splitlines()
+    )
+    if linux_has_job_policy_override:
+        return [
+            "linux-premerge must not use job-level continue-on-error or "
+            "defaults overrides for the performance-pin gate"
+        ]
+
+    step_body = step_match.group("body")
+    run_match = re.search(r"^        run: \|[+-]?\s*$", step_body, re.MULTILINE)
+    if not run_match:
+        return [
+            "the performance-pin step must contain a block-scalar shell run "
+            "for its straight-line prefix"
+        ]
+    run_line_count = sum(
+        bool(re.match(r"^        run: \|[+-]?\s*$", line))
+        for line in step_body.splitlines()
+    )
+    unexpected_metadata = [
+        line.strip()
+        for line in step_body.splitlines()
+        if line.strip()
+        and not line.lstrip().startswith("#")
+        and not re.match(r"^        run: \|[+-]?\s*$", line)
+        and not line.startswith("          ")
+    ]
+    if run_line_count != 1 or unexpected_metadata:
+        details = unexpected_metadata
+        if run_line_count != 1:
+            details = [f"run block occurs {run_line_count} times"] + details
+        return [
+            "the performance-pin step must not set disabling or custom "
+            "execution metadata; only comments or blanks may precede or "
+            "follow its run block: "
+            + ", ".join(details)
+        ]
+
+    # Keep only the block-scalar shell body. The step's YAML metadata and later
+    # steps are not executable lines in this named step.
+    shell_lines = []
+    run_body = step_body[run_match.end() :]
+    if run_body.startswith("\n"):
+        run_body = run_body[1:]
+    for line in run_body.splitlines():
+        if line.startswith("          "):
+            shell_lines.append(line[10:])
+        elif not line.strip():
+            shell_lines.append("")
+        else:
+            break
+    while shell_lines and shell_lines[-1] == "":
+        shell_lines.pop()
+
+    # Keep the de-indented physical shell lines intact. In particular, a `#`
+    # adjacent to a command is shell data rather than a source comment, and a
+    # blank/comment line inside this backslash chain must not disappear.
+    executable_lines = shell_lines
+    significant_lines = [line for line in executable_lines if line.strip()]
+    visible_builds = [
+        index
+        for index, line in enumerate(significant_lines)
+        if line == VISIBLE_RUE_BENCH_BUILD
+    ]
+    warm_captures = [
+        index
+        for index, line in enumerate(significant_lines)
+        if line == WARM_RUE_BENCH_CAPTURE
+    ]
+    if len(visible_builds) != 1:
+        errors = [
+            "the performance-pin step must visibly run exactly one ci-timed "
+            "rue-bench build targeting //crates/rue-bench:rue-bench"
+        ]
+        if not visible_builds:
+            errors.append(
+                "the performance-pin step has no executable ci-timed rue-bench build"
+            )
+        return errors
+    if len(warm_captures) != 1:
+        return [
+            "the performance-pin step must retain exactly one warm rue-bench "
+            "--show-simple-output path-only capture"
+        ]
+    if visible_builds[0] + 1 != warm_captures[0]:
+        return [
+            "the visible ci-timed rue-bench build must precede the warm "
+            "path-only capture in the performance-pin step without an "
+            "intervening command or control line"
+        ]
+    if tuple(executable_lines) != PERFORMANCE_PINS_COMMANDS:
+        return [
+            "the performance-pin step must keep the exact straight-line "
+            "command sequence through check-pins and all expected arguments"
+        ]
+
+    uploader_matches = list(
+        re.finditer(
+            r"^      - name: Upload failing-suite output\n"
+            r"(?P<body>.*?)(?=^      - |\Z)",
+            linux,
+            re.MULTILINE | re.DOTALL,
+        )
+    )
+    if len(uploader_matches) != 1:
+        return [
+            "linux-premerge must contain exactly one failure-artifact uploader "
+            "('Upload failing-suite output') step"
+        ]
+    uploader = uploader_matches[0]
+    if uploader.start() <= step_match.start():
+        return [
+            "linux-premerge must upload failing-suite output after the "
+            "performance-pin step"
+        ]
+    uploader_lines = [
+        line
+        for line in uploader.group("body").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    if tuple(uploader_lines) != PERFORMANCE_FAILURE_UPLOADER:
+        return [
+            "linux-premerge failure-artifact uploader must retain its exact "
+            "raw metadata mapping: expected "
+            + repr(PERFORMANCE_FAILURE_UPLOADER)
+            + "; got "
+            + repr(tuple(uploader_lines))
+        ]
+    return []
+
+
 def lane_target_drift(workflow: str, script: Path = AFFECTED_TARGETS_SCRIPT) -> list[str]:
     """Reject native target lists in YAML; membership belongs to the graph.
 
@@ -542,6 +745,15 @@ def validate(
     workflow = ci_path.read_text()
     native_runner = native_runner_path.read_text()
     errors: list[str] = []
+    if any(
+        not line.lstrip().startswith("#")
+        and re.match(r"^(?:['\"]?defaults['\"]?|<<)\s*:", line)
+        for line in workflow.splitlines()
+    ):
+        errors.append(
+            "workflow must not define top-level defaults or merge overrides "
+            "that can replace the runner shell"
+        )
     try:
         valgrind_install = valgrind_install_path.read_text()
     except OSError as error:
@@ -630,6 +842,7 @@ def validate(
         errors.append("remote-execution must remain merge-group-only")
 
     linux = jobs.get("linux-premerge", "")
+    errors.extend(performance_pin_step_errors(workflow))
     for required in (
         "runs-on: ubuntu-latest",
         "Run complete target-independent premerge suite",


### PR DESCRIPTION
## Summary

- build `rue-bench` visibly through `ci-timed` before the warm path-only lookup in linux premerge
- pin the complete raw performance-pin command sequence and its failure-log uploader
- reject disabling metadata, shell/control-flow masking, malformed continuations, reordered commands, and altered targets or arguments

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` — Pass 33
- `scripts/rue premerge` — Pass 201
- `./buck2 test //:ci-gate-validator-tool-tests //:ci-gate-validation` — Pass 2; validator mutations 86/86
- Python 3.9 baseline validation
- Bash 3.2 baseline validation

Fixes RUE-1856.
