### PR TITLE
RUE-1840: memoize the visibility domain per file

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -160,8 +160,8 @@ pub use semantic_type_resolution::{
     SemanticTypeConstructorHead, SemanticTypeConstructorParameter, SemanticTypeFact,
     SemanticTypeFactKind, SemanticTypeSyntaxError, SemanticTypeSyntaxFailure,
     SemanticTypeSyntaxProvider, SemanticValueSyntax, SemanticVisibilityDomain,
-    resolve_semantic_module_path, resolve_structured_semantic_type_syntax,
-    resolve_structured_semantic_type_syntax_with,
+    SemanticVisibilityDomainCache, resolve_semantic_module_path,
+    resolve_structured_semantic_type_syntax, resolve_structured_semantic_type_syntax_with,
 };
 pub use types::{
     ArrayLen, ArrayTypeId, EnumDef, EnumId, LangItem, ModuleDef, ModuleId, PtrConstTypeId,

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -915,6 +915,17 @@ pub trait DurableBodyLookupSource<K, M>: Clone {
     fn source_path(&self, _file: FileId) -> Option<Arc<str>> {
         None
     }
+    /// The visibility domain of a file, derived from its source path.
+    ///
+    /// `None` means the source has no path for the file at all, which callers
+    /// distinguish from a path that yields no domain. Implementors backed by a
+    /// path table should override this to memoize per file (RUE-1840): the
+    /// default derivation is a path parse plus an `Arc<str>` allocation, and
+    /// the same few files are asked for repeatedly.
+    fn visibility_domain(&self, file: FileId) -> Option<crate::SemanticVisibilityDomain> {
+        self.source_path(file)
+            .map(|path| crate::SemanticVisibilityDomain::from_file_path(Some(&path)))
+    }
     fn out_of_scope_integer_const_paths(&self, _current: &K, _name: &str) -> Vec<Arc<str>> {
         Vec::new()
     }
@@ -3535,10 +3546,9 @@ where
         AggregateFactsTrait::aggregate_source_path(&self.aggregate, span)
     }
     fn aggregate_visibility_domain(&self, file: FileId) -> crate::SemanticVisibilityDomain {
-        self.source.source_path(file).map_or_else(
-            || AggregateFactsTrait::aggregate_visibility_domain(&self.aggregate, file),
-            |path| crate::SemanticVisibilityDomain::from_file_path(Some(&path)),
-        )
+        self.source.visibility_domain(file).unwrap_or_else(|| {
+            AggregateFactsTrait::aggregate_visibility_domain(&self.aggregate, file)
+        })
     }
 }
 
@@ -3753,8 +3763,9 @@ where
         &self,
         authority: TypeRootAuthority,
     ) -> crate::SemanticVisibilityDomain {
-        let path = self.source.source_path(authority.file());
-        crate::SemanticVisibilityDomain::from_file_path(path.as_deref())
+        self.source
+            .visibility_domain(authority.file())
+            .unwrap_or_else(|| crate::SemanticVisibilityDomain::from_file_path(None))
     }
 
     fn type_syntax_named_type(

--- a/crates/rue-air/src/semantic_type_resolution.rs
+++ b/crates/rue-air/src/semantic_type_resolution.rs
@@ -5,9 +5,11 @@
 //! structural resolution, qualified-path walking, visibility, and constructor
 //! argument binding.
 
+use std::cell::RefCell;
 use std::path::Path;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use lasso::{Key, Spur};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -24,6 +26,58 @@ impl SemanticVisibilityDomain {
 
     pub fn is_visible_from(&self, accessing: &Self, is_public: bool) -> bool {
         is_public || accessing.0.is_none() || self.0.is_none() || accessing.0 == self.0
+    }
+}
+
+/// Per-file memo for [`SemanticVisibilityDomain::from_file_path`].
+///
+/// A file's visibility domain is a pure function of its source path, but
+/// deriving it costs a path parse, a lossy UTF-8 conversion and a fresh
+/// `Arc<str>`. RUE-1840 stopped resolution from deriving it on the fast
+/// paths; this stops the derivations that remain from repeating, since they
+/// name the same handful of files over and over.
+///
+/// Only a *found* path is memoized. A path table can be filled lazily — the
+/// compiler's is, resolving a module's locator on first use — so a file with
+/// no path yet can acquire one, and recording the miss would pin the wrong
+/// domain for the rest of the table's life. A miss costs a repeated probe;
+/// that is the cheap half.
+///
+/// Given that, this caches a pure function of one path table: it belongs
+/// beside that table and shares its lifetime, and whatever drops the paths
+/// drops the domains derived from them. There is nothing else to invalidate
+/// it against.
+#[derive(Debug)]
+pub struct SemanticVisibilityDomainCache<F> {
+    derived: RefCell<AHashMap<F, SemanticVisibilityDomain>>,
+}
+
+impl<F> Default for SemanticVisibilityDomainCache<F> {
+    fn default() -> Self {
+        Self {
+            derived: RefCell::new(AHashMap::new()),
+        }
+    }
+}
+
+impl<F: Copy + Eq + std::hash::Hash> SemanticVisibilityDomainCache<F> {
+    /// The visibility domain for `file`, deriving it on first use.
+    ///
+    /// `source_path` is invoked once per distinct `file` that has one, and on
+    /// every lookup for a file that does not — see the type docs for why the
+    /// absent case is deliberately not recorded.
+    pub fn domain(
+        &self,
+        file: F,
+        source_path: impl FnOnce() -> Option<Arc<str>>,
+    ) -> Option<SemanticVisibilityDomain> {
+        let cached = self.derived.borrow().get(&file).cloned();
+        if cached.is_some() {
+            return cached;
+        }
+        let derived = SemanticVisibilityDomain::from_file_path(Some(&source_path()?));
+        self.derived.borrow_mut().insert(file, derived.clone());
+        Some(derived)
     }
 }
 
@@ -2685,6 +2739,60 @@ mod tests {
             fixture.accessing_domain_calls.get(),
             1,
             "a selected named type must still derive the visibility domain"
+        );
+    }
+
+    #[test]
+    fn the_visibility_domain_cache_derives_once_per_file() {
+        // RUE-1840, second half. Resolution now derives the accessing domain
+        // only where it is read, but the derivations that remain name the same
+        // handful of files over and over, and `from_file_path` is a path parse,
+        // a lossy UTF-8 conversion and a fresh Arc<str> every time.
+        let cache = SemanticVisibilityDomainCache::default();
+        let probes = std::cell::Cell::new(0u32);
+        let probe = |path: Option<&'static str>| {
+            probes.set(probes.get() + 1);
+            path.map(Arc::<str>::from)
+        };
+
+        let expected = SemanticVisibilityDomain::from_file_path(Some("app/sub/main.rue"));
+        for _ in 0..5 {
+            assert_eq!(
+                cache.domain(7u32, || probe(Some("app/sub/main.rue"))),
+                Some(expected.clone())
+            );
+        }
+        assert_eq!(probes.get(), 1, "a repeated lookup re-derived the domain");
+
+        // A distinct file is a distinct key, so it derives once more: the memo
+        // is per file, not a single last-seen slot.
+        assert_eq!(
+            cache.domain(8u32, || probe(Some("app/other/main.rue"))),
+            Some(SemanticVisibilityDomain::from_file_path(Some(
+                "app/other/main.rue"
+            )))
+        );
+        assert_eq!(
+            probes.get(),
+            2,
+            "a second file did not derive its own domain"
+        );
+
+        // A file with no path yet must NOT be memoized as absent. The
+        // compiler's path table is filled lazily — `module_source` inserts a
+        // module's physical path the first time its locator resolves — so a
+        // lookup can miss and the same file acquire a path immediately after.
+        // Recording the miss would pin that file at "no domain" for the life
+        // of the table, silently widening what is visible from it.
+        let mut path: Option<&'static str> = None;
+        assert_eq!(cache.domain(9u32, || probe(path)), None);
+        path = Some("app/late/main.rue");
+        assert_eq!(
+            cache.domain(9u32, || probe(path)),
+            Some(SemanticVisibilityDomain::from_file_path(Some(
+                "app/late/main.rue"
+            ))),
+            "a file that acquired a path after a miss kept the stale absence"
         );
     }
 

--- a/crates/rue-compiler/src/revisioned_query_database/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/provider.rs
@@ -523,6 +523,9 @@ pub(crate) struct CompilerBodyDurableSource<'a> {
     pub(super) dynamic_anonymous: Rc<std::cell::RefCell<CanonicalAnonymousNominalRegistry>>,
     pub(super) durable_payloads: Rc<std::cell::RefCell<BodyDurablePayloadCache>>,
     pub(super) source_paths: Rc<std::cell::RefCell<AHashMap<crate::FileId, Arc<str>>>>,
+    /// Visibility domains derived from `source_paths`, memoized per file
+    /// (RUE-1840). Lives and dies with the path table it is derived from.
+    pub(super) visibility_domains: Rc<rue_air::SemanticVisibilityDomainCache<crate::FileId>>,
     pub(crate) source_locators:
         Rc<std::cell::RefCell<AHashMap<ModuleId, rue_air::DurableBodySourceLocator>>>,
 }
@@ -552,6 +555,7 @@ impl<'a> CompilerBodyDurableSource<'a> {
             dynamic_anonymous: Rc::new(std::cell::RefCell::new(dynamic_anonymous)),
             durable_payloads: Rc::new(std::cell::RefCell::new(BodyDurablePayloadCache::default())),
             source_paths: Rc::new(std::cell::RefCell::new(source_paths)),
+            visibility_domains: Rc::new(rue_air::SemanticVisibilityDomainCache::default()),
             source_locators: Rc::new(std::cell::RefCell::new(source_locators)),
         }
     }
@@ -1026,6 +1030,14 @@ impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
 
     fn source_path(&self, file: crate::FileId) -> Option<Arc<str>> {
         self.source_paths.borrow().get(&file).cloned()
+    }
+
+    /// Memoized override of the deriving default: `from_file_path` is a path
+    /// parse and an `Arc<str>` allocation, and the resolver asks for the same
+    /// few files once per named-type resolution (RUE-1840).
+    fn visibility_domain(&self, file: crate::FileId) -> Option<rue_air::SemanticVisibilityDomain> {
+        self.visibility_domains
+            .domain(file, || self.source_path(file))
     }
 
     fn out_of_scope_integer_const_paths(


### PR DESCRIPTION
Second half of RUE-1840. Referenced without a closing keyword — the issue is
already Done from #2812, and this does not need to reopen it.

## Problem

RUE-1840 proposed two independent fixes. #2812 landed the first: the accessing
domain is derived next to its readers, so the substituted, primitive and builtin
fast paths no longer derive one they discard.

The derivations that remain still repeat per named-type resolution, and they name
the same handful of files over and over. `source_path` is already cheap — a hash
and an `Arc` clone off the provider's path table — but `SemanticVisibilityDomain::from_file_path`
is not: it parses the path, converts it lossily to UTF-8 and allocates a fresh
`Arc<str>`, every time.

## Change

`DurableBodyLookupSource` gains a `visibility_domain` hook. Its default derives
exactly what the two call sites derived inline, so every implementor keeps its
current behaviour — of the two that exist, the test fixture takes the default and
only the compiler's durable source overrides it.

That override is a per-`FileId` memo living beside `source_paths`, the table it is
derived from. They are constructed together, cloned together through the same
`Rc`, and dropped together on revision turnover, so there is nothing extra to
invalidate against.

### Only a found path is memoized

This is the part worth reviewing. `module_source` fills `source_paths` lazily, when
a module's locator first resolves — so a file can miss and then acquire a path.
Recording the miss would pin that file at "no domain" for the life of the table,
and since `is_visible_from` returns `true` whenever either domain is absent, that
would silently *widen* what is visible from it. A miss costs a repeated probe
instead, which is the cheap half.

I had this wrong in my first draft and caught it re-reading the diff against
`module_source`, so the guard pins it explicitly.

## Scope

Still deriving directly, deliberately: the `defining_domain` constructions in
`body.rs`, `durable_comptime.rs` and `provider_body_host.rs`. Those are keyed on
module and definition path strings rather than a `FileId`, so they want their own
key, not this cache.

## Guard

`the_visibility_domain_cache_derives_once_per_file` — repeated lookups of one file
derive once, a second file derives its own, and a file that acquires a path after a
miss picks it up rather than keeping the stale absence.

**I verified both halves bite:**

| Broken how | Failure |
|---|---|
| memo consult bypassed | `a repeated lookup re-derived the domain` |
| absence recorded | `a file that acquired a path after a miss kept the stale absence` |

## Validation

- `scripts/rue unit rue-air` — 806 passed, 0 failed (805 before, plus the guard).
- `scripts/rue unit rue-compiler` — 1133 passed, 0 failed.
- `buck2 test //crates/rue-air:{clippy,fmt-check,debug-assert-check}` and the same
  three for `rue-compiler` — 6 pass, 0 fail. Run as `test`, not `build`.
- `buck2 test //crates/rue-oracle-diff:oracle-diff-test` — 1 pass. This touches type
  resolution, so it is corpus-affecting.
- `scripts/rue quick` — 33 pass, 0 fail.
- `scripts/rue premerge` — 203 pass, 0 fail, suite PASSED.

Behaviour is unchanged: the memo returns the same domain the inline derivation
produced, and the absent case still round-trips as absent on every lookup.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nmb41AiKasPE74Vm3BFd8n)_