### PR TITLE
RUE-1837: walk for anonymous type sites only where the parser saw one

### DIFF
--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -2839,7 +2839,10 @@ fn build_definition_index(
                 vec![signature_prefix(function.span, function.body.span())?],
                 None,
                 Some(function.body.span()),
-                rue_rir::anonymous_type_sites(&function.body).into(),
+                declaration_anonymous_sites_for(
+                    function.contains_anonymous_type_literal,
+                    &function.body,
+                ),
             )?,
             Item::Struct(structure) => {
                 let owner_name = resolve_name(structure.name)?;
@@ -2902,7 +2905,10 @@ fn build_definition_index(
                         vec![signature_prefix(method.span, method.body.span())?],
                         None,
                         Some(method.body.span()),
-                        rue_rir::anonymous_type_sites(&method.body).into(),
+                        declaration_anonymous_sites_for(
+                            method.contains_anonymous_type_literal,
+                            &method.body,
+                        ),
                     )?;
                 }
             }
@@ -2951,7 +2957,10 @@ fn build_definition_index(
                     vec![signature_prefix(value.span, value.init.span())?],
                     Some(initializer),
                     None,
-                    rue_rir::anonymous_type_sites(&value.init).into(),
+                    declaration_anonymous_sites_for(
+                        value.contains_anonymous_type_literal,
+                        &value.init,
+                    ),
                 )?;
             }
             Item::DropFn(value) => push(
@@ -2975,7 +2984,7 @@ fn build_definition_index(
                 vec![signature_prefix(value.span, value.body.span())?],
                 None,
                 Some(value.body.span()),
-                rue_rir::anonymous_type_sites(&value.body).into(),
+                declaration_anonymous_sites_for(value.contains_anonymous_type_literal, &value.body),
             )?,
             Item::Extern(block) => {
                 for (function_index, function) in block.fns.iter().enumerate() {
@@ -3220,6 +3229,28 @@ fn candidate_parameter_mode(mode: rue_parser::ast::ParamMode) -> (DeclarationPar
         rue_parser::ast::ParamMode::Inout => (DeclarationParameterMode::Inout, false),
         rue_parser::ast::ParamMode::Comptime => (DeclarationParameterMode::Value, true),
     }
+}
+
+/// The anonymous-type-site table for a declaration body, walking it only when
+/// the parser recorded a value-position anonymous `struct {..}` / `enum {..}`
+/// literal inside it (RUE-1837).
+///
+/// `anonymous_type_sites` is a complete recursive traversal of the body
+/// expression tree, but anonymous type literals exist only inside comptime
+/// type-constructor bodies, so for nearly every declaration it visited every
+/// node to return an empty table. The empty result is shared, so a body without
+/// literals costs neither the walk nor an allocation. Behavior is identical:
+/// an empty table is exactly what the walk produced for these bodies.
+fn declaration_anonymous_sites_for(
+    contains_anonymous_type_literal: bool,
+    body: &rue_parser::Expr,
+) -> Arc<[rue_rir::AnonymousTypeSite]> {
+    static EMPTY: std::sync::OnceLock<Arc<[rue_rir::AnonymousTypeSite]>> =
+        std::sync::OnceLock::new();
+    if !contains_anonymous_type_literal {
+        return Arc::clone(EMPTY.get_or_init(|| Arc::from([])));
+    }
+    rue_rir::anonymous_type_sites(body).into()
 }
 
 fn signature_prefix(declaration: Span, payload: Span) -> CompileResult<Span> {
@@ -3515,6 +3546,60 @@ extern "C" { fn getpid() -> i32; }
                 )
             })
             .collect()
+    }
+
+    /// RUE-1837: the anonymous-site walk is gated on a parser-recorded flag, so
+    /// the gate is sound only if that flag is set for every body the walk would
+    /// have found a site in. Assert both directions on one module: the two
+    /// value-position literal forms still get their sites, and a body with none
+    /// gets the empty table the walk always produced for it.
+    #[test]
+    fn gated_anonymous_site_tables_still_record_every_literal() {
+        let source = snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                r#"
+fn plain(value: i32) -> i32 { value + value }
+fn Opt(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn Wrap(comptime T: type) -> type {
+    struct { value: T }
+}
+"#,
+            )],
+            1,
+        );
+        let parsed = parse_source_snapshot_modules(&source).unwrap();
+        let module = parsed.modules()[0].clone();
+
+        let mut kinds = Vec::new();
+        let mut empty_bodies = 0usize;
+        for key in module.definitions().declaration_keys_in_source_order() {
+            let sites = module
+                .declaration_anonymous_sites(key)
+                .expect("every indexed declaration has a site table");
+            if sites.is_empty() {
+                empty_bodies += 1;
+            }
+            kinds.extend(sites.iter().map(|site| site.kind));
+        }
+        kinds.sort_unstable_by_key(|kind| format!("{kind:?}"));
+
+        assert_eq!(
+            kinds,
+            vec![
+                rue_rir::AnonymousTypeSiteKind::Enum,
+                rue_rir::AnonymousTypeSiteKind::Struct
+            ],
+            "gating dropped an anonymous type site"
+        );
+        assert_eq!(
+            empty_bodies, 1,
+            "the literal-free body should have an empty table, and only it"
+        );
     }
 
     #[test]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -119,6 +119,12 @@ pub struct ConstDecl {
     pub init: Box<Expr>,
     /// Span covering the entire const declaration
     pub span: Span,
+    /// Whether the body contains a value-position anonymous `struct {..}` or
+    /// `enum {..}` literal. Recorded by the parser, which has the only two
+    /// production sites, so the definition index can skip the full
+    /// `anonymous_type_sites` body walk for the overwhelming majority of
+    /// declarations that contain none (RUE-1837).
+    pub contains_anonymous_type_literal: bool,
 }
 
 /// A struct declaration.
@@ -210,6 +216,12 @@ pub struct DropFn {
     pub body: Expr,
     /// Span covering the entire drop fn
     pub span: Span,
+    /// Whether the body contains a value-position anonymous `struct {..}` or
+    /// `enum {..}` literal. Recorded by the parser, which has the only two
+    /// production sites, so the definition index can skip the full
+    /// `anonymous_type_sites` body walk for the overwhelming majority of
+    /// declarations that contain none (RUE-1837).
+    pub contains_anonymous_type_literal: bool,
 }
 
 /// A method definition in an impl block.
@@ -231,6 +243,12 @@ pub struct Method {
     pub body: Expr,
     /// Span covering the entire method
     pub span: Span,
+    /// Whether the body contains a value-position anonymous `struct {..}` or
+    /// `enum {..}` literal. Recorded by the parser, which has the only two
+    /// production sites, so the definition index can skip the full
+    /// `anonymous_type_sites` body walk for the overwhelming majority of
+    /// declarations that contain none (RUE-1837).
+    pub contains_anonymous_type_literal: bool,
 }
 
 /// A place-returning function result qualifier (ADR-0062).
@@ -308,6 +326,12 @@ pub struct Function {
     pub export_abi: Option<String>,
     /// Span covering the entire function
     pub span: Span,
+    /// Whether the body contains a value-position anonymous `struct {..}` or
+    /// `enum {..}` literal. Recorded by the parser, which has the only two
+    /// production sites, so the definition index can skip the full
+    /// `anonymous_type_sites` body walk for the overwhelming majority of
+    /// declarations that contain none (RUE-1837).
+    pub contains_anonymous_type_literal: bool,
 }
 
 /// A foreign-declaration block: `extern "C" { fn getpid() -> i32; }`.

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -21,6 +21,11 @@ pub struct Parser {
     file_id: FileId,
     errors: diagnostics::ParserDiagnostics,
     interner_error: Option<lasso::LassoErrorKind>,
+    /// Count of value-position anonymous `struct {..}` / `enum {..}` literals
+    /// parsed so far. Declaration parsers compare it across their body parse to
+    /// record `contains_anonymous_type_literal` (RUE-1837); only the difference
+    /// across a body matters, so it never needs resetting.
+    anonymous_type_literals: usize,
 }
 struct PrimitiveTypeSpurs {
     i8: Spur,
@@ -108,6 +113,16 @@ impl PrimitiveTypeSpurs {
 }
 
 impl Parser {
+    /// Snapshot the anonymous-type-literal counter before parsing a body.
+    fn anonymous_literal_mark(&self) -> usize {
+        self.anonymous_type_literals
+    }
+
+    /// Whether any anonymous type literal was parsed since `mark`.
+    fn saw_anonymous_literal_since(&self, mark: usize) -> bool {
+        self.anonymous_type_literals != mark
+    }
+
     /// Create a parser from lexer tokens and their shared symbol interner.
     pub fn new(tokens: Vec<Token>, mut interner: ThreadedRodeo) -> Self {
         let file_id = tokens.first().map(|t| t.span.file_id).unwrap_or_default();
@@ -126,6 +141,7 @@ impl Parser {
             file_id,
             errors: diagnostics::ParserDiagnostics::default(),
             interner_error,
+            anonymous_type_literals: 0,
         }
     }
 
@@ -149,6 +165,7 @@ impl Parser {
             file_id,
             errors: diagnostics::ParserDiagnostics::default(),
             interner_error,
+            anonymous_type_literals: 0,
         }
     }
 

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -122,8 +122,11 @@ impl Parser {
         let name = self.ident()?;
         let params = self.params()?;
         let (return_type, place_return) = self.return_type_with_place_mode()?;
+        let anonymous_mark = self.anonymous_literal_mark();
         let body = Expr::Block(self.block()?);
+        let contains_anonymous_type_literal = self.saw_anonymous_literal_since(anonymous_mark);
         Ok(Function {
+            contains_anonymous_type_literal,
             directives,
             visibility,
             is_unchecked,
@@ -369,8 +372,11 @@ impl Parser {
         self.expect(TokenKind::LParen)?;
         let self_tok = self.expect(TokenKind::SelfValue)?;
         self.expect(TokenKind::RParen)?;
+        let anonymous_mark = self.anonymous_literal_mark();
         let body = Expr::Block(self.block()?);
+        let contains_anonymous_type_literal = self.saw_anonymous_literal_since(anonymous_mark);
         Ok(DropFn {
+            contains_anonymous_type_literal,
             type_name,
             self_param: SelfParam {
                 mode: ParamMode::Normal,
@@ -396,9 +402,12 @@ impl Parser {
             None
         };
         self.expect(TokenKind::Eq)?;
+        let anonymous_mark = self.anonymous_literal_mark();
         let init = Box::new(self.expr()?);
+        let contains_anonymous_type_literal = self.saw_anonymous_literal_since(anonymous_mark);
         self.expect(TokenKind::Semi)?;
         Ok(ConstDecl {
+            contains_anonymous_type_literal,
             directives,
             visibility,
             name,

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -192,6 +192,11 @@ impl Parser {
                 }))
             }
             TokenKind::Struct => {
+                // The only two production sites for value-position anonymous
+                // type literals; the enclosing declaration reads the counter to
+                // decide whether its body needs an anonymous-site walk
+                // (RUE-1837).
+                self.anonymous_type_literals += 1;
                 let type_expr = self.anonymous_struct_type(true)?;
                 Ok(Expr::TypeLit(TypeLitExpr {
                     span: type_expr.span(),
@@ -199,6 +204,7 @@ impl Parser {
                 }))
             }
             TokenKind::Enum => {
+                self.anonymous_type_literals += 1;
                 self.bump();
                 let variants = self.enum_variants()?;
                 let span = self.span_from(start);

--- a/crates/rue-parser/src/parser/types.rs
+++ b/crates/rue-parser/src/parser/types.rs
@@ -290,8 +290,11 @@ impl Parser {
         }
         self.expect(TokenKind::RParen)?;
         let (return_type, place_return) = self.return_type_with_place_mode()?;
+        let anonymous_mark = self.anonymous_literal_mark();
         let body = Expr::Block(self.block()?);
+        let contains_anonymous_type_literal = self.saw_anonymous_literal_since(anonymous_mark);
         Ok(Method {
+            contains_anonymous_type_literal,
             directives,
             name,
             receiver,
@@ -310,9 +313,12 @@ impl Parser {
         self.expect(TokenKind::LParen)?;
         let tok = self.expect(TokenKind::SelfValue)?;
         self.expect(TokenKind::RParen)?;
+        let anonymous_mark = self.anonymous_literal_mark();
         let body = Expr::Block(self.block()?);
+        let contains_anonymous_type_literal = self.saw_anonymous_literal_since(anonymous_mark);
         let span = self.span_from(start);
         Ok(Method {
+            contains_anonymous_type_literal,
             directives: Directives::new(),
             name: Ident {
                 name: self.syms.drop_marker,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -4153,6 +4153,9 @@ mod tests {
                 type_expr: array,
                 span,
             })),
+            // An array type literal, not a value-position anonymous
+            // struct/enum, so the body carries no anonymous type site.
+            contains_anonymous_type_literal: false,
             span,
         });
 


### PR DESCRIPTION
Fixes RUE-1837.

## Problem

Building the parsed definition index ran `rue_rir::anonymous_type_sites`
unconditionally for every function, method, const initializer and drop fn.

That walk is a complete recursive traversal of the body expression tree,
maintaining a path `Vec` via push/pop at every node — but it records a site only
for a value-position anonymous `struct {..}` / `enum {..}` literal, which exist
only inside comptime type-constructor bodies. For nearly every declaration it
visited every node and returned an empty table: a full extra AST traversal per
body, on every module parse and every warm re-parse of an edited module, stacked
on the parser's own pass and AstGen's lowering pass.

## Change

The parser has exactly two production sites for those literals, so count them
there, and record `contains_anonymous_type_literal` on `Function`, `Method`,
`ConstDecl` and `DropFn` by comparing the counter across the body parse. The
index consults the flag and shares one empty table otherwise, so a body with no
literal costs neither the walk nor an allocation.

## Why the gate is sound

The gate is only correct if the flag is set whenever the walk could record
anything. I verified that closure rather than assuming it:

- The walk has exactly **one** `push` site, reached only from `record`.
- `record` is called only from the `Expr::TypeLit` arms for
  `TypeExpr::AnonymousStruct` and `TypeExpr::AnonymousEnum`, and it deliberately
  does **not** descend into the nested `TypeExpr` ("its methods are separate
  producer roots").
- Those two forms are produced only by the two instrumented expression arms:
  `anonymous_struct_type` has exactly one caller, and `ty()` never dispatches on
  `Struct`/`Enum`, so the remaining `TypeLit` arm (primitives via `ty()`) cannot
  yield either.

Counting *before* parsing the literal's contents keeps a nested declaration's own
flag independent of an enclosing literal.

## Guard

`gated_anonymous_site_tables_still_record_every_literal` asserts both directions
on one module: both literal forms still produce their sites (one `Enum`, one
`Struct`), and the literal-free body still gets the empty table the walk always
produced for it.

**I verified the guard bites** by forcing the gate to skip the walk — the test
failed with `gating dropped an anonymous type site`, and passed again once
restored.

## Validation

- `scripts/rue unit rue-parser` — 63 passed; `rue-compiler` — 1131 passed, 0 failed.
- `scripts/rue quick` — 33 pass, 0 fail. (An earlier run caught a `rue-rir` test
  fixture needing the new field; that fixture's `TypeLit` is an array type, not an
  anonymous struct/enum, so `false` is the correct value.)
- `rue-parser-clippy`, `rue-parser-fmt-check`, `rue-compiler-clippy`,
  `rue-compiler-fmt-check` green.
- `//crates/rue:rue` and `//crates/rue-frontend-diff:rue-frontend-diff` build.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nmb41AiKasPE74Vm3BFd8n)_