### PR TITLE
RUE-1851: make intrinsic lowering typed end to end

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -1455,6 +1455,7 @@ fn comptime_instdata_evaluation_has_one_production_authority() {
         ),
         ("integer_semantics", include_str!("integer_semantics.rs")),
         ("intern_pool", include_str!("intern_pool.rs")),
+        ("intrinsic", include_str!("intrinsic.rs")),
         ("layout", include_str!("layout.rs")),
         ("lib", include_str!("lib.rs")),
         ("module_registry", include_str!("module_registry.rs")),
@@ -3865,4 +3866,86 @@ fn sema_diagnostics_use_the_friendly_type_display_authority() {
         1,
         "canonical comptime display interleaving must have one AIR owner"
     );
+}
+
+#[test]
+fn intrinsic_semantics_have_one_typed_authority_across_sema_and_durable_air() {
+    let known = include_str!("sema/known_symbols.rs");
+    let analysis = include_str!("sema/analysis/intrinsics.rs");
+    let pointers = include_str!("sema/analysis/pointers.rs");
+    let ownership = include_str!("sema/analysis/ownership.rs");
+    let air = include_str!("inst.rs");
+    let durable = include_str!("semantic_body.rs");
+    let export = include_str!("sema/semantic_body_export.rs");
+    let import = include_str!("semantic_import.rs");
+
+    assert_eq!(
+        known
+            .matches("pub fn get_parse_intrinsic_operation(")
+            .count(),
+        1,
+        "parse intrinsic symbols must have one typed classifier"
+    );
+    assert_eq!(
+        analysis
+            .matches("known.get_parse_intrinsic_operation(name)")
+            .count(),
+        1,
+        "sema must consume the one parse classifier exactly once"
+    );
+    assert!(analysis.contains("\"arg_ptr\",\n                crate::IntrinsicOperation::ArgPtr"));
+    assert!(analysis.contains("\"env_ptr\",\n                crate::IntrinsicOperation::EnvPtr"));
+
+    assert!(air.contains(
+        "Intrinsic {\n        /// Typed intrinsic semantics selected by semantic analysis.\n        operation: crate::IntrinsicOperation,"
+    ));
+    assert!(durable.contains(
+        "Intrinsic {\n        operation: crate::IntrinsicOperation,\n        name: Arc<str>,"
+    ));
+    assert!(durable.contains(
+        "D::Intrinsic {\n                operation,\n                name,\n                args,\n            } => D::Intrinsic {\n                operation: *operation,"
+    ));
+    assert!(export.contains("operation: *operation"));
+    assert!(import.contains("operation.validate_call(type_pool, &arguments, ty)"));
+    assert!(import.contains("source_name != operation.expected_spelling()"));
+    assert!(
+        import
+            .find("operation.validate_call(type_pool, &arguments, ty)")
+            .unwrap()
+            < import.find("let name = intern(source_name)?").unwrap(),
+        "durable import must validate before publishing the diagnostic symbol"
+    );
+
+    let empty_slice = ownership
+        .split("if arr_len == 0 {")
+        .nth(1)
+        .and_then(|source| source.split("} else {").next())
+        .expect("empty-slice lowering branch");
+    assert!(empty_slice.contains("data: AirInstData::Const(0)"));
+    assert!(empty_slice.contains("ty: ptr_ty"));
+    assert!(!empty_slice.contains("IntrinsicOperation::IntToPtr"));
+
+    for (name, source) in [
+        ("known symbols", known),
+        ("sema intrinsic analysis", analysis),
+        ("sema pointer analysis", pointers),
+        ("sema ownership analysis", ownership),
+        ("AIR", air),
+        ("durable AIR", durable),
+        ("durable export", export),
+        ("durable import", import),
+    ] {
+        for forbidden in [
+            "IntrinsicSelector",
+            "resolve_intrinsic_operation",
+            "intrinsic_operation_from_name",
+            "operation_from_name",
+            "expect(\"parse intrinsic",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{name} contains a second intrinsic selection path: {forbidden}"
+            );
+        }
+    }
 }

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -1332,13 +1332,13 @@ impl AirEditor {
 
     pub fn add_intrinsic(
         &mut self,
-        runtime: Option<crate::RuntimeCallKind>,
+        operation: crate::IntrinsicOperation,
         name: Spur,
         args: &[AirRef],
         ty: Type,
         span: Span,
     ) -> Result<AirRef, AirBuildError> {
-        self.air.add_intrinsic(runtime, name, args, ty, span)
+        self.air.add_intrinsic(operation, name, args, ty, span)
     }
 
     pub fn add_block(
@@ -2423,7 +2423,7 @@ impl Air {
 
     pub(crate) fn add_intrinsic(
         &mut self,
-        runtime: Option<crate::RuntimeCallKind>,
+        operation: crate::IntrinsicOperation,
         name: Spur,
         args: &[AirRef],
         ty: Type,
@@ -2434,7 +2434,7 @@ impl Air {
         let args = self.add_intrinsic_args(args)?;
         Ok(self.push_inst(AirInst {
             data: AirInstData::Intrinsic {
-                runtime,
+                operation,
                 name,
                 args,
             },
@@ -3627,8 +3627,8 @@ pub enum AirInstData {
 
     /// Intrinsic call (e.g., @dbg)
     Intrinsic {
-        /// Runtime helper/adaptation selected for runtime-backed intrinsics.
-        runtime: Option<crate::RuntimeCallKind>,
+        /// Typed intrinsic semantics selected by semantic analysis.
+        operation: crate::IntrinsicOperation,
         /// Intrinsic name (without @, interned)
         name: Spur,
         /// Start index into extra array for arguments
@@ -3961,13 +3961,11 @@ impl Air {
                     writeln!(f, ")")?;
                 }
                 AirInstData::Intrinsic {
-                    runtime,
+                    operation,
                     name,
                     args,
                 } => {
-                    if let Some(runtime) = runtime {
-                        write!(f, "runtime.{runtime:?} ")?;
-                    }
+                    write!(f, "{operation:?} ")?;
                     match interner {
                         Some(interner) => write!(f, "intrinsic @{}(", interner.resolve(name))?,
                         None => write!(f, "intrinsic @sym:{}(", name.into_usize())?,
@@ -4302,19 +4300,30 @@ mod tests {
             .unwrap();
         air.add_call_generic(generic, &[], &[], &[], Type::UNIT, Span::new(0, 0))
             .unwrap();
-        air.add_intrinsic(None, intrinsic, &[], Type::UNIT, Span::new(0, 0))
-            .unwrap();
+        let condition = air.add_inst(AirInst {
+            data: AirInstData::BoolConst(true),
+            ty: Type::BOOL,
+            span: Span::new(0, 0),
+        });
+        air.add_intrinsic(
+            crate::IntrinsicOperation::AssertFailed,
+            intrinsic,
+            &[condition],
+            Type::UNIT,
+            Span::new(0, 0),
+        )
+        .unwrap();
 
         let resolved = air.display_with_interner(&interner).to_string();
         assert!(resolved.contains("call @callee()"));
         assert!(resolved.contains("call_generic @generic<>()"));
-        assert!(resolved.contains("intrinsic @assert()"));
+        assert!(resolved.contains("intrinsic @assert("));
 
         // The context-free Display API remains backward compatible.
         let raw = air.to_string();
         assert!(raw.contains(&format!("call @{}()", call.into_usize())));
         assert!(raw.contains(&format!("call_generic @{}<>()", generic.into_usize())));
-        assert!(raw.contains(&format!("intrinsic @sym:{}()", intrinsic.into_usize())));
+        assert!(raw.contains(&format!("intrinsic @sym:{}(", intrinsic.into_usize())));
     }
 
     #[test]

--- a/crates/rue-air/src/intrinsic.rs
+++ b/crates/rue-air/src/intrinsic.rs
@@ -1,0 +1,1671 @@
+//! The typed authority for intrinsic semantics.
+//!
+//! An intrinsic's spelling is retained on AIR for diagnostics and stable
+//! presentation, but this operation is the only value consumed by later
+//! phases.  In particular, runtime helper identity is derived from this value
+//! rather than carried in a second optional channel.
+
+use crate::{
+    Air, AirArgMode, AirInstData, AirProjection, AirRef, EnumDef, FrozenTypeInternPool,
+    RuntimeAirArgument, RuntimeAirType, RuntimeCallKind, Type, TypeInternPool, TypeKind,
+};
+
+/// The structural origin of an AIR intrinsic operand.
+///
+/// Most intrinsics consume ordinary rvalues. Address-taking intrinsics instead
+/// require a durable place read, and `@field_ptr` additionally requires that
+/// the read's final projection select a field. Keeping this evidence beside
+/// the operand's type and mode lets durable import and CFG construction apply
+/// one complete contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntrinsicAirArgumentSource {
+    Value,
+    Load,
+    Param,
+    PlaceRead { terminal_field: bool },
+}
+
+/// One argument presented to the shared operation-level AIR validator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IntrinsicAirArgument {
+    pub ty: Type,
+    pub mode: AirArgMode,
+    pub source: IntrinsicAirArgumentSource,
+}
+
+impl IntrinsicAirArgument {
+    /// Describe an ordinary computed value. Tests and post-AIR consumers that
+    /// do not carry a place operand use this constructor.
+    pub const fn value(ty: Type, mode: AirArgMode) -> Self {
+        Self {
+            ty,
+            mode,
+            source: IntrinsicAirArgumentSource::Value,
+        }
+    }
+
+    #[cfg(test)]
+    const fn load(ty: Type, mode: AirArgMode) -> Self {
+        Self {
+            ty,
+            mode,
+            source: IntrinsicAirArgumentSource::Load,
+        }
+    }
+
+    #[cfg(test)]
+    const fn field_place_read(ty: Type, mode: AirArgMode) -> Self {
+        Self {
+            ty,
+            mode,
+            source: IntrinsicAirArgumentSource::PlaceRead {
+                terminal_field: true,
+            },
+        }
+    }
+}
+
+/// Build the exact operand descriptor consumed by [`IntrinsicOperation::validate_call`].
+/// Both durable import and CFG construction call this function on their AIR,
+/// so provenance cannot drift between the two trust boundaries.
+pub fn intrinsic_air_argument_with_place_lookup(
+    air: &Air,
+    value: AirRef,
+    mode: AirArgMode,
+    terminal_field: impl FnOnce(crate::AirPlaceRef) -> bool,
+) -> IntrinsicAirArgument {
+    let instruction = air.get(value);
+    let source = match &instruction.data {
+        AirInstData::Load { .. } => IntrinsicAirArgumentSource::Load,
+        AirInstData::Param { .. } => IntrinsicAirArgumentSource::Param,
+        AirInstData::PlaceRead { place } => IntrinsicAirArgumentSource::PlaceRead {
+            terminal_field: terminal_field(*place),
+        },
+        _ => IntrinsicAirArgumentSource::Value,
+    };
+    IntrinsicAirArgument {
+        ty: instruction.ty,
+        mode,
+        source,
+    }
+}
+
+/// Build an intrinsic operand descriptor from a fully constructed AIR owner.
+pub fn intrinsic_air_argument(air: &Air, value: AirRef, mode: AirArgMode) -> IntrinsicAirArgument {
+    intrinsic_air_argument_with_place_lookup(air, value, mode, |place| {
+        let place = air.get_place(place);
+        matches!(
+            air.get_place_projections(place).last(),
+            Some(AirProjection::Field { .. })
+        )
+    })
+}
+
+/// Type-pool operations needed to validate and marshal an intrinsic call.
+/// Implementations for both mutable semantic-import pools and frozen CFG pools
+/// keep the operation validator single-sourced across phase boundaries.
+pub trait RuntimeAirTypePool {
+    fn runtime_air_type(&self, ty: Type) -> Option<RuntimeAirType>;
+    fn runtime_air_result_type(&self, ty: Type) -> Option<RuntimeAirType>;
+    fn ptr_const_def(&self, id: crate::PtrConstTypeId) -> Type;
+    fn ptr_mut_def(&self, id: crate::PtrMutTypeId) -> Type;
+}
+
+/// Convert an AIR value type to the compact type vocabulary used by the
+/// runtime-call manifest.  This is shared by durable import and CFG so the
+/// manifest remains the sole authority for runtime intrinsic call shapes.
+fn runtime_air_type_in_pool(pool: &TypeInternPool, ty: Type) -> Option<RuntimeAirType> {
+    if ty == Type::UNIT {
+        return Some(RuntimeAirType::Unit);
+    }
+    if ty == Type::I64 {
+        return Some(RuntimeAirType::I64);
+    }
+    if ty == Type::U64 {
+        return Some(RuntimeAirType::U64);
+    }
+    if ty == Type::U32 {
+        return Some(RuntimeAirType::U32);
+    }
+    if ty == Type::BOOL {
+        return Some(RuntimeAirType::Bool);
+    }
+    if ty == Type::NEVER {
+        return Some(RuntimeAirType::Never);
+    }
+    if ty.is_signed() {
+        return Some(RuntimeAirType::SignedInteger);
+    }
+    if ty.is_unsigned() {
+        return Some(RuntimeAirType::UnsignedInteger);
+    }
+    if let TypeKind::Struct(struct_id) = ty.kind() {
+        let name: &str = &pool.struct_def(struct_id).name;
+        if pool.is_strbuf(struct_id) || crate::is_string_view_struct_name(name) {
+            return Some(RuntimeAirType::Text);
+        }
+    }
+    if let Some(ptr) = ty.as_ptr_const()
+        && pool.ptr_const_def(ptr) == Type::U8
+    {
+        return Some(RuntimeAirType::ConstBytePointer);
+    }
+    if let Some(ptr) = ty.as_ptr_mut() {
+        return Some(if pool.ptr_mut_def(ptr) == Type::U8 {
+            RuntimeAirType::MutBytePointer
+        } else {
+            RuntimeAirType::MutPointer
+        });
+    }
+    None
+}
+
+/// Convert an intrinsic result type to the runtime manifest vocabulary.
+fn runtime_air_result_type_in_pool(pool: &TypeInternPool, ty: Type) -> Option<RuntimeAirType> {
+    if ty == Type::U8 {
+        return Some(RuntimeAirType::U8);
+    }
+    if let TypeKind::Struct(struct_id) = ty.kind()
+        && pool.is_strbuf(struct_id)
+    {
+        return Some(RuntimeAirType::StrBuf);
+    }
+    if let TypeKind::Enum(enum_id) = ty.kind() {
+        let definition = pool.enum_def(enum_id);
+        let payload = exact_option_payload(&definition)?;
+        if let TypeKind::Struct(struct_id) = payload.kind()
+            && pool.is_strbuf(struct_id)
+        {
+            return Some(RuntimeAirType::OptionStrBuf);
+        }
+        return Some(match payload {
+            Type::I32 => RuntimeAirType::OptionI32,
+            Type::I64 => RuntimeAirType::OptionI64,
+            Type::U32 => RuntimeAirType::OptionU32,
+            Type::U64 => RuntimeAirType::OptionU64,
+            _ => return None,
+        });
+    }
+    runtime_air_type_in_pool(pool, ty)
+}
+
+/// Return the payload of the one accepted Option layout. Runtime return
+/// marshalling assumes a two-variant `Some(T) | None` enum, so accepting a
+/// lookalike with extra variants or a payload-bearing `None` would make its
+/// result-slot layout unsound.
+fn exact_option_payload(definition: &EnumDef) -> Option<Type> {
+    if definition.variant_count() != 2 {
+        return None;
+    }
+    let mut some = None;
+    let mut none = None;
+    for (index, name) in definition.variants.iter().enumerate() {
+        match name.as_ref() {
+            "Some" if some.replace(index).is_none() => {}
+            "None" if none.replace(index).is_none() => {}
+            _ => return None,
+        }
+    }
+    let some = some?;
+    let none = none?;
+    let [payload] = definition.variant_payload(some) else {
+        return None;
+    };
+    if !definition.variant_payload(none).is_empty() {
+        return None;
+    }
+    Some(*payload)
+}
+
+impl RuntimeAirTypePool for TypeInternPool {
+    fn runtime_air_type(&self, ty: Type) -> Option<RuntimeAirType> {
+        runtime_air_type_in_pool(self, ty)
+    }
+
+    fn runtime_air_result_type(&self, ty: Type) -> Option<RuntimeAirType> {
+        runtime_air_result_type_in_pool(self, ty)
+    }
+
+    fn ptr_const_def(&self, id: crate::PtrConstTypeId) -> Type {
+        self.ptr_const_def(id)
+    }
+
+    fn ptr_mut_def(&self, id: crate::PtrMutTypeId) -> Type {
+        self.ptr_mut_def(id)
+    }
+}
+
+impl RuntimeAirTypePool for FrozenTypeInternPool {
+    fn runtime_air_type(&self, ty: Type) -> Option<RuntimeAirType> {
+        if ty == Type::UNIT {
+            return Some(RuntimeAirType::Unit);
+        }
+        if ty == Type::I64 {
+            return Some(RuntimeAirType::I64);
+        }
+        if ty == Type::U64 {
+            return Some(RuntimeAirType::U64);
+        }
+        if ty == Type::U32 {
+            return Some(RuntimeAirType::U32);
+        }
+        if ty == Type::BOOL {
+            return Some(RuntimeAirType::Bool);
+        }
+        if ty == Type::NEVER {
+            return Some(RuntimeAirType::Never);
+        }
+        if ty.is_signed() {
+            return Some(RuntimeAirType::SignedInteger);
+        }
+        if ty.is_unsigned() {
+            return Some(RuntimeAirType::UnsignedInteger);
+        }
+        if let TypeKind::Struct(struct_id) = ty.kind() {
+            let name: &str = &self.struct_def(struct_id).name;
+            if self.is_strbuf(struct_id) || crate::is_string_view_struct_name(name) {
+                return Some(RuntimeAirType::Text);
+            }
+        }
+        if let Some(ptr) = ty.as_ptr_const()
+            && self.ptr_const_def(ptr) == Type::U8
+        {
+            return Some(RuntimeAirType::ConstBytePointer);
+        }
+        if let Some(ptr) = ty.as_ptr_mut() {
+            return Some(if self.ptr_mut_def(ptr) == Type::U8 {
+                RuntimeAirType::MutBytePointer
+            } else {
+                RuntimeAirType::MutPointer
+            });
+        }
+        None
+    }
+
+    fn runtime_air_result_type(&self, ty: Type) -> Option<RuntimeAirType> {
+        if ty == Type::U8 {
+            return Some(RuntimeAirType::U8);
+        }
+        if let TypeKind::Struct(struct_id) = ty.kind()
+            && self.is_strbuf(struct_id)
+        {
+            return Some(RuntimeAirType::StrBuf);
+        }
+        if let TypeKind::Enum(enum_id) = ty.kind() {
+            let definition = self.enum_def(enum_id);
+            let payload = exact_option_payload(definition)?;
+            if let TypeKind::Struct(struct_id) = payload.kind()
+                && self.is_strbuf(struct_id)
+            {
+                return Some(RuntimeAirType::OptionStrBuf);
+            }
+            return Some(match payload {
+                Type::I32 => RuntimeAirType::OptionI32,
+                Type::I64 => RuntimeAirType::OptionI64,
+                Type::U32 => RuntimeAirType::OptionU32,
+                Type::U64 => RuntimeAirType::OptionU64,
+                _ => return None,
+            });
+        }
+        self.runtime_air_type(ty)
+    }
+
+    fn ptr_const_def(&self, id: crate::PtrConstTypeId) -> Type {
+        self.ptr_const_def(id)
+    }
+
+    fn ptr_mut_def(&self, id: crate::PtrMutTypeId) -> Type {
+        self.ptr_mut_def(id)
+    }
+}
+
+pub fn runtime_air_type(pool: &impl RuntimeAirTypePool, ty: Type) -> Option<RuntimeAirType> {
+    pool.runtime_air_type(ty)
+}
+
+pub fn runtime_air_result_type(pool: &impl RuntimeAirTypePool, ty: Type) -> Option<RuntimeAirType> {
+    pool.runtime_air_result_type(ty)
+}
+
+/// A total, semantically selected intrinsic operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IntrinsicOperation {
+    PanicNoMessage,
+    Panic,
+    AssertFailed,
+    AssertWithMessage,
+    BoundsCheck,
+    DebugI64,
+    DebugU64,
+    DebugBool,
+    DebugStr,
+    ReadLine,
+    ParseI32,
+    ParseI64,
+    ParseU32,
+    ParseU64,
+    RandomU32,
+    RandomU64,
+    PtrToInt,
+    IntToPtr,
+    PtrRead,
+    PtrReadUnaligned,
+    PtrWrite,
+    PtrWriteUnaligned,
+    PtrOffset,
+    Alloc,
+    AllocZeroed,
+    Free,
+    Realloc,
+    Resize,
+    ByteCopy,
+    ByteMove,
+    ByteSet,
+    ArgCount,
+    ArgPtr,
+    ArgLen,
+    EnvCount,
+    EnvPtr,
+    EnvLen,
+    Raw,
+    RawMut,
+    FieldPtr,
+    Syscall,
+    BitCast,
+}
+
+impl IntrinsicOperation {
+    /// Every semantic identity, kept in one place so consumers and tests can
+    /// prove that dispatch remains exhaustive when a new intrinsic is added.
+    pub const ALL: [Self; 42] = [
+        Self::PanicNoMessage,
+        Self::Panic,
+        Self::AssertFailed,
+        Self::AssertWithMessage,
+        Self::BoundsCheck,
+        Self::DebugI64,
+        Self::DebugU64,
+        Self::DebugBool,
+        Self::DebugStr,
+        Self::ReadLine,
+        Self::ParseI32,
+        Self::ParseI64,
+        Self::ParseU32,
+        Self::ParseU64,
+        Self::RandomU32,
+        Self::RandomU64,
+        Self::PtrToInt,
+        Self::IntToPtr,
+        Self::PtrRead,
+        Self::PtrReadUnaligned,
+        Self::PtrWrite,
+        Self::PtrWriteUnaligned,
+        Self::PtrOffset,
+        Self::Alloc,
+        Self::AllocZeroed,
+        Self::Free,
+        Self::Realloc,
+        Self::Resize,
+        Self::ByteCopy,
+        Self::ByteMove,
+        Self::ByteSet,
+        Self::ArgCount,
+        Self::ArgPtr,
+        Self::ArgLen,
+        Self::EnvCount,
+        Self::EnvPtr,
+        Self::EnvLen,
+        Self::Raw,
+        Self::RawMut,
+        Self::FieldPtr,
+        Self::Syscall,
+        Self::BitCast,
+    ];
+
+    /// The canonical spelling used for diagnostics and display. This is not
+    /// used for semantic dispatch (several operations intentionally share a
+    /// spelling, such as the panic and debug families).
+    pub const fn expected_spelling(self) -> &'static str {
+        match self {
+            Self::PanicNoMessage | Self::Panic => "panic",
+            Self::AssertFailed | Self::AssertWithMessage => "assert",
+            Self::BoundsCheck => "assert",
+            Self::DebugI64 | Self::DebugU64 | Self::DebugBool | Self::DebugStr => "dbg",
+            Self::ReadLine => "read_line",
+            Self::ParseI32 => "parse_i32",
+            Self::ParseI64 => "parse_i64",
+            Self::ParseU32 => "parse_u32",
+            Self::ParseU64 => "parse_u64",
+            Self::RandomU32 => "random_u32",
+            Self::RandomU64 => "random_u64",
+            Self::PtrToInt => "ptr_to_int",
+            Self::IntToPtr => "int_to_ptr",
+            Self::PtrRead => "ptr_read",
+            Self::PtrReadUnaligned => "ptr_read_unaligned",
+            Self::PtrWrite => "ptr_write",
+            Self::PtrWriteUnaligned => "ptr_write_unaligned",
+            Self::PtrOffset => "ptr_offset",
+            Self::Alloc => "alloc",
+            Self::AllocZeroed => "alloc_zeroed",
+            Self::Free => "free",
+            Self::Realloc => "realloc",
+            Self::Resize => "resize",
+            Self::ByteCopy => "byte_copy",
+            Self::ByteMove => "byte_move",
+            Self::ByteSet => "byte_set",
+            Self::ArgCount => "arg_count",
+            Self::ArgPtr => "arg_ptr",
+            Self::ArgLen => "arg_len",
+            Self::EnvCount => "env_count",
+            Self::EnvPtr => "env_ptr",
+            Self::EnvLen => "env_len",
+            Self::Raw => "raw",
+            Self::RawMut => "raw_mut",
+            Self::FieldPtr => "field_ptr",
+            Self::Syscall => "syscall",
+            Self::BitCast => "bitCast",
+        }
+    }
+
+    pub fn from_runtime_call(runtime: RuntimeCallKind) -> Option<Self> {
+        Some(match runtime {
+            RuntimeCallKind::PanicNoMessage => Self::PanicNoMessage,
+            RuntimeCallKind::Panic => Self::Panic,
+            RuntimeCallKind::AssertFailed => Self::AssertFailed,
+            RuntimeCallKind::AssertWithMessage => Self::AssertWithMessage,
+            RuntimeCallKind::BoundsCheck => Self::BoundsCheck,
+            RuntimeCallKind::DebugI64 => Self::DebugI64,
+            RuntimeCallKind::DebugU64 => Self::DebugU64,
+            RuntimeCallKind::DebugBool => Self::DebugBool,
+            RuntimeCallKind::DebugStr => Self::DebugStr,
+            RuntimeCallKind::ReadLine => Self::ReadLine,
+            RuntimeCallKind::ParseI32 => Self::ParseI32,
+            RuntimeCallKind::ParseI64 => Self::ParseI64,
+            RuntimeCallKind::ParseU32 => Self::ParseU32,
+            RuntimeCallKind::ParseU64 => Self::ParseU64,
+            RuntimeCallKind::RandomU32 => Self::RandomU32,
+            RuntimeCallKind::RandomU64 => Self::RandomU64,
+            RuntimeCallKind::Alloc => Self::Alloc,
+            RuntimeCallKind::AllocZeroed => Self::AllocZeroed,
+            RuntimeCallKind::Free => Self::Free,
+            RuntimeCallKind::Realloc => Self::Realloc,
+            RuntimeCallKind::Resize => Self::Resize,
+            RuntimeCallKind::ArgCount => Self::ArgCount,
+            RuntimeCallKind::ArgPtr => Self::ArgPtr,
+            RuntimeCallKind::ArgLen => Self::ArgLen,
+            RuntimeCallKind::EnvCount => Self::EnvCount,
+            RuntimeCallKind::EnvPtr => Self::EnvPtr,
+            RuntimeCallKind::EnvLen => Self::EnvLen,
+            RuntimeCallKind::ByteCopy => Self::ByteCopy,
+            RuntimeCallKind::ByteMove => Self::ByteMove,
+            RuntimeCallKind::ByteSet => Self::ByteSet,
+            RuntimeCallKind::StrByteAt
+            | RuntimeCallKind::StrCharScalar
+            | RuntimeCallKind::StrCharNext
+            | RuntimeCallKind::StrCharScalarLossy
+            | RuntimeCallKind::StrCharNextLossy
+            | RuntimeCallKind::ToString
+            | RuntimeCallKind::ToStringUnsigned
+            | RuntimeCallKind::StrPrintAggregate
+            | RuntimeCallKind::StrPrintProjected
+            | RuntimeCallKind::StrPrintlnAggregate
+            | RuntimeCallKind::StrPrintlnProjected => return None,
+        })
+    }
+
+    pub fn takes_place_address(self) -> bool {
+        matches!(self, Self::Raw | Self::RawMut | Self::FieldPtr)
+    }
+
+    /// Runtime-backed operations retain their ABI identity in this enum. Pure
+    /// operations intentionally return `None` and never acquire a runtime
+    /// metadata side channel.
+    pub fn runtime_call(self) -> Option<RuntimeCallKind> {
+        Some(match self {
+            Self::PanicNoMessage => RuntimeCallKind::PanicNoMessage,
+            Self::Panic => RuntimeCallKind::Panic,
+            Self::AssertFailed => RuntimeCallKind::AssertFailed,
+            Self::AssertWithMessage => RuntimeCallKind::AssertWithMessage,
+            Self::BoundsCheck => RuntimeCallKind::BoundsCheck,
+            Self::ReadLine => RuntimeCallKind::ReadLine,
+            Self::ParseI32 => RuntimeCallKind::ParseI32,
+            Self::ParseI64 => RuntimeCallKind::ParseI64,
+            Self::ParseU32 => RuntimeCallKind::ParseU32,
+            Self::ParseU64 => RuntimeCallKind::ParseU64,
+            Self::RandomU32 => RuntimeCallKind::RandomU32,
+            Self::RandomU64 => RuntimeCallKind::RandomU64,
+            Self::Alloc => RuntimeCallKind::Alloc,
+            Self::AllocZeroed => RuntimeCallKind::AllocZeroed,
+            Self::Free => RuntimeCallKind::Free,
+            Self::Realloc => RuntimeCallKind::Realloc,
+            Self::Resize => RuntimeCallKind::Resize,
+            Self::ArgCount => RuntimeCallKind::ArgCount,
+            Self::ArgPtr => RuntimeCallKind::ArgPtr,
+            Self::ArgLen => RuntimeCallKind::ArgLen,
+            Self::EnvCount => RuntimeCallKind::EnvCount,
+            Self::EnvPtr => RuntimeCallKind::EnvPtr,
+            Self::EnvLen => RuntimeCallKind::EnvLen,
+            Self::ByteCopy => RuntimeCallKind::ByteCopy,
+            Self::ByteMove => RuntimeCallKind::ByteMove,
+            Self::ByteSet => RuntimeCallKind::ByteSet,
+            Self::DebugI64 => RuntimeCallKind::DebugI64,
+            Self::DebugU64 => RuntimeCallKind::DebugU64,
+            Self::DebugBool => RuntimeCallKind::DebugBool,
+            Self::DebugStr => RuntimeCallKind::DebugStr,
+            Self::PtrToInt
+            | Self::IntToPtr
+            | Self::PtrRead
+            | Self::PtrReadUnaligned
+            | Self::PtrWrite
+            | Self::PtrWriteUnaligned
+            | Self::PtrOffset
+            | Self::Raw
+            | Self::RawMut
+            | Self::FieldPtr
+            | Self::Syscall
+            | Self::BitCast => return None,
+        })
+    }
+
+    /// Alias named after the ABI concept for callers that need to derive a
+    /// runtime helper from the typed operation.
+    pub fn runtime_call_kind(self) -> Option<RuntimeCallKind> {
+        self.runtime_call()
+    }
+
+    pub fn panic_no_message(self) -> bool {
+        matches!(self, Self::PanicNoMessage)
+    }
+
+    /// Validate an intrinsic's complete AIR call shape. Runtime-backed
+    /// operations delegate to the RuntimeCallKind manifest; pure operations
+    /// keep their pointer/provenance relationships here as well.
+    pub fn validate_call(
+        self,
+        pool: &impl RuntimeAirTypePool,
+        args: &[IntrinsicAirArgument],
+        result: Type,
+    ) -> bool {
+        if args.iter().any(|arg| arg.mode != AirArgMode::Normal) {
+            return false;
+        }
+        if let Some(runtime) = self.runtime_call_kind() {
+            let Some(arguments) = args
+                .iter()
+                .map(|arg| {
+                    runtime_air_type(pool, arg.ty)
+                        .map(|ty| RuntimeAirArgument { ty, mode: arg.mode })
+                })
+                .collect::<Option<Vec<_>>>()
+            else {
+                return false;
+            };
+            return runtime.validate()
+                && runtime_air_result_type(pool, result)
+                    .is_some_and(|result| runtime.validate_air_call(&arguments, result));
+        }
+        let Some(first) = args.first() else {
+            return false;
+        };
+        match self {
+            Self::PtrToInt => {
+                args.len() == 1
+                    && (first.ty.is_ptr() || first.ty == Type::NEVER)
+                    && result == Type::U64
+            }
+            Self::IntToPtr => {
+                args.len() == 1
+                    && (first.ty == Type::U64 || first.ty == Type::NEVER)
+                    && (result.as_ptr_mut().is_some() || result == Type::NEVER)
+            }
+            Self::PtrRead | Self::PtrReadUnaligned => {
+                args.len() == 1
+                    && match first.ty.kind() {
+                        TypeKind::PtrConst(id) => pool.ptr_const_def(id) == result,
+                        TypeKind::PtrMut(id) => pool.ptr_mut_def(id) == result,
+                        _ => false,
+                    }
+            }
+            Self::PtrWrite | Self::PtrWriteUnaligned => {
+                args.len() == 2
+                    && result == Type::UNIT
+                    && match first.ty.kind() {
+                        TypeKind::PtrMut(id) => {
+                            let pointee = pool.ptr_mut_def(id);
+                            args[1].ty == pointee || args[1].ty == Type::NEVER
+                        }
+                        _ => false,
+                    }
+            }
+            Self::PtrOffset => {
+                args.len() == 2
+                    && (args[1].ty.is_integer() || args[1].ty == Type::NEVER)
+                    && if first.ty == Type::NEVER {
+                        result == Type::NEVER
+                    } else {
+                        first.ty.is_ptr() && result == first.ty
+                    }
+            }
+            Self::Raw => {
+                args.len() == 1
+                    && matches!(
+                        first.source,
+                        IntrinsicAirArgumentSource::Load
+                            | IntrinsicAirArgumentSource::Param
+                            | IntrinsicAirArgumentSource::PlaceRead { .. }
+                    )
+                    && match result.kind() {
+                        TypeKind::PtrConst(id) => pool.ptr_const_def(id) == first.ty,
+                        _ => false,
+                    }
+            }
+            Self::RawMut => {
+                args.len() == 1
+                    && matches!(
+                        first.source,
+                        IntrinsicAirArgumentSource::Load
+                            | IntrinsicAirArgumentSource::Param
+                            | IntrinsicAirArgumentSource::PlaceRead { .. }
+                    )
+                    && match result.kind() {
+                        TypeKind::PtrMut(id) => pool.ptr_mut_def(id) == first.ty,
+                        _ => false,
+                    }
+            }
+            Self::FieldPtr => {
+                args.len() == 1
+                    && matches!(
+                        first.source,
+                        IntrinsicAirArgumentSource::PlaceRead {
+                            terminal_field: true
+                        }
+                    )
+                    && match result.kind() {
+                        TypeKind::PtrMut(id) => pool.ptr_mut_def(id) == first.ty,
+                        _ => false,
+                    }
+            }
+            Self::Syscall => {
+                (1..=7).contains(&args.len())
+                    && args
+                        .iter()
+                        .all(|arg| arg.ty == Type::U64 || arg.ty == Type::NEVER)
+                    && result == Type::I64
+            }
+            Self::BitCast => {
+                args.len() == 1
+                    && first.ty.is_integer()
+                    && first.ty.integer_semantics().map(|integer| integer.bits())
+                        == result.integer_semantics().map(|integer| integer.bits())
+            }
+            Self::PanicNoMessage
+            | Self::Panic
+            | Self::AssertFailed
+            | Self::AssertWithMessage
+            | Self::BoundsCheck
+            | Self::DebugI64
+            | Self::DebugU64
+            | Self::DebugBool
+            | Self::DebugStr
+            | Self::ReadLine
+            | Self::ParseI32
+            | Self::ParseI64
+            | Self::ParseU32
+            | Self::ParseU64
+            | Self::RandomU32
+            | Self::RandomU64
+            | Self::Alloc
+            | Self::AllocZeroed
+            | Self::Free
+            | Self::Realloc
+            | Self::Resize
+            | Self::ByteCopy
+            | Self::ByteMove
+            | Self::ByteSet
+            | Self::ArgCount
+            | Self::ArgPtr
+            | Self::ArgLen
+            | Self::EnvCount
+            | Self::EnvPtr
+            | Self::EnvLen => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EnumDef, LangItem, StructDef};
+    use lasso::ThreadedRodeo;
+    use rue_span::FileId;
+    use std::collections::BTreeSet;
+    use std::sync::Arc;
+
+    const EXACT_OPERATIONS: [(IntrinsicOperation, &str); 42] = [
+        (IntrinsicOperation::PanicNoMessage, "panic"),
+        (IntrinsicOperation::Panic, "panic"),
+        (IntrinsicOperation::AssertFailed, "assert"),
+        (IntrinsicOperation::AssertWithMessage, "assert"),
+        (IntrinsicOperation::BoundsCheck, "assert"),
+        (IntrinsicOperation::DebugI64, "dbg"),
+        (IntrinsicOperation::DebugU64, "dbg"),
+        (IntrinsicOperation::DebugBool, "dbg"),
+        (IntrinsicOperation::DebugStr, "dbg"),
+        (IntrinsicOperation::ReadLine, "read_line"),
+        (IntrinsicOperation::ParseI32, "parse_i32"),
+        (IntrinsicOperation::ParseI64, "parse_i64"),
+        (IntrinsicOperation::ParseU32, "parse_u32"),
+        (IntrinsicOperation::ParseU64, "parse_u64"),
+        (IntrinsicOperation::RandomU32, "random_u32"),
+        (IntrinsicOperation::RandomU64, "random_u64"),
+        (IntrinsicOperation::PtrToInt, "ptr_to_int"),
+        (IntrinsicOperation::IntToPtr, "int_to_ptr"),
+        (IntrinsicOperation::PtrRead, "ptr_read"),
+        (IntrinsicOperation::PtrReadUnaligned, "ptr_read_unaligned"),
+        (IntrinsicOperation::PtrWrite, "ptr_write"),
+        (IntrinsicOperation::PtrWriteUnaligned, "ptr_write_unaligned"),
+        (IntrinsicOperation::PtrOffset, "ptr_offset"),
+        (IntrinsicOperation::Alloc, "alloc"),
+        (IntrinsicOperation::AllocZeroed, "alloc_zeroed"),
+        (IntrinsicOperation::Free, "free"),
+        (IntrinsicOperation::Realloc, "realloc"),
+        (IntrinsicOperation::Resize, "resize"),
+        (IntrinsicOperation::ByteCopy, "byte_copy"),
+        (IntrinsicOperation::ByteMove, "byte_move"),
+        (IntrinsicOperation::ByteSet, "byte_set"),
+        (IntrinsicOperation::ArgCount, "arg_count"),
+        (IntrinsicOperation::ArgPtr, "arg_ptr"),
+        (IntrinsicOperation::ArgLen, "arg_len"),
+        (IntrinsicOperation::EnvCount, "env_count"),
+        (IntrinsicOperation::EnvPtr, "env_ptr"),
+        (IntrinsicOperation::EnvLen, "env_len"),
+        (IntrinsicOperation::Raw, "raw"),
+        (IntrinsicOperation::RawMut, "raw_mut"),
+        (IntrinsicOperation::FieldPtr, "field_ptr"),
+        (IntrinsicOperation::Syscall, "syscall"),
+        (IntrinsicOperation::BitCast, "bitCast"),
+    ];
+
+    const EXACT_RUNTIME_MAPPINGS: [(IntrinsicOperation, RuntimeCallKind); 30] = [
+        (
+            IntrinsicOperation::PanicNoMessage,
+            RuntimeCallKind::PanicNoMessage,
+        ),
+        (IntrinsicOperation::Panic, RuntimeCallKind::Panic),
+        (
+            IntrinsicOperation::AssertFailed,
+            RuntimeCallKind::AssertFailed,
+        ),
+        (
+            IntrinsicOperation::AssertWithMessage,
+            RuntimeCallKind::AssertWithMessage,
+        ),
+        (
+            IntrinsicOperation::BoundsCheck,
+            RuntimeCallKind::BoundsCheck,
+        ),
+        (IntrinsicOperation::DebugI64, RuntimeCallKind::DebugI64),
+        (IntrinsicOperation::DebugU64, RuntimeCallKind::DebugU64),
+        (IntrinsicOperation::DebugBool, RuntimeCallKind::DebugBool),
+        (IntrinsicOperation::DebugStr, RuntimeCallKind::DebugStr),
+        (IntrinsicOperation::ReadLine, RuntimeCallKind::ReadLine),
+        (IntrinsicOperation::ParseI32, RuntimeCallKind::ParseI32),
+        (IntrinsicOperation::ParseI64, RuntimeCallKind::ParseI64),
+        (IntrinsicOperation::ParseU32, RuntimeCallKind::ParseU32),
+        (IntrinsicOperation::ParseU64, RuntimeCallKind::ParseU64),
+        (IntrinsicOperation::RandomU32, RuntimeCallKind::RandomU32),
+        (IntrinsicOperation::RandomU64, RuntimeCallKind::RandomU64),
+        (IntrinsicOperation::Alloc, RuntimeCallKind::Alloc),
+        (
+            IntrinsicOperation::AllocZeroed,
+            RuntimeCallKind::AllocZeroed,
+        ),
+        (IntrinsicOperation::Free, RuntimeCallKind::Free),
+        (IntrinsicOperation::Realloc, RuntimeCallKind::Realloc),
+        (IntrinsicOperation::Resize, RuntimeCallKind::Resize),
+        (IntrinsicOperation::ByteCopy, RuntimeCallKind::ByteCopy),
+        (IntrinsicOperation::ByteMove, RuntimeCallKind::ByteMove),
+        (IntrinsicOperation::ByteSet, RuntimeCallKind::ByteSet),
+        (IntrinsicOperation::ArgCount, RuntimeCallKind::ArgCount),
+        (IntrinsicOperation::ArgPtr, RuntimeCallKind::ArgPtr),
+        (IntrinsicOperation::ArgLen, RuntimeCallKind::ArgLen),
+        (IntrinsicOperation::EnvCount, RuntimeCallKind::EnvCount),
+        (IntrinsicOperation::EnvPtr, RuntimeCallKind::EnvPtr),
+        (IntrinsicOperation::EnvLen, RuntimeCallKind::EnvLen),
+    ];
+
+    const ORDINARY_CALL_ONLY: [RuntimeCallKind; 11] = [
+        RuntimeCallKind::StrByteAt,
+        RuntimeCallKind::StrCharScalar,
+        RuntimeCallKind::StrCharNext,
+        RuntimeCallKind::StrCharScalarLossy,
+        RuntimeCallKind::StrCharNextLossy,
+        RuntimeCallKind::ToString,
+        RuntimeCallKind::ToStringUnsigned,
+        RuntimeCallKind::StrPrintAggregate,
+        RuntimeCallKind::StrPrintProjected,
+        RuntimeCallKind::StrPrintlnAggregate,
+        RuntimeCallKind::StrPrintlnProjected,
+    ];
+
+    #[test]
+    fn all_operations_are_unique_and_runtime_mapping_is_symmetric() {
+        assert_eq!(IntrinsicOperation::ALL.len(), 42);
+        assert_eq!(
+            IntrinsicOperation::ALL,
+            EXACT_OPERATIONS.map(|(operation, _)| operation)
+        );
+        for (index, operation) in IntrinsicOperation::ALL.iter().enumerate() {
+            assert_eq!(
+                IntrinsicOperation::ALL[..index]
+                    .iter()
+                    .filter(|previous| *previous == operation)
+                    .count(),
+                0,
+                "duplicate intrinsic operation at index {index}"
+            );
+            if let Some(runtime) = operation.runtime_call_kind() {
+                assert_eq!(
+                    IntrinsicOperation::from_runtime_call(runtime),
+                    Some(*operation)
+                );
+            }
+            assert_eq!(
+                operation.expected_spelling(),
+                EXACT_OPERATIONS[index].1,
+                "spelling drifted for {operation:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn inventory_and_runtime_partition_are_exact() {
+        const SPELLINGS: [&str; 36] = [
+            "panic",
+            "assert",
+            "dbg",
+            "read_line",
+            "parse_i32",
+            "parse_i64",
+            "parse_u32",
+            "parse_u64",
+            "random_u32",
+            "random_u64",
+            "ptr_to_int",
+            "int_to_ptr",
+            "ptr_read",
+            "ptr_read_unaligned",
+            "ptr_write",
+            "ptr_write_unaligned",
+            "ptr_offset",
+            "alloc",
+            "alloc_zeroed",
+            "free",
+            "realloc",
+            "resize",
+            "byte_copy",
+            "byte_move",
+            "byte_set",
+            "arg_count",
+            "arg_ptr",
+            "arg_len",
+            "env_count",
+            "env_ptr",
+            "env_len",
+            "raw",
+            "raw_mut",
+            "field_ptr",
+            "syscall",
+            "bitCast",
+        ];
+        let spellings = IntrinsicOperation::ALL
+            .iter()
+            .map(|operation| operation.expected_spelling())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(spellings.len(), SPELLINGS.len());
+        assert_eq!(spellings, SPELLINGS.into_iter().collect());
+
+        let runtime = IntrinsicOperation::ALL
+            .iter()
+            .filter_map(|operation| operation.runtime_call_kind())
+            .collect::<Vec<_>>();
+        assert_eq!(runtime.len(), 30);
+        assert_eq!(
+            IntrinsicOperation::ALL
+                .iter()
+                .filter(|operation| operation.runtime_call_kind().is_none())
+                .count(),
+            12
+        );
+        assert_eq!(
+            runtime
+                .iter()
+                .enumerate()
+                .filter(|(index, kind)| !runtime[..*index].contains(kind))
+                .count(),
+            30
+        );
+        assert_eq!(
+            runtime,
+            EXACT_RUNTIME_MAPPINGS.map(|(_, runtime)| runtime),
+            "the exact intrinsic-to-runtime map drifted"
+        );
+        assert_eq!(RuntimeCallKind::ALL.len(), 41);
+        for kind in RuntimeCallKind::ALL {
+            assert_eq!(
+                IntrinsicOperation::from_runtime_call(kind).is_some(),
+                !ORDINARY_CALL_ONLY.contains(&kind),
+                "runtime mapping partition drifted for {kind:?}"
+            );
+        }
+        assert_eq!(
+            ORDINARY_CALL_ONLY.len(),
+            RuntimeCallKind::ALL.len() - runtime.len()
+        );
+        for (operation, runtime) in EXACT_RUNTIME_MAPPINGS {
+            assert_eq!(operation.runtime_call_kind(), Some(runtime));
+            assert_eq!(
+                IntrinsicOperation::from_runtime_call(runtime),
+                Some(operation)
+            );
+        }
+        for runtime in ORDINARY_CALL_ONLY {
+            assert_eq!(IntrinsicOperation::from_runtime_call(runtime), None);
+        }
+    }
+
+    #[test]
+    fn pure_validator_checks_every_shape_and_relation() {
+        let pool = TypeInternPool::new();
+        let ptr_const_i32 = Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::I32));
+        let ptr_mut_i32 = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::I32));
+        let ptr_mut_u64 = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::U64));
+        let normal = crate::AirArgMode::Normal;
+
+        let describe = |operation: IntrinsicOperation, args: Vec<(Type, AirArgMode)>| {
+            args.into_iter()
+                .enumerate()
+                .map(|(index, (ty, mode))| match (operation, index) {
+                    (IntrinsicOperation::Raw | IntrinsicOperation::RawMut, 0) => {
+                        IntrinsicAirArgument::load(ty, mode)
+                    }
+                    (IntrinsicOperation::FieldPtr, 0) => {
+                        IntrinsicAirArgument::field_place_read(ty, mode)
+                    }
+                    _ => IntrinsicAirArgument::value(ty, mode),
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for (operation, args, result) in [
+            (
+                IntrinsicOperation::PtrToInt,
+                vec![(ptr_const_i32, normal)],
+                Type::U64,
+            ),
+            (
+                IntrinsicOperation::IntToPtr,
+                vec![(Type::U64, normal)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::PtrRead,
+                vec![(ptr_const_i32, normal)],
+                Type::I32,
+            ),
+            (
+                IntrinsicOperation::PtrReadUnaligned,
+                vec![(ptr_mut_i32, normal)],
+                Type::I32,
+            ),
+            (
+                IntrinsicOperation::PtrWrite,
+                vec![(ptr_mut_i32, normal), (Type::I32, normal)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::PtrWriteUnaligned,
+                vec![(ptr_mut_i32, normal), (Type::I32, normal)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::PtrOffset,
+                vec![(ptr_const_i32, normal), (Type::I64, normal)],
+                ptr_const_i32,
+            ),
+            (
+                IntrinsicOperation::Raw,
+                vec![(Type::I32, normal)],
+                ptr_const_i32,
+            ),
+            (
+                IntrinsicOperation::RawMut,
+                vec![(Type::I32, normal)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::FieldPtr,
+                vec![(Type::I32, normal)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::Syscall,
+                vec![(Type::U64, normal)],
+                Type::I64,
+            ),
+            (
+                IntrinsicOperation::Syscall,
+                vec![(Type::U64, normal); 7],
+                Type::I64,
+            ),
+            (
+                IntrinsicOperation::BitCast,
+                vec![(Type::I32, normal)],
+                Type::U32,
+            ),
+            (
+                IntrinsicOperation::BitCast,
+                vec![(Type::I64, normal)],
+                Type::U64,
+            ),
+        ] {
+            let args = describe(operation, args);
+            assert!(
+                operation.validate_call(&pool, &args, result),
+                "canonical pure call rejected: {operation:?} {args:?} -> {result:?}"
+            );
+            let mut wrong_mode = args.clone();
+            wrong_mode[0].mode = crate::AirArgMode::Borrow;
+            assert!(!operation.validate_call(&pool, &wrong_mode, result));
+        }
+
+        let invalid = [
+            (
+                IntrinsicOperation::PtrToInt,
+                vec![(Type::I32, normal)],
+                Type::U64,
+            ),
+            (
+                IntrinsicOperation::PtrToInt,
+                vec![(ptr_const_i32, normal)],
+                Type::I64,
+            ),
+            (
+                IntrinsicOperation::IntToPtr,
+                vec![(Type::I64, normal)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::IntToPtr,
+                vec![(Type::U64, normal)],
+                ptr_const_i32,
+            ),
+            (
+                IntrinsicOperation::PtrRead,
+                vec![(ptr_const_i32, normal)],
+                Type::U64,
+            ),
+            (
+                IntrinsicOperation::PtrWrite,
+                vec![(ptr_const_i32, normal), (Type::I32, normal)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::PtrWrite,
+                vec![(ptr_mut_i32, normal), (Type::U64, normal)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::PtrOffset,
+                vec![(ptr_const_i32, normal), (Type::BOOL, normal)],
+                ptr_const_i32,
+            ),
+            (
+                IntrinsicOperation::PtrOffset,
+                vec![(ptr_const_i32, normal), (Type::I64, normal)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::Raw,
+                vec![(Type::I32, normal)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::RawMut,
+                vec![(Type::I32, normal)],
+                ptr_mut_u64,
+            ),
+            (
+                IntrinsicOperation::FieldPtr,
+                vec![(Type::I32, normal)],
+                ptr_mut_u64,
+            ),
+            (IntrinsicOperation::Syscall, vec![], Type::I64),
+            (
+                IntrinsicOperation::Syscall,
+                vec![(Type::U64, normal); 8],
+                Type::I64,
+            ),
+            (
+                IntrinsicOperation::Syscall,
+                vec![(Type::I64, normal)],
+                Type::I64,
+            ),
+            (
+                IntrinsicOperation::BitCast,
+                vec![(Type::I32, normal)],
+                Type::U64,
+            ),
+            (
+                IntrinsicOperation::BitCast,
+                vec![(Type::BOOL, normal)],
+                Type::BOOL,
+            ),
+        ];
+        for (operation, args, result) in invalid {
+            let args = describe(operation, args);
+            assert!(
+                !operation.validate_call(&pool, &args, result),
+                "counterfeit pure call accepted: {operation:?} {args:?} -> {result:?}"
+            );
+        }
+        for operation in IntrinsicOperation::ALL {
+            assert!(!operation.validate_call(&pool, &[], Type::UNIT));
+        }
+    }
+
+    #[test]
+    fn pure_validator_matches_bottom_coercion_and_place_provenance_matrix() {
+        use IntrinsicAirArgumentSource as S;
+
+        let pool = TypeInternPool::new();
+        let ptr_const_i32 = Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::I32));
+        let ptr_mut_i32 = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::I32));
+        let ptr_const_never = Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::NEVER));
+        let ptr_mut_never = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::NEVER));
+        let n = AirArgMode::Normal;
+        let value = |ty| IntrinsicAirArgument::value(ty, n);
+        let source = |ty, source| IntrinsicAirArgument {
+            ty,
+            mode: n,
+            source,
+        };
+
+        let accepted = [
+            (
+                IntrinsicOperation::PtrToInt,
+                vec![value(Type::NEVER)],
+                Type::U64,
+            ),
+            (
+                IntrinsicOperation::IntToPtr,
+                vec![value(Type::NEVER)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::IntToPtr,
+                vec![value(Type::U64)],
+                Type::NEVER,
+            ),
+            (
+                IntrinsicOperation::IntToPtr,
+                vec![value(Type::NEVER)],
+                Type::NEVER,
+            ),
+            (
+                IntrinsicOperation::PtrRead,
+                vec![value(ptr_const_never)],
+                Type::NEVER,
+            ),
+            (
+                IntrinsicOperation::PtrWrite,
+                vec![value(ptr_mut_i32), value(Type::NEVER)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::PtrWriteUnaligned,
+                vec![value(ptr_mut_never), value(Type::NEVER)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::PtrOffset,
+                vec![value(Type::NEVER), value(Type::I64)],
+                Type::NEVER,
+            ),
+            (
+                IntrinsicOperation::PtrOffset,
+                vec![value(Type::NEVER), value(Type::NEVER)],
+                Type::NEVER,
+            ),
+            (
+                IntrinsicOperation::PtrOffset,
+                vec![value(ptr_const_i32), value(Type::NEVER)],
+                ptr_const_i32,
+            ),
+            (
+                IntrinsicOperation::Raw,
+                vec![source(Type::NEVER, S::Load)],
+                ptr_const_never,
+            ),
+            (
+                IntrinsicOperation::RawMut,
+                vec![source(Type::NEVER, S::Param)],
+                ptr_mut_never,
+            ),
+            (
+                IntrinsicOperation::RawMut,
+                vec![source(
+                    Type::I32,
+                    S::PlaceRead {
+                        terminal_field: false,
+                    },
+                )],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::FieldPtr,
+                vec![source(
+                    Type::NEVER,
+                    S::PlaceRead {
+                        terminal_field: true,
+                    },
+                )],
+                ptr_mut_never,
+            ),
+            (
+                IntrinsicOperation::Syscall,
+                vec![value(Type::NEVER)],
+                Type::I64,
+            ),
+            (
+                IntrinsicOperation::Syscall,
+                vec![value(Type::U64), value(Type::NEVER), value(Type::U64)],
+                Type::I64,
+            ),
+        ];
+        for (operation, args, result) in accepted {
+            assert!(
+                operation.validate_call(&pool, &args, result),
+                "bottom/place call rejected: {operation:?} {args:?} -> {result:?}"
+            );
+        }
+
+        let rejected = [
+            (
+                IntrinsicOperation::PtrToInt,
+                vec![value(Type::NEVER)],
+                Type::I64,
+            ),
+            (
+                IntrinsicOperation::IntToPtr,
+                vec![value(Type::I32)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::IntToPtr,
+                vec![value(Type::NEVER)],
+                ptr_const_i32,
+            ),
+            (
+                IntrinsicOperation::PtrRead,
+                vec![value(Type::NEVER)],
+                Type::NEVER,
+            ),
+            (
+                IntrinsicOperation::PtrWrite,
+                vec![value(Type::NEVER), value(Type::I32)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::PtrWrite,
+                vec![value(ptr_mut_i32), value(Type::I64)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::PtrOffset,
+                vec![value(Type::NEVER), value(Type::I64)],
+                ptr_const_i32,
+            ),
+            (
+                IntrinsicOperation::PtrOffset,
+                vec![value(ptr_const_i32), value(Type::BOOL)],
+                ptr_const_i32,
+            ),
+            (
+                IntrinsicOperation::PtrOffset,
+                vec![value(Type::I32), value(Type::NEVER)],
+                Type::I32,
+            ),
+            (
+                IntrinsicOperation::Raw,
+                vec![value(Type::I32)],
+                ptr_const_i32,
+            ),
+            (
+                IntrinsicOperation::RawMut,
+                vec![value(Type::I32)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::FieldPtr,
+                vec![source(Type::I32, S::Load)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::FieldPtr,
+                vec![source(Type::I32, S::Param)],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::FieldPtr,
+                vec![source(
+                    Type::I32,
+                    S::PlaceRead {
+                        terminal_field: false,
+                    },
+                )],
+                ptr_mut_i32,
+            ),
+            (
+                IntrinsicOperation::Syscall,
+                vec![value(Type::U64), value(Type::BOOL)],
+                Type::I64,
+            ),
+            (
+                IntrinsicOperation::BitCast,
+                vec![value(Type::NEVER)],
+                Type::U64,
+            ),
+        ];
+        for (operation, args, result) in rejected {
+            assert!(
+                !operation.validate_call(&pool, &args, result),
+                "counterfeit bottom/place call accepted: {operation:?} {args:?} -> {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_option_results_require_the_exact_shape_in_mutable_and_frozen_pools() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let (strbuf_id, _) = pool.register_struct(
+            interner.get_or_intern("StrBuf"),
+            StructDef {
+                name: "StrBuf".into(),
+                fields: vec![],
+                is_copy: false,
+                is_linear: false,
+                declared_linear: false,
+                destructor: None,
+                is_builtin: true,
+                is_pub: true,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        pool.set_struct_lang_item(strbuf_id, LangItem::StrBuf);
+        let strbuf = Type::new_struct(strbuf_id);
+        let register = |name: &'static str, variants: &[(&'static str, Vec<Type>)]| {
+            let (id, _) = pool.register_enum(
+                interner.get_or_intern(name),
+                EnumDef {
+                    name: name.into(),
+                    variants: variants
+                        .iter()
+                        .map(|(name, _)| Arc::<str>::from(*name))
+                        .collect::<Vec<_>>()
+                        .into(),
+                    variant_payloads: variants
+                        .iter()
+                        .map(|(_, payload)| payload.clone())
+                        .collect(),
+                    is_pub: true,
+                    is_non_exhaustive: false,
+                    file_id: FileId::DEFAULT,
+                },
+            );
+            Type::new_enum(id)
+        };
+
+        let canonical = [
+            (
+                register("OptionI32", &[("Some", vec![Type::I32]), ("None", vec![])]),
+                RuntimeAirType::OptionI32,
+            ),
+            (
+                register("OptionI64", &[("Some", vec![Type::I64]), ("None", vec![])]),
+                RuntimeAirType::OptionI64,
+            ),
+            (
+                register("OptionU32", &[("Some", vec![Type::U32]), ("None", vec![])]),
+                RuntimeAirType::OptionU32,
+            ),
+            (
+                register("OptionU64", &[("Some", vec![Type::U64]), ("None", vec![])]),
+                RuntimeAirType::OptionU64,
+            ),
+            (
+                register("OptionStrBuf", &[("Some", vec![strbuf]), ("None", vec![])]),
+                RuntimeAirType::OptionStrBuf,
+            ),
+            (
+                register("Reversed", &[("None", vec![]), ("Some", vec![Type::I32])]),
+                RuntimeAirType::OptionI32,
+            ),
+        ];
+        let malformed = [
+            register(
+                "PayloadNoneExtra",
+                &[
+                    ("Some", vec![Type::I32]),
+                    ("None", vec![Type::I64, Type::I64]),
+                    ("Extra", vec![]),
+                ],
+            ),
+            register(
+                "PayloadNone",
+                &[("Some", vec![Type::I32]), ("None", vec![Type::I64])],
+            ),
+            register(
+                "Extra",
+                &[
+                    ("Some", vec![Type::I32]),
+                    ("None", vec![]),
+                    ("Extra", vec![]),
+                ],
+            ),
+            register("MissingNone", &[("Some", vec![Type::I32])]),
+            register(
+                "DuplicateSome",
+                &[("Some", vec![Type::I32]), ("Some", vec![])],
+            ),
+            register("MissingSome", &[("None", vec![]), ("Other", vec![])]),
+            register("EmptySome", &[("Some", vec![]), ("None", vec![])]),
+            register(
+                "WideSome",
+                &[("Some", vec![Type::I32, Type::I32]), ("None", vec![])],
+            ),
+            register(
+                "UnsupportedSome",
+                &[("Some", vec![Type::BOOL]), ("None", vec![])],
+            ),
+        ];
+
+        for (ty, expected) in canonical {
+            assert_eq!(runtime_air_result_type(&pool, ty), Some(expected));
+        }
+        for ty in malformed {
+            assert_eq!(runtime_air_result_type(&pool, ty), None);
+        }
+
+        let pool = pool.freeze();
+        for (ty, expected) in canonical {
+            assert_eq!(runtime_air_result_type(&pool, ty), Some(expected));
+        }
+        for ty in malformed {
+            assert_eq!(runtime_air_result_type(&pool, ty), None);
+        }
+    }
+
+    #[test]
+    fn runtime_validator_accepts_exact_manifest_shapes_and_rejects_counterfeits() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let register_struct = |name: &'static str| {
+            let (id, _) = pool.register_struct(
+                interner.get_or_intern(name),
+                StructDef {
+                    name: name.into(),
+                    fields: vec![],
+                    is_copy: true,
+                    is_linear: false,
+                    declared_linear: false,
+                    destructor: None,
+                    is_builtin: true,
+                    is_pub: true,
+                    file_id: FileId::DEFAULT,
+                },
+            );
+            Type::new_struct(id)
+        };
+        let text = register_struct("str");
+        let strbuf = register_struct("StrBuf");
+        pool.set_struct_lang_item(strbuf.as_struct().unwrap(), LangItem::StrBuf);
+        let option = |name: &'static str, payload: Type| {
+            let (id, _) = pool.register_enum(
+                interner.get_or_intern(name),
+                EnumDef {
+                    name: name.into(),
+                    variants: Arc::from([Arc::from("Some"), Arc::from("None")]),
+                    variant_payloads: vec![vec![payload], vec![]],
+                    is_pub: true,
+                    is_non_exhaustive: false,
+                    file_id: FileId::DEFAULT,
+                },
+            );
+            Type::new_enum(id)
+        };
+        let option_strbuf = option("OptionStrBuf", strbuf);
+        let option_i32 = option("OptionI32", Type::I32);
+        let option_i64 = option("OptionI64", Type::I64);
+        let option_u32 = option("OptionU32", Type::U32);
+        let option_u64 = option("OptionU64", Type::U64);
+        let const_u8 = Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::U8));
+        let mut_u8 = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::U8));
+        let n = crate::AirArgMode::Normal;
+        let signatures = [
+            (IntrinsicOperation::PanicNoMessage, vec![], Type::NEVER),
+            (IntrinsicOperation::Panic, vec![(text, n)], Type::NEVER),
+            (
+                IntrinsicOperation::AssertFailed,
+                vec![(Type::BOOL, n)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::AssertWithMessage,
+                vec![(Type::BOOL, n), (text, n)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::BoundsCheck,
+                vec![(Type::BOOL, n)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::DebugI64,
+                vec![(Type::I64, n)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::DebugU64,
+                vec![(Type::U64, n)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::DebugBool,
+                vec![(Type::BOOL, n)],
+                Type::UNIT,
+            ),
+            (IntrinsicOperation::DebugStr, vec![(text, n)], Type::UNIT),
+            (IntrinsicOperation::ReadLine, vec![], option_strbuf),
+            (IntrinsicOperation::ParseI32, vec![(text, n)], option_i32),
+            (IntrinsicOperation::ParseI64, vec![(text, n)], option_i64),
+            (IntrinsicOperation::ParseU32, vec![(text, n)], option_u32),
+            (IntrinsicOperation::ParseU64, vec![(text, n)], option_u64),
+            (IntrinsicOperation::RandomU32, vec![], Type::U32),
+            (IntrinsicOperation::RandomU64, vec![], Type::U64),
+            (
+                IntrinsicOperation::Alloc,
+                vec![(Type::U64, n), (Type::U64, n)],
+                mut_u8,
+            ),
+            (
+                IntrinsicOperation::AllocZeroed,
+                vec![(Type::U64, n), (Type::U64, n)],
+                mut_u8,
+            ),
+            (
+                IntrinsicOperation::Free,
+                vec![(mut_u8, n), (Type::U64, n), (Type::U64, n)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::Realloc,
+                vec![(mut_u8, n), (Type::U64, n), (Type::U64, n), (Type::U64, n)],
+                mut_u8,
+            ),
+            (
+                IntrinsicOperation::Resize,
+                vec![(mut_u8, n), (Type::U64, n), (Type::U64, n), (Type::U64, n)],
+                Type::BOOL,
+            ),
+            (
+                IntrinsicOperation::ByteCopy,
+                vec![(mut_u8, n), (const_u8, n), (Type::U64, n)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::ByteMove,
+                vec![(mut_u8, n), (const_u8, n), (Type::U64, n)],
+                Type::UNIT,
+            ),
+            (
+                IntrinsicOperation::ByteSet,
+                vec![(mut_u8, n), (Type::U8, n), (Type::U64, n)],
+                Type::UNIT,
+            ),
+            (IntrinsicOperation::ArgCount, vec![], Type::U64),
+            (IntrinsicOperation::ArgPtr, vec![(Type::U64, n)], mut_u8),
+            (IntrinsicOperation::ArgLen, vec![(Type::U64, n)], Type::U64),
+            (IntrinsicOperation::EnvCount, vec![], Type::U64),
+            (IntrinsicOperation::EnvPtr, vec![(Type::U64, n)], mut_u8),
+            (IntrinsicOperation::EnvLen, vec![(Type::U64, n)], Type::U64),
+        ];
+        assert_eq!(signatures.len(), EXACT_RUNTIME_MAPPINGS.len());
+        for (index, (operation, args, result)) in signatures.into_iter().enumerate() {
+            assert_eq!(operation, EXACT_RUNTIME_MAPPINGS[index].0);
+            let args = args
+                .into_iter()
+                .map(|(ty, mode)| IntrinsicAirArgument::value(ty, mode))
+                .collect::<Vec<_>>();
+            assert!(
+                operation.validate_call(&pool, &args, result),
+                "canonical runtime call rejected: {operation:?} {args:?} -> {result:?}"
+            );
+            let mut extra = args.clone();
+            extra.push(IntrinsicAirArgument::value(Type::I32, n));
+            assert!(!operation.validate_call(&pool, &extra, result));
+            assert!(!operation.validate_call(&pool, &args, Type::ERROR));
+            if !args.is_empty() {
+                let mut wrong_type = args.clone();
+                wrong_type[0].ty = Type::ERROR;
+                assert!(!operation.validate_call(&pool, &wrong_type, result));
+                let mut wrong_mode = args.clone();
+                wrong_mode[0].mode = crate::AirArgMode::Inout;
+                assert!(!operation.validate_call(&pool, &wrong_mode, result));
+                let short = &args[..args.len() - 1];
+                assert!(!operation.validate_call(&pool, short, result));
+            }
+        }
+    }
+}

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -21,6 +21,7 @@ mod inference;
 mod inst;
 pub mod integer_semantics;
 mod intern_pool;
+mod intrinsic;
 pub mod layout;
 mod module_registry;
 mod param_arena;
@@ -66,6 +67,11 @@ pub use intern_pool::{
     EnumData, EnumDefEntry, FrozenTypeInternPool, MAX_COMPOSITE_TYPES, StructData, StructDefEntry,
     TypeData, TypeInternPool, TypeInternPoolStats, TypeValidationError,
     composite_type_limit_message,
+};
+pub use intrinsic::{
+    IntrinsicAirArgument, IntrinsicAirArgumentSource, IntrinsicOperation, RuntimeAirTypePool,
+    intrinsic_air_argument, intrinsic_air_argument_with_place_lookup, runtime_air_result_type,
+    runtime_air_type,
 };
 pub use layout::{Layout, LayoutKind, PaddingRange, SLOT_BYTES};
 pub use module_registry::ModuleRegistry;

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -354,11 +354,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             self.analyze_read_line_intrinsic(air, name, inst_ref, &args, span, result_expected, ctx)
         } else if name == known.to_string {
             self.analyze_to_string_intrinsic(air, &args, span, ctx)
-        } else if let Some(intrinsic_name_str) = known.get_parse_intrinsic_name(name) {
+        } else if let Some(operation) = known.get_parse_intrinsic_operation(name) {
+            let intrinsic_name_str = operation.expected_spelling();
             self.analyze_parse_intrinsic(
                 air,
                 name,
                 inst_ref,
+                operation,
                 intrinsic_name_str,
                 &args,
                 span,
@@ -382,7 +384,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 air,
                 name,
                 "arg_count",
-                crate::RuntimeCallKind::ArgCount,
+                crate::IntrinsicOperation::ArgCount,
                 &args,
                 span,
             )
@@ -391,7 +393,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 air,
                 name,
                 "env_count",
-                crate::RuntimeCallKind::EnvCount,
+                crate::IntrinsicOperation::EnvCount,
                 &args,
                 span,
             )
@@ -400,7 +402,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 air,
                 name,
                 "arg_len",
-                crate::RuntimeCallKind::ArgLen,
+                crate::IntrinsicOperation::ArgLen,
                 &args,
                 span,
                 ctx,
@@ -410,7 +412,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 air,
                 name,
                 "env_len",
-                crate::RuntimeCallKind::EnvLen,
+                crate::IntrinsicOperation::EnvLen,
                 &args,
                 span,
                 ctx,
@@ -420,7 +422,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 air,
                 name,
                 "arg_ptr",
-                crate::RuntimeCallKind::ArgPtr,
+                crate::IntrinsicOperation::ArgPtr,
                 inst_ref,
                 &args,
                 span,
@@ -431,7 +433,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 air,
                 name,
                 "env_ptr",
-                crate::RuntimeCallKind::EnvPtr,
+                crate::IntrinsicOperation::EnvPtr,
                 inst_ref,
                 &args,
                 span,
@@ -933,15 +935,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             (arg_result.air_ref, Vec::new())
         };
         let intrinsic_ref = air.add_intrinsic(
-            Some(if arg_type == Type::BOOL {
-                crate::RuntimeCallKind::DebugBool
+            if arg_type == Type::BOOL {
+                crate::IntrinsicOperation::DebugBool
             } else if self.is_strbuf(arg_type) || self.is_str_like(arg_type) {
-                crate::RuntimeCallKind::DebugStr
+                crate::IntrinsicOperation::DebugStr
             } else if arg_type.is_signed() {
-                crate::RuntimeCallKind::DebugI64
+                crate::IntrinsicOperation::DebugI64
             } else {
-                crate::RuntimeCallKind::DebugU64
-            }),
+                crate::IntrinsicOperation::DebugU64
+            },
             self.known_symbols().dbg,
             &[arg_ref],
             Type::UNIT,
@@ -1133,7 +1135,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // returns, so it participates in never coercion just like a `-> !`
             // call, `return`, or `break` (spec 3.4:2, 4.13:5b; RUE-512).
             let air_ref = air.add_intrinsic(
-                Some(crate::RuntimeCallKind::PanicNoMessage),
+                crate::IntrinsicOperation::PanicNoMessage,
                 self.known_symbols().panic,
                 &[],
                 Type::NEVER,
@@ -1165,7 +1167,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             (arg_result.air_ref, Vec::new())
         };
         let intrinsic_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::Panic),
+            crate::IntrinsicOperation::Panic,
             self.known_symbols().panic,
             &[arg_ref],
             Type::NEVER,
@@ -1257,11 +1259,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         let intrinsic_ref = air.add_intrinsic(
-            Some(if args.len() > 1 {
-                crate::RuntimeCallKind::AssertWithMessage
+            if args.len() > 1 {
+                crate::IntrinsicOperation::AssertWithMessage
             } else {
-                crate::RuntimeCallKind::AssertFailed
-            }),
+                crate::IntrinsicOperation::AssertFailed
+            },
             self.known_symbols().assert,
             &extra_data,
             Type::UNIT,
@@ -1474,7 +1476,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
 
-        let air_ref = air.add_intrinsic(None, name, &[arg_result.air_ref], target_ty, span)?;
+        let air_ref = air.add_intrinsic(
+            crate::IntrinsicOperation::BitCast,
+            name,
+            &[arg_result.air_ref],
+            target_ty,
+            span,
+        )?;
         Ok(AnalysisResult::new(air_ref, target_ty))
     }
 
@@ -1633,7 +1641,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // The intrinsic lowers to a runtime call whose result codegen packs
         // into this `Option(StrBuf)` enum (discriminant + StrBuf payload).
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::ReadLine),
+            crate::IntrinsicOperation::ReadLine,
             name,
             &[],
             option_ty,
@@ -1746,6 +1754,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         air: &mut Air,
         name: Spur,
         inst_ref: InstRef,
+        operation: crate::IntrinsicOperation,
         intrinsic_name_str: &str,
         args: &[RirCallArg],
         span: Span,
@@ -1781,13 +1790,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
 
-        // Determine the payload integer type based on the intrinsic name.
-        let (payload_type, payload_display) = match intrinsic_name_str {
-            "parse_i32" => (Type::I32, "i32"),
-            "parse_i64" => (Type::I64, "i64"),
-            "parse_u32" => (Type::U32, "u32"),
-            "parse_u64" => (Type::U64, "u64"),
-            _ => unreachable!(),
+        // Determine the payload integer type from the semantic operation chosen
+        // by symbol analysis. The spelling remains diagnostic-only.
+        let (payload_type, payload_display) = match operation {
+            crate::IntrinsicOperation::ParseI32 => (Type::I32, "i32"),
+            crate::IntrinsicOperation::ParseI64 => (Type::I64, "i64"),
+            crate::IntrinsicOperation::ParseU32 => (Type::U32, "u32"),
+            crate::IntrinsicOperation::ParseU64 => (Type::U64, "u64"),
+            _ => unreachable!("non-parse operation passed to parse analysis"),
         };
 
         // The result is `Option(int)`: `Some(n)` on success, `None` on parse
@@ -1816,19 +1826,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         } else {
             (arg_result.air_ref, Vec::new())
         };
-        let intrinsic_ref = air.add_intrinsic(
-            Some(match intrinsic_name_str {
-                "parse_i32" => crate::RuntimeCallKind::ParseI32,
-                "parse_i64" => crate::RuntimeCallKind::ParseI64,
-                "parse_u32" => crate::RuntimeCallKind::ParseU32,
-                "parse_u64" => crate::RuntimeCallKind::ParseU64,
-                _ => unreachable!(),
-            }),
-            name,
-            &[arg_ref],
-            option_ty,
-            span,
-        )?;
+        let intrinsic_ref = air.add_intrinsic(operation, name, &[arg_ref], option_ty, span)?;
         let air_ref =
             self.wrap_value_with_temp_scope(air, intrinsic_ref, option_ty, span, temp_scope)?;
         Ok(AnalysisResult::new(air_ref, option_ty))
@@ -1856,7 +1854,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Create the intrinsic instruction that returns u32
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::RandomU32),
+            crate::IntrinsicOperation::RandomU32,
             name,
             &[],
             Type::U32,
@@ -1887,7 +1885,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Create the intrinsic instruction that returns u64
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::RandomU64),
+            crate::IntrinsicOperation::RandomU64,
             name,
             &[],
             Type::U64,
@@ -1906,7 +1904,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         air: &mut Air,
         name: Spur,
         display: &str,
-        runtime: crate::RuntimeCallKind,
+        operation: crate::IntrinsicOperation,
         args: &[RirCallArg],
         span: Span,
     ) -> CompileResult<AnalysisResult> {
@@ -1920,7 +1918,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         }
-        let air_ref = air.add_intrinsic(Some(runtime), name, &[], Type::U64, span)?;
+        let air_ref = air.add_intrinsic(operation, name, &[], Type::U64, span)?;
         Ok(AnalysisResult::new(air_ref, Type::U64))
     }
 
@@ -1934,7 +1932,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         air: &mut Air,
         name: Spur,
         display: &str,
-        runtime: crate::RuntimeCallKind,
+        operation: crate::IntrinsicOperation,
         args: &[RirCallArg],
         span: Span,
         ctx: &mut AnalysisContext,
@@ -1951,7 +1949,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
         let index = self.analyze_inst(air, args[0].value, ctx)?;
         self.require_process_index_type(display, index.ty, span)?;
-        let air_ref = air.add_intrinsic(Some(runtime), name, &[index.air_ref], Type::U64, span)?;
+        let air_ref = air.add_intrinsic(operation, name, &[index.air_ref], Type::U64, span)?;
         Ok(AnalysisResult::new(air_ref, Type::U64))
     }
 
@@ -1966,7 +1964,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         air: &mut Air,
         name: Spur,
         display: &str,
-        runtime: crate::RuntimeCallKind,
+        operation: crate::IntrinsicOperation,
         inst_ref: InstRef,
         args: &[RirCallArg],
         span: Span,
@@ -1992,7 +1990,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         {
             return Err(self.type_mismatch_error(expected, result_ty, span));
         }
-        let air_ref = air.add_intrinsic(Some(runtime), name, &[index.air_ref], result_ty, span)?;
+        let air_ref = air.add_intrinsic(operation, name, &[index.air_ref], result_ty, span)?;
         Ok(AnalysisResult::new(air_ref, result_ty))
     }
 

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -4385,7 +4385,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             });
             Some(air.add_intrinsic(
-                Some(crate::RuntimeCallKind::BoundsCheck),
+                crate::IntrinsicOperation::BoundsCheck,
                 self.known_symbols().assert,
                 &[lower_bound_ref],
                 Type::UNIT,
@@ -4426,7 +4426,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             span,
         });
         let upper_check_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::BoundsCheck),
+            crate::IntrinsicOperation::BoundsCheck,
             self.known_symbols().assert,
             &[upper_bound_ref],
             Type::UNIT,
@@ -4435,14 +4435,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // element = @ptr_read(@ptr_offset(ptr, index)).
         let off_ref = air.add_intrinsic(
-            None,
+            crate::IntrinsicOperation::PtrOffset,
             self.known_symbols().ptr_offset,
             &[ptr_ref, index_result.air_ref],
             ptr_ty,
             span,
         )?;
         let elem_ref = air.add_intrinsic(
-            None,
+            crate::IntrinsicOperation::PtrRead,
             self.known_symbols().ptr_read,
             &[off_ref],
             elem_ty,
@@ -7335,14 +7335,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // A zero-length slice never dereferences its pointer: every read is
             // guarded by `i < len`, and `len` is 0. Do not form `@raw(arr[0])`
             // for `[T; 0]`; that is not a valid place and underflows in some
-            // codegen paths. Use a conventional null pointer word instead.
-            air.add_intrinsic(
-                None,
-                self.known_symbols().int_to_ptr,
-                &[zero_ref],
-                ptr_ty,
+            // codegen paths. Use a conventional null pointer word with the
+            // slice field's exact const-pointer type. This is compiler-owned
+            // representation data, not the source `@int_to_ptr` operation,
+            // whose single semantic contract remains `u64 -> ptr mut T`.
+            air.add_inst(AirInst {
+                data: AirInstData::Const(0),
+                ty: ptr_ty,
                 span,
-            )?
+            })
         } else {
             // ptr word = @raw(arr[0]) : ptr const T. Build a place read of
             // element 0 and take its address, exactly as source `@raw(arr[0])`
@@ -7358,7 +7359,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ty: arr_elem,
                 span,
             });
-            air.add_intrinsic(None, self.known_symbols().raw, &[elem0_read], ptr_ty, span)?
+            air.add_intrinsic(
+                crate::IntrinsicOperation::Raw,
+                self.known_symbols().raw,
+                &[elem0_read],
+                ptr_ty,
+                span,
+            )?
         };
 
         // len word = N (compile-time array length).

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -95,7 +95,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         // Create the intrinsic call instruction
-        let air_ref = air.add_intrinsic(None, name, &[ptr_result.air_ref], pointee_type, span)?;
+        let air_ref = air.add_intrinsic(
+            if unaligned {
+                crate::IntrinsicOperation::PtrReadUnaligned
+            } else {
+                crate::IntrinsicOperation::PtrRead
+            },
+            name,
+            &[ptr_result.air_ref],
+            pointee_type,
+            span,
+        )?;
         Ok(AnalysisResult::with_continues(
             air_ref,
             pointee_type,
@@ -214,7 +224,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Create the intrinsic call instruction
         let air_ref = air.add_intrinsic(
-            None,
+            if unaligned {
+                crate::IntrinsicOperation::PtrWriteUnaligned
+            } else {
+                crate::IntrinsicOperation::PtrWrite
+            },
             name,
             &[ptr_result.air_ref, value_result.air_ref],
             Type::UNIT,
@@ -280,7 +294,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Create the intrinsic call instruction (returns same pointer type)
         let air_ref = air.add_intrinsic(
-            None,
+            crate::IntrinsicOperation::PtrOffset,
             name,
             &[ptr_result.air_ref, offset_result.air_ref],
             ptr_type,
@@ -330,7 +344,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         // Create the intrinsic call instruction (returns u64)
-        let air_ref = air.add_intrinsic(None, name, &[ptr_result.air_ref], Type::U64, span)?;
+        let air_ref = air.add_intrinsic(
+            crate::IntrinsicOperation::PtrToInt,
+            name,
+            &[ptr_result.air_ref],
+            Type::U64,
+            span,
+        )?;
         Ok(AnalysisResult::with_continues(
             air_ref,
             Type::U64,
@@ -405,7 +425,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         // Create the intrinsic call instruction
-        let air_ref = air.add_intrinsic(None, name, &[addr_result.air_ref], result_type, span)?;
+        let air_ref = air.add_intrinsic(
+            crate::IntrinsicOperation::IntToPtr,
+            name,
+            &[addr_result.air_ref],
+            result_type,
+            span,
+        )?;
         Ok(AnalysisResult::with_continues(
             air_ref,
             result_type,
@@ -458,11 +484,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
         let zeroed = name == self.known_symbols().alloc_zeroed;
         let air_ref = air.add_intrinsic(
-            Some(if zeroed {
-                crate::RuntimeCallKind::AllocZeroed
+            if zeroed {
+                crate::IntrinsicOperation::AllocZeroed
             } else {
-                crate::RuntimeCallKind::Alloc
-            }),
+                crate::IntrinsicOperation::Alloc
+            },
             name,
             &[size.air_ref, align.air_ref],
             result_ty,
@@ -517,7 +543,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         self.require_intrinsic_type("realloc", new_size.ty, Type::U64, span)?;
         self.require_power_of_two_align("realloc", args[2].value, span, ctx)?;
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::Realloc),
+            crate::IntrinsicOperation::Realloc,
             name,
             &[
                 ptr.air_ref,
@@ -581,7 +607,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         self.require_intrinsic_type("resize", new_size.ty, Type::U64, span)?;
         self.require_power_of_two_align("resize", args[2].value, span, ctx)?;
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::Resize),
+            crate::IntrinsicOperation::Resize,
             name,
             &[
                 ptr.air_ref,
@@ -634,7 +660,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         self.require_intrinsic_type("free", align.ty, Type::U64, span)?;
         self.require_power_of_two_align("free", args[2].value, span, ctx)?;
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::Free),
+            crate::IntrinsicOperation::Free,
             name,
             &[ptr.air_ref, size.air_ref, align.air_ref],
             Type::UNIT,
@@ -715,11 +741,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         self.require_intrinsic_type(&intrinsic, size.ty, Type::U64, span)?;
         let overlapping = name == self.known_symbols().byte_move;
         let air_ref = air.add_intrinsic(
-            Some(if overlapping {
-                crate::RuntimeCallKind::ByteMove
+            if overlapping {
+                crate::IntrinsicOperation::ByteMove
             } else {
-                crate::RuntimeCallKind::ByteCopy
-            }),
+                crate::IntrinsicOperation::ByteCopy
+            },
             name,
             &[dst.air_ref, src.air_ref, size.air_ref],
             Type::UNIT,
@@ -767,7 +793,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         )?;
         self.require_intrinsic_type("byte_set", size.ty, Type::U64, span)?;
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::ByteSet),
+            crate::IntrinsicOperation::ByteSet,
             name,
             &[dst.air_ref, byte.air_ref, size.air_ref],
             Type::UNIT,
@@ -928,7 +954,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // @raw/@raw_mut/@field_ptr in the AIR; codegen lowers all three the
         // same way (address of the operand place).
         let name = result_name;
-        let air_ref = air.add_intrinsic(None, name, &[arg_result.air_ref], result_type, span)?;
+        let operation = if result_name == self.known_symbols().field_ptr {
+            crate::IntrinsicOperation::FieldPtr
+        } else if is_mut {
+            crate::IntrinsicOperation::RawMut
+        } else {
+            crate::IntrinsicOperation::Raw
+        };
+        let air_ref =
+            air.add_intrinsic(operation, name, &[arg_result.air_ref], result_type, span)?;
         Ok(AnalysisResult::with_continues(
             air_ref,
             result_type,
@@ -1040,7 +1074,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         // Create the intrinsic call instruction
-        let air_ref = air.add_intrinsic(None, name, &arg_refs, Type::I64, span)?;
+        let air_ref = air.add_intrinsic(
+            crate::IntrinsicOperation::Syscall,
+            name,
+            &arg_refs,
+            Type::I64,
+            span,
+        )?;
         Ok(AnalysisResult::with_continues(
             air_ref,
             Type::I64,

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -271,18 +271,17 @@ impl KnownSymbols {
         })
     }
 
-    /// Check if a symbol matches any of the parse intrinsics.
-    ///
-    /// Returns the parse intrinsic name as a string if it matches, or None.
-    pub fn get_parse_intrinsic_name(&self, sym: Spur) -> Option<&'static str> {
+    /// Return the semantic operation selected by a parse intrinsic symbol.
+    /// Diagnostic spelling is derived from the resulting typed operation.
+    pub fn get_parse_intrinsic_operation(&self, sym: Spur) -> Option<crate::IntrinsicOperation> {
         if sym == self.parse_i32 {
-            Some("parse_i32")
+            Some(crate::IntrinsicOperation::ParseI32)
         } else if sym == self.parse_i64 {
-            Some("parse_i64")
+            Some(crate::IntrinsicOperation::ParseI64)
         } else if sym == self.parse_u32 {
-            Some("parse_u32")
+            Some(crate::IntrinsicOperation::ParseU32)
         } else if sym == self.parse_u64 {
-            Some("parse_u64")
+            Some(crate::IntrinsicOperation::ParseU64)
         } else {
             None
         }
@@ -369,27 +368,38 @@ mod tests {
     }
 
     #[test]
-    fn get_parse_intrinsic_name() {
+    fn parse_intrinsic_classifier_has_exact_spelling_to_operation_table() {
         let interner = ThreadedRodeo::new();
         let known = KnownSymbols::new(&interner);
 
-        assert_eq!(
-            known.get_parse_intrinsic_name(known.parse_i32),
-            Some("parse_i32")
-        );
-        assert_eq!(
-            known.get_parse_intrinsic_name(known.parse_i64),
-            Some("parse_i64")
-        );
-        assert_eq!(
-            known.get_parse_intrinsic_name(known.parse_u32),
-            Some("parse_u32")
-        );
-        assert_eq!(
-            known.get_parse_intrinsic_name(known.parse_u64),
-            Some("parse_u64")
-        );
-        assert_eq!(known.get_parse_intrinsic_name(known.dbg), None);
+        let exact = [
+            (
+                "parse_i32",
+                known.parse_i32,
+                crate::IntrinsicOperation::ParseI32,
+            ),
+            (
+                "parse_i64",
+                known.parse_i64,
+                crate::IntrinsicOperation::ParseI64,
+            ),
+            (
+                "parse_u32",
+                known.parse_u32,
+                crate::IntrinsicOperation::ParseU32,
+            ),
+            (
+                "parse_u64",
+                known.parse_u64,
+                crate::IntrinsicOperation::ParseU64,
+            ),
+        ];
+        for (spelling, symbol, operation) in exact {
+            assert_eq!(interner.resolve(&symbol), spelling);
+            assert_eq!(known.get_parse_intrinsic_operation(symbol), Some(operation));
+            assert_eq!(operation.expected_spelling(), spelling);
+        }
+        assert_eq!(known.get_parse_intrinsic_operation(known.dbg), None);
     }
 
     #[test]

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -408,11 +408,11 @@ pub(crate) fn export_body<H: SemanticBodyExportHost>(
             },
             AirInstData::CallGeneric { .. } => return Err(F::UnsupportedGenericCall),
             AirInstData::Intrinsic {
-                runtime,
+                operation,
                 name,
                 args,
             } => SemanticBodyInstData::Intrinsic {
-                runtime: *runtime,
+                operation: *operation,
                 name: Arc::from(host.resolve_publication_symbol(name)),
                 args: intrinsic_args(args)?,
             },

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -329,7 +329,7 @@ pub enum SemanticBodyInstData<K, M> {
     },
     CallGeneric,
     Intrinsic {
-        runtime: Option<crate::RuntimeCallKind>,
+        operation: crate::IntrinsicOperation,
         name: Arc<str>,
         args: Arc<[SemanticBodyCallArg]>,
     },
@@ -673,11 +673,11 @@ impl<K, M> SemanticBodyInstData<K, M> {
             },
             D::CallGeneric => D::CallGeneric,
             D::Intrinsic {
-                runtime,
+                operation,
                 name,
                 args,
             } => D::Intrinsic {
-                runtime: *runtime,
+                operation: *operation,
                 name: name.clone(),
                 args: args.clone(),
             },
@@ -1182,6 +1182,7 @@ pub enum SemanticBodyImportFailure {
     InvalidStringReference,
     InvalidSourceOrder,
     InvalidParameterModes,
+    InvalidIntrinsicOperation,
     InvalidParameterDrop,
     InvalidBorrowSlot,
     InvalidAnchor,
@@ -1316,8 +1317,8 @@ mod schema_tests {
             },
             D::CallGeneric,
             D::Intrinsic {
-                runtime: None,
-                name: Arc::from("intrinsic"),
+                operation: crate::IntrinsicOperation::AssertFailed,
+                name: Arc::from("assert"),
                 args: call_args(&[1]),
             },
             D::Param { index: 0 },
@@ -1556,6 +1557,48 @@ mod schema_tests {
                 ..
             } if key == "mapped:accessor"
         ));
+    }
+
+    #[test]
+    fn every_intrinsic_operation_is_durable_and_survives_identity_remapping() {
+        for operation in crate::IntrinsicOperation::ALL {
+            let durable = SemanticBodyInstData::<&str, &str>::Intrinsic {
+                operation,
+                name: Arc::from(operation.expected_spelling()),
+                args: call_args(&[1]),
+            };
+            let remapped = durable
+                .try_map_keys(&|key| Ok::<_, ()>(format!("mapped:{key}")), &|module| {
+                    Ok::<_, ()>(format!("mapped:{module}"))
+                })
+                .unwrap();
+            let SemanticBodyInstData::Intrinsic {
+                operation: remapped_operation,
+                name,
+                args,
+            } = remapped
+            else {
+                panic!("intrinsic remapping changed the durable instruction kind")
+            };
+            assert_eq!(remapped_operation, operation);
+            assert_eq!(name.as_ref(), operation.expected_spelling());
+            assert_eq!(args.as_ref(), call_args(&[1]).as_ref());
+        }
+
+        let assert = SemanticBodyInstData::<(), ()>::Intrinsic {
+            operation: crate::IntrinsicOperation::AssertFailed,
+            name: Arc::from("assert"),
+            args: call_args(&[1]),
+        };
+        let bounds = SemanticBodyInstData::<(), ()>::Intrinsic {
+            operation: crate::IntrinsicOperation::BoundsCheck,
+            name: Arc::from("assert"),
+            args: call_args(&[1]),
+        };
+        assert_ne!(
+            assert, bounds,
+            "retained body equality must include the typed semantic operation even when name and shape agree"
+        );
     }
 
     #[test]

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -985,17 +985,40 @@ where
                 }
                 SemanticBodyInstData::CallGeneric => return Err(F::UnsupportedGenericCall),
                 SemanticBodyInstData::Intrinsic {
-                    runtime,
+                    operation,
                     name,
                     args,
                 } => {
-                    let name = intern(name.as_ref())?;
+                    let source_name = name.as_ref();
                     if args.iter().any(|arg| arg.mode != crate::AirArgMode::Normal) {
                         return Err(F::InvalidParameterModes);
                     }
                     let values = args.iter().map(|arg| arg.value).collect::<Vec<_>>();
                     let values = refs(&values, current)?;
-                    air.add_intrinsic(*runtime, name, &values, ty, span)?;
+                    if source_name != operation.expected_spelling() {
+                        return Err(F::InvalidIntrinsicOperation);
+                    }
+                    let arguments = values
+                        .iter()
+                        .map(|value| {
+                            crate::intrinsic_air_argument_with_place_lookup(
+                                &air,
+                                *value,
+                                crate::AirArgMode::Normal,
+                                |place| {
+                                    matches!(
+                                        body.places[place.as_u32() as usize].projections.last(),
+                                        Some(SemanticBodyProjection::Field { .. })
+                                    )
+                                },
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    if !operation.validate_call(type_pool, &arguments, ty) {
+                        return Err(F::InvalidIntrinsicOperation);
+                    }
+                    let name = intern(source_name)?;
+                    air.add_intrinsic(*operation, name, &values, ty, span)?;
                     continue;
                 }
                 SemanticBodyInstData::Param { index } => AirInstData::Param { index: *index },
@@ -3213,9 +3236,13 @@ mod tests {
         let mut input = body(vec![
             D::Const(42),
             D::Intrinsic {
-                runtime: None,
-                name: Arc::from("compiler-intrinsic"),
-                args: Arc::new([]),
+                operation: crate::IntrinsicOperation::BitCast,
+                name: Arc::from("bitCast"),
+                args: vec![crate::SemanticBodyCallArg {
+                    value: 0,
+                    mode: crate::AirArgMode::Normal,
+                }]
+                .into(),
             },
             D::Ret(Some(1)),
         ]);
@@ -3261,7 +3288,7 @@ mod tests {
         assert_eq!(output.body_span.file_id, FileId::new(7));
         assert!(output.completeness.is_complete());
         assert_eq!(output.interner.get("main"), output.interner.get("main"));
-        assert!(output.interner.get("compiler-intrinsic").is_some());
+        assert!(output.interner.get("bitCast").is_some());
         assert_eq!(output.num_locals, 3);
         assert_eq!(output.num_param_slots, 2);
         assert_eq!(output.param_modes.by_ref(), [true, false]);
@@ -3984,10 +4011,15 @@ mod tests {
         assert_eq!(after_failure.interner().len(), baseline_symbols);
 
         let invalid = body(vec![
+            D::Const(0),
             D::Intrinsic {
-                runtime: None,
-                name: Arc::from("failed_import_symbol"),
-                args: Arc::new([]),
+                operation: crate::IntrinsicOperation::BitCast,
+                name: Arc::from("bitCast"),
+                args: vec![crate::SemanticBodyCallArg {
+                    value: 0,
+                    mode: crate::AirArgMode::Normal,
+                }]
+                .into(),
             },
             D::Add(3, 0),
         ]);
@@ -4001,11 +4033,18 @@ mod tests {
             "preflight must not publish an intrinsic symbol before a later failure"
         );
 
-        let valid = body(vec![D::Intrinsic {
-            runtime: None,
-            name: Arc::from("successful_import_symbol"),
-            args: Arc::new([]),
-        }]);
+        let valid = body(vec![
+            D::Const(0),
+            D::Intrinsic {
+                operation: crate::IntrinsicOperation::BitCast,
+                name: Arc::from("bitCast"),
+                args: vec![crate::SemanticBodyCallArg {
+                    value: 0,
+                    mode: crate::AirArgMode::Normal,
+                }]
+                .into(),
+            },
+        ]);
         let after_failure_body = after_failure
             .import_body(&valid, Span::with_file(FileId::DEFAULT, 0, 100))
             .unwrap();
@@ -4015,13 +4054,13 @@ mod tests {
         let crate::AirInstData::Intrinsic {
             name: after_failure_name,
             ..
-        } = after_failure_body.air.instructions()[0].data
+        } = after_failure_body.air.instructions()[1].data
         else {
             panic!("expected reconstructed intrinsic")
         };
         let crate::AirInstData::Intrinsic {
             name: fresh_name, ..
-        } = fresh_body.air.instructions()[0].data
+        } = fresh_body.air.instructions()[1].data
         else {
             panic!("expected reconstructed intrinsic")
         };
@@ -4031,6 +4070,532 @@ mod tests {
             format!("{:?}", fresh_body.air),
             "a failed import must not perturb any packed AIR word"
         );
+    }
+
+    #[test]
+    fn intrinsic_counterfeit_matrix_rolls_back_before_symbols_types_or_air_are_published() {
+        use crate::{
+            SemanticBodyImportFailure as F, SemanticBodyInstData as D, SemanticImportType,
+        };
+        let after_failures = Epoch::new(vec![], vec![], vec![]).unwrap();
+        let fresh = Epoch::new(vec![], vec![], vec![]).unwrap();
+        let valid = body(vec![
+            D::Const(0),
+            D::Intrinsic {
+                operation: crate::IntrinsicOperation::BitCast,
+                name: Arc::from("bitCast"),
+                args: vec![crate::SemanticBodyCallArg {
+                    value: 0,
+                    mode: crate::AirArgMode::Normal,
+                }]
+                .into(),
+            },
+        ]);
+
+        let mutate =
+            |mut body: crate::SemanticBody<&'static str, &'static str>,
+             edit: fn(&mut [crate::SemanticBodyInst<&'static str, &'static str>])| {
+                let mut instructions = body.instructions.to_vec();
+                edit(&mut instructions);
+                body.instructions = instructions.into();
+                body
+            };
+        let counterfeits = [
+            (
+                "operation",
+                mutate(valid.clone(), |instructions| {
+                    let D::Intrinsic { operation, .. } = &mut instructions[1].data else {
+                        unreachable!()
+                    };
+                    *operation = crate::IntrinsicOperation::PtrRead;
+                }),
+                F::InvalidIntrinsicOperation,
+            ),
+            (
+                "diagnostic name",
+                mutate(valid.clone(), |instructions| {
+                    let D::Intrinsic { name, .. } = &mut instructions[1].data else {
+                        unreachable!()
+                    };
+                    *name = Arc::from("counterfeit");
+                }),
+                F::InvalidIntrinsicOperation,
+            ),
+            (
+                "missing argument",
+                mutate(valid.clone(), |instructions| {
+                    let D::Intrinsic { args, .. } = &mut instructions[1].data else {
+                        unreachable!()
+                    };
+                    *args = Arc::new([]);
+                }),
+                F::InvalidIntrinsicOperation,
+            ),
+            (
+                "extra argument",
+                mutate(valid.clone(), |instructions| {
+                    let D::Intrinsic { args, .. } = &mut instructions[1].data else {
+                        unreachable!()
+                    };
+                    *args = vec![
+                        crate::SemanticBodyCallArg {
+                            value: 0,
+                            mode: crate::AirArgMode::Normal,
+                        },
+                        crate::SemanticBodyCallArg {
+                            value: 0,
+                            mode: crate::AirArgMode::Normal,
+                        },
+                    ]
+                    .into();
+                }),
+                F::InvalidIntrinsicOperation,
+            ),
+            (
+                "argument mode",
+                mutate(valid.clone(), |instructions| {
+                    let D::Intrinsic { args, .. } = &mut instructions[1].data else {
+                        unreachable!()
+                    };
+                    *args = vec![crate::SemanticBodyCallArg {
+                        value: 0,
+                        mode: crate::AirArgMode::Borrow,
+                    }]
+                    .into();
+                }),
+                F::InvalidParameterModes,
+            ),
+            (
+                "operand type",
+                mutate(valid.clone(), |instructions| {
+                    instructions[0].ty = SemanticImportType::U64;
+                }),
+                F::InvalidIntrinsicOperation,
+            ),
+            (
+                "result type",
+                mutate(valid.clone(), |instructions| {
+                    instructions[1].ty = SemanticImportType::U64;
+                }),
+                F::InvalidIntrinsicOperation,
+            ),
+        ];
+
+        let initial_symbols = after_failures.interner().len();
+        let initial_types = after_failures.type_pool().stats();
+        for (counterfeit, body, expected) in counterfeits {
+            let result = after_failures
+                .import_body(&body, Span::with_file(FileId::DEFAULT, 0, 100))
+                .expect_err(counterfeit);
+            assert_eq!(result, expected, "counterfeit {counterfeit}");
+            assert_eq!(
+                after_failures.interner().len(),
+                initial_symbols,
+                "counterfeit {counterfeit} published a diagnostic name"
+            );
+            assert_eq!(
+                after_failures.type_pool().stats(),
+                initial_types,
+                "counterfeit {counterfeit} published a type"
+            );
+        }
+
+        let after_failures_body = after_failures
+            .import_body(&valid, Span::with_file(FileId::DEFAULT, 0, 100))
+            .unwrap();
+        let fresh_body = fresh
+            .import_body(&valid, Span::with_file(FileId::DEFAULT, 0, 100))
+            .unwrap();
+        assert_eq!(
+            format!("{:?}", after_failures_body.air),
+            format!("{:?}", fresh_body.air)
+        );
+        assert_eq!(
+            after_failures.interner().get("bitCast"),
+            fresh.interner().get("bitCast")
+        );
+    }
+
+    #[test]
+    fn address_taking_intrinsics_validate_durable_place_provenance_before_publication() {
+        use crate::{
+            AirArgMode, AirPlaceBase, IntrinsicOperation, NominalInstanceKey, SemanticBodyCallArg,
+            SemanticBodyImportFailure as F, SemanticBodyInstData as D, SemanticBodyPlace,
+            SemanticBodyProjection,
+        };
+
+        let epoch = Epoch::new(
+            vec![nominal(
+                "record",
+                "Record",
+                SemanticImportNominalKind::Struct,
+            )],
+            vec![],
+            vec![],
+        )
+        .unwrap();
+        epoch
+            .complete_struct(
+                &"record",
+                &[
+                    (Arc::from("field"), ImportType::I32),
+                    (Arc::from("bottom"), ImportType::Never),
+                ],
+                false,
+                false,
+                false,
+            )
+            .unwrap();
+
+        let intrinsic_body = |source: D<&'static str, &'static str>,
+                              source_ty: ImportType,
+                              operation: IntrinsicOperation,
+                              result_ty: ImportType| {
+            let spelling = operation.expected_spelling();
+            let mut input = body(vec![
+                source,
+                D::Intrinsic {
+                    operation,
+                    name: Arc::from(spelling),
+                    args: vec![SemanticBodyCallArg {
+                        value: 0,
+                        mode: AirArgMode::Normal,
+                    }]
+                    .into(),
+                },
+            ]);
+            input.return_type = result_ty.clone();
+            let instructions = Arc::make_mut(&mut input.instructions);
+            instructions[0].ty = source_ty;
+            instructions[1].ty = result_ty;
+            input
+        };
+        let local = |mut input: crate::SemanticBody<&'static str, &'static str>| {
+            input.num_locals = 1;
+            input
+        };
+        let param = |mut input: crate::SemanticBody<&'static str, &'static str>| {
+            input.num_param_slots = 1;
+            input.param_by_ref = Arc::from([false]);
+            input.param_writable = Arc::from([true]);
+            input
+        };
+        let bare_place = |mut input: crate::SemanticBody<&'static str, &'static str>| {
+            input.num_locals = 1;
+            input.places = Arc::from([SemanticBodyPlace {
+                base: AirPlaceBase::Local(0),
+                base_type: ImportType::I32,
+                projections: Arc::new([]),
+            }]);
+            input
+        };
+        let field_place = |mut input: crate::SemanticBody<&'static str, &'static str>| {
+            input.num_locals = 1;
+            input.places = Arc::from([SemanticBodyPlace {
+                base: AirPlaceBase::Local(0),
+                base_type: ImportType::Nominal("record"),
+                projections: Arc::from([SemanticBodyProjection::Field {
+                    struct_key: NominalInstanceKey::Named("record"),
+                    field_index: 0,
+                }]),
+            }]);
+            input
+        };
+        let bottom_place = |mut input: crate::SemanticBody<&'static str, &'static str>| {
+            input.num_locals = 1;
+            input.places = Arc::from([SemanticBodyPlace {
+                base: AirPlaceBase::Local(0),
+                base_type: ImportType::Never,
+                projections: Arc::new([]),
+            }]);
+            input
+        };
+        let bottom_field_place = |mut input: crate::SemanticBody<&'static str, &'static str>| {
+            input.num_locals = 1;
+            input.places = Arc::from([SemanticBodyPlace {
+                base: AirPlaceBase::Local(0),
+                base_type: ImportType::Nominal("record"),
+                projections: Arc::from([SemanticBodyProjection::Field {
+                    struct_key: NominalInstanceKey::Named("record"),
+                    field_index: 1,
+                }]),
+            }]);
+            input
+        };
+        let ptr_const_i32 = ImportType::PtrConst(Arc::new(ImportType::I32));
+        let ptr_mut_i32 = ImportType::PtrMut(Arc::new(ImportType::I32));
+        let ptr_const_never = ImportType::PtrConst(Arc::new(ImportType::Never));
+        let ptr_mut_never = ImportType::PtrMut(Arc::new(ImportType::Never));
+
+        let invalid = [
+            (
+                "const to raw",
+                intrinsic_body(
+                    D::Const(0),
+                    ImportType::I32,
+                    IntrinsicOperation::Raw,
+                    ptr_const_i32.clone(),
+                ),
+            ),
+            (
+                "const to raw_mut",
+                intrinsic_body(
+                    D::Const(0),
+                    ImportType::I32,
+                    IntrinsicOperation::RawMut,
+                    ptr_mut_i32.clone(),
+                ),
+            ),
+            (
+                "load to field_ptr",
+                local(intrinsic_body(
+                    D::Load { slot: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::FieldPtr,
+                    ptr_mut_i32.clone(),
+                )),
+            ),
+            (
+                "param to field_ptr",
+                param(intrinsic_body(
+                    D::Param { index: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::FieldPtr,
+                    ptr_mut_i32.clone(),
+                )),
+            ),
+            (
+                "non-field place to field_ptr",
+                bare_place(intrinsic_body(
+                    D::PlaceRead { place: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::FieldPtr,
+                    ptr_mut_i32.clone(),
+                )),
+            ),
+        ];
+        let initial_symbols = epoch.interner().len();
+        let initial_types = epoch.type_pool().stats();
+        for (label, input) in invalid {
+            assert_eq!(
+                epoch
+                    .import_body(&input, Span::with_file(FileId::DEFAULT, 0, 100))
+                    .expect_err(label),
+                F::InvalidIntrinsicOperation,
+                "counterfeit {label}"
+            );
+            assert_eq!(epoch.interner().len(), initial_symbols, "{label} symbols");
+            assert_eq!(epoch.type_pool().stats(), initial_types, "{label} types");
+        }
+
+        let accepted = [
+            (
+                "load to raw",
+                local(intrinsic_body(
+                    D::Load { slot: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::Raw,
+                    ptr_const_i32.clone(),
+                )),
+            ),
+            (
+                "param to raw",
+                param(intrinsic_body(
+                    D::Param { index: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::Raw,
+                    ptr_const_i32.clone(),
+                )),
+            ),
+            (
+                "place to raw",
+                bare_place(intrinsic_body(
+                    D::PlaceRead { place: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::Raw,
+                    ptr_const_i32.clone(),
+                )),
+            ),
+            (
+                "bottom place to raw",
+                bottom_place(intrinsic_body(
+                    D::PlaceRead { place: 0 },
+                    ImportType::Never,
+                    IntrinsicOperation::Raw,
+                    ptr_const_never,
+                )),
+            ),
+            (
+                "load to raw_mut",
+                local(intrinsic_body(
+                    D::Load { slot: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::RawMut,
+                    ptr_mut_i32.clone(),
+                )),
+            ),
+            (
+                "param to raw_mut",
+                param(intrinsic_body(
+                    D::Param { index: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::RawMut,
+                    ptr_mut_i32.clone(),
+                )),
+            ),
+            (
+                "place to raw_mut",
+                bare_place(intrinsic_body(
+                    D::PlaceRead { place: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::RawMut,
+                    ptr_mut_i32.clone(),
+                )),
+            ),
+            (
+                "terminal field to field_ptr",
+                field_place(intrinsic_body(
+                    D::PlaceRead { place: 0 },
+                    ImportType::I32,
+                    IntrinsicOperation::FieldPtr,
+                    ptr_mut_i32,
+                )),
+            ),
+            (
+                "terminal bottom field to field_ptr",
+                bottom_field_place(intrinsic_body(
+                    D::PlaceRead { place: 0 },
+                    ImportType::Never,
+                    IntrinsicOperation::FieldPtr,
+                    ptr_mut_never,
+                )),
+            ),
+        ];
+        for (label, input) in accepted {
+            epoch
+                .import_body(&input, Span::with_file(FileId::DEFAULT, 0, 100))
+                .unwrap_or_else(|error| panic!("canonical {label} rejected: {error:?}"));
+        }
+    }
+
+    #[test]
+    fn runtime_option_result_counterfeits_roll_back_before_publication() {
+        use crate::{
+            IntrinsicOperation, SemanticBodyImportFailure as F, SemanticBodyInstData as D,
+        };
+
+        let shapes = [
+            ("valid", "ValidOption"),
+            ("payload_none_extra", "PayloadNoneExtra"),
+            ("payload_none", "PayloadNone"),
+            ("extra", "ExtraOption"),
+            ("duplicate", "DuplicateOption"),
+            ("wide_some", "WideSomeOption"),
+        ];
+        let epoch = Epoch::new(
+            shapes
+                .iter()
+                .map(|(key, name)| nominal(key, name, SemanticImportNominalKind::Enum))
+                .collect(),
+            vec![],
+            vec![],
+        )
+        .unwrap();
+        let variants = |values: &[(&'static str, &[ImportType])]| {
+            values
+                .iter()
+                .map(|(name, payload)| (Arc::from(*name), Arc::from(*payload)))
+                .collect::<Vec<_>>()
+        };
+        epoch
+            .complete_enum(
+                &"valid",
+                &variants(&[("Some", &[ImportType::I32]), ("None", &[])]),
+            )
+            .unwrap();
+        epoch
+            .complete_enum(
+                &"payload_none_extra",
+                &variants(&[
+                    ("Some", &[ImportType::I32]),
+                    ("None", &[ImportType::I64, ImportType::I64]),
+                    ("Extra", &[]),
+                ]),
+            )
+            .unwrap();
+        epoch
+            .complete_enum(
+                &"payload_none",
+                &variants(&[("Some", &[ImportType::I32]), ("None", &[ImportType::I64])]),
+            )
+            .unwrap();
+        epoch
+            .complete_enum(
+                &"extra",
+                &variants(&[("Some", &[ImportType::I32]), ("None", &[]), ("Extra", &[])]),
+            )
+            .unwrap();
+        epoch
+            .complete_enum(
+                &"duplicate",
+                &variants(&[("Some", &[ImportType::I32]), ("Some", &[])]),
+            )
+            .unwrap();
+        epoch
+            .complete_enum(
+                &"wide_some",
+                &variants(&[("Some", &[ImportType::I32, ImportType::I32]), ("None", &[])]),
+            )
+            .unwrap();
+
+        let parse_i32 = |key: &'static str| {
+            let result = ImportType::Nominal(key);
+            let text = ImportType::BuiltinNominal {
+                name: Arc::from("str"),
+                kind: SemanticImportNominalKind::Struct,
+            };
+            let mut input = body(vec![
+                D::StringConst(0),
+                D::Intrinsic {
+                    operation: IntrinsicOperation::ParseI32,
+                    name: Arc::from("parse_i32"),
+                    args: Arc::from([crate::SemanticBodyCallArg {
+                        value: 0,
+                        mode: crate::AirArgMode::Normal,
+                    }]),
+                },
+            ]);
+            input.return_type = result.clone();
+            let instructions = Arc::make_mut(&mut input.instructions);
+            instructions[0].ty = text;
+            instructions[1].ty = result;
+            input.strings = Arc::from([Arc::from("0")]);
+            input
+        };
+        let initial_symbols = epoch.interner().len();
+        let initial_types = epoch.type_pool().stats();
+        for key in [
+            "payload_none_extra",
+            "payload_none",
+            "extra",
+            "duplicate",
+            "wide_some",
+        ] {
+            assert_eq!(
+                epoch
+                    .import_body(&parse_i32(key), Span::with_file(FileId::DEFAULT, 0, 100),)
+                    .expect_err(key),
+                F::InvalidIntrinsicOperation
+            );
+            assert_eq!(epoch.interner().len(), initial_symbols, "{key} symbols");
+            assert_eq!(epoch.type_pool().stats(), initial_types, "{key} types");
+        }
+        epoch
+            .import_body(
+                &parse_i32("valid"),
+                Span::with_file(FileId::DEFAULT, 0, 100),
+            )
+            .expect("exact Option body must still import after counterfeits");
     }
 
     #[test]

--- a/crates/rue-cfg/src/api_inventory.rs
+++ b/crates/rue-cfg/src/api_inventory.rs
@@ -210,3 +210,30 @@ fn validated_cfg_consuming_editor_conversion_does_not_copy_payloads() {
     assert!(conversion.contains("self.0"));
     assert!(!conversion.contains("clone("));
 }
+
+#[test]
+fn cfg_intrinsics_revalidate_and_preserve_the_semantic_operation() {
+    let build = include_str!("build.rs");
+    let production = build
+        .split("\n#[cfg(test)]\nmod ")
+        .next()
+        .expect("CFG production prefix");
+    assert_eq!(
+        production.matches("operation.validate_call(").count(),
+        1,
+        "CFG construction must have one shared intrinsic call-shape defense"
+    );
+    assert!(production.contains("operation: *operation"));
+    for forbidden in [
+        "expected_spelling",
+        "resolve_intrinsic",
+        "intrinsic_operation_from_name",
+        "match self.interner.resolve(name)",
+        "unsupported intrinsic",
+    ] {
+        assert!(
+            !production.contains(forbidden),
+            "CFG construction regained intrinsic name dispatch or fallback: {forbidden}"
+        );
+    }
+}

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -269,7 +269,6 @@ pub struct CfgBuilder<'a> {
     /// Canonical pool for struct, enum, array, and pointer definitions.
     type_pool: &'a FrozenTypeInternPool,
     /// Interner for resolving symbols to strings
-    interner: &'a ThreadedRodeo,
     /// Compiler-owned projection of legacy live callable names to canonical
     /// machine symbols. Cleanup lowering consumes this same authority as AIR.
     source_symbol_resolver: Box<dyn Fn(&str) -> Option<Spur> + 'a>,
@@ -451,85 +450,11 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn runtime_air_type(&self, ty: Type) -> Option<rue_air::RuntimeAirType> {
-        use rue_air::RuntimeAirType as R;
-
-        if ty == Type::UNIT {
-            return Some(R::Unit);
-        }
-        if ty == Type::I64 {
-            return Some(R::I64);
-        }
-        if ty == Type::U64 {
-            return Some(R::U64);
-        }
-        if ty == Type::U32 {
-            return Some(R::U32);
-        }
-        if ty == Type::BOOL {
-            return Some(R::Bool);
-        }
-        if ty == Type::NEVER {
-            return Some(R::Never);
-        }
-        if ty.is_signed() {
-            return Some(R::SignedInteger);
-        }
-        if ty.is_unsigned() {
-            return Some(R::UnsignedInteger);
-        }
-        if let TypeKind::Struct(struct_id) = ty.kind() {
-            let name: &str = &self.type_pool.struct_def(struct_id).name;
-            if self.type_pool.is_strbuf(struct_id) || rue_air::is_string_view_struct_name(name) {
-                return Some(R::Text);
-            }
-        }
-        if let Some(ptr) = ty.as_ptr_const()
-            && self.type_pool.ptr_const_def(ptr) == Type::U8
-        {
-            return Some(R::ConstBytePointer);
-        }
-        if let Some(ptr) = ty.as_ptr_mut() {
-            return Some(if self.type_pool.ptr_mut_def(ptr) == Type::U8 {
-                R::MutBytePointer
-            } else {
-                R::MutPointer
-            });
-        }
-        None
+        rue_air::runtime_air_type(self.type_pool, ty)
     }
 
     fn runtime_air_result_type(&self, ty: Type) -> Option<rue_air::RuntimeAirType> {
-        use rue_air::RuntimeAirType as R;
-
-        if ty == Type::U8 {
-            return Some(R::U8);
-        }
-        if let TypeKind::Struct(struct_id) = ty.kind()
-            && self.type_pool.is_strbuf(struct_id)
-        {
-            return Some(R::StrBuf);
-        }
-        if let TypeKind::Enum(enum_id) = ty.kind() {
-            let definition = self.type_pool.enum_def(enum_id);
-            let some = definition.find_variant("Some")?;
-            definition.find_variant("None")?;
-            let [payload] = definition.variant_payload(some) else {
-                return None;
-            };
-            if let TypeKind::Struct(struct_id) = payload.kind()
-                && self.type_pool.is_strbuf(struct_id)
-            {
-                return Some(R::OptionStrBuf);
-            }
-            return Some(match *payload {
-                Type::I32 => R::OptionI32,
-                Type::I64 => R::OptionI64,
-                Type::U32 => R::OptionU32,
-                Type::U64 => R::OptionU64,
-                _ => return None,
-            });
-        }
-        self.runtime_air_type(ty)
+        rue_air::runtime_air_result_type(self.type_pool, ty)
     }
 
     fn assert_valid_runtime_call_args(
@@ -593,7 +518,7 @@ impl<'a> CfgBuilder<'a> {
         fn_name: &str,
         type_pool: &'a FrozenTypeInternPool,
         param_modes: impl Into<ParamSlotModes>,
-        interner: &'a ThreadedRodeo,
+        _interner: &'a ThreadedRodeo,
         allow_unreachable_code: bool,
         callable_kind: AnalyzedCallableKind,
         source_symbol_resolver: impl Fn(&str) -> Option<Spur> + 'a,
@@ -608,7 +533,6 @@ impl<'a> CfgBuilder<'a> {
                 param_modes,
             ),
             type_pool,
-            interner,
             source_symbol_resolver: Box::new(source_symbol_resolver),
             current_block: BlockId(0),
             loop_stack: Vec::new(),
@@ -1361,19 +1285,19 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::Intrinsic {
-                runtime,
+                operation,
                 name,
                 args,
             } => {
-                if let Some(runtime) = runtime {
-                    self.assert_valid_runtime_call_args(
-                        *runtime,
-                        self.air
-                            .get_intrinsic_args(args)
-                            .map(|arg| (arg, AirArgMode::Normal)),
-                        ty,
-                    );
-                }
+                let arguments = self
+                    .air
+                    .get_intrinsic_args(args)
+                    .map(|arg| rue_air::intrinsic_air_argument(self.air, arg, AirArgMode::Normal))
+                    .collect::<Vec<_>>();
+                assert!(
+                    operation.validate_call(self.type_pool, &arguments, ty),
+                    "intrinsic {operation:?} has invalid AIR call shape"
+                );
                 let mut arg_vals = Vec::new();
                 for arg in self.air.get_intrinsic_args(args) {
                     let Some(val) = self.lower_value(arg) else {
@@ -1387,7 +1311,7 @@ impl<'a> CfgBuilder<'a> {
                 // operand's base slot so optimization passes (constopt) never
                 // rewrite its loads into constants — a `Const` operand would be
                 // dereferenced as an address (RUE-521 O1+ segfault).
-                if matches!(self.interner.resolve(name), "raw" | "raw_mut" | "field_ptr")
+                if operation.takes_place_address()
                     && let Some(&place_val) = arg_vals.first()
                 {
                     match &self.cfg.get_inst(place_val).data {
@@ -1416,7 +1340,7 @@ impl<'a> CfgBuilder<'a> {
                 let args = self.payload_or(args_result, CfgIntrinsicArgs::EMPTY, span);
                 let intrinsic_value = self.emit(
                     CfgInstData::Intrinsic {
-                        runtime: *runtime,
+                        operation: *operation,
                         name: *name,
                         args,
                     },
@@ -4135,6 +4059,278 @@ mod tests {
             .unwrap()
             .into_editor()
         }
+    }
+
+    #[test]
+    fn durable_intrinsic_bottom_coercions_build_cfg_in_every_sema_position() {
+        use SemanticBodyInstData as D;
+
+        #[derive(Clone)]
+        enum Operand {
+            Diverge,
+            Value(ImportTy),
+        }
+
+        let ptr_const_i32 = ImportTy::PtrConst(Arc::new(ImportTy::I32));
+        let ptr_mut_i32 = ImportTy::PtrMut(Arc::new(ImportTy::I32));
+        let cases = [
+            (
+                "ptr_to_int arg",
+                rue_air::IntrinsicOperation::PtrToInt,
+                vec![Operand::Diverge],
+                ImportTy::U64,
+            ),
+            (
+                "int_to_ptr arg",
+                rue_air::IntrinsicOperation::IntToPtr,
+                vec![Operand::Diverge],
+                ptr_mut_i32.clone(),
+            ),
+            (
+                "int_to_ptr contextual result",
+                rue_air::IntrinsicOperation::IntToPtr,
+                vec![Operand::Value(ImportTy::U64)],
+                ImportTy::Never,
+            ),
+            (
+                "ptr_write value",
+                rue_air::IntrinsicOperation::PtrWrite,
+                vec![Operand::Value(ptr_mut_i32.clone()), Operand::Diverge],
+                ImportTy::Unit,
+            ),
+            (
+                "ptr_offset pointer",
+                rue_air::IntrinsicOperation::PtrOffset,
+                vec![Operand::Diverge, Operand::Value(ImportTy::I64)],
+                ImportTy::Never,
+            ),
+            (
+                "ptr_offset offset",
+                rue_air::IntrinsicOperation::PtrOffset,
+                vec![Operand::Value(ptr_const_i32.clone()), Operand::Diverge],
+                ptr_const_i32.clone(),
+            ),
+            (
+                "ptr_offset both",
+                rue_air::IntrinsicOperation::PtrOffset,
+                vec![Operand::Diverge, Operand::Diverge],
+                ImportTy::Never,
+            ),
+            (
+                "syscall first",
+                rue_air::IntrinsicOperation::Syscall,
+                vec![Operand::Diverge],
+                ImportTy::I64,
+            ),
+            (
+                "syscall later",
+                rue_air::IntrinsicOperation::Syscall,
+                vec![Operand::Value(ImportTy::U64), Operand::Diverge],
+                ImportTy::I64,
+            ),
+        ];
+
+        for (label, operation, operands, result) in cases {
+            let mut fixture = BodyFixture::new(result.clone());
+            let mut args = Vec::new();
+            for operand in operands {
+                let value = match operand {
+                    Operand::Diverge => fixture.inst(
+                        D::Intrinsic {
+                            operation: rue_air::IntrinsicOperation::PanicNoMessage,
+                            name: Arc::from("panic"),
+                            args: Arc::new([]),
+                        },
+                        ImportTy::Never,
+                    ),
+                    Operand::Value(ty) => fixture.inst(D::Const(0), ty),
+                };
+                args.push(SemanticBodyCallArg {
+                    value,
+                    mode: AirArgMode::Normal,
+                });
+            }
+            let call = fixture.inst(
+                D::Intrinsic {
+                    operation,
+                    name: Arc::from(operation.expected_spelling()),
+                    args: args.into(),
+                },
+                result.clone(),
+            );
+            fixture.inst(D::Ret(Some(call)), result);
+            let cfg = fixture.build_cfg();
+            assert_all_blocks_terminated(&cfg);
+            assert!(
+                cfg.blocks()
+                    .iter()
+                    .any(|block| { matches!(block.terminator, Terminator::Unreachable) }),
+                "{label} must preserve operand divergence"
+            );
+        }
+    }
+
+    fn build_forged_address_source(operation: rue_air::IntrinsicOperation, place_read: bool) {
+        let interner = ThreadedRodeo::default();
+        let type_pool = rue_air::TypeInternPool::new();
+        let ptr_const_i32 = Type::new_ptr_const(type_pool.intern_ptr_const_from_type(Type::I32));
+        let ptr_mut_i32 = Type::new_ptr_mut(type_pool.intern_ptr_mut_from_type(Type::I32));
+        let type_pool = type_pool.freeze();
+        let span = rue_span::Span::new(0, 1);
+        let result_ty = if operation == rue_air::IntrinsicOperation::Raw {
+            ptr_const_i32
+        } else {
+            ptr_mut_i32
+        };
+        let mut air = AirEditor::new(result_ty);
+        let source = if place_read {
+            let place = air
+                .make_place(AirPlaceBase::Local(0), Type::I32, [])
+                .unwrap();
+            air.add_place_read(place, Type::I32, span)
+        } else {
+            air.add_const(0, Type::I32, span)
+        };
+        let intrinsic = air
+            .add_intrinsic(
+                operation,
+                interner.get_or_intern(operation.expected_spelling()),
+                &[source],
+                result_ty,
+                span,
+            )
+            .unwrap();
+        air.add_ret(Some(intrinsic), result_ty, span);
+        build_editor_cfg(
+            air,
+            u32::from(place_read),
+            0,
+            "forged address source",
+            &type_pool,
+            vec![],
+            &interner,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "intrinsic Raw has invalid AIR call shape")]
+    fn cfg_rejects_const_as_raw_source_before_backend_lowering() {
+        build_forged_address_source(rue_air::IntrinsicOperation::Raw, false);
+    }
+
+    #[test]
+    #[should_panic(expected = "intrinsic RawMut has invalid AIR call shape")]
+    fn cfg_rejects_const_as_raw_mut_source_before_backend_lowering() {
+        build_forged_address_source(rue_air::IntrinsicOperation::RawMut, false);
+    }
+
+    #[test]
+    #[should_panic(expected = "intrinsic FieldPtr has invalid AIR call shape")]
+    fn cfg_rejects_non_field_place_as_field_ptr_source_before_backend_lowering() {
+        build_forged_address_source(rue_air::IntrinsicOperation::FieldPtr, true);
+    }
+
+    fn build_frozen_cfg_runtime_option_result(use_counterfeit: bool) -> Cfg {
+        let interner = ThreadedRodeo::default();
+        let type_pool = rue_air::TypeInternPool::new();
+        let byte_ptr = Type::new_ptr_const(type_pool.intern_ptr_const_from_type(Type::U8));
+        let text_id = register_fixture_struct(
+            &type_pool,
+            &interner,
+            "str",
+            vec![
+                rue_air::StructField {
+                    name: "ptr".into(),
+                    ty: byte_ptr,
+                },
+                rue_air::StructField {
+                    name: "len".into(),
+                    ty: Type::U64,
+                },
+            ],
+            None,
+        );
+        let text = Type::new_struct(text_id);
+        let option = |name: &str, variants: Vec<(&str, Vec<Type>)>| {
+            let (id, _) = type_pool.register_enum(
+                interner.get_or_intern(name),
+                rue_air::EnumDef {
+                    name: Arc::from(name),
+                    variants: variants
+                        .iter()
+                        .map(|(name, _)| Arc::<str>::from(*name))
+                        .collect::<Vec<_>>()
+                        .into(),
+                    variant_payloads: variants.into_iter().map(|(_, payload)| payload).collect(),
+                    is_pub: true,
+                    is_non_exhaustive: false,
+                    file_id: FileId::DEFAULT,
+                },
+            );
+            Type::new_enum(id)
+        };
+        let exact = option(
+            "ExactOption",
+            vec![("Some", vec![Type::I32]), ("None", vec![])],
+        );
+        let counterfeit_ty = option(
+            "CounterfeitOption",
+            vec![
+                ("Some", vec![Type::I32]),
+                ("None", vec![Type::I64, Type::I64]),
+                ("Extra", vec![]),
+            ],
+        );
+        let type_pool = type_pool.freeze();
+        let span = rue_span::Span::new(0, 1);
+        let result_ty = if use_counterfeit {
+            counterfeit_ty
+        } else {
+            exact
+        };
+        let mut air = AirEditor::new(result_ty);
+        let input = air.add_param(0, text, span);
+        let intrinsic = air
+            .add_intrinsic(
+                rue_air::IntrinsicOperation::ParseI32,
+                interner.get_or_intern("parse_i32"),
+                &[input],
+                result_ty,
+                span,
+            )
+            .unwrap();
+        air.add_ret(Some(intrinsic), result_ty, span);
+        build_editor_cfg(
+            air,
+            0,
+            2,
+            "parse_i32",
+            &type_pool,
+            vec![false, false],
+            &interner,
+        )
+    }
+
+    #[test]
+    fn frozen_cfg_accepts_the_exact_runtime_option_shape() {
+        let exact_cfg = build_frozen_cfg_runtime_option_result(false);
+        assert!(exact_cfg.blocks().iter().any(|block| {
+            block.insts.iter().any(|value| {
+                matches!(
+                    exact_cfg.get_inst(*value).data,
+                    CfgInstData::Intrinsic {
+                        operation: rue_air::IntrinsicOperation::ParseI32,
+                        ..
+                    }
+                )
+            })
+        }));
+    }
+
+    #[test]
+    #[should_panic(expected = "intrinsic ParseI32 has invalid AIR call shape")]
+    fn frozen_cfg_rejects_a_counterfeit_runtime_option_shape() {
+        build_frozen_cfg_runtime_option_result(true);
     }
 
     /// Declare the fixtures' droppable resource nominal: `StrBuf`-shaped with

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -1280,7 +1280,7 @@ fn translate_data(
             }
         }
         Intrinsic {
-            runtime,
+            operation,
             name,
             args,
         } => {
@@ -1290,7 +1290,7 @@ fn translate_data(
                 .map(|&value| splice.value(value))
                 .collect();
             Intrinsic {
-                runtime: *runtime,
+                operation: *operation,
                 name: *name,
                 args: dst.push_intrinsic_args(args)?,
             }
@@ -3158,9 +3158,9 @@ mod tests {
                 )
                 .unwrap();
             let element = cfg
-                .append_intrinsic(
+                .append_intrinsic_operation(
                     entry,
-                    None,
+                    rue_air::IntrinsicOperation::PtrRead,
                     interner.get_or_intern("ptr_read"),
                     [data],
                     Type::I64,
@@ -3217,9 +3217,9 @@ mod tests {
                 )
                 .unwrap();
             let data = cfg
-                .append_intrinsic(
+                .append_intrinsic_operation(
                     entry,
-                    None,
+                    rue_air::IntrinsicOperation::Raw,
                     interner.get_or_intern("raw"),
                     [base],
                     ptr_ty,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -209,11 +209,11 @@ impl CfgInstData {
                 args: args.duplicate(),
             },
             Self::Intrinsic {
-                runtime,
+                operation,
                 name,
                 args,
             } => Self::Intrinsic {
-                runtime: *runtime,
+                operation: *operation,
                 name: *name,
                 args: args.duplicate(),
             },
@@ -521,8 +521,8 @@ pub enum CfgInstData {
 
     /// Intrinsic call (e.g., @dbg). Arguments use the intrinsic-value family.
     Intrinsic {
-        /// Runtime helper/adaptation selected by semantic analysis.
-        runtime: Option<rue_air::RuntimeCallKind>,
+        /// Typed intrinsic semantics selected by semantic analysis.
+        operation: rue_air::IntrinsicOperation,
         /// Intrinsic name (interned symbol)
         name: Spur,
         /// Start index into Cfg's extra array
@@ -1271,11 +1271,11 @@ impl Cfg {
                         .map_err(CfgRemapError::Edit)?,
                 },
                 Intrinsic {
-                    runtime,
+                    operation,
                     name,
                     args,
                 } => Intrinsic {
-                    runtime: *runtime,
+                    operation: *operation,
                     name: domain!(symbol(*name)),
                     args: cfg
                         .push_intrinsic_args(self.intrinsic_args(args).iter().copied())
@@ -2325,11 +2325,10 @@ impl Cfg {
         ))
     }
 
-    /// Append an intrinsic and store its operands in this CFG's value store.
-    pub fn append_intrinsic(
+    pub fn append_intrinsic_operation(
         &mut self,
         block: BlockId,
-        runtime: Option<rue_air::RuntimeCallKind>,
+        operation: rue_air::IntrinsicOperation,
         name: Spur,
         args: impl IntoIterator<Item = CfgValue>,
         ty: Type,
@@ -2344,7 +2343,7 @@ impl Cfg {
             block,
             CfgInst {
                 data: CfgInstData::Intrinsic {
-                    runtime,
+                    operation,
                     name,
                     args,
                 },
@@ -3410,13 +3409,11 @@ impl Cfg {
                 write!(f, ")")
             }
             CfgInstData::Intrinsic {
-                runtime,
+                operation,
                 name,
                 args,
             } => {
-                if let Some(runtime) = runtime {
-                    write!(f, "runtime.{runtime:?} ")?;
-                }
+                write!(f, "{operation:?} ")?;
                 match interner {
                     Some(interner) => write!(f, "intrinsic @{}(", interner.resolve(name))?,
                     None => write!(f, "intrinsic @{}(", name.into_usize())?,
@@ -3740,13 +3737,22 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
+        let condition = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::BoolConst(true),
+                ty: Type::BOOL,
+                span: Span::new(0, 0),
+            },
+        );
+        let args = cfg.push_intrinsic_args([condition]).unwrap();
         cfg.add_inst_to_block(
             entry,
             CfgInst {
                 data: CfgInstData::Intrinsic {
-                    runtime: None,
+                    operation: rue_air::IntrinsicOperation::AssertFailed,
                     name: intrinsic,
-                    args: crate::payload::CfgIntrinsicArgs::EMPTY,
+                    args,
                 },
                 ty: Type::UNIT,
                 span: Span::new(0, 0),
@@ -3756,12 +3762,12 @@ mod tests {
 
         let resolved = cfg.display_with_interner(&interner).to_string();
         assert!(resolved.contains("call @callee()"));
-        assert!(resolved.contains("intrinsic @assert()"));
+        assert!(resolved.contains("intrinsic @assert("));
 
         // The context-free Display API remains backward compatible.
         let raw = cfg.to_string();
         assert!(raw.contains(&format!("call @{}()", call.into_usize())));
-        assert!(raw.contains(&format!("intrinsic @{}()", intrinsic.into_usize())));
+        assert!(raw.contains(&format!("intrinsic @{}(", intrinsic.into_usize())));
     }
 
     #[test]
@@ -3911,9 +3917,9 @@ mod tests {
             )
             .unwrap();
         let intrinsic = cfg
-            .append_intrinsic(
+            .append_intrinsic_operation(
                 entry,
-                None,
+                rue_air::IntrinsicOperation::BitCast,
                 interner.get_or_intern("intrinsic"),
                 [old],
                 Type::I32,
@@ -3988,6 +3994,13 @@ mod tests {
             cloned.get_struct_fields(&cloned.get_inst(strukt).data),
             [old, replacement]
         );
+        assert!(matches!(
+            cloned.get_inst(intrinsic).data,
+            CfgInstData::Intrinsic {
+                operation: rue_air::IntrinsicOperation::BitCast,
+                ..
+            }
+        ));
 
         let remapped = cfg
             .try_remap_domains::<()>(Ok, Ok, Ok, Ok, Ok, |span| {
@@ -4011,6 +4024,13 @@ mod tests {
             remapped.get_enum_payload(&remapped.get_inst(enm).data),
             [old]
         );
+        assert!(matches!(
+            remapped.get_inst(intrinsic).data,
+            CfgInstData::Intrinsic {
+                operation: rue_air::IntrinsicOperation::BitCast,
+                ..
+            }
+        ));
 
         let mut rewritten = remapped;
         rewritten
@@ -4028,6 +4048,13 @@ mod tests {
             rewritten.get_intrinsic_args(&rewritten.get_inst(intrinsic).data),
             [replacement]
         );
+        assert!(matches!(
+            rewritten.get_inst(intrinsic).data,
+            CfgInstData::Intrinsic {
+                operation: rue_air::IntrinsicOperation::BitCast,
+                ..
+            }
+        ));
         assert_eq!(
             rewritten.get_struct_fields(&rewritten.get_inst(strukt).data),
             [replacement, replacement]
@@ -4118,12 +4145,12 @@ mod tests {
             },
         );
         let intrinsic = cfg
-            .append_intrinsic(
+            .append_intrinsic_operation(
                 entry,
-                None,
+                rue_air::IntrinsicOperation::BitCast,
                 Spur::default(),
                 [old],
-                Type::UNIT,
+                Type::I32,
                 Span::new(7, 8),
             )
             .unwrap();
@@ -4198,12 +4225,12 @@ mod tests {
         );
         const USES: usize = 256;
         for _ in 0..USES {
-            cfg.append_intrinsic(
+            cfg.append_intrinsic_operation(
                 entry,
-                None,
+                rue_air::IntrinsicOperation::BitCast,
                 Spur::default(),
                 [old],
-                Type::UNIT,
+                Type::I32,
                 Span::new(5, 6),
             )
             .unwrap();

--- a/crates/rue-cfg/src/opt/classify.rs
+++ b/crates/rue-cfg/src/opt/classify.rs
@@ -302,7 +302,8 @@ mod tests {
         let interner = ThreadedRodeo::new();
         let name = interner.get_or_intern("f");
         let args = cfg.push_call_args(std::iter::empty()).unwrap();
-        let iargs = cfg.push_intrinsic_args(std::iter::empty()).unwrap();
+        let condition = add(&mut cfg, CfgInstData::BoolConst(true), Type::BOOL);
+        let iargs = cfg.push_intrinsic_args([condition]).unwrap();
 
         let effecting = [
             add(
@@ -317,7 +318,7 @@ mod tests {
             add(
                 &mut cfg,
                 CfgInstData::Intrinsic {
-                    runtime: None,
+                    operation: rue_air::IntrinsicOperation::AssertFailed,
                     name,
                     args: iargs,
                 },

--- a/crates/rue-cfg/src/opt/constopt.rs
+++ b/crates/rue-cfg/src/opt/constopt.rs
@@ -314,7 +314,7 @@ mod tests {
         let ptr = push(
             &mut cfg,
             CfgInstData::Intrinsic {
-                runtime: None,
+                operation: rue_air::IntrinsicOperation::Raw,
                 name: raw_sym,
                 args,
             },

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -618,7 +618,7 @@ mod tests {
         let ptr = push(
             &mut cfg,
             CfgInstData::Intrinsic {
-                runtime: None,
+                operation: rue_air::IntrinsicOperation::Raw,
                 name: Spur::try_from_usize(0).unwrap(),
                 args,
             },

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -783,8 +783,10 @@ fn remap_data(
                 mode: a.mode,
             }))?,
         },
-        CfgInstData::Intrinsic { runtime, name, .. } => CfgInstData::Intrinsic {
-            runtime: *runtime,
+        CfgInstData::Intrinsic {
+            operation, name, ..
+        } => CfgInstData::Intrinsic {
+            operation: *operation,
             name: *name,
             args: cfg.push_intrinsic_args(operands.values.iter().map(|v| m(*v)))?,
         },

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1751,18 +1751,6 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    fn lower_option_intrinsic(
-        &mut self,
-        plan: &crate::value_plan::IntrinsicPlan,
-        _intrinsic: crate::value_plan::OptionIntrinsic,
-    ) -> crate::value_plan::MaterializedValue {
-        self.lower_runtime_call(
-            plan.runtime_call
-                .clone()
-                .expect("option intrinsic runtime call plan"),
-        )
-    }
-
     fn lower_intrinsic_plan(
         &mut self,
         plan: crate::value_plan::IntrinsicPlan,
@@ -1770,33 +1758,39 @@ impl<'a> CfgLower<'a> {
         let operation = plan.operation;
         let mut slots = Vec::new();
         let primary = match operation {
-            crate::value_plan::IntrinsicOperation::Option { intrinsic, .. } => {
-                let result = self.lower_option_intrinsic(&plan, intrinsic);
+            rue_air::IntrinsicOperation::ReadLine
+            | rue_air::IntrinsicOperation::ParseI32
+            | rue_air::IntrinsicOperation::ParseI64
+            | rue_air::IntrinsicOperation::ParseU32
+            | rue_air::IntrinsicOperation::ParseU64 => {
+                let result = self.lower_runtime_call(
+                    plan.runtime_call
+                        .clone()
+                        .expect("option intrinsic runtime call plan"),
+                );
                 slots = result.slots;
                 result.primary
             }
-            crate::value_plan::IntrinsicOperation::RandomU32
-            | crate::value_plan::IntrinsicOperation::RandomU64 => {
+            rue_air::IntrinsicOperation::RandomU32 | rue_air::IntrinsicOperation::RandomU64 => {
                 self.lower_runtime_call(
                     plan.runtime_call
                         .expect("random intrinsic runtime call plan"),
                 )
                 .primary
             }
-            crate::value_plan::IntrinsicOperation::ArgCount
-            | crate::value_plan::IntrinsicOperation::ArgPtr
-            | crate::value_plan::IntrinsicOperation::ArgLen
-            | crate::value_plan::IntrinsicOperation::EnvCount
-            | crate::value_plan::IntrinsicOperation::EnvPtr
-            | crate::value_plan::IntrinsicOperation::EnvLen => {
+            rue_air::IntrinsicOperation::ArgCount
+            | rue_air::IntrinsicOperation::ArgPtr
+            | rue_air::IntrinsicOperation::ArgLen
+            | rue_air::IntrinsicOperation::EnvCount
+            | rue_air::IntrinsicOperation::EnvPtr
+            | rue_air::IntrinsicOperation::EnvLen => {
                 self.lower_runtime_call(
                     plan.runtime_call
                         .expect("process arg/env intrinsic runtime call plan"),
                 )
                 .primary
             }
-            crate::value_plan::IntrinsicOperation::PtrToInt
-            | crate::value_plan::IntrinsicOperation::IntToPtr => {
+            rue_air::IntrinsicOperation::PtrToInt | rue_air::IntrinsicOperation::IntToPtr => {
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovRR {
                     dst: Operand::Virtual(dst),
@@ -1808,8 +1802,11 @@ impl<'a> CfgLower<'a> {
             // rebuilds only the bits above the shared width, which belong to the
             // source type's register image. The shared planner picked the form
             // from the target type; this leaf just spells it.
-            crate::value_plan::IntrinsicOperation::BitCast(form) => {
+            rue_air::IntrinsicOperation::BitCast => {
                 use crate::value_plan::BitCastForm;
+                let form = plan
+                    .bit_cast_form
+                    .expect("bitCast intrinsic must carry its contextual form");
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovRR {
                     dst: Operand::Virtual(dst),
@@ -1843,7 +1840,8 @@ impl<'a> CfgLower<'a> {
                 }
                 dst
             }
-            crate::value_plan::IntrinsicOperation::PtrRead => {
+            rue_air::IntrinsicOperation::PtrRead
+            | rue_air::IntrinsicOperation::PtrReadUnaligned => {
                 let ptr = plan.args[0].primary;
                 let count = plan.result_slots;
                 if let Some(map) = &plan.physical_slots {
@@ -1887,7 +1885,8 @@ impl<'a> CfgLower<'a> {
                     dst
                 }
             }
-            crate::value_plan::IntrinsicOperation::PtrWrite => {
+            rue_air::IntrinsicOperation::PtrWrite
+            | rue_air::IntrinsicOperation::PtrWriteUnaligned => {
                 let ptr = plan.args[0].primary;
                 let value = &plan.args[1];
                 if let Some(map) = &plan.physical_slots {
@@ -1941,7 +1940,7 @@ impl<'a> CfgLower<'a> {
                 });
                 dst
             }
-            crate::value_plan::IntrinsicOperation::PtrOffset => {
+            rue_air::IntrinsicOperation::PtrOffset => {
                 let offset = plan.args[1].primary;
                 let offset = match plan.args[1].integer_extension {
                     crate::value_plan::IntegerExtension::None => offset,
@@ -1987,39 +1986,41 @@ impl<'a> CfgLower<'a> {
             // The unified allocation family and the bulk byte primitives are
             // pure runtime calls: the shared plan already carries their
             // operands in helper order (ADR-0059 Phase 3, RUE-961).
-            crate::value_plan::IntrinsicOperation::Alloc => {
+            rue_air::IntrinsicOperation::Alloc => {
                 self.lower_runtime_call(plan.runtime_call.expect("alloc runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::AllocZeroed => {
+            rue_air::IntrinsicOperation::AllocZeroed => {
                 self.lower_runtime_call(plan.runtime_call.expect("alloc-zeroed runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Free => {
+            rue_air::IntrinsicOperation::Free => {
                 self.lower_runtime_call(plan.runtime_call.expect("free runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Realloc => {
+            rue_air::IntrinsicOperation::Realloc => {
                 self.lower_runtime_call(plan.runtime_call.expect("realloc runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Resize => {
+            rue_air::IntrinsicOperation::Resize => {
                 self.lower_runtime_call(plan.runtime_call.expect("resize runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::ByteCopy => {
+            rue_air::IntrinsicOperation::ByteCopy => {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-copy runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::ByteMove => {
+            rue_air::IntrinsicOperation::ByteMove => {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-move runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::ByteSet => {
+            rue_air::IntrinsicOperation::ByteSet => {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-set runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::PlaceAddress => {
+            rue_air::IntrinsicOperation::Raw
+            | rue_air::IntrinsicOperation::RawMut
+            | rue_air::IntrinsicOperation::FieldPtr => {
                 let place = plan.args[0]
                     .place
                     .as_ref()
@@ -2028,11 +2029,14 @@ impl<'a> CfgLower<'a> {
                 crate::place_lower::lower_place_addr_plan(self, dst, place);
                 dst
             }
-            crate::value_plan::IntrinsicOperation::Debug => {
+            rue_air::IntrinsicOperation::DebugI64
+            | rue_air::IntrinsicOperation::DebugU64
+            | rue_air::IntrinsicOperation::DebugBool
+            | rue_air::IntrinsicOperation::DebugStr => {
                 self.lower_runtime_call(plan.runtime_call.expect("debug runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Syscall => {
+            rue_air::IntrinsicOperation::Syscall => {
                 let stack_space = i32::try_from(
                     checked_aligned_cell_region_bytes(
                         u64::try_from(plan.args.len())
@@ -2115,6 +2119,13 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Physical(Reg::X0),
                 });
                 dst
+            }
+            rue_air::IntrinsicOperation::PanicNoMessage
+            | rue_air::IntrinsicOperation::Panic
+            | rue_air::IntrinsicOperation::AssertFailed
+            | rue_air::IntrinsicOperation::AssertWithMessage
+            | rue_air::IntrinsicOperation::BoundsCheck => {
+                unreachable!("trap handled above")
             }
         };
         crate::value_plan::MaterializedValue { primary, slots }
@@ -3109,9 +3120,6 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn resolve_symbol(&self, symbol: lasso::Spur) -> String {
         self.symbols.resolve(self.interner.resolve(&symbol))
     }
-    fn resolve_intrinsic_symbol(&self, symbol: lasso::Spur) -> String {
-        self.interner.resolve(&symbol).to_owned()
-    }
     fn resolve_named_symbol(&self, symbol: &str) -> String {
         self.symbols.resolve(symbol)
     }
@@ -3833,8 +3841,8 @@ impl crate::aggregate_eq::AggregateEqPlanBackend for CfgLower<'_> {
 mod tests {
     use super::*;
     use rue_air::{
-        EnumDef, EnumId, ParamSlotModes, RuntimeCallKind, SourceParamAbi, StructDef, StructField,
-        StructId, TypeInternPool,
+        EnumDef, EnumId, ParamSlotModes, SourceParamAbi, StructDef, StructField, StructId,
+        TypeInternPool,
     };
     use rue_cfg::{CfgArgMode, CfgCallArg, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_span::{FileId, Span};
@@ -4115,16 +4123,16 @@ mod tests {
 
         fn intrinsic(
             &mut self,
-            runtime: Option<RuntimeCallKind>,
+            operation: rue_air::IntrinsicOperation,
             name: &str,
             args: &[CfgValue],
             ty: Type,
         ) -> CfgValue {
             let name = self.interner.get_or_intern(name);
             self.cfg
-                .append_intrinsic(
+                .append_intrinsic_operation(
                     self.current,
-                    runtime,
+                    operation,
                     name,
                     args.iter().copied(),
                     ty,
@@ -4241,13 +4249,23 @@ mod tests {
         let align_i32 = fixture.konst(align, Type::I32);
         let align = fixture.cast(align_i32, Type::I32, Type::U64);
         let raw = fixture.intrinsic(
-            Some(RuntimeCallKind::Alloc),
+            rue_air::IntrinsicOperation::Alloc,
             "alloc",
             &[size, align],
             raw_ptr_ty,
         );
-        let address = fixture.intrinsic(None, "ptr_to_int", &[raw], Type::U64);
-        let pointer = fixture.intrinsic(None, "int_to_ptr", &[address], ptr_ty);
+        let address = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrToInt,
+            "ptr_to_int",
+            &[raw],
+            Type::U64,
+        );
+        let pointer = fixture.intrinsic(
+            rue_air::IntrinsicOperation::IntToPtr,
+            "int_to_ptr",
+            &[address],
+            ptr_ty,
+        );
         fixture.alloc(slot, pointer);
     }
 
@@ -4261,14 +4279,24 @@ mod tests {
         ptr_ty: Type,
     ) {
         let pointer = fixture.load(slot, ptr_ty);
-        let address = fixture.intrinsic(None, "ptr_to_int", &[pointer], Type::U64);
-        let laundered = fixture.intrinsic(None, "int_to_ptr", &[address], raw_ptr_ty);
+        let address = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrToInt,
+            "ptr_to_int",
+            &[pointer],
+            Type::U64,
+        );
+        let laundered = fixture.intrinsic(
+            rue_air::IntrinsicOperation::IntToPtr,
+            "int_to_ptr",
+            &[address],
+            raw_ptr_ty,
+        );
         let size_i32 = fixture.konst(size, Type::I32);
         let size = fixture.cast(size_i32, Type::I32, Type::U64);
         let align_i32 = fixture.konst(align, Type::I32);
         let align = fixture.cast(align_i32, Type::I32, Type::U64);
         fixture.intrinsic(
-            Some(RuntimeCallKind::Free),
+            rue_air::IntrinsicOperation::Free,
             "free",
             &[laundered, size, align],
             Type::UNIT,
@@ -4432,11 +4460,26 @@ mod tests {
         checked_alloc(&mut fixture, 0, 4, 4, raw_ptr_ty, ptr_ty);
         let pointer = fixture.load(0, ptr_ty);
         let five = fixture.konst(5, Type::I32);
-        fixture.intrinsic(None, "ptr_write", &[pointer, five], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, five],
+            Type::UNIT,
+        );
         fixture.unit();
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[read], Type::UNIT);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            Type::I32,
+        );
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[read],
+            Type::UNIT,
+        );
         fixture.unit();
         checked_free(&mut fixture, 0, 4, 4, raw_ptr_ty, ptr_ty);
         fixture.unit();
@@ -4498,11 +4541,21 @@ mod tests {
         let pointer = fixture.load(0, ptr_ty);
         let forty_two = fixture.konst(42, Type::I32);
         let variant = fixture.enum_variant(opt_id, 0, &[forty_two], opt_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, variant], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, variant],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, opt_ty);
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], opt_ty);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            opt_ty,
+        );
         fixture.alloc(1, read);
         let scrutinee = fixture.load(1, opt_ty);
         let some_arm = fixture.cfg.new_block();
@@ -4525,14 +4578,24 @@ mod tests {
         );
         fixture.alloc(3, payload);
         let x = fixture.load(3, Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[x], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[x],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.dead(3, Type::I32);
         fixture.cfg.set_goto(some_arm, join, []);
 
         fixture.current = none_arm;
         let zero = fixture.konst(0, Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[zero], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[zero],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.cfg.set_goto(none_arm, join, []);
 
@@ -4605,7 +4668,12 @@ mod tests {
         let z = fixture.konst(3, Type::I32);
         let point = fixture.struct_init(point_id, &[x, y, z], point_ty);
         let variant = fixture.enum_variant(r_id, 0, &[point], r_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, variant], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, variant],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.unit();
         fixture.unit();
@@ -4662,11 +4730,21 @@ mod tests {
         let b = fixture.konst(1000, Type::I32);
         let c = fixture.konst(9, Type::U8);
         let padded = fixture.struct_init(padded_id, &[a, b, c], padded_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, padded], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, padded],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, padded_ty);
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], padded_ty);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            padded_ty,
+        );
         fixture.alloc(1, read);
         let b = fixture.place_read(
             PlaceBase::Local(1),
@@ -4677,7 +4755,12 @@ mod tests {
             }],
             Type::I32,
         );
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[b], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[b],
+            Type::UNIT,
+        );
         fixture.unit();
         checked_free(&mut fixture, 0, 12, 4, raw_ptr_ty, ptr_ty);
         fixture.unit();
@@ -4741,11 +4824,21 @@ mod tests {
         let twenty = fixture.konst(20, Type::I32);
         let xs = fixture.array_init(&[ten, twenty], xs_ty);
         let has_arr = fixture.struct_init(has_arr_id, &[tag, xs], has_arr_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, has_arr], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, has_arr],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, has_arr_ty);
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], has_arr_ty);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            has_arr_ty,
+        );
         fixture.alloc(1, read);
         checked_free(&mut fixture, 0, 12, 4, raw_ptr_ty, ptr_ty);
         let mut elements = Vec::new();
@@ -4772,7 +4865,12 @@ mod tests {
         fixture.dead(0, ptr_ty);
         fixture.alloc(4, sum);
         let r = fixture.load(4, Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[r], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[r],
+            Type::UNIT,
+        );
         fixture.unit();
         let result = fixture.konst(0, Type::I32);
         fixture.dead(4, Type::I32);
@@ -4831,11 +4929,21 @@ mod tests {
         let y = fixture.konst(2, Type::I32);
         let point = fixture.struct_init(point_id, &[x, y], point_ty);
         let variant = fixture.enum_variant(opt_id, 0, &[point], opt_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, variant], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, variant],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, opt_ty);
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], opt_ty);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            opt_ty,
+        );
         fixture.alloc(1, read);
         checked_free(&mut fixture, 0, 12, 4, raw_ptr_ty, ptr_ty);
         let scrutinee = fixture.load(1, opt_ty);
@@ -4892,7 +5000,12 @@ mod tests {
         fixture.dead(0, ptr_ty);
         fixture.alloc(6, join_value);
         let r = fixture.load(6, Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[r], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[r],
+            Type::UNIT,
+        );
         fixture.unit();
         let result = fixture.konst(0, Type::I32);
         fixture.dead(6, Type::I32);
@@ -4944,7 +5057,12 @@ mod tests {
         let five = fixture.konst(5, Type::I64);
         let variant = fixture.enum_variant(bad_id, 0, &[five], bad_ty);
         let has_bad = fixture.struct_init(has_bad_id, &[variant], has_bad_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, has_bad], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, has_bad],
+            Type::UNIT,
+        );
         fixture.unit();
         checked_free(&mut fixture, 0, 16, 8, raw_ptr_ty, ptr_ty);
         fixture.unit();
@@ -5000,7 +5118,12 @@ mod tests {
             }],
             Type::I32,
         );
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[b], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[b],
+            Type::UNIT,
+        );
         fixture.unit();
         let result = fixture.konst(0, Type::I32);
         fixture.dead(0, padded_ty);
@@ -5205,7 +5328,12 @@ mod tests {
         let pointer = fixture.load(0, ptr_ty);
         let five = fixture.konst(5, Type::I64);
         let variant = fixture.enum_variant(bad_id, 0, &[five], bad_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, variant], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, variant],
+            Type::UNIT,
+        );
         fixture.unit();
         checked_free(&mut fixture, 0, 16, 8, raw_ptr_ty, ptr_ty);
         fixture.unit();
@@ -5642,7 +5770,7 @@ mod tests {
         let size = fixture.konst(3, Type::U64);
         let align = fixture.konst(1, Type::U64);
         let p = fixture.intrinsic(
-            Some(RuntimeCallKind::Alloc),
+            rue_air::IntrinsicOperation::Alloc,
             "alloc",
             &[size, align],
             ptr_ty,
@@ -5650,9 +5778,19 @@ mod tests {
         fixture.alloc(0, p);
         let p = fixture.load(0, ptr_ty);
         let one = fixture.konst(1, Type::I32);
-        let offset = fixture.intrinsic(None, "ptr_offset", &[p, one], ptr_ty);
+        let offset = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrOffset,
+            "ptr_offset",
+            &[p, one],
+            ptr_ty,
+        );
         let byte = fixture.konst(255, Type::U8);
-        fixture.intrinsic(None, "ptr_write", &[offset, byte], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[offset, byte],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, ptr_ty);
         let p = fixture.load(0, ptr_ty);
@@ -5660,7 +5798,7 @@ mod tests {
         let old_align = fixture.konst(1, Type::U64);
         let new_size = fixture.konst(5, Type::U64);
         let q = fixture.intrinsic(
-            Some(RuntimeCallKind::Realloc),
+            rue_air::IntrinsicOperation::Realloc,
             "realloc",
             &[p, old_size, old_align, new_size],
             ptr_ty,
@@ -5669,14 +5807,24 @@ mod tests {
         fixture.live(2, Type::U8);
         let q = fixture.load(1, ptr_ty);
         let one = fixture.konst(1, Type::I32);
-        let offset = fixture.intrinsic(None, "ptr_offset", &[q, one], ptr_ty);
-        let byte = fixture.intrinsic(None, "ptr_read", &[offset], Type::U8);
+        let offset = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrOffset,
+            "ptr_offset",
+            &[q, one],
+            ptr_ty,
+        );
+        let byte = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[offset],
+            Type::U8,
+        );
         fixture.alloc(2, byte);
         let q = fixture.load(1, ptr_ty);
         let size = fixture.konst(5, Type::U64);
         let align = fixture.konst(1, Type::U64);
         fixture.intrinsic(
-            Some(RuntimeCallKind::Free),
+            rue_air::IntrinsicOperation::Free,
             "free",
             &[q, size, align],
             Type::UNIT,
@@ -5748,7 +5896,7 @@ mod tests {
         let size = fixture.konst(2, Type::U64);
         let align = fixture.konst(1, Type::U64);
         let p = fixture.intrinsic(
-            Some(RuntimeCallKind::Alloc),
+            rue_air::IntrinsicOperation::Alloc,
             "alloc",
             &[size, align],
             ptr_ty,
@@ -5756,21 +5904,41 @@ mod tests {
         fixture.alloc(0, p);
         let p = fixture.load(0, ptr_ty);
         let zero = fixture.konst(0, Type::I32);
-        let offset = fixture.intrinsic(None, "ptr_offset", &[p, zero], ptr_ty);
+        let offset = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrOffset,
+            "ptr_offset",
+            &[p, zero],
+            ptr_ty,
+        );
         let byte = fixture.konst(65, Type::U8);
-        fixture.intrinsic(None, "ptr_write", &[offset, byte], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[offset, byte],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, Type::U8);
         let p = fixture.load(0, ptr_ty);
         let one = fixture.konst(1, Type::I32);
-        let offset = fixture.intrinsic(None, "ptr_offset", &[p, one], ptr_ty);
-        let byte = fixture.intrinsic(None, "ptr_read", &[offset], Type::U8);
+        let offset = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrOffset,
+            "ptr_offset",
+            &[p, one],
+            ptr_ty,
+        );
+        let byte = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[offset],
+            Type::U8,
+        );
         fixture.alloc(1, byte);
         let p = fixture.load(0, ptr_ty);
         let size = fixture.konst(2, Type::U64);
         let align = fixture.konst(1, Type::U64);
         fixture.intrinsic(
-            Some(RuntimeCallKind::Free),
+            rue_air::IntrinsicOperation::Free,
             "free",
             &[p, size, align],
             Type::UNIT,

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -151,6 +151,56 @@ fn production_codegen_does_not_call_frozen_declaration_test_adapters() {
 }
 
 #[test]
+fn intrinsic_codegen_dispatch_is_typed_and_has_no_name_fallback() {
+    let value_plan = include_str!("value_plan.rs");
+    assert!(value_plan.contains("let operation = *operation;"));
+    assert!(value_plan.contains("operation == IntrinsicOperation::BitCast"));
+    assert!(!value_plan.contains("pub enum IntrinsicOperation"));
+    for (name, source) in [
+        ("value_plan", value_plan),
+        ("x86_64/cfg_lower", include_str!("x86_64/cfg_lower.rs")),
+        ("aarch64/cfg_lower", include_str!("aarch64/cfg_lower.rs")),
+        ("local_storage", include_str!("local_storage.rs")),
+        ("types", include_str!("types.rs")),
+        ("place_lower", include_str!("place_lower.rs")),
+        ("stack_frame", include_str!("stack_frame.rs")),
+        ("cfg_lower", include_str!("cfg_lower.rs")),
+    ] {
+        for forbidden in [
+            "IntrinsicSelector",
+            "IntrinsicKind",
+            "resolve_intrinsic_symbol",
+            "expected_spelling",
+            "intrinsic_operation_from_name",
+            "unsupported intrinsic",
+            "match self.interner.resolve(&name)",
+            "match interner.resolve(&name)",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{name} contains removed intrinsic name dispatch: {forbidden}"
+            );
+        }
+    }
+    assert!(value_plan.contains("pub operation: IntrinsicOperation"));
+    assert!(value_plan.contains("operation.runtime_call_kind()"));
+    assert!(value_plan.contains("match operation {"));
+    for forbidden in [
+        "if values.len() == 0",
+        "if values.len() == 1",
+        "if args.len() == 0",
+        "if args.len() == 1",
+        "match values.len()",
+        "match args.len()",
+    ] {
+        assert!(
+            !value_plan.contains(forbidden),
+            "value planning regained call-shape intrinsic selection: {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn value_planning_uses_the_air_integer_semantics_kernel() {
     let source = include_str!("value_plan.rs");
     assert!(source.contains("ty.integer_semantics().map(Into::into)"));

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -188,7 +188,9 @@ fn format_cfg_inst_data_impl(
                 .unwrap_or(name);
             format!("call @{}({})", name, args.join(", "))
         }
-        CfgInstData::Intrinsic { runtime, name, .. } => {
+        CfgInstData::Intrinsic {
+            operation, name, ..
+        } => {
             let args: Vec<String> = cfg
                 .get_intrinsic_args(data)
                 .iter()
@@ -197,10 +199,7 @@ fn format_cfg_inst_data_impl(
             let name = interner
                 .map(|interner| interner.resolve(name).to_string())
                 .unwrap_or_else(|| name.into_usize().to_string());
-            let prefix = runtime
-                .map(|runtime| format!("runtime.{runtime:?} "))
-                .unwrap_or_default();
-            format!("{prefix}intrinsic @{}({})", name, args.join(", "))
+            format!("intrinsic {operation:?} @{}({})", name, args.join(", "))
         }
         CfgInstData::StructInit { struct_id, .. } => {
             let fields: Vec<String> = cfg

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -581,11 +581,11 @@ mod tests {
     use aarch64::MAX_ADD_SUB_IMMEDIATE;
     use lasso::ThreadedRodeo;
     use rue_air::{
-        AirEditor, AirValidationContext, FrozenTypeInternPool, Type, TypeInternPool,
-        layout::SLOT_BYTES,
+        AirEditor, AirValidationContext, FrozenTypeInternPool, IntrinsicOperation, StructDef,
+        StructField, Type, TypeInternPool, layout::SLOT_BYTES,
     };
-    use rue_cfg::{CfgBuilder, ValidatedCfg};
-    use rue_span::Span;
+    use rue_cfg::{Cfg, CfgBuilder, CfgInst, CfgInstData, ValidatedCfg};
+    use rue_span::{FileId, Span};
 
     #[test]
     fn stable_atom_aliases_compact_to_one_dense_string_deterministically() {
@@ -742,10 +742,10 @@ mod tests {
         let interner = ThreadedRodeo::new();
         let mut air = AirEditor::new(Type::I64);
         let span = Span::new(0, 2);
-        let number = air.add_const(1, Type::I64, span);
+        let number = air.add_const(1, Type::U64, span);
         let result = air
             .add_intrinsic(
-                None,
+                rue_air::IntrinsicOperation::Syscall,
                 interner.get_or_intern("syscall"),
                 &[number],
                 Type::I64,
@@ -770,6 +770,207 @@ mod tests {
             rue_air::AnalyzedCallableKind::Ordinary,
         );
         (cfg_output.cfg.unwrap(), type_pool, interner)
+    }
+
+    fn diagnostic_intrinsic_cfg(
+        operation: IntrinsicOperation,
+        diagnostic_name: &str,
+    ) -> (
+        ValidatedCfg,
+        FrozenTypeInternPool,
+        ThreadedRodeo,
+        Vec<String>,
+    ) {
+        let type_pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let ptr_u8 = Type::new_ptr_const(type_pool.intern_ptr_const_from_type(Type::U8));
+        let (str_id, _) = type_pool.register_struct(
+            interner.get_or_intern("str"),
+            StructDef {
+                name: "str".into(),
+                fields: vec![
+                    StructField {
+                        name: "ptr".into(),
+                        ty: ptr_u8,
+                    },
+                    StructField {
+                        name: "len".into(),
+                        ty: Type::U64,
+                    },
+                ],
+                is_copy: true,
+                is_linear: false,
+                declared_linear: false,
+                destructor: None,
+                is_builtin: true,
+                is_pub: true,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let str_ty = Type::new_struct(str_id);
+        let result_ty = if matches!(
+            operation,
+            IntrinsicOperation::PanicNoMessage | IntrinsicOperation::Panic
+        ) {
+            Type::NEVER
+        } else {
+            Type::UNIT
+        };
+        let type_pool = type_pool.freeze();
+        let mut cfg = Cfg::new(
+            result_ty,
+            0,
+            0,
+            "typed_intrinsic_dispatch".to_owned(),
+            Vec::<bool>::new(),
+        );
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let span = Span::new(0, 1);
+        let mut append = |data, ty| cfg.append_inst(entry, CfgInst { data, ty, span });
+        let args = match operation {
+            IntrinsicOperation::PanicNoMessage => vec![],
+            IntrinsicOperation::Panic | IntrinsicOperation::DebugStr => {
+                vec![append(CfgInstData::StringConst(0), str_ty)]
+            }
+            IntrinsicOperation::AssertFailed | IntrinsicOperation::BoundsCheck => {
+                vec![append(CfgInstData::BoolConst(false), Type::BOOL)]
+            }
+            IntrinsicOperation::AssertWithMessage => vec![
+                append(CfgInstData::BoolConst(false), Type::BOOL),
+                append(CfgInstData::StringConst(0), str_ty),
+            ],
+            IntrinsicOperation::DebugI64 => vec![append(CfgInstData::Const(7), Type::I64)],
+            IntrinsicOperation::DebugU64 => vec![append(CfgInstData::Const(7), Type::U64)],
+            IntrinsicOperation::DebugBool => {
+                vec![append(CfgInstData::BoolConst(true), Type::BOOL)]
+            }
+            IntrinsicOperation::ReadLine
+            | IntrinsicOperation::ParseI32
+            | IntrinsicOperation::ParseI64
+            | IntrinsicOperation::ParseU32
+            | IntrinsicOperation::ParseU64
+            | IntrinsicOperation::RandomU32
+            | IntrinsicOperation::RandomU64
+            | IntrinsicOperation::PtrToInt
+            | IntrinsicOperation::IntToPtr
+            | IntrinsicOperation::PtrRead
+            | IntrinsicOperation::PtrReadUnaligned
+            | IntrinsicOperation::PtrWrite
+            | IntrinsicOperation::PtrWriteUnaligned
+            | IntrinsicOperation::PtrOffset
+            | IntrinsicOperation::Alloc
+            | IntrinsicOperation::AllocZeroed
+            | IntrinsicOperation::Free
+            | IntrinsicOperation::Realloc
+            | IntrinsicOperation::Resize
+            | IntrinsicOperation::ByteCopy
+            | IntrinsicOperation::ByteMove
+            | IntrinsicOperation::ByteSet
+            | IntrinsicOperation::ArgCount
+            | IntrinsicOperation::ArgPtr
+            | IntrinsicOperation::ArgLen
+            | IntrinsicOperation::EnvCount
+            | IntrinsicOperation::EnvPtr
+            | IntrinsicOperation::EnvLen
+            | IntrinsicOperation::Raw
+            | IntrinsicOperation::RawMut
+            | IntrinsicOperation::FieldPtr
+            | IntrinsicOperation::Syscall
+            | IntrinsicOperation::BitCast => {
+                panic!("fixture only accepts trap and debug operations")
+            }
+        };
+        let _intrinsic = cfg
+            .append_intrinsic_operation(
+                entry,
+                operation,
+                interner.get_or_intern(diagnostic_name),
+                args,
+                result_ty,
+                span,
+            )
+            .unwrap();
+        if result_ty == Type::NEVER {
+            cfg.set_unreachable(entry);
+        } else {
+            cfg.set_return(entry, None);
+        }
+        (
+            cfg.finish(&type_pool)
+                .expect("typed intrinsic fixture must validate"),
+            type_pool,
+            interner,
+            vec!["typed diagnostic payload".to_owned()],
+        )
+    }
+
+    fn pointer_zero_cfgs() -> (
+        ValidatedCfg,
+        ValidatedCfg,
+        FrozenTypeInternPool,
+        ThreadedRodeo,
+    ) {
+        let type_pool = TypeInternPool::new();
+        let ptr_const = Type::new_ptr_const(type_pool.intern_ptr_const_from_type(Type::I32));
+        let ptr_mut = Type::new_ptr_mut(type_pool.intern_ptr_mut_from_type(Type::I32));
+        let type_pool = type_pool.freeze();
+        let interner = ThreadedRodeo::new();
+        let span = Span::new(0, 1);
+
+        let build = |synthesized_const: bool| {
+            let mut cfg = Cfg::new(
+                Type::U64,
+                0,
+                0,
+                "empty_slice_pointer_bytes".to_owned(),
+                Vec::<bool>::new(),
+            );
+            let entry = cfg.new_block();
+            cfg.entry = entry;
+            let pointer = if synthesized_const {
+                cfg.append_inst(
+                    entry,
+                    CfgInst {
+                        data: CfgInstData::Const(0),
+                        ty: ptr_const,
+                        span,
+                    },
+                )
+            } else {
+                let zero = cfg.append_inst(
+                    entry,
+                    CfgInst {
+                        data: CfgInstData::Const(0),
+                        ty: Type::U64,
+                        span,
+                    },
+                );
+                cfg.append_intrinsic_operation(
+                    entry,
+                    IntrinsicOperation::IntToPtr,
+                    interner.get_or_intern("int_to_ptr"),
+                    [zero],
+                    ptr_mut,
+                    span,
+                )
+                .unwrap()
+            };
+            let address = cfg
+                .append_intrinsic_operation(
+                    entry,
+                    IntrinsicOperation::PtrToInt,
+                    interner.get_or_intern("ptr_to_int"),
+                    [pointer],
+                    Type::U64,
+                    span,
+                )
+                .unwrap();
+            cfg.set_return(entry, Some(address));
+            cfg.finish(&type_pool)
+                .expect("pointer fixture must validate")
+        };
+        (build(true), build(false), type_pool, interner)
     }
 
     /// Assert that a `--emit regalloc` projection exercises the widened
@@ -923,6 +1124,107 @@ mod tests {
                 with_authority.machine_code.relocations.len(),
                 without_authority.machine_code.relocations.len()
             );
+        }
+    }
+
+    fn generate_machine_code_for_target(
+        cfg: &ValidatedCfg,
+        type_pool: &FrozenTypeInternPool,
+        strings: &[String],
+        interner: &ThreadedRodeo,
+        target: rue_target::Target,
+    ) -> MachineCode {
+        match target.arch() {
+            rue_target::Arch::X86_64 => x86_64::generate(cfg, type_pool, strings, interner, target),
+            rue_target::Arch::Aarch64 => {
+                aarch64::generate(cfg, type_pool, strings, interner, target)
+            }
+        }
+        .expect("production backend generation should succeed")
+    }
+
+    #[test]
+    fn typed_trap_and_debug_dispatch_ignores_counterfeit_diagnostic_names_on_every_target() {
+        let operations = [
+            IntrinsicOperation::PanicNoMessage,
+            IntrinsicOperation::Panic,
+            IntrinsicOperation::AssertFailed,
+            IntrinsicOperation::AssertWithMessage,
+            IntrinsicOperation::BoundsCheck,
+            IntrinsicOperation::DebugI64,
+            IntrinsicOperation::DebugU64,
+            IntrinsicOperation::DebugBool,
+            IntrinsicOperation::DebugStr,
+        ];
+        for operation in operations {
+            let (canonical, canonical_types, canonical_interner, canonical_strings) =
+                diagnostic_intrinsic_cfg(operation, operation.expected_spelling());
+            let (counterfeit, counterfeit_types, counterfeit_interner, counterfeit_strings) =
+                diagnostic_intrinsic_cfg(operation, "counterfeit_diagnostic_name");
+            for target in [
+                rue_target::Target::X86_64Linux,
+                rue_target::Target::Aarch64Linux,
+                rue_target::Target::Aarch64Macos,
+            ] {
+                let canonical_code = generate_machine_code_for_target(
+                    &canonical,
+                    &canonical_types,
+                    &canonical_strings,
+                    &canonical_interner,
+                    target,
+                );
+                let counterfeit_code = generate_machine_code_for_target(
+                    &counterfeit,
+                    &counterfeit_types,
+                    &counterfeit_strings,
+                    &counterfeit_interner,
+                    target,
+                );
+                assert_same_machine_code(&canonical_code, &counterfeit_code);
+
+                let helper = operation
+                    .runtime_call_kind()
+                    .expect("trap/debug operation is runtime backed")
+                    .helper()
+                    .symbol();
+                assert!(
+                    canonical_code
+                        .relocations
+                        .iter()
+                        .any(|relocation| relocation.symbol == helper),
+                    "{operation:?} on {target:?} must select {helper}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn synthesized_empty_slice_pointer_const_preserves_previous_native_bytes() {
+        let (pointer_const, previous_int_to_ptr, type_pool, interner) = pointer_zero_cfgs();
+        for target in [
+            rue_target::Target::X86_64Linux,
+            rue_target::Target::Aarch64Linux,
+            rue_target::Target::Aarch64Macos,
+        ] {
+            let current = generate_product_for_target(
+                &pointer_const,
+                &type_pool,
+                &[],
+                &interner,
+                target,
+                BackendArtifactRequest::default(),
+            )
+            .machine_code;
+            let previous = generate_product_for_target(
+                &previous_int_to_ptr,
+                &type_pool,
+                &[],
+                &interner,
+                target,
+                BackendArtifactRequest::default(),
+            )
+            .machine_code;
+            assert_same_machine_code(&current, &previous);
         }
     }
 

--- a/crates/rue-codegen/src/local_storage.rs
+++ b/crates/rue-codegen/src/local_storage.rs
@@ -348,12 +348,12 @@ impl SlotReferences {
 fn collect_slot_references(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
+    _interner: &ThreadedRodeo,
 ) -> Option<SlotReferences> {
     let num_locals = cfg.num_locals();
     let span_of = |ty: Type| crate::types::type_slot_span(type_pool, ty);
     let mut per_value = vec![None; cfg.value_count()];
-    let escaping = address_escaping_operands(cfg, interner);
+    let escaping = address_escaping_operands(cfg);
 
     for block in cfg.blocks() {
         for &value in &block.insts {
@@ -421,15 +421,15 @@ fn collect_slot_references(
 /// operation in `value_plan`). The pointer those produce is a first-class
 /// value that can outlive the operand's storage window, so the slot behind it
 /// never shares.
-fn address_escaping_operands(cfg: &Cfg, interner: &ThreadedRodeo) -> Vec<bool> {
+fn address_escaping_operands(cfg: &Cfg) -> Vec<bool> {
     let mut escaping = vec![false; cfg.value_count()];
     for block in cfg.blocks() {
         for &value in &block.insts {
             let data = &cfg.get_inst(value).data;
-            let CfgInstData::Intrinsic { name, .. } = data else {
+            let CfgInstData::Intrinsic { operation, .. } = data else {
                 continue;
             };
-            if !matches!(interner.resolve(name), "raw" | "raw_mut" | "field_ptr") {
+            if !operation.takes_place_address() {
                 continue;
             }
             for &arg in cfg.get_intrinsic_args(data) {

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -1328,7 +1328,14 @@ mod tests {
             )
             .unwrap();
         let all_zst = cfg
-            .append_intrinsic(entry, None, raw, [empty_unit], ptr_unit_ty, span())
+            .append_intrinsic_operation(
+                entry,
+                rue_air::IntrinsicOperation::Raw,
+                raw,
+                [empty_unit],
+                ptr_unit_ty,
+                span(),
+            )
             .unwrap();
         alloc_slot(&mut cfg, entry, 0, all_zst);
         storage_live(&mut cfg, entry, 1, tail_ty);
@@ -1353,7 +1360,14 @@ mod tests {
             )
             .unwrap();
         let tail_zst = cfg
-            .append_intrinsic(entry, None, raw, [tail_unit], ptr_unit_ty, span())
+            .append_intrinsic_operation(
+                entry,
+                rue_air::IntrinsicOperation::Raw,
+                raw,
+                [tail_unit],
+                ptr_unit_ty,
+                span(),
+            )
             .unwrap();
         alloc_slot(&mut cfg, entry, 2, tail_zst);
         let borrow_operand = cfg
@@ -1509,9 +1523,9 @@ mod tests {
             )
             .unwrap();
         let address = cfg
-            .append_intrinsic(
+            .append_intrinsic_operation(
                 entry,
-                None,
+                rue_air::IntrinsicOperation::Raw,
                 interner.get_or_intern("raw"),
                 [element],
                 ptr_i32_ty,

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -1505,9 +1505,9 @@ mod tests {
         storage_live(&mut cfg, entry, 2, ptr_ty);
         let probe = load_slot(&mut cfg, entry, 1, Type::I32);
         let raw = cfg
-            .append_intrinsic(
+            .append_intrinsic_operation(
                 entry,
-                None,
+                rue_air::IntrinsicOperation::RawMut,
                 interner.get_or_intern("raw_mut"),
                 [probe],
                 ptr_ty,
@@ -1517,9 +1517,9 @@ mod tests {
         alloc_slot(&mut cfg, entry, 2, raw);
         let pointer = load_slot(&mut cfg, entry, 2, ptr_ty);
         let nine = konst(&mut cfg, entry, 9, Type::I32);
-        cfg.append_intrinsic(
+        cfg.append_intrinsic_operation(
             entry,
-            None,
+            rue_air::IntrinsicOperation::PtrWrite,
             interner.get_or_intern("ptr_write"),
             [pointer, nine],
             Type::UNIT,

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -910,7 +910,7 @@ fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
 pub(crate) fn compact_physical_access_unsupported(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
+    _interner: &ThreadedRodeo,
 ) -> Option<Type> {
     // A non-slot-identical aggregate (struct/array/enum) whose whole-value
     // marshalling across a CALL boundary is still unimplemented (RUE-976's
@@ -1037,9 +1037,17 @@ pub(crate) fn compact_physical_access_unsupported(
             // (RUE-1000); a struct/array (or intractable enum) pointee is
             // refused. The byte-addressed raw-byte family is not matched here —
             // it is correct under any layout.
-            CfgInstData::Intrinsic { name, .. } => {
-                let op = interner.resolve(name);
-                if matches!(op, "ptr_read" | "ptr_write" | "alloc" | "free" | "realloc") {
+            CfgInstData::Intrinsic { operation, .. } => {
+                if matches!(
+                    operation,
+                    rue_air::IntrinsicOperation::PtrRead
+                        | rue_air::IntrinsicOperation::PtrReadUnaligned
+                        | rue_air::IntrinsicOperation::PtrWrite
+                        | rue_air::IntrinsicOperation::PtrWriteUnaligned
+                        | rue_air::IntrinsicOperation::Alloc
+                        | rue_air::IntrinsicOperation::Free
+                        | rue_air::IntrinsicOperation::Realloc
+                ) {
                     let mut relevant = vec![inst.ty];
                     for &arg in cfg.get_intrinsic_args(&inst.data) {
                         relevant.push(cfg.get_inst(arg).ty);
@@ -1090,7 +1098,6 @@ pub(crate) fn compact_physical_access_unsupported(
 fn frame_raw_aggregate_pointer_unsupported(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
 ) -> Option<Type> {
     let non_slot_identical_aggregate = |ty: Type| -> bool {
         matches!(
@@ -1102,10 +1109,10 @@ fn frame_raw_aggregate_pointer_unsupported(
     for raw in 0..cfg.value_count() {
         let value = CfgValue::from_raw(raw as u32);
         let inst = cfg.get_inst(value);
-        let CfgInstData::Intrinsic { name, .. } = &inst.data else {
+        let CfgInstData::Intrinsic { operation, .. } = &inst.data else {
             continue;
         };
-        if !matches!(interner.resolve(name), "raw" | "raw_mut" | "field_ptr") {
+        if !operation.takes_place_address() {
             continue;
         }
 
@@ -1152,7 +1159,7 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
     // A raw pointer into a non-slot-identical frame aggregate mixes the frame's
     // slot layout with compact-image pointer semantics (RUE-1035 M2). Name the
     // construct — not the preview — and point at the working heap alternative.
-    if let Some(ty) = frame_raw_aggregate_pointer_unsupported(cfg, type_pool, interner) {
+    if let Some(ty) = frame_raw_aggregate_pointer_unsupported(cfg, type_pool) {
         let name = rue_air::drop_glue_names::type_name(ty, type_pool);
         return Err(rue_error::CompileError::without_span(
             rue_error::ErrorKind::InternalCodegenError(format!(

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -11,7 +11,8 @@
 //! architecture cannot quietly invent a different scalar/aggregate policy.
 
 use lasso::Spur;
-use rue_air::{EnumId, IntegerType, RuntimeCallKind, StructId, TypeKind};
+use rue_air::IntrinsicOperation;
+use rue_air::{EnumId, IntegerType, StructId, TypeKind};
 use rue_cfg::{CfgInstData, CfgValue, Place, PlaceBase, Projection, Type};
 use rue_runtime_abi::RuntimeHelperId;
 
@@ -260,83 +261,12 @@ pub enum DebugValuePlan {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OptionIntrinsic {
-    ReadLine,
-    ParseI32,
-    ParseI64,
-    ParseU32,
-    ParseU64,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IntrinsicOperation {
-    Option {
-        intrinsic: OptionIntrinsic,
-        some_discriminant: u64,
-        none_discriminant: u64,
-    },
-    RandomU32,
-    RandomU64,
-    PtrToInt,
-    IntToPtr,
-    PtrRead,
-    PtrWrite,
-    PtrOffset,
-    /// The unified byte-and-alignment allocation family (ADR-0059 Phase 3,
-    /// RUE-961). Every operand — the block pointer, the byte sizes, and the
-    /// alignment — is a user-supplied value, so these carry no layout-derived
-    /// payload; typed allocation is source-computed `@size_of`/`@align_of`
-    /// arithmetic at the call site.
-    Alloc,
-    AllocZeroed,
-    Free,
-    Realloc,
-    Resize,
-    ByteCopy,
-    ByteMove,
-    ByteSet,
-    ArgCount,
-    ArgPtr,
-    ArgLen,
-    EnvCount,
-    EnvPtr,
-    EnvLen,
-    PlaceAddress,
-    Debug,
-    Syscall,
-    /// Same-width two's-complement reinterpretation, `@bitCast` (RUE-952). The
-    /// language operation moves no bits; the payload is only the renormalization
-    /// the *register image* of the target type needs, selected here so neither
-    /// backend re-derives a width policy.
-    BitCast(BitCastForm),
-}
-
-/// How a `@bitCast` result reaches the target type's canonical register image
-/// (RUE-952).
-///
-/// Rue keeps an integer in a register in the canonical image of its own type:
-/// an 8/16-bit value is sign-/zero-extended per its signedness (the form
-/// `emit_subword_narrow` and `emit_wrap_narrow` restore), a 32-bit value has
-/// bits 32..63 clear (what a 32-bit ALU op leaves behind), and a 64-bit value
-/// occupies the whole register. A reinterpretation keeps the low `N` bits and
-/// changes only which type reads them, so the bits above `N` — which belong to
-/// the *source* type's image, and for a negative constant are its sign
-/// extension — must be rebuilt for the target.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BitCastForm {
-    /// 64-bit: the two images are the same 64 bits; a plain register move.
     Move,
-    /// Re-extend the low byte for a signed 8-bit target.
     Sign8,
-    /// Clear all but the low byte for an unsigned 8-bit target.
     Zero8,
-    /// Re-extend the low halfword for a signed 16-bit target.
     Sign16,
-    /// Clear all but the low halfword for an unsigned 16-bit target.
     Zero16,
-    /// Clear bits 32..63 for a 32-bit target of either signedness: that is the
-    /// canonical 32-bit image, and a signed consumer re-extends it itself
-    /// (`integer_extension` yields `Sign32` for `i32`).
     Zero32,
 }
 
@@ -356,11 +286,19 @@ pub fn bit_cast_form(to: Type) -> BitCastForm {
 
 #[derive(Debug, Clone)]
 pub struct IntrinsicPlan {
+    /// The exact payload-free semantic identity selected by sema. Contextual
+    /// layout facts live in their own fields and never replace this authority.
     pub operation: IntrinsicOperation,
     /// Shared runtime entry selected from the intrinsic semantics. Target
     /// adapters marshal this helper through their call leaf and do not map
     /// language intrinsics to runtime names themselves.
     pub runtime_call: Option<crate::runtime_call_plan::RuntimeCallPlan>,
+    /// Layout-dependent option tags, derived from the result type only for
+    /// the option-producing runtime operations.
+    pub option_discriminants: Option<(u64, u64)>,
+    /// Contextual normalization for the one payload-free `BitCast` operation.
+    /// `None` for every other operation.
+    pub bit_cast_form: Option<BitCastForm>,
     pub args: Vec<IntrinsicArgPlan>,
     pub result_ty: Type,
     pub result_slots: u32,
@@ -465,9 +403,6 @@ pub trait ValueLowerAdapter:
     /// The target-C psABI flavor for this backend: SysV AMD64 on x86-64, AAPCS64
     /// on AArch64. Names the classifier that governs a foreign-call boundary.
     fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor;
-    /// Resolve an intrinsic dispatch name without applying callable-machine
-    /// aliases. A source callable may legally share an intrinsic's spelling.
-    fn resolve_intrinsic_symbol(&self, symbol: Spur) -> String;
     fn resolve_named_symbol(&self, symbol: &str) -> String;
     fn call_arg_register_budget(&self) -> usize;
     fn return_register_budget(&self) -> u32;
@@ -1581,13 +1516,13 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             cache_result(adapter, value, result);
             Some(ValueKind::Call)
         }
-        CfgInstData::Intrinsic { runtime, name, .. } => {
-            assert!(
-                runtime.is_none_or(|runtime| runtime.validate()),
-                "intrinsic runtime metadata must be valid before codegen"
-            );
+        CfgInstData::Intrinsic {
+            operation, name: _, ..
+        } => {
             let args = ctx.cfg.get_intrinsic_args(&inst.data);
-            let name_string = adapter.resolve_intrinsic_symbol(*name);
+            let operation = *operation;
+            let bit_cast_form =
+                (operation == IntrinsicOperation::BitCast).then(|| bit_cast_form(inst.ty));
             let values: Vec<IntrinsicArgPlan> = args
                 .iter()
                 .copied()
@@ -1603,43 +1538,72 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     }
                 })
                 .collect();
-            if name_string == "panic" {
-                let result = adapter.emit_trap(TrapPlan::Panic {
-                    call: if let Some(arg) = values.first().filter(|arg| arg.slots.len() >= 2) {
+            if matches!(
+                operation,
+                IntrinsicOperation::PanicNoMessage | IntrinsicOperation::Panic
+            ) {
+                let runtime = operation
+                    .runtime_call_kind()
+                    .expect("panic operation must be runtime-backed");
+                let call = match operation {
+                    IntrinsicOperation::PanicNoMessage => {
+                        crate::runtime_call_plan::RuntimeCallPlan::no_args(runtime.helper())
+                    }
+                    IntrinsicOperation::Panic => {
+                        let message = values
+                            .first()
+                            .expect("validated panic must have one text argument");
                         crate::runtime_call_plan::RuntimeCallPlan::expect_manifest(
-                            RuntimeHelperId::Panic,
+                            runtime.helper(),
                             [
                                 crate::runtime_call_plan::RuntimeCallArg::const_pointer(
-                                    arg.slots[0],
+                                    message.slots[0],
                                     rue_runtime_abi::AbiType::Byte,
                                 ),
                                 crate::runtime_call_plan::RuntimeCallArg::value(
-                                    arg.slots[1],
+                                    message.slots[1],
                                     rue_runtime_abi::AbiType::U64,
                                 ),
                             ],
                         )
-                    } else {
-                        crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                            RuntimeHelperId::PanicNoMessage,
-                        )
-                    },
-                });
+                    }
+                    _ => unreachable!("non-panic operation in panic dispatch"),
+                };
+                let result = adapter.emit_trap(TrapPlan::Panic { call });
                 cache_result(adapter, value, result);
                 Some(ValueKind::Intrinsic)
-            } else if name_string == "assert" {
-                let message = values.get(1).map(|arg| MaterializedValue {
-                    primary: arg.primary,
-                    slots: arg.slots.clone(),
-                });
-                let call = if *runtime == Some(RuntimeCallKind::BoundsCheck) {
-                    // Slice indexing carries a typed compiler trap identity on
-                    // the existing conditional `assert` shape. Preserve that
-                    // identity through CFG lowering so it reaches the shared
-                    // bounds helper used by fixed-array projections.
-                    crate::runtime_call_plan::RuntimeCallPlan::no_args(RuntimeHelperId::BoundsCheck)
-                } else {
-                    trap_runtime_call(message.as_ref())
+            } else if matches!(
+                operation,
+                IntrinsicOperation::AssertFailed
+                    | IntrinsicOperation::AssertWithMessage
+                    | IntrinsicOperation::BoundsCheck
+            ) {
+                let runtime = operation
+                    .runtime_call_kind()
+                    .expect("assert operation must be runtime-backed");
+                let call = match operation {
+                    IntrinsicOperation::AssertFailed | IntrinsicOperation::BoundsCheck => {
+                        crate::runtime_call_plan::RuntimeCallPlan::no_args(runtime.helper())
+                    }
+                    IntrinsicOperation::AssertWithMessage => {
+                        let message = values
+                            .get(1)
+                            .expect("validated message assertion must carry text");
+                        crate::runtime_call_plan::RuntimeCallPlan::expect_manifest(
+                            runtime.helper(),
+                            [
+                                crate::runtime_call_plan::RuntimeCallArg::const_pointer(
+                                    message.slots[0],
+                                    rue_runtime_abi::AbiType::Byte,
+                                ),
+                                crate::runtime_call_plan::RuntimeCallArg::value(
+                                    message.slots[1],
+                                    rue_runtime_abi::AbiType::U64,
+                                ),
+                            ],
+                        )
+                    }
+                    _ => unreachable!("non-assert operation in assert dispatch"),
                 };
                 let result = adapter.emit_trap(TrapPlan::Assert {
                     condition: values[0].primary,
@@ -1648,114 +1612,6 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                 cache_result(adapter, value, result);
                 Some(ValueKind::Intrinsic)
             } else {
-                let operation = match name_string.as_str() {
-                    "read_line" => IntrinsicOperation::Option {
-                        intrinsic: OptionIntrinsic::ReadLine,
-                        some_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .0,
-                        none_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .1,
-                    },
-                    "parse_i32" => IntrinsicOperation::Option {
-                        intrinsic: OptionIntrinsic::ParseI32,
-                        some_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .0,
-                        none_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .1,
-                    },
-                    "parse_i64" => IntrinsicOperation::Option {
-                        intrinsic: OptionIntrinsic::ParseI64,
-                        some_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .0,
-                        none_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .1,
-                    },
-                    "parse_u32" => IntrinsicOperation::Option {
-                        intrinsic: OptionIntrinsic::ParseU32,
-                        some_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .0,
-                        none_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .1,
-                    },
-                    "parse_u64" => IntrinsicOperation::Option {
-                        intrinsic: OptionIntrinsic::ParseU64,
-                        some_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .0,
-                        none_discriminant: crate::types::option_variant_discriminants(
-                            ctx.type_pool,
-                            inst.ty,
-                        )
-                        .1,
-                    },
-                    "random_u32" => IntrinsicOperation::RandomU32,
-                    "random_u64" => IntrinsicOperation::RandomU64,
-                    // `@bitCast` renames the operand's bits at the result type
-                    // (RUE-952). Only the result type matters: the widths agree
-                    // by construction (sema rejects the cross-width form with
-                    // E0950), so the plan carries just the target's canonical
-                    // register image.
-                    "bitCast" => IntrinsicOperation::BitCast(bit_cast_form(inst.ty)),
-                    "ptr_to_int" => IntrinsicOperation::PtrToInt,
-                    "int_to_ptr" => IntrinsicOperation::IntToPtr,
-                    // The `_unaligned` scalar access pair (ADR-0059 Phase 4,
-                    // RUE-978/RUE-962) shares the aligned lowering: on x86-64 and
-                    // AArch64 a scalar load/store tolerates any address, so the
-                    // interim distinction is a semantic contract (spec 9.2:14k),
-                    // not a distinct instruction. Folding the names here keeps the
-                    // narrow-access and image-marshalling plans identical.
-                    "ptr_read" | "ptr_read_unaligned" => IntrinsicOperation::PtrRead,
-                    "ptr_write" | "ptr_write_unaligned" => IntrinsicOperation::PtrWrite,
-                    "ptr_offset" => IntrinsicOperation::PtrOffset,
-                    // The unified allocation family carries physical byte
-                    // sizes and an explicit alignment in its own operands
-                    // (ADR-0059 Phase 3, RUE-961), so nothing here consults a
-                    // pointee layout: every operand passes straight through.
-                    "alloc" => IntrinsicOperation::Alloc,
-                    "alloc_zeroed" => IntrinsicOperation::AllocZeroed,
-                    "free" => IntrinsicOperation::Free,
-                    "realloc" => IntrinsicOperation::Realloc,
-                    "resize" => IntrinsicOperation::Resize,
-                    "byte_copy" => IntrinsicOperation::ByteCopy,
-                    "byte_move" => IntrinsicOperation::ByteMove,
-                    "byte_set" => IntrinsicOperation::ByteSet,
-                    "arg_count" => IntrinsicOperation::ArgCount,
-                    "arg_ptr" => IntrinsicOperation::ArgPtr,
-                    "arg_len" => IntrinsicOperation::ArgLen,
-                    "env_count" => IntrinsicOperation::EnvCount,
-                    "env_ptr" => IntrinsicOperation::EnvPtr,
-                    "env_len" => IntrinsicOperation::EnvLen,
-                    "raw" | "raw_mut" | "field_ptr" => IntrinsicOperation::PlaceAddress,
-                    "dbg" => IntrinsicOperation::Debug,
-                    "syscall" => IntrinsicOperation::Syscall,
-                    _ => panic!("unsupported intrinsic {name_string}"),
-                };
                 let scale = match operation {
                     IntrinsicOperation::PtrOffset if !args.is_empty() => {
                         Some(crate::allocation::pointer_offset_scale_plan(
@@ -1766,68 +1622,65 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     _ => None,
                 };
                 let result_slots = ctx.type_slot_count(inst.ty);
-                let runtime_call = intrinsic_runtime_call(&operation, &values, result_slots);
-                // A narrow-scalar `@ptr_read`/`@ptr_write` under the compact
-                // layout accesses 1/2/4 physical bytes with the pointee's
-                // extension (RUE-989). The read's pointee is its result type; the
-                // write's pointee is the value operand's type. Every other
-                // operation, a full-slot scalar, or the gate being off yields
-                // `None`, preserving the slot-shaped path.
-                let narrow_access = match operation {
-                    IntrinsicOperation::PtrRead => {
-                        crate::types::narrow_scalar_access(ctx.type_pool, inst.ty)
-                    }
-                    IntrinsicOperation::PtrWrite => crate::types::narrow_scalar_access(
-                        ctx.type_pool,
-                        ctx.cfg.get_inst(args[1]).ty,
-                    ),
-                    _ => None,
-                };
+                let option_discriminants = matches!(
+                    operation,
+                    IntrinsicOperation::ReadLine
+                        | IntrinsicOperation::ParseI32
+                        | IntrinsicOperation::ParseI64
+                        | IntrinsicOperation::ParseU32
+                        | IntrinsicOperation::ParseU64
+                )
+                .then(|| crate::types::option_variant_discriminants(ctx.type_pool, inst.ty));
+                let runtime_call =
+                    intrinsic_runtime_call(&operation, &values, result_slots, option_discriminants);
+                // The aligned and unaligned pointer families share one physical
+                // access plan. The semantic operation remains distinct, but both
+                // backends consume the same pointee layout metadata.
+                let pointer_access = pointer_access_plan(
+                    operation,
+                    inst.ty,
+                    args.get(1).map(|arg| ctx.cfg.get_inst(*arg).ty),
+                );
+                // A narrow-scalar pointer read/write under the compact layout
+                // accesses 1/2/4 physical bytes with the pointee's extension
+                // (RUE-989). Every other operation, a full-slot scalar, or the
+                // gate being off yields `None`, preserving the slot-shaped path.
+                let narrow_access = pointer_access.and_then(|access| {
+                    crate::types::narrow_scalar_access(ctx.type_pool, access.pointee_ty)
+                });
                 // A compact aggregate pointee marshals its whole value through the
                 // pointer via its internal-slot → physical-byte image: a compact
                 // enum (RUE-1000) or a compact struct (RUE-987). The read's pointee
                 // is its result type; the write's pointee is the value operand's
                 // type. Scalars (narrow access) and slot-identical structs (the
                 // byte-identical full-slot path) yield `None`.
-                let physical_slots = match operation {
-                    IntrinsicOperation::PtrRead => {
-                        crate::types::pointer_image_slot_map(ctx.type_pool, inst.ty)
-                    }
-                    IntrinsicOperation::PtrWrite => crate::types::pointer_image_slot_map(
-                        ctx.type_pool,
-                        ctx.cfg.get_inst(args[1]).ty,
-                    ),
-                    _ => None,
-                };
+                let physical_slots = pointer_access.and_then(|access| {
+                    crate::types::pointer_image_slot_map(ctx.type_pool, access.pointee_ty)
+                });
                 // A heterogeneous compact aggregate pointee (no variant-independent
                 // map) marshals through the pointer with a per-variant tag dispatch
                 // (RUE-1037). Only when the single map above is `None`.
                 let dispatch_image = if physical_slots.is_some() {
                     None
                 } else {
-                    match operation {
-                        IntrinsicOperation::PtrRead => {
-                            crate::types::aggregate_dispatch_image(ctx.type_pool, inst.ty)
-                        }
-                        IntrinsicOperation::PtrWrite => crate::types::aggregate_dispatch_image(
-                            ctx.type_pool,
-                            ctx.cfg.get_inst(args[1]).ty,
-                        ),
-                        _ => None,
-                    }
+                    pointer_access.and_then(|access| {
+                        crate::types::aggregate_dispatch_image(ctx.type_pool, access.pointee_ty)
+                    })
                 };
-                // A compact enum `@ptr_write` initializes the whole image, so the
-                // pointee's padding is zeroed before the field stores (ADR-0052
-                // ruling 5). Only the write needs it; the read never stores.
-                let image_padding = match operation {
-                    IntrinsicOperation::PtrWrite if physical_slots.is_some() => ctx
+                // A compact enum pointer write initializes the whole image, so
+                // the pointee's padding is zeroed before the field stores
+                // (ADR-0052 ruling 5). Only writes need it; reads never store.
+                let image_padding = match pointer_access {
+                    Some(access) if access.is_write && physical_slots.is_some() => ctx
                         .type_pool
-                        .compact_image_padding_ranges(ctx.cfg.get_inst(args[1]).ty),
+                        .compact_image_padding_ranges(access.pointee_ty),
                     _ => Vec::new(),
                 };
                 let result = adapter.emit_intrinsic(IntrinsicPlan {
                     operation,
                     runtime_call,
+                    option_discriminants,
+                    bit_cast_form,
                     args: values,
                     result_ty: inst.ty,
                     result_slots,
@@ -1972,149 +1825,149 @@ fn realize_alloc_operands(
         .collect()
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PointerAccessPlan {
+    pointee_ty: Type,
+    is_write: bool,
+}
+
+fn pointer_access_plan(
+    operation: IntrinsicOperation,
+    result_ty: Type,
+    write_value_ty: Option<Type>,
+) -> Option<PointerAccessPlan> {
+    match operation {
+        IntrinsicOperation::PtrRead | IntrinsicOperation::PtrReadUnaligned => {
+            Some(PointerAccessPlan {
+                pointee_ty: result_ty,
+                is_write: false,
+            })
+        }
+        IntrinsicOperation::PtrWrite | IntrinsicOperation::PtrWriteUnaligned => {
+            Some(PointerAccessPlan {
+                pointee_ty: write_value_ty
+                    .expect("validated pointer write must carry its value operand"),
+                is_write: true,
+            })
+        }
+        _ => None,
+    }
+}
+
 fn intrinsic_runtime_call(
     operation: &IntrinsicOperation,
     args: &[IntrinsicArgPlan],
     result_slots: u32,
+    option_discriminants: Option<(u64, u64)>,
 ) -> Option<crate::runtime_call_plan::RuntimeCallPlan> {
     use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallPlan};
-    use rue_air::RuntimeCallKind;
     use rue_runtime_abi::{AbiType, AggregateShapeId};
 
-    let (helper, call_args) = match operation {
-        IntrinsicOperation::Option { intrinsic, .. } => match intrinsic {
-            OptionIntrinsic::ReadLine => (
-                RuntimeHelperId::ReadLine,
-                vec![
-                    RuntimeCallArg::out_pointer(AggregateShapeId::OptionStrBufResult),
-                    RuntimeCallArg::immediate(option_discriminants(operation).0, AbiType::U64),
-                    RuntimeCallArg::immediate(option_discriminants(operation).1, AbiType::U64),
+    let runtime = operation.runtime_call_kind()?;
+    let helper = runtime.helper();
+    let call_args = match operation {
+        IntrinsicOperation::ReadLine => {
+            let (some, none) = option_discriminants
+                .expect("validated option-producing intrinsic must carry discriminants");
+            vec![
+                RuntimeCallArg::out_pointer(AggregateShapeId::OptionStrBufResult),
+                RuntimeCallArg::immediate(some, AbiType::U64),
+                RuntimeCallArg::immediate(none, AbiType::U64),
+            ]
+        }
+        IntrinsicOperation::ParseI32
+        | IntrinsicOperation::ParseI64
+        | IntrinsicOperation::ParseU32
+        | IntrinsicOperation::ParseU64 => {
+            let (some, none) = option_discriminants
+                .expect("validated option-producing intrinsic must carry discriminants");
+            let arg = args
+                .first()
+                .expect("validated parse intrinsic must carry text");
+            vec![
+                RuntimeCallArg::out_pointer(AggregateShapeId::OptionIntResult),
+                RuntimeCallArg::const_pointer(arg.slots[0], AbiType::Byte),
+                RuntimeCallArg::value(arg.slots[1], AbiType::U64),
+                RuntimeCallArg::immediate(some, AbiType::U64),
+                RuntimeCallArg::immediate(none, AbiType::U64),
+            ]
+        }
+        IntrinsicOperation::RandomU32
+        | IntrinsicOperation::RandomU64
+        | IntrinsicOperation::ArgCount
+        | IntrinsicOperation::EnvCount => vec![],
+        IntrinsicOperation::ArgLen
+        | IntrinsicOperation::EnvLen
+        | IntrinsicOperation::ArgPtr
+        | IntrinsicOperation::EnvPtr => {
+            vec![RuntimeCallArg::value(args[0].primary, AbiType::U64)]
+        }
+        IntrinsicOperation::Alloc
+        | IntrinsicOperation::AllocZeroed
+        | IntrinsicOperation::Free
+        | IntrinsicOperation::Realloc
+        | IntrinsicOperation::Resize => realize_alloc_operands(runtime, args),
+        IntrinsicOperation::ByteCopy | IntrinsicOperation::ByteMove => vec![
+            RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
+            RuntimeCallArg::const_pointer(args[1].primary, AbiType::Byte),
+            RuntimeCallArg::value(args[2].primary, AbiType::U64),
+        ],
+        IntrinsicOperation::ByteSet => vec![
+            RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
+            RuntimeCallArg::extended(args[1].primary, args[1].integer_extension, AbiType::U64),
+            RuntimeCallArg::value(args[2].primary, AbiType::U64),
+        ],
+        IntrinsicOperation::DebugI64
+        | IntrinsicOperation::DebugU64
+        | IntrinsicOperation::DebugBool
+        | IntrinsicOperation::DebugStr => {
+            let arg = args
+                .first()
+                .expect("validated debug intrinsic must carry one value");
+            match operation {
+                IntrinsicOperation::DebugStr => vec![
+                    RuntimeCallArg::const_pointer(arg.slots[0], AbiType::Byte),
+                    RuntimeCallArg::value(arg.slots[1], AbiType::U64),
                 ],
-            ),
-            intrinsic => {
-                let arg = args.first()?;
-                let helper = match intrinsic {
-                    OptionIntrinsic::ParseI32 => RuntimeHelperId::ParseI32,
-                    OptionIntrinsic::ParseI64 => RuntimeHelperId::ParseI64,
-                    OptionIntrinsic::ParseU32 => RuntimeHelperId::ParseU32,
-                    OptionIntrinsic::ParseU64 => RuntimeHelperId::ParseU64,
-                    OptionIntrinsic::ReadLine => unreachable!(),
-                };
-                (
-                    helper,
-                    vec![
-                        RuntimeCallArg::out_pointer(AggregateShapeId::OptionIntResult),
-                        RuntimeCallArg::const_pointer(arg.slots[0], AbiType::Byte),
-                        RuntimeCallArg::value(arg.slots[1], AbiType::U64),
-                        RuntimeCallArg::immediate(option_discriminants(operation).0, AbiType::U64),
-                        RuntimeCallArg::immediate(option_discriminants(operation).1, AbiType::U64),
-                    ],
-                )
+                IntrinsicOperation::DebugI64 => vec![RuntimeCallArg::extended(
+                    arg.primary,
+                    arg.integer_extension,
+                    AbiType::I64,
+                )],
+                IntrinsicOperation::DebugU64 => vec![RuntimeCallArg::extended(
+                    arg.primary,
+                    arg.integer_extension,
+                    AbiType::U64,
+                )],
+                IntrinsicOperation::DebugBool => vec![RuntimeCallArg::extended(
+                    arg.primary,
+                    arg.integer_extension,
+                    AbiType::BoolWordI64,
+                )],
+                _ => unreachable!("non-debug operation in debug dispatch"),
             }
-        },
-        IntrinsicOperation::RandomU32 => (RuntimeHelperId::RandomU32, vec![]),
-        IntrinsicOperation::RandomU64 => (RuntimeHelperId::RandomU64, vec![]),
-        IntrinsicOperation::ArgCount => (RuntimeHelperId::ArgCount, vec![]),
-        IntrinsicOperation::EnvCount => (RuntimeHelperId::EnvCount, vec![]),
-        IntrinsicOperation::ArgLen => (
-            RuntimeHelperId::ArgLen,
-            vec![RuntimeCallArg::value(args[0].primary, AbiType::U64)],
-        ),
-        IntrinsicOperation::EnvLen => (
-            RuntimeHelperId::EnvLen,
-            vec![RuntimeCallArg::value(args[0].primary, AbiType::U64)],
-        ),
-        IntrinsicOperation::ArgPtr => (
-            RuntimeHelperId::ArgPtr,
-            vec![RuntimeCallArg::value(args[0].primary, AbiType::U64)],
-        ),
-        IntrinsicOperation::EnvPtr => (
-            RuntimeHelperId::EnvPtr,
-            vec![RuntimeCallArg::value(args[0].primary, AbiType::U64)],
-        ),
-        IntrinsicOperation::Alloc => (
-            RuntimeHelperId::Alloc,
-            realize_alloc_operands(RuntimeCallKind::Alloc, args),
-        ),
-        IntrinsicOperation::AllocZeroed => (
-            RuntimeHelperId::AllocZeroed,
-            realize_alloc_operands(RuntimeCallKind::AllocZeroed, args),
-        ),
-        IntrinsicOperation::Free => (
-            RuntimeHelperId::Free,
-            realize_alloc_operands(RuntimeCallKind::Free, args),
-        ),
-        IntrinsicOperation::ByteCopy => (
-            RuntimeHelperId::ByteCopy,
-            vec![
-                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
-                RuntimeCallArg::const_pointer(args[1].primary, AbiType::Byte),
-                RuntimeCallArg::value(args[2].primary, AbiType::U64),
-            ],
-        ),
-        IntrinsicOperation::ByteMove => (
-            RuntimeHelperId::ByteMove,
-            vec![
-                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
-                RuntimeCallArg::const_pointer(args[1].primary, AbiType::Byte),
-                RuntimeCallArg::value(args[2].primary, AbiType::U64),
-            ],
-        ),
-        IntrinsicOperation::ByteSet => (
-            RuntimeHelperId::ByteSet,
-            vec![
-                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
-                RuntimeCallArg::extended(args[1].primary, args[1].integer_extension, AbiType::U64),
-                RuntimeCallArg::value(args[2].primary, AbiType::U64),
-            ],
-        ),
-        IntrinsicOperation::Realloc => (
-            RuntimeHelperId::Realloc,
-            realize_alloc_operands(RuntimeCallKind::Realloc, args),
-        ),
-        IntrinsicOperation::Resize => (
-            RuntimeHelperId::Resize,
-            realize_alloc_operands(RuntimeCallKind::Resize, args),
-        ),
-        IntrinsicOperation::Debug => {
-            let arg = args.first()?;
-            if arg.slots.len() >= 2 {
-                (
-                    RuntimeHelperId::DebugStr,
-                    vec![
-                        RuntimeCallArg::const_pointer(arg.slots[0], AbiType::Byte),
-                        RuntimeCallArg::value(arg.slots[1], AbiType::U64),
-                    ],
-                )
-            } else {
-                let (helper, ty) = match arg.debug {
-                    DebugValuePlan::Bool => (RuntimeHelperId::DebugBool, AbiType::BoolWordI64),
-                    DebugValuePlan::Integer(IntegerWidth { signed: true, .. }) => {
-                        (RuntimeHelperId::DebugI64, AbiType::I64)
-                    }
-                    DebugValuePlan::Integer(IntegerWidth { signed: false, .. }) => {
-                        (RuntimeHelperId::DebugU64, AbiType::U64)
-                    }
-                    DebugValuePlan::String | DebugValuePlan::Other => return None,
-                };
-                (
-                    helper,
-                    vec![RuntimeCallArg::extended(
-                        arg.primary,
-                        arg.integer_extension,
-                        ty,
-                    )],
-                )
-            }
+        }
+        IntrinsicOperation::Panic
+        | IntrinsicOperation::PanicNoMessage
+        | IntrinsicOperation::AssertFailed
+        | IntrinsicOperation::AssertWithMessage
+        | IntrinsicOperation::BoundsCheck => {
+            unreachable!("trap runtime calls are planned by exact operation above")
         }
         IntrinsicOperation::PtrToInt
         | IntrinsicOperation::IntToPtr
         | IntrinsicOperation::PtrRead
+        | IntrinsicOperation::PtrReadUnaligned
         | IntrinsicOperation::PtrWrite
+        | IntrinsicOperation::PtrWriteUnaligned
         | IntrinsicOperation::PtrOffset
-        | IntrinsicOperation::PlaceAddress
-        | IntrinsicOperation::BitCast(_)
-        | IntrinsicOperation::Syscall => return None,
+        | IntrinsicOperation::Raw
+        | IntrinsicOperation::RawMut
+        | IntrinsicOperation::FieldPtr
+        | IntrinsicOperation::BitCast
+        | IntrinsicOperation::Syscall => {
+            unreachable!("pure intrinsic cannot have a runtime-call mapping")
+        }
     };
     let plan = RuntimeCallPlan::expect_manifest(helper, call_args);
     if let Some(shape) = plan.out_shape() {
@@ -2125,40 +1978,6 @@ fn intrinsic_runtime_call(
         );
     }
     Some(plan)
-}
-
-fn option_discriminants(operation: &IntrinsicOperation) -> (u64, u64) {
-    match operation {
-        IntrinsicOperation::Option {
-            some_discriminant,
-            none_discriminant,
-            ..
-        } => (*some_discriminant, *none_discriminant),
-        _ => unreachable!(),
-    }
-}
-
-fn trap_runtime_call(
-    message: Option<&MaterializedValue>,
-) -> crate::runtime_call_plan::RuntimeCallPlan {
-    if message.is_some_and(|value| value.slots.len() >= 2) {
-        let message = message.unwrap();
-        crate::runtime_call_plan::RuntimeCallPlan::expect_manifest(
-            RuntimeHelperId::Panic,
-            [
-                crate::runtime_call_plan::RuntimeCallArg::const_pointer(
-                    message.slots[0],
-                    rue_runtime_abi::AbiType::Byte,
-                ),
-                crate::runtime_call_plan::RuntimeCallArg::value(
-                    message.slots[1],
-                    rue_runtime_abi::AbiType::U64,
-                ),
-            ],
-        )
-    } else {
-        crate::runtime_call_plan::RuntimeCallPlan::no_args(RuntimeHelperId::AssertFailed)
-    }
 }
 
 fn power_of_two_shift(ctx: &CfgLowerContext<'_>, value: CfgValue) -> Option<u8> {
@@ -2368,13 +2187,14 @@ mod tests {
 
     use super::{
         ComparisonPreparation, DebugValuePlan, IntegerExtension, IntegerWidth, IntrinsicArgPlan,
-        IntrinsicOperation, MaterializationRequirement, MaterializedValue, OptionIntrinsic,
-        StoragePolicy, StoreDestination, ValuePlan, ValueShape, assert_slot_policy,
-        comparison_integer_width, integer_range, type_bits, type_range,
+        MaterializationRequirement, PointerAccessPlan, StoragePolicy, StoreDestination, ValuePlan,
+        ValueShape, assert_slot_policy, comparison_integer_width, integer_range,
+        pointer_access_plan, type_bits, type_range,
     };
     use lasso::ThreadedRodeo;
     use rue_air::{
-        EnumDef, LangItem, ParamSlotModes, RuntimeCallKind, StructDef, StructField, TypeInternPool,
+        EnumDef, IntrinsicOperation, LangItem, ParamSlotModes, StructDef, StructField,
+        TypeInternPool,
     };
     use rue_cfg::{Cfg, CfgInst, CfgInstData, CfgValue, Place, Type};
     use rue_runtime_abi::RuntimeHelperId;
@@ -2572,9 +2392,16 @@ mod tests {
             .append_call(entry, None, call_name, [], Type::I32, Span::new(0, 0))
             .unwrap();
         values.borrow_mut().push(call);
-        let panic_name = interner.get_or_intern("panic");
+        let assert_name = interner.get_or_intern("assert");
         let intrinsic = cfg
-            .append_intrinsic(entry, None, panic_name, [], Type::UNIT, Span::new(0, 0))
+            .append_intrinsic_operation(
+                entry,
+                rue_air::IntrinsicOperation::AssertFailed,
+                assert_name,
+                [bool_constant],
+                Type::UNIT,
+                Span::new(0, 0),
+            )
             .unwrap();
         values.borrow_mut().push(intrinsic);
         let struct_value = cfg
@@ -3175,7 +3002,14 @@ mod tests {
         cfg.entry = entry;
         let input = cfg.append_inst(entry, inst(CfgInstData::Const(0xFFFF_FFFF), Type::U32));
         let result = cfg
-            .append_intrinsic(entry, None, bit_cast, [input], Type::U32, Span::new(0, 0))
+            .append_intrinsic_operation(
+                entry,
+                rue_air::IntrinsicOperation::BitCast,
+                bit_cast,
+                [input],
+                Type::U32,
+                Span::new(0, 0),
+            )
             .expect("synthetic bitCast should append");
         cfg.set_return(entry, Some(result));
 
@@ -3339,30 +3173,65 @@ mod tests {
     }
 
     #[test]
-    fn assert_trap_plan_selects_manifest_runtime_call() {
-        let condition = crate::vreg::VReg::new(0);
-        let no_message = MaterializedValue {
-            primary: condition,
-            slots: Vec::new(),
-        };
-        let message = MaterializedValue {
-            primary: crate::vreg::VReg::new(1),
-            slots: vec![crate::vreg::VReg::new(1), crate::vreg::VReg::new(2)],
-        };
+    fn aligned_and_unaligned_pointer_operations_share_one_physical_access_plan() {
+        let read = Some(PointerAccessPlan {
+            pointee_ty: Type::U16,
+            is_write: false,
+        });
+        assert_eq!(
+            pointer_access_plan(IntrinsicOperation::PtrRead, Type::U16, None),
+            read
+        );
+        assert_eq!(
+            pointer_access_plan(IntrinsicOperation::PtrReadUnaligned, Type::U16, None),
+            read
+        );
 
+        let write = Some(PointerAccessPlan {
+            pointee_ty: Type::U8,
+            is_write: true,
+        });
         assert_eq!(
-            super::trap_runtime_call(None).helper(),
-            RuntimeHelperId::AssertFailed
+            pointer_access_plan(IntrinsicOperation::PtrWrite, Type::UNIT, Some(Type::U8),),
+            write
         );
         assert_eq!(
-            super::trap_runtime_call(Some(&no_message)).helper(),
-            RuntimeHelperId::AssertFailed
+            pointer_access_plan(
+                IntrinsicOperation::PtrWriteUnaligned,
+                Type::UNIT,
+                Some(Type::U8),
+            ),
+            write
         );
         assert_eq!(
-            super::trap_runtime_call(Some(&message)).helper(),
-            RuntimeHelperId::Panic
+            pointer_access_plan(IntrinsicOperation::BitCast, Type::U16, Some(Type::U8)),
+            None
         );
-        assert_eq!(super::trap_runtime_call(Some(&message)).args().len(), 2);
+    }
+
+    #[test]
+    fn trap_operations_have_exact_manifest_runtime_identities() {
+        for (operation, helper) in [
+            (
+                IntrinsicOperation::PanicNoMessage,
+                RuntimeHelperId::PanicNoMessage,
+            ),
+            (IntrinsicOperation::Panic, RuntimeHelperId::Panic),
+            (
+                IntrinsicOperation::AssertFailed,
+                RuntimeHelperId::AssertFailed,
+            ),
+            (
+                IntrinsicOperation::AssertWithMessage,
+                RuntimeHelperId::Panic,
+            ),
+            (
+                IntrinsicOperation::BoundsCheck,
+                RuntimeHelperId::BoundsCheck,
+            ),
+        ] {
+            assert_eq!(operation.runtime_call_kind().unwrap().helper(), helper);
+        }
     }
 
     #[test]
@@ -3373,9 +3242,9 @@ mod tests {
         let entry = cfg.new_block();
         cfg.entry = entry;
         let condition = cfg.append_inst(entry, inst(CfgInstData::BoolConst(false), Type::BOOL));
-        cfg.append_intrinsic(
+        cfg.append_intrinsic_operation(
             entry,
-            Some(RuntimeCallKind::BoundsCheck),
+            rue_air::IntrinsicOperation::BoundsCheck,
             assert_name,
             [condition],
             Type::UNIT,
@@ -3418,27 +3287,35 @@ mod tests {
             ..scalar_arg.clone()
         };
 
-        let option = |intrinsic| IntrinsicOperation::Option {
-            intrinsic,
-            some_discriminant: 1,
-            none_discriminant: 0,
-        };
         let call = |operation, args: &[IntrinsicArgPlan], result_slots| {
-            super::intrinsic_runtime_call(&operation, args, result_slots)
-                .expect("operation should have a runtime call")
+            super::intrinsic_runtime_call(
+                &operation,
+                args,
+                result_slots,
+                matches!(
+                    operation,
+                    IntrinsicOperation::ReadLine
+                        | IntrinsicOperation::ParseI32
+                        | IntrinsicOperation::ParseI64
+                        | IntrinsicOperation::ParseU32
+                        | IntrinsicOperation::ParseU64
+                )
+                .then_some((1, 0)),
+            )
+            .expect("operation should have a runtime call")
         };
 
         assert_eq!(
-            call(option(OptionIntrinsic::ReadLine), &[], 4).helper(),
+            call(IntrinsicOperation::ReadLine, &[], 4).helper(),
             RuntimeHelperId::ReadLine
         );
-        for (intrinsic, helper) in [
-            (OptionIntrinsic::ParseI32, RuntimeHelperId::ParseI32),
-            (OptionIntrinsic::ParseI64, RuntimeHelperId::ParseI64),
-            (OptionIntrinsic::ParseU32, RuntimeHelperId::ParseU32),
-            (OptionIntrinsic::ParseU64, RuntimeHelperId::ParseU64),
+        for (operation, helper) in [
+            (IntrinsicOperation::ParseI32, RuntimeHelperId::ParseI32),
+            (IntrinsicOperation::ParseI64, RuntimeHelperId::ParseI64),
+            (IntrinsicOperation::ParseU32, RuntimeHelperId::ParseU32),
+            (IntrinsicOperation::ParseU64, RuntimeHelperId::ParseU64),
         ] {
-            let plan = call(option(intrinsic), std::slice::from_ref(&string_arg), 2);
+            let plan = call(operation, std::slice::from_ref(&string_arg), 2);
             assert_eq!(plan.helper(), helper);
             assert_eq!(plan.args().len(), 5);
         }
@@ -3516,7 +3393,7 @@ mod tests {
         );
         assert_eq!(
             call(
-                IntrinsicOperation::Debug,
+                IntrinsicOperation::DebugBool,
                 std::slice::from_ref(&scalar_arg),
                 0,
             )
@@ -3525,7 +3402,7 @@ mod tests {
         );
         assert_eq!(
             call(
-                IntrinsicOperation::Debug,
+                IntrinsicOperation::DebugStr,
                 std::slice::from_ref(&string_arg),
                 0,
             )

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2008,18 +2008,6 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    fn lower_option_intrinsic(
-        &mut self,
-        plan: &crate::value_plan::IntrinsicPlan,
-        _intrinsic: crate::value_plan::OptionIntrinsic,
-    ) -> crate::value_plan::MaterializedValue {
-        self.lower_runtime_call(
-            plan.runtime_call
-                .clone()
-                .expect("option intrinsic runtime call plan"),
-        )
-    }
-
     fn lower_intrinsic_plan(
         &mut self,
         plan: crate::value_plan::IntrinsicPlan,
@@ -2027,33 +2015,39 @@ impl<'a> CfgLower<'a> {
         let operation = plan.operation;
         let mut slots = Vec::new();
         let primary = match operation {
-            crate::value_plan::IntrinsicOperation::Option { intrinsic, .. } => {
-                let result = self.lower_option_intrinsic(&plan, intrinsic);
+            rue_air::IntrinsicOperation::ReadLine
+            | rue_air::IntrinsicOperation::ParseI32
+            | rue_air::IntrinsicOperation::ParseI64
+            | rue_air::IntrinsicOperation::ParseU32
+            | rue_air::IntrinsicOperation::ParseU64 => {
+                let result = self.lower_runtime_call(
+                    plan.runtime_call
+                        .clone()
+                        .expect("option intrinsic runtime call plan"),
+                );
                 slots = result.slots;
                 result.primary
             }
-            crate::value_plan::IntrinsicOperation::RandomU32
-            | crate::value_plan::IntrinsicOperation::RandomU64 => {
+            rue_air::IntrinsicOperation::RandomU32 | rue_air::IntrinsicOperation::RandomU64 => {
                 self.lower_runtime_call(
                     plan.runtime_call
                         .expect("random intrinsic runtime call plan"),
                 )
                 .primary
             }
-            crate::value_plan::IntrinsicOperation::ArgCount
-            | crate::value_plan::IntrinsicOperation::ArgPtr
-            | crate::value_plan::IntrinsicOperation::ArgLen
-            | crate::value_plan::IntrinsicOperation::EnvCount
-            | crate::value_plan::IntrinsicOperation::EnvPtr
-            | crate::value_plan::IntrinsicOperation::EnvLen => {
+            rue_air::IntrinsicOperation::ArgCount
+            | rue_air::IntrinsicOperation::ArgPtr
+            | rue_air::IntrinsicOperation::ArgLen
+            | rue_air::IntrinsicOperation::EnvCount
+            | rue_air::IntrinsicOperation::EnvPtr
+            | rue_air::IntrinsicOperation::EnvLen => {
                 self.lower_runtime_call(
                     plan.runtime_call
                         .expect("process arg/env intrinsic runtime call plan"),
                 )
                 .primary
             }
-            crate::value_plan::IntrinsicOperation::PtrToInt
-            | crate::value_plan::IntrinsicOperation::IntToPtr => {
+            rue_air::IntrinsicOperation::PtrToInt | rue_air::IntrinsicOperation::IntToPtr => {
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Virtual(dst),
@@ -2065,8 +2059,11 @@ impl<'a> CfgLower<'a> {
             // rebuilds only the bits above the shared width, which belong to the
             // source type's register image. The shared planner picked the form
             // from the target type; this leaf just spells it.
-            crate::value_plan::IntrinsicOperation::BitCast(form) => {
+            rue_air::IntrinsicOperation::BitCast => {
                 use crate::value_plan::BitCastForm;
+                let form = plan
+                    .bit_cast_form
+                    .expect("bitCast intrinsic must carry its contextual form");
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Virtual(dst),
@@ -2100,7 +2097,8 @@ impl<'a> CfgLower<'a> {
                 }
                 dst
             }
-            crate::value_plan::IntrinsicOperation::PtrRead => {
+            rue_air::IntrinsicOperation::PtrRead
+            | rue_air::IntrinsicOperation::PtrReadUnaligned => {
                 let ptr = plan.args[0].primary;
                 let count = plan.result_slots;
                 if let Some(map) = &plan.physical_slots {
@@ -2145,7 +2143,8 @@ impl<'a> CfgLower<'a> {
                     dst
                 }
             }
-            crate::value_plan::IntrinsicOperation::PtrWrite => {
+            rue_air::IntrinsicOperation::PtrWrite
+            | rue_air::IntrinsicOperation::PtrWriteUnaligned => {
                 let ptr = plan.args[0].primary;
                 let value = &plan.args[1];
                 if let Some(map) = &plan.physical_slots {
@@ -2200,7 +2199,7 @@ impl<'a> CfgLower<'a> {
                 });
                 dst
             }
-            crate::value_plan::IntrinsicOperation::PtrOffset => {
+            rue_air::IntrinsicOperation::PtrOffset => {
                 let offset = plan.args[1].primary;
                 let offset = match plan.args[1].integer_extension {
                     crate::value_plan::IntegerExtension::None => offset,
@@ -2249,39 +2248,41 @@ impl<'a> CfgLower<'a> {
             // The unified allocation family and the bulk byte primitives are
             // pure runtime calls: the shared plan already carries their
             // operands in helper order (ADR-0059 Phase 3, RUE-961).
-            crate::value_plan::IntrinsicOperation::Alloc => {
+            rue_air::IntrinsicOperation::Alloc => {
                 self.lower_runtime_call(plan.runtime_call.expect("alloc runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::AllocZeroed => {
+            rue_air::IntrinsicOperation::AllocZeroed => {
                 self.lower_runtime_call(plan.runtime_call.expect("alloc-zeroed runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Free => {
+            rue_air::IntrinsicOperation::Free => {
                 self.lower_runtime_call(plan.runtime_call.expect("free runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Realloc => {
+            rue_air::IntrinsicOperation::Realloc => {
                 self.lower_runtime_call(plan.runtime_call.expect("realloc runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Resize => {
+            rue_air::IntrinsicOperation::Resize => {
                 self.lower_runtime_call(plan.runtime_call.expect("resize runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::ByteCopy => {
+            rue_air::IntrinsicOperation::ByteCopy => {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-copy runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::ByteMove => {
+            rue_air::IntrinsicOperation::ByteMove => {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-move runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::ByteSet => {
+            rue_air::IntrinsicOperation::ByteSet => {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-set runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::PlaceAddress => {
+            rue_air::IntrinsicOperation::Raw
+            | rue_air::IntrinsicOperation::RawMut
+            | rue_air::IntrinsicOperation::FieldPtr => {
                 let place = plan.args[0]
                     .place
                     .as_ref()
@@ -2290,11 +2291,14 @@ impl<'a> CfgLower<'a> {
                 crate::place_lower::lower_place_addr_plan(self, dst, place);
                 dst
             }
-            crate::value_plan::IntrinsicOperation::Debug => {
+            rue_air::IntrinsicOperation::DebugI64
+            | rue_air::IntrinsicOperation::DebugU64
+            | rue_air::IntrinsicOperation::DebugBool
+            | rue_air::IntrinsicOperation::DebugStr => {
                 self.lower_runtime_call(plan.runtime_call.expect("debug runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Syscall => {
+            rue_air::IntrinsicOperation::Syscall => {
                 let syscall_regs = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::R10, Reg::R8, Reg::R9];
                 for arg in plan.args.iter().rev() {
                     self.mir.push(X86Inst::MovRR {
@@ -2322,6 +2326,13 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Physical(Reg::Rax),
                 });
                 dst
+            }
+            rue_air::IntrinsicOperation::PanicNoMessage
+            | rue_air::IntrinsicOperation::Panic
+            | rue_air::IntrinsicOperation::AssertFailed
+            | rue_air::IntrinsicOperation::AssertWithMessage
+            | rue_air::IntrinsicOperation::BoundsCheck => {
+                unreachable!("trap handled above")
             }
         };
         crate::value_plan::MaterializedValue { primary, slots }
@@ -2929,9 +2940,6 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     }
     fn resolve_symbol(&self, symbol: lasso::Spur) -> String {
         self.symbols.resolve(self.interner.resolve(&symbol))
-    }
-    fn resolve_intrinsic_symbol(&self, symbol: lasso::Spur) -> String {
-        self.interner.resolve(&symbol).to_owned()
     }
     fn resolve_named_symbol(&self, symbol: &str) -> String {
         self.symbols.resolve(symbol)
@@ -3615,8 +3623,8 @@ impl crate::aggregate_eq::AggregateEqPlanBackend for CfgLower<'_> {
 mod tests {
     use super::*;
     use rue_air::{
-        EnumDef, EnumId, ParamSlotModes, RuntimeCallKind, SourceParamAbi, StructDef, StructField,
-        StructId, TypeInternPool,
+        EnumDef, EnumId, ParamSlotModes, SourceParamAbi, StructDef, StructField, StructId,
+        TypeInternPool,
     };
     use rue_cfg::{CfgArgMode, CfgCallArg, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_span::{FileId, Span};
@@ -3893,16 +3901,16 @@ mod tests {
 
         fn intrinsic(
             &mut self,
-            runtime: Option<RuntimeCallKind>,
+            operation: rue_air::IntrinsicOperation,
             name: &str,
             args: &[CfgValue],
             ty: Type,
         ) -> CfgValue {
             let name = self.interner.get_or_intern(name);
             self.cfg
-                .append_intrinsic(
+                .append_intrinsic_operation(
                     self.current,
-                    runtime,
+                    operation,
                     name,
                     args.iter().copied(),
                     ty,
@@ -4006,13 +4014,23 @@ mod tests {
         let align_i32 = fixture.konst(align, Type::I32);
         let align = fixture.cast(align_i32, Type::I32, Type::U64);
         let raw = fixture.intrinsic(
-            Some(RuntimeCallKind::Alloc),
+            rue_air::IntrinsicOperation::Alloc,
             "alloc",
             &[size, align],
             raw_ptr_ty,
         );
-        let address = fixture.intrinsic(None, "ptr_to_int", &[raw], Type::U64);
-        let pointer = fixture.intrinsic(None, "int_to_ptr", &[address], ptr_ty);
+        let address = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrToInt,
+            "ptr_to_int",
+            &[raw],
+            Type::U64,
+        );
+        let pointer = fixture.intrinsic(
+            rue_air::IntrinsicOperation::IntToPtr,
+            "int_to_ptr",
+            &[address],
+            ptr_ty,
+        );
         fixture.alloc(slot, pointer);
     }
 
@@ -4026,14 +4044,24 @@ mod tests {
         ptr_ty: Type,
     ) {
         let pointer = fixture.load(slot, ptr_ty);
-        let address = fixture.intrinsic(None, "ptr_to_int", &[pointer], Type::U64);
-        let laundered = fixture.intrinsic(None, "int_to_ptr", &[address], raw_ptr_ty);
+        let address = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrToInt,
+            "ptr_to_int",
+            &[pointer],
+            Type::U64,
+        );
+        let laundered = fixture.intrinsic(
+            rue_air::IntrinsicOperation::IntToPtr,
+            "int_to_ptr",
+            &[address],
+            raw_ptr_ty,
+        );
         let size_i32 = fixture.konst(size, Type::I32);
         let size = fixture.cast(size_i32, Type::I32, Type::U64);
         let align_i32 = fixture.konst(align, Type::I32);
         let align = fixture.cast(align_i32, Type::I32, Type::U64);
         fixture.intrinsic(
-            Some(RuntimeCallKind::Free),
+            rue_air::IntrinsicOperation::Free,
             "free",
             &[laundered, size, align],
             Type::UNIT,
@@ -4114,11 +4142,26 @@ mod tests {
         checked_alloc(&mut fixture, 0, 4, 4, raw_ptr_ty, ptr_ty);
         let pointer = fixture.load(0, ptr_ty);
         let five = fixture.konst(5, Type::I32);
-        fixture.intrinsic(None, "ptr_write", &[pointer, five], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, five],
+            Type::UNIT,
+        );
         fixture.unit();
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[read], Type::UNIT);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            Type::I32,
+        );
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[read],
+            Type::UNIT,
+        );
         fixture.unit();
         checked_free(&mut fixture, 0, 4, 4, raw_ptr_ty, ptr_ty);
         fixture.unit();
@@ -4180,11 +4223,21 @@ mod tests {
         let pointer = fixture.load(0, ptr_ty);
         let forty_two = fixture.konst(42, Type::I32);
         let variant = fixture.enum_variant(opt_id, 0, &[forty_two], opt_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, variant], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, variant],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, opt_ty);
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], opt_ty);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            opt_ty,
+        );
         fixture.alloc(1, read);
         let scrutinee = fixture.load(1, opt_ty);
         let some_arm = fixture.cfg.new_block();
@@ -4207,14 +4260,24 @@ mod tests {
         );
         fixture.alloc(3, payload);
         let x = fixture.load(3, Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[x], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[x],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.dead(3, Type::I32);
         fixture.cfg.set_goto(some_arm, join, []);
 
         fixture.current = none_arm;
         let zero = fixture.konst(0, Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[zero], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[zero],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.cfg.set_goto(none_arm, join, []);
 
@@ -4282,11 +4345,21 @@ mod tests {
         let b = fixture.konst(1000, Type::I32);
         let c = fixture.konst(9, Type::U8);
         let padded = fixture.struct_init(padded_id, &[a, b, c], padded_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, padded], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, padded],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, padded_ty);
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], padded_ty);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            padded_ty,
+        );
         fixture.alloc(1, read);
         let b = fixture.place_read(
             PlaceBase::Local(1),
@@ -4297,7 +4370,12 @@ mod tests {
             }],
             Type::I32,
         );
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[b], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[b],
+            Type::UNIT,
+        );
         fixture.unit();
         checked_free(&mut fixture, 0, 12, 4, raw_ptr_ty, ptr_ty);
         fixture.unit();
@@ -4362,11 +4440,21 @@ mod tests {
         let twenty = fixture.konst(20, Type::I32);
         let xs = fixture.array_init(&[ten, twenty], xs_ty);
         let has_arr = fixture.struct_init(has_arr_id, &[tag, xs], has_arr_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, has_arr], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, has_arr],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, has_arr_ty);
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], has_arr_ty);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            has_arr_ty,
+        );
         fixture.alloc(1, read);
         checked_free(&mut fixture, 0, 12, 4, raw_ptr_ty, ptr_ty);
         let mut elements = Vec::new();
@@ -4393,7 +4481,12 @@ mod tests {
         fixture.dead(0, ptr_ty);
         fixture.alloc(4, sum);
         let r = fixture.load(4, Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[r], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[r],
+            Type::UNIT,
+        );
         fixture.unit();
         let result = fixture.konst(0, Type::I32);
         fixture.dead(4, Type::I32);
@@ -4452,11 +4545,21 @@ mod tests {
         let y = fixture.konst(2, Type::I32);
         let point = fixture.struct_init(point_id, &[x, y], point_ty);
         let variant = fixture.enum_variant(opt_id, 0, &[point], opt_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, variant], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, variant],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, opt_ty);
         let pointer = fixture.load(0, ptr_ty);
-        let read = fixture.intrinsic(None, "ptr_read", &[pointer], opt_ty);
+        let read = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[pointer],
+            opt_ty,
+        );
         fixture.alloc(1, read);
         checked_free(&mut fixture, 0, 12, 4, raw_ptr_ty, ptr_ty);
         let scrutinee = fixture.load(1, opt_ty);
@@ -4513,7 +4616,12 @@ mod tests {
         fixture.dead(0, ptr_ty);
         fixture.alloc(6, join_value);
         let r = fixture.load(6, Type::I32);
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[r], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[r],
+            Type::UNIT,
+        );
         fixture.unit();
         let result = fixture.konst(0, Type::I32);
         fixture.dead(6, Type::I32);
@@ -4565,7 +4673,12 @@ mod tests {
         let five = fixture.konst(5, Type::I64);
         let variant = fixture.enum_variant(bad_id, 0, &[five], bad_ty);
         let has_bad = fixture.struct_init(has_bad_id, &[variant], has_bad_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, has_bad], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, has_bad],
+            Type::UNIT,
+        );
         fixture.unit();
         checked_free(&mut fixture, 0, 16, 8, raw_ptr_ty, ptr_ty);
         fixture.unit();
@@ -4621,7 +4734,12 @@ mod tests {
             }],
             Type::I32,
         );
-        fixture.intrinsic(Some(RuntimeCallKind::DebugI64), "dbg", &[b], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::DebugI64,
+            "dbg",
+            &[b],
+            Type::UNIT,
+        );
         fixture.unit();
         let result = fixture.konst(0, Type::I32);
         fixture.dead(0, padded_ty);
@@ -4677,7 +4795,12 @@ mod tests {
         let z = fixture.konst(3, Type::I32);
         let point = fixture.struct_init(point_id, &[x, y, z], point_ty);
         let variant = fixture.enum_variant(r_id, 0, &[point], r_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, variant], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, variant],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.unit();
         fixture.unit();
@@ -5051,7 +5174,12 @@ mod tests {
         let pointer = fixture.load(0, ptr_ty);
         let five = fixture.konst(5, Type::I64);
         let variant = fixture.enum_variant(bad_id, 0, &[five], bad_ty);
-        fixture.intrinsic(None, "ptr_write", &[pointer, variant], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[pointer, variant],
+            Type::UNIT,
+        );
         fixture.unit();
         checked_free(&mut fixture, 0, 16, 8, raw_ptr_ty, ptr_ty);
         fixture.unit();
@@ -5533,7 +5661,7 @@ mod tests {
         let size = fixture.konst(3, Type::U64);
         let align = fixture.konst(1, Type::U64);
         let p = fixture.intrinsic(
-            Some(RuntimeCallKind::Alloc),
+            rue_air::IntrinsicOperation::Alloc,
             "alloc",
             &[size, align],
             ptr_ty,
@@ -5541,9 +5669,19 @@ mod tests {
         fixture.alloc(0, p);
         let p = fixture.load(0, ptr_ty);
         let one = fixture.konst(1, Type::I32);
-        let offset = fixture.intrinsic(None, "ptr_offset", &[p, one], ptr_ty);
+        let offset = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrOffset,
+            "ptr_offset",
+            &[p, one],
+            ptr_ty,
+        );
         let byte = fixture.konst(255, Type::U8);
-        fixture.intrinsic(None, "ptr_write", &[offset, byte], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[offset, byte],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, ptr_ty);
         let p = fixture.load(0, ptr_ty);
@@ -5551,7 +5689,7 @@ mod tests {
         let old_align = fixture.konst(1, Type::U64);
         let new_size = fixture.konst(5, Type::U64);
         let q = fixture.intrinsic(
-            Some(RuntimeCallKind::Realloc),
+            rue_air::IntrinsicOperation::Realloc,
             "realloc",
             &[p, old_size, old_align, new_size],
             ptr_ty,
@@ -5560,14 +5698,24 @@ mod tests {
         fixture.live(2, Type::U8);
         let q = fixture.load(1, ptr_ty);
         let one = fixture.konst(1, Type::I32);
-        let offset = fixture.intrinsic(None, "ptr_offset", &[q, one], ptr_ty);
-        let byte = fixture.intrinsic(None, "ptr_read", &[offset], Type::U8);
+        let offset = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrOffset,
+            "ptr_offset",
+            &[q, one],
+            ptr_ty,
+        );
+        let byte = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[offset],
+            Type::U8,
+        );
         fixture.alloc(2, byte);
         let q = fixture.load(1, ptr_ty);
         let size = fixture.konst(5, Type::U64);
         let align = fixture.konst(1, Type::U64);
         fixture.intrinsic(
-            Some(RuntimeCallKind::Free),
+            rue_air::IntrinsicOperation::Free,
             "free",
             &[q, size, align],
             Type::UNIT,
@@ -5641,7 +5789,7 @@ mod tests {
         let size = fixture.konst(2, Type::U64);
         let align = fixture.konst(1, Type::U64);
         let p = fixture.intrinsic(
-            Some(RuntimeCallKind::Alloc),
+            rue_air::IntrinsicOperation::Alloc,
             "alloc",
             &[size, align],
             ptr_ty,
@@ -5649,21 +5797,41 @@ mod tests {
         fixture.alloc(0, p);
         let p = fixture.load(0, ptr_ty);
         let zero = fixture.konst(0, Type::I32);
-        let offset = fixture.intrinsic(None, "ptr_offset", &[p, zero], ptr_ty);
+        let offset = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrOffset,
+            "ptr_offset",
+            &[p, zero],
+            ptr_ty,
+        );
         let byte = fixture.konst(65, Type::U8);
-        fixture.intrinsic(None, "ptr_write", &[offset, byte], Type::UNIT);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[offset, byte],
+            Type::UNIT,
+        );
         fixture.unit();
         fixture.live(1, Type::U8);
         let p = fixture.load(0, ptr_ty);
         let one = fixture.konst(1, Type::I32);
-        let offset = fixture.intrinsic(None, "ptr_offset", &[p, one], ptr_ty);
-        let byte = fixture.intrinsic(None, "ptr_read", &[offset], Type::U8);
+        let offset = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrOffset,
+            "ptr_offset",
+            &[p, one],
+            ptr_ty,
+        );
+        let byte = fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrRead,
+            "ptr_read",
+            &[offset],
+            Type::U8,
+        );
         fixture.alloc(1, byte);
         let p = fixture.load(0, ptr_ty);
         let size = fixture.konst(2, Type::U64);
         let align = fixture.konst(1, Type::U64);
         fixture.intrinsic(
-            Some(RuntimeCallKind::Free),
+            rue_air::IntrinsicOperation::Free,
             "free",
             &[p, size, align],
             Type::UNIT,

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -1126,7 +1126,9 @@ drop fn StrBuf(self) { }
                     .iter()
                     .flat_map(|block| block.insts.iter())
                     .filter_map(|value| match cfg.get_inst(*value).data {
-                        rue_cfg::CfgInstData::Intrinsic { runtime, .. } => runtime,
+                        rue_cfg::CfgInstData::Intrinsic { operation, .. } => {
+                            operation.runtime_call()
+                        }
                         _ => None,
                     })
                     .collect();
@@ -1204,7 +1206,9 @@ drop fn StrBuf(self) { }
                     .iter()
                     .flat_map(|block| block.insts.iter())
                     .filter_map(|value| match cfg.get_inst(*value).data {
-                        rue_cfg::CfgInstData::Intrinsic { runtime, .. } => runtime,
+                        rue_cfg::CfgInstData::Intrinsic { operation, .. } => {
+                            operation.runtime_call()
+                        }
                         _ => None,
                     })
                     .collect();
@@ -1277,6 +1281,123 @@ drop fn StrBuf(self) { }
                 }
                 test_compile_source(&source)
                     .unwrap_or_else(|error| panic!("{name} must compile and link: {error}"));
+            }
+        }
+
+        #[test]
+        fn pure_intrinsics_accept_bottom_only_in_their_semantic_positions() {
+            let accepted = [
+                (
+                    "ptr_to_int argument",
+                    r#"
+                        fn diverge() -> ! { loop {} }
+                        fn probe() -> u64 { checked { @ptr_to_int(diverge()) } }
+                        fn main() -> i32 { probe(); 0 }
+                    "#,
+                ),
+                (
+                    "int_to_ptr argument",
+                    r#"
+                        fn diverge() -> ! { loop {} }
+                        fn probe() -> ptr mut i32 { checked { @int_to_ptr(diverge()) } }
+                        fn main() -> i32 { probe(); 0 }
+                    "#,
+                ),
+                (
+                    "int_to_ptr contextual result",
+                    r#"
+                        fn probe() -> ! {
+                            let zero: u64 = 0;
+                            checked { @int_to_ptr(zero) }
+                        }
+                        fn main() -> i32 { probe() }
+                    "#,
+                ),
+                (
+                    "ptr_write value",
+                    r#"
+                        fn diverge() -> ! { loop {} }
+                        fn probe() {
+                            checked {
+                                let zero: u64 = 0;
+                                let p: ptr mut i32 = @int_to_ptr(zero);
+                                @ptr_write(p, diverge());
+                            }
+                        }
+                        fn main() -> i32 { probe(); 0 }
+                    "#,
+                ),
+                (
+                    "ptr_offset pointer",
+                    r#"
+                        fn diverge() -> ! { loop {} }
+                        fn probe() -> ! { checked { @ptr_offset(diverge(), 1) } }
+                        fn main() -> i32 { probe() }
+                    "#,
+                ),
+                (
+                    "ptr_offset offset",
+                    r#"
+                        fn diverge() -> ! { loop {} }
+                        fn probe() -> ptr mut i32 {
+                            checked {
+                                let zero: u64 = 0;
+                                let p: ptr mut i32 = @int_to_ptr(zero);
+                                @ptr_offset(p, diverge())
+                            }
+                        }
+                        fn main() -> i32 { probe(); 0 }
+                    "#,
+                ),
+                (
+                    "syscall argument",
+                    r#"
+                        fn diverge() -> ! { loop {} }
+                        fn probe() -> i64 { checked { @syscall(diverge()) } }
+                        fn main() -> i32 { probe(); 0 }
+                    "#,
+                ),
+            ];
+            for (label, source) in accepted {
+                test_cfg(source).unwrap_or_else(|error| panic!("{label} must reach CFG: {error}"));
+            }
+
+            let rejected = [
+                (
+                    "ptr_read bottom pointer",
+                    r#"fn diverge() -> ! { loop {} } fn main() -> i32 { checked { @ptr_read(diverge()) } }"#,
+                ),
+                (
+                    "ptr_write bottom pointer",
+                    r#"fn diverge() -> ! { loop {} } fn main() { checked { @ptr_write(diverge(), 1); } }"#,
+                ),
+                (
+                    "ptr_offset noninteger",
+                    r#"fn main() -> i32 { checked { let zero: u64 = 0; let p: ptr mut i32 = @int_to_ptr(zero); @ptr_offset(p, true); } 0 }"#,
+                ),
+                (
+                    "raw divergent rvalue",
+                    r#"fn diverge() -> ! { loop {} } fn main() -> i32 { checked { @raw(diverge()); } 0 }"#,
+                ),
+                (
+                    "bitCast bottom operand",
+                    r#"fn diverge() -> ! { loop {} } fn main() -> i32 { let _: u64 = @bitCast(diverge()); 0 }"#,
+                ),
+                (
+                    "syscall non-u64",
+                    r#"fn main() -> i32 { checked { @syscall(true); } 0 }"#,
+                ),
+                (
+                    "int_to_ptr non-u64",
+                    r#"fn main() -> i32 { checked { let _: ptr mut i32 = @int_to_ptr(true); } 0 }"#,
+                ),
+                (
+                    "int_to_ptr unconstrained",
+                    r#"fn main() -> i32 { let zero: u64 = 0; checked { @int_to_ptr(zero); } 0 }"#,
+                ),
+            ];
+            for (label, source) in rejected {
+                assert!(test_cfg(source).is_err(), "{label} must be rejected");
             }
         }
 

--- a/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
+++ b/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
@@ -121,17 +121,14 @@ fn fallible_intrinsic_option_enums(
     let mut found = Vec::new();
     for function in semantic.functions() {
         for (_, inst) in function.record.air.iter() {
-            if let rue_air::AirInstData::Intrinsic {
-                runtime: Some(runtime),
-                ..
-            } = &inst.data
+            if let rue_air::AirInstData::Intrinsic { operation, .. } = &inst.data
                 && matches!(
-                    runtime,
-                    rue_air::RuntimeCallKind::ParseI32
-                        | rue_air::RuntimeCallKind::ParseI64
-                        | rue_air::RuntimeCallKind::ParseU32
-                        | rue_air::RuntimeCallKind::ParseU64
-                        | rue_air::RuntimeCallKind::ReadLine
+                    operation,
+                    rue_air::IntrinsicOperation::ParseI32
+                        | rue_air::IntrinsicOperation::ParseI64
+                        | rue_air::IntrinsicOperation::ParseU32
+                        | rue_air::IntrinsicOperation::ParseU64
+                        | rue_air::IntrinsicOperation::ReadLine
                 )
                 && let rue_air::TypeKind::Enum(enum_id) = inst.ty.kind()
             {
@@ -141,7 +138,7 @@ fn fallible_intrinsic_option_enums(
                     ["Some", "None"],
                     "the intrinsic result must be Option-shaped",
                 );
-                found.push((*runtime, def.name.to_string()));
+                found.push((operation.runtime_call().unwrap(), def.name.to_string()));
             }
         }
     }

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -2721,7 +2721,7 @@ fn reused_parse_runtime_symbol_relocates_to_the_current_interner() {
                     .flat_map(|block| block.insts.iter())
                     .filter_map(|value| match cfg.get_inst(*value).data {
                         rue_cfg::CfgInstData::Intrinsic {
-                            runtime: Some(rue_air::RuntimeCallKind::ParseI64),
+                            operation: rue_air::IntrinsicOperation::ParseI64,
                             name,
                             ..
                         } => Some(function.record.interner.resolve(&name).to_owned()),

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1084,58 +1084,123 @@ fn unsupported(kind: UnsupportedKind, detail: impl Into<String>) -> Flow {
     Flow::Unsupported(Unsupported::new(kind, detail))
 }
 
-fn unsupported_intrinsic_kind(name: &str) -> UnsupportedKind {
+fn unsupported_intrinsic_kind_for_operation(
+    operation: rue_air::IntrinsicOperation,
+) -> UnsupportedKind {
     use ExternalDependencyKind as External;
     use SemanticGapKind as Semantic;
     use UnsupportedIntrinsicKind as Intrinsic;
 
-    match name {
-        "parse_i32" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseI32)),
-        "parse_i64" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseI64)),
-        "parse_u32" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseU32)),
-        "parse_u64" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseU64)),
+    match operation {
+        rue_air::IntrinsicOperation::ParseI32 => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseI32))
+        }
+        rue_air::IntrinsicOperation::ParseI64 => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseI64))
+        }
+        rue_air::IntrinsicOperation::ParseU32 => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseU32))
+        }
+        rue_air::IntrinsicOperation::ParseU64 => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseU64))
+        }
         // `@ptr_read_unaligned`/`@ptr_write_unaligned` (ADR-0059) differ from the
         // aligned forms only in the alignment *requirement* on the address. The
         // oracle does not model alignment, so they share the aligned forms'
         // semantics and gap classification.
-        "ptr_read" | "ptr_read_unaligned" => {
+        rue_air::IntrinsicOperation::PtrRead | rue_air::IntrinsicOperation::PtrReadUnaligned => {
             UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::PointerRead))
         }
-        "ptr_write" | "ptr_write_unaligned" => {
+        rue_air::IntrinsicOperation::PtrWrite | rue_air::IntrinsicOperation::PtrWriteUnaligned => {
             UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::PointerWrite))
         }
-        "ptr_offset" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::PointerOffset)),
-        "ptr_to_int" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::PointerToInt)),
-        "int_to_ptr" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::IntToPointer)),
-        "raw" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::RawAddress)),
-        "raw_mut" => {
+        rue_air::IntrinsicOperation::PtrOffset => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::PointerOffset))
+        }
+        rue_air::IntrinsicOperation::PtrToInt => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::PointerToInt))
+        }
+        rue_air::IntrinsicOperation::IntToPtr => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::IntToPointer))
+        }
+        rue_air::IntrinsicOperation::Raw => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::RawAddress))
+        }
+        rue_air::IntrinsicOperation::RawMut => {
             UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::RawMutableAddress))
         }
-        "field_ptr" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::FieldPointer)),
-        "alloc" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Allocate)),
-        "alloc_zeroed" => {
+        rue_air::IntrinsicOperation::FieldPtr => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::FieldPointer))
+        }
+        rue_air::IntrinsicOperation::Alloc => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Allocate))
+        }
+        rue_air::IntrinsicOperation::AllocZeroed => {
             UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::AllocateZeroed))
         }
-        "free" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Free)),
-        "realloc" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Reallocate)),
-        "resize" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Resize)),
-        "byte_copy" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteCopy)),
-        "byte_move" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteMove)),
-        "byte_set" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteSet)),
-        "read_line" => UnsupportedKind::ExternalDependency(External::StandardInput),
-        "random_u32" => UnsupportedKind::ExternalDependency(External::RandomU32),
-        "random_u64" => UnsupportedKind::ExternalDependency(External::RandomU64),
-        "syscall" => UnsupportedKind::ExternalDependency(External::SystemCall),
+        rue_air::IntrinsicOperation::Free => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Free))
+        }
+        rue_air::IntrinsicOperation::Realloc => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Reallocate))
+        }
+        rue_air::IntrinsicOperation::Resize => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Resize))
+        }
+        rue_air::IntrinsicOperation::ByteCopy => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteCopy))
+        }
+        rue_air::IntrinsicOperation::ByteMove => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteMove))
+        }
+        rue_air::IntrinsicOperation::ByteSet => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteSet))
+        }
+        rue_air::IntrinsicOperation::ReadLine => {
+            UnsupportedKind::ExternalDependency(External::StandardInput)
+        }
+        rue_air::IntrinsicOperation::RandomU32 => {
+            UnsupportedKind::ExternalDependency(External::RandomU32)
+        }
+        rue_air::IntrinsicOperation::RandomU64 => {
+            UnsupportedKind::ExternalDependency(External::RandomU64)
+        }
+        rue_air::IntrinsicOperation::Syscall => {
+            UnsupportedKind::ExternalDependency(External::SystemCall)
+        }
         // Process arguments/environment are captured from loader-supplied
         // process state at entry, so their values lie outside deterministic Rue
         // semantics — an external dependency like `@random_*` (RUE-935).
-        "arg_count" => UnsupportedKind::ExternalDependency(External::ArgCount),
-        "arg_ptr" => UnsupportedKind::ExternalDependency(External::ArgPtr),
-        "arg_len" => UnsupportedKind::ExternalDependency(External::ArgLen),
-        "env_count" => UnsupportedKind::ExternalDependency(External::EnvCount),
-        "env_ptr" => UnsupportedKind::ExternalDependency(External::EnvPtr),
-        "env_len" => UnsupportedKind::ExternalDependency(External::EnvLen),
-        _ => UnsupportedKind::ContractViolation(ContractViolationKind::UnexpectedIntrinsic),
+        rue_air::IntrinsicOperation::ArgCount => {
+            UnsupportedKind::ExternalDependency(External::ArgCount)
+        }
+        rue_air::IntrinsicOperation::ArgPtr => {
+            UnsupportedKind::ExternalDependency(External::ArgPtr)
+        }
+        rue_air::IntrinsicOperation::ArgLen => {
+            UnsupportedKind::ExternalDependency(External::ArgLen)
+        }
+        rue_air::IntrinsicOperation::EnvCount => {
+            UnsupportedKind::ExternalDependency(External::EnvCount)
+        }
+        rue_air::IntrinsicOperation::EnvPtr => {
+            UnsupportedKind::ExternalDependency(External::EnvPtr)
+        }
+        rue_air::IntrinsicOperation::EnvLen => {
+            UnsupportedKind::ExternalDependency(External::EnvLen)
+        }
+        rue_air::IntrinsicOperation::PanicNoMessage
+        | rue_air::IntrinsicOperation::Panic
+        | rue_air::IntrinsicOperation::AssertFailed
+        | rue_air::IntrinsicOperation::AssertWithMessage
+        | rue_air::IntrinsicOperation::BoundsCheck
+        | rue_air::IntrinsicOperation::DebugI64
+        | rue_air::IntrinsicOperation::DebugU64
+        | rue_air::IntrinsicOperation::DebugBool
+        | rue_air::IntrinsicOperation::DebugStr
+        | rue_air::IntrinsicOperation::BitCast => {
+            UnsupportedKind::ContractViolation(ContractViolationKind::UnexpectedIntrinsic)
+        }
     }
 }
 
@@ -1147,7 +1212,43 @@ fn unsupported_runtime_call_kind(kind: RuntimeCallKind) -> Option<UnsupportedRun
         RuntimeCallKind::StrPrintlnAggregate | RuntimeCallKind::StrPrintlnProjected => {
             Some(UnsupportedRuntimeCallKind::Println)
         }
-        _ => None,
+        RuntimeCallKind::StrByteAt
+        | RuntimeCallKind::StrCharScalar
+        | RuntimeCallKind::StrCharNext
+        | RuntimeCallKind::StrCharScalarLossy
+        | RuntimeCallKind::StrCharNextLossy
+        | RuntimeCallKind::ToString
+        | RuntimeCallKind::ToStringUnsigned
+        | RuntimeCallKind::DebugI64
+        | RuntimeCallKind::DebugU64
+        | RuntimeCallKind::DebugBool
+        | RuntimeCallKind::DebugStr
+        | RuntimeCallKind::Panic
+        | RuntimeCallKind::PanicNoMessage
+        | RuntimeCallKind::AssertFailed
+        | RuntimeCallKind::AssertWithMessage
+        | RuntimeCallKind::BoundsCheck
+        | RuntimeCallKind::ReadLine
+        | RuntimeCallKind::ParseI32
+        | RuntimeCallKind::ParseI64
+        | RuntimeCallKind::ParseU32
+        | RuntimeCallKind::ParseU64
+        | RuntimeCallKind::RandomU32
+        | RuntimeCallKind::RandomU64
+        | RuntimeCallKind::Alloc
+        | RuntimeCallKind::AllocZeroed
+        | RuntimeCallKind::Free
+        | RuntimeCallKind::Realloc
+        | RuntimeCallKind::Resize
+        | RuntimeCallKind::ArgCount
+        | RuntimeCallKind::ArgPtr
+        | RuntimeCallKind::ArgLen
+        | RuntimeCallKind::EnvCount
+        | RuntimeCallKind::EnvPtr
+        | RuntimeCallKind::EnvLen
+        | RuntimeCallKind::ByteCopy
+        | RuntimeCallKind::ByteMove
+        | RuntimeCallKind::ByteSet => None,
     }
 }
 
@@ -1344,7 +1445,7 @@ impl<'a> Interp<'a> {
     /// length words from turning a bounded failure into an unbounded
     /// allocation or byte loop.
     fn text_bytes_bounded(&self, val: &Value, max_len: Option<usize>) -> Step<Vec<u8>> {
-        let gap = unsupported_intrinsic_kind("ptr_read");
+        let gap = unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead);
         let Some((target, len)) = Self::text_ptr_len(val) else {
             return Err(unsupported(gap, "text value is not a materialized header"));
         };
@@ -1611,7 +1712,9 @@ impl<'a> Interp<'a> {
             } else {
                 let Some(pointer) = pointer else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "projected output has a null buffer with nonzero length",
                     ));
                 };
@@ -1620,7 +1723,9 @@ impl<'a> Interp<'a> {
                         self.byte_at(
                             pointer,
                             offset as i128,
-                            unsupported_intrinsic_kind("ptr_read"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrRead,
+                            ),
                         )
                     })
                     .collect::<Step<Vec<_>>>()?
@@ -1750,23 +1855,27 @@ impl<'a> Interp<'a> {
         self.option_payload(ty) == Some(payload)
     }
 
-    /// Whether this exact `@int_to_ptr(0) -> ptr const T` is the compiler's
+    /// Whether this exact pointer-typed `Const(0)` is the compiler's
     /// synthesized null pointer for an empty borrowed array slice.
     ///
     /// A zero constant and const-pointer result are not sufficient provenance:
     /// user-authored `@int_to_ptr(0)` could otherwise be mislabeled as this
-    /// model gap. Require the intrinsic to feed field 0 of the canonical
+    /// model gap. Require the value to feed field 0 of the canonical
     /// two-word `[T] { ptr, len: 0 }` StructInit emitted by slice coercion.
-    fn is_empty_slice_pointer(&self, cfg: &Cfg, intrinsic: CfgValue) -> bool {
-        if cfg.value_use_count(intrinsic) != 1 {
+    fn is_empty_slice_pointer(&self, cfg: &Cfg, pointer: CfgValue) -> bool {
+        let pointer_inst = cfg.get_inst(pointer);
+        if !pointer_inst.ty.is_ptr_const()
+            || !matches!(pointer_inst.data, CfgInstData::Const(0))
+            || cfg.value_use_count(pointer) != 1
+        {
             return false;
         }
-        let pointer_ty = cfg.get_inst(intrinsic).ty;
+        let pointer_ty = pointer_inst.ty;
         cfg.blocks()
             .iter()
             .filter_map(|block| {
-                let intrinsic_index = block.insts.iter().position(|value| *value == intrinsic)?;
-                Some(block.insts.iter().skip(intrinsic_index + 1).copied())
+                let pointer_index = block.insts.iter().position(|value| *value == pointer)?;
+                Some(block.insts.iter().skip(pointer_index + 1).copied())
             })
             .flatten()
             .any(|value| {
@@ -1787,7 +1896,7 @@ impl<'a> Interp<'a> {
                     return false;
                 }
                 let fields = cfg.get_struct_fields(data);
-                fields[0] == intrinsic
+                fields[0] == pointer
                     && cfg.get_inst(fields[1]).ty == Type::U64
                     && matches!(cfg.get_inst(fields[1]).data, CfgInstData::Const(0))
                     && cfg.blocks().iter().any(|block| {
@@ -1953,27 +2062,60 @@ impl<'a> Interp<'a> {
     fn classify_unsupported_intrinsic(
         &self,
         cfg: &Cfg,
-        intrinsic: CfgValue,
-        name: &str,
+        _intrinsic: CfgValue,
+        operation: rue_air::IntrinsicOperation,
         args: &[CfgValue],
         result_ty: Type,
     ) -> UnsupportedKind {
-        let kind = unsupported_intrinsic_kind(name);
+        let kind = unsupported_intrinsic_kind_for_operation(operation);
         if kind.model_gap().is_none() {
             return kind;
         }
 
-        let arity_matches = match name {
-            "read_line" | "random_u32" | "random_u64" | "arg_count" | "env_count" => {
-                args.is_empty()
+        let arity_matches = match operation {
+            rue_air::IntrinsicOperation::ReadLine
+            | rue_air::IntrinsicOperation::RandomU32
+            | rue_air::IntrinsicOperation::RandomU64
+            | rue_air::IntrinsicOperation::ArgCount
+            | rue_air::IntrinsicOperation::EnvCount => args.is_empty(),
+            rue_air::IntrinsicOperation::PtrWrite
+            | rue_air::IntrinsicOperation::PtrWriteUnaligned
+            | rue_air::IntrinsicOperation::PtrOffset
+            | rue_air::IntrinsicOperation::Alloc
+            | rue_air::IntrinsicOperation::AllocZeroed => args.len() == 2,
+            rue_air::IntrinsicOperation::ByteCopy
+            | rue_air::IntrinsicOperation::ByteMove
+            | rue_air::IntrinsicOperation::ByteSet
+            | rue_air::IntrinsicOperation::Free => args.len() == 3,
+            rue_air::IntrinsicOperation::Realloc | rue_air::IntrinsicOperation::Resize => {
+                args.len() == 4
             }
-            "ptr_write" | "ptr_write_unaligned" | "ptr_offset" | "alloc" | "alloc_zeroed" => {
-                args.len() == 2
-            }
-            "byte_copy" | "byte_move" | "byte_set" | "free" => args.len() == 3,
-            "realloc" | "resize" => args.len() == 4,
-            "syscall" => (1..=7).contains(&args.len()),
-            _ => args.len() == 1,
+            rue_air::IntrinsicOperation::Syscall => (1..=7).contains(&args.len()),
+            rue_air::IntrinsicOperation::Panic
+            | rue_air::IntrinsicOperation::AssertFailed
+            | rue_air::IntrinsicOperation::BoundsCheck
+            | rue_air::IntrinsicOperation::DebugI64
+            | rue_air::IntrinsicOperation::DebugU64
+            | rue_air::IntrinsicOperation::DebugBool
+            | rue_air::IntrinsicOperation::DebugStr
+            | rue_air::IntrinsicOperation::ParseI32
+            | rue_air::IntrinsicOperation::ParseI64
+            | rue_air::IntrinsicOperation::ParseU32
+            | rue_air::IntrinsicOperation::ParseU64
+            | rue_air::IntrinsicOperation::PtrToInt
+            | rue_air::IntrinsicOperation::IntToPtr
+            | rue_air::IntrinsicOperation::PtrRead
+            | rue_air::IntrinsicOperation::PtrReadUnaligned
+            | rue_air::IntrinsicOperation::ArgPtr
+            | rue_air::IntrinsicOperation::ArgLen
+            | rue_air::IntrinsicOperation::EnvPtr
+            | rue_air::IntrinsicOperation::EnvLen
+            | rue_air::IntrinsicOperation::Raw
+            | rue_air::IntrinsicOperation::RawMut
+            | rue_air::IntrinsicOperation::FieldPtr
+            | rue_air::IntrinsicOperation::BitCast => args.len() == 1,
+            rue_air::IntrinsicOperation::PanicNoMessage => args.is_empty(),
+            rue_air::IntrinsicOperation::AssertWithMessage => args.len() == 2,
         };
         if !arity_matches {
             return UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicArity);
@@ -1982,81 +2124,93 @@ impl<'a> Interp<'a> {
         let ty = |index: usize| cfg.get_inst(args[index]).ty;
         let is_text =
             |index: usize| self.is_str_like_type(ty(index)) || self.is_owned_string_type(ty(index));
-        let mut validated_kind = kind;
-        let signature_matches = match name {
-            "parse_i32" => is_text(0) && self.is_option_of(result_ty, Type::I32),
-            "parse_i64" => is_text(0) && self.is_option_of(result_ty, Type::I64),
-            "parse_u32" => is_text(0) && self.is_option_of(result_ty, Type::U32),
-            "parse_u64" => is_text(0) && self.is_option_of(result_ty, Type::U64),
-            "ptr_read" | "ptr_read_unaligned" => self
+        let validated_kind = kind;
+        let signature_matches = match operation {
+            rue_air::IntrinsicOperation::ParseI32 => {
+                is_text(0) && self.is_option_of(result_ty, Type::I32)
+            }
+            rue_air::IntrinsicOperation::ParseI64 => {
+                is_text(0) && self.is_option_of(result_ty, Type::I64)
+            }
+            rue_air::IntrinsicOperation::ParseU32 => {
+                is_text(0) && self.is_option_of(result_ty, Type::U32)
+            }
+            rue_air::IntrinsicOperation::ParseU64 => {
+                is_text(0) && self.is_option_of(result_ty, Type::U64)
+            }
+            rue_air::IntrinsicOperation::PtrRead
+            | rue_air::IntrinsicOperation::PtrReadUnaligned => self
                 .pointer_pointee(ty(0))
                 .is_some_and(|(pointee, _)| pointee == result_ty),
-            "ptr_write" | "ptr_write_unaligned" => {
-                self.pointer_pointee(ty(0))
-                    .is_some_and(|(pointee, mutable)| {
-                        mutable && pointee == ty(1) && result_ty == Type::UNIT
-                    })
+            rue_air::IntrinsicOperation::PtrWrite
+            | rue_air::IntrinsicOperation::PtrWriteUnaligned => self
+                .pointer_pointee(ty(0))
+                .is_some_and(|(pointee, mutable)| {
+                    mutable && (pointee == ty(1) || ty(1) == Type::NEVER) && result_ty == Type::UNIT
+                }),
+            rue_air::IntrinsicOperation::PtrOffset => {
+                (ty(1).is_integer() || ty(1) == Type::NEVER)
+                    && if ty(0) == Type::NEVER {
+                        result_ty == Type::NEVER
+                    } else {
+                        self.pointer_pointee(ty(0)).is_some() && result_ty == ty(0)
+                    }
             }
-            "ptr_offset" => {
-                self.pointer_pointee(ty(0)).is_some() && ty(1).is_integer() && result_ty == ty(0)
+            rue_air::IntrinsicOperation::PtrToInt => {
+                (self.pointer_pointee(ty(0)).is_some() || ty(0) == Type::NEVER)
+                    && result_ty == Type::U64
             }
-            "ptr_to_int" => self.pointer_pointee(ty(0)).is_some() && result_ty == Type::U64,
-            "int_to_ptr" => {
-                let pointer = self.pointer_pointee(result_ty);
-                if ty(0) == Type::U64 && pointer.is_some_and(|(_, mutable)| mutable) {
-                    true
-                } else if ty(0) == Type::U64
-                    && pointer.is_some_and(|(_, mutable)| !mutable)
-                    && matches!(cfg.get_inst(args[0]).data, CfgInstData::Const(0))
-                    && self.is_empty_slice_pointer(cfg, intrinsic)
-                {
-                    validated_kind = UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
-                        UnsupportedIntrinsicKind::EmptySlicePointer,
-                    ));
-                    true
-                } else {
-                    false
-                }
+            rue_air::IntrinsicOperation::IntToPtr => {
+                (ty(0) == Type::U64 || ty(0) == Type::NEVER)
+                    && (result_ty == Type::NEVER
+                        || self
+                            .pointer_pointee(result_ty)
+                            .is_some_and(|(_, mutable)| mutable))
             }
-            "raw" => {
+            rue_air::IntrinsicOperation::Raw => {
                 self.intrinsic_arg_is_place(cfg, args[0])
                     && self
                         .pointer_pointee(result_ty)
                         .is_some_and(|(pointee, mutable)| !mutable && pointee == ty(0))
             }
-            "raw_mut" => {
+            rue_air::IntrinsicOperation::RawMut => {
                 self.intrinsic_arg_is_place(cfg, args[0])
                     && self
                         .pointer_pointee(result_ty)
                         .is_some_and(|(pointee, mutable)| mutable && pointee == ty(0))
             }
-            "field_ptr" => {
+            rue_air::IntrinsicOperation::FieldPtr => {
                 self.intrinsic_arg_is_field_place(cfg, args[0])
                     && self
                         .pointer_pointee(result_ty)
                         .is_some_and(|(pointee, mutable)| mutable && pointee == ty(0))
             }
-            "alloc" | "alloc_zeroed" => {
+            rue_air::IntrinsicOperation::Alloc | rue_air::IntrinsicOperation::AllocZeroed => {
                 ty(0) == Type::U64
                     && ty(1) == Type::U64
                     && self.pointer_pointee(result_ty) == Some((Type::U8, true))
             }
-            "free" => {
+            rue_air::IntrinsicOperation::Free => {
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && ty(1) == Type::U64
                     && ty(2) == Type::U64
                     && result_ty == Type::UNIT
             }
-            "realloc" | "resize" => {
+            rue_air::IntrinsicOperation::Realloc | rue_air::IntrinsicOperation::Resize => {
                 // `(p, old_size, align, new_size)`; `@realloc` hands back the
                 // (possibly moved) block, `@resize` reports in-place success.
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && ty(1) == Type::U64
                     && ty(2) == Type::U64
                     && ty(3) == Type::U64
-                    && result_ty == if name == "resize" { Type::BOOL } else { ty(0) }
+                    && result_ty
+                        == if operation == rue_air::IntrinsicOperation::Resize {
+                            Type::BOOL
+                        } else {
+                            ty(0)
+                        }
             }
-            "byte_copy" | "byte_move" => {
+            rue_air::IntrinsicOperation::ByteCopy | rue_air::IntrinsicOperation::ByteMove => {
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && self
                         .pointer_pointee(ty(1))
@@ -2064,26 +2218,42 @@ impl<'a> Interp<'a> {
                     && ty(2) == Type::U64
                     && result_ty == Type::UNIT
             }
-            "byte_set" => {
+            rue_air::IntrinsicOperation::ByteSet => {
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && ty(1) == Type::U8
                     && ty(2) == Type::U64
                     && result_ty == Type::UNIT
             }
-            "read_line" => self
+            rue_air::IntrinsicOperation::ReadLine => self
                 .option_payload(result_ty)
                 .is_some_and(|payload| self.is_owned_string_type(payload)),
-            "random_u32" => result_ty == Type::U32,
-            "random_u64" => result_ty == Type::U64,
-            "arg_count" | "env_count" => result_ty == Type::U64,
-            "arg_len" | "env_len" => ty(0) == Type::U64 && result_ty == Type::U64,
-            "arg_ptr" | "env_ptr" => {
+            rue_air::IntrinsicOperation::RandomU32 => result_ty == Type::U32,
+            rue_air::IntrinsicOperation::RandomU64 => result_ty == Type::U64,
+            rue_air::IntrinsicOperation::ArgCount | rue_air::IntrinsicOperation::EnvCount => {
+                result_ty == Type::U64
+            }
+            rue_air::IntrinsicOperation::ArgLen | rue_air::IntrinsicOperation::EnvLen => {
+                ty(0) == Type::U64 && result_ty == Type::U64
+            }
+            rue_air::IntrinsicOperation::ArgPtr | rue_air::IntrinsicOperation::EnvPtr => {
                 ty(0) == Type::U64 && self.pointer_pointee(result_ty) == Some((Type::U8, true))
             }
-            "syscall" => {
-                args.iter().all(|arg| cfg.get_inst(*arg).ty == Type::U64) && result_ty == Type::I64
+            rue_air::IntrinsicOperation::Syscall => {
+                args.iter().all(|arg| {
+                    let ty = cfg.get_inst(*arg).ty;
+                    ty == Type::U64 || ty == Type::NEVER
+                }) && result_ty == Type::I64
             }
-            _ => false,
+            rue_air::IntrinsicOperation::PanicNoMessage
+            | rue_air::IntrinsicOperation::Panic
+            | rue_air::IntrinsicOperation::AssertFailed
+            | rue_air::IntrinsicOperation::AssertWithMessage
+            | rue_air::IntrinsicOperation::BoundsCheck
+            | rue_air::IntrinsicOperation::DebugI64
+            | rue_air::IntrinsicOperation::DebugU64
+            | rue_air::IntrinsicOperation::DebugBool
+            | rue_air::IntrinsicOperation::DebugStr
+            | rue_air::IntrinsicOperation::BitCast => false,
         };
         if signature_matches {
             validated_kind
@@ -2099,23 +2269,103 @@ impl<'a> Interp<'a> {
     fn preflight_abort_intrinsic(
         &self,
         cfg: &Cfg,
-        name: &str,
+        operation: rue_air::IntrinsicOperation,
         args: &[CfgValue],
         result_ty: Type,
     ) -> Step<Option<AbortIntrinsic>> {
-        let intrinsic = match name {
-            "panic" => AbortIntrinsic::Panic,
-            "assert" => AbortIntrinsic::Assert,
-            _ => return Ok(None),
+        let intrinsic = match operation {
+            rue_air::IntrinsicOperation::PanicNoMessage | rue_air::IntrinsicOperation::Panic => {
+                AbortIntrinsic::Panic
+            }
+            rue_air::IntrinsicOperation::AssertFailed
+            | rue_air::IntrinsicOperation::AssertWithMessage => AbortIntrinsic::Assert,
+            rue_air::IntrinsicOperation::BoundsCheck
+            | rue_air::IntrinsicOperation::DebugI64
+            | rue_air::IntrinsicOperation::DebugU64
+            | rue_air::IntrinsicOperation::DebugBool
+            | rue_air::IntrinsicOperation::DebugStr
+            | rue_air::IntrinsicOperation::ReadLine
+            | rue_air::IntrinsicOperation::ParseI32
+            | rue_air::IntrinsicOperation::ParseI64
+            | rue_air::IntrinsicOperation::ParseU32
+            | rue_air::IntrinsicOperation::ParseU64
+            | rue_air::IntrinsicOperation::RandomU32
+            | rue_air::IntrinsicOperation::RandomU64
+            | rue_air::IntrinsicOperation::PtrToInt
+            | rue_air::IntrinsicOperation::IntToPtr
+            | rue_air::IntrinsicOperation::PtrRead
+            | rue_air::IntrinsicOperation::PtrReadUnaligned
+            | rue_air::IntrinsicOperation::PtrWrite
+            | rue_air::IntrinsicOperation::PtrWriteUnaligned
+            | rue_air::IntrinsicOperation::PtrOffset
+            | rue_air::IntrinsicOperation::Alloc
+            | rue_air::IntrinsicOperation::AllocZeroed
+            | rue_air::IntrinsicOperation::Free
+            | rue_air::IntrinsicOperation::Realloc
+            | rue_air::IntrinsicOperation::Resize
+            | rue_air::IntrinsicOperation::ByteCopy
+            | rue_air::IntrinsicOperation::ByteMove
+            | rue_air::IntrinsicOperation::ByteSet
+            | rue_air::IntrinsicOperation::ArgCount
+            | rue_air::IntrinsicOperation::ArgPtr
+            | rue_air::IntrinsicOperation::ArgLen
+            | rue_air::IntrinsicOperation::EnvCount
+            | rue_air::IntrinsicOperation::EnvPtr
+            | rue_air::IntrinsicOperation::EnvLen
+            | rue_air::IntrinsicOperation::Raw
+            | rue_air::IntrinsicOperation::RawMut
+            | rue_air::IntrinsicOperation::FieldPtr
+            | rue_air::IntrinsicOperation::Syscall
+            | rue_air::IntrinsicOperation::BitCast => return Ok(None),
         };
-        let arity_matches = match intrinsic {
-            AbortIntrinsic::Panic => args.len() <= 1,
-            AbortIntrinsic::Assert => (1..=2).contains(&args.len()),
+        let arity_matches = match operation {
+            rue_air::IntrinsicOperation::PanicNoMessage => args.is_empty(),
+            rue_air::IntrinsicOperation::Panic => args.len() == 1,
+            rue_air::IntrinsicOperation::AssertFailed => args.len() == 1,
+            rue_air::IntrinsicOperation::AssertWithMessage => args.len() == 2,
+            rue_air::IntrinsicOperation::BoundsCheck
+            | rue_air::IntrinsicOperation::DebugI64
+            | rue_air::IntrinsicOperation::DebugU64
+            | rue_air::IntrinsicOperation::DebugBool
+            | rue_air::IntrinsicOperation::DebugStr
+            | rue_air::IntrinsicOperation::ReadLine
+            | rue_air::IntrinsicOperation::ParseI32
+            | rue_air::IntrinsicOperation::ParseI64
+            | rue_air::IntrinsicOperation::ParseU32
+            | rue_air::IntrinsicOperation::ParseU64
+            | rue_air::IntrinsicOperation::RandomU32
+            | rue_air::IntrinsicOperation::RandomU64
+            | rue_air::IntrinsicOperation::PtrToInt
+            | rue_air::IntrinsicOperation::IntToPtr
+            | rue_air::IntrinsicOperation::PtrRead
+            | rue_air::IntrinsicOperation::PtrReadUnaligned
+            | rue_air::IntrinsicOperation::PtrWrite
+            | rue_air::IntrinsicOperation::PtrWriteUnaligned
+            | rue_air::IntrinsicOperation::PtrOffset
+            | rue_air::IntrinsicOperation::Alloc
+            | rue_air::IntrinsicOperation::AllocZeroed
+            | rue_air::IntrinsicOperation::Free
+            | rue_air::IntrinsicOperation::Realloc
+            | rue_air::IntrinsicOperation::Resize
+            | rue_air::IntrinsicOperation::ByteCopy
+            | rue_air::IntrinsicOperation::ByteMove
+            | rue_air::IntrinsicOperation::ByteSet
+            | rue_air::IntrinsicOperation::ArgCount
+            | rue_air::IntrinsicOperation::ArgPtr
+            | rue_air::IntrinsicOperation::ArgLen
+            | rue_air::IntrinsicOperation::EnvCount
+            | rue_air::IntrinsicOperation::EnvPtr
+            | rue_air::IntrinsicOperation::EnvLen
+            | rue_air::IntrinsicOperation::Raw
+            | rue_air::IntrinsicOperation::RawMut
+            | rue_air::IntrinsicOperation::FieldPtr
+            | rue_air::IntrinsicOperation::Syscall
+            | rue_air::IntrinsicOperation::BitCast => false,
         };
         if !arity_matches {
             return Err(unsupported(
                 UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicArity),
-                format!("intrinsic @{name} arity"),
+                format!("intrinsic @{} arity", operation.expected_spelling()),
             ));
         }
 
@@ -2138,7 +2388,7 @@ impl<'a> Interp<'a> {
         if !signature_matches {
             return Err(unsupported(
                 UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
-                format!("intrinsic @{name} signature"),
+                format!("intrinsic @{} signature", operation.expected_spelling()),
             ));
         }
         Ok(Some(intrinsic))
@@ -2243,11 +2493,14 @@ impl<'a> Interp<'a> {
         &mut self,
         cfg: &'a Cfg,
         frame: &mut Frame,
-        name: &str,
+        operation: rue_air::IntrinsicOperation,
         args: &[CfgValue],
         result_ty: Type,
     ) -> Step<Value> {
-        if name != "assert" || result_ty != Type::UNIT || args.len() != 1 {
+        if operation != rue_air::IntrinsicOperation::BoundsCheck
+            || result_ty != Type::UNIT
+            || args.len() != 1
+        {
             return Err(unsupported(
                 UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
                 "compiler bounds-check intrinsic signature",
@@ -2274,6 +2527,90 @@ impl<'a> Interp<'a> {
                 &[b"error: index out of bounds\n"],
             )
         }
+    }
+
+    /// Evaluate an already typed debug operation. The operation selects the
+    /// runtime contract; the operand type is retained only for integer-width
+    /// formatting and text layout after that exact contract has passed.
+    fn eval_debug_intrinsic(
+        &mut self,
+        cfg: &'a Cfg,
+        frame: &mut Frame,
+        operation: rue_air::IntrinsicOperation,
+        args: &[CfgValue],
+        result_ty: Type,
+    ) -> Step<Value> {
+        let [arg] = args else {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::DebugArity),
+                "@dbg arity",
+            ));
+        };
+        let arg_ty = cfg.get_inst(*arg).ty;
+        if !operation.validate_call(
+            self.type_pool(),
+            &[rue_air::IntrinsicAirArgument::value(
+                arg_ty,
+                rue_air::AirArgMode::Normal,
+            )],
+            result_ty,
+        ) {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+                "@dbg typed operation signature",
+            ));
+        }
+        let val = self.eval(cfg, frame, *arg)?;
+        match operation {
+            rue_air::IntrinsicOperation::DebugI64 => self.write_dbg(&val, arg_ty)?,
+            rue_air::IntrinsicOperation::DebugU64 => self.write_dbg(&val, arg_ty)?,
+            rue_air::IntrinsicOperation::DebugBool => self.write_dbg(&val, arg_ty)?,
+            rue_air::IntrinsicOperation::DebugStr => self.write_dbg(&val, arg_ty)?,
+            rue_air::IntrinsicOperation::PanicNoMessage
+            | rue_air::IntrinsicOperation::Panic
+            | rue_air::IntrinsicOperation::AssertFailed
+            | rue_air::IntrinsicOperation::AssertWithMessage
+            | rue_air::IntrinsicOperation::BoundsCheck
+            | rue_air::IntrinsicOperation::ReadLine
+            | rue_air::IntrinsicOperation::ParseI32
+            | rue_air::IntrinsicOperation::ParseI64
+            | rue_air::IntrinsicOperation::ParseU32
+            | rue_air::IntrinsicOperation::ParseU64
+            | rue_air::IntrinsicOperation::RandomU32
+            | rue_air::IntrinsicOperation::RandomU64
+            | rue_air::IntrinsicOperation::PtrToInt
+            | rue_air::IntrinsicOperation::IntToPtr
+            | rue_air::IntrinsicOperation::PtrRead
+            | rue_air::IntrinsicOperation::PtrReadUnaligned
+            | rue_air::IntrinsicOperation::PtrWrite
+            | rue_air::IntrinsicOperation::PtrWriteUnaligned
+            | rue_air::IntrinsicOperation::PtrOffset
+            | rue_air::IntrinsicOperation::Alloc
+            | rue_air::IntrinsicOperation::AllocZeroed
+            | rue_air::IntrinsicOperation::Free
+            | rue_air::IntrinsicOperation::Realloc
+            | rue_air::IntrinsicOperation::Resize
+            | rue_air::IntrinsicOperation::ByteCopy
+            | rue_air::IntrinsicOperation::ByteMove
+            | rue_air::IntrinsicOperation::ByteSet
+            | rue_air::IntrinsicOperation::ArgCount
+            | rue_air::IntrinsicOperation::ArgPtr
+            | rue_air::IntrinsicOperation::ArgLen
+            | rue_air::IntrinsicOperation::EnvCount
+            | rue_air::IntrinsicOperation::EnvPtr
+            | rue_air::IntrinsicOperation::EnvLen
+            | rue_air::IntrinsicOperation::Raw
+            | rue_air::IntrinsicOperation::RawMut
+            | rue_air::IntrinsicOperation::FieldPtr
+            | rue_air::IntrinsicOperation::Syscall
+            | rue_air::IntrinsicOperation::BitCast => {
+                return Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::UnexpectedIntrinsic),
+                    "non-debug operation reached debug evaluation",
+                ));
+            }
+        }
+        Ok(Value::Unit)
     }
 
     fn write_dbg(&mut self, val: &Value, ty: Type) -> Step<()> {
@@ -2930,7 +3267,7 @@ impl<'a> Interp<'a> {
     /// Read `len` bytes starting at a raw text pointer (the projected-char
     /// path's `ptr`/`len` pair), through the modeled allocation store.
     fn bytes_from_ptr(&self, ptr: &Value, len: i128) -> Step<Vec<u8>> {
-        let gap = unsupported_intrinsic_kind("ptr_read");
+        let gap = unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead);
         if len <= 0 {
             return Ok(Vec::new());
         }
@@ -3054,6 +3391,14 @@ impl<'a> Interp<'a> {
         let ty = inst.ty;
         let result = match &inst.data {
             CfgInstData::Const(n) => {
+                if *n == 0 && ty.is_ptr_const() && self.is_empty_slice_pointer(cfg, v) {
+                    return Err(unsupported(
+                        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
+                            UnsupportedIntrinsicKind::EmptySlicePointer,
+                        )),
+                        "compiler-synthesized empty-slice null pointer",
+                    ));
+                }
                 // The constant is stored as a 64-bit two's-complement bit
                 // pattern (e.g. i32::MIN is `18446744071562067968` =
                 // 0xFFFFFFFF80000000), so a signed type reinterprets it as
@@ -3491,7 +3836,9 @@ impl<'a> Interp<'a> {
                                         }
                                         PlaceBase::Indirect(_) => {
                                             return Err(unsupported(
-                                                unsupported_intrinsic_kind("ptr_write"),
+                                                unsupported_intrinsic_kind_for_operation(
+                                                    rue_air::IntrinsicOperation::PtrWrite,
+                                                ),
                                                 "indirect place reached simple call writeback",
                                             ));
                                         }
@@ -3508,61 +3855,118 @@ impl<'a> Interp<'a> {
                 }
             }
 
-            CfgInstData::Intrinsic { runtime, name, .. } => {
-                let iname = self.interner().resolve(name).to_string();
+            CfgInstData::Intrinsic { operation, .. } => {
                 let args = cfg.get_intrinsic_args(&inst.data).to_vec();
-                if *runtime == Some(RuntimeCallKind::BoundsCheck) {
-                    self.eval_bounds_check_intrinsic(cfg, frame, &iname, &args, ty)?
-                } else if let Some(intrinsic) =
-                    self.preflight_abort_intrinsic(cfg, &iname, &args, ty)?
-                {
-                    self.eval_abort_intrinsic(cfg, frame, intrinsic, &args)?
-                } else if iname == "bitCast" {
-                    // `@bitCast` is fully modeled, not a gap: a same-width
-                    // reinterpretation is exactly a `to_bits`/`from_bits` round
-                    // trip in the value model (RUE-952).
-                    self.eval_bit_cast(cfg, frame, &args, ty)?
-                } else if iname == "syscall" {
-                    let kind = self.classify_unsupported_intrinsic(cfg, v, &iname, &args, ty);
-                    if kind
-                        != UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall)
-                    {
-                        return Err(unsupported(kind, format!("intrinsic @{iname}")));
+                match *operation {
+                    rue_air::IntrinsicOperation::BoundsCheck => {
+                        self.eval_bounds_check_intrinsic(cfg, frame, *operation, &args, ty)?
                     }
-                    let values = self.eval_all(cfg, frame, &args)?;
-                    self.eval_stdout_syscall(&values)?
-                } else if iname != "dbg" {
-                    // Classify first: the same static arity/signature validation
-                    // that gates a model-gap registration also gates execution, so
-                    // a malformed intrinsic still reports its contract violation
-                    // rather than being run. A validated, now-modeled heap/pointer
-                    // intrinsic executes; every other typed gap is reported.
-                    let kind = self.classify_unsupported_intrinsic(cfg, v, &iname, &args, ty);
-                    match kind {
-                        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(ik))
-                            if modeled_pointer_intrinsic(ik) =>
+                    rue_air::IntrinsicOperation::PanicNoMessage
+                    | rue_air::IntrinsicOperation::Panic
+                    | rue_air::IntrinsicOperation::AssertFailed
+                    | rue_air::IntrinsicOperation::AssertWithMessage => {
+                        let Some(intrinsic) =
+                            self.preflight_abort_intrinsic(cfg, *operation, &args, ty)?
+                        else {
+                            return Err(unsupported(
+                                UnsupportedKind::ContractViolation(
+                                    ContractViolationKind::IntrinsicSignature,
+                                ),
+                                format!("intrinsic @{} signature", operation.expected_spelling()),
+                            ));
+                        };
+                        self.eval_abort_intrinsic(cfg, frame, intrinsic, &args)?
+                    }
+                    rue_air::IntrinsicOperation::BitCast => {
+                        // `@bitCast` is fully modeled, not a gap: a same-width
+                        // reinterpretation is exactly a `to_bits`/`from_bits` round
+                        // trip in the value model (RUE-952).
+                        self.eval_bit_cast(cfg, frame, &args, ty)?
+                    }
+                    rue_air::IntrinsicOperation::Syscall => {
+                        let kind =
+                            self.classify_unsupported_intrinsic(cfg, v, *operation, &args, ty);
+                        if kind
+                            != UnsupportedKind::ExternalDependency(
+                                ExternalDependencyKind::SystemCall,
+                            )
                         {
-                            match self.eval_pointer_intrinsic(cfg, frame, &iname, &args, ty)? {
-                                Some(value) => value,
-                                None => {
-                                    return Err(unsupported(kind, format!("intrinsic @{iname}")));
+                            return Err(unsupported(
+                                kind,
+                                format!("intrinsic @{}", operation.expected_spelling()),
+                            ));
+                        }
+                        let values = self.eval_all(cfg, frame, &args)?;
+                        self.eval_stdout_syscall(&values)?
+                    }
+                    rue_air::IntrinsicOperation::DebugI64
+                    | rue_air::IntrinsicOperation::DebugU64
+                    | rue_air::IntrinsicOperation::DebugBool
+                    | rue_air::IntrinsicOperation::DebugStr => {
+                        self.eval_debug_intrinsic(cfg, frame, *operation, &args, ty)?
+                    }
+                    rue_air::IntrinsicOperation::ReadLine
+                    | rue_air::IntrinsicOperation::ParseI32
+                    | rue_air::IntrinsicOperation::ParseI64
+                    | rue_air::IntrinsicOperation::ParseU32
+                    | rue_air::IntrinsicOperation::ParseU64
+                    | rue_air::IntrinsicOperation::RandomU32
+                    | rue_air::IntrinsicOperation::RandomU64
+                    | rue_air::IntrinsicOperation::PtrToInt
+                    | rue_air::IntrinsicOperation::IntToPtr
+                    | rue_air::IntrinsicOperation::PtrRead
+                    | rue_air::IntrinsicOperation::PtrReadUnaligned
+                    | rue_air::IntrinsicOperation::PtrWrite
+                    | rue_air::IntrinsicOperation::PtrWriteUnaligned
+                    | rue_air::IntrinsicOperation::PtrOffset
+                    | rue_air::IntrinsicOperation::Alloc
+                    | rue_air::IntrinsicOperation::AllocZeroed
+                    | rue_air::IntrinsicOperation::Free
+                    | rue_air::IntrinsicOperation::Realloc
+                    | rue_air::IntrinsicOperation::Resize
+                    | rue_air::IntrinsicOperation::ByteCopy
+                    | rue_air::IntrinsicOperation::ByteMove
+                    | rue_air::IntrinsicOperation::ByteSet
+                    | rue_air::IntrinsicOperation::ArgCount
+                    | rue_air::IntrinsicOperation::ArgPtr
+                    | rue_air::IntrinsicOperation::ArgLen
+                    | rue_air::IntrinsicOperation::EnvCount
+                    | rue_air::IntrinsicOperation::EnvPtr
+                    | rue_air::IntrinsicOperation::EnvLen
+                    | rue_air::IntrinsicOperation::Raw
+                    | rue_air::IntrinsicOperation::RawMut
+                    | rue_air::IntrinsicOperation::FieldPtr => {
+                        // Classify first: the same static arity/signature validation
+                        // that gates a model-gap registration also gates execution, so
+                        // a malformed intrinsic still reports its contract violation
+                        // rather than being run. A validated, now-modeled heap/pointer
+                        // intrinsic executes; every other typed gap is reported.
+                        let kind =
+                            self.classify_unsupported_intrinsic(cfg, v, *operation, &args, ty);
+                        match kind {
+                            UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(ik))
+                                if modeled_pointer_intrinsic(ik) =>
+                            {
+                                match self
+                                    .eval_pointer_intrinsic(cfg, frame, *operation, &args, ty)?
+                                {
+                                    Some(value) => value,
+                                    None => {
+                                        return Err(unsupported(
+                                            kind,
+                                            format!("intrinsic @{}", operation.expected_spelling()),
+                                        ));
+                                    }
                                 }
                             }
+                            _ => {
+                                return Err(unsupported(
+                                    kind,
+                                    format!("intrinsic @{}", operation.expected_spelling()),
+                                ));
+                            }
                         }
-                        _ => return Err(unsupported(kind, format!("intrinsic @{iname}"))),
                     }
-                } else {
-                    let [arg] = args.as_slice() else {
-                        return Err(unsupported(
-                            UnsupportedKind::ContractViolation(ContractViolationKind::DebugArity),
-                            "@dbg arity",
-                        ));
-                    };
-                    let arg = *arg;
-                    let arg_ty = cfg.get_inst(arg).ty;
-                    let val = self.eval(cfg, frame, arg)?;
-                    self.write_dbg(&val, arg_ty)?;
-                    Value::Unit
                 }
             }
 
@@ -4049,7 +4453,7 @@ impl<'a> Interp<'a> {
                 "accessor place reached oracle storage",
             )),
             PlaceBase::Indirect(_) => Err(unsupported(
-                unsupported_intrinsic_kind("ptr_read"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 "indirect place requires evaluated pointer storage",
             )),
         }
@@ -4073,8 +4477,15 @@ impl<'a> Interp<'a> {
         let mut cur = match base {
             PlaceBase::Indirect(pointer) => {
                 let pointer = self.eval(cfg, frame, pointer)?;
-                let target = self.expect_ptr(pointer, unsupported_intrinsic_kind("ptr_read"))?;
-                self.ptr_cell_read(&target, view_type, unsupported_intrinsic_kind("ptr_read"))?
+                let target = self.expect_ptr(
+                    pointer,
+                    unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
+                )?;
+                self.ptr_cell_read(
+                    &target,
+                    view_type,
+                    unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
+                )?
             }
             _ => self.base_value_of(frame, base)?,
         };
@@ -4174,21 +4585,26 @@ impl<'a> Interp<'a> {
         }
         if let PlaceBase::Indirect(pointer) = base {
             let pointer = self.eval(cfg, frame, pointer)?;
-            let target = self.expect_ptr(pointer, unsupported_intrinsic_kind("ptr_write"))?;
+            let target = self.expect_ptr(
+                pointer,
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
+            )?;
             if path.is_empty() {
                 return self
                     .ptr_cell_write(
                         &target,
                         view_type,
                         val,
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                     )
                     .map_err(Flow::from);
             }
             let mut root = self.ptr_cell_read(
                 &target,
                 place.base_type,
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
             )?;
             let mut cur = &mut root;
             for (idx, _) in &path {
@@ -4213,7 +4629,7 @@ impl<'a> Interp<'a> {
                     &target,
                     place.base_type,
                     root,
-                    unsupported_intrinsic_kind("ptr_write"),
+                    unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                 )
                 .map_err(Flow::from);
         }
@@ -4239,7 +4655,7 @@ impl<'a> Interp<'a> {
                 &target,
                 pointee,
                 val,
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
             );
         }
         let root: &mut Value = {
@@ -4417,19 +4833,19 @@ impl<'a> Interp<'a> {
     fn promoted_slot_value(&self, alloc: usize) -> Step<Value> {
         let allocation = self.heap.get(alloc).ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_read"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 "promoted allocation is missing",
             )
         })?;
         if allocation.freed {
             return Err(unsupported(
-                unsupported_intrinsic_kind("ptr_read"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 "promoted allocation was freed",
             ));
         }
         let ty = allocation.root_ty.ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_read"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 "raw allocation has no typed view",
             )
         })?;
@@ -4450,7 +4866,7 @@ impl<'a> Interp<'a> {
             .and_then(|allocation| allocation.root_ty)
             .ok_or_else(|| {
                 unsupported(
-                    unsupported_intrinsic_kind("ptr_write"),
+                    unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                     "raw allocation has no typed view",
                 )
             })?;
@@ -4460,7 +4876,7 @@ impl<'a> Interp<'a> {
             .is_some_and(|allocation| allocation.freed)
         {
             return Err(unsupported(
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                 "promoted allocation was freed",
             ));
         }
@@ -4468,7 +4884,7 @@ impl<'a> Interp<'a> {
         let allocation = &mut self.heap[alloc];
         if bytes.len() != allocation.bytes.len() {
             return Err(unsupported(
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                 "promoted value layout changed",
             ));
         }
@@ -4607,19 +5023,19 @@ impl<'a> Interp<'a> {
     ) -> Step<(Vec<u8>, Vec<bool>, Vec<Option<PtrTarget>>)> {
         if !self.is_materializable_type(ty) {
             return Err(unsupported(
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                 "type has no target representation",
             ));
         }
         let size = usize::try_from(self.try_type_byte_size(ty).ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                 "type has no target layout",
             )
         })?)
         .map_err(|_| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                 "layout exceeds host range",
             )
         })?;
@@ -4630,7 +5046,7 @@ impl<'a> Interp<'a> {
         let mut provenance = vec![None; size];
         let layout = self.try_layout(ty).ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                 "type has no target layout",
             )
         })?;
@@ -4678,19 +5094,25 @@ impl<'a> Interp<'a> {
                 initialized.fill(true);
                 let def = self.type_pool().try_struct_def(id).ok_or_else(|| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "struct type metadata",
                     )
                 })?;
                 let LayoutKind::Struct { field_offsets, .. } = layout.kind else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "struct layout kind",
                     ));
                 };
                 if fields.len() != def.fields.len() {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "struct value shape",
                     ));
                 }
@@ -4699,19 +5121,25 @@ impl<'a> Interp<'a> {
                         self.encode_value(value, field.ty)?;
                     let start = usize::try_from(offset).map_err(|_| {
                         unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "field offset exceeds host range",
                         )
                     })?;
                     let end = start.checked_add(field_bytes.len()).ok_or_else(|| {
                         unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "field representation offset overflow",
                         )
                     })?;
                     if end > bytes.len() {
                         return Err(unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "field representation exceeds layout",
                         ));
                     }
@@ -4724,31 +5152,41 @@ impl<'a> Interp<'a> {
                 initialized.fill(true);
                 let (element_ty, count) = self.type_pool().try_array_def(id).ok_or_else(|| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "array type metadata",
                     )
                 })?;
                 let LayoutKind::Array { element, .. } = layout.kind else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "array layout kind",
                     ));
                 };
                 let count = usize::try_from(count).map_err(|_| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "array count exceeds host range",
                     )
                 })?;
                 if elements.len() != count {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "array value shape",
                     ));
                 }
                 let stride = usize::try_from(element.stride).map_err(|_| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "array stride exceeds host range",
                     )
                 })?;
@@ -4757,19 +5195,25 @@ impl<'a> Interp<'a> {
                         self.encode_value(value, element_ty)?;
                     let start = index.checked_mul(stride).ok_or_else(|| {
                         unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "array representation offset overflow",
                         )
                     })?;
                     let end = start.checked_add(field_bytes.len()).ok_or_else(|| {
                         unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "array representation offset overflow",
                         )
                     })?;
                     if end > bytes.len() {
                         return Err(unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "array element exceeds layout",
                         ));
                     }
@@ -4782,7 +5226,9 @@ impl<'a> Interp<'a> {
                 initialized.fill(true);
                 let def = self.type_pool().try_enum_def(id).ok_or_else(|| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "enum type metadata",
                     )
                 })?;
@@ -4793,7 +5239,9 @@ impl<'a> Interp<'a> {
                     }
                     _ => {
                         return Err(unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "enum value shape",
                         ));
                     }
@@ -4811,25 +5259,33 @@ impl<'a> Interp<'a> {
                 } = layout.kind
                 else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "enum layout kind",
                     ));
                 };
                 let tag_size = usize::try_from(tag_layout.size).map_err(|_| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "enum tag exceeds host range",
                     )
                 })?;
                 if tag_size > bytes.len() {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "enum tag exceeds layout",
                     ));
                 }
                 if tag >= def.variant_count() || tag >= variants.len() {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "enum discriminant outside representation",
                     ));
                 }
@@ -4841,13 +5297,17 @@ impl<'a> Interp<'a> {
                 }
                 let Some(payload) = def.variant_payloads.get(tag) else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "enum payload metadata is incomplete",
                     ));
                 };
                 if payload.len() != fields.len() {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_write"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrWrite,
+                        ),
                         "enum payload shape",
                     ));
                 }
@@ -4856,19 +5316,25 @@ impl<'a> Interp<'a> {
                         self.encode_value(value, *field_ty)?;
                     let start = usize::try_from(*offset).map_err(|_| {
                         unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "enum field offset exceeds host range",
                         )
                     })?;
                     let end = start.checked_add(field_bytes.len()).ok_or_else(|| {
                         unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "enum field offset overflow",
                         )
                     })?;
                     if end > bytes.len() {
                         return Err(unsupported(
-                            unsupported_intrinsic_kind("ptr_write"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrWrite,
+                            ),
                             "enum field exceeds layout",
                         ));
                     }
@@ -4880,7 +5346,7 @@ impl<'a> Interp<'a> {
             }
             _ => {
                 return Err(unsupported(
-                    unsupported_intrinsic_kind("ptr_write"),
+                    unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                     "value/type representation mismatch",
                 ));
             }
@@ -4899,25 +5365,25 @@ impl<'a> Interp<'a> {
     ) -> Step<Value> {
         let size = usize::try_from(self.try_type_byte_size(ty).ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_read"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 "type has no target layout",
             )
         })?)
         .map_err(|_| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_read"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 "layout exceeds host range",
             )
         })?;
         if bytes.len() < size || initialized.len() < size || provenance.len() < size {
             return Err(unsupported(
-                unsupported_intrinsic_kind("ptr_read"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 "typed view exceeds allocation",
             ));
         }
         let layout = self.try_layout(ty).ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_read"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 "type has no target layout",
             )
         })?;
@@ -4925,7 +5391,9 @@ impl<'a> Interp<'a> {
             TypeKind::Bool => {
                 if !initialized[0] {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "read of uninitialized bool",
                     ));
                 }
@@ -4933,7 +5401,9 @@ impl<'a> Interp<'a> {
                     0 => Ok(Value::Bool(false)),
                     1 => Ok(Value::Bool(true)),
                     _ => Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "invalid bool representation",
                     )),
                 }
@@ -4948,7 +5418,9 @@ impl<'a> Interp<'a> {
             | TypeKind::U64 => {
                 if initialized[..size].iter().any(|ready| !ready) {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "read of uninitialized integer representation",
                     ));
                 }
@@ -4962,7 +5434,9 @@ impl<'a> Interp<'a> {
             TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => {
                 if initialized[..size].iter().any(|ready| !ready) {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "read of uninitialized pointer representation",
                     ));
                 }
@@ -4979,7 +5453,9 @@ impl<'a> Interp<'a> {
                 }
                 let Some(first) = provenance[..size].first().and_then(|p| p.clone()) else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "pointer representation lacks provenance",
                     ));
                 };
@@ -4989,13 +5465,17 @@ impl<'a> Interp<'a> {
                     || self.ptr_address(&first) != raw
                 {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "pointer representation provenance mismatch",
                     ));
                 }
                 let Some((pointee, _)) = self.pointer_pointee(ty) else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "pointer representation has no pointee type",
                     ));
                 };
@@ -5006,13 +5486,17 @@ impl<'a> Interp<'a> {
             TypeKind::Struct(id) => {
                 let def = self.type_pool().try_struct_def(id).ok_or_else(|| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "struct type metadata",
                     )
                 })?;
                 let LayoutKind::Struct { field_offsets, .. } = layout.kind else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "struct layout kind",
                     ));
                 };
@@ -5020,13 +5504,17 @@ impl<'a> Interp<'a> {
                 for (field, offset) in def.fields.iter().zip(field_offsets) {
                     let start = usize::try_from(offset).map_err(|_| {
                         unsupported(
-                            unsupported_intrinsic_kind("ptr_read"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrRead,
+                            ),
                             "struct field offset exceeds host range",
                         )
                     })?;
                     if start > size {
                         return Err(unsupported(
-                            unsupported_intrinsic_kind("ptr_read"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrRead,
+                            ),
                             "struct field offset outside representation",
                         ));
                     }
@@ -5042,25 +5530,33 @@ impl<'a> Interp<'a> {
             TypeKind::Array(id) => {
                 let (element_ty, count) = self.type_pool().try_array_def(id).ok_or_else(|| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "array type metadata",
                     )
                 })?;
                 let LayoutKind::Array { element, .. } = layout.kind else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "array layout kind",
                     ));
                 };
                 let count = usize::try_from(count).map_err(|_| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "array count exceeds host range",
                     )
                 })?;
                 let stride = usize::try_from(element.stride).map_err(|_| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "array stride exceeds host range",
                     )
                 })?;
@@ -5068,13 +5564,17 @@ impl<'a> Interp<'a> {
                 for index in 0..count {
                     let start = index.checked_mul(stride).ok_or_else(|| {
                         unsupported(
-                            unsupported_intrinsic_kind("ptr_read"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrRead,
+                            ),
                             "array element offset overflow",
                         )
                     })?;
                     if start > size {
                         return Err(unsupported(
-                            unsupported_intrinsic_kind("ptr_read"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrRead,
+                            ),
                             "array element offset outside representation",
                         ));
                     }
@@ -5089,29 +5589,42 @@ impl<'a> Interp<'a> {
             }
             TypeKind::Enum(id) => {
                 let def = self.type_pool().try_enum_def(id).ok_or_else(|| {
-                    unsupported(unsupported_intrinsic_kind("ptr_read"), "enum type metadata")
+                    unsupported(
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
+                        "enum type metadata",
+                    )
                 })?;
                 let LayoutKind::Enum { tag, variants, .. } = layout.kind else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "enum layout kind",
                     ));
                 };
                 let tag_size = usize::try_from(tag.size).map_err(|_| {
                     unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "enum tag exceeds host range",
                     )
                 })?;
                 if tag_size > size {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "enum tag exceeds layout",
                     ));
                 }
                 if initialized[..tag_size].iter().any(|ready| !ready) {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "read of uninitialized enum discriminant",
                     ));
                 }
@@ -5121,13 +5634,17 @@ impl<'a> Interp<'a> {
                 }
                 if raw >= def.variant_count() || raw >= variants.len() {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "enum discriminant outside representation",
                     ));
                 }
                 let Some(payload) = def.variant_payloads.get(raw) else {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("ptr_read"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
                         "enum payload metadata is incomplete",
                     ));
                 };
@@ -5138,7 +5655,9 @@ impl<'a> Interp<'a> {
                 for (field_ty, offset) in payload.iter().zip(&variants[raw]) {
                     let start = usize::try_from(*offset).map_err(|_| {
                         unsupported(
-                            unsupported_intrinsic_kind("ptr_read"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrRead,
+                            ),
                             "enum field offset exceeds host range",
                         )
                     })?;
@@ -5147,27 +5666,35 @@ impl<'a> Interp<'a> {
                             usize::try_from(self.try_type_byte_size(*field_ty).ok_or_else(
                                 || {
                                     unsupported(
-                                        unsupported_intrinsic_kind("ptr_read"),
+                                        unsupported_intrinsic_kind_for_operation(
+                                            rue_air::IntrinsicOperation::PtrRead,
+                                        ),
                                         "enum field has no target layout",
                                     )
                                 },
                             )?)
                             .map_err(|_| {
                                 unsupported(
-                                    unsupported_intrinsic_kind("ptr_read"),
+                                    unsupported_intrinsic_kind_for_operation(
+                                        rue_air::IntrinsicOperation::PtrRead,
+                                    ),
                                     "enum field layout exceeds host range",
                                 )
                             })?,
                         )
                         .ok_or_else(|| {
                             unsupported(
-                                unsupported_intrinsic_kind("ptr_read"),
+                                unsupported_intrinsic_kind_for_operation(
+                                    rue_air::IntrinsicOperation::PtrRead,
+                                ),
                                 "enum field offset overflow",
                             )
                         })?;
                     if field_end > size {
                         return Err(unsupported(
-                            unsupported_intrinsic_kind("ptr_read"),
+                            unsupported_intrinsic_kind_for_operation(
+                                rue_air::IntrinsicOperation::PtrRead,
+                            ),
                             "enum field offset outside representation",
                         ));
                     }
@@ -5181,7 +5708,7 @@ impl<'a> Interp<'a> {
                 Ok(Value::Aggregate(values))
             }
             _ => Err(unsupported(
-                unsupported_intrinsic_kind("ptr_read"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 "unsupported typed representation",
             )),
         }
@@ -5190,13 +5717,13 @@ impl<'a> Interp<'a> {
     fn heap_alloc_value(&mut self, root: Value, ty: Type, _wrapped_scalar: bool) -> Step<usize> {
         let size = usize::try_from(self.try_type_byte_size(ty).ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                 "type has no target layout",
             )
         })?)
         .map_err(|_| {
             unsupported(
-                unsupported_intrinsic_kind("ptr_write"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
                 "layout exceeds host range",
             )
         })?;
@@ -5545,21 +6072,22 @@ impl<'a> Interp<'a> {
 
     /// Execute a heap/pointer intrinsic whose signature already validated as a
     /// modeled model-gap kind. Returns `Ok(None)` to fall through to the existing
-    /// typed-gap path (e.g. the empty-slice `@int_to_ptr(0)` special case, or an
-    /// arbitrary-integer `@int_to_ptr`).
+    /// typed-gap path (for example an arbitrary-integer `@int_to_ptr`).
     fn eval_pointer_intrinsic(
         &mut self,
         cfg: &'a Cfg,
         frame: &mut Frame,
-        name: &str,
+        operation: rue_air::IntrinsicOperation,
         args: &[CfgValue],
         result_ty: Type,
     ) -> Step<Option<Value>> {
-        let gap = unsupported_intrinsic_kind(name);
+        let gap = unsupported_intrinsic_kind_for_operation(operation);
         // Evaluate operands eagerly and left-to-right, matching native lowering,
         // except `@raw`/`@raw_mut`/`@field_ptr` whose operand is an lvalue place.
-        match name {
-            "raw" | "raw_mut" | "field_ptr" => {
+        match operation {
+            rue_air::IntrinsicOperation::Raw
+            | rue_air::IntrinsicOperation::RawMut
+            | rue_air::IntrinsicOperation::FieldPtr => {
                 let pointee = cfg.get_inst(args[0]).ty;
                 let target = match &cfg.get_inst(args[0]).data {
                     CfgInstData::PlaceRead { place } => {
@@ -5588,19 +6116,23 @@ impl<'a> Interp<'a> {
             // representation bytes; only the latter marks those bytes
             // initialized. Typed reads from ordinary `@alloc` therefore stay
             // fail-closed until the program writes the representation.
-            "alloc" | "alloc_zeroed" => {
+            rue_air::IntrinsicOperation::Alloc | rue_air::IntrinsicOperation::AllocZeroed => {
                 let size = self.eval(cfg, frame, args[0])?.as_int();
                 let align = self.eval(cfg, frame, args[1])?.as_int();
-                Ok(Some(self.do_alloc(size, name == "alloc_zeroed", align)?))
+                Ok(Some(self.do_alloc(
+                    size,
+                    operation == rue_air::IntrinsicOperation::AllocZeroed,
+                    align,
+                )?))
             }
-            "free" => {
+            rue_air::IntrinsicOperation::Free => {
                 let p = self.eval(cfg, frame, args[0])?;
                 let size = self.eval(cfg, frame, args[1])?.as_int();
                 let align = self.eval(cfg, frame, args[2])?.as_int();
                 self.do_free(p, size, align, gap)?;
                 Ok(Some(Value::Unit))
             }
-            "realloc" => {
+            rue_air::IntrinsicOperation::Realloc => {
                 let p = self.eval(cfg, frame, args[0])?;
                 let old_size = self.eval(cfg, frame, args[1])?.as_int();
                 let align = self.eval(cfg, frame, args[2])?.as_int();
@@ -5613,7 +6145,7 @@ impl<'a> Interp<'a> {
             // native allocator is also always free to do. A program whose
             // result depends on a `true` here is depending on allocator
             // internals the language does not promise.
-            "resize" => {
+            rue_air::IntrinsicOperation::Resize => {
                 let p = self.eval(cfg, frame, args[0])?;
                 let old_size = self.eval(cfg, frame, args[1])?.as_int();
                 let align = self.eval(cfg, frame, args[2])?.as_int();
@@ -5627,21 +6159,23 @@ impl<'a> Interp<'a> {
                 }
                 Ok(Some(Value::Bool(false)))
             }
-            "ptr_read" | "ptr_read_unaligned" => {
+            rue_air::IntrinsicOperation::PtrRead
+            | rue_air::IntrinsicOperation::PtrReadUnaligned => {
                 let p = self.eval(cfg, frame, args[0])?;
                 let target = self.expect_ptr(p, gap)?;
                 let pointee = self
                     .pointer_pointee(cfg.get_inst(args[0]).ty)
                     .map(|(ty, _)| ty)
                     .ok_or_else(|| unsupported(gap, "pointer read operand type"))?;
-                let value = if name == "ptr_read_unaligned" {
+                let value = if operation == rue_air::IntrinsicOperation::PtrReadUnaligned {
                     self.ptr_cell_read_unaligned(&target, pointee, gap)?
                 } else {
                     self.ptr_cell_read(&target, pointee, gap)?
                 };
                 Ok(Some(value))
             }
-            "ptr_write" | "ptr_write_unaligned" => {
+            rue_air::IntrinsicOperation::PtrWrite
+            | rue_air::IntrinsicOperation::PtrWriteUnaligned => {
                 let p = self.eval(cfg, frame, args[0])?;
                 let val = self.eval(cfg, frame, args[1])?;
                 let target = self.expect_ptr(p, gap)?;
@@ -5649,14 +6183,14 @@ impl<'a> Interp<'a> {
                     .pointer_pointee(cfg.get_inst(args[0]).ty)
                     .map(|(ty, _)| ty)
                     .ok_or_else(|| unsupported(gap, "pointer write operand type"))?;
-                if name == "ptr_write_unaligned" {
+                if operation == rue_air::IntrinsicOperation::PtrWriteUnaligned {
                     self.ptr_cell_write_unaligned(&target, pointee, val, gap)?;
                 } else {
                     self.ptr_cell_write(&target, pointee, val, gap)?;
                 }
                 Ok(Some(Value::Unit))
             }
-            "ptr_offset" => {
+            rue_air::IntrinsicOperation::PtrOffset => {
                 let p = self.eval(cfg, frame, args[0])?;
                 let by = self.eval(cfg, frame, args[1])?.as_int();
                 match p {
@@ -5689,7 +6223,7 @@ impl<'a> Interp<'a> {
                     _ => Err(unsupported(gap, "@ptr_offset of non-pointer")),
                 }
             }
-            "ptr_to_int" => {
+            rue_air::IntrinsicOperation::PtrToInt => {
                 let p = self.eval(cfg, frame, args[0])?;
                 let value = match p {
                     Value::Ptr(Some(t)) => Value::AddressInt {
@@ -5701,7 +6235,7 @@ impl<'a> Interp<'a> {
                 };
                 Ok(Some(value))
             }
-            "int_to_ptr" => {
+            rue_air::IntrinsicOperation::IntToPtr => {
                 let address = self.eval(cfg, frame, args[0])?;
                 let (addr, provenance) = match address {
                     Value::AddressInt { value, provenance } => {
@@ -5728,7 +6262,7 @@ impl<'a> Interp<'a> {
                     None => Ok(None),
                 }
             }
-            "byte_copy" | "byte_move" => {
+            rue_air::IntrinsicOperation::ByteCopy | rue_air::IntrinsicOperation::ByteMove => {
                 let dst = self.eval(cfg, frame, args[0])?;
                 let src = self.eval(cfg, frame, args[1])?;
                 let count = self.eval(cfg, frame, args[2])?.as_int();
@@ -5744,7 +6278,7 @@ impl<'a> Interp<'a> {
                     .map_err(|_| unsupported(gap, "byte count exceeds host range"))?;
                 let (src_alloc, src_start, src_end) = self.byte_range(&src, count, gap)?;
                 let (dst_alloc, dst_start, dst_end) = self.byte_range(&dst, count, gap)?;
-                if name == "byte_copy"
+                if operation == rue_air::IntrinsicOperation::ByteCopy
                     && src_alloc == dst_alloc
                     && src_start < dst_end
                     && dst_start < src_end
@@ -5771,7 +6305,7 @@ impl<'a> Interp<'a> {
                 allocation.provenance[dst_start..dst_end].clone_from_slice(&provenance);
                 Ok(Some(Value::Unit))
             }
-            "byte_set" => {
+            rue_air::IntrinsicOperation::ByteSet => {
                 let p = self.eval(cfg, frame, args[0])?;
                 let val = self.eval(cfg, frame, args[1])?.as_int();
                 let count = self.eval(cfg, frame, args[2])?.as_int();
@@ -5794,7 +6328,30 @@ impl<'a> Interp<'a> {
                 allocation.provenance[start..end].fill(None);
                 Ok(Some(Value::Unit))
             }
-            _ => Ok(None),
+            rue_air::IntrinsicOperation::PanicNoMessage
+            | rue_air::IntrinsicOperation::Panic
+            | rue_air::IntrinsicOperation::AssertFailed
+            | rue_air::IntrinsicOperation::AssertWithMessage
+            | rue_air::IntrinsicOperation::BoundsCheck
+            | rue_air::IntrinsicOperation::DebugI64
+            | rue_air::IntrinsicOperation::DebugU64
+            | rue_air::IntrinsicOperation::DebugBool
+            | rue_air::IntrinsicOperation::DebugStr
+            | rue_air::IntrinsicOperation::ReadLine
+            | rue_air::IntrinsicOperation::ParseI32
+            | rue_air::IntrinsicOperation::ParseI64
+            | rue_air::IntrinsicOperation::ParseU32
+            | rue_air::IntrinsicOperation::ParseU64
+            | rue_air::IntrinsicOperation::RandomU32
+            | rue_air::IntrinsicOperation::RandomU64
+            | rue_air::IntrinsicOperation::ArgCount
+            | rue_air::IntrinsicOperation::ArgPtr
+            | rue_air::IntrinsicOperation::ArgLen
+            | rue_air::IntrinsicOperation::EnvCount
+            | rue_air::IntrinsicOperation::EnvPtr
+            | rue_air::IntrinsicOperation::EnvLen
+            | rue_air::IntrinsicOperation::Syscall
+            | rue_air::IntrinsicOperation::BitCast => Ok(None),
         }
     }
 
@@ -5889,14 +6446,17 @@ impl<'a> Interp<'a> {
     /// `@alloc(size, align)`: reserve canonical representation bytes. Ordinary
     /// allocation bytes are uninitialized; `alloc_zeroed` marks them ready.
     fn do_alloc(&mut self, size: i128, zeroed: bool, align: i128) -> Step<Value> {
-        let align = self.checked_alignment(align, unsupported_intrinsic_kind("alloc"))?;
+        let align = self.checked_alignment(
+            align,
+            unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Alloc),
+        )?;
         let Some(_bytes) = self.alloc_byte_size(size, 1)? else {
             return Ok(Value::Ptr(None));
         };
         self.materialize_cells_guard(size)?;
         let count = usize::try_from(size).map_err(|_| {
             unsupported(
-                unsupported_intrinsic_kind("alloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Alloc),
                 "allocation exceeds host range",
             )
         })?;
@@ -5964,10 +6524,13 @@ impl<'a> Interp<'a> {
     /// allocation valid (spec 8.6:3), and traps on a `new * stride` overflow
     /// like the compiled size arithmetic (spec 8.6:1).
     fn do_realloc(&mut self, p: Value, old_size: i128, align: i128, new_size: i128) -> Step<Value> {
-        let align = self.checked_alignment(align, unsupported_intrinsic_kind("realloc"))?;
+        let align = self.checked_alignment(
+            align,
+            unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
+        )?;
         if old_size < 0 || new_size < 0 {
             return Err(unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "negative realloc size",
             ));
         }
@@ -5977,7 +6540,9 @@ impl<'a> Interp<'a> {
             Value::Ptr(None) => {
                 if old_size != 0 {
                     return Err(unsupported(
-                        unsupported_intrinsic_kind("realloc"),
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::Realloc,
+                        ),
                         "null realloc requires old size zero",
                     ));
                 }
@@ -5985,35 +6550,38 @@ impl<'a> Interp<'a> {
             }
             _ => return Ok(Value::Ptr(None)),
         };
-        self.allocation_for_target(&target, unsupported_intrinsic_kind("realloc"))?;
+        self.allocation_for_target(
+            &target,
+            unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
+        )?;
         if target.byte_offset != 0 {
             return Err(unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "realloc requires the allocation base as ptr mut u8",
             ));
         }
         let Some(allocation) = self.heap.get(target.alloc) else {
             return Err(unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "realloc allocation missing",
             ));
         };
         if allocation.origin != AllocationOrigin::Heap {
             return Err(unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "realloc requires an allocator-owned allocation",
             ));
         }
         if allocation.declared_alignment != align {
             return Err(unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "realloc alignment does not match the live allocation",
             ));
         }
         let actual_old_size = allocation.bytes.len() as i128;
         if old_size != actual_old_size {
             return Err(unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "realloc old size does not match the live allocation",
             ));
         }
@@ -6030,20 +6598,20 @@ impl<'a> Interp<'a> {
         }
         let new_count = usize::try_from(new_size).map_err(|_| {
             unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "allocation exceeds host range",
             )
         })?;
         self.materialize_cells_guard(new_size)?;
         let old_kind = allocation_kind(old_size, align).ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "old allocation has no allocator classification",
             )
         })?;
         let new_kind = allocation_kind(new_size, align).ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "new allocation has no allocator classification",
             )
         })?;
@@ -6073,7 +6641,7 @@ impl<'a> Interp<'a> {
         let (old_bytes, old_initialized, old_provenance) = {
             let old = self.heap.get(target.alloc).ok_or_else(|| {
                 unsupported(
-                    unsupported_intrinsic_kind("realloc"),
+                    unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                     "realloc allocation missing",
                 )
             })?;
@@ -6090,7 +6658,7 @@ impl<'a> Interp<'a> {
         let copy = old_bytes.len().min(new_count);
         let destination = self.heap.get_mut(new_target.alloc).ok_or_else(|| {
             unsupported(
-                unsupported_intrinsic_kind("realloc"),
+                unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::Realloc),
                 "new allocation missing",
             )
         })?;
@@ -6178,8 +6746,8 @@ impl<'a> Interp<'a> {
 }
 
 /// Whether the interpreter now executes this pointer/heap intrinsic instead of
-/// reporting it as a model gap. Excludes the still-unmodeled text parses and the
-/// empty-slice `@int_to_ptr(0)` special case (kept as its own typed gap).
+/// reporting it as a model gap. Excludes the still-unmodeled text parses; the
+/// compiler-owned empty-slice null is a typed `Const(0)`, not an intrinsic.
 fn modeled_pointer_intrinsic(kind: UnsupportedIntrinsicKind) -> bool {
     use UnsupportedIntrinsicKind as I;
     matches!(

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -23,6 +23,49 @@ fn oracle_uses_air_synthetic_type_identity_policy() {
     }
 }
 
+#[test]
+fn oracle_intrinsic_contracts_and_evaluation_use_only_the_typed_operation() {
+    let source = include_str!("lib.rs");
+    assert!(source.contains(
+        "fn unsupported_intrinsic_kind_for_operation(\n    operation: rue_air::IntrinsicOperation"
+    ));
+    assert!(source.contains("CfgInstData::Intrinsic { operation, .. }"));
+    assert!(source.contains("match *operation {"));
+
+    let pointer_eval = source
+        .split("fn eval_pointer_intrinsic(")
+        .nth(1)
+        .and_then(|source| source.split("\n    fn expect_ptr(").next())
+        .expect("typed pointer-intrinsic evaluator");
+    assert!(pointer_eval.contains("match operation {"));
+    assert!(!pointer_eval.contains("_ => Ok(None)"));
+
+    let debug_eval = source
+        .split("fn eval_debug_intrinsic(")
+        .nth(1)
+        .and_then(|source| source.split("\n    fn write_dbg(").next())
+        .expect("typed debug-intrinsic evaluator");
+    assert!(debug_eval.contains("operation.validate_call("));
+    assert!(debug_eval.contains("match operation {"));
+    assert!(!debug_eval.contains("_ =>"));
+
+    for forbidden in [
+        "IntrinsicSelector",
+        "impl From<&str>",
+        "fn unsupported_intrinsic_kind(name",
+        "unsupported_intrinsic_kind(name",
+        "intrinsic_operation_from_name",
+        "operation_from_name",
+        "match name.as_str()",
+        "match name {\n            \"ptr_",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "oracle regained intrinsic string selection or compatibility fallback: {forbidden}"
+        );
+    }
+}
+
 mod call_contracts;
 mod place_contracts;
 
@@ -834,77 +877,83 @@ fn valid_unmodeled_program_is_unsupported_not_a_compile_error() {
 #[test]
 fn every_known_unsupported_intrinsic_has_a_closed_kind() {
     use UnsupportedIntrinsicKind as Intrinsic;
+    use rue_air::IntrinsicOperation as Operation;
 
-    for (name, intrinsic) in [
-        ("parse_i32", Intrinsic::ParseI32),
-        ("parse_i64", Intrinsic::ParseI64),
-        ("parse_u32", Intrinsic::ParseU32),
-        ("parse_u64", Intrinsic::ParseU64),
-        ("ptr_read", Intrinsic::PointerRead),
-        ("ptr_write", Intrinsic::PointerWrite),
-        ("ptr_offset", Intrinsic::PointerOffset),
-        ("ptr_to_int", Intrinsic::PointerToInt),
-        ("int_to_ptr", Intrinsic::IntToPointer),
-        ("raw", Intrinsic::RawAddress),
-        ("raw_mut", Intrinsic::RawMutableAddress),
-        ("field_ptr", Intrinsic::FieldPointer),
-        ("alloc", Intrinsic::Allocate),
-        ("free", Intrinsic::Free),
-        ("realloc", Intrinsic::Reallocate),
-        ("alloc_zeroed", Intrinsic::AllocateZeroed),
-        ("resize", Intrinsic::Resize),
-        ("byte_move", Intrinsic::ByteMove),
-        ("byte_copy", Intrinsic::ByteCopy),
-        ("byte_set", Intrinsic::ByteSet),
+    for (operation, intrinsic) in [
+        (Operation::ParseI32, Intrinsic::ParseI32),
+        (Operation::ParseI64, Intrinsic::ParseI64),
+        (Operation::ParseU32, Intrinsic::ParseU32),
+        (Operation::ParseU64, Intrinsic::ParseU64),
+        (Operation::PtrRead, Intrinsic::PointerRead),
+        (Operation::PtrReadUnaligned, Intrinsic::PointerRead),
+        (Operation::PtrWrite, Intrinsic::PointerWrite),
+        (Operation::PtrWriteUnaligned, Intrinsic::PointerWrite),
+        (Operation::PtrOffset, Intrinsic::PointerOffset),
+        (Operation::PtrToInt, Intrinsic::PointerToInt),
+        (Operation::IntToPtr, Intrinsic::IntToPointer),
+        (Operation::Raw, Intrinsic::RawAddress),
+        (Operation::RawMut, Intrinsic::RawMutableAddress),
+        (Operation::FieldPtr, Intrinsic::FieldPointer),
+        (Operation::Alloc, Intrinsic::Allocate),
+        (Operation::Free, Intrinsic::Free),
+        (Operation::Realloc, Intrinsic::Reallocate),
+        (Operation::AllocZeroed, Intrinsic::AllocateZeroed),
+        (Operation::Resize, Intrinsic::Resize),
+        (Operation::ByteMove, Intrinsic::ByteMove),
+        (Operation::ByteCopy, Intrinsic::ByteCopy),
+        (Operation::ByteSet, Intrinsic::ByteSet),
     ] {
         let expected = UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(intrinsic));
-        assert_eq!(unsupported_intrinsic_kind(name), expected, "@{name}");
+        assert_eq!(
+            unsupported_intrinsic_kind_for_operation(operation),
+            expected,
+            "{operation:?}"
+        );
         assert!(
             expected.model_gap().is_some(),
-            "@{name} must be registrable"
+            "{operation:?} must be registrable"
         );
     }
 
-    for (name, dependency) in [
-        ("read_line", ExternalDependencyKind::StandardInput),
-        ("random_u32", ExternalDependencyKind::RandomU32),
-        ("random_u64", ExternalDependencyKind::RandomU64),
-        ("syscall", ExternalDependencyKind::SystemCall),
-        ("arg_count", ExternalDependencyKind::ArgCount),
-        ("arg_ptr", ExternalDependencyKind::ArgPtr),
-        ("arg_len", ExternalDependencyKind::ArgLen),
-        ("env_count", ExternalDependencyKind::EnvCount),
-        ("env_ptr", ExternalDependencyKind::EnvPtr),
-        ("env_len", ExternalDependencyKind::EnvLen),
+    for (operation, dependency) in [
+        (Operation::ReadLine, ExternalDependencyKind::StandardInput),
+        (Operation::RandomU32, ExternalDependencyKind::RandomU32),
+        (Operation::RandomU64, ExternalDependencyKind::RandomU64),
+        (Operation::Syscall, ExternalDependencyKind::SystemCall),
+        (Operation::ArgCount, ExternalDependencyKind::ArgCount),
+        (Operation::ArgPtr, ExternalDependencyKind::ArgPtr),
+        (Operation::ArgLen, ExternalDependencyKind::ArgLen),
+        (Operation::EnvCount, ExternalDependencyKind::EnvCount),
+        (Operation::EnvPtr, ExternalDependencyKind::EnvPtr),
+        (Operation::EnvLen, ExternalDependencyKind::EnvLen),
     ] {
         assert_eq!(
-            unsupported_intrinsic_kind(name),
+            unsupported_intrinsic_kind_for_operation(operation),
             UnsupportedKind::ExternalDependency(dependency),
-            "@{name}"
+            "{operation:?}"
         );
     }
 
-    for name in [
-        "dbg",
-        "panic",
-        "assert",
-        "drop",
-        "intCast",
-        "cast",
-        "to_string",
-        "test_preview_gate",
-        "import",
-        "target_arch",
-        "target_os",
-        "__rue_char_next",
-        "unknown_future_intrinsic",
+    for operation in [
+        Operation::PanicNoMessage,
+        Operation::Panic,
+        Operation::AssertFailed,
+        Operation::AssertWithMessage,
+        Operation::BoundsCheck,
+        Operation::DebugI64,
+        Operation::DebugU64,
+        Operation::DebugBool,
+        Operation::DebugStr,
+        Operation::BitCast,
     ] {
         assert_eq!(
-            unsupported_intrinsic_kind(name),
+            unsupported_intrinsic_kind_for_operation(operation),
             UnsupportedKind::ContractViolation(ContractViolationKind::UnexpectedIntrinsic),
-            "@{name} must fail closed if it unexpectedly survives lowering"
+            "{operation:?} must fail closed if it unexpectedly reaches gap classification"
         );
     }
+
+    assert_eq!(Operation::ALL.len(), 42);
 }
 
 #[test]

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -35,6 +35,21 @@ fn expect_observed(result: Step<()>) {
     }
 }
 
+fn contract_interp(state: &CompileState) -> Interp<'_> {
+    Interp {
+        state,
+        stdout_trace: Vec::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+        heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
+        heap_metadata_bytes: 0,
+    }
+}
+
 fn find_call_metadata(
     state: &CompileState,
     expected_name: &str,
@@ -356,15 +371,33 @@ fn random_intrinsic_requires_exact_arity_and_result_type() {
         heap_metadata_bytes: 0,
     };
     assert_eq!(
-        interp.classify_unsupported_intrinsic(cfg, inst, "random_u32", &args, result),
+        interp.classify_unsupported_intrinsic(
+            cfg,
+            inst,
+            rue_air::IntrinsicOperation::RandomU32,
+            &args,
+            result,
+        ),
         UnsupportedKind::ExternalDependency(ExternalDependencyKind::RandomU32)
     );
     assert_eq!(
-        interp.classify_unsupported_intrinsic(cfg, inst, "random_u32", &[inst], result),
+        interp.classify_unsupported_intrinsic(
+            cfg,
+            inst,
+            rue_air::IntrinsicOperation::RandomU32,
+            &[inst],
+            result,
+        ),
         UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicArity)
     );
     assert_eq!(
-        interp.classify_unsupported_intrinsic(cfg, inst, "random_u32", &args, Type::U64),
+        interp.classify_unsupported_intrinsic(
+            cfg,
+            inst,
+            rue_air::IntrinsicOperation::RandomU32,
+            &args,
+            Type::U64,
+        ),
         UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature)
     );
 }
@@ -402,6 +435,47 @@ fn find_intrinsic_in_function<'a>(
     let (value, args, ty) =
         found.unwrap_or_else(|| panic!("missing @{expected_name} in {function_name}"));
     (cfg, value, args, ty)
+}
+
+fn find_empty_slice_pointer_in_function<'a>(
+    state: &'a CompileState,
+    function_name: &str,
+) -> (&'a Cfg, CfgValue, CfgValue) {
+    let function = state
+        .functions
+        .iter()
+        .position(|function| function.is_source_named(function_name))
+        .unwrap_or_else(|| panic!("missing CFG for {function_name}"));
+    let cfg = &state.functions[function].cfg;
+    let pool = &state.functions[function].type_pool;
+    let mut found = None;
+    for init in cfg
+        .blocks()
+        .iter()
+        .flat_map(|block| block.insts.iter().copied())
+    {
+        let data = &cfg.get_inst(init).data;
+        let CfgInstData::StructInit { struct_id, .. } = data else {
+            continue;
+        };
+        let fields = cfg.get_struct_fields(data);
+        if !rue_air::is_slice_struct_name(&pool.struct_def(*struct_id).name)
+            || fields.len() != 2
+            || !matches!(cfg.get_inst(fields[0]).data, CfgInstData::Const(0))
+            || !cfg.get_inst(fields[0]).ty.is_ptr_const()
+            || cfg.get_inst(fields[1]).ty != Type::U64
+            || !matches!(cfg.get_inst(fields[1]).data, CfgInstData::Const(0))
+        {
+            continue;
+        }
+        assert!(
+            found.replace((fields[0], init)).is_none(),
+            "expected exactly one empty-slice pointer in {function_name}"
+        );
+    }
+    let (pointer, init) =
+        found.unwrap_or_else(|| panic!("missing empty-slice pointer in {function_name}"));
+    (cfg, pointer, init)
 }
 
 #[test]
@@ -535,19 +609,24 @@ fn panic_never_signature_is_an_oracle_contract_for_both_arities() {
         state.select_source_function(function_name);
         let (cfg, _intrinsic, args, result_ty) =
             find_intrinsic_in_function(&state, function_name, "panic");
+        let operation = if function_name == "panic_no_message" {
+            rue_air::IntrinsicOperation::PanicNoMessage
+        } else {
+            rue_air::IntrinsicOperation::Panic
+        };
         // `@panic` diverges, so the compiler types it `!` (never) (RUE-512).
         assert_eq!(result_ty, Type::NEVER, "{function_name} compiler metadata");
         // The abort preflight (the oracle's panic contract since RUE-589)
         // accepts exactly the never-typed shape...
         assert!(
             matches!(
-                interp.preflight_abort_intrinsic(cfg, "panic", &args, result_ty),
+                interp.preflight_abort_intrinsic(cfg, operation, &args, result_ty,),
                 Ok(Some(AbortIntrinsic::Panic))
             ),
             "{function_name} never signature must pass preflight"
         );
         // ...and rejects stale unit-typed metadata as a contract violation.
-        match interp.preflight_abort_intrinsic(cfg, "panic", &args, Type::UNIT) {
+        match interp.preflight_abort_intrinsic(cfg, operation, &args, Type::UNIT) {
             Err(Flow::Unsupported(unsupported)) => assert_eq!(
                 unsupported.kind(),
                 UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
@@ -556,6 +635,22 @@ fn panic_never_signature_is_an_oracle_contract_for_both_arities() {
             _ => panic!("{function_name}: stale unit-typed metadata must be a contract violation"),
         }
     }
+}
+
+#[test]
+fn oracle_intrinsic_execution_is_operation_selected() {
+    let source = include_str!("../lib.rs");
+    let intrinsic_branch = source
+        .split("CfgInstData::Intrinsic {")
+        .nth(1)
+        .expect("oracle intrinsic execution branch");
+    assert!(intrinsic_branch.contains("operation.expected_spelling()"));
+    assert!(intrinsic_branch.contains("self.classify_unsupported_intrinsic(cfg, v, *operation"));
+    assert!(
+        intrinsic_branch.contains(".eval_pointer_intrinsic(cfg, frame, *operation, &args, ty)")
+    );
+    assert!(!intrinsic_branch.contains("self.interner().resolve(name)"));
+    assert!(!intrinsic_branch.contains("&iname"));
 }
 
 #[test]
@@ -849,8 +944,7 @@ fn abort_intrinsics_require_exact_runtime_value_shapes() {
 }
 
 #[test]
-fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
-    let preview_features = PreviewFeatures::new();
+fn empty_slice_null_is_a_const_gap_and_user_int_to_ptr_stays_distinct() {
     let source = r#"const ZERO: u64 = 0;
         fn slice_len(borrow s: [i32]) -> u64 { s.len() }
         fn user_pointer(borrow s: [i32]) -> u64 {
@@ -862,42 +956,41 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         fn route(borrow s: [i32]) -> u64 {
             slice_len(borrow s) + user_pointer(borrow s)
         }
-        fn offset_probe() -> u64 {
-            let a = [1, 2];
-            checked { @ptr_to_int(@ptr_offset(@raw(a[0]), 1)) }
-        }
         fn main() -> i32 {
             let empty: [i32; 0] = [];
-            @intCast(route(borrow empty) + offset_probe())
+            @intCast(route(borrow empty))
         }"#;
-    let state = query_cfg_state(source).expect("pointer provenance probe must compile");
-    let interp = Interp {
-        state: &state,
-        stdout_trace: Vec::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-        heap: Vec::new(),
-        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
-        heap_metadata_bytes: 0,
-    };
 
-    let (slice_cfg, slice_inst, slice_args, slice_result) =
-        find_intrinsic_in_function(&state, "main", "int_to_ptr");
+    let state = query_cfg_state(source).expect("empty-slice provenance probe must compile");
+    let (cfg, pointer, _init) = find_empty_slice_pointer_in_function(&state, "main");
     state.select_source_function("main");
+    let mut interp = contract_interp(&state);
+    assert!(interp.is_empty_slice_pointer(cfg, pointer));
+    let mut frame = Frame {
+        params: Vec::new(),
+        locals: vec![None; cfg.num_locals() as usize],
+        cache: HashMap::new(),
+        promoted: HashMap::new(),
+        param_places: HashMap::new(),
+        place_return: false,
+    };
+    let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, pointer));
     assert_eq!(
-        interp.classify_unsupported_intrinsic(
-            slice_cfg,
-            slice_inst,
-            "int_to_ptr",
-            &slice_args,
-            slice_result,
-        ),
+        unsupported.kind(),
         UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
             UnsupportedIntrinsicKind::EmptySlicePointer,
         ))
+    );
+    assert!(
+        cfg.blocks()
+            .iter()
+            .flat_map(|block| block.insts.iter().copied())
+            .filter_map(|value| match cfg.get_inst(value).data {
+                CfgInstData::Intrinsic { operation, .. } => Some(operation),
+                _ => None,
+            })
+            .all(|operation| operation != rue_air::IntrinsicOperation::IntToPtr),
+        "the compiler-owned null must not masquerade as source @int_to_ptr"
     );
 
     let (user_cfg, user_inst, user_args, user_result) =
@@ -908,401 +1001,129 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         CfgInstData::Const(0)
     ));
     assert_eq!(
-        interp.classify_unsupported_intrinsic(
+        contract_interp(&state).classify_unsupported_intrinsic(
             user_cfg,
             user_inst,
-            "int_to_ptr",
+            rue_air::IntrinsicOperation::IntToPtr,
             &user_args,
             user_result,
         ),
         UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
             UnsupportedIntrinsicKind::IntToPointer,
-        ))
-    );
-    let (offset_cfg, offset_inst, offset_args, offset_result) =
-        find_intrinsic_in_function(&state, "offset_probe", "ptr_offset");
-    state.select_source_function("offset_probe");
-    assert_eq!(
-        interp.classify_unsupported_intrinsic(
-            offset_cfg,
-            offset_inst,
-            "ptr_offset",
-            &offset_args,
-            offset_result,
-        ),
-        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
-            UnsupportedIntrinsicKind::PointerOffset,
-        ))
-    );
-    assert_eq!(
-        interp.classify_unsupported_intrinsic(
-            offset_cfg,
-            offset_inst,
-            "ptr_offset",
-            &offset_args[..1],
-            offset_result,
-        ),
-        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicArity)
-    );
-    assert_eq!(
-        interp.classify_unsupported_intrinsic(
-            offset_cfg,
-            offset_inst,
-            "ptr_offset",
-            &[offset_args[0], offset_args[0]],
-            offset_result,
-        ),
-        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature)
-    );
-    assert_eq!(
-        interp.classify_unsupported_intrinsic(
-            offset_cfg,
-            offset_inst,
-            "ptr_offset",
-            &offset_args,
-            Type::U64,
-        ),
-        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
-        "ptr_offset must return the exact input pointer type"
+        )),
+        "a user-authored zero keeps the source IntToPtr identity"
     );
 
-    // Simulate compiler signature drift faithfully: mutate the instruction's
-    // own result type, rather than only passing an inconsistent classifier
-    // argument, then verify that a user-authored zero still lacks the exact
-    // downstream slice-StructInit provenance.
-    let mut drift_state = query_cfg_state_with_preview_features(source, &preview_features)
-        .expect("pointer provenance drift probe must compile");
-    let (_, _, _, drift_slice_result) =
-        find_intrinsic_in_function(&drift_state, "main", "int_to_ptr");
-    let main_index = drift_state.select_source_function("main");
-    let (slice_pointer_is_mut, slice_pointee) = match drift_slice_result.kind() {
-        TypeKind::PtrConst(id) => (
-            false,
-            drift_state.functions[main_index]
-                .type_pool
-                .ptr_const_def(id),
-        ),
-        TypeKind::PtrMut(id) => (
-            true,
-            drift_state.functions[main_index].type_pool.ptr_mut_def(id),
-        ),
-        _ => panic!("empty-slice pointer synthesis must return a pointer"),
-    };
-    let (_, drift_user_inst, _, _) =
-        find_intrinsic_in_function(&drift_state, "user_pointer", "int_to_ptr");
-    let drift_user_index = drift_state
-        .functions
-        .iter()
-        .position(|function| function.is_source_named("user_pointer"))
-        .expect("user_pointer CFG");
-    drift_state.select_source_function("user_pointer");
-    let type_pool = drift_state.type_pool().clone();
-    let drift_slice_result = if slice_pointer_is_mut {
-        Type::new_ptr_mut(
-            type_pool
-                .all_ptr_mut_ids()
-                .find(|id| type_pool.ptr_mut_def(*id) == slice_pointee)
-                .expect("user-pointer domain contains the synthesized slice pointer type"),
-        )
-    } else {
-        Type::new_ptr_const(
-            type_pool
-                .all_ptr_const_ids()
-                .find(|id| type_pool.ptr_const_def(*id) == slice_pointee)
-                .expect("user-pointer domain contains the synthesized slice pointer type"),
-        )
-    };
-    drift_state.functions[drift_user_index]
-        .cfg
-        .try_edit(&type_pool, |editor| {
-            editor.replace_inst_type(drift_user_inst, drift_slice_result)
-        })
-        .unwrap();
-    let (drift_cfg, drift_inst, drift_args, drift_result) =
-        find_intrinsic_in_function(&drift_state, "user_pointer", "int_to_ptr");
-    drift_state.select_source_function("user_pointer");
-    let drift_interp = Interp {
-        state: &drift_state,
-        stdout_trace: Vec::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-        heap: Vec::new(),
-        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
-        heap_metadata_bytes: 0,
-    };
-    assert_eq!(
-        drift_interp.classify_unsupported_intrinsic(
-            drift_cfg,
-            drift_inst,
-            "int_to_ptr",
-            &drift_args,
-            drift_result,
-        ),
-        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
-        "a user-authored zero is not the synthesized empty-slice pointer"
-    );
+    let preview = PreviewFeatures::new();
 
-    let mut extra_use_state = query_cfg_state_with_preview_features(source, &preview_features)
-        .expect("empty-slice exclusive-use probe must compile");
-    let (_, extra_slice_inst, _, extra_slice_result) =
-        find_intrinsic_in_function(&extra_use_state, "main", "int_to_ptr");
-    let extra_main = extra_use_state
+    let mut extra_pointer_use = query_cfg_state_with_preview_features(source, &preview)
+        .expect("extra pointer-use probe must compile");
+    let main = extra_pointer_use
         .functions
         .iter()
         .position(|function| function.is_source_named("main"))
-        .expect("main CFG");
-    let outer_cast = extra_use_state.functions[extra_main]
-        .cfg
-        .blocks()
-        .iter()
-        .flat_map(|block| block.insts.iter().copied())
-        .find(|value| {
-            matches!(
-                extra_use_state.functions[extra_main]
-                    .cfg
-                    .get_inst(*value)
-                    .data,
-                CfgInstData::IntCast { .. }
-            )
-        })
-        .expect("outer result cast");
-    let type_pool = extra_use_state.type_pool().clone();
-    extra_use_state.functions[extra_main]
-        .cfg
-        .try_edit(&type_pool, |editor| {
-            editor.replace_int_cast(outer_cast, extra_slice_inst, extra_slice_result)
-        })
         .unwrap();
-    let (extra_cfg, extra_inst, extra_args, extra_result) =
-        find_intrinsic_in_function(&extra_use_state, "main", "int_to_ptr");
-    let extra_interp = Interp {
-        state: &extra_use_state,
-        stdout_trace: Vec::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-        heap: Vec::new(),
-        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
-        heap_metadata_bytes: 0,
-    };
-    assert_eq!(
-        extra_interp.classify_unsupported_intrinsic(
-            extra_cfg,
-            extra_inst,
-            "int_to_ptr",
-            &extra_args,
-            extra_result,
-        ),
-        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
-        "an extra use cannot borrow synthesized empty-slice provenance"
-    );
-
-    let mut extra_init_use_state = query_cfg_state_with_preview_features(source, &preview_features)
-        .expect("empty-slice StructInit exclusive-use probe must compile");
-    let (_, extra_init_pointer, _, _) =
-        find_intrinsic_in_function(&extra_init_use_state, "main", "int_to_ptr");
-    let extra_init_main = extra_init_use_state
-        .functions
-        .iter()
-        .position(|function| function.is_source_named("main"))
-        .expect("main CFG");
-    let (slice_init, slice_ty, outer_cast) = {
-        let cfg = &extra_init_use_state.functions[extra_init_main].cfg;
-        let slice_init = cfg
-            .blocks()
-            .iter()
-            .flat_map(|block| block.insts.iter().copied())
-            .find(|value| {
-                let data = &cfg.get_inst(*value).data;
-                let CfgInstData::StructInit { .. } = data else {
-                    return false;
-                };
-                cfg.get_struct_fields(data).first() == Some(&extra_init_pointer)
-            })
-            .expect("empty-slice StructInit");
+    let (pointer, pointer_ty, outer_cast) = {
+        let cfg = &extra_pointer_use.functions[main].cfg;
+        let (_, pointer, _) = find_empty_slice_pointer_in_function(&extra_pointer_use, "main");
         let outer_cast = cfg
             .blocks()
             .iter()
             .flat_map(|block| block.insts.iter().copied())
             .find(|value| matches!(cfg.get_inst(*value).data, CfgInstData::IntCast { .. }))
             .expect("outer result cast");
-        (slice_init, cfg.get_inst(slice_init).ty, outer_cast)
+        (pointer, cfg.get_inst(pointer).ty, outer_cast)
     };
-    let type_pool = extra_init_use_state.type_pool().clone();
-    extra_init_use_state.functions[extra_init_main]
+    let pool = extra_pointer_use.functions[main].type_pool.clone();
+    extra_pointer_use.functions[main]
         .cfg
-        .try_edit(&type_pool, |editor| {
-            editor.replace_int_cast(outer_cast, slice_init, slice_ty)
+        .try_edit(&pool, |editor| {
+            editor.replace_int_cast(outer_cast, pointer, pointer_ty)
         })
         .unwrap();
-    let (extra_init_cfg, extra_init_inst, extra_init_args, extra_init_result) =
-        find_intrinsic_in_function(&extra_init_use_state, "main", "int_to_ptr");
-    assert_eq!(extra_init_cfg.value_use_count(extra_init_inst), 1);
-    assert_eq!(extra_init_cfg.value_use_count(slice_init), 2);
-    let extra_init_interp = Interp {
-        state: &extra_init_use_state,
-        stdout_trace: Vec::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-        heap: Vec::new(),
-        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
-        heap_metadata_bytes: 0,
-    };
-    assert_eq!(
-        extra_init_interp.classify_unsupported_intrinsic(
-            extra_init_cfg,
-            extra_init_inst,
-            "int_to_ptr",
-            &extra_init_args,
-            extra_init_result,
-        ),
-        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
-        "an extra slice-StructInit use cannot borrow synthesized empty-slice provenance"
-    );
+    let cfg = &extra_pointer_use.functions[main].cfg;
+    assert_eq!(cfg.value_use_count(pointer), 2);
+    assert!(!contract_interp(&extra_pointer_use).is_empty_slice_pointer(cfg, pointer));
 
-    let mut wrong_consumer_state = query_cfg_state_with_preview_features(source, &preview_features)
-        .expect("empty-slice consumer-mode probe must compile");
-    let (_, wrong_consumer_pointer, _, _) =
-        find_intrinsic_in_function(&wrong_consumer_state, "main", "int_to_ptr");
-    let wrong_consumer_main = wrong_consumer_state
+    let mut extra_init_use = query_cfg_state_with_preview_features(source, &preview)
+        .expect("extra slice-use probe must compile");
+    let main = extra_init_use
         .functions
         .iter()
         .position(|function| function.is_source_named("main"))
-        .expect("main CFG");
-    let (wrong_consumer_init, consumer, mut consumer_args) = {
-        let cfg = &wrong_consumer_state.functions[wrong_consumer_main].cfg;
-        let init = cfg
+        .unwrap();
+    let (pointer, init, init_ty, outer_cast) = {
+        let cfg = &extra_init_use.functions[main].cfg;
+        let (_, pointer, init) = find_empty_slice_pointer_in_function(&extra_init_use, "main");
+        let outer_cast = cfg
             .blocks()
             .iter()
             .flat_map(|block| block.insts.iter().copied())
-            .find(|value| {
-                let data = &cfg.get_inst(*value).data;
-                let CfgInstData::StructInit { .. } = data else {
-                    return false;
-                };
-                cfg.get_struct_fields(data).first() == Some(&wrong_consumer_pointer)
-            })
-            .expect("empty-slice StructInit");
+            .find(|value| matches!(cfg.get_inst(*value).data, CfgInstData::IntCast { .. }))
+            .expect("outer result cast");
+        (pointer, init, cfg.get_inst(init).ty, outer_cast)
+    };
+    let pool = extra_init_use.functions[main].type_pool.clone();
+    extra_init_use.functions[main]
+        .cfg
+        .try_edit(&pool, |editor| {
+            editor.replace_int_cast(outer_cast, init, init_ty)
+        })
+        .unwrap();
+    let cfg = &extra_init_use.functions[main].cfg;
+    assert_eq!(cfg.value_use_count(init), 2);
+    assert!(!contract_interp(&extra_init_use).is_empty_slice_pointer(cfg, pointer));
+
+    let mut wrong_consumer = query_cfg_state_with_preview_features(source, &preview)
+        .expect("consumer-mode probe must compile");
+    let main = wrong_consumer
+        .functions
+        .iter()
+        .position(|function| function.is_source_named("main"))
+        .unwrap();
+    let (pointer, init, consumer, mut args) = {
+        let cfg = &wrong_consumer.functions[main].cfg;
+        let (_, pointer, init) = find_empty_slice_pointer_in_function(&wrong_consumer, "main");
         let (consumer, args) = cfg
             .blocks()
             .iter()
             .flat_map(|block| block.insts.iter().copied())
             .find_map(|value| {
                 let data = &cfg.get_inst(value).data;
-                let CfgInstData::Call { .. } = data else {
-                    return None;
-                };
-                let args = cfg.get_call_args(data);
-                args.iter()
-                    .any(|arg| arg.value == init)
-                    .then(|| (value, args.to_vec()))
+                matches!(data, CfgInstData::Call { .. })
+                    .then(|| (value, cfg.get_call_args(data).to_vec()))
+                    .filter(|(_, args)| args.iter().any(|arg| arg.value == init))
             })
-            .expect("empty-slice call consumer");
-        (init, consumer, args)
+            .expect("slice call consumer");
+        (pointer, init, consumer, args)
     };
-    let slice_arg = consumer_args
-        .iter_mut()
-        .find(|arg| arg.value == wrong_consumer_init)
-        .expect("empty-slice call argument");
-    assert_eq!(slice_arg.mode, CfgArgMode::Normal);
-    slice_arg.mode = CfgArgMode::Borrow;
-    let type_pool = wrong_consumer_state.type_pool().clone();
-    let cfg = &mut wrong_consumer_state.functions[wrong_consumer_main].cfg;
-    cfg.try_edit(&type_pool, |editor| {
-        editor.replace_call_args(consumer, consumer_args)
-    })
-    .unwrap();
-    let (wrong_consumer_cfg, wrong_consumer_inst, wrong_consumer_args, wrong_consumer_result) =
-        find_intrinsic_in_function(&wrong_consumer_state, "main", "int_to_ptr");
-    assert_eq!(wrong_consumer_cfg.value_use_count(wrong_consumer_inst), 1);
-    assert_eq!(wrong_consumer_cfg.value_use_count(wrong_consumer_init), 1);
-    let wrong_consumer_interp = Interp {
-        state: &wrong_consumer_state,
-        stdout_trace: Vec::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-        heap: Vec::new(),
-        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
-        heap_metadata_bytes: 0,
-    };
-    assert_eq!(
-        wrong_consumer_interp.classify_unsupported_intrinsic(
-            wrong_consumer_cfg,
-            wrong_consumer_inst,
-            "int_to_ptr",
-            &wrong_consumer_args,
-            wrong_consumer_result,
-        ),
-        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
-        "the synthesized slice StructInit must have one normal call consumer"
-    );
+    args.iter_mut()
+        .find(|arg| arg.value == init)
+        .expect("slice argument")
+        .mode = CfgArgMode::Borrow;
+    let pool = wrong_consumer.functions[main].type_pool.clone();
+    wrong_consumer.functions[main]
+        .cfg
+        .try_edit(&pool, |editor| editor.replace_call_args(consumer, args))
+        .unwrap();
+    let cfg = &wrong_consumer.functions[main].cfg;
+    assert!(!contract_interp(&wrong_consumer).is_empty_slice_pointer(cfg, pointer));
 
-    let mut wrong_init_state = query_cfg_state_with_preview_features(source, &preview_features)
-        .expect("empty-slice StructInit type probe must compile");
-    let (_, wrong_init_pointer, _, _) =
-        find_intrinsic_in_function(&wrong_init_state, "main", "int_to_ptr");
-    let wrong_init_main = wrong_init_state
+    let mut wrong_init_type = query_cfg_state_with_preview_features(source, &preview)
+        .expect("slice type probe must compile");
+    let main = wrong_init_type
         .functions
         .iter()
         .position(|function| function.is_source_named("main"))
-        .expect("main CFG");
-    let slice_init = {
-        let cfg = &wrong_init_state.functions[wrong_init_main].cfg;
-        cfg.blocks()
-            .iter()
-            .flat_map(|block| block.insts.iter().copied())
-            .find(|value| {
-                let data = &cfg.get_inst(*value).data;
-                let CfgInstData::StructInit { .. } = data else {
-                    return false;
-                };
-                cfg.get_struct_fields(data).first() == Some(&wrong_init_pointer)
-            })
-            .expect("empty-slice StructInit")
-    };
-    let type_pool = wrong_init_state.type_pool().clone();
-    wrong_init_state.functions[wrong_init_main]
-        .cfg
-        .try_edit(&type_pool, |editor| {
-            editor.replace_inst_type(slice_init, Type::UNIT)
-        })
         .unwrap();
-    let (wrong_init_cfg, wrong_init_inst, wrong_init_args, wrong_init_result) =
-        find_intrinsic_in_function(&wrong_init_state, "main", "int_to_ptr");
-    let wrong_init_interp = Interp {
-        state: &wrong_init_state,
-        stdout_trace: Vec::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-        heap: Vec::new(),
-        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
-        heap_metadata_bytes: 0,
-    };
-    assert_eq!(
-        wrong_init_interp.classify_unsupported_intrinsic(
-            wrong_init_cfg,
-            wrong_init_inst,
-            "int_to_ptr",
-            &wrong_init_args,
-            wrong_init_result,
-        ),
-        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
-        "the slice StructInit result type must match its struct metadata"
-    );
+    let (_, pointer, init) = find_empty_slice_pointer_in_function(&wrong_init_type, "main");
+    let pool = wrong_init_type.functions[main].type_pool.clone();
+    wrong_init_type.functions[main]
+        .cfg
+        .try_edit(&pool, |editor| editor.replace_inst_type(init, Type::UNIT))
+        .unwrap();
+    let cfg = &wrong_init_type.functions[main].cfg;
+    assert!(!contract_interp(&wrong_init_type).is_empty_slice_pointer(cfg, pointer));
 }
 
 #[test]
@@ -1328,7 +1149,13 @@ fn validated_cfg_rejects_out_of_bounds_field_pointer_projection_metadata() {
             heap_metadata_bytes: 0,
         };
         assert_eq!(
-            interp.classify_unsupported_intrinsic(cfg, inst, "field_ptr", &args, result),
+            interp.classify_unsupported_intrinsic(
+                cfg,
+                inst,
+                rue_air::IntrinsicOperation::FieldPtr,
+                &args,
+                result,
+            ),
             UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
                 UnsupportedIntrinsicKind::FieldPointer,
             ))
@@ -1496,6 +1323,131 @@ fn query_cfg_state_with_trusted_std(
 const TRUSTED_OPTION_MODULE_SOURCE: &str =
     "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }";
 
+const TRUSTED_STRBUF_MODULE_SOURCE: &str = r#"pub struct StrBuf {
+    buf: ptr mut u8,
+    len: u64,
+    cap: u64,
+    fn len(borrow self) -> u64 { self.len }
+    fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
+}
+drop fn StrBuf(self) { }"#;
+
+#[test]
+fn every_source_intrinsic_operation_survives_semantic_export_import_and_cfg_build() {
+    let source = r#"const option = @import("std/option.rue");
+        const strbuf = @import("std/strbuf.rue");
+        const Option = option.Option;
+        const StrBuf = strbuf.StrBuf;
+
+        struct Pair { value: i32 }
+
+        fn panic_no_message() { @panic() }
+        fn panic_with_message() { @panic("boom") }
+
+        fn fallible() -> i32 {
+            let OStrBuf = Option(StrBuf);
+            let OI32 = Option(i32);
+            let OI64 = Option(i64);
+            let OU32 = Option(u32);
+            let OU64 = Option(u64);
+            let _line: OStrBuf = @read_line();
+            let _i32: OI32 = @parse_i32("1");
+            let _i64: OI64 = @parse_i64("2");
+            let _u32: OU32 = @parse_u32("3");
+            let _u64: OU64 = @parse_u64("4");
+            0
+        }
+
+        fn bounds(borrow values: [i64], index: u64) -> i32 {
+            @intCast(values[index])
+        }
+
+        fn pointer_and_runtime() -> i32 {
+            let mut value: i32 = 1;
+            let mut pair = Pair { value: 2 };
+            let signed: i32 = -1;
+            let unsigned: u32 = 1;
+            let wide_signed: i64 = -2;
+            let wide_unsigned: u64 = 2;
+            @assert(true);
+            @assert(true, "ok");
+            @dbg(wide_signed);
+            @dbg(wide_unsigned);
+            @dbg(true);
+            @dbg("text");
+            let _: u32 = @bitCast(signed);
+            let _: i32 = @bitCast(unsigned);
+            let _: u32 = @random_u32();
+            let _: u64 = @random_u64();
+            let _: u64 = @arg_count();
+            let _: ptr mut u8 = checked { @arg_ptr(0) };
+            let _: u64 = @arg_len(0);
+            let _: u64 = @env_count();
+            let _: ptr mut u8 = checked { @env_ptr(0) };
+            let _: u64 = @env_len(0);
+            checked {
+                let shared: ptr const i32 = @raw(value);
+                let mutable: ptr mut i32 = @raw_mut(value);
+                let field: ptr mut i32 = @field_ptr(pair.value);
+                let address: u64 = @ptr_to_int(shared);
+                let _: ptr mut i32 = @int_to_ptr(address);
+                let _: i32 = @ptr_read(shared);
+                let _: i32 = @ptr_read_unaligned(shared);
+                @ptr_write(mutable, 3);
+                @ptr_write_unaligned(field, 4);
+                let _: ptr const i32 = @ptr_offset(shared, 1);
+
+                let raw: ptr mut u8 = @alloc(8, 1);
+                let zeroed: ptr mut u8 = @alloc_zeroed(8, 1);
+                @byte_copy(raw, zeroed, 1);
+                @byte_move(raw, zeroed, 1);
+                @byte_set(raw, 0, 1);
+                let grown: ptr mut u8 = @realloc(raw, 8, 1, 16);
+                let _: bool = @resize(grown, 16, 1, 8);
+                @free(grown, 16, 1);
+                @free(zeroed, 8, 1);
+                let _: i64 = @syscall(0);
+            };
+            0
+        }
+
+        fn main() -> i32 {
+            let seed = @random_u32();
+            let values: [i64; 2] = [1, 2];
+            if seed == 1 { panic_no_message(); }
+            if seed == 2 { panic_with_message(); }
+            fallible() + bounds(borrow values, @intCast(seed)) + pointer_and_runtime()
+        }"#;
+    let state = query_cfg_state_with_trusted_std(
+        source,
+        &[
+            (2, "/project/std/strbuf.rue", TRUSTED_STRBUF_MODULE_SOURCE),
+            (3, "/project/std/option.rue", TRUSTED_OPTION_MODULE_SOURCE),
+        ],
+    )
+    .expect("the full intrinsic source table must compile through durable CFG import");
+    let mut operations = std::collections::HashSet::new();
+    for function in &state.functions {
+        for value in function
+            .cfg
+            .blocks()
+            .iter()
+            .flat_map(|block| block.insts.iter().copied())
+        {
+            if let CfgInstData::Intrinsic { operation, .. } = function.cfg.get_inst(value).data {
+                operations.insert(operation);
+            }
+        }
+    }
+    assert_eq!(rue_air::IntrinsicOperation::ALL.len(), 42);
+    for operation in rue_air::IntrinsicOperation::ALL {
+        assert!(
+            operations.contains(&operation),
+            "source-to-CFG pipeline lost {operation:?}"
+        );
+    }
+}
+
 #[test]
 fn option_returning_intrinsics_require_the_exact_payload_type() {
     // A fallible intrinsic's result is the exact trusted std `Option(payload)`
@@ -1539,7 +1491,7 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
         interp.classify_unsupported_intrinsic(
             parse32_cfg,
             parse32_inst,
-            "parse_i32",
+            rue_air::IntrinsicOperation::ParseI32,
             &parse32_args,
             parse32_result,
         ),
@@ -1552,7 +1504,7 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
         interp.classify_unsupported_intrinsic(
             parse64_cfg,
             parse64_inst,
-            "parse_i64",
+            rue_air::IntrinsicOperation::ParseI64,
             &parse64_args,
             parse64_result,
         ),
@@ -1565,7 +1517,7 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
         interp.classify_unsupported_intrinsic(
             parse32_cfg,
             parse32_inst,
-            "parse_i32",
+            rue_air::IntrinsicOperation::ParseI32,
             &parse32_args,
             Type::U64,
         ),
@@ -1619,14 +1571,26 @@ fn read_line_requires_trusted_source_strbuf_payload_metadata() {
     let (cfg, inst, args, result) = find_intrinsic_in_function(&state, "line", "read_line");
     state.select_source_function("line");
     assert_eq!(
-        interp.classify_unsupported_intrinsic(cfg, inst, "read_line", &args, result),
+        interp.classify_unsupported_intrinsic(
+            cfg,
+            inst,
+            rue_air::IntrinsicOperation::ReadLine,
+            &args,
+            result,
+        ),
         UnsupportedKind::ExternalDependency(ExternalDependencyKind::StandardInput)
     );
 
     let _ = find_intrinsic_in_function(&state, "parse", "parse_i32");
     state.select_source_function("line");
     assert_eq!(
-        interp.classify_unsupported_intrinsic(cfg, inst, "read_line", &args, Type::I32),
+        interp.classify_unsupported_intrinsic(
+            cfg,
+            inst,
+            rue_air::IntrinsicOperation::ReadLine,
+            &args,
+            Type::I32,
+        ),
         UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
         "an arbitrary Option payload must not satisfy @read_line"
     );

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -711,7 +711,7 @@ fn validated_cfg_requires_exact_type_and_writable_storage_for_whole_place_writes
                         return None;
                     };
                     let CfgInstData::Intrinsic {
-                        runtime: Some(RuntimeCallKind::RandomU32),
+                        operation: rue_air::IntrinsicOperation::RandomU32,
                         ..
                     } = cfg.get_inst(rhs).data
                     else {


### PR DESCRIPTION
Summary

- introduce one total IntrinsicOperation selected by semantic analysis and preserved through AIR, CFG, both backends, and the oracle
- centralize intrinsic spellings, signatures, runtime mappings, and validation so downstream lowering no longer re-dispatches on names
- preserve addressable-place and exact Option invariants, and unify aligned and unaligned pointer access planning
- represent empty slice pointers as typed null constants

Validation

- scripts/rue quick: 33 targets passed on the final trunk base
- scripts/rue premerge: 205 targets passed
- focused CFG and codegen suites: 365 and 815 tests passed on the final trunk base
- adversarial architecture review completed with no actionable findings
- scripts/rue test: 237 targets passed; its six local-only oracle corpus actions aborted before case results because macOS returned EAGAIN while spawning worker threads. Focused oracle tests passed, and CI remains the cross-platform corpus authority.

Fixes RUE-1851