### PR TITLE
RUE-1790: reclaim finished worktree Buck outputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ scripts/rue fmt                      # format changed Rust files
 scripts/rue storage status           # inventory Buck disk use across worktrees
 scripts/rue storage plan             # dry-run host-wide stale cleanup
 scripts/rue storage clean            # reclaim stale Buck2 artifacts host-wide
+scripts/rue storage reclaim-finished RUE_ROOT [RUE_ROOT ...] # explicit finished-root output reclaim
 scripts/rue cache install            # securely install the shared cache config
 scripts/rue cache apply --all        # provision current Git/Codex worktrees
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,6 +30,7 @@ scripts/rue storage status           # inventory Buck usage across worktrees
 scripts/rue storage plan             # dry-run host-wide stale cleanup
 scripts/rue storage clean            # remove stale Buck artifacts host-wide
 scripts/rue storage guard            # run the emergency low-disk preflight now
+scripts/rue storage reclaim-finished /exact/root # reclaim outputs for a finished root
 ```
 
 For direct compiler invocations, resolve the binary through `scripts/rue-bin`:

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -69,7 +69,9 @@ scripts/rue storage status            # sizes, source state, and cache state
 scripts/rue storage plan [AGE]        # Buck dry-run in every registered worktree
 scripts/rue storage clean [AGE]       # stale + adaptive cleanup; default 1w
 scripts/rue storage guard             # run the build preflight explicitly
+scripts/rue storage guard --finished-root /exact/root # name caller-confirmed finished output
 scripts/rue storage reset /exact/root # full Buck reset of an explicit target
+scripts/rue storage reclaim-finished /exact/root # reclaim a caller-confirmed finished root
 ```
 
 Every `./buck2 build`, `test`, `run`, or `install` invocation runs the same
@@ -90,8 +92,29 @@ outputs and may promote older tracked, non-active outputs when the host is below
 the 20% target. `reset` is the migration escape hatch for an older worktree whose
 artifacts predate persisted materializer state; it validates every named path as
 a registered Rue worktree before it resets any of them. Neither command removes
-source files or worktrees. `scripts/rue gc` remains a compatibility alias for
-the host-wide one-week stale cleanup.
+source files or worktrees. `reclaim-finished` is the explicit lifecycle handoff
+for a root whose caller knows its work is finished: it accepts only exact
+registered Rue worktree roots, verifies their live Git identity belongs to the
+coordinator's worktree family, refuses the current checkout and ambiguous
+inventory entries, and uses Buck's `clean --exit-when notidle` liveness check
+for every existing isolation. Dirty source is valid and does not influence the
+finishedness decision. A root with no existing Buck isolation entries succeeds
+without invoking destructive cleanup. When pressure remains after ordinary TTL cleanup, `guard` may name
+caller-supplied `--finished-root` values that still have output and pass a
+non-destructive Buck probe, but never reclaims them automatically; run the
+printed command explicitly. If a later named root refuses its destructive
+liveness check, earlier roots may already have been reclaimed; the command
+stops immediately and never continues to later roots.
+Current, active, and zero-output roots are not reported as eligible. Reclaim
+stops on a changed output root or isolation set; residual Buck-owned metadata
+in a cleaned isolation is reported honestly rather than treated as a failed
+cleanup. A new isolation can leave an earlier isolation reclaimed while the
+command stops for review, just as a later named root can stop a multi-root
+command after earlier roots succeeded. Per-isolation liveness rechecks can
+similarly reclaim earlier isolations in the same root before a later isolation
+refuses and stops the command.
+`scripts/rue gc` remains a compatibility alias for the host-wide one-week
+stale cleanup.
 
 The default setup is for the shared **action cache**. Normal commands stay on
 `--prefer-local`; add `--prefer-remote` explicitly when remote execution is the

--- a/scripts/rue
+++ b/scripts/rue
@@ -23,6 +23,8 @@
 #   scripts/rue frontend-manifest  Refresh the audited frontend corpus manifest
 #   scripts/rue fmt                Format the code (./fmt.sh)
 #   scripts/rue storage [args...]  Inspect or reclaim Buck outputs across worktrees
+#   scripts/rue storage reclaim-finished ROOT ...
+#                                  Explicitly reclaim outputs for finished roots
 #   scripts/rue gc [age]           Compatibility alias for host-wide stale cleanup
 #   scripts/rue cache [args...]    Provision the shared BuildBuddy action cache
 #   scripts/rue path               Print the absolute binary path (build if needed)

--- a/scripts/rue-storage
+++ b/scripts/rue-storage
@@ -10,7 +10,8 @@ usage() {
 usage: scripts/rue-storage status
        scripts/rue-storage plan [STALE_AGE]
        scripts/rue-storage clean [STALE_AGE]
-       scripts/rue-storage guard
+       scripts/rue-storage guard [--finished-root RUE_ROOT ...]
+       scripts/rue-storage reclaim-finished RUE_ROOT [RUE_ROOT ...]
        scripts/rue-storage reset RUE_ROOT [RUE_ROOT ...]
 
 status inventories every registered Rue worktree and its buck-out size. plan
@@ -25,8 +26,10 @@ where ENOSPC is a real risk — between the floors the guard warns and
 proceeds, because on a busy multi-worktree host the free space held by
 active sibling builds is not reclaimable and blocking every build there
 starves the host without protecting it (RUE-1331). reset fully removes Buck
-outputs only from the exact registered roots named by the caller. Source
-worktrees are never removed.
+outputs only from the exact registered roots named by the caller. reclaim-finished
+does the same for caller-authorized finished roots, using Buck's non-preempting
+liveness check for each existing Buck isolation and preserving tracked and
+untracked source content. Source worktrees are never removed.
 EOF
 }
 
@@ -51,7 +54,7 @@ hard_floor_gib=4
 
 collect_roots() {
     local inventory
-    if ! inventory="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null)"; then
+    if ! inventory="$(git_reclaim -C "$repo_root" worktree list --porcelain 2>/dev/null)"; then
         echo "error: cannot inventory registered worktrees; refusing cleanup (fail-closed)" >&2
         return 1
     fi
@@ -80,13 +83,25 @@ human_kib() {
 
 source_state() {
     local out
-    if ! out="$(git -C "$1" status --porcelain 2>/dev/null)"; then
+    if ! out="$(git_reclaim -C "$1" status --porcelain 2>/dev/null)"; then
         printf 'unknown'
     elif [[ -n "$out" ]]; then
         printf 'dirty'
     else
         printf 'clean'
     fi
+}
+
+# Reclaim decisions must use the repository selected by each explicit -C
+# root, never ambient Git environment that could redirect inventory, identity,
+# or source-state probes to an unrelated checkout. Keep ordinary Git commands
+# on the same safe path as well; unsetting the object/config selectors closes
+# the remaining ways for a caller's environment to change repository meaning.
+git_reclaim() {
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_INDEX_FILE \
+        -u GIT_OBJECT_DIRECTORY -u GIT_ALTERNATE_OBJECT_DIRECTORIES \
+        -u GIT_CEILING_DIRECTORIES -u GIT_DISCOVERY_ACROSS_FILESYSTEM \
+        -u GIT_NAMESPACE git "$@"
 }
 
 cache_state() {
@@ -295,6 +310,9 @@ guard_low_disk() {
     pressure="$(emergency_pressure)" || return 1
     after="$(describe_free)" || return 1
     if [[ "$pressure" == low ]]; then
+        if (( ${#FINISHED_EVIDENCE_ROOTS[@]} > 0 )); then
+            report_finished_evidence
+        fi
         echo "warning: host filesystem still has only ${after} free; trying largest legacy Buck roots while preserving active work" >&2
         # Escalation is best-effort; the hard floor below makes the decision.
         reset_legacy_under_pressure || true
@@ -331,6 +349,650 @@ canonical_registered_root() {
     return 1
 }
 
+# The explicit reclaim path has a stricter inventory contract than the
+# host-wide status/TTL commands. Every entry must be a usable Rue checkout and
+# every canonical path must be unique; otherwise an alias could make the
+# caller authorize a different checkout than the one inspected.
+canonical_reclaim_root() {
+    local requested="$1" canonical root root_canonical roots seen=""
+    if ! canonical="$(cd "$requested" 2>/dev/null && pwd -P)"; then
+        echo "error: reclaim-finished target is not a directory: $requested" >&2
+        return 1
+    fi
+    if [[ "$canonical" == *$'\n'* ]]; then
+        echo "error: reclaim-finished target path is ambiguous; refusing reclaim: $requested" >&2
+        return 1
+    fi
+    roots="$(collect_roots)" || return 1
+    while IFS= read -r root; do
+        [[ -n "$root" ]] || continue
+        if ! is_rue_root "$root"; then
+            echo "error: registered worktree is not a usable Rue checkout; refusing reclaim: $root" >&2
+            return 1
+        fi
+        if ! root_canonical="$(cd "$root" 2>/dev/null && pwd -P)"; then
+            echo "error: cannot canonicalize registered worktree; refusing reclaim: $root" >&2
+            return 1
+        fi
+        if [[ "$root_canonical" == *$'\n'* ]]; then
+            echo "error: registered worktree path is ambiguous; refusing reclaim: $root" >&2
+            return 1
+        fi
+        if [[ "$seen" == *$'\n'"$root_canonical"$'\n'* ]]; then
+            echo "error: registered worktree inventory has ambiguous duplicate root: $root_canonical" >&2
+            return 1
+        fi
+        seen+=$'\n'"$root_canonical"$'\n'
+        if [[ "$root_canonical" == "$canonical" ]]; then
+            verify_reclaim_git_identity "$root_canonical" || return 1
+            printf '%s\n' "$root_canonical"
+        fi
+    done <<<"$roots"
+    if [[ "$seen" != *$'\n'"$canonical"$'\n'* ]]; then
+        echo "error: reclaim-finished target is not a registered Rue worktree: $requested" >&2
+        return 1
+    fi
+}
+
+canonical_git_path() {
+    local base="$1" path="$2"
+    if [[ "$path" == /* ]]; then
+        cd "$path" 2>/dev/null && pwd -P
+    else
+        cd "$base/$path" 2>/dev/null && pwd -P
+    fi
+}
+
+verify_reclaim_git_identity() {
+    local root="$1" coordinator_common candidate_common candidate_git_dir candidate_top pointer expected_pointer
+    if ! coordinator_common="$(git_reclaim -C "$repo_root" rev-parse --git-common-dir 2>/dev/null)" ||
+        ! coordinator_common="$(canonical_git_path "$repo_root" "$coordinator_common")"; then
+        echo "error: cannot inspect coordinator Git identity; refusing reclaim for $root" >&2
+        return 1
+    fi
+    if ! candidate_common="$(git_reclaim -C "$root" rev-parse --git-common-dir 2>/dev/null)" ||
+        ! candidate_common="$(canonical_git_path "$root" "$candidate_common")" ||
+        [[ "$candidate_common" != "$coordinator_common" ]]; then
+        echo "error: target is not in the coordinator's Git worktree family; refusing reclaim for $root" >&2
+        return 1
+    fi
+    if ! candidate_git_dir="$(git_reclaim -C "$root" rev-parse --git-dir 2>/dev/null)" ||
+        ! candidate_git_dir="$(canonical_git_path "$root" "$candidate_git_dir")"; then
+        echo "error: cannot inspect target Git worktree admin directory; refusing reclaim for $root" >&2
+        return 1
+    fi
+    if [[ "$candidate_git_dir" != "$coordinator_common" ]]; then
+        case "$candidate_git_dir/" in
+            "$coordinator_common/worktrees/"*) ;;
+            *)
+                echo "error: target Git worktree admin directory is outside the coordinator mapping; refusing reclaim for $root" >&2
+                return 1
+                ;;
+        esac
+        if [[ -L "$candidate_git_dir/gitdir" || ! -f "$candidate_git_dir/gitdir" ]] ||
+            ! IFS= read -r pointer <"$candidate_git_dir/gitdir" ||
+            [[ -z "$pointer" || "$pointer" == gitdir:* ]]; then
+            echo "error: target Git worktree admin back-pointer is missing; refusing reclaim for $root" >&2
+            return 1
+        fi
+        if [[ -L "$root/.git" || ! -f "$root/.git" ]]; then
+            echo "error: target Git worktree link file is missing; refusing reclaim for $root" >&2
+            return 1
+        fi
+        expected_pointer="$(canonical_file_path "$root" "$root/.git")" || return 1
+        # Git may write a relative back-pointer when the worktree uses
+        # --relative-paths; it is relative to the admin directory, not root.
+        if ! pointer="$(canonical_file_path "$candidate_git_dir" "$pointer")" ||
+            [[ "$pointer" != "$expected_pointer" ]]; then
+            echo "error: target Git worktree admin back-pointer does not match its registered root; refusing reclaim for $root" >&2
+            return 1
+        fi
+    else
+        # A linked worktree has a .git file, while the coordinator's main
+        # checkout has a real .git directory. Do not accept a main-looking
+        # candidate whose .git merely points at the coordinator metadata.
+        if [[ -L "$root/.git" || ! -d "$root/.git" ]] ||
+            ! candidate_git_dir="$(cd "$root/.git" 2>/dev/null && pwd -P)" ||
+            [[ "$candidate_git_dir" != "$coordinator_common" ]]; then
+            echo "error: target main-worktree Git metadata does not match the coordinator; refusing reclaim for $root" >&2
+            return 1
+        fi
+    fi
+    if ! candidate_top="$(git_reclaim -C "$root" rev-parse --show-toplevel 2>/dev/null)" ||
+        ! candidate_top="$(cd "$candidate_top" 2>/dev/null && pwd -P)" ||
+        [[ "$candidate_top" != "$root" ]]; then
+        echo "error: target Git top-level does not match its registered root; refusing reclaim for $root" >&2
+        return 1
+    fi
+    if [[ "${2:-}" == print-admin ]]; then
+        printf '%s\n' "$candidate_git_dir"
+    fi
+}
+
+filesystem_identity() {
+    local path="$1" identity
+    # GNU stat's -f means filesystem statistics (not file dev:inode), so try
+    # its exact file form first. BSD/macOS rejects -c and then provides the
+    # equivalent fields through -f.
+    if identity="$(stat -c '%d:%i' "$path" 2>/dev/null)" &&
+        [[ "$identity" =~ ^[0-9]+:[0-9]+$ ]]; then
+        printf '%s\n' "$identity"
+        return 0
+    fi
+    if identity="$(stat -f '%d:%i' "$path" 2>/dev/null)" &&
+        [[ "$identity" =~ ^[0-9]+:[0-9]+$ ]]; then
+        printf '%s\n' "$identity"
+        return 0
+    fi
+    echo "error: cannot inspect filesystem identity for $path; refusing reclaim" >&2
+    return 1
+}
+
+canonical_file_path() {
+    local base="$1" path="$2" directory filename canonical_directory
+    if [[ "$path" == /* ]]; then
+        directory="${path%/*}"
+        filename="${path##*/}"
+    else
+        directory="$base/${path%/*}"
+        filename="${path##*/}"
+    fi
+    [[ -n "$directory" ]] || directory=/
+    if ! canonical_directory="$(cd "$directory" 2>/dev/null && pwd -P)"; then
+        return 1
+    fi
+    printf '%s/%s\n' "$canonical_directory" "$filename"
+}
+
+# `du` is part of the validation boundary for explicit cleanup. A failed or
+# malformed size probe must not be interpreted as an empty buck-out.
+reclaim_size_kib() {
+    local root="$1" kib
+    if [[ ! -e "$root/buck-out" && ! -L "$root/buck-out" ]]; then
+        printf '0\n'
+        return 0
+    fi
+    if [[ -L "$root/buck-out" || ! -d "$root/buck-out" ]]; then
+        echo "error: Buck output root is not a directory; refusing reclaim for $root" >&2
+        return 1
+    fi
+    if ! kib="$(du -sk "$root/buck-out" 2>/dev/null | awk 'NR == 1 && $1 ~ /^[0-9]+$/ { print $1; found = 1 } END { if (!found) exit 1 }')" ||
+        [[ ! "$kib" =~ ^[0-9]+$ ]]; then
+        echo "error: cannot inspect Buck output size for $root; refusing reclaim" >&2
+        return 1
+    fi
+    printf '%s\n' "$kib"
+}
+
+# Enumerate only the isolation directories that already exist under this
+# root. Each Buck operation is scoped to one such isolation, so a newly-created
+# alternate isolation is never swept by a broad default clean. Every
+# directory, including Buck's default v2 isolation, is passed explicitly as
+# --isolation-dir so inherited isolation settings cannot retarget cleanup.
+run_isolation_clean() {
+    local root="$1" path="$2" mode="$3" expected_admin="${4:-}" expected_admin_identity="${5:-}" expected_identity="${6:-}" expected_output_identity="${7:-}" expected_isolation_identity="${8:-}" isolation
+    local current_admin current_admin_identity current_identity
+    local -a args=()
+    (
+        cd "$root" 2>/dev/null || return 1
+        validate_isolation_path "$root" "$path" || return 1
+        validate_pinned_output_identity "$root" "$expected_output_identity" || return 1
+        validate_pinned_path_identity "$path" "$expected_isolation_identity" || return 1
+        if [[ "$mode" == destructive ]]; then
+            verify_registered_reclaim_root "$root" || return 1
+            current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
+            current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
+            current_identity="$(filesystem_identity "$root")" || return 1
+            if [[ "$current_admin" != "$expected_admin" ||
+                "$current_admin_identity" != "$expected_admin_identity" ||
+                "$current_identity" != "$expected_identity" ]]; then
+                echo "error: registered worktree identity changed since reclaim validation; refusing reclaim for $root" >&2
+                return 1
+            fi
+        fi
+        if [[ "$path" == "$root/buck-out" ]]; then
+            isolation=v2
+        else
+            isolation="${path##*/}"
+        fi
+        args=(--isolation-dir "$isolation" clean)
+        if [[ "$mode" == preflight ]]; then
+            args+=(--dry-run --exit-when notidle)
+            "$repo_root/buck2" "${args[@]}" >/dev/null
+        elif [[ "$mode" == evidence ]]; then
+            args+=(--stale 1w --tracked-only --dry-run --exit-when notidle)
+            "$repo_root/buck2" "${args[@]}" >/dev/null
+        else
+            args+=(--exit-when notidle)
+            "$repo_root/buck2" "${args[@]}"
+        fi
+    )
+}
+
+validate_isolation_path() {
+    local root="$1" path="$2"
+    if [[ -L "$root/buck-out" || ! -d "$root/buck-out" ]]; then
+        echo "error: Buck output root changed while reclaiming; refusing reclaim for $root" >&2
+        return 1
+    fi
+    if [[ "$path" != "$root/buck-out" && "$path" != "$root/buck-out/"* ]]; then
+        echo "error: Buck isolation path is outside buck-out; refusing reclaim for $root: $path" >&2
+        return 1
+    fi
+    if [[ -L "$path" || ! -d "$path" ]]; then
+        echo "error: Buck isolation changed while reclaiming; refusing reclaim for $root: $path" >&2
+        return 1
+    fi
+}
+
+reclaim_output_identity() {
+    local root="$1"
+    if [[ ! -e "$root/buck-out" && ! -L "$root/buck-out" ]]; then
+        printf 'absent\n'
+    else
+        filesystem_identity "$root/buck-out"
+    fi
+}
+
+validate_pinned_output_identity() {
+    local root="$1" expected="$2" current
+    current="$(reclaim_output_identity "$root")" || return 1
+    if [[ "$current" != "$expected" ]]; then
+        echo "error: Buck output root identity changed during reclaim; refusing reclaim for $root" >&2
+        return 1
+    fi
+}
+
+validate_pinned_path_identity() {
+    local path="$1" expected="$2" current
+    current="$(filesystem_identity "$path")" || return 1
+    if [[ "$current" != "$expected" ]]; then
+        echo "error: Buck isolation identity changed during reclaim; refusing reclaim for $path" >&2
+        return 1
+    fi
+}
+
+isolation_identity_snapshot() {
+    local snapshot="$1" path
+    while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        filesystem_identity "$path" || return 1
+    done <<<"$snapshot"
+}
+
+snapshot_identity_at() {
+    local identities="$1" wanted="$2" index=0 identity
+    while IFS= read -r identity; do
+        if (( index == wanted )); then
+            printf '%s\n' "$identity"
+            return 0
+        fi
+        index=$((index + 1))
+    done <<<"$identities"
+    return 1
+}
+
+verify_registered_reclaim_root() {
+    local target="$1" roots root canonical found=0 seen=""
+    roots="$(collect_roots)" || return 1
+    while IFS= read -r root; do
+        [[ -n "$root" ]] || continue
+        if ! is_rue_root "$root" ||
+            ! canonical="$(cd "$root" 2>/dev/null && pwd -P)"; then
+            echo "error: registered worktree inventory changed or became unusable; refusing reclaim for $target" >&2
+            return 1
+        fi
+        if [[ "$canonical" == *$'\n'* ]]; then
+            echo "error: registered worktree path became ambiguous; refusing reclaim for $target" >&2
+            return 1
+        fi
+        if [[ "$seen" == *$'\n'"$canonical"$'\n'* ]]; then
+            echo "error: registered worktree inventory became ambiguous; refusing reclaim for $target" >&2
+            return 1
+        fi
+        seen+=$'\n'"$canonical"$'\n'
+        [[ "$canonical" == "$target" ]] && found=1
+    done <<<"$roots"
+    if (( found == 0 )); then
+        echo "error: reclaim target is no longer a registered Rue worktree; refusing reclaim for $target" >&2
+        return 1
+    fi
+}
+
+validate_isolation_snapshot() {
+    local root="$1" snapshot="$2" current
+    if ! current="$(snapshot_isolations "$root")" || [[ "$current" != "$snapshot" ]]; then
+        echo "error: Buck isolation set changed since liveness preflight; refusing reclaim for $root" >&2
+        return 1
+    fi
+}
+
+validate_post_reclaim_snapshot() {
+    local root="$1" initial="$2" current path residual
+    if ! current="$(snapshot_isolations "$root")"; then
+        return 1
+    fi
+    while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        case $'\n'"$initial"$'\n' in
+            *$'\n'"$path"$'\n'*) ;;
+            *)
+                echo "error: new Buck isolation appeared during reclaim; refusing to continue for $root: $path" >&2
+                return 1
+                ;;
+        esac
+        if ! residual="$(find "$path" ! -type d -print -quit 2>/dev/null)"; then
+            echo "error: cannot inspect residual Buck output after reclaiming $root" >&2
+            return 1
+        fi
+        if [[ -n "$residual" ]]; then
+            echo "warning: Buck retained output in the cleaned isolation for $root: $residual" >&2
+        fi
+    done <<<"$current"
+}
+
+# Output a newline-separated snapshot of direct isolation paths. Direct files
+# are retained as a compatibility fixture for the default v2 isolation; a
+# mixture of files and directories, or any symlink, is ambiguous and refused.
+snapshot_isolations() {
+    local root="$1" path snapshot="" default_path="" found=0 direct=0
+    if [[ -L "$root/buck-out" ]]; then
+        echo "error: Buck output root is a symlink; refusing reclaim for $root" >&2
+        return 1
+    fi
+    if [[ ! -e "$root/buck-out" ]]; then
+        return 0
+    fi
+    if [[ ! -d "$root/buck-out" ]]; then
+        echo "error: Buck output root is not a directory; refusing reclaim for $root" >&2
+        return 1
+    fi
+    for path in "$root"/buck-out/* "$root"/buck-out/.[!.]* "$root"/buck-out/..?*; do
+        [[ -e "$path" || -L "$path" ]] || continue
+        if [[ "$path" == *$'\n'* ]]; then
+            echo "error: Buck isolation path contains a newline; refusing reclaim for $root" >&2
+            return 1
+        fi
+        if [[ -L "$path" ]]; then
+            echo "error: Buck isolation is a symlink; refusing reclaim for $root: $path" >&2
+            return 1
+        elif [[ -d "$path" ]]; then
+            found=1
+            if [[ "${path##*/}" == v2 ]]; then
+                default_path="$path"
+            else
+                snapshot+="${snapshot:+$'\n'}${path}"
+            fi
+        elif [[ -f "$path" ]]; then
+            direct=1
+        else
+            echo "error: unknown direct Buck output entry; refusing reclaim for $root: $path" >&2
+            return 1
+        fi
+    done
+    if (( found > 0 && direct > 0 )); then
+        echo "error: Buck output mixes direct files and isolation directories; refusing reclaim for $root" >&2
+        return 1
+    fi
+    if (( found == 0 && direct > 0 )); then
+        snapshot="$root/buck-out"
+    elif [[ -n "$default_path" ]]; then
+        snapshot="${default_path}${snapshot:+$'\n'}${snapshot}"
+    fi
+    printf '%s\n' "$snapshot"
+}
+
+clean_isolation_snapshot() {
+    local root="$1" mode="$2" snapshot="$3" expected_admin="${4:-}" expected_admin_identity="${5:-}" expected_identity="${6:-}" expected_output_identity="${7:-}" expected_isolation_identities="${8:-}" path path_index=0 expected_path_identity
+    validate_isolation_snapshot "$root" "$snapshot" || return 1
+    [[ -n "$snapshot" ]] || return 0
+    while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        expected_path_identity="$(snapshot_identity_at "$expected_isolation_identities" "$path_index")" || return 1
+        run_isolation_clean "$root" "$path" "$mode" "$expected_admin" "$expected_admin_identity" "$expected_identity" "$expected_output_identity" "$expected_path_identity" || return 1
+        path_index=$((path_index + 1))
+    done <<<"$snapshot"
+}
+
+reclaim_finished_roots() {
+    local requested root state kib before after reclaimed existing index snapshot admin identity current_admin current_identity current_admin_identity output_identity isolation_identities initial_snapshot initial_output_identity initial_isolation_identities current_snapshot current_isolation_identities
+    local -a roots=() states=() sizes=() isolation_snapshots=() isolation_identity_snapshots=() output_identities=() admin_dirs=() admin_identities=() root_identities=()
+    # Resolve and inspect every requested root before invoking Buck for any
+    # root. The caller's explicit list is the finishedness signal; clean and
+    # dirty source states are both accepted.
+    for requested in "$@"; do
+        root="$(canonical_reclaim_root "$requested")" || return 1
+        if [[ "$root" == "$repo_root" ]]; then
+            echo "error: refusing reclaim-finished for the current coordinator worktree: $requested" >&2
+            return 1
+        fi
+        if (( ${#roots[@]} > 0 )); then
+            for existing in "${roots[@]}"; do
+                if [[ "$existing" == "$root" ]]; then
+                    echo "error: reclaim-finished target was named more than once: $requested" >&2
+                    return 1
+                fi
+            done
+        fi
+        # Pin the registered Git/root identity and output generation before any
+        # source, size, or isolation probes. A replacement during those probes
+        # must not become the new accepted baseline.
+        admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
+        admin_identity="$(filesystem_identity "$admin")" || return 1
+        identity="$(filesystem_identity "$root")" || return 1
+        initial_output_identity="$(reclaim_output_identity "$root")" || return 1
+        initial_snapshot="$(snapshot_isolations "$root")" || return 1
+        initial_isolation_identities="$(isolation_identity_snapshot "$initial_snapshot")" || return 1
+        state="$(source_state "$root")"
+        if [[ "$state" == unknown ]]; then
+            echo "error: cannot inspect source state for $root; refusing reclaim" >&2
+            return 1
+        fi
+        kib="$(reclaim_size_kib "$root")" || return 1
+        output_identity="$(reclaim_output_identity "$root")" || return 1
+        if [[ "$output_identity" != "$initial_output_identity" ]]; then
+            echo "error: Buck output generation changed during initial reclaim validation; refusing reclaim for $root" >&2
+            return 1
+        fi
+        current_snapshot="$(snapshot_isolations "$root")" || return 1
+        current_isolation_identities="$(isolation_identity_snapshot "$current_snapshot")" || return 1
+        if [[ "$current_snapshot" != "$initial_snapshot" ||
+            "$current_isolation_identities" != "$initial_isolation_identities" ]]; then
+            echo "error: Buck isolation generation changed during initial reclaim validation; refusing reclaim for $root" >&2
+            return 1
+        fi
+        current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
+        current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
+        current_identity="$(filesystem_identity "$root")" || return 1
+        if [[ "$current_admin" != "$admin" ||
+            "$current_admin_identity" != "$admin_identity" ||
+            "$current_identity" != "$identity" ]]; then
+            echo "error: registered worktree identity changed during initial reclaim validation; refusing reclaim for $root" >&2
+            return 1
+        fi
+        snapshot="$initial_snapshot"
+        isolation_identities="$initial_isolation_identities"
+        roots+=("$root")
+        states+=("$state")
+        sizes+=("$kib")
+        isolation_snapshots+=("$snapshot")
+        isolation_identity_snapshots+=("$isolation_identities")
+        output_identities+=("$output_identity")
+        admin_dirs+=("$admin")
+        admin_identities+=("$admin_identity")
+        root_identities+=("$identity")
+    done
+
+    # Probe every snapshotted target while all targets are still untouched. This
+    # closes the common multi-root case where a later active daemon would
+    # otherwise be discovered only after an earlier root had been reclaimed.
+    # The destructive call below repeats the authority check because a daemon
+    # can become active between this harmless probe and cleanup.
+    for index in "${!roots[@]}"; do
+        root="${roots[$index]}"
+        [[ -n "${isolation_snapshots[$index]}" ]] || continue
+        if ! clean_isolation_snapshot "$root" preflight "${isolation_snapshots[$index]}" "" "" "" "${output_identities[$index]}" "${isolation_identity_snapshots[$index]}"; then
+            echo "error: Buck refused reclaim-finished preflight for $root (the worktree may be active); no roots reclaimed" >&2
+            return 1
+        fi
+    done
+
+    for index in "${!roots[@]}"; do
+        root="${roots[$index]}"
+        if ! validate_isolation_snapshot "$root" "${isolation_snapshots[$index]}"; then
+            return 1
+        fi
+        validate_pinned_output_identity "$root" "${output_identities[$index]}" || return 1
+        verify_registered_reclaim_root "$root" || return 1
+        current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
+        current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
+        current_identity="$(filesystem_identity "$root")" || return 1
+        if [[ "$current_admin" != "${admin_dirs[$index]}" ||
+            "$current_admin_identity" != "${admin_identities[$index]}" ||
+            "$current_identity" != "${root_identities[$index]}" ]]; then
+            echo "error: registered worktree identity changed since reclaim validation; refusing reclaim for $root" >&2
+            return 1
+        fi
+        if [[ -z "${isolation_snapshots[$index]}" ]]; then
+            printf 'reclaim-finished: %s — zero Buck output; reclaimed 0 KiB\n' "$root"
+            continue
+        fi
+        before="$(reclaim_size_kib "$root")" || return 1
+        printf 'reclaim-finished: %s (caller-authorized finished root; source %s)\n' "$root" "${states[$index]}"
+        # Buck owns the liveness decision for this exact isolation.
+        current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
+        current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
+        current_identity="$(filesystem_identity "$root")" || return 1
+        if [[ "$current_admin" != "${admin_dirs[$index]}" ||
+            "$current_admin_identity" != "${admin_identities[$index]}" ||
+            "$current_identity" != "${root_identities[$index]}" ]]; then
+            echo "error: registered worktree identity changed since reclaim validation; refusing reclaim for $root" >&2
+            return 1
+        fi
+        if ! clean_isolation_snapshot "$root" destructive "${isolation_snapshots[$index]}" "${admin_dirs[$index]}" "${admin_identities[$index]}" "${root_identities[$index]}" "${output_identities[$index]}" "${isolation_identity_snapshots[$index]}"; then
+            echo "error: Buck refused reclaim-finished for $root (the worktree may be active); no further roots reclaimed" >&2
+            return 1
+        fi
+        verify_registered_reclaim_root "$root" || return 1
+        current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
+        current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
+        current_identity="$(filesystem_identity "$root")" || return 1
+        if [[ "$current_admin" != "${admin_dirs[$index]}" ||
+            "$current_admin_identity" != "${admin_identities[$index]}" ||
+            "$current_identity" != "${root_identities[$index]}" ]]; then
+            echo "error: registered worktree identity changed during reclaim; refusing terminal success for $root" >&2
+            return 1
+        fi
+        after="$(reclaim_size_kib "$root")" || return 1
+        if ! validate_post_reclaim_snapshot "$root" "${isolation_snapshots[$index]}"; then
+            return 1
+        fi
+        reclaimed=$((before - after))
+        if (( reclaimed < 0 )); then
+            printf 'reclaim-finished: %s — observed output growth of %s (residual %s)\n' "$root" "$(human_kib "$((-reclaimed))")" "$(human_kib "$after")"
+        elif (( after > 0 )); then
+            printf 'reclaim-finished: %s — reclaimed %s (residual %s)\n' "$root" "$(human_kib "$reclaimed")" "$(human_kib "$after")"
+        else
+            printf 'reclaim-finished: %s — reclaimed %s\n' "$root" "$(human_kib "$reclaimed")"
+        fi
+    done
+}
+
+validate_finished_evidence() {
+    local requested root state existing admin admin_identity root_identity
+    local -a evidence_roots=() evidence_admin_dirs=() evidence_admin_identities=() evidence_root_identities=()
+    for requested in "$@"; do
+        root="$(canonical_reclaim_root "$requested")" || return 1
+        if [[ "$root" == "$repo_root" ]]; then
+            echo "error: --finished-root cannot name the current coordinator worktree: $requested" >&2
+            return 1
+        fi
+        if (( ${#evidence_roots[@]} > 0 )); then
+            for existing in "${evidence_roots[@]}"; do
+                if [[ "$existing" == "$root" ]]; then
+                    echo "error: --finished-root named the same registered root more than once: $requested" >&2
+                    return 1
+                fi
+            done
+        fi
+        state="$(source_state "$root")"
+        [[ "$state" != unknown ]] || {
+            echo "error: cannot inspect --finished-root source state for $root; refusing guard evidence" >&2
+            return 1
+        }
+        admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
+        admin_identity="$(filesystem_identity "$admin")" || return 1
+        root_identity="$(filesystem_identity "$root")" || return 1
+        evidence_roots+=("$root")
+        evidence_admin_dirs+=("$admin")
+        evidence_admin_identities+=("$admin_identity")
+        evidence_root_identities+=("$root_identity")
+    done
+    FINISHED_EVIDENCE_ROOTS=("${evidence_roots[@]}")
+    FINISHED_EVIDENCE_ADMIN_DIRS=("${evidence_admin_dirs[@]}")
+    FINISHED_EVIDENCE_ADMIN_IDENTITIES=("${evidence_admin_identities[@]}")
+    FINISHED_EVIDENCE_ROOT_IDENTITIES=("${evidence_root_identities[@]}")
+}
+
+validate_finished_evidence_identity() {
+    local index="$1" root current_admin current_admin_identity current_identity
+    root="${FINISHED_EVIDENCE_ROOTS[$index]}"
+    verify_registered_reclaim_root "$root" || return 1
+    current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
+    current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
+    current_identity="$(filesystem_identity "$root")" || return 1
+    if [[ "$current_admin" != "${FINISHED_EVIDENCE_ADMIN_DIRS[$index]}" ||
+        "$current_admin_identity" != "${FINISHED_EVIDENCE_ADMIN_IDENTITIES[$index]}" ||
+        "$current_identity" != "${FINISHED_EVIDENCE_ROOT_IDENTITIES[$index]}" ]]; then
+        echo "error: caller-supplied finished-root identity changed; refusing guard evidence for $root" >&2
+        return 1
+    fi
+}
+
+report_finished_evidence() {
+    local index root kib snapshot quoted_root output_identity isolation_identities
+    for index in "${!FINISHED_EVIDENCE_ROOTS[@]}"; do
+        root="${FINISHED_EVIDENCE_ROOTS[$index]}"
+        validate_finished_evidence_identity "$index" || return 1
+        kib="$(reclaim_size_kib "$root")" || return 1
+        (( kib > 0 )) || continue
+        # This non-destructive probe lets Buck reject a live daemon and shows
+        # whether the normal one-week tracked cleanup still has output to
+        # consider. A successful probe plus nonzero output is caller evidence;
+        # it is never auto-reclaimed here.
+        snapshot="$(snapshot_isolations "$root")" || return 1
+        output_identity="$(reclaim_output_identity "$root")" || return 1
+        isolation_identities="$(isolation_identity_snapshot "$snapshot")" || return 1
+        if ! clean_isolation_snapshot "$root" evidence "$snapshot" "" "" "" "$output_identity" "$isolation_identities" >/dev/null 2>&1; then
+            continue
+        fi
+        validate_finished_evidence_identity "$index" || return 1
+        kib="$(reclaim_size_kib "$root")" || return 1
+        (( kib > 0 )) || continue
+        quoted_root="$(printf '%q' "$root")"
+        printf 'warning: caller-supplied finished root is eligible for reclaim-finished: %s\n' "$root" >&2
+        printf 'warning: reclaim it explicitly with: scripts/rue storage reclaim-finished %s\n' "$quoted_root" >&2
+    done
+}
+
+FINISHED_EVIDENCE_ROOTS=()
+FINISHED_EVIDENCE_ADMIN_DIRS=()
+FINISHED_EVIDENCE_ADMIN_IDENTITIES=()
+FINISHED_EVIDENCE_ROOT_IDENTITIES=()
+
+guard_command() {
+    local -a finished_evidence=()
+    while [[ $# -gt 0 ]]; do
+        [[ "$1" == --finished-root && $# -ge 2 && -n "$2" ]] || { usage >&2; return 2; }
+        finished_evidence+=("$2")
+        shift 2
+    done
+    if (( ${#finished_evidence[@]} > 0 )); then
+        validate_finished_evidence "${finished_evidence[@]}"
+    fi
+    guard_low_disk
+}
+
 reset_roots() {
     local requested root
     # Resolve every target before cleaning any of them, so a typo cannot cause
@@ -357,8 +1019,11 @@ case "$command" in
         stale_all "$command" "${1:-1w}"
         ;;
     guard)
-        [[ $# -eq 0 ]] || { usage >&2; exit 2; }
-        guard_low_disk
+        guard_command "$@"
+        ;;
+    reclaim-finished)
+        [[ $# -gt 0 ]] || { usage >&2; exit 2; }
+        reclaim_finished_roots "$@"
         ;;
     reset)
         [[ $# -gt 0 ]] || { usage >&2; exit 2; }

--- a/scripts/test-cleanup-scripts.sh
+++ b/scripts/test-cleanup-scripts.sh
@@ -46,6 +46,8 @@ make_sandbox() {
   cp "$SCRIPTS_DIR/$name" "$sb/scripts/$name"
   chmod +x "$sb/scripts/$name"
   if [[ "$name" == rue-storage ]]; then
+    mkdir -p "$sb/.git"
+    mkdir -p "$sb/.git/worktrees/root-1" "$sb/.git/worktrees/root-2" "$sb/.git/worktrees/root-3"
     cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
 printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
@@ -76,6 +78,14 @@ run_script() { # run_script <sandbox> <name> [args...]
 }
 
 calls() { cat "$1/calls.log" 2>/dev/null; }
+
+# reclaim-finished now scopes even Buck's default v2 isolation explicitly;
+# recognize both that argv shape and the legacy host-wide `clean` form. Keep
+# reset/TTL assertions on their original matchers because those paths retain
+# their distinct contracts.
+has_reclaim_buck_destructive_call() {
+  grep -Eq '(^|:)((--isolation-dir [^[:space:]]+ )?clean) --exit-when notidle([[:space:]]|$)' "$1/calls.log" 2>/dev/null
+}
 
 # ===========================================================================
 # jj-tidy — remote branch deletion must be fail-closed
@@ -180,8 +190,15 @@ EOF
 # ===========================================================================
 
 setup_storage_root() {
-  local root="$1"
+  local root="$1" parent name admin
+  mkdir -p "$root"
+  parent="$(cd "$root/.." && pwd -P)"
+  name="${root##*/}"
+  admin="$parent/.git/worktrees/$name"
   mkdir -p "$root/buck-out"
+  mkdir -p "$admin"
+  printf 'gitdir: %s\n' "$admin" >"$root/.git"
+  printf '%s/.git\n' "$root" >"$admin/gitdir"
   : >"$root/.buckconfig"
   cat >"$root/buck2" <<'EOF'
 #!/usr/bin/env bash
@@ -514,6 +531,1051 @@ EOF
   rm -rf "$sb"
 }
 
+test_storage_reclaim_finished_preserves_dirty_and_clean_sources() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  setup_storage_root "$sb/root-2"
+  setup_storage_root "$sb/root-3"
+  printf '../../../root-1/.git\n' >"$sb/.git/worktrees/root-1/gitdir"
+  printf 'dirty source\n' >"$sb/root-1/dirty.rue"
+  printf 'clean source\n' >"$sb/root-2/clean.rue"
+  printf 'output\n' >"$sb/root-1/buck-out/artifact"
+  printf 'output\n' >"$sb/root-2/buck-out/artifact"
+  printf 'sibling output\n' >"$sb/root-3/buck-out/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then rm -rf "$PWD/buck-out"; fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n\\nworktree %s/root-3\\n' "$sb" "$sb" "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; *root-3*) printf '%s/.git/worktrees/root-3\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) if [[ "\$*" == *root-1* ]]; then printf ' M dirty.rue\\n'; fi ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/root-2" || rc=$?
+  check "storage: reclaim-finished covers dirty and clean roots" "$([ "$rc" -eq 0 ] && [ "$(grep -c 'clean --exit-when notidle$' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+  check "storage: dirty source survives reclaim byte-for-byte" "$([ -f "$sb/root-1/dirty.rue" ] && [ "$(cat "$sb/root-1/dirty.rue")" = 'dirty source' ] && echo 0 || echo 1)"
+  check "storage: clean source survives reclaim byte-for-byte" "$([ -f "$sb/root-2/clean.rue" ] && [ "$(cat "$sb/root-2/clean.rue")" = 'clean source' ] && echo 0 || echo 1)"
+  check "storage: unnamed sibling output survives reclaim" "$([ -f "$sb/root-3/buck-out/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_invalid_and_current_targets() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf output >"$sb/root-1/buck-out/artifact"
+  mkdir -p "$sb/counterfeit/buck-out"
+  : >"$sb/counterfeit/.buckconfig"
+  printf '#!/bin/sh\n' >"$sb/counterfeit/buck2"; chmod +x "$sb/counterfeit/buck2"
+  : >"$sb/.buckconfig"
+  ln -s "$sb" "$sb/current-alias"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s\\n\\nworktree %s/root-1\\n' "$sb" "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/counterfeit" || rc=$?
+  check "storage: counterfeit target is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  rc=0; : >"$sb/calls.log"
+  run_script "$sb" rue-storage reclaim-finished "$sb" || rc=$?
+  check "storage: current coordinator root is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  rc=0; : >"$sb/calls.log"
+  run_script "$sb" rue-storage reclaim-finished "$sb/current-alias" || rc=$?
+  check "storage: current coordinator symlink alias is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_replacement_clone_identity() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf output >"$sb/root-1/buck-out/artifact"
+  mkdir -p "$sb/other.git"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) if [[ "\$*" == *root-1* ]]; then printf '%s/other.git\\n' "$sb"; else printf '%s/.git\\n' "$sb"; fi ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: replacement clone at registered path is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_ignores_ambient_git_selection() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf output >"$sb/root-1/buck-out/artifact"
+  mkdir -p "$sb/foreign.git" "$sb/foreign-root"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ -n "\${GIT_DIR:-}" || -n "\${GIT_WORK_TREE:-}" || -n "\${GIT_COMMON_DIR:-}" || -n "\${GIT_INDEX_FILE:-}" ]]; then
+  case "\$*" in
+    *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+    *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+    *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+    *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+    *"status --porcelain"*) : ;;
+    *) exit 1 ;;
+  esac
+else
+  case "\$*" in
+    *"worktree list --porcelain"*) printf 'worktree %s\\n' "$sb" ;;
+    *) exit 1 ;;
+  esac
+fi
+EOF
+  chmod +x "$sb/fakebin/git"
+  GIT_DIR="$sb/foreign.git" GIT_WORK_TREE="$sb/foreign-root" GIT_COMMON_DIR="$sb/foreign.git" GIT_INDEX_FILE="$sb/foreign-index" \
+    run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: ambient Git selection cannot authorize a foreign root" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/root-1/buck-out/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_main_metadata_counterfeit() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf output >"$sb/root-1/buck-out/artifact"
+  rm -f "$sb/root-1/.git"
+  ln -s "$sb/.git" "$sb/root-1/.git"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: main-worktree metadata counterfeit is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/root-1/buck-out/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_same_common_counterfeit() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf output >"$sb/root-1/buck-out/artifact"
+  mkdir -p "$sb/.git/other-admin"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/other-admin\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: same-common-dir counterfeit with wrong worktree admin is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/root-1/buck-out/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_isolation_symlink_escape() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/outside"
+  printf outside >"$sb/outside/artifact"
+  ln -s "$sb/outside" "$sb/root-1/buck-out/escape"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: symlinked direct isolation is refused without Buck cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/outside/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_non_directory_output_root() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  rm -rf "$sb/root-1/buck-out"
+  printf 'not a directory' >"$sb/root-1/buck-out"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: non-directory Buck output root is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ "$(cat "$sb/root-1/buck-out")" = 'not a directory' ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_output_root_swap() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/outside"
+  printf output >"$sb/root-1/buck-out/artifact"
+  printf outside >"$sb/outside/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *--dry-run* ]]; then
+  mv "$PWD/buck-out" "$PWD/buck-out-saved"
+  ln -s "$PWD/../outside" "$PWD/buck-out"
+fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  : >"$CALLS.destructive"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: swapped Buck output root is refused before destructive clean" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out-saved/artifact" ] && [ "$(cat "$sb/outside/artifact")" = outside ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_regular_output_root_replacement() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf original >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *--dry-run* ]]; then
+  mv "$PWD/buck-out" "$PWD/buck-out-saved"
+  mkdir -p "$PWD/buck-out/v2"
+  printf replacement >"$PWD/buck-out/v2/artifact"
+fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  : >"$CALLS.destructive"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: same-path output-root generation replacement is refused" "$([ "$rc" -ne 0 ] && grep -q 'output root identity changed' "$sb/out.log" && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && [ -f "$sb/root-1/buck-out-saved/v2/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_initial_probe_replacement() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf original >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"status --porcelain"* && ! -e "\$CALLS.probed" ]]; then
+  : >"\$CALLS.probed"
+  mv "$sb/root-1" "$sb/root-1-probed"
+  mkdir "$sb/root-1"
+  cp "$sb/root-1-probed/.git" "$sb/root-1/.git"
+  cp "$sb/root-1-probed/.buckconfig" "$sb/root-1/.buckconfig"
+  cp "$sb/root-1-probed/buck2" "$sb/root-1/buck2"
+  mv "$sb/root-1-probed/buck-out" "$sb/root-1/buck-out"
+  printf '%s/.git\\n' "$sb/root-1" >"$sb/.git/worktrees/root-1/gitdir"
+fi
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: initial probe root replacement is refused" "$([ "$rc" -ne 0 ] && [ -e "$sb/calls.log.probed" ] && [ -d "$sb/root-1-probed" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && grep -q 'registered worktree identity changed during initial reclaim validation' "$sb/out.log" && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_initial_probe_isolation_replacement() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf original >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"status --porcelain"* && ! -e "\$CALLS.child-probed" ]]; then
+  : >"\$CALLS.child-probed"
+  mv "$sb/root-1/buck-out/v2" "$sb/root-1/v2-probed"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf replacement >"$sb/root-1/buck-out/v2/artifact"
+fi
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: initial probe isolation replacement is refused" "$([ "$rc" -ne 0 ] && [ -e "$sb/calls.log.child-probed" ] && [ -f "$sb/root-1/v2-probed/artifact" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && grep -q 'Buck isolation generation changed during initial reclaim validation' "$sb/out.log" && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_initial_probe_new_isolation() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf original >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"status --porcelain"* && ! -e "\$CALLS.new-isolation" ]]; then
+  : >"\$CALLS.new-isolation"
+  mkdir -p "$sb/root-1/buck-out/compiler-repro"
+  printf new >"$sb/root-1/buck-out/compiler-repro/artifact"
+fi
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: initial probe new isolation is refused" "$([ "$rc" -ne 0 ] && [ -e "$sb/calls.log.new-isolation" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && [ -f "$sb/root-1/buck-out/compiler-repro/artifact" ] && grep -q 'Buck isolation generation changed during initial reclaim validation' "$sb/out.log" && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_regular_isolation_replacement() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf original >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *--dry-run* ]]; then
+  mv "$PWD/buck-out/v2" "$PWD/v2-saved"
+  mkdir -p "$PWD/buck-out/v2"
+  printf replacement >"$PWD/buck-out/v2/artifact"
+fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  : >"$CALLS.destructive"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: same-path isolation generation replacement is refused" "$([ "$rc" -ne 0 ] && grep -q 'isolation identity changed' "$sb/out.log" && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && [ -f "$sb/root-1/v2-saved/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_worktree_replacement() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf output >"$sb/root-1/buck-out/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *--dry-run* ]]; then
+  mv "$PWD" "$PWD-replaced"
+  mkdir "$PWD"
+  cp "$PWD-replaced/.buckconfig" "$PWD/.buckconfig"
+  cp "$PWD-replaced/buck2" "$PWD/buck2"
+  mkdir "$PWD/buck-out"
+fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  : >"$CALLS.destructive"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: replaced registered worktree is refused before destructive clean" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1-replaced/buck-out/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_valid_same_path_replacement() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf original >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+set -e
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *--dry-run* ]]; then
+  test_sb="${CALLS%/calls.log}"
+  mv "$PWD" "$PWD-replaced"
+  mkdir -p "$PWD/buck-out/v2" "$test_sb/.git/worktrees/replacement"
+  : >"$PWD/.buckconfig"
+  cp "$PWD-replaced/buck2" "$PWD/buck2"
+  printf 'gitdir: %s/.git/worktrees/replacement\n' "$test_sb" >"$PWD/.git"
+  printf '%s/.git\n' "$PWD" >"$test_sb/.git/worktrees/replacement/gitdir"
+  printf replacement >"$PWD/buck-out/v2/artifact"
+  : >"$CALLS.replaced"
+fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  : >"$CALLS.destructive"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) if [[ -f "\$CALLS.replaced" ]]; then printf '%s/.git/worktrees/replacement\\n' "$sb"; else printf '%s/.git/worktrees/root-1\\n' "$sb"; fi ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: valid same-path Git worktree replacement is refused before destructive clean" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_handles_empty_isolation_that_gains_output() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  setup_storage_root "$sb/root-2"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf output >"$sb/root-2/buck-out/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$PWD" == *'/root-1' && "$*" == *--dry-run* ]]; then
+  printf gained >"$PWD/buck-out/v2/artifact"
+fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  rm -rf "$PWD/buck-out/v2" "$PWD/buck-out/artifact"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; esac ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/root-2" || rc=$?
+  check "storage: empty isolation is preflighted and reclaimed after gaining output" "$([ "$rc" -eq 0 ] && grep -q 'clean --exit-when notidle$' "$sb/calls.log" && [ ! -e "$sb/root-1/buck-out/v2" ] && [ ! -e "$sb/root-2/buck-out/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_cleans_zero_byte_output_entry() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  : >"$sb/root-1/buck-out/v2/zero-byte"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  rm -f "$PWD/buck-out/v2/zero-byte"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: zero-byte output entry is preflighted and reclaimed" "$([ "$rc" -eq 0 ] && [ ! -e "$sb/root-1/buck-out/v2/zero-byte" ] && [ "$(grep -c -- '--isolation-dir v2 clean --dry-run --exit-when notidle' "$sb/calls.log")" -eq 1 ] && [ "$(grep -c -- '--isolation-dir v2 clean --exit-when notidle' "$sb/calls.log")" -eq 1 ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rechecks_empty_root_after_later_preflight() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  setup_storage_root "$sb/root-2"
+  printf root2 >"$sb/root-2/buck-out/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$PWD" == *'/root-2' && "$*" == *--dry-run* ]]; then
+  mkdir -p "$PWD/../root-1/buck-out/v2"
+  printf appeared >"$PWD/../root-1/buck-out/v2/artifact"
+fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  : >"$CALLS.destructive"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; esac ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/root-2" || rc=$?
+  check "storage: later preflight growth of an empty root is refused before all destructive cleanup" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && ! grep -q 'zero Buck output' "$sb/out.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_new_isolation_after_clean() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf output >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  rm -rf "$PWD/buck-out/v2"
+  mkdir -p "$PWD/buck-out/new-isolation"
+  printf new >"$PWD/buck-out/new-isolation/artifact"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: new isolation after clean is refused and remains for review" "$([ "$rc" -ne 0 ] && [ -f "$sb/root-1/buck-out/new-isolation/artifact" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_reports_buck_owned_residual() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf output >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  rm -f "$PWD/buck-out/v2/artifact"
+  printf buck-log >"$PWD/buck-out/v2/log"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: Buck-owned residual is reported after successful exact-isolation clean" "$([ "$rc" -eq 0 ] && grep -q 'residual' "$sb/out.log" && [ -f "$sb/root-1/buck-out/v2/log" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_reports_non_directory_residual() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf output >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  rm -f "$PWD/buck-out/v2/artifact"
+  mkfifo "$PWD/buck-out/v2/buck-fifo"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: non-directory Buck residual is reported" "$([ "$rc" -eq 0 ] && grep -q 'buck-fifo' "$sb/out.log" && [ -p "$sb/root-1/buck-out/v2/buck-fifo" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_rejects_root_replacement_after_clean() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2"
+  printf output >"$sb/root-1/buck-out/v2/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  mv "$PWD" "$PWD-replaced"
+  mkdir -p "$PWD/buck-out/v2"
+  : >"$PWD/.buckconfig"
+  cp "$PWD-replaced/buck2" "$PWD/buck2"
+  printf replacement >"$PWD/buck-out/v2/artifact"
+  : >"$CALLS.replaced"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) if [[ -f "\$CALLS.replaced" ]]; then printf '%s/.git/worktrees/replacement\\n' "$sb"; else printf '%s/.git/worktrees/root-1\\n' "$sb"; fi ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: root replacement after clean suppresses terminal success" "$([ "$rc" -ne 0 ] && ! grep -q 'reclaimed' "$sb/out.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_explicitly_scopes_v2_with_environment_override() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2" "$sb/root-1/buck-out/compiler-repro"
+  printf v2 >"$sb/root-1/buck-out/v2/artifact"
+  printf repro >"$sb/root-1/buck-out/compiler-repro/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ -f "$CALLS.active-v2" && "$*" == *'--isolation-dir v2 clean'* && "$*" == *--dry-run* ]]; then exit 7; fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  if [[ "$*" == *'--isolation-dir compiler-repro'* ]]; then rm -rf "$PWD/buck-out/compiler-repro"; else rm -rf "$PWD/buck-out/v2"; fi
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  : >"$sb/calls.log.active-v2"
+  BUCK_ISOLATION_DIR=compiler-repro run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: active explicit v2 isolation blocks every cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/root-1/buck-out/v2/artifact" ] && [ -f "$sb/root-1/buck-out/compiler-repro/artifact" ] && echo 0 || echo 1)"
+  rm -f "$sb/calls.log.active-v2"; : >"$sb/calls.log"; rc=0
+  BUCK_ISOLATION_DIR=compiler-repro run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: environment override cannot retarget explicit isolation cleanup" "$([ "$rc" -eq 0 ] && [ "$(grep -c -- '--isolation-dir v2 clean --dry-run --exit-when notidle' "$sb/calls.log")" -eq 1 ] && [ "$(grep -c -- '--isolation-dir v2 clean --exit-when notidle' "$sb/calls.log")" -eq 1 ] && [ "$(grep -c -- '--isolation-dir compiler-repro clean --dry-run --exit-when notidle' "$sb/calls.log")" -eq 1 ] && [ "$(grep -c -- '--isolation-dir compiler-repro clean --exit-when notidle' "$sb/calls.log")" -eq 1 ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_alias_active_and_zero_output() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  setup_storage_root "$sb/root-2"
+  printf output >"$sb/root-1/buck-out/artifact"
+  ln -s "$sb/root-1" "$sb/root-1-alias"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$PWD" == *'/root-1' ]]; then exit 7; fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1-alias" || rc=$?
+  check "storage: active Buck root is refused" "$([ "$rc" -ne 0 ] && grep -q 'root-1' "$sb/out.log" && echo 0 || echo 1)"
+  : >"$sb/calls.log"; rc=0
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-2" || rc=$?
+  check "storage: zero-output root succeeds without destructive Buck cleanup" "$([ "$rc" -eq 0 ] && ! has_reclaim_buck_destructive_call "$sb" && grep -q 'zero Buck output' "$sb/out.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_alias_and_preflight_validate_all() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  setup_storage_root "$sb/root-2"
+  printf one >"$sb/root-1/buck-out/artifact"
+  printf two >"$sb/root-2/buck-out/artifact"
+  ln -s "$sb/root-1" "$sb/root-1-alias"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$PWD" == *'/root-2' && "$*" == *--dry-run* ]]; then exit 7; fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then rm -rf "$PWD/buck-out"; fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1-alias" "$sb/root-2" || rc=$?
+  check "storage: later active preflight prevents all destructive cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  check "storage: earlier output survives later preflight refusal" "$([ -f "$sb/root-1/buck-out/artifact" ] && echo 0 || echo 1)"
+  check "storage: later output survives its preflight refusal" "$([ -f "$sb/root-2/buck-out/artifact" ] && echo 0 || echo 1)"
+
+  : >"$sb/calls.log"; rc=0
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1-alias" || rc=$?
+  check "storage: symlink alias reclaims its canonical registered root" "$([ "$rc" -eq 0 ] && [ ! -e "$sb/root-1/buck-out" ] && [ "$(grep -c 'clean --exit-when notidle$' "$sb/calls.log")" -eq 1 ] && echo 0 || echo 1)"
+
+  mkdir -p "$sb/root-1/buck-out"; printf one >"$sb/root-1/buck-out/artifact"
+  : >"$sb/calls.log"; rc=0
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/root-1-alias" || rc=$?
+  check "storage: canonical and alias duplicate is refused before cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_reclaim_finished_scopes_every_isolation() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  mkdir -p "$sb/root-1/buck-out/v2" "$sb/root-1/buck-out/compiler-repro"
+  printf default >"$sb/root-1/buck-out/v2/artifact"
+  printf alternate >"$sb/root-1/buck-out/compiler-repro/artifact"
+cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ -f "$CALLS.active-alternate" && "$*" == *--isolation-dir*compiler-repro* && "$*" == *--dry-run* ]]; then exit 7; fi
+if [[ -f "$CALLS.activate-on-destructive" && "$*" == *--isolation-dir*compiler-repro* && "$*" != *--dry-run* ]]; then exit 7; fi
+if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
+  if [[ "$*" == *'--isolation-dir compiler-repro'* ]]; then rm -rf "$PWD/buck-out/compiler-repro"; else rm -rf "$PWD/buck-out/v2"; fi
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$sb/fakebin/git"
+: >"$sb/calls.log.active-alternate"
+run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: active alternate isolation prevents all cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  check "storage: default isolation survives alternate refusal" "$([ -f "$sb/root-1/buck-out/v2/artifact" ] && echo 0 || echo 1)"
+  check "storage: alternate isolation survives its refusal" "$([ -f "$sb/root-1/buck-out/compiler-repro/artifact" ] && echo 0 || echo 1)"
+
+  rm -f "$sb/calls.log.active-alternate"
+  : >"$sb/calls.log.activate-on-destructive"
+  : >"$sb/calls.log"; rc=0
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: destructive alternate refusal stops within-root cleanup" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/root-1/buck-out/v2" ] && [ -f "$sb/root-1/buck-out/compiler-repro/artifact" ] && echo 0 || echo 1)"
+  rm -f "$sb/calls.log.activate-on-destructive"
+  : >"$sb/calls.log"; rc=0
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: idle alternate isolation can reclaim after refusal" "$([ "$rc" -eq 0 ] && [ ! -e "$sb/root-1/buck-out/compiler-repro" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_guard_finished_evidence_rechecks_output_after_ttl_cleanup() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf output >"$sb/root-1/buck-out/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$1" == audit ]]; then printf '{"buck2.defer_write_actions":"true"}\n'; fi
+if [[ "$1" == clean && "$*" == *--stale* && "$*" != *--dry-run* ]]; then rm -rf "$PWD/buck-out"; fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  cat >"$sb/fakebin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'disk 100000 95000 5000 95%% /\n'
+EOF
+  chmod +x "$sb/fakebin/df"
+  run_script "$sb" rue-storage guard --finished-root "$sb/root-1" || rc=$?
+  check "storage: guard does not advertise output removed by ordinary TTL cleanup" "$(! grep -q 'reclaim-finished' "$sb/out.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_guard_finished_evidence_rejects_root_replacement() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf output >"$sb/root-1/buck-out/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$1" == audit ]]; then printf '{"buck2.defer_write_actions":"true"}\n'; fi
+if [[ "$*" == *--stale* && "$*" == *--dry-run* ]]; then
+  mv "$PWD" "$PWD-replaced"
+  mkdir -p "$PWD"
+  cp "$PWD-replaced/.buckconfig" "$PWD/.buckconfig"
+  cp "$PWD-replaced/buck2" "$PWD/buck2"
+  cp "$PWD-replaced/.git" "$PWD/.git"
+  mkdir -p "$PWD/buck-out"
+  printf replacement >"$PWD/buck-out/artifact"
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  cat >"$sb/fakebin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'disk 100000 95000 5000 95%% /\n'
+EOF
+  chmod +x "$sb/fakebin/df"
+  run_script "$sb" rue-storage guard --finished-root "$sb/root-1" || rc=$?
+  check "storage: guard rejects finished evidence after root replacement" "$([ "$rc" -ne 0 ] && [ -d "$sb/root-1-replaced" ] && [ "$(cat "$sb/root-1/buck-out/artifact")" = replacement ] && ! grep -q 'eligible for reclaim-finished' "$sb/out.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_guard_rejects_malformed_evidence_and_reclaim_rejects_unknown_source() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  : >"$sb/.buckconfig"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s\\n' "$sb" ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage guard --finished-root || rc=$?
+  check "storage: malformed finished-root option fails with usage" "$([ "$rc" -eq 2 ] && grep -q '^usage:' "$sb/out.log" && echo 0 || echo 1)"
+  check "storage: malformed finished-root option invokes no cleanup" "$(! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+
+  setup_storage_root "$sb/root-1"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) exit 1 ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"; : >"$sb/calls.log"; rc=0
+  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
+  check "storage: unknown source state refuses reclaim" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_guard_names_only_caller_supplied_finished_evidence() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf output >"$sb/root-1/buck-out/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$1" == audit ]]; then
+  printf '{"buck2.defer_write_actions":"true"}\n'
+fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  cat >"$sb/fakebin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'disk 100000 95000 5000 95%% /\n'
+EOF
+  chmod +x "$sb/fakebin/df"
+  run_script "$sb" rue-storage guard --finished-root "$sb/root-1" || rc=$?
+  check "storage: guard accepts caller-supplied finished evidence" "$([ "$rc" -ne 0 ] && grep -q 'reclaim-finished' "$sb/out.log" && echo 0 || echo 1)"
+  check "storage: guard evidence does not auto-reclaim" "$(! grep -q 'clean --exit-when notidle$' "$sb/calls.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_guard_skips_active_evidence_and_names_idle_evidence() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  setup_storage_root "$sb/root-2"
+  printf active >"$sb/root-1/buck-out/artifact"
+  printf idle >"$sb/root-2/buck-out/artifact"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+if [[ "$1" == audit ]]; then printf '{"buck2.defer_write_actions":"true"}\n'; fi
+if [[ "$PWD" == *'/root-1' && "$*" == *--dry-run* ]]; then exit 7; fi
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
+  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
+  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
+  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
+  *"status --porcelain"*) : ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/git"
+  cat >"$sb/fakebin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'disk 100000 95000 5000 95%% /\n'
+EOF
+  chmod +x "$sb/fakebin/df"
+  run_script "$sb" rue-storage guard --finished-root "$sb/root-1" --finished-root "$sb/root-2" || rc=$?
+  check "storage: active evidence is skipped while idle evidence is named" "$([ "$rc" -ne 0 ] && grep -q "root-2" "$sb/out.log" && ! grep -q "root-1.*eligible" "$sb/out.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
 # --- run everything ---------------------------------------------------------
 
 test_jjtidy_gh_failure_deletes_nothing
@@ -527,6 +1589,38 @@ test_storage_guard_proceeds_between_cleanup_and_hard_floors
 test_storage_guard_survives_cleanup_failure_between_floors
 test_storage_guard_still_refuses_below_hard_floor_when_cleanup_fails
 test_storage_reset_validates_all_targets_first
+test_storage_reclaim_finished_preserves_dirty_and_clean_sources
+test_storage_reclaim_finished_rejects_invalid_and_current_targets
+test_storage_reclaim_finished_rejects_replacement_clone_identity
+test_storage_reclaim_finished_ignores_ambient_git_selection
+test_storage_reclaim_finished_rejects_main_metadata_counterfeit
+test_storage_reclaim_finished_rejects_same_common_counterfeit
+test_storage_reclaim_finished_rejects_isolation_symlink_escape
+test_storage_reclaim_finished_rejects_non_directory_output_root
+test_storage_reclaim_finished_rejects_output_root_swap
+test_storage_reclaim_finished_rejects_regular_output_root_replacement
+test_storage_reclaim_finished_rejects_initial_probe_replacement
+test_storage_reclaim_finished_rejects_initial_probe_isolation_replacement
+test_storage_reclaim_finished_rejects_initial_probe_new_isolation
+test_storage_reclaim_finished_rejects_regular_isolation_replacement
+test_storage_reclaim_finished_rejects_worktree_replacement
+test_storage_reclaim_finished_rejects_valid_same_path_replacement
+test_storage_reclaim_finished_handles_empty_isolation_that_gains_output
+test_storage_reclaim_finished_cleans_zero_byte_output_entry
+test_storage_reclaim_finished_rechecks_empty_root_after_later_preflight
+test_storage_reclaim_finished_rejects_new_isolation_after_clean
+test_storage_reclaim_finished_reports_buck_owned_residual
+test_storage_reclaim_finished_reports_non_directory_residual
+test_storage_reclaim_finished_rejects_root_replacement_after_clean
+test_storage_reclaim_finished_explicitly_scopes_v2_with_environment_override
+test_storage_reclaim_finished_alias_active_and_zero_output
+test_storage_reclaim_finished_alias_and_preflight_validate_all
+test_storage_reclaim_finished_scopes_every_isolation
+test_storage_guard_finished_evidence_rechecks_output_after_ttl_cleanup
+test_storage_guard_finished_evidence_rejects_root_replacement
+test_storage_guard_rejects_malformed_evidence_and_reclaim_rejects_unknown_source
+test_storage_guard_names_only_caller_supplied_finished_evidence
+test_storage_guard_skips_active_evidence_and_names_idle_evidence
 
 echo "--------------------------------------------------"
 if [ "$FAILURES" -eq 0 ]; then


### PR DESCRIPTION
Fixes RUE-1790

## Summary

- add explicit reclaim-finished cleanup for caller-authorized, exactly registered Rue worktree roots and advisory finished-root guard evidence
- fail closed across Git identity, output-generation, isolation-liveness, and replacement races before Buck owns each exact-isolation clean
- document the partial-cleanup contract and add 79 safety checks covering dirty sources, active work, counterfeits, races, multiple roots and isolations, and zero-output cases

## Validation

- /bin/bash scripts/test-cleanup-scripts.sh (79 checks)
- ./buck2 test //:cleanup-script-tests
- scripts/rue quick
- scripts/rue premerge (201 targets)
- Bash 3.2 and Python 3.9 baseline validators
- real Buck cleanup against a throwaway main checkout and linked worktree
- scripts/rue test: 233 targets passed; six oracle corpus actions hit host thread-spawn EAGAIN on the saturated local machine and are left to fresh-runner CI