### PR TITLE
RUE-1853: reject stale first-party Rust dependencies

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -33,6 +33,7 @@
 
 load("//:rue_rules.bzl", "rue_program", "rue_program_family", "rue_program_staging", "rue_program_test")
 load("//:test_defs.bzl", "rue_sh_test", "rue_test_suite")
+
 load(":corpus.bzl", "cached_corpus_suite")
 
 rue_sh_test(
@@ -931,10 +932,35 @@ rue_test_suite(
     name = "repository-quality-gates",
     tests = [
         ":adr-registry-validation",
+        ":rustc-first-party-unused-deps-wrapper-tests",
         ":spec-traceability",
         ":tutorial-snippet-tests",
         ":tutorial-snippet-tool-tests",
     ],
+)
+
+python_bootstrap_binary(
+    name = "rustc-first-party-unused-deps-wrapper",
+    main = "scripts/rustc-first-party-unused-deps.py",
+    visibility = ["PUBLIC"],
+)
+
+rue_sh_test(
+    name = "rustc-first-party-unused-deps-wrapper-tests",
+    test = "scripts/test-rustc-first-party-unused-deps.py",
+    resources = [
+        "scripts/rustc-first-party-unused-deps.py",
+        ":gatelib-sources",
+        "toolchains//:rust-toolchain-registration-source",
+        "toolchains//rust:rust-toolchain-declarations-source",
+        "toolchains//rust:rust-toolchain-rule-source",
+    ],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "RUE_RUST_TOOLCHAIN_DECLARATIONS": "$(location toolchains//rust:rust-toolchain-declarations-source)",
+        "RUE_RUST_TOOLCHAIN_REGISTRATION": "$(location toolchains//:rust-toolchain-registration-source)",
+        "RUE_RUST_TOOLCHAIN_RULE": "$(location toolchains//rust:rust-toolchain-rule-source)",
+    },
 )
 
 rue_sh_test(

--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -5,7 +5,6 @@ rue_crate(
     test_platform = "native",
     deps = [
         "//crates/rue-air:rue-air",
-        "//crates/rue-builtins:rue-builtins",
         "//crates/rue-cfg:rue-cfg",
         "//crates/rue-error:rue-error",
         "//crates/rue-runtime-abi:rue-runtime-abi",

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -6,7 +6,6 @@ _DEPS = [
     # The published phase taxonomy lives with the measurement contract, so the
     # collector and the run-object schema cannot drift on wire names.
     "//crates/rue-perf-schema:rue-perf-schema",
-    "//crates/rue-rir:rue-rir",
     "//crates/rue-target:rue-target",
     "//third-party:ahash",
     "//third-party:libc",

--- a/rust-project.json
+++ b/rust-project.json
@@ -358,10 +358,6 @@
           "name": "rue_air"
         },
         {
-          "crate": 4,
-          "name": "rue_builtins"
-        },
-        {
           "crate": 5,
           "name": "rue_cfg"
         },
@@ -1266,10 +1262,6 @@
           "name": "rue_perf_schema"
         },
         {
-          "crate": 20,
-          "name": "rue_rir"
-        },
-        {
           "crate": 26,
           "name": "rue_target"
         },
@@ -1332,10 +1324,6 @@
         {
           "crate": 18,
           "name": "rue_perf_schema"
-        },
-        {
-          "crate": 20,
-          "name": "rue_rir"
         },
         {
           "crate": 26,

--- a/scripts/rustc-first-party-unused-deps.py
+++ b/scripts/rustc-first-party-unused-deps.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Run rustc and reject only unused direct first-party Rue crate dependencies.
+
+Buck's Rust action requests rustc's `unused-externs-silent` notification, but
+the upstream switch covers every `--extern`. This wrapper changes that lint to
+force-warn so an unused third-party crate cannot fail compilation, then filters
+the notification using the owner encoded in each hermetic Buck artifact path.
+Only artifacts proved to be owned by `root//crates/...` are promoted to errors;
+unknown workspace layouts fail closed for an audited production consumer.
+
+The wrapper is the toolchain compiler, so it sees the exact configured crate
+root, cfgs, generated/mapped sources, proc macros, aliases, and extern names.
+It preserves rustc stdout and every unrelated stderr record verbatim.
+Enforcement happens on each configured production compilation that actually
+runs; this is not a proactive all-target or all-configuration audit. The
+pre-existing first-party findings are an explicit target/concrete-dependency
+baseline with per-edge reasons. It is reviewed debt, not self-pruning evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from enum import Enum, auto
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+
+UNUSED_FLAGS = {
+    "-Wunused-crate-dependencies",
+    "-Wunused_crate_dependencies",
+}
+FORCE_WARN = "--force-warn=unused-crate-dependencies"
+ARTIFACT_LAYOUT = re.compile(r"(?:^|/)art/(?P<cell>[^/]+)/(?P<rest>.+)")
+FIRST_PARTY_LAYOUT = re.compile(
+    r"^(?:[0-9a-f]{16,}/)?(?P<package>crates(?:/[^/]+)+)/__(?P<target>[^/]+)__/"
+)
+KNOWN_ROOT_NON_FIRST_PARTY = ("third-party/", "toolchains/", "prelude/")
+
+
+class Ownership(Enum):
+    FIRST_PARTY = auto()
+    KNOWN_NON_FIRST_PARTY = auto()
+    UNKNOWN = auto()
+
+
+@dataclass(frozen=True)
+class BaselineEntry:
+    consumer: str
+    dependency: str
+    reason: str
+
+
+# Exact target identities after configured alias resolution. Each entry is
+# reviewed baseline debt applied in every configuration, not a self-pruning
+# exception. Reasons record why the edge remains outside RUE-1853's two-edge
+# deletion scope; they do not assert that the dependency is needed in production.
+BASELINE_ENTRIES = (
+    BaselineEntry(
+        "root//crates/rue-codegen:rue-codegen",
+        "root//crates/rue-span:rue-span",
+        "used by codegen's in-source test modules; production/test dependency separation is follow-up scope",
+    ),
+    BaselineEntry(
+        "root//crates/rue-fuzz:rue-fuzz",
+        "root//crates/rue-air:rue-air",
+        "the fuzz binary uses rue-air-fuzz-support instead of the base crate directly",
+    ),
+    BaselineEntry(
+        "root//crates/rue-fuzz:rue-fuzz",
+        "root//crates/rue-cfg:rue-cfg",
+        "the fuzz binary uses rue-cfg-fuzz-support instead of the base crate directly",
+    ),
+    BaselineEntry(
+        "root//crates/rue-fuzz:rue-fuzz",
+        "root//crates/rue-rir:rue-rir",
+        "the fuzz binary uses rue-rir-fuzz-support instead of the base crate directly",
+    ),
+    BaselineEntry(
+        "root//crates/rue:rue-driver",
+        "root//crates/rue-perf-schema:rue-perf-schema",
+        "the shared driver dependency list also serves binaries whose timing module uses the schema",
+    ),
+    BaselineEntry(
+        "root//crates/rue:rue-driver",
+        "root//crates/rue-target:rue-target",
+        "the shared driver dependency list also serves binaries whose output path uses target metadata",
+    ),
+    BaselineEntry(
+        "root//crates/rue-air:rue-air-fuzz-support",
+        "root//crates/rue-lexer:rue-lexer",
+        "the manual fuzz-support target reuses all AIR sources, where lexer use is test-gated",
+    ),
+    BaselineEntry(
+        "root//crates/rue-air:rue-air-fuzz-support",
+        "root//crates/rue-parser:rue-parser",
+        "the manual fuzz-support target reuses all AIR sources, where parser use is test-gated",
+    ),
+)
+BASELINE = {(entry.consumer, entry.dependency): entry for entry in BASELINE_ENTRIES}
+if len(BASELINE) != len(BASELINE_ENTRIES):
+    raise RuntimeError("duplicate first-party unused-dependency baseline edge")
+
+
+def configured_consumer(args: Sequence[str]) -> Optional[str]:
+    values = [
+        arg[len("-Cmetadata=") :].split("#", 1)[0]
+        for arg in args
+        if arg.startswith("-Cmetadata=root//")
+    ]
+    return values[0] if len(values) == 1 else None
+
+
+def extern_artifacts(args: Sequence[str]) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        value: Optional[str] = None
+        if arg.startswith("--extern="):
+            value = arg[len("--extern=") :]
+        elif arg == "--extern" and index + 1 < len(args):
+            index += 1
+            value = args[index]
+        if value and "=" in value:
+            name, artifact = value.split("=", 1)
+            if name in result and result[name] != artifact:
+                raise ValueError(f"ambiguous --extern artifact for {name!r}")
+            result[name] = artifact
+        index += 1
+    return result
+
+
+def inspection_args(args: Sequence[str], depth: int = 0) -> List[str]:
+    """Expand rustc response files for policy inspection only."""
+    if depth > 8:
+        raise ValueError("rustc response-file nesting exceeds 8")
+    result: List[str] = []
+    for arg in args:
+        if arg.startswith("@"):
+            path = Path(arg[1:])
+            if not path.is_file():
+                raise ValueError(f"rustc response file does not exist: {path}")
+            result.extend(inspection_args(path.read_text().splitlines(), depth + 1))
+        else:
+            result.append(arg)
+    return result
+
+
+def _rewrite_response(path: Path, temporary: List[Path], depth: int) -> Path:
+    if depth > 8:
+        raise ValueError("rustc response-file nesting exceeds 8")
+    rewritten: List[str] = []
+    for line in path.read_text().splitlines():
+        if line in UNUSED_FLAGS:
+            rewritten.append(FORCE_WARN)
+        elif line.startswith("@"):
+            nested = _rewrite_response(Path(line[1:]), temporary, depth + 1)
+            rewritten.append("@" + str(nested))
+        else:
+            rewritten.append(line)
+    handle = tempfile.NamedTemporaryFile(
+        mode="w", prefix="rue-rustc-args-", suffix=".txt", delete=False
+    )
+    with handle:
+        handle.write("\n".join(rewritten) + "\n")
+    result = Path(handle.name)
+    temporary.append(result)
+    return result
+
+
+def invocation_args(args: Sequence[str]) -> Tuple[List[str], List[Path]]:
+    """Force-warn the lint without flattening Buck's response-file command."""
+    result: List[str] = []
+    temporary: List[Path] = []
+    try:
+        for arg in args:
+            if arg in UNUSED_FLAGS:
+                result.append(FORCE_WARN)
+            elif arg.startswith("@"):
+                result.append("@" + str(_rewrite_response(Path(arg[1:]), temporary, 0)))
+            else:
+                result.append(arg)
+    except (OSError, UnicodeError, ValueError):
+        for path in temporary:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        raise
+    return result, temporary
+
+
+def classify_owner(artifact: str) -> Tuple[Ownership, Optional[str]]:
+    layout = ARTIFACT_LAYOUT.search(artifact.replace("\\", "/"))
+    if layout is None:
+        return Ownership.UNKNOWN, None
+    cell = layout.group("cell")
+    rest = layout.group("rest")
+    if cell != "root":
+        return Ownership.KNOWN_NON_FIRST_PARTY, None
+    match = FIRST_PARTY_LAYOUT.match(rest)
+    if match is not None:
+        owner = f"root//{match.group('package')}:{match.group('target')}"
+        return Ownership.FIRST_PARTY, owner
+    unhashed_rest = re.sub(r"^[0-9a-f]{16,}/", "", rest)
+    if unhashed_rest.startswith(KNOWN_ROOT_NON_FIRST_PARTY):
+        return Ownership.KNOWN_NON_FIRST_PARTY, None
+    return Ownership.UNKNOWN, None
+
+
+def compiler_output_paths(args: Sequence[str]) -> List[Path]:
+    """Return the concrete files rustc was asked to create."""
+    values: List[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg.startswith("--emit="):
+            values.extend(arg[len("--emit=") :].split(","))
+        elif arg == "--emit" and index + 1 < len(args):
+            index += 1
+            values.extend(args[index].split(","))
+        elif arg.startswith("-o="):
+            values.append("output=" + arg[len("-o=") :])
+        elif arg == "-o" and index + 1 < len(args):
+            index += 1
+            values.append("output=" + args[index])
+        index += 1
+    return [Path(value.split("=", 1)[1]) for value in values if "=" in value]
+
+
+def remove_compiler_outputs(paths: Sequence[Path]) -> List[str]:
+    """Remove every explicit output and return deterministic cleanup errors."""
+    errors: List[str] = []
+    for path in paths:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as error:
+            errors.append(f"{path}: {error}")
+    for path in paths:
+        if path.exists() or path.is_symlink():
+            message = f"{path}: output still exists after cleanup"
+            if not any(error.startswith(f"{path}:") for error in errors):
+                errors.append(message)
+    return errors
+
+
+def filter_unused(
+    diagnostic: Dict[str, object],
+    consumer: Optional[str],
+    externs: Dict[str, str],
+    audit_consumer: bool = True,
+) -> Tuple[Optional[Dict[str, object]], List[Tuple[str, str]]]:
+    raw_names = diagnostic.get("unused_extern_names")
+    if not isinstance(raw_names, list):
+        return diagnostic, []
+    names = sorted({name for name in raw_names if isinstance(name, str)})
+    findings: List[Tuple[str, str]] = []
+    kept: List[str] = []
+    for name in names:
+        artifact = externs.get(name)
+        if artifact is None:
+            raise ValueError(f"unused extern {name!r} has no unique --extern artifact")
+        ownership, owner = classify_owner(artifact)
+        if not audit_consumer:
+            continue
+        if ownership == Ownership.KNOWN_NON_FIRST_PARTY:
+            continue
+        if ownership == Ownership.UNKNOWN:
+            raise ValueError(f"unused extern {name!r} has unknown Buck artifact ownership: {artifact!r}")
+        assert owner is not None
+        if consumer is None:
+            raise ValueError("first-party unused extern has no unique configured consumer metadata")
+        if (consumer, owner) in BASELINE:
+            continue
+        kept.append(name)
+        findings.append((consumer, owner))
+    if not kept:
+        return None, []
+    diagnostic["unused_extern_names"] = kept
+    diagnostic["lint_level"] = "deny"
+    return diagnostic, findings
+
+
+def policy_diagnostic(consumer: str, dependency: str) -> Dict[str, object]:
+    message = f"unused direct first-party Rust dependency: {consumer} -> {dependency}"
+    return {
+        "$message_type": "diagnostic",
+        "message": message,
+        "code": {"code": "unused_crate_dependencies", "explanation": None},
+        "level": "error",
+        "spans": [],
+        "children": [],
+        "rendered": "error: " + message + "\n",
+    }
+
+
+def run(argv: Sequence[str]) -> int:
+    if not argv:
+        print("rustc-first-party-unused-deps: missing compiler", file=sys.stderr)
+        return 2
+    compiler, raw_args = argv[0], list(argv[1:])
+    temporary: List[Path] = []
+    try:
+        inspected = inspection_args(raw_args)
+        consumer = configured_consumer(inspected)
+        audit_consumer = (
+            "--test" not in inspected
+            and (consumer is None or consumer.startswith("root//crates/"))
+        )
+        externs = extern_artifacts(inspected)
+        outputs = compiler_output_paths(inspected)
+        args, temporary = invocation_args(raw_args)
+    except (OSError, UnicodeError, ValueError) as error:
+        print(f"rustc-first-party-unused-deps: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        process = subprocess.Popen(
+            [compiler] + args,
+            stdout=None,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except OSError as error:
+        print(f"rustc-first-party-unused-deps: {error}", file=sys.stderr)
+        for path in temporary:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        return 2
+    assert process.stderr is not None
+    forwarded_signals: List[int] = []
+
+    def forward_signal(signum: int, _frame: object) -> None:
+        if not forwarded_signals:
+            forwarded_signals.append(signum)
+        try:
+            os.killpg(process.pid, signum)
+        except ProcessLookupError:
+            pass
+
+    handled_signals = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
+    previous_handlers = {
+        signum: signal.signal(signum, forward_signal) for signum in handled_signals
+    }
+    policy_failed = False
+    wrapper_failed = False
+    try:
+        for line in process.stderr:
+            try:
+                diagnostic = json.loads(line)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                sys.stderr.buffer.write(line)
+                continue
+            if not isinstance(diagnostic, dict):
+                sys.stderr.buffer.write(line)
+                continue
+            try:
+                filtered, findings = filter_unused(
+                    diagnostic, consumer, externs, audit_consumer=audit_consumer
+                )
+            except ValueError as error:
+                print(f"rustc-first-party-unused-deps: {error}", file=sys.stderr)
+                wrapper_failed = True
+                continue
+            policy_failed = policy_failed or bool(findings)
+            if filtered is not None:
+                sys.stderr.write(json.dumps(filtered, separators=(",", ":")) + "\n")
+            for finding in findings:
+                sys.stderr.write(
+                    json.dumps(policy_diagnostic(*finding), separators=(",", ":")) + "\n"
+                )
+        returncode = process.wait()
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+    for path in temporary:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+    if forwarded_signals:
+        received_signal = forwarded_signals[0]
+        signal.signal(received_signal, signal.SIG_DFL)
+        os.kill(os.getpid(), received_signal)
+        return 128 + received_signal
+    if returncode != 0:
+        if returncode < 0:
+            received_signal = -returncode
+            signal.signal(received_signal, signal.SIG_DFL)
+            os.kill(os.getpid(), received_signal)
+            return 128 + received_signal
+        return returncode
+    if policy_failed or wrapper_failed:
+        cleanup_errors = remove_compiler_outputs(outputs)
+        if cleanup_errors:
+            for error in cleanup_errors:
+                print(
+                    f"rustc-first-party-unused-deps: cannot remove compiler output: {error}",
+                    file=sys.stderr,
+                )
+            return 2
+    if wrapper_failed:
+        return 2
+    return 1 if policy_failed else 0
+
+
+def main() -> int:
+    return run(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-rustc-first-party-unused-deps.py
+++ b/scripts/test-rustc-first-party-unused-deps.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""Focused tests for the repo-owned rustc unused-dependency wrapper."""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from gatelib import load_script
+
+WRAPPER = load_script("rustc-first-party-unused-deps.py", __file__)
+
+EXPECTED_TOOLCHAINS = {
+    ("prelude//os:linux", "prelude//cpu:arm64"): "toolchains//rust:hermetic-linux-aarch64",
+    ("prelude//os:linux", "prelude//cpu:x86_64"): "toolchains//rust:hermetic-linux-x86_64",
+    ("prelude//os:macos", "prelude//cpu:arm64"): "toolchains//rust:hermetic-macos-aarch64",
+    ("prelude//os:macos", "prelude//cpu:x86_64"): "toolchains//rust:hermetic-macos-x86_64",
+}
+
+
+def calls_named(source: str, name: str):
+    tree = ast.parse(source)
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == name
+    ]
+
+
+def string_keyword(call, name: str) -> str:
+    for keyword in call.keywords:
+        if keyword.arg == name and isinstance(keyword.value, ast.Constant):
+            if isinstance(keyword.value.value, str):
+                return keyword.value.value
+    raise ValueError(f"{name} must be a literal string")
+
+
+def rust_alias_mapping(source: str):
+    aliases = [
+        call
+        for call in calls_named(source, "toolchain_alias")
+        if string_keyword(call, "name") == "rust"
+    ]
+    if len(aliases) != 1:
+        raise ValueError("expected exactly one rust toolchain_alias")
+    actual = next(
+        (keyword.value for keyword in aliases[0].keywords if keyword.arg == "actual"), None
+    )
+    if not (
+        isinstance(actual, ast.Call)
+        and isinstance(actual.func, ast.Name)
+        and actual.func.id == "select"
+        and len(actual.args) == 1
+        and isinstance(actual.args[0], ast.Dict)
+    ):
+        raise ValueError("rust toolchain_alias actual must be a nested select")
+    result = {}
+    for os_node, cpu_select in zip(actual.args[0].keys, actual.args[0].values):
+        if not isinstance(os_node, ast.Constant) or not isinstance(os_node.value, str):
+            raise ValueError("rust toolchain OS key must be a literal string")
+        if not (
+            isinstance(cpu_select, ast.Call)
+            and isinstance(cpu_select.func, ast.Name)
+            and cpu_select.func.id == "select"
+            and len(cpu_select.args) == 1
+            and isinstance(cpu_select.args[0], ast.Dict)
+        ):
+            raise ValueError("rust toolchain CPU mapping must be a nested select")
+        for cpu_node, target_node in zip(cpu_select.args[0].keys, cpu_select.args[0].values):
+            if not all(
+                isinstance(node, ast.Constant) and isinstance(node.value, str)
+                for node in (cpu_node, target_node)
+            ):
+                raise ValueError("rust toolchain CPU and target must be literal strings")
+            result[(os_node.value, cpu_node.value)] = target_node.value
+    return result
+
+
+def declared_audited_toolchains(source: str):
+    result = set()
+    for call in calls_named(source, "hermetic_rust_toolchain"):
+        name = string_keyword(call, "name")
+        enabled = next(
+            (keyword.value for keyword in call.keywords if keyword.arg == "report_unused_deps"),
+            None,
+        )
+        if isinstance(enabled, ast.Constant) and enabled.value is True:
+            result.add("toolchains//rust:" + name)
+    return result
+
+
+def validate_rule_forwarding(source: str) -> None:
+    forwarding = "report_unused_deps = ctx.attrs.report_unused_deps,"
+    attribute = '"report_unused_deps": attrs.bool(default = False),'
+    if source.count(forwarding) != 1:
+        raise ValueError("RustToolchainInfo must forward report_unused_deps exactly once")
+    if source.count(attribute) != 1:
+        raise ValueError("hermetic toolchain must declare report_unused_deps exactly once")
+
+
+class WrapperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.fake = self.root / "fake-compiler.py"
+        self.fake.write_text(
+            """#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+path = os.environ.get("FAKE_ARGS")
+if path:
+    open(path, "w").write(json.dumps(sys.argv[1:]))
+for arg in sys.argv[1:]:
+    if arg.startswith("--emit=metadata="):
+        Path(arg[len("--emit=metadata="):]).write_text("artifact")
+raw = os.environ.get("FAKE_UNUSED", "")
+if raw:
+    print(json.dumps({"unused_extern_names": raw.split(","), "lint_level": "warn"}), file=sys.stderr)
+extra = os.environ.get("FAKE_STDERR")
+if extra:
+    print(extra, file=sys.stderr)
+print("compiler stdout")
+if os.environ.get("FAKE_WAIT_READY"):
+    import signal
+    ready = Path(os.environ["FAKE_WAIT_READY"])
+    received = Path(os.environ["FAKE_WAIT_RECEIVED"])
+    def stop(signum, _frame):
+        received.write_text(str(signum))
+        raise SystemExit(0)
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGHUP, stop)
+    ready.write_text(str(os.getpid()))
+    while True:
+        signal.pause()
+if os.environ.get("FAKE_SIGNAL"):
+    os.kill(os.getpid(), int(os.environ["FAKE_SIGNAL"]))
+raise SystemExit(int(os.environ.get("FAKE_EXIT", "0")))
+"""
+        )
+        self.fake.chmod(0o755)
+        self.args_file = self.root / "args.json"
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    @staticmethod
+    def artifact(package: str, target: str) -> str:
+        return f"buck-out/v2/art/root/{package}/__{target}__/hash/LPPM/lib.rmeta"
+
+    def invoke(
+        self,
+        unused: str,
+        externs,
+        consumer: str = "root//crates/app:app",
+        output: Path = None,
+        extra_args=(),
+        **env,
+    ):
+        argv = [
+            sys.executable,
+            str(Path(__file__).with_name("rustc-first-party-unused-deps.py")),
+            str(self.fake),
+            "-Dwarnings",
+            "-Wunused-crate-dependencies",
+            f"-Cmetadata={consumer}#configured-hash",
+        ]
+        if output is not None:
+            argv.append("--emit=metadata=" + str(output))
+        argv.extend(extra_args)
+        argv.extend(f"--extern={name}={artifact}" for name, artifact in externs.items())
+        process_env = os.environ.copy()
+        process_env.update({"FAKE_UNUSED": unused, "FAKE_ARGS": str(self.args_file)})
+        process_env.update(env)
+        return subprocess.run(argv, text=True, capture_output=True, env=process_env)
+
+    def test_unused_first_party_dependency_is_rejected_from_real_wrapper_process(self):
+        result = self.invoke(
+            "dep",
+            {"dep": self.artifact("crates/dep", "dep")},
+        )
+        self.assertEqual(result.returncode, 1)
+        records = [json.loads(line) for line in result.stderr.splitlines()]
+        diagnostic = records[0]
+        self.assertEqual(diagnostic["unused_extern_names"], ["dep"])
+        self.assertEqual(diagnostic["lint_level"], "deny")
+        self.assertEqual(records[1]["level"], "error")
+        self.assertIn("root//crates/app:app -> root//crates/dep:dep", records[1]["message"])
+        args = json.loads(self.args_file.read_text())
+        self.assertIn("--force-warn=unused-crate-dependencies", args)
+        self.assertNotIn("-Wunused-crate-dependencies", args)
+        self.assertEqual(result.stdout, "compiler stdout\n")
+
+    def test_unused_third_party_dependency_is_not_rejected(self):
+        result = self.invoke(
+            "serde",
+            {"serde": self.artifact("third-party", "serde-1.0.0")},
+        )
+        self.assertEqual(result.returncode, 0)
+
+        test_action = self.invoke(
+            "dep",
+            {"dep": self.artifact("crates/test-support", "test-support")},
+            consumer="root//crates/app:app-test",
+            extra_args=("--test",),
+        )
+        self.assertEqual(test_action.returncode, 0)
+        self.assertEqual(result.stderr, "")
+
+    def test_policy_failure_removes_rustc_output_but_third_party_finding_does_not(self):
+        output = self.root / "artifact.rmeta"
+        rejected = self.invoke(
+            "dep", {"dep": self.artifact("crates/dep", "dep")}, output=output
+        )
+        self.assertEqual(rejected.returncode, 1)
+        self.assertFalse(output.exists())
+
+        accepted = self.invoke(
+            "serde", {"serde": self.artifact("third-party", "serde")}, output=output
+        )
+        self.assertEqual(accepted.returncode, 0)
+        self.assertEqual(output.read_text(), "artifact")
+
+    def test_mixed_notification_retains_only_first_party_names_deterministically(self):
+        result = self.invoke(
+            "serde,dep",
+            {
+                "serde": self.artifact("third-party", "serde-1.0.0"),
+                "dep": self.artifact("crates/dep", "dep"),
+            },
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(json.loads(result.stderr.splitlines()[0])["unused_extern_names"], ["dep"])
+
+    def test_exact_baseline_edge_is_suppressed_but_neighbor_is_not(self):
+        result = self.invoke(
+            "rue_span,other",
+            {
+                "rue_span": self.artifact("crates/rue-span", "rue-span"),
+                "other": self.artifact("crates/other", "other"),
+            },
+            consumer="root//crates/rue-codegen:rue-codegen",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(json.loads(result.stderr.splitlines()[0])["unused_extern_names"], ["other"])
+
+    def test_manual_target_and_renamed_extern_use_concrete_artifact_owner(self):
+        result = self.invoke(
+            "wire_name",
+            {"wire_name": self.artifact("crates/manual", "manual-support")},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("wire_name", result.stderr)
+        self.assertEqual(
+            WRAPPER.classify_owner(self.artifact("crates/manual", "_internal_")),
+            (WRAPPER.Ownership.FIRST_PARTY, "root//crates/manual:_internal_"),
+        )
+
+    def test_artifact_ownership_is_explicit_and_supports_buck_layouts(self):
+        cases = {
+            self.artifact("crates/generated/nested", "macro-provider"): (
+                WRAPPER.Ownership.FIRST_PARTY,
+                "root//crates/generated/nested:macro-provider",
+            ),
+            "/remote/worker/root/buck-out/v2/art/root/crates/dep/__dep__/hash/lib.rmeta": (
+                WRAPPER.Ownership.FIRST_PARTY,
+                "root//crates/dep:dep",
+            ),
+            "buck-out/v2/art/root/0123456789abcdef/crates/dep/__dep__/lib.rmeta": (
+                WRAPPER.Ownership.FIRST_PARTY,
+                "root//crates/dep:dep",
+            ),
+            self.artifact("third-party", "serde"): (
+                WRAPPER.Ownership.KNOWN_NON_FIRST_PARTY,
+                None,
+            ),
+            "buck-out/v2/art/toolchains/hash/rust/__rustc__/rustc": (
+                WRAPPER.Ownership.KNOWN_NON_FIRST_PARTY,
+                None,
+            ),
+            "buck-out/v2/art/external-cell/pkg/__dep__/lib.rmeta": (
+                WRAPPER.Ownership.KNOWN_NON_FIRST_PARTY,
+                None,
+            ),
+            "buck-out/v2/art/root/generated/__dep__/lib.rmeta": (
+                WRAPPER.Ownership.UNKNOWN,
+                None,
+            ),
+        }
+        for artifact, expected in cases.items():
+            with self.subTest(artifact=artifact):
+                self.assertEqual(WRAPPER.classify_owner(artifact), expected)
+
+    def test_unknown_artifact_ownership_fails_closed_only_for_audited_consumer(self):
+        unknown = "buck-out/v2/art/root/generated/__dep__/lib.rmeta"
+        result = self.invoke("dep", {"dep": unknown})
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("unknown Buck artifact ownership", result.stderr)
+        test_action = self.invoke(
+            "dep", {"dep": unknown}, extra_args=("--test",)
+        )
+        self.assertEqual(test_action.returncode, 0)
+
+    def test_relative_select_and_alias_spelling_do_not_affect_configured_identity(self):
+        diagnostic = {"unused_extern_names": ["renamed"], "lint_level": "warn"}
+        filtered, findings = WRAPPER.filter_unused(
+            diagnostic,
+            "root//crates/app:app",
+            {"renamed": self.artifact("crates/dep", "concrete")},
+        )
+        self.assertIsNotNone(filtered)
+        self.assertEqual(findings, [("root//crates/app:app", "root//crates/dep:concrete")])
+
+    def test_test_only_and_non_crate_consumers_are_outside_production_policy(self):
+        diagnostic = {"unused_extern_names": ["dep"], "lint_level": "warn"}
+        filtered, findings = WRAPPER.filter_unused(
+            diagnostic,
+            "root//crates/app:app-test",
+            {"dep": self.artifact("crates/test-support", "test-support")},
+            audit_consumer=False,
+        )
+        self.assertIsNone(filtered)
+        self.assertEqual(findings, [])
+
+        result = self.invoke(
+            "dep",
+            {"dep": self.artifact("crates/dep", "dep")},
+            consumer="root//third-party:build-script",
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_non_policy_stderr_and_compiler_exit_are_preserved(self):
+        result = self.invoke("", {}, FAKE_STDERR="ordinary compiler error", FAKE_EXIT="7")
+        self.assertEqual(result.returncode, 7)
+        self.assertEqual(result.stderr, "ordinary compiler error\n")
+
+    def test_compiler_signal_is_relayed(self):
+        result = self.invoke("", {}, FAKE_SIGNAL="15")
+        self.assertEqual(result.returncode, -15)
+
+    def test_wrapper_termination_reaches_live_compiler_and_is_relayed(self):
+        ready = self.root / "ready"
+        received = self.root / "received"
+        env = os.environ.copy()
+        env.update(
+            {
+                "FAKE_WAIT_READY": str(ready),
+                "FAKE_WAIT_RECEIVED": str(received),
+            }
+        )
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(Path(__file__).with_name("rustc-first-party-unused-deps.py")),
+                str(self.fake),
+                "-Cmetadata=root//crates/app:app#configured-hash",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+        for _ in range(100):
+            if ready.exists():
+                break
+            time.sleep(0.02)
+        self.assertTrue(ready.exists())
+        process.terminate()
+        process.communicate(timeout=5)
+        self.assertEqual(process.returncode, -15)
+        self.assertEqual(received.read_text(), "15")
+
+    def test_missing_configured_consumer_fails_closed_for_first_party_only(self):
+        result = self.invoke(
+            "dep",
+            {"dep": self.artifact("crates/dep", "dep")},
+            consumer="not-a-buck-target",
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("no unique configured consumer", result.stderr)
+
+    def test_ambiguous_extern_artifacts_fail_closed(self):
+        with self.assertRaisesRegex(ValueError, "ambiguous"):
+            WRAPPER.extern_artifacts(
+                [
+                    "--extern=dep=one",
+                    "--extern",
+                    "dep=two",
+                ]
+            )
+
+    def test_response_file_is_inspected_and_rewritten_without_flattening(self):
+        response = self.root / "rustc.args"
+        response.write_text(
+            "\n".join(
+                [
+                    "-Dwarnings",
+                    "-Wunused-crate-dependencies",
+                    "-Cmetadata=root//crates/app:app#configured-hash",
+                    "--extern=dep=" + self.artifact("crates/dep", "dep"),
+                ]
+            )
+            + "\n"
+        )
+        process_env = os.environ.copy()
+        process_env.update({"FAKE_UNUSED": "dep", "FAKE_ARGS": str(self.args_file)})
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).with_name("rustc-first-party-unused-deps.py")),
+                str(self.fake),
+                "@" + str(response),
+            ],
+            text=True,
+            capture_output=True,
+            env=process_env,
+        )
+        self.assertEqual(result.returncode, 1)
+        forwarded = json.loads(self.args_file.read_text())
+        self.assertEqual(len(forwarded), 1)
+        self.assertTrue(forwarded[0].startswith("@"))
+        self.assertNotEqual(forwarded[0][1:], str(response))
+        self.assertFalse(Path(forwarded[0][1:]).exists())
+        self.assertIn("dep", result.stderr)
+
+    def test_response_file_replaces_lint_before_invoking_compiler(self):
+        response = self.root / "rustc.args"
+        response.write_text("-Dwarnings\n-Wunused-crate-dependencies\n")
+        args, temporary = WRAPPER.invocation_args(["@" + str(response)])
+        try:
+            self.assertEqual(len(args), 1)
+            rewritten = Path(args[0][1:]).read_text().splitlines()
+            self.assertEqual(rewritten, ["-Dwarnings", WRAPPER.FORCE_WARN])
+        finally:
+            for path in temporary:
+                path.unlink()
+
+    def test_output_parsing_covers_multiple_emit_and_output_forms(self):
+        self.assertEqual(
+            WRAPPER.compiler_output_paths(
+                [
+                    "--emit=metadata=one.rmeta,dep-info=one.d",
+                    "--emit",
+                    "link=one-bin",
+                    "-o=two-bin",
+                    "-o",
+                    "three-bin",
+                ]
+            ),
+            [
+                Path("one.rmeta"),
+                Path("one.d"),
+                Path("one-bin"),
+                Path("two-bin"),
+                Path("three-bin"),
+            ],
+        )
+
+    def test_output_cleanup_attempts_every_path_before_reporting(self):
+        first = self.root / "first"
+        second = self.root / "second"
+        first.write_text("first")
+        second.write_text("second")
+        real_unlink = Path.unlink
+
+        def selective_unlink(path, *args, **kwargs):
+            if path == first:
+                raise PermissionError("fixture refusal")
+            return real_unlink(path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", selective_unlink):
+            errors = WRAPPER.remove_compiler_outputs([first, second])
+        self.assertEqual(len(errors), 1)
+        self.assertIn("first", errors[0])
+        self.assertTrue(first.exists())
+        self.assertFalse(second.exists())
+
+    def test_baseline_entries_are_exact_unique_and_reasoned(self):
+        self.assertEqual(len(WRAPPER.BASELINE_ENTRIES), 8)
+        self.assertEqual(len(WRAPPER.BASELINE), len(WRAPPER.BASELINE_ENTRIES))
+        for entry in WRAPPER.BASELINE_ENTRIES:
+            self.assertTrue(entry.consumer.startswith("root//crates/"))
+            self.assertTrue(entry.dependency.startswith("root//crates/"))
+            self.assertGreaterEqual(len(entry.reason.split()), 6)
+
+
+class ToolchainRegistrationTests(unittest.TestCase):
+    def test_every_supported_registration_uses_an_audited_toolchain(self):
+        registration = Path(os.environ["RUE_RUST_TOOLCHAIN_REGISTRATION"]).read_text()
+        declarations = Path(os.environ["RUE_RUST_TOOLCHAIN_DECLARATIONS"]).read_text()
+        mapping = rust_alias_mapping(registration)
+        self.assertEqual(mapping, EXPECTED_TOOLCHAINS)
+        self.assertEqual(declared_audited_toolchains(declarations), set(mapping.values()))
+
+    def test_compiler_and_clippy_are_both_wrapped_by_the_policy_tool(self):
+        source = Path(os.environ["RUE_RUST_TOOLCHAIN_RULE"]).read_text()
+        validate_rule_forwarding(source)
+        self.assertIn("compiler = RunInfo(args = cmd_args(\n        unused_deps_wrapper,\n        rustc_bin,", source)
+        self.assertIn('unused_deps_wrapper = ctx.attrs.unused_deps_wrapper[DefaultInfo].default_outputs[0]', source)
+        self.assertIn('                "exec python3 ",', source)
+        self.assertIn('                " \\\"$@\\\"",\n                delimiter = "",', source)
+        self.assertIn('default = "root//:rustc-first-party-unused-deps-wrapper"', source)
+
+    def test_report_unused_deps_forwarding_and_attribute_fail_closed_on_mutation(self):
+        source = Path(os.environ["RUE_RUST_TOOLCHAIN_RULE"]).read_text()
+        mutations = (
+            source.replace(
+                "report_unused_deps = ctx.attrs.report_unused_deps,", "", 1
+            ),
+            source.replace(
+                "report_unused_deps = ctx.attrs.report_unused_deps,",
+                "report_unused_deps = False,",
+                1,
+            ),
+            source.replace('"report_unused_deps": attrs.bool(default = False),', "", 1),
+            source.replace(
+                '"report_unused_deps": attrs.bool(default = False),',
+                '"report_unused_deps": attrs.string(default = "false"),',
+                1,
+            ),
+        )
+        for mutation in mutations:
+            with self.subTest():
+                with self.assertRaises(ValueError):
+                    validate_rule_forwarding(mutation)
+
+    def test_future_or_unregistered_toolchain_cannot_be_silently_omitted(self):
+        declarations = Path(os.environ["RUE_RUST_TOOLCHAIN_DECLARATIONS"]).read_text()
+        incomplete = declarations.replace(
+            '    report_unused_deps = True,\n    deny_lints = ["warnings"],',
+            '    report_unused_deps = False,\n    deny_lints = ["warnings"],',
+            1,
+        )
+        self.assertNotEqual(
+            declared_audited_toolchains(incomplete), set(EXPECTED_TOOLCHAINS.values())
+        )
+
+        registration = Path(os.environ["RUE_RUST_TOOLCHAIN_REGISTRATION"]).read_text()
+        future = registration.replace(
+            '"prelude//cpu:x86_64": "toolchains//rust:hermetic-linux-x86_64",',
+            '"prelude//cpu:x86_64": "toolchains//rust:future-linux-x86_64",',
+            1,
+        )
+        self.assertNotEqual(rust_alias_mapping(future), EXPECTED_TOOLCHAINS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -23,6 +23,12 @@ load(":cxx_tools.bzl", "cxx_tools_with_linker")
 load(":rue.bzl", "rue_toolchain")
 load(":remote_test_execution.bzl", "noop_remote_test_execution_toolchain")
 
+export_file(
+    name = "rust-toolchain-registration-source",
+    src = "BUCK",
+    visibility = ["root//:rustc-first-party-unused-deps-wrapper-tests"],
+)
+
 cxx_tools_with_linker(
     name = "cxx-tools",
     linker = select({

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -9,6 +9,18 @@ load(":defs.bzl", "RUST_VERSION", "RUST_STD_RELEASES", "hermetic_rust_toolchain"
 load("@root//:test_defs.bzl", "rue_sh_test")
 
 export_file(
+    name = "rust-toolchain-declarations-source",
+    src = "BUCK",
+    visibility = ["root//:rustc-first-party-unused-deps-wrapper-tests"],
+)
+
+export_file(
+    name = "rust-toolchain-rule-source",
+    src = "defs.bzl",
+    visibility = ["root//:rustc-first-party-unused-deps-wrapper-tests"],
+)
+
+export_file(
     name = "merge-sysroot",
     src = "merge_sysroot.sh",
 )
@@ -184,6 +196,7 @@ hermetic_rust_toolchain(
     merge_script = ":merge-sysroot",
     target_triple = "x86_64-unknown-linux-gnu",
     default_edition = "2024",
+    report_unused_deps = True,
     deny_lints = ["warnings"],
     allow_lints = _CLIPPY_ALLOW,
     clippy_toml = "root//:clippy-config",
@@ -200,6 +213,7 @@ hermetic_rust_toolchain(
     merge_script = ":merge-sysroot",
     target_triple = "aarch64-unknown-linux-gnu",
     default_edition = "2024",
+    report_unused_deps = True,
     deny_lints = ["warnings"],
     allow_lints = _CLIPPY_ALLOW,
     clippy_toml = "root//:clippy-config",
@@ -216,6 +230,7 @@ hermetic_rust_toolchain(
     merge_script = ":merge-sysroot",
     target_triple = "aarch64-apple-darwin",
     default_edition = "2024",
+    report_unused_deps = True,
     deny_lints = ["warnings"],
     allow_lints = _CLIPPY_ALLOW,
     clippy_toml = "root//:clippy-config",
@@ -232,6 +247,7 @@ hermetic_rust_toolchain(
     merge_script = ":merge-sysroot",
     target_triple = "x86_64-apple-darwin",
     default_edition = "2024",
+    report_unused_deps = True,
     deny_lints = ["warnings"],
     allow_lints = _CLIPPY_ALLOW,
     clippy_toml = "root//:clippy-config",

--- a/toolchains/rust/defs.bzl
+++ b/toolchains/rust/defs.bzl
@@ -129,7 +129,12 @@ def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
     # merged sysroot contains relative links into it (RUE-316/RUE-1225).
     # This is the relocatable, canonical approach ($ORIGIN RPATH), not an
     # absolute-path LD_LIBRARY_PATH hack.
-    compiler = RunInfo(args = cmd_args(rustc_bin, hidden = [rustc_dist, std_dist]))
+    unused_deps_wrapper = ctx.attrs.unused_deps_wrapper[DefaultInfo].default_outputs[0]
+    compiler = RunInfo(args = cmd_args(
+        unused_deps_wrapper,
+        rustc_bin,
+        hidden = [rustc_dist, std_dist],
+    ))
     rustdoc = RunInfo(args = cmd_args(rustdoc_bin, hidden = [rustc_dist, std_dist]))
 
     # clippy-driver dynamically loads librustc_driver from rustc/lib/, but
@@ -152,12 +157,22 @@ def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
             # Set library path for both macOS and Linux
             cmd_args(clippy_lib_dir, format = "export DYLD_LIBRARY_PATH=\"{}\""),
             cmd_args(clippy_lib_dir, format = "export LD_LIBRARY_PATH=\"{}\""),
-            cmd_args(clippy_bin, format = "exec {} \"$@\""),
+            cmd_args(
+                "exec python3 ",
+                unused_deps_wrapper,
+                " ",
+                clippy_bin,
+                " \"$@\"",
+                delimiter = "",
+            ),
         ],
         is_executable = True,
         allow_args = True,
     )
-    clippy_driver = RunInfo(args = cmd_args(clippy_wrapper, hidden = [clippy_bin, clippy_lib_dir, std_dist]))
+    clippy_driver = RunInfo(args = cmd_args(
+        clippy_wrapper,
+        hidden = [unused_deps_wrapper, clippy_bin, clippy_lib_dir, std_dist],
+    ))
 
     # Build a merged sysroot by running the checked-in shell script. Keeping the
     # script as an explicit action input ensures content changes invalidate the
@@ -224,6 +239,10 @@ hermetic_rust_toolchain = rule(
         ),
         "merge_script": attrs.source(
             doc = "Portable script that assembles a relocatable Rust sysroot",
+        ),
+        "unused_deps_wrapper": attrs.exec_dep(
+            providers = [DefaultInfo],
+            default = "root//:rustc-first-party-unused-deps-wrapper",
         ),
         "target_triple": attrs.string(
             doc = "The target triple (e.g., x86_64-unknown-linux-gnu)",


### PR DESCRIPTION
## Summary

- remove the two verified stale direct first-party dependency edges
- route Rust unused-extern reporting through a configured-target, first-party-only guard
- pin the exact reviewed compatibility baseline and toolchain wiring with structural tests

## Testing

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue premerge`
- focused wrapper, Clippy, affected unit-test, and build targets

Fixes RUE-1853