### PR TITLE
RUE-1845: index archive members instead of decoding every one

### DIFF
--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -917,6 +917,61 @@ fn validate_runtime_archive_only_with_cancellation(
     validate_runtime_archive_with_cancellation(runtime_bytes, target, cancellation).map(|_| ())
 }
 
+/// Index the runtime archive for linking, decoding only what selection reads.
+///
+/// Two costs used to be paid on every link, both proportional to the whole
+/// archive rather than to what the link takes from it (RUE-1845). The embedded
+/// x86-64 runtime is 297 members and 4.2 MB, of which a typical link extracts
+/// one 45 KB member.
+///
+/// **The parse.** Selection asks only which members define which symbols, so
+/// members are indexed rather than decoded, and only the selected ones are
+/// parsed in full. `ArchiveIndex` documents what that narrows: a member whose
+/// section or relocation contents are malformed now fails when it is linked
+/// rather than when the archive is read, and a member that is never linked
+/// cannot affect the output.
+///
+/// **The ABI check.** `validate_runtime_inventory` is a conformance check over
+/// the whole archive — every required runtime helper present exactly once,
+/// reserved export IDs, the ABI version symbol — and it reads section flags and
+/// bytes, so it needs every member decoded. For the *embedded* archive it is
+/// also redundant: `pipeline_tests::test_embedded_runtimes_are_valid` runs
+/// exactly this validation over all three embedded runtimes, and the archive is
+/// `include_bytes!` data, so the bytes that test checks are the bytes every
+/// compile links. Re-deriving the verdict per process moved a build-time
+/// guarantee into every user's compile. A caller-supplied archive is not
+/// covered by that test and still takes the full parse and the full check.
+fn validated_runtime_index_with_cancellation<'a>(
+    runtime_bytes: &'a [u8],
+    target: Target,
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<rue_linker::ArchiveIndex<'a>> {
+    check_cancellation(cancellation)?;
+    if !std::ptr::eq(runtime_bytes, runtime_for_target(target)) {
+        validate_runtime_archive_with_cancellation(runtime_bytes, target, cancellation)?;
+    }
+    check_cancellation(cancellation)?;
+    let index =
+        rue_linker::ArchiveIndex::parse_strict_objects_with_cancellation(runtime_bytes, || {
+            cancellation.is_canceled()
+        })
+        .map_err(|error| {
+            if matches!(error, rue_linker::ArchiveError::Canceled) {
+                crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)
+            } else {
+                compile_control(link_error(format!(
+                    "embedded rue-runtime archive is invalid: {error}"
+                )))
+            }
+        })?;
+    if index.is_empty() {
+        return Err(compile_control(link_error(
+            "embedded rue-runtime archive contains no object files",
+        )));
+    }
+    Ok(index)
+}
+
 fn validate_runtime_archive_with_cancellation(
     runtime_bytes: &[u8],
     target: Target,
@@ -1087,13 +1142,10 @@ fn finish_internal_link_with_cancellation(
                 .map_err(map_linker_control)?;
         }
         check_cancellation(cancellation)?;
-        let runtime = validate_runtime_archive_with_cancellation(
-            runtime_bytes,
-            options.target,
-            cancellation,
-        )?;
+        let runtime =
+            validated_runtime_index_with_cancellation(runtime_bytes, options.target, cancellation)?;
         linker
-            .add_archive_with_cancellation(runtime, &mut || cancellation.is_canceled())
+            .add_archive_index_with_cancellation(&runtime, &mut || cancellation.is_canceled())
             .map_err(map_linker_control)?;
     }
     let executable = linker
@@ -1814,6 +1866,114 @@ mod runtime_archive_validation_tests {
             Target::X86_64Linux => Target::Aarch64Linux,
             Target::Aarch64Linux | Target::Aarch64Macos => Target::X86_64Linux,
         }
+    }
+
+    #[test]
+    fn indexing_an_archive_yields_the_symbols_a_full_parse_yields() {
+        // RUE-1845: archive member selection reads only symbols, so members are
+        // indexed rather than decoded and only the selected ones are parsed in
+        // full. That is only sound if indexing produces the *same* symbols —
+        // selection is first-eligible in member order, so a divergence in
+        // either the member list or a member's symbols silently extracts a
+        // different member.
+        for &target in Target::all() {
+            let bytes = runtime_for_target(target);
+            let full = Archive::parse_strict_objects(bytes)
+                .unwrap_or_else(|error| panic!("{target} full parse: {error}"));
+            let index = rue_linker::ArchiveIndex::parse_strict_objects(bytes)
+                .unwrap_or_else(|error| panic!("{target} index parse: {error}"));
+
+            assert_eq!(
+                full.objects.len(),
+                index.len(),
+                "{target}: indexing found a different number of members"
+            );
+            for (position, (object, member)) in full.objects.iter().zip(index.members()).enumerate()
+            {
+                assert_eq!(
+                    object.machine, member.parsed.machine,
+                    "{target} member {position}: machine differs"
+                );
+                assert_eq!(
+                    object.format, member.parsed.format,
+                    "{target} member {position}: format differs"
+                );
+                assert_eq!(
+                    object.symbols.len(),
+                    member.parsed.symbols.len(),
+                    "{target} member {position}: symbol count differs"
+                );
+                for (a, b) in object.symbols.iter().zip(&member.parsed.symbols) {
+                    assert_eq!(a.name, b.name, "{target} member {position}: name");
+                    assert_eq!(
+                        a.section_index, b.section_index,
+                        "{target} member {position}: section index for `{}`",
+                        a.name
+                    );
+                    assert_eq!(
+                        a.value, b.value,
+                        "{target} member {position}: value for `{}`",
+                        a.name
+                    );
+                    assert_eq!(
+                        a.size, b.size,
+                        "{target} member {position}: size for `{}`",
+                        a.name
+                    );
+                    assert_eq!(
+                        a.binding, b.binding,
+                        "{target} member {position}: binding for `{}`",
+                        a.name
+                    );
+                    assert_eq!(
+                        a.sym_type, b.sym_type,
+                        "{target} member {position}: type for `{}`",
+                        a.name
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn indexing_the_embedded_runtime_does_not_parse_every_member() {
+        // The point of the index (RUE-1845): a fresh compile stops decoding the
+        // whole archive. `RUNTIME_ARCHIVE_PARSES` counts the whole-archive
+        // decode, so the embedded path must not reach it — its ABI conformance
+        // is established by `test_embedded_runtimes_are_valid` at build time,
+        // over the same `include_bytes!` bytes every compile links.
+        let target = Target::X86_64Linux;
+        let before = RUNTIME_ARCHIVE_PARSES.load(std::sync::atomic::Ordering::Relaxed);
+        let index = validated_runtime_index_with_cancellation(
+            runtime_for_target(target),
+            target,
+            &rue_query::CancellationToken::default(),
+        )
+        .expect("the embedded runtime indexes");
+        let after = RUNTIME_ARCHIVE_PARSES.load(std::sync::atomic::Ordering::Relaxed);
+
+        assert!(!index.is_empty(), "the embedded runtime has members");
+        assert_eq!(
+            before, after,
+            "indexing the embedded runtime fell back to a whole-archive parse"
+        );
+
+        // A caller-supplied archive is not covered by that build-time test, so
+        // it still takes the full parse and the full ABI check.
+        let supplied = runtime_for_target(target).to_vec();
+        let before = RUNTIME_ARCHIVE_PARSES.load(std::sync::atomic::Ordering::Relaxed);
+        validated_runtime_index_with_cancellation(
+            &supplied,
+            target,
+            &rue_query::CancellationToken::default(),
+        )
+        .expect("a copy of the embedded runtime is still a valid runtime");
+        let after = RUNTIME_ARCHIVE_PARSES.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            before + 1,
+            after,
+            "a caller-supplied archive must still be fully validated"
+        );
     }
 
     #[test]

--- a/crates/rue-linker/src/archive.rs
+++ b/crates/rue-linker/src/archive.rs
@@ -3,7 +3,7 @@
 //! This module parses Unix ar archives, which are used for static libraries.
 //! Rust's `crate-type = "staticlib"` produces these.
 
-use crate::elf::{ObjectFile, ParseError};
+use crate::elf::{ObjectFile, ObjectSymbols, ParseError};
 
 /// AR archive magic bytes.
 const AR_MAGIC: &[u8] = b"!<arch>\n";
@@ -105,142 +105,241 @@ impl Archive {
         strict_objects: bool,
         cancellation: &mut impl FnMut() -> bool,
     ) -> Result<Self, ArchiveError> {
+        let members = collect_members(data, strict_objects, cancellation, |member, cancel| {
+            ObjectFile::parse_with_cancellation(member, cancel)
+        })?;
+        Ok(Archive {
+            objects: members.into_iter().map(|member| member.parsed).collect(),
+        })
+    }
+}
+
+/// One object member of an archive, with whatever was decoded from it.
+#[derive(Debug)]
+pub struct ArchiveMember<'a, T> {
+    /// The member's name as recorded in the archive.
+    pub name: String,
+    /// The member's bytes, borrowed from the archive.
+    pub data: &'a [u8],
+    /// What `collect_members` decoded from `data`.
+    pub parsed: T,
+}
+
+/// Walk an archive's members in order, decoding each with `parse_member`.
+///
+/// The member filtering is here and nowhere else, so every view of an archive
+/// agrees on which members exist and in what order — which archive member
+/// selection depends on, since it extracts the first eligible provider in
+/// member order.
+fn collect_members<'a, T>(
+    data: &'a [u8],
+    strict_objects: bool,
+    cancellation: &mut impl FnMut() -> bool,
+    mut parse_member: impl FnMut(&'a [u8], &mut dyn FnMut() -> bool) -> Result<T, ParseError>,
+) -> Result<Vec<ArchiveMember<'a, T>>, ArchiveError> {
+    if cancellation() {
+        return Err(ArchiveError::Canceled);
+    }
+    // Check magic
+    if data.len() < AR_MAGIC.len() {
+        return Err(ArchiveError::TooShort);
+    }
+    if &data[..AR_MAGIC.len()] != AR_MAGIC {
+        return Err(ArchiveError::InvalidMagic);
+    }
+
+    let mut members = Vec::new();
+    let mut offset = AR_MAGIC.len();
+
+    loop {
         if cancellation() {
             return Err(ArchiveError::Canceled);
         }
-        // Check magic
-        if data.len() < AR_MAGIC.len() {
-            return Err(ArchiveError::TooShort);
-        }
-        if &data[..AR_MAGIC.len()] != AR_MAGIC {
-            return Err(ArchiveError::InvalidMagic);
-        }
-
-        let mut objects = Vec::new();
-        let mut offset = AR_MAGIC.len();
-
-        loop {
-            if cancellation() {
-                return Err(ArchiveError::Canceled);
-            }
-            let header_end = checked_offset_add(offset, HEADER_SIZE)?;
-            if header_end > data.len() {
-                if strict_objects && offset != data.len() {
-                    return Err(ArchiveError::TooShort);
-                }
-                break;
-            }
-
-            // Parse header (60 bytes):
-            // - Name:      16 bytes (space-padded, may end with '/')
-            // - Timestamp: 12 bytes (decimal ASCII)
-            // - Owner ID:   6 bytes (decimal ASCII)
-            // - Group ID:   6 bytes (decimal ASCII)
-            // - Mode:       8 bytes (octal ASCII)
-            // - Size:      10 bytes (decimal ASCII)
-            // - Terminator: 2 bytes ("`\n")
-            let header = &data[offset..header_end];
-
-            // Name: first 16 bytes
-            let name = std::str::from_utf8(&header[0..16])
-                .map_err(|_| ArchiveError::InvalidHeader("invalid name encoding".into()))?
-                .trim();
-
-            // Size: bytes 48-58 (10 bytes), decimal ASCII
-            let size_str = std::str::from_utf8(&header[48..58])
-                .map_err(|_| ArchiveError::InvalidHeader("invalid size encoding".into()))?
-                .trim();
-            let size: usize = size_str.parse().map_err(|_| {
-                ArchiveError::InvalidHeader(format!("invalid size: '{}'", size_str))
-            })?;
-
-            // Header terminator should be "`\n"
-            if &header[58..60] != b"`\n" {
-                return Err(ArchiveError::InvalidHeader("invalid terminator".into()));
-            }
-
-            offset = header_end;
-
-            // Handle BSD long filename format (#1/N where N is the name length)
-            // The real filename is embedded at the start of the member data.
-            let (actual_name, name_len) = if name.starts_with("#1/") {
-                let name_len: usize = name[3..].trim().parse().map_err(|_| {
-                    ArchiveError::InvalidHeader(format!(
-                        "invalid BSD name length: '{}'",
-                        &name[3..]
-                    ))
-                })?;
-                // The actual name is at the start of the member data
-                let name_end = checked_offset_add(offset, name_len)?;
-                if name_end > data.len() {
-                    return Err(ArchiveError::TooShort);
-                }
-                let actual_name = std::str::from_utf8(&data[offset..name_end])
-                    .map_err(|_| ArchiveError::InvalidHeader("invalid BSD name encoding".into()))?
-                    .trim_end_matches('\0')
-                    .to_string();
-                (actual_name, name_len)
-            } else {
-                (name.to_string(), 0)
-            };
-
-            // Skip special entries:
-            // - "/" or "/SYM64/" : Symbol table (GNU/LLVM style)
-            // - "//" : Long filename table (GNU style)
-            // - "__.SYMDEF" or "__.SYMDEF SORTED" : Symbol table (BSD style)
-            let is_special = actual_name == "/"
-                || actual_name == "//"
-                || actual_name == "/SYM64/"
-                || actual_name.starts_with("__.SYMDEF");
-
-            if is_special {
-                offset = checked_offset_add(offset, size)?;
-                // Pad to even boundary
-                if offset % 2 == 1 {
-                    offset = checked_offset_add(offset, 1)?;
-                }
-                continue;
-            }
-
-            // Read member data (skip over BSD long filename if present)
-            let member_start = checked_offset_add(offset, name_len)?;
-            let member_size = size.checked_sub(name_len).ok_or(ArchiveError::Overflow)?;
-            let end_offset = checked_offset_add(member_start, member_size)?;
-            if end_offset > data.len() {
+        let header_end = checked_offset_add(offset, HEADER_SIZE)?;
+        if header_end > data.len() {
+            if strict_objects && offset != data.len() {
                 return Err(ArchiveError::TooShort);
             }
-            let member_data = &data[member_start..end_offset];
+            break;
+        }
 
-            // Try to parse as object file (ELF or Mach-O).
-            // Non-object members (e.g., LLVM bitcode files from LTO builds) are skipped.
-            match ObjectFile::parse_with_cancellation(member_data, &mut *cancellation) {
-                Ok(obj) => objects.push(obj),
-                Err(crate::elf::ParseError::Canceled) => return Err(ArchiveError::Canceled),
-                Err(source) if strict_objects && looks_like_native_object(member_data) => {
-                    return Err(ArchiveError::ObjectMemberParse {
-                        member: actual_name,
-                        source,
-                    });
-                }
-                Err(_) => {
-                    // Member is not a valid object file. This is common for:
-                    // - LLVM bitcode files (.bc) in LTO-enabled builds
-                    // - Rust metadata files
-                    // - Other non-object archive members
-                    // We silently skip these since we only need object files.
-                }
+        // Parse header (60 bytes):
+        // - Name:      16 bytes (space-padded, may end with '/')
+        // - Timestamp: 12 bytes (decimal ASCII)
+        // - Owner ID:   6 bytes (decimal ASCII)
+        // - Group ID:   6 bytes (decimal ASCII)
+        // - Mode:       8 bytes (octal ASCII)
+        // - Size:      10 bytes (decimal ASCII)
+        // - Terminator: 2 bytes ("`\n")
+        let header = &data[offset..header_end];
+
+        // Name: first 16 bytes
+        let name = std::str::from_utf8(&header[0..16])
+            .map_err(|_| ArchiveError::InvalidHeader("invalid name encoding".into()))?
+            .trim();
+
+        // Size: bytes 48-58 (10 bytes), decimal ASCII
+        let size_str = std::str::from_utf8(&header[48..58])
+            .map_err(|_| ArchiveError::InvalidHeader("invalid size encoding".into()))?
+            .trim();
+        let size: usize = size_str
+            .parse()
+            .map_err(|_| ArchiveError::InvalidHeader(format!("invalid size: '{}'", size_str)))?;
+
+        // Header terminator should be "`\n"
+        if &header[58..60] != b"`\n" {
+            return Err(ArchiveError::InvalidHeader("invalid terminator".into()));
+        }
+
+        offset = header_end;
+
+        // Handle BSD long filename format (#1/N where N is the name length)
+        // The real filename is embedded at the start of the member data.
+        let (actual_name, name_len) = if name.starts_with("#1/") {
+            let name_len: usize = name[3..].trim().parse().map_err(|_| {
+                ArchiveError::InvalidHeader(format!("invalid BSD name length: '{}'", &name[3..]))
+            })?;
+            // The actual name is at the start of the member data
+            let name_end = checked_offset_add(offset, name_len)?;
+            if name_end > data.len() {
+                return Err(ArchiveError::TooShort);
             }
+            let actual_name = std::str::from_utf8(&data[offset..name_end])
+                .map_err(|_| ArchiveError::InvalidHeader("invalid BSD name encoding".into()))?
+                .trim_end_matches('\0')
+                .to_string();
+            (actual_name, name_len)
+        } else {
+            (name.to_string(), 0)
+        };
 
+        // Skip special entries:
+        // - "/" or "/SYM64/" : Symbol table (GNU/LLVM style)
+        // - "//" : Long filename table (GNU style)
+        // - "__.SYMDEF" or "__.SYMDEF SORTED" : Symbol table (BSD style)
+        let is_special = actual_name == "/"
+            || actual_name == "//"
+            || actual_name == "/SYM64/"
+            || actual_name.starts_with("__.SYMDEF");
+
+        if is_special {
             offset = checked_offset_add(offset, size)?;
             // Pad to even boundary
             if offset % 2 == 1 {
                 offset = checked_offset_add(offset, 1)?;
             }
+            continue;
         }
 
-        Ok(Archive { objects })
+        // Read member data (skip over BSD long filename if present)
+        let member_start = checked_offset_add(offset, name_len)?;
+        let member_size = size.checked_sub(name_len).ok_or(ArchiveError::Overflow)?;
+        let end_offset = checked_offset_add(member_start, member_size)?;
+        if end_offset > data.len() {
+            return Err(ArchiveError::TooShort);
+        }
+        let member_data = &data[member_start..end_offset];
+
+        // Try to parse as object file (ELF or Mach-O).
+        // Non-object members (e.g., LLVM bitcode files from LTO builds) are skipped.
+        match parse_member(member_data, &mut *cancellation) {
+            Ok(parsed) => members.push(ArchiveMember {
+                name: actual_name,
+                data: member_data,
+                parsed,
+            }),
+            Err(crate::elf::ParseError::Canceled) => return Err(ArchiveError::Canceled),
+            Err(source) if strict_objects && looks_like_native_object(member_data) => {
+                return Err(ArchiveError::ObjectMemberParse {
+                    member: actual_name,
+                    source,
+                });
+            }
+            Err(_) => {
+                // Member is not a valid object file. This is common for:
+                // - LLVM bitcode files (.bc) in LTO-enabled builds
+                // - Rust metadata files
+                // - Other non-object archive members
+                // We silently skip these since we only need object files.
+            }
+        }
+
+        offset = checked_offset_add(offset, size)?;
+        // Pad to even boundary
+        if offset % 2 == 1 {
+            offset = checked_offset_add(offset, 1)?;
+        }
     }
 
+    Ok(members)
+}
+
+/// An archive indexed for member selection: every member's symbols, plus the
+/// bytes needed to decode that member in full once it is actually selected.
+///
+/// Selection asks only which members define which symbols, and that answer
+/// never depends on section contents or relocations — so decoding those for the
+/// members a link discards is pure waste. The embedded runtime archive is 297
+/// members, of which a typical link extracts one (RUE-1845).
+///
+/// The validation this performs is correspondingly narrower than
+/// [`Archive::parse_strict_objects`]: every member's headers and symbol table
+/// must parse, but a member whose *section or relocation contents* are
+/// malformed is caught when it is linked rather than when the archive is read.
+/// A member that is never selected never reaches the linker, so its contents
+/// cannot affect the output.
+#[derive(Debug)]
+pub struct ArchiveIndex<'a> {
+    members: Vec<ArchiveMember<'a, ObjectSymbols>>,
+}
+
+impl<'a> ArchiveIndex<'a> {
+    /// Index an archive, rejecting members that advertise a supported native
+    /// object magic but whose headers or symbol table do not parse.
+    #[must_use = "parsing returns a Result that must be checked"]
+    pub fn parse_strict_objects(data: &'a [u8]) -> Result<Self, ArchiveError> {
+        Self::parse_impl(data, true, &mut || false)
+    }
+
+    /// Index a strict archive with bounded caller-owned cancellation checks.
+    pub fn parse_strict_objects_with_cancellation(
+        data: &'a [u8],
+        mut cancellation: impl FnMut() -> bool,
+    ) -> Result<Self, ArchiveError> {
+        Self::parse_impl(data, true, &mut cancellation)
+    }
+
+    fn parse_impl(
+        data: &'a [u8],
+        strict_objects: bool,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<Self, ArchiveError> {
+        let members = collect_members(data, strict_objects, cancellation, |member, cancel| {
+            ObjectFile::parse_symbols_with_cancellation(member, cancel)
+        })?;
+        Ok(Self { members })
+    }
+
+    /// The indexed members, in archive order.
+    #[must_use]
+    pub fn members(&self) -> &[ArchiveMember<'a, ObjectSymbols>] {
+        &self.members
+    }
+
+    /// Returns the number of object members.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.members.len()
+    }
+
+    /// Returns true if the archive contains no object members.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
+}
+
+impl Archive {
     /// Returns true if the archive contains no object files.
     #[must_use]
     pub fn is_empty(&self) -> bool {

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -730,6 +730,40 @@ impl std::fmt::Display for ParseError {
 
 impl std::error::Error for ParseError {}
 
+/// What archive member selection needs from one object: its symbols, and the
+/// container and architecture facts a target check reads.
+///
+/// Deliberately not an `ObjectFile`: this carries no sections, and a value that
+/// looks like a fully decoded object but has none would be a trap.
+#[derive(Debug, Clone)]
+pub struct ObjectSymbols {
+    /// The object's symbol table, identical to a full parse's.
+    pub symbols: Vec<Symbol>,
+    /// The machine architecture recorded in the object header.
+    pub machine: ElfMachine,
+    /// The object's container format.
+    pub format: ObjectFormat,
+}
+
+/// How much of an object file to decode.
+///
+/// Archive member selection reads only the symbol table (RUE-1845): it asks
+/// which members define which symbols, and the answer never depends on section
+/// contents or relocations. Decoding those for a member that is then discarded
+/// is the bulk of parsing an archive — the embedded runtime is 297 members of
+/// which a link typically extracts one.
+///
+/// The depth never affects the symbols produced. `SymbolsOnly` yields exactly
+/// the symbol table `Full` yields; it omits sections and relocations, and with
+/// them the bounds checks that only their contents can fail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParseDepth {
+    /// Sections with their contents, symbols, and relocations.
+    Full,
+    /// The symbol table alone.
+    SymbolsOnly,
+}
+
 impl ObjectFile {
     /// Parse a relocatable object file (ELF or Mach-O).
     ///
@@ -740,12 +774,42 @@ impl ObjectFile {
         Self::parse_with_cancellation(data, || false)
     }
 
+    /// Parse only what archive member selection reads, for one object.
+    ///
+    /// Produces exactly the symbols [`ObjectFile::parse_with_cancellation`]
+    /// produces. Sections and relocations are not decoded, so a member whose
+    /// section or relocation contents are malformed parses here and fails only
+    /// if it is actually linked — see [`ParseDepth`].
+    ///
+    /// Returns [`ObjectSymbols`] rather than an `ObjectFile`, so an object with
+    /// no sections cannot be mistaken for a fully decoded one.
+    pub fn parse_symbols_with_cancellation(
+        data: &[u8],
+        mut cancellation: impl FnMut() -> bool,
+    ) -> Result<ObjectSymbols, ParseError> {
+        Self::parse_at_depth(data, ParseDepth::SymbolsOnly, &mut cancellation).map(|object| {
+            ObjectSymbols {
+                symbols: object.symbols,
+                machine: object.machine,
+                format: object.format,
+            }
+        })
+    }
+
     /// Parse an object with bounded caller-owned cancellation checkpoints.
     pub fn parse_with_cancellation(
         data: &[u8],
         mut cancellation: impl FnMut() -> bool,
     ) -> Result<Self, ParseError> {
-        check_parse_cancellation(&mut cancellation)?;
+        Self::parse_at_depth(data, ParseDepth::Full, &mut cancellation)
+    }
+
+    fn parse_at_depth(
+        data: &[u8],
+        depth: ParseDepth,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<Self, ParseError> {
+        check_parse_cancellation(cancellation)?;
         // Need at least 4 bytes to check magic
         if data.len() < 4 {
             return Err(ParseError::TooShort);
@@ -753,9 +817,9 @@ impl ObjectFile {
 
         // Dispatch based on magic bytes
         if data[0..4] == ELF_MAGIC {
-            Self::parse_elf(data, &mut cancellation)
+            Self::parse_elf(data, depth, cancellation)
         } else if data.len() >= 4 && read_u32(data, 0) == MH_MAGIC_64 {
-            Self::parse_macho(data, &mut cancellation)
+            Self::parse_macho(data, depth, cancellation)
         } else {
             Err(ParseError::UnknownFormat)
         }
@@ -764,8 +828,15 @@ impl ObjectFile {
     /// Parse a Mach-O 64-bit relocatable object file.
     ///
     /// Extracts sections, symbols, and relocations from a Mach-O object file.
+    ///
+    /// Unlike ELF, a symbols-only parse still walks the section headers: a
+    /// Mach-O symbol's value is an address that must be made section-relative
+    /// by subtracting its section's `addr`, so the addresses are load-bearing
+    /// for the symbols themselves. Only the section *contents* and the
+    /// relocations are skipped.
     fn parse_macho(
         data: &[u8],
+        depth: ParseDepth,
         cancellation: &mut impl FnMut() -> bool,
     ) -> Result<Self, ParseError> {
         // Minimum size check for Mach-O header
@@ -907,7 +978,9 @@ impl ObjectFile {
                         // checked add so a malformed offset/size near usize::MAX
                         // is rejected instead of wrapping (RUE-334), mirroring
                         // the ELF path's checked_add bounds validation.
-                        let section_data = if size > 0 && offset > 0 {
+                        let section_data = if depth == ParseDepth::SymbolsOnly {
+                            Vec::new()
+                        } else if size > 0 && offset > 0 {
                             let end = offset
                                 .checked_add(size as usize)
                                 .ok_or_else(|| ParseError::SectionOutOfBounds(full_name.clone()))?;
@@ -1119,7 +1192,11 @@ impl ObjectFile {
         }
 
         // Parse relocations for each section
-        for (section_index, nreloc, reloff) in section_reloc_info {
+        let sections_with_relocations = match depth {
+            ParseDepth::Full => section_reloc_info,
+            ParseDepth::SymbolsOnly => Vec::new(),
+        };
+        for (section_index, nreloc, reloff) in sections_with_relocations {
             check_parse_cancellation(cancellation)?;
             if nreloc == 0 {
                 continue;
@@ -1293,7 +1370,11 @@ impl ObjectFile {
     }
 
     /// Parse an ELF64 relocatable object file.
-    fn parse_elf(data: &[u8], cancellation: &mut impl FnMut() -> bool) -> Result<Self, ParseError> {
+    fn parse_elf(
+        data: &[u8],
+        depth: ParseDepth,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<Self, ParseError> {
         check_parse_cancellation(cancellation)?;
         // Check minimum size for ELF header
         if data.len() < ELF64_EHDR_SIZE {
@@ -1424,8 +1505,15 @@ impl ObjectFile {
         }
         let shstrtab_data = &data[shstrtab.offset as usize..shstrtab_end as usize];
 
-        // Second pass: create sections with names
-        for (i, raw) in raw_sections.iter().enumerate() {
+        // Second pass: create sections with names. A symbols-only parse skips
+        // it wholesale: an ELF symbol's `section_index` is its raw `st_shndx`
+        // resolved against `raw_sections`, never against the list built here, so
+        // the symbols below are identical either way.
+        let sections_to_build: &[RawSection] = match depth {
+            ParseDepth::Full => &raw_sections,
+            ParseDepth::SymbolsOnly => &[],
+        };
+        for (i, raw) in sections_to_build.iter().enumerate() {
             check_parse_cancellation(cancellation)?;
             let name = read_utf8_cstring_with_cancellation(
                 shstrtab_data,
@@ -1632,8 +1720,14 @@ impl ObjectFile {
             }
         }
 
-        // Parse relocations
-        for raw in raw_sections.iter() {
+        // Parse relocations. Selection never reads them, and they are the
+        // largest single item in an archive parse (RUE-1845): the embedded
+        // x86-64 runtime carries 35,672 of them across 6,594 sections.
+        let sections_with_relocations: &[RawSection] = match depth {
+            ParseDepth::Full => &raw_sections,
+            ParseDepth::SymbolsOnly => &[],
+        };
+        for raw in sections_with_relocations.iter() {
             check_parse_cancellation(cancellation)?;
             if raw.sh_type != SHT_RELA {
                 continue;

--- a/crates/rue-linker/src/lib.rs
+++ b/crates/rue-linker/src/lib.rs
@@ -18,10 +18,10 @@ mod linker;
 pub mod macho;
 mod util;
 
-pub use archive::{Archive, ArchiveError};
+pub use archive::{Archive, ArchiveError, ArchiveIndex, ArchiveMember};
 pub use elf::{
-    ElfMachine, ObjectFile, ObjectFormat, Relocation, RelocationType, Section, SectionFlags,
-    StructuredObject, StructuredRelocation, Symbol, SymbolBinding, SymbolType,
+    ElfMachine, ObjectFile, ObjectFormat, ObjectSymbols, Relocation, RelocationType, Section,
+    SectionFlags, StructuredObject, StructuredRelocation, Symbol, SymbolBinding, SymbolType,
 };
 pub use emit::{CodeRelocation, ObjectBuilder};
 pub use linker::{LinkError, Linker};

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -6,7 +6,7 @@ use ahash::{AHashMap, AHashSet};
 use rue_target::Target;
 use tracing::info_span;
 
-use crate::archive::Archive;
+use crate::archive::{Archive, ArchiveIndex};
 use crate::constants::{
     ELF_MAGIC, ELF64_EHDR_SIZE, ELF64_PHDR_SIZE, ELFCLASS64, ELFDATA2LSB, ET_EXEC, EV_CURRENT,
     PF_R, PF_W, PF_X, PT_LOAD,
@@ -880,6 +880,12 @@ pub enum LinkError {
         symbol_index: usize,
         symbol_count: usize,
     },
+    /// An archive member the link selected failed to decode.
+    ///
+    /// Selection reads only symbols, so a member whose section or relocation
+    /// contents are malformed surfaces here — when the link needs it — rather
+    /// than when the archive was read (RUE-1845).
+    ArchiveMemberParse { member: String, source: String },
     /// Feature not yet implemented.
     NotImplemented(&'static str),
 }
@@ -971,6 +977,9 @@ impl std::fmt::Display for LinkError {
                     "relocation references invalid symbol index {} (object has {} symbols)",
                     symbol_index, symbol_count
                 )
+            }
+            LinkError::ArchiveMemberParse { member, source } => {
+                write!(f, "failed to parse archive member '{member}': {source}")
             }
             LinkError::NotImplemented(feature) => {
                 write!(f, "{} not yet implemented", feature)
@@ -1313,13 +1322,78 @@ impl Linker {
         cancellation: &mut impl FnMut() -> bool,
     ) -> Result<(), LinkError> {
         check_cancellation(cancellation)?;
-        // Convert to a Vec we can index into
-        let archive_objects: Vec<ObjectFile> = archive.objects.into_iter().collect();
+        let archive_objects: Vec<ObjectFile> = archive.objects;
+        let selected = {
+            let member_symbols: Vec<&[Symbol]> = archive_objects
+                .iter()
+                .map(|object| object.symbols.as_slice())
+                .collect();
+            self.select_archive_members(&member_symbols, cancellation)?
+        };
 
-        // Decide which members are needed. Every name below is borrowed from
-        // `self` or from `archive_objects` — both outlive this block — so
-        // resolution copies no symbol names; scoping the borrows here lets the
-        // selected members move into `self` afterwards.
+        // Now actually add the selected objects
+        for (idx, object) in archive_objects.into_iter().enumerate() {
+            check_cancellation(cancellation)?;
+            if selected[idx] {
+                self.add_object_with_cancellation(object, cancellation)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Add the members of an indexed archive that this link needs.
+    ///
+    /// The counterpart of [`Linker::add_archive_with_cancellation`] for an
+    /// archive that was indexed rather than fully parsed: selection reads the
+    /// indexed symbols, and only the selected members are decoded (RUE-1845).
+    /// A member whose contents are malformed therefore fails here, at the point
+    /// the link needs it, rather than when the archive was read.
+    pub fn add_archive_index_with_cancellation(
+        &mut self,
+        index: &ArchiveIndex<'_>,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<(), LinkError> {
+        check_cancellation(cancellation)?;
+        let selected = {
+            let member_symbols: Vec<&[Symbol]> = index
+                .members()
+                .iter()
+                .map(|member| member.parsed.symbols.as_slice())
+                .collect();
+            self.select_archive_members(&member_symbols, cancellation)?
+        };
+
+        for (member, take) in index.members().iter().zip(selected) {
+            check_cancellation(cancellation)?;
+            if !take {
+                continue;
+            }
+            let object = ObjectFile::parse_with_cancellation(member.data, &mut *cancellation)
+                .map_err(|source| match source {
+                    crate::elf::ParseError::Canceled => LinkError::Canceled,
+                    source => LinkError::ArchiveMemberParse {
+                        member: member.name.clone(),
+                        source: source.to_string(),
+                    },
+                })?;
+            self.add_object_with_cancellation(object, cancellation)?;
+        }
+
+        Ok(())
+    }
+
+    /// Decide which archive members this link needs, reading only their symbols.
+    ///
+    /// Shared by both archive entry points so an owned archive and an indexed
+    /// one make identical choices. Every name below is borrowed from `self` or
+    /// from `member_symbols` — both outlive this call — so resolution copies no
+    /// symbol names.
+    fn select_archive_members(
+        &self,
+        member_symbols: &[&[Symbol]],
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<Vec<bool>, LinkError> {
         let selected: Vec<bool> = {
             // Map each symbol to every member that defines it, in archive member
             // order. A last-writer-wins `AHashMap::insert` index would instead bind
@@ -1329,9 +1403,9 @@ impl Linker {
             // Retaining the ordered provider list keeps selection first-eligible and
             // independent of hash iteration order.
             let mut symbol_providers: AHashMap<&str, Vec<usize>> = AHashMap::new();
-            for (obj_idx, obj) in archive_objects.iter().enumerate() {
+            for (obj_idx, symbols) in member_symbols.iter().enumerate() {
                 check_cancellation(cancellation)?;
-                for sym in &obj.symbols {
+                for sym in symbols.iter() {
                     check_cancellation(cancellation)?;
                     if provides_definition(sym) {
                         symbol_providers.entry(&sym.name).or_default().push(obj_idx);
@@ -1340,7 +1414,7 @@ impl Linker {
             }
 
             // Track which archive objects we've selected and which symbols are defined
-            let mut selected: Vec<bool> = vec![false; archive_objects.len()];
+            let mut selected: Vec<bool> = vec![false; member_symbols.len()];
             let mut defined: AHashSet<&str> =
                 self.global_symbols.keys().map(String::as_str).collect();
 
@@ -1395,7 +1469,7 @@ impl Linker {
                 // The member's own definitions satisfy later references, and its
                 // own references join the worklist — the transitive step the
                 // fixed-point rescan used to perform.
-                for sym in &archive_objects[obj_idx].symbols {
+                for sym in member_symbols[obj_idx].iter() {
                     check_cancellation(cancellation)?;
                     if provides_definition(sym) {
                         defined.insert(&sym.name);
@@ -1408,16 +1482,7 @@ impl Linker {
 
             selected
         };
-
-        // Now actually add the selected objects
-        for (idx, obj) in archive_objects.into_iter().enumerate() {
-            check_cancellation(cancellation)?;
-            if selected[idx] {
-                self.add_object_with_cancellation(obj, cancellation)?;
-            }
-        }
-
-        Ok(())
+        Ok(selected)
     }
 
     /// Link all objects and produce an executable.


### PR DESCRIPTION
Follows #2825 on RUE-1845. Referenced without a closing keyword — see **Scope**.

## Measurements first

The issue proposes memoizing the parsed archive across links. I measured before building, and that is the wrong axis: a one-shot `rue build` performs exactly **one** internal link, so caching across links does nothing for the case that ships.

x86-64 embedded runtime:

| | |
|---|---|
| Archive | 297 members, 4.21 MB |
| Structure | 6,594 sections, **35,672 relocations**, 3,792 symbols |
| Members a real link selects | **1** (`fn main() -> i32 { 0 }` and `examples/binary_search.rue` alike) |
| Full parse | 12.2 ms |
| Section-byte copies alone | 0.85 ms — **5.6%** of the parse |

So zero-copy sections is also the wrong target. The cost is building 6,594 section records and 35,672 relocation records for members that are then discarded. The only thing that fixes 297-parsed-1-used is not parsing.

## What forced the full decode, and why neither needed to

**Selection reads only symbols.** It asks which members define which symbols, and that never depends on section contents or relocations. Members are now indexed, and only selected members are parsed in full.

`ParseDepth::SymbolsOnly` skips the ELF section pass wholesale — an ELF symbol's `section_index` is its raw `st_shndx` resolved against the section *headers*, never against the built section list — and skips relocations in both backends. Mach-O still walks section headers: a Mach-O symbol's value is an address made section-relative by subtracting its section's `addr`, so the addresses are load-bearing for the symbols themselves. Only contents and relocations are skipped there. **The depth never affects the symbols produced.**

**Validation forced the rest — and this is the part worth review.** `validate_runtime_inventory` is not a parse check; it is an ABI conformance check over the whole archive (every required helper present exactly once, reserved export IDs, the ABI version symbol) that reads section flags and bytes, so it needs every member decoded.

For the *embedded* archive it is also redundant. `pipeline_tests::test_embedded_runtimes_are_valid` runs exactly this validation over all three embedded runtimes, and the archive is `include_bytes!` data — the bytes that test checks are the bytes every compile links. Re-deriving the verdict per process moved a build-time guarantee into every user's compile. A caller-supplied archive is not covered by that test and still takes the full parse and the full check.

### Nothing is checked less

`validate_defined_symbols` already runs on every object entering the linker, so the symbol-extent property the inventory pre-checked is enforced at the point of use, on exactly the members that reach the output. A member that is never selected cannot affect the output, and its contents are now checked when it is linked rather than when the archive is read.

## Result

Fresh compile of `fn main() -> i32 { 0 }`, best of 12 on both sides in one session:

**44 ms → 28 ms.** The archive parse itself: **12.2 ms → 3.9 ms.**

## Keeping the two views honest

`collect_members` is the single place member filtering lives, so an owned archive and an indexed one cannot disagree about which members exist or in what order — which selection depends on, since it extracts the first eligible provider in member order. `select_archive_members` is likewise shared by both entry points, so they cannot make different choices.

`parse_symbols_with_cancellation` returns `ObjectSymbols`, not an `ObjectFile`: a value that looked like a decoded object but had no sections would be a trap.

## Guards

| Guard | Broken how | Failure |
|---|---|---|
| `indexing_an_archive_yields_the_symbols_a_full_parse_yields` | drop the `STT_SECTION` name fallback under `SymbolsOnly` | `x86-64-linux member 0: name` |
| `indexing_the_embedded_runtime_does_not_parse_every_member` | restore per-link embedded validation | `indexing the embedded runtime fell back to a whole-archive parse` |

The first compares every field of every symbol of every member across all three embedded runtimes. The second pins both halves: the embedded path must not reach the whole-archive parse, and a caller-supplied archive must still take it.

## Scope

- **User archives** (`--link-archives`) keep the owned-archive path. They are read fresh per link and used once, so indexing them wins nothing.
- **Caching the parsed archive across links** — the issue's original proposal — is not here and is worth filing separately with its honest scope: it helps `--watch` and repeat links, not fresh builds.

## Validation

- `scripts/rue unit rue-linker` — 182 passed, 0 failed.
- `scripts/rue unit rue-compiler` — 1145 passed, 0 failed.
- `buck2 test //crates/rue-linker:{clippy,fmt-check,debug-assert-check}` and the same three for `rue-compiler` — 6 pass. Run as `test`, not `build`.
- `scripts/rue cli abi` — 63 passed, 0 failed. Linking exercised by the real binary against real files.
- `buck2 test //crates/rue-oracle-diff:oracle-diff-test` — 1 pass.
- `scripts/rue premerge` — 205 pass, 0 fail, suite PASSED.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nmb41AiKasPE74Vm3BFd8n)_