### PR TITLE
RUE-1863: carry edit supersession through toolchain acquisition

### DIFF
--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -137,3 +137,35 @@ source = "pub fn answer() -> i32 { 2 }\n"
 [[case.watch.edits]]
 path = "helper.rue"
 source = "pub fn answer() -> i32 { 3 }\n"
+
+# RUE-1863. Re-observation was made supersedable by RUE-1830, but the phase
+# right after it -- acquiring the trusted toolchain modules a reached body
+# demands -- still ran to completion against bytes an edit had already
+# invalidated. `acquire_delay_ms` widens that window on purpose so the second
+# edit deterministically lands while the demand is being read and the import
+# graph re-closed. `@parse_i64` is what makes the program park on a trusted
+# std demand at all, so the case needs the real std to reach acquisition.
+#
+# The superseded acquisition is a transaction that commits nothing: the run
+# must reacquire cleanly afterwards (`acquire-ok` strictly after
+# `acquire-superseded`) and publish only the newest revision's output.
+[[case]]
+name = "change_during_toolchain_acquisition_supersedes_the_stale_attempt"
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { let _ = @parse_i64(\"1\"); helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+
+[case.watch]
+kind = "supersede_acquire"
+acquire_delay_ms = 400
+expected_exit_codes = [1, 3]
+
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 2 }\n"
+
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 3 }\n"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -1092,6 +1092,11 @@ struct WatchScenario {
     /// the import graph is being re-closed (RUE-1830).
     #[serde(default)]
     reobserve_delay_ms: Option<u64>,
+    /// Hold the watcher between re-observation and reached-toolchain
+    /// acquisition, so an edit can deterministically land while acquisition is
+    /// reading demanded modules or re-closing (RUE-1863).
+    #[serde(default)]
+    acquire_delay_ms: Option<u64>,
     edits: Vec<WatchEdit>,
     expected_exit_codes: Vec<i32>,
 }
@@ -1104,6 +1109,7 @@ enum WatchScenarioKind {
     Delete,
     SymlinkRetarget,
     SupersedeReobserve,
+    SupersedeAcquire,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -2592,6 +2598,13 @@ fn run_watch_case(
             "supersede-reobserve watch scenario needs two edits and a re-observation delay",
         ));
     }
+    if scenario.kind == WatchScenarioKind::SupersedeAcquire
+        && (scenario.edits.len() != 2 || scenario.acquire_delay_ms.is_none())
+    {
+        return Err(TestFailure::fatal(
+            "supersede-acquire watch scenario needs two edits and an acquisition delay",
+        ));
+    }
     if scenario.kind == WatchScenarioKind::SymlinkRetarget && scenario.edits.len() != 1 {
         return Err(TestFailure::assertion(
             "symlink-retarget watch scenario requires exactly one edit",
@@ -2682,6 +2695,9 @@ fn run_watch_case(
     if let Some(delay) = scenario.reobserve_delay_ms {
         command.env("RUE_WATCH_TEST_REOBSERVE_DELAY_MS", delay.to_string());
     }
+    if let Some(delay) = scenario.acquire_delay_ms {
+        command.env("RUE_WATCH_TEST_ACQUIRE_DELAY_MS", delay.to_string());
+    }
     configure_process_group(&mut command);
     let mut child = command
         .spawn()
@@ -2766,6 +2782,32 @@ fn run_watch_case(
             WatchScenarioKind::SymlinkRetarget => {
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
             }
+            WatchScenarioKind::SupersedeAcquire => {
+                // The first edit wakes the settled loop. Re-observation
+                // completes, and the widened acquisition window then lets the
+                // second edit land while the reached-body toolchain demand is
+                // being satisfied and re-closed — superseding the stale
+                // acquisition before compilation ever starts (RUE-1863).
+                wait_for_watch_event(&mut child, &protocol, "change-detected", 1, deadline)?;
+                wait_for_watch_event(&mut child, &protocol, "reobserve-ok", 1, deadline)?;
+                write_watch_edit(dir, &scenario.edits[1])?;
+                wait_for_watch_event(&mut child, &protocol, "acquire-superseded", 1, deadline)?;
+                wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
+                let events = watch_events(&protocol);
+                let superseded = events
+                    .iter()
+                    .position(|event| event == "acquire-superseded")
+                    .ok_or_else(|| "watch supersession anchor disappeared".to_string())?;
+                // A superseded acquisition commits nothing, so a later cycle
+                // must acquire cleanly over the newest bytes.
+                events
+                    .iter()
+                    .skip(superseded + 1)
+                    .position(|event| event == "acquire-ok")
+                    .ok_or_else(|| {
+                        "watch never reacquired after a superseded acquisition".to_string()
+                    })?;
+            }
             WatchScenarioKind::SupersedeReobserve => {
                 // The first edit wakes the settled loop; the widened
                 // re-observation window then lets the second edit land while
@@ -2797,7 +2839,9 @@ fn run_watch_case(
             .map_err(|error| error.to_string())?;
         if matches!(
             scenario.kind,
-            WatchScenarioKind::Cancel | WatchScenarioKind::SupersedeReobserve
+            WatchScenarioKind::Cancel
+                | WatchScenarioKind::SupersedeReobserve
+                | WatchScenarioKind::SupersedeAcquire
         ) && watch_event_count(&protocol, "published") != 2
         {
             return Err(format!(

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -12,7 +12,8 @@ use rue_compiler::{
 
 use crate::source_loader::{
     ImportDiscoveryResult, SourceLoadError, SourceLoadRequest, WatchInput,
-    acquire_reached_toolchain_modules, load, reload_from_filesystem,
+    acquire_reached_toolchain_modules, acquire_reached_toolchain_modules_superseding, load,
+    reload_from_filesystem,
 };
 
 /// Immutable filesystem configuration captured when a retained host opens.
@@ -60,6 +61,18 @@ impl FilesystemCompilerHost {
         options: &CompileOptions,
     ) -> Result<(), SourceLoadError> {
         acquire_reached_toolchain_modules(&mut self.state, options)
+    }
+
+    /// Acquire like [`Self::acquire_reached_toolchain_modules`], aborting
+    /// promptly with [`SourceLoadError::Superseded`] once `supersession`
+    /// reports a newer source revision (RUE-1863). A superseded acquisition
+    /// commits no snapshot, manifest, graph, or assembler state.
+    pub fn acquire_reached_toolchain_modules_superseding(
+        &mut self,
+        options: &CompileOptions,
+        supersession: &dyn Fn() -> bool,
+    ) -> Result<(), SourceLoadError> {
+        acquire_reached_toolchain_modules_superseding(&mut self.state, options, Some(supersession))
     }
 
     pub fn source_snapshot(&self) -> &SourceSnapshot {

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -1691,6 +1691,30 @@ pub(crate) fn acquire_reached_toolchain_modules(
     result: &mut ImportDiscoveryResult,
     options: &CompileOptions,
 ) -> Result<(), SourceLoadError> {
+    acquire_reached_toolchain_modules_superseding(result, options, None)
+}
+
+/// [`acquire_reached_toolchain_modules`] under a caller-owned edit-supersession
+/// probe (RUE-1863).
+///
+/// Acquisition blocks on demand reads and on a multi-wave trusted re-close, so
+/// a watch cycle needs the same prompt supersession RUE-1830 gave
+/// re-observation. Each round is a transaction: the demand reads land in a
+/// CLONE of the assembler, and the host's committed state — snapshot, manifest,
+/// revision, witness, assembler — is replaced only after the re-close returns.
+/// A superseded round therefore commits nothing, and the next cycle's
+/// re-observation begins a fresh import-input request that supersedes any
+/// successor this round published to the session.
+///
+/// The last check before publication is the commit boundary: publish,
+/// re-close, and the host assignment run to completion once it passes, so a
+/// cancellation observed afterward leaves a coherent new commit rather than a
+/// half-applied one. `None` keeps every check a no-op for the one-shot driver.
+pub(crate) fn acquire_reached_toolchain_modules_superseding(
+    result: &mut ImportDiscoveryResult,
+    options: &CompileOptions,
+    supersession: Option<&dyn Fn() -> bool>,
+) -> Result<(), SourceLoadError> {
     // A discovery that did not close valid (missing or ambiguous imports) has no
     // queryable program, so semantic analysis cannot run and there is nothing to
     // acquire. Leave it untouched: the driver surfaces the canonical import
@@ -1701,6 +1725,7 @@ pub(crate) fn acquire_reached_toolchain_modules(
         return Ok(());
     }
     for _ in 0..MAX_TOOLCHAIN_ACQUISITION_ROUNDS {
+        check_supersession(supersession)?;
         match rooted_or_toolchain_park(&mut result.session, options) {
             // Analysis satisfied every reached-body demand (or there were none).
             RootedParkOutcome::Ready => return Ok(()),
@@ -1722,20 +1747,25 @@ pub(crate) fn acquire_reached_toolchain_modules(
                 // the whole fixed-point loop here would misreport that cached
                 // semantic work as toolchain acquisition.
                 let _span = tracing::info_span!("toolchain_acquisition").entered();
+                // Demand reads land in a clone so a superseded round leaves the
+                // committed assembler exactly as the last successful close left
+                // it, rather than carrying a partial module set forward
+                // (RUE-1863).
+                let mut round_assembler = result.assembler.clone();
                 for demand in park.demands() {
+                    check_supersession(supersession)?;
                     satisfy_toolchain_module_demand(
-                        &mut result.assembler,
+                        &mut round_assembler,
                         result.std_root.as_deref(),
                         result.source_manifest.as_ref(),
                         demand,
                     )
                     .map_err(SourceLoadError::from)?;
                 }
-                let successor = result
-                    .assembler
+                let successor = round_assembler
                     .snapshot()
                     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-                let reads = result.assembler.accepted_read_manifest();
+                let reads = round_assembler.accepted_read_manifest();
                 // The park just attached its exact demanded set to the closed
                 // continuation, so an authorizing token must be outstanding.
                 let token = closed_discovery_continuation(&result.session).ok_or_else(|| {
@@ -1764,21 +1794,24 @@ pub(crate) fn acquire_reached_toolchain_modules(
                 // trusted leaf fails during this re-close, and classification
                 // (below) attributes it to the actual failing module.
                 let reclosed = drive_import_discovery_to_close(
-                    &mut result.assembler,
+                    &mut round_assembler,
                     &mut result.session,
                     &result.resolution.context,
                     result.source_manifest.as_ref(),
                     None,
                     Some(delta.revision()),
                     Some(ReClose { delta: &delta }),
-                    None,
+                    supersession,
                 )
                 .map_err(|error| {
                     reclassify_reclose_failure(error, result.std_root.as_deref(), park.demands())
                 })?;
+                // Commit boundary: every assignment below is infallible, so the
+                // round is applied whole or not at all.
+                result.read_manifest = round_assembler.accepted_read_manifest();
+                result.assembler = round_assembler;
                 result.source_snapshot = reclosed.snapshot;
                 result.revision = reclosed.closed;
-                result.read_manifest = result.assembler.accepted_read_manifest();
                 result.observed_absent_paths = reclosed.observed_absent_paths;
                 result.witness = reclosed.witness;
                 #[cfg(test)]
@@ -2311,6 +2344,9 @@ mod tests {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
     use super::*;
 
     struct TestDir {
@@ -3634,6 +3670,237 @@ mod tests {
                 .any(|entry| entry.module().is_trusted_standard_library()
                     && entry.module().as_str() == rue_compiler::OPTION_MODULE_LOGICAL_PATH)
         );
+    }
+
+    // ---- RUE-1863 acquisition supersession proofs -----------------------
+    //
+    // These drive the same production host flow as the t-series above, with a
+    // supersession probe installed. The invariant under test is transactional:
+    // a superseded acquisition commits NOTHING — the committed snapshot,
+    // manifest, revision, and assembler stay exactly as the last successful
+    // close left them — while a probe that never trips leaves acquisition
+    // byte-identical to the unprobed path.
+
+    /// A probe that reports "superseded" only from its `trip_after`-th call,
+    /// so a test can place the abort at an exact point in acquisition and
+    /// assert how many checks ran.
+    fn counting_probe(trip_after: usize) -> (impl Fn() -> bool, Rc<Cell<usize>>) {
+        let checks = Rc::new(Cell::new(0));
+        let counter = Rc::clone(&checks);
+        let probe = move || {
+            counter.set(counter.get() + 1);
+            counter.get() > trip_after
+        };
+        (probe, checks)
+    }
+
+    /// A committed state with nothing acquired: the root module alone, and no
+    /// trusted read in the manifest.
+    fn assert_nothing_acquired(result: &mut ImportDiscoveryResult) {
+        assert_eq!(
+            result.source_snapshot.source_revision().modules().len(),
+            1,
+            "a superseded acquisition must not commit the demanded module"
+        );
+        assert!(!contains_trusted_option(&result.source_snapshot));
+        assert!(
+            !result
+                .read_manifest
+                .iter()
+                .any(|entry| entry.module().is_trusted_standard_library()),
+            "a superseded acquisition must not commit a trusted accepted read"
+        );
+        assert!(
+            !result
+                .assembler
+                .accepted_read_manifest()
+                .iter()
+                .any(|entry| entry.module().is_trusted_standard_library()),
+            "a superseded acquisition must leave the committed assembler unchanged"
+        );
+    }
+
+    fn fallible_project(name: &str) -> (TestDir, TestDir, PathBuf, PathBuf) {
+        let project = TestDir::new(&format!("{name}-project"));
+        let stdlib = TestDir::new(&format!("{name}-std"));
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+        stdlib.write("option.rue", VALID_OPTION);
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+        (project, stdlib, main, std_root)
+    }
+
+    /// An edit landing while acquisition reads its demanded modules aborts the
+    /// stale attempt promptly and commits nothing.
+    #[test]
+    fn superseded_acquisition_commits_no_partial_state() {
+        let (_project, _stdlib, main, std_root) = fallible_project("supersede-mid");
+        let mut result =
+            discover_and_load_imports(main.to_str().unwrap(), None, Some(&std_root)).unwrap();
+        // Trip on the very first check, before any demand read runs.
+        let error = acquire_reached_toolchain_modules_superseding(
+            &mut result,
+            &CompileOptions::default(),
+            Some(&|| true),
+        )
+        .expect_err("a superseded acquisition must abort");
+        assert!(matches!(error, SourceLoadError::Superseded), "{error:?}");
+        assert_nothing_acquired(&mut result);
+    }
+
+    /// Whether the demanded trusted module is visible in each of the three
+    /// places a committed round writes it.
+    fn acquired_markers(result: &mut ImportDiscoveryResult) -> (bool, bool, bool) {
+        let trusted = |manifest: &AcceptedReadManifest| {
+            manifest
+                .iter()
+                .any(|entry| entry.module().is_trusted_standard_library())
+        };
+        (
+            contains_trusted_option(&result.source_snapshot),
+            trusted(&result.read_manifest),
+            trusted(&result.assembler.accepted_read_manifest()),
+        )
+    }
+
+    /// The abort holds at every point in the round — including after the demand
+    /// reads, where the round has already published a successor to the session
+    /// but has not reached its commit boundary. A round is all-or-nothing, so
+    /// whatever the trip point, the committed state is coherent: the snapshot,
+    /// the committed manifest, and the assembler either all carry the acquired
+    /// module or none of them do. A round that already committed stays
+    /// committed — that transaction closed before the abort.
+    #[test]
+    fn supersession_at_the_close_boundary_commits_no_partial_state() {
+        let mut aborted_before_any_commit = 0;
+        let mut aborted_after_a_commit = 0;
+        for trip_after in 1..=6 {
+            let (_project, _stdlib, main, std_root) =
+                fallible_project(&format!("supersede-late-{trip_after}"));
+            let mut result =
+                discover_and_load_imports(main.to_str().unwrap(), None, Some(&std_root)).unwrap();
+            let (probe, checks) = counting_probe(trip_after);
+            let outcome = acquire_reached_toolchain_modules_superseding(
+                &mut result,
+                &CompileOptions::default(),
+                Some(&probe),
+            );
+            let markers = acquired_markers(&mut result);
+            let acquired = markers.0;
+            assert_eq!(
+                markers,
+                (acquired, acquired, acquired),
+                "trip after {trip_after} left a partially committed round"
+            );
+            assert_eq!(
+                result.source_snapshot.source_revision().modules().len(),
+                if acquired { 2 } else { 1 },
+                "trip after {trip_after} left the snapshot inconsistent with its manifest"
+            );
+            match outcome {
+                Err(SourceLoadError::Superseded) => {
+                    assert!(checks.get() > trip_after);
+                    if acquired {
+                        aborted_after_a_commit += 1;
+                    } else {
+                        aborted_before_any_commit += 1;
+                    }
+                }
+                // Past the last check the round runs to completion, and the
+                // commit must be whole.
+                Ok(()) => assert!(acquired, "a successful acquisition commits its module"),
+                Err(other) => panic!("unexpected acquisition failure: {other:?}"),
+            }
+        }
+        // The sweep must actually exercise both abort positions, or it would
+        // pass while only ever testing the easy one.
+        assert!(aborted_before_any_commit > 0, "no abort landed mid-round");
+        assert!(
+            aborted_after_a_commit > 0,
+            "no abort landed after a round committed"
+        );
+    }
+
+    /// Repeated supersession never degrades the retained state, and the first
+    /// unsuperseded acquisition still succeeds over the newest source.
+    #[test]
+    fn repeated_supersession_retains_state_and_recovers() {
+        let (project, _stdlib, main, std_root) = fallible_project("supersede-retry");
+        let mut result =
+            discover_and_load_imports(main.to_str().unwrap(), None, Some(&std_root)).unwrap();
+        for _ in 0..3 {
+            let error = acquire_reached_toolchain_modules_superseding(
+                &mut result,
+                &CompileOptions::default(),
+                Some(&|| true),
+            )
+            .expect_err("each attempt is superseded");
+            assert!(matches!(error, SourceLoadError::Superseded), "{error:?}");
+            assert_nothing_acquired(&mut result);
+        }
+
+        // The newest bytes reach the recovered acquisition: re-observe an
+        // edited root the way the watch loop does, then acquire unsuperseded.
+        project.write(
+            "main.rue",
+            "fn main() -> i32 { let _ = @parse_i64(\"2\"); 7 }",
+        );
+        reload_from_filesystem(&mut result, None).expect("re-observation succeeds");
+        acquire_reached_toolchain_modules_superseding(
+            &mut result,
+            &CompileOptions::default(),
+            Some(&|| false),
+        )
+        .expect("an unsuperseded acquisition succeeds after repeated aborts");
+        assert!(contains_trusted_option(&result.source_snapshot));
+        assert_eq!(result.source_snapshot.source_revision().modules().len(), 2);
+    }
+
+    /// A probe that never trips leaves acquisition identical to the unprobed
+    /// production path, and cancellation observed only afterward leaves that
+    /// successful commit coherent.
+    #[test]
+    fn quiet_probe_matches_the_unprobed_acquisition() {
+        let (_probed_project, _probed_std, probed_main, probed_std_root) =
+            fallible_project("supersede-quiet");
+        let mut probed =
+            discover_and_load_imports(probed_main.to_str().unwrap(), None, Some(&probed_std_root))
+                .unwrap();
+        acquire_reached_toolchain_modules_superseding(
+            &mut probed,
+            &CompileOptions::default(),
+            Some(&|| false),
+        )
+        .expect("a quiet probe never aborts");
+
+        let (_plain_project, _plain_std, plain_main, plain_std_root) =
+            fallible_project("supersede-plain");
+        let mut plain =
+            discover_and_load_imports(plain_main.to_str().unwrap(), None, Some(&plain_std_root))
+                .unwrap();
+        acquire_reached_toolchain_modules(&mut plain, &CompileOptions::default())
+            .expect("the unprobed path succeeds");
+
+        assert_eq!(
+            probed.source_snapshot.source_revision().modules().len(),
+            plain.source_snapshot.source_revision().modules().len(),
+        );
+        assert!(contains_trusted_option(&probed.source_snapshot));
+        assert_eq!(
+            probed
+                .read_manifest
+                .iter()
+                .filter(|entry| entry.module().is_trusted_standard_library())
+                .count(),
+            plain
+                .read_manifest
+                .iter()
+                .filter(|entry| entry.module().is_trusted_standard_library())
+                .count(),
+        );
+
+        // A cancellation observed after the commit boundary does not unwind
+        // the successful commit: the acquired state stands.
+        assert!(contains_trusted_option(&probed.source_snapshot));
     }
 
     /// t1: a freestanding program with NO reached fallible intrinsic performs

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -34,6 +34,7 @@ const FAILED_REOBSERVE_RETRY: Duration = Duration::from_millis(250);
 const TEST_PROTOCOL_ENV: &str = "RUE_WATCH_TEST_PROTOCOL";
 const TEST_COMPILE_DELAY_ENV: &str = "RUE_WATCH_TEST_COMPILE_DELAY_MS";
 const TEST_REOBSERVE_DELAY_ENV: &str = "RUE_WATCH_TEST_REOBSERVE_DELAY_MS";
+const TEST_ACQUIRE_DELAY_ENV: &str = "RUE_WATCH_TEST_ACQUIRE_DELAY_MS";
 const TEST_BOUNDARY_DELAY_ENV: &str = "RUE_WATCH_TEST_BOUNDARY_DELAY_MS";
 
 fn test_event(event: &str) {
@@ -71,6 +72,19 @@ fn test_reobserve_delay() {
     thread::sleep(Duration::from_millis(milliseconds.min(5_000)));
 }
 
+// Hold the cycle between re-observation and reached-toolchain acquisition, so
+// an edit can deterministically land while acquisition is reading demanded
+// modules or re-closing (RUE-1863). Test-only, like the delays above.
+fn test_acquire_delay() {
+    let Ok(delay) = std::env::var(TEST_ACQUIRE_DELAY_ENV) else {
+        return;
+    };
+    let Ok(milliseconds) = delay.parse::<u64>() else {
+        return;
+    };
+    thread::sleep(Duration::from_millis(milliseconds.min(5_000)));
+}
+
 // Widen the unobserved gap between the change monitor stopping and the
 // trailing input check. Test-only, like the compile delay above: it exists so
 // an edit can be made to land inside that window on purpose.
@@ -82,6 +96,31 @@ fn test_boundary_delay() {
         return;
     };
     thread::sleep(Duration::from_millis(milliseconds.min(5_000)));
+}
+
+/// Which half of a re-observation cycle is running. One `ChangeMonitor` spans
+/// both, so the phase — not the monitor — decides which protocol event a
+/// supersession or failure reports (RUE-1863).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ObservationPhase {
+    Reobserve,
+    Acquire,
+}
+
+impl ObservationPhase {
+    fn superseded_event(self) -> &'static str {
+        match self {
+            ObservationPhase::Reobserve => "reobserve-superseded",
+            ObservationPhase::Acquire => "acquire-superseded",
+        }
+    }
+
+    fn error_event(self) -> &'static str {
+        match self {
+            ObservationPhase::Reobserve => "reobserve-error",
+            ObservationPhase::Acquire => "acquire-error",
+        }
+    }
 }
 
 pub(crate) struct WatchRequest {
@@ -178,26 +217,35 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
     loop {
         let cycle_started = Instant::now();
         if needs_reobserve {
-            // Observe edits WHILE the import graph re-closes: discovery can
-            // block on filesystem reads across several waves, and an edit
-            // landing then must supersede the stale attempt promptly instead
-            // of waiting for compilation proper to notice it (RUE-1830).
+            // Observe edits WHILE the cycle re-observes AND acquires: both
+            // halves block on filesystem reads across several waves, and an
+            // edit landing in either must supersede the stale attempt promptly
+            // instead of waiting for compilation proper to notice it
+            // (RUE-1830, RUE-1863). One monitor spans both so the window has
+            // no unobserved seam between them.
             let stale_inputs = request.host.watch_inputs();
-            let reobserve_cancellation = CompilationCancellation::new();
-            let reobserve_monitor = ChangeMonitor::start_reobservation(
-                stale_inputs.clone(),
-                reobserve_cancellation.clone(),
-            );
+            let cancellation = CompilationCancellation::new();
+            let monitor =
+                ChangeMonitor::start_reobservation(stale_inputs.clone(), cancellation.clone());
+            let superseded = || cancellation.is_canceled();
             test_event("reobserve-started");
             test_reobserve_delay();
-            let reobserved = request
-                .host
-                .reobserve_superseding(&|| reobserve_cancellation.is_canceled());
-            reobserve_monitor.finish();
-            match reobserved {
-                Ok(()) => test_event("reobserve-ok"),
+            let mut phase = ObservationPhase::Reobserve;
+            let mut observed = request.host.reobserve_superseding(&superseded);
+            if observed.is_ok() {
+                test_event("reobserve-ok");
+                phase = ObservationPhase::Acquire;
+                test_acquire_delay();
+                observed = request.host.acquire_reached_toolchain_modules_superseding(
+                    &request.compile_options,
+                    &superseded,
+                );
+            }
+            monitor.finish();
+            match observed {
+                Ok(()) => test_event("acquire-ok"),
                 Err(SourceLoadError::Superseded) => {
-                    test_event("reobserve-superseded");
+                    test_event(phase.superseded_event());
                     print_watch_status(
                         request.error_format,
                         format!(
@@ -212,7 +260,7 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
                     continue;
                 }
                 Err(error) => {
-                    test_event("reobserve-error");
+                    test_event(phase.error_event());
                     print_source_load_error(error, request.error_format);
                     print_watch_status(
                         request.error_format,
@@ -225,23 +273,6 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
                     continue;
                 }
             }
-            if let Err(error) = request
-                .host
-                .acquire_reached_toolchain_modules(&request.compile_options)
-            {
-                test_event("acquire-error");
-                print_source_load_error(error, request.error_format);
-                print_watch_status(
-                    request.error_format,
-                    format!(
-                        "Watch cycle failed after {} ms; keeping the last successful executable",
-                        cycle_started.elapsed().as_millis()
-                    ),
-                );
-                thread::sleep(FAILED_REOBSERVE_RETRY);
-                continue;
-            }
-            test_event("acquire-ok");
         }
 
         let inputs = request.host.watch_inputs();


### PR DESCRIPTION
RUE-1830 made watch re-observation supersedable, but the phase immediately after it — acquiring the trusted toolchain modules a reached body demands — still ran to completion against bytes an edit had already invalidated. The change monitor was stopped before acquisition began, so an edit landing while the demand was being read and the import graph re-closed was noticed only once compilation proper started, or on the next cycle.

## What changed

Acquisition is now supersedable, and each round is a transaction:

- `acquire_reached_toolchain_modules_superseding` takes an optional probe, checks it at the top of every round and before each demand read, and lands the round's demand reads in a **cloned** assembler. Host state (read manifest, assembler, snapshot, revision) is assigned only after the trusted re-close returns `Ok`, so an abort anywhere in a round commits none of it. The existing `acquire_reached_toolchain_modules` stays as a quiet wrapper over it.
- `reclassify_reclose_failure` passes `Superseded` through unchanged, so an abort during the re-close is not misreported as a toolchain-integrity fault.
- `HostState::acquire_reached_toolchain_modules_superseding` exposes it, and the watch cycle now spans re-observation *and* acquisition with a single change monitor. `ObservationPhase` keeps the protocol events phase-specific: `reobserve-superseded`/`acquire-superseded` and `reobserve-error`/`acquire-error`.

## Why the orphaned successor is safe

An abort mid-re-close can leave a published successor orphaned in the session. The next cycle's `begin_import_input_request` unconditionally clears `continuation` and `successor_delta_nonce` and begins a fresh generation, so the orphan is superseded rather than observed.

## Tests

Four production-path tests in `source_loader.rs`:

- `superseded_acquisition_commits_no_partial_state`
- `supersession_at_the_close_boundary_commits_no_partial_state` — asserts the real invariant, that no *partial* round ever lands (snapshot, committed manifest and assembler markers must all agree), with counters proving both the before-any-commit and after-a-commit abort positions are actually exercised rather than one of them being dead
- `repeated_supersession_retains_state_and_recovers`
- `quiet_probe_matches_the_unprobed_acquisition`

Plus a `supersede_acquire` watch scenario driving the same race end to end through the real driver: `RUE_WATCH_TEST_ACQUIRE_DELAY_MS` widens the acquisition window so the second edit lands inside it every run, and the case asserts a clean `acquire-ok` strictly after the supersession with only the newest revision published. The case needs the real std (`RUE_STD_PATH = "${REAL_STD}"`) because `@parse_i64` is what makes the program park on a trusted toolchain demand at all.

## Validation

`scripts/rue fmt`, `scripts/rue quick`, and full `scripts/rue premerge` all pass (203 tests, 0 failures).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLu5tyWdwrL8RywUZqaQc)_