### PR TITLE
RUE-1845: stop re-parsing the embedded runtime archive to validate it

### DIFF
--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -444,6 +444,11 @@ static RUNTIME_AARCH64_LINUX_VALIDATION: std::sync::OnceLock<Result<(), String>>
     std::sync::OnceLock::new();
 static RUNTIME_AARCH64_MACOS_VALIDATION: std::sync::OnceLock<Result<(), String>> =
     std::sync::OnceLock::new();
+/// Times the embedded runtime archive has actually been decoded. Parsing it
+/// materializes every member — headers, symbol tables, relocations, and a
+/// `Vec<u8>` per section — so this count is the real cost being avoided
+/// (RUE-1845).
+static RUNTIME_ARCHIVE_PARSES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Return the embedded rue-runtime archive matching `target`.
 pub(crate) fn runtime_for_target(target: Target) -> &'static [u8] {
@@ -877,12 +882,48 @@ fn validate_runtime_archive(runtime_bytes: &[u8], target: Target) -> Result<Arch
     validate_parsed_runtime_archive(archive, runtime_bytes, target)
 }
 
+/// The per-target validation memo.
+fn embedded_runtime_validation(target: Target) -> &'static std::sync::OnceLock<Result<(), String>> {
+    match target {
+        Target::X86_64Linux => &RUNTIME_X86_64_LINUX_VALIDATION,
+        Target::Aarch64Linux => &RUNTIME_AARCH64_LINUX_VALIDATION,
+        Target::Aarch64Macos => &RUNTIME_AARCH64_MACOS_VALIDATION,
+    }
+}
+
+/// Validate the embedded runtime archive without materializing it.
+///
+/// The system-linker path writes the archive bytes to disk verbatim and never
+/// needs the parsed form. Once the per-target verdict is memoized there is
+/// nothing left to compute, so decoding several megabytes of archive only to
+/// drop it is pure overhead on every link after the first — including every
+/// warm rebuild in a retained `--watch` session, where the embedded bytes
+/// cannot change within the process (RUE-1845).
+fn validate_runtime_archive_only_with_cancellation(
+    runtime_bytes: &[u8],
+    target: Target,
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<()> {
+    check_cancellation(cancellation)?;
+    // The same physical-identity test the memo itself is keyed on: a
+    // caller-supplied archive that merely compares equal is still validated.
+    if std::ptr::eq(runtime_bytes, runtime_for_target(target))
+        && let Some(validation) = embedded_runtime_validation(target).get()
+    {
+        return validation
+            .clone()
+            .map_err(|error| compile_control(link_error(error)));
+    }
+    validate_runtime_archive_with_cancellation(runtime_bytes, target, cancellation).map(|_| ())
+}
+
 fn validate_runtime_archive_with_cancellation(
     runtime_bytes: &[u8],
     target: Target,
     cancellation: &rue_query::CancellationToken,
 ) -> CancellableLinkResult<Archive> {
     check_cancellation(cancellation)?;
+    RUNTIME_ARCHIVE_PARSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let archive = Archive::parse_strict_objects_with_cancellation(runtime_bytes, || {
         cancellation.is_canceled()
     })
@@ -902,11 +943,7 @@ fn validate_runtime_archive_with_cancellation(
     }
     check_cancellation(cancellation)?;
     let embedded_runtime = runtime_for_target(target);
-    let embedded_validation = match target {
-        Target::X86_64Linux => &RUNTIME_X86_64_LINUX_VALIDATION,
-        Target::Aarch64Linux => &RUNTIME_AARCH64_LINUX_VALIDATION,
-        Target::Aarch64Macos => &RUNTIME_AARCH64_MACOS_VALIDATION,
-    };
+    let embedded_validation = embedded_runtime_validation(target);
     if std::ptr::eq(runtime_bytes, embedded_runtime) {
         if let Some(validation) = embedded_validation.get() {
             validation
@@ -971,11 +1008,7 @@ fn validate_parsed_runtime_archive(
         validate_runtime_inventory(&inventory, runtime_target(target))
     };
     let embedded_runtime = runtime_for_target(target);
-    let embedded_validation = match target {
-        Target::X86_64Linux => &RUNTIME_X86_64_LINUX_VALIDATION,
-        Target::Aarch64Linux => &RUNTIME_AARCH64_LINUX_VALIDATION,
-        Target::Aarch64Macos => &RUNTIME_AARCH64_MACOS_VALIDATION,
-    };
+    let embedded_validation = embedded_runtime_validation(target);
     if std::ptr::eq(runtime_bytes, embedded_runtime) {
         embedded_validation.get_or_init(validate).clone()?;
     } else {
@@ -1252,7 +1285,7 @@ pub(crate) fn link_system_with_warnings_and_cancellation(
     let runtime_bytes = runtime_for_target(options.target);
     // The system linker consumes the archive bytes directly, so validate the
     // embedded target and typed ABI before writing them to disk.
-    validate_runtime_archive_with_cancellation(runtime_bytes, options.target, cancellation)?;
+    validate_runtime_archive_only_with_cancellation(runtime_bytes, options.target, cancellation)?;
     check_cancellation(cancellation)?;
 
     // Set up temporary directory with object files and runtime
@@ -2197,5 +2230,40 @@ mod runtime_archive_validation_tests {
         oversized[value_offset..value_offset + 8].copy_from_slice(&(value - 1).to_le_bytes());
         let err = validation_error(&oversized);
         assert!(err.contains("has size 2, expected 1 byte"), "{err}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RUE-1845: the system-linker path writes the embedded archive bytes to
+    /// disk verbatim, so once the per-target verdict is memoized it must not
+    /// decode the archive again. The decode materializes every member, so this
+    /// is the cost the validation-only entry point exists to avoid.
+    #[test]
+    fn validating_the_embedded_runtime_stops_reparsing_it() {
+        let target = Target::X86_64Linux;
+        let bytes = runtime_for_target(target);
+        let cancellation = rue_query::CancellationToken::new();
+
+        // Prime the verdict. Whether this particular call is the one that
+        // parses depends on what else ran first in the process, so only the
+        // steady state below is asserted.
+        validate_runtime_archive_only_with_cancellation(bytes, target, &cancellation).unwrap();
+        assert!(
+            embedded_runtime_validation(target).get().is_some(),
+            "the verdict should be memoized after one validation"
+        );
+
+        let before = RUNTIME_ARCHIVE_PARSES.load(std::sync::atomic::Ordering::Relaxed);
+        for _ in 0..4 {
+            validate_runtime_archive_only_with_cancellation(bytes, target, &cancellation).unwrap();
+        }
+        assert_eq!(
+            RUNTIME_ARCHIVE_PARSES.load(std::sync::atomic::Ordering::Relaxed),
+            before,
+            "validating the embedded archive re-parsed it after the verdict was memoized"
+        );
     }
 }


### PR DESCRIPTION
Addresses RUE-1845 for the system-linker path. See **Scope**; referenced without a
closing keyword.

## Problem

The system-linker path writes the embedded runtime bytes to disk **verbatim** and
never needs the parsed archive — but it called the archive-returning validation
entry point, which decodes every member (headers, symbol tables, relocations, and
a `Vec` per section) and then dropped the result.

Only the *verdict* is memoized. So every link after the first decoded several
megabytes purely to re-derive a value already sitting in the `OnceLock`, and paid
it again on every warm rebuild in a retained `--watch` session, where the embedded
bytes cannot change within the process.

## Change

A validation-only entry point that consults the memo **before** parsing, keyed on
the same `std::ptr::eq` physical-identity test the memo itself uses — so a
caller-supplied archive that merely compares equal is still fully validated.

Both validation variants now take their per-target memo from one
`embedded_runtime_validation` helper instead of repeating the three-arm mapping
(it appeared twice).

## Scope

The **internal-link** path still needs the parsed archive to feed
`add_archive_with_cancellation`, so its parse remains.

Memoizing that one is what the issue's main proposal describes, and it is not a
memo: it needs `Archive.objects` held as `Arc` so `add_archive` can
take `&Archive` and clone only the selected members. Neither `Archive` nor
`ObjectFile` derives `Clone` today, and `add_archive_with_cancellation` consumes
its argument and moves members out — so it is a reshape of the linker's archive
API, in the code path every single link goes through. I did not want to take that
on in the same change as a memo lookup.

## Guard

A `RUNTIME_ARCHIVE_PARSES` counter incremented where the decode actually happens,
plus `validating_the_embedded_runtime_stops_reparsing_it`: after the verdict is
memoized, repeated validation must not decode the archive again. The test primes
the verdict first and asserts only the steady state, so it does not depend on what
else ran earlier in the process.

**I verified it bites** by bypassing the memo consult — the test failed with
`validating the embedded archive re-parsed it after the verdict was memoized` —
and passed again once restored.

## Validation

On the first commit (`4e8ec4430`):

- `scripts/rue unit rue-compiler` — 1133 passed, 0 failed.
- `scripts/rue cli abi` — 63 passed, 0 failed. Linking is exercised by the real
  binary against real files, which is the coverage that matters for this path.
- `rue-compiler-clippy`, `rue-compiler-fmt-check`,
  `rue-compiler-debug-assert-check` green.

On the current head (`c6e08a3f3`, after merging trunk):

- `scripts/rue premerge` — 203 pass, 0 fail, suite PASSED.
- `scripts/rue quick` — 33 pass, 0 fail.
- `buck2 test //crates/rue-compiler:{rue-compiler-clippy,rue-compiler-fmt-check,rue-compiler-debug-assert-check}`
  — 3 pass, 0 fail.

Validation behavior is unchanged: the same verdict is produced for the same bytes,
and a non-embedded archive still takes the full parse-and-validate path.

## Why the branch was merged with trunk

The first run's `test (linux-x64-cli-shard-0)` died on a remote action cache
`403 Forbidden` before any test body ran (`NO TESTS RAN`; the failing targets were
toolchain archives and std genrules this diff does not touch), and the cancelled
siblings followed from it. The branch was two commits behind trunk, so merging the
current base is a real update the PR needed anyway — and it re-runs CI from a fresh
head rather than replaying the poisoned one.
