### PR TITLE
RUE-1855: narrow clippy CI with affected targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,33 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: affected-targets
     steps:
       - uses: actions/checkout@v6
 
+      # RUE-1855: clippy is both gated and graph-narrowed. An explicit
+      # selective decision may skip the heavy setup while preserving this
+      # required job/check identity. Missing, malformed, or failed selection
+      # state runs the lane; only the gate's verified exit-1 decision writes
+      # run=false, and the heavy-step conditions require its matching proof and
+      # gate outputs from a successful selection step before they may skip.
+      - name: Lane selection
+        id: sel
+        env:
+          RUE_AFFECTED_FULL: ${{ needs.affected-targets.outputs.full }}
+          RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
+          RUE_AFFECTED_LANES_COUNT: ${{ needs.affected-targets.outputs.selected_lanes_count }}
+          RUE_AFFECTED_LANES_DIGEST: ${{ needs.affected-targets.outputs.selected_lanes_digest }}
+          RUE_AFFECTED_NARROWED: ${{ needs.affected-targets.outputs.narrowed }}
+          RUE_AFFECTED_NARROWING_STATUS: ${{ needs.affected-targets.outputs.narrowing_status }}
+          RUE_AFFECTED_HEAD_TARGET_COUNT: ${{ needs.affected-targets.outputs.head_target_count }}
+          RUE_AFFECTED_IMPACTED_CLOSURE_COUNT: ${{ needs.affected-targets.outputs.impacted_closure_count }}
+          RUE_AFFECTED_IMPACTED_TARGET_COUNT: ${{ needs.affected-targets.outputs.impacted_target_count }}
+        run: scripts/ci-clippy select
+
       - name: Bootstrap dotslash
+        if: ${{ always() && (steps.sel.outcome != 'success' || steps.sel.outputs.run != 'false' || steps.sel.outputs.proof_status != 'SELECTIVE' || steps.sel.outputs.gate_status != 'DESELECTED') }}
         uses: ./.github/actions/bootstrap-dotslash
 
       # BuildBuddy remote action cache (RUE-316/RUE-1006). GitHub withholds
@@ -157,6 +180,7 @@ jobs:
       # merge queue serializes on this workflow. The cold fallback is
       # mandatory; this step must never fail because the secret is absent.
       - name: Provision remote build cache
+        if: ${{ always() && (steps.sel.outcome != 'success' || steps.sel.outputs.run != 'false' || steps.sel.outputs.proof_status != 'SELECTIVE' || steps.sel.outputs.gate_status != 'DESELECTED') }}
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
@@ -167,7 +191,24 @@ jobs:
           scripts/provision-build-cache install
           scripts/provision-build-cache apply
 
+      # Materialize the planner output once. `narrowed=true` is valid only with
+      # a non-empty live impacted closure and verified selection/gate state; an
+      # absent value is degraded state, never permission to run nothing.
+      # `narrow-scope` performs the final syntax and live-scope validation.
+      - name: Impacted target list
+        if: ${{ always() && (steps.sel.outcome != 'success' || steps.sel.outputs.run != 'false' || steps.sel.outputs.proof_status != 'SELECTIVE' || steps.sel.outputs.gate_status != 'DESELECTED') }}
+        id: narrow
+        env:
+          RUE_CLIPPY_PROOF_STATUS: ${{ steps.sel.outputs.proof_status }}
+          RUE_CLIPPY_GATE_STATUS: ${{ steps.sel.outputs.gate_status }}
+          RUE_AFFECTED_NARROWED: ${{ needs.affected-targets.outputs.narrowed }}
+          RUE_AFFECTED_IMPACTED: ${{ needs.affected-targets.outputs.impacted }}
+          RUE_AFFECTED_IMPACTED_TARGET_COUNT: ${{ needs.affected-targets.outputs.impacted_target_count }}
+          RUE_AFFECTED_IMPACTED_TARGETS_DIGEST: ${{ needs.affected-targets.outputs.impacted_targets_digest }}
+        run: scripts/ci-clippy materialize
+
       - name: Run clippy
+        if: ${{ always() && (steps.sel.outcome != 'success' || steps.sel.outputs.run != 'false' || steps.sel.outputs.proof_status != 'SELECTIVE' || steps.sel.outputs.gate_status != 'DESELECTED') }}
         # Every crate emits its own `<name>-clippy` test from the
         # rue_crate/rue_binary macros (RUE-1153). Running them as tests means
         # Buck must materialize each crate's [clippy.txt] before its gate can
@@ -177,14 +218,10 @@ jobs:
         # then scored what it could not read as clean (RUE-1152). Workspace
         # lint policy (deny warnings + grandfathered allow-list) lives in
         # toolchains/rust/BUCK.
-        run: |
-          mapfile -t TARGETS < <(./buck2 uquery "kind('sh_test', 'root//crates/...')" | grep -- '-clippy$')
-          if [ "${#TARGETS[@]}" -eq 0 ]; then
-            echo "clippy: no -clippy targets found; the query or the macros are broken" >&2
-            exit 1
-          fi
-          echo "Running clippy across ${#TARGETS[@]} crates..."
-          ./buck2 test "${TARGETS[@]}"
+        env:
+          NARROW_FILE: ${{ steps.narrow.outputs.file }}
+          NARROW_STATUS: ${{ steps.narrow.outputs.status }}
+        run: scripts/ci-clippy run
 
   actionlint:
     runs-on: ubuntu-latest
@@ -404,6 +441,9 @@ jobs:
         # `rue_ci_dedicated_lane` label in BUCK, and test.sh subtracts that label
         # when CI=true. This step no longer names them: the CI-contract job
         # fails if the labeled set and the platform-corpus matrix disagree.
+        # RUE-1855 gives the graph-owned clippy gates the analogous
+        # `rue_ci_clippy_lane` label; their required job is their only test
+        # owner in CI, rather than a duplicate inside this broad selection.
         #
         # RUE-1260: `buck2 test` prints a per-target tally and a `✗ <target>`
         # line, so a target whose process dies without emitting a result line
@@ -971,11 +1011,11 @@ jobs:
   # merge_group and workflow_dispatch always force the authoritative full run;
   # the decision is fail-open, so any tool/VCS/graph error, or any change to an
   # out-of-graph input (the ./buck2 pin, test.sh, scripts/ci-*, this workflow,
-  # .buckconfig/BUCK/.bzl/toolchains), runs the whole corpus. Only the
-  # platform-corpus heavy suites below consult this; every other job in the
-  # workflow runs unconditionally, so selection can only ever drop the corpus
-  # jobs that BTD proved unaffected. The scripts stay fail-open by construction,
-  # and scripts/test-affected-targets.sh pins the force-full and gate logic.
+  # .buckconfig/BUCK/.bzl/toolchains), runs the complete registered work. The
+  # platform corpora and selectable lanes consult its gate; linux-premerge,
+  # native units, and clippy also intersect small verified closures with their
+  # registered live scopes. The scripts stay fail-open by construction, and
+  # scripts/test-affected-targets.sh pins the force-full and gate logic.
   affected-targets:
     runs-on: ubuntu-latest
     name: affected targets (linux-x64)
@@ -988,6 +1028,11 @@ jobs:
       # now fails closed on that, because the failure only appears on the
       # peripheral PRs the gating exists for, and never on a CI-touching one.
       selected_lanes: ${{ steps.decide.outputs.selected_lanes }}
+      # Independently transported outputs can be missing or truncated while
+      # another output still arrives. The count and content proof distinguish
+      # that from a deliberately empty selected-lane set.
+      selected_lanes_count: ${{ steps.decide.outputs.selected_lanes_count }}
+      selected_lanes_digest: ${{ steps.decide.outputs.selected_lanes_digest }}
       # The impacted-target closure, and the determinator's own flag for whether
       # narrowing to it is worthwhile. Consumers key on `narrowed`; an absent or
       # empty `impacted` therefore reads as "run everything", never "run
@@ -996,7 +1041,13 @@ jobs:
       impacted: ${{ steps.decide.outputs.impacted }}
       narrowing_status: ${{ steps.decide.outputs.narrowing_status }}
       head_target_count: ${{ steps.decide.outputs.head_target_count }}
+      # Raw BTD closure size is separate from the runnable head intersection;
+      # consumers need both to reproduce the planner's narrowing state exactly.
+      impacted_closure_count: ${{ steps.decide.outputs.impacted_closure_count }}
       impacted_target_count: ${{ steps.decide.outputs.impacted_target_count }}
+      # The clippy materializer accepts a narrowing candidate only when the
+      # complete multiline payload matches both this count and digest.
+      impacted_targets_digest: ${{ steps.decide.outputs.impacted_targets_digest }}
     steps:
       - uses: actions/checkout@v6
         # BTD compares the graph at the merge-base and at the head, so the base

--- a/BUCK
+++ b/BUCK
@@ -1348,6 +1348,7 @@ rue_sh_test(
     ],
     resources = [
         "scripts/affected-targets",
+        "scripts/ci-clippy",
         "scripts/ci-required-results.py",
         # The gate pins the bounded apt timeout/retry/lock policy as well as
         # the workflow wiring, so installer-only edits must invalidate it.
@@ -1429,6 +1430,7 @@ rue_sh_test(
     test = "scripts/test-validate-ci-gate.py",
     resources = [
         "scripts/affected-targets",
+        "scripts/ci-clippy",
         "scripts/ci-required-results.py",
         "scripts/run-native-platform-corpus.sh",
         "scripts/validate-ci-gate.py",
@@ -1632,6 +1634,8 @@ rue_sh_test(
     test = "scripts/test-affected-targets.sh",
     resources = [
         "scripts/affected-targets",
+        "scripts/ci-affected-payload.py",
+        "scripts/ci-clippy",
         "scripts/ci-corpus-decision",
         "scripts/ci-corpus-selected",
         "scripts/parse-btd-impacted.py",

--- a/crates/defs.bzl
+++ b/crates/defs.bzl
@@ -147,9 +147,13 @@ def _clippy_check(name):
         name = name + "-clippy",
         test = "//crates:clippy-gate",
         args = ["$(location :" + name + "[clippy.txt])"],
-        # Premerge tier; excluded from quick iteration so `scripts/rue quick`
-        # keeps meaning "unit tests only" (see quick-test.sh).
-        labels = rue_test_labels("premerge", labels = ["rue_not_quick"]),
+        # The required clippy job owns these gates. Keep the premerge tier for
+        # direct developer selection, but required CI subtracts the ownership
+        # label so linux-premerge does not execute the same gates a second time.
+        labels = rue_test_labels(
+            "premerge",
+            labels = ["rue_ci_clippy_lane", "rue_not_quick"],
+        ),
     )
 
 def rue_crate(

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -525,11 +525,12 @@ How it decides:
 
 - **Lane membership is queried, not transcribed.** The premerge lane is
   `attrfilter(labels, 'rue_test_tier_premerge', set(//... toolchains//...))`
-  minus the `rue_cli_shard` and `rue_ci_dedicated_lane` sets; the corpus and
-  gated-lane inventories come from `scripts/affected-targets corpus-targets`
-  and `lane-targets`, which are the lists CI's determinator already consults.
-  A lane added to `SELECTABLE_LANES` and not classified by the gate fails it,
-  so this adds no unwatched row to ADR-0069's ledger.
+  minus the `rue_cli_shard`, `rue_ci_dedicated_lane`, and
+  `rue_ci_clippy_lane` sets; the corpus and gated-lane inventories come from
+  `scripts/affected-targets corpus-targets` and `lane-targets`, which are the
+  lists CI's determinator already consults. A lane added to `SELECTABLE_LANES`
+  and not classified by the gate fails it, so this adds no unwatched row to
+  ADR-0069's ledger.
 - **Identities come from `--list`.** Each target is listed with the exact args
   and env its own Buck target carries, so the scaling matrix's
   `--ignored scaling_matrix` selection lists three tests and the CLI shards
@@ -597,13 +598,13 @@ verdict covers. Three groups:
   `--list` inventory non-authoritative, so they remain explicitly classified in
   `NOT_LISTABLE` and outside ordinary duplicate accounting.
 
-## Affected-corpus selection on pull requests (RUE-1119)
+## Affected-target selection on pull requests (RUE-1119)
 
-On a `pull_request` run, the heavy `platform-corpus` suites are selected down to
-the ones the change actually affects; `merge_group` and `workflow_dispatch`
-always run the full corpus and remain the authoritative `//...` gate. Selection
-uses Meta's off-the-shelf Buck Target Determinator (BTD,
-`facebookincubator/buck2-change-detector`) rather than a bespoke
+On a `pull_request` run, the heavy `platform-corpus` suites and registered lanes
+are selected down to the work the change actually affects; `merge_group` and
+`workflow_dispatch` always run the complete live inventories and remain the
+authoritative `//...` gate. Selection uses Meta's off-the-shelf Buck Target
+Determinator (BTD, `facebookincubator/buck2-change-detector`) rather than a bespoke
 `owner()`/`rdeps()` query: the `affected-targets` job dumps the Buck graph with
 `buck2 targets` at the merge-base and at the head and feeds both dumps plus the
 changed-file list to `btd`, whose impacted-target closure is intersected with
@@ -631,16 +632,53 @@ Selection is applied **within** each gated job, not by skipping the job:
 the heavy steps (paying only the runner spin-up) while the check still reports
 success, so no branch-protection change is required.
 
-RUE-1130 extended that gate from the `platform-corpus` corpora to six further
-lanes — `native (linux-arm64)`, `native (macos-arm64)`, `release (linux-x64)`,
-`valgrind (linux-x64)`, `asan (linux-x64)`, and
-`compiler reproducibility (linux-x64)`. Each is named in `SELECTABLE_LANES` and
-maps to the Buck targets it actually executes (`lane_targets`); a lane runs when
-any of those targets is in BTD's impacted closure. Gating the corpora alone had
-saved nothing measurable: a documentation change cost 444s against 465s for a
+The gate covers eight named lanes: `clippy`, `native (linux-arm64)`, `native
+(macos-arm64)`, `release (linux-x64)`, `valgrind (linux-x64)`, `asan
+(linux-x64)`, `compiler reproducibility (linux-x64)`, and `rue_program digest
+sensitivity (linux-x64)`. Each is named in `SELECTABLE_LANES` and maps to the
+Buck targets it actually executes (`lane_targets`); a lane runs when any of
+those targets is in BTD's impacted closure. Gating the corpora alone had saved
+nothing measurable: a documentation change cost 444s against 465s for a
 compiler change, because the lanes that dominate a run were not consulting the
-determinator. On four measured peripheral runs the extension frees 905–1034s of
-runner time each.
+determinator. On four measured peripheral runs the RUE-1130 extension freed
+905–1034s of runner time each.
+
+Clippy is also a registered graph-narrowing consumer. Its one canonical live
+inventory is every `sh_test` under `root//crates/...` whose label ends exactly
+in `-clippy`; that same computation supplies both its lane-selection proxies
+and its runnable allowlist. Every member also carries `rue_ci_clippy_lane`, and
+the live CI validator requires the label-owned set to equal that canonical
+inventory exactly before Linux premerge may subtract it. A verified selective
+deselection skips DotSlash, cache, and provisioning work while the existing
+`clippy` job/check still finishes successfully. Each heavy step requires the
+selection step itself to have succeeded and all three outputs to agree on that
+deselection (`run=false`, `proof_status=SELECTIVE`, and
+`gate_status=DESELECTED`); any partial output or failed step runs instead.
+
+The planner publishes a canonical item count and SHA-256 content proof beside
+both independently transported payloads: the space-separated selected-lane
+list and the newline-separated live impacted closure. Clippy accepts a
+selective deselection only when the complete lane payload, canonical positive
+head count, raw BTD closure count, live impacted count, and narrowing status all
+verify. The state must reproduce the planner exactly: `CANDIDATE/true` if and
+only if the raw closure is nonempty, no larger than the canonical limit, and
+has a nonempty live intersection; every other coherent state is
+`DECLINED/false`. The live count may exceed neither the raw closure nor the head
+graph. When the lane is selected, the adapter also carries the successful
+lane-gate verdict into the materializer. It materializes a small closure only
+when both verdicts remain verified and that payload exactly matches its count
+and digest, then runs
+`impacted ∩ clippy`; a proved empty intersection logs an intentional no-op and
+succeeds, while a nonempty intersection runs only those live clippy gates.
+Candidate verification reads the planner's `narrow-limit` authority directly,
+so the default 600-target threshold and any supported override cannot drift at
+the consumer boundary. The limit applies to the raw BTD closure, including
+base-only labels, rather than only its smaller runnable head intersection.
+Missing, truncated, reordered, malformed, or inconsistent payloads and
+metadata fail open to the full inventory, as does any selection or gate
+failure. A successful canonical live query with zero clippy targets remains a
+hard error—including on the first narrowed query—because it means the query or
+crate macros are broken, not that a particular diff has no clippy work.
 
 `linux-premerge` is handled differently, because skipping it wholesale on a
 representative subset is exactly the RUE-924 failure mode. It is **narrowed**
@@ -653,12 +691,13 @@ is where the build cost goes: the lane spends 286–317s building every crate
 whenever a compiler crate changes, and an unimpacted crate's test binary has
 nothing to prove.
 
-Narrowing is declined, and the ordinary pattern used, whenever nothing is
+Narrowing is declined, and the ordinary scope used, whenever nothing is
 impacted or so much is that the pattern is the better expression of it
 (`RUE_AFFECTED_NARROW_LIMIT`, default 600 targets — a compiler change reaches
 most of the graph, so narrowing it saves nothing). Consumers key on the
-determinator's `narrowed` flag rather than on the list being non-empty, so an
-absent, empty, or oversized list always reads as "run everything". `test.sh`
+determinator's `narrowed` flag rather than on the list being non-empty. An
+absent, malformed, corrupt, or oversized candidate therefore reads as "run
+everything"; scope-query or intersection failure does too. `test.sh`
 applies the same rule: an unset, unreadable, or empty `RUE_TEST_TARGETS_FILE`
 runs the full pattern, and only a readable non-empty list narrows.
 

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Affected-target selection for pull-request CI (RUE-1119, extended by RUE-1130).
 #
-# On a pull_request run, only the heavy corpus suites a change actually affects
-# need to run; the merge queue (merge_group) remains the authoritative full
-# `//...` run. This script decides, for one PR, which of the selectable corpus
-# targets are affected, using Meta's off-the-shelf Buck Target Determinator
-# (BTD, facebookincubator/buck2-change-detector) rather than a hand-rolled
-# `owner()`/`rdeps()` query.
+# On a pull_request run, only the registered heavy work a change actually
+# affects needs to run; the merge queue (merge_group) remains the authoritative
+# full `//...` run. This script decides, for one PR, which selectable corpus
+# targets and lanes are affected, using Meta's off-the-shelf Buck Target
+# Determinator (BTD, facebookincubator/buck2-change-detector) rather than a
+# hand-rolled `owner()`/`rdeps()` query.
 #
 # SAFETY MODEL (this is the whole point). Under-selection silently drops
 # coverage — a suite that never runs cannot fail (RUE-924). So every decision
@@ -38,6 +38,8 @@
 #                      deliberately added here.
 #   is-selectable-lane Exit 0 only for a gated workflow lane (RUE-1130).
 #   lane-targets       Print the Buck targets a gated lane executes.
+#   clippy-owned-targets
+#                      Print live targets carrying clippy's CI-owner label.
 #   native-targets     Print every live-graph target carrying native scope.
 #   corpus-targets     Print the corpus targets the platform-corpus matrix runs.
 #   lanes              Print the gated workflow lane names.
@@ -47,6 +49,7 @@
 #                      the lane's own scope, and neither spelling of that scope
 #                      may name a corpus action (RUE-1511).
 #   scope-registry     Print the auditable narrowed-lane scope contract.
+#   narrow-limit       Print the canonical maximum impacted closure size.
 #   scope-targets      Print a lane's unnarrowed scope from that contract.
 #   narrow-scope       Intersect an impacted closure with a registered scope.
 #
@@ -110,6 +113,7 @@ SELECTABLE_CORPUS=(
 # the live graph, so a target added since this file was written is still
 # discovered — it simply is not built or run when the diff cannot reach it.
 SELECTABLE_LANES=(
+    clippy
     native-linux-arm64
     native-macos-arm64
     release
@@ -126,14 +130,15 @@ SELECTABLE_LANES=(
 # can reject a workflow that grows a second, unreviewed narrowing path.
 scope_registry() {
     printf '%s\n' \
+        'clippy|graph|crates_sh_test_ending_-clippy' \
         'linux-premerge-build|pattern|//crates/...' \
-        'linux-premerge-tests|graph|rue_test_tier_premerge-minus-dedicated' \
+        'linux-premerge-tests|graph|rue_test_tier_premerge-minus-dedicated-and-clippy' \
         'native-platforms-units|graph|rue_platform_native'
 }
 
 is_scope_consumer() {
     case "$1" in
-        linux-premerge-build|linux-premerge-tests|native-platforms-units) return 0 ;;
+        clippy|linux-premerge-build|linux-premerge-tests|native-platforms-units) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -142,6 +147,11 @@ is_scope_consumer() {
 # An unknown lane prints nothing, and the gate treats that as "run".
 lane_targets() {
     case "$1" in
+        clippy)
+            # The lane proxy and the runnable scope are one live inventory.
+            # Keeping both consumers on this function prevents a newly added
+            # crate from being selectable but not runnable, or vice versa.
+            clippy_targets ;;
         native-linux-arm64|native-macos-arm64)
             # Unit membership is graph-owned. The two corpus targets remain
             # selection proxies because their host-evaluated only_on cases are
@@ -169,6 +179,57 @@ lane_targets() {
         *)
             return 1 ;;
     esac
+}
+
+# The one canonical clippy inventory. Every Rue crate macro emits a sh_test
+# whose label ends exactly in `-clippy`; querying the live graph keeps new and
+# renamed crates self-enrolling. The same function supplies lane selection and
+# registered narrowing, so there is no transcribed target list or peer query.
+#
+# Return 2, distinct from a query failure, when the live query succeeds but the
+# inventory is empty. That is a broken macro/query invariant and must remain a
+# hard error; it is not the same thing as a verified impacted intersection that
+# happens to contain no clippy targets.
+clippy_targets() {
+    local buck2 queried target targets=""
+    buck2="$(buck2_bin)"
+    if ! queried="$("$buck2" uquery "kind('sh_test', 'root//crates/...')")"; then
+        echo "affected-targets: could not query live clippy targets" >&2
+        return 1
+    fi
+    if ! queried="$(normalize_cell <<<"$queried")"; then
+        echo "affected-targets: could not normalize live clippy targets" >&2
+        return 1
+    fi
+    while IFS= read -r target; do
+        if [[ "$target" == *-clippy ]]; then
+            targets+="${targets:+$'\n'}$target"
+        fi
+    done <<<"$queried"
+    if [[ -z "$targets" ]]; then
+        echo "affected-targets: live clippy graph selection is empty" >&2
+        return 2
+    fi
+    printf '%s\n' "$targets"
+}
+
+# The owner-label set is deliberately not a runnable inventory. CI executes
+# only clippy_targets() above; the live validator compares this independently
+# queried ownership set with that canonical suffix-derived set so neither a
+# missing label nor a label on an unrelated target can remove coverage.
+clippy_owned_targets() {
+    local buck2 targets
+    buck2="$(buck2_bin)"
+    if ! targets="$("$buck2" uquery "attrfilter(labels, 'rue_ci_clippy_lane', //crates/...)")"; then
+        echo "affected-targets: could not query rue_ci_clippy_lane targets" >&2
+        return 1
+    fi
+    targets="$(normalize_cell <<<"$targets" | grep . || true)"
+    if [[ -z "$targets" ]]; then
+        echo "affected-targets: rue_ci_clippy_lane graph selection is empty" >&2
+        return 1
+    fi
+    printf '%s\n' "$targets"
 }
 
 # The one canonical native unit selection. Keep this query here so the
@@ -281,11 +342,23 @@ emit_output_multiline() {
     } >>"$GITHUB_OUTPUT"
 }
 
+payload_proof() {
+    python3 "$repo_root/scripts/ci-affected-payload.py" proof "$1"
+}
+
 # RUE-1130. Beyond this many impacted targets, narrowing a lane to an explicit
 # list saves nothing — a compiler change reaches most of the graph, so the list
 # is the graph — and the `//...` pattern is cheaper to express and to read.
 # Emitting nothing means "do not narrow", which every consumer treats as full.
 NARROW_LIMIT="${RUE_AFFECTED_NARROW_LIMIT:-600}"
+
+narrow_limit() {
+    if ! [[ "$NARROW_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+        echo "affected-targets: narrow limit must be a canonical positive decimal" >&2
+        return 1
+    fi
+    printf '%s\n' "$NARROW_LIMIT"
+}
 
 # Intersect a newline-separated impacted list (file) with the targets given as
 # arguments, preserving argument order. Used by lanes whose contents are a fixed
@@ -385,7 +458,8 @@ deferred_corpus_targets() {
     # carriers even when their names do not end in `-action` or match the test.
     query="attrfilter(labels, rue_test_tier_premerge, //crates/...)"
     query="$query except (attrfilter(labels, rue_ci_dedicated_lane, //crates/...)"
-    query="$query + attrfilter(labels, rue_cli_shard, //crates/...))"
+    query="$query + attrfilter(labels, rue_cli_shard, //crates/...)"
+    query="$query + attrfilter(labels, rue_ci_clippy_lane, //crates/...))"
     if ! covered="$("$buck2" uquery "$query")"; then
         echo "affected-targets: could not query the premerge-tier test selection" >&2
         return 1
@@ -519,7 +593,8 @@ workflow_test_targets() {
     base="set(//... toolchains//...)"
     query="attrfilter(labels, rue_test_tier_premerge, $base)"
     query="$query except (attrfilter(labels, rue_ci_dedicated_lane, $base)"
-    query="$query + attrfilter(labels, rue_cli_shard, $base))"
+    query="$query + attrfilter(labels, rue_cli_shard, $base)"
+    query="$query + attrfilter(labels, rue_ci_clippy_lane, $base))"
     if ! targets="$("$buck2" uquery "$query")"; then
         echo "affected-targets: could not expand the premerge test scope" >&2
         return 1
@@ -539,6 +614,7 @@ scope_targets() {
     local consumer="$1"
     is_scope_consumer "$consumer" || return 1
     case "$consumer" in
+        clippy) clippy_targets ;;
         linux-premerge-build) build_scope "" strict ;;
         linux-premerge-tests) workflow_test_targets ;;
         native-platforms-units) native_platform_targets ;;
@@ -559,20 +635,43 @@ emit_scope_summary() {
     fi
 }
 
-# Produce a narrowed scope by construction.  Pattern lanes use their own
+# A narrowing candidate is emitted only when the planner found at least one
+# live impacted target. An empty or syntactically malformed file therefore
+# means the job output was lost or corrupted, not "nothing is impacted". Keep
+# stale but well-formed labels valid: exact intersection with the current live
+# scope safely drops a target removed since the determinator dump.
+valid_impacted_file() {
+    local file="$1"
+    [[ -r "$file" && -f "$file" && -s "$file" ]] || return 1
+    awk '
+        NF != 1 || $0 !~ /^\/\/[^[:space:]]*:[^[:space:]]+$/ { bad = 1 }
+        END { exit (NR > 0 && !bad) ? 0 : 1 }
+    ' "$file"
+}
+
+# Produce a narrowed scope by construction. Pattern lanes use their own
 # scope-aware query; graph lanes first obtain their live allowlist and then
-# intersect it.  A query failure is non-zero so callers retain the full
-# unnarrowed scope rather than claiming a verified subset.
+# intersect it. A query failure is non-zero so callers retain the full
+# unnarrowed scope rather than claiming a verified subset. Preserve a scope
+# resolver's distinct status (notably clippy's successful-but-empty status 2)
+# so the workflow can keep that invariant a hard error.
 narrow_scope() {
-    local consumer="$1" file="$2" scope narrowed target total_count selected_count
+    local consumer="$1" file="$2" scope narrowed target total_count selected_count scope_status
     is_scope_consumer "$consumer" || return 1
-    if [[ ! -r "$file" || -d "$file" ]]; then
-        emit_scope_summary "$consumer" DEGRADED "" "" "impacted list unavailable; full scope used"
+    if ! valid_impacted_file "$file"; then
+        emit_scope_summary "$consumer" DEGRADED "" "" "impacted list unavailable or malformed; full scope used"
         return 1
     fi
-    if ! scope="$(scope_targets "$consumer")"; then
-        emit_scope_summary "$consumer" DEGRADED "" "" "scope query unavailable; full scope used"
-        return 1
+    if scope="$(scope_targets "$consumer")"; then
+        :
+    else
+        scope_status=$?
+        if [[ "$scope_status" -eq 2 ]]; then
+            emit_scope_summary "$consumer" FAILED "" "" "live scope inventory rejected; hard failure"
+        else
+            emit_scope_summary "$consumer" DEGRADED "" "" "scope query unavailable; full scope used"
+        fi
+        return "$scope_status"
     fi
     local targets=()
     while IFS= read -r target; do
@@ -610,7 +709,7 @@ emit_manifest() {
         fi
     done
     {
-        echo "### Affected-corpus selection (RUE-1119)"
+        echo "### Affected-target selection (RUE-1119)"
         echo
         echo "- Decision: **${mode}**"
         echo "- Reason: ${reason}"
@@ -643,7 +742,7 @@ emit_manifest() {
             echo "| ${target} | ${state} |"
         done
         echo
-        echo "| Gated lane (RUE-1130) | Selection |"
+        echo "| Gated lane (RUE-1130/RUE-1855) | Selection |"
         echo "| --- | --- |"
         local lane
         for lane in "${SELECTABLE_LANES[@]}"; do
@@ -666,10 +765,14 @@ decide_full() {
     emit_output full "true"
     emit_output selected ""
     emit_output selected_lanes ""
+    emit_output selected_lanes_count ""
+    emit_output selected_lanes_digest ""
     emit_output_multiline impacted ""
+    emit_output impacted_targets_digest ""
     emit_output narrowed "false"
     emit_output narrowing_status "$status"
     emit_output head_target_count ""
+    emit_output impacted_closure_count ""
     emit_output impacted_target_count ""
     emit_manifest "full" "$reason" "" "" "$status"
     exit 0
@@ -677,12 +780,31 @@ decide_full() {
 
 decide_select() {
     local selected="$1" reason="$2" lanes="${3:-}" impacted_file="${4:-}" head_count="${5:-}" closure_count="${6:-}" live_count="${7:-0}"
+    local lane_proof lane_count lane_digest impacted_proof proved_live_count impacted_digest limit
+    if ! limit="$(narrow_limit)"; then
+        decide_full "narrow limit is unavailable or malformed"
+    fi
+    if ! lane_proof="$(printf '%s' "$lanes" | payload_proof lanes)"; then
+        decide_full "could not prove the selected-lane payload"
+    fi
+    lane_count="${lane_proof%% *}"
+    lane_digest="${lane_proof#* }"
+    if ! impacted_proof="$(payload_proof targets <"$impacted_file")"; then
+        decide_full "could not prove the live impacted-target payload"
+    fi
+    proved_live_count="${impacted_proof%% *}"
+    impacted_digest="${impacted_proof#* }"
+    if [[ "$proved_live_count" != "$live_count" ]]; then
+        decide_full "live impacted-target count disagrees with its payload"
+    fi
     echo "affected-targets: SELECTIVE run — ${reason}"
     echo "affected-targets: selected corpus targets: ${selected:-<none>}"
     echo "affected-targets: selected lanes: ${lanes:-<none>}"
     emit_output full "false"
     emit_output selected "$selected"
     emit_output selected_lanes "$lanes"
+    emit_output selected_lanes_count "$lane_count"
+    emit_output selected_lanes_digest "$lane_digest"
     # Narrowing is an optimization layered on the selective decision, and it is
     # declined independently: too many impacted targets, or none at all, both
     # mean the lane keeps its ordinary pattern. `narrowed` is the single flag
@@ -690,19 +812,21 @@ decide_select() {
     # "narrow to nothing".
     local impacted_count="${closure_count:-0}"
     local narrowing_status="DECLINED"
-    if [[ "$impacted_count" -gt 0 && "$impacted_count" -le "$NARROW_LIMIT" && "$live_count" -gt 0 ]]; then
+    if [[ "$impacted_count" -gt 0 && "$impacted_count" -le "$limit" && "$live_count" -gt 0 ]]; then
         narrowing_status="CANDIDATE"
         echo "affected-targets: ${live_count} live impacted targets are eligible for registered scope verification"
         emit_output_multiline impacted "$impacted_file"
         emit_output narrowed "true"
     else
-        echo "affected-targets: not narrowing (${impacted_count} impacted targets; limit ${NARROW_LIMIT})"
+        echo "affected-targets: not narrowing (${impacted_count} impacted targets; limit ${limit})"
         emit_output_multiline impacted ""
         emit_output narrowed "false"
     fi
     emit_output narrowing_status "$narrowing_status"
     emit_output head_target_count "$head_count"
-    emit_output impacted_target_count "$live_count"
+    emit_output impacted_closure_count "$impacted_count"
+    emit_output impacted_target_count "$proved_live_count"
+    emit_output impacted_targets_digest "$impacted_digest"
     emit_manifest "select" "$reason" "$selected" "$lanes" "$narrowing_status" "$head_count" "$live_count"
     exit 0
 }
@@ -887,6 +1011,9 @@ main() {
         scope-registry)
             [[ $# -eq 1 ]] || { echo "usage: scripts/affected-targets scope-registry" >&2; exit 2; }
             scope_registry ;;
+        narrow-limit)
+            [[ $# -eq 1 ]] || { echo "usage: scripts/affected-targets narrow-limit" >&2; exit 2; }
+            narrow_limit ;;
         scope-targets)
             [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets scope-targets LANE" >&2; exit 2; }
             scope_targets "$2" ;;
@@ -896,6 +1023,9 @@ main() {
         lane-targets)
             [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets lane-targets LANE" >&2; exit 2; }
             lane_targets "$2" ;;
+        clippy-owned-targets)
+            [[ $# -eq 1 ]] || { echo "usage: scripts/affected-targets clippy-owned-targets" >&2; exit 2; }
+            clippy_owned_targets ;;
         native-targets)
             [[ $# -eq 1 ]] || { echo "usage: scripts/affected-targets native-targets" >&2; exit 2; }
             native_platform_targets ;;
@@ -904,7 +1034,7 @@ main() {
         lanes)
             lanes ;;
         *)
-            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets|native-targets|corpus-targets|lanes|intersect|build-scope|scope-registry|scope-targets|narrow-scope]" >&2
+            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets|clippy-owned-targets|native-targets|corpus-targets|lanes|intersect|build-scope|scope-registry|narrow-limit|scope-targets|narrow-scope]" >&2
             exit 2 ;;
     esac
 }

--- a/scripts/ci-affected-payload.py
+++ b/scripts/ci-affected-payload.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Create and verify canonical affected-target payload proofs.
+
+GitHub job outputs are transported as independent strings. A count and SHA-256
+over a canonical serialization let a consumer distinguish a deliberately empty
+selection from a missing, truncated, reordered, or otherwise mutated payload.
+Candidate decisions are also bounded by the planner's locally resolved
+canonical narrow limit.
+This is an integrity check for one workflow run, not a cryptographic trust
+boundary: changes to this script themselves force the authoritative full run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass
+
+
+CANONICAL_COUNT = re.compile(r"(?:0|[1-9][0-9]*)\Z")
+CANONICAL_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+LANE = re.compile(r"[a-z0-9][a-z0-9-]*\Z")
+TARGET = re.compile(r"//[^\s:]*:[^\s:]+\Z")
+
+
+class PayloadError(ValueError):
+    """The payload or its claimed proof is not canonical."""
+
+
+@dataclass(frozen=True)
+class Payload:
+    items: tuple[str, ...]
+    canonical: str
+
+    @property
+    def count(self) -> int:
+        return len(self.items)
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.canonical.encode("utf-8")).hexdigest()
+
+
+def parse_payload(kind: str, raw: str) -> Payload:
+    if "\r" in raw:
+        raise PayloadError("carriage returns are not canonical")
+
+    if kind == "lanes":
+        if "\n" in raw:
+            raise PayloadError("lane payload must be one line")
+        items = () if not raw else tuple(raw.split(" "))
+        if any(not item or not LANE.fullmatch(item) for item in items):
+            raise PayloadError("lane payload contains an invalid token")
+        canonical = " ".join(items)
+    elif kind == "targets":
+        # Planner files conventionally end each target with one newline. Job
+        # outputs do not preserve that terminal newline, so both spellings map
+        # to the same proof; extra blank lines remain invalid.
+        body = raw
+        if body.endswith("\n") and body != "\n":
+            body = body[:-1]
+        if "\n\n" in body or body == "\n":
+            raise PayloadError("target payload contains an empty line")
+        items = () if not body else tuple(body.split("\n"))
+        if any(not TARGET.fullmatch(item) for item in items):
+            raise PayloadError("target payload contains an invalid label")
+        canonical = "\n".join(items)
+    else:
+        raise PayloadError(f"unknown payload kind {kind!r}")
+
+    if len(items) != len(set(items)):
+        raise PayloadError("payload contains a duplicate item")
+    return Payload(items, canonical)
+
+
+def parse_count(value: str, name: str) -> int:
+    if not CANONICAL_COUNT.fullmatch(value):
+        raise PayloadError(f"{name} is not a canonical non-negative decimal")
+    return int(value)
+
+
+def verify(payload: Payload, expected_count: str, expected_digest: str) -> None:
+    count = parse_count(expected_count, "expected count")
+    if not CANONICAL_DIGEST.fullmatch(expected_digest):
+        raise PayloadError("expected digest is not 64 lowercase hexadecimal digits")
+    if payload.count != count:
+        raise PayloadError(
+            f"payload count mismatch: expected {count}, received {payload.count}"
+        )
+    if payload.digest != expected_digest:
+        raise PayloadError("payload digest mismatch")
+
+
+def write_payload(kind: str, payload: Payload) -> None:
+    if payload.items:
+        sys.stdout.write(payload.canonical)
+        if kind == "targets":
+            sys.stdout.write("\n")
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    commands = result.add_subparsers(dest="command", required=True)
+
+    proof = commands.add_parser("proof")
+    proof.add_argument("kind", choices=("lanes", "targets"))
+
+    check = commands.add_parser("verify")
+    check.add_argument("kind", choices=("lanes", "targets"))
+    check.add_argument("expected_count")
+    check.add_argument("expected_digest")
+    check.add_argument("--require-nonempty", action="store_true")
+
+    decision = commands.add_parser("verify-decision")
+    decision.add_argument("expected_lane_count")
+    decision.add_argument("expected_lane_digest")
+    decision.add_argument("narrowed")
+    decision.add_argument("narrowing_status")
+    decision.add_argument("head_target_count")
+    decision.add_argument("impacted_closure_count")
+    decision.add_argument("impacted_target_count")
+    decision.add_argument("narrow_limit")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        kind = "lanes" if args.command == "verify-decision" else args.kind
+        payload = parse_payload(kind, sys.stdin.read())
+        if args.command == "proof":
+            print(f"{payload.count} {payload.digest}")
+            return 0
+        if args.command == "verify":
+            verify(payload, args.expected_count, args.expected_digest)
+            if args.require_nonempty and payload.count == 0:
+                raise PayloadError("payload must be nonempty")
+            write_payload(args.kind, payload)
+            return 0
+
+        verify(payload, args.expected_lane_count, args.expected_lane_digest)
+        head_count = parse_count(args.head_target_count, "head target count")
+        closure_count = parse_count(
+            args.impacted_closure_count, "impacted closure count"
+        )
+        live_count = parse_count(
+            args.impacted_target_count, "impacted target count"
+        )
+        narrow_limit = parse_count(args.narrow_limit, "narrow limit")
+        if head_count == 0:
+            raise PayloadError("head target count must be positive")
+        if narrow_limit == 0:
+            raise PayloadError("narrow limit must be positive")
+        if live_count > head_count:
+            raise PayloadError("impacted target count exceeds the head graph")
+        if live_count > closure_count:
+            raise PayloadError("live impacted count exceeds the raw closure")
+        state = (args.narrowing_status, args.narrowed)
+        if state not in {("CANDIDATE", "true"), ("DECLINED", "false")}:
+            raise PayloadError("narrowing status and flag are inconsistent")
+        candidate = 0 < closure_count <= narrow_limit and live_count > 0
+        expected_state = (
+            ("CANDIDATE", "true") if candidate else ("DECLINED", "false")
+        )
+        if state != expected_state:
+            raise PayloadError(
+                "narrowing state disagrees with closure count, live count, or limit"
+            )
+        return 0
+    except PayloadError as error:
+        print(f"affected payload invalid: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-clippy
+++ b/scripts/ci-clippy
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Fail-open clippy lane adapter for affected-target selection (RUE-1855).
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+proof="$repo_root/scripts/ci-affected-payload.py"
+decision="$repo_root/scripts/ci-corpus-decision"
+affected="$repo_root/scripts/affected-targets"
+buck2="$repo_root/buck2"
+
+select_lane() {
+    local proof_status="DEGRADED" narrow_limit=""
+    if [[ "${RUE_AFFECTED_FULL:-}" == "false" ]]; then
+        if ! narrow_limit="$("$affected" narrow-limit)"; then
+            echo "clippy canonical narrow limit is unavailable or malformed; running the full live inventory" >&2
+            RUE_AFFECTED_FULL=""
+            export RUE_AFFECTED_FULL
+        elif ! printf '%s' "${RUE_AFFECTED_LANES:-}" | "$proof" verify-decision \
+            "${RUE_AFFECTED_LANES_COUNT:-}" \
+            "${RUE_AFFECTED_LANES_DIGEST:-}" \
+            "${RUE_AFFECTED_NARROWED:-}" \
+            "${RUE_AFFECTED_NARROWING_STATUS:-}" \
+            "${RUE_AFFECTED_HEAD_TARGET_COUNT:-}" \
+            "${RUE_AFFECTED_IMPACTED_CLOSURE_COUNT:-}" \
+            "${RUE_AFFECTED_IMPACTED_TARGET_COUNT:-}" \
+            "$narrow_limit" >/dev/null; then
+            echo "clippy selection payload or metadata is incomplete or inconsistent; running the full live inventory" >&2
+            RUE_AFFECTED_FULL=""
+            export RUE_AFFECTED_FULL
+        else
+            proof_status="SELECTIVE"
+        fi
+    elif [[ "${RUE_AFFECTED_FULL:-}" == "true" ]]; then
+        proof_status="FULL"
+    fi
+    "$decision" clippy
+    local decision_status=$?
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf 'proof_status=%s\n' "$proof_status" >>"$GITHUB_OUTPUT"
+    fi
+    return "$decision_status"
+}
+
+append_scope_summary() {
+    [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+    printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+}
+
+materialize_impacted() {
+    if [[ -z "${RUNNER_TEMP:-}" || -z "${GITHUB_OUTPUT:-}" ]]; then
+        echo "ci-clippy: RUNNER_TEMP and GITHUB_OUTPUT are required" >&2
+        return 2
+    fi
+    local file="$RUNNER_TEMP/impacted-clippy-targets.txt"
+    local status="DECLINED"
+    : >"$file"
+    if [[ "${RUE_CLIPPY_PROOF_STATUS:-}" == "SELECTIVE" \
+        && "${RUE_CLIPPY_GATE_STATUS:-}" == "RUN" \
+        && "${RUE_AFFECTED_NARROWED:-}" == "true" ]]; then
+        if printf '%s' "${RUE_AFFECTED_IMPACTED:-}" | "$proof" verify targets \
+            "${RUE_AFFECTED_IMPACTED_TARGET_COUNT:-}" \
+            "${RUE_AFFECTED_IMPACTED_TARGETS_DIGEST:-}" \
+            --require-nonempty >"$file"; then
+            status="CANDIDATE"
+        else
+            status="DEGRADED"
+            echo "clippy impacted payload proof failed; running the full live inventory" >&2
+            append_scope_summary '- `clippy`: **DEGRADED**; saved share **not applicable** (impacted output unavailable or corrupt; full scope used).'
+        fi
+    elif [[ "${RUE_CLIPPY_PROOF_STATUS:-}" == "FULL" \
+        && "${RUE_CLIPPY_GATE_STATUS:-}" == "RUN" ]]; then
+        append_scope_summary '- `clippy`: **DECLINED**; saved share **not applicable** (full scope used).'
+    elif [[ "${RUE_CLIPPY_PROOF_STATUS:-}" == "SELECTIVE" \
+        && "${RUE_CLIPPY_GATE_STATUS:-}" == "RUN" \
+        && "${RUE_AFFECTED_NARROWED:-}" == "false" ]]; then
+        append_scope_summary '- `clippy`: **DECLINED**; saved share **not applicable** (full scope used).'
+    else
+        status="DEGRADED"
+        echo "clippy selection, gate, or narrowing decision is unavailable; running the full live inventory" >&2
+        append_scope_summary '- `clippy`: **DEGRADED**; saved share **not applicable** (selection, gate, or narrowing decision unavailable; full scope used).'
+    fi
+    {
+        printf 'file=%s\n' "$file"
+        printf 'status=%s\n' "$status"
+    } >>"$GITHUB_OUTPUT"
+}
+
+run_clippy() {
+    local selection="full"
+    local targets_text=""
+    local narrow_status scope_status target
+    if [[ "${NARROW_STATUS:-}" == "CANDIDATE" ]]; then
+        if targets_text="$("$affected" narrow-scope clippy "${NARROW_FILE:-}")"; then
+            if [[ -z "$targets_text" ]]; then
+                echo "clippy: verified impacted subset is empty; intentional no-op"
+                return 0
+            fi
+            selection="narrowed"
+        else
+            narrow_status=$?
+            if [[ "$narrow_status" -eq 2 ]]; then
+                echo "clippy: no live -clippy targets found; the query or crate macros are broken" >&2
+                return 1
+            fi
+            echo "clippy: scope resolution or intersection failed; running the full live inventory" >&2
+        fi
+    fi
+    if [[ "$selection" == "full" ]]; then
+        if targets_text="$("$affected" scope-targets clippy)"; then
+            :
+        else
+            scope_status=$?
+            if [[ "$scope_status" -eq 2 ]]; then
+                echo "clippy: no live -clippy targets found; the query or crate macros are broken" >&2
+                return 1
+            fi
+            # This broad pattern is the fail-open superset when the canonical
+            # live inventory cannot be resolved; it is not a peer graph query.
+            echo "clippy: live scope unavailable; running all crate tests as the fail-open superset" >&2
+            "$buck2" test //crates/...
+            return $?
+        fi
+    fi
+    local targets=()
+    while IFS= read -r target; do
+        [[ -n "$target" ]] && targets+=("$target")
+    done <<<"$targets_text"
+    if [[ "${#targets[@]}" -eq 0 ]]; then
+        echo "clippy: resolved live inventory is unexpectedly empty" >&2
+        return 1
+    fi
+    echo "Running $selection clippy scope across ${#targets[@]} crates..."
+    "$buck2" test "${targets[@]}"
+}
+
+case "${1:-}" in
+    select)
+        [[ $# -eq 1 ]] || { echo "usage: scripts/ci-clippy select" >&2; exit 2; }
+        select_lane ;;
+    materialize)
+        [[ $# -eq 1 ]] || { echo "usage: scripts/ci-clippy materialize" >&2; exit 2; }
+        materialize_impacted ;;
+    run)
+        [[ $# -eq 1 ]] || { echo "usage: scripts/ci-clippy run" >&2; exit 2; }
+        run_clippy ;;
+    *)
+        echo "usage: scripts/ci-clippy {select|materialize|run}" >&2
+        exit 2 ;;
+esac

--- a/scripts/ci-corpus-decision
+++ b/scripts/ci-corpus-decision
@@ -12,6 +12,7 @@ fi
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 gate="${RUE_AFFECTED_GATE:-$repo_root/scripts/ci-corpus-selected}"
 run=true
+gate_status=RUN
 
 if "$gate" "$1"; then
     :
@@ -19,13 +20,18 @@ else
     status=$?
     if [[ "$status" -eq 1 ]]; then
         run=false
+        gate_status=DESELECTED
     else
+        gate_status=DEGRADED
         echo "Corpus selection failed unexpectedly (exit $status); running full corpus." >&2
     fi
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    printf 'run=%s\n' "$run" >>"$GITHUB_OUTPUT"
+    {
+        printf 'run=%s\n' "$run"
+        printf 'gate_status=%s\n' "$gate_status"
+    } >>"$GITHUB_OUTPUT"
 else
     printf 'run=%s\n' "$run"
 fi

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -24,6 +24,8 @@ GATE=(bash "$SCRIPTS_DIR/ci-corpus-selected")
 REPO_ROOT="$(cd "$SCRIPTS_DIR/.." && pwd)"
 DECISION=(bash "$SCRIPTS_DIR/ci-corpus-decision")
 PARSER=(python3 "$SCRIPTS_DIR/parse-btd-impacted.py")
+PAYLOAD=(python3 "$SCRIPTS_DIR/ci-affected-payload.py")
+CLIPPY=(bash "$SCRIPTS_DIR/ci-clippy")
 
 # Native lane membership is intentionally graph-derived. Keep these shell
 # tests hermetic by supplying a tiny live-graph stand-in for the representative
@@ -31,7 +33,15 @@ PARSER=(python3 "$SCRIPTS_DIR/parse-btd-impacted.py")
 native_graph_stub="$(mktemp)"
 cat >"$native_graph_stub" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' root//crates/rue-codegen:rue-codegen-test
+case "${2:-}" in
+  kind*)
+    printf '%s\n' \
+      root//crates/rue-codegen:rue-codegen-clippy \
+      root//crates/rue-codegen:rue-codegen-debug-assert-check ;;
+  *rue_ci_clippy_lane*)
+    printf '%s\n' root//crates/rue-codegen:rue-codegen-clippy ;;
+  *) printf '%s\n' root//crates/rue-codegen:rue-codegen-test ;;
+esac
 EOF
 chmod +x "$native_graph_stub"
 export RUE_AFFECTED_BUCK2="$native_graph_stub"
@@ -95,6 +105,8 @@ expect_full "test.sh"
 expect_full "scripts/ci-heavy-suite"
 expect_full "scripts/ci-timed"
 expect_full "scripts/ci-corpus-selected"
+expect_full "scripts/ci-affected-payload.py"
+expect_full "scripts/ci-clippy"
 expect_full "scripts/affected-targets"
 expect_full "btd"
 expect_full "scripts/provision-build-cache"
@@ -179,7 +191,7 @@ check_lane() { # check_lane <desc> <expected-status> <full> <lanes> <lane>
 # Every gated lane must be recognized; an unrecognized name would silently fall
 # through to the corpus path and be treated as an unknown target (fail-open),
 # which is safe but would make the lane permanently ungated.
-for lane in native-linux-arm64 native-macos-arm64 release valgrind asan compiler-reproducibility rue-program-digests; do
+for lane in clippy native-linux-arm64 native-macos-arm64 release valgrind asan compiler-reproducibility rue-program-digests; do
   TESTS=$((TESTS + 1))
   if "${AFFECTED[@]}" is-selectable-lane "$lane"; then
     pass "lane: $lane is selectable"
@@ -188,9 +200,26 @@ for lane in native-linux-arm64 native-macos-arm64 release valgrind asan compiler
   fi
 done
 
+TESTS=$((TESTS + 1))
+if [ "$("${AFFECTED[@]}" clippy-owned-targets)" = \
+    "//crates/rue-codegen:rue-codegen-clippy" ]; then
+  pass "clippy: owner-label query matches the canonical test in the stub graph"
+else
+  fail "clippy: owner-label query drifted from the canonical test in the stub graph"
+fi
+
+TESTS=$((TESTS + 1))
+usage_status=0
+usage_output="$("${AFFECTED[@]}" not-a-command 2>&1)" || usage_status=$?
+if [ "$usage_status" -eq 2 ] && grep -Fq 'clippy-owned-targets' <<<"$usage_output"; then
+  pass "affected-targets: catch-all usage lists clippy-owned-targets"
+else
+  fail "affected-targets: catch-all usage omits clippy-owned-targets"
+fi
+
 # Each lane must name at least one representative Buck target, or it could never
 # be selected and would be deselected on every selective run.
-for lane in native-linux-arm64 native-macos-arm64 release valgrind asan compiler-reproducibility rue-program-digests; do
+for lane in clippy native-linux-arm64 native-macos-arm64 release valgrind asan compiler-reproducibility rue-program-digests; do
   TESTS=$((TESTS + 1))
   if [ -n "$("${AFFECTED[@]}" lane-targets "$lane")" ]; then
     pass "lane: $lane declares representative targets"
@@ -205,6 +234,8 @@ check_lane "unselected lane deselected" 1 "false" "asan" "valgrind"
 check_lane "empty lane selection deselects" 1 "false" "" "valgrind"
 check_lane "unset full runs lane (fail-open)" 0 "" "" "valgrind"
 check_lane "malformed lane selection is an error" 2 "false" "not-a-lane" "valgrind"
+check_lane "selected clippy lane runs" 0 "false" "clippy" "clippy"
+check_lane "unselected clippy lane is intentionally deselected" 1 "false" "release" "clippy"
 # A lane name must not be satisfied by a corpus target list, and vice versa:
 # the two selections are read from different environment variables.
 check_lane "corpus selection does not select a lane" 1 "false" "" "release"
@@ -223,7 +254,7 @@ fi
 # view of what runs.
 TESTS=$((TESTS + 1))
 if [ "$("${AFFECTED[@]}" lanes | sort | tr '\n' ' ')" \
-    = "asan compiler-reproducibility native-linux-arm64 native-macos-arm64 release rue-program-digests valgrind " ]; then
+    = "asan clippy compiler-reproducibility native-linux-arm64 native-macos-arm64 release rue-program-digests valgrind " ]; then
   pass "lanes: the gated lane inventory is exposed in full"
 else
   fail "lanes: printed $("${AFFECTED[@]}" lanes | tr '\n' ' ')"
@@ -249,10 +280,30 @@ expect_full "crates/rue-runtime-asan/Cargo.toml"
 # The registry is the one source of truth for every narrowed-lane scope.
 TESTS=$((TESTS + 1))
 if [ "$(${AFFECTED[@]} scope-registry | tr '\n' ' ')" = \
-     "linux-premerge-build|pattern|//crates/... linux-premerge-tests|graph|rue_test_tier_premerge-minus-dedicated native-platforms-units|graph|rue_platform_native " ]; then
+     "clippy|graph|crates_sh_test_ending_-clippy linux-premerge-build|pattern|//crates/... linux-premerge-tests|graph|rue_test_tier_premerge-minus-dedicated-and-clippy native-platforms-units|graph|rue_platform_native " ]; then
   pass "narrow: scope registry declares every consumer"
 else
   fail "narrow: scope registry drifted"
+fi
+
+# The planner and every narrowing consumer read the same canonical threshold.
+TESTS=$((TESTS + 1))
+if [ "$("${AFFECTED[@]}" narrow-limit)" = "600" ]; then
+  pass "narrow: default canonical limit is exposed"
+else
+  fail "narrow: default canonical limit is unavailable"
+fi
+TESTS=$((TESTS + 1))
+if [ "$(RUE_AFFECTED_NARROW_LIMIT=7 "${AFFECTED[@]}" narrow-limit)" = "7" ]; then
+  pass "narrow: supported custom limit has one authority"
+else
+  fail "narrow: custom canonical limit was ignored"
+fi
+TESTS=$((TESTS + 1))
+if RUE_AFFECTED_NARROW_LIMIT=00 "${AFFECTED[@]}" narrow-limit >/dev/null 2>&1; then
+  fail "narrow: malformed canonical limit was accepted"
+else
+  pass "narrow: malformed canonical limit fails open"
 fi
 TESTS=$((TESTS + 1))
 if ! "${AFFECTED[@]}" scope-targets future-lane >/dev/null 2>&1; then
@@ -329,6 +380,127 @@ if ! GITHUB_STEP_SUMMARY="$degraded_scope_summary" RUE_AFFECTED_BUCK2="$narrow_r
   pass "narrow: degraded scope summary cannot masquerade as verified"
 else
   fail "narrow: degraded scope summary is missing or contradictory"
+fi
+
+# RUE-1855: lane selection and narrowing must consume the same complete live
+# set of crate-local sh_tests whose labels end exactly in `-clippy`.
+cat >"$narrow_root/clippy-buck" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" != "uquery" ] || [ "${2:-}" != "kind('sh_test', 'root//crates/...')" ]; then
+  echo "clippy-buck: unexpected query" >&2
+  exit 1
+fi
+printf '%s\n' \
+  root//crates/rue-alpha:rue-alpha-clippy \
+  root//crates/rue-alpha:rue-alpha-debug-assert-check \
+  root//crates/rue-beta:rue-beta-clippy
+EOF
+chmod +x "$narrow_root/clippy-buck"
+
+TESTS=$((TESTS + 1))
+clippy_lane="$(RUE_AFFECTED_BUCK2="$narrow_root/clippy-buck" "${AFFECTED[@]}" lane-targets clippy)"
+clippy_scope="$(RUE_AFFECTED_BUCK2="$narrow_root/clippy-buck" "${AFFECTED[@]}" scope-targets clippy)"
+if [ "$clippy_lane" = "$clippy_scope" ] && \
+    [ "$(tr '\n' ' ' <<<"$clippy_scope")" = \
+      "//crates/rue-alpha:rue-alpha-clippy //crates/rue-beta:rue-beta-clippy " ]; then
+  pass "clippy: lane proxy and runnable scope share the exact live inventory"
+else
+  fail "clippy: lane proxy and runnable scope drifted"
+fi
+
+printf '%s\n' \
+  //crates/rue-beta:rue-beta-clippy \
+  //crates/removed:removed-clippy \
+  //crates/rue-alpha:rue-alpha-debug-assert-check \
+  >"$narrow_root/clippy-impacted"
+TESTS=$((TESTS + 1))
+clippy_subset="$(RUE_AFFECTED_BUCK2="$narrow_root/clippy-buck" "${AFFECTED[@]}" \
+  narrow-scope clippy "$narrow_root/clippy-impacted")"
+if [ "$clippy_subset" = "//crates/rue-beta:rue-beta-clippy" ]; then
+  pass "clippy: narrowed scope keeps only live impacted -clippy targets"
+else
+  fail "clippy: narrowed scope retained a non-clippy or dead target"
+fi
+
+# A well-formed target removed from the live graph is safely absent, and an
+# impacted closure with no clippy intersection is a verified empty subset.
+printf '%s\n' //crates/removed:removed-clippy >"$narrow_root/clippy-stale-only"
+clippy_empty_summary="$narrow_root/clippy-empty-summary"
+TESTS=$((TESTS + 1))
+if [ -z "$(GITHUB_STEP_SUMMARY="$clippy_empty_summary" \
+    RUE_AFFECTED_BUCK2="$narrow_root/clippy-buck" "${AFFECTED[@]}" \
+    narrow-scope clippy "$narrow_root/clippy-stale-only")" ] && \
+    grep -Fq '**VERIFIED** subset; selected **0/2** targets; unweighted saved share **100.00%**' "$clippy_empty_summary"; then
+  pass "clippy: stale-only impact is a visible verified empty subset"
+else
+  fail "clippy: stale-only impact did not produce the verified no-op contract"
+fi
+
+# Empty or malformed planner output is corrupt state, not a verified no-op.
+TESTS=$((TESTS + 1))
+if ! RUE_AFFECTED_BUCK2="$narrow_root/clippy-buck" "${AFFECTED[@]}" \
+    narrow-scope clippy "$narrow_root/none" >/dev/null 2>&1; then
+  pass "clippy: empty impacted output degrades to the full scope"
+else
+  fail "clippy: empty impacted output masqueraded as a verified subset"
+fi
+printf '%s\n' not-a-target >"$narrow_root/clippy-malformed"
+TESTS=$((TESTS + 1))
+if ! RUE_AFFECTED_BUCK2="$narrow_root/clippy-buck" "${AFFECTED[@]}" \
+    narrow-scope clippy "$narrow_root/clippy-malformed" >/dev/null 2>&1; then
+  pass "clippy: malformed impacted output degrades to the full scope"
+else
+  fail "clippy: malformed impacted output masqueraded as a verified subset"
+fi
+
+cat >"$narrow_root/clippy-empty-buck" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' root//crates/rue-alpha:rue-alpha-debug-assert-check
+EOF
+chmod +x "$narrow_root/clippy-empty-buck"
+TESTS=$((TESTS + 1))
+clippy_hard_error_summary="$narrow_root/clippy-hard-error-summary"
+if GITHUB_STEP_SUMMARY="$clippy_hard_error_summary" \
+    RUE_AFFECTED_BUCK2="$narrow_root/clippy-empty-buck" "${AFFECTED[@]}" \
+    scope-targets clippy >/dev/null 2>&1; then
+  fail "clippy: empty successful live query was accepted"
+else
+  clippy_status=$?
+  if [ "$clippy_status" -eq 2 ]; then
+    pass "clippy: empty successful live query remains a distinct hard error"
+  else
+    fail "clippy: empty successful live query returned $clippy_status instead of 2"
+  fi
+fi
+
+TESTS=$((TESTS + 1))
+if GITHUB_STEP_SUMMARY="$clippy_hard_error_summary" \
+    RUE_AFFECTED_BUCK2="$narrow_root/clippy-empty-buck" "${AFFECTED[@]}" \
+    narrow-scope clippy "$narrow_root/clippy-impacted" >/dev/null 2>&1; then
+  fail "clippy: empty live inventory was accepted while narrowing"
+else
+  clippy_status=$?
+  if [ "$clippy_status" -eq 2 ] && \
+      grep -Fq '**FAILED**' "$clippy_hard_error_summary" && \
+      grep -Fq 'live scope inventory rejected; hard failure' "$clippy_hard_error_summary" && \
+      ! grep -Fq 'full scope used' "$clippy_hard_error_summary"; then
+    pass "clippy: empty live inventory reports its hard failure accurately"
+  else
+    fail "clippy: empty live inventory summary misreported a full-scope fallback"
+  fi
+fi
+
+TESTS=$((TESTS + 1))
+if RUE_AFFECTED_BUCK2="$narrow_root/absent" "${AFFECTED[@]}" \
+    scope-targets clippy >/dev/null 2>&1; then
+  fail "clippy: failed live query was accepted"
+else
+  clippy_status=$?
+  if [ "$clippy_status" -eq 1 ]; then
+    pass "clippy: failed live query remains a fail-open scope error"
+  else
+    fail "clippy: failed live query returned unexpected status $clippy_status"
+  fi
 fi
 
 # A missing file is an unavailable intersection, never a verified empty one.
@@ -739,21 +911,180 @@ decision_root="$(mktemp -d)"
 printf '#!/usr/bin/env bash\nexit 1\n' >"$decision_root/deselect"
 printf '#!/usr/bin/env bash\nexit 2\n' >"$decision_root/crash"
 chmod +x "$decision_root/deselect" "$decision_root/crash"
-check_decision() { # check_decision <description> <gate> <expected-output>
-  local desc="$1" gate="$2" expected="$3" output="$decision_root/output"
+check_decision() { # check_decision <description> <gate> <expected-output> <expected-status>
+  local desc="$1" gate="$2" expected="$3" expected_status="$4"
+  local output="$decision_root/output"
   TESTS=$((TESTS + 1))
   : >"$output"
   if RUE_AFFECTED_GATE="$gate" GITHUB_OUTPUT="$output" "${DECISION[@]}" "//:spec-tests" >/dev/null 2>&1 && \
-      grep -Fxq "run=$expected" "$output"; then
+      grep -Fxq "run=$expected" "$output" && \
+      grep -Fxq "gate_status=$expected_status" "$output"; then
     pass "decision: $desc"
   else
     fail "decision: $desc"
   fi
 }
-check_decision "exit 1 intentionally deselects" "$decision_root/deselect" false
-check_decision "crashing gate runs" "$decision_root/crash" true
-check_decision "missing gate runs" "$decision_root/missing" true
+check_decision "exit 1 intentionally deselects" "$decision_root/deselect" false DESELECTED
+check_decision "crashing gate runs" "$decision_root/crash" true DEGRADED
+check_decision "missing gate runs" "$decision_root/missing" true DEGRADED
 rm -rf "$decision_root"
+
+# The clippy adapter binds independently transported payloads to planner proofs.
+# These are runtime tests of the exact script the workflow invokes; structural
+# tests in test-validate-ci-gate.py separately prevent the workflow from
+# bypassing it.
+proof_parts() { # proof_parts <kind> <payload>
+  local kind="$1" payload="$2"
+  printf '%s' "$payload" | "${PAYLOAD[@]}" proof "$kind"
+}
+
+clippy_select_root="$(mktemp -d)"
+check_clippy_select() { # description expected-run expected-proof expected-gate payload proof narrowed status head closure live [limit]
+  local desc="$1" expected="$2"
+  local expected_proof="$3" expected_gate="$4" payload="$5" proof_value="$6"
+  local narrowed="$7" status="$8" head="$9" closure="${10}" live="${11}"
+  local narrow_limit="${12:-}"
+  local count="${proof_value%% *}" digest="${proof_value#* }"
+  local output="$clippy_select_root/output"
+  TESTS=$((TESTS + 1))
+  : >"$output"
+  if RUE_AFFECTED_NARROW_LIMIT="$narrow_limit" \
+      RUE_AFFECTED_FULL=false \
+      RUE_AFFECTED_LANES="$payload" \
+      RUE_AFFECTED_LANES_COUNT="$count" \
+      RUE_AFFECTED_LANES_DIGEST="$digest" \
+      RUE_AFFECTED_NARROWED="$narrowed" \
+      RUE_AFFECTED_NARROWING_STATUS="$status" \
+      RUE_AFFECTED_HEAD_TARGET_COUNT="$head" \
+      RUE_AFFECTED_IMPACTED_CLOSURE_COUNT="$closure" \
+      RUE_AFFECTED_IMPACTED_TARGET_COUNT="$live" \
+      GITHUB_OUTPUT="$output" \
+      "${CLIPPY[@]}" select >/dev/null 2>&1 && \
+      grep -Fxq "run=$expected" "$output" && \
+      grep -Fxq "proof_status=$expected_proof" "$output" && \
+      grep -Fxq "gate_status=$expected_gate" "$output"; then
+    pass "clippy selection proof: $desc"
+  else
+    fail "clippy selection proof: $desc"
+  fi
+}
+
+empty_lane_proof="$(proof_parts lanes "")"
+clippy_lane_proof="$(proof_parts lanes "clippy")"
+two_lane_proof="$(proof_parts lanes "clippy release")"
+invalid_lane_proof="$(proof_parts lanes "clippy not-a-lane")"
+check_clippy_select "missing lane payload fails open" true DEGRADED RUN "" "$clippy_lane_proof" false DECLINED 2 0 0
+check_clippy_select "valid-prefix lane truncation fails open" true DEGRADED RUN "clippy" "$two_lane_proof" true CANDIDATE 3 1 1
+check_clippy_select "lane payload mutation fails open" true DEGRADED RUN "release" "$clippy_lane_proof" true CANDIDATE 3 1 1
+check_clippy_select "leading-zero head metadata fails open" true DEGRADED RUN "" "$empty_lane_proof" false DECLINED 00 0 0
+check_clippy_select "zero-impact CANDIDATE metadata fails open" true DEGRADED RUN "clippy" "$clippy_lane_proof" true CANDIDATE 3 0 0
+check_clippy_select "legitimate empty lane set deselects" false SELECTIVE DESELECTED "" "$empty_lane_proof" false DECLINED 3 0 0
+check_clippy_select "valid selected clippy lane runs" true SELECTIVE RUN "clippy" "$clippy_lane_proof" true CANDIDATE 3 1 1
+check_clippy_select "gate rejection cannot authorize narrowing" true SELECTIVE DEGRADED "clippy not-a-lane" "$invalid_lane_proof" true CANDIDATE 3 1 1
+check_clippy_select "closure at the canonical limit with live impact is a candidate" true SELECTIVE RUN "clippy" "$clippy_lane_proof" true CANDIDATE 100 600 100
+check_clippy_select "oversized closure with a small live set rejects candidate" true DEGRADED RUN "clippy" "$clippy_lane_proof" true CANDIDATE 100 601 100
+check_clippy_select "oversized closure with a small live set accepts declined" true SELECTIVE RUN "clippy" "$clippy_lane_proof" false DECLINED 100 601 100
+check_clippy_select "bounded closure with no live targets accepts declined" true SELECTIVE RUN "clippy" "$clippy_lane_proof" false DECLINED 100 10 0
+check_clippy_select "bounded live closure cannot be falsely declined" true DEGRADED RUN "clippy" "$clippy_lane_proof" false DECLINED 100 600 100
+check_clippy_select "empty-live closure cannot be a candidate" true DEGRADED RUN "clippy" "$clippy_lane_proof" true CANDIDATE 100 10 0
+check_clippy_select "live count cannot exceed raw closure" true DEGRADED RUN "clippy" "$clippy_lane_proof" true CANDIDATE 3 1 2
+check_clippy_select "missing closure count fails open" true DEGRADED RUN "clippy" "$clippy_lane_proof" true CANDIDATE 3 "" 1
+check_clippy_select "malformed closure count fails open" true DEGRADED RUN "clippy" "$clippy_lane_proof" true CANDIDATE 3 01 1
+check_clippy_select "candidate exactly at a custom canonical limit remains selective" true SELECTIVE RUN "clippy" "$clippy_lane_proof" true CANDIDATE 2 2 2 2
+check_clippy_select "candidate above a custom canonical limit fails open" true DEGRADED RUN "clippy" "$clippy_lane_proof" true CANDIDATE 2 3 2 2
+check_clippy_select "malformed canonical limit fails open" true DEGRADED RUN "clippy" "$clippy_lane_proof" true CANDIDATE 3 1 1 00
+
+check_clippy_materialize() { # description expected-status payload proof expected-file [proof-status] [gate-status]
+  local desc="$1" expected_status="$2" payload="$3" proof_value="$4" expected_file="$5"
+  local proof_status="${6:-SELECTIVE}" gate_status="${7:-RUN}"
+  local count="${proof_value%% *}" digest="${proof_value#* }"
+  local output="$clippy_select_root/materialize-output"
+  local summary="$clippy_select_root/materialize-summary"
+  local file="$clippy_select_root/impacted-clippy-targets.txt"
+  TESTS=$((TESTS + 1))
+  : >"$output"
+  : >"$summary"
+  if RUNNER_TEMP="$clippy_select_root" \
+      GITHUB_OUTPUT="$output" \
+      GITHUB_STEP_SUMMARY="$summary" \
+      RUE_CLIPPY_PROOF_STATUS="$proof_status" \
+      RUE_CLIPPY_GATE_STATUS="$gate_status" \
+      RUE_AFFECTED_NARROWED=true \
+      RUE_AFFECTED_IMPACTED="$payload" \
+      RUE_AFFECTED_IMPACTED_TARGET_COUNT="$count" \
+      RUE_AFFECTED_IMPACTED_TARGETS_DIGEST="$digest" \
+      "${CLIPPY[@]}" materialize >/dev/null 2>&1 && \
+      grep -Fxq "status=$expected_status" "$output" && \
+      cmp -s "$file" "$expected_file"; then
+    pass "clippy impacted proof: $desc"
+  else
+    fail "clippy impacted proof: $desc"
+  fi
+}
+
+: >"$clippy_select_root/empty"
+clippy_first=$'//crates/one:one-clippy\n//crates/two:two-test'
+non_clippy_first=$'//crates/two:two-test\n//crates/one:one-clippy'
+clippy_first_proof="$(proof_parts targets "$clippy_first")"
+non_clippy_first_proof="$(proof_parts targets "$non_clippy_first")"
+printf '%s\n' "$clippy_first" >"$clippy_select_root/complete"
+check_clippy_materialize \
+  "clippy-retaining valid prefix degrades" DEGRADED \
+  "//crates/one:one-clippy" "$clippy_first_proof" "$clippy_select_root/empty"
+check_clippy_materialize \
+  "non-clippy-retaining valid prefix degrades" DEGRADED \
+  "//crates/two:two-test" "$non_clippy_first_proof" "$clippy_select_root/empty"
+check_clippy_materialize \
+  "complete canonical payload remains a candidate" CANDIDATE \
+  "$clippy_first" "$clippy_first_proof" "$clippy_select_root/complete"
+check_clippy_materialize \
+  "selection proof failure forces the full inventory" DEGRADED \
+  "$clippy_first" "$clippy_first_proof" "$clippy_select_root/empty" DEGRADED RUN
+check_clippy_materialize \
+  "gate failure forces the full inventory" DEGRADED \
+  "$clippy_first" "$clippy_first_proof" "$clippy_select_root/empty" SELECTIVE DEGRADED
+check_clippy_materialize \
+  "authoritative full selection cannot narrow" DECLINED \
+  "$clippy_first" "$clippy_first_proof" "$clippy_select_root/empty" FULL RUN
+
+# A successful-empty canonical query is a hard error on the first narrowed
+# attempt. It must not be retried as a full query that can fail and enter the
+# broad passing fallback.
+clippy_runner_root="$(mktemp -d)"
+mkdir -p "$clippy_runner_root/scripts"
+cp "$SCRIPTS_DIR/ci-clippy" "$clippy_runner_root/scripts/ci-clippy"
+chmod +x "$clippy_runner_root/scripts/ci-clippy"
+cat >"$clippy_runner_root/scripts/affected-targets" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >>"${CLIPPY_AFFECTED_LOG:?}"
+case "$1" in
+  narrow-scope) exit "${CLIPPY_NARROW_RC:-0}" ;;
+  scope-targets) exit "${CLIPPY_SCOPE_RC:-1}" ;;
+  *) exit 2 ;;
+esac
+EOF
+cat >"$clippy_runner_root/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CLIPPY_BUCK_LOG:?}"
+EOF
+chmod +x "$clippy_runner_root/scripts/affected-targets" "$clippy_runner_root/buck2"
+TESTS=$((TESTS + 1))
+: >"$clippy_runner_root/affected.log"
+: >"$clippy_runner_root/buck.log"
+if ! NARROW_STATUS=CANDIDATE \
+    NARROW_FILE="$clippy_runner_root/impacted" \
+    CLIPPY_NARROW_RC=2 \
+    CLIPPY_SCOPE_RC=1 \
+    CLIPPY_AFFECTED_LOG="$clippy_runner_root/affected.log" \
+    CLIPPY_BUCK_LOG="$clippy_runner_root/buck.log" \
+    "$clippy_runner_root/scripts/ci-clippy" run >/dev/null 2>&1 && \
+    [ "$(tr '\n' ' ' <"$clippy_runner_root/affected.log")" = "narrow-scope " ] && \
+    [ ! -s "$clippy_runner_root/buck.log" ]; then
+  pass "clippy runner: first narrow-scope rc=2 is an immediate hard error"
+else
+  fail "clippy runner: first narrow-scope rc=2 was retried or fell back"
+fi
+rm -rf "$clippy_select_root" "$clippy_runner_root"
 
 # --- strict BTD JSON decoding -----------------------------------------------
 
@@ -806,14 +1137,23 @@ fi
 TESTS=$((TESTS + 1))
 integration_root="$(mktemp -d)"
 mkdir -p "$integration_root/scripts" "$integration_root/bin" "$integration_root/docs"
-cp "$SCRIPTS_DIR/affected-targets" "$SCRIPTS_DIR/parse-btd-impacted.py" "$integration_root/scripts/"
+cp "$SCRIPTS_DIR/affected-targets" \
+  "$SCRIPTS_DIR/ci-affected-payload.py" \
+  "$SCRIPTS_DIR/parse-btd-impacted.py" \
+  "$integration_root/scripts/"
 chmod +x "$integration_root/scripts/affected-targets"
 
 cat >"$integration_root/bin/fake-buck" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" = "uquery" ]; then
-  printf 'root//:spec-tests\n'
+  case "${2:-}" in
+    kind*)
+      printf 'root//crates/rue-span:rue-span-clippy\n' ;;
+    attrfilter*)
+      printf 'root//crates/rue-codegen:rue-codegen-test\n' ;;
+    *) exit 1 ;;
+  esac
   exit 0
 fi
 output=""
@@ -847,6 +1187,12 @@ git -C "$integration_root" add . && git -C "$integration_root" commit -qm base
 printf 'after\n' >"$integration_root/docs/input.txt"
 git -C "$integration_root" add docs/input.txt && git -C "$integration_root" commit -qm head
 printf 'M\tdocs/input.txt\n' >"$integration_root/expected-changes"
+integration_selected_lanes="native-linux-arm64 native-macos-arm64"
+integration_lane_proof="$(proof_parts lanes "$integration_selected_lanes")"
+integration_lane_count="${integration_lane_proof%% *}"
+integration_lane_digest="${integration_lane_proof#* }"
+integration_impacted_proof="$(proof_parts targets "//:spec-tests")"
+integration_impacted_digest="${integration_impacted_proof#* }"
 if (
   cd "$integration_root" &&
   RUE_AFFECTED_BASE_SHA=HEAD~1 \
@@ -860,9 +1206,14 @@ if (
   scripts/affected-targets decide >/dev/null
 ) && grep -Fxq 'full=false' "$integration_root/output" && \
     grep -Fxq 'selected=//:spec-tests' "$integration_root/output" && \
+    grep -Fxq "selected_lanes=$integration_selected_lanes" "$integration_root/output" && \
+    grep -Fxq "selected_lanes_count=$integration_lane_count" "$integration_root/output" && \
+    grep -Fxq "selected_lanes_digest=$integration_lane_digest" "$integration_root/output" && \
     grep -Fxq 'narrowing_status=CANDIDATE' "$integration_root/output" && \
     grep -Fxq 'head_target_count=2' "$integration_root/output" && \
+    grep -Fxq 'impacted_closure_count=2' "$integration_root/output" && \
     grep -Fxq 'impacted_target_count=1' "$integration_root/output" && \
+    grep -Fxq "impacted_targets_digest=$integration_impacted_digest" "$integration_root/output" && \
     ! grep -Fq '//crates/deleted:base-only' "$integration_root/output" && \
     grep -Fq 'Live impacted closure: **1** targets (**50.00%' "$integration_root/summary" && \
     grep -Fq 'exact saved share is reported after each registered lane scope' "$integration_root/summary" && \
@@ -873,12 +1224,12 @@ if (
     grep -Fxq -- "$integration_root/bin/fake-buck" "$integration_root/btd-args"; then
   pass "integration: BTD selects a corpus from Git status and receives pinned Buck wrapper"
 else
-  fail "integration: selective BTD decision contract"
+  fail "integration: selective BTD decision contract ($(tr '\n' ' ' <"$integration_root/output"))"
 fi
 
-# A native graph query is required only for selective lane planning. If it
-# fails, the planner must choose the safe full run rather than silently omit
-# both native lanes (RUE-1266).
+# Every graph-owned lane proxy is required for selective planning. If the
+# canonical clippy query fails, the planner must choose the safe full run
+# rather than silently omit the clippy lane.
 cat >"$integration_root/bin/failing-buck" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -910,9 +1261,9 @@ if (
 ) && grep -Fxq 'full=true' "$failure_output" && \
     grep -Fxq 'narrowing_status=DEGRADED' "$failure_output" && \
     grep -Fq 'Planner reach: **not applicable**' "$integration_root/degraded-summary"; then
-  pass "decision: native graph query failure runs full suite"
+  pass "decision: clippy graph query failure runs full suite"
 else
-  fail "decision: native graph query failure did not fail open to full suite"
+  fail "decision: clippy graph query failure did not fail open to full suite"
 fi
 
 cat >"$integration_root/bin/empty-head-buck" <<'EOF'
@@ -966,6 +1317,23 @@ if (
   pass "decision: authoritative full run reports no saved share"
 else
   fail "decision: authoritative full run fabricated a saved share"
+fi
+
+TESTS=$((TESTS + 1))
+dispatch_output="$integration_root/dispatch-output"
+dispatch_summary="$integration_root/dispatch-summary"
+if (
+  cd "$integration_root" &&
+  RUE_AFFECTED_EVENT=workflow_dispatch \
+  GITHUB_OUTPUT="$dispatch_output" \
+  GITHUB_STEP_SUMMARY="$dispatch_summary" \
+  scripts/affected-targets decide >/dev/null 2>&1
+) && grep -Fxq 'full=true' "$dispatch_output" && \
+    grep -Fxq 'narrowing_status=DECLINED' "$dispatch_output" && \
+    grep -Fq "authoritative full run for event 'workflow_dispatch'" "$dispatch_summary"; then
+  pass "decision: workflow_dispatch remains an authoritative full run"
+else
+  fail "decision: workflow_dispatch did not force the full suite"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -20,7 +20,13 @@ ROOT_BUCK = Path(os.environ.get("RUE_ROOT_BUCK", MODULE.ROOT_BUCK))
 
 class GateValidatorTests(unittest.TestCase):
     def validate_text(
-        self, text, native_runner=None, test_runner=None, buck=None, valgrind_install=None
+        self,
+        text,
+        native_runner=None,
+        test_runner=None,
+        buck=None,
+        valgrind_install=None,
+        clippy_adapter=None,
     ):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "ci.yml"
@@ -47,8 +53,19 @@ class GateValidatorTests(unittest.TestCase):
                 if valgrind_install is not None
                 else MODULE.VALGRIND_INSTALL_SCRIPT.read_text()
             )
+            clippy_adapter_path = Path(directory) / "ci-clippy"
+            clippy_adapter_path.write_text(
+                clippy_adapter
+                if clippy_adapter is not None
+                else MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+            )
             return MODULE.validate(
-                path, runner_path, test_runner_path, buck_path, installer_path
+                path,
+                runner_path,
+                test_runner_path,
+                buck_path,
+                installer_path,
+                clippy_adapter_path,
             )
 
     def test_current_workflow_is_valid(self):
@@ -721,6 +738,331 @@ class GateValidatorTests(unittest.TestCase):
     def test_declared_need_outputs_pass(self):
         self.assertEqual(self.validate_text(SOURCE.read_text()), [])
 
+    # RUE-1855: clippy keeps the same required check identity while waiting on
+    # the determinator. Both job-level always() and the dependency are needed:
+    # without the former, an upstream failure silently skips the required job.
+    def test_clippy_must_wait_for_affected_targets_with_always_semantics(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            "  clippy:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    if: ${{ always() }}\n"
+            "    needs: affected-targets\n",
+            "  clippy:\n    runs-on: ubuntu-latest\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("clippy must use job-level always()", errors)
+        self.assertIn("clippy must depend exactly once on affected-targets", errors)
+
+    def test_clippy_displayed_identity_cannot_change(self):
+        changed = SOURCE.read_text().replace(
+            "  clippy:\n    runs-on: ubuntu-latest\n",
+            "  clippy:\n    runs-on: ubuntu-latest\n    name: renamed lint\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("existing displayed job/check identity", errors)
+
+    def test_clippy_heavy_setup_fails_open_on_missing_selection_output(self):
+        source = SOURCE.read_text()
+        mutations = (
+            # A transported run=false alone cannot prove intentional deselection.
+            "if: ${{ always() && steps.sel.outputs.run != 'false' }}",
+            # A failed selection step must run even if its partial outputs look valid.
+            "if: ${{ always() && (steps.sel.outputs.run != 'false' || "
+            "steps.sel.outputs.proof_status != 'SELECTIVE' || "
+            "steps.sel.outputs.gate_status != 'DESELECTED') }}",
+            # Missing proof or gate outputs are degraded state, never a skip.
+            "if: ${{ always() && (steps.sel.outcome != 'success' || "
+            "steps.sel.outputs.run != 'false' || "
+            "steps.sel.outputs.gate_status != 'DESELECTED') }}",
+            "if: ${{ always() && (steps.sel.outcome != 'success' || "
+            "steps.sel.outputs.run != 'false' || "
+            "steps.sel.outputs.proof_status != 'SELECTIVE') }}",
+        )
+        for mutation in mutations:
+            changed = source.replace(MODULE.CLIPPY_HEAVY_GATE, mutation, 1)
+            self.assertNotEqual(changed, source, "splice anchor no longer matches ci.yml")
+            errors = "\n".join(self.validate_text(changed))
+            self.assertIn("Bootstrap dotslash", errors)
+            self.assertIn("successful, proved lane deselection", errors)
+
+    def test_clippy_uses_the_repository_owned_dotslash_bootstrap(self):
+        source = SOURCE.read_text()
+        clippy = MODULE.job_blocks(source)["clippy"]
+        changed_clippy = clippy.replace(
+            "        uses: ./.github/actions/bootstrap-dotslash\n",
+            "        run: true\n",
+            1,
+        )
+        changed = source.replace(clippy, changed_clippy, 1)
+        self.assertNotEqual(changed, source, "splice anchor no longer matches ci.yml")
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("repository-owned dotslash bootstrap", errors)
+
+    def test_clippy_heavy_step_runtime_contract(self):
+        cases = (
+            ("success", "false", "", "DESELECTED", True),
+            ("success", "false", "SELECTIVE", "", True),
+            ("failure", "false", "SELECTIVE", "DESELECTED", True),
+            ("success", "true", "SELECTIVE", "DESELECTED", True),
+            ("success", "false", "SELECTIVE", "DESELECTED", False),
+        )
+        for outcome, run, proof, gate, expected_run in cases:
+            with self.subTest(outcome=outcome, run=run, proof=proof, gate=gate):
+                self.assertEqual(
+                    MODULE.clippy_heavy_step_runs(outcome, run, proof, gate),
+                    expected_run,
+                )
+
+    def test_clippy_lane_gate_must_use_the_canonical_lane(self):
+        changed = SOURCE.read_text().replace(
+            "run: scripts/ci-clippy select",
+            'run: scripts/ci-corpus-decision "release"',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("complete proved decision", errors)
+
+    def test_clippy_incomplete_decision_metadata_cannot_deselect(self):
+        changed = SOURCE.read_text().replace(
+            "          RUE_AFFECTED_LANES_DIGEST: ${{ needs.affected-targets.outputs.selected_lanes_digest }}\n",
+            "",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("complete proved decision", errors)
+
+    def test_clippy_raw_closure_count_is_declared_and_consumed(self):
+        source = SOURCE.read_text()
+        changed = source.replace(
+            "          RUE_AFFECTED_IMPACTED_CLOSURE_COUNT: ${{ needs.affected-targets.outputs.impacted_closure_count }}\n",
+            "",
+            1,
+        )
+        self.assertNotEqual(changed, source, "splice anchor no longer matches ci.yml")
+        self.assertIn("complete proved decision", "\n".join(self.validate_text(changed)))
+
+        changed = source.replace(
+            "      impacted_closure_count: ${{ steps.decide.outputs.impacted_closure_count }}\n",
+            "",
+            1,
+        )
+        self.assertNotEqual(changed, source, "splice anchor no longer matches ci.yml")
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn(
+            "needs.affected-targets.outputs.impacted_closure_count is referenced",
+            errors,
+        )
+
+    def test_clippy_adapter_must_verify_the_raw_closure_count(self):
+        source = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+        changed = source.replace(
+            '            "${RUE_AFFECTED_IMPACTED_CLOSURE_COUNT:-}" \\\n',
+            "",
+            1,
+        )
+        self.assertNotEqual(changed, source, "splice anchor no longer matches ci-clippy")
+        self.assertIn(
+            "complete planner proof",
+            "\n".join(MODULE.clippy_adapter_errors(changed)),
+        )
+
+    def test_clippy_impacted_payload_requires_count_and_digest(self):
+        changed = SOURCE.read_text().replace(
+            "          RUE_AFFECTED_IMPACTED_TARGETS_DIGEST: ${{ needs.affected-targets.outputs.impacted_targets_digest }}\n",
+            "",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("complete impacted payload proof", errors)
+
+    def test_clippy_materializer_requires_verified_selection_and_gate(self):
+        source = SOURCE.read_text()
+        for line in (
+            "          RUE_CLIPPY_PROOF_STATUS: ${{ steps.sel.outputs.proof_status }}\n",
+            "          RUE_CLIPPY_GATE_STATUS: ${{ steps.sel.outputs.gate_status }}\n",
+        ):
+            changed = source.replace(line, "", 1)
+            self.assertNotEqual(changed, source, "splice anchor no longer matches ci.yml")
+            errors = "\n".join(self.validate_text(changed))
+            self.assertIn("complete impacted payload proof", errors)
+
+    def test_clippy_adapter_cannot_narrow_after_selection_or_gate_failure(self):
+        source = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+        for condition in (
+            '"${RUE_CLIPPY_PROOF_STATUS:-}" == "SELECTIVE"',
+            '"${RUE_CLIPPY_GATE_STATUS:-}" == "RUN"',
+        ):
+            changed = source.replace(condition, '"true" == "true"', 1)
+            self.assertNotEqual(changed, source, "splice anchor no longer matches ci-clippy")
+            errors = "\n".join(MODULE.clippy_adapter_errors(changed))
+            self.assertIn("authenticate the complete impacted payload", errors)
+
+    def test_clippy_selection_uses_the_canonical_planner_narrow_limit(self):
+        source = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+        mutations = (
+            source.replace(
+                'narrow_limit="$("$affected" narrow-limit)"',
+                'narrow_limit="600"',
+                1,
+            ),
+            source.replace('"$narrow_limit" >/dev/null', '"600" >/dev/null', 1),
+        )
+        for changed in mutations:
+            self.assertNotEqual(changed, source, "splice anchor no longer matches ci-clippy")
+            errors = "\n".join(MODULE.clippy_adapter_errors(changed))
+            self.assertIn("canonical narrow limit", errors)
+
+    def test_clippy_cannot_reintroduce_a_peer_graph_query(self):
+        changed = SOURCE.read_text().replace(
+            "run: scripts/ci-clippy run",
+            "run: ./buck2 uquery \"kind('sh_test', 'root//crates/...')\"",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("reviewed registry-derived runner", errors)
+        self.assertIn("must not invoke Buck directly", errors)
+
+    def test_clippy_registered_intersection_cannot_be_bypassed(self):
+        adapter = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text().replace(
+            '"$affected" narrow-scope clippy "${NARROW_FILE:-}"',
+            '"$affected" scope-targets clippy',
+            1,
+        )
+        errors = "\n".join(
+            self.validate_text(SOURCE.read_text(), clippy_adapter=adapter)
+        )
+        self.assertIn("exact registry-derived execution program", errors)
+        self.assertIn("target text must come only from registered", errors)
+
+    def test_clippy_scope_failure_retains_the_broad_fail_open_superset(self):
+        adapter = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text().replace(
+            '"$buck2" test //crates/...', "true", 1
+        )
+        errors = "\n".join(
+            self.validate_text(SOURCE.read_text(), clippy_adapter=adapter)
+        )
+        self.assertIn("broad fail-open test fallback", errors)
+
+    def test_clippy_empty_live_and_empty_subset_contracts_are_distinct(self):
+        source = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+        changed = source.replace(
+            'if [[ "$narrow_status" -eq 2 ]]; then',
+            'if [[ "$narrow_status" -eq 99 ]]; then',
+            1,
+        )
+        self.assertIn(
+            "first narrow-scope query reports an empty live inventory",
+            "\n".join(MODULE.clippy_adapter_errors(changed)),
+        )
+        changed = source.replace(
+            "verified impacted subset is empty; intentional no-op",
+            "nothing selected",
+            1,
+        )
+        self.assertIn(
+            "successfully stop on a proved empty impacted subset",
+            "\n".join(MODULE.clippy_adapter_errors(changed)),
+        )
+        changed = source.replace(
+            'echo "clippy: verified impacted subset is empty; intentional no-op"\n'
+            "                return 0",
+            'echo "clippy: verified impacted subset is empty; intentional no-op"\n'
+            "                return 1",
+            1,
+        )
+        self.assertIn(
+            "successfully stop on a proved empty impacted subset",
+            "\n".join(MODULE.clippy_adapter_errors(changed)),
+        )
+
+    def test_clippy_target_array_cannot_be_hardcoded_or_appended(self):
+        source = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+        mutations = (
+            source.replace(
+                "    local targets=()",
+                "    local targets=(//crates/one:one-clippy)",
+                1,
+            ),
+            source.replace(
+                '    done <<<"$targets_text"',
+                '    done <<<"$targets_text"\n'
+                '    targets+=(//crates/one:one-clippy)',
+                1,
+            ),
+        )
+        for changed in mutations:
+            with self.subTest(changed=changed):
+                errors = "\n".join(MODULE.clippy_adapter_errors(changed))
+                self.assertIn("target array must start empty", errors)
+
+    def test_clippy_cannot_add_extra_buck_test_or_build(self):
+        source = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+        for command in (
+            '"$buck2" test //crates/one:one-clippy',
+            '"$buck2" build //crates/...',
+            "./buck2 test //crates/one:one-clippy",
+            "buck2 build //crates/...",
+        ):
+            changed = source.replace(
+                '    echo "Running $selection clippy scope',
+                f"    {command}\n    echo \"Running $selection clippy scope",
+                1,
+            )
+            with self.subTest(command=command):
+                errors = "\n".join(MODULE.clippy_adapter_errors(changed))
+                self.assertIn("must not add Buck target executions", errors)
+
+    def test_clippy_dispatch_cannot_append_work_after_reviewed_runner(self):
+        source = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+        changed = source.replace(
+            "        run_clippy ;;",
+            '        run_clippy; "$buck2" test //crates/one:one-clippy ;;',
+            1,
+        )
+        errors = "\n".join(MODULE.clippy_adapter_errors(changed))
+        self.assertIn("top-level dispatch", errors)
+        self.assertIn("must not add Buck target executions", errors)
+
+    def test_clippy_rejects_every_direct_buck_graph_query_form(self):
+        source = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+        commands = (
+            "query",
+            "uquery",
+            "cquery",
+            "aquery",
+            "bxl",
+            "targets",
+        )
+        for command in commands:
+            changed = source.replace(
+                '    echo "Running $selection clippy scope',
+                f'    "$buck2" {command} //...\n'
+                '    echo "Running $selection clippy scope',
+                1,
+            )
+            with self.subTest(command=command):
+                errors = "\n".join(MODULE.clippy_adapter_errors(changed))
+                self.assertIn("direct Buck graph queries", errors)
+
+    def test_clippy_graph_query_cannot_hide_behind_global_flags(self):
+        source = MODULE.CLIPPY_ADAPTER_SCRIPT.read_text()
+        for invocation in (
+            '"$buck2" --isolation-dir peer cquery //...',
+            "./buck2 --isolation-dir peer cquery //...",
+        ):
+            changed = source.replace(
+                '    echo "Running $selection clippy scope',
+                f"    {invocation}\n"
+                '    echo "Running $selection clippy scope',
+                1,
+            )
+            with self.subTest(invocation=invocation):
+                errors = "\n".join(MODULE.clippy_adapter_errors(changed))
+                self.assertIn("direct Buck graph queries", errors)
+
     def test_future_narrowing_consumer_must_be_registered(self):
         changed = SOURCE.read_text() + (
             "\n  future-narrowed-lane:\n"
@@ -965,6 +1307,72 @@ class GateValidatorTests(unittest.TestCase):
 
     def test_lane_targets_and_job_agree_today(self):
         self.assertEqual(MODULE.lane_target_drift(SOURCE.read_text()), [])
+
+    def test_clippy_live_proxy_and_registered_scope_must_agree(self):
+        with tempfile.TemporaryDirectory() as directory:
+            script = Path(directory) / "affected-targets"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "case \"$1:${2:-}\" in\n"
+                "  lane-targets:clippy) echo //crates/one:one-clippy;;\n"
+                "  scope-targets:clippy) echo //crates/two:two-clippy;;\n"
+                "  clippy-owned-targets:) echo //crates/two:two-clippy;;\n"
+                "esac\n"
+            )
+            errors = MODULE.clippy_lane_ownership(script)
+        self.assertIn(
+            "clippy lane proxy and registered runnable scope disagree",
+            "\n".join(errors),
+        )
+
+    def test_clippy_live_inventory_rejects_noncanonical_targets(self):
+        with tempfile.TemporaryDirectory() as directory:
+            script = Path(directory) / "affected-targets"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "echo //crates/one:one-clippy //crates/one:one-fmt-check\n"
+            )
+            errors = MODULE.clippy_lane_ownership(script)
+        self.assertIn("outside the canonical live set", "\n".join(errors))
+        self.assertIn("one-fmt-check", "\n".join(errors))
+
+    def test_clippy_owner_label_rejects_a_non_suffix_target(self):
+        with tempfile.TemporaryDirectory() as directory:
+            script = Path(directory) / "affected-targets"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "case \"$1\" in\n"
+                "  lane-targets|scope-targets) echo //crates/one:one-clippy;;\n"
+                "  clippy-owned-targets) echo //crates/one:one-clippy //crates/one:one-test;;\n"
+                "esac\n"
+            )
+            errors = "\n".join(MODULE.clippy_lane_ownership(script))
+        self.assertIn("owner label contains targets outside the canonical live set", errors)
+        self.assertIn("labels targets outside the canonical live inventory", errors)
+        self.assertIn("one-test", errors)
+
+    def test_clippy_canonical_suffix_target_cannot_lack_owner_label(self):
+        with tempfile.TemporaryDirectory() as directory:
+            script = Path(directory) / "affected-targets"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "case \"$1\" in\n"
+                "  lane-targets|scope-targets) echo //crates/one:one-clippy //crates/two:two-clippy;;\n"
+                "  clippy-owned-targets) echo //crates/one:one-clippy;;\n"
+                "esac\n"
+            )
+            errors = "\n".join(MODULE.clippy_lane_ownership(script))
+        self.assertIn("canonical live clippy targets missing rue_ci_clippy_lane", errors)
+        self.assertIn("two-clippy", errors)
+
+    def test_clippy_owner_label_exactly_matches_canonical_inventory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            script = Path(directory) / "affected-targets"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "echo //crates/one:one-clippy //crates/two:two-clippy\n"
+            )
+            self.assertEqual(MODULE.clippy_lane_ownership(script), [])
 
     def test_unreadable_lane_script_fails_closed(self):
         # Ownership validation fails closed when its canonical graph query is

--- a/scripts/test-validate-test-duplication.py
+++ b/scripts/test-validate-test-duplication.py
@@ -496,7 +496,12 @@ class LaneModelTests(unittest.TestCase):
             'case "$1" in\n'
             f'  lanes) printf "%s\\n" {" ".join(lanes)} ;;\n'
             "  corpus-targets) echo //:cli-tests-shard-0 ;;\n"
-            "  lane-targets) echo //:release-smoke ;;\n"
+            "  lane-targets)\n"
+            "    if [ \"$2\" = clippy ]; then\n"
+            "      echo //crates/rue-lexer:rue-lexer-clippy\n"
+            "    else\n"
+            "      echo //:release-smoke\n"
+            "    fi ;;\n"
             "esac\n"
         )
         return script
@@ -528,6 +533,26 @@ class LaneModelTests(unittest.TestCase):
         self.assertEqual(
             set(GATE.LANE_PLATFORMS) & GATE.SELECTION_PROXY_LANES, set()
         )
+
+    def test_dedicated_clippy_targets_are_not_also_premerge_members(self):
+        class ClippyBuck:
+            root = Path(".")
+
+            def uquery(self, expression, attributes):
+                return {
+                    "//crates/rue-lexer:rue-lexer-clippy": {
+                        "labels": [GATE.CLIPPY_LANE_LABEL]
+                    },
+                    "//crates/rue-lexer:rue-lexer-test": {"labels": []},
+                }
+
+        with tempfile.TemporaryDirectory() as directory:
+            script = self.fake_affected_targets(
+                Path(directory), sorted(set(GATE.LANE_PLATFORMS) | GATE.SELECTION_PROXY_LANES)
+            )
+            lanes = GATE.lane_membership(ClippyBuck(), script)
+        self.assertIn("//crates/rue-lexer:rue-lexer-clippy", lanes["clippy"])
+        self.assertNotIn("//crates/rue-lexer:rue-lexer-clippy", lanes["linux-premerge"])
 
     def test_the_determinator_exposes_the_inventories_this_gate_reads(self):
         for subcommand in ("corpus-targets", "lanes"):

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -1545,17 +1545,21 @@ EOF
   check "test.sh: the union tier filters no tier out" \
     "$([ "$rc" -eq 0 ] && ! grep -Eq -- '--(include|exclude) rue_test_tier_' "$sb/calls.log" && echo 0 || echo 1)"
 
-  # Required CI gives these corpora their own platform-corpus job; a local run
-  # must still cover them.
+  # Required CI gives the heavy corpora and clippy gates their own jobs; a local
+  # run must still cover both sets through the ordinary premerge tier.
   : >"$sb/calls.log"; rc=0
   out="$(cd "$sb" && CI=true FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
   check "test.sh: required CI subtracts the dedicated-lane label" \
     "$([ "$rc" -eq 0 ] && grep -Fq -- '--exclude rue_ci_dedicated_lane' "$sb/calls.log" && echo 0 || echo 1)"
+  check "test.sh: required CI subtracts the dedicated clippy-lane label" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--exclude rue_ci_clippy_lane' "$sb/calls.log" && echo 0 || echo 1)"
 
   : >"$sb/calls.log"; rc=0
   out="$(cd "$sb" && FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
   check "test.sh: a local run still covers the dedicated-lane corpora" \
     "$([ "$rc" -eq 0 ] && ! grep -Fq -- '--exclude rue_ci_dedicated_lane' "$sb/calls.log" && echo 0 || echo 1)"
+  check "test.sh: a local run still covers the dedicated clippy gates" \
+    "$([ "$rc" -eq 0 ] && ! grep -Fq -- '--exclude rue_ci_clippy_lane' "$sb/calls.log" && echo 0 || echo 1)"
 
   # The exit code is the verdict, and the sentinel agrees with it (RUE-579).
   rc=0

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -18,6 +18,7 @@ TEST_RUNNER_SOURCE = (
 )
 ROOT_BUCK = Path(__file__).resolve().parents[1] / "BUCK"
 VALGRIND_INSTALL_SCRIPT = Path(__file__).with_name("install-valgrind")
+CLIPPY_ADAPTER_SCRIPT = Path(__file__).with_name("ci-clippy")
 
 # RUE-1161: the platform each entry of the harness's CI_EXECUTED_TARGETS claims
 # a required lane for, and the workflow text that proves that lane exists. The
@@ -200,10 +201,12 @@ def narrowing_contract_errors(
     jobs = job_blocks(workflow)
     errors: list[str] = []
     expected_by_job = {
+        "clippy": {"clippy"},
         "linux-premerge": {"linux-premerge-build", "linux-premerge-tests"},
         "native-platforms": {"native-platforms-units"},
     }
     expected_command_lines = {
+        "clippy": "run: scripts/ci-clippy run",
         "linux-premerge-build": (
             'elif ! scope="$(scripts/affected-targets narrow-scope '
             'linux-premerge-build "$NARROW_FILE")"; then'
@@ -228,8 +231,16 @@ def narrowing_contract_errors(
         executable = [line.split("#", 1)[0] for line in block.splitlines()]
         stripped_lines = [line.strip() for line in executable if line.strip()]
         executable_text = "\n".join(executable)
-        consumes_impacted = "needs.affected-targets.outputs.impacted" in executable_text
-        consumes_narrowed = "needs.affected-targets.outputs.narrowed" in executable_text
+        impacted_refs = re.findall(
+            r"needs\.affected-targets\.outputs\.impacted(?![A-Za-z0-9_-])",
+            executable_text,
+        )
+        narrowed_refs = re.findall(
+            r"needs\.affected-targets\.outputs\.narrowed(?![A-Za-z0-9_-])",
+            executable_text,
+        )
+        consumes_impacted = bool(impacted_refs)
+        consumes_narrowed = bool(narrowed_refs)
         if not (consumes_narrowed or consumes_impacted):
             continue
         expected_scopes = expected_by_job.get(job)
@@ -238,7 +249,7 @@ def narrowing_contract_errors(
                 f"{job} consumes impacted narrowing but is absent from the scope registry"
             )
             continue
-        if executable_text.count("needs.affected-targets.outputs.impacted") != 1:
+        if len(impacted_refs) != 1:
             errors.append(f"{job} must materialize the impacted output exactly once")
         raw_file_ref = "${{ steps.narrow.outputs.file }}"
         if executable_text.count(raw_file_ref) != 1:
@@ -248,16 +259,18 @@ def narrowing_contract_errors(
                 errors.append(
                     f"{job} has a raw impacted-file consumer outside a registered narrow-scope preparer"
                 )
-        expected_narrow_file_line = {
-            "linux-premerge": expected_command_lines["linux-premerge-build"],
-            "native-platforms": expected_command_lines["native-platforms-units"],
-        }[job]
-        narrow_file_uses = [line for line in stripped_lines if "$NARROW_FILE" in line]
-        if narrow_file_uses != [expected_narrow_file_line]:
-            errors.append(
-                f"{job} must expose $NARROW_FILE only to its registered narrow-scope command"
-            )
+        if job != "clippy":
+            expected_narrow_file_line = {
+                "linux-premerge": expected_command_lines["linux-premerge-build"],
+                "native-platforms": expected_command_lines["native-platforms-units"],
+            }[job]
+            narrow_file_uses = [line for line in stripped_lines if "$NARROW_FILE" in line]
+            if narrow_file_uses != [expected_narrow_file_line]:
+                errors.append(
+                    f"{job} must expose $NARROW_FILE only to its registered narrow-scope command"
+                )
         allowed_local_file_uses = {
+            "clippy": set(),
             "linux-premerge": {
                 ': >"$file"',
                 'printf \'%s\\n\' "$RUE_AFFECTED_IMPACTED" | sed \'/^$/d\' >"$file"',
@@ -306,7 +319,12 @@ def narrowing_contract_errors(
                 )
             else:
                 used_scopes.add(consumer)
-        if job == "linux-premerge":
+        if job == "clippy":
+            if stripped_lines.count("run: scripts/ci-clippy materialize") != 1:
+                errors.append(
+                    "clippy must materialize its raw impacted output through the reviewed adapter"
+                )
+        elif job == "linux-premerge":
             if stripped_lines.count(
                 'if scope="$(scripts/affected-targets scope-targets linux-premerge-build)"; then'
             ) != 1:
@@ -336,11 +354,480 @@ def narrowing_contract_errors(
                 )
             if stripped_lines.count('narrowed="$native_targets"') != 1:
                 errors.append("native-platforms must retain its full-scope degraded fallback")
-        if "GITHUB_STEP_SUMMARY" not in executable_text or "saved share" not in executable_text:
+        if job != "clippy" and (
+            "GITHUB_STEP_SUMMARY" not in executable_text
+            or "saved share" not in executable_text
+        ):
             errors.append(f"{job} must publish final per-scope saved-share visibility")
     unused = set(registry) - used_scopes
     for consumer in sorted(unused):
         errors.append(f"registered scope {consumer!r} has no workflow narrow-scope consumer")
+    return errors
+
+
+CLIPPY_HEAVY_GATE = (
+    "if: ${{ always() && (steps.sel.outcome != 'success' || "
+    "steps.sel.outputs.run != 'false' || "
+    "steps.sel.outputs.proof_status != 'SELECTIVE' || "
+    "steps.sel.outputs.gate_status != 'DESELECTED') }}"
+)
+
+
+def clippy_heavy_step_runs(
+    outcome: str, run: str, proof_status: str, gate_status: str
+) -> bool:
+    """Whether a clippy heavy step runs under the proved-deselection contract."""
+    return not (
+        outcome == "success"
+        and run == "false"
+        and proof_status == "SELECTIVE"
+        and gate_status == "DESELECTED"
+    )
+
+
+def clippy_workflow_errors(workflow: str) -> list[str]:
+    """Pin the clippy job identity and its thin reviewed-adapter calls."""
+    block = job_blocks(workflow).get("clippy", "")
+    errors: list[str] = []
+    direct_if = [
+        line.strip()
+        for line in block.splitlines()
+        if not line.lstrip().startswith("#") and re.match(r"^    if\s*:", line)
+    ]
+    if direct_if != ["if: ${{ always() }}"]:
+        errors.append(
+            "clippy must use job-level always() so an affected-targets failure cannot skip it"
+        )
+    if sum(line.strip() == "needs: affected-targets" for line in block.splitlines()) != 1:
+        errors.append("clippy must depend exactly once on affected-targets")
+    if any(
+        re.match(r"^    name\s*:", line)
+        for line in block.splitlines()
+        if not line.lstrip().startswith("#")
+    ):
+        errors.append(
+            "clippy must retain its existing displayed job/check identity (the clippy job id)"
+        )
+
+    step_pattern = re.compile(
+        r"^      - name: (?P<name>[^\n]+)\n(?P<body>.*?)(?=^      - |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    steps: dict[str, list[str]] = {}
+    for match in step_pattern.finditer(block):
+        steps.setdefault(match.group("name"), []).append(match.group("body"))
+    for name in (
+        "Bootstrap dotslash",
+        "Provision remote build cache",
+        "Impacted target list",
+        "Run clippy",
+    ):
+        bodies = steps.get(name, [])
+        if len(bodies) != 1 or sum(
+            line.strip() == CLIPPY_HEAVY_GATE for line in bodies[0].splitlines()
+        ) != 1:
+            errors.append(
+                f"clippy step {name!r} may skip only after a successful, proved lane deselection"
+            )
+    bootstrap = steps.get("Bootstrap dotslash", [])
+    if len(bootstrap) == 1 and sum(
+        line.strip() == "uses: ./.github/actions/bootstrap-dotslash"
+        for line in bootstrap[0].splitlines()
+    ) != 1:
+        errors.append("clippy must use the repository-owned dotslash bootstrap")
+
+    selection = steps.get("Lane selection", [])
+    selection_contract = (
+        "id: sel",
+        "RUE_AFFECTED_FULL: ${{ needs.affected-targets.outputs.full }}",
+        "RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}",
+        "RUE_AFFECTED_LANES_COUNT: ${{ needs.affected-targets.outputs.selected_lanes_count }}",
+        "RUE_AFFECTED_LANES_DIGEST: ${{ needs.affected-targets.outputs.selected_lanes_digest }}",
+        "RUE_AFFECTED_NARROWED: ${{ needs.affected-targets.outputs.narrowed }}",
+        "RUE_AFFECTED_NARROWING_STATUS: ${{ needs.affected-targets.outputs.narrowing_status }}",
+        "RUE_AFFECTED_HEAD_TARGET_COUNT: ${{ needs.affected-targets.outputs.head_target_count }}",
+        "RUE_AFFECTED_IMPACTED_CLOSURE_COUNT: ${{ needs.affected-targets.outputs.impacted_closure_count }}",
+        "RUE_AFFECTED_IMPACTED_TARGET_COUNT: ${{ needs.affected-targets.outputs.impacted_target_count }}",
+        "run: scripts/ci-clippy select",
+    )
+    if len(selection) != 1 or any(
+        required not in selection[0] for required in selection_contract
+    ):
+        errors.append(
+            "clippy lane selection must pass the complete proved decision to the reviewed adapter"
+        )
+    impacted = steps.get("Impacted target list", [])
+    impacted_contract = (
+        "id: narrow",
+        "RUE_CLIPPY_PROOF_STATUS: ${{ steps.sel.outputs.proof_status }}",
+        "RUE_CLIPPY_GATE_STATUS: ${{ steps.sel.outputs.gate_status }}",
+        "RUE_AFFECTED_NARROWED: ${{ needs.affected-targets.outputs.narrowed }}",
+        "RUE_AFFECTED_IMPACTED: ${{ needs.affected-targets.outputs.impacted }}",
+        "RUE_AFFECTED_IMPACTED_TARGET_COUNT: ${{ needs.affected-targets.outputs.impacted_target_count }}",
+        "RUE_AFFECTED_IMPACTED_TARGETS_DIGEST: ${{ needs.affected-targets.outputs.impacted_targets_digest }}",
+        "run: scripts/ci-clippy materialize",
+    )
+    if len(impacted) != 1 or any(
+        required not in impacted[0] for required in impacted_contract
+    ):
+        errors.append(
+            "clippy must pass the complete impacted payload proof to the reviewed materializer"
+        )
+    runner = steps.get("Run clippy", [])
+    runner_contract = (
+        "NARROW_FILE: ${{ steps.narrow.outputs.file }}",
+        "NARROW_STATUS: ${{ steps.narrow.outputs.status }}",
+        "run: scripts/ci-clippy run",
+    )
+    if len(runner) != 1 or any(
+        required not in runner[0] for required in runner_contract
+    ):
+        errors.append("clippy must execute only the reviewed registry-derived runner")
+
+    for name, bodies in (
+        ("Lane selection", selection),
+        ("Impacted target list", impacted),
+        ("Run clippy", runner),
+    ):
+        if len(bodies) == 1 and sum(
+            line.strip().startswith("run:") for line in bodies[0].splitlines()
+        ) != 1:
+            errors.append(f"clippy step {name!r} must have exactly one run command")
+
+    executable_lines = [
+        line.split("#", 1)[0]
+        for line in block.splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+    if any(
+        re.search(
+            r"(?<![A-Za-z0-9_.-])(?:\./)?buck2(?:\s|$)",
+            line,
+        )
+        for line in executable_lines
+    ):
+        errors.append(
+            "clippy workflow must not invoke Buck directly; its reviewed adapter owns execution"
+        )
+    executable = "\n".join(executable_lines)
+    for required, message in (
+        (
+            "BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}",
+            "clippy must preserve fork-safe BuildBuddy secret handling",
+        ),
+        (
+            "scripts/provision-build-cache install",
+            "clippy must preserve remote-cache provisioning",
+        ),
+        (
+            "scripts/provision-build-cache apply",
+            "clippy must preserve remote-cache provisioning",
+        ),
+    ):
+        if required not in executable:
+            errors.append(message)
+    return errors
+
+
+def shell_function_lines(source: str, name: str) -> list[str]:
+    """Executable, comment-insensitive lines from one simple Bash function."""
+    match = re.search(
+        rf"^{re.escape(name)}\(\) \{{\n(?P<body>.*?)^\}}",
+        source,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        return []
+    return [
+        line.strip()
+        for line in match.group("body").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def shell_top_level_lines(source: str, function_names: tuple[str, ...]) -> list[str]:
+    """Executable lines outside the adapter's reviewed function bodies."""
+    remaining = source
+    for name in function_names:
+        remaining = re.sub(
+            rf"^{re.escape(name)}\(\) \{{\n.*?^\}}\n?",
+            "",
+            remaining,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+    return [
+        line.strip()
+        for line in remaining.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+CLIPPY_SELECT_PROGRAM = (
+    'local proof_status="DEGRADED" narrow_limit=""',
+    'if [[ "${RUE_AFFECTED_FULL:-}" == "false" ]]; then',
+    'if ! narrow_limit="$("$affected" narrow-limit)"; then',
+    'echo "clippy canonical narrow limit is unavailable or malformed; running the full live inventory" >&2',
+    'RUE_AFFECTED_FULL=""',
+    "export RUE_AFFECTED_FULL",
+    'elif ! printf \'%s\' "${RUE_AFFECTED_LANES:-}" | "$proof" verify-decision \\',
+    '"${RUE_AFFECTED_LANES_COUNT:-}" \\',
+    '"${RUE_AFFECTED_LANES_DIGEST:-}" \\',
+    '"${RUE_AFFECTED_NARROWED:-}" \\',
+    '"${RUE_AFFECTED_NARROWING_STATUS:-}" \\',
+    '"${RUE_AFFECTED_HEAD_TARGET_COUNT:-}" \\',
+    '"${RUE_AFFECTED_IMPACTED_CLOSURE_COUNT:-}" \\',
+    '"${RUE_AFFECTED_IMPACTED_TARGET_COUNT:-}" \\',
+    '"$narrow_limit" >/dev/null; then',
+    'echo "clippy selection payload or metadata is incomplete or inconsistent; running the full live inventory" >&2',
+    'RUE_AFFECTED_FULL=""',
+    "export RUE_AFFECTED_FULL",
+    "else",
+    'proof_status="SELECTIVE"',
+    "fi",
+    'elif [[ "${RUE_AFFECTED_FULL:-}" == "true" ]]; then',
+    'proof_status="FULL"',
+    "fi",
+    '"$decision" clippy',
+    "local decision_status=$?",
+    'if [[ -n "${GITHUB_OUTPUT:-}" ]]; then',
+    'printf \'proof_status=%s\\n\' "$proof_status" >>"$GITHUB_OUTPUT"',
+    "fi",
+    'return "$decision_status"',
+)
+
+CLIPPY_MATERIALIZE_PROGRAM = (
+    'if [[ -z "${RUNNER_TEMP:-}" || -z "${GITHUB_OUTPUT:-}" ]]; then',
+    'echo "ci-clippy: RUNNER_TEMP and GITHUB_OUTPUT are required" >&2',
+    "return 2",
+    "fi",
+    'local file="$RUNNER_TEMP/impacted-clippy-targets.txt"',
+    'local status="DECLINED"',
+    ': >"$file"',
+    'if [[ "${RUE_CLIPPY_PROOF_STATUS:-}" == "SELECTIVE" \\',
+    '&& "${RUE_CLIPPY_GATE_STATUS:-}" == "RUN" \\',
+    '&& "${RUE_AFFECTED_NARROWED:-}" == "true" ]]; then',
+    'if printf \'%s\' "${RUE_AFFECTED_IMPACTED:-}" | "$proof" verify targets \\',
+    '"${RUE_AFFECTED_IMPACTED_TARGET_COUNT:-}" \\',
+    '"${RUE_AFFECTED_IMPACTED_TARGETS_DIGEST:-}" \\',
+    '--require-nonempty >"$file"; then',
+    'status="CANDIDATE"',
+    "else",
+    'status="DEGRADED"',
+    'echo "clippy impacted payload proof failed; running the full live inventory" >&2',
+    "append_scope_summary '- `clippy`: **DEGRADED**; saved share **not applicable** (impacted output unavailable or corrupt; full scope used).'",
+    "fi",
+    'elif [[ "${RUE_CLIPPY_PROOF_STATUS:-}" == "FULL" \\',
+    '&& "${RUE_CLIPPY_GATE_STATUS:-}" == "RUN" ]]; then',
+    "append_scope_summary '- `clippy`: **DECLINED**; saved share **not applicable** (full scope used).'",
+    'elif [[ "${RUE_CLIPPY_PROOF_STATUS:-}" == "SELECTIVE" \\',
+    '&& "${RUE_CLIPPY_GATE_STATUS:-}" == "RUN" \\',
+    '&& "${RUE_AFFECTED_NARROWED:-}" == "false" ]]; then',
+    "append_scope_summary '- `clippy`: **DECLINED**; saved share **not applicable** (full scope used).'",
+    "else",
+    'status="DEGRADED"',
+    'echo "clippy selection, gate, or narrowing decision is unavailable; running the full live inventory" >&2',
+    "append_scope_summary '- `clippy`: **DEGRADED**; saved share **not applicable** (selection, gate, or narrowing decision unavailable; full scope used).'",
+    "fi",
+    "{",
+    'printf \'file=%s\\n\' "$file"',
+    'printf \'status=%s\\n\' "$status"',
+    '} >>"$GITHUB_OUTPUT"',
+)
+
+CLIPPY_RUN_PROGRAM = (
+    'local selection="full"',
+    'local targets_text=""',
+    "local narrow_status scope_status target",
+    'if [[ "${NARROW_STATUS:-}" == "CANDIDATE" ]]; then',
+    'if targets_text="$("$affected" narrow-scope clippy "${NARROW_FILE:-}")"; then',
+    'if [[ -z "$targets_text" ]]; then',
+    'echo "clippy: verified impacted subset is empty; intentional no-op"',
+    "return 0",
+    "fi",
+    'selection="narrowed"',
+    "else",
+    "narrow_status=$?",
+    'if [[ "$narrow_status" -eq 2 ]]; then',
+    'echo "clippy: no live -clippy targets found; the query or crate macros are broken" >&2',
+    "return 1",
+    "fi",
+    'echo "clippy: scope resolution or intersection failed; running the full live inventory" >&2',
+    "fi",
+    "fi",
+    'if [[ "$selection" == "full" ]]; then',
+    'if targets_text="$("$affected" scope-targets clippy)"; then',
+    ":",
+    "else",
+    "scope_status=$?",
+    'if [[ "$scope_status" -eq 2 ]]; then',
+    'echo "clippy: no live -clippy targets found; the query or crate macros are broken" >&2',
+    "return 1",
+    "fi",
+    'echo "clippy: live scope unavailable; running all crate tests as the fail-open superset" >&2',
+    '"$buck2" test //crates/...',
+    "return $?",
+    "fi",
+    "fi",
+    "local targets=()",
+    "while IFS= read -r target; do",
+    '[[ -n "$target" ]] && targets+=("$target")',
+    'done <<<"$targets_text"',
+    'if [[ "${#targets[@]}" -eq 0 ]]; then',
+    'echo "clippy: resolved live inventory is unexpectedly empty" >&2',
+    "return 1",
+    "fi",
+    'echo "Running $selection clippy scope across ${#targets[@]} crates..."',
+    '"$buck2" test "${targets[@]}"',
+)
+
+CLIPPY_SUMMARY_PROGRAM = (
+    '[[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0',
+    'printf \'%s\\n\' "$1" >>"$GITHUB_STEP_SUMMARY"',
+)
+
+CLIPPY_TOP_LEVEL_PROGRAM = (
+    "set -uo pipefail",
+    'repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"',
+    'proof="$repo_root/scripts/ci-affected-payload.py"',
+    'decision="$repo_root/scripts/ci-corpus-decision"',
+    'affected="$repo_root/scripts/affected-targets"',
+    'buck2="$repo_root/buck2"',
+    'case "${1:-}" in',
+    "select)",
+    '[[ $# -eq 1 ]] || { echo "usage: scripts/ci-clippy select" >&2; exit 2; }',
+    "select_lane ;;",
+    "materialize)",
+    '[[ $# -eq 1 ]] || { echo "usage: scripts/ci-clippy materialize" >&2; exit 2; }',
+    "materialize_impacted ;;",
+    "run)",
+    '[[ $# -eq 1 ]] || { echo "usage: scripts/ci-clippy run" >&2; exit 2; }',
+    "run_clippy ;;",
+    "*)",
+    'echo "usage: scripts/ci-clippy {select|materialize|run}" >&2',
+    "exit 2 ;;",
+    "esac",
+)
+
+
+def clippy_adapter_errors(source: str) -> list[str]:
+    """Pin payload verification, rc semantics, and Buck target provenance."""
+    errors: list[str] = []
+    select_lines = shell_function_lines(source, "select_lane")
+    materialize_lines = shell_function_lines(source, "materialize_impacted")
+    run_lines = shell_function_lines(source, "run_clippy")
+    summary_lines = shell_function_lines(source, "append_scope_summary")
+    top_level_lines = shell_top_level_lines(
+        source,
+        (
+            "select_lane",
+            "append_scope_summary",
+            "materialize_impacted",
+            "run_clippy",
+        ),
+    )
+    if tuple(select_lines) != CLIPPY_SELECT_PROGRAM:
+        errors.append(
+            "clippy adapter must bind the selected-lane payload and canonical narrow limit to its complete planner proof"
+        )
+    if tuple(materialize_lines) != CLIPPY_MATERIALIZE_PROGRAM:
+        errors.append(
+            "clippy adapter must authenticate the complete impacted payload before narrowing"
+        )
+    if tuple(run_lines) != CLIPPY_RUN_PROGRAM:
+        errors.append(
+            "clippy runner must retain the exact registry-derived execution program"
+        )
+    if tuple(summary_lines) != CLIPPY_SUMMARY_PROGRAM:
+        errors.append("clippy adapter must retain its bounded scope-summary writer")
+    if tuple(top_level_lines) != CLIPPY_TOP_LEVEL_PROGRAM:
+        errors.append(
+            "clippy adapter top-level dispatch must invoke only its reviewed subcommands"
+        )
+
+    graph_commands = {"query", "uquery", "cquery", "aquery", "bxl", "targets"}
+    target_commands = {"build", "test", "run"}
+    graph_lines: list[str] = []
+    target_lines: list[str] = []
+    buck_marker = re.compile(r'(?:"?\$buck2"?|(?<![A-Za-z0-9_.-])(?:\./)?buck2)')
+    all_lines = top_level_lines + select_lines + materialize_lines + summary_lines + run_lines
+    for line in all_lines:
+        marker = buck_marker.search(line)
+        if not marker:
+            continue
+        words = re.findall(r"[A-Za-z][A-Za-z0-9_-]*", line[marker.end() :])
+        command = next(
+            (word for word in words if word in graph_commands | target_commands),
+            None,
+        )
+        if command in graph_commands:
+            graph_lines.append(line)
+        if command in target_commands:
+            target_lines.append(line)
+    if graph_lines:
+        errors.append(
+            "clippy runner must not run direct Buck graph queries in any query form"
+        )
+    expected_target_lines = [
+        '"$buck2" test //crates/...',
+        '"$buck2" test "${targets[@]}"',
+    ]
+    if target_lines != expected_target_lines:
+        errors.append(
+            "clippy runner must not add Buck target executions outside its full fallback and registry-derived array"
+        )
+
+    array_writes = [
+        line
+        for line in run_lines
+        if re.search(r"(?:^|\s)(?:local\s+)?targets(?:\+)?=", line)
+    ]
+    if array_writes != [
+        "local targets=()",
+        '[[ -n "$target" ]] && targets+=("$target")',
+    ]:
+        errors.append(
+            "clippy target array must start empty and be populated only from registry output"
+        )
+    target_text_writes = [line for line in run_lines if "targets_text=" in line]
+    if target_text_writes != [
+        'local targets_text=""',
+        'if targets_text="$("$affected" narrow-scope clippy "${NARROW_FILE:-}")"; then',
+        'if targets_text="$("$affected" scope-targets clippy)"; then',
+    ]:
+        errors.append(
+            "clippy executable target text must come only from registered narrow/full scopes"
+        )
+    def has_sequence(expected: tuple[str, ...]) -> bool:
+        width = len(expected)
+        return any(
+            tuple(run_lines[index : index + width]) == expected
+            for index in range(len(run_lines) - width + 1)
+        )
+
+    empty_error = (
+        'echo "clippy: no live -clippy targets found; the query or crate macros are broken" >&2',
+        "return 1",
+        "fi",
+    )
+    if not has_sequence(('if [[ "$narrow_status" -eq 2 ]]; then',) + empty_error):
+        errors.append(
+            "clippy must hard-fail immediately when the first narrow-scope query reports an empty live inventory"
+        )
+    if not has_sequence(('if [[ "$scope_status" -eq 2 ]]; then',) + empty_error):
+        errors.append("clippy must keep a successful empty full live inventory as a hard error")
+    if not has_sequence(
+        (
+            'if [[ -z "$targets_text" ]]; then',
+            'echo "clippy: verified impacted subset is empty; intentional no-op"',
+            "return 0",
+            "fi",
+        )
+    ):
+        errors.append(
+            "clippy must log and successfully stop on a proved empty impacted subset"
+        )
+    if '"$buck2" test //crates/...' not in run_lines:
+        errors.append("clippy must retain its broad fail-open test fallback")
     return errors
 
 
@@ -698,6 +1185,67 @@ def native_lane_ownership(
     return errors
 
 
+def clippy_lane_ownership(script: Path = AFFECTED_TARGETS_SCRIPT) -> list[str]:
+    """Require selection, execution, and CI-owner labels to be exactly equal."""
+    outputs: dict[str, set[str]] = {}
+    errors: list[str] = []
+    for command, args in (
+        ("lane proxy", ("lane-targets", "clippy")),
+        ("registered scope", ("scope-targets", "clippy")),
+        ("owner label", ("clippy-owned-targets",)),
+    ):
+        result = subprocess.run(
+            ["bash", str(script), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip()
+            errors.append(
+                f"clippy {command} query failed" + (f": {detail}" if detail else "")
+            )
+            continue
+        targets = [target for target in result.stdout.split() if target]
+        if not targets:
+            errors.append(f"clippy {command} is empty")
+            continue
+        if len(targets) != len(set(targets)):
+            errors.append(f"clippy {command} contains duplicate targets")
+        invalid = sorted(
+            target
+            for target in set(targets)
+            if not (
+                (target.startswith("//crates/") or target.startswith("//crates:"))
+                and target.endswith("-clippy")
+            )
+        )
+        if invalid:
+            errors.append(
+                f"clippy {command} contains targets outside the canonical live set: "
+                + ", ".join(invalid)
+            )
+        outputs[command] = set(targets)
+    if {"lane proxy", "registered scope"} <= set(outputs) and outputs[
+        "lane proxy"
+    ] != outputs["registered scope"]:
+        errors.append("clippy lane proxy and registered runnable scope disagree")
+    if {"registered scope", "owner label"} <= set(outputs):
+        missing_labels = sorted(outputs["registered scope"] - outputs["owner label"])
+        extra_labels = sorted(outputs["owner label"] - outputs["registered scope"])
+        if missing_labels:
+            errors.append(
+                "canonical live clippy targets missing rue_ci_clippy_lane: "
+                + ", ".join(missing_labels)
+            )
+        if extra_labels:
+            errors.append(
+                "rue_ci_clippy_lane labels targets outside the canonical live inventory: "
+                + ", ".join(extra_labels)
+            )
+    return errors
+
+
 def valgrind_install_errors(workflow: str, script: str) -> list[str]:
     """Keep Valgrind installation bounded and on its canonical script path."""
     block = job_blocks(workflow).get("valgrind", "")
@@ -741,6 +1289,7 @@ def validate(
     test_runner_path: Path = TEST_RUNNER_SOURCE,
     buck_path: Path = ROOT_BUCK,
     valgrind_install_path: Path = VALGRIND_INSTALL_SCRIPT,
+    clippy_adapter_path: Path = CLIPPY_ADAPTER_SCRIPT,
 ) -> list[str]:
     workflow = ci_path.read_text()
     native_runner = native_runner_path.read_text()
@@ -759,6 +1308,11 @@ def validate(
     except OSError as error:
         errors.append(f"Valgrind installer unreadable: {error}")
         valgrind_install = ""
+    try:
+        clippy_adapter = clippy_adapter_path.read_text()
+    except OSError as error:
+        errors.append(f"clippy adapter unreadable: {error}")
+        clippy_adapter = ""
     try:
         jobs = job_blocks(workflow)
     except ValueError as error:
@@ -1047,6 +1601,8 @@ def validate(
     errors.extend(undeclared_need_outputs(workflow, jobs))
     errors.extend(lane_target_drift(workflow))
     errors.extend(narrowing_contract_errors(workflow))
+    errors.extend(clippy_workflow_errors(workflow))
+    errors.extend(clippy_adapter_errors(clippy_adapter))
 
     if "  pull_request:\n" not in workflow or "  merge_group:\n" not in workflow:
         errors.append("CI must run on both pull_request and merge_group")
@@ -1082,6 +1638,7 @@ def main() -> int:
     )
     if not args.structural_only:
         errors.extend(native_lane_ownership(args.workflow.read_text()))
+        errors.extend(clippy_lane_ownership())
     if errors:
         for error in errors:
             print(f"error: {error}")

--- a/scripts/validate-test-duplication.py
+++ b/scripts/validate-test-duplication.py
@@ -20,9 +20,9 @@ How it works:
 
 1. **Lane membership comes from the live graph, never from YAML.** The premerge
    lane is `attrfilter(labels, 'rue_test_tier_premerge', ...)` minus the
-   `rue_cli_shard` and `rue_ci_dedicated_lane` sets — the derivation
-   `docs/notes/rue-1250-premerge-critical-path.md` measured and `test.sh`
-   executes. The corpus and gated-lane inventories come from
+   `rue_cli_shard`, `rue_ci_dedicated_lane`, and `rue_ci_clippy_lane` sets —
+   the derivation `docs/notes/rue-1250-premerge-critical-path.md` measured and
+   `test.sh` executes. The corpus and gated-lane inventories come from
    `scripts/affected-targets`, which is the same list CI's determinator already
    consults, so this gate adds no new hand-maintained row to ADR-0069's ledger.
 2. **Identities come from `--list` on the test binaries.** Cheap and exact: it
@@ -58,6 +58,7 @@ AFFECTED_TARGETS = ROOT / "scripts" / "affected-targets"
 TIER_PREMERGE = "rue_test_tier_premerge"
 CLI_SHARD_LABEL = "rue_cli_shard"
 DEDICATED_LANE_LABEL = "rue_ci_dedicated_lane"
+CLIPPY_LANE_LABEL = "rue_ci_clippy_lane"
 
 PREMERGE_QUERY = (
     "attrfilter(labels, '" + TIER_PREMERGE + "', set(//... toolchains//...))"
@@ -65,11 +66,12 @@ PREMERGE_QUERY = (
 
 # Which platform executes which lane. `linux-premerge` and `platform-corpus`
 # are the two halves of the linux-x64 test load: the premerge tier minus the
-# corpora that own their own job, and those corpora. The rest are the gated
-# lanes RUE-1130 named.
+# corpora and clippy gates that own their own job, and those owned lanes. The
+# rest are gated selection proxies named by RUE-1130.
 LANE_PLATFORMS = {
     "linux-premerge": "linux-x64",
     "platform-corpus": "linux-x64",
+    "clippy": "linux-x64",
     "release": "linux-x64",
     "native-linux-arm64": "linux-arm64",
     "native-macos-arm64": "macos-arm64",
@@ -949,10 +951,14 @@ def lane_membership(buck: Buck, script: Path = AFFECTED_TARGETS) -> dict[str, li
 
     shards = {target for target, tags in labels.items() if CLI_SHARD_LABEL in tags}
     dedicated = {target for target, tags in labels.items() if DEDICATED_LANE_LABEL in tags}
+    clippy_owned = {target for target, tags in labels.items() if CLIPPY_LANE_LABEL in tags}
 
     lanes = {
-        "linux-premerge": sorted(set(labels) - shards - dedicated),
+        "linux-premerge": sorted(set(labels) - shards - dedicated - clippy_owned),
         "platform-corpus": sorted(affected_targets("corpus-targets", script=script)),
+        # RUE-1855: these are runnable sh_tests, not representative proxies.
+        # Their live inventory is shared with clippy's affected-lane selector.
+        "clippy": sorted(affected_targets("lane-targets", "clippy", script=script)),
         "release": sorted(affected_targets("lane-targets", "release", script=script)),
     }
     for lane in ("native-linux-arm64", "native-macos-arm64"):

--- a/test.sh
+++ b/test.sh
@@ -221,11 +221,13 @@ if [[ $# -eq 0 ]]; then
         elif [[ "$test_tier" != all ]]; then
             test_args+=(--include "rue_test_tier_$test_tier")
         fi
-        # Required CI gives these corpora their own platform-corpus job; the label
-        # is the only place that set is written down (scripts/validate-ci-gate.py
-        # fails if a labeled corpus has no job).
+        # Required CI gives the heavy corpora and clippy gates their own jobs;
+        # graph labels keep linux-premerge from executing either owned set a
+        # second time. scripts/validate-ci-gate.py fails if a dedicated corpus
+        # has no owner, and validate-test-duplication.py proves the complete
+        # scheduled sets do not overlap accidentally.
         if [[ "${CI:-}" == "true" ]]; then
-            test_args+=(--exclude rue_ci_dedicated_lane)
+            test_args+=(--exclude rue_ci_dedicated_lane --exclude rue_ci_clippy_lane)
         fi
 
         echo "Running the $test_tier tier..."


### PR DESCRIPTION
## Summary

- register clippy as a graph-owned selectable lane with one canonical live target inventory
- authenticate selection and impacted-target payloads before permitting a narrowed or empty run; degraded state uses the full scope, while an empty live inventory remains a hard error
- preserve the required clippy job identity while skipping heavy setup only for a proved deselection
- remove clippy gates from duplicate CI premerge ownership while retaining them in local suites
- document and validate the contract

## Validation

- affected-target tests: 164 checks
- CI gate tests: 113 checks, plus live ownership validation
- duplication tests: 34 checks, plus the live execution inventory
- Bash and Python baselines, workflow parsing, formatting, and diff checks
- quick: 33/33; premerge: 205/205
- broad suite: 237 targets passed; six slow oracle build actions reached the macOS thread-spawn ceiling, independently reproduced in isolated O2/O3 runs with no semantic mismatch

Fixes RUE-1855