### PR TITLE
RUE-1865: canonicalize loop preheaders before LICM

### DIFF
--- a/crates/rue-cfg/src/opt/licm.rs
+++ b/crates/rue-cfg/src/opt/licm.rs
@@ -55,29 +55,27 @@
 //! in the preheader in discovery (dependency) order, so a hoisted operand always
 //! precedes its hoisted user.
 //!
-//! ## Placement in the pipeline and the recompute rule
+//! ## Placement in the pipeline and the canonical preheader contract
 //!
 //! LICM runs at `-O3` only, **after** the whole `-O1`/`-O2` sequence
 //! (`constopt` → `peephole` → `simplify` → `forward` → `cse`), so it works on a
 //! CFG whose constants are already folded and whose trivial control flow is
 //! already threaded — the invariant operands it keys on are as exposed as the
 //! earlier passes can make them — and **before** the final `dce`, which sweeps
-//! anything the moves orphan. It recomputes the dominator tree and loop forest
-//! from scratch (ADR-0054's recompute-per-pass rule). Moving instructions
-//! between existing blocks does not change CFG edges, dominators, or loop
-//! membership, so the same forest remains authoritative. Creating a dedicated
-//! preheader does change edges; only then does LICM stop consuming the current
-//! forest and recompute before continuing. An **irreducible** forest makes the
-//! pass a no-op: the analysis refuses to describe a multi-entry cycle, so there
-//! is nothing to hoist.
+//! anything the moves orphan. The `-O3` driver first establishes canonical
+//! preheaders for every natural loop. LICM then computes the dominator tree and
+//! loop forest exactly once and only moves instructions between existing
+//! blocks, so that forest remains authoritative for the whole pass. An
+//! **irreducible** forest makes the pass a no-op: the analysis refuses to
+//! describe a multi-entry cycle, so there is nothing to hoist.
 //!
 //! Nested loops are processed **innermost first** (the forest's nesting orders
 //! them by body size): an op invariant for an inner loop hoists to the inner
-//! preheader, which sits in the outer loop's body, and a later sweep can hoist it
-//! again to the outer preheader if it is invariant there too. An op that is not
-//! invariant for the inner loop cannot be invariant for the outer one either (the
-//! varying operand lives in the inner body, which is part of the outer body), so
-//! innermost-first never misses a hoist.
+//! preheader, which sits in the outer loop's body, and the later outer-loop
+//! visit can hoist it again to the outer preheader if it is invariant there too.
+//! An op that is not invariant for the inner loop cannot be invariant for the
+//! outer one either (the varying operand lives in the inner body, which is part
+//! of the outer body), so innermost-first never misses a hoist.
 
 use std::collections::VecDeque;
 
@@ -85,27 +83,26 @@ use rue_air::FrozenTypeInternPool;
 
 use super::CfgOptimizationError;
 use super::classify;
-use super::loops::{LoopId, NaturalLoop, ensure_preheader, loops};
+use super::loops::{LoopId, NaturalLoop, loops, may_have_cycle_by_block_order, preheader};
 use super::slot_facts::{self, LoopSlotFacts};
 use crate::dominators::DominatorTree;
-use crate::{BlockId, Cfg, CfgInstData, CfgValue, Terminator};
+use crate::{BlockId, Cfg, CfgInstData, CfgValue};
 
 /// Bounded-work counters for one LICM run (RUE-794 discipline).
 ///
 /// Every field is monotone and structurally bounded. One forest computation
-/// visits each loop until a dedicated preheader changes CFG edges. Within a
-/// loop, each instruction is scanned once for slot facts and once for hoist
-/// eligibility, each candidate dependency is recorded once, and each
-/// discovered invariant leaves the worklist once.
+/// visits each loop once. Within a loop, each instruction is scanned once for
+/// slot facts and once for hoist eligibility, each candidate dependency is
+/// recorded once, and each discovered invariant leaves the worklist once.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Stats {
     /// Dominator-tree and loop-forest computations, including the initial one.
     pub forest_computations: u64,
-    /// Whole-function definition-block scans. One per sweep, not one per loop
+    /// Whole-function definition-block scans. One per run, not one per loop
     /// analyzed (RUE-1843): hoisting only relocates instructions to a known
     /// preheader, so the table is patched in place instead of rebuilt.
     pub def_block_scans: u64,
-    /// Per-loop invariance analyses performed (one per loop visited in a sweep).
+    /// Per-loop invariance analyses performed (one per loop visited).
     pub loops_analyzed: u64,
     /// Loop-body instructions tested for hoist eligibility.
     pub instructions_examined: u64,
@@ -127,9 +124,6 @@ pub struct Stats {
     pub worklist_pops: u64,
     /// Instructions moved into a preheader across all loops.
     pub invariants_hoisted: u64,
-    /// Dedicated preheader blocks materialized (an existing unconditional
-    /// single-entry predecessor is reused instead of counted here).
-    pub preheaders_materialized: u64,
     /// Times the shared discovery workspace grew its whole-function-sized
     /// tables. One per run in the steady state, not one per loop analyzed
     /// (RUE-1843) — a regression to per-loop allocation shows up here.
@@ -137,10 +131,13 @@ pub struct Stats {
 }
 
 /// Run loop-invariant code motion. Call at `-O3` only, after the `-O2` passes
-/// and before DCE (see the module docs). Returns its work counters. The type
-/// pool feeds preheader materialization's typed block-param payloads (RUE-840),
-/// whose capacity failures propagate as the pass error.
-pub fn run(cfg: &mut Cfg, type_pool: &FrozenTypeInternPool) -> Result<Stats, CfgOptimizationError> {
+/// and before DCE (see the module docs). The caller must first establish
+/// canonical preheaders with `loops::normalize_preheaders`. Returns its work
+/// counters. The type-pool parameter is retained for the pass API contract.
+pub fn run(
+    cfg: &mut Cfg,
+    _type_pool: &FrozenTypeInternPool,
+) -> Result<Stats, CfgOptimizationError> {
     // Every directed cycle contains an edge whose target is no later than its
     // source in the total block-id order. Proving that no such edge exists is
     // therefore enough to skip both dominator construction and loop discovery.
@@ -157,87 +154,44 @@ pub fn run(cfg: &mut Cfg, type_pool: &FrozenTypeInternPool) -> Result<Stats, Cfg
     // reallocated (RUE-1843).
     let mut workspace = HoistWorkspace::default();
 
-    // Recompute dominators + loops from scratch after each actual CFG-edge
-    // change (ADR-0054). Instruction-only motion leaves the forest valid, so
-    // one computation can serve every loop in that sweep.
-    loop {
-        stats.forest_computations += 1;
-        let dom = DominatorTree::compute(cfg);
-        let forest = loops(cfg, &dom);
-        // An irreducible forest carries no loops, so this is a natural no-op;
-        // an empty (loop-free) forest likewise.
-        if forest.is_irreducible() || forest.is_empty() {
-            break;
-        }
+    stats.forest_computations += 1;
+    let dom = DominatorTree::compute(cfg);
+    let forest = loops(cfg, &dom);
+    // An irreducible forest carries no loops, so this is a natural no-op;
+    // an empty (loop-free) forest likewise.
+    if forest.is_irreducible() || forest.is_empty() {
+        return Ok(stats);
+    }
 
-        // Innermost first: a smaller body is nested more deeply. Hoisting from
-        // the innermost loop first lets its results bubble outward on later
-        // sweeps.
-        let mut order: Vec<LoopId> = (0..forest.len()).collect();
-        order.sort_by_key(|&id| forest.get(id).body.len());
-        // The forest contains only reachable natural loops. Keep an explicit
-        // shared reachability set for slot-fact scans so disconnected
-        // counterfeit blocks can never become memory barriers, and compute it
-        // once per sweep rather than once per loop.
-        let reachable = super::dce::compute_reachable_blocks(cfg);
+    // Innermost first: a smaller body is nested more deeply. Hoisting from
+    // the innermost loop first lets its results bubble outward when the later
+    // outer-loop visit sees them in the inner preheader.
+    let mut order: Vec<LoopId> = (0..forest.len()).collect();
+    order.sort_by_key(|&id| forest.get(id).body.len());
+    // The forest contains only reachable natural loops. Keep an explicit
+    // shared reachability set for slot-fact scans so disconnected
+    // counterfeit blocks can never become memory barriers, and compute it
+    // once per run rather than once per loop.
+    let reachable = super::dce::compute_reachable_blocks(cfg);
 
-        // One whole-function def-block scan per sweep. Instruction-only motion
-        // keeps it accurate as long as each hoist patches the entries it moved,
-        // and any sweep that materializes a preheader breaks out below and
-        // recomputes both the forest and this table (RUE-1843).
-        let mut def_block = compute_def_blocks(cfg, &mut stats);
+    // One whole-function def-block scan per run. Instruction-only motion keeps
+    // it accurate as long as each hoist patches the entries it moved
+    // (RUE-1843).
+    let mut def_block = compute_def_blocks(cfg, &mut stats);
 
-        let mut cfg_changed = false;
-        for id in order {
-            stats.loops_analyzed += 1;
-            if hoist_loop(
-                cfg,
-                forest.get(id),
-                type_pool,
-                &mut def_block,
-                &reachable,
-                &mut workspace,
-                &mut stats,
-            )?
-            .cfg_changed
-            {
-                // A dedicated preheader changed edges, so the forest is stale.
-                cfg_changed = true;
-                break;
-            }
-        }
-        if !cfg_changed {
-            break;
-        }
+    for id in order {
+        stats.loops_analyzed += 1;
+        hoist_loop(
+            cfg,
+            forest.get(id),
+            &mut def_block,
+            &reachable,
+            &mut workspace,
+            &mut stats,
+        );
     }
 
     Ok(stats)
-}
-
-fn may_have_cycle_by_block_order(cfg: &Cfg) -> bool {
-    for raw in 0..cfg.block_count() {
-        let block = BlockId::from_raw(raw as u32);
-        let observe = |target: BlockId| target.as_u32() <= block.as_u32();
-        let may_cycle = match &cfg.get_block(block).terminator {
-            Terminator::Goto { target, .. } => observe(*target),
-            Terminator::Branch {
-                then_block,
-                else_block,
-                ..
-            } => observe(*then_block) || observe(*else_block),
-            Terminator::Switch { cases, default, .. } => {
-                cfg.switch_cases(cases)
-                    .iter()
-                    .any(|(_, target)| observe(*target))
-                    || observe(*default)
-            }
-            Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => false,
-        };
-        if may_cycle {
-            return true;
-        }
-    }
-    false
 }
 
 /// Whole-function-sized scratch for invariant discovery, owned by the run
@@ -246,7 +200,7 @@ fn may_have_cycle_by_block_order(cfg: &Cfg) -> bool {
 /// Every table is indexed by `CfgValue` or `BlockId`, so each is sized by the
 /// *function* — but only the current loop's candidates are ever written. A
 /// fresh set per loop meant six allocations proportional to the whole function
-/// for every loop in every sweep, paid in full even by a loop with no
+/// for every loop in the run, paid in full even by a loop with no
 /// candidates at all, since they are built before the zero-hoist early return.
 /// `pending` alone is 8 bytes per value and `dependents` a 24-byte `Vec` header
 /// per value before a single push.
@@ -297,9 +251,9 @@ impl HoistWorkspace {
         self.order.clear();
         self.worklist.clear();
 
-        // Grow only. Materializing a preheader adds a block and can add typed
-        // block params, so both counts can rise between sweeps; neither ever
-        // falls, and truncating would discard capacity for no gain.
+        // Grow only. Canonical normalization has already established every
+        // preheader, so the graph cannot grow during this LICM run; retaining
+        // capacity across loop visits avoids per-loop allocation.
         let values = cfg.value_count();
         let blocks = cfg.block_count();
         let grow_values = self.candidate.len() < values;
@@ -325,22 +279,14 @@ impl HoistWorkspace {
     }
 }
 
-/// Hoist every trap-free invariant instruction out of `lp` into its preheader.
-/// Reports whether materializing the destination changed CFG edges.
-#[derive(Default)]
-struct HoistResult {
-    cfg_changed: bool,
-}
-
 fn hoist_loop(
     cfg: &mut Cfg,
     lp: &NaturalLoop,
-    type_pool: &FrozenTypeInternPool,
     def_block: &mut Vec<Option<BlockId>>,
     reachable: &super::dce::BitSet,
     workspace: &mut HoistWorkspace,
     stats: &mut Stats,
-) -> Result<HoistResult, CfgOptimizationError> {
+) {
     // Classify each body instruction once. The classifier remains the sole
     // authority for trap/effect eligibility; the worklist below only answers
     // whether eligible operands become available at the preheader.
@@ -424,18 +370,12 @@ fn hoist_loop(
     }
 
     if order.is_empty() {
-        return Ok(HoistResult::default());
+        return;
     }
 
-    // Materialize the preheader once, then relocate each invariant instruction
-    // into it. `ensure_preheader` reuses a suitable existing predecessor when it
-    // can, inserting a block only when it must.
-    let before = cfg.block_count();
-    let ph = ensure_preheader(cfg, lp, type_pool)?;
-    let cfg_changed = cfg.block_count() > before;
-    if cfg_changed {
-        stats.preheaders_materialized += 1;
-    }
+    // Canonical O3 normalization has already established this destination.
+    // Merely looking it up cannot change CFG edges or invalidate the forest.
+    let ph = preheader(cfg, lp).expect("LICM requires canonical loop preheaders");
 
     for &block in &lp.body {
         cfg.get_block_mut(block)
@@ -450,7 +390,6 @@ fn hoist_loop(
     }
 
     stats.invariants_hoisted += order.len() as u64;
-    Ok(HoistResult { cfg_changed })
 }
 
 /// Whether `value` is eligible to hoist on its own merits, independent of its
@@ -517,6 +456,12 @@ mod tests {
 
     fn test_type_pool() -> FrozenTypeInternPool {
         rue_air::TypeInternPool::new().freeze()
+    }
+
+    /// Exercise LICM through the same canonical-preheader boundary as O3.
+    fn run(cfg: &mut Cfg, type_pool: &FrozenTypeInternPool) -> Result<Stats, CfgOptimizationError> {
+        super::super::loops::normalize_preheaders(cfg, type_pool)?;
+        super::run(cfg, type_pool)
     }
 
     fn goto(target: BlockId) -> Terminator {
@@ -783,15 +728,15 @@ mod tests {
         assert!(stats.invariants_hoisted >= 2);
 
         // RUE-1843: the whole-function definition-block table is built once per
-        // sweep, not once per loop analyzed. This fixture has two nested loops,
-        // so it analyzes strictly more loops than it takes sweeps — which is
-        // what makes the second assertion bite: restoring the per-loop scan
+        // run, not once per loop analyzed. This fixture has two nested loops,
+        // so it analyzes strictly more loops than whole-function scans — which
+        // is what makes the second assertion bite: restoring the per-loop scan
         // makes the scan count track `loops_analyzed` instead. The counter is
         // incremented inside `compute_def_blocks` itself, so it cannot drift
         // from the number of scans actually performed.
         assert_eq!(
             stats.def_block_scans, stats.forest_computations,
-            "one definition-block scan per sweep, alongside the forest"
+            "one definition-block scan per run, alongside the forest"
         );
         assert!(
             stats.loops_analyzed > stats.def_block_scans,
@@ -803,15 +748,15 @@ mod tests {
 
         // Same bound for the discovery workspace (RUE-1843): its six tables are
         // sized by the function, so allocating a set per loop cost the whole
-        // function's size for every loop in every sweep — paid even by a loop
+        // function's size for every loop in the run — paid even by a loop
         // with no candidates, since they are built before the zero-hoist early
-        // return. One workspace is reset per loop instead, and only grows when
-        // the graph does, which within a sweep can happen at most once: the
-        // sweep breaks out as soon as materializing a preheader changes edges.
+        // return. One workspace is reset per loop instead; canonical
+        // normalization has already finished every graph edit, so it grows at
+        // most once to the final graph's dimensions.
         assert!(
             stats.hoist_workspace_growths <= stats.forest_computations,
-            "workspace grew {} times across {} sweeps; it should grow only when \
-             the graph does",
+            "workspace grew {} times during one {}-forest run; it should grow \
+             only to the final graph dimensions",
             stats.hoist_workspace_growths,
             stats.forest_computations,
         );
@@ -870,7 +815,6 @@ mod tests {
         let before = cfg.block_count();
         let stats = run(&mut cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 0);
-        assert_eq!(stats.preheaders_materialized, 0);
         assert_eq!(cfg.block_count(), before, "no preheader inserted");
     }
 
@@ -1493,7 +1437,6 @@ mod tests {
         assert_eq!(stats.candidate_dependencies, 0);
         assert_eq!(stats.worklist_pops, LOOP_COUNT as u64);
         assert_eq!(stats.invariants_hoisted, LOOP_COUNT as u64);
-        assert_eq!(stats.preheaders_materialized, 0);
         assert!(
             loads
                 .iter()
@@ -1504,10 +1447,10 @@ mod tests {
     }
 
     #[test]
-    fn recomputes_forest_only_after_materializing_preheader() {
+    fn canonical_normalization_keeps_licm_to_one_forest() {
         // Entry has a sibling successor, so it cannot serve as the loop
-        // preheader. Hoisting inserts one block and triggers exactly one
-        // structural recomputation.
+        // preheader. Canonical normalization inserts it before LICM; the pass
+        // itself performs only instruction motion and computes one forest.
         let mut cfg = make_cfg();
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -1527,8 +1470,7 @@ mod tests {
 
         let stats = run(&mut cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 1);
-        assert_eq!(stats.preheaders_materialized, 1);
-        assert_eq!(stats.forest_computations, 2);
+        assert_eq!(stats.forest_computations, 1);
         assert_ne!(block_of(&cfg, invariant), Some(body));
         cfg.verify().unwrap();
     }

--- a/crates/rue-cfg/src/opt/loops.rs
+++ b/crates/rue-cfg/src/opt/loops.rs
@@ -15,7 +15,8 @@
 //!    no loops, so no consumer ever guesses a body for a tangle the dominator
 //!    tree cannot describe.
 //!
-//! 2. **Preheader materialization** ([`ensure_preheader`]). A loop's preheader
+//! 2. **Canonical preheader normalization** ([`normalize_preheaders`]). A
+//!    loop's preheader
 //!    is a dedicated block that dominates the header and runs exactly once per
 //!    loop entry — the block LICM hoists *into*. The header's predecessors split
 //!    into **back-edge predecessors** (latches, inside the body) and **outside
@@ -30,13 +31,13 @@
 //!    into such a predecessor would run the hoisted work on the sibling arm's
 //!    path too.
 //!
-//! LICM (RUE-927, `opt/licm.rs`) is the live pipeline consumer: it runs at
-//! `-O3` from `opt/mod.rs` and drives [`loops`] and [`ensure_preheader`].
-//! Constant-trip unrolling (RUE-928) is the tracked next consumer; the few
-//! items only it will need carry targeted allows below. Dominators and loops
-//! are **recomputed per pass, never cached** (ADR-0054): every mutation here
-//! invalidates the dominator tree, and recompute-per-pass is O(blocks) and
-//! trivially correct at Rue's scale.
+//! The `-O3` pipeline normalizes every natural loop before either loop transform
+//! runs. Splitting an entry edge changes only that loop header's predecessors,
+//! so one forest can safely drive every distinct header even though an inner
+//! preheader becomes part of each enclosing loop's body. LICM then computes a
+//! fresh forest that observes those final bodies and restricts itself to
+//! instruction motion. Dominators and loops are **recomputed per pass, never
+//! cached** (ADR-0054).
 
 use crate::dominators::DominatorTree;
 use crate::{BlockId, Cfg, CfgEditError, Terminator};
@@ -395,6 +396,93 @@ pub(crate) fn ensure_preheader(
     ensure_preheader_with_injection(cfg, lp, type_pool, PayloadFailureInjection::default())
 }
 
+/// Work performed while establishing the canonical `-O3` preheader form.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PreheaderNormalizationStats {
+    /// Fresh dominator-tree and loop-forest computations.
+    pub(crate) forest_computations: u64,
+    /// Loops whose existing preheader was classified or materialized.
+    pub(crate) loops_examined: u64,
+    /// Dedicated preheader blocks inserted.
+    pub(crate) preheaders_materialized: u64,
+}
+
+/// Ensure that every natural loop has a dedicated preheader.
+///
+/// Materialization redirects only outside edges that already target the loop's
+/// own header. It cannot change another header's predecessor set or create a
+/// loop, so the initial forest remains sufficient to normalize every distinct
+/// header in one sweep. An inner insertion does change enclosing loop *bodies*;
+/// consumers therefore compute their own fresh forest after normalization.
+pub(crate) fn normalize_preheaders(
+    cfg: &mut Cfg,
+    type_pool: &FrozenTypeInternPool,
+) -> Result<PreheaderNormalizationStats, CfgOptimizationError> {
+    let mut stats = PreheaderNormalizationStats::default();
+    if !may_have_cycle_by_block_order(cfg) {
+        return Ok(stats);
+    }
+
+    stats.forest_computations += 1;
+    let dom = DominatorTree::compute(cfg);
+    let forest = loops(cfg, &dom);
+    if forest.is_irreducible() || forest.is_empty() {
+        return Ok(stats);
+    }
+
+    let mut order: Vec<LoopId> = (0..forest.len()).collect();
+    order.sort_by_key(|&id| {
+        let lp = forest.get(id);
+        (lp.body.len(), lp.header.as_u32())
+    });
+
+    for id in order {
+        stats.loops_examined += 1;
+        let before = cfg.block_count();
+        ensure_preheader(cfg, forest.get(id), type_pool)?;
+        if cfg.block_count() != before {
+            stats.preheaders_materialized += 1;
+        }
+    }
+    Ok(stats)
+}
+
+/// Cheaply prove that a CFG is acyclic from its total block-id order.
+///
+/// Every directed cycle contains an edge whose target is no later than its
+/// source. A non-forward edge in an acyclic graph is only a conservative false
+/// positive; `false` is a proof that loop analysis can be skipped.
+pub(crate) fn may_have_cycle_by_block_order(cfg: &Cfg) -> bool {
+    for raw in 0..cfg.block_count() {
+        let block = BlockId::from_raw(raw as u32);
+        let observe = |target: BlockId| target.as_u32() <= block.as_u32();
+        let may_cycle = match &cfg.get_block(block).terminator {
+            Terminator::Goto { target, .. } => observe(*target),
+            Terminator::Branch {
+                then_block,
+                else_block,
+                ..
+            } => observe(*then_block) || observe(*else_block),
+            Terminator::Switch { cases, default, .. } => {
+                cfg.switch_cases(cases)
+                    .iter()
+                    .any(|(_, target)| observe(*target))
+                    || observe(*default)
+            }
+            Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => false,
+        };
+        if may_cycle {
+            return true;
+        }
+    }
+    false
+}
+
+/// Return the preheader guaranteed by [`normalize_preheaders`].
+pub(crate) fn preheader(cfg: &Cfg, lp: &NaturalLoop) -> Option<BlockId> {
+    classify_preheader(cfg, lp).reusable
+}
+
 #[derive(Default)]
 struct PayloadFailureInjection {
     #[cfg(test)]
@@ -456,7 +544,7 @@ fn ensure_preheader_with_injection(
     injection.before_validation(cfg, ph);
     // Validate the materialized preheader with the materialization verifier, NOT
     // the strict `verify_with_type_pool`. Preheader materialization runs
-    // mid-pipeline during LICM (RUE-927), between `simplify` and the pipeline's
+    // mid-pipeline during canonical O3 normalization, between `cse` and LICM,
     // final DCE, so the CFG legitimately carries two kinds of transient debris
     // that DCE has not swept yet and that this edit did not introduce:
     //   * detached-but-in-arena dead values left by `forward`/`cse` — tolerated
@@ -887,6 +975,98 @@ mod tests {
         assert_eq!(outer.parent, None);
         let outer_id = forest.loops().iter().position(|l| l.header == o).unwrap();
         assert_eq!(inner.parent, Some(outer_id));
+    }
+
+    #[test]
+    fn normalization_materializes_nested_headers_from_one_forest() {
+        // Both loop entries are Branch arms, so neither predecessor is a
+        // preheader. One forest safely drives both header splits; the consumer's
+        // fresh forest must then include the inner preheader in the enclosing
+        // outer loop body.
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let outer = cfg.new_block();
+        let inner = cfg.new_block();
+        let inner_body = cfg.new_block();
+        let outer_latch = cfg.new_block();
+        let exit = cfg.new_block();
+
+        let entry_cond = bool_const(&mut cfg, entry);
+        cfg.set_terminator(entry, branch(entry_cond, outer, exit));
+        let outer_cond = bool_const(&mut cfg, outer);
+        cfg.set_terminator(outer, branch(outer_cond, inner, exit));
+        let inner_cond = bool_const(&mut cfg, inner);
+        cfg.set_terminator(inner, branch(inner_cond, inner_body, outer_latch));
+        cfg.set_terminator(inner_body, goto(inner));
+        cfg.set_terminator(outer_latch, goto(outer));
+        cfg.set_terminator(exit, Terminator::Return { value: None });
+        cfg.verify().unwrap();
+
+        let before = cfg.block_count();
+        let stats = normalize_preheaders(&mut cfg, &test_type_pool()).unwrap();
+        assert_eq!(stats.preheaders_materialized, 2);
+        assert_eq!(stats.forest_computations, 1);
+        assert_eq!(cfg.block_count(), before + 2);
+
+        let inner_ph = BlockId::from_raw(before as u32);
+        let forest = analyze(&cfg);
+        let outer_loop = loop_of(&forest, outer);
+        let inner_loop = loop_of(&forest, inner);
+        assert_eq!(preheader(&cfg, inner_loop), Some(inner_ph));
+        assert!(
+            outer_loop.contains(inner_ph),
+            "the final outer body must include the materialized inner preheader"
+        );
+        assert!(preheader(&cfg, outer_loop).is_some());
+        cfg.verify().unwrap();
+
+        let second = normalize_preheaders(&mut cfg, &test_type_pool()).unwrap();
+        assert_eq!(second.preheaders_materialized, 0);
+        assert_eq!(second.forest_computations, 1);
+        assert_eq!(cfg.block_count(), before + 2);
+    }
+
+    #[test]
+    fn normalization_reuses_existing_preheaders_without_editing() {
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let header = cfg.new_block();
+        let body = cfg.new_block();
+        let exit = cfg.new_block();
+        cfg.set_terminator(entry, goto(header));
+        let cond = bool_const(&mut cfg, header);
+        cfg.set_terminator(header, branch(cond, body, exit));
+        cfg.set_terminator(body, goto(header));
+        cfg.set_terminator(exit, Terminator::Return { value: None });
+
+        let before = cfg.block_count();
+        let stats = normalize_preheaders(&mut cfg, &test_type_pool()).unwrap();
+        assert_eq!(stats.preheaders_materialized, 0);
+        assert_eq!(stats.forest_computations, 1);
+        assert_eq!(stats.loops_examined, 1);
+        assert_eq!(cfg.block_count(), before);
+    }
+
+    #[test]
+    fn normalization_skips_forest_construction_for_acyclic_cfgs() {
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let then_block = cfg.new_block();
+        let else_block = cfg.new_block();
+        let exit = cfg.new_block();
+        let cond = bool_const(&mut cfg, entry);
+        cfg.set_terminator(entry, branch(cond, then_block, else_block));
+        cfg.set_terminator(then_block, goto(exit));
+        cfg.set_terminator(else_block, goto(exit));
+        cfg.set_terminator(exit, Terminator::Return { value: None });
+
+        let stats = normalize_preheaders(&mut cfg, &test_type_pool()).unwrap();
+        assert_eq!(stats.forest_computations, 0);
+        assert_eq!(stats.loops_examined, 0);
+        assert_eq!(stats.preheaders_materialized, 0);
     }
 
     #[test]
@@ -1581,15 +1761,13 @@ mod tests {
             previous = next;
         }
         cfg.set_terminator(previous, Terminator::Return { value: None });
-        let dom = DominatorTree::compute(&cfg);
-        let forest = loops(&cfg, &dom);
-        assert_eq!(forest.len(), LOOPS);
         let blocks_before = cfg.block_count();
         Cfg::reset_test_clone_count();
         reset_test_preheader_pred_scan_count();
-        for lp in forest.loops() {
-            ensure_preheader(&mut cfg, lp, &test_type_pool()).unwrap();
-        }
+        let stats = normalize_preheaders(&mut cfg, &test_type_pool()).unwrap();
+        assert_eq!(stats.forest_computations, 1);
+        assert_eq!(stats.loops_examined, LOOPS as u64);
+        assert_eq!(stats.preheaders_materialized, LOOPS as u64);
         assert_eq!(cfg.block_count(), blocks_before + LOOPS);
         assert_eq!(Cfg::test_clone_count(), 0);
         assert_eq!(test_preheader_pred_scan_count(), LOOPS);

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -12,9 +12,10 @@
 //!   simplification, dead code elimination)
 //! - `-O2`: `-O1` plus value forwarding / copy propagation (RUE-914) and
 //!   dominator-scoped common-subexpression elimination (RUE-913, RUE-1874)
-//! - `-O3`: `-O2` plus loop-invariant code motion (RUE-927), which hoists
-//!   trap-free invariant computations out of loops into their preheaders, and
-//!   bounded constant-trip full unrolling (RUE-928)
+//! - `-O3`: `-O2` plus canonical loop-preheader normalization, loop-invariant
+//!   code motion (RUE-927), which hoists trap-free invariant computations out
+//!   of loops into their preheaders, and bounded constant-trip full unrolling
+//!   (RUE-928)
 //!
 //! ## Pipeline
 //!
@@ -414,8 +415,12 @@ pub fn optimize_with_budget(
                     cse::run(&mut cfg)?;
                 }
 
-                // Loop-invariant code motion (RUE-927), at -O3 only — the first
-                // pass gated strictly above -O2 (ADR-0054 Phase 2). Runs after
+                // Canonical loop normalization and LICM (RUE-927), at -O3
+                // only — the first work gated strictly above -O2 (ADR-0054
+                // Phases 1-2). Normalization establishes a preheader for every
+                // natural loop to a fixed point before either loop transform.
+                // LICM then computes one current forest and changes no CFG
+                // edges. Runs after
                 // the whole -O1/-O2 sequence so the invariant operands it keys
                 // on are as exposed as constant folding, simplification,
                 // forwarding, and CSE can make them, and before DCE, which
@@ -426,6 +431,7 @@ pub fn optimize_with_budget(
                 // never runs (the inverse of RUE-57). It recomputes dominators
                 // + loops per the ADR's recompute rule.
                 if matches!(level, OptLevel::O3) {
+                    loops::normalize_preheaders(&mut cfg, type_pool)?;
                     licm::run(&mut cfg, type_pool)?;
                     // Full constant-trip unrolling follows LICM and is
                     // followed by a mandatory cleanup fixpoint. Analyses are
@@ -475,6 +481,19 @@ fn publish_optimization(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{BlockId, Cfg, CfgInst, CfgInstData, CfgValue, Terminator, Type};
+    use rue_span::Span;
+
+    fn push(cfg: &mut Cfg, block: BlockId, data: CfgInstData, ty: Type) -> CfgValue {
+        cfg.add_inst_to_block(
+            block,
+            CfgInst {
+                data,
+                ty,
+                span: Span::new(0, 0),
+            },
+        )
+    }
 
     #[test]
     fn optimizer_rewrite_boundaries_are_explicitly_in_place() {
@@ -527,8 +546,8 @@ mod tests {
     #[test]
     fn preheader_materialization_edits_the_graph_in_place() {
         // Preheader materialization runs inside optimize_with_budget's private
-        // editor. A failed edit propagates through LICM into `pass_result`, and
-        // `publish_optimization` checks that result before publishing the
+        // editor. A failed normalization edit propagates into `pass_result`,
+        // and `publish_optimization` checks that result before publishing the
         // poisoned editor, so a second whole-CFG rollback owner is redundant.
         // Inspect production code only: loop-analysis tests clone graphs for
         // before/after and failure-injection fixtures.
@@ -542,6 +561,136 @@ mod tests {
             0,
             "preheader materialization reacquired a whole-CFG clone"
         );
+    }
+
+    #[test]
+    fn empty_canonical_preheader_is_reclaimed_before_publication() {
+        // The entry Branch cannot itself be the loop preheader, so O3
+        // normalization must split its loop edge. With no invariant work to
+        // retain, final simplify threads around that empty block and DCE
+        // reclaims it: the CFG handed to codegen has the same block population
+        // as O2, which performs no normalization.
+        let pool = rue_air::TypeInternPool::new().freeze();
+        let mut cfg = Cfg::new(Type::UNIT, 0, 1, "test".to_string(), vec![false]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let header = cfg.new_block();
+        let body = cfg.new_block();
+        let exit = cfg.new_block();
+        let cond = push(&mut cfg, entry, CfgInstData::Param { index: 0 }, Type::BOOL);
+        cfg.set_terminator(
+            entry,
+            Terminator::Branch {
+                cond,
+                then_block: header,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
+                else_block: exit,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
+            },
+        );
+        cfg.set_terminator(
+            header,
+            Terminator::Branch {
+                cond,
+                then_block: body,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
+                else_block: exit,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
+            },
+        );
+        cfg.set_terminator(
+            body,
+            Terminator::Goto {
+                target: header,
+                args: crate::payload::CfgGotoArgs::EMPTY,
+            },
+        );
+        cfg.set_terminator(exit, Terminator::Return { value: None });
+        let cfg = cfg.finish(&pool).unwrap();
+
+        let o2 = optimize(cfg.clone(), OptLevel::O2, &pool).unwrap();
+        let o3 = optimize(cfg, OptLevel::O3, &pool).unwrap();
+        assert_eq!(o3.block_count(), o2.block_count());
+        assert_eq!(o3.block_count(), 3);
+    }
+
+    #[test]
+    fn nonempty_canonical_preheader_survives_final_cleanup() {
+        // The body computes a dynamic but trap-free invariant used by the next
+        // header iteration. LICM moves it into the materialized preheader; the
+        // final cleanup may remove the now-empty body, but must retain the
+        // nonempty preheader as the defining block outside the final loop.
+        let pool = rue_air::TypeInternPool::new().freeze();
+        let mut cfg = Cfg::new(
+            Type::I32,
+            0,
+            3,
+            "test".to_string(),
+            vec![false, false, false],
+        );
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let header = cfg.new_block();
+        let body = cfg.new_block();
+        let exit = cfg.new_block();
+        let a = push(&mut cfg, entry, CfgInstData::Param { index: 0 }, Type::I32);
+        let b = push(&mut cfg, entry, CfgInstData::Param { index: 1 }, Type::I32);
+        let cond = push(&mut cfg, entry, CfgInstData::Param { index: 2 }, Type::BOOL);
+        let current = cfg.add_block_param(header, Type::I32);
+        let result = cfg.add_block_param(exit, Type::I32);
+        let then_args = cfg.push_then_args([a]).unwrap();
+        let else_args = cfg.push_else_args([a]).unwrap();
+        cfg.set_terminator(
+            entry,
+            Terminator::Branch {
+                cond,
+                then_block: header,
+                then_args,
+                else_block: exit,
+                else_args,
+            },
+        );
+        let else_args = cfg.push_else_args([current]).unwrap();
+        cfg.set_terminator(
+            header,
+            Terminator::Branch {
+                cond,
+                then_block: body,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
+                else_block: exit,
+                else_args,
+            },
+        );
+        let invariant = push(&mut cfg, body, CfgInstData::BitOr(a, b), Type::I32);
+        let args = cfg.push_goto_args([invariant]).unwrap();
+        cfg.set_terminator(
+            body,
+            Terminator::Goto {
+                target: header,
+                args,
+            },
+        );
+        cfg.set_terminator(
+            exit,
+            Terminator::Return {
+                value: Some(result),
+            },
+        );
+        let cfg = cfg.finish(&pool).unwrap();
+        let optimized = optimize(cfg, OptLevel::O3, &pool).unwrap();
+
+        let defining_block = optimized
+            .block_ids()
+            .find(|&block| optimized.get_block(block).insts.contains(&invariant))
+            .expect("the live invariant remains attached");
+        let dom = crate::dominators::DominatorTree::compute(&optimized);
+        let forest = loops::loops(&optimized, &dom);
+        assert_eq!(forest.len(), 1);
+        assert_eq!(
+            loops::preheader(&optimized, forest.get(0)),
+            Some(defining_block)
+        );
+        assert!(!forest.get(0).contains(defining_block));
     }
 
     #[test]

--- a/docs/designs/0054-loop-optimizations.md
+++ b/docs/designs/0054-loop-optimizations.md
@@ -213,9 +213,14 @@ implementation would be exactly the duplicate-analysis smell that guidance warns
 against, and the landed module already avoids it.
 
 **Invalidation discipline: recompute per pass initially.** Dominators and loops
-are **recomputed by each pass that needs them, not cached across passes.** Loop
-passes mutate the CFG (LICM inserts a preheader and moves instructions;
-unrolling clones blocks), which invalidates dominators; a cache would need
+are **recomputed by each pass that needs them, not cached across passes.** The
+canonical `-O3` normalization step materializes every natural-loop preheader
+before either loop transform. Splitting an entry edge changes only that loop
+header's predecessors and cannot create a new loop, so one forest safely drives
+normalization of every distinct header. An inner preheader does become part of
+each enclosing loop body; LICM's own fresh forest observes those final bodies
+before LICM only moves instructions. Unrolling retains its separate
+recompute-after-mutation behavior. A cross-pass cache would need
 careful incremental maintenance that is not worth it at Rue's scale and is a
 ready source of stale-analysis miscompiles. Recompute-per-pass is O(blocks) and
 trivially correct. Caching within a *single* pass (compute once, use for all


### PR DESCRIPTION
## Summary

- establish reusable or materialized preheaders once before the O3 loop passes
- keep LICM instruction-motion-only with one current loop-forest computation
- document and test nested-loop, acyclic, cleanup, and bounded-work behavior

## Validation

- `./buck2 test //crates/rue-cfg:rue-cfg-test //crates/rue-cfg:rue-cfg-clippy //crates/rue-cfg:rue-cfg-debug-assert-check`
- `scripts/rue quick`
- complete O3 CLI oracle corpus: 232 cases in 29 bounded batches
- complete O3 spec oracle corpus: 73 cases in 10 bounded batches
- `scripts/rue premerge` (205 targets passed)
- `scripts/rue test` attempted; monolithic oracle actions were host-thread-limited with `EAGAIN`, with no semantic disagreement
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-1865