### PR TITLE
RUE-1659: defer structural read anchors

### DIFF
--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -628,7 +628,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         air: &mut Air,
         module_id: crate::types::ModuleId,
         member_name: Spur,
-        atom_anchor: Option<rue_rir::RirStructuralAnchor>,
+        atom_anchor: Option<InstRef>,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
@@ -749,6 +749,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // A value const (e.g. `pub const ANSWER = ...`) accessed as a
             // module member: materialize the value that was evaluated at
             // declaration time, typed as declared (RUE-160).
+            let atom_anchor = match const_info.value {
+                ConstValue::String(_) => atom_anchor.and_then(|instruction| {
+                    self.body_rir_ref()
+                        .materialize_const_use_anchor(instruction)
+                }),
+                _ => None,
+            };
             let (data, ty) = self.materialize_const_value(
                 ctx,
                 const_info.value,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -258,12 +258,9 @@ pub(crate) fn root_variable_of(rir: &Rir, inst_ref: InstRef) -> Option<Spur> {
     }
 }
 
-pub(crate) fn const_use_anchor_of(
-    rir: &Rir,
-    inst_ref: InstRef,
-) -> Option<rue_rir::RirStructuralAnchor> {
+pub(crate) fn const_use_anchor_of(rir: &Rir, inst_ref: InstRef) -> Option<InstRef> {
     match &rir.get(inst_ref).data {
-        InstData::VarRef { anchor, .. } => anchor.clone(),
+        InstData::VarRef { .. } => Some(inst_ref),
         InstData::FieldGet { base, .. } => const_use_anchor_of(rir, *base),
         _ => None,
     }

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1590,9 +1590,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 air, directives, *name, *is_mut, *ty, *init, *iter_elem, inst.span, ctx,
             ),
 
-            InstData::VarRef { name, anchor } => {
+            InstData::VarRef { name, .. } => {
                 let resolved_ty = ctx.resolved_type_of(inst_ref);
-                self.analyze_var_ref(air, *name, anchor.clone(), inst.span, resolved_ty, ctx)
+                self.analyze_var_ref(air, *name, Some(inst_ref), inst.span, resolved_ty, ctx)
             }
 
             InstData::Assign { name, value } => {
@@ -1893,7 +1893,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         &mut self,
         air: &mut Air,
         name: Spur,
-        atom_anchor: Option<rue_rir::RirStructuralAnchor>,
+        atom_anchor: Option<InstRef>,
         span: Span,
         // The Hindley-Milner-resolved type of this reference, if known. Used
         // to recover the declared width of a captured comptime value parameter
@@ -2230,6 +2230,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     span,
                 ));
             }
+            let atom_anchor = match const_info.value {
+                ConstValue::String(_) => atom_anchor.and_then(|instruction| {
+                    self.body_rir_ref()
+                        .materialize_const_use_anchor(instruction)
+                }),
+                _ => None,
+            };
             let (data, ty) = self.materialize_const_value(
                 ctx,
                 const_info.value,

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -1385,7 +1385,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
 
         // For VarRef, we handle it specially: check for full moves but don't mark as moved
-        if let InstData::VarRef { name, anchor } = &inst.data {
+        if let InstData::VarRef { name, .. } = &inst.data {
             // Check if it's a parameter — unless a `let` shadowed it with a
             // same-named local, which then wins for all later references
             // (spec 5.1:10, RUE-278); the local is resolved just below.
@@ -1433,7 +1433,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return self.analyze_var_ref(
                     air,
                     *name,
-                    anchor.clone(),
+                    Some(inst_ref),
                     inst.span,
                     resolved_ty,
                     ctx,

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -2622,6 +2622,78 @@ mod tests {
         assert_scheduled_codegen_matches_fresh_link(true);
     }
 
+    #[test]
+    fn named_module_const_resolution_keeps_read_anchor_identity_when_retained_or_fresh() {
+        fn atoms(
+            cfg: &RootedCfgOutput,
+        ) -> Vec<(rue_air::LocalAtomKind, String, rue_rir::RirStructuralAnchor)> {
+            cfg.functions()
+                .iter()
+                .flat_map(|function| function.record.local_atoms.iter())
+                .map(|atom| {
+                    (
+                        atom.identity.kind,
+                        atom.content.to_string(),
+                        atom.identity.anchor.clone(),
+                    )
+                })
+                .collect()
+        }
+
+        let first = SourceSnapshot::single(
+            "<named-const-anchor>",
+            r#"
+                const MESSAGE: str = "hello";
+                fn main() -> i32 {
+                    @dbg(MESSAGE);
+                    @dbg(MESSAGE);
+                    0
+                }
+            "#,
+        )
+        .unwrap();
+        let shifted = SourceSnapshot::single(
+            "<named-const-anchor>",
+            r#"
+                // Absolute coordinates change; producer structure does not.
+                const MESSAGE: str = "hello";
+                fn main() -> i32 {
+                    @dbg(MESSAGE);
+                    @dbg(MESSAGE);
+                    0
+                }
+            "#,
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+
+        let mut retained_session = CompilerSession::new();
+        retained_session
+            .update_for_presentation(&first)
+            .into_result()
+            .unwrap();
+        let first_atoms = atoms(&retained_session.rooted_cfg(&options).unwrap());
+        assert_eq!(first_atoms.len(), 2);
+        assert!(first_atoms.iter().all(|(kind, content, _)| {
+            *kind == rue_air::LocalAtomKind::ReadOnlyData && content == "hello"
+        }));
+        assert_ne!(first_atoms[0].2, first_atoms[1].2);
+
+        retained_session
+            .update_for_presentation(&shifted)
+            .into_result()
+            .unwrap();
+        let retained_atoms = atoms(&retained_session.rooted_cfg(&options).unwrap());
+        let mut fresh_session = CompilerSession::new();
+        fresh_session
+            .update_for_presentation(&shifted)
+            .into_result()
+            .unwrap();
+        let fresh_atoms = atoms(&fresh_session.rooted_cfg(&options).unwrap());
+        assert_eq!(retained_atoms, first_atoms);
+        assert_eq!(fresh_atoms, retained_atoms);
+    }
+
     #[cfg(unix)]
     #[test]
     #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]

--- a/crates/rue-rir/BUCK
+++ b/crates/rue-rir/BUCK
@@ -4,6 +4,7 @@ rue_crate(
     name = "rue-rir",
     deps = [
         "//crates/rue-lexer:rue-lexer",
+        "//crates/rue-error:rue-error",
         "//crates/rue-parser:rue-parser",
         "//crates/rue-span:rue-span",
         "//third-party:ahash",
@@ -17,6 +18,7 @@ native.rust_library(
     srcs = glob(["src/**/*.rs"]),
     deps = [
         "//crates/rue-lexer:rue-lexer",
+        "//crates/rue-error:rue-error",
         "//crates/rue-parser:rue-parser",
         "//crates/rue-span:rue-span",
         "//third-party:ahash",

--- a/crates/rue-rir/src/api_inventory.rs
+++ b/crates/rue-rir/src/api_inventory.rs
@@ -310,6 +310,10 @@ fn rir_structural_anchor_storage_is_tied_to_retained_charge() {
         1,
         "optional structural-anchor storage changed"
     );
+    assert!(
+        !include_str!("lib.rs").contains("RirDeferredStructuralAnchor,"),
+        "producer-private deferred anchors must not enter the public hub"
+    );
 
     let charge = source_region(
         validation,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -19,7 +19,8 @@ use rue_parser::{
 
 use crate::inst::{
     Inst, InstData, InstRef, InternalIntrinsic, PayloadFallback, RepeatCount, Rir, RirArgMode,
-    RirCallArg, RirDirective, RirEditor, RirParam, RirParamMode, RirPattern,
+    RirCallArg, RirDeferredStructuralAnchor, RirDirective, RirEditor, RirParam, RirParamMode,
+    RirPattern,
 };
 
 trait RecordPayloadFailure<T> {
@@ -68,7 +69,7 @@ pub struct AstGen<'a> {
     /// route is relative to its producing definition and contains no spans or
     /// global instruction ordinals. Still the source of string-literal and
     /// read-only-data anchors; anonymous-type anchors no longer derive from it.
-    structural_path: Vec<crate::RirStructuralPathSegment>,
+    structural_path: Option<std::sync::Arc<crate::inst::RirStructuralPathPrefix>>,
     /// The single anonymous-type anchor authority (RUE-1089, Theme 1). Each
     /// value-position anonymous type literal reachable while reducing a producer
     /// body is recorded here by exact source span when that producer root is
@@ -168,7 +169,7 @@ impl<'a> AstGen<'a> {
             payload_error: None,
             for_counter: 0,
             compound_counter: 0,
-            structural_path: Vec::new(),
+            structural_path: None,
             anonymous_anchors: AHashMap::new(),
             authoritative_anonymous_anchors: false,
             producer_root_depth: 0,
@@ -410,9 +411,15 @@ impl<'a> AstGen<'a> {
         segment: crate::RirStructuralPathSegment,
         action: impl FnOnce(&mut Self) -> T,
     ) -> T {
-        self.structural_path.push(segment);
+        let parent = self.structural_path.take();
+        let len = parent.as_ref().map_or(1, |parent| parent.len + 1);
+        self.structural_path = Some(std::sync::Arc::new(crate::inst::RirStructuralPathPrefix {
+            parent: parent.clone(),
+            segment,
+            len,
+        }));
         let result = action(self);
-        self.structural_path.pop();
+        self.structural_path = parent;
         result
     }
 
@@ -531,15 +538,18 @@ impl<'a> AstGen<'a> {
     }
 
     fn string_literal_anchor(&self, occurrence: u32) -> crate::RirStructuralAnchor {
-        let mut segments = self.structural_path.clone();
-        segments.push(crate::RirStructuralPathSegment::StringLiteral(occurrence));
-        crate::RirStructuralAnchor::new(segments)
+        RirDeferredStructuralAnchor::new(
+            self.structural_path.clone(),
+            crate::RirStructuralPathSegment::StringLiteral(occurrence),
+        )
+        .materialize()
     }
 
-    fn read_only_data_anchor(&self, occurrence: u32) -> crate::RirStructuralAnchor {
-        let mut segments = self.structural_path.clone();
-        segments.push(crate::RirStructuralPathSegment::ReadOnlyData(occurrence));
-        crate::RirStructuralAnchor::new(segments)
+    fn read_only_data_anchor(&self, occurrence: u32) -> RirDeferredStructuralAnchor {
+        RirDeferredStructuralAnchor::new(
+            self.structural_path.clone(),
+            crate::RirStructuralPathSegment::ReadOnlyData(occurrence),
+        )
     }
 
     fn gen_item(&mut self, item: &Item) -> AstGenItemRoots {
@@ -1057,13 +1067,11 @@ impl<'a> AstGen<'a> {
                 data: InstData::UnitConst,
                 span: lit.span,
             }),
-            Expr::Ident(ident) => self.rir.add_inst(Inst {
-                data: InstData::VarRef {
-                    name: self.symbol(ident.name),
-                    anchor: Some(self.read_only_data_anchor(0)),
-                },
-                span: ident.span,
-            }),
+            Expr::Ident(ident) => self.rir.add_deferred_var_ref(
+                self.symbol(ident.name),
+                self.read_only_data_anchor(0),
+                ident.span,
+            ),
             Expr::Binary(bin) => {
                 let lhs = self.gen_expr_at(crate::RirStructuralPathSegment::Operand(0), &bin.left);
                 let rhs = self.gen_expr_at(crate::RirStructuralPathSegment::Operand(1), &bin.right);
@@ -2309,13 +2317,10 @@ impl<'a> AstGen<'a> {
                 // reference to the name would, so a compound assignment to a
                 // module constant reports its error the same way a plain one
                 // does rather than diverging on anchor handling.
-                CompoundPlace::Var(name) => this.rir.add_inst(Inst {
-                    data: InstData::VarRef {
-                        name: *name,
-                        anchor: Some(this.read_only_data_anchor(0)),
-                    },
-                    span,
-                }),
+                CompoundPlace::Var(name) => {
+                    this.rir
+                        .add_deferred_var_ref(*name, this.read_only_data_anchor(0), span)
+                }
                 CompoundPlace::Projected { root, steps } => {
                     let base = this.gen_place_root(root);
                     this.gen_place_projections(base, steps)
@@ -2543,6 +2548,74 @@ mod tests {
         astgen.append_items(&ast.items);
         let rir = astgen.finish();
         (rir, interner)
+    }
+
+    fn deferred_read_anchors(source: &str, spelling: &str) -> Vec<RirDeferredStructuralAnchor> {
+        let (rir, interner) = gen_rir(source);
+        rir.iter()
+            .filter_map(|(reference, instruction)| match &instruction.data {
+                InstData::VarRef { name, anchor: None } if interner.resolve(name) == spelling => {
+                    rir.deferred_structural_anchor(reference).cloned()
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn deferred_identifier_and_compound_read_materialize_exact_old_paths() {
+        use crate::RirStructuralPathSegment as S;
+
+        let ordinary = deferred_read_anchors("fn f() -> i32 { X }", "X");
+        assert_eq!(ordinary.len(), 1);
+        assert_eq!(
+            ordinary[0].materialize(),
+            crate::RirStructuralAnchor::new(vec![
+                S::Body,
+                S::Body,
+                S::Operand(0),
+                S::ReadOnlyData(0)
+            ])
+        );
+
+        let compound = deferred_read_anchors("fn f() -> i32 { X += 1; X }", "X");
+        assert_eq!(compound.len(), 2);
+        assert_eq!(
+            compound[0].materialize(),
+            crate::RirStructuralAnchor::new(vec![
+                S::Body,
+                S::Body,
+                S::Statement(0),
+                S::Operand(COMPOUND_READ_SEGMENT),
+                S::ReadOnlyData(0),
+            ])
+        );
+        assert_eq!(
+            compound[1].materialize(),
+            crate::RirStructuralAnchor::new(vec![
+                S::Body,
+                S::Body,
+                S::Operand(0),
+                S::ReadOnlyData(0)
+            ])
+        );
+    }
+
+    #[test]
+    fn escaped_deferred_anchor_retains_only_its_own_producer_prefix() {
+        let small = deferred_read_anchors("fn keep() -> i32 { X }", "X").remove(0);
+        let mut large_source = "fn keep() -> i32 { X } fn unrelated() -> i32 { ".to_owned();
+        for _ in 0..2_000 {
+            large_source.push_str("unresolved; ");
+        }
+        large_source.push_str("0 }");
+        let escaped = deferred_read_anchors(&large_source, "X").remove(0);
+        assert_eq!(small, escaped);
+        assert_eq!(
+            small.retained_allocation_charge(),
+            escaped.retained_allocation_charge(),
+            "an escaped shallow occurrence must not retain unrelated producer paths"
+        );
     }
 
     #[test]

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -22,6 +22,10 @@ pub use printer::*;
 pub struct Rir {
     /// All instructions across the canonical module sequence.
     instructions: Vec<Inst>,
+    /// Producer-private structural paths for source variable reads. Entries
+    /// are aligned with `instructions`; public flat anchors remain in
+    /// `InstData::VarRef` only for explicitly constructed RIR.
+    deferred_structural_anchors: Vec<Option<RirDeferredStructuralAnchor>>,
     /// Extra data for variable-length instruction payloads.
     extra: Vec<u32>,
     /// Declaration-local structured type syntax referenced by type-bearing
@@ -46,6 +50,7 @@ pub struct Rir {
 impl PartialEq for Rir {
     fn eq(&self, other: &Self) -> bool {
         self.instructions == other.instructions
+            && self.deferred_structural_anchors == other.deferred_structural_anchors
             && self.extra == other.extra
             && self.type_syntax == other.type_syntax
             && self.instruction_limit_exceeded == other.instruction_limit_exceeded

--- a/crates/rue-rir/src/inst/editor.rs
+++ b/crates/rue-rir/src/inst/editor.rs
@@ -154,6 +154,9 @@ impl RirEditor {
             Ok(value) => Ok(value),
             Err(error) => {
                 self.rir.instructions.truncate(instruction_len);
+                self.rir
+                    .deferred_structural_anchors
+                    .truncate(instruction_len);
                 self.rir.extra.truncate(extra_len);
                 Err(error)
             }
@@ -164,6 +167,28 @@ impl RirEditor {
     /// below, whose descriptors never escape the editor.
     pub fn add_inst(&mut self, inst: Inst) -> InstRef {
         self.rir.add_inst(inst)
+    }
+
+    pub(crate) fn add_deferred_var_ref(
+        &mut self,
+        name: Spur,
+        anchor: RirDeferredStructuralAnchor,
+        span: Span,
+    ) -> InstRef {
+        let instruction = self.rir.add_inst(Inst {
+            data: InstData::VarRef { name, anchor: None },
+            span,
+        });
+        self.rir.set_deferred_structural_anchor(instruction, anchor);
+        instruction
+    }
+
+    pub(crate) fn set_deferred_structural_anchor(
+        &mut self,
+        instruction: InstRef,
+        anchor: RirDeferredStructuralAnchor,
+    ) {
+        self.rir.set_deferred_structural_anchor(instruction, anchor);
     }
 
     /// The implementation-limit rejection latched by an infallible
@@ -845,7 +870,7 @@ impl RirEditor {
                 };
                 let span = take_span(RirSpanField::Instruction)?;
                 let payload_free = |data| Inst { data, span };
-                match &instruction.data {
+                let destination_instruction = match &instruction.data {
                     InstData::IntConst(value) => {
                         self.add_inst(payload_free(InstData::IntConst(*value)))
                     }
@@ -1427,6 +1452,10 @@ impl RirEditor {
                         self.add_anon_enum_type(&variants, &payloads, anchor.clone(), span)?
                     }
                 };
+                if let Some(anchor) = source.deferred_structural_anchor(source_instruction) {
+                    self.rir
+                        .set_deferred_structural_anchor(destination_instruction, anchor.clone());
+                }
             }
             if let Some((slot, _)) = mapped_spans.next() {
                 return Err(RirSpanRemapError::UnconsumedSlot(slot));
@@ -1451,6 +1480,9 @@ impl RirEditor {
         })();
         if result.is_err() {
             self.rir.instructions.truncate(instruction_start as usize);
+            self.rir
+                .deferred_structural_anchors
+                .truncate(instruction_start as usize);
             self.rir.extra.truncate(extra_start as usize);
             self.type_syntax.rollback(type_snapshot);
         }
@@ -1481,6 +1513,7 @@ impl RirEditor {
             intrinsic,
             args: range,
         };
+        self.rir.deferred_structural_anchors[instruction.as_u32() as usize] = None;
         Ok(())
     }
 

--- a/crates/rue-rir/src/inst/packed.rs
+++ b/crates/rue-rir/src/inst/packed.rs
@@ -18,7 +18,10 @@ use crate::{RirTypeSyntaxNode, RirTypeSyntaxRange, RirTypeSyntaxSymbol};
 use super::*;
 
 const MAGIC: &[u8; 4] = b"RIRP";
-const VERSION: u8 = 4;
+// Packed RIR is a private, ephemeral compiler-cache format. The cache header
+// version is checked before decoding, so changing this byte invalidates every
+// prior representation instead of requiring compatibility decoding.
+const VERSION: u8 = 5;
 const HEADER_LEN: usize = 64;
 
 /// One fallible source intrinsic whose result requires a trusted `Option`
@@ -408,6 +411,10 @@ impl PackedValidatedRir {
         .decode();
         if result.is_err() {
             destination.rir.instructions.truncate(instruction_len);
+            destination
+                .rir
+                .deferred_structural_anchors
+                .truncate(instruction_len);
             destination.rir.extra.truncate(extra_len);
             destination.type_syntax.rollback(type_snapshot);
             destination.rir.instruction_limit_exceeded = capacity_latch;
@@ -561,6 +568,8 @@ struct Encoder<E, C, P> {
     type_count: usize,
     current_type: u32,
     fallible_intrinsics: RirFallibleIntrinsicSet,
+    deferred_prefix_ids: HashMap<*const RirStructuralPathPrefix, u32>,
+    deferred_prefix_count: u32,
     marker: std::marker::PhantomData<fn() -> E>,
 }
 
@@ -580,6 +589,8 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
             type_count: 0,
             current_type: 0,
             fallible_intrinsics: RirFallibleIntrinsicSet::default(),
+            deferred_prefix_ids: HashMap::new(),
+            deferred_prefix_count: 0,
             marker: std::marker::PhantomData,
         }
     }
@@ -1097,55 +1108,7 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
         self.count(anchor.segments().len())?;
         for segment in anchor.segments() {
             self.check()?;
-            match *segment {
-                RirStructuralPathSegment::Body => self.byte(0)?,
-                RirStructuralPathSegment::ParameterType(value) => {
-                    self.byte(1)?;
-                    self.u32(value)?;
-                }
-                RirStructuralPathSegment::ReturnType => self.byte(2)?,
-                RirStructuralPathSegment::Statement(value) => {
-                    self.byte(3)?;
-                    self.u32(value)?;
-                }
-                RirStructuralPathSegment::Operand(value) => {
-                    self.byte(4)?;
-                    self.u32(value)?;
-                }
-                RirStructuralPathSegment::Branch(value) => {
-                    self.byte(5)?;
-                    self.u32(value)?;
-                }
-                RirStructuralPathSegment::MatchArm(value) => {
-                    self.byte(6)?;
-                    self.u32(value)?;
-                }
-                RirStructuralPathSegment::FieldType(value) => {
-                    self.byte(7)?;
-                    self.u32(value)?;
-                }
-                RirStructuralPathSegment::VariantPayload { variant, payload } => {
-                    self.byte(8)?;
-                    self.u32(variant)?;
-                    self.u32(payload)?;
-                }
-                RirStructuralPathSegment::Method(value) => {
-                    self.byte(9)?;
-                    self.u32(value)?;
-                }
-                RirStructuralPathSegment::AnonymousType(value) => {
-                    self.byte(10)?;
-                    self.u32(value)?;
-                }
-                RirStructuralPathSegment::StringLiteral(value) => {
-                    self.byte(11)?;
-                    self.u32(value)?;
-                }
-                RirStructuralPathSegment::ReadOnlyData(value) => {
-                    self.byte(12)?;
-                    self.u32(value)?;
-                }
-            }
+            self.anchor_segment(*segment)?;
         }
         Ok(())
     }
@@ -1157,6 +1120,181 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
         self.boolean(anchor.is_some())?;
         if let Some(anchor) = anchor {
             self.anchor(anchor)?;
+        }
+        Ok(())
+    }
+
+    fn anchor_segment(
+        &mut self,
+        segment: RirStructuralPathSegment,
+    ) -> Result<(), PackedRirEncodeError<E>> {
+        match segment {
+            RirStructuralPathSegment::Body => self.byte(0)?,
+            RirStructuralPathSegment::ParameterType(value) => {
+                self.byte(1)?;
+                self.u32(value)?;
+            }
+            RirStructuralPathSegment::ReturnType => self.byte(2)?,
+            RirStructuralPathSegment::Statement(value) => {
+                self.byte(3)?;
+                self.u32(value)?;
+            }
+            RirStructuralPathSegment::Operand(value) => {
+                self.byte(4)?;
+                self.u32(value)?;
+            }
+            RirStructuralPathSegment::Branch(value) => {
+                self.byte(5)?;
+                self.u32(value)?;
+            }
+            RirStructuralPathSegment::MatchArm(value) => {
+                self.byte(6)?;
+                self.u32(value)?;
+            }
+            RirStructuralPathSegment::FieldType(value) => {
+                self.byte(7)?;
+                self.u32(value)?;
+            }
+            RirStructuralPathSegment::VariantPayload { variant, payload } => {
+                self.byte(8)?;
+                self.u32(variant)?;
+                self.u32(payload)?;
+            }
+            RirStructuralPathSegment::Method(value) => {
+                self.byte(9)?;
+                self.u32(value)?;
+            }
+            RirStructuralPathSegment::AnonymousType(value) => {
+                self.byte(10)?;
+                self.u32(value)?;
+            }
+            RirStructuralPathSegment::StringLiteral(value) => {
+                self.byte(11)?;
+                self.u32(value)?;
+            }
+            RirStructuralPathSegment::ReadOnlyData(value) => {
+                self.byte(12)?;
+                self.u32(value)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn deferred_prefix_id(&self, prefix: &RirStructuralPathPrefix) -> Option<u32> {
+        self.deferred_prefix_ids
+            .get(&(prefix as *const RirStructuralPathPrefix))
+            .copied()
+    }
+
+    fn unseen_deferred_prefixes(&self, mut prefix: &RirStructuralPathPrefix) -> usize {
+        let mut count = 0;
+        loop {
+            if self.deferred_prefix_id(prefix).is_some() {
+                return count;
+            }
+            count += 1;
+            let Some(parent) = prefix.parent.as_deref() else {
+                return count;
+            };
+            prefix = parent;
+        }
+    }
+
+    fn define_deferred_prefix(
+        &mut self,
+        prefix: &RirStructuralPathPrefix,
+    ) -> Result<u32, PackedRirEncodeError<E>> {
+        self.check()?;
+        if let Some(id) = self.deferred_prefix_id(prefix) {
+            return Ok(id);
+        }
+        let parent = if let Some(parent) = &prefix.parent {
+            Some(self.define_deferred_prefix(parent)?)
+        } else {
+            None
+        };
+        self.boolean(parent.is_some())?;
+        if let Some(parent) = parent {
+            self.u32(parent)?;
+        }
+        self.anchor_segment(prefix.segment)?;
+        self.deferred_prefix_ids
+            .try_reserve(1)
+            .map_err(|_| PackedRirEncodeError::CapacityFailure)?;
+        let id = self.deferred_prefix_count;
+        self.deferred_prefix_count = self
+            .deferred_prefix_count
+            .checked_add(1)
+            .ok_or(PackedRirEncodeError::ResourceLimit)?;
+        self.deferred_prefix_ids
+            .insert(prefix as *const RirStructuralPathPrefix, id);
+        Ok(id)
+    }
+
+    fn define_flat_prefix(
+        &mut self,
+        segments: &[RirStructuralPathSegment],
+    ) -> Result<Option<u32>, PackedRirEncodeError<E>> {
+        let mut parent = None;
+        for &segment in segments {
+            self.check()?;
+            self.boolean(parent.is_some())?;
+            if let Some(parent) = parent {
+                self.u32(parent)?;
+            }
+            self.anchor_segment(segment)?;
+            let id = self.deferred_prefix_count;
+            self.deferred_prefix_count = self
+                .deferred_prefix_count
+                .checked_add(1)
+                .ok_or(PackedRirEncodeError::ResourceLimit)?;
+            parent = Some(id);
+        }
+        Ok(parent)
+    }
+
+    fn deferred_anchor(
+        &mut self,
+        anchor: &RirDeferredStructuralAnchor,
+    ) -> Result<(), PackedRirEncodeError<E>> {
+        self.check()?;
+        let (prefix, tail) = if let Some(flat) = &anchor.flat {
+            let Some((&tail, prefix_segments)) = flat.segments().split_last() else {
+                self.count(0)?;
+                self.boolean(false)?;
+                self.boolean(false)?;
+                return Ok(());
+            };
+            self.count(prefix_segments.len())?;
+            (self.define_flat_prefix(prefix_segments)?, tail)
+        } else {
+            let new_prefixes = anchor
+                .prefix
+                .as_deref()
+                .map_or(0, |prefix| self.unseen_deferred_prefixes(prefix));
+            self.count(new_prefixes)?;
+            let prefix = if let Some(prefix) = &anchor.prefix {
+                Some(self.define_deferred_prefix(prefix)?)
+            } else {
+                None
+            };
+            (prefix, anchor.tail)
+        };
+        self.boolean(prefix.is_some())?;
+        if let Some(prefix) = prefix {
+            self.u32(prefix)?;
+        }
+        self.boolean(true)?;
+        self.anchor_segment(tail)
+    }
+
+    fn optional_deferred_anchor(
+        &mut self,
+        anchor: Option<&RirDeferredStructuralAnchor>,
+    ) -> Result<(), PackedRirEncodeError<E>> {
+        self.boolean(anchor.is_some())?;
+        if let Some(anchor) = anchor {
+            self.deferred_anchor(anchor)?;
         }
         Ok(())
     }
@@ -1526,6 +1664,7 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
                 self.byte(44)?;
                 self.symbol(*name)?;
                 self.optional_anchor(anchor.as_ref())?;
+                self.optional_deferred_anchor(rir.deferred_structural_anchor(instruction))?;
             }
             InstData::Assign { name, value } => {
                 self.byte(45)?;
@@ -1972,6 +2111,7 @@ struct Decoder<'a, E, C, S, P> {
     symbols: u32,
     types: u32,
     type_nodes: Vec<RirTypeSyntaxRef>,
+    deferred_prefixes: Vec<Arc<RirStructuralPathPrefix>>,
     source_instruction: u32,
     destination_instruction_start: u32,
     spans_read: u32,
@@ -2007,6 +2147,7 @@ impl<
             symbols: 0,
             types: 0,
             type_nodes: Vec::new(),
+            deferred_prefixes: Vec::new(),
             source_instruction: 0,
             destination_instruction_start: 0,
             spans_read: 0,
@@ -2937,7 +3078,20 @@ impl<
             44 => {
                 let name = self.symbol(reader)?;
                 let anchor = self.optional_anchor(reader)?;
-                add!(InstData::VarRef { name, anchor })
+                let deferred = self.optional_deferred_anchor(reader)?;
+                if anchor.is_some() && deferred.is_some() {
+                    return Err(PackedRirDecodeError::InvalidTag {
+                        family: "variable reference anchor storage",
+                        tag: 3,
+                    }
+                    .into());
+                }
+                let instruction = add!(InstData::VarRef { name, anchor });
+                if let Some(deferred) = deferred {
+                    self.destination
+                        .set_deferred_structural_anchor(instruction, deferred);
+                }
+                instruction
             }
             45 => {
                 let name = self.symbol(reader)?;
@@ -3192,27 +3346,7 @@ impl<
             .map_err(|_| Self::capacity("structural anchor"))?;
         for _ in 0..count {
             self.check()?;
-            let tag = Self::byte_tag(reader, "structural anchor segment", 12)?;
-            let segment = match tag {
-                0 => RirStructuralPathSegment::Body,
-                1 => RirStructuralPathSegment::ParameterType(reader.u32()?),
-                2 => RirStructuralPathSegment::ReturnType,
-                3 => RirStructuralPathSegment::Statement(reader.u32()?),
-                4 => RirStructuralPathSegment::Operand(reader.u32()?),
-                5 => RirStructuralPathSegment::Branch(reader.u32()?),
-                6 => RirStructuralPathSegment::MatchArm(reader.u32()?),
-                7 => RirStructuralPathSegment::FieldType(reader.u32()?),
-                8 => RirStructuralPathSegment::VariantPayload {
-                    variant: reader.u32()?,
-                    payload: reader.u32()?,
-                },
-                9 => RirStructuralPathSegment::Method(reader.u32()?),
-                10 => RirStructuralPathSegment::AnonymousType(reader.u32()?),
-                11 => RirStructuralPathSegment::StringLiteral(reader.u32()?),
-                12 => RirStructuralPathSegment::ReadOnlyData(reader.u32()?),
-                _ => unreachable!(),
-            };
-            segments.push(segment);
+            segments.push(Self::anchor_segment(reader)?);
         }
         Ok(RirStructuralAnchor::new(segments))
     }
@@ -3223,6 +3357,105 @@ impl<
     ) -> Result<Option<RirStructuralAnchor>, PackedRirAppendError<E>> {
         if reader.boolean("optional structural anchor")? {
             self.anchor(reader).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn anchor_segment(
+        reader: &mut Reader<'_>,
+    ) -> Result<RirStructuralPathSegment, PackedRirDecodeError> {
+        let tag = Self::byte_tag(reader, "structural anchor segment", 12)?;
+        Ok(match tag {
+            0 => RirStructuralPathSegment::Body,
+            1 => RirStructuralPathSegment::ParameterType(reader.u32()?),
+            2 => RirStructuralPathSegment::ReturnType,
+            3 => RirStructuralPathSegment::Statement(reader.u32()?),
+            4 => RirStructuralPathSegment::Operand(reader.u32()?),
+            5 => RirStructuralPathSegment::Branch(reader.u32()?),
+            6 => RirStructuralPathSegment::MatchArm(reader.u32()?),
+            7 => RirStructuralPathSegment::FieldType(reader.u32()?),
+            8 => RirStructuralPathSegment::VariantPayload {
+                variant: reader.u32()?,
+                payload: reader.u32()?,
+            },
+            9 => RirStructuralPathSegment::Method(reader.u32()?),
+            10 => RirStructuralPathSegment::AnonymousType(reader.u32()?),
+            11 => RirStructuralPathSegment::StringLiteral(reader.u32()?),
+            12 => RirStructuralPathSegment::ReadOnlyData(reader.u32()?),
+            _ => unreachable!(),
+        })
+    }
+
+    fn deferred_anchor(
+        &mut self,
+        reader: &mut Reader<'_>,
+    ) -> Result<RirDeferredStructuralAnchor, PackedRirAppendError<E>> {
+        let definitions = Self::count(reader, "deferred structural prefixes", 2)?;
+        self.deferred_prefixes
+            .try_reserve(definitions)
+            .map_err(|_| Self::capacity("deferred structural prefixes"))?;
+        for _ in 0..definitions {
+            self.check()?;
+            let parent = if reader.boolean("deferred structural prefix parent")? {
+                let reference = reader.u32()? as usize;
+                Some(self.deferred_prefixes.get(reference).cloned().ok_or(
+                    PackedRirDecodeError::CountOutOfBounds {
+                        family: "deferred structural prefix reference",
+                    },
+                )?)
+            } else {
+                None
+            };
+            let segment = Self::anchor_segment(reader)?;
+            let len = parent.as_ref().map_or(1, |parent| parent.len + 1);
+            if len > MAX_DEFERRED_STRUCTURAL_PATH {
+                return Err(PackedRirDecodeError::CountOutOfBounds {
+                    family: "deferred structural path depth",
+                }
+                .into());
+            }
+            self.deferred_prefixes
+                .push(Arc::new(RirStructuralPathPrefix {
+                    parent,
+                    segment,
+                    len,
+                }));
+        }
+        let prefix = if reader.boolean("deferred structural anchor prefix")? {
+            let reference = reader.u32()? as usize;
+            Some(self.deferred_prefixes.get(reference).cloned().ok_or(
+                PackedRirDecodeError::CountOutOfBounds {
+                    family: "deferred structural anchor prefix reference",
+                },
+            )?)
+        } else {
+            None
+        };
+        if !reader.boolean("deferred structural anchor tail")? {
+            return Ok(RirDeferredStructuralAnchor::from_flat(
+                RirStructuralAnchor::new(Vec::new()),
+            ));
+        }
+        let tail = Self::anchor_segment(reader)?;
+        if prefix
+            .as_ref()
+            .is_some_and(|prefix| prefix.len.saturating_add(1) > MAX_DEFERRED_STRUCTURAL_PATH)
+        {
+            return Err(PackedRirDecodeError::CountOutOfBounds {
+                family: "deferred structural path depth",
+            }
+            .into());
+        }
+        Ok(RirDeferredStructuralAnchor::new(prefix, tail))
+    }
+
+    fn optional_deferred_anchor(
+        &mut self,
+        reader: &mut Reader<'_>,
+    ) -> Result<Option<RirDeferredStructuralAnchor>, PackedRirAppendError<E>> {
+        if reader.boolean("optional deferred structural anchor")? {
+            self.deferred_anchor(reader).map(Some)
         } else {
             Ok(None)
         }
@@ -3431,6 +3664,59 @@ mod tests {
             |_slot, span| Ok((span.start, span.end)),
         )
         .unwrap()
+    }
+
+    fn production_deferred_owner(source: &str) -> (ValidatedRir, ThreadedRodeo, InstRef) {
+        let (tokens, symbols) = Lexer::new(source).tokenize().unwrap();
+        let (ast, symbols) = Parser::new(tokens, symbols).parse().unwrap();
+        let mut astgen = crate::AstGen::with_symbol_normalizer(&symbols, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = ValidatedRir::finish(
+            astgen.finish_editor(),
+            &RirValidationContext {
+                symbol_count: symbols.len(),
+                source_lengths: &[(FileId::DEFAULT, source.len() as u32)],
+            },
+        )
+        .unwrap();
+        let root = rir
+            .iter()
+            .find_map(|(reference, instruction)| {
+                matches!(instruction.data, InstData::FnDecl { .. }).then_some(reference)
+            })
+            .unwrap();
+        (rir, symbols, root)
+    }
+
+    fn decode_deferred_fixture(
+        bytes: &[u8],
+        mut checkpoint: impl FnMut() -> Result<(), ()>,
+    ) -> Result<RirDeferredStructuralAnchor, PackedRirAppendError<()>> {
+        let mut destination = RirEditor::new();
+        let mut decoder = Decoder {
+            bytes: &[],
+            destination: &mut destination,
+            root_methods: None,
+            revalidate_symbols: false,
+            checkpoint: &mut checkpoint,
+            remap_symbol: |_ordinal| Ok(Spur::try_from_usize(0).unwrap()),
+            remap_span: |_slot, _basis| Ok(Span::new(0, 0)),
+            instructions: 0,
+            symbols: 0,
+            types: 0,
+            type_nodes: Vec::new(),
+            deferred_prefixes: Vec::new(),
+            source_instruction: 0,
+            destination_instruction_start: 0,
+            spans_read: 0,
+            marker: std::marker::PhantomData,
+        };
+        let mut reader = Reader::new(bytes);
+        let anchor = decoder.deferred_anchor(&mut reader)?;
+        if reader.remaining() != 0 {
+            return Err(PackedRirDecodeError::TrailingBytes.into());
+        }
+        Ok(anchor)
     }
 
     fn pack_intrinsics(names: &[&str]) -> PackedValidatedRir {
@@ -3854,11 +4140,11 @@ mod tests {
     }
 
     #[test]
-    fn wrong_version_is_rejected_without_destination_mutation() {
+    fn packed_v4_is_rejected_without_destination_mutation() {
         let (source, symbols, root) = validated_owner(false);
         let packed = pack(&source, &symbols, root);
         let mut bytes = packed.as_bytes().to_vec();
-        bytes[4] = VERSION + 1;
+        bytes[4] = 4;
         let corrupt = PackedValidatedRir(Arc::from(bytes));
         let mut destination = RirEditor::new();
         destination.add_inst(Inst {
@@ -3872,7 +4158,7 @@ mod tests {
         assert!(matches!(
             append(&corrupt, &mut destination),
             Err(PackedRirAppendError::Decode(
-                PackedRirDecodeError::UnsupportedVersion(_)
+                PackedRirDecodeError::UnsupportedVersion(4)
             ))
         ));
         assert_eq!(
@@ -3881,6 +4167,190 @@ mod tests {
         );
         assert_eq!(destination.rir.extra, before_extra);
         assert!(destination.rir.instruction_limit_exceeded);
+    }
+
+    #[test]
+    fn packed_v5_production_deferred_prefixes_roundtrip_repack_and_share() {
+        let source_text = "fn f() -> i32 { MODULE_LOOKING + MODULE_LOOKING }";
+        let (source, symbols, root) = production_deferred_owner(source_text);
+        let packed = pack(&source, &symbols, root);
+        let (decoded, metadata) = packed
+            .try_decode_validated(
+                PackedRirProjection {
+                    symbol_count: symbols.len(),
+                    file_id: FileId::DEFAULT,
+                    declaration_start: 0,
+                    source_length: source_text.len() as u32,
+                },
+                || Ok::<_, ()>(()),
+            )
+            .unwrap();
+        assert_eq!(metadata.declaration, root);
+        assert!(source.exact_eq(&decoded));
+        assert_eq!(pack(&decoded, &symbols, root).as_bytes(), packed.as_bytes());
+
+        let prefixes = decoded
+            .iter()
+            .filter_map(|(reference, instruction)| {
+                matches!(instruction.data, InstData::VarRef { .. })
+                    .then(|| decoded.deferred_structural_anchor(reference))
+                    .flatten()
+                    .and_then(|anchor| anchor.prefix.as_ref())
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(prefixes.len(), 2);
+        assert!(Arc::ptr_eq(
+            prefixes[0].parent.as_ref().unwrap(),
+            prefixes[1].parent.as_ref().unwrap()
+        ));
+    }
+
+    #[test]
+    fn packed_v5_rejects_forward_prefix_parent_and_invalid_anchor_reference() {
+        let forward_parent = [1, 1, 0, 0, 0, 0];
+        assert!(matches!(
+            decode_deferred_fixture(&forward_parent, || Ok(())),
+            Err(PackedRirAppendError::Decode(
+                PackedRirDecodeError::CountOutOfBounds {
+                    family: "deferred structural prefix reference"
+                }
+            ))
+        ));
+
+        // One root `Body` definition followed by a reference to nonexistent
+        // prefix 1 and a syntactically valid tail.
+        let invalid_anchor = [1, 0, 0, 1, 1, 1, 12, 0];
+        assert!(matches!(
+            decode_deferred_fixture(&invalid_anchor, || Ok(())),
+            Err(PackedRirAppendError::Decode(
+                PackedRirDecodeError::CountOutOfBounds {
+                    family: "deferred structural anchor prefix reference"
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn packed_v5_rejects_flat_and_deferred_var_ref_anchor_without_mutation() {
+        let source_text = "fn f() -> i32 { MODULE_LOOKING }";
+        let (source, symbols, root) = production_deferred_owner(source_text);
+        let packed = pack(&source, &symbols, root);
+        let header = Header::parse(packed.as_bytes()).unwrap();
+        let mut bytes = packed.as_bytes().to_vec();
+        let opcode = bytes[header.instructions_offset..header.basis_offset]
+            .windows(4)
+            .position(|window| window[0] == 44 && window[2] == 0 && window[3] == 1)
+            .map(|offset| header.instructions_offset + offset)
+            .expect("production VarRef has flat=false and deferred=true");
+        bytes[opcode + 2] = 1;
+        bytes.insert(opcode + 3, 0); // empty public flat anchor
+        set_header(&mut bytes, 48, header.basis_offset + 1);
+        set_header(&mut bytes, 52, header.end_offset + 1);
+        let corrupt = PackedValidatedRir(Arc::from(bytes));
+
+        let mut destination = RirEditor::new();
+        let existing_name = Spur::try_from_usize(0).unwrap();
+        destination.add_deferred_var_ref(
+            existing_name,
+            RirDeferredStructuralAnchor::new(None, RirStructuralPathSegment::ReadOnlyData(0)),
+            Span::new(4, 5),
+        );
+        destination.rir.extra.push(17);
+        destination.rir.instruction_limit_exceeded = true;
+        let before_instructions = format!("{:?}", destination.rir.instructions);
+        let before_deferred = destination.rir.deferred_structural_anchors.clone();
+        let before_extra = destination.rir.extra.clone();
+
+        assert!(matches!(
+            append(&corrupt, &mut destination),
+            Err(PackedRirAppendError::Decode(
+                PackedRirDecodeError::InvalidTag {
+                    family: "variable reference anchor storage",
+                    tag: 3
+                }
+            ))
+        ));
+        assert_eq!(
+            format!("{:?}", destination.rir.instructions),
+            before_instructions
+        );
+        assert_eq!(destination.rir.deferred_structural_anchors, before_deferred);
+        assert_eq!(destination.rir.extra, before_extra);
+        assert!(destination.rir.instruction_limit_exceeded);
+    }
+
+    fn chained_prefix_fixture(definitions: usize) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        put_u32(&mut bytes, definitions as u32);
+        for index in 0..definitions {
+            bytes.push(u8::from(index != 0));
+            if index != 0 {
+                put_u32(&mut bytes, (index - 1) as u32);
+            }
+            bytes.push(0); // Body
+        }
+        bytes.push(1);
+        put_u32(&mut bytes, definitions.saturating_sub(1) as u32);
+        bytes.push(1);
+        bytes.push(12); // ReadOnlyData
+        bytes.push(0);
+        bytes
+    }
+
+    #[test]
+    fn packed_v5_enforces_the_exact_deferred_depth_bound() {
+        let maximum = chained_prefix_fixture(MAX_DEFERRED_STRUCTURAL_PATH - 1);
+        assert_eq!(
+            decode_deferred_fixture(&maximum, || Ok(())).unwrap().len,
+            MAX_DEFERRED_STRUCTURAL_PATH
+        );
+
+        let too_deep = chained_prefix_fixture(MAX_DEFERRED_STRUCTURAL_PATH);
+        assert!(matches!(
+            decode_deferred_fixture(&too_deep, || Ok(())),
+            Err(PackedRirAppendError::Decode(
+                PackedRirDecodeError::CountOutOfBounds {
+                    family: "deferred structural path depth"
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn packed_v5_prefix_traversal_is_cancellable() {
+        let (source, _, _) = production_deferred_owner("fn f() -> i32 { MODULE_LOOKING }");
+        let deferred = source
+            .iter()
+            .find_map(|(reference, instruction)| {
+                matches!(instruction.data, InstData::VarRef { .. })
+                    .then(|| source.deferred_structural_anchor(reference).cloned())
+                    .flatten()
+            })
+            .unwrap();
+        let mut encode_checkpoints = 0;
+        let mut encoder = Encoder::new(
+            || {
+                encode_checkpoints += 1;
+                (encode_checkpoints < 4).then_some(()).ok_or(())
+            },
+            |_slot, _span| Ok((0, 0)),
+        );
+        assert!(matches!(
+            encoder.deferred_anchor(&deferred),
+            Err(PackedRirEncodeError::Checkpoint(()))
+        ));
+        assert_eq!(encode_checkpoints, 4);
+
+        let fixture = chained_prefix_fixture(32);
+        let mut decode_checkpoints = 0;
+        assert!(matches!(
+            decode_deferred_fixture(&fixture, || {
+                decode_checkpoints += 1;
+                (decode_checkpoints < 8).then_some(()).ok_or(())
+            }),
+            Err(PackedRirAppendError::Checkpoint(()))
+        ));
+        assert_eq!(decode_checkpoints, 8);
     }
 
     #[test]

--- a/crates/rue-rir/src/inst/payload.rs
+++ b/crates/rue-rir/src/inst/payload.rs
@@ -836,7 +836,44 @@ impl Rir {
             return InstRef::from_raw(0);
         }
         self.instructions.push(inst);
+        self.deferred_structural_anchors.push(None);
         InstRef::from_raw(index)
+    }
+
+    pub(crate) fn set_deferred_structural_anchor(
+        &mut self,
+        instruction: InstRef,
+        anchor: RirDeferredStructuralAnchor,
+    ) {
+        self.deferred_structural_anchors[instruction.as_u32() as usize] = Some(anchor);
+    }
+
+    pub(crate) fn deferred_structural_anchor(
+        &self,
+        instruction: InstRef,
+    ) -> Option<&RirDeferredStructuralAnchor> {
+        self.deferred_structural_anchors
+            .get(instruction.as_u32() as usize)
+            .and_then(Option::as_ref)
+    }
+
+    /// Materialize the structural anchor for a semantically proven named
+    /// string-constant use. Explicit public anchors take precedence; ordinary
+    /// source reads consult the producer-private deferred side table.
+    pub fn materialize_const_use_anchor(
+        &self,
+        instruction: InstRef,
+    ) -> Option<RirStructuralAnchor> {
+        match &self.get(instruction).data {
+            InstData::VarRef {
+                anchor: Some(anchor),
+                ..
+            } => Some(anchor.clone()),
+            InstData::VarRef { anchor: None, .. } => self
+                .deferred_structural_anchor(instruction)
+                .map(RirDeferredStructuralAnchor::materialize),
+            _ => None,
+        }
     }
 
     /// The implementation-limit rejection latched during construction, if the

--- a/crates/rue-rir/src/inst/schema.rs
+++ b/crates/rue-rir/src/inst/schema.rs
@@ -235,6 +235,132 @@ impl RirStructuralAnchor {
     }
 }
 
+/// A source occurrence whose structural anchor is materialized only if semantic
+/// resolution proves that the read names module-level read-only data.
+///
+/// AstGen shares the immutable prefix nodes between syntax descendants and
+/// stores the occurrence's final segment inline. Extending the producer cursor
+/// is O(1), and recording a variable read performs no allocation or path copy.
+#[derive(Debug, Clone)]
+pub(crate) struct RirDeferredStructuralAnchor {
+    pub(crate) prefix: Option<std::sync::Arc<RirStructuralPathPrefix>>,
+    pub(crate) tail: RirStructuralPathSegment,
+    pub(crate) len: usize,
+    pub(crate) flat: Option<RirStructuralAnchor>,
+}
+
+#[derive(Debug)]
+pub(crate) struct RirStructuralPathPrefix {
+    pub(crate) parent: Option<std::sync::Arc<RirStructuralPathPrefix>>,
+    pub(crate) segment: RirStructuralPathSegment,
+    pub(crate) len: usize,
+}
+
+pub(crate) const MAX_DEFERRED_STRUCTURAL_PATH: usize = rue_error::MAX_NESTING_DEPTH * 4;
+
+impl RirDeferredStructuralAnchor {
+    pub(crate) fn new(
+        prefix: Option<std::sync::Arc<RirStructuralPathPrefix>>,
+        tail: RirStructuralPathSegment,
+    ) -> Self {
+        let len = prefix.as_ref().map_or(1, |prefix| prefix.len + 1);
+        Self {
+            prefix,
+            tail,
+            len,
+            flat: None,
+        }
+    }
+
+    pub(crate) fn from_flat(anchor: RirStructuralAnchor) -> Self {
+        let segments = anchor.segments();
+        let tail = segments
+            .last()
+            .copied()
+            .unwrap_or(RirStructuralPathSegment::Body);
+        Self {
+            prefix: None,
+            tail,
+            len: segments.len(),
+            flat: Some(anchor),
+        }
+    }
+
+    /// Materialize the original public flat anchor at the semantic const-use
+    /// boundary. Parser-produced chains are bounded by `MAX_NESTING_DEPTH`;
+    /// packed input is validated before reaching this representation.
+    pub(crate) fn materialize(&self) -> RirStructuralAnchor {
+        if let Some(flat) = &self.flat {
+            return flat.clone();
+        }
+        let mut segments = vec![self.tail; self.len];
+        let mut index = self.len - 1;
+        let mut cursor = self.prefix.as_deref();
+        while let Some(node) = cursor {
+            index -= 1;
+            segments[index] = node.segment;
+            cursor = node.parent.as_deref();
+        }
+        RirStructuralAnchor::new(segments)
+    }
+
+    pub(crate) fn retained_allocation_charge(&self) -> u64 {
+        if let Some(flat) = &self.flat {
+            return std::mem::size_of_val(flat.segments()) as u64;
+        }
+        self.prefix.as_ref().map_or(0, |prefix| {
+            prefix.len as u64 * std::mem::size_of::<RirStructuralPathPrefix>() as u64
+        })
+    }
+}
+
+impl PartialEq for RirDeferredStructuralAnchor {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len != other.len || self.tail != other.tail {
+            return false;
+        }
+        if let (Some(left), Some(right)) = (&self.flat, &other.flat) {
+            return left == right;
+        }
+        if let Some(flat) = &self.flat {
+            return chained_prefix_equals(
+                other.prefix.as_deref(),
+                &flat.segments()[..self.len - 1],
+            );
+        }
+        if let Some(flat) = &other.flat {
+            return chained_prefix_equals(self.prefix.as_deref(), &flat.segments()[..self.len - 1]);
+        }
+        let mut left = self.prefix.as_deref();
+        let mut right = other.prefix.as_deref();
+        while let (Some(a), Some(b)) = (left, right) {
+            if a.segment != b.segment {
+                return false;
+            }
+            left = a.parent.as_deref();
+            right = b.parent.as_deref();
+        }
+        left.is_none() && right.is_none()
+    }
+}
+
+impl Eq for RirDeferredStructuralAnchor {}
+
+fn chained_prefix_equals(
+    mut node: Option<&RirStructuralPathPrefix>,
+    segments: &[RirStructuralPathSegment],
+) -> bool {
+    let mut index = segments.len();
+    while let Some(current) = node {
+        if index == 0 || current.segment != segments[index - 1] {
+            return false;
+        }
+        index -= 1;
+        node = current.parent.as_deref();
+    }
+    index == 0
+}
+
 /// A single RIR instruction.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Inst {

--- a/crates/rue-rir/src/inst/tests.rs
+++ b/crates/rue-rir/src/inst/tests.rs
@@ -64,6 +64,8 @@ mod resource_limit_tests {
 mod typed_payload_tests {
     use super::*;
     use lasso::ThreadedRodeo;
+    use rue_lexer::Lexer;
+    use rue_parser::Parser;
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::cell::Cell;
     thread_local! {
@@ -130,6 +132,114 @@ mod typed_payload_tests {
             ALLOCATION_COUNT.with(Cell::get),
             ALLOCATION_BYTES.with(Cell::get),
         )
+    }
+
+    fn complete_source_evidence(source: &str) -> (usize, usize) {
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();
+        let mut packed_len = 0;
+        let allocations = allocations_during(|| {
+            let mut astgen = crate::AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+            astgen.append_items(&ast.items);
+            let rir = ValidatedRir::finish(
+                astgen.finish_editor(),
+                &RirValidationContext {
+                    symbol_count: interner.len(),
+                    source_lengths: &[(FileId::DEFAULT, source.len() as u32)],
+                },
+            )
+            .unwrap();
+            let root = rir
+                .iter()
+                .find_map(|(reference, instruction)| {
+                    matches!(instruction.data, InstData::FnDecl { .. }).then_some(reference)
+                })
+                .unwrap();
+            let packed = rir
+                .try_pack_candidate(
+                    &interner,
+                    PackedRirMetadata {
+                        declaration: root,
+                        method_owner: None,
+                    },
+                    || Ok::<_, std::convert::Infallible>(()),
+                    |_slot, span| Ok((span.start, span.end)),
+                )
+                .unwrap();
+            packed_len = packed.as_bytes().len();
+            std::hint::black_box((rir.retained_allocation_charge(), packed.as_bytes()));
+        });
+        (allocations, packed_len)
+    }
+
+    fn repeated_expression_source(depth: usize, atom: &str, count: usize) -> String {
+        let mut source = "fn f() -> i32 { ".to_owned();
+        for _ in 0..depth {
+            source.push_str("{ ");
+        }
+        for index in 0..count {
+            if index != 0 {
+                source.push_str(" + ");
+            }
+            source.push_str(atom);
+        }
+        for _ in 0..depth {
+            source.push_str(" }");
+        }
+        source.push_str(" }");
+        source
+    }
+
+    #[test]
+    fn complete_unresolved_read_pipeline_has_no_per_occurrence_path_allocation() {
+        let count = 64;
+        for depth in [1, 32] {
+            let (identifiers, identifier_bytes) = complete_source_evidence(
+                &repeated_expression_source(depth, "MODULE_LOOKING", count),
+            );
+            let (literals, _) =
+                complete_source_evidence(&repeated_expression_source(depth, "1", count));
+            assert!(
+                identifiers <= literals + 12,
+                "{count} reads at depth {depth} added {} allocations; deferred reads must not allocate one path pointee per occurrence",
+                identifiers.saturating_sub(literals)
+            );
+            assert!(
+                identifier_bytes < 16_384,
+                "shared-prefix packing emitted {identifier_bytes} bytes for {count} reads at depth {depth}"
+            );
+        }
+
+        fn compound_source(depth: usize, count: usize) -> String {
+            let mut source = "fn f() -> i32 { ".to_owned();
+            for _ in 0..depth {
+                source.push_str("{ ");
+            }
+            for _ in 0..count {
+                source.push_str("MODULE_LOOKING += 1; ");
+            }
+            source.push('0');
+            for _ in 0..depth {
+                source.push_str(" }");
+            }
+            source.push_str(" }");
+            source
+        }
+
+        let (shallow_one, _) = complete_source_evidence(&compound_source(1, 1));
+        let (shallow_many, shallow_bytes) = complete_source_evidence(&compound_source(1, count));
+        let (deep_one, _) = complete_source_evidence(&compound_source(32, 1));
+        let (deep_many, deep_bytes) = complete_source_evidence(&compound_source(32, count));
+        let shallow_increment = shallow_many - shallow_one;
+        let deep_increment = deep_many - deep_one;
+        assert!(
+            deep_increment <= shallow_increment + 8,
+            "repeating compound reads added {deep_increment} allocations at depth 32 versus {shallow_increment} at depth 1"
+        );
+        assert!(
+            deep_bytes <= shallow_bytes + 512,
+            "nesting copied every compound path into packed RIR: shallow={shallow_bytes}, deep={deep_bytes}"
+        );
     }
 
     #[test]
@@ -862,6 +972,7 @@ mod typed_payload_tests {
         .unwrap();
 
         let dense = (rir.len() * std::mem::size_of::<Inst>()) as u64
+            + (rir.len() * std::mem::size_of::<Option<RirDeferredStructuralAnchor>>()) as u64
             + (rir.extra_len() * std::mem::size_of::<u32>()) as u64
             + rir.type_syntax().retained_allocation_charge();
         assert_eq!(

--- a/crates/rue-rir/src/inst/validation.rs
+++ b/crates/rue-rir/src/inst/validation.rs
@@ -162,21 +162,27 @@ impl ValidatedRir {
     /// Logical heap bytes retained by this RIR owner, excluding the inline
     /// [`ValidatedRir`] value itself.
     ///
-    /// Dense instruction and payload storage is charged by logical length.
+    /// Dense instruction, deferred-anchor slot, and payload storage is charged
+    /// by logical length.
     /// Every structural-anchor `Arc` pointee is charged in full along each
     /// reaching instruction path, including when multiple instructions share
     /// one allocation. This matches Rue's allocator-independent retained-value
     /// policy and leaves the enclosing owner responsible for the inline value.
     pub fn retained_allocation_charge(&self) -> u64 {
         let instructions = self.len().saturating_mul(std::mem::size_of::<Inst>()) as u64;
+        let deferred_slots = self
+            .len()
+            .saturating_mul(std::mem::size_of::<Option<RirDeferredStructuralAnchor>>())
+            as u64;
         let payload = self.extra_len().saturating_mul(std::mem::size_of::<u32>()) as u64;
         let type_syntax = self.type_syntax().retained_allocation_charge();
         self.iter().fold(
             instructions
+                .saturating_add(deferred_slots)
                 .saturating_add(payload)
                 .saturating_add(type_syntax),
-            |charge, (_, instruction)| {
-                let anchors = match &instruction.data {
+            |charge, (reference, instruction)| {
+                let flat_anchors = match &instruction.data {
                     InstData::StringConst { anchor, .. }
                     | InstData::AnonStructType { anchor, .. }
                     | InstData::AnonEnumType { anchor, .. } => {
@@ -188,7 +194,10 @@ impl ValidatedRir {
                     } => std::mem::size_of_val(anchor.segments()) as u64,
                     _ => 0,
                 };
-                charge.saturating_add(anchors)
+                let deferred = self
+                    .deferred_structural_anchor(reference)
+                    .map_or(0, RirDeferredStructuralAnchor::retained_allocation_charge);
+                charge.saturating_add(flat_anchors).saturating_add(deferred)
             },
         )
     }
@@ -344,7 +353,31 @@ impl Rir {
 
     /// Validate every variable-length payload before publishing this RIR.
     pub fn validate_payloads(&self) -> Result<(), RirPayloadError> {
-        for (_, inst) in self.iter() {
+        if self.deferred_structural_anchors.len() != self.instructions.len() {
+            return Err(rir_payload_error! {
+                family: "deferred structural anchors",
+                start: 0,
+                extent: 0,
+                record: None,
+                expected: self.instructions.len(),
+                actual: self.deferred_structural_anchors.len(),
+                reason: "side metadata is not aligned with instructions",
+            });
+        }
+        for (reference, inst) in self.iter() {
+            if self.deferred_structural_anchor(reference).is_some()
+                && !matches!(inst.data, InstData::VarRef { anchor: None, .. })
+            {
+                return Err(rir_payload_error! {
+                    family: "deferred structural anchors",
+                    start: reference.as_u32(),
+                    extent: 1,
+                    record: None,
+                    expected: 1,
+                    actual: 1,
+                    reason: "deferred anchor does not belong to an unanchored variable read",
+                });
+            }
             match &inst.data {
                 InstData::Match { arms, .. } => self.validate_match_range(arms)?,
                 InstData::FnDecl {


### PR DESCRIPTION
## Summary

- defer identifier read anchors in private RIR side metadata with shared prefixes
- materialize flat anchors only after semantic analysis resolves named string constants, preserving the public RIR API and anchor identity
- version packed RIR transport and validate malformed deferred-anchor data deterministically and atomically

## Testing

- scripts/rue premerge
- scripts/rue test (238 tests passed; six oracle corpus actions could not spawn worker threads because this desktop host was at its per-user process ceiling)
- isolated oracle corpus retry (same host-level EAGAIN before case execution)

Fixes RUE-1659