### PR TITLE
RUE-1862: make watch reobservation transactional

### DIFF
--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -115,9 +115,9 @@ source = "fn main() -> i32 { 3 }\n"
 # while discovery was still re-closing could not supersede the stale attempt:
 # it was noticed only once compilation proper began, or on the next cycle.
 # `reobserve_delay_ms` widens the re-closure window on purpose so the second
-# edit deterministically lands inside it. The superseded attempt must commit
-# nothing: exactly one fresh re-observation over the newest bytes follows, and
-# only the newest revision's output ever publishes.
+# edit deterministically lands inside it. The cycle may retain a coherent close
+# only after its atomic commit boundary, but it must re-observe newest bytes
+# before compiling; only the newest revision's output ever publishes.
 [[case]]
 name = "change_during_reobserve_supersedes_the_stale_attempt"
 files = [

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -1087,9 +1087,8 @@ struct WatchScenario {
     /// was acted on but never announced on the protocol.
     #[serde(default)]
     boundary_delay_ms: Option<u64>,
-    /// Hold the watcher between starting its re-observation monitor and the
-    /// re-observation itself, so an edit can deterministically land while
-    /// the import graph is being re-closed (RUE-1830).
+    /// Hold retained re-observation inside its first physical-read boundary,
+    /// so an edit deterministically supersedes in-progress discovery.
     #[serde(default)]
     reobserve_delay_ms: Option<u64>,
     /// Hold the watcher between re-observation and reached-toolchain
@@ -2460,6 +2459,59 @@ fn watch_event_count(path: &Path, event: &str) -> usize {
         .count()
 }
 
+fn assert_fresh_cycle_after_supersession(
+    events: &[String],
+    superseded: usize,
+) -> Result<(), String> {
+    let fresh_reobserve_started = events
+        .iter()
+        .enumerate()
+        .skip(superseded + 1)
+        .find_map(|(index, event)| (event == "reobserve-started").then_some(index))
+        .ok_or_else(|| {
+            "watch never started a fresh re-observation after supersession".to_string()
+        })?;
+    let fresh_reobserve_ok = events
+        .iter()
+        .enumerate()
+        .skip(fresh_reobserve_started + 1)
+        .find_map(|(index, event)| (event == "reobserve-ok").then_some(index))
+        .ok_or_else(|| {
+            "watch never completed the fresh re-observation after supersession".to_string()
+        })?;
+    let fresh_acquire_ok = events
+        .iter()
+        .enumerate()
+        .skip(fresh_reobserve_ok + 1)
+        .find_map(|(index, event)| (event == "acquire-ok").then_some(index))
+        .ok_or_else(|| {
+            "watch never completed fresh toolchain acquisition after supersession".to_string()
+        })?;
+    let fresh_compile_started = events
+        .iter()
+        .enumerate()
+        .skip(fresh_acquire_ok + 1)
+        .find_map(|(index, event)| (event == "compile-started").then_some(index))
+        .ok_or_else(|| "watch never compiled the fresh revision after supersession".to_string())?;
+    let second_publication = events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| (event == "published").then_some(index))
+        .nth(1)
+        .ok_or_else(|| "watch never published the fresh revision".to_string())?;
+    if !(superseded < fresh_reobserve_started
+        && fresh_reobserve_started < fresh_reobserve_ok
+        && fresh_reobserve_ok < fresh_acquire_ok
+        && fresh_acquire_ok < fresh_compile_started
+        && fresh_compile_started < second_publication)
+    {
+        return Err(format!(
+            "watch fresh-cycle protocol order was invalid after supersession: {events:?}"
+        ));
+    }
+    Ok(())
+}
+
 fn finish_watch_child(
     mut child: std::process::Child,
     stdout: std::thread::JoinHandle<Vec<u8>>,
@@ -2798,15 +2850,22 @@ fn run_watch_case(
                     .iter()
                     .position(|event| event == "acquire-superseded")
                     .ok_or_else(|| "watch supersession anchor disappeared".to_string())?;
-                // A superseded acquisition commits nothing, so a later cycle
-                // must acquire cleanly over the newest bytes.
-                events
+                let reobserve_ok = events
                     .iter()
-                    .skip(superseded + 1)
-                    .position(|event| event == "acquire-ok")
-                    .ok_or_else(|| {
-                        "watch never reacquired after a superseded acquisition".to_string()
-                    })?;
+                    .position(|event| event == "reobserve-ok")
+                    .ok_or_else(|| "watch reobserve anchor disappeared".to_string())?;
+                if events[reobserve_ok..superseded]
+                    .iter()
+                    .any(|event| matches!(event.as_str(), "acquire-ok" | "compile-started"))
+                {
+                    return Err(format!(
+                        "watch compiled a stale partially acquired revision: {events:?}"
+                    ));
+                }
+                // A superseded acquisition commits nothing, so a later cycle
+                // must reobserve, acquire, compile, and publish over the newest
+                // bytes in that exact order.
+                assert_fresh_cycle_after_supersession(&events, superseded)?;
             }
             WatchScenarioKind::SupersedeReobserve => {
                 // The first edit wakes the settled loop; the widened
@@ -2815,6 +2874,13 @@ fn run_watch_case(
                 // attempt before compilation ever starts (RUE-1830).
                 wait_for_watch_event(&mut child, &protocol, "change-detected", 1, deadline)?;
                 wait_for_watch_event(&mut child, &protocol, "reobserve-started", 1, deadline)?;
+                wait_for_watch_event(
+                    &mut child,
+                    &protocol,
+                    "reobserve-read-boundary",
+                    1,
+                    deadline,
+                )?;
                 write_watch_edit(dir, &scenario.edits[1])?;
                 wait_for_watch_event(&mut child, &protocol, "reobserve-superseded", 1, deadline)?;
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
@@ -2823,16 +2889,23 @@ fn run_watch_case(
                     .iter()
                     .position(|event| event == "reobserve-superseded")
                     .ok_or_else(|| "watch supersession anchor disappeared".to_string())?;
-                // The superseded attempt committed nothing: a fresh
-                // re-observation over the newest bytes follows it before the
-                // next compile can start.
-                events
+                let reobserve = events
                     .iter()
-                    .skip(superseded + 1)
-                    .position(|event| event == "reobserve-ok")
-                    .ok_or_else(|| {
-                        "watch never reobserved the newest revision after supersession".to_string()
-                    })?;
+                    .position(|event| event == "reobserve-started")
+                    .ok_or_else(|| "watch reobserve anchor disappeared".to_string())?;
+                if events[reobserve..superseded].iter().any(|event| {
+                    matches!(
+                        event.as_str(),
+                        "reobserve-ok" | "acquire-ok" | "compile-started"
+                    )
+                }) {
+                    return Err(format!(
+                        "watch compiled a stale partially reobserved revision: {events:?}"
+                    ));
+                }
+                // A fresh cycle must complete every host boundary over the
+                // newest bytes before compilation and the second publication.
+                assert_fresh_cycle_after_supersession(&events, superseded)?;
             }
         }
         assert_watch_program(contract, &program, scenario.expected_exit_codes[1])

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -397,15 +397,15 @@ fn revisioned_database_hub_and_registered_family_authority_are_structural() {
         });
     assert_eq!(
         (declarations.len(), fingerprint),
-        (202, 7_082_883_898_404_990_306),
+        (205, 12_983_246_186_944_960_561),
         "crate-visible declaration names, signatures, fields, or phase owners changed"
     );
 
-    // The split must preserve the original crate-visible declaration set. The
-    // baseline is an identity manifest extracted from the pre-split source;
-    // this catches newly widened helpers even when a source-shape fingerprint
-    // is accidentally updated alongside them. The cfg(test) registration
-    // manifest is intentionally an inventory-only addition and is excluded.
+    // The baseline began as the identity manifest extracted from the pre-split
+    // source and grows only for reviewed cross-module authorities. This catches
+    // accidentally widened helpers even when a source-shape fingerprint is
+    // updated alongside them. The cfg(test) registration manifest is
+    // intentionally an inventory-only addition and is excluded.
     let mut actual_identities = REVISIONED_DATABASE_PHASES
         .iter()
         .flat_map(|(_, source)| crate_visible_declaration_identities(source))
@@ -556,6 +556,8 @@ fn:projected_declaration_semantics_for_modules
 fn:begin_import_inputs
 fn:import_frontier
 fn:current_import_revision
+fn:restore_import_revision_after_abort
+fn:commit_import_request
 fn:import_frontier_roots_requested
 fn:exact_import_groups_dispatched
 fn:import_view_full_leaves_published
@@ -580,6 +582,7 @@ fn:parse_program
 fn:compose_candidate_module_rirs
 fn:projected_module_indexes
 fn:select_parse
+fn:select_parse_candidate
 fn:parse_attempt_view
 fn:parse_origin_attempt_ids
 fn:runtime_retention_metrics

--- a/crates/rue-compiler/src/revisioned_query_database/body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body.rs
@@ -7539,6 +7539,94 @@ impl RevisionedQueryDatabase {
         self.current_import_revision
     }
 
+    /// Reselect the exact closed-valid import view after a filesystem host
+    /// abandons a partially published request. Immutable candidate revisions
+    /// remain retained normally, but none may stay selected after cancellation.
+    pub(crate) fn restore_import_revision_after_abort(
+        &mut self,
+        revision: Option<ImportInputRevision>,
+    ) -> CompileResult<()> {
+        if self.committed_import_revision != revision {
+            return Err(import_input_error(
+                "cannot restore an aborted import request: committed revision selection disagrees with the closed artifact",
+            ));
+        }
+        let reselected = self
+            .parse_selection
+            .reselect_last_good()
+            .map_err(|error| {
+                import_input_error(format!(
+                    "cannot restore an aborted import request: the committed parse terminal is unavailable: {error:?}"
+                ))
+            })?;
+        if revision.is_some() && !reselected {
+            return Err(import_input_error(
+                "cannot restore an aborted import request: the committed import view has no last-good parse terminal",
+            ));
+        }
+        let Some(revision) = revision else {
+            self.current_import_revision = None;
+            self.active_import_context = None;
+            self.lineage_additions.clear();
+            self.refresh_import_input_protected_revisions();
+            return Ok(());
+        };
+        let runtime_revision = Revision::new(revision.revision_id, revision.compatibility_token);
+        let context = {
+            let store = lock_import_store(&self.import_store);
+            let view = store
+                .revisions
+                .iter()
+                .find(|view| view.revision == runtime_revision)
+                .ok_or_else(|| {
+                    import_input_error(
+                        "cannot restore an aborted import request: the committed input view is no longer retained",
+                    )
+                })?;
+            if view.generation != revision.request_generation {
+                return Err(import_input_error(
+                    "cannot restore an aborted import request: the committed input generation does not match",
+                ));
+            }
+            view.context.clone()
+        };
+        let module_view_retained = {
+            let store = self
+                .module_store
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            store.by_revision.contains_key(&runtime_revision)
+        };
+        if !module_view_retained {
+            return Err(import_input_error(
+                "cannot restore an aborted import request: the committed module input view is no longer retained",
+            ));
+        }
+        self.current_import_revision = Some(revision);
+        self.active_compatibility_token = revision.compatibility_token;
+        self.active_import_context = Some(context);
+        self.lineage_additions.clear();
+        self.refresh_import_input_protected_revisions();
+        Ok(())
+    }
+
+    /// Promote the request's selected input revision only after import close
+    /// and public parse adoption have both succeeded.
+    pub(crate) fn commit_import_request(&mut self) {
+        let committed = self.current_import_revision;
+        let pin = committed.map(|revision| {
+            self.parse.retain_revision(Revision::new(
+                revision.revision_id,
+                revision.compatibility_token,
+            ))
+        });
+        self.committed_import_revision = committed;
+        // Install the new runtime root before the old pin drops so a successful
+        // close never creates an eviction gap between committed revisions.
+        self.committed_import_revision_pin = pin;
+        self.refresh_import_input_protected_revisions();
+    }
+
     /// Cumulative import-occurrence roots dispatched by [`Self::import_frontier`].
     /// See the field docs on `import_frontier_roots_requested`.
     pub(crate) fn import_frontier_roots_requested(&self) -> u64 {
@@ -8212,6 +8300,7 @@ impl RevisionedQueryDatabase {
         leaves.extend(publish_module_inputs_delta(
             &self.module_store,
             revision,
+            parent_runtime,
             snapshot,
             &new_sources,
         ));
@@ -8838,19 +8927,54 @@ impl RevisionedQueryDatabase {
         &mut self,
         attempt: &QueryRequestAttempt<crate::session::ParseQueryRecord>,
     ) {
+        self.select_parse_inner(attempt, true);
+    }
+
+    /// Select a staging parse as request-current without promoting it across
+    /// the import-discovery commit boundary.
+    pub(crate) fn select_parse_candidate(
+        &mut self,
+        attempt: &QueryRequestAttempt<crate::session::ParseQueryRecord>,
+    ) {
+        self.select_parse_inner(attempt, false);
+    }
+
+    fn select_parse_inner(
+        &mut self,
+        attempt: &QueryRequestAttempt<crate::session::ParseQueryRecord>,
+        promote: bool,
+    ) {
         if attempt.execution() == RequestExecution::Aborted {
             self.parse_selection.clear_current();
         }
         if let Some(terminal) = attempt.terminal() {
-            self.parse_selection
-                .publish(terminal)
-                .expect("selected terminal belongs to the Parse family");
+            if promote {
+                self.parse_selection
+                    .publish(terminal)
+                    .expect("selected terminal belongs to the Parse family");
+            } else {
+                self.parse_selection
+                    .publish_candidate(terminal)
+                    .expect("candidate terminal belongs to the Parse family");
+            }
             // Publication establishes the runtime selection root before the
             // request bridge lease ends, so the terminal stays protected while
             // the diagnostic attempt index retains this request.
             attempt.release_result_lease();
         }
-        let protected_revisions = [
+        self.refresh_import_input_protected_revisions();
+        // Exact source stamps live exactly as long as a parse memo key (or the
+        // current request before selection). They are never independently FIFO
+        // evicted while a terminal can still observe the stamp.
+        self.source_stamps.retain(|(source, _)| {
+            self.parse
+                .any_retained_key(|key| key.key.pinned_source() == Some(source))
+        });
+        debug_assert!(self.source_stamps.len() <= self.parse.retention().memo_nodes);
+    }
+
+    fn refresh_import_input_protected_revisions(&mut self) {
+        let mut protected_revisions = [
             self.parse_selection.current(),
             self.parse_selection.last_good(),
         ]
@@ -8858,6 +8982,15 @@ impl RevisionedQueryDatabase {
         .flatten()
         .map(|terminal| terminal.revision())
         .collect::<BTreeSet<_>>();
+        for revision in [self.current_import_revision, self.committed_import_revision]
+            .into_iter()
+            .flatten()
+        {
+            protected_revisions.insert(Revision::new(
+                revision.revision_id,
+                revision.compatibility_token,
+            ));
+        }
         {
             let mut store = self
                 .module_store
@@ -8871,14 +9004,6 @@ impl RevisionedQueryDatabase {
             store.protected_revisions = protected_revisions;
             trim_import_input_views(&mut store);
         }
-        // Exact source stamps live exactly as long as a parse memo key (or the
-        // current request before selection). They are never independently FIFO
-        // evicted while a terminal can still observe the stamp.
-        self.source_stamps.retain(|(source, _)| {
-            self.parse
-                .any_retained_key(|key| key.key.pinned_source() == Some(source))
-        });
-        debug_assert!(self.source_stamps.len() <= self.parse.retention().memo_nodes);
     }
 
     pub(crate) fn parse_attempt_view(

--- a/crates/rue-compiler/src/revisioned_query_database/parse_import.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/parse_import.rs
@@ -637,6 +637,10 @@ pub(super) struct RetainedValueStamp {
 #[derive(Debug)]
 pub(super) struct ModuleInputStore {
     pub(super) revisions: VecDeque<Arc<ModuleInputView>>,
+    /// Exact revision lookup for every retained module view. Recency is not a
+    /// lineage authority: an aborted successor remains retained after the
+    /// session reselects its committed predecessor.
+    pub(super) by_revision: AHashMap<Revision, Arc<ModuleInputView>>,
     /// Runtime selection roots may outlive the ordinary recency window. At
     /// most current and last-good are protected, so retained views are bounded
     /// by the window plus two.
@@ -666,6 +670,7 @@ impl Default for ModuleInputStore {
     fn default() -> Self {
         Self {
             revisions: VecDeque::new(),
+            by_revision: AHashMap::new(),
             protected_revisions: BTreeSet::new(),
             retention_limit: MODULE_INPUT_REVISION_RETENTION,
             next_stamp: 1,
@@ -1487,8 +1492,19 @@ pub(super) fn release_stamp_value<T: Eq + Hash>(
     }
 }
 
+fn index_module_input_view(store: &mut ModuleInputStore, view: &Arc<ModuleInputView>) {
+    assert!(
+        store
+            .by_revision
+            .insert(view.revision, view.clone())
+            .is_none(),
+        "module input revisions are immutable and uniquely numbered"
+    );
+}
+
 #[cfg(test)]
 pub(super) fn retain_module_input_view(store: &mut ModuleInputStore, view: Arc<ModuleInputView>) {
+    index_module_input_view(store, &view);
     store.revisions.push_back(view);
     trim_module_input_views(store);
 }
@@ -1507,7 +1523,13 @@ pub(super) fn trim_module_input_views(store: &mut ModuleInputStore) {
             .revisions
             .remove(index)
             .expect("an evictable module input view has a valid index");
+        let indexed = store
+            .by_revision
+            .remove(&evicted.revision)
+            .expect("every retained module input view has an exact index entry");
+        assert!(Arc::ptr_eq(&evicted, &indexed));
         let lease = evicted.stamp_lease.clone();
+        drop(indexed);
         drop(evicted);
         release_orphaned_module_stamp_leases(store, lease);
     }
@@ -1546,6 +1568,13 @@ pub(super) fn discard_module_input_view(store: &Mutex<ModuleInputStore>, revisio
         .pop_back()
         .expect("a failed runtime publication has a pending module view");
     assert_eq!(view.revision, revision);
+    assert!(
+        store
+            .by_revision
+            .get(&revision)
+            .is_none_or(|indexed| !Arc::ptr_eq(&view, indexed)),
+        "a failed runtime publication never indexes its pending module view"
+    );
     let lease = view.stamp_lease.clone();
     drop(view);
     release_orphaned_module_stamp_leases(&mut store, lease);
@@ -1560,6 +1589,12 @@ pub(super) fn commit_module_input_view(store: &Mutex<ModuleInputStore>, revision
         Some(revision),
         "runtime publication commits the pending module view"
     );
+    let view = store
+        .revisions
+        .back()
+        .expect("a committed module input revision retains its view")
+        .clone();
+    index_module_input_view(&mut store, &view);
     trim_module_input_views(&mut store);
 }
 
@@ -1950,6 +1985,7 @@ pub(super) fn additive_diff<'a, T: Clone + PartialEq + 'a>(
 pub(super) fn publish_module_inputs_delta(
     store: &Mutex<ModuleInputStore>,
     revision: Revision,
+    parent_revision: Revision,
     snapshot: &SourceSnapshot,
     new_sources: &[ModuleRevision],
 ) -> Vec<(InputIdentity, u64)> {
@@ -1957,9 +1993,9 @@ pub(super) fn publish_module_inputs_delta(
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let parent_view = store
-        .revisions
-        .back()
-        .expect("a module overlay extends a retained parent view")
+        .by_revision
+        .get(&parent_revision)
+        .expect("a module overlay extends its retained exact parent view")
         .clone();
     let parent_lease = parent_view.stamp_lease.clone();
     let mut leaves = Vec::new();

--- a/crates/rue-compiler/src/revisioned_query_database/registrations.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations.rs
@@ -950,6 +950,8 @@ impl RevisionedQueryDatabase {
             body_closure_anonymous_digest_forcing,
             next_import_request: 0,
             current_import_revision: None,
+            committed_import_revision: None,
+            committed_import_revision_pin: None,
             active_compatibility_token: 1,
             ordinary_lineage_published: false,
             active_import_context: None,

--- a/crates/rue-compiler/src/revisioned_query_database/shared.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/shared.rs
@@ -674,6 +674,19 @@ pub(crate) struct RevisionedQueryDatabase {
         Arc<Mutex<TestBodyClosureAnonymousDigestForcing>>,
     pub(super) next_import_request: u64,
     pub(super) current_import_revision: Option<ImportInputRevision>,
+    /// The exact import-input revision adopted by the latest successful close.
+    /// Candidate request views may replace `current_import_revision` while open,
+    /// but this independently protects and restores the public semantic view.
+    pub(super) committed_import_revision: Option<ImportInputRevision>,
+    /// Runtime-view root for `committed_import_revision`. Module/import stores
+    /// have their own bounded histories, but every query against those inputs
+    /// also requires the shared runtime revision itself to remain published.
+    pub(super) committed_import_revision_pin: Option<
+        rue_query::RevisionPin<
+            CompatibilityKey<crate::session::ParseQueryKey>,
+            crate::session::ParseQueryRecord,
+        >,
+    >,
     /// Compatibility namespace shared by ordinary snapshot publication and
     /// rooted import publication. The first rooted request can bind an
     /// existing ordinary-update lineage to its observation context; later

--- a/crates/rue-compiler/src/revisioned_query_database/tests.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests.rs
@@ -10245,11 +10245,22 @@ fn failed_runtime_publication_releases_pending_input_stamp_leases() {
         published_leaves_before,
         "a rejected runtime publication is not counted as published work"
     );
+    let module_store = database
+        .module_store
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(module_store.by_revision.len(), module_store.revisions.len());
+    for view in &module_store.revisions {
+        assert!(Arc::ptr_eq(
+            view,
+            module_store
+                .by_revision
+                .get(&view.revision)
+                .expect("every committed module view keeps its exact index entry")
+        ));
+    }
     assert_eq!(
-        database
-            .module_store
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        module_store
             .revisions
             .back()
             .unwrap()
@@ -10257,6 +10268,7 @@ fn failed_runtime_publication_releases_pending_input_stamp_leases() {
             .source_revision(),
         snapshot.source_revision()
     );
+    drop(module_store);
     assert_eq!(reads, assembler.accepted_read_manifest());
 }
 

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -149,6 +149,9 @@ impl ImportDiscoveryRevisionArtifact {
     pub(crate) fn status(&self) -> ImportDiscoveryRevisionStatus {
         self.status
     }
+    fn input_revision(&self) -> Option<crate::ImportInputRevision> {
+        self.input_revision
+    }
     pub(crate) fn source_revision(&self) -> &SourceRevision {
         &self.source_revision
     }
@@ -262,6 +265,14 @@ pub struct CompilerSession {
     /// cleared by the successor close it authorizes (or by any new import-input
     /// request/source update, so a stale delta can neither stage nor close).
     successor_delta_nonce: Option<u64>,
+    /// Exact session-facing selectors that existed before the current rooted
+    /// import-input request began or before a trusted successor overlay was
+    /// published. Candidate parsing and import diagnostics may move these
+    /// selectors while the request is open; a superseded filesystem observation
+    /// restores this snapshot after the revisioned input database reselects its
+    /// committed root. Immutable terminals computed by the discarded request may
+    /// remain retained, but none stays selected.
+    import_request_checkpoint: Option<ImportRequestCheckpoint>,
     /// Monotonic nonce source for continuation tokens; a token is valid only
     /// while its nonce matches the outstanding state.
     next_continuation_nonce: u64,
@@ -744,6 +755,17 @@ impl CompilerSession {
         self.published.as_ref()
     }
 
+    fn capture_import_request_checkpoint(&self) -> ImportRequestCheckpoint {
+        ImportRequestCheckpoint {
+            validated_accepted_reads: self.validated_accepted_reads.clone(),
+            continuation: self.continuation.clone(),
+            discovery_attempt: self.queries.discovery_attempt.clone(),
+            prior_discovery: self.queries.prior_discovery.clone(),
+            batch_diagnostic_order: self.batch_diagnostic_order.clone(),
+            diagnostics: self.diagnostics.clone(),
+        }
+    }
+
     /// Begins one fresh rooted external-input request with granular immutable
     /// module source, accepted-read provenance, and observation leaves.
     /// Successor carry is available only through batch publication.
@@ -753,13 +775,29 @@ impl CompilerSession {
         context: crate::ImportDiscoveryContext,
         accepted_reads: crate::AcceptedReadManifest,
     ) -> crate::CompileResult<crate::ImportInputRevision> {
+        // Preserve the first uncommitted request boundary. A fresh observation
+        // may deliberately supersede a provisional trusted successor after its
+        // selectors have moved, but that successor is still part of the same
+        // transaction: replacing this checkpoint would make abort restore the
+        // provisional selectors and consumed continuation instead of the exact
+        // committed predecessor (RUE-1862).
+        if self.import_request_checkpoint.is_none() {
+            self.import_request_checkpoint = Some(self.capture_import_request_checkpoint());
+        }
         // A fresh observation generation invalidates any outstanding
         // trusted-toolchain continuation and successor-delta authority (RUE-1112).
         self.continuation = None;
         self.successor_delta_nonce = None;
-        self.queries
+        let begun = self
+            .queries
             .revisioned
-            .begin_import_inputs(snapshot, context, accepted_reads)
+            .begin_import_inputs(snapshot, context, accepted_reads);
+        if begun.is_err()
+            && let Err(rollback) = self.abort_import_input_request()
+        {
+            return Err(rollback);
+        }
+        begun
     }
 
     pub(crate) fn import_demand_frontier_for_roots(
@@ -947,8 +985,9 @@ impl CompilerSession {
                 };
                 Some(IncrementalImportStage {
                     revision: current,
-                    delta: added,
+                    plan_delta: added.clone(),
                     predecessor_plan,
+                    parse_delta: added,
                     predecessor_parse,
                     inherited_parse_work: predecessor.parse_work,
                 })
@@ -1374,7 +1413,7 @@ impl CompilerSession {
                 "the successor delta is stale (superseded by a newer publish, request, or close)",
             ));
         }
-        let Some((current, snapshot, context, accepted_reads, ledger, _)) =
+        let Some((current, snapshot, context, accepted_reads, ledger, transition)) =
             self.queries.revisioned.current_import_view_state()
         else {
             return Err(reject(
@@ -1414,6 +1453,7 @@ impl CompilerSession {
             accepted_reads,
             ledger,
             revision: current,
+            transition,
             delta: new_modules.into(),
         })
     }
@@ -1430,29 +1470,119 @@ impl CompilerSession {
         delta: &TrustedSuccessorDelta,
     ) -> Result<crate::ImportDiscoveryPlan, CompileErrors> {
         let state = self.derive_successor_state(delta)?;
-        let Some(predecessor) = self.last_good_discovery_artifact() else {
-            return Err(CompileErrors::from(CompileError::without_span(
-                ErrorKind::InvalidCompilerInput(
-                    "trusted-toolchain successor has no committed predecessor".into(),
-                ),
-            )));
-        };
-        let Some(predecessor_plan) = predecessor.plan.clone() else {
-            return Err(CompileErrors::from(CompileError::without_span(
-                ErrorKind::InvalidCompilerInput(
-                    "trusted-toolchain predecessor carries no import plan".into(),
-                ),
-            )));
-        };
-        let Some(predecessor_parse) = self.queries.revisioned.last_good_parse_terminal().cloned()
-        else {
-            return Err(CompileErrors::from(CompileError::without_span(
-                ErrorKind::InvalidCompilerInput(
-                    "trusted-toolchain predecessor carries no exact parse terminal".into(),
-                ),
-            )));
-        };
         let revision = state.revision;
+        let reject = |message: &str| {
+            CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("trusted-toolchain successor staging rejected: {message}"),
+            )))
+        };
+
+        // The successor plan's delta means every module added since the
+        // committed close. Keep that plan anchored to the committed artifact so
+        // close-time graph reduction sees the complete cumulative delta even
+        // when the final staging round appends nothing.
+        let committed = self
+            .last_good_discovery_artifact()
+            .filter(|artifact| {
+                artifact.input_revision.is_some_and(|predecessor| {
+                    predecessor.request_generation == revision.request_generation
+                })
+            })
+            .ok_or_else(|| {
+                reject("the successor has no committed predecessor in its generation")
+            })?;
+        if let crate::revisioned_query_database::ImportInputTransition::TrustedSuccessor {
+            parent,
+            ..
+        } = &state.transition
+            && committed.input_revision != Some(*parent)
+        {
+            return Err(reject(
+                "the first trusted-successor step does not extend the committed predecessor",
+            ));
+        }
+        let predecessor_plan = committed
+            .plan
+            .clone()
+            .ok_or_else(|| reject("the committed predecessor has no import plan"))?;
+        let plan_delta = state.delta.clone();
+
+        // Parse staging has a deliberately narrower predecessor: the exact
+        // request-local candidate produced by the previous round. A request may
+        // also stage the same immutable input view again after its frontier
+        // becomes empty to prove the closing witness. Chain that zero-delta
+        // stage to the exact open artifact for this revision. Neither path
+        // promotes the provisional terminal across the commit boundary.
+        let same_revision = self.open_discovery.as_ref().filter(|artifact| {
+            artifact.status == ImportDiscoveryRevisionStatus::Open
+                && artifact.input_revision == Some(revision)
+                && continues_discovery_lifecycle(
+                    artifact,
+                    &state.snapshot,
+                    &state.context,
+                    &state.accepted_reads,
+                    &state.ledger,
+                )
+        });
+        let (parse_delta, predecessor_parse, inherited_parse_work) = if let Some(predecessor) =
+            same_revision
+        {
+            let parse = predecessor.staging_parse_terminal.clone().ok_or_else(|| {
+                reject("the open same-revision predecessor has no exact parse terminal")
+            })?;
+            (
+                Arc::<[crate::ModuleRevision]>::from([]),
+                parse,
+                predecessor.parse_work,
+            )
+        } else {
+            match &state.transition {
+                crate::revisioned_query_database::ImportInputTransition::HostBatch {
+                    parent,
+                    added,
+                } => {
+                    let predecessor = self
+                        .open_discovery
+                        .as_ref()
+                        .filter(|artifact| {
+                            artifact.status == ImportDiscoveryRevisionStatus::Open
+                                && artifact.input_revision == Some(*parent)
+                        })
+                        .ok_or_else(|| {
+                            reject("the host-batch parent has no exact open predecessor artifact")
+                        })?;
+                    let parse = predecessor.staging_parse_terminal.clone().ok_or_else(|| {
+                        reject("the open host-batch predecessor has no exact parse terminal")
+                    })?;
+                    (added.clone(), parse, predecessor.parse_work)
+                }
+                crate::revisioned_query_database::ImportInputTransition::TrustedSuccessor {
+                    parent,
+                    added,
+                } => {
+                    let predecessor = self
+                        .last_good_discovery_artifact()
+                        .filter(|artifact| artifact.input_revision == Some(*parent))
+                        .ok_or_else(|| {
+                            reject("the trusted successor has no exact committed predecessor")
+                        })?;
+                    let parse = self
+                        .queries
+                        .revisioned
+                        .last_good_parse_terminal()
+                        .cloned()
+                        .ok_or_else(|| {
+                            reject("the committed predecessor has no exact parse terminal")
+                        })?;
+                    (added.clone(), parse, predecessor.parse_work)
+                }
+                crate::revisioned_query_database::ImportInputTransition::Fresh => {
+                    return Err(reject(
+                        "a fresh import view cannot consume trusted-successor authority",
+                    ));
+                }
+            }
+        };
         self.stage_import_discovery_inner(
             &state.snapshot,
             state.context,
@@ -1461,10 +1591,11 @@ impl CompilerSession {
             Some(revision),
             Some(IncrementalImportStage {
                 revision,
-                delta: state.delta,
+                plan_delta,
                 predecessor_plan,
+                parse_delta,
                 predecessor_parse,
-                inherited_parse_work: predecessor.parse_work,
+                inherited_parse_work,
             }),
         )
     }
@@ -1520,7 +1651,7 @@ impl CompilerSession {
         incremental: Option<IncrementalImportStage>,
     ) -> Result<crate::ImportDiscoveryPlan, CompileErrors> {
         let new_module_ids: Option<Vec<crate::ModuleId>> = incremental.as_ref().map(|stage| {
-            let delta = &stage.delta;
+            let delta = &stage.plan_delta;
             delta
                 .iter()
                 .map(|revision| revision.module.clone())
@@ -1588,7 +1719,7 @@ impl CompilerSession {
                 incremental.as_ref().map(|stage| {
                     (
                         stage.revision,
-                        &stage.delta,
+                        &stage.parse_delta,
                         stage.predecessor_parse.clone(),
                     )
                 }),
@@ -2163,6 +2294,8 @@ impl CompilerSession {
                     attached_demands: None,
                 }
             });
+        self.queries.revisioned.commit_import_request();
+        self.import_request_checkpoint = None;
         Ok(artifact)
     }
 
@@ -2349,6 +2482,11 @@ impl CompilerSession {
         // topology are inherited unchanged, only the verified added leaves'
         // source/provenance leaves are published, and the overlay re-derives the
         // additions from the published parent view (they must equal `added`).
+        let checkpoint = self.capture_import_request_checkpoint();
+        assert!(
+            self.import_request_checkpoint.is_none(),
+            "a committed predecessor must clear its import-request checkpoint before successor publication"
+        );
         let published = self
             .queries
             .revisioned
@@ -2361,6 +2499,12 @@ impl CompilerSession {
                 state.revision.frontier_round + 1,
             )
             .map_err(CompileErrors::from)?;
+        // Successor publication mutates the selected import view before the
+        // host's trusted re-close can commit. Preserve the exact committed
+        // predecessor selectors so any failed or superseded re-close can roll
+        // the overlay back without letting a later request checkpoint it as
+        // committed state (RUE-1862/RUE-1863).
+        self.import_request_checkpoint = Some(checkpoint);
         // Consume the single-use continuation only on success.
         self.continuation = None;
         // Mint the opaque successor-delta authority from the VERIFIED `added`
@@ -2750,6 +2894,7 @@ impl CompilerSession {
         snapshot: &SourceSnapshot,
         presentation: DiagnosticAttemptProvenance,
         attempt_id: AttemptId,
+        promote_selection: bool,
     ) -> (
         ParseQueryRecord,
         Arc<dyn AttemptView>,
@@ -2859,7 +3004,11 @@ impl CompilerSession {
                         invalidation,
                     })
                 });
-        self.queries.revisioned.select_parse(&attempt);
+        if promote_selection {
+            self.queries.revisioned.select_parse(&attempt);
+        } else {
+            self.queries.revisioned.select_parse_candidate(&attempt);
+        }
         let terminal = attempt
             .terminal()
             .unwrap_or_else(|| panic!("parse query aborted: {:?}", attempt.abort()))
@@ -3140,7 +3289,7 @@ impl CompilerSession {
                 })
             },
         );
-        self.queries.revisioned.select_parse(&attempt);
+        self.queries.revisioned.select_parse_candidate(&attempt);
         let terminal = attempt
             .terminal()
             .unwrap_or_else(|| panic!("parse query aborted: {:?}", attempt.abort()))
@@ -3224,7 +3373,7 @@ impl CompilerSession {
                 let order = crate::shared_segments::SharedList::flat(order.into());
                 self.select_diagnostic_presentation(Some(order.clone()));
                 let presentation = DiagnosticAttemptProvenance::Presentation(order);
-                self.execute_parse_query(snapshot, presentation, attempt_id)
+                self.execute_parse_query(snapshot, presentation, attempt_id, false)
             }
         };
         guard.started();
@@ -3245,7 +3394,7 @@ impl CompilerSession {
         let mut guard = self.metrics.begin_unprojected("parse");
         let attempt_id = guard.id;
         let (record, view, execution, parse_work, invalidation, _) =
-            self.execute_parse_query(snapshot, presentation, attempt_id);
+            self.execute_parse_query(snapshot, presentation, attempt_id, true);
         guard.started();
         self.metrics.update(parse_work, invalidation.clone());
         let result = record.result.clone();
@@ -5571,6 +5720,61 @@ impl CompilerSession {
                 panic!("uncanceled rooted body-closure request aborted: {abort:?}")
             }
         }
+    }
+
+    /// Discard protocol-only state from a superseded filesystem observation.
+    /// Immutable query terminals may remain retained, but no open attempt is
+    /// allowed to shadow the last closed-valid discovery selected for public
+    /// semantic queries.
+    pub(crate) fn abort_import_input_request(&mut self) -> crate::CompileResult<()> {
+        let committed = self.last_good_discovery_artifact().map(|artifact| {
+            (
+                artifact.input_revision(),
+                artifact.snapshot().clone(),
+                artifact.accepted_read_manifest().clone(),
+                artifact.ledger().clone(),
+            )
+        });
+        self.open_discovery = None;
+        self.successor_delta_nonce = None;
+        self.queries
+            .revisioned
+            .restore_import_revision_after_abort(
+                committed.as_ref().and_then(|(revision, _, _, _)| *revision),
+            )?;
+        if let Some(checkpoint) = self.import_request_checkpoint.take() {
+            self.validated_accepted_reads = checkpoint.validated_accepted_reads;
+            self.continuation = checkpoint.continuation;
+            self.queries.discovery_attempt = checkpoint.discovery_attempt;
+            self.queries.prior_discovery = checkpoint.prior_discovery;
+            self.batch_diagnostic_order = checkpoint.batch_diagnostic_order;
+            self.diagnostics = checkpoint.diagnostics;
+            // A fresh rooted import request invalidates a provisional trusted
+            // successor delta permanently. Restoring only its nonce after the
+            // revisioned database has reselected the committed predecessor
+            // would manufacture a live-looking capability whose exact overlay
+            // revision and lineage no longer exist.
+            self.successor_delta_nonce = None;
+            self.refresh_retention_metrics();
+            return Ok(());
+        }
+        self.validated_accepted_reads = committed
+            .as_ref()
+            .map(|(_, snapshot, accepted_reads, _)| (snapshot.clone(), accepted_reads.clone()));
+        self.continuation = committed.and_then(|(revision, snapshot, accepted_reads, ledger)| {
+            revision.map(|revision| {
+                self.next_continuation_nonce += 1;
+                ContinuationState {
+                    nonce: self.next_continuation_nonce,
+                    revision,
+                    snapshot,
+                    accepted_reads,
+                    ledger,
+                    attached_demands: None,
+                }
+            })
+        });
+        Ok(())
     }
 
     fn attach_toolchain_park(&mut self, park: &crate::ParkedToolchainModules) {

--- a/crates/rue-compiler/src/session/discovery_continuation.rs
+++ b/crates/rue-compiler/src/session/discovery_continuation.rs
@@ -70,6 +70,11 @@ pub(super) struct SuccessorState {
     pub(super) ledger: crate::ImportObservationLedger,
     /// The published lineage identity this state was read from.
     pub(super) revision: crate::ImportInputRevision,
+    /// The exact compiler-owned step that produced `revision`. Successor
+    /// staging uses this to bind request-local candidate chaining to the open
+    /// artifact that consumed the transition's parent, never to ambient parse
+    /// selection state.
+    pub(super) transition: crate::revisioned_query_database::ImportInputTransition,
     /// The appended module revisions (view sources minus the committed
     /// predecessor), in canonical module order.
     pub(super) delta: Arc<[crate::ModuleRevision]>,
@@ -81,8 +86,15 @@ pub(super) struct SuccessorState {
 /// existing capability protocol.
 pub(super) struct IncrementalImportStage {
     pub(super) revision: crate::ImportInputRevision,
-    pub(super) delta: Arc<[crate::ModuleRevision]>,
+    /// Modules added since the plan predecessor. Trusted-successor plans stay
+    /// anchored at the committed close, so this is cumulative across the
+    /// request and remains the close-time delta segment.
+    pub(super) plan_delta: Arc<[crate::ModuleRevision]>,
     pub(super) predecessor_plan: crate::ImportDiscoveryPlan,
+    /// Modules added since the exact parse predecessor. Unlike `plan_delta`,
+    /// this chains through request-local candidates and is empty when the same
+    /// immutable input revision is staged again for its closing witness.
+    pub(super) parse_delta: Arc<[crate::ModuleRevision]>,
     pub(super) predecessor_parse: Arc<rue_query::QueryTerminal<ParseQueryRecord>>,
     pub(super) inherited_parse_work: ParsedModulesWork,
 }
@@ -97,6 +109,16 @@ pub(super) struct ContinuationState {
     /// The exact sorted missing-demand set the rooted park attached, or `None`
     /// while the closed state is non-authorizing (no park has arrived for it).
     pub(super) attached_demands: Option<Arc<[crate::TrustedToolchainModuleDemand]>>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ImportRequestCheckpoint {
+    pub(super) validated_accepted_reads: Option<(SourceSnapshot, crate::AcceptedReadManifest)>,
+    pub(super) continuation: Option<ContinuationState>,
+    pub(super) discovery_attempt: Option<Arc<ImportDiscoveryRevisionArtifact>>,
+    pub(super) prior_discovery: Option<Arc<ImportDiscoveryRevisionArtifact>>,
+    pub(super) batch_diagnostic_order: Option<crate::shared_segments::SharedList<crate::ModuleId>>,
+    pub(super) diagnostics: DiagnosticAttemptStore,
 }
 
 /// Convert an unsatisfied trusted-toolchain park to the error a stable

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -786,14 +786,7 @@ fn closed_continuation_for(
     let revision = session
         .begin_import_input_request(&snapshot, ctx.clone(), reads.clone())
         .unwrap();
-    let plan = session
-        .stage_import_discovery(
-            &snapshot,
-            ctx.clone(),
-            reads.shared_slice(),
-            crate::ImportObservationLedger::default(),
-        )
-        .unwrap();
+    let plan = session.stage_import_input_request(revision).unwrap();
     let roots = plan.demand_roots();
     let frontier = session
         .import_demand_frontier_for_roots(revision, &plan, crate::ImportDemandMode::Rooted, &roots)
@@ -802,8 +795,7 @@ fn closed_continuation_for(
         frontier.requests().is_empty(),
         "a freestanding root closes with an empty frontier",
     );
-    let ledger = session.import_observation_ledger(revision).unwrap();
-    session.close_import_discovery(ledger).unwrap();
+    session.close_import_input_request(revision).unwrap();
     // A bare close is non-authorizing: no demand set has been attached yet.
     assert!(
         session.closed_discovery_continuation().is_none(),
@@ -1094,6 +1086,171 @@ fn trusted_successor_publishes_additive_leaf_in_same_generation() {
         successor.source_revision().modules().len(),
         predecessor_modules.len() + 1,
     );
+}
+
+#[test]
+fn failed_trusted_successor_reclose_restores_exact_committed_selectors() {
+    let (mut session, token, frontier, _predecessor, _reads, mut assembler) = closed_continuation();
+    let retry_token = token.clone();
+    let committed_revision = session.queries.revisioned.current_import_revision();
+    let committed_attempt = session
+        .queries
+        .discovery_attempt
+        .clone()
+        .expect("the predecessor close selects its discovery attempt");
+    let committed_prior = session.queries.prior_discovery.clone();
+    let committed_order = session.batch_diagnostic_order.clone();
+    let committed_diagnostics = session
+        .diagnostics
+        .latest()
+        .cloned()
+        .expect("the predecessor close selects its diagnostic batch");
+    let committed_parse = session
+        .selected_parse_terminal()
+        .expect("the predecessor close selects its parse terminal");
+    let (committed_validated_snapshot, committed_validated_reads) = session
+        .validated_accepted_reads
+        .clone()
+        .expect("the predecessor close validates its accepted reads");
+
+    assembler
+        .add_explicit(
+            "/sdk/option.rue",
+            "/sdk/option.rue",
+            crate::PhysicalFileIdentity::new(2, 2),
+            continuation_metadata(),
+            Arc::new(
+                r#"const missing = @import("missing.rue"); pub fn Option(comptime T: type) -> type { enum { Some(T), None } }"#
+                    .to_owned(),
+            ),
+        )
+        .unwrap();
+    let successor = assembler.snapshot().unwrap();
+    let successor_reads = assembler.accepted_read_manifest();
+    let delta = session
+        .publish_trusted_toolchain_successor(token, &frontier, &successor, successor_reads.clone())
+        .expect("the trusted successor publishes");
+    session
+        .stage_import_discovery_successor(&delta)
+        .expect("the successor stage moves the provisional selectors");
+    session
+        .close_import_discovery_successor(&delta)
+        .expect_err("the unresolved successor import records a failed close");
+    assert!(
+        !Arc::ptr_eq(
+            session
+                .queries
+                .discovery_attempt
+                .as_ref()
+                .expect("the failed close selects its attempted discovery"),
+            &committed_attempt,
+        ),
+        "the regression must move the discovery-attempt selector before abort"
+    );
+    assert!(
+        session
+            .queries
+            .prior_discovery
+            .as_ref()
+            .is_some_and(|prior| Arc::ptr_eq(prior, &committed_attempt)),
+        "the failed close must retain the committed predecessor as prior discovery"
+    );
+    assert!(
+        !Arc::ptr_eq(
+            session
+                .diagnostics
+                .latest()
+                .expect("the failed close selects its diagnostics"),
+            &committed_diagnostics,
+        ),
+        "the regression must move the diagnostic selector before abort"
+    );
+    assert!(
+        !Arc::ptr_eq(
+            &session
+                .selected_parse_terminal()
+                .expect("the failed successor retains its staged parse terminal"),
+            &committed_parse,
+        ),
+        "the regression must move the parse selector before abort"
+    );
+
+    // A newer filesystem observation supersedes this failed successor before
+    // the driver aborts it. Beginning that request must invalidate the delta
+    // without checkpointing provisional selectors or a consumed continuation
+    // as though they were committed state.
+    session
+        .begin_import_input_request(
+            &successor,
+            continuation_std_context(),
+            successor_reads.clone(),
+        )
+        .expect("the superseding fresh request begins");
+    assert!(
+        session.stage_import_discovery_successor(&delta).is_err(),
+        "the fresh request invalidates the provisional successor delta"
+    );
+
+    session
+        .abort_import_input_request()
+        .expect("the failed successor round rolls back exactly");
+
+    assert_eq!(
+        session.queries.revisioned.current_import_revision(),
+        committed_revision,
+        "abort must reselect the committed predecessor revision"
+    );
+    assert!(Arc::ptr_eq(
+        session
+            .queries
+            .discovery_attempt
+            .as_ref()
+            .expect("abort restores the committed discovery attempt"),
+        &committed_attempt,
+    ));
+    match (
+        session.queries.prior_discovery.as_ref(),
+        committed_prior.as_ref(),
+    ) {
+        (Some(restored), Some(committed)) => assert!(Arc::ptr_eq(restored, committed)),
+        (None, None) => {}
+        _ => panic!("abort changed the prior-discovery selector"),
+    }
+    assert_eq!(session.batch_diagnostic_order, committed_order);
+    assert!(Arc::ptr_eq(
+        session
+            .diagnostics
+            .latest()
+            .expect("abort restores the committed diagnostic selector"),
+        &committed_diagnostics,
+    ));
+    assert!(Arc::ptr_eq(
+        &session
+            .selected_parse_terminal()
+            .expect("abort restores the committed parse selector"),
+        &committed_parse,
+    ));
+    let (restored_snapshot, restored_reads) = session
+        .validated_accepted_reads
+        .as_ref()
+        .expect("abort restores validated accepted reads");
+    assert!(restored_snapshot.is_same_exact_snapshot(&committed_validated_snapshot));
+    assert_eq!(restored_reads, &committed_validated_reads);
+    assert!(session.import_request_checkpoint.is_none());
+    assert!(session.successor_delta_nonce.is_none());
+    assert!(
+        session.stage_import_discovery_successor(&delta).is_err(),
+        "abort permanently invalidates the provisional successor delta"
+    );
+
+    let restored_token = session
+        .closed_discovery_continuation()
+        .expect("abort restores the exact authorizing continuation");
+    assert_eq!(restored_token.nonce, retry_token.nonce);
+    assert_eq!(restored_token.revision, retry_token.revision);
+    session
+        .publish_trusted_toolchain_successor(retry_token, &frontier, &successor, successor_reads)
+        .expect("the restored continuation authorizes a clean retry");
 }
 
 #[test]

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -536,6 +536,14 @@ pub fn rooted_or_toolchain_park(
     session.rooted_or_toolchain_park(options)
 }
 
+/// Discard protocol-only state from a superseded filesystem observation while
+/// retaining the session's last closed-valid discovery.
+pub fn abort_import_input_request(
+    session: &mut crate::CompilerSession,
+) -> crate::CompileResult<()> {
+    session.abort_import_input_request()
+}
+
 /// Mint the single-use trusted-toolchain continuation for the current successful
 /// import-discovery close, if one is outstanding (RUE-1112).
 pub fn closed_discovery_continuation(

--- a/crates/rue-query/src/retention.rs
+++ b/crates/rue-query/src/retention.rs
@@ -401,6 +401,25 @@ where
         Ok(())
     }
 
+    /// Select a provisional current terminal without promoting it to the
+    /// last-good publication root. Callers use this while a larger transaction
+    /// is still open; only its successful commit may call [`Self::publish`].
+    pub fn publish_candidate(&mut self, terminal: &Arc<QueryTerminal<V>>) -> Result<(), PinError> {
+        self.current = Some(self.family.pin_terminal(terminal)?);
+        Ok(())
+    }
+
+    /// Restore the independently pinned last-good terminal as request-current.
+    /// Returns `false` and clears current when no successful publication exists.
+    pub fn reselect_last_good(&mut self) -> Result<bool, PinError> {
+        let Some(terminal) = self.last_good().cloned() else {
+            self.current = None;
+            return Ok(false);
+        };
+        self.current = Some(self.family.pin_terminal(&terminal)?);
+        Ok(true)
+    }
+
     /// Current selected attempt, including a deterministic failure.
     pub fn current(&self) -> Option<&Arc<QueryTerminal<V>>> {
         self.current.as_ref().map(TerminalPin::terminal)

--- a/crates/rue-query/src/tests.rs
+++ b/crates/rue-query/src/tests.rs
@@ -8746,6 +8746,13 @@ fn family_policy_and_selection_preserve_last_good_above_terminals() {
         )
         .unwrap();
     let mut selection = family.selection();
+    selection.publish(&success).unwrap();
+    selection.publish_candidate(&red).unwrap();
+    assert!(Arc::ptr_eq(selection.current().unwrap(), &red));
+    assert!(Arc::ptr_eq(selection.last_good().unwrap(), &success));
+    assert!(selection.reselect_last_good().unwrap());
+    assert!(Arc::ptr_eq(selection.current().unwrap(), &success));
+    assert!(Arc::ptr_eq(selection.last_good().unwrap(), &success));
     selection.publish(&red).unwrap();
     selection.publish(&failure).unwrap();
     assert!(Arc::ptr_eq(selection.current().unwrap(), &failure));

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -46,8 +46,10 @@ impl FilesystemCompilerHost {
 
     /// Re-observe like [`Self::reobserve`], aborting promptly with
     /// [`SourceLoadError::Superseded`] once `supersession` reports a newer
-    /// source revision (RUE-1830). A superseded attempt commits no snapshot,
-    /// manifest, or graph; the caller restarts from the newest bytes.
+    /// source revision (RUE-1830). A superseded attempt never exposes partial
+    /// state: a pre-commit abort keeps the prior snapshot, manifest, and graph,
+    /// while a signal observed after close may retain that one coherent closed
+    /// successor. The caller restarts from the newest bytes either way.
     pub fn reobserve_superseding(
         &mut self,
         supersession: &dyn Fn() -> bool,
@@ -66,7 +68,9 @@ impl FilesystemCompilerHost {
     /// Acquire like [`Self::acquire_reached_toolchain_modules`], aborting
     /// promptly with [`SourceLoadError::Superseded`] once `supersession`
     /// reports a newer source revision (RUE-1863). A superseded acquisition
-    /// commits no snapshot, manifest, graph, or assembler state.
+    /// never exposes partial state: a pre-commit abort keeps the prior state,
+    /// while a signal observed after publication may retain that one coherent
+    /// committed acquisition round.
     pub fn acquire_reached_toolchain_modules_superseding(
         &mut self,
         options: &CompileOptions,

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -1,16 +1,16 @@
 use std::env;
 use std::fs;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use ahash::{AHashMap, AHashSet};
 use rue_compiler::unstable::{
     AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
     ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave, ImportInputRevision,
     ImportObservation, ImportObservationStatus, RootedParkOutcome, TrustedSuccessorDelta,
-    begin_import_input_request, begin_import_wave_with_accepted_reads,
+    abort_import_input_request, begin_import_input_request, begin_import_wave_with_accepted_reads,
     close_import_discovery_successor, close_import_input_request, closed_discovery_continuation,
     discovery_attempt, extend_import_wave, import_demand_frontier_for_roots,
     import_observation_ledger, plan_delta_roots, plan_round_roots,
@@ -19,14 +19,14 @@ use rue_compiler::unstable::{
 };
 #[cfg(test)]
 use rue_compiler::unstable::{
-    accepted_read_identity_lookups, accepted_read_identity_visits, committed_successor_sharing,
-    exact_import_groups_dispatched, handoff_observation_visits, handoff_observations,
-    import_close_records_reduced, import_frontier_roots_requested, import_plan_groups_constructed,
-    import_view_full_leaves_published, import_view_ledger_entries_cloned,
-    import_view_overlay_leaves_published, import_view_read_entries_compared,
-    import_view_source_entries_compared, parse_invalidation_entries_compared,
-    parse_key_entries_compared, parse_modules_dispatched, parse_sources_materialized,
-    snapshot_module_resolution_visits, snapshot_module_resolutions,
+    accepted_read_identity_lookups, accepted_read_identity_visits, committed_import_discovery,
+    committed_successor_sharing, exact_import_groups_dispatched, handoff_observation_visits,
+    handoff_observations, import_close_records_reduced, import_frontier_roots_requested,
+    import_plan_groups_constructed, import_view_full_leaves_published,
+    import_view_ledger_entries_cloned, import_view_overlay_leaves_published,
+    import_view_read_entries_compared, import_view_source_entries_compared,
+    parse_invalidation_entries_compared, parse_key_entries_compared, parse_modules_dispatched,
+    parse_sources_materialized, snapshot_module_resolution_visits, snapshot_module_resolutions,
 };
 #[cfg(test)]
 use rue_compiler::unstable::{frontend_query_invalidations, rooted_cfg};
@@ -70,6 +70,8 @@ pub struct WatchInput {
     requested_path: PathBuf,
     canonical_path: PathBuf,
     expected_fingerprint: Option<WatchFingerprint>,
+    symlink_boundary: Option<PathBuf>,
+    expected_symlink_route: Arc<[PhysicalFileIdentity]>,
 }
 
 impl WatchInput {
@@ -82,6 +84,24 @@ impl WatchInput {
             requested_path,
             canonical_path,
             expected_fingerprint: Some(fingerprint),
+            symlink_boundary: None,
+            expected_symlink_route: Arc::from([]),
+        }
+    }
+
+    fn new_with_symlink_route(
+        requested_path: PathBuf,
+        canonical_path: PathBuf,
+        fingerprint: WatchFingerprint,
+        symlink_boundary: PathBuf,
+        expected_symlink_route: Arc<[PhysicalFileIdentity]>,
+    ) -> Self {
+        Self {
+            requested_path,
+            canonical_path,
+            expected_fingerprint: Some(fingerprint),
+            symlink_boundary: Some(symlink_boundary),
+            expected_symlink_route,
         }
     }
 
@@ -93,6 +113,8 @@ impl WatchInput {
             canonical_path: path.clone(),
             requested_path: path,
             expected_fingerprint: None,
+            symlink_boundary: None,
+            expected_symlink_route: Arc::from([]),
         }
     }
 
@@ -106,6 +128,13 @@ impl WatchInput {
 
     pub fn expected_fingerprint(&self) -> Option<WatchFingerprint> {
         self.expected_fingerprint
+    }
+
+    fn symlink_route_changed(&self) -> bool {
+        self.symlink_boundary.as_ref().is_some_and(|boundary| {
+            symlink_route(&self.requested_path, boundary).as_ref()
+                != self.expected_symlink_route.as_ref()
+        })
     }
 }
 
@@ -126,6 +155,9 @@ where
     inputs.iter().any(|input| {
         let requested = input.requested_path();
         let canonical = input.canonical_path();
+        if input.symlink_route_changed() {
+            return true;
+        }
         if input.expected_fingerprint().is_none() {
             return !matches!(
                 fs::canonicalize(requested),
@@ -149,6 +181,9 @@ pub fn watch_input_fingerprints(inputs: &[WatchInput]) -> Vec<Option<WatchFinger
     inputs
         .iter()
         .map(|input| {
+            if input.symlink_route_changed() {
+                return None;
+            }
             if input.requested_path() != input.canonical_path()
                 && fs::canonicalize(input.requested_path()).ok().as_deref()
                     != Some(input.canonical_path())
@@ -523,10 +558,14 @@ fn reobserve_accepted_reads(
     manifest: &AcceptedReadManifest,
     source_manifest: Option<&SourceManifest>,
     context: &ImportDiscoveryContext,
+    control: DiscoveryControl<'_>,
 ) -> Result<AHashMap<String, AcceptedImportSource>, SourceLoadError> {
+    control.checkpoint()?;
     let now = SystemTime::now();
     let mut observed = AHashMap::with_capacity(manifest.len());
     for entry in manifest.iter() {
+        control.checkpoint()?;
+        test_reobserve_delay(control)?;
         let cached_source = snapshot
             .shared_source_for_module(entry.module())
             .ok_or_else(|| {
@@ -588,12 +627,27 @@ fn reobserve_accepted_reads(
                 &boundary,
             )?
         };
+        control.checkpoint()?;
         observed.insert(entry.requested_path().to_owned(), accepted);
     }
+    control.checkpoint()?;
     Ok(observed)
 }
 
 fn execute_import_request(
+    request: ImportDiscoveryRequest,
+    source_manifest: Option<&SourceManifest>,
+    reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
+    control: DiscoveryControl<'_>,
+) -> Result<ImportObservation, SourceLoadError> {
+    control.checkpoint()?;
+    let observation =
+        execute_import_request_uncancelled(request, source_manifest, reobserved_reads);
+    control.checkpoint()?;
+    Ok(observation)
+}
+
+fn execute_import_request_uncancelled(
     request: ImportDiscoveryRequest,
     source_manifest: Option<&SourceManifest>,
     reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
@@ -748,9 +802,10 @@ pub enum SourceLoadError {
     /// message.
     Toolchain(ToolchainIntegrityError),
     /// A caller-supplied supersession probe reported a newer source revision
-    /// while import discovery was still re-closing the graph (RUE-1830). The
-    /// superseded attempt committed no snapshot, manifest, or graph; the
-    /// caller restarts observation from the newest bytes.
+    /// while import discovery was re-closing the graph (RUE-1830). Before the
+    /// atomic close boundary the attempt is aborted and the prior committed
+    /// selection remains authoritative. A change observed just after that
+    /// boundary reports supersession while retaining the coherent new close.
     Superseded,
     /// A trusted toolchain module resolves to a path the hermetic build
     /// configuration forbids (RUE-1112). This is deterministically DISTINCT
@@ -759,6 +814,61 @@ pub enum SourceLoadError {
     /// toolchain. It carries its own outer classification and presentation, never
     /// the "toolchain integrity" / broken-installation framing.
     HermeticDenial(HermeticDenialError),
+}
+
+#[derive(Clone, Copy, Default)]
+struct DiscoveryControl<'a> {
+    supersession: Option<&'a dyn Fn() -> bool>,
+}
+
+impl<'a> DiscoveryControl<'a> {
+    fn superseding(supersession: Option<&'a dyn Fn() -> bool>) -> Self {
+        Self { supersession }
+    }
+
+    fn checkpoint(self) -> Result<(), SourceLoadError> {
+        check_supersession(self.supersession)
+    }
+}
+
+// Production-inert watch synchronization. The CLI integration harness uses
+// this only to hold a retained re-observation inside its first filesystem
+// boundary long enough to place an edit there deterministically. Unlike a
+// fixed sleep, the wait polls the real cycle supersession authority and exits
+// as soon as the change monitor observes newer bytes.
+const TEST_REOBSERVE_DELAY_ENV: &str = "RUE_WATCH_TEST_REOBSERVE_DELAY_MS";
+const TEST_WATCH_PROTOCOL_ENV: &str = "RUE_WATCH_TEST_PROTOCOL";
+static TEST_REOBSERVE_DELAY_USED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+fn test_reobserve_delay(control: DiscoveryControl<'_>) -> Result<(), SourceLoadError> {
+    if control.supersession.is_none() {
+        return Ok(());
+    }
+    if env::var_os(TEST_WATCH_PROTOCOL_ENV).is_none() {
+        return Ok(());
+    }
+    let Ok(delay) = env::var(TEST_REOBSERVE_DELAY_ENV) else {
+        return Ok(());
+    };
+    let Ok(milliseconds) = delay.parse::<u64>() else {
+        return Ok(());
+    };
+    if TEST_REOBSERVE_DELAY_USED.swap(true, std::sync::atomic::Ordering::AcqRel) {
+        return Ok(());
+    }
+    if let Some(path) = env::var_os(TEST_WATCH_PROTOCOL_ENV)
+        && let Ok(mut protocol) = fs::OpenOptions::new().create(true).append(true).open(path)
+    {
+        let _ = writeln!(protocol, "reobserve-read-boundary");
+        let _ = protocol.flush();
+    }
+    let deadline = Instant::now() + Duration::from_millis(milliseconds.min(5_000));
+    while Instant::now() < deadline {
+        control.checkpoint()?;
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    control.checkpoint()
 }
 
 /// Turn a host-side contradiction into the canonical graceful ICE diagnostic.
@@ -850,10 +960,13 @@ impl ImportDiscoveryResult {
                 .shared_source_for_module(entry.module())
                 .expect("an accepted read has source bytes in the committed snapshot");
             let fingerprint = WatchFingerprint::from_bytes(source.as_bytes());
-            paths.push(WatchInput::new(
-                PathBuf::from(entry.requested_path()),
+            let requested = PathBuf::from(entry.requested_path());
+            paths.push(WatchInput::new_with_symlink_route(
+                requested.clone(),
                 PathBuf::from(entry.canonical_path()),
                 fingerprint,
+                spelling_boundary(&self.resolution.context, &requested),
+                Arc::from(entry.symlink_route().to_vec()),
             ));
         }
         paths.extend(
@@ -1026,6 +1139,23 @@ thread_local! {
     /// contract covers.
     static WAVE_PUBLISH_HOOK: std::cell::RefCell<Option<Box<dyn FnMut()>>> =
         const { std::cell::RefCell::new(None) };
+    /// Test hook fired after one import stage has selected its provisional
+    /// parse terminal, before any frontier or close may consume it.
+    static IMPORT_STAGE_HOOK: std::cell::RefCell<Option<Box<dyn FnMut(ImportInputRevision)>>> =
+        const { std::cell::RefCell::new(None) };
+    /// Test hook fired after close has published a failed candidate attempt but
+    /// before the retained host decides whether that failure was superseded.
+    static IMPORT_FAILED_CLOSE_HOOK: std::cell::RefCell<Option<Box<dyn FnMut()>>> =
+        const { std::cell::RefCell::new(None) };
+    /// Test hook fired after all import work is assembled but before the final
+    /// accepted-read route validation and close.
+    static IMPORT_PRE_CLOSE_HOOK: std::cell::RefCell<Option<Box<dyn FnMut()>>> =
+        const { std::cell::RefCell::new(None) };
+    /// Test hook fired after a successful close has been copied into every
+    /// host-visible field, immediately before superseding callers observe the
+    /// commit boundary.
+    static IMPORT_COMMIT_HOOK: std::cell::RefCell<Option<Box<dyn FnMut()>>> =
+        const { std::cell::RefCell::new(None) };
     /// Waves discarded by that verification and re-run.
     static WAVE_STAMP_RERUNS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
@@ -1033,6 +1163,42 @@ thread_local! {
 #[cfg(test)]
 fn fire_wave_publish_hook() {
     WAVE_PUBLISH_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().as_mut() {
+            hook();
+        }
+    });
+}
+
+#[cfg(test)]
+fn fire_import_stage_hook(input_revision: ImportInputRevision) {
+    IMPORT_STAGE_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().as_mut() {
+            hook(input_revision);
+        }
+    });
+}
+
+#[cfg(test)]
+fn fire_import_failed_close_hook() {
+    IMPORT_FAILED_CLOSE_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().as_mut() {
+            hook();
+        }
+    });
+}
+
+#[cfg(test)]
+fn fire_import_pre_close_hook() {
+    IMPORT_PRE_CLOSE_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().as_mut() {
+            hook();
+        }
+    });
+}
+
+#[cfg(test)]
+fn fire_import_commit_hook() {
+    IMPORT_COMMIT_HOOK.with(|hook| {
         if let Some(hook) = hook.borrow_mut().as_mut() {
             hook();
         }
@@ -1047,12 +1213,56 @@ fn fire_wave_publish_hook() {
 /// hop's. Verifying the whole batch here, fail-closed, is what makes that window
 /// safe: a revision can never mix a stale read with a fresh one, because a single
 /// disagreement discards the wave and re-runs it.
-fn wave_reads_are_stable(wave: &ImportDiscoveryWave) -> bool {
-    wave.accepted_reads().iter().all(|source| {
-        fs::metadata(Path::new(source.canonical_path())).is_ok_and(|metadata| {
-            physical_file_identity(&metadata) == source.metadata_identity()
-                && file_metadata_fingerprint(&metadata) == source.metadata_fingerprint()
+fn accepted_path_is_stable(
+    context: &ImportDiscoveryContext,
+    requested_path: &str,
+    canonical_path: &str,
+    expected_route: &[PhysicalFileIdentity],
+    expected_identity: PhysicalFileIdentity,
+    expected_fingerprint: FileMetadataFingerprint,
+) -> bool {
+    let requested = Path::new(requested_path);
+    let canonical = Path::new(canonical_path);
+    let boundary = spelling_boundary(context, requested);
+    let route_before = symlink_route(requested, &boundary);
+    let observed_canonical = fs::canonicalize(requested).ok();
+    let observed_metadata = fs::metadata(canonical).ok();
+    let route_after = symlink_route(requested, &boundary);
+    route_before.as_ref() == expected_route
+        && route_after.as_ref() == expected_route
+        && observed_canonical.as_deref() == Some(canonical)
+        && observed_metadata.is_some_and(|metadata| {
+            physical_file_identity(&metadata) == expected_identity
+                && file_metadata_fingerprint(&metadata) == expected_fingerprint
         })
+}
+
+fn wave_reads_are_stable(wave: &ImportDiscoveryWave, context: &ImportDiscoveryContext) -> bool {
+    wave.accepted_reads().iter().all(|source| {
+        accepted_path_is_stable(
+            context,
+            source.requested_path(),
+            source.canonical_path(),
+            source.symlink_route(),
+            source.metadata_identity(),
+            source.metadata_fingerprint(),
+        )
+    })
+}
+
+fn accepted_manifest_reads_are_stable(
+    manifest: &AcceptedReadManifest,
+    context: &ImportDiscoveryContext,
+) -> bool {
+    manifest.iter().all(|entry| {
+        accepted_path_is_stable(
+            context,
+            entry.requested_path(),
+            entry.canonical_path(),
+            entry.symlink_route(),
+            entry.metadata_identity(),
+            entry.metadata_fingerprint(),
+        )
     })
 }
 
@@ -1070,9 +1280,10 @@ fn run_import_wave(
     frontier: &ImportDemandFrontier,
     source_manifest: Option<&SourceManifest>,
     reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
-    supersession: Option<&dyn Fn() -> bool>,
+    control: DiscoveryControl<'_>,
 ) -> Result<(ImportInputRevision, ImportDemandFrontier), SourceLoadError> {
     for attempt in 0..=WAVE_STAMP_RETRIES {
+        control.checkpoint()?;
         let accepted_reads = assembler.accepted_read_manifest();
         let mut wave = begin_import_wave_with_accepted_reads(
             staging,
@@ -1083,19 +1294,38 @@ fn run_import_wave(
         )
         .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
         while !wave.is_complete() {
-            check_supersession(supersession)?;
+            control.checkpoint()?;
             let observations = wave
                 .requests()
                 .iter()
                 .cloned()
-                .map(|request| execute_import_request(request, source_manifest, reobserved_reads))
-                .collect::<Vec<_>>();
+                .map(|request| {
+                    execute_import_request(request, source_manifest, reobserved_reads, control)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
             extend_import_wave(staging, &mut wave, observations)
                 .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+            control.checkpoint()?;
         }
         #[cfg(test)]
         fire_wave_publish_hook();
-        if !wave_reads_are_stable(&wave) {
+        control.checkpoint()?;
+        if !accepted_manifest_reads_are_stable(&accepted_reads, plan.context()) {
+            if reobserved_reads.is_some() || control.supersession.is_some() {
+                return Err(SourceLoadError::Superseded);
+            }
+            return Err(SourceLoadError::Message(
+                "Error: a previously accepted source route changed during import discovery"
+                    .to_owned(),
+            ));
+        }
+        if !wave_reads_are_stable(&wave, plan.context()) {
+            // A retained request's observations were captured before this wave.
+            // Retrying the same frozen map would only rediscover the obsolete
+            // route; abort the request so the next watch cycle re-observes it.
+            if reobserved_reads.is_some() {
+                return Err(SourceLoadError::Superseded);
+            }
             #[cfg(test)]
             WAVE_STAMP_RERUNS.with(|count| count.set(count.get() + 1));
             if attempt == WAVE_STAMP_RETRIES {
@@ -1111,9 +1341,11 @@ fn run_import_wave(
         assembler
             .add_wave_reads(&wave)
             .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        control.checkpoint()?;
         let successor_snapshot = assembler
             .snapshot()
             .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        control.checkpoint()?;
         return publish_import_wave(
             staging,
             wave,
@@ -1128,7 +1360,7 @@ fn run_import_wave(
 /// Fail promptly with [`SourceLoadError::Superseded`] once the caller's
 /// probe reports that a newer source revision replaced the bytes this
 /// discovery attempt is reading (RUE-1830). `None` keeps every check a no-op
-/// for one-shot loads and toolchain re-closes.
+/// for one-shot loads.
 fn check_supersession(supersession: Option<&dyn Fn() -> bool>) -> Result<(), SourceLoadError> {
     if supersession.is_some_and(|probe| probe()) {
         return Err(SourceLoadError::Superseded);
@@ -1144,8 +1376,9 @@ fn drive_import_discovery_to_close(
     reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
     continuation: Option<ImportInputRevision>,
     reclose: Option<ReClose<'_>>,
-    supersession: Option<&dyn Fn() -> bool>,
+    control: DiscoveryControl<'_>,
 ) -> Result<ClosedDiscovery, SourceLoadError> {
+    control.checkpoint()?;
     // Exactly one import-input request is opened per external request, here,
     // before the frontier loop below. Rounds inside that loop publish overlay
     // successors which inherit this request's compatibility token, so the whole
@@ -1168,6 +1401,7 @@ fn drive_import_discovery_to_close(
         }
     };
     let final_plan;
+    let final_ledger;
     let witness;
     // The previous round's frontier, once there is one. It names the exact
     // occurrences whose host answers arrive this round and which may therefore
@@ -1185,10 +1419,10 @@ fn drive_import_discovery_to_close(
     let mut cumulative_witness_closures = 0_u32;
     let mut reroot_witness_closures = 0_u32;
     loop {
-        // A newer revision supersedes this attempt between rounds; the
-        // per-hop check inside the ordinary wave bounds a superseded
-        // attempt's residual filesystem work to one hop (RUE-1830).
-        check_supersession(supersession)?;
+        // A newer revision supersedes this attempt between rounds. The same
+        // control is also checked around every accepted physical read and
+        // before publication, bounding stale work without publishing it.
+        control.checkpoint()?;
         // One frontier round: plan and frontier construction (which owns the
         // canonical parse of everything read so far), then the host reads that
         // answer the frontier's requests. Both halves are timed so a discovery
@@ -1215,6 +1449,9 @@ fn drive_import_discovery_to_close(
                 None => stage_import_input_request(staging, input_revision),
             }
         };
+        #[cfg(test)]
+        fire_import_stage_hook(input_revision);
+        control.checkpoint()?;
         let plan = match staged {
             Ok(plan) => plan,
             Err(_) => {
@@ -1301,9 +1538,11 @@ fn drive_import_discovery_to_close(
                 roots = whole_plan;
             }
         };
+        control.checkpoint()?;
         drop(plan_span);
         if frontier.requests().is_empty() {
             final_plan = plan;
+            final_ledger = ledger;
             witness = frontier;
             break;
         }
@@ -1320,9 +1559,10 @@ fn drive_import_discovery_to_close(
                     .iter()
                     .cloned()
                     .map(|request| {
-                        execute_import_request(request, source_manifest, reobserved_reads)
+                        execute_import_request(request, source_manifest, reobserved_reads, control)
                     })
-                    .collect::<Vec<_>>();
+                    .collect::<Result<Vec<_>, _>>()?;
+                control.checkpoint()?;
                 // In a trusted-toolchain re-close every frontier request resolves
                 // an `@import` edge owned by an appended leaf or a leaf newly
                 // discovered from it (e.g. strbuf → arraybuf/rawbuf). These edges
@@ -1344,6 +1584,16 @@ fn drive_import_discovery_to_close(
                 assembler
                     .add_successor_plan_reads(&plan, &next_ledger)
                     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+                if !accepted_manifest_reads_are_stable(&assembler.accepted_read_manifest(), context)
+                {
+                    if reobserved_reads.is_some() || control.supersession.is_some() {
+                        return Err(SourceLoadError::Superseded);
+                    }
+                    return Err(SourceLoadError::Message(
+                        "Error: a source route changed before trusted successor publication"
+                            .to_owned(),
+                    ));
+                }
                 let successor_snapshot = assembler
                     .snapshot()
                     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
@@ -1373,7 +1623,7 @@ fn drive_import_discovery_to_close(
                     &frontier,
                     source_manifest,
                     reobserved_reads,
-                    supersession,
+                    control,
                 )?;
                 input_revision = revision;
                 previous_frontier = Some(published);
@@ -1381,10 +1631,22 @@ fn drive_import_discovery_to_close(
         }
     }
 
+    control.checkpoint()?;
+    #[cfg(test)]
+    fire_import_pre_close_hook();
     let _close_span = tracing::info_span!("import_discovery_close").entered();
     let snapshot = assembler
         .snapshot()
         .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+    if !accepted_manifest_reads_are_stable(&assembler.accepted_read_manifest(), context) {
+        if reobserved_reads.is_some() || control.supersession.is_some() {
+            return Err(SourceLoadError::Superseded);
+        }
+        return Err(SourceLoadError::Message(
+            "Error: a source route changed before import discovery could close".to_owned(),
+        ));
+    }
+    control.checkpoint()?;
     debug_assert_eq!(final_plan.source_revision(), snapshot.source_revision());
     // A trusted-toolchain successor closes over only the modules its opaque delta
     // capability authorizes, merging their topology into the committed
@@ -1396,6 +1658,13 @@ fn drive_import_discovery_to_close(
     let closed = match close_result {
         Ok(closed) => closed,
         Err(errors) => {
+            // A failed close is still pre-commit candidate state. If a newer
+            // filesystem revision arrived while close was computing, report
+            // supersession so the caller restores the exact committed request
+            // rather than selecting diagnostics from the obsolete failure.
+            #[cfg(test)]
+            fire_import_failed_close_hook();
+            control.checkpoint()?;
             let attempted = discovery_attempt(staging)
                 .expect("failed closure publishes an attempted import revision");
             if DependencyEnvelope::from_closed_revision(&attempted).is_some() {
@@ -1412,8 +1681,11 @@ fn drive_import_discovery_to_close(
             }
         }
     };
-    let observed_absent_paths = import_observation_ledger(staging, input_revision)
-        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?
+    // The exact ledger whose empty frontier authorized this close is already
+    // in hand. Project the host's negative observations from that immutable
+    // value before returning; no fallible session lookup may occur after the
+    // compiler has committed but before the host installs the same close.
+    let observed_absent_paths = final_ledger
         .iter()
         .filter(|observation| matches!(observation.status(), ImportObservationStatus::Absent))
         .map(|observation| PathBuf::from(observation.request().requested_path()))
@@ -1546,7 +1818,7 @@ pub(crate) fn discover_and_load_imports(
         None,
         None,
         None,
-        None,
+        DiscoveryControl::default(),
     )?;
 
     Ok(ImportDiscoveryResult {
@@ -1573,13 +1845,15 @@ pub(crate) fn reload_from_filesystem(
     result: &mut ImportDiscoveryResult,
     supersession: Option<&dyn Fn() -> bool>,
 ) -> Result<(), SourceLoadError> {
-    check_supersession(supersession)?;
+    let control = DiscoveryControl::superseding(supersession);
+    control.checkpoint()?;
     let source_manifest = result
         .source_manifest
         .as_ref()
         .map(|manifest| SourceManifest::load(manifest.path.to_string_lossy().as_ref()))
         .transpose()
         .map_err(SourceLoadError::Message)?;
+    control.checkpoint()?;
     validate_manifest_allows_source(
         source_manifest.as_ref(),
         result.resolution.root_path.to_string_lossy().as_ref(),
@@ -1602,6 +1876,7 @@ pub(crate) fn reload_from_filesystem(
         &result.read_manifest,
         source_manifest.as_ref(),
         &context,
+        control,
     )?;
     let root_module = result.source_snapshot.source_revision().root();
     let root_entry = result
@@ -1636,7 +1911,7 @@ pub(crate) fn reload_from_filesystem(
     // for requests the new rooted frontier actually issues; making every old
     // read explicit would keep modules that are no longer reachable after an
     // import-set edit and grow the retained snapshot monotonically.
-    let close = drive_import_discovery_to_close(
+    let close = match drive_import_discovery_to_close(
         &mut assembler,
         &mut result.session,
         &context,
@@ -1644,8 +1919,19 @@ pub(crate) fn reload_from_filesystem(
         Some(&reobserved),
         None,
         None,
-        supersession,
-    )?;
+        control,
+    ) {
+        Err(SourceLoadError::Superseded) => {
+            abort_import_input_request(&mut result.session).map_err(|errors| {
+                SourceLoadError::Compiler {
+                    snapshot: Some(result.source_snapshot.clone()),
+                    errors: errors.into(),
+                }
+            })?;
+            return Err(SourceLoadError::Superseded);
+        }
+        outcome => outcome?,
+    };
     result.source_snapshot = close.snapshot;
     result.read_manifest = assembler.accepted_read_manifest();
     result.observed_absent_paths = close.observed_absent_paths;
@@ -1662,7 +1948,14 @@ pub(crate) fn reload_from_filesystem(
             result.witness_discharge = close.witness_discharge;
         }
     }
-    Ok(())
+    // A successful close is an atomic commit boundary. Supersession observed
+    // here reports that the watch cycle should restart, but the fully installed
+    // host/session revision remains coherent and becomes the next cycle's
+    // re-observation baseline; rolling only the assembler back would splice two
+    // different committed revisions together.
+    #[cfg(test)]
+    fire_import_commit_hook();
+    control.checkpoint()
 }
 
 /// Bounded rounds for reached-body trusted-toolchain acquisition. Each satisfied
@@ -1702,19 +1995,20 @@ pub(crate) fn acquire_reached_toolchain_modules(
 /// re-observation. Each round is a transaction: the demand reads land in a
 /// CLONE of the assembler, and the host's committed state — snapshot, manifest,
 /// revision, witness, assembler — is replaced only after the re-close returns.
-/// A superseded round therefore commits nothing, and the next cycle's
-/// re-observation begins a fresh import-input request that supersedes any
-/// successor this round published to the session.
+/// The compiler may provisionally stage that successor while the re-close runs,
+/// but a supersession before close aborts the import-input request, restores the
+/// session's committed selectors, and leaves every host field unchanged.
 ///
-/// The last check before publication is the commit boundary: publish,
-/// re-close, and the host assignment run to completion once it passes, so a
-/// cancellation observed afterward leaves a coherent new commit rather than a
-/// half-applied one. `None` keeps every check a no-op for the one-shot driver.
+/// A successful close is the commit boundary. The infallible host assignments
+/// then run to completion, so supersession observed afterward keeps the new
+/// session and host close coherent rather than rolling either half back.
+/// `None` keeps every check a no-op for the one-shot driver.
 pub(crate) fn acquire_reached_toolchain_modules_superseding(
     result: &mut ImportDiscoveryResult,
     options: &CompileOptions,
     supersession: Option<&dyn Fn() -> bool>,
 ) -> Result<(), SourceLoadError> {
+    let control = DiscoveryControl::superseding(supersession);
     // A discovery that did not close valid (missing or ambiguous imports) has no
     // queryable program, so semantic analysis cannot run and there is nothing to
     // acquire. Leave it untouched: the driver surfaces the canonical import
@@ -1725,7 +2019,7 @@ pub(crate) fn acquire_reached_toolchain_modules_superseding(
         return Ok(());
     }
     for _ in 0..MAX_TOOLCHAIN_ACQUISITION_ROUNDS {
-        check_supersession(supersession)?;
+        control.checkpoint()?;
         match rooted_or_toolchain_park(&mut result.session, options) {
             // Analysis satisfied every reached-body demand (or there were none).
             RootedParkOutcome::Ready => return Ok(()),
@@ -1753,7 +2047,7 @@ pub(crate) fn acquire_reached_toolchain_modules_superseding(
                 // (RUE-1863).
                 let mut round_assembler = result.assembler.clone();
                 for demand in park.demands() {
-                    check_supersession(supersession)?;
+                    control.checkpoint()?;
                     satisfy_toolchain_module_demand(
                         &mut round_assembler,
                         result.std_root.as_deref(),
@@ -1793,7 +2087,7 @@ pub(crate) fn acquire_reached_toolchain_modules_superseding(
                 // closed and never re-rooted. A malformed or missing transitive
                 // trusted leaf fails during this re-close, and classification
                 // (below) attributes it to the actual failing module.
-                let reclosed = drive_import_discovery_to_close(
+                let reclosed = match drive_import_discovery_to_close(
                     &mut round_assembler,
                     &mut result.session,
                     &result.resolution.context,
@@ -1801,11 +2095,24 @@ pub(crate) fn acquire_reached_toolchain_modules_superseding(
                     None,
                     Some(delta.revision()),
                     Some(ReClose { delta: &delta }),
-                    supersession,
-                )
-                .map_err(|error| {
-                    reclassify_reclose_failure(error, result.std_root.as_deref(), park.demands())
-                })?;
+                    control,
+                ) {
+                    Ok(reclosed) => reclosed,
+                    Err(error) => {
+                        let error = reclassify_reclose_failure(
+                            error,
+                            result.std_root.as_deref(),
+                            park.demands(),
+                        );
+                        abort_import_input_request(&mut result.session).map_err(|errors| {
+                            SourceLoadError::Compiler {
+                                snapshot: Some(result.source_snapshot.clone()),
+                                errors: errors.into(),
+                            }
+                        })?;
+                        return Err(error);
+                    }
+                };
                 // Commit boundary: every assignment below is infallible, so the
                 // round is applied whole or not at all.
                 result.read_manifest = round_assembler.accepted_read_manifest();
@@ -2373,6 +2680,37 @@ mod tests {
             fs::write(&path, source).unwrap();
             path
         }
+    }
+
+    fn exact_snapshot_projection(
+        snapshot: &SourceSnapshot,
+    ) -> Vec<(u32, String, String, String, String, String)> {
+        snapshot
+            .files()
+            .map(|source| {
+                (
+                    source.file_id.index(),
+                    source.path.to_owned(),
+                    source.source.to_owned(),
+                    snapshot
+                        .module_id(source.file_id)
+                        .expect("snapshot file has a module identity")
+                        .as_str()
+                        .to_owned(),
+                    format!(
+                        "{:?}",
+                        snapshot
+                            .source_id(source.file_id)
+                            .expect("snapshot file has a source identity")
+                    ),
+                    snapshot
+                        .metadata()
+                        .logical_path(source.file_id)
+                        .expect("snapshot file has a logical path")
+                        .to_owned(),
+                )
+            })
+            .collect()
     }
 
     #[test]
@@ -3104,6 +3442,522 @@ mod tests {
         }
     }
 
+    #[test]
+    fn superseded_reobserve_after_partial_candidate_stage_preserves_committed_revision_and_recovers()
+     {
+        let dir = TestDir::new("superseded-reobserve-stage");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let leaf = dir.write("leaf.rue", "pub fn value() -> i32 { 1 }");
+        dir.write("next.rue", "pub fn value() -> i32 { 9 }");
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let committed_revision = result.revision.source_revision().clone();
+        let committed_snapshot = result.source_snapshot.clone();
+        let committed_reads = result.read_manifest.clone();
+        let committed_watch_inputs = result.watch_inputs();
+        let committed_assembler = result.assembler.snapshot().unwrap();
+        let committed_semantic =
+            rooted_cfg(&mut result.session, &CompileOptions::default()).unwrap();
+        let committed_invalidations = frontend_query_invalidations(&result.session);
+
+        fs::write(
+            &leaf,
+            r#"pub const next = @import("next.rue"); pub fn value() -> i32 { next.value() }"#,
+        )
+        .unwrap();
+        let superseded = std::rc::Rc::new(std::cell::Cell::new(false));
+        let supersede_from_hook = superseded.clone();
+        IMPORT_STAGE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move |revision| {
+                if revision.frontier_round() > 0 {
+                    supersede_from_hook.set(true);
+                }
+            }));
+        });
+        let probe = || superseded.get();
+        let outcome = reload_from_filesystem(&mut result, Some(&probe));
+        IMPORT_STAGE_HOOK.with(|hook| *hook.borrow_mut() = None);
+
+        assert!(matches!(outcome, Err(SourceLoadError::Superseded)));
+        assert_eq!(result.revision.source_revision(), &committed_revision);
+        assert_eq!(
+            exact_snapshot_projection(&result.source_snapshot),
+            exact_snapshot_projection(&committed_snapshot)
+        );
+        assert_eq!(result.read_manifest, committed_reads);
+        assert_eq!(result.watch_inputs(), committed_watch_inputs);
+        assert_eq!(
+            exact_snapshot_projection(&result.assembler.snapshot().unwrap()),
+            exact_snapshot_projection(&committed_assembler)
+        );
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .all(|source| !source.source.contains("next.value()")),
+            "a superseded candidate stage must not replace the host's committed source snapshot"
+        );
+        assert!(
+            result
+                .source_snapshot
+                .source_revision()
+                .modules()
+                .iter()
+                .all(|module| module.module.as_str() != "next.rue"),
+            "the source published by the partial wave must stay outside the committed snapshot"
+        );
+        let session_revision = committed_import_discovery(&result.session)
+            .expect("the retained session keeps its last good discovery");
+        assert_eq!(
+            session_revision.source_revision(),
+            &committed_revision,
+            "a superseded open attempt must not replace the session's committed graph"
+        );
+        let restored_semantic = rooted_cfg(&mut result.session, &CompileOptions::default())
+            .expect("public semantic queries continue serving the last closed revision");
+        assert_same_rooted_cfg_identity(&committed_semantic, &restored_semantic);
+        assert_eq!(
+            frontend_query_invalidations(&result.session),
+            committed_invalidations,
+            "rollback must reselect the committed terminal without invalidating its semantic cone"
+        );
+
+        reload_from_filesystem(&mut result, None)
+            .expect("the next observation recovers from the discarded attempt");
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| source.source.contains("next.value()")),
+            "the recovery attempt must close against the newest source bytes"
+        );
+        assert!(
+            result
+                .source_snapshot
+                .source_revision()
+                .modules()
+                .iter()
+                .any(|module| module.module.as_str() == "next.rue"),
+            "recovery must publish the newly reached source"
+        );
+        rooted_cfg(&mut result.session, &CompileOptions::default())
+            .expect("the recovered graph must reach semantic analysis");
+    }
+
+    #[test]
+    fn supersession_after_wave_reads_aborts_before_publication() {
+        let dir = TestDir::new("superseded-reobserve-wave");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let leaf = dir.write("leaf.rue", "pub fn value() -> i32 { 1 }");
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let committed_revision = result.revision.source_revision().clone();
+        let committed_snapshot = result.source_snapshot.clone();
+        let committed_reads = result.read_manifest.clone();
+        let committed_watch_inputs = result.watch_inputs();
+        let committed_assembler = result.assembler.snapshot().unwrap();
+        let committed_semantic =
+            rooted_cfg(&mut result.session, &CompileOptions::default()).unwrap();
+
+        fs::write(&leaf, "pub fn value() -> i32 { 2 }").unwrap();
+        let superseded = std::rc::Rc::new(std::cell::Cell::new(false));
+        let supersede_from_hook = superseded.clone();
+        WAVE_PUBLISH_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || supersede_from_hook.set(true)));
+        });
+        let probe = || superseded.get();
+        let outcome = reload_from_filesystem(&mut result, Some(&probe));
+        WAVE_PUBLISH_HOOK.with(|hook| *hook.borrow_mut() = None);
+
+        assert!(matches!(outcome, Err(SourceLoadError::Superseded)));
+        assert_eq!(result.revision.source_revision(), &committed_revision);
+        assert_eq!(
+            exact_snapshot_projection(&result.source_snapshot),
+            exact_snapshot_projection(&committed_snapshot)
+        );
+        assert_eq!(result.read_manifest, committed_reads);
+        assert_eq!(result.watch_inputs(), committed_watch_inputs);
+        assert_eq!(
+            exact_snapshot_projection(&result.assembler.snapshot().unwrap()),
+            exact_snapshot_projection(&committed_assembler)
+        );
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| source.source.contains("value() -> i32 { 1 }")),
+            "the fully read but unpublished wave must not replace committed bytes"
+        );
+        let session_revision = committed_import_discovery(&result.session)
+            .expect("the session restores its prior committed discovery");
+        assert_eq!(session_revision.source_revision(), &committed_revision);
+        let restored_semantic = rooted_cfg(&mut result.session, &CompileOptions::default())
+            .expect("an unpublished wave cannot poison the committed semantic root");
+        assert_same_rooted_cfg_identity(&committed_semantic, &restored_semantic);
+
+        reload_from_filesystem(&mut result, None)
+            .expect("a fresh observation publishes the newest complete wave");
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| source.source.contains("value() -> i32 { 2 }"))
+        );
+    }
+
+    #[test]
+    fn superseded_failed_stage_restores_the_committed_discovery_selector() {
+        let dir = TestDir::new("superseded-failed-stage");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let leaf = dir.write("leaf.rue", "pub fn value() -> i32 { 1 }");
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let committed_revision = result.revision.source_revision().clone();
+        let committed_semantic =
+            rooted_cfg(&mut result.session, &CompileOptions::default()).unwrap();
+
+        fs::write(&leaf, "pub fn value( -> i32 { 2 }").unwrap();
+        let superseded = std::rc::Rc::new(std::cell::Cell::new(false));
+        let supersede_from_hook = superseded.clone();
+        IMPORT_STAGE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move |_| supersede_from_hook.set(true)));
+        });
+        let probe = || superseded.get();
+        let outcome = reload_from_filesystem(&mut result, Some(&probe));
+        IMPORT_STAGE_HOOK.with(|hook| *hook.borrow_mut() = None);
+
+        assert!(matches!(outcome, Err(SourceLoadError::Superseded)));
+        let committed = committed_import_discovery(&result.session)
+            .expect("the failed candidate selector is replaced by the committed discovery");
+        assert_eq!(committed.source_revision(), &committed_revision);
+        let restored = rooted_cfg(&mut result.session, &CompileOptions::default())
+            .expect("failed candidate diagnostics cannot shadow the committed semantic root");
+        assert_same_rooted_cfg_identity(&committed_semantic, &restored);
+    }
+
+    #[test]
+    fn supersession_during_failed_close_restores_the_committed_revision() {
+        let dir = TestDir::new("superseded-failed-close");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let leaf = dir.write("leaf.rue", "pub fn value() -> i32 { 1 }");
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let committed_revision = result.revision.source_revision().clone();
+        let committed_semantic =
+            rooted_cfg(&mut result.session, &CompileOptions::default()).unwrap();
+
+        fs::remove_file(&leaf).unwrap();
+        let superseded = std::rc::Rc::new(std::cell::Cell::new(false));
+        let supersede_from_hook = superseded.clone();
+        IMPORT_FAILED_CLOSE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || supersede_from_hook.set(true)));
+        });
+        let probe = || superseded.get();
+        let outcome = reload_from_filesystem(&mut result, Some(&probe));
+        IMPORT_FAILED_CLOSE_HOOK.with(|hook| *hook.borrow_mut() = None);
+
+        assert!(matches!(outcome, Err(SourceLoadError::Superseded)));
+        let committed = committed_import_discovery(&result.session)
+            .expect("the obsolete failed close cannot replace the committed discovery");
+        assert_eq!(committed.source_revision(), &committed_revision);
+        let restored = rooted_cfg(&mut result.session, &CompileOptions::default())
+            .expect("failed-close supersession restores the committed semantic root");
+        assert_same_rooted_cfg_identity(&committed_semantic, &restored);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_retarget_between_wave_read_and_publication_is_superseded() {
+        let dir = TestDir::new("superseded-wave-symlink-route");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("alias.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let first = dir.write("first.rue", "pub fn value() -> i32 { 1 }");
+        let second = dir.write("second.rue", "pub fn value() -> i32 { 2 }");
+        let alias = dir.path.join("alias.rue");
+        std::os::unix::fs::symlink(&first, &alias).unwrap();
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let committed_revision = result.revision.source_revision().clone();
+
+        // Force a fresh wave while its requested alias still resolves to A.
+        fs::write(
+            &main,
+            "const leaf = @import(\"alias.rue\"); fn main() -> i32 { leaf.value() + 0 }",
+        )
+        .unwrap();
+        let superseded = std::rc::Rc::new(std::cell::Cell::new(false));
+        let supersede_from_hook = superseded.clone();
+        let alias_from_hook = alias.clone();
+        let second_from_hook = second.clone();
+        let fired = std::rc::Rc::new(std::cell::Cell::new(false));
+        let fired_from_hook = fired.clone();
+        WAVE_PUBLISH_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                if !fired_from_hook.replace(true) {
+                    fs::remove_file(&alias_from_hook).unwrap();
+                    std::os::unix::fs::symlink(&second_from_hook, &alias_from_hook).unwrap();
+                    supersede_from_hook.set(true);
+                }
+            }));
+        });
+        let probe = || superseded.get();
+        let outcome = reload_from_filesystem(&mut result, Some(&probe));
+        WAVE_PUBLISH_HOOK.with(|hook| *hook.borrow_mut() = None);
+
+        assert!(matches!(outcome, Err(SourceLoadError::Superseded)));
+        assert_eq!(result.revision.source_revision(), &committed_revision);
+        reload_from_filesystem(&mut result, None)
+            .expect("the next observation closes against the retargeted alias");
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| { source.source.contains("value() -> i32 { 2 }") })
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_root_route_swap_before_close_is_superseded_and_rolled_back() {
+        let dir = TestDir::new("superseded-pre-close-root-route");
+        let real_main = dir.write(
+            "real-main.rue",
+            r#"const leaf = @import("leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let leaf = dir.write("leaf.rue", "pub fn value() -> i32 { 1 }");
+        let root = dir.path.join("main.rue");
+        std::os::unix::fs::symlink(&real_main, &root).unwrap();
+        let mut result = discover_and_load_imports(root.to_str().unwrap(), None, None).unwrap();
+        let committed_revision = result.revision.source_revision().clone();
+        let committed_snapshot = result.source_snapshot.clone();
+        let committed_reads = result.read_manifest.clone();
+        let committed_watch_inputs = result.watch_inputs();
+        let committed_assembler = result.assembler.snapshot().unwrap();
+        let committed_semantic =
+            rooted_cfg(&mut result.session, &CompileOptions::default()).unwrap();
+
+        fs::write(&leaf, "pub fn value() -> i32 { 2 }").unwrap();
+        let original_identity = physical_file_identity(&fs::symlink_metadata(&root).unwrap());
+        let replacement = dir.path.join("replacement-main");
+        std::os::unix::fs::symlink(&real_main, &replacement).unwrap();
+        let replacement_identity =
+            physical_file_identity(&fs::symlink_metadata(&replacement).unwrap());
+        assert_ne!(
+            original_identity, replacement_identity,
+            "the test must replace the root spelling with a distinct symlink inode"
+        );
+        let root_from_hook = root.clone();
+        let replacement_from_hook = replacement.clone();
+        IMPORT_PRE_CLOSE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                fs::rename(&replacement_from_hook, &root_from_hook).unwrap();
+            }));
+        });
+        let outcome = reload_from_filesystem(&mut result, None);
+        IMPORT_PRE_CLOSE_HOOK.with(|hook| *hook.borrow_mut() = None);
+
+        assert!(matches!(outcome, Err(SourceLoadError::Superseded)));
+        assert_eq!(result.revision.source_revision(), &committed_revision);
+        assert_eq!(
+            exact_snapshot_projection(&result.source_snapshot),
+            exact_snapshot_projection(&committed_snapshot)
+        );
+        assert_eq!(result.read_manifest, committed_reads);
+        assert_eq!(result.watch_inputs(), committed_watch_inputs);
+        assert_eq!(
+            exact_snapshot_projection(&result.assembler.snapshot().unwrap()),
+            exact_snapshot_projection(&committed_assembler)
+        );
+        let restored_semantic = rooted_cfg(&mut result.session, &CompileOptions::default())
+            .expect("a pre-close route swap cannot poison the committed semantic root");
+        assert_same_rooted_cfg_identity(&committed_semantic, &restored_semantic);
+        assert_eq!(
+            fs::canonicalize(&root).unwrap(),
+            fs::canonicalize(&real_main).unwrap()
+        );
+        assert_eq!(fs::read(&root).unwrap(), fs::read(&real_main).unwrap());
+
+        reload_from_filesystem(&mut result, None)
+            .expect("the next retained observation closes over the settled replacement route");
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| source.source.contains("value() -> i32 { 2 }"))
+        );
+    }
+
+    #[test]
+    fn superseded_reobserve_at_close_boundary_keeps_the_new_commit_coherent() {
+        let dir = TestDir::new("superseded-reobserve-close");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let leaf = dir.write("leaf.rue", "pub fn value() -> i32 { 1 }");
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+
+        fs::write(&leaf, "pub fn value() -> i32 { 2 }").unwrap();
+        let superseded = std::rc::Rc::new(std::cell::Cell::new(false));
+        let supersede_from_hook = superseded.clone();
+        IMPORT_COMMIT_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || supersede_from_hook.set(true)));
+        });
+        let probe = || superseded.get();
+        let outcome = reload_from_filesystem(&mut result, Some(&probe));
+        IMPORT_COMMIT_HOOK.with(|hook| *hook.borrow_mut() = None);
+
+        assert!(matches!(outcome, Err(SourceLoadError::Superseded)));
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| source.source.contains("value() -> i32 { 2 }")),
+            "supersession after close must keep the newly committed bytes"
+        );
+        let assembled = result.assembler.snapshot().unwrap();
+        assert_eq!(
+            assembled.source_revision(),
+            result.source_snapshot.source_revision(),
+            "host snapshot and assembler must name the same atomic close"
+        );
+        assert_eq!(
+            result.read_manifest,
+            result.assembler.accepted_read_manifest(),
+            "host and assembler provenance must advance together"
+        );
+        assert_eq!(
+            result.revision.source_revision(),
+            result.source_snapshot.source_revision(),
+            "the public discovery view must match the installed host snapshot"
+        );
+        let session_revision = committed_import_discovery(&result.session)
+            .expect("the successful close remains the session commit");
+        assert_eq!(
+            session_revision.source_revision(),
+            result.source_snapshot.source_revision(),
+            "session and host must agree after post-close supersession"
+        );
+
+        reload_from_filesystem(&mut result, None)
+            .expect("the next observation continues from the coherent commit");
+        rooted_cfg(&mut result.session, &CompileOptions::default())
+            .expect("the committed revision remains semantically usable");
+    }
+
+    #[test]
+    fn repeated_superseded_candidate_stages_keep_the_committed_import_view_pinned() {
+        const IMPORT_RETENTION_FLOOR: usize = 64;
+        const MODULE_RETENTION_FLOOR: usize = 4096;
+        // The bounded FIFO may retain one older selected root beyond its
+        // unprotected history floor; this is the same last-good overage the
+        // ordinary module-stamp retention contract permits.
+        const SELECTED_ROOT_OVERAGE: usize = 1;
+        const ABORTS: usize = 70;
+
+        let dir = TestDir::new("superseded-stage-retention");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let leaf = dir.write("leaf.rue", "pub fn value() -> i32 { 1 }");
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let committed_revision = result.revision.source_revision().clone();
+        let committed_snapshot = result.source_snapshot.clone();
+        let committed_reads = result.read_manifest.clone();
+        let committed_watch_inputs = result.watch_inputs();
+        let committed_assembler = result.assembler.snapshot().unwrap();
+        let committed_semantic =
+            rooted_cfg(&mut result.session, &CompileOptions::default()).unwrap();
+        let committed_invalidations = frontend_query_invalidations(&result.session);
+
+        for attempt in 0..ABORTS {
+            fs::write(
+                &leaf,
+                format!("pub fn value() -> i32 {{ {} }}", attempt + 2),
+            )
+            .unwrap();
+            let superseded = std::rc::Rc::new(std::cell::Cell::new(false));
+            let supersede_from_hook = superseded.clone();
+            IMPORT_STAGE_HOOK.with(|hook| {
+                *hook.borrow_mut() = Some(Box::new(move |_| supersede_from_hook.set(true)));
+            });
+            let probe = || superseded.get();
+            let outcome = reload_from_filesystem(&mut result, Some(&probe));
+            IMPORT_STAGE_HOOK.with(|hook| *hook.borrow_mut() = None);
+
+            assert!(
+                matches!(outcome, Err(SourceLoadError::Superseded)),
+                "candidate attempt {attempt} must be superseded after staging"
+            );
+            assert_eq!(
+                result.revision.source_revision(),
+                &committed_revision,
+                "candidate attempt {attempt} must restore the committed revision"
+            );
+            assert_eq!(
+                exact_snapshot_projection(&result.source_snapshot),
+                exact_snapshot_projection(&committed_snapshot),
+                "candidate attempt {attempt} must preserve the exact host snapshot"
+            );
+            assert_eq!(
+                result.read_manifest, committed_reads,
+                "candidate attempt {attempt} must preserve accepted-read provenance"
+            );
+            assert_eq!(
+                result.watch_inputs(),
+                committed_watch_inputs,
+                "candidate attempt {attempt} must preserve the exact watch baseline"
+            );
+            assert_eq!(
+                exact_snapshot_projection(&result.assembler.snapshot().unwrap()),
+                exact_snapshot_projection(&committed_assembler),
+                "candidate attempt {attempt} must preserve assembler identity"
+            );
+        }
+
+        let restored_semantic = rooted_cfg(&mut result.session, &CompileOptions::default())
+            .expect("the committed view survives pressure beyond the 64-view retention cap");
+        assert_same_rooted_cfg_identity(&committed_semantic, &restored_semantic);
+        assert_eq!(
+            frontend_query_invalidations(&result.session),
+            committed_invalidations,
+            "repeated rollback must not invalidate the committed semantic cone"
+        );
+        let retention = result.session.unstable_metrics().retention();
+        assert!(
+            retention.retained_module_input_views <= MODULE_RETENTION_FLOOR + SELECTED_ROOT_OVERAGE,
+            "module-input history must remain within its floor plus selected root while the committed root is pinned; got {}",
+            retention.retained_module_input_views,
+        );
+        assert!(
+            retention.retained_import_input_views <= IMPORT_RETENTION_FLOOR + SELECTED_ROOT_OVERAGE,
+            "import-input history must remain within its floor plus selected root while the committed root is pinned; got {}",
+            retention.retained_import_input_views,
+        );
+
+        reload_from_filesystem(&mut result, None)
+            .expect("a fresh request still closes after repeated superseded stages");
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| source.source.contains("value() -> i32 { 71 }")),
+            "recovery must publish the newest bytes after retention pressure"
+        );
+        rooted_cfg(&mut result.session, &CompileOptions::default())
+            .expect("the newest source must reach semantic analysis after retention pressure");
+    }
+
     /// ADR-0075 determinism: the ledger's read order and the revision's contents
     /// are properties of the compiler's candidate policy, not of how many query
     /// workers happen to be running. A wave dedupes host operations and derives
@@ -3180,6 +4034,33 @@ mod tests {
             .expect("test module is present")
             .source
             .clone()
+    }
+
+    fn assert_same_rooted_cfg_identity(
+        before: &rue_compiler::unstable::RootedCfgOutput,
+        after: &rue_compiler::unstable::RootedCfgOutput,
+    ) {
+        assert_eq!(before.functions().len(), after.functions().len());
+        for (before, after) in before.functions().iter().zip(after.functions()) {
+            assert_eq!(before.source_name(), after.source_name());
+            assert!(
+                std::ptr::eq(before.air(), after.air()),
+                "{} must reuse the exact committed AIR",
+                before.source_name()
+            );
+            assert!(
+                std::ptr::eq(before.cfg(), after.cfg()),
+                "{} must reuse the exact committed CFG",
+                before.source_name()
+            );
+            assert!(
+                std::ptr::eq(before.type_pool(), after.type_pool()),
+                "{} must reuse the exact committed type pool",
+                before.source_name()
+            );
+            assert!(Arc::ptr_eq(before.interner(), after.interner()));
+            assert!(Arc::ptr_eq(before.strings(), after.strings()));
+        }
     }
 
     #[test]
@@ -3353,6 +4234,47 @@ mod tests {
             entry.requested_path() == alias.to_string_lossy()
                 && entry.canonical_path() == canonical.to_string_lossy()
         }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn watch_inputs_detect_same_target_symlink_inode_replacement() {
+        let dir = TestDir::new("watch-same-target-symlink-replacement");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("alias/leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let target_dir = dir.path.join("target");
+        let target = dir.write("target/leaf.rue", "pub fn value() -> i32 { 1 }");
+        let alias = dir.path.join("alias");
+        std::os::unix::fs::symlink(&target_dir, &alias).unwrap();
+        let result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let inputs = result.watch_inputs();
+        assert!(!watch_inputs_changed(&inputs));
+
+        let original_identity = physical_file_identity(&fs::symlink_metadata(&alias).unwrap());
+        let replacement = dir.path.join("replacement-alias");
+        std::os::unix::fs::symlink(&target_dir, &replacement).unwrap();
+        let replacement_identity =
+            physical_file_identity(&fs::symlink_metadata(&replacement).unwrap());
+        assert_ne!(
+            original_identity, replacement_identity,
+            "the test must replace the directory symlink with a distinct inode"
+        );
+        fs::rename(&replacement, &alias).unwrap();
+
+        assert_eq!(
+            fs::canonicalize(alias.join("leaf.rue")).unwrap(),
+            fs::canonicalize(&target).unwrap()
+        );
+        assert_eq!(
+            fs::read(alias.join("leaf.rue")).unwrap(),
+            fs::read(&target).unwrap()
+        );
+        assert!(
+            watch_inputs_changed(&inputs),
+            "a new symlink inode is a route change even when target and bytes are identical"
+        );
     }
 
     #[cfg(unix)]
@@ -3773,7 +4695,8 @@ mod tests {
     fn supersession_at_the_close_boundary_commits_no_partial_state() {
         let mut aborted_before_any_commit = 0;
         let mut aborted_after_a_commit = 0;
-        for trip_after in 1..=6 {
+        let mut completed_past_last_check = false;
+        for trip_after in 1..=64 {
             let (_project, _stdlib, main, std_root) =
                 fallible_project(&format!("supersede-late-{trip_after}"));
             let mut result =
@@ -3807,8 +4730,17 @@ mod tests {
                 }
                 // Past the last check the round runs to completion, and the
                 // commit must be whole.
-                Ok(()) => assert!(acquired, "a successful acquisition commits its module"),
+                Ok(()) => {
+                    assert!(acquired, "a successful acquisition commits its module");
+                    completed_past_last_check = true;
+                }
                 Err(other) => panic!("unexpected acquisition failure: {other:?}"),
+            }
+            if aborted_before_any_commit > 0
+                && aborted_after_a_commit > 0
+                && completed_past_last_check
+            {
+                break;
             }
         }
         // The sweep must actually exercise both abort positions, or it would
@@ -3817,6 +4749,10 @@ mod tests {
         assert!(
             aborted_after_a_commit > 0,
             "no abort landed after a round committed"
+        );
+        assert!(
+            completed_past_last_check,
+            "the bounded sweep never passed the final supersession checkpoint"
         );
     }
 
@@ -3853,6 +4789,48 @@ mod tests {
         .expect("an unsuperseded acquisition succeeds after repeated aborts");
         assert!(contains_trusted_option(&result.source_snapshot));
         assert_eq!(result.source_snapshot.source_revision().modules().len(), 2);
+    }
+
+    /// Route drift in a newly reached trusted leaf is supersession, even when
+    /// the caller's explicit probe stays quiet. The acquisition must not
+    /// publish the stale environmental failure or any partial trusted state.
+    #[test]
+    fn superseding_acquisition_classifies_newly_reached_route_drift_as_superseded() {
+        let project = TestDir::new("supersede-new-trusted-route-project");
+        let stdlib = TestDir::new("supersede-new-trusted-route-std");
+        let main = project.write("main.rue", READ_LINE_ROOT);
+        let std_root = write_read_line_std(&stdlib);
+        let strbuf = std_root.join("strbuf.rue");
+        let mut result =
+            discover_and_load_imports(main.to_str().unwrap(), None, Some(&std_root)).unwrap();
+
+        let hook_fired = Rc::new(Cell::new(false));
+        let hook_fired_from_stage = Rc::clone(&hook_fired);
+        IMPORT_STAGE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move |_| {
+                if !hook_fired_from_stage.replace(true) {
+                    fs::write(&strbuf, format!("{VALID_STRBUF}\n")).unwrap();
+                }
+            }));
+        });
+        let outcome = acquire_reached_toolchain_modules_superseding(
+            &mut result,
+            &CompileOptions::default(),
+            Some(&|| false),
+        );
+        IMPORT_STAGE_HOOK.with(|hook| *hook.borrow_mut() = None);
+
+        assert!(hook_fired.get(), "the test must drift the reached route");
+        assert!(matches!(outcome, Err(SourceLoadError::Superseded)));
+        assert_nothing_acquired(&mut result);
+
+        acquire_reached_toolchain_modules_superseding(
+            &mut result,
+            &CompileOptions::default(),
+            Some(&|| false),
+        )
+        .expect("a fresh acquisition succeeds after the drift is reobserved");
+        assert_eq!(trusted_read_count(&result.read_manifest), 4);
     }
 
     /// A probe that never trips leaves acquisition identical to the unprobed

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -1,8 +1,7 @@
-#[cfg(test)]
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
@@ -13,8 +12,7 @@ use rue_compiler::{CompileOptions, LinkerMode};
 #[cfg(test)]
 use rue_driver::watch_inputs_changed_with_reader;
 use rue_driver::{
-    FilesystemCompilerHost, SourceLoadError, WatchFingerprint, WatchInput,
-    watch_input_fingerprints, watch_inputs_changed,
+    FilesystemCompilerHost, SourceLoadError, WatchFingerprint, WatchInput, watch_inputs_changed,
 };
 
 use crate::compile::{CancellableCompileRequest, CompileCycleOutcome, execute_cancellable};
@@ -33,7 +31,6 @@ const FAILED_REOBSERVE_RETRY: Duration = Duration::from_millis(250);
 // synchronization without wall-clock sleeps.
 const TEST_PROTOCOL_ENV: &str = "RUE_WATCH_TEST_PROTOCOL";
 const TEST_COMPILE_DELAY_ENV: &str = "RUE_WATCH_TEST_COMPILE_DELAY_MS";
-const TEST_REOBSERVE_DELAY_ENV: &str = "RUE_WATCH_TEST_REOBSERVE_DELAY_MS";
 const TEST_ACQUIRE_DELAY_ENV: &str = "RUE_WATCH_TEST_ACQUIRE_DELAY_MS";
 const TEST_BOUNDARY_DELAY_ENV: &str = "RUE_WATCH_TEST_BOUNDARY_DELAY_MS";
 
@@ -50,20 +47,6 @@ fn test_event(event: &str) {
 
 fn test_compile_delay() {
     let Ok(delay) = std::env::var(TEST_COMPILE_DELAY_ENV) else {
-        return;
-    };
-    let Ok(milliseconds) = delay.parse::<u64>() else {
-        return;
-    };
-    thread::sleep(Duration::from_millis(milliseconds.min(5_000)));
-}
-
-// Hold the cycle between starting the re-observation monitor and the
-// re-observation itself. Test-only, like the compile delay: it exists so an
-// edit can deterministically land while the graph is being re-closed
-// (RUE-1830).
-fn test_reobserve_delay() {
-    let Ok(delay) = std::env::var(TEST_REOBSERVE_DELAY_ENV) else {
         return;
     };
     let Ok(milliseconds) = delay.parse::<u64>() else {
@@ -137,6 +120,21 @@ struct ChangeMonitor {
     thread: thread::JoinHandle<()>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WatchObservation {
+    requested_route: Vec<WatchSymlinkObservation>,
+    requested_canonical: Option<PathBuf>,
+    requested_fingerprint: Option<WatchFingerprint>,
+    canonical_fingerprint: Option<WatchFingerprint>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WatchSymlinkObservation {
+    path: PathBuf,
+    target: PathBuf,
+    identity: Option<(u64, u64)>,
+}
+
 impl ChangeMonitor {
     fn start(inputs: Vec<WatchInput>, cancellation: CompilationCancellation) -> Self {
         let stop = Arc::new(AtomicBool::new(false));
@@ -169,8 +167,12 @@ impl ChangeMonitor {
     /// the cycle runs, so only a post-baseline edit supersedes the attempt.
     /// The thread stays silent on the test protocol; the superseded cycle
     /// announces itself through its own milestone.
-    fn start_reobservation(inputs: Vec<WatchInput>, cancellation: CompilationCancellation) -> Self {
-        let baseline = current_fingerprints(&inputs);
+    fn start_reobservation(
+        inputs: Vec<WatchInput>,
+        cancellation: CompilationCancellation,
+    ) -> (Self, Vec<WatchObservation>) {
+        let baseline = current_observations(&inputs);
+        let thread_baseline = baseline.clone();
         let stop = Arc::new(AtomicBool::new(false));
         let changed = Arc::new(AtomicBool::new(false));
         let thread_stop = stop.clone();
@@ -178,7 +180,7 @@ impl ChangeMonitor {
         let thread = thread::spawn(move || {
             let mut poll = PollBackoff::new();
             while !thread_stop.load(Ordering::Acquire) {
-                if current_fingerprints(&inputs) != baseline {
+                if current_observations(&inputs) != thread_baseline {
                     thread_changed.store(true, Ordering::Release);
                     cancellation.cancel();
                     return;
@@ -186,11 +188,14 @@ impl ChangeMonitor {
                 thread::park_timeout(poll.next_delay());
             }
         });
-        Self {
-            stop,
-            changed,
-            thread,
-        }
+        (
+            Self {
+                stop,
+                changed,
+                thread,
+            },
+            baseline,
+        )
     }
 
     fn changed(&self) -> bool {
@@ -225,11 +230,10 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
             // no unobserved seam between them.
             let stale_inputs = request.host.watch_inputs();
             let cancellation = CompilationCancellation::new();
-            let monitor =
+            let (monitor, observation_baseline) =
                 ChangeMonitor::start_reobservation(stale_inputs.clone(), cancellation.clone());
             let superseded = || cancellation.is_canceled();
             test_event("reobserve-started");
-            test_reobserve_delay();
             let mut phase = ObservationPhase::Reobserve;
             let mut observed = request.host.reobserve_superseding(&superseded);
             if observed.is_ok() {
@@ -241,23 +245,28 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
                     &superseded,
                 );
             }
-            monitor.finish();
+            let monitor_changed = monitor.finish();
+            let changed =
+                monitor_changed || current_observations(&stale_inputs) != observation_baseline;
+            if changed || matches!(&observed, Err(SourceLoadError::Superseded)) {
+                test_event(phase.superseded_event());
+                print_watch_status(
+                    request.error_format,
+                    format!(
+                        "Watch re-observation superseded after {} ms; a newer source revision is available",
+                        cycle_started.elapsed().as_millis()
+                    ),
+                );
+                // Each phase commits either nothing or one coherent close. Let
+                // the burst settle, then re-observe the exact physical routes
+                // from the newest bytes; `needs_reobserve` remains set.
+                debounce(&stale_inputs);
+                continue;
+            }
             match observed {
                 Ok(()) => test_event("acquire-ok"),
                 Err(SourceLoadError::Superseded) => {
-                    test_event(phase.superseded_event());
-                    print_watch_status(
-                        request.error_format,
-                        format!(
-                            "Watch re-observation superseded after {} ms; a newer source revision is available",
-                            cycle_started.elapsed().as_millis()
-                        ),
-                    );
-                    // The superseded attempt committed nothing. Let the burst
-                    // settle, then re-observe from the newest bytes;
-                    // `needs_reobserve` is still set.
-                    debounce(&stale_inputs);
-                    continue;
+                    unreachable!("supersession was handled before source errors")
                 }
                 Err(error) => {
                     test_event(phase.error_event());
@@ -450,11 +459,11 @@ fn wait_for_change(inputs: &[WatchInput]) {
 }
 
 fn debounce(inputs: &[WatchInput]) {
-    let mut previous = current_fingerprints(inputs);
+    let mut previous = current_observations(inputs);
     let mut quiet_since = Instant::now();
     while quiet_since.elapsed() < QUIET_PERIOD {
         thread::sleep(POLL_INTERVAL);
-        let current = current_fingerprints(inputs);
+        let current = current_observations(inputs);
         if current != previous {
             previous = current;
             quiet_since = Instant::now();
@@ -511,8 +520,57 @@ fn cycle_boundary_action(changed: bool, monitor_changed: bool) -> CycleBoundary 
     }
 }
 
-fn current_fingerprints(inputs: &[WatchInput]) -> Vec<Option<WatchFingerprint>> {
-    watch_input_fingerprints(inputs)
+/// Capture the physical state at the beginning of a retained re-observation.
+///
+/// The accepted `WatchInput` still names the committed closure the loader is
+/// allowed to revisit, but its embedded fingerprint is necessarily stale after
+/// the edit that requested this cycle. Monitoring against that fingerprint
+/// would cancel every attempt immediately. This separate baseline observes the
+/// current requested route and both requested/canonical bytes, so only a later
+/// edit supersedes the attempt, including symlink retargets and appearances of
+/// previously absent candidates.
+fn current_observations(inputs: &[WatchInput]) -> Vec<WatchObservation> {
+    inputs
+        .iter()
+        .map(|input| WatchObservation {
+            requested_route: current_symlink_route(input.requested_path()),
+            requested_canonical: fs::canonicalize(input.requested_path()).ok(),
+            requested_fingerprint: WatchFingerprint::read(input.requested_path()),
+            canonical_fingerprint: WatchFingerprint::read(input.canonical_path()),
+        })
+        .collect()
+}
+
+fn current_symlink_route(path: &Path) -> Vec<WatchSymlinkObservation> {
+    let mut current = PathBuf::new();
+    let mut route = Vec::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        let Ok(target) = fs::read_link(&current) else {
+            continue;
+        };
+        let identity = fs::symlink_metadata(&current)
+            .ok()
+            .and_then(|metadata| symlink_identity(&metadata));
+        route.push(WatchSymlinkObservation {
+            path: current.clone(),
+            target,
+            identity,
+        });
+    }
+    route
+}
+
+#[cfg(unix)]
+fn symlink_identity(metadata: &fs::Metadata) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some((metadata.dev(), metadata.ino()))
+}
+
+#[cfg(not(unix))]
+fn symlink_identity(_: &fs::Metadata) -> Option<(u64, u64)> {
+    None
 }
 
 #[cfg(test)]
@@ -620,6 +678,91 @@ mod tests {
         fs::write(&path, b"bravo").unwrap();
         assert!(inputs_changed(&inputs));
         fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn reobserve_baseline_accepts_the_triggering_edit_and_detects_the_next_one() {
+        let path = std::env::temp_dir().join(format!(
+            "rue-watch-reobserve-baseline-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::write(&path, b"one").unwrap();
+        let inputs = vec![WatchInput::new(
+            path.clone(),
+            path.clone(),
+            WatchFingerprint::from_bytes(b"one"),
+        )];
+
+        fs::write(&path, b"two").unwrap();
+        let baseline = current_observations(&inputs);
+        assert_eq!(
+            current_observations(&inputs),
+            baseline,
+            "the edit which requested re-observation is the attempt baseline, not a new cancellation"
+        );
+
+        fs::write(&path, b"six").unwrap();
+        assert_ne!(
+            current_observations(&inputs),
+            baseline,
+            "a later same-length edit must supersede the in-flight re-observation"
+        );
+        fs::remove_file(path).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reobserve_baseline_distinguishes_repeated_dangling_directory_retargets() {
+        let root = std::env::temp_dir().join(format!(
+            "rue-watch-reobserve-route-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let real = root.join("real");
+        fs::create_dir_all(&real).unwrap();
+        let leaf = real.join("leaf.rue");
+        fs::write(&leaf, b"source").unwrap();
+        let alias = root.join("alias");
+        std::os::unix::fs::symlink("real", &alias).unwrap();
+        let requested = alias.join("leaf.rue");
+        let canonical = fs::canonicalize(&requested).unwrap();
+        let inputs = vec![WatchInput::new(
+            requested,
+            canonical,
+            WatchFingerprint::from_bytes(b"source"),
+        )];
+
+        fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink("missing-a", &alias).unwrap();
+        let baseline = current_observations(&inputs);
+        assert!(
+            baseline[0]
+                .requested_route
+                .iter()
+                .any(|component| component.target == Path::new("missing-a")),
+            "the baseline must retain the raw dangling directory route"
+        );
+        assert!(baseline[0].requested_fingerprint.is_none());
+
+        fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink("missing-b", &alias).unwrap();
+        assert_ne!(
+            current_observations(&inputs),
+            baseline,
+            "a second dangling directory retarget must supersede the in-flight observation"
+        );
+
+        fs::remove_file(alias).unwrap();
+        fs::remove_file(leaf).unwrap();
+        fs::remove_dir(real).unwrap();
+        fs::remove_dir(root).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make retained import discovery transactional across re-observation, trusted-successor staging, and close, restoring the exact committed session and query selectors when a request is superseded
- observe requested and canonical physical routes at the read boundary, including symlink identity changes, so stale waves abort before compilation while coherent closes remain committed
- retain committed module and import roots and add deterministic compiler, query, and CLI regressions for partial staging, failed close, repeated supersession, retention pressure, and watch protocol ordering

## Validation

- focused compiler and query supersession, rollback, retention, and API-inventory tests
- `scripts/rue cli watch` (7/7)
- `scripts/rue quick` (33/33)
- `scripts/rue premerge` (205/205)
- `scripts/rue fmt`
- `git diff --check origin/trunk...HEAD`

Fixes RUE-1862
