### PR TITLE
RUE-1825: centralize the dotslash bootstrap in one composite action

### DIFF
--- a/.github/actions/bootstrap-dotslash/action.yml
+++ b/.github/actions/bootstrap-dotslash/action.yml
@@ -1,0 +1,83 @@
+name: Bootstrap dotslash
+description: >-
+  Install the pinned dotslash launcher and cache the buck2 binary it downloads.
+
+# Every job that runs `./buck2` needs the same two steps, and for a long time
+# every one of them carried its own copy. The copies drifted: some cached only
+# the Linux store, some both; the key spelling varied between a literal
+# platform name, `matrix.name`, and `matrix.cache_name`; and eight install
+# sites (the four performance workflows and the website deploy) had no cache
+# step at all, so every scheduled run re-downloaded buck2 from the releases
+# CDN. RUE-1854 had already shown what a silently wrong cache costs here.
+#
+# This action is the single owner of that pairing. Installing dotslash without
+# its cache is no longer something a workflow can express, because installing
+# dotslash is no longer something a workflow does directly —
+# `//:dotslash-bootstrap-validation` fails any workflow that reaches for
+# `facebook/install-dotslash` itself.
+#
+# Callers keep their own `if:` on the `uses:` step; a skipped step runs none of
+# the steps inside, so conditional jobs neither install nor restore.
+inputs:
+  cache-name:
+    description: >-
+      Cache-key identity for this runner. The vocabulary is `linux-x64`,
+      `linux-arm64`, and `macos-arm64`, optionally prefixed with a scope that
+      keeps an on-demand workflow's store separate from required CI's
+      (`repetitions-linux-x64`, `soak-linux-x64`). Two runners that would
+      restore each other's binaries must never share a value.
+    required: false
+    default: linux-x64
+  with-btd:
+    description: >-
+      Set to `true` in a job that also runs `./btd`, so the key hashes btd's
+      pinned manifest as well and a btd pin bump invalidates the shared store.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Install dotslash
+      # Pinned: the moving `latest` branch broke macOS runners (sha256sum
+      # flags) on 2026-06-18.
+      uses: facebook/install-dotslash@v2
+
+    # `buck2` is a bash wrapper; the pinned release digests live in the
+    # `buck2-bin` DotSlash manifest, so that is what the key must hash — a key
+    # on the wrapper survives a pin bump, reports an exact hit on a store
+    # without the new binary, and (because an exact hit suppresses the save)
+    # never writes the downloaded one back. RUE-1854 is that bug, and
+    # `//:dotslash-cache-key-validation` is the gate that keeps it fixed.
+    #
+    # Both store paths are listed unconditionally: `~/.cache/dotslash` is the
+    # Linux location, `~/Library/Caches/dotslash` the macOS one, and
+    # actions/cache skips a path that does not exist. Caching the buck2 binary
+    # is the whole point — buck-out and ~/.cache/buck2 were cached once and
+    # were inert, since OSS buck2 keeps no action cache across daemon restarts
+    # (RUE-144).
+    - name: Cache dotslash artifacts
+      if: inputs.with-btd != 'true'
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cache/dotslash
+          ~/Library/Caches/dotslash
+        key: dotslash-${{ inputs.cache-name }}-${{ hashFiles('buck2-bin') }}
+        restore-keys: |
+          dotslash-${{ inputs.cache-name }}-
+
+    # The same step for a job that shares the store with btd. `hashFiles` takes
+    # its globs as separate literal arguments, so the two-manifest key cannot
+    # be folded into the one above by interpolating an input — the variant
+    # lives here rather than being copied back out into the workflows.
+    - name: Cache dotslash artifacts (with btd)
+      if: inputs.with-btd == 'true'
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cache/dotslash
+          ~/Library/Caches/dotslash
+        key: dotslash-${{ inputs.cache-name }}-${{ hashFiles('buck2-bin', 'btd') }}
+        restore-keys: |
+          dotslash-${{ inputs.cache-name }}-

--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -40,19 +40,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
-
-      # The buck2 binary itself, not build artifacts: this job deliberately
-      # clears buck-out and rebuilds cold, but re-downloading buck2 from the
-      # releases CDN is a network dependency the probe does not exist to test.
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      # The bootstrap's cache covers the buck2 binary itself, not build
+      # artifacts: this job deliberately clears buck-out and rebuilds cold,
+      # but re-downloading buck2 from the releases CDN is a network
+      # dependency the probe does not exist to test.
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Guard — secret present
         env:
@@ -151,16 +144,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
-
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Guard — secret present
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,20 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      # Cache the dotslash-downloaded buck2 binary (see the `test` job for the
-      # rationale on which paths are worth caching).
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Check formatting
         # Every crate package emits one directory-named `<crate>-fmt-check`
@@ -159,20 +147,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      # Cache the dotslash-downloaded buck2 binary (see the `test` job for the
-      # rationale on which paths are worth caching).
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       # BuildBuddy remote action cache (RUE-316/RUE-1006). GitHub withholds
       # repo secrets from pull_request runs whose head branch lives in a fork —
@@ -235,20 +211,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
-
-      # Cache the dotslash-downloaded buck2 binary (see the `test` job for the
-      # rationale on which paths are worth caching).
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Require and provision remote execution
         env:
@@ -315,24 +279,8 @@ jobs:
         # count commits is the `performance-staleness` job, which takes its own
         # `fetch-depth: 0` checkout for the purpose (RUE-1258, RUE-1504).
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      # Cache the dotslash-downloaded buck2 binary (~/.cache/dotslash on
-      # Linux, ~/Library/Caches/dotslash on macOS; actions/cache skips paths
-      # that don't exist). The previous cache of buck-out/v2/gen +
-      # ~/.cache/buck2 was inert: OSS buck2 has no persistent action cache
-      # across daemon restarts, and ~/.cache/buck2 is not a path buck2 uses —
-      # multi-GB saved/restored for zero hits. (RUE-144)
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       # BuildBuddy remote action cache (RUE-316/RUE-1006/RUE-1019); see the
       # clippy job for the secret-availability contract. Compiler
@@ -638,20 +586,8 @@ jobs:
           # see the history fails rather than passing. (RUE-1258)
           fetch-depth: 0
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      # Same dotslash cache as the other Linux lanes; see linux-premerge for
-      # why these are the only paths worth caching (RUE-144).
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       # BuildBuddy remote action cache (RUE-316/RUE-1006/RUE-1019); see the
       # clippy job for the secret-availability contract. This lane builds the
@@ -851,20 +787,11 @@ jobs:
         if: runner.os == 'macOS' && steps.sel.outputs.run == 'true'
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
-      - name: Install dotslash
+      - name: Bootstrap dotslash
         if: steps.sel.outputs.run == 'true'
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      - name: Cache dotslash artifacts
-        if: steps.sel.outputs.run == 'true'
-        uses: actions/cache@v5
+        uses: ./.github/actions/bootstrap-dotslash
         with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-${{ matrix.name }}-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-${{ matrix.name }}-
+          cache-name: ${{ matrix.name }}
 
       - name: Provision remote build cache
         if: steps.sel.outputs.run == 'true'
@@ -978,18 +905,9 @@ jobs:
           RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
         run: scripts/ci-corpus-decision "compiler-reproducibility"
 
-      - name: Install dotslash
+      - name: Bootstrap dotslash
         if: steps.sel.outputs.run == 'true'
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      - name: Cache dotslash artifacts
-        if: steps.sel.outputs.run == 'true'
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Verify compiler build reproducibility
         if: steps.sel.outputs.run == 'true'
@@ -1027,18 +945,9 @@ jobs:
           RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
         run: scripts/ci-corpus-decision "rue-program-digests"
 
-      - name: Install dotslash
+      - name: Bootstrap dotslash
         if: steps.sel.outputs.run == 'true'
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      - name: Cache dotslash artifacts
-        if: steps.sel.outputs.run == 'true'
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Provision remote cache
         if: steps.sel.outputs.run == 'true'
@@ -1095,20 +1004,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install dotslash
+      - name: Bootstrap dotslash
         if: github.event_name == 'pull_request'
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      - name: Cache dotslash artifacts
-        if: github.event_name == 'pull_request'
-        uses: actions/cache@v5
+        uses: ./.github/actions/bootstrap-dotslash
         with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin', 'btd') }}
-          restore-keys: |
-            dotslash-linux-x64-
+          with-btd: 'true'
 
       - name: Provision remote build cache
         if: github.event_name == 'pull_request'
@@ -1234,20 +1134,11 @@ jobs:
         if: runner.os == 'macOS' && steps.sel.outputs.run == 'true'
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
-      - name: Install dotslash
+      - name: Bootstrap dotslash
         if: steps.sel.outputs.run == 'true'
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      - name: Cache dotslash artifacts
-        if: steps.sel.outputs.run == 'true'
-        uses: actions/cache@v5
+        uses: ./.github/actions/bootstrap-dotslash
         with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-${{ matrix.cache_name }}-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-${{ matrix.cache_name }}-
+          cache-name: ${{ matrix.cache_name }}
 
       - name: Provision remote build cache
         if: steps.sel.outputs.run == 'true'
@@ -1310,22 +1201,9 @@ jobs:
           RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
         run: scripts/ci-corpus-decision "release"
 
-      - name: Install dotslash
+      - name: Bootstrap dotslash
         if: steps.sel.outputs.run == 'true'
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      # Same dotslash cache as the other jobs (buck2 binary only; see the `test`
-      # job for why buck-out isn't worth caching).
-      - name: Cache dotslash artifacts
-        if: steps.sel.outputs.run == 'true'
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+        uses: ./.github/actions/bootstrap-dotslash
 
       # BuildBuddy remote action cache (RUE-316/RUE-1006); see the clippy job
       # for the secret-availability contract.
@@ -1378,18 +1256,9 @@ jobs:
           RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
         run: scripts/ci-corpus-decision "valgrind"
 
-      - name: Install dotslash
+      - name: Bootstrap dotslash
         if: steps.sel.outputs.run == 'true'
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      - name: Cache dotslash artifacts
-        if: steps.sel.outputs.run == 'true'
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Provision remote build cache
         if: steps.sel.outputs.run == 'true'
@@ -1482,17 +1351,8 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@v6
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/dotslash
-            ~/Library/Caches/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
       - name: Validate aggregate gate and platform responsibilities
         run: scripts/validate-ci-gate.py .github/workflows/ci.yml
 

--- a/.github/workflows/correctness-repetitions.yml
+++ b/.github/workflows/correctness-repetitions.yml
@@ -47,12 +47,10 @@ jobs:
         shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v6
-      - uses: facebook/install-dotslash@v2
-      - uses: actions/cache@v5
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
         with:
-          path: ~/.cache/dotslash
-          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: dotslash-repetitions-linux-x64-
+          cache-name: repetitions-linux-x64
       - name: Repeat correctness shard and retain every failure
         env:
           RUE_REPETITION_LOG_DIR: ${{ runner.temp }}/repetitions
@@ -103,12 +101,10 @@ jobs:
       targets: ${{ steps.inventory.outputs.targets }}
     steps:
       - uses: actions/checkout@v6
-      - uses: facebook/install-dotslash@v2
-      - uses: actions/cache@v5
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
         with:
-          path: ~/.cache/dotslash
-          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: dotslash-repetitions-linux-x64-
+          cache-name: repetitions-linux-x64
       - name: Enumerate every corpus that runs as a build action
         id: inventory
         # Both exclusions are the CLI corpus, which `repeat-cli-shards` above
@@ -149,12 +145,10 @@ jobs:
         target: ${{ fromJSON(needs.corpus-inventory.outputs.targets) }}
     steps:
       - uses: actions/checkout@v6
-      - uses: facebook/install-dotslash@v2
-      - uses: actions/cache@v5
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
         with:
-          path: ~/.cache/dotslash
-          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: dotslash-repetitions-linux-x64-
+          cache-name: repetitions-linux-x64
       - name: Execute the corpus against the current tree
         env:
           RUE_CORPUS_CACHE_FREE: "1"
@@ -183,12 +177,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: facebook/install-dotslash@v2
-      - uses: actions/cache@v5
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
         with:
-          path: ~/.cache/dotslash
-          key: dotslash-soak-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: dotslash-soak-linux-x64-
+          cache-name: soak-linux-x64
       - name: Soak the differential oracle under process oversubscription
         env:
           RUE_SOAK_LOG_DIR: ${{ runner.temp }}/soak

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -80,8 +80,8 @@ jobs:
           # than clone depth.
           fetch-depth: 0
 
-      - name: Setup dotslash
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Build website
         run: website/build.sh

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,20 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
-
-      # Cache the dotslash-downloaded buck2 binary. The previous cache of
-      # buck-out/v2/gen + ~/.cache/buck2 was inert — OSS buck2 has no
-      # persistent action cache across daemon restarts, and ~/.cache/buck2
-      # is not a path buck2 uses. (RUE-144)
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Create seed corpus
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --init-corpus crates/rue-fuzz/spec-seeds

--- a/.github/workflows/performance-calibration.yml
+++ b/.github/workflows/performance-calibration.yml
@@ -90,12 +90,15 @@ jobs:
         include:
           - os: ubuntu-24.04
             platform: x86_64-linux
+            cache_name: linux-x64
             image: ubuntu-24.04
           - os: ubuntu-24.04-arm
             platform: aarch64-linux
+            cache_name: linux-arm64
             image: ubuntu-24.04
           - os: macos-15
             platform: aarch64-macos
+            cache_name: macos-arm64
             image: macos-15
     runs-on: ${{ matrix.os }}
     name: calibrate (${{ matrix.platform }})
@@ -108,8 +111,10 @@ jobs:
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
+        with:
+          cache-name: ${{ matrix.cache_name }}
 
       - name: Build the compiler and the runner
         run: |
@@ -195,12 +200,15 @@ jobs:
         include:
           - os: ubuntu-24.04
             platform: x86_64-linux
+            cache_name: linux-x64
             image: ubuntu-24.04
           - os: ubuntu-24.04-arm
             platform: aarch64-linux
+            cache_name: linux-arm64
             image: ubuntu-24.04
           - os: macos-15
             platform: aarch64-macos
+            cache_name: macos-arm64
             image: macos-15
     runs-on: ${{ matrix.os }}
     name: calibrate runtime (${{ matrix.platform }})
@@ -220,8 +228,10 @@ jobs:
       # Fetches the pinned peers as well as Rue's own tools: `zola` and `hugo`
       # at the repository root are dotslash shims, and the runtime harness runs
       # the canary against the same corpus gazette builds.
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
+        with:
+          cache-name: ${{ matrix.cache_name }}
 
       - name: Build the compiler and the runner
         run: |

--- a/.github/workflows/performance-collect.yml
+++ b/.github/workflows/performance-collect.yml
@@ -95,12 +95,15 @@ jobs:
         include:
           - os: ubuntu-24.04
             platform: x86_64-linux
+            cache_name: linux-x64
             image: ubuntu-24.04
           - os: ubuntu-24.04-arm
             platform: aarch64-linux
+            cache_name: linux-arm64
             image: ubuntu-24.04
           - os: macos-15
             platform: aarch64-macos
+            cache_name: macos-arm64
             image: macos-15
     runs-on: ${{ matrix.os }}
     name: measure (${{ matrix.platform }})
@@ -114,8 +117,10 @@ jobs:
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
+        with:
+          cache-name: ${{ matrix.cache_name }}
 
       - name: Build the compiler and the runner
         run: |
@@ -250,9 +255,11 @@ jobs:
         include:
           - os: ubuntu-24.04
             platform: x86_64-linux
+            cache_name: linux-x64
             image: ubuntu-24.04
           - os: ubuntu-24.04-arm
             platform: aarch64-linux
+            cache_name: linux-arm64
             image: ubuntu-24.04
     runs-on: ${{ matrix.os }}
     name: runtime (${{ matrix.platform }})
@@ -270,8 +277,10 @@ jobs:
       # Fetches `rue`'s pinned peers as well as its own tools: `zola` and `hugo`
       # at the repository root are dotslash shims, and the runtime leg runs both
       # against the same corpus gazette builds (ADR-0072 Decision 5).
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
+        with:
+          cache-name: ${{ matrix.cache_name }}
 
       - name: Build the compiler and the runner
         run: |
@@ -424,8 +433,10 @@ jobs:
       - name: Select Xcode 16.2
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
+        with:
+          cache-name: macos-arm64
 
       - name: Build the compiler and the runner
         run: |

--- a/.github/workflows/performance-incremental.yml
+++ b/.github/workflows/performance-incremental.yml
@@ -29,8 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Build the retained-session runner
         run: ./buck2 build //crates/rue-bench:rue-bench

--- a/.github/workflows/performance-scaling.yml
+++ b/.github/workflows/performance-scaling.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Build the compiler and measurement runner
         run: ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench --target-platforms //platforms:release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install dotslash
-        uses: facebook/install-dotslash@v2
-
-      - name: Cache dotslash artifacts
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+      - name: Bootstrap dotslash
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Provision remote build cache
         env:
@@ -108,18 +100,9 @@ jobs:
       - uses: actions/checkout@v6
         if: steps.select.outputs.run == 'true'
 
-      - name: Install dotslash
+      - name: Bootstrap dotslash
         if: steps.select.outputs.run == 'true'
-        uses: facebook/install-dotslash@v2
-
-      - name: Cache dotslash artifacts
-        if: steps.select.outputs.run == 'true'
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/dotslash
-          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}
-          restore-keys: |
-            dotslash-linux-x64-
+        uses: ./.github/actions/bootstrap-dotslash
 
       - name: Provision remote build cache
         if: steps.select.outputs.run == 'true'

--- a/BUCK
+++ b/BUCK
@@ -1011,21 +1011,53 @@ rue_sh_test(
 # one back — every job re-downloads it on every run, silently, because
 # dotslash succeeds either way. The glob matches the validator's own default
 # discovery so a newly added workflow is covered the day it lands.
+#
+# RUE-1825 moved the cache step itself into the composite action, so the
+# sources are the whole `.github` tree and both gates below walk it: the
+# workflows are where an install may not appear, the action is where the one
+# surviving key lives.
 filegroup(
-    name = "dotslash-cache-key-workflows",
-    srcs = glob([".github/workflows/*.yml", ".github/workflows/*.yaml"]),
+    name = "dotslash-github-sources",
+    srcs = glob([
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+        ".github/actions/**/*.yml",
+        ".github/actions/**/*.yaml",
+    ]),
 )
 
 rue_sh_test(
     name = "dotslash-cache-key-validation",
     test = "scripts/validate-dotslash-cache-keys.py",
-    args = ["$(location :dotslash-cache-key-workflows)/.github/workflows"],
+    args = ["$(location :dotslash-github-sources)/.github"],
 )
 
 rue_sh_test(
     name = "dotslash-cache-key-tool-tests",
     test = "scripts/test-dotslash-cache-keys.py",
     resources = ["scripts/validate-dotslash-cache-keys.py"] +
+        [":gatelib-sources"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
+# RUE-1825: installing dotslash and caching the binary it downloads is one
+# operation, and copies of it drifted until eight install sites had lost the
+# cache half entirely. `.github/actions/bootstrap-dotslash` owns the pairing;
+# this gate keeps it the only owner, and fails if the action stops doing
+# either half rather than passing vacuously over conforming callers.
+rue_sh_test(
+    name = "dotslash-bootstrap-validation",
+    test = "scripts/validate-dotslash-bootstrap.py",
+    args = ["$(location :dotslash-github-sources)/.github"],
+    resources = [":gatelib-sources"],
+)
+
+rue_sh_test(
+    name = "dotslash-bootstrap-tool-tests",
+    test = "scripts/test-dotslash-bootstrap.py",
+    resources = ["scripts/validate-dotslash-bootstrap.py"] +
         [":gatelib-sources"],
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",

--- a/scripts/test-dotslash-bootstrap.py
+++ b/scripts/test-dotslash-bootstrap.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Focused tests for the dotslash bootstrap-centralization gate (RUE-1825)."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+bootstrap = load_script("validate-dotslash-bootstrap.py", __file__)
+
+CALLER = (
+    "jobs:\n  build:\n    steps:\n"
+    "      - uses: actions/checkout@v6\n"
+    "      - name: Bootstrap dotslash\n"
+    "        uses: ./.github/actions/bootstrap-dotslash\n"
+)
+ACTION = (
+    "name: Bootstrap dotslash\n"
+    "runs:\n  using: composite\n  steps:\n"
+    "    - uses: facebook/install-dotslash@v2\n"
+    "    - uses: actions/cache@v5\n"
+    "      with:\n"
+    "        path: ~/.cache/dotslash\n"
+    "        key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}\n"
+)
+
+
+class DotslashBootstrapTests(unittest.TestCase):
+    def validate(
+        self,
+        workflows: dict[str, str] | None = None,
+        action: str | None = ACTION,
+    ) -> list[str]:
+        """Run the gate over a synthetic `.github` tree."""
+
+        with tempfile.TemporaryDirectory() as directory:
+            github = Path(directory) / ".github"
+            (github / "workflows").mkdir(parents=True)
+            for name, text in (workflows or {"ci.yml": CALLER}).items():
+                (github / "workflows" / name).write_text(text)
+            if action is not None:
+                canonical = github / "actions" / "bootstrap-dotslash"
+                canonical.mkdir(parents=True)
+                (canonical / "action.yml").write_text(action)
+            return bootstrap.validate(github)
+
+    def test_accepts_a_workflow_that_goes_through_the_action(self) -> None:
+        self.assertEqual(self.validate(), [])
+
+    def test_rejects_a_direct_upstream_install(self) -> None:
+        # The regression itself: a job that installs dotslash on its own is a
+        # job whose cache step can go missing, which is how the seven
+        # performance-workflow gaps were introduced.
+        errors = self.validate(
+            {
+                "ci.yml": CALLER,
+                "perf.yml": (
+                    "jobs:\n  measure:\n    steps:\n"
+                    "      - name: Install dotslash\n"
+                    "        uses: facebook/install-dotslash@v2\n"
+                ),
+            }
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("installs dotslash directly", errors[0])
+        self.assertIn("perf.yml:5", errors[0])
+
+    def test_rejects_a_workflow_declaring_its_own_dotslash_cache(self) -> None:
+        # The other half of the same copy: the cache without the install is
+        # just as much a fork of the policy the action owns.
+        errors = self.validate(
+            {
+                "ci.yml": CALLER
+                + "      - uses: actions/cache@v5\n"
+                "        with:\n"
+                "          key: dotslash-linux-x64-${{ hashFiles('buck2-bin') }}\n"
+            }
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("declares its own dotslash cache key", errors[0])
+
+    def test_rejects_a_missing_canonical_action(self) -> None:
+        errors = self.validate(action=None)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("missing", errors[0])
+
+    def test_rejects_an_action_that_stopped_installing(self) -> None:
+        # Without this the gate would pass over workflows that conform to a
+        # bootstrap which no longer bootstraps anything.
+        errors = self.validate(
+            action=ACTION.replace("    - uses: facebook/install-dotslash@v2\n", "")
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("no longer installs dotslash", errors[0])
+
+    def test_rejects_an_action_that_stopped_caching(self) -> None:
+        errors = self.validate(
+            action="name: Bootstrap dotslash\nruns:\n  using: composite\n  steps:\n"
+            "    - uses: facebook/install-dotslash@v2\n"
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("no longer declares a dotslash cache", errors[0])
+
+    def test_rejects_a_tree_where_nothing_calls_the_action(self) -> None:
+        # A renamed bootstrap leaves every workflow trivially conforming; the
+        # caller count is what stops that from reading as a pass (RUE-1152).
+        errors = self.validate({"ci.yml": "jobs:\n  build:\n    steps: []\n"})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("no workflow uses", errors[0])
+
+    def test_covers_a_later_added_yaml_workflow(self) -> None:
+        # The gate takes the directory, so a workflow added tomorrow — in
+        # either spelling of the extension — is checked without editing it.
+        errors = self.validate(
+            {
+                "ci.yml": CALLER,
+                "later.yaml": (
+                    "jobs:\n  build:\n    steps:\n"
+                    "      - uses: facebook/install-dotslash@v2\n"
+                ),
+            }
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("later.yaml:4", errors[0])
+
+    def test_reports_every_offending_site(self) -> None:
+        errors = self.validate(
+            {
+                "ci.yml": CALLER,
+                "a.yml": "steps:\n  - uses: facebook/install-dotslash@v2\n",
+                "b.yml": "steps:\n  - uses: facebook/install-dotslash@v2\n",
+            }
+        )
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(any("a.yml" in error for error in errors))
+        self.assertTrue(any("b.yml" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -955,7 +955,7 @@ class GateValidatorTests(unittest.TestCase):
         source = SOURCE.read_text()
         prefix, contract = source.split("  ci-contract:\n", 1)
         contract = contract.replace(
-            "      - name: Install dotslash\n        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18\n",
+            "      - name: Bootstrap dotslash\n        uses: ./.github/actions/bootstrap-dotslash\n",
             "",
             1,
         )

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -804,9 +804,14 @@ def validate(
         errors.append("ci-contract no longer runs the live graph validator")
     validator_invocation = "scripts/validate-ci-gate.py .github/workflows/ci.yml"
     validator_position = contract.find(validator_invocation)
-    if "facebook/install-dotslash@v2" not in contract:
+    # RUE-1825: the install is no longer spelled in the workflow — every job
+    # bootstraps through the one composite action that owns the install and its
+    # cache together. What this asserts is unchanged: the toolchain is there
+    # before the live Buck validator runs.
+    bootstrap = "uses: ./.github/actions/bootstrap-dotslash"
+    if bootstrap not in contract:
         errors.append("ci-contract must install dotslash before the live Buck validator")
-    elif validator_position < 0 or contract.index("facebook/install-dotslash@v2") > validator_position:
+    elif validator_position < 0 or contract.index(bootstrap) > validator_position:
         errors.append("ci-contract must install dotslash before the live Buck validator")
     if "--structural-only" in contract:
         errors.append("ci-contract must run live graph ownership validation, not structural-only mode")

--- a/scripts/validate-dotslash-bootstrap.py
+++ b/scripts/validate-dotslash-bootstrap.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Route every dotslash install through the one repository-owned bootstrap.
+
+Installing the dotslash launcher and caching the buck2 binary it downloads are
+one operation, and for a long time every job spelled both halves itself. The
+copies drifted -- differing store paths, three different cache-key spellings --
+and eight of them (the four performance workflows and the website deploy)
+carried the install with no cache at all, so every scheduled run re-downloaded
+buck2 from the releases CDN. RUE-1476 fixed the merge-queue half of that and
+named these gaps; they survived because the install/cache pairing had no owner
+(RUE-1825).
+
+`.github/actions/bootstrap-dotslash` is that owner. This gate keeps it the only
+one: a workflow may not reach for `facebook/install-dotslash`, and may not
+declare a `dotslash-` cache of its own, because either half on its own is the
+copy whose other half goes missing.
+
+The gate also checks the action still does both jobs. Without that, deleting
+the install or the cache step inside it -- or renaming the action out from
+under the callers -- would leave every workflow trivially conforming and this
+gate passing over nothing (the vacuous-pass failure mode of RUE-1152).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import run_gate
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATTERNS = ("*.yml", "*.yaml")
+ACTION_DIRECTORY = "bootstrap-dotslash"
+ACTION_REFERENCE = f"./.github/actions/{ACTION_DIRECTORY}"
+UPSTREAM_INSTALLER = "facebook/install-dotslash"
+DOTSLASH_KEY = re.compile(r"^\s*key:\s*.*dotslash-")
+CACHE_STEP = re.compile(r"uses:\s*actions/cache(?:/[a-z]+)?@")
+
+
+def workflows_in(directory: Path) -> list[Path]:
+    """Every workflow file under `directory`, in a stable order."""
+
+    return sorted(
+        path for pattern in WORKFLOW_PATTERNS for path in directory.rglob(pattern)
+    )
+
+
+def check_workflows(workflows: list[Path]) -> tuple[list[str], int]:
+    """Errors from the caller side, and how many callers use the action."""
+
+    errors: list[str] = []
+    callers = 0
+    for path in workflows:
+        lines = path.read_text().splitlines()
+        callers += sum(1 for line in lines if ACTION_REFERENCE in line)
+        for number, line in enumerate(lines, 1):
+            if UPSTREAM_INSTALLER in line:
+                errors.append(
+                    f"{path}:{number}: installs dotslash directly; use "
+                    f"`uses: {ACTION_REFERENCE}` so the install cannot be "
+                    "separated from its cache"
+                )
+            if DOTSLASH_KEY.match(line):
+                errors.append(
+                    f"{path}:{number}: declares its own dotslash cache key; "
+                    f"{ACTION_REFERENCE} owns the store paths and key policy"
+                )
+    return errors, callers
+
+
+def check_action(action: Path) -> list[str]:
+    """Errors from the action side: it must still install and still cache."""
+
+    if not action.is_file():
+        return [
+            f"{action}: the canonical dotslash bootstrap is missing; every "
+            "workflow would be free to install dotslash its own way again"
+        ]
+    text = action.read_text()
+    errors: list[str] = []
+    if UPSTREAM_INSTALLER not in text:
+        errors.append(
+            f"{action}: no longer installs dotslash, so the workflows that "
+            "call it get no toolchain and this gate checks nothing"
+        )
+    if not (CACHE_STEP.search(text) and any(map(DOTSLASH_KEY.match, text.splitlines()))):
+        errors.append(
+            f"{action}: no longer declares a dotslash cache, which is the half "
+            "the copies kept losing"
+        )
+    return errors
+
+
+def validate(github: Path) -> list[str]:
+    workflows = workflows_in(github / "workflows")
+    errors, callers = check_workflows(workflows)
+    errors += check_action(github / "actions" / ACTION_DIRECTORY / "action.yml")
+    if not callers:
+        errors.append(
+            f"no workflow uses {ACTION_REFERENCE}; a renamed bootstrap would "
+            "leave this gate passing over workflows it no longer recognizes"
+        )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "github",
+        nargs="?",
+        type=Path,
+        default=ROOT / ".github",
+        help="the .github directory holding workflows/ and actions/",
+    )
+    arguments = parser.parse_args()
+    github = arguments.github
+    return run_gate(
+        lambda: validate(github),
+        f"dotslash bootstrap centralized: every install in "
+        f"{len(workflows_in(github / 'workflows'))} workflow(s) goes through "
+        f"{ACTION_REFERENCE}",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-dotslash-cache-keys.py
+++ b/scripts/validate-dotslash-cache-keys.py
@@ -27,14 +27,20 @@ WORKFLOW_PATTERNS = ("*.yml", "*.yaml")
 
 
 def workflows_in(directory: Path) -> list[Path]:
-    """Every workflow file in `directory`, in a stable order."""
+    """Every workflow or action file under `directory`, in a stable order.
+
+    The walk is recursive because the keys no longer live only in
+    `.github/workflows`: RUE-1825 moved the cache step into the composite
+    action at `.github/actions/bootstrap-dotslash/action.yml`, and a gate that
+    stopped at the top level of `.github` would have checked nothing.
+    """
 
     return sorted(
-        path for pattern in WORKFLOW_PATTERNS for path in directory.glob(pattern)
+        path for pattern in WORKFLOW_PATTERNS for path in directory.rglob(pattern)
     )
 
 
-DEFAULT_WORKFLOWS = workflows_in(ROOT / ".github" / "workflows")
+DEFAULT_WORKFLOWS = workflows_in(ROOT / ".github")
 # An `actions/cache` key for the dotslash store. The store path is what makes
 # it a dotslash cache, but the key prefix is the reviewed convention and is
 # what a new copy-pasted step carries.
@@ -87,12 +93,13 @@ def main() -> int:
         "workflows",
         nargs="*",
         type=Path,
-        help="workflow files, or a directory whose workflow files are all checked",
+        help="workflow or action files, or a directory whose files are all checked",
     )
     args = parser.parse_args()
 
     # A directory argument keeps the checked set identical to what CI actually
-    # runs: a workflow added tomorrow is covered without editing this gate.
+    # runs: a workflow or composite action added tomorrow is covered without
+    # editing this gate.
     workflows = [
         workflow
         for argument in args.workflows
@@ -108,7 +115,7 @@ def main() -> int:
         # A rename of the cache-key convention would otherwise turn this gate
         # into a vacuous pass over files it no longer recognizes.
         errors.append(
-            "no dotslash cache key found in any checked workflow; the gate would "
+            "no dotslash cache key found in any checked file; the gate would "
             "silently check nothing"
         )
     if errors:
@@ -118,7 +125,7 @@ def main() -> int:
 
     print(
         f"dotslash cache keys valid: {keys} key(s) across "
-        f"{len(workflows)} workflow(s) hash {PINNED_MANIFEST}"
+        f"{len(workflows)} file(s) hash {PINNED_MANIFEST}"
     )
     return 0
 


### PR DESCRIPTION
Fixes RUE-1825.

## Problem

Installing the dotslash launcher and caching the buck2 binary it downloads are one operation, and every job spelled both halves itself. The copies drifted — some cached only the Linux store, some both; the key was spelled as a literal platform name, `matrix.name`, or `matrix.cache_name` — and **eight of the 30 install sites carried no cache step at all**: both jobs in `performance-calibration.yml`, all three in `performance-collect.yml`, and one each in `performance-incremental.yml`, `performance-scaling.yml`, and `deploy-website.yml`. Every scheduled run of those re-downloaded buck2 from the releases CDN.

RUE-1476 fixed the merge-queue half of this and its completion comment named the performance gaps. They survived because the install/cache pairing had no owner.

## Fix

`.github/actions/bootstrap-dotslash` is now that owner. It installs the pinned launcher and declares the cache in one place: both store paths unconditionally (`actions/cache` skips a path that does not exist), and the key on `buck2-bin`, the pinned DotSlash manifest, per RUE-1854.

Two inputs cover the variation that is real:

| input | why |
| --- | --- |
| `cache-name` | the runner's cache identity |
| `with-btd` | the one job sharing the store with btd, whose two-manifest `hashFiles('buck2-bin', 'btd')` cannot be folded into the other by interpolating an input |

All 30 sites go through it. Callers keep their own `if:`, and a skipped `uses:` step runs nothing inside, so conditional jobs still neither install nor restore.

Cache identity is now one vocabulary — `linux-x64`, `linux-arm64`, `macos-arm64`, optionally scoped (`repetitions-`, `soak-`) where an on-demand workflow kept its store separate. The performance matrices gain a `cache_name` column because their own `platform` values are the measurement vocabulary (`x86_64-linux`); that was moot while those rows had no cache at all, but defaulting them would have pointed three platforms at one key.

## Guard

`//:dotslash-bootstrap-validation` keeps it centralized: a workflow may not use `facebook/install-dotslash`, nor declare a `dotslash-` cache key of its own — either half alone is the copy whose other half goes missing.

It also checks the action still installs, still caches, and that some workflow still calls it. Without those, deleting a step inside the action or renaming it out from under the callers would leave every workflow trivially conforming and the gate passing over nothing — RUE-1152's failure mode. `scripts/test-dotslash-bootstrap.py` pins all of it in 9 tests, and **each failure mode was verified to fail against the real tree**, not only fixtures.

## Two existing gates adjusted

- The RUE-1854 key gate now walks `.github` recursively rather than just `.github/workflows`, because the one surviving key lives in the action. Left alone it failed with its own anti-vacuity error — which is exactly what that assertion is for.
- `validate-ci-gate.py`'s "ci-contract installs dotslash before the live Buck validator" check reads the bootstrap reference instead of the upstream action. What it asserts is unchanged.

## Validation

- `actionlint` 1.7.12 — clean. It resolves the local action and type-checks its inputs; verified by introducing a misspelled input and watching it fail, then restoring.
- `scripts/rue fmt` — clean.
- Full `scripts/rue premerge` — **205 tests, 0 failures** (203 before, plus the two new gates).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLu5tyWdwrL8RywUZqaQc)_