### PR TITLE
RUE-1854: key dotslash caches on the pinned manifest

### DIFF
--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -158,7 +158,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -170,7 +170,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -246,7 +246,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -330,7 +330,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -647,7 +647,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -860,7 +860,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-${{ matrix.name }}-${{ hashFiles('buck2') }}
+          key: dotslash-${{ matrix.name }}-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-${{ matrix.name }}-
 
@@ -985,7 +985,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -1034,7 +1034,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -1104,7 +1104,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2', 'btd') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin', 'btd') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -1243,7 +1243,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-${{ matrix.cache_name }}-${{ hashFiles('buck2') }}
+          key: dotslash-${{ matrix.cache_name }}-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-${{ matrix.cache_name }}-
 
@@ -1321,7 +1321,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -1385,7 +1385,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -1488,7 +1488,7 @@ jobs:
           path: |
             ~/.cache/dotslash
             ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
       - name: Validate aggregate gate and platform responsibilities

--- a/.github/workflows/correctness-repetitions.yml
+++ b/.github/workflows/correctness-repetitions.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: dotslash-repetitions-linux-x64-
       - name: Repeat correctness shard and retain every failure
         env:
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: dotslash-repetitions-linux-x64-
       - name: Enumerate every corpus that runs as a build action
         id: inventory
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: dotslash-repetitions-linux-x64-
       - name: Execute the corpus against the current tree
         env:
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-soak-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-soak-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: dotslash-soak-linux-x64-
       - name: Soak the differential oracle under process oversubscription
         env:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
           restore-keys: |
             dotslash-linux-x64-
 

--- a/BUCK
+++ b/BUCK
@@ -1004,6 +1004,34 @@ rue_sh_test(
     },
 )
 
+# RUE-1854: `buck2` is a wrapper script; the DotSlash manifest carrying the
+# pinned release digests is `buck2-bin`. A dotslash cache key hashing the
+# wrapper does not move when the pin is bumped, so actions/cache reports an
+# exact hit on a store without the new binary and never saves the downloaded
+# one back — every job re-downloads it on every run, silently, because
+# dotslash succeeds either way. The glob matches the validator's own default
+# discovery so a newly added workflow is covered the day it lands.
+filegroup(
+    name = "dotslash-cache-key-workflows",
+    srcs = glob([".github/workflows/*.yml", ".github/workflows/*.yaml"]),
+)
+
+rue_sh_test(
+    name = "dotslash-cache-key-validation",
+    test = "scripts/validate-dotslash-cache-keys.py",
+    args = ["$(location :dotslash-cache-key-workflows)/.github/workflows"],
+)
+
+rue_sh_test(
+    name = "dotslash-cache-key-tool-tests",
+    test = "scripts/test-dotslash-cache-keys.py",
+    resources = ["scripts/validate-dotslash-cache-keys.py"] +
+        [":gatelib-sources"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
 # The structural complement of the per-crate debug-assertion checks
 # (RUE-1525): those run only for crates that emit them, so deleting a crate
 # would leave its ledger entries permanently unchecked. This gate fails when

--- a/scripts/test-dotslash-cache-keys.py
+++ b/scripts/test-dotslash-cache-keys.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Focused tests for the dotslash cache-key policy (RUE-1854)."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+keys = load_script("validate-dotslash-cache-keys.py", __file__)
+
+
+def cache_step(key: str) -> str:
+    return (
+        "jobs:\n  build:\n    steps:\n"
+        "      - uses: actions/cache@v4\n"
+        "        with:\n"
+        "          path: |\n            ~/.cache/dotslash\n"
+        f"          key: {key}\n"
+        "          restore-keys: |\n            dotslash-linux-x64-\n"
+    )
+
+
+class DotslashCacheKeyTests(unittest.TestCase):
+    def validate(self, workflow: str) -> tuple[list[str], int]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ci.yml"
+            path.write_text(workflow)
+            return keys.validate(path)
+
+    def test_rejects_hashing_the_wrapper(self) -> None:
+        # The exact regression: the wrapper does not change on a pin bump, so
+        # the key stays put and the stale store is never replaced.
+        errors, found = self.validate(
+            cache_step("dotslash-linux-x64-${{ hashFiles('buck2') }}")
+        )
+        self.assertEqual(found, 1)
+        self.assertEqual(len(errors), 2)
+        self.assertIn("wrapper", errors[0])
+        self.assertIn("buck2-bin", errors[1])
+
+    def test_accepts_hashing_the_pinned_manifest(self) -> None:
+        errors, found = self.validate(
+            cache_step("dotslash-linux-x64-${{ hashFiles('buck2-bin') }}")
+        )
+        self.assertEqual((errors, found), ([], 1))
+
+    def test_accepts_additional_tool_manifests(self) -> None:
+        # affected-targets caches btd's binary in the same store, so its key
+        # legitimately hashes both manifests.
+        errors, found = self.validate(
+            cache_step("dotslash-linux-x64-${{ hashFiles('buck2-bin', 'btd') }}")
+        )
+        self.assertEqual((errors, found), ([], 1))
+
+    def test_rejects_a_key_hashing_nothing(self) -> None:
+        errors, found = self.validate(cache_step("dotslash-linux-x64-v1"))
+        self.assertEqual(found, 1)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("hashes no file", errors[0])
+
+    def test_accepts_a_matrix_scoped_key(self) -> None:
+        errors, found = self.validate(
+            cache_step("dotslash-${{ matrix.name }}-${{ hashFiles('buck2-bin') }}")
+        )
+        self.assertEqual((errors, found), ([], 1))
+
+    def test_ignores_unrelated_cache_keys(self) -> None:
+        errors, found = self.validate(
+            cache_step("cargo-registry-${{ hashFiles('Cargo.lock') }}")
+        )
+        self.assertEqual((errors, found), ([], 0))
+
+    def test_directory_argument_covers_every_workflow(self) -> None:
+        # The Buck gate passes a directory so a workflow added later is
+        # checked without editing the gate.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "ci.yml").write_text(
+                cache_step("dotslash-linux-x64-${{ hashFiles('buck2-bin') }}")
+            )
+            (root / "later.yaml").write_text(
+                cache_step("dotslash-macos-arm64-${{ hashFiles('buck2') }}")
+            )
+            found = keys.workflows_in(root)
+            self.assertEqual([path.name for path in found], ["ci.yml", "later.yaml"])
+            errors = [error for path in found for error in keys.validate(path)[0]]
+            self.assertEqual(len(errors), 2)
+
+    def test_reports_every_offending_key(self) -> None:
+        workflow = cache_step(
+            "dotslash-linux-x64-${{ hashFiles('buck2') }}"
+        ) + cache_step("dotslash-macos-arm64-${{ hashFiles('buck2') }}")
+        errors, found = self.validate(workflow)
+        self.assertEqual(found, 2)
+        self.assertEqual(len(errors), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-dotslash-cache-keys.py
+++ b/scripts/validate-dotslash-cache-keys.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Key every dotslash cache on the pinned manifest, not the wrapper script.
+
+`buck2` is a bash wrapper; the DotSlash manifest carrying the pinned release
+digests is `buck2-bin` (the wrapper execs `dotslash "$repo_root/buck2-bin"`).
+A cache key hashing the wrapper does not change when the pin is bumped, so
+`actions/cache` reports an exact hit on a store that lacks the new binary and
+therefore never saves the freshly downloaded one back — every job in every run
+re-downloads tens of megabytes, indefinitely and silently, because dotslash
+succeeds either way (RUE-1854).
+
+So a `dotslash-` cache key must hash `buck2-bin`, and must not hash the
+`buck2` wrapper: naming the wrapper would reinstate the stale-key window on
+any pin bump that leaves it untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATTERNS = ("*.yml", "*.yaml")
+
+
+def workflows_in(directory: Path) -> list[Path]:
+    """Every workflow file in `directory`, in a stable order."""
+
+    return sorted(
+        path for pattern in WORKFLOW_PATTERNS for path in directory.glob(pattern)
+    )
+
+
+DEFAULT_WORKFLOWS = workflows_in(ROOT / ".github" / "workflows")
+# An `actions/cache` key for the dotslash store. The store path is what makes
+# it a dotslash cache, but the key prefix is the reviewed convention and is
+# what a new copy-pasted step carries.
+DOTSLASH_KEY = re.compile(r"^\s*key:\s*(?P<key>.*dotslash-.*)$")
+HASH_FILES = re.compile(r"hashFiles\((?P<arguments>[^)]*)\)")
+QUOTED = re.compile(r"""['"](?P<name>[^'"]*)['"]""")
+PINNED_MANIFEST = "buck2-bin"
+WRAPPER = "buck2"
+
+
+def validate(path: Path) -> tuple[list[str], int]:
+    """Return this file's errors and how many dotslash keys it declares."""
+
+    errors: list[str] = []
+    keys = 0
+    for line_number, line in enumerate(path.read_text().splitlines(), 1):
+        match = DOTSLASH_KEY.match(line)
+        if not match:
+            continue
+        keys += 1
+        key = match.group("key")
+        hashed = [
+            name
+            for arguments in HASH_FILES.finditer(key)
+            for name in QUOTED.findall(arguments.group("arguments"))
+        ]
+        if not hashed:
+            errors.append(
+                f"{path}:{line_number}: dotslash cache key hashes no file; key it on "
+                f"{PINNED_MANIFEST!r} so a pin bump invalidates the entry"
+            )
+            continue
+        if WRAPPER in hashed:
+            errors.append(
+                f"{path}:{line_number}: dotslash cache key hashes the {WRAPPER!r} wrapper; "
+                f"the pinned digests live in {PINNED_MANIFEST!r}, so a pin bump would "
+                "leave this key unchanged and the cached store permanently stale"
+            )
+        if PINNED_MANIFEST not in hashed:
+            errors.append(
+                f"{path}:{line_number}: dotslash cache key does not hash {PINNED_MANIFEST!r}; "
+                "a bumped pin would restore a store without the new binary and never save it back"
+            )
+    return errors, keys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "workflows",
+        nargs="*",
+        type=Path,
+        help="workflow files, or a directory whose workflow files are all checked",
+    )
+    args = parser.parse_args()
+
+    # A directory argument keeps the checked set identical to what CI actually
+    # runs: a workflow added tomorrow is covered without editing this gate.
+    workflows = [
+        workflow
+        for argument in args.workflows
+        for workflow in (workflows_in(argument) if argument.is_dir() else [argument])
+    ] or DEFAULT_WORKFLOWS
+    errors: list[str] = []
+    keys = 0
+    for path in workflows:
+        file_errors, file_keys = validate(path)
+        errors += file_errors
+        keys += file_keys
+    if not keys:
+        # A rename of the cache-key convention would otherwise turn this gate
+        # into a vacuous pass over files it no longer recognizes.
+        errors.append(
+            "no dotslash cache key found in any checked workflow; the gate would "
+            "silently check nothing"
+        )
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"dotslash cache keys valid: {keys} key(s) across "
+        f"{len(workflows)} workflow(s) hash {PINNED_MANIFEST}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes RUE-1854.

## Problem

Every `actions/cache` step for the dotslash store keyed on `hashFiles('buck2')` — but `buck2` is a bash wrapper (`# Rue's Buck2 entry point. The pinned DotSlash manifest lives in buck2-bin`), and the manifest carrying the pinned release digests is `buck2-bin`.

So a pin bump — which edits `buck2-bin` and leaves the wrapper untouched — moved no cache key. `actions/cache` reported an **exact** hit, restored a store lacking the new binary, and because an exact hit suppresses the end-of-job save, never wrote the freshly downloaded one back. Every job in every run then re-downloaded the ~33–39 MB archive from GitHub releases indefinitely — silently, because dotslash succeeds either way and the cache step still reports a hit.

## Fix

All 22 keys now hash the manifest:

| workflow | keys |
| --- | --- |
| `ci.yml` | 13 (incl. the affected-targets key, now `hashFiles('buck2-bin', 'btd')` — `btd` was already correct, being btd's own manifest) |
| `cache-probe.yml` | 2 |
| `correctness-repetitions.yml` | 4 |
| `fuzz.yml` | 1 |
| `release.yml` | 2 |

`restore-keys` prefixes are untouched, so a pin bump restores the previous store and then saves a fresh entry containing the new binary — exactly the behavior the key is supposed to produce. Every `hashFiles(...)` occurrence in `.github/workflows` is now one of these keys; nothing unrelated changed.

## Guard

`scripts/validate-dotslash-cache-keys.py` (+ `//:dotslash-cache-key-validation`) fails a `dotslash-` cache key that hashes the `buck2` wrapper, hashes no file at all, or omits `buck2-bin` — and fails when no such key is found anywhere, so renaming the convention cannot turn the gate into a vacuous pass (the failure mode RUE-1152 hid). It takes the workflow *directory*, matching its own default discovery, so a workflow added later is covered without editing the gate.

`scripts/test-dotslash-cache-keys.py` (+ `//:dotslash-cache-key-tool-tests`) pins that behavior in 8 tests: the wrapper regression, the accepted manifest key, the two-manifest `btd` key, a key hashing nothing, a matrix-scoped key, an unrelated (`cargo-registry-`) key being ignored, multiple offending keys each reported, and directory expansion covering a later-added `.yaml` workflow.

## Validation

- `//:dotslash-cache-key-validation` + `//:dotslash-cache-key-tool-tests` — pass; each failure mode verified to fail before the fix
- Neighboring workflow gates (`ci-gate-validation`, `required-ci-container-pin-validation`, `scheduled-workflow-tool-tests`) — pass
- `scripts/rue quick` and full `scripts/rue premerge` — pass, exit 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLu5tyWdwrL8RywUZqaQc)_