### PR TITLE
RUE-1864: reuse checked const index evaluation

### DIFF
--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -528,7 +528,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         )
                     })?;
                     if !ctx.comptime_type_vars.is_empty() {
-                        self.set_anon_struct_type_subst(struct_id, ctx.comptime_type_vars.clone());
+                        self.set_anon_struct_type_subst(
+                            struct_id,
+                            ctx.comptime_type_vars.snapshot(),
+                        );
                     }
                 }
 

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -65,7 +65,7 @@ use super::comptime::{
     ComptimeStructuredTypeResolution, ComptimeStructuredTypes, ComptimeTrap, ComptimeType,
     ComptimeTypeAlgebra, ComptimeValueAlgebra,
 };
-use super::context::{AnalysisContext, ConstValue};
+use super::context::{AnalysisContext, CheckedConstIndexCandidate, ConstValue};
 use super::info::FunctionCallInfo;
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 
@@ -82,6 +82,75 @@ pub(crate) type ComptimeEnv<'a> = GenericComptimeEnv<
     FileId,
     super::anon_structs::IssuedStableProducerId,
 >;
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CheckedConstIndexTestStats {
+    pub evaluations: u64,
+    pub hits: u64,
+    pub canceled_hits: u64,
+    pub candidate_hits: u64,
+    pub candidate_rejections: u64,
+    pub candidate_comparisons: u64,
+    pub comparison_nodes: u64,
+}
+
+#[cfg(test)]
+thread_local! {
+    static CANCEL_ON_CHECKED_CONST_INDEX_HIT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static CHECKED_CONST_INDEX_HIT_REACHED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(crate) fn with_cancellation_on_checked_const_index_hit<R>(action: impl FnOnce() -> R) -> R {
+    CANCEL_ON_CHECKED_CONST_INDEX_HIT.with(|armed| {
+        let previous = armed.replace(true);
+        CHECKED_CONST_INDEX_HIT_REACHED.with(|reached| reached.set(false));
+        let result = action();
+        armed.set(previous);
+        CHECKED_CONST_INDEX_HIT_REACHED.with(|reached| reached.set(false));
+        result
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn checked_const_index_hit_requests_cancellation() -> bool {
+    CANCEL_ON_CHECKED_CONST_INDEX_HIT.with(std::cell::Cell::get)
+        && CHECKED_CONST_INDEX_HIT_REACHED.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+thread_local! {
+    static CHECKED_CONST_INDEX_TEST_STATS: std::cell::Cell<CheckedConstIndexTestStats> =
+        const { std::cell::Cell::new(CheckedConstIndexTestStats {
+            evaluations: 0,
+            hits: 0,
+            canceled_hits: 0,
+            candidate_hits: 0,
+            candidate_rejections: 0,
+            candidate_comparisons: 0,
+            comparison_nodes: 0,
+        }) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_checked_const_index_test_stats() {
+    CHECKED_CONST_INDEX_TEST_STATS.with(|stats| stats.set(CheckedConstIndexTestStats::default()));
+}
+
+#[cfg(test)]
+pub(crate) fn checked_const_index_test_stats() -> CheckedConstIndexTestStats {
+    CHECKED_CONST_INDEX_TEST_STATS.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+fn update_checked_const_index_test_stats(update: impl FnOnce(&mut CheckedConstIndexTestStats)) {
+    CHECKED_CONST_INDEX_TEST_STATS.with(|stats| {
+        let mut current = stats.get();
+        update(&mut current);
+        stats.set(current);
+    });
+}
 
 /// Incremental ordinary-body binding state. It is intentionally not Clone:
 /// each admitted call owns one source-order binding transaction, and the
@@ -253,7 +322,7 @@ impl<'a>
     pub(crate) fn for_analysis(ctx: &'a AnalysisContext) -> Self {
         Self {
             canonical_identity: Some(ctx.canonical_producer.clone()),
-            type_subst: ctx.comptime_type_vars.clone(),
+            type_subst: ctx.comptime_type_vars.snapshot(),
             value_subst: ctx.comptime_value_vars.clone(),
             resolved_types: Some(ctx.resolved_types),
             // Borrow the caller's live locals instead of snapshotting their
@@ -488,17 +557,276 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     pub(crate) fn try_get_const_index_checked(
         &mut self,
         inst_ref: InstRef,
-        ctx: &AnalysisContext,
+        ctx: &mut AnalysisContext,
     ) -> CompileResult<Option<i128>> {
+        let scope = ctx.checked_const_index_scope_key();
+        let cache_key = AnalysisContext::checked_const_index_cache_key(inst_ref, scope.clone());
+        if let Some(value) = ctx
+            .checked_const_index_cache
+            .borrow()
+            .get(&cache_key)
+            .copied()
+        {
+            #[cfg(test)]
+            CHECKED_CONST_INDEX_HIT_REACHED.with(|reached| reached.set(true));
+            // A memo hit must not let retained work bypass the owning query's
+            // cancellation boundary.
+            let cancellation = self.check_canceled();
+            #[cfg(test)]
+            if cancellation.is_err() {
+                update_checked_const_index_test_stats(|stats| stats.canceled_hits += 1);
+            }
+            cancellation?;
+            ctx.checked_const_index_cache_hits
+                .set(ctx.checked_const_index_cache_hits.get().saturating_add(1));
+            #[cfg(test)]
+            update_checked_const_index_test_stats(|stats| stats.hits += 1);
+            return Ok(Some(value));
+        }
+        let span = self.body_rir_ref().get(inst_ref).span;
+        let candidate_key = AnalysisContext::checked_const_index_candidate_key(span);
+        let candidates = ctx
+            .checked_const_index_candidates
+            .borrow()
+            .get(&candidate_key)
+            .cloned()
+            .unwrap_or_default();
+        for candidate in candidates {
+            ctx.checked_const_index_candidate_comparisons.set(
+                ctx.checked_const_index_candidate_comparisons
+                    .get()
+                    .saturating_add(1),
+            );
+            let (equivalent, nodes) =
+                self.checked_const_index_expressions_equivalent(&candidate, inst_ref, ctx);
+            ctx.checked_const_index_comparison_nodes.set(
+                ctx.checked_const_index_comparison_nodes
+                    .get()
+                    .saturating_add(nodes),
+            );
+            #[cfg(test)]
+            update_checked_const_index_test_stats(|stats| {
+                stats.candidate_comparisons += 1;
+                stats.comparison_nodes = stats.comparison_nodes.saturating_add(nodes);
+            });
+            if equivalent {
+                #[cfg(test)]
+                CHECKED_CONST_INDEX_HIT_REACHED.with(|reached| reached.set(true));
+                let cancellation = self.check_canceled();
+                #[cfg(test)]
+                if cancellation.is_err() {
+                    update_checked_const_index_test_stats(|stats| stats.canceled_hits += 1);
+                }
+                cancellation?;
+                ctx.checked_const_index_cache
+                    .borrow_mut()
+                    .insert(cache_key, candidate.value);
+                ctx.checked_const_index_cache_hits
+                    .set(ctx.checked_const_index_cache_hits.get().saturating_add(1));
+                #[cfg(test)]
+                update_checked_const_index_test_stats(|stats| {
+                    stats.hits += 1;
+                    stats.candidate_hits += 1;
+                });
+                return Ok(Some(candidate.value));
+            }
+            #[cfg(test)]
+            update_checked_const_index_test_stats(|stats| stats.candidate_rejections += 1);
+        }
+        ctx.checked_const_index_evaluations
+            .set(ctx.checked_const_index_evaluations.get().saturating_add(1));
+        #[cfg(test)]
+        update_checked_const_index_test_stats(|stats| stats.evaluations += 1);
         let mut env = ComptimeEnv::for_analysis(ctx);
         // Full i128 backing value, NOT the i64 narrowing: `as_integer()`
         // returns None for a u64 constant above i64::MAX, which made an
         // exactly-known out-of-bounds index (`a[18446744073709551615]`)
         // indistinguishable from a runtime index and skip the compile-time
         // bounds check (RUE-532).
-        Ok(self
+        let value = self
             .eval_const_expr(inst_ref, &mut env)?
-            .and_then(|v| v.as_int_value()))
+            .and_then(|v| v.as_int_value());
+        drop(env);
+        if let Some(value) = value {
+            ctx.checked_const_index_cache
+                .borrow_mut()
+                .insert(cache_key, value);
+            ctx.checked_const_index_candidates
+                .borrow_mut()
+                .entry(candidate_key)
+                .or_default()
+                .push(CheckedConstIndexCandidate {
+                    root: inst_ref,
+                    value,
+                    runtime_local_names: ctx.locals.keys().copied().collect(),
+                    comptime_type_vars: ctx.comptime_type_vars.snapshot(),
+                });
+        }
+        Ok(value)
+    }
+
+    /// Typed equivalence for the expression forms admitted to cross-root reuse.
+    /// Unsupported forms conservatively miss and evaluate normally. This work
+    /// runs only after a successful same-span candidate exists. Failed probes
+    /// are never admitted to either cache; an ordinary failure with no prior
+    /// candidate avoids structural comparison entirely.
+    fn checked_const_index_expressions_equivalent(
+        &self,
+        candidate: &CheckedConstIndexCandidate,
+        right: InstRef,
+        ctx: &AnalysisContext,
+    ) -> (bool, u64) {
+        let mut pending = vec![(candidate.root, right)];
+        let mut visited = AHashSet::new();
+        let mut nodes = 0_u64;
+        while let Some((left, right)) = pending.pop() {
+            if !visited.insert((left, right)) {
+                continue;
+            }
+            nodes = nodes.saturating_add(1);
+            let left_inst = self.body_rir_ref().get(left);
+            let right_inst = self.body_rir_ref().get(right);
+            if left_inst.span != right_inst.span
+                || ctx.resolved_type_of(left) != ctx.resolved_type_of(right)
+            {
+                return (false, nodes);
+            }
+            let equivalent = match (&left_inst.data, &right_inst.data) {
+                (InstData::IntConst(left), InstData::IntConst(right)) => left == right,
+                (InstData::BoolConst(left), InstData::BoolConst(right)) => left == right,
+                (InstData::UnitConst, InstData::UnitConst) => true,
+                (
+                    InstData::VarRef {
+                        name: left_name, ..
+                    },
+                    InstData::VarRef {
+                        name: right_name, ..
+                    },
+                ) => {
+                    left_name == right_name
+                        && candidate.runtime_local_names.contains(left_name)
+                            == ctx.locals.contains_key(right_name)
+                        && candidate.comptime_type_vars.get(left_name)
+                            == ctx.comptime_type_vars.get(right_name)
+                }
+                (
+                    InstData::FieldGet {
+                        base: left_base,
+                        field: left_field,
+                    },
+                    InstData::FieldGet {
+                        base: right_base,
+                        field: right_field,
+                    },
+                ) => {
+                    pending.push((*left_base, *right_base));
+                    left_field == right_field
+                }
+                (InstData::Neg { operand: left }, InstData::Neg { operand: right })
+                | (InstData::Not { operand: left }, InstData::Not { operand: right })
+                | (InstData::BitNot { operand: left }, InstData::BitNot { operand: right })
+                | (InstData::Comptime { expr: left }, InstData::Comptime { expr: right }) => {
+                    pending.push((*left, *right));
+                    true
+                }
+                (InstData::Add { lhs: ll, rhs: lr }, InstData::Add { lhs: rl, rhs: rr })
+                | (InstData::Sub { lhs: ll, rhs: lr }, InstData::Sub { lhs: rl, rhs: rr })
+                | (InstData::Mul { lhs: ll, rhs: lr }, InstData::Mul { lhs: rl, rhs: rr })
+                | (InstData::Div { lhs: ll, rhs: lr }, InstData::Div { lhs: rl, rhs: rr })
+                | (InstData::Mod { lhs: ll, rhs: lr }, InstData::Mod { lhs: rl, rhs: rr })
+                | (InstData::BitAnd { lhs: ll, rhs: lr }, InstData::BitAnd { lhs: rl, rhs: rr })
+                | (InstData::BitOr { lhs: ll, rhs: lr }, InstData::BitOr { lhs: rl, rhs: rr })
+                | (InstData::BitXor { lhs: ll, rhs: lr }, InstData::BitXor { lhs: rl, rhs: rr })
+                | (InstData::Shl { lhs: ll, rhs: lr }, InstData::Shl { lhs: rl, rhs: rr })
+                | (InstData::Shr { lhs: ll, rhs: lr }, InstData::Shr { lhs: rl, rhs: rr }) => {
+                    pending.extend([(*lr, *rr), (*ll, *rl)]);
+                    true
+                }
+                (
+                    InstData::TypeIntrinsic {
+                        name: left_name,
+                        type_arg: left_type,
+                    },
+                    InstData::TypeIntrinsic {
+                        name: right_name,
+                        type_arg: right_type,
+                    },
+                ) => {
+                    let syntax_equivalent = self
+                        .checked_const_index_named_type_syntax_equivalent(*left_type, *right_type);
+                    let binding_equivalent = self
+                        .checked_const_index_named_type_syntax_symbol(*left_type)
+                        .zip(self.checked_const_index_named_type_syntax_symbol(*right_type))
+                        .is_none_or(|(left, right)| {
+                            left == right
+                                && candidate.comptime_type_vars.get(&left)
+                                    == ctx.comptime_type_vars.get(&right)
+                        });
+                    left_name == right_name && syntax_equivalent && binding_equivalent
+                }
+                (
+                    InstData::OffsetOf {
+                        type_arg: left_type,
+                        field: left_field,
+                    },
+                    InstData::OffsetOf {
+                        type_arg: right_type,
+                        field: right_field,
+                    },
+                ) => {
+                    let syntax_equivalent = self
+                        .checked_const_index_named_type_syntax_equivalent(*left_type, *right_type);
+                    let binding_equivalent = self
+                        .checked_const_index_named_type_syntax_symbol(*left_type)
+                        .zip(self.checked_const_index_named_type_syntax_symbol(*right_type))
+                        .is_none_or(|(left, right)| {
+                            left == right
+                                && candidate.comptime_type_vars.get(&left)
+                                    == ctx.comptime_type_vars.get(&right)
+                        });
+                    left_field == right_field && syntax_equivalent && binding_equivalent
+                }
+                _ => false,
+            };
+            if !equivalent {
+                return (false, nodes);
+            }
+        }
+        (true, nodes)
+    }
+
+    /// The checked-index cases needing type-syntax reuse currently name a
+    /// comptime alias or generic parameter. Compare that spelling through the
+    /// typed arena; every richer syntax conservatively evaluates again.
+    fn checked_const_index_named_type_syntax_equivalent(
+        &self,
+        left: rue_rir::RirTypeSyntaxRef,
+        right: rue_rir::RirTypeSyntaxRef,
+    ) -> bool {
+        use rue_rir::RirTypeSyntaxNode;
+
+        let arena = self.body_rir_ref().type_syntax();
+        match (arena.node(left), arena.node(right)) {
+            (Some(RirTypeSyntaxNode::Named(left)), Some(RirTypeSyntaxNode::Named(right))) => {
+                arena.symbol(*left) == arena.symbol(*right)
+            }
+            (Some(RirTypeSyntaxNode::Unit), Some(RirTypeSyntaxNode::Unit))
+            | (Some(RirTypeSyntaxNode::Never), Some(RirTypeSyntaxNode::Never)) => true,
+            _ => false,
+        }
+    }
+
+    fn checked_const_index_named_type_syntax_symbol(
+        &self,
+        reference: rue_rir::RirTypeSyntaxRef,
+    ) -> Option<Spur> {
+        use rue_rir::RirTypeSyntaxNode;
+
+        let arena = self.body_rir_ref().type_syntax();
+        let RirTypeSyntaxNode::Named(symbol) = arena.node(reference)? else {
+            return None;
+        };
+        arena.symbol(*symbol).copied()
     }
 
     /// Check if an RIR instruction is a direct reference to a `comptime`

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -6,11 +6,14 @@
 //! embedded here as [`AnalysisContext::ownership`].
 
 use ahash::{AHashMap, AHashSet};
+use std::cell::{Cell, RefCell};
+use std::hash::{Hash, Hasher};
+use std::rc::Rc;
 use std::sync::Arc;
 
 use lasso::Spur;
 use rue_error::CompileWarning;
-use rue_rir::{RirParamMode, SymbolHandle};
+use rue_rir::{InstRef, RirParamMode, SymbolHandle};
 use rue_span::{FileId, Span};
 
 use super::ownership_state::OwnershipState;
@@ -56,6 +59,116 @@ pub(crate) struct ParamInfo {
     /// receiver; mutations affect the callee's copy only, with no
     /// write-back to the caller (that is `Inout`).
     pub is_mut: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CheckedConstIndexScopeKey(Rc<()>);
+
+impl CheckedConstIndexScopeKey {
+    pub(crate) fn fresh() -> Self {
+        Self(Rc::new(()))
+    }
+}
+
+impl PartialEq for CheckedConstIndexScopeKey {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for CheckedConstIndexScopeKey {}
+
+impl Hash for CheckedConstIndexScopeKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Rc::as_ptr(&self.0).hash(state);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CheckedConstIndexScopeState {
+    current: CheckedConstIndexScopeKey,
+    stack: Vec<CheckedConstIndexScopeKey>,
+}
+
+impl CheckedConstIndexScopeState {
+    pub(crate) fn new() -> Self {
+        Self {
+            current: CheckedConstIndexScopeKey::fresh(),
+            stack: Vec::new(),
+        }
+    }
+
+    fn key(&self) -> CheckedConstIndexScopeKey {
+        self.current.clone()
+    }
+
+    fn changed(&mut self) {
+        self.current = CheckedConstIndexScopeKey::fresh();
+    }
+
+    fn push(&mut self) {
+        self.stack.push(self.current.clone());
+    }
+
+    fn pop(&mut self) {
+        self.current = self
+            .stack
+            .pop()
+            .expect("analysis scope identity stack stays parallel to lexical scopes");
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CheckedConstIndexCacheKey {
+    root: InstRef,
+    scope: CheckedConstIndexScopeKey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CheckedConstIndexCandidateKey {
+    span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CheckedConstIndexCandidate {
+    pub root: InstRef,
+    pub value: i128,
+    pub runtime_local_names: AHashSet<Spur>,
+    pub comptime_type_vars: AHashMap<Spur, Type>,
+}
+
+/// Read-only outside this module so scope-state mutations cannot bypass the
+/// checked-index identity refresh/restore paths.
+#[derive(Debug, Clone)]
+pub(crate) struct ScopeStateMap<V>(AHashMap<Spur, V>);
+
+impl<V> ScopeStateMap<V> {
+    pub(crate) fn new(values: AHashMap<Spur, V>) -> Self {
+        Self(values)
+    }
+
+    fn insert(&mut self, name: Spur, value: V) -> Option<V> {
+        self.0.insert(name, value)
+    }
+
+    fn remove(&mut self, name: &Spur) -> Option<V> {
+        self.0.remove(name)
+    }
+
+    pub(crate) fn snapshot(&self) -> AHashMap<Spur, V>
+    where
+        V: Clone,
+    {
+        self.0.clone()
+    }
+}
+
+impl<V> std::ops::Deref for ScopeStateMap<V> {
+    type Target = AHashMap<Spur, V>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 /// Resolves parameter names without making tiny signatures pay for an index.
@@ -144,7 +257,7 @@ pub(crate) struct AnalysisContext<'a> {
     /// File that owns the function body currently being analyzed.
     pub current_file_id: FileId,
     /// Local variables in scope
-    pub locals: AHashMap<Spur, LocalVar>,
+    pub locals: ScopeStateMap<LocalVar>,
     /// Function parameters (immutable reference, shared across the function)
     pub params: &'a [ParamInfo],
     /// Body-scoped parameter-name index shared by every semantic consumer.
@@ -177,6 +290,9 @@ pub(crate) struct AnalysisContext<'a> {
     /// [`AnalysisContext::bind_comptime_type_var`], never by inserting into
     /// `comptime_type_vars` directly.
     pub comptime_type_scope_stack: Vec<Vec<(Spur, Option<Type>)>>,
+    /// Persistent identity of the exact runtime-name/type-alias environment.
+    /// Scope mutations replace it; scope pop restores the saved identity.
+    pub(crate) checked_const_index_scope_state: CheckedConstIndexScopeState,
     /// Resolved types from HM inference.
     /// Maps RIR instruction refs to their resolved concrete types.
     /// This is populated by running constraint generation and unification
@@ -220,12 +336,38 @@ pub(crate) struct AnalysisContext<'a> {
     /// When a variable is bound to a comptime type (e.g., `let P = make_point()` where
     /// `make_point() -> type`), this map stores the resolved type so it can be used
     /// as a type annotation (e.g., `let p: P = ...`).
-    pub comptime_type_vars: AHashMap<Spur, Type>,
+    pub comptime_type_vars: ScopeStateMap<Type>,
     /// Comptime value variables: maps variable symbols to their compile-time constant values.
     /// When an anonymous struct method captures comptime parameters from the enclosing function
     /// (e.g., `fn FixedBuffer(comptime N: i32)` creates a struct with methods that reference `N`),
     /// this map stores the captured values so method bodies can resolve them.
     pub comptime_value_vars: AHashMap<Spur, ConstValue>,
+    /// Successful checked integer-index evaluations for this one canonical
+    /// body analysis. AstGen deliberately duplicates a compound assignment's
+    /// source index into its read and write RIR nodes. Exact-root hits are
+    /// constant-time; distinct roots first share a cheap source-occurrence
+    /// candidate and are reused only after typed structural equivalence. Both
+    /// The exact-root lookup carries every mutable environment component
+    /// consulted by `ComptimeEnv::for_analysis`.
+    /// Producer, specialization/value substitutions, file/import identity, and
+    /// resolved types are fixed by this context's body-local lifetime.
+    pub checked_const_index_cache: Rc<RefCell<AHashMap<CheckedConstIndexCacheKey, i128>>>,
+    /// Successful source-occurrence candidates. A distinct AstGen duplicate
+    /// reaches structural and relevant-scope validation only after this cheap
+    /// span lookup. Candidate environment snapshots are created only for a
+    /// successful evaluator result; a failing probe can compare an existing
+    /// candidate but is never itself admitted.
+    pub checked_const_index_candidates:
+        Rc<RefCell<AHashMap<CheckedConstIndexCandidateKey, Vec<CheckedConstIndexCandidate>>>>,
+    /// Actual checked index evaluator invocations in this body. Cache hits do
+    /// not increment this production work counter.
+    pub checked_const_index_evaluations: Rc<Cell<u64>>,
+    /// Successful checked index cache lookups in this body.
+    pub checked_const_index_cache_hits: Rc<Cell<u64>>,
+    /// Distinct-root candidates subjected to typed structural comparison.
+    pub checked_const_index_candidate_comparisons: Rc<Cell<u64>>,
+    /// RIR node pairs visited by those comparisons.
+    pub checked_const_index_comparison_nodes: Rc<Cell<u64>>,
     /// Functions referenced during analysis of this function.
     /// Used for demand-driven semantic analysis (ADR-0045) to track
     /// which functions need to be analyzed. Each entry is a function name symbol.
@@ -341,13 +483,12 @@ impl DivergenceKinds {
 }
 
 // Import InstRef for use in resolved_types
-use rue_rir::InstRef;
 
 impl ScopedContext for AnalysisContext<'_> {
     type VarInfo = LocalVar;
 
     fn locals_mut(&mut self) -> &mut AHashMap<Spur, Self::VarInfo> {
-        &mut self.locals
+        &mut self.locals.0
     }
 
     fn scope_stack_mut(&mut self) -> &mut Vec<Vec<(Spur, Option<Self::VarInfo>)>> {
@@ -367,6 +508,12 @@ impl ScopedContext for AnalysisContext<'_> {
     /// E0205). Applies to every scoped binding form that reaches
     /// `insert_local`: nested `let`, `match` payload bindings, loop binders.
     fn insert_local(&mut self, symbol: Spur, var: LocalVar) {
+        // Const evaluation observes only runtime-name membership. Replaying a
+        // declaration over an already-live runtime binding does not change
+        // that state; adding the name or hiding a type alias does.
+        if !self.locals.contains_key(&symbol) || self.comptime_type_vars.contains_key(&symbol) {
+            self.refresh_checked_const_index_scope_state();
+        }
         let old_value = self.locals.insert(symbol, var);
         // Track in the current scope (if any) for cleanup on pop
         if let Some(current_scope) = self.scope_stack.last_mut() {
@@ -387,6 +534,7 @@ impl ScopedContext for AnalysisContext<'_> {
     }
 
     fn push_scope(&mut self) {
+        self.checked_const_index_scope_state.push();
         self.scope_stack.push(Vec::with_capacity(2));
         self.ownership.push_scope_frame();
         self.comptime_type_scope_stack.push(Vec::new());
@@ -421,10 +569,35 @@ impl ScopedContext for AnalysisContext<'_> {
                 }
             }
         }
+        self.checked_const_index_scope_state.pop();
     }
 }
 
 impl<'a> AnalysisContext<'a> {
+    pub(crate) fn checked_const_index_scope_key(&self) -> CheckedConstIndexScopeKey {
+        // `ComptimeEnv` asks locals only for name membership; slots, mutability,
+        // ownership state, and local types cannot affect const evaluation.
+        // Parameter runtime names are immutable for the body and therefore do
+        // not enter this per-probe state. Comptime values, producer identity,
+        // defining file/imports, and resolved types are likewise body-fixed.
+        self.checked_const_index_scope_state.key()
+    }
+
+    fn refresh_checked_const_index_scope_state(&mut self) {
+        self.checked_const_index_scope_state.changed();
+    }
+
+    pub(crate) fn checked_const_index_cache_key(
+        root: InstRef,
+        scope: CheckedConstIndexScopeKey,
+    ) -> CheckedConstIndexCacheKey {
+        CheckedConstIndexCacheKey { root, scope }
+    }
+
+    pub(crate) fn checked_const_index_candidate_key(span: Span) -> CheckedConstIndexCandidateKey {
+        CheckedConstIndexCandidateKey { span }
+    }
+
     /// Resolve one function parameter through the body's canonical lookup.
     pub(crate) fn param(&self, name: Spur) -> Option<&'a ParamInfo> {
         self.param_index.get(self.params, name)
@@ -462,6 +635,11 @@ impl<'a> AnalysisContext<'a> {
     /// `comptime_type_vars` and `locals` in different orders, so leaving
     /// both live would resolve the name inconsistently.
     pub fn bind_comptime_type_var(&mut self, symbol: Spur, ty: Type) {
+        if self.comptime_type_vars.get(&symbol).copied() != Some(ty)
+            || self.locals.contains_key(&symbol)
+        {
+            self.refresh_checked_const_index_scope_state();
+        }
         let old_alias = self.comptime_type_vars.insert(symbol, ty);
         if let Some(alias_frame) = self.comptime_type_scope_stack.last_mut() {
             alias_frame.push((symbol, old_alias));
@@ -504,6 +682,7 @@ impl<'a> AnalysisContext<'a> {
             return_type: self.return_type,
             scope_stack: self.scope_stack.clone(),
             comptime_type_scope_stack: self.comptime_type_scope_stack.clone(),
+            checked_const_index_scope_state: self.checked_const_index_scope_state.clone(),
             resolved_types: self.resolved_types,
             resolved_continues: self.resolved_continues,
             comptime_selections: self.comptime_selections,
@@ -516,6 +695,14 @@ impl<'a> AnalysisContext<'a> {
             local_atoms: self.local_atoms.clone(),
             comptime_type_vars: self.comptime_type_vars.clone(),
             comptime_value_vars: self.comptime_value_vars.clone(),
+            checked_const_index_cache: self.checked_const_index_cache.clone(),
+            checked_const_index_candidates: self.checked_const_index_candidates.clone(),
+            checked_const_index_evaluations: self.checked_const_index_evaluations.clone(),
+            checked_const_index_cache_hits: self.checked_const_index_cache_hits.clone(),
+            checked_const_index_candidate_comparisons: self
+                .checked_const_index_candidate_comparisons
+                .clone(),
+            checked_const_index_comparison_nodes: self.checked_const_index_comparison_nodes.clone(),
             referenced_functions: AHashSet::new(),
             referenced_methods: AHashSet::new(),
             expected_type: None,
@@ -805,6 +992,33 @@ mod tests {
                 Some(param.abi_slot)
             );
         }
+    }
+
+    #[test]
+    fn checked_index_scope_identity_clones_changes_and_restores_exactly() {
+        let mut state = CheckedConstIndexScopeState::new();
+        let baseline = state.key();
+        state.push();
+        state.changed();
+        let bind = state.key();
+        let fork = state.clone();
+        assert_eq!(
+            bind,
+            fork.key(),
+            "a context fork preserves exact scope state"
+        );
+
+        state.changed();
+        let shadow = state.key();
+        assert_ne!(baseline, bind, "a binding allocates a new state identity");
+        assert_ne!(bind, shadow, "a shadow allocates another state identity");
+
+        state.pop();
+        let restored = state.key();
+        assert_eq!(
+            baseline, restored,
+            "popping a scope restores the saved identity rather than hashing contents"
+        );
     }
 
     // =========================================================================

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -84,6 +84,10 @@ pub(crate) struct ExpressionAnalysisBreakdown {
     pub(crate) staged_binding_trie_updates: u64,
     pub(crate) staged_binding_trie_lookups: u64,
     pub(crate) staged_probe_nodes: u64,
+    pub(crate) checked_const_index_evaluations: u64,
+    pub(crate) checked_const_index_cache_hits: u64,
+    pub(crate) checked_const_index_candidate_comparisons: u64,
+    pub(crate) checked_const_index_comparison_nodes: u64,
     pub(crate) air_emission_validation_ns: u64,
 }
 
@@ -2311,7 +2315,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             canonical_producer,
             canonical_function_identity,
             current_file_id: self.body_rir_ref().get(body).span.file_id,
-            locals: AHashMap::new(),
+            locals: super::context::ScopeStateMap::new(AHashMap::new()),
             params: &param_vec,
             param_index: &param_index,
             next_slot: 0,
@@ -2321,6 +2325,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             return_type,
             scope_stack: Vec::new(),
             comptime_type_scope_stack: Vec::new(),
+            checked_const_index_scope_state: super::context::CheckedConstIndexScopeState::new(),
             resolved_types: &resolved_types,
             resolved_continues: &resolved_continues,
             comptime_selections: &comptime_selections,
@@ -2331,8 +2336,16 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             local_string_table: AHashMap::new(),
             local_strings: Vec::new(),
             local_atoms: Vec::new(),
-            comptime_type_vars,
+            comptime_type_vars: super::context::ScopeStateMap::new(comptime_type_vars),
             comptime_value_vars,
+            checked_const_index_cache: std::rc::Rc::new(std::cell::RefCell::new(AHashMap::new())),
+            checked_const_index_candidates: std::rc::Rc::new(std::cell::RefCell::new(
+                AHashMap::new(),
+            )),
+            checked_const_index_evaluations: std::rc::Rc::new(std::cell::Cell::new(0)),
+            checked_const_index_cache_hits: std::rc::Rc::new(std::cell::Cell::new(0)),
+            checked_const_index_candidate_comparisons: std::rc::Rc::new(std::cell::Cell::new(0)),
+            checked_const_index_comparison_nodes: std::rc::Rc::new(std::cell::Cell::new(0)),
             referenced_functions: AHashSet::new(),
             referenced_methods: AHashSet::new(),
             expected_type: None,
@@ -2484,6 +2497,14 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 staged_binding_trie_updates: inference_breakdown.staged_binding_trie_updates,
                 staged_binding_trie_lookups: inference_breakdown.staged_binding_trie_lookups,
                 staged_probe_nodes: inference_breakdown.staged_probe_nodes,
+                checked_const_index_evaluations: ctx.checked_const_index_evaluations.get(),
+                checked_const_index_cache_hits: ctx.checked_const_index_cache_hits.get(),
+                checked_const_index_candidate_comparisons: ctx
+                    .checked_const_index_candidate_comparisons
+                    .get(),
+                checked_const_index_comparison_nodes: ctx
+                    .checked_const_index_comparison_nodes
+                    .get(),
                 air_emission_validation_ns,
             });
 

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -56,6 +56,41 @@ fn elapsed_ns(started: Instant) -> u64 {
     u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
 }
 
+#[cfg(test)]
+thread_local! {
+    static PROVIDER_BODY_TEST_OWNER_FILE: Cell<Option<FileId>> = const { Cell::new(None) };
+}
+
+#[cfg(test)]
+fn provider_body_test_owner_file() -> Option<FileId> {
+    PROVIDER_BODY_TEST_OWNER_FILE.get()
+}
+
+#[cfg(not(test))]
+fn provider_body_test_owner_file() -> Option<FileId> {
+    None
+}
+
+/// Admit a deliberately multi-file counterfeit RIR to the ordinary-body test
+/// engine while preserving the one-source-file production contract.
+#[cfg(test)]
+pub(crate) fn with_provider_body_test_owner_file<T>(
+    owner_file: FileId,
+    f: impl FnOnce() -> T,
+) -> T {
+    struct Restore(Option<FileId>);
+
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            PROVIDER_BODY_TEST_OWNER_FILE.set(self.0);
+        }
+    }
+
+    let previous = PROVIDER_BODY_TEST_OWNER_FILE.replace(Some(owner_file));
+    let _restore = Restore(previous);
+    f()
+}
+
 fn publish_provider_body_breakdown(
     host_setup_ns: u64,
     expression_engine_ns: u64,
@@ -104,6 +139,11 @@ fn publish_provider_body_breakdown(
         staged_binding_trie_updates = expression.staged_binding_trie_updates,
         staged_binding_trie_lookups = expression.staged_binding_trie_lookups,
         staged_probe_nodes = expression.staged_probe_nodes,
+        checked_const_index_evaluations = expression.checked_const_index_evaluations,
+        checked_const_index_cache_hits = expression.checked_const_index_cache_hits,
+        checked_const_index_candidate_comparisons = expression
+            .checked_const_index_candidate_comparisons,
+        checked_const_index_comparison_nodes = expression.checked_const_index_comparison_nodes,
         staged_precompute_nodes = precompute
             .alias_nodes_visited
             .saturating_add(precompute.alias_block_statements)
@@ -738,6 +778,14 @@ pub struct ProviderBodyWork {
     pub staged_binding_trie_lookups: u64,
     /// Precompute nodes visited once by the staged snapshot.
     pub staged_precompute_nodes: u64,
+    /// Checked integer-index evaluator invocations after body-local reuse.
+    pub checked_const_index_evaluations: u64,
+    /// Successful body-local checked integer-index cache lookups.
+    pub checked_const_index_cache_hits: u64,
+    /// Distinct-root occurrence candidates compared structurally.
+    pub checked_const_index_candidate_comparisons: u64,
+    /// RIR node pairs visited by structural candidate comparisons.
+    pub checked_const_index_comparison_nodes: u64,
 }
 
 impl ProviderBodyWork {
@@ -762,6 +810,11 @@ impl ProviderBodyWork {
             .saturating_add(precompute.inline_scan_bodies)
             .saturating_add(precompute.inline_raw_candidates)
             .saturating_add(precompute.inline_final_candidates);
+        self.checked_const_index_evaluations = expression.checked_const_index_evaluations;
+        self.checked_const_index_cache_hits = expression.checked_const_index_cache_hits;
+        self.checked_const_index_candidate_comparisons =
+            expression.checked_const_index_candidate_comparisons;
+        self.checked_const_index_comparison_nodes = expression.checked_const_index_comparison_nodes;
         self
     }
 }
@@ -5494,11 +5547,14 @@ where
     M: Clone + Eq + Hash + Ord,
 {
     let result = (|| -> CompileResult<ProviderOrdinaryBody<K, M>> {
-        let owner_file = bundle.source_file_id().ok_or_else(|| {
-            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                "provider body RIR does not have one source file".into(),
-            ))
-        })?;
+        let owner_file = bundle
+            .source_file_id()
+            .or_else(provider_body_test_owner_file)
+            .ok_or_else(|| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                    "provider body RIR does not have one source file".into(),
+                ))
+            })?;
         let host_setup_started = Instant::now();
         let mut host = ProviderBodyHost::new(
             provider, source, bundle, key, owner_file, name, owner_kind, owner_name, target,

--- a/crates/rue-air/src/sema/provider_fixture.rs
+++ b/crates/rue-air/src/sema/provider_fixture.rs
@@ -32,7 +32,7 @@ use rue_error::{CompileResult, PreviewFeatures};
 use rue_lexer::Lexer;
 use rue_parser::Parser;
 use rue_rir::{AstGen, RirEditor, RirValidationContext, ValidatedRir};
-use rue_span::FileId;
+use rue_span::{FileId, Span};
 use rue_target::Target;
 
 use super::provider::{
@@ -123,6 +123,10 @@ pub(crate) struct FixtureFacts {
     methods: AHashMap<FixtureKey, DurableMethod<FixtureKey, FixtureModule>>,
     nominals: AHashMap<FixtureKey, DurableNominal<FixtureKey, FixtureModule>>,
     consts: AHashMap<FixtureKey, DurableConst<FixtureKey, FixtureModule>>,
+    root_modules: AHashMap<Arc<str>, FixtureModule>,
+    module_bindings: AHashMap<(FixtureModule, Arc<str>), FixtureModule>,
+    module_files: AHashMap<FixtureModule, FileId>,
+    qualified_consts: AHashMap<(FixtureModule, Arc<str>), FixtureKey>,
 }
 
 /// The in-memory durable fact source handed to the production body host. Facts
@@ -237,26 +241,42 @@ impl DurableBodyLookupSource<FixtureKey, FixtureModule> for FixtureFactSource {
     fn root_module_binding(
         &self,
         _current: &FixtureKey,
-        _name: &str,
+        name: &str,
     ) -> Option<super::DurableBodyModuleBinding<FixtureKey, FixtureModule>> {
-        // The fixture is a single module with no `@import` bindings.
-        None
+        let target = self.0.root_modules.get(name)?.clone();
+        Some(super::DurableBodyModuleBinding {
+            definition: FixtureKey::value_const(name),
+            target,
+            is_public: true,
+        })
     }
 
     fn module_binding(
         &self,
-        _module: &FixtureModule,
-        _name: &str,
+        module: &FixtureModule,
+        name: &str,
     ) -> Option<super::DurableBodyModuleBinding<FixtureKey, FixtureModule>> {
-        None
+        let target = self
+            .0
+            .module_bindings
+            .get(&(module.clone(), Arc::from(name)))?
+            .clone();
+        Some(super::DurableBodyModuleBinding {
+            definition: FixtureKey::value_const(name),
+            target,
+            is_public: true,
+        })
     }
 
     fn qualified_free_function(&self, _module: &FixtureModule, _name: &str) -> Option<FixtureKey> {
         None
     }
 
-    fn qualified_value_const(&self, _module: &FixtureModule, _name: &str) -> Option<FixtureKey> {
-        None
+    fn qualified_value_const(&self, module: &FixtureModule, name: &str) -> Option<FixtureKey> {
+        self.0
+            .qualified_consts
+            .get(&(module.clone(), Arc::from(name)))
+            .cloned()
     }
 
     fn qualified_nominal(
@@ -269,6 +289,15 @@ impl DurableBodyLookupSource<FixtureKey, FixtureModule> for FixtureFactSource {
 
     fn module_path(&self, module: &FixtureModule) -> String {
         module.to_string()
+    }
+
+    fn module_source(&self, module: &FixtureModule) -> Option<super::DurableBodySourceLocator> {
+        let file_id = *self.0.module_files.get(module)?;
+        Some(super::DurableBodySourceLocator {
+            file_id,
+            physical_path: module.clone(),
+            source_length: 0,
+        })
     }
 
     fn definition_kind(&self, definition: &FixtureKey) -> Option<StableDefinitionKind> {
@@ -377,6 +406,9 @@ impl BodyFactProvider for UnconsultedFactProvider {
     fn is_canceled(&self) -> bool {
         #[cfg(test)]
         {
+            if super::comptime_eval::checked_const_index_hit_requests_cancellation() {
+                return true;
+            }
             return FIXTURE_CANCELLATION_AFTER.with(|configured| {
                 FIXTURE_CANCELLATION_CHECKS.with(|count| {
                     let checks = count.get() + 1;
@@ -741,6 +773,48 @@ impl ProviderFixture {
         key
     }
 
+    pub(crate) fn declare_imported_const(
+        &mut self,
+        alias: &str,
+        module: &str,
+        name: &str,
+        ty: FixtureType,
+        value: FixtureConstValue,
+    ) -> FixtureKey {
+        let module: FixtureModule = Arc::from(module);
+        self.facts
+            .root_modules
+            .insert(Arc::from(alias), module.clone());
+        let key = FixtureKey::value_const(&format!("{module}::{name}"));
+        self.facts.consts.insert(
+            key.clone(),
+            DurableConst {
+                is_public: true,
+                ty,
+                value,
+            },
+        );
+        self.facts
+            .qualified_consts
+            .insert((module, Arc::from(name)), key.clone());
+        key
+    }
+
+    pub(crate) fn declare_imported_module_binding(
+        &mut self,
+        module: &str,
+        alias: &str,
+        target: &str,
+    ) {
+        self.facts
+            .module_bindings
+            .insert((Arc::from(module), Arc::from(alias)), Arc::from(target));
+    }
+
+    pub(crate) fn set_imported_module_file(&mut self, module: &str, file: FileId) {
+        self.facts.module_files.insert(Arc::from(module), file);
+    }
+
     /// Run the production provider body path over the free function `function`
     /// declared in `source`, which must contain exactly that declaration —
     /// mirroring the compiler's per-body plan, whose RIR bundle carries one
@@ -755,6 +829,8 @@ impl ProviderFixture {
             StableDefinitionKind::Function,
             None,
             |_| {},
+            None,
+            &[],
         )
     }
 
@@ -915,6 +991,8 @@ impl ProviderFixture {
             kind,
             Some(owner),
             |_| {},
+            None,
+            &[],
         )
     }
 
@@ -932,6 +1010,8 @@ impl ProviderFixture {
             StableDefinitionKind::Destructor,
             Some(owner),
             |_| {},
+            None,
+            &[],
         )
     }
 
@@ -951,6 +1031,48 @@ impl ProviderFixture {
             StableDefinitionKind::Function,
             None,
             edit,
+            None,
+            &[],
+        )
+    }
+
+    /// [`Self::analyze`] with canonical RIR instruction spans remapped after
+    /// validation. This lets production-path controls counterfeit occurrence
+    /// coordinates without exposing mutable validated instructions.
+    pub(crate) fn analyze_span_edited(
+        &self,
+        source: &str,
+        function: &str,
+        mut remap: impl FnMut(rue_rir::RirSpanSlot, Span) -> Span,
+    ) -> CompileResult<FixtureBody> {
+        self.analyze_declaration(
+            source,
+            FixtureKey::function(function),
+            function,
+            StableDefinitionKind::Function,
+            None,
+            |_| {},
+            Some(&mut remap),
+            &[],
+        )
+    }
+
+    pub(crate) fn analyze_span_edited_with_files(
+        &self,
+        source: &str,
+        function: &str,
+        extra_source_lengths: &[(FileId, u32)],
+        mut remap: impl FnMut(rue_rir::RirSpanSlot, Span) -> Span,
+    ) -> CompileResult<FixtureBody> {
+        self.analyze_declaration(
+            source,
+            FixtureKey::function(function),
+            function,
+            StableDefinitionKind::Function,
+            None,
+            |_| {},
+            Some(&mut remap),
+            extra_source_lengths,
         )
     }
 
@@ -962,6 +1084,8 @@ impl ProviderFixture {
         kind: StableDefinitionKind,
         owner_name: Option<&str>,
         edit: impl FnOnce(&mut RirEditor),
+        mut remap: Option<&mut dyn FnMut(rue_rir::RirSpanSlot, Span) -> Span>,
+        extra_source_lengths: &[(FileId, u32)],
     ) -> CompileResult<FixtureBody> {
         let (tokens, interner) = Lexer::new(source).tokenize().expect("fixture source lexes");
         let (ast, interner) = Parser::new(tokens, interner)
@@ -977,32 +1101,47 @@ impl ProviderFixture {
         astgen.append_items(&ast.items);
         let mut editor = astgen.finish_editor();
         edit(&mut editor);
-        let source_lengths = [(self.facts.file, source.len() as u32)];
-        let rir = ValidatedRir::finish(
-            editor,
-            &RirValidationContext {
-                symbol_count: interner.len(),
-                source_lengths: &source_lengths,
-            },
-        )
-        .expect("fixture RIR validates");
+        let mut source_lengths = vec![(self.facts.file, source.len() as u32)];
+        source_lengths.extend_from_slice(extra_source_lengths);
+        let validation = RirValidationContext {
+            symbol_count: interner.len(),
+            source_lengths: &source_lengths,
+        };
+        let rir = ValidatedRir::finish(editor, &validation).expect("fixture RIR validates");
+        let rir = if let Some(remap) = remap.as_mut() {
+            rir.try_rewrite_span_slots(
+                &validation,
+                || Ok::<_, std::convert::Infallible>(()),
+                |slot, span| Ok::<_, std::convert::Infallible>(remap(slot, span)),
+            )
+            .expect("fixture span edit preserves validated RIR")
+        } else {
+            rir
+        };
         let bundle = BodyRirBundle::new(
             rir,
             rue_rir::SharedSymbolSpace::adopt(std::sync::Arc::new(interner)),
         );
         let facts = FixtureFactSource(Rc::new(self.facts.clone()));
-        analyze_provider_ordinary_body(
-            &UnconsultedFactProvider,
-            facts,
-            &bundle,
-            key,
-            name,
-            kind,
-            owner_name,
-            Target::host().expect("host target resolves"),
-            self.preview.clone(),
-            &self.well_known,
-        )
+        let analyze = || {
+            analyze_provider_ordinary_body(
+                &UnconsultedFactProvider,
+                facts,
+                &bundle,
+                key,
+                name,
+                kind,
+                owner_name,
+                Target::host().expect("host target resolves"),
+                self.preview.clone(),
+                &self.well_known,
+            )
+        };
+        if extra_source_lengths.is_empty() {
+            analyze()
+        } else {
+            super::provider_body_host::with_provider_body_test_owner_file(self.facts.file, analyze)
+        }
     }
 }
 

--- a/crates/rue-air/src/sema/provider_fixture_tests.rs
+++ b/crates/rue-air/src/sema/provider_fixture_tests.rs
@@ -11,6 +11,10 @@ use rue_error::ErrorKind;
 use std::sync::Arc;
 
 use super::comptime::MAX_COMPTIME_CALL_DEPTH;
+use super::comptime_eval::{
+    checked_const_index_test_stats, reset_checked_const_index_test_stats,
+    with_cancellation_on_checked_const_index_hit,
+};
 use super::ordinary_engine::{
     comptime_reduction_test_keys, comptime_reduction_test_stats,
     reset_comptime_reduction_test_stats,
@@ -47,6 +51,466 @@ fn provider_body_types_integer_addition() {
     let add = air.get(crate::AirRef::from_raw(2));
     assert!(matches!(add.data, crate::AirInstData::Add(_, _)));
     assert_eq!(add.ty, crate::types::Type::I32);
+}
+
+#[test]
+fn checked_const_index_is_shared_between_inference_and_ownership() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    let source = "fn main() { let mut values: [i32; 2] = [10, 20]; values[1 + 0] += 2; }";
+
+    let first = fixture
+        .analyze(source, "main")
+        .expect("constant array index analyzes");
+    let retained = fixture
+        .analyze(source, "main")
+        .expect("retained constant array index analyzes");
+
+    assert_eq!(first.work.checked_const_index_evaluations, 1);
+    assert_eq!(first.work.checked_const_index_cache_hits, 1);
+    assert_eq!(first.work.checked_const_index_candidate_comparisons, 1);
+    assert_eq!(first.work.checked_const_index_comparison_nodes, 3);
+    assert_eq!(retained.work.checked_const_index_evaluations, 1);
+    assert_eq!(retained.work.checked_const_index_cache_hits, 1);
+    assert_eq!(first.export.body, retained.export.body);
+}
+
+#[test]
+fn runtime_index_failure_is_not_cached_between_probes() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function(
+        "lookup",
+        vec![value_param("index", SemanticImportType::I32)],
+        SemanticImportType::Unit,
+    );
+    let body = fixture
+        .analyze(
+            "fn lookup(index: i32) { let mut values: [i32; 2] = [10, 20]; values[index] += 2; }",
+            "lookup",
+        )
+        .expect("runtime array index analyzes");
+
+    assert_eq!(body.work.checked_const_index_evaluations, 2);
+    assert_eq!(body.work.checked_const_index_cache_hits, 0);
+    assert_eq!(body.work.checked_const_index_candidate_comparisons, 0);
+    assert_eq!(body.work.checked_const_index_comparison_nodes, 0);
+}
+
+#[test]
+fn checked_const_index_cache_preserves_runtime_shadow_scope() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_const(
+        "index",
+        SemanticImportType::I32,
+        SemanticImportConstValue::Integer(1),
+    );
+    fixture.declare_function("update", Vec::new(), SemanticImportType::Unit);
+    let source = "fn update() { let mut values: [i32; 2] = [10, 20]; values[index] += 2; { let index: i32 = 0; values[index] += 2; } }";
+    let mut occurrences = source.match_indices("index").map(|(start, _)| start);
+    let outer = occurrences.next().expect("outer index spelling");
+    let binding = occurrences.next().expect("shadow binding spelling");
+    let inner = occurrences.next().expect("inner index spelling");
+    assert!(binding < inner);
+    let outer_span = rue_span::Span::new(outer as u32, (outer + 5) as u32);
+    let inner_span = rue_span::Span::new(inner as u32, (inner + 5) as u32);
+    let body = fixture
+        .analyze_span_edited(source, "update", |_, span| {
+            if span == inner_span { outer_span } else { span }
+        })
+        .expect("runtime shadow preserves index classification");
+
+    // The outer comptime parameter evaluates once and is shared. The inner
+    // runtime local shadows that same name and both probes must retry as
+    // non-constant rather than hitting the outer result.
+    assert_eq!(body.work.checked_const_index_evaluations, 3);
+    assert_eq!(body.work.checked_const_index_cache_hits, 1);
+    assert_eq!(body.work.checked_const_index_candidate_comparisons, 3);
+}
+
+#[test]
+fn checked_const_index_cache_preserves_type_alias_bind_shadow_and_restore() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    let source = "fn main() { let mut values: [i32; 16] = [0; 16]; let Alias = i32; values[@size_of(Alias)] += 1; { let Alias = i64; values[@size_of(Alias)] += 1; } values[@size_of(Alias)] += 1; }";
+    let occurrences = source
+        .match_indices("@size_of(Alias)")
+        .map(|(start, spelling)| rue_span::Span::new(start as u32, (start + spelling.len()) as u32))
+        .collect::<Vec<_>>();
+    let [first, shadowed, restored] = occurrences.as_slice() else {
+        panic!("fixture has three type-alias index occurrences");
+    };
+    let body = fixture
+        .analyze_span_edited(source, "main", |_, span| {
+            if span == *shadowed || span == *restored {
+                *first
+            } else {
+                span
+            }
+        })
+        .expect("type alias scope is restored after the nested block");
+
+    // All three roots counterfeit the same occurrence coordinate. These
+    // type-intrinsic probes do not produce cache-eligible integers at this
+    // checked-index phase, so bind, shadow, and restored probes all retry and
+    // preserve their source-order semantics rather than publishing a result.
+    assert_eq!(body.work.checked_const_index_evaluations, 6);
+    assert_eq!(body.work.checked_const_index_cache_hits, 0);
+    assert_eq!(body.work.checked_const_index_candidate_comparisons, 0);
+}
+
+#[test]
+fn counterfeit_same_span_index_expression_cannot_hit() {
+    let source =
+        "fn main() { let mut values: [i32; 2] = [10, 20]; values[1] += 2; values[1 / 0] += 2; }";
+    let first_index = source.find("values[1]").expect("first index") + "values[".len();
+    let failed_index = source.find("1 / 0").expect("failing index");
+    let first_index_span = rue_span::Span::new(first_index as u32, (first_index + 1) as u32);
+    let failed_index_span = rue_span::Span::new(failed_index as u32, (failed_index + 5) as u32);
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    let mut first_failure = None;
+    for _attempt in 0..2 {
+        reset_checked_const_index_test_stats();
+        let error = fixture
+            .analyze_span_edited(source, "main", |_, span| {
+                if span == failed_index_span {
+                    first_index_span
+                } else {
+                    span
+                }
+            })
+            .map(|_| ())
+            .expect_err("the same-span trapping expression must be evaluated and rejected");
+        let stats = checked_const_index_test_stats();
+        assert_eq!(stats.evaluations, 2);
+        // The first candidate hit belongs to the first successful compound
+        // index's duplicate. The distinct trapping root reaches a second
+        // comparison, is rejected, evaluated, and never publishes a value.
+        assert_eq!(stats.hits, 1);
+        assert_eq!(stats.candidate_hits, 1);
+        assert_eq!(stats.candidate_rejections, 1);
+        assert_eq!(stats.candidate_comparisons, 2);
+        assert_eq!(stats.comparison_nodes, 2);
+        assert!(
+            matches!(
+                &error.kind,
+                ErrorKind::ComptimeEvaluationFailed { reason }
+                    if reason == "division by zero (this operation would panic at runtime)"
+            ),
+            "unexpected counterfeit diagnostic: {error:?}"
+        );
+        assert_eq!(error_source_slice(source, &error), "1");
+        let span = error.span();
+        if let Some((first_kind, first_span)) = &first_failure {
+            assert_eq!(
+                first_kind, &error.kind,
+                "malformed class must retry exactly"
+            );
+            assert_eq!(*first_span, span, "malformed span must retry exactly");
+        } else {
+            first_failure = Some((error.kind, span));
+        }
+    }
+}
+
+#[test]
+fn distinct_successful_same_span_expression_cannot_reuse_candidate() {
+    let source = "fn main() { let mut values: [i32; 2] = [0, 0]; values[1] += 1; values[2] += 1; }";
+    let one = source.find("values[1]").expect("first index") + "values[".len();
+    let two = source.find("values[2]").expect("second index") + "values[".len();
+    let one_span = rue_span::Span::new(one as u32, (one + 1) as u32);
+    let two_span = rue_span::Span::new(two as u32, (two + 1) as u32);
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    reset_checked_const_index_test_stats();
+    let error = fixture
+        .analyze_span_edited(source, "main", |_, span| {
+            if span == two_span { one_span } else { span }
+        })
+        .map(|_| ())
+        .expect_err("the counterfeit integer two remains out of bounds");
+    assert!(
+        matches!(
+            error.kind,
+            ErrorKind::IndexOutOfBounds {
+                index: 2,
+                length: 2
+            }
+        ),
+        "unexpected child-file diagnostic: {error:?}"
+    );
+    let stats = checked_const_index_test_stats();
+    assert_eq!(stats.evaluations, 2);
+    assert_eq!(stats.hits, 1);
+}
+
+#[test]
+fn same_root_span_with_different_child_files_preserves_uncached_behavior() {
+    let source = "fn main() { let mut values: [i32; 2] = [0, 0]; values[first.LIMIT] += 1; values[second.LIMIT] += 1; }";
+    let first_root_start = source.find("first.LIMIT").expect("first qualified index");
+    let second_root_start = source.find("second.LIMIT").expect("second qualified index");
+    let first_root = rue_span::Span::new(first_root_start as u32, (first_root_start + 11) as u32);
+    let second_root =
+        rue_span::Span::new(second_root_start as u32, (second_root_start + 12) as u32);
+    let second_base = rue_span::Span::new(second_root_start as u32, (second_root_start + 6) as u32);
+    let first_file = rue_span::FileId::new(1);
+
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_imported_const(
+        "first",
+        "fixture/first.rue",
+        "LIMIT",
+        SemanticImportType::I32,
+        SemanticImportConstValue::Integer(1),
+    );
+    fixture.declare_imported_const(
+        "second",
+        "fixture/second.rue",
+        "LIMIT",
+        SemanticImportType::I32,
+        SemanticImportConstValue::Integer(2),
+    );
+    fixture.declare_imported_module_binding("fixture/first.rue", "second", "fixture/second.rue");
+    fixture.set_imported_module_file("fixture/first.rue", first_file);
+    fixture.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    reset_checked_const_index_test_stats();
+    let result = fixture.analyze_span_edited_with_files(
+        source,
+        "main",
+        &[(first_file, source.len() as u32)],
+        |_, span| {
+            if span == second_root {
+                first_root
+            } else if span == second_base {
+                rue_span::Span::with_file(first_file, span.start, span.end)
+            } else {
+                span
+            }
+        },
+    );
+    let error = result
+        .map(|_| ())
+        .expect_err("the foreign child span remains invalid at publication");
+    assert!(
+        matches!(
+            &error.kind,
+            ErrorKind::OutputPublication(reason)
+                if reason == "provider body export failed: ForeignSpan"
+        ),
+        "unexpected child-file diagnostic: {error:?}"
+    );
+    assert_eq!(error.span(), None);
+    let stats = checked_const_index_test_stats();
+    assert_eq!(stats.evaluations, 4);
+    assert_eq!(stats.hits, 0);
+    assert_eq!(stats.candidate_comparisons, 0);
+}
+
+#[test]
+fn non_integer_index_diagnostic_retries_before_checked_cache_admission() {
+    let source = "fn main() { let mut values: [i32; 2] = [0, 0]; values[true] += 1; }";
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    let mut first_failure = None;
+    for _attempt in 0..2 {
+        reset_checked_const_index_test_stats();
+        let error = fixture
+            .analyze(source, "main")
+            .map(|_| ())
+            .expect_err("a boolean index is rejected");
+        assert!(matches!(
+            &error.kind,
+            ErrorKind::TypeMismatch { expected, found }
+                if expected == "integer type" && found == "bool"
+        ));
+        assert_eq!(error_source_slice(source, &error), "true");
+        assert_eq!(checked_const_index_test_stats().evaluations, 0);
+        let span = error.span();
+        if let Some((first_kind, first_span)) = &first_failure {
+            assert_eq!(first_kind, &error.kind);
+            assert_eq!(*first_span, span);
+        } else {
+            first_failure = Some((error.kind, span));
+        }
+    }
+}
+
+#[test]
+fn cancellation_wins_at_checked_const_index_cache_hit() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    let source = "fn main() { let mut values: [i32; 2] = [10, 20]; values[1 + 0] += 2; }";
+    reset_checked_const_index_test_stats();
+    let result = with_cancellation_on_checked_const_index_hit(|| fixture.analyze(source, "main"));
+    let stats = checked_const_index_test_stats();
+    let error = result
+        .map(|_| ())
+        .expect_err("cancellation at the primed cache hit must win");
+    assert!(
+        matches!(&error.kind, ErrorKind::InternalError(message) if message == "body analysis query canceled"),
+        "unexpected cancellation diagnostic: {error:?}"
+    );
+    assert_eq!(stats.evaluations, 1);
+    assert_eq!(stats.hits, 0);
+    assert_eq!(stats.canceled_hits, 1);
+}
+
+#[test]
+fn checked_const_index_cache_is_body_and_specialization_local() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_function(
+        "update",
+        vec![comptime_type_param("T")],
+        SemanticImportType::Unit,
+    );
+    let four = fixture.declare_struct("Four", vec![("x", SemanticImportType::I32)], true);
+    let eight = fixture.declare_struct("Eight", vec![("x", SemanticImportType::I64)], true);
+    let source = "fn update(comptime T: type) { let mut values: [i32; 16] = [0; 16]; values[@size_of(T)] += 2; }";
+
+    let i32_body = fixture
+        .analyze_specialized_with_types(source, "update", &[SemanticImportType::Nominal(four)], &[])
+        .expect("four-byte specialization analyzes");
+    let i64_body = fixture
+        .analyze_specialized_with_types(
+            source,
+            "update",
+            &[SemanticImportType::Nominal(eight)],
+            &[],
+        )
+        .expect("eight-byte specialization analyzes");
+
+    for body in [&i32_body, &i64_body] {
+        assert_eq!(body.work.checked_const_index_evaluations, 2);
+        assert_eq!(body.work.checked_const_index_cache_hits, 0);
+        assert_eq!(body.work.checked_const_index_candidate_comparisons, 0);
+    }
+    assert_ne!(i32_body.export.body, i64_body.export.body);
+}
+
+#[test]
+fn checked_const_index_cache_is_imported_generic_identity_local() {
+    let mut fixture = ProviderFixture::new();
+    let limit = fixture.declare_const(
+        "LIMIT",
+        SemanticImportType::I32,
+        SemanticImportConstValue::Integer(1),
+    );
+    fixture.declare_function(
+        "update",
+        vec![comptime_type_param("T")],
+        SemanticImportType::Unit,
+    );
+    let four = fixture.declare_struct("Four", vec![("x", SemanticImportType::I32)], true);
+    let eight = fixture.declare_struct("Eight", vec![("x", SemanticImportType::I64)], true);
+    let source = "fn update(comptime T: type) { let mut values: [i32; 16] = [0; 16]; values[LIMIT + @size_of(T)] += 2; }";
+
+    let mut exports = Vec::new();
+    for ty in [four, eight] {
+        let body = fixture
+            .analyze_specialized_with_types(
+                source,
+                "update",
+                &[SemanticImportType::Nominal(ty)],
+                &[],
+            )
+            .expect("imported generic index analyzes");
+        assert_eq!(body.work.checked_const_index_evaluations, 2);
+        assert_eq!(body.work.checked_const_index_cache_hits, 0);
+        assert_eq!(body.work.checked_const_index_candidate_comparisons, 0);
+        assert!(body.referenced_values.contains(&limit));
+        exports.push(body.export.body);
+    }
+    assert_ne!(exports[0], exports[1]);
+}
+
+#[test]
+fn qualified_imported_const_index_preserves_uncached_retry_behavior() {
+    let mut fixture = ProviderFixture::new();
+    let limit = fixture.declare_imported_const(
+        "module",
+        "fixture/module.rue",
+        "LIMIT",
+        SemanticImportType::I32,
+        SemanticImportConstValue::Integer(1),
+    );
+    fixture.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    let body = fixture
+        .analyze(
+            "fn main() { let mut values: [i32; 2] = [0, 0]; values[module.LIMIT] += 1; }",
+            "main",
+        )
+        .expect("qualified imported constant index analyzes");
+
+    assert_eq!(
+        (
+            body.work.checked_const_index_evaluations,
+            body.work.checked_const_index_cache_hits,
+            body.work.checked_const_index_candidate_comparisons,
+            body.work.checked_const_index_comparison_nodes,
+        ),
+        (2, 0, 0, 0)
+    );
+    assert!(body.referenced_values.contains(&limit));
+}
+
+#[test]
+fn checked_const_index_cache_isolated_across_imported_const_bodies() {
+    let source = "fn main() { let mut values: [i32; 2] = [0, 0]; values[LIMIT] += 1; }";
+
+    let mut in_bounds = ProviderFixture::new();
+    in_bounds.declare_const(
+        "LIMIT",
+        SemanticImportType::I32,
+        SemanticImportConstValue::Integer(1),
+    );
+    in_bounds.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    in_bounds
+        .analyze(source, "main")
+        .expect("the first imported value is in bounds");
+
+    let mut out_of_bounds = ProviderFixture::new();
+    out_of_bounds.declare_const(
+        "LIMIT",
+        SemanticImportType::I32,
+        SemanticImportConstValue::Integer(2),
+    );
+    out_of_bounds.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    let error = out_of_bounds
+        .analyze(source, "main")
+        .map(|_| ())
+        .expect_err("the second imported value must not reuse the first body");
+    assert!(matches!(
+        error.kind,
+        ErrorKind::IndexOutOfBounds {
+            index: 2,
+            length: 2
+        }
+    ));
+    assert_eq!(error_source_slice(source, &error), "LIMIT");
+}
+
+#[test]
+fn checked_const_index_cache_isolated_across_anonymous_producers() {
+    let safe_source = "fn main() { let T = struct { x: i32 }; let mut values: [i32; 8] = [0; 8]; values[@size_of(T)] += 1; }";
+    let wide_source = "fn main() { let T = struct { x: i64 }; let mut values: [i32; 8] = [0; 8]; values[@size_of(T)] += 1; }";
+
+    let mut safe = ProviderFixture::new();
+    safe.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    let safe_body = safe
+        .analyze(safe_source, "main")
+        .expect("the four-byte anonymous producer analyzes");
+
+    let mut wide = ProviderFixture::new();
+    wide.declare_function("main", Vec::new(), SemanticImportType::Unit);
+    let wide_body = wide
+        .analyze(wide_source, "main")
+        .expect("the wide anonymous producer analyzes independently");
+    for body in [&safe_body, &wide_body] {
+        assert_eq!(body.work.checked_const_index_evaluations, 2);
+        assert_eq!(body.work.checked_const_index_cache_hits, 0);
+        assert_eq!(body.work.checked_const_index_candidate_comparisons, 0);
+    }
+    assert_ne!(safe_body.export.body, wide_body.export.body);
 }
 
 #[test]


### PR DESCRIPTION
Fixes RUE-1864.

Cache successful checked constant-index results within one canonical body analysis. Exact instruction hits use a persistent lexical-scope identity; duplicated compound-assignment expressions require typed structural and scope equivalence before reuse. Failures, cancellations, retained queries, specializations, imports, generics, and anonymous producers remain isolated.

Validation:
- scripts/rue unit air index
- scripts/rue quick
- scripts/rue premerge
- oracle-diff generated smoke (full local corpus was attempted twice but the host could not spawn query workers; required CI remains authoritative)