### PR TITLE
RUE-1626: make semantic hash boundaries deterministic

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -3296,21 +3296,46 @@ fn semantic_schema_scaffolding_stays_exhaustive_and_reviewable() {
 fn local_semantic_materialization_owns_complete_cfg_inputs_without_a_peer_cache() {
     let import = include_str!("semantic_import.rs");
     let providers = include_str!("sema/provider_body_host.rs");
+    let materialization = import
+        .split("pub struct SemanticLocalMaterialization")
+        .nth(1)
+        .and_then(|source| source.split("\n}").next())
+        .expect("local materialization declaration");
 
     for owned in [
         "pub air: crate::ValidatedAir",
         "pub type_pool: crate::FrozenTypeInternPool",
         "pub interner: Arc<ThreadedRodeo>",
-        "pub aggregate_types:",
+        "aggregate_types: ahash::AHashMap<",
         "pub strings: Vec<String>",
         "pub body_span: Span",
         "pub completeness: SemanticLocalCompleteness",
     ] {
         assert!(
-            import.contains(owned),
+            materialization.contains(owned),
             "local semantic materialization lost owned CFG input: {owned}"
         );
     }
+    let aggregate_accessors = import
+        .split("impl<K, M> SemanticLocalMaterialization<K, M>")
+        .nth(1)
+        .and_then(|source| source.split("/// An AIR type branded").next())
+        .expect("local materialization accessor implementation");
+    for accessor in [
+        "pub fn aggregate_type(",
+        "pub fn has_aggregate_type(",
+        "pub fn aggregate_type_count(",
+        "pub fn aggregate_type_entries(",
+    ] {
+        assert!(
+            aggregate_accessors.contains(accessor),
+            "local materialization lost accessor: {accessor}"
+        );
+    }
+    assert!(
+        !materialization.contains("pub aggregate_types:"),
+        "local materialization leaked its aggregate map"
+    );
     assert!(import.contains("pub fn new_local("));
     assert!(import.contains("pub fn materialize_local_body("));
     assert!(import.contains("local_completeness: Option<SemanticLocalCompleteness>"));
@@ -3344,16 +3369,133 @@ fn local_semantic_materialization_owns_complete_cfg_inputs_without_a_peer_cache(
         assert!(body.contains("pub interner: Arc<ThreadedRodeo>"));
     }
     for forbidden in ["Mutex<", "RwLock<", "QueryFamily<", "cache:", "selected:"] {
-        let materialization = import
-            .split("pub struct SemanticLocalMaterialization")
-            .nth(1)
-            .and_then(|source| source.split("\n}").next())
-            .expect("local materialization declaration");
         assert!(
             !materialization.contains(forbidden),
             "body-local materialization became peer state: {forbidden}"
         );
     }
+}
+
+#[test]
+fn semantic_hash_boundaries_pin_only_their_exact_authorities() {
+    fn region<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+        source
+            .split(start)
+            .nth(1)
+            .and_then(|source| source.split(end).next())
+            .unwrap_or_else(|| panic!("missing guarded source region {start:?}..{end:?}"))
+    }
+
+    // 1. Expression inference is an AHash lookup table, while the production
+    // allocation call site imposes RIR order before creating array types.
+    let generate = include_str!("inference/generate.rs");
+    let generator = region(
+        generate,
+        "pub struct ConstraintGenerator<'a>",
+        "impl<'a> ConstraintGenerator<'a>",
+    );
+    assert!(generator.contains("expr_types: ahash::AHashMap<InstRef, InferType>"));
+    assert!(!generator.contains("std::collections::HashMap"));
+    let expr_api = region(
+        generate,
+        "/// Get the expression type mapping.",
+        "/// Enter a lexical scope:",
+    );
+    assert!(expr_api.contains("pub fn expr_types(&self) -> &ahash::AHashMap<InstRef, InferType>"));
+    assert!(expr_api.contains("ahash::AHashMap<InstRef, InferType>,"));
+    assert!(!expr_api.contains("std::collections::HashMap"));
+    let type_inference = include_str!("sema/analysis/type_inference.rs");
+    let array_allocation = region(
+        type_inference,
+        "// Pre-collect all array types from resolved InferTypes",
+        "let unification_resolution_ns",
+    );
+    let ordered = array_allocation
+        .find("expr_types_in_rir_order(&expr_types)")
+        .expect("production expression ordering call");
+    let precreate = array_allocation
+        .find("self.pre_create_array_types_from_infer_type(&resolved)")
+        .expect("production array precreation call");
+    assert!(ordered < precreate);
+    assert!(!array_allocation.contains("for (_, infer_ty) in &expr_types"));
+
+    // 2. Method reachability stays request-local AHash state through analysis
+    // and export; the imported body intentionally exposes no live-key set.
+    let context = include_str!("sema/context.rs");
+    let analysis_context = region(
+        context,
+        "pub(crate) struct AnalysisContext<'a>",
+        "impl<'a> AnalysisContext<'a>",
+    );
+    assert!(
+        analysis_context
+            .contains("pub(crate) referenced_methods: ahash::AHashSet<(StructId, Spur)>")
+    );
+    assert!(!analysis_context.contains("std::collections::HashSet"));
+    let export = include_str!("sema/semantic_body_export.rs");
+    let export_signature = region(export, "pub(crate) fn export_body", ") -> Result");
+    assert!(
+        export_signature.contains("method_references: &ahash::AHashSet<(crate::StructId, Spur)>")
+    );
+    assert!(!export_signature.contains("std::collections::HashSet"));
+    let specialized = include_str!("specialize.rs");
+    let specialized_body = region(specialized, "pub(crate) struct OneSpecializedBody", "\n}");
+    assert!(
+        specialized_body
+            .contains("pub(crate) referenced_methods: ahash::AHashSet<(StructId, Spur)>")
+    );
+    let provider = include_str!("sema/provider_body_host.rs");
+    let provider_body = region(provider, "pub struct ProviderOrdinaryBody", "\n}");
+    assert!(!provider_body.contains("referenced_methods"));
+    let semantic_body = include_str!("semantic_body.rs");
+    let imported_body = region(
+        semantic_body,
+        "pub struct SemanticImportedBody<K, M>",
+        "\n}",
+    );
+    assert!(!imported_body.contains("method_references"));
+    // 3-4. The two anonymous live-type registries use AHash only as lookup
+    // storage. Their ordering/selection helpers cannot consult a live pool id.
+    let provider_host = region(
+        provider,
+        "struct ProviderBodyHost<'a, P, S, K, M>",
+        "impl<'a, P, S, K, M> ProviderBodyHost",
+    );
+    assert!(provider_host.contains(
+        "canonical_anonymous_types:\n        ahash::AHashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>"
+    ));
+    assert!(provider_host.contains(
+        "RefCell<ahash::AHashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>>"
+    ));
+    assert!(!provider_host.contains("std::collections::HashMap"));
+    let anonymous_helpers = include_str!("sema/anon_structs.rs");
+    let export_order = region(
+        anonymous_helpers,
+        "fn anonymous_export_cmp",
+        "/// Project live anonymous entries",
+    );
+    let consulted_selection = region(
+        anonymous_helpers,
+        "pub(crate) fn canonical_consulted_type",
+        "#[cfg(test)]",
+    );
+    assert!(!export_order.contains("as_u32"));
+    assert!(!consulted_selection.contains("as_u32"));
+
+    // 5. CFG materialization owns a private AHash table and exports only
+    // hasher-neutral point/size/ordered-entry accessors.
+    let import = include_str!("semantic_import.rs");
+    let materialization = region(
+        import,
+        "pub struct SemanticLocalMaterialization<K, M>",
+        "\n}",
+    );
+    assert!(
+        materialization
+            .contains("aggregate_types: ahash::AHashMap<crate::Type, TypeInstanceKey<K, M>>")
+    );
+    assert!(!materialization.contains("pub aggregate_types:"));
+    assert!(!materialization.contains("std::collections::HashMap"));
 }
 
 #[test]

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -20,6 +20,10 @@ use rue_rir::{InstData, InstRef, RepeatCount, Rir, RirTypeSyntaxNode, RirTypeSyn
 use rue_span::{FileId, Span};
 
 use ahash::AHashMap;
+#[cfg(test)]
+use ahash::RandomState;
+#[cfg(test)]
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -344,13 +348,10 @@ pub struct ConstraintGenerator<'a> {
     constraints: Vec<Constraint>,
     /// Mapping from RIR instruction to its inferred type.
     ///
-    /// Deliberately the std hasher while the rest of this generator uses
-    /// `AHashMap`: type inference walks this map to pre-create array types
-    /// (`pre_create_array_types_from_infer_type`), so its iteration order
-    /// decides the pool indices those array types receive, and those indices
-    /// are later a sort key (`sort_unstable_by_key(Type::as_u32)`). The order
-    /// is observable, so the hasher is not a free choice here.
-    expr_types: std::collections::HashMap<InstRef, InferType>,
+    /// Expression types are keyed by instruction reference. Consumers impose
+    /// instruction order before any operation whose result can observe type
+    /// pool allocation, so this remains an unordered fast lookup map.
+    expr_types: ahash::AHashMap<InstRef, InferType>,
     /// Whether each generated expression reaches its next evaluation point.
     expr_continues: AHashMap<InstRef, bool>,
     /// Function signatures (for call type checking). `None` when the generator
@@ -507,6 +508,74 @@ pub struct ConstraintGenerator<'a> {
     type_pool: &'a TypeInternPool,
 }
 
+/// Return expression types in canonical RIR order. Lookup storage is
+/// intentionally unordered, but array precreation must allocate composite
+/// types in instruction order so pool indices do not depend on hash buckets.
+pub(crate) fn expr_types_in_rir_order(
+    expr_types: &AHashMap<InstRef, InferType>,
+) -> Vec<(&InstRef, &InferType)> {
+    let mut ordered = expr_types.iter().collect::<Vec<_>>();
+    ordered.sort_unstable_by_key(|(inst_ref, _)| inst_ref.as_u32());
+    ordered
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct ExprTypesTestLayout {
+    state: RandomState,
+    reverse_insertion: bool,
+}
+
+#[cfg(test)]
+thread_local! {
+    static EXPR_TYPES_TEST_LAYOUT: RefCell<Option<ExprTypesTestLayout>> = const { RefCell::new(None) };
+}
+
+/// Run a production body-analysis transaction with a controlled expression-map
+/// layout. This is test-only instrumentation for proving that semantic output
+/// does not depend on AHash's seed or insertion order.
+#[cfg(test)]
+pub(crate) fn with_expr_types_test_layout<R>(
+    seeds: [u64; 4],
+    reverse_insertion: bool,
+    action: impl FnOnce() -> R,
+) -> R {
+    EXPR_TYPES_TEST_LAYOUT.with(|configured| {
+        let previous = configured.replace(Some(ExprTypesTestLayout {
+            state: RandomState::with_seeds(seeds[0], seeds[1], seeds[2], seeds[3]),
+            reverse_insertion,
+        }));
+        let result = action();
+        configured.replace(previous);
+        result
+    })
+}
+
+fn new_expr_types_map() -> AHashMap<InstRef, InferType> {
+    #[cfg(test)]
+    if let Some(layout) = EXPR_TYPES_TEST_LAYOUT.with(|configured| configured.borrow().clone()) {
+        return AHashMap::with_hasher(layout.state);
+    }
+    AHashMap::new()
+}
+
+fn finalize_expr_types_map(
+    expr_types: AHashMap<InstRef, InferType>,
+) -> AHashMap<InstRef, InferType> {
+    #[cfg(test)]
+    if let Some(layout) = EXPR_TYPES_TEST_LAYOUT.with(|configured| configured.borrow().clone()) {
+        let mut entries = expr_types.into_iter().collect::<Vec<_>>();
+        entries.sort_unstable_by_key(|(inst_ref, _)| inst_ref.as_u32());
+        if layout.reverse_insertion {
+            entries.reverse();
+        }
+        let mut rebuilt = AHashMap::with_hasher(layout.state);
+        rebuilt.extend(entries);
+        return rebuilt;
+    }
+    expr_types
+}
+
 impl<'a> ConstraintGenerator<'a> {
     #[inline]
     fn note_sibling_attempt(&self) {
@@ -585,7 +654,7 @@ impl<'a> ConstraintGenerator<'a> {
             interner,
             type_vars: TypeVarAllocator::new(),
             constraints: Vec::with_capacity(rir_capacity),
-            expr_types: std::collections::HashMap::new(),
+            expr_types: new_expr_types_map(),
             expr_continues: AHashMap::new(),
             functions: Some(functions),
             builtin_structs: Some(builtin_structs),
@@ -647,7 +716,7 @@ impl<'a> ConstraintGenerator<'a> {
             interner,
             type_vars: TypeVarAllocator::new(),
             constraints: Vec::with_capacity(rir_capacity),
-            expr_types: std::collections::HashMap::new(),
+            expr_types: new_expr_types_map(),
             expr_continues: AHashMap::new(),
             functions: None,
             builtin_structs: None,
@@ -1389,7 +1458,7 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     /// Get the expression type mapping.
-    pub fn expr_types(&self) -> &std::collections::HashMap<InstRef, InferType> {
+    pub fn expr_types(&self) -> &ahash::AHashMap<InstRef, InferType> {
         &self.expr_types
     }
 
@@ -1406,17 +1475,18 @@ impl<'a> ConstraintGenerator<'a> {
         Vec<TypeVarId>,
         Vec<TypeVarId>,
         Type,
-        std::collections::HashMap<InstRef, InferType>,
+        ahash::AHashMap<InstRef, InferType>,
         AHashMap<InstRef, bool>,
         u32,
         Vec<Type>,
     ) {
+        let expr_types = finalize_expr_types_map(self.expr_types);
         (
             self.constraints,
             self.int_literal_vars,
             self.string_literal_vars,
             self.string_literal_default,
-            self.expr_types,
+            expr_types,
             self.expr_continues,
             self.type_vars.count(),
             self.fixed_string_types,

--- a/crates/rue-air/src/inference/mod.rs
+++ b/crates/rue-air/src/inference/mod.rs
@@ -51,6 +51,9 @@ mod unify;
 // Re-export all public types
 pub use constraint::{Constraint, Substitution};
 pub(crate) use generate::LazyInferenceFacts;
+pub(crate) use generate::expr_types_in_rir_order;
+#[cfg(test)]
+pub(crate) use generate::with_expr_types_test_layout;
 pub use generate::{
     ConstraintContext, ConstraintGenerator, ExprInfo, FrontierParamOverlay, FunctionSig,
     LocalVarInfo, MethodSig, ParamVarInfo,

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -864,7 +864,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // This ensures all array types are created before the conversion loop, which
         // enables parallelization of function analysis (mutation happens here, not in
         // infer_type_to_type).
-        for (_, infer_ty) in &expr_types {
+        //
+        // `expr_types` is an unordered lookup map. RIR instruction order is the
+        // canonical order for pool allocation; relying on a map walk here would
+        // make array Type values depend on the process hash seed.
+        let ordered_expr_types = crate::inference::expr_types_in_rir_order(&expr_types);
+        for (_, infer_ty) in &ordered_expr_types {
             let resolved = unifier.resolve_infer_type(infer_ty);
             self.pre_create_array_types_from_infer_type(&resolved);
         }
@@ -873,7 +878,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Since we pre-created all array types above, infer_type_to_type only
         // performs lookups (no mutation).
         let mut resolved_types = AHashMap::new();
-        for (inst_ref, infer_ty) in &expr_types {
+        for (inst_ref, infer_ty) in ordered_expr_types {
             let resolved = unifier.resolve_infer_type(infer_ty);
             let concrete_ty = self.infer_type_to_type(&resolved);
             resolved_types.insert(*inst_ref, concrete_ty);

--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -6,10 +6,9 @@
 //! structural comparison of fields, variants, method signatures, or bodies. Two
 //! distinct producers that declare the same shape are distinct, non-assignable
 //! types. There is no cross-producer structural search or stable-minimum
-//! representative: each producer key owns exactly one entity. Anchor variants of
-//! the *same* producer (a body reached under different definition-relative
-//! anchor prefixes) alias to that one entity, which is all the alias map now
-//! retains.
+//! representative: each full producer key owns exactly one entity. Different
+//! anchors under the same producer remain distinct; only semantically empty
+//! specialization wrappers on the producer spine are canonical aliases.
 //!
 //! It also implements the enum analog (`find_or_create_anon_enum`): anonymous
 //! enum types produced by comptime type functions like
@@ -117,4 +116,348 @@ pub(crate) fn anonymous_key_cmp(
     anonymous_producer_root(&left.producer)
         .cmp(&anonymous_producer_root(&right.producer))
         .then_with(|| left.cmp(right))
+}
+
+/// Total presentation order for complete durable anonymous exports.
+///
+/// The producer-root/key prefix preserves the established presentation order.
+/// Live pool ids never cross this boundary and identical duplicates are
+/// interchangeable. Conflicting payloads for one canonical identity are
+/// rejected before this presentation order is imposed.
+fn anonymous_export_cmp(
+    left: &crate::SemanticProducedAnonymousNominal,
+    right: &crate::SemanticProducedAnonymousNominal,
+) -> Ordering {
+    anonymous_key_cmp(&left.identity, &right.identity).then_with(|| left.cmp(right))
+}
+
+/// Project live anonymous entries completely before imposing presentation
+/// order. This keeps body-local pool allocation out of the exported artifact.
+pub(crate) fn collect_anonymous_exports(
+    entries: impl IntoIterator<
+        Item = Result<crate::SemanticProducedAnonymousNominal, crate::SemanticBodyExportFailure>,
+    >,
+) -> Result<
+    std::sync::Arc<[crate::SemanticProducedAnonymousNominal]>,
+    crate::SemanticBodyExportFailure,
+> {
+    let mut by_identity = std::collections::BTreeMap::new();
+    for result in entries {
+        let mut export = result?;
+        export.identity = export.identity.with_canonical_producer().into_owned();
+        match by_identity.entry(export.identity.clone()) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(export);
+            }
+            std::collections::btree_map::Entry::Occupied(entry) if entry.get() == &export => {}
+            std::collections::btree_map::Entry::Occupied(_) => {
+                return Err(crate::SemanticBodyExportFailure::AmbiguousStableIdentity);
+            }
+        }
+    }
+    let mut exports = by_identity.into_values().collect::<Vec<_>>();
+    exports.sort_by(anonymous_export_cmp);
+    Ok(exports.into())
+}
+
+/// Select the canonical live type for a consulted anonymous identity.
+///
+/// Empty-specialization producer aliases can give the same complete identity
+/// more than one issued spelling. Every matching spelling must name the same
+/// live type; disagreement is counterfeit/ambiguous and lookup fails closed.
+/// The full canonical key remains the identity authority, so anchors and kinds
+/// are never collapsed merely because their producers match.
+pub(crate) fn canonical_consulted_type<'a, I>(
+    entries: I,
+    identity: &IssuedAnonymousNominalKey,
+    kind: crate::AnonymousNominalKind,
+) -> Result<Option<crate::Type>, crate::SemanticBodyExportFailure>
+where
+    I: Iterator<Item = (&'a crate::Type, &'a IssuedAnonymousNominalKey)>,
+{
+    let canonical = identity.with_canonical_producer();
+    if canonical.kind != kind {
+        return Err(crate::SemanticBodyExportFailure::WrongStableIdentityKind);
+    }
+    let mut selected = None;
+    for (ty, candidate) in entries {
+        if candidate.with_canonical_producer().as_ref() != canonical.as_ref() {
+            continue;
+        }
+        let matching_kind = match kind {
+            crate::AnonymousNominalKind::Struct => ty.as_struct().is_some(),
+            crate::AnonymousNominalKind::Enum => ty.as_enum().is_some(),
+        };
+        if !matching_kind {
+            return Err(crate::SemanticBodyExportFailure::WrongStableIdentityKind);
+        }
+        match selected {
+            None => selected = Some(*ty),
+            Some(selected) if selected == *ty => {}
+            Some(_) => {
+                return Err(crate::SemanticBodyExportFailure::AmbiguousStableIdentity);
+            }
+        }
+    }
+    Ok(selected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ahash::{AHashMap, RandomState};
+    use std::sync::Arc;
+
+    fn definition_identity(kind: crate::AnonymousNominalKind) -> IssuedAnonymousNominalKey {
+        crate::AnonymousNominalKey {
+            kind,
+            producer: crate::StableProducerId::Definition(crate::SemanticDefinitionToken::new(
+                7, 11,
+            )),
+            anchor: rue_rir::RirStructuralAnchor::new(Vec::new()),
+        }
+    }
+
+    fn produced(
+        identity: &IssuedAnonymousNominalKey,
+        field: &str,
+        ty: crate::TypeInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+    ) -> crate::SemanticProducedAnonymousNominal {
+        crate::SemanticProducedAnonymousNominal {
+            identity: identity.clone(),
+            shape: crate::SemanticProducedAnonymousNominalShape::Struct {
+                fields: Arc::from([(Arc::from(field), ty)]),
+                methods: Arc::new([]),
+            },
+            type_captures: Arc::new([]),
+            value_captures: Arc::new([]),
+        }
+    }
+
+    #[test]
+    fn anonymous_exports_order_and_dedup_by_complete_durable_facts() {
+        fn run(
+            seeds: [u64; 4],
+            reverse_insertion: bool,
+            reverse_live_ids: bool,
+        ) -> Arc<[crate::SemanticProducedAnonymousNominal]> {
+            let first_identity = definition_identity(crate::AnonymousNominalKind::Struct);
+            let mut second_identity = first_identity.clone();
+            second_identity.anchor = rue_rir::RirStructuralAnchor::new(vec![
+                rue_rir::RirStructuralPathSegment::AnonymousType(1),
+            ]);
+            let first = produced(&first_identity, "a", crate::TypeInstanceKey::I32);
+            let second = produced(&second_identity, "b", crate::TypeInstanceKey::I64);
+            let low = crate::Type::new_struct(crate::StructId::from_pool_index(2));
+            let middle = crate::Type::new_struct(crate::StructId::from_pool_index(5));
+            let high = crate::Type::new_struct(crate::StructId::from_pool_index(9));
+            let (first_ty, second_ty) = if reverse_live_ids {
+                (high, low)
+            } else {
+                (low, high)
+            };
+            let mut entries = vec![
+                (first_ty, first.clone()),
+                (second_ty, second),
+                (middle, first),
+            ];
+            if reverse_insertion {
+                entries.reverse();
+            }
+            let mut table = AHashMap::with_hasher(RandomState::with_seeds(
+                seeds[0], seeds[1], seeds[2], seeds[3],
+            ));
+            for (ty, entry) in entries {
+                table.insert(ty, entry);
+            }
+
+            collect_anonymous_exports(table.iter().map(|(ty, _)| {
+                Ok::<_, crate::SemanticBodyExportFailure>(
+                    table.get(ty).expect("projected entry").clone(),
+                )
+            }))
+            .expect("durable projection is infallible")
+        }
+
+        let forward = run([1, 2, 3, 4], false, false);
+        let reversed = run([9, 8, 7, 6], true, true);
+        assert_eq!(forward, reversed);
+        assert_eq!(forward.len(), 2, "identical durable duplicates collapse");
+        assert!(forward[0] < forward[1]);
+    }
+
+    #[test]
+    fn anonymous_exports_reject_conflicting_payloads_for_one_canonical_identity() {
+        let (direct, specialized) = producer_aliases(crate::AnonymousNominalKind::Struct);
+        let direct = produced(&direct, "a", crate::TypeInstanceKey::I32);
+        let counterfeit = produced(&specialized, "b", crate::TypeInstanceKey::I64);
+        assert_eq!(
+            collect_anonymous_exports([Ok(direct), Ok(counterfeit)]),
+            Err(crate::SemanticBodyExportFailure::AmbiguousStableIdentity)
+        );
+    }
+
+    fn producer_aliases(
+        kind: crate::AnonymousNominalKind,
+    ) -> (IssuedAnonymousNominalKey, IssuedAnonymousNominalKey) {
+        let definition = crate::SemanticDefinitionToken::new(7, 11);
+        let base = crate::FunctionInstanceKey::Definition(definition);
+        let direct = crate::AnonymousNominalKey {
+            kind,
+            producer: crate::StableProducerId::Function(crate::Node::new(base.clone())),
+            anchor: rue_rir::RirStructuralAnchor::new(vec![
+                rue_rir::RirStructuralPathSegment::AnonymousType(0),
+            ]),
+        };
+        let specialized = crate::AnonymousNominalKey {
+            kind,
+            producer: crate::StableProducerId::Function(crate::Node::new(
+                crate::FunctionInstanceKey::Specialization {
+                    base: crate::Node::new(base),
+                    arguments: crate::CanonicalArguments {
+                        types: Arc::new([]),
+                        values: Arc::new([]),
+                    },
+                },
+            )),
+            anchor: direct.anchor.clone(),
+        };
+        assert_eq!(
+            direct.with_canonical_producer(),
+            specialized.with_canonical_producer()
+        );
+        (direct, specialized)
+    }
+
+    fn live_type(kind: crate::AnonymousNominalKind, index: u32) -> crate::Type {
+        match kind {
+            crate::AnonymousNominalKind::Struct => {
+                crate::Type::new_struct(crate::StructId::from_pool_index(index))
+            }
+            crate::AnonymousNominalKind::Enum => {
+                crate::Type::new_enum(crate::EnumId::from_pool_index(index))
+            }
+        }
+    }
+
+    #[test]
+    fn consulted_anonymous_selection_canonicalizes_empty_specialization_spelling() {
+        for kind in [
+            crate::AnonymousNominalKind::Struct,
+            crate::AnonymousNominalKind::Enum,
+        ] {
+            let (direct, specialized) = producer_aliases(kind);
+            let selected = live_type(kind, 9);
+            let entries = [(selected, direct.clone()), (selected, specialized.clone())];
+            for reverse in [false, true] {
+                for requested_alias in [&direct, &specialized] {
+                    let selected_alias = if reverse {
+                        canonical_consulted_type(
+                            entries.iter().rev().map(|(ty, key)| (ty, key)),
+                            requested_alias,
+                            kind,
+                        )
+                    } else {
+                        canonical_consulted_type(
+                            entries.iter().map(|(ty, key)| (ty, key)),
+                            requested_alias,
+                            kind,
+                        )
+                    };
+                    assert_eq!(
+                        selected_alias,
+                        Ok(Some(selected)),
+                        "canonical producer spelling must not change lookup for {kind:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn consulted_anonymous_selection_keeps_different_anchors_distinct() {
+        for kind in [
+            crate::AnonymousNominalKind::Struct,
+            crate::AnonymousNominalKind::Enum,
+        ] {
+            let (direct, _) = producer_aliases(kind);
+            let mut sibling = direct.clone();
+            sibling.anchor = rue_rir::RirStructuralAnchor::new(vec![
+                rue_rir::RirStructuralPathSegment::AnonymousType(1),
+            ]);
+            let direct_ty = live_type(kind, 9);
+            let sibling_ty = live_type(kind, 2);
+            let entries = [(direct_ty, direct.clone()), (sibling_ty, sibling.clone())];
+            for reverse in [false, true] {
+                let selected_direct = if reverse {
+                    canonical_consulted_type(
+                        entries.iter().rev().map(|(ty, key)| (ty, key)),
+                        &direct,
+                        kind,
+                    )
+                } else {
+                    canonical_consulted_type(
+                        entries.iter().map(|(ty, key)| (ty, key)),
+                        &direct,
+                        kind,
+                    )
+                };
+                assert_eq!(selected_direct, Ok(Some(direct_ty)));
+                let selected_sibling = if reverse {
+                    canonical_consulted_type(
+                        entries.iter().rev().map(|(ty, key)| (ty, key)),
+                        &sibling,
+                        kind,
+                    )
+                } else {
+                    canonical_consulted_type(
+                        entries.iter().map(|(ty, key)| (ty, key)),
+                        &sibling,
+                        kind,
+                    )
+                };
+                assert_eq!(selected_sibling, Ok(Some(sibling_ty)));
+            }
+        }
+    }
+
+    #[test]
+    fn consulted_anonymous_selection_rejects_distinct_live_types_for_one_identity() {
+        for kind in [
+            crate::AnonymousNominalKind::Struct,
+            crate::AnonymousNominalKind::Enum,
+        ] {
+            let (direct, specialized) = producer_aliases(kind);
+            let entries = [
+                (live_type(kind, 8), direct.clone()),
+                (live_type(kind, 1), specialized),
+            ];
+            assert_eq!(
+                canonical_consulted_type(entries.iter().map(|(ty, key)| (ty, key)), &direct, kind),
+                Err(crate::SemanticBodyExportFailure::AmbiguousStableIdentity)
+            );
+            assert_eq!(
+                canonical_consulted_type(
+                    entries.iter().rev().map(|(ty, key)| (ty, key)),
+                    &direct,
+                    kind,
+                ),
+                Err(crate::SemanticBodyExportFailure::AmbiguousStableIdentity)
+            );
+        }
+    }
+
+    #[test]
+    fn consulted_anonymous_selection_rejects_wrong_live_kind_for_exact_identity() {
+        let identity = definition_identity(crate::AnonymousNominalKind::Struct);
+        let wrong = live_type(crate::AnonymousNominalKind::Enum, 3);
+        assert_eq!(
+            canonical_consulted_type(
+                [(&wrong, &identity)].into_iter(),
+                &identity,
+                crate::AnonymousNominalKind::Struct,
+            ),
+            Err(crate::SemanticBodyExportFailure::WrongStableIdentityKind)
+        );
+    }
 }

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -232,7 +232,7 @@ pub(crate) struct AnalysisContext<'a> {
     pub referenced_functions: AHashSet<Spur>,
     /// Methods referenced during analysis of this function.
     /// Each entry is (struct_id, method_name) matching the key format in methods map.
-    pub referenced_methods: std::collections::HashSet<(StructId, Spur)>,
+    pub(crate) referenced_methods: ahash::AHashSet<(StructId, Spur)>,
     /// The type this expression is expected to produce, when sema knows it from
     /// a surrounding annotation or pattern. Set narrowly around a
     /// let-initializer (to the resolved annotation type) and around a `match`
@@ -517,7 +517,7 @@ impl<'a> AnalysisContext<'a> {
             comptime_type_vars: self.comptime_type_vars.clone(),
             comptime_value_vars: self.comptime_value_vars.clone(),
             referenced_functions: AHashSet::new(),
-            referenced_methods: std::collections::HashSet::new(),
+            referenced_methods: AHashSet::new(),
             expected_type: None,
             infer_ctx: self.infer_ctx,
             accessor_trailing_yield: self.accessor_trailing_yield,

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -294,12 +294,12 @@ pub(crate) trait AnonymousNominalLedger {
     fn anonymous_struct_id(
         &self,
         identity: &super::anon_structs::IssuedAnonymousNominalKey,
-    ) -> Option<StructId>;
+    ) -> Result<Option<StructId>, crate::SemanticBodyExportFailure>;
 
     fn anonymous_enum_id(
         &self,
         identity: &super::anon_structs::IssuedAnonymousNominalKey,
-    ) -> Option<EnumId>;
+    ) -> Result<Option<EnumId>, crate::SemanticBodyExportFailure>;
 
     fn anonymous_struct_identities_mut(
         &mut self,
@@ -1304,7 +1304,15 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         sigs: &[super::AnonMethodSig],
         captured: &AHashMap<Spur, ConstValue>,
     ) -> CompileResult<(Type, bool)> {
-        if let Some(id) = self.storage.anonymous_struct_id(&identity) {
+        if let Some(id) = self
+            .storage
+            .anonymous_struct_id(&identity)
+            .map_err(|failure| {
+                CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
+                    "anonymous struct registry lookup failed: {failure:?}"
+                )))
+            })?
+        {
             return Ok((Type::new_struct(id), false));
         }
         let digest = self.stable_anonymous_identity_digest(&identity);
@@ -1362,7 +1370,15 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         names: &[String],
         payloads: &[Vec<Type>],
     ) -> CompileResult<Type> {
-        if let Some(id) = self.storage.anonymous_enum_id(&identity) {
+        if let Some(id) = self
+            .storage
+            .anonymous_enum_id(&identity)
+            .map_err(|failure| {
+                CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
+                    "anonymous enum registry lookup failed: {failure:?}"
+                )))
+            })?
+        {
             return Ok(Type::new_enum(id));
         }
         let digest = self.stable_anonymous_identity_digest(&identity);
@@ -1738,7 +1754,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         AHashSet<Spur>,
-        std::collections::HashSet<(StructId, Spur)>,
+        AHashSet<(StructId, Spur)>,
     )> {
         for (_, ty, _, is_comptime) in &param_info {
             reject_runtime_type_value(*ty, *is_comptime, span)?;
@@ -1827,7 +1843,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         AHashSet<Spur>,
-        std::collections::HashSet<(StructId, Spur)>,
+        AHashSet<(StructId, Spur)>,
     )> {
         let symbol = self.intern_body_symbol(full_name)?;
         let identity = crate::FunctionInstanceKey::Definition(
@@ -1883,7 +1899,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         AHashSet<Spur>,
-        std::collections::HashSet<(StructId, Spur)>,
+        AHashSet<(StructId, Spur)>,
     )> {
         for (_, ty, _, is_comptime) in &resolved_params {
             reject_runtime_type_value(*ty, *is_comptime, span)?;
@@ -1971,7 +1987,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         AHashSet<Spur>,
-        std::collections::HashSet<(StructId, Spur)>,
+        AHashSet<(StructId, Spur)>,
     )> {
         let self_name = self.intern_body_symbol("self")?;
         let params = [(self_name, struct_type, RirParamMode::Normal, false)];
@@ -2059,7 +2075,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<String>,
         Vec<crate::LocalAtomRecord<crate::SemanticDefinitionToken, crate::SemanticModuleToken>>,
         AHashSet<Spur>,
-        std::collections::HashSet<(StructId, Spur)>,
+        AHashSet<(StructId, Spur)>,
     )> {
         self.analyze_function_internal(
             infer_ctx,
@@ -2092,7 +2108,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<String>,
         Vec<crate::LocalAtomRecord<crate::SemanticDefinitionToken, crate::SemanticModuleToken>>,
         AHashSet<Spur>,
-        std::collections::HashSet<(StructId, Spur)>,
+        AHashSet<(StructId, Spur)>,
     )> {
         self.analyze_function_internal(
             infer_ctx,
@@ -2129,7 +2145,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<String>,
         Vec<crate::LocalAtomRecord<crate::SemanticDefinitionToken, crate::SemanticModuleToken>>,
         AHashSet<Spur>,
-        std::collections::HashSet<(StructId, Spur)>,
+        AHashSet<(StructId, Spur)>,
     )> {
         let expression_setup_started = Instant::now();
         let mut air = Air::new(return_type);
@@ -2318,7 +2334,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             comptime_type_vars,
             comptime_value_vars,
             referenced_functions: AHashSet::new(),
-            referenced_methods: std::collections::HashSet::new(),
+            referenced_methods: AHashSet::new(),
             expected_type: None,
             infer_ctx,
             accessor_trailing_yield: None,

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -561,7 +561,7 @@ fn anonymous_identity_issuance_preserves_partial_failure_order() {
 
 /// Stable, request-independent description of an anonymous nominal created by
 /// one successful provider body transaction.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SemanticProducedAnonymousNominal {
     pub identity: crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
     pub shape: SemanticProducedAnonymousNominalShape,
@@ -579,7 +579,7 @@ pub struct SemanticProducedAnonymousNominal {
     >,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SemanticProducedAnonymousNominalShape {
     Struct {
         fields: Arc<
@@ -600,7 +600,7 @@ pub enum SemanticProducedAnonymousNominalShape {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SemanticProducedAnonymousMethodSignature {
     pub name: Arc<str>,
     pub has_self: bool,
@@ -617,7 +617,7 @@ pub struct SemanticProducedAnonymousMethodSignature {
     pub result: SemanticProducedAnonymousMethodType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SemanticProducedAnonymousMethodType {
     SelfType,
     Concrete(TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>),
@@ -633,7 +633,6 @@ pub struct ProviderOrdinaryBody<K, M> {
     pub warnings: Vec<rue_error::CompileWarning>,
     pub strings: Vec<String>,
     pub referenced_functions: AHashSet<Spur>,
-    pub referenced_methods: std::collections::HashSet<(StructId, Spur)>,
     pub referenced_definitions: Vec<K>,
     pub referenced_values: Vec<K>,
     pub referenced_specializations:
@@ -1202,18 +1201,10 @@ struct ProviderBodyHost<'a, P, S, K, M> {
     anon_struct_identities: AHashMap<super::anon_structs::IssuedAnonymousNominalKey, StructId>,
     anon_enum_identities: AHashMap<super::anon_structs::IssuedAnonymousNominalKey, EnumId>,
     anonymous_digest_owners: AHashMap<u128, super::anon_structs::IssuedAnonymousNominalKey>,
-    /// Kept on the std hasher, unlike its neighbours: `produced_anonymous_nominals`
-    /// walks this map into the exported nominal payload and sorts that payload by
-    /// identity alone, so two entries sharing an identity would keep whatever
-    /// order the table iterated in. The sort key is not total over the entries,
-    /// which makes the iteration order reachable from an emitted artifact.
     canonical_anonymous_types:
-        std::collections::HashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>,
-    /// Kept on the std hasher for the same class of reason: `anonymous_struct_id`
-    /// and `anonymous_enum_id` scan this map with `find_map`, which answers with
-    /// an arbitrary member of the matching set rather than a canonical one.
+        ahash::AHashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>,
     consulted_anonymous_types:
-        RefCell<std::collections::HashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>>,
+        RefCell<ahash::AHashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>>,
     durable_anonymous_types: AHashMap<Type, crate::AnonymousNominalKey<K, M>>,
     anon_struct_method_sigs: AHashMap<StructId, Vec<super::AnonMethodSig>>,
     anon_struct_captured_values: AHashMap<StructId, AHashMap<Spur, ConstValue>>,
@@ -1376,8 +1367,8 @@ where
             anon_struct_identities: AHashMap::new(),
             anon_enum_identities: AHashMap::new(),
             anonymous_digest_owners: AHashMap::new(),
-            canonical_anonymous_types: std::collections::HashMap::new(),
-            consulted_anonymous_types: RefCell::new(std::collections::HashMap::new()),
+            canonical_anonymous_types: AHashMap::new(),
+            consulted_anonymous_types: RefCell::new(AHashMap::new()),
             durable_anonymous_types: AHashMap::new(),
             anon_struct_method_sigs: AHashMap::new(),
             anon_struct_captured_values: AHashMap::new(),
@@ -2901,138 +2892,133 @@ where
             })
         }
 
-        let mut identities = self
+        let identities = self
             .canonical_anonymous_types
             .iter()
             .filter(|(_, identity)| !initial.contains(*identity))
             .map(|(ty, identity)| (*ty, identity.clone()))
             .collect::<Vec<_>>();
-        identities
-            .sort_by(|(_, left), (_, right)| super::anon_structs::anonymous_key_cmp(left, right));
-        identities
-            .into_iter()
-            .map(|(ty, identity)| {
-                let (shape, type_captures, value_captures) = match ty.kind() {
-                    TypeKind::Struct(struct_id) => {
-                        let definition = self.type_pool.struct_def(struct_id);
-                        let fields = definition
-                            .fields
-                            .iter()
-                            .map(|field| {
-                                Ok((
-                                    Arc::from(field.name.as_str()),
-                                    self.canonical_type_instance(field.ty)?,
-                                ))
+        let exports = identities.into_iter().map(|(ty, identity)| {
+            let (shape, type_captures, value_captures) = match ty.kind() {
+                TypeKind::Struct(struct_id) => {
+                    let definition = self.type_pool.struct_def(struct_id);
+                    let fields = definition
+                        .fields
+                        .iter()
+                        .map(|field| {
+                            Ok((
+                                Arc::from(field.name.as_str()),
+                                self.canonical_type_instance(field.ty)?,
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
+                    let methods = self
+                        .anon_struct_method_sigs
+                        .get(&struct_id)
+                        .into_iter()
+                        .flat_map(|methods| methods.iter())
+                        .map(|method| {
+                            Ok(crate::SemanticProducedAnonymousMethodSignature {
+                                name: Arc::from(self.interner.resolve(&method.name)),
+                                has_self: method.has_self,
+                                self_mode: mode(method.self_mode),
+                                returns_borrow: method.returns_borrow,
+                                returns_inout: method.returns_inout,
+                                parameters: method
+                                    .param_types
+                                    .iter()
+                                    .zip(&method.param_modes)
+                                    .zip(&method.param_comptime)
+                                    .map(|((ty, parameter_mode), comptime)| {
+                                        Ok((
+                                            method_type(self, ty, &identity)?,
+                                            mode(*parameter_mode),
+                                            *comptime,
+                                        ))
+                                    })
+                                    .collect::<Result<Vec<_>, _>>()?
+                                    .into(),
+                                result: method_type(self, &method.return_type, &identity)?,
                             })
-                            .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
-                        let methods = self
-                            .anon_struct_method_sigs
-                            .get(&struct_id)
-                            .into_iter()
-                            .flat_map(|methods| methods.iter())
-                            .map(|method| {
-                                Ok(crate::SemanticProducedAnonymousMethodSignature {
-                                    name: Arc::from(self.interner.resolve(&method.name)),
-                                    has_self: method.has_self,
-                                    self_mode: mode(method.self_mode),
-                                    returns_borrow: method.returns_borrow,
-                                    returns_inout: method.returns_inout,
-                                    parameters: method
-                                        .param_types
-                                        .iter()
-                                        .zip(&method.param_modes)
-                                        .zip(&method.param_comptime)
-                                        .map(|((ty, parameter_mode), comptime)| {
-                                            Ok((
-                                                method_type(self, ty, &identity)?,
-                                                mode(*parameter_mode),
-                                                *comptime,
-                                            ))
-                                        })
-                                        .collect::<Result<Vec<_>, _>>()?
-                                        .into(),
-                                    result: method_type(self, &method.return_type, &identity)?,
-                                })
-                            })
-                            .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
-                        let mut type_captures: Vec<(
-                            Arc<str>,
-                            TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
-                        )> = self
-                            .anon_struct_type_subst
-                            .get(&struct_id)
-                            .into_iter()
-                            .flat_map(|captures| captures.iter())
-                            .map(|(name, ty)| {
-                                Ok((
-                                    Arc::from(self.interner.resolve(name)),
-                                    self.canonical_type_instance(*ty)?,
-                                ))
-                            })
-                            .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
-                        type_captures.sort_by(|left, right| left.0.cmp(&right.0));
-                        let mut value_captures: Vec<(
-                            Arc<str>,
-                            CanonicalArgumentValue<SemanticDefinitionToken, SemanticModuleToken>,
-                        )> = self
-                            .anon_struct_captured_values
-                            .get(&struct_id)
-                            .into_iter()
-                            .flat_map(|captures| captures.iter())
-                            .map(|(name, value)| {
-                                Ok((
-                                    Arc::from(self.interner.resolve(name)),
-                                    self.canonical_argument_value(*value)?,
-                                ))
-                            })
-                            .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
-                        value_captures.sort_by(|left, right| left.0.cmp(&right.0));
-                        (
-                            crate::SemanticProducedAnonymousNominalShape::Struct {
-                                fields: fields.into(),
-                                methods: methods.into(),
-                            },
-                            type_captures,
-                            value_captures,
-                        )
-                    }
-                    TypeKind::Enum(enum_id) => {
-                        let definition = self.type_pool.enum_def(enum_id);
-                        let variants = definition
-                            .variants
-                            .iter()
-                            .enumerate()
-                            .map(|(index, name)| {
-                                Ok((
-                                    name.clone(),
-                                    definition
-                                        .variant_payload(index)
-                                        .iter()
-                                        .map(|ty| self.canonical_type_instance(*ty))
-                                        .collect::<Result<Vec<_>, _>>()?
-                                        .into(),
-                                ))
-                            })
-                            .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
-                        (
-                            crate::SemanticProducedAnonymousNominalShape::Enum {
-                                variants: variants.into(),
-                            },
-                            Vec::new(),
-                            Vec::new(),
-                        )
-                    }
-                    _ => return Err(crate::SemanticBodyExportFailure::UnsupportedType),
-                };
-                Ok(crate::SemanticProducedAnonymousNominal {
-                    identity,
-                    shape,
-                    type_captures: type_captures.into(),
-                    value_captures: value_captures.into(),
-                })
+                        })
+                        .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
+                    let mut type_captures: Vec<(
+                        Arc<str>,
+                        TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+                    )> = self
+                        .anon_struct_type_subst
+                        .get(&struct_id)
+                        .into_iter()
+                        .flat_map(|captures| captures.iter())
+                        .map(|(name, ty)| {
+                            Ok((
+                                Arc::from(self.interner.resolve(name)),
+                                self.canonical_type_instance(*ty)?,
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
+                    type_captures.sort_by(|left, right| left.0.cmp(&right.0));
+                    let mut value_captures: Vec<(
+                        Arc<str>,
+                        CanonicalArgumentValue<SemanticDefinitionToken, SemanticModuleToken>,
+                    )> = self
+                        .anon_struct_captured_values
+                        .get(&struct_id)
+                        .into_iter()
+                        .flat_map(|captures| captures.iter())
+                        .map(|(name, value)| {
+                            Ok((
+                                Arc::from(self.interner.resolve(name)),
+                                self.canonical_argument_value(*value)?,
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
+                    value_captures.sort_by(|left, right| left.0.cmp(&right.0));
+                    (
+                        crate::SemanticProducedAnonymousNominalShape::Struct {
+                            fields: fields.into(),
+                            methods: methods.into(),
+                        },
+                        type_captures,
+                        value_captures,
+                    )
+                }
+                TypeKind::Enum(enum_id) => {
+                    let definition = self.type_pool.enum_def(enum_id);
+                    let variants = definition
+                        .variants
+                        .iter()
+                        .enumerate()
+                        .map(|(index, name)| {
+                            Ok((
+                                name.clone(),
+                                definition
+                                    .variant_payload(index)
+                                    .iter()
+                                    .map(|ty| self.canonical_type_instance(*ty))
+                                    .collect::<Result<Vec<_>, _>>()?
+                                    .into(),
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
+                    (
+                        crate::SemanticProducedAnonymousNominalShape::Enum {
+                            variants: variants.into(),
+                        },
+                        Vec::new(),
+                        Vec::new(),
+                    )
+                }
+                _ => return Err(crate::SemanticBodyExportFailure::UnsupportedType),
+            };
+            Ok(crate::SemanticProducedAnonymousNominal {
+                identity,
+                shape,
+                type_captures: type_captures.into(),
+                value_captures: value_captures.into(),
             })
-            .collect::<Result<Vec<_>, _>>()
-            .map(Arc::from)
+        });
+        super::anon_structs::collect_anonymous_exports(exports)
     }
 
     fn install_provider_anonymous_methods(
@@ -4992,41 +4978,51 @@ where
     fn anonymous_struct_id(
         &self,
         identity: &super::anon_structs::IssuedAnonymousNominalKey,
-    ) -> Option<StructId> {
-        self.anon_struct_identities
-            .get(identity)
-            .copied()
-            .or_else(|| {
-                self.consulted_anonymous_types
-                    .borrow()
-                    .iter()
-                    .find_map(|(ty, candidate)| {
-                        (candidate.with_canonical_producer().as_ref()
-                            == identity.with_canonical_producer().as_ref())
-                        .then(|| ty.as_struct())
-                        .flatten()
-                    })
-            })
+    ) -> Result<Option<StructId>, crate::SemanticBodyExportFailure> {
+        let local = self.anon_struct_identities.get(identity).copied();
+        let consulted = super::anon_structs::canonical_consulted_type(
+            self.consulted_anonymous_types.borrow().iter(),
+            identity,
+            crate::AnonymousNominalKind::Struct,
+        )?
+        .map(|ty| {
+            ty.as_struct()
+                .ok_or(crate::SemanticBodyExportFailure::WrongStableIdentityKind)
+        })
+        .transpose()?;
+        match (local, consulted) {
+            (Some(local), Some(consulted)) if local != consulted => {
+                Err(crate::SemanticBodyExportFailure::AmbiguousStableIdentity)
+            }
+            (Some(local), _) => Ok(Some(local)),
+            (_, Some(consulted)) => Ok(Some(consulted)),
+            (None, None) => Ok(None),
+        }
     }
 
     fn anonymous_enum_id(
         &self,
         identity: &super::anon_structs::IssuedAnonymousNominalKey,
-    ) -> Option<EnumId> {
-        self.anon_enum_identities
-            .get(identity)
-            .copied()
-            .or_else(|| {
-                self.consulted_anonymous_types
-                    .borrow()
-                    .iter()
-                    .find_map(|(ty, candidate)| {
-                        (candidate.with_canonical_producer().as_ref()
-                            == identity.with_canonical_producer().as_ref())
-                        .then(|| ty.as_enum())
-                        .flatten()
-                    })
-            })
+    ) -> Result<Option<EnumId>, crate::SemanticBodyExportFailure> {
+        let local = self.anon_enum_identities.get(identity).copied();
+        let consulted = super::anon_structs::canonical_consulted_type(
+            self.consulted_anonymous_types.borrow().iter(),
+            identity,
+            crate::AnonymousNominalKind::Enum,
+        )?
+        .map(|ty| {
+            ty.as_enum()
+                .ok_or(crate::SemanticBodyExportFailure::WrongStableIdentityKind)
+        })
+        .transpose()?;
+        match (local, consulted) {
+            (Some(local), Some(consulted)) if local != consulted => {
+                Err(crate::SemanticBodyExportFailure::AmbiguousStableIdentity)
+            }
+            (Some(local), _) => Ok(Some(local)),
+            (_, Some(consulted)) => Ok(Some(consulted)),
+            (None, None) => Ok(None),
+        }
     }
 
     fn anonymous_struct_identities_mut(
@@ -5322,6 +5318,131 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
+}
+
+#[cfg(test)]
+pub(crate) struct ConsultedAnonymousConflictProbe {
+    pub(super) result: CompileResult<(Type, bool)>,
+    pub(super) export_result:
+        Result<Arc<[crate::SemanticProducedAnonymousNominal]>, crate::SemanticBodyExportFailure>,
+    pub(super) generated_symbol_was_added: bool,
+    pub(super) additional_canonical_type_was_published: bool,
+    pub(super) type_pool_len_changed: bool,
+}
+
+/// Exercise the production host/ordinary-engine mint boundary with a
+/// deliberately counterfeit consulted registry. The two pre-existing live
+/// types are test input; the probe reports whether lookup incorrectly minted
+/// and published a third type after detecting their shared identity.
+#[cfg(test)]
+pub(super) fn probe_consulted_anonymous_struct_conflict<P, S, K, M>(
+    provider: &P,
+    source: S,
+    bundle: &BodyRirBundle,
+    key: K,
+    name: &str,
+    durable_identity: &crate::AnonymousNominalKey<K, M>,
+    well_known: &ProviderWellKnownOptionFacts<K, M>,
+) -> CompileResult<ConsultedAnonymousConflictProbe>
+where
+    P: BodyFactProvider,
+    S: DurableNominalSource<K, M>
+        + DurableAnonymousSource<K, M>
+        + DurableCallableSource<K, M>
+        + DurableConstSource<K, M>
+        + DurableBodyLookupSource<K, M>,
+    K: Clone + Eq + Hash + Ord,
+    M: Clone + Eq + Hash + Ord,
+{
+    let owner_file = bundle.source_file_id().ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InvalidCompilerInput(
+            "conflict probe body has no source file".into(),
+        ))
+    })?;
+    let mut host = ProviderBodyHost::new(
+        provider,
+        source,
+        bundle,
+        key,
+        owner_file,
+        name,
+        crate::StableDefinitionKind::Function,
+        None,
+        Target::host().ok_or_else(|| {
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "conflict probe target is unavailable".into(),
+            ))
+        })?,
+        PreviewFeatures::new(),
+        well_known,
+    )
+    .map_err(identity_mint_compile_error)?
+    .ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InvalidCompilerInput(
+            "conflict probe host could not be constructed".into(),
+        ))
+    })?;
+    let identity = host
+        .register_and_issue_anonymous_identity(durable_identity)
+        .ok_or_else(|| {
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "conflict probe identity could not be issued".into(),
+            ))
+        })?;
+    let first = Type::new_struct(host.type_pool.reserve_struct_id());
+    let second = Type::new_struct(host.type_pool.reserve_struct_id());
+    for (ty, name, field, field_ty) in [
+        (first, "counterfeit_a", "a", Type::I32),
+        (second, "counterfeit_b", "b", Type::I64),
+    ] {
+        let id = ty.as_struct().expect("probe types are structs");
+        let name_spur = host.intern_name(name).ok_or_else(|| {
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "conflict probe symbol could not be interned".into(),
+            ))
+        })?;
+        host.type_pool.complete_struct_registration(
+            id,
+            name_spur,
+            crate::types::StructDef {
+                name: Arc::from(name),
+                fields: vec![crate::types::StructField {
+                    name: field.to_owned(),
+                    ty: field_ty,
+                }],
+                is_copy: true,
+                is_linear: false,
+                declared_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+    }
+    host.consulted_anonymous_types
+        .borrow_mut()
+        .extend([(first, identity.clone()), (second, identity.clone())]);
+    host.canonical_anonymous_types
+        .extend([(first, identity.clone()), (second, identity.clone())]);
+    let generated_before = host.generated_structs.len();
+    let canonical_before = host.canonical_anonymous_types.len();
+    let type_pool_len_before = host.type_pool.len();
+    let result = OrdinaryBodyEngine::new(&mut host).find_or_create_anon_struct(
+        identity,
+        &[],
+        &[],
+        &AHashMap::new(),
+    );
+    let export_result = host.produced_anonymous_nominals(&AHashSet::new());
+    Ok(ConsultedAnonymousConflictProbe {
+        result,
+        export_result,
+        generated_symbol_was_added: host.generated_structs.len() != generated_before,
+        additional_canonical_type_was_published: host.canonical_anonymous_types.len()
+            != canonical_before,
+        type_pool_len_changed: host.type_pool.len() != type_pool_len_before,
+    })
 }
 
 /// Run the canonical ordinary expression engine over one exact local RIR.
@@ -5709,7 +5830,6 @@ where
             warnings,
             strings,
             referenced_functions,
-            referenced_methods,
             referenced_definitions,
             referenced_values,
             referenced_specializations,

--- a/crates/rue-air/src/sema/provider_fixture.rs
+++ b/crates/rue-air/src/sema/provider_fixture.rs
@@ -758,6 +758,44 @@ impl ProviderFixture {
         )
     }
 
+    pub(crate) fn probe_consulted_anonymous_struct_conflict(
+        &self,
+        source: &str,
+        function: &str,
+        identity: &AnonymousNominalKey<FixtureKey, FixtureModule>,
+    ) -> CompileResult<super::provider_body_host::ConsultedAnonymousConflictProbe> {
+        let (tokens, interner) = Lexer::new(source).tokenize().expect("fixture source lexes");
+        let (ast, interner) = Parser::new(tokens, interner)
+            .parse()
+            .expect("fixture source parses");
+        assert_eq!(ast.items.len(), 1, "conflict probe carries one body");
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let editor = astgen.finish_editor();
+        let source_lengths = [(self.facts.file, source.len() as u32)];
+        let rir = ValidatedRir::finish(
+            editor,
+            &RirValidationContext {
+                symbol_count: interner.len(),
+                source_lengths: &source_lengths,
+            },
+        )
+        .expect("fixture RIR validates");
+        let bundle = BodyRirBundle::new(
+            rir,
+            rue_rir::SharedSymbolSpace::adopt(std::sync::Arc::new(interner)),
+        );
+        super::provider_body_host::probe_consulted_anonymous_struct_conflict(
+            &UnconsultedFactProvider,
+            FixtureFactSource(Rc::new(self.facts.clone())),
+            &bundle,
+            FixtureKey::function(function),
+            function,
+            identity,
+            &self.well_known,
+        )
+    }
+
     /// Run one exact comptime specialization through the production provider
     /// body host. This is the fixture equivalent of the compiler's
     /// specialization query and lets tests exercise recursive body evaluation

--- a/crates/rue-air/src/sema/provider_fixture_tests.rs
+++ b/crates/rue-air/src/sema/provider_fixture_tests.rs
@@ -16,9 +16,9 @@ use super::ordinary_engine::{
     reset_comptime_reduction_test_stats,
 };
 use super::provider_fixture::{
-    MethodShape, ProviderFixture, StructShape, comptime_type_param, comptime_value_param,
-    error_source_slice, mode_param, value_param, with_fixture_cancellation_after,
-    with_fixture_durable_integer,
+    FixtureKey, MethodShape, ProviderFixture, StructShape, comptime_type_param,
+    comptime_value_param, error_source_slice, mode_param, value_param,
+    with_fixture_cancellation_after, with_fixture_durable_integer,
 };
 use super::{
     ComptimeCallKey, ComptimeCallMemoLookup, ComptimeCompletedCallMemo, ComptimeMemoizedOutcome,
@@ -807,6 +807,36 @@ fn provider_body_produces_anonymous_nominal_identity() {
         super::provider_body_host::SemanticProducedAnonymousNominalShape::Struct { fields, .. }
             if fields.len() == 1 && &*fields[0].0 == "value"
     ));
+}
+
+#[test]
+fn provider_body_consulted_identity_conflict_cannot_fall_through_to_mint() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
+    let identity = crate::AnonymousNominalKey {
+        kind: crate::AnonymousNominalKind::Struct,
+        producer: StableProducerId::Function(crate::Node::new(
+            crate::FunctionInstanceKey::Definition(FixtureKey::function("main")),
+        )),
+        anchor: rue_rir::RirStructuralAnchor::new(vec![
+            rue_rir::RirStructuralPathSegment::Body,
+            rue_rir::RirStructuralPathSegment::AnonymousType(0),
+        ]),
+    };
+    let probe = fixture
+        .probe_consulted_anonymous_struct_conflict("fn main() -> i32 { 0 }", "main", &identity)
+        .expect("counterfeit consulted registry reaches the production mint boundary");
+    let error = probe
+        .result
+        .expect_err("ambiguous consulted identities must not mint a replacement");
+    assert!(matches!(error.kind, ErrorKind::OutputPublication(_)));
+    assert_eq!(
+        probe.export_result,
+        Err(crate::SemanticBodyExportFailure::AmbiguousStableIdentity)
+    );
+    assert!(!probe.generated_symbol_was_added);
+    assert!(!probe.additional_canonical_type_was_published);
+    assert!(!probe.type_pool_len_changed);
 }
 
 // A fact that was never seeded fails closed: the miss surfaces as an ordinary

--- a/crates/rue-air/src/sema/provider_semantics_tests.rs
+++ b/crates/rue-air/src/sema/provider_semantics_tests.rs
@@ -1059,6 +1059,64 @@ fn provider_body_infers_array_types() {
     assert_eq!(body.function.air.return_type(), Type::I32);
 }
 
+#[test]
+fn provider_array_type_allocation_is_stable_across_expr_map_layouts() {
+    fn snapshot(seeds: [u64; 4], reverse_insertion: bool) -> Vec<(u32, u32, u64)> {
+        let body = crate::inference::with_expr_types_test_layout(seeds, reverse_insertion, || {
+            let mut fixture = ProviderFixture::new();
+            fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
+            fixture.analyze(
+                "fn main() -> i32 {
+                        let flags = [true, false, true];
+                        let pairs = [[1, 2], [3, 4]];
+                        let values = [5, 6, 7, 8];
+                        if flags[0] { pairs[0][0] + values[0] } else { 0 }
+                    }",
+                "main",
+            )
+        })
+        .expect("array inference succeeds through the provider body path");
+        assert!(
+            body.function.air.iter().any(|(_, inst)| inst.ty.is_array()),
+            "the semantic artifact must retain array-typed instructions"
+        );
+        body.type_pool
+            .all_array_ids()
+            .into_iter()
+            .map(|id| {
+                let (element, length) = body.type_pool.array_def(id);
+                (Type::new_array(id).as_u32(), element.as_u32(), length)
+            })
+            .collect()
+    }
+
+    let configurations = [
+        ([1, 2, 3, 4], false),
+        ([91, 73, 55, 37], true),
+        ([0, 0, 0, 0], false),
+        ([u64::MAX, 0, u64::MAX, 0], true),
+        ([13, 21, 34, 55], false),
+        ([89, 144, 233, 377], true),
+        ([0x1234, 0x5678, 0x9abc, 0xdef0], false),
+        ([0xfedc, 0xba98, 0x7654, 0x3210], true),
+    ];
+    let baseline = snapshot(configurations[0].0, configurations[0].1);
+    for (seeds, reverse_insertion) in configurations.into_iter().skip(1) {
+        assert_eq!(
+            snapshot(seeds, reverse_insertion),
+            baseline,
+            "array allocation changed for seeds {seeds:?}, reverse insertion={reverse_insertion}"
+        );
+    }
+    assert_eq!(baseline.len(), 4);
+    let mut lengths = baseline
+        .iter()
+        .map(|(_, _, length)| *length)
+        .collect::<Vec<_>>();
+    lengths.sort_unstable();
+    assert_eq!(lengths, [2, 2, 3, 4]);
+}
+
 // Migrated from `tests::test_array_index_signed_type_is_accepted`: any integer
 // type indexes an array (spec 7.1:7); range violations trap at runtime.
 #[test]

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -60,7 +60,7 @@ pub(crate) fn export_body<H: SemanticBodyExportHost>(
             SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
         >,
     >,
-    method_references: &std::collections::HashSet<(crate::StructId, Spur)>,
+    method_references: &ahash::AHashSet<(crate::StructId, Spur)>,
 ) -> Result<SemanticBodyExport, F> {
     let warning_anchor = |span: Span| {
         if span.file_id != body_span.file_id

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -1143,14 +1143,6 @@ pub struct SemanticImportedBody<K, M> {
     pub param_modes: ParamSlotModes,
     pub allow_unreachable_code: bool,
     pub warnings: Arc<[rue_error::CompileWarning]>,
-    /// The body's recorded method references projected into the importing
-    /// session's live `(receiver, method)` keys. Import hosts that resolve
-    /// nominals (the staged-body importer) populate this; validation-only
-    /// hosts leave it empty because no reachability consumer reads it there.
-    ///
-    /// Kept on the std hasher: `rue-compiler` and `rue-cfg` construct and walk
-    /// this field, so its hasher is part of AIR's public surface.
-    pub method_references: std::collections::HashSet<(crate::StructId, lasso::Spur)>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -563,10 +563,7 @@ pub struct SemanticLocalMaterialization<K, M> {
     pub allow_unreachable_code: bool,
     pub type_pool: crate::FrozenTypeInternPool,
     pub interner: Arc<ThreadedRodeo>,
-    /// Kept on the std hasher: `rue-compiler` reads this field directly and
-    /// passes it on by reference, so its hasher is part of AIR's public surface
-    /// rather than an internal choice.
-    pub aggregate_types: std::collections::HashMap<crate::Type, TypeInstanceKey<K, M>>,
+    aggregate_types: ahash::AHashMap<crate::Type, TypeInstanceKey<K, M>>,
     /// Exact caller-owned handles explicitly pre-materialized for a mandatory
     /// accessor splice, paired with their stable type identities.
     pub materialized_types: Vec<(crate::Type, SemanticImportType<K, M>)>,
@@ -574,6 +571,33 @@ pub struct SemanticLocalMaterialization<K, M> {
     pub warnings: Arc<[rue_error::CompileWarning]>,
     pub body_span: Span,
     pub completeness: SemanticLocalCompleteness,
+}
+
+impl<K, M> SemanticLocalMaterialization<K, M> {
+    /// Look up the stable identity for one complete local aggregate type.
+    ///
+    /// The backing table is deliberately private: callers should depend on
+    /// this narrow lookup rather than on AIR's map implementation or hasher.
+    pub fn aggregate_type(&self, ty: crate::Type) -> Option<&TypeInstanceKey<K, M>> {
+        self.aggregate_types.get(&ty)
+    }
+
+    pub fn has_aggregate_type(&self, ty: crate::Type) -> bool {
+        self.aggregate_types.contains_key(&ty)
+    }
+
+    pub fn aggregate_type_count(&self) -> usize {
+        self.aggregate_types.len()
+    }
+
+    /// Iterate aggregate identities in the canonical local type-pool order.
+    pub fn aggregate_type_entries(
+        &self,
+    ) -> impl Iterator<Item = (&crate::Type, &TypeInstanceKey<K, M>)> {
+        let mut entries = self.aggregate_types.iter().collect::<Vec<_>>();
+        entries.sort_unstable_by_key(|(ty, _)| ty.as_u32());
+        entries.into_iter()
+    }
 }
 
 /// An AIR type branded with the import epoch which issued it.
@@ -1188,7 +1212,6 @@ where
             ),
             allow_unreachable_code: body.allow_unreachable_code,
             warnings: Arc::from(warnings),
-            method_references: std::collections::HashSet::new(),
         })
     }
     pub fn new(
@@ -1636,7 +1659,7 @@ where
             })
             .collect::<Result<Vec<_>, SemanticBodyImportFailure>>()?;
         let complete_types = self.type_pool.complete_type_handles();
-        let mut aggregate_types = std::collections::HashMap::with_capacity(complete_types.len());
+        let mut aggregate_types = ahash::AHashMap::with_capacity(complete_types.len());
         for ty in complete_types {
             if matches!(
                 ty.kind(),
@@ -1657,7 +1680,6 @@ where
             param_modes,
             allow_unreachable_code,
             warnings,
-            method_references: _,
         } = imported;
         Ok(SemanticLocalMaterialization {
             identity,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -326,7 +326,7 @@ pub(crate) struct OneSpecializedBody {
     pub(crate) warnings: Vec<CompileWarning>,
     pub(crate) local_strings: Vec<String>,
     pub(crate) referenced_functions: AHashSet<Spur>,
-    pub(crate) referenced_methods: std::collections::HashSet<(StructId, Spur)>,
+    pub(crate) referenced_methods: ahash::AHashSet<(StructId, Spur)>,
     pub(crate) dependencies: Vec<crate::SemanticDefinitionToken>,
     pub(crate) dependency_boundary_complete: bool,
     pub(crate) identity: crate::SemanticSpecializationIdentity<

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1653,30 +1653,27 @@ fn build_cfg(
             ));
         }
     };
-    let implicit_destructor_dependencies_complete =
-        output.implicit_named_destructors.iter().all(|id| {
-            materialized
-                .aggregate_types
-                .contains_key(&rue_air::Type::new_struct(*id))
-        });
+    let implicit_destructor_dependencies_complete = output
+        .implicit_named_destructors
+        .iter()
+        .all(|id| materialized.has_aggregate_type(rue_air::Type::new_struct(*id)));
     let mut implicit_destructor_targets = output
         .implicit_named_destructors
         .iter()
         .filter_map(|id| {
             materialized
-                .aggregate_types
-                .get(&rue_air::Type::new_struct(*id))
+                .aggregate_type(rue_air::Type::new_struct(*id))
                 .cloned()
         })
         .collect::<std::collections::BTreeSet<_>>();
     let implicit_drop_glue_dependencies_complete = output
         .implicit_drop_glue_types
         .iter()
-        .all(|ty| materialized.aggregate_types.contains_key(ty));
+        .all(|ty| materialized.has_aggregate_type(*ty));
     let implicit_drop_glue_targets = output
         .implicit_drop_glue_types
         .iter()
-        .filter_map(|ty| materialized.aggregate_types.get(ty).cloned())
+        .filter_map(|ty| materialized.aggregate_type(*ty).cloned())
         .collect::<std::collections::BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
@@ -1689,7 +1686,7 @@ fn build_cfg(
         // the live type pool for same-named structs outside this CFG's domain.
         implicit_destructor_targets.insert(owner.clone());
     }
-    let local_aggregate_type_aliases = materialized.aggregate_types.len();
+    let local_aggregate_type_aliases = materialized.aggregate_type_count();
     let local_materialized_type_handles = materialized.materialized_types.len();
     let interner_retained_charge = frozen_interner_retained_charge(&materialized.interner);
     let value = CfgValue::Available(Arc::new(CfgRecord {

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -10,10 +10,22 @@ use crate::retained_charge::RetainedCharge;
 
 type CanonicalType = SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>;
 
+pub(crate) trait AggregateTypeLookup {
+    fn aggregate_type(&self, ty: Type) -> Option<&crate::TypeInstanceKey>;
+}
+
+impl AggregateTypeLookup
+    for rue_air::SemanticLocalMaterialization<crate::StableDefinitionKey, crate::ModuleId>
+{
+    fn aggregate_type(&self, ty: Type) -> Option<&crate::TypeInstanceKey> {
+        self.aggregate_type(ty)
+    }
+}
+
 #[cfg(test)]
 pub(crate) struct CfgTypeAdmissionIndex<'a> {
     pool: &'a rue_air::FrozenTypeInternPool,
-    aggregates: &'a std::collections::HashMap<Type, crate::TypeInstanceKey>,
+    aggregates: &'a dyn AggregateTypeLookup,
     live_by_stable: Option<AHashMap<CanonicalType, Type>>,
 }
 
@@ -21,7 +33,7 @@ pub(crate) struct CfgTypeAdmissionIndex<'a> {
 impl<'a> CfgTypeAdmissionIndex<'a> {
     pub(crate) fn new(
         pool: &'a rue_air::FrozenTypeInternPool,
-        aggregates: &'a std::collections::HashMap<Type, crate::TypeInstanceKey>,
+        aggregates: &'a dyn AggregateTypeLookup,
     ) -> Self {
         Self {
             pool,
@@ -120,7 +132,7 @@ fn live_instruction_kind(data: &AirInstData) -> rue_air::SemanticBodyInstKind {
 fn canonical_type_from_live_cached(
     ty: Type,
     pool: &rue_air::FrozenTypeInternPool,
-    aggregates: &std::collections::HashMap<Type, crate::TypeInstanceKey>,
+    aggregates: &dyn AggregateTypeLookup,
     stable_by_live: &mut AHashMap<Type, CanonicalType>,
 ) -> Result<CanonicalType, CfgDomainFailure> {
     if let Some(stable) = stable_by_live.get(&ty) {
@@ -164,9 +176,11 @@ fn canonical_type_from_live_cached(
             aggregates,
             stable_by_live,
         )?)),
-        K::Struct(_) | K::Enum(_) => {
-            canonical_type_from_instance(aggregates.get(&ty).ok_or(CfgDomainFailure::Missing)?)?
-        }
+        K::Struct(_) | K::Enum(_) => canonical_type_from_instance(
+            aggregates
+                .aggregate_type(ty)
+                .ok_or(CfgDomainFailure::Missing)?,
+        )?,
         K::Module(_) | K::Error => return Err(CfgDomainFailure::Unsupported),
     };
     stable_by_live.insert(ty, stable.clone());
@@ -231,7 +245,7 @@ fn record_cfg_type(
     types: &mut Vec<(Type, CanonicalType)>,
     ty: Type,
     pool: &rue_air::FrozenTypeInternPool,
-    aggregates: &std::collections::HashMap<Type, crate::TypeInstanceKey>,
+    aggregates: &dyn AggregateTypeLookup,
     stable_by_live: &mut AHashMap<Type, CanonicalType>,
 ) -> Result<(), CfgDomainFailure> {
     match canonical_type_from_live_cached(ty, pool, aggregates, stable_by_live) {
@@ -1093,7 +1107,7 @@ impl CfgDomainProjection {
             &mut types,
             air.return_type(),
             type_pool,
-            &materialization.aggregate_types,
+            materialization,
             &mut stable_by_live,
         )?;
         let mut stable_strings = Vec::new();
@@ -1104,7 +1118,7 @@ impl CfgDomainProjection {
                 &mut types,
                 current.ty,
                 type_pool,
-                &materialization.aggregate_types,
+                materialization,
                 &mut stable_by_live,
             )?;
             spans.push((
@@ -1123,7 +1137,7 @@ impl CfgDomainProjection {
                     &mut types,
                     *ty,
                     type_pool,
-                    &materialization.aggregate_types,
+                    materialization,
                     &mut stable_by_live,
                 )?,
                 AirInstData::IntCast { from_ty, .. } => {
@@ -1131,7 +1145,7 @@ impl CfgDomainProjection {
                         &mut types,
                         *from_ty,
                         type_pool,
-                        &materialization.aggregate_types,
+                        materialization,
                         &mut stable_by_live,
                     )?;
                 }
@@ -1167,7 +1181,7 @@ impl CfgDomainProjection {
                         &mut types,
                         ty,
                         type_pool,
-                        &materialization.aggregate_types,
+                        materialization,
                         &mut stable_by_live,
                     )?;
                 }
@@ -1178,7 +1192,7 @@ impl CfgDomainProjection {
                         &mut types,
                         ty,
                         type_pool,
-                        &materialization.aggregate_types,
+                        materialization,
                         &mut stable_by_live,
                     )?;
                 }
@@ -1190,7 +1204,7 @@ impl CfgDomainProjection {
                                 &mut types,
                                 ty,
                                 type_pool,
-                                &materialization.aggregate_types,
+                                materialization,
                                 &mut stable_by_live,
                             )?;
                         }
@@ -1204,7 +1218,7 @@ impl CfgDomainProjection {
                 &mut types,
                 place.base_type,
                 type_pool,
-                &materialization.aggregate_types,
+                materialization,
                 &mut stable_by_live,
             )?;
             for projection in air.get_place_projections(place) {
@@ -1216,7 +1230,7 @@ impl CfgDomainProjection {
                     &mut types,
                     ty,
                     type_pool,
-                    &materialization.aggregate_types,
+                    materialization,
                     &mut stable_by_live,
                 )?;
             }
@@ -1226,7 +1240,7 @@ impl CfgDomainProjection {
                 &mut types,
                 *ty,
                 type_pool,
-                &materialization.aggregate_types,
+                materialization,
                 &mut stable_by_live,
             )?;
         }
@@ -1318,7 +1332,7 @@ impl CfgDomainProjection {
                     match canonical_type_from_live_cached(
                         child,
                         type_pool,
-                        &materialization.aggregate_types,
+                        materialization,
                         &mut stable_by_live,
                     ) {
                         Ok(stable) => {
@@ -1466,6 +1480,14 @@ mod tests {
         projection_with(symbol, StableCfgSymbol::Intrinsic(Arc::from("stable")))
     }
 
+    struct EmptyAggregateTypes;
+
+    impl AggregateTypeLookup for EmptyAggregateTypes {
+        fn aggregate_type(&self, _ty: Type) -> Option<&crate::TypeInstanceKey> {
+            None
+        }
+    }
+
     #[test]
     fn type_admission_index_stays_lazy_when_domains_already_cover_types() {
         let interner = lasso::ThreadedRodeo::new();
@@ -1473,7 +1495,7 @@ mod tests {
         let old = projection(symbol);
         let mut current = projection(symbol);
         let pool = rue_air::TypeInternPool::new().freeze();
-        let aggregates = std::collections::HashMap::new();
+        let aggregates = EmptyAggregateTypes;
         let mut admission = CfgTypeAdmissionIndex::new(&pool, &aggregates);
 
         current.admit_stable_types(&old, &mut admission).unwrap();

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -91,12 +91,218 @@ impl DurableAnonymousNominal {
         }
     }
 
+    /// Rebuild this fact under the one canonical spelling of its producer.
+    /// Empty-specialization aliases and concrete references to the owning type
+    /// in method signatures are transport spellings, not distinct anonymous
+    /// content at durable merge boundaries.
+    pub(crate) fn with_canonical_identity(&self) -> Self {
+        let identity = self.identity.with_canonical_producer().into_owned();
+        let shape = normalize_anonymous_shape(&identity, &self.shape);
+        if identity == self.identity && shape == self.shape {
+            return self.clone();
+        }
+        Self::new(
+            identity,
+            shape,
+            self.type_captures.clone(),
+            self.value_captures.clone(),
+        )
+    }
+
     pub(crate) fn source_symbol(&self) -> &Arc<str> {
         &self.source_symbol
     }
 
     pub(crate) fn anonymous_identity_digest(&self) -> u128 {
         self.anonymous_digest
+    }
+}
+
+fn reconcile_optional_projection<T: Eq>(left: &Arc<[T]>, right: &Arc<[T]>) -> Option<Arc<[T]>> {
+    if left == right || right.is_empty() {
+        Some(left.clone())
+    } else if left.is_empty() {
+        Some(right.clone())
+    } else {
+        None
+    }
+}
+
+fn normalize_anonymous_method_type(
+    owner: &crate::AnonymousNominalKey,
+    ty: &DurableAnonymousMethodType,
+) -> DurableAnonymousMethodType {
+    match ty {
+        DurableAnonymousMethodType::Concrete(DurableType::AnonymousNominal(identity))
+            if identity.with_canonical_producer().as_ref() == owner =>
+        {
+            DurableAnonymousMethodType::SelfType
+        }
+        _ => ty.clone(),
+    }
+}
+
+fn anonymous_method_type_needs_normalization(
+    owner: &crate::AnonymousNominalKey,
+    ty: &DurableAnonymousMethodType,
+) -> bool {
+    matches!(
+        ty,
+        DurableAnonymousMethodType::Concrete(DurableType::AnonymousNominal(identity))
+            if identity.with_canonical_producer().as_ref() == owner
+    )
+}
+
+fn normalize_anonymous_methods(
+    owner: &crate::AnonymousNominalKey,
+    methods: &Arc<[DurableAnonymousMethodSignature]>,
+) -> Arc<[DurableAnonymousMethodSignature]> {
+    if !methods.iter().any(|method| {
+        anonymous_method_type_needs_normalization(owner, &method.result)
+            || method
+                .parameters
+                .iter()
+                .any(|(ty, _, _)| anonymous_method_type_needs_normalization(owner, ty))
+    }) {
+        return methods.clone();
+    }
+    methods
+        .iter()
+        .map(|method| DurableAnonymousMethodSignature {
+            name: method.name.clone(),
+            has_self: method.has_self,
+            self_mode: method.self_mode,
+            returns_borrow: method.returns_borrow,
+            returns_inout: method.returns_inout,
+            parameters: method
+                .parameters
+                .iter()
+                .map(|(ty, mode, comptime)| {
+                    (normalize_anonymous_method_type(owner, ty), *mode, *comptime)
+                })
+                .collect::<Vec<_>>()
+                .into(),
+            result: normalize_anonymous_method_type(owner, &method.result),
+            has_body: method.has_body,
+        })
+        .collect::<Vec<_>>()
+        .into()
+}
+
+fn normalize_anonymous_shape(
+    owner: &crate::AnonymousNominalKey,
+    shape: &DurableAnonymousNominalShape,
+) -> DurableAnonymousNominalShape {
+    match shape {
+        DurableAnonymousNominalShape::Struct { fields, methods } => {
+            DurableAnonymousNominalShape::Struct {
+                fields: fields.clone(),
+                methods: normalize_anonymous_methods(owner, methods),
+            }
+        }
+        DurableAnonymousNominalShape::Enum { variants } => DurableAnonymousNominalShape::Enum {
+            variants: variants.clone(),
+        },
+    }
+}
+
+/// Reconcile two transport projections of one durable anonymous fact.
+///
+/// Producer evaluation and provider-local body analysis both carry the full
+/// materialized shape, but only the projection that needs an anonymous member
+/// environment is required to retain capture and method metadata. An empty
+/// metadata slice is therefore an admissible thin projection; a non-empty
+/// slice enriches it. Method projections may also spell the owner's type as
+/// either `SelfType` or the full anonymous identity; those spellings normalize
+/// before comparison. The materialized fields/variants must always agree, and
+/// two non-empty normalized metadata projections must agree exactly.
+pub(crate) fn reconcile_anonymous_nominals(
+    left: &DurableAnonymousNominal,
+    right: &DurableAnonymousNominal,
+) -> Result<DurableAnonymousNominal, crate::AnonymousNominalKey> {
+    let left = left.with_canonical_identity();
+    let right = right.with_canonical_identity();
+    if left.identity != right.identity {
+        return Err(right.identity);
+    }
+    let shape = match (&left.shape, &right.shape) {
+        (
+            DurableAnonymousNominalShape::Struct {
+                fields: left_fields,
+                methods: left_methods,
+            },
+            DurableAnonymousNominalShape::Struct {
+                fields: right_fields,
+                methods: right_methods,
+            },
+        ) if left_fields == right_fields => DurableAnonymousNominalShape::Struct {
+            fields: left_fields.clone(),
+            methods: reconcile_optional_projection(left_methods, right_methods)
+                .ok_or_else(|| left.identity.clone())?,
+        },
+        (
+            DurableAnonymousNominalShape::Enum {
+                variants: left_variants,
+            },
+            DurableAnonymousNominalShape::Enum {
+                variants: right_variants,
+            },
+        ) if left_variants == right_variants => DurableAnonymousNominalShape::Enum {
+            variants: left_variants.clone(),
+        },
+        _ => return Err(left.identity),
+    };
+    let type_captures = reconcile_optional_projection(&left.type_captures, &right.type_captures)
+        .ok_or_else(|| left.identity.clone())?;
+    let value_captures = reconcile_optional_projection(&left.value_captures, &right.value_captures)
+        .ok_or_else(|| left.identity.clone())?;
+    Ok(DurableAnonymousNominal::new(
+        left.identity,
+        shape,
+        type_captures,
+        value_captures,
+    ))
+}
+
+/// Insert one durable anonymous fact without permitting last-writer-wins
+/// replacement. Exact duplicates and compatible thin/rich projections
+/// reconcile; conflicting payloads for the same full canonical identity fail
+/// closed.
+pub(crate) fn merge_anonymous_nominal(
+    values: &mut std::collections::BTreeMap<crate::AnonymousNominalKey, DurableAnonymousNominal>,
+    nominal: &DurableAnonymousNominal,
+) -> Result<(), crate::AnonymousNominalKey> {
+    let nominal = nominal.with_canonical_identity();
+    match values.entry(nominal.identity.clone()) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(nominal);
+            Ok(())
+        }
+        std::collections::btree_map::Entry::Occupied(mut entry) => {
+            let reconciled = reconcile_anonymous_nominals(entry.get(), &nominal)?;
+            if entry.get() != &reconciled {
+                entry.insert(reconciled);
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Insert a complete producer publication. Unlike downstream projections,
+/// every producer export carries all method and capture metadata, so only an
+/// exact duplicate may share its full canonical identity.
+pub(crate) fn merge_complete_anonymous_nominal(
+    values: &mut std::collections::BTreeMap<crate::AnonymousNominalKey, DurableAnonymousNominal>,
+    nominal: &DurableAnonymousNominal,
+) -> Result<(), crate::AnonymousNominalKey> {
+    let nominal = nominal.with_canonical_identity();
+    match values.entry(nominal.identity.clone()) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(nominal);
+            Ok(())
+        }
+        std::collections::btree_map::Entry::Occupied(entry) if entry.get() == &nominal => Ok(()),
+        std::collections::btree_map::Entry::Occupied(entry) => Err(entry.key().clone()),
     }
 }
 
@@ -367,5 +573,104 @@ mod tests {
         });
         assert_ne!(nominal, variant);
         assert_eq!(hash_of(&nominal), hash_of(&variant));
+    }
+
+    #[test]
+    fn anonymous_merge_reconciles_only_explicit_thin_projection_metadata() {
+        let identity = identity();
+        let fields: Arc<[(Arc<str>, DurableType)]> =
+            Arc::from([(Arc::from("value"), DurableType::I32)]);
+        let thin = DurableAnonymousNominal::new(
+            identity.clone(),
+            DurableAnonymousNominalShape::Struct {
+                fields: fields.clone(),
+                methods: Arc::from([]),
+            },
+            Arc::from([]),
+            Arc::from([]),
+        );
+        let method = DurableAnonymousMethodSignature {
+            name: Arc::from("get"),
+            has_self: true,
+            self_mode: DurableParameterMode::Value,
+            returns_borrow: false,
+            returns_inout: false,
+            parameters: Arc::from([]),
+            result: DurableAnonymousMethodType::Concrete(DurableType::I32),
+            has_body: true,
+        };
+        let rich = DurableAnonymousNominal::new(
+            identity.clone(),
+            DurableAnonymousNominalShape::Struct {
+                fields,
+                methods: Arc::from([method]),
+            },
+            Arc::from([(Arc::from("T"), DurableType::I32)]),
+            Arc::from([]),
+        );
+        for pair in [[&thin, &rich], [&rich, &thin]] {
+            let mut merged = std::collections::BTreeMap::new();
+            merge_anonymous_nominal(&mut merged, pair[0]).unwrap();
+            merge_anonymous_nominal(&mut merged, pair[1]).unwrap();
+            assert_eq!(merged.get(&identity), Some(&rich));
+        }
+
+        let conflicting_captures = DurableAnonymousNominal::new(
+            identity.clone(),
+            rich.shape.clone(),
+            Arc::from([(Arc::from("T"), DurableType::I64)]),
+            Arc::from([]),
+        );
+        let mut merged = std::collections::BTreeMap::new();
+        merge_anonymous_nominal(&mut merged, &rich).unwrap();
+        assert_eq!(
+            merge_anonymous_nominal(&mut merged, &conflicting_captures),
+            Err(identity)
+        );
+    }
+
+    #[test]
+    fn anonymous_merge_normalizes_self_method_type_spelling_in_both_orders() {
+        let identity = identity();
+        let method = |result| DurableAnonymousMethodSignature {
+            name: Arc::from("make"),
+            has_self: false,
+            self_mode: DurableParameterMode::Value,
+            returns_borrow: false,
+            returns_inout: false,
+            parameters: Arc::from([]),
+            result,
+            has_body: true,
+        };
+        let nominal = |result| {
+            DurableAnonymousNominal::new(
+                identity.clone(),
+                DurableAnonymousNominalShape::Struct {
+                    fields: Arc::from([]),
+                    methods: Arc::from([method(result)]),
+                },
+                Arc::from([]),
+                Arc::from([]),
+            )
+        };
+        let self_spelled = nominal(DurableAnonymousMethodType::SelfType);
+        let concrete_spelled = nominal(DurableAnonymousMethodType::Concrete(
+            DurableType::AnonymousNominal(identity.clone()),
+        ));
+
+        for pair in [
+            [&self_spelled, &concrete_spelled],
+            [&concrete_spelled, &self_spelled],
+        ] {
+            let mut merged = std::collections::BTreeMap::new();
+            merge_anonymous_nominal(&mut merged, pair[0]).unwrap();
+            merge_anonymous_nominal(&mut merged, pair[1]).unwrap();
+            assert_eq!(merged.get(&identity), Some(&self_spelled));
+
+            let mut complete = std::collections::BTreeMap::new();
+            merge_complete_anonymous_nominal(&mut complete, pair[0]).unwrap();
+            merge_complete_anonymous_nominal(&mut complete, pair[1]).unwrap();
+            assert_eq!(complete.get(&identity), Some(&self_spelled));
+        }
     }
 }

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -136,7 +136,7 @@ impl SharedDeclarationFactIndex {
 pub(crate) struct LocalFactSelectionIndex<'facts> {
     declarations: &'facts [DurableDeclarationSemantic],
     shared: &'facts SharedDeclarationFactIndex,
-    anonymous: AHashMap<&'facts crate::AnonymousNominalKey, &'facts DurableAnonymousNominal>,
+    anonymous: AHashMap<crate::AnonymousNominalKey, &'facts DurableAnonymousNominal>,
 }
 
 impl<'facts> LocalFactSelectionIndex<'facts> {
@@ -144,21 +144,32 @@ impl<'facts> LocalFactSelectionIndex<'facts> {
         shared: &'facts SharedDeclarationFactIndex,
         declarations: &'facts [DurableDeclarationSemantic],
         anonymous_nominals: &'facts [DurableAnonymousNominal],
-    ) -> (Self, LocalFactSelectionIndexWork) {
+    ) -> Result<(Self, LocalFactSelectionIndexWork), LocalFactSelectionFailure> {
         let mut work = LocalFactSelectionIndexWork::default();
         let mut anonymous = AHashMap::with_capacity(anonymous_nominals.len());
         for nominal in anonymous_nominals {
             work.anonymous_nominals_scanned += 1;
-            anonymous.insert(&nominal.identity, nominal);
+            let identity = nominal.identity.with_canonical_producer().into_owned();
+            match anonymous.entry(identity.clone()) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(nominal);
+                }
+                std::collections::hash_map::Entry::Occupied(entry)
+                    if entry.get().with_canonical_identity()
+                        == nominal.with_canonical_identity() => {}
+                std::collections::hash_map::Entry::Occupied(_) => {
+                    return Err(LocalFactSelectionFailure::ConflictingAnonymous(identity));
+                }
+            }
         }
-        (
+        Ok((
             Self {
                 declarations,
                 shared,
                 anonymous,
             },
             work,
-        )
+        ))
     }
 
     fn declaration(&self, key: &StableDefinitionKey) -> Option<&'facts DurableDeclarationSemantic> {
@@ -624,8 +635,9 @@ impl RetainedCharge for LocalMaterializationFacts {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum LocalFactSelectionFailure {
-    MissingNamedNominal(StableDefinitionKey),
-    MissingAnonymousNominal(crate::AnonymousNominalKey),
+    MissingNamed(StableDefinitionKey),
+    MissingAnonymous(crate::AnonymousNominalKey),
+    ConflictingAnonymous(crate::AnonymousNominalKey),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1380,8 +1392,9 @@ pub(crate) fn select_materialization_facts(
                         .insert(crate::NominalInstanceKey::Named(key.clone()));
                 }
                 T::AnonymousNominal(key) => {
+                    let key = key.with_canonical_producer().into_owned();
                     self.opaque_nominals
-                        .insert(crate::NominalInstanceKey::Anonymous(Node::new(key.clone())));
+                        .insert(crate::NominalInstanceKey::Anonymous(Node::new(key)));
                 }
                 T::BuiltinNominal { kind, name } => {
                     self.builtin(
@@ -1408,8 +1421,14 @@ pub(crate) fn select_materialization_facts(
         }
 
         fn nominal(&mut self, nominal: &crate::NominalInstanceKey) {
+            let nominal = match nominal {
+                crate::NominalInstanceKey::Anonymous(key) => crate::NominalInstanceKey::Anonymous(
+                    Node::new(key.with_canonical_producer().into_owned()),
+                ),
+                _ => nominal.clone(),
+            };
             if self.seen_nominals.insert(nominal.clone()) {
-                self.pending_nominals.push(nominal.clone());
+                self.pending_nominals.push(nominal);
             }
         }
 
@@ -1509,7 +1528,7 @@ pub(crate) fn select_materialization_facts(
                     crate::NominalInstanceKey::Named(key) => {
                         let declaration =
                             self.index.declaration(&key).cloned().ok_or_else(|| {
-                                LocalFactSelectionFailure::MissingNamedNominal(key.clone())
+                                LocalFactSelectionFailure::MissingNamed(key.clone())
                             })?;
                         self.modules.insert(key.module().clone());
                         self.selected_declarations
@@ -1538,17 +1557,18 @@ pub(crate) fn select_materialization_facts(
                         }
                     }
                     crate::NominalInstanceKey::Anonymous(key) => {
+                        let canonical = key.with_canonical_producer().into_owned();
                         let nominal = self
                             .index
                             .anonymous
-                            .get(&*key)
+                            .get(&canonical)
                             .copied()
-                            .cloned()
                             .ok_or_else(|| {
-                                LocalFactSelectionFailure::MissingAnonymousNominal((*key).clone())
-                            })?;
+                                LocalFactSelectionFailure::MissingAnonymous((*key).clone())
+                            })?
+                            .with_canonical_identity();
                         self.selected_anonymous
-                            .insert((*key).clone(), nominal.clone());
+                            .insert(canonical.clone(), nominal.clone());
                         for (_, ty) in nominal.type_captures.iter() {
                             self.semantic_type(ty);
                         }
@@ -1569,7 +1589,9 @@ pub(crate) fn select_materialization_facts(
                                     if method.has_self && method.name.as_ref() == "__drop" {
                                         self.callable(&FunctionInstanceKey::AnonymousMember {
                                             owner: Node::new(crate::TypeInstanceKey::Nominal(
-                                                crate::NominalInstanceKey::Anonymous(key.clone()),
+                                                crate::NominalInstanceKey::Anonymous(Node::new(
+                                                    canonical.clone(),
+                                                )),
                                             )),
                                             member: crate::AnonymousMemberKey {
                                                 kind: crate::AnonymousMemberKind::Destructor,
@@ -1597,9 +1619,10 @@ pub(crate) fn select_materialization_facts(
                 match nominal {
                     crate::NominalInstanceKey::Builtin { .. } => {}
                     crate::NominalInstanceKey::Named(key) => {
-                        let declaration = self.index.declaration(&key).ok_or_else(|| {
-                            LocalFactSelectionFailure::MissingNamedNominal(key.clone())
-                        })?;
+                        let declaration = self
+                            .index
+                            .declaration(&key)
+                            .ok_or_else(|| LocalFactSelectionFailure::MissingNamed(key.clone()))?;
                         let payload = match declaration.payload {
                             DurableDeclarationPayload::Struct { .. } => {
                                 DurableDeclarationPayload::Struct {
@@ -1627,10 +1650,15 @@ pub(crate) fn select_materialization_facts(
                         );
                     }
                     crate::NominalInstanceKey::Anonymous(key) => {
+                        let canonical = key.with_canonical_producer().into_owned();
                         let nominal =
-                            self.index.anonymous.get(&*key).copied().ok_or_else(|| {
-                                LocalFactSelectionFailure::MissingAnonymousNominal((*key).clone())
-                            })?;
+                            self.index
+                                .anonymous
+                                .get(&canonical)
+                                .copied()
+                                .ok_or_else(|| {
+                                    LocalFactSelectionFailure::MissingAnonymous((*key).clone())
+                                })?;
                         let shape = match nominal.shape {
                             DurableAnonymousNominalShape::Struct { .. } => {
                                 DurableAnonymousNominalShape::Struct {
@@ -1644,8 +1672,10 @@ pub(crate) fn select_materialization_facts(
                                 }
                             }
                         };
-                        self.selected_anonymous
-                            .insert((*key).clone(), nominal.with_shape(shape));
+                        self.selected_anonymous.insert(
+                            canonical,
+                            nominal.with_shape(shape).with_canonical_identity(),
+                        );
                     }
                 }
             }
@@ -2095,8 +2125,7 @@ mod tests {
         )
         .unwrap();
         let ty = output
-            .aggregate_types
-            .iter()
+            .aggregate_type_entries()
             .find_map(|(ty, identity)| {
                 (identity
                     == &crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(
@@ -2205,7 +2234,8 @@ mod tests {
         let mut selection_body = body();
         selection_body.return_type = rue_air::SemanticImportType::Nominal(record);
         let shared = SharedDeclarationFactIndex::new(&declarations);
-        let (index, work) = LocalFactSelectionIndex::new(&shared, &declarations, &[]);
+        let (index, work) =
+            LocalFactSelectionIndex::new(&shared, &declarations, &[]).expect("facts are unique");
         assert_eq!(work, LocalFactSelectionIndexWork::default());
         let facts = select_materialization_facts(
             &FunctionInstanceKey::Definition(function.clone()),
@@ -2275,7 +2305,8 @@ mod tests {
             crate::semantic_identity::anonymous_nominal_digest(&identity)
         );
         let shared = SharedDeclarationFactIndex::new(&[]);
-        let (index, _) = LocalFactSelectionIndex::new(&shared, &[], std::slice::from_ref(&nominal));
+        let (index, _) = LocalFactSelectionIndex::new(&shared, &[], std::slice::from_ref(&nominal))
+            .expect("facts are unique");
         let symbols = AHashMap::from([(
             FunctionInstanceKey::Definition(function.clone()),
             Arc::from("probe"),
@@ -2316,6 +2347,98 @@ mod tests {
             DurableAnonymousNominalShape::Struct { fields, methods }
                 if fields.is_empty() && methods.is_empty()
         ));
+    }
+
+    #[test]
+    fn anonymous_fact_selection_index_rejects_conflicting_duplicate_identity() {
+        use rue_rir::{RirStructuralAnchor, RirStructuralPathSegment};
+
+        let function = definition(
+            ModuleId::from_validated_canonical("main.rue"),
+            StableDefinitionKind::Function,
+            "probe",
+            None,
+        );
+        let identity = crate::AnonymousNominalKey {
+            kind: crate::AnonymousNominalKind::Struct,
+            producer: crate::StableProducerId::Definition(function),
+            anchor: RirStructuralAnchor::new(vec![
+                RirStructuralPathSegment::Body,
+                RirStructuralPathSegment::AnonymousType(0),
+            ]),
+        };
+        let original = DurableAnonymousNominal::new(
+            identity.clone(),
+            DurableAnonymousNominalShape::Struct {
+                fields: Arc::from([(Arc::from("value"), rue_air::SemanticImportType::I32)]),
+                methods: Arc::from([]),
+            },
+            Arc::from([]),
+            Arc::from([]),
+        );
+        let counterfeit = original.with_shape(DurableAnonymousNominalShape::Struct {
+            fields: Arc::from([(Arc::from("counterfeit"), rue_air::SemanticImportType::I64)]),
+            methods: Arc::from([]),
+        });
+        let shared = SharedDeclarationFactIndex::new(&[]);
+        assert!(matches!(
+            LocalFactSelectionIndex::new(&shared, &[], &[original, counterfeit]),
+            Err(LocalFactSelectionFailure::ConflictingAnonymous(found))
+                if found == identity
+        ));
+    }
+
+    #[test]
+    fn anonymous_fact_selection_resolves_empty_specialization_alias_canonically() {
+        let function = definition(
+            ModuleId::from_validated_canonical("main.rue"),
+            StableDefinitionKind::Function,
+            "probe",
+            None,
+        );
+        let canonical = crate::AnonymousNominalKey {
+            kind: crate::AnonymousNominalKind::Struct,
+            producer: crate::StableProducerId::Function(Node::new(
+                FunctionInstanceKey::Definition(function.clone()),
+            )),
+            anchor: rue_rir::RirStructuralAnchor::new(vec![
+                rue_rir::RirStructuralPathSegment::Body,
+                rue_rir::RirStructuralPathSegment::AnonymousType(0),
+            ]),
+        };
+        let mut alias = canonical.clone();
+        alias.producer =
+            crate::StableProducerId::Function(Node::new(FunctionInstanceKey::Specialization {
+                base: Node::new(FunctionInstanceKey::Definition(function.clone())),
+                arguments: crate::CanonicalArguments::default(),
+            }));
+        let nominal = DurableAnonymousNominal::new(
+            canonical.clone(),
+            DurableAnonymousNominalShape::Struct {
+                fields: Arc::from([]),
+                methods: Arc::from([]),
+            },
+            Arc::from([]),
+            Arc::from([]),
+        );
+        let shared = SharedDeclarationFactIndex::new(&[]);
+        let (index, _) = LocalFactSelectionIndex::new(&shared, &[], std::slice::from_ref(&nominal))
+            .expect("canonical fact is unique");
+        let mut selection_body = body();
+        selection_body.return_type = rue_air::SemanticImportType::AnonymousNominal(alias);
+        let selected = select_materialization_facts(
+            &FunctionInstanceKey::Definition(function.clone()),
+            &selection_body,
+            &index,
+            &AHashMap::from([(
+                FunctionInstanceKey::Definition(function),
+                Arc::from("probe"),
+            )]),
+            &mut LocalMaterializationFactInterner::default(),
+        )
+        .expect("empty-specialization spelling selects the canonical fact");
+        assert_eq!(selected.anonymous_nominals.len(), 1);
+        assert_eq!(selected.anonymous_nominals[0].identity, canonical);
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database/body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body.rs
@@ -840,6 +840,22 @@ pub(super) fn collect_durable_anonymous_nominal_dependencies(
     }
 }
 
+pub(super) fn enqueue_unselected_anonymous_dependencies(
+    selected: &BTreeMap<
+        crate::AnonymousNominalKey,
+        crate::durable_semantics::DurableAnonymousNominal,
+    >,
+    pending: &mut BTreeSet<crate::AnonymousNominalKey>,
+    dependencies: impl IntoIterator<Item = crate::AnonymousNominalKey>,
+) {
+    pending.extend(
+        dependencies
+            .into_iter()
+            .map(|dependency| dependency.with_canonical_producer().into_owned())
+            .filter(|dependency| !selected.contains_key(dependency)),
+    );
+}
+
 pub(crate) fn semantic_candidate_import_occurrences(
     rir: &rue_rir::ValidatedRir,
     symbols: &[&str],
@@ -1756,6 +1772,38 @@ impl SemanticNucleusTypeProvider<'_> {
         );
     }
 
+    pub(super) fn merge_anonymous_projections(
+        &mut self,
+        nominals: &[crate::durable_semantics::DurableAnonymousNominal],
+    ) -> Result<
+        (),
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        for nominal in nominals {
+            crate::durable_semantics::merge_anonymous_nominal(
+                &mut self.anonymous_nominals,
+                nominal,
+            )
+            .map_err(|identity| {
+                Self::provider_failure_value(format!(
+                    "conflicting durable anonymous facts for {identity:?}"
+                ))
+            })?;
+        }
+        Ok(())
+    }
+
+    fn anonymous_projection(
+        &self,
+        identity: &crate::AnonymousNominalKey,
+    ) -> Option<crate::durable_semantics::DurableAnonymousNominal> {
+        let identity = identity.with_canonical_producer();
+        self.anonymous_nominals.get(identity.as_ref()).cloned()
+    }
+
     pub(super) fn ffi_shape_failure(
         &mut self,
         ty: &crate::durable_semantics::DurableType,
@@ -2065,13 +2113,7 @@ impl SemanticNucleusTypeProvider<'_> {
                         return Err(error);
                     }
                 };
-                self.anonymous_nominals.extend(
-                    resolved
-                        .anonymous_nominals
-                        .iter()
-                        .cloned()
-                        .map(|nominal| (nominal.identity.clone(), nominal)),
-                );
+                self.merge_anonymous_projections(&resolved.anonymous_nominals)?;
                 let signature = resolved.signature;
                 let carries = match signature {
                     P::Struct {
@@ -2109,7 +2151,7 @@ impl SemanticNucleusTypeProvider<'_> {
                 Ok(carries)
             }
             T::AnonymousNominal(key) => {
-                let Some(nominal) = self.anonymous_nominals.get(key).cloned() else {
+                let Some(nominal) = self.anonymous_projection(key) else {
                     return Self::provider_failure(
                         "anonymous nominal is unavailable while checking linearity",
                     );
@@ -2285,7 +2327,7 @@ impl SemanticNucleusTypeProvider<'_> {
                 Ok(has_glue)
             }
             T::AnonymousNominal(key) => {
-                let nominal = self.anonymous_nominals.get(key).cloned().ok_or_else(|| {
+                let nominal = self.anonymous_projection(key).ok_or_else(|| {
                     Self::provider_failure_value(
                         "anonymous nominal is unavailable while checking drop glue",
                     )
@@ -2430,13 +2472,7 @@ impl SemanticNucleusTypeProvider<'_> {
                             ))
                         })?;
                 let resolved = self.resolved_signature(candidate)?;
-                self.anonymous_nominals.extend(
-                    resolved
-                        .anonymous_nominals
-                        .iter()
-                        .cloned()
-                        .map(|nominal| (nominal.identity.clone(), nominal)),
-                );
+                self.merge_anonymous_projections(&resolved.anonymous_nominals)?;
                 let is_copy = match resolved.signature {
                     P::Struct { is_copy, .. } => is_copy,
                     P::Enum { variants, .. } => {
@@ -2460,7 +2496,7 @@ impl SemanticNucleusTypeProvider<'_> {
                 Ok(is_copy)
             }
             T::AnonymousNominal(key) => {
-                let nominal = self.anonymous_nominals.get(key).cloned().ok_or_else(|| {
+                let nominal = self.anonymous_projection(key).ok_or_else(|| {
                     Self::provider_failure_value(
                         "anonymous nominal is unavailable while checking Copy",
                     )
@@ -2806,12 +2842,15 @@ impl SemanticNucleusTypeProvider<'_> {
                 ));
             };
             let resolved = provider.resolved_signature(candidate)?;
-            let anonymous = resolved
-                .anonymous_nominals
-                .iter()
-                .cloned()
-                .map(|nominal| (nominal.identity.clone(), nominal))
-                .collect::<BTreeMap<_, _>>();
+            let mut anonymous = BTreeMap::new();
+            for nominal in resolved.anonymous_nominals.iter() {
+                crate::durable_semantics::merge_anonymous_nominal(&mut anonymous, nominal)
+                    .map_err(|identity| {
+                        Self::provider_failure_value(format!(
+                            "conflicting durable anonymous facts for {identity:?}"
+                        ))
+                    })?;
+            }
             let mut neighbors = BTreeSet::new();
             match &resolved.signature {
                 P::Struct { fields, .. } => {
@@ -3091,12 +3130,7 @@ impl SemanticNucleusTypeProvider<'_> {
         let crate::durable_semantics::DurableConstValue::Type(value) = *value else {
             return Ok(None);
         };
-        self.anonymous_nominals.extend(
-            anonymous_nominals
-                .iter()
-                .cloned()
-                .map(|value| (value.identity.clone(), value)),
-        );
+        self.merge_anonymous_projections(&anonymous_nominals)?;
         self.dependencies.extend(dependencies.iter().cloned());
         let is_public = self.identity_key_visibility(&key)?;
         Ok(Some(rue_air::SemanticTypeFact {
@@ -5039,9 +5073,11 @@ impl BodyTransactionEvaluator {
             let body_payload_kinds = toolchain_demand.payload_kinds();
             let mut selected_anonymous = BTreeMap::new();
             let mut pending_anonymous = collect_instance_anonymous_nominals(&key.instance);
+            let canonical_instance = key.instance.with_collapsed_empty_specializations();
             while let Some(identity) = pending_anonymous.pop_first() {
+                let identity = identity.with_canonical_producer().into_owned();
                 if let crate::StableProducerId::Function(function) = &identity.producer
-                    && function.as_ref() != &key.instance
+                    && function.as_ref() != canonical_instance.as_ref()
                 {
                     let produced = match context.query_registered(
                         &self.body_produced_anonymous,
@@ -5069,13 +5105,21 @@ impl BodyTransactionEvaluator {
                             return Err(QueryAbort::Canceled);
                         }
                     };
-                    selected_anonymous.extend(
-                        produced
-                            .0
-                            .iter()
-                            .cloned()
-                            .map(|nominal| (nominal.identity.clone(), nominal)),
-                    );
+                    for nominal in produced.0.iter() {
+                        if let Err(identity) = crate::durable_semantics::merge_anonymous_nominal(
+                            &mut selected_anonymous,
+                            nominal,
+                        ) {
+                            *producer_transport_failure.borrow_mut() = Some(Box::new(
+                                crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
+                                    Arc::from(format!(
+                                        "conflicting durable anonymous facts for {identity:?}"
+                                    )),
+                                ),
+                            ));
+                            return Err(QueryAbort::Canceled);
+                        }
+                    }
                 }
                 if !selected_anonymous.contains_key(&identity) {
                     let query = anonymous_nominal_query_key(&identity, &key.configuration)
@@ -5093,15 +5137,27 @@ impl BodyTransactionEvaluator {
                     else {
                         return Err(QueryAbort::Canceled);
                     };
-                    selected_anonymous.insert(nominal.identity.clone(), nominal.clone());
+                    if let Err(identity) = crate::durable_semantics::merge_anonymous_nominal(
+                        &mut selected_anonymous,
+                        nominal,
+                    ) {
+                        *producer_transport_failure.borrow_mut() = Some(Box::new(
+                            crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
+                                Arc::from(format!(
+                                    "conflicting durable anonymous facts for {identity:?}"
+                                )),
+                            ),
+                        ));
+                        return Err(QueryAbort::Canceled);
+                    }
                 }
                 if let Some(nominal) = selected_anonymous.get(&identity) {
                     let mut dependencies = BTreeSet::new();
                     collect_durable_anonymous_nominal_dependencies(nominal, &mut dependencies);
-                    pending_anonymous.extend(
-                        dependencies
-                            .into_iter()
-                            .filter(|dependency| !selected_anonymous.contains_key(dependency)),
+                    enqueue_unselected_anonymous_dependencies(
+                        &selected_anonymous,
+                        &mut pending_anonymous,
+                        dependencies,
                     );
                 }
             }
@@ -5254,7 +5310,19 @@ impl BodyTransactionEvaluator {
                     };
                     option_by_payload.push((payload, option_type.clone()));
                     for nominal in projection.anonymous_nominals.iter() {
-                        nominals.insert(nominal.identity.clone(), nominal.clone());
+                        if let Err(identity) = crate::durable_semantics::merge_anonymous_nominal(
+                            &mut nominals,
+                            nominal,
+                        ) {
+                            *well_known_resolution_failure.borrow_mut() =
+                                Some(WellKnownOptionResolutionFailure::WrongProjection {
+                                    payload: payload_kind,
+                                    detail: Arc::from(format!(
+                                        "conflicting durable anonymous facts for {identity:?}"
+                                    )),
+                                });
+                            return Err(QueryAbort::Canceled);
+                        }
                     }
                 }
                 crate::body_query::WellKnownOptionResolution {
@@ -5874,35 +5942,58 @@ impl BodyTransactionEvaluator {
                                         .map(crate::body_query::BodyReference::Callable),
                                 );
                                 collect_published_body_references(&body, &mut references);
-                                let produced = produced_anonymous_nominals
+                                let mut produced = BTreeMap::new();
+                                let conflict = produced_anonymous_nominals
                                     .0
                                     .iter()
                                     .chain(locally_produced.0.iter())
-                                    .cloned()
-                                    .map(|nominal| (nominal.identity.clone(), nominal))
-                                    .collect::<BTreeMap<_, _>>();
-                                crate::body_query::BodyTransaction::Success {
-                                    body: Arc::new(
-                                        crate::body_query::CanonicalBody::Specialization {
-                                            identity,
-                                            body,
-                                            dependencies: dependencies.into(),
-                                            dependency_boundary_complete: analyzed
-                                                .export
-                                                .dependency_boundary_complete,
-                                        },
-                                    ),
-                                    references: crate::body_query::BodyReferences(
-                                        references.into_iter().collect::<Vec<_>>().into(),
-                                    ),
-                                    produced_anonymous_nominals:
-                                        crate::body_query::BodyProducedAnonymousNominals(
-                                            produced.into_values().collect::<Vec<_>>().into(),
+                                    .find_map(|nominal| {
+                                        crate::durable_semantics::merge_anonymous_nominal(
+                                            &mut produced,
+                                            nominal,
+                                        )
+                                        .err()
+                                    });
+                                if let Some(identity) = conflict {
+                                    crate::body_query::BodyTransaction::DeterministicFailure {
+                                        diagnostic_basis: None,
+                                        errors: crate::CompileErrors::from(
+                                            crate::CompileError::without_span(
+                                                rue_error::ErrorKind::OutputPublication(format!(
+                                                    "provider specialization produced conflicting anonymous facts for {identity:?}"
+                                                )),
+                                            ),
                                         ),
-                                    consulted_anonymous_nominals: consulted_anonymous_nominals
-                                        .clone(),
-                                    lookup_observations:
-                                        crate::body_query::BodyLookupObservations::default(),
+                                        references: crate::body_query::BodyReferences(
+                                            Arc::from([]),
+                                        ),
+                                        lookup_observations:
+                                            crate::body_query::BodyLookupObservations::default(),
+                                    }
+                                } else {
+                                    crate::body_query::BodyTransaction::Success {
+                                        body: Arc::new(
+                                            crate::body_query::CanonicalBody::Specialization {
+                                                identity,
+                                                body,
+                                                dependencies: dependencies.into(),
+                                                dependency_boundary_complete: analyzed
+                                                    .export
+                                                    .dependency_boundary_complete,
+                                            },
+                                        ),
+                                        references: crate::body_query::BodyReferences(
+                                            references.into_iter().collect::<Vec<_>>().into(),
+                                        ),
+                                        produced_anonymous_nominals:
+                                            crate::body_query::BodyProducedAnonymousNominals(
+                                                produced.into_values().collect::<Vec<_>>().into(),
+                                            ),
+                                        consulted_anonymous_nominals: consulted_anonymous_nominals
+                                            .clone(),
+                                        lookup_observations:
+                                            crate::body_query::BodyLookupObservations::default(),
+                                    }
                                 }
                             }
                             _ => crate::body_query::BodyTransaction::DeterministicFailure {
@@ -5936,7 +6027,8 @@ impl BodyTransactionEvaluator {
                     ))
                     .with_terminal_kind(QueryTerminalKind::Failure));
                 };
-                let Some(owner_fact) = selected_anonymous.get(owner_identity) else {
+                let canonical_owner = owner_identity.with_canonical_producer();
+                let Some(owner_fact) = selected_anonymous.get(canonical_owner.as_ref()) else {
                     return Ok(QueryOutput::success(Self::lowering_failure(
                         &definition,
                         "anonymous member owner fact is unavailable",
@@ -7095,12 +7187,23 @@ impl RevisionedQueryDatabase {
                         ..
                     } = &resolution
                     {
-                        anonymous_nominals.extend(
-                            projected
-                                .iter()
-                                .cloned()
-                                .map(|value| (value.identity.clone(), value)),
-                        );
+                        for value in projected.iter() {
+                            if let Err(identity) = crate::durable_semantics::merge_anonymous_nominal(
+                                &mut anonymous_nominals,
+                                value,
+                            ) {
+                                return Err(SemanticNucleusBatchFailure::Stable {
+                                    declaration: Some(declaration.clone()),
+                                    failure: Box::new(
+                                        crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
+                                            Arc::from(format!(
+                                                "conflicting durable anonymous facts for {identity:?}"
+                                            )),
+                                        ),
+                                    ),
+                                });
+                            }
+                        }
                         dependencies.extend(projected_dependencies.iter().cloned());
                         for gate in deferred_ownership.iter() {
                             let Value::DeferredOwnership = request(Key::DeferredOwnership(
@@ -7224,13 +7327,23 @@ impl RevisionedQueryDatabase {
                             unreachable!("deferred ownership query returned the wrong projection")
                         };
                     }
-                    anonymous_nominals.extend(
-                        signature
-                            .anonymous_nominals
-                            .iter()
-                            .cloned()
-                            .map(|value| (value.identity.clone(), value)),
-                    );
+                    for value in signature.anonymous_nominals.iter() {
+                        if let Err(identity) = crate::durable_semantics::merge_anonymous_nominal(
+                            &mut anonymous_nominals,
+                            value,
+                        ) {
+                            return Err(SemanticNucleusBatchFailure::Stable {
+                                declaration: Some(declaration.clone()),
+                                failure: Box::new(
+                                    crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
+                                        Arc::from(format!(
+                                            "conflicting durable anonymous facts for {identity:?}"
+                                        )),
+                                    ),
+                                ),
+                            });
+                        }
+                    }
                     dependencies.extend(signature.dependencies.iter().cloned());
                     let is_c_export = matches!(
                         &signature.signature,

--- a/crates/rue-compiler/src/revisioned_query_database/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/provider.rs
@@ -293,17 +293,7 @@ pub(super) struct CanonicalAnonymousNominalRegistry {
     // never iterated, so map order cannot affect the durable projection.
     pub(super) by_identity:
         AHashMap<crate::AnonymousNominalKey, Rc<crate::durable_semantics::DurableAnonymousNominal>>,
-}
-
-/// Whether an anonymous shape declares any method.
-pub(super) fn anonymous_shape_declares_methods(
-    shape: &crate::durable_semantics::DurableAnonymousNominalShape,
-) -> bool {
-    matches!(
-        shape,
-        crate::durable_semantics::DurableAnonymousNominalShape::Struct { methods, .. }
-            if !methods.is_empty()
-    )
+    conflicting: AHashSet<crate::AnonymousNominalKey>,
 }
 
 impl CanonicalAnonymousNominalRegistry {
@@ -321,21 +311,34 @@ impl CanonicalAnonymousNominalRegistry {
         nominals: impl IntoIterator<Item = &'nominal crate::durable_semantics::DurableAnonymousNominal>,
     ) {
         for nominal in nominals {
-            let identity = nominal.identity.with_canonical_producer().into_owned();
-            match self.by_identity.entry(identity) {
+            let nominal = nominal.with_canonical_identity();
+            let identity = nominal.identity.clone();
+            if self.conflicting.contains(&identity) {
+                continue;
+            }
+            match self.by_identity.entry(identity.clone()) {
                 std::collections::hash_map::Entry::Vacant(entry) => {
-                    entry.insert(Rc::new(nominal.clone()));
+                    entry.insert(Rc::new(nominal));
                 }
                 std::collections::hash_map::Entry::Occupied(mut entry) => {
-                    // A declaration projection may carry only the anonymous
-                    // shape while a later producer-body fact carries methods.
-                    // Never replace that richer authority with a thin repeat;
-                    // otherwise equal canonical producer forms could make a
-                    // later lookup repeat the producer query.
-                    if anonymous_shape_declares_methods(&nominal.shape)
-                        || !anonymous_shape_declares_methods(&entry.get().shape)
-                    {
-                        entry.insert(Rc::new(nominal.clone()));
+                    // Declaration and producer-body projections may omit
+                    // capture/method metadata they do not consume. Reconcile
+                    // only that explicit thin/rich relation; disagreeing
+                    // shapes or two different non-empty metadata payloads
+                    // poison the identity permanently.
+                    match crate::durable_semantics::reconcile_anonymous_nominals(
+                        entry.get(),
+                        &nominal,
+                    ) {
+                        Ok(reconciled) => {
+                            if entry.get().as_ref() != &reconciled {
+                                entry.insert(Rc::new(reconciled));
+                            }
+                        }
+                        Err(_) => {
+                            entry.remove();
+                            self.conflicting.insert(identity);
+                        }
                     }
                 }
             }
@@ -345,10 +348,15 @@ impl CanonicalAnonymousNominalRegistry {
     pub(super) fn get(
         &self,
         identity: &crate::AnonymousNominalKey,
-    ) -> Option<Rc<crate::durable_semantics::DurableAnonymousNominal>> {
-        self.by_identity
-            .get(identity.with_canonical_producer().as_ref())
-            .cloned()
+    ) -> Result<
+        Option<Rc<crate::durable_semantics::DurableAnonymousNominal>>,
+        crate::AnonymousNominalKey,
+    > {
+        let identity = identity.with_canonical_producer();
+        if self.conflicting.contains(identity.as_ref()) {
+            return Err(identity.into_owned());
+        }
+        Ok(self.by_identity.get(identity.as_ref()).cloned())
     }
 }
 
@@ -580,12 +588,15 @@ impl<'a> CompilerBodyDurableSource<'a> {
         }
     }
 
-    pub(super) fn anonymous_nominal(
+    fn try_anonymous_nominal(
         &self,
         key: &crate::AnonymousNominalKey,
-    ) -> Option<Rc<crate::durable_semantics::DurableAnonymousNominal>> {
+    ) -> Result<
+        Option<Rc<crate::durable_semantics::DurableAnonymousNominal>>,
+        crate::AnonymousNominalKey,
+    > {
         use rue_air::BodyFactProvider;
-        let cached = self.dynamic_anonymous.borrow().get(key);
+        let cached = self.dynamic_anonymous.borrow().get(key)?;
         let cached_has_methods = cached.as_ref().is_some_and(|nominal| {
             matches!(
                 &nominal.shape,
@@ -596,7 +607,7 @@ impl<'a> CompilerBodyDurableSource<'a> {
             )
         });
         if cached_has_methods {
-            return cached;
+            return Ok(cached);
         }
         let body_producer: Option<std::borrow::Cow<'_, crate::FunctionInstanceKey>> =
             match &key.producer {
@@ -617,8 +628,8 @@ impl<'a> CompilerBodyDurableSource<'a> {
                 Some(crate::body_query::ProducedAnonymous::Produced(produced)) => {
                     let mut dynamic = self.dynamic_anonymous.borrow_mut();
                     dynamic.extend(produced.0.iter());
-                    if let Some(nominal) = dynamic.get(key) {
-                        return Some(nominal);
+                    if let Some(nominal) = dynamic.get(key)? {
+                        return Ok(Some(nominal));
                     }
                 }
                 Some(crate::body_query::ProducedAnonymous::ProducerFailed(_)) | None => {}
@@ -638,13 +649,18 @@ impl<'a> CompilerBodyDurableSource<'a> {
                 crate::StableDefinitionKey,
                 ModuleId,
             >>::reduce_comptime_call(self, definition, &[], &[]);
-            if let Some(nominal) = self.dynamic_anonymous.borrow().get(key) {
-                return Some(nominal);
+            if let Some(nominal) = self.dynamic_anonymous.borrow().get(key)? {
+                return Ok(Some(nominal));
             }
         }
         let producer = match &key.producer {
             crate::StableProducerId::Definition(definition) => definition,
-            crate::StableProducerId::Function(function) => function_definition_key(function)?,
+            crate::StableProducerId::Function(function) => {
+                let Some(producer) = function_definition_key(function) else {
+                    return Ok(None);
+                };
+                producer
+            }
         };
         let facts = self
             .candidate(producer)
@@ -652,7 +668,29 @@ impl<'a> CompilerBodyDurableSource<'a> {
             .unwrap_or_default();
         let mut dynamic = self.dynamic_anonymous.borrow_mut();
         dynamic.extend(facts.iter());
-        dynamic.get(key).or(cached)
+        dynamic.get(key)
+    }
+
+    pub(super) fn anonymous_nominal(
+        &self,
+        key: &crate::AnonymousNominalKey,
+    ) -> Option<Rc<crate::durable_semantics::DurableAnonymousNominal>> {
+        match self.try_anonymous_nominal(key) {
+            Ok(nominal) => nominal,
+            Err(identity) => {
+                *self
+                    .provider
+                    .queries
+                    .producer_transport_failure
+                    .borrow_mut() = Some(Box::new(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(Arc::from(
+                        format!("conflicting durable anonymous facts for {identity:?}"),
+                    )),
+                ));
+                self.provider.observe_abort(QueryAbort::Canceled);
+                None
+            }
+        }
     }
 
     pub(super) fn signature(
@@ -1904,7 +1942,7 @@ pub(super) fn project_provider_produced_anonymous_nominals(
         rue_air::SemanticParameterMode::Borrow => Mode::Borrow,
         rue_air::SemanticParameterMode::Inout => Mode::Inout,
     };
-    values
+    let projected = values
         .iter()
         .map(|value| {
             let identity = value
@@ -1987,8 +2025,15 @@ pub(super) fn project_provider_produced_anonymous_nominals(
                     .into(),
             ))
         })
-        .collect::<Result<Vec<_>, _>>()
-        .map(|values| crate::body_query::BodyProducedAnonymousNominals(values.into()))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut by_identity = BTreeMap::new();
+    for nominal in &projected {
+        crate::durable_semantics::merge_complete_anonymous_nominal(&mut by_identity, nominal)
+            .map_err(|_| rue_air::SemanticStableResolutionFailure::Ambiguous)?;
+    }
+    Ok(crate::body_query::BodyProducedAnonymousNominals(
+        by_identity.into_values().collect::<Vec<_>>().into(),
+    ))
 }
 
 #[allow(dead_code)]

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_reachability.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_reachability.rs
@@ -675,13 +675,22 @@ $runtime
                                     });
                                 break;
                             };
-                            produced_anonymous.extend(
-                                produced
-                                    .0
-                                    .iter()
-                                    .cloned()
-                                    .map(|nominal| (nominal.identity.clone(), nominal)),
-                            );
+                            let conflict = produced.0.iter().find_map(|nominal| {
+                                crate::durable_semantics::merge_anonymous_nominal(
+                                    &mut produced_anonymous,
+                                    nominal,
+                                )
+                                .err()
+                            });
+                            if let Some(identity) = conflict {
+                                fatal = Some(crate::body_query::BodyClosureFatal::BodyAvailability {
+                                    instance: instance.as_ref().clone(),
+                                    detail: Arc::from(format!(
+                                        "conflicting anonymous facts for {identity:?}"
+                                    )),
+                                });
+                                break;
+                            }
                         }
                         for reference in references.0.iter() {
                             match reference {

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
@@ -432,11 +432,7 @@ $runtime
                                 substitutions: BTreeMap::new(),
                                 value_substitutions: BTreeMap::new(),
                                 deferred_value_parameters: BTreeMap::new(),
-                                anonymous_nominals: anonymous_nominals
-                                    .iter()
-                                    .cloned()
-                                    .map(|nominal| (nominal.identity.clone(), nominal))
-                                    .collect(),
+                                anonymous_nominals: BTreeMap::new(),
                                 dependency_source,
                                 dependency_kind:
                                     rue_air::DeclarationTypeDependencyKind::Signature,
@@ -444,6 +440,19 @@ $runtime
                                 deferred_ownership: BTreeSet::new(),
                                 ownership_properties: BTreeMap::new(),
                             };
+                            if let Err(error) = provider
+                                .merge_anonymous_projections(anonymous_nominals.as_ref())
+                            {
+                                match error {
+                                    rue_air::SemanticProviderError::Failure(failure) => {
+                                        return Ok(QueryOutput::success(Value::Failure(failure))
+                                            .with_terminal_kind(QueryTerminalKind::Failure));
+                                    }
+                                    rue_air::SemanticProviderError::Abort(abort) => {
+                                        return Err(abort);
+                                    }
+                                }
+                            }
                             let gate_type_name = deferred_gate_type_diagnostic_name(
                                 context,
                                 family,
@@ -1125,10 +1134,23 @@ $runtime
                                                 };
                                                 match dependency {
                                                     Value::AnonymousNominal(value) => {
-                                                        anonymous_nominals.insert(
-                                                            value.identity.clone(),
-                                                            value.clone(),
-                                                        );
+                                                        if let Err(identity) =
+                                                            crate::durable_semantics::merge_anonymous_nominal(
+                                                                &mut anonymous_nominals,
+                                                                value,
+                                                            )
+                                                        {
+                                                            return Ok(QueryOutput::success(
+                                                                Value::Failure(Failure::Resolution(
+                                                                    Arc::from(format!(
+                                                                        "conflicting durable anonymous facts for {identity:?}"
+                                                                    )),
+                                                                )),
+                                                            )
+                                                            .with_terminal_kind(
+                                                                QueryTerminalKind::Failure,
+                                                            ));
+                                                        }
                                                     }
                                                     Value::Failure(failure) => {
                                                         return Ok(QueryOutput::success(

--- a/crates/rue-compiler/src/revisioned_query_database/tests.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests.rs
@@ -6,7 +6,7 @@ use crate::{
     ImportObservation, PhysicalFileIdentity, SourceMetadata,
 };
 use rue_span::FileId;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[test]
 fn semantic_comptime_call_depth_guard_restores_after_every_exit() {
@@ -7894,11 +7894,11 @@ fn compiler_body_anonymous_registry_is_canonical_and_indexed() {
         .map(|offset| registry_start + offset)
         .expect("anonymous registry remains separate from its consumer");
     let registry = &compiler[registry_start..registry_end];
-    assert!(registry.contains("with_canonical_producer().into_owned()"));
-    assert!(registry.contains("self.by_identity\n            .get("));
+    assert!(registry.contains("with_canonical_identity()"));
+    assert!(registry.contains("self.by_identity.get(identity.as_ref()).cloned()"));
 
     let lookup_start = compiler
-        .find("pub(super) fn anonymous_nominal(")
+        .find("fn try_anonymous_nominal(")
         .expect("body provider retains anonymous lookup");
     let lookup_end = compiler[lookup_start..]
         .find("\n    pub(super) fn signature(")
@@ -7906,6 +7906,9 @@ fn compiler_body_anonymous_registry_is_canonical_and_indexed() {
         .expect("anonymous lookup stays bounded");
     let lookup = &compiler[lookup_start..lookup_end];
     assert!(lookup.contains("dynamic.get(key)"));
+    assert!(lookup.contains("try_anonymous_nominal(key)"));
+    assert!(lookup.contains("producer_transport_failure"));
+    assert!(!lookup.contains(".or(cached)"));
     assert!(!lookup.contains(".values()"));
     assert!(!lookup.contains(".iter().find("));
 }
@@ -7951,24 +7954,192 @@ fn compiler_body_anonymous_registry_unifies_producers_and_keeps_rich_facts() {
                 has_body: false,
             }]),
         },
-        Arc::from([]),
+        Arc::from([(Arc::from("T"), rue_air::SemanticImportType::I32)]),
         Arc::from([]),
     );
 
     let mut registry = CanonicalAnonymousNominalRegistry::default();
     registry.extend([&thin]);
-    let canonical_thin = registry.get(&canonical).unwrap();
-    let wrapped_thin = registry.get(&wrapped).unwrap();
-    assert_eq!(canonical_thin.as_ref(), &thin);
+    let canonical_thin = registry.get(&canonical).unwrap().unwrap();
+    let wrapped_thin = registry.get(&wrapped).unwrap().unwrap();
+    assert_eq!(canonical_thin.as_ref(), &thin.with_canonical_identity());
     assert!(Rc::ptr_eq(&canonical_thin, &wrapped_thin));
     registry.extend([&rich]);
     registry.extend([&thin]);
 
     assert_eq!(registry.by_identity.len(), 1);
-    let canonical_rich = registry.get(&canonical).unwrap();
-    let wrapped_rich = registry.get(&wrapped).unwrap();
-    assert_eq!(canonical_rich.as_ref(), &rich);
+    let canonical_rich = registry.get(&canonical).unwrap().unwrap();
+    let wrapped_rich = registry.get(&wrapped).unwrap().unwrap();
+    assert_eq!(canonical_rich.as_ref(), &rich.with_canonical_identity());
     assert!(Rc::ptr_eq(&canonical_rich, &wrapped_rich));
+
+    let counterfeit = rich.with_shape(
+        crate::durable_semantics::DurableAnonymousNominalShape::Struct {
+            fields: Arc::from([(Arc::from("counterfeit"), rue_air::SemanticImportType::I64)]),
+            methods: Arc::from([]),
+        },
+    );
+    registry.extend([&counterfeit]);
+    assert_eq!(registry.by_identity.len(), 0);
+    assert_eq!(registry.get(&canonical), Err(canonical.clone()));
+    assert_eq!(registry.get(&wrapped), Err(canonical.clone()));
+
+    let conflicting_captures = crate::durable_semantics::DurableAnonymousNominal::new(
+        canonical.clone(),
+        rich.shape.clone(),
+        Arc::from([(Arc::from("T"), rue_air::SemanticImportType::I64)]),
+        Arc::from([]),
+    );
+    let mut capture_registry = CanonicalAnonymousNominalRegistry::default();
+    capture_registry.extend([&rich]);
+    capture_registry.extend([&conflicting_captures]);
+    assert_eq!(capture_registry.by_identity.len(), 0);
+    assert_eq!(capture_registry.get(&canonical), Err(canonical));
+}
+
+#[test]
+fn anonymous_dependency_frontier_canonicalizes_aliases_before_deduplication() {
+    let canonical = anonymous_identity_for_digest_test(
+        "DependencyProducer",
+        rue_air::AnonymousNominalKind::Struct,
+    );
+    let crate::StableProducerId::Function(base) = canonical.producer.clone() else {
+        unreachable!("digest-test helper uses a function producer")
+    };
+    let mut wrapped = canonical.clone();
+    wrapped.producer =
+        crate::StableProducerId::Function(Node::new(crate::FunctionInstanceKey::Specialization {
+            base,
+            arguments: crate::CanonicalArguments::default(),
+        }));
+    let fact = crate::durable_semantics::DurableAnonymousNominal::new(
+        canonical.clone(),
+        crate::durable_semantics::DurableAnonymousNominalShape::Struct {
+            fields: Arc::from([]),
+            methods: Arc::from([]),
+        },
+        Arc::from([]),
+        Arc::from([]),
+    );
+    let selected = BTreeMap::from([(canonical.clone(), fact)]);
+    let mut pending = BTreeSet::new();
+    enqueue_unselected_anonymous_dependencies(
+        &selected,
+        &mut pending,
+        [wrapped.clone(), canonical.clone()],
+    );
+    assert!(
+        pending.is_empty(),
+        "an alias of a selected identity must not re-enter the frontier"
+    );
+
+    enqueue_unselected_anonymous_dependencies(
+        &BTreeMap::new(),
+        &mut pending,
+        [wrapped, canonical.clone()],
+    );
+    assert_eq!(pending, BTreeSet::from([canonical]));
+}
+
+#[test]
+fn provider_produced_anonymous_projection_rejects_conflicting_duplicate_identity() {
+    let token = rue_air::SemanticDefinitionToken::new(4, 2);
+    let base = rue_air::FunctionInstanceKey::Definition(token);
+    let direct = rue_air::AnonymousNominalKey {
+        kind: rue_air::AnonymousNominalKind::Struct,
+        producer: rue_air::StableProducerId::Function(rue_air::Node::new(base.clone())),
+        anchor: rue_rir::RirStructuralAnchor::new(vec![
+            rue_rir::RirStructuralPathSegment::Body,
+            rue_rir::RirStructuralPathSegment::AnonymousType(0),
+        ]),
+    };
+    let mut alias = direct.clone();
+    alias.producer = rue_air::StableProducerId::Function(rue_air::Node::new(
+        rue_air::FunctionInstanceKey::Specialization {
+            base: rue_air::Node::new(base),
+            arguments: rue_air::CanonicalArguments::default(),
+        },
+    ));
+    let produced = |identity, field, ty| rue_air::SemanticProducedAnonymousNominal {
+        identity,
+        shape: rue_air::SemanticProducedAnonymousNominalShape::Struct {
+            fields: Arc::from([(Arc::from(field), ty)]),
+            methods: Arc::from([]),
+        },
+        type_captures: Arc::from([]),
+        value_captures: Arc::from([]),
+    };
+    let definitions = AHashMap::from([(
+        token,
+        crate::StableDefinitionKey::from_stable_parts(
+            ModuleId::from_validated_canonical("main.rue"),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "producer",
+            None,
+        ),
+    )]);
+    let result = project_provider_produced_anonymous_nominals(
+        &[
+            produced(direct, "a", rue_air::TypeInstanceKey::I32),
+            produced(alias, "b", rue_air::TypeInstanceKey::I64),
+        ],
+        &definitions,
+        &AHashMap::new(),
+    );
+    assert_eq!(
+        result,
+        Err(rue_air::SemanticStableResolutionFailure::Ambiguous)
+    );
+}
+
+#[test]
+fn provider_produced_anonymous_projection_rejects_relocated_thin_rich_duplicate() {
+    let first_token = rue_air::SemanticDefinitionToken::new(4, 2);
+    let second_token = rue_air::SemanticDefinitionToken::new(5, 2);
+    let identity = |token| rue_air::AnonymousNominalKey {
+        kind: rue_air::AnonymousNominalKind::Struct,
+        producer: rue_air::StableProducerId::Function(rue_air::Node::new(
+            rue_air::FunctionInstanceKey::Definition(token),
+        )),
+        anchor: rue_rir::RirStructuralAnchor::new(vec![
+            rue_rir::RirStructuralPathSegment::Body,
+            rue_rir::RirStructuralPathSegment::AnonymousType(0),
+        ]),
+    };
+    let produced = |token, type_captures| rue_air::SemanticProducedAnonymousNominal {
+        identity: identity(token),
+        shape: rue_air::SemanticProducedAnonymousNominalShape::Struct {
+            fields: Arc::from([(Arc::from("value"), rue_air::TypeInstanceKey::I32)]),
+            methods: Arc::from([]),
+        },
+        type_captures,
+        value_captures: Arc::from([]),
+    };
+    let thin = produced(first_token, Arc::from([]));
+    let rich = produced(
+        second_token,
+        Arc::from([(Arc::from("T"), rue_air::TypeInstanceKey::I32)]),
+    );
+    let stable_producer = crate::StableDefinitionKey::from_stable_parts(
+        ModuleId::from_validated_canonical("main.rue"),
+        crate::StableDefinitionNamespace::Value,
+        crate::StableDefinitionKind::Function,
+        "producer",
+        None,
+    );
+    let definitions = AHashMap::from([
+        (first_token, stable_producer.clone()),
+        (second_token, stable_producer),
+    ]);
+
+    for produced in [[thin.clone(), rich.clone()], [rich.clone(), thin.clone()]] {
+        assert_eq!(
+            project_provider_produced_anonymous_nominals(&produced, &definitions, &AHashMap::new(),),
+            Err(rue_air::SemanticStableResolutionFailure::Ambiguous),
+            "complete provider publications must conflict after token relocation in either order"
+        );
+    }
 }
 
 #[test]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -5094,12 +5094,16 @@ impl CompilerSession {
             errors.extend(fatal_errors.iter().cloned());
         }
 
-        let mut anonymous = projection
-            .anonymous_nominals
-            .iter()
-            .cloned()
-            .map(|fact| (fact.identity.clone(), fact))
-            .collect::<BTreeMap<_, _>>();
+        let mut anonymous = BTreeMap::new();
+        for fact in projection.anonymous_nominals.iter() {
+            if let Err(identity) =
+                crate::durable_semantics::merge_anonymous_nominal(&mut anonymous, fact)
+            {
+                errors.push(CompileError::without_span(ErrorKind::OutputPublication(
+                    format!("conflicting anonymous facts for {identity:?}"),
+                )));
+            }
+        }
         for closure_body in closure.bodies.iter() {
             let rue_query::QueryOutcome::Success(bundle) = closure_body.bundle.outcome() else {
                 unreachable!("BodyAnalysisBundle publishes typed values")
@@ -5143,14 +5147,26 @@ impl CompilerSession {
                     .iter()
                     .chain(consulted_anonymous_nominals.0.iter())
                 {
-                    anonymous.insert(fact.identity.clone(), fact.clone());
+                    if let Err(identity) =
+                        crate::durable_semantics::merge_anonymous_nominal(&mut anonymous, fact)
+                    {
+                        errors.push(CompileError::without_span(ErrorKind::OutputPublication(
+                            format!("conflicting anonymous facts for {identity:?}"),
+                        )));
+                    }
                 }
             }
             if let Some(crate::body_query::ProducedAnonymous::Produced(produced)) =
                 &bundle.produced_anonymous
             {
                 for fact in produced.0.iter() {
-                    anonymous.insert(fact.identity.clone(), fact.clone());
+                    if let Err(identity) =
+                        crate::durable_semantics::merge_anonymous_nominal(&mut anonymous, fact)
+                    {
+                        errors.push(CompileError::without_span(ErrorKind::OutputPublication(
+                            format!("conflicting anonymous facts for {identity:?}"),
+                        )));
+                    }
                 }
             }
         }
@@ -5484,7 +5500,12 @@ impl CompilerSession {
                 &graph.declaration_index,
                 &graph.declarations,
                 &graph.anonymous_nominals,
-            );
+            )
+            .map_err(|error| {
+                CompileError::without_span(ErrorKind::OutputPublication(format!(
+                    "CFG materialization index rejected anonymous facts: {error:?}"
+                )))
+            })?;
         work.cfg.materialization_index_builds += 1;
         work.cfg.materialization_declarations_scanned += index_work.declarations_scanned;
         work.cfg.materialization_anonymous_nominals_scanned +=


### PR DESCRIPTION
## Summary

- replace semantic hash-iteration boundaries with deterministic ordering and canonical anonymous-nominal selection
- reject conflicting durable semantic facts instead of allowing insertion order to choose a winner
- preserve source-order array allocation while keeping narrow, documented AHash boundaries
- add randomized and durable-query regressions for fresh, retained, and reordered execution paths

## Validation

- `scripts/rue premerge` (203 passed)
- `scripts/rue quick` (33 passed)
- full Rue AIR unit suite (811 passed)
- full Rue compiler unit suite (1,134 passed, 43 ignored)
- focused deterministic-boundary and anonymous-nominal regressions
- AIR and compiler clippy targets

Fixes RUE-1626.