### PR TITLE
RUE-1830: observe edits while re-closing the import graph

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -1595,6 +1595,9 @@ fn source_load_error(error: SourceLoadError) -> String {
         SourceLoadError::Compiler { errors, .. } => errors.to_string(),
         SourceLoadError::Toolchain(error) => format!("{error:?}"),
         SourceLoadError::HermeticDenial(error) => format!("{error:?}"),
+        // The bench harness supplies no supersession probe, so its loads can
+        // never supersede (RUE-1830).
+        SourceLoadError::Superseded => "source observation superseded".to_owned(),
     }
 }
 

--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -109,3 +109,31 @@ source = "fn main() -> i32 { 2 }\n"
 [[case.watch.edits]]
 path = "main.rue"
 source = "fn main() -> i32 { 3 }\n"
+
+# RUE-1830. A watch cycle used to start its change monitor only after
+# re-observation and import-graph closure had completed, so an edit landing
+# while discovery was still re-closing could not supersede the stale attempt:
+# it was noticed only once compilation proper began, or on the next cycle.
+# `reobserve_delay_ms` widens the re-closure window on purpose so the second
+# edit deterministically lands inside it. The superseded attempt must commit
+# nothing: exactly one fresh re-observation over the newest bytes follows, and
+# only the newest revision's output ever publishes.
+[[case]]
+name = "change_during_reobserve_supersedes_the_stale_attempt"
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+]
+
+[case.watch]
+kind = "supersede_reobserve"
+reobserve_delay_ms = 400
+expected_exit_codes = [1, 3]
+
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 2 }\n"
+
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 3 }\n"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -1087,6 +1087,11 @@ struct WatchScenario {
     /// was acted on but never announced on the protocol.
     #[serde(default)]
     boundary_delay_ms: Option<u64>,
+    /// Hold the watcher between starting its re-observation monitor and the
+    /// re-observation itself, so an edit can deterministically land while
+    /// the import graph is being re-closed (RUE-1830).
+    #[serde(default)]
+    reobserve_delay_ms: Option<u64>,
     edits: Vec<WatchEdit>,
     expected_exit_codes: Vec<i32>,
 }
@@ -1098,6 +1103,7 @@ enum WatchScenarioKind {
     Cancel,
     Delete,
     SymlinkRetarget,
+    SupersedeReobserve,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -2579,6 +2585,13 @@ fn run_watch_case(
             "delete watch scenario requires delete and restore edits",
         ));
     }
+    if scenario.kind == WatchScenarioKind::SupersedeReobserve
+        && (scenario.edits.len() != 2 || scenario.reobserve_delay_ms.is_none())
+    {
+        return Err(TestFailure::fatal(
+            "supersede-reobserve watch scenario needs two edits and a re-observation delay",
+        ));
+    }
     if scenario.kind == WatchScenarioKind::SymlinkRetarget && scenario.edits.len() != 1 {
         return Err(TestFailure::assertion(
             "symlink-retarget watch scenario requires exactly one edit",
@@ -2666,6 +2679,9 @@ fn run_watch_case(
     if let Some(delay) = scenario.boundary_delay_ms {
         command.env("RUE_WATCH_TEST_BOUNDARY_DELAY_MS", delay.to_string());
     }
+    if let Some(delay) = scenario.reobserve_delay_ms {
+        command.env("RUE_WATCH_TEST_REOBSERVE_DELAY_MS", delay.to_string());
+    }
     configure_process_group(&mut command);
     let mut child = command
         .spawn()
@@ -2750,11 +2766,39 @@ fn run_watch_case(
             WatchScenarioKind::SymlinkRetarget => {
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
             }
+            WatchScenarioKind::SupersedeReobserve => {
+                // The first edit wakes the settled loop; the widened
+                // re-observation window then lets the second edit land while
+                // the import graph is re-closing, superseding the stale
+                // attempt before compilation ever starts (RUE-1830).
+                wait_for_watch_event(&mut child, &protocol, "change-detected", 1, deadline)?;
+                wait_for_watch_event(&mut child, &protocol, "reobserve-started", 1, deadline)?;
+                write_watch_edit(dir, &scenario.edits[1])?;
+                wait_for_watch_event(&mut child, &protocol, "reobserve-superseded", 1, deadline)?;
+                wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
+                let events = watch_events(&protocol);
+                let superseded = events
+                    .iter()
+                    .position(|event| event == "reobserve-superseded")
+                    .ok_or_else(|| "watch supersession anchor disappeared".to_string())?;
+                // The superseded attempt committed nothing: a fresh
+                // re-observation over the newest bytes follows it before the
+                // next compile can start.
+                events
+                    .iter()
+                    .skip(superseded + 1)
+                    .position(|event| event == "reobserve-ok")
+                    .ok_or_else(|| {
+                        "watch never reobserved the newest revision after supersession".to_string()
+                    })?;
+            }
         }
         assert_watch_program(contract, &program, scenario.expected_exit_codes[1])
             .map_err(|error| error.to_string())?;
-        if scenario.kind == WatchScenarioKind::Cancel
-            && watch_event_count(&protocol, "published") != 2
+        if matches!(
+            scenario.kind,
+            WatchScenarioKind::Cancel | WatchScenarioKind::SupersedeReobserve
+        ) && watch_event_count(&protocol, "published") != 2
         {
             return Err(format!(
                 "watch published a stale intermediate revision: expected exactly 2 publications, events were {:?}",

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -40,7 +40,18 @@ impl FilesystemCompilerHost {
 
     /// Re-observe the exact accepted-read closure and publish its successor.
     pub fn reobserve(&mut self) -> Result<(), SourceLoadError> {
-        reload_from_filesystem(&mut self.state)
+        reload_from_filesystem(&mut self.state, None)
+    }
+
+    /// Re-observe like [`Self::reobserve`], aborting promptly with
+    /// [`SourceLoadError::Superseded`] once `supersession` reports a newer
+    /// source revision (RUE-1830). A superseded attempt commits no snapshot,
+    /// manifest, or graph; the caller restarts from the newest bytes.
+    pub fn reobserve_superseding(
+        &mut self,
+        supersession: &dyn Fn() -> bool,
+    ) -> Result<(), SourceLoadError> {
+        reload_from_filesystem(&mut self.state, Some(supersession))
     }
 
     /// Satisfy compiler-issued reached-body toolchain demands for this revision.

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1613,6 +1613,14 @@ pub(crate) fn render_source_load_error(
             error.to_string(),
             error_format,
         ),
+        // Watch supersession never surfaces as a user-facing failure: the
+        // watch loop consumes it and restarts from the newest bytes
+        // (RUE-1830). This rendering exists only for an unexpected escape.
+        SourceLoadError::Superseded => render_driver_error(
+            ErrorCode::DRIVER_SOURCE_LOAD,
+            "source observation superseded by a newer revision".to_owned(),
+            error_format,
+        ),
         SourceLoadError::Compiler { snapshot, errors } => {
             let infos = snapshot
                 .as_ref()

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -747,6 +747,11 @@ pub enum SourceLoadError {
     /// environmental error, not a program error — surfaced loudly with its own
     /// message.
     Toolchain(ToolchainIntegrityError),
+    /// A caller-supplied supersession probe reported a newer source revision
+    /// while import discovery was still re-closing the graph (RUE-1830). The
+    /// superseded attempt committed no snapshot, manifest, or graph; the
+    /// caller restarts observation from the newest bytes.
+    Superseded,
     /// A trusted toolchain module resolves to a path the hermetic build
     /// configuration forbids (RUE-1112). This is deterministically DISTINCT
     /// from a broken toolchain: the installation may be intact, but the sandbox
@@ -1065,6 +1070,7 @@ fn run_import_wave(
     frontier: &ImportDemandFrontier,
     source_manifest: Option<&SourceManifest>,
     reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
+    supersession: Option<&dyn Fn() -> bool>,
 ) -> Result<(ImportInputRevision, ImportDemandFrontier), SourceLoadError> {
     for attempt in 0..=WAVE_STAMP_RETRIES {
         let accepted_reads = assembler.accepted_read_manifest();
@@ -1077,6 +1083,7 @@ fn run_import_wave(
         )
         .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
         while !wave.is_complete() {
+            check_supersession(supersession)?;
             let observations = wave
                 .requests()
                 .iter()
@@ -1118,6 +1125,17 @@ fn run_import_wave(
     unreachable!("the wave retry loop returns or fails on its last attempt")
 }
 
+/// Fail promptly with [`SourceLoadError::Superseded`] once the caller's
+/// probe reports that a newer source revision replaced the bytes this
+/// discovery attempt is reading (RUE-1830). `None` keeps every check a no-op
+/// for one-shot loads and toolchain re-closes.
+fn check_supersession(supersession: Option<&dyn Fn() -> bool>) -> Result<(), SourceLoadError> {
+    if supersession.is_some_and(|probe| probe()) {
+        return Err(SourceLoadError::Superseded);
+    }
+    Ok(())
+}
+
 fn drive_import_discovery_to_close(
     assembler: &mut DiscoverySourceAssembler,
     staging: &mut CompilerSession,
@@ -1126,6 +1144,7 @@ fn drive_import_discovery_to_close(
     reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
     continuation: Option<ImportInputRevision>,
     reclose: Option<ReClose<'_>>,
+    supersession: Option<&dyn Fn() -> bool>,
 ) -> Result<ClosedDiscovery, SourceLoadError> {
     // Exactly one import-input request is opened per external request, here,
     // before the frontier loop below. Rounds inside that loop publish overlay
@@ -1166,6 +1185,10 @@ fn drive_import_discovery_to_close(
     let mut cumulative_witness_closures = 0_u32;
     let mut reroot_witness_closures = 0_u32;
     loop {
+        // A newer revision supersedes this attempt between rounds; the
+        // per-hop check inside the ordinary wave bounds a superseded
+        // attempt's residual filesystem work to one hop (RUE-1830).
+        check_supersession(supersession)?;
         // One frontier round: plan and frontier construction (which owns the
         // canonical parse of everything read so far), then the host reads that
         // answer the frontier's requests. Both halves are timed so a discovery
@@ -1350,6 +1373,7 @@ fn drive_import_discovery_to_close(
                     &frontier,
                     source_manifest,
                     reobserved_reads,
+                    supersession,
                 )?;
                 input_revision = revision;
                 previous_frontier = Some(published);
@@ -1522,6 +1546,7 @@ pub(crate) fn discover_and_load_imports(
         None,
         None,
         None,
+        None,
     )?;
 
     Ok(ImportDiscoveryResult {
@@ -1546,7 +1571,9 @@ pub(crate) fn discover_and_load_imports(
 // accepted-read closure through this filesystem soundness boundary.
 pub(crate) fn reload_from_filesystem(
     result: &mut ImportDiscoveryResult,
+    supersession: Option<&dyn Fn() -> bool>,
 ) -> Result<(), SourceLoadError> {
+    check_supersession(supersession)?;
     let source_manifest = result
         .source_manifest
         .as_ref()
@@ -1617,6 +1644,7 @@ pub(crate) fn reload_from_filesystem(
         Some(&reobserved),
         None,
         None,
+        supersession,
     )?;
     result.source_snapshot = close.snapshot;
     result.read_manifest = assembler.accepted_read_manifest();
@@ -1743,6 +1771,7 @@ pub(crate) fn acquire_reached_toolchain_modules(
                     None,
                     Some(delta.revision()),
                     Some(ReClose { delta: &delta }),
+                    None,
                 )
                 .map_err(|error| {
                     reclassify_reclose_failure(error, result.std_root.as_deref(), park.demands())
@@ -2967,7 +2996,8 @@ mod tests {
                 .expect("an empty std path means no configured toolchain");
 
         assert!(result.std_root.is_none());
-        reload_from_filesystem(&mut result).expect("reload preserves the empty-path contract");
+        reload_from_filesystem(&mut result, None)
+            .expect("reload preserves the empty-path contract");
         assert!(result.std_root.is_none());
     }
 
@@ -3130,7 +3160,7 @@ mod tests {
         let semantic_before = rooted_cfg(&mut result.session, &CompileOptions::default()).unwrap();
 
         fs::write(&leaf, leaf_source).unwrap();
-        reload_from_filesystem(&mut result).unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
         let semantic_after = rooted_cfg(&mut result.session, &CompileOptions::default()).unwrap();
 
         assert_eq!(module_source_id(&result, "leaf.rue"), source_id);
@@ -3163,7 +3193,7 @@ mod tests {
         // Same-length bytes make size useless, and this write happens inside the
         // timestamp window in which an unchanged mtime cannot establish order.
         fs::write(&leaf, "pub fn value() -> i32 { 2 }").unwrap();
-        reload_from_filesystem(&mut result).unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
 
         assert_ne!(module_source_id(&result, "leaf.rue"), source_id);
         assert!(
@@ -3203,7 +3233,7 @@ mod tests {
             discover_and_load_imports(main.to_str().unwrap(), Some(manifest), None).unwrap();
 
         fs::write(&manifest_path, "main.rue\n").unwrap();
-        match reload_from_filesystem(&mut result) {
+        match reload_from_filesystem(&mut result, None) {
             Err(SourceLoadError::Compiler { errors, .. }) => {
                 let rendered = errors.to_string();
                 assert!(rendered.contains("source manifest"), "{rendered}");
@@ -3236,7 +3266,7 @@ mod tests {
 
         fs::remove_file(&alias).unwrap();
         std::os::unix::fs::symlink(&second, &alias).unwrap();
-        reload_from_filesystem(&mut result).unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
 
         let second_canonical = fs::canonicalize(&second).unwrap();
         let leaf = result
@@ -3274,7 +3304,7 @@ mod tests {
         let source_id = module_source_id(&result, "alias.rue");
         let canonical = fs::canonicalize(&target).unwrap();
 
-        reload_from_filesystem(&mut result).unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
 
         assert_eq!(module_source_id(&result, "alias.rue"), source_id);
         assert!(
@@ -3301,7 +3331,7 @@ mod tests {
         let mut result = discover_and_load_imports(alias.to_str().unwrap(), None, None).unwrap();
         fs::remove_file(&alias).unwrap();
         std::os::unix::fs::symlink(&second, &alias).unwrap();
-        reload_from_filesystem(&mut result).unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
 
         let second_canonical = fs::canonicalize(&second).unwrap();
         assert!(
@@ -3337,7 +3367,7 @@ mod tests {
         fs::remove_file(&alias).unwrap();
         std::os::unix::fs::symlink(&std_dir, &alias).unwrap();
 
-        let error = reload_from_filesystem(&mut result)
+        let error = reload_from_filesystem(&mut result, None)
             .expect_err("a retained project retarget into std must fail closed");
         assert!(matches!(
             error,
@@ -3364,7 +3394,7 @@ mod tests {
         // Leave the requested alias in place but make its target disappear:
         // retained observation must not silently reuse the old canonical read.
         fs::remove_file(&target).unwrap();
-        reload_from_filesystem(&mut result).unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
         assert_eq!(
             result.revision.status(),
             ImportDiscoveryStatus::ClosedAttempted
@@ -3379,7 +3409,7 @@ mod tests {
 
         fs::remove_file(&alias).unwrap();
         std::os::unix::fs::symlink(&replacement, &alias).unwrap();
-        reload_from_filesystem(&mut result).unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
         assert!(
             result
                 .source_snapshot
@@ -3415,7 +3445,7 @@ mod tests {
         std::os::unix::fs::symlink(&second, &alias).unwrap();
         fs::write(&manifest_path, "main.rue\nfirst.rue\nsecond.rue\n").unwrap();
 
-        match reload_from_filesystem(&mut result) {
+        match reload_from_filesystem(&mut result, None) {
             Err(SourceLoadError::Compiler {
                 snapshot: Some(snapshot),
                 errors,
@@ -3531,6 +3561,9 @@ mod tests {
             }
             Err(SourceLoadError::HermeticDenial(error)) => {
                 panic!("import policy denial escaped as a hermetic toolchain denial: {error}")
+            }
+            Err(SourceLoadError::Superseded) => {
+                panic!("one-shot load supplies no supersession probe, so it can never supersede")
             }
             Ok(_) => panic!("policy denial unexpectedly closed successfully"),
         }
@@ -3732,6 +3765,9 @@ mod tests {
             SourceLoadError::HermeticDenial(error) => error.to_string(),
             SourceLoadError::Message(message) => message.clone(),
             SourceLoadError::Compiler { errors, .. } => errors.to_string(),
+            SourceLoadError::Superseded => {
+                panic!("these fixtures supply no supersession probe, so loads never supersede")
+            }
         }
     }
 

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -33,6 +33,7 @@ const FAILED_REOBSERVE_RETRY: Duration = Duration::from_millis(250);
 // synchronization without wall-clock sleeps.
 const TEST_PROTOCOL_ENV: &str = "RUE_WATCH_TEST_PROTOCOL";
 const TEST_COMPILE_DELAY_ENV: &str = "RUE_WATCH_TEST_COMPILE_DELAY_MS";
+const TEST_REOBSERVE_DELAY_ENV: &str = "RUE_WATCH_TEST_REOBSERVE_DELAY_MS";
 const TEST_BOUNDARY_DELAY_ENV: &str = "RUE_WATCH_TEST_BOUNDARY_DELAY_MS";
 
 fn test_event(event: &str) {
@@ -48,6 +49,20 @@ fn test_event(event: &str) {
 
 fn test_compile_delay() {
     let Ok(delay) = std::env::var(TEST_COMPILE_DELAY_ENV) else {
+        return;
+    };
+    let Ok(milliseconds) = delay.parse::<u64>() else {
+        return;
+    };
+    thread::sleep(Duration::from_millis(milliseconds.min(5_000)));
+}
+
+// Hold the cycle between starting the re-observation monitor and the
+// re-observation itself. Test-only, like the compile delay: it exists so an
+// edit can deterministically land while the graph is being re-closed
+// (RUE-1830).
+fn test_reobserve_delay() {
+    let Ok(delay) = std::env::var(TEST_REOBSERVE_DELAY_ENV) else {
         return;
     };
     let Ok(milliseconds) = delay.parse::<u64>() else {
@@ -108,6 +123,37 @@ impl ChangeMonitor {
         }
     }
 
+    /// Monitor for edits landing after `baseline` — the debounced disk state
+    /// this cycle's re-observation is about to read (RUE-1830). The compile
+    /// monitor's comparison against the last committed observation would trip
+    /// immediately here: while re-observing, the pending edit IS the reason
+    /// the cycle runs, so only a post-baseline edit supersedes the attempt.
+    /// The thread stays silent on the test protocol; the superseded cycle
+    /// announces itself through its own milestone.
+    fn start_reobservation(inputs: Vec<WatchInput>, cancellation: CompilationCancellation) -> Self {
+        let baseline = current_fingerprints(&inputs);
+        let stop = Arc::new(AtomicBool::new(false));
+        let changed = Arc::new(AtomicBool::new(false));
+        let thread_stop = stop.clone();
+        let thread_changed = changed.clone();
+        let thread = thread::spawn(move || {
+            let mut poll = PollBackoff::new();
+            while !thread_stop.load(Ordering::Acquire) {
+                if current_fingerprints(&inputs) != baseline {
+                    thread_changed.store(true, Ordering::Release);
+                    cancellation.cancel();
+                    return;
+                }
+                thread::park_timeout(poll.next_delay());
+            }
+        });
+        Self {
+            stop,
+            changed,
+            thread,
+        }
+    }
+
     fn changed(&self) -> bool {
         self.changed.load(Ordering::Acquire)
     }
@@ -132,8 +178,39 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
     loop {
         let cycle_started = Instant::now();
         if needs_reobserve {
-            match request.host.reobserve() {
+            // Observe edits WHILE the import graph re-closes: discovery can
+            // block on filesystem reads across several waves, and an edit
+            // landing then must supersede the stale attempt promptly instead
+            // of waiting for compilation proper to notice it (RUE-1830).
+            let stale_inputs = request.host.watch_inputs();
+            let reobserve_cancellation = CompilationCancellation::new();
+            let reobserve_monitor = ChangeMonitor::start_reobservation(
+                stale_inputs.clone(),
+                reobserve_cancellation.clone(),
+            );
+            test_event("reobserve-started");
+            test_reobserve_delay();
+            let reobserved = request
+                .host
+                .reobserve_superseding(&|| reobserve_cancellation.is_canceled());
+            reobserve_monitor.finish();
+            match reobserved {
                 Ok(()) => test_event("reobserve-ok"),
+                Err(SourceLoadError::Superseded) => {
+                    test_event("reobserve-superseded");
+                    print_watch_status(
+                        request.error_format,
+                        format!(
+                            "Watch re-observation superseded after {} ms; a newer source revision is available",
+                            cycle_started.elapsed().as_millis()
+                        ),
+                    );
+                    // The superseded attempt committed nothing. Let the burst
+                    // settle, then re-observe from the newest bytes;
+                    // `needs_reobserve` is still set.
+                    debounce(&stale_inputs);
+                    continue;
+                }
                 Err(error) => {
                     test_event("reobserve-error");
                     print_source_load_error(error, request.error_format);


### PR DESCRIPTION
Fixes RUE-1830.

## Problem

A watch cycle started its `ChangeMonitor` only after `reobserve` + `acquire_reached_toolchain_modules` + graph closure had completed, and `drive_import_discovery_to_close` had no cancellation authority. An edit landing during a blocked import read or multi-wave discovery could not supersede the stale attempt — it was noticed only once compilation proper began, or on the next cycle. The publication guard protected correctness; the missing behavior was prompt supersession of stale front-end I/O and parsing.

## Fix

- `drive_import_discovery_to_close` accepts an optional supersession probe, checked between frontier rounds and per hop inside the ordinary import wave. Tripping returns the new `SourceLoadError::Superseded`. `reload_from_filesystem` commits its snapshot/manifest/graph only after a successful close, so a superseded attempt leaves the host state untouched.
- The watch loop starts a re-observation monitor **before** reobserving, via the new `FilesystemCompilerHost::reobserve_superseding`. The monitor is baselined against the **debounced disk state**, not the last committed observation — those fingerprints are stale by definition (the pending edit is the reason the cycle re-observes), and comparing against them would supersede every attempt (a livelock).
- A superseded cycle emits the `reobserve-superseded` milestone, prints a status line, debounces, and re-observes from the newest bytes.
- One-shot loads and the trusted toolchain re-close pass no probe; `acquire_reached_toolchain_modules` is untouched — the zero-import and toolchain-acquisition paths keep their current behavior per the acceptance list.

## Tests

New deterministic watch scenario `change_during_reobserve_supersedes_the_stale_attempt` (`cases/watch.toml`), driven by the new `RUE_WATCH_TEST_REOBSERVE_DELAY_MS` seam (the re-observation analogue of the existing compile/boundary delays): the first edit wakes the settled loop, the second lands while the graph is re-closing, and the case proves the stale attempt exits with `reobserve-superseded`, a fresh `reobserve-ok` follows over the newest bytes, exactly two publications occur, and the final executable carries the newest revision. All six watch scenarios pass.

## Validation

- `buck2 run //crates/rue-cli-tests:cli -- watch` — 6/6 scenarios green
- rue crate tests, `scripts/rue quick`, full `scripts/rue premerge` — pass, exit 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLu5tyWdwrL8RywUZqaQc)_