### PR TITLE
RUE-1842: unroll in place instead of through a dead transactional clone

### DIFF
--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -492,6 +492,34 @@ mod tests {
     }
 
     #[test]
+    fn unrolling_edits_the_graph_in_place() {
+        // RUE-1842, following RUE-1663: `unroll_one` used to run against a
+        // whole-CFG transactional clone that protected nothing. An `Err`
+        // propagates through `optimize_with_budget`'s `?` into
+        // `publish_optimization`, whose first statement is `pass_result?`, so
+        // the preserved original could never be read. RUE-1663 removed this
+        // clone class from the sibling passes but explicitly left unroll out,
+        // and the guard above does not watch it — hence this one.
+        let source = include_str!("unroll.rs");
+        assert_eq!(
+            source.matches("let mut edited = cfg.clone();").count(),
+            0,
+            "unroll reacquired a transactional whole-CFG clone"
+        );
+        // The remaining whole-graph clone in `unroll_one` is a different thing
+        // and is deliberately still here: it is the pristine read snapshot the
+        // pass copies original blocks from while it appends new ones and
+        // rewires original terminators. Narrowing it to the loop subgraph is
+        // tracked on RUE-1842; this assertion pins that it is the only one left,
+        // so its removal or duplication has to be a deliberate edit.
+        assert_eq!(
+            source.matches("let source = cfg.clone();").count(),
+            1,
+            "the pristine unroll snapshot moved; re-check what reads it"
+        );
+    }
+
+    #[test]
     fn optimizer_edit_failures_preserve_the_failure_kind() {
         let cfg = crate::Cfg::new(crate::Type::UNIT, 0, 0, "test".to_string(), vec![]);
         let type_pool = rue_air::TypeInternPool::new().freeze();

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -106,10 +106,15 @@ pub fn run_with_budget(
                 stats.budget_refusals += 1;
                 continue;
             }
-            let mut edited = cfg.clone();
-            match unroll_one(&mut edited, lp, trip) {
+            // Edited in place. The transactional clone this used to take
+            // protected nothing (RUE-1842, following RUE-1663): the `Err` arm
+            // propagates out of `run_with_budget`, through
+            // `optimize_with_budget`'s `?`, into `publish_optimization`, whose
+            // first statement is `pass_result?` — so a partially unrolled graph
+            // is never validated or published, and the preserved original was
+            // never read.
+            match unroll_one(cfg, lp, trip) {
                 Ok((blocks, values, instructions)) => {
-                    *cfg = edited;
                     stats.loops_unrolled += 1;
                     stats.blocks_cloned += blocks;
                     stats.values_cloned += values;


### PR DESCRIPTION
Addresses RUE-1842 — the provably-dead clone. See **Scope**; referenced without a
closing keyword.

## Problem

`run_with_budget` cloned the whole CFG before each accepted unroll and overwrote
the original on success.

The clone protected nothing, and the proof is short enough to check: the failure
arm `return Err(error)` propagates out of `run_with_budget`, through
`optimize_with_budget`'s `?`, into `publish_optimization` — whose **first
statement** is `pass_result?`. So a partially unrolled graph is never validated or
published, and the preserved original could never be read.

This is exactly the clone class RUE-1663 removed from `cse`, `forward`, `peephole`
and `simplify`. That issue explicitly left `unroll` out of scope, and the source
guard it added does not watch `unroll.rs` — so both clones survived.

## Change

Unroll the graph in place. One of the two whole-CFG clones per accepted unroll is
gone; for a function with k unrollable loops that is k fewer full-graph copies.

## Scope

The issue's other items are **not** included:

- **Narrowing the second clone** (`unroll_one`'s pristine snapshot) to the loop
  subgraph. That one is load-bearing, not dead: the pass appends new blocks *and
  rewires original terminators* as it goes, so reads of the original shape must
  come from a snapshot taken beforehand. Narrowing it means giving the pass a read
  view over body blocks' params, instructions, terminators and owner-bound payload
  slices — 14 distinct accessor reads — i.e. a new abstraction inside a
  correctness-critical pass, not a mechanical edit.
- **Unrolling every non-overlapping loop per forest computation**, which changes
  the pass's ordering semantics.
- **Batching `recognize`'s whole-graph external-use scan.**

## Guard

`unrolling_edits_the_graph_in_place`, beside the RUE-1663 guard it complements:

- the transactional clone must not come back, and
- the remaining pristine snapshot must stay at exactly **one** — so removing it
  (which would be a correctness bug) or duplicating it has to be a deliberate edit
  that updates this test.

## Validation

- `scripts/rue unit rue-cfg` — 356 passed, 0 failed, including the existing unroll
  tests unchanged.
- `//crates/rue-oracle-diff:oracle-diff-test` — pass. Unrolling affects -O3
  codegen, so this is the focused check AGENTS.md names for corpus-affecting
  changes.
- `scripts/rue quick` — 33 pass, 0 fail.
- `rue-cfg-clippy`, `rue-cfg-fmt-check`, `rue-cfg-debug-assert-check` green.

No change to emitted code: the same loops are unrolled the same way, into the
graph directly rather than into a copy of it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nmb41AiKasPE74Vm3BFd8n)_