### PR TITLE
RUE-1838: borrow live locals for the per-expression comptime probe

### DIFF
--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -1561,6 +1561,36 @@ mod value_domain_tests {
         NAMED_TYPE_MISSING.with(|missing| missing.set(false));
     }
 
+    /// RUE-1838: `ComptimeEnv::for_analysis` reports runtime locals through the
+    /// borrowed membership hook instead of snapshotting every in-scope local's
+    /// name on every per-expression probe. `is_runtime_local_name` is the only
+    /// reader of either spelling, so the two must be indistinguishable to it —
+    /// including for a name that is absent, where the hook must answer `false`
+    /// rather than fall through to a stale empty set.
+    #[test]
+    fn borrowed_local_membership_matches_a_snapshotted_name_set() {
+        let present = FakeName { ordinal: 21 };
+        let absent = FakeName { ordinal: 22 };
+
+        let mut snapshotted =
+            ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        snapshotted.runtime_local_names.insert(present.clone());
+
+        let live: AHashSet<FakeName> = [present.clone()].into_iter().collect();
+        let mut borrowed =
+            ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        borrowed.runtime_local_name_membership =
+            Some(std::sync::Arc::new(move |name| live.contains(name)));
+
+        assert!(snapshotted.is_runtime_local_name(&present));
+        assert!(borrowed.is_runtime_local_name(&present));
+        assert!(!snapshotted.is_runtime_local_name(&absent));
+        assert!(!borrowed.is_runtime_local_name(&absent));
+
+        // The hook-backed env carries no snapshot at all: that is the point.
+        assert!(borrowed.runtime_local_names.is_empty());
+    }
+
     #[test]
     fn named_array_length_classifies_lexical_bindings_before_global_lookup() {
         let name = FakeName { ordinal: 7 };

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -262,8 +262,12 @@ impl<'a>
             // The borrowed-membership hook already exists and is already used by
             // the staged entry points; `is_runtime_local_name` consults both.
             runtime_local_names: AHashSet::new(),
-            runtime_local_name_membership: Some(std::sync::Arc::new(move |name| {
-                ctx.locals.contains_key(name)
+            runtime_local_name_membership: Some(std::sync::Arc::new({
+                // Capture only the locals map, not the whole context: `&ctx`
+                // is neither `Send` nor `Sync`, and an `Arc` over a closure
+                // holding it trips `clippy::arc_with_non_send_sync`.
+                let locals = &ctx.locals;
+                move |name: &Spur| locals.contains_key(name)
             })),
             runtime_binding_names: ctx.params.iter().map(|param| param.name).collect(),
             locals: AHashMap::new(),

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -254,8 +254,17 @@ impl<'a>
             type_subst: ctx.comptime_type_vars.clone(),
             value_subst: ctx.comptime_value_vars.clone(),
             resolved_types: Some(ctx.resolved_types),
-            runtime_local_names: ctx.locals.keys().copied().collect(),
-            runtime_local_name_membership: None,
+            // Borrow the caller's live locals instead of snapshotting their
+            // names. `for_analysis` sits on per-expression probe paths (every
+            // array index, every borrow operand, every `comptime` block), so a
+            // fresh O(locals) set allocation and hash per probe made a body with
+            // L locals and I probe sites do O(L x I) redundant set-building.
+            // The borrowed-membership hook already exists and is already used by
+            // the staged entry points; `is_runtime_local_name` consults both.
+            runtime_local_names: AHashSet::new(),
+            runtime_local_name_membership: Some(std::sync::Arc::new(move |name| {
+                ctx.locals.contains_key(name)
+            })),
             runtime_binding_names: ctx.params.iter().map(|param| param.name).collect(),
             locals: AHashMap::new(),
             const_module_members: AHashMap::new(),


### PR DESCRIPTION
Addresses RUE-1838 — the part that was already a one-liner waiting to be used.
See **Scope**; the issue is referenced without a closing keyword.

## Problem

`ComptimeEnv::for_analysis` collected every in-scope local's name into a fresh
`AHashSet` on construction (`ctx.locals.keys().copied().collect()`), while leaving
`runtime_local_name_membership: None` — even though that borrowed-membership hook
already exists and is already threaded by the staged entry points.

The constructor sits on per-expression probe paths: every array-index expression
via `try_get_const_index_checked`, every borrow operand, every `comptime` block,
and the ownership pass repeats the same probes after inference. A body with L
locals and I probe sites therefore did O(L × I) redundant set building — quadratic
in body size, in exactly the long generated-code bodies where sema time already
concentrates.

## Change

Point the hook at the caller's live locals instead of snapshotting their names.
`is_runtime_local_name` consults the set *and* the hook, so the answers are
unchanged.

The closure captures `&ctx.locals`, not `ctx`. That matters: a reference to
`AnalysisContext` is neither `Send` nor `Sync`, so an `Arc` over a closure holding
one trips `clippy::arc_with_non_send_sync`. A shared reference to the locals map
is `Sync`, so the `Arc` is well-formed on its own terms rather than by suppressing
the lint. (The first commit here got that wrong and failed the `rue-air` clippy
gate; the second fixes it.)

### Why nothing else observes the emptied set

- Its only reader is `is_runtime_local_name`.
- The only *production* writer, `try_eval_type_alias_init`, assigns it on a
  `with_subst` env, whose hook is `None` — so that path is untouched.
- Both `clear()` sites are test fixtures on `ComptimeEnv::new()` envs.

## Scope

The issue's remaining parts are deliberately **not** included:

- **Borrowing the substitution maps** means giving `ComptimeEnv` a lifetime over
  them plus an overlay map for the entries evaluation inserts into `env.locals` —
  a redesign, not a swap.
- **Memoizing `try_get_const_index_checked` per (body, InstRef)** needs a cache
  keyed on a body identity the env does not currently carry.
- **`runtime_binding_names`** is left alone: unlike locals it is read *directly*
  at four production sites rather than through a helper, and is pinned by name in
  `api_inventory`, so there is no equivalent hook to reuse — and parameter counts
  are small next to local counts.

This change is the one the issue describes as already having its mechanism in
place, so it stands alone cleanly.

## Guard

`borrowed_local_membership_matches_a_snapshotted_name_set`: the hook-backed and
snapshot-backed spellings must be indistinguishable to `is_runtime_local_name`,
for a present name **and** an absent one — the latter being where a hook that
silently fell through to the now-empty set would show up. It also asserts the
hook-backed env carries no snapshot at all, which is the point.

## Validation

On the current head (`2080668d0`):

- `buck2 test //crates/rue-air:{rue-air-clippy,rue-air-fmt-check,rue-air-debug-assert-check}`
  — 3 pass, 0 fail. Run as `test`, not `build`: the gate only executes under
  `test`, which is how the first commit's clippy failure got past me locally.
- `scripts/rue premerge` — 201 pass, 0 fail, suite PASSED.
- `scripts/rue unit rue-air` — 805 passed, 0 failed (804 before, plus the guard).
- `scripts/rue quick` — 33 pass, 0 fail.
