### PR TITLE
RUE-985: add IPv6 socket address support

### DIFF
--- a/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
@@ -377,7 +377,8 @@ differential_opt = true
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Ipv4Addr { a: u8, b: u8, c: u8, d: u8 }
-enum IpAddr { V4(Ipv4Addr) }
+struct Ipv6Addr { bytes: [u8; 16] }
+enum IpAddr { V4(Ipv4Addr), V6(Ipv6Addr) }
 struct SockAddr { ip: IpAddr, port: u16 }
 enum NetworkError {
     Unsupported, PermissionDenied, AddressInUse, AddressNotAvailable,
@@ -390,7 +391,15 @@ fn local_addr_ok() -> NetResult {
 }
 fn local_addr_err() -> NetResult { NetResult.Err(NetworkError.Other(111)) }
 fn octet_sum(ip: IpAddr) -> i64 {
-    match ip { IpAddr.V4(v4) => @intCast(v4.a) + @intCast(v4.b) + @intCast(v4.c) + @intCast(v4.d), }
+    match ip {
+        IpAddr.V4(v4) => @intCast(v4.a) + @intCast(v4.b) + @intCast(v4.c) + @intCast(v4.d),
+        IpAddr.V6(v6) => {
+            let mut total: i64 = 0;
+            let mut i: u64 = 0;
+            while i < 16 { total += @intCast(v6.bytes[i]); i += 1; }
+            total
+        },
+    }
 }
 fn err_code(e: NetworkError) -> i64 {
     match e {

--- a/crates/rue-cli-tests/cases/std_net.toml
+++ b/crates/rue-cli-tests/cases/std_net.toml
@@ -1,4 +1,4 @@
-# std.net address model + target sockaddr_in marshalling (RUE-982/RUE-986,
+# std.net IPv4/IPv6 address model + target sockaddr marshalling (RUE-982/RUE-985/RUE-986,
 # ADR-0060).
 #
 # The marshaller is the ONE place that knows the kernel byte layout, so these
@@ -8,8 +8,8 @@
 
 [section]
 id = "cli.std_net"
-name = "Standard library v1 — std.net addresses (RUE-982)"
-description = "Ipv4Addr/IpAddr/SockAddr and byte-exact target sockaddr_in marshalling."
+name = "Standard library — std.net addresses (RUE-982/RUE-985)"
+description = "Ipv4Addr/Ipv6Addr/IpAddr/SockAddr and byte-exact target sockaddr marshalling."
 
 # Every byte of the marshalled sockaddr_in, plus octets() and the named
 # constructors. Port 0x1f90 (8080) has distinct hi/lo bytes, and the address
@@ -145,3 +145,127 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "443\n16\n2\n192\n2\n1\n"
+
+[[case]]
+name = "net_sockaddr_in6_exact_layout"
+description = "Linux sockaddr_in6 uses AF_INET6, be port, zero flow/scope, and 16 exact address octets."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["x86-64-linux", "aarch64-linux"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let ip = std.net.Ipv6Addr.new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    let octets = ip.octets();
+    @dbg(octets[0]); @dbg(octets[15]);
+    let b = std.net.SockAddr.v6(ip, 0x1f90).to_sockaddr_in6();
+    @dbg(b[0]); @dbg(b[1]); @dbg(b[2]); @dbg(b[3]);
+    let mut flow_scope_zeros: i32 = 0;
+    let mut i: u64 = 4;
+    while i < 8 { if b[i] == 0 { flow_scope_zeros += 1; } i += 1; }
+    i = 24;
+    while i < 28 { if b[i] == 0 { flow_scope_zeros += 1; } i += 1; }
+    @dbg(flow_scope_zeros);
+    i = 8;
+    while i < 24 { @dbg(b[i]); i += 1; }
+    @dbg(std.net.sockaddr_in6_len());
+    let lo = std.net.Ipv6Addr.localhost().octets();
+    @dbg(lo[0]); @dbg(lo[14]); @dbg(lo[15]);
+    let any = std.net.Ipv6Addr.unspecified().octets();
+    @dbg(any[0]); @dbg(any[15]);
+    0
+}
+""" }]
+stdout = "1\n16\n10\n0\n31\n144\n8\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n28\n0\n0\n1\n0\n0\n"
+
+[[case]]
+name = "net_sockaddr_in6_darwin_exact_layout"
+description = "Darwin sockaddr_in6 uses sin6_len=28, AF_INET6=30, be port, zero flow/scope, and exact octets."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["aarch64-macos"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let b = std.net.SockAddr.v6(
+        std.net.Ipv6Addr.new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+        0x1f90
+    ).to_sockaddr_in6();
+    @dbg(b[0]); @dbg(b[1]); @dbg(b[2]); @dbg(b[3]);
+    @dbg(b[4]); @dbg(b[7]); @dbg(b[8]); @dbg(b[23]); @dbg(b[24]); @dbg(b[27]);
+    @dbg(std.net.sockaddr_in6_len());
+    0
+}
+""" }]
+stdout = "28\n30\n31\n144\n0\n0\n1\n16\n0\n0\n28\n"
+
+[[case]]
+name = "net_sockaddr_in6_decode_and_reject_malformed"
+description = "sockaddr_in6 round-trips and rejects wrong family plus nonzero flowinfo/scope_id."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn rejected(b: [u8; 28]) -> i32 {
+    let O = std.option.Option(std.net.SockAddr);
+    match std.net.SockAddr.from_sockaddr_in6(b) {
+        O.Some(a) => 0,
+        O.None => 1,
+    }
+}
+
+fn rejected4(b: [u8; 16]) -> i32 {
+    let O = std.option.Option(std.net.SockAddr);
+    match std.net.SockAddr.from_sockaddr_in(b) {
+        O.Some(a) => 0,
+        O.None => 1,
+    }
+}
+
+fn main() -> i32 {
+    let O = std.option.Option(std.net.SockAddr);
+    let addr = std.net.SockAddr.v6(std.net.Ipv6Addr.localhost(), 443);
+    let good = addr.to_sockaddr_in6();
+    match std.net.SockAddr.from_sockaddr_in6(good) {
+        O.Some(back) => {
+            @dbg(back.port);
+            let b = back.to_sockaddr_in6();
+            @dbg(b[8]); @dbg(b[22]); @dbg(b[23]);
+        },
+        O.None => { @dbg(0 - 1); },
+    }
+    let wrong_family = match @target_os() {
+        Os.Linux => [2, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+        Os.Macos => [28, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+    };
+    @dbg(rejected(wrong_family));
+    // Linux has no embedded length byte, so its distinct control counterfeits
+    // AF_INET6 in big-endian order. Darwin instead counterfeits sin6_len.
+    let wrong_prefix = match @target_os() {
+        Os.Linux => [0, 10, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+        Os.Macos => [27, 30, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+    };
+    @dbg(rejected(wrong_prefix));
+    let flow = match @target_os() {
+        Os.Linux => [10, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+        Os.Macos => [28, 30, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+    };
+    @dbg(rejected(flow));
+    let scope = match @target_os() {
+        Os.Linux => [10, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0],
+        Os.Macos => [28, 30, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0],
+    };
+    @dbg(rejected(scope));
+    let counterfeit4 = match @target_os() {
+        Os.Linux => [2, 0, 0, 1, 127, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+        Os.Macos => [16, 2, 0, 1, 127, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+    };
+    @dbg(rejected4(counterfeit4));
+    0
+}
+""" }]
+stdout = "443\n0\n0\n1\n1\n1\n1\n1\n1\n"

--- a/crates/rue-cli-tests/cases/std_net.toml
+++ b/crates/rue-cli-tests/cases/std_net.toml
@@ -170,9 +170,11 @@ fn main() -> i32 {
     i = 8;
     while i < 24 { @dbg(b[i]); i += 1; }
     @dbg(std.net.sockaddr_in6_len());
-    let lo = std.net.Ipv6Addr.localhost().octets();
+    let lo_addr = std.net.Ipv6Addr.localhost();
+    let lo = lo_addr.octets();
     @dbg(lo[0]); @dbg(lo[14]); @dbg(lo[15]);
-    let any = std.net.Ipv6Addr.unspecified().octets();
+    let any_addr = std.net.Ipv6Addr.unspecified();
+    let any = any_addr.octets();
     @dbg(any[0]); @dbg(any[15]);
     0
 }

--- a/crates/rue-cli-tests/cases/std_net_tcp.toml
+++ b/crates/rue-cli-tests/cases/std_net_tcp.toml
@@ -1,4 +1,4 @@
-# std.net blocking TCP v1 (RUE-983, ADR-0060) — real sockets over loopback.
+# std.net blocking TCP (RUE-983/RUE-985, ADR-0060) — real sockets over loopback.
 #
 # The loopback case runs the whole blocking client/server surface in one process:
 # bind on an ephemeral port (port 0 + local_addr, so no fixed port is
@@ -11,8 +11,8 @@
 
 [section]
 id = "cli.std_net_tcp"
-name = "Standard library v1 — std.net blocking TCP (RUE-983/RUE-986)"
-description = "TcpListener/TcpStream over loopback: connect/accept/read/write/shutdown/close."
+name = "Standard library — std.net blocking TCP (RUE-983/RUE-985/RUE-986)"
+description = "IPv4/IPv6 TcpListener/TcpStream loopback: connect/accept/read/write/shutdown/close."
 
 [[case]]
 name = "tcp_loopback_round_trip"
@@ -399,6 +399,72 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "1\n"
+
+[[case]]
+name = "tcp_ipv6_loopback_round_trip"
+description = "IPv6 ::1 bind/local_addr/connect/accept and byte transfer use sockaddr_in6 end to end."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn fail(code: i32) -> i32 { @dbg(code); 1 }
+
+fn main() -> i32 {
+    let RL = std.result.Result(std.net.TcpListener, std.net.NetworkError);
+    let RS = std.result.Result(std.net.TcpStream, std.net.NetworkError);
+    let RA = std.result.Result(std.net.SockAddr, std.net.NetworkError);
+    let RU = std.result.Result(u64, std.net.NetworkError);
+    let RUnit = std.result.Result((), std.net.NetworkError);
+
+    let mut listener = match std.net.TcpListener.bind(
+        std.net.SockAddr.v6(std.net.Ipv6Addr.localhost(), 0)
+    ) {
+        RL.Ok(l) => l,
+        RL.Err(e) => { return fail(201); },
+    };
+    let local = match listener.local_addr() {
+        RA.Ok(a) => a,
+        RA.Err(e) => { return fail(202); },
+    };
+    let port = local.port;
+    let local_bytes = local.to_sockaddr_in6();
+    if port == 0 || local_bytes[23] != 1 { return fail(203); }
+    @dbg(1);
+
+    let mut client = match std.net.TcpStream.connect(
+        std.net.SockAddr.v6(std.net.Ipv6Addr.localhost(), port)
+    ) {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(204); },
+    };
+    let mut server = match listener.accept() {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(205); },
+    };
+    let mut out = std.arraybuf.ArrayBuf(u8).new();
+    out.push(118); out.push(54);
+    match client.write_all(borrow out) {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(206); },
+    }
+    let mut input = std.arraybuf.ArrayBuf(u8).with_capacity(8);
+    match server.read(inout input) {
+        RU.Ok(n) => {
+            if n != 2 { return fail(207); }
+            @dbg(input.get_or(0, 0)); @dbg(input.get_or(1, 0));
+        },
+        RU.Err(e) => { return fail(208); },
+    }
+    match client.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(209); } }
+    match server.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(210); } }
+    match listener.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(211); } }
+    @dbg(2);
+    0
+}
+""" }]
+stdout = "1\n118\n54\n2\n"
 
 # Darwin's orderly FIN semantics may allow sends after a peer EOF. Shut down
 # the peer's receive direction, close it, and shut down the client's send

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -410,6 +410,12 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.std_net_tcp",
+        "tcp_ipv6_loopback_round_trip",
+        external(ExternalDependencyKind::SystemCall),
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.std_net_tcp",
         "tcp_loopback_round_trip",
         external(ExternalDependencyKind::SystemCall),
         &["aarch64-linux", "aarch64-macos", "x86-64-linux"],

--- a/docs/designs/0060-network-io-v1.md
+++ b/docs/designs/0060-network-io-v1.md
@@ -28,21 +28,21 @@ order conversion in reusable Rue library code rather than compiler intrinsics.
 
 ## Summary
 
-`std.net` v1 provides blocking TCP clients and servers on Linux x86-64,
-aarch64, and AArch64 macOS. It supports IPv4 addresses through an extensible
-public address enum,
-marshals kernel socket addresses explicitly through a `SockAddr` abstraction,
-and exposes separate owned `TcpListener` and `TcpStream` descriptor types.
-Errors are normalized from errno into a target-independent network error enum.
-UDP, IPv6, DNS, TLS, and nonblocking/readiness APIs are outside v1.
+`std.net` v1 introduced blocking IPv4 TCP clients and servers on Linux x86-64,
+aarch64 Linux, and AArch64 macOS. It marshals kernel socket addresses explicitly
+through a `SockAddr` abstraction and exposes separate owned `TcpListener` and
+`TcpStream` descriptor types. Errors are normalized from errno into a
+target-independent network error enum. RUE-985 subsequently extended the same
+public address enum and TCP paths with IPv6. UDP, DNS, TLS, and
+nonblocking/readiness APIs remain outside the implemented surface.
 
 ## Context
 
-Rue's standard library can perform file IO, but cannot yet connect to a service
-or accept a TCP connection. RUE-713 is the design gate for that facility. The
-main decisions are the initial protocol and platform scope, a public address
-shape that does not fossilize IPv4, and a sound boundary between Rue values and
-kernel ABI structures.
+Before this design was implemented, Rue's standard library could perform file
+IO but could not connect to a service or accept a TCP connection. RUE-713 was
+the design gate for that facility. The main decisions were the initial protocol
+and platform scope, a public address shape that would not fossilize IPv4, and a
+sound boundary between Rue values and kernel ABI structures.
 
 Current source and tests constrain this ADR. ADR-0057 and RUE-712 established
 `std.fs` as pure Rue over `@syscall`, including errno normalization and the
@@ -81,17 +81,19 @@ polling, or readiness API. UDP is deferred without a current issue;
 nonblocking/readiness also needs no issue now. These boundaries keep v1 focused
 on the smallest end-to-end client/server facility.
 
-### 2. Public addresses are IPv4 today without being IPv4-shaped forever
+### 2. The public address enum supports compatible family extensions
 
-The public address API follows Rust's extensible shape: an enum has one IPv4
-variant initially, rather than putting four octets directly into every network
-operation. Conceptually:
+The public address API follows Rust's extensible shape. The original v1 enum had
+one IPv4 variant rather than putting four octets directly into every network
+operation; RUE-985 added the IPv6 variant without reshaping those operations.
+Conceptually:
 
 ```rue
 struct Ipv4Addr { a: u8, b: u8, c: u8, d: u8 }
 
 enum IpAddr {
     V4(Ipv4Addr),
+    V6(Ipv6Addr),
 }
 
 struct SockAddr {
@@ -103,7 +105,8 @@ struct SockAddr {
 Names may be adjusted to match standard-library conventions, but the contract
 is an extensible address enum plus a socket address carrying an address and
 port. The top-level connect/bind surface must not be shaped as four IPv4 octets.
-RUE-982 owns the IPv4 types and `SockAddr`; RUE-985 tracks adding IPv6.
+RUE-982 introduced the IPv4 types and `SockAddr`; RUE-985 extended the same
+model with `Ipv6Addr` and `IpAddr.V6`.
 
 ### 3. `SockAddr` owns explicit kernel marshalling
 
@@ -132,6 +135,13 @@ physical representation matches the kernel.
 This boundary is deliberate isolation. IPv6 has a different structure and
 size; adding it extends the `SockAddr` marshaller without exposing kernel
 layouts through the public API.
+
+The IPv6 extension uses the target's 28-byte `sockaddr_in6`: a target-correct
+family prefix, big-endian port, zero flowinfo, 16 address octets in network
+order, and zero scope ID. Linux uses `AF_INET6=10` as a native/little-endian
+`u16`; Darwin uses `sin6_len=28` followed by `AF_INET6=30`. Kernel-filled
+addresses with nonzero flowinfo or scope are rejected until those values have
+a lossless public representation.
 
 ### 4. Byte order is explicit, reusable Rue library code
 
@@ -219,8 +229,8 @@ port, impose bounded timeouts, and clean up both processes and descriptors on
 success or failure. This is real compiled-binary coverage, not only unit tests
 of marshalling helpers.
 
-RUE-985 (IPv6) remains deferred work related to RUE-713; it is not in the v1
-dependency chain.
+IPv6 remains outside the original v1 dependency chain, but RUE-985 subsequently
+added it through the address-model and marshalling extension point above.
 
 ## Consequences
 
@@ -229,7 +239,7 @@ dependency chain.
 - Rue programs gain a minimal, useful TCP client and server facility without
   expanding the Rust runtime or its cross-target archive surface.
 - Explicit marshalling prevents accidental dependence on Rue struct layout and
-  gives future IPv6 support one well-defined extension point.
+  provided IPv6 with one well-defined extension point.
 - Address and error APIs are portable shapes rather than Linux integer/layout
   details leaking into user code.
 - Separate affine listener and stream types make descriptor ownership and valid
@@ -237,7 +247,8 @@ dependency chain.
 
 ### Negative
 
-- v1 is IPv4-only.
+- IPv6 flowinfo and scope ID are not represented publicly; decoding rejects
+  nonzero values rather than discarding them.
 - Syscall numbers, socket constants, errno mappings, and ABI marshalling remain
   target-maintained library data.
 - Without traits, `File` and `TcpStream` have deliberately duplicated method
@@ -248,7 +259,8 @@ dependency chain.
 
 - The design adds no language feature, preview gate, compiler intrinsic, or
   runtime Rust helper.
-- DNS, TLS, UDP, IPv6, and readiness remain separable library work.
+- DNS, TLS, UDP, textual IPv6 conversion, zone-name resolution, and readiness
+  remain separable library work.
 
 ## Alternatives Considered
 
@@ -273,7 +285,7 @@ dependency chain.
 
 ## Future Work
 
-- RUE-985: IPv6 address variants and kernel marshalling.
+- Textual IPv6 parsing/formatting and interface-name zone resolution.
 - UDP, nonblocking/readiness, DNS, and TLS after their requirements are settled.
 
 ## References
@@ -284,4 +296,4 @@ dependency chain.
 - ADR-0059 — endianness remains explicit source-defined library policy
 - RUE-945 — implemented Darwin `@syscall` error normalization
 - RUE-970, RUE-982, RUE-983, RUE-984 — v1 implementation chain
-- RUE-985 — deferred IPv6 work
+- RUE-985 — IPv6 address variants and kernel marshalling

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -24,7 +24,7 @@
 //   remove_dir/metadata, and directory enumeration via fs.read_dir/fs.walk
 //   (deterministically ordered `DirEntries`)
 // - std.binary: endianness-explicit integer<->byte conversions
-// - std.net: network IO v1 address model + target sockaddr marshalling
+// - std.net: IPv4/IPv6 address model + target sockaddr marshalling and TCP
 // - std.c: transparent C scalar-type aliases for the FFI boundary
 //   (c_int/c_long/c_size_t/wchar_t/...) sized per the target psABI
 
@@ -47,8 +47,8 @@ pub const fs = @import("fs.rue");
 // Endianness-explicit integer<->byte conversions (RUE-970, ADR-0059/0060).
 pub const binary = @import("binary.rue");
 
-// Network IO v1: address model + target sockaddr marshalling (RUE-982/RUE-986,
-// ADR-0060).
+// Network IO: IPv4/IPv6 address model + target sockaddr marshalling and
+// blocking TCP (RUE-982/RUE-985/RUE-986, ADR-0060).
 pub const net = @import("net.rue");
 
 // C FFI transparent scalar aliases (RUE-742, ADR-0064 Amendment 1 / P1.5):

--- a/std/net.rue
+++ b/std/net.rue
@@ -7,18 +7,16 @@
 // byte array that checked code hands to `@syscall` (ADR-0060 §3).
 //
 // The public shape follows Rust's extensible address model (ADR-0060 §2): an
-// `IpAddr` enum with one IPv4 variant today, so the top-level surface is not
-// four-octets-shaped forever. IPv6 adds a variant later (RUE-985); it is not a
-// speculative representation here.
+// `IpAddr` enum carries either an IPv4 or IPv6 address, so the top-level socket
+// surface is independent of the kernel address-family layout.
 //
 //     const std = @import("std");
 //     let addr = std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 8080);
 //     let bytes = addr.to_sockaddr_in();     // target sockaddr_in, 16 bytes
 //
-// PLATFORM SCOPE (ADR-0060 §7): the marshalled layout is the target's IPv4
-// `sockaddr_in`. Linux uses a native/little-endian family field; Darwin uses
-// `sin_len` followed by the one-byte family field. Both supported layouts are
-// exactly 16 bytes and are selected by the target-aware ABI helpers below.
+// PLATFORM SCOPE (ADR-0060 §7): Linux uses native/little-endian family fields;
+// Darwin uses a leading length byte and one-byte family. `sockaddr_in` is 16
+// bytes and `sockaddr_in6` is 28 bytes on every supported target.
 
 const binary = @import("binary.rue");
 const option = @import("option.rue");
@@ -29,11 +27,24 @@ fn _af_inet() -> u16 {
     2
 }
 
+// AF_INET6 differs between Linux and Darwin.
+fn _af_inet6() -> u16 {
+    match @target_os() {
+        Os.Linux => 10,
+        Os.Macos => 30,
+    }
+}
+
 // Byte size of the marshalled target `sockaddr_in`. Callers pass this as the
 // address length at the syscall boundary and validate kernel-returned lengths
 // against it before decoding.
 pub fn sockaddr_in_len() -> u64 {
     16
+}
+
+// Byte size of the marshalled target `sockaddr_in6`.
+pub fn sockaddr_in6_len() -> u64 {
+    28
 }
 
 // An IPv4 address as its four dotted-quad octets: `a.b.c.d`.
@@ -64,10 +75,35 @@ pub struct Ipv4Addr {
     }
 }
 
-// An IP address. v1 carries IPv4 only; IPv6 becomes a second variant later
-// (RUE-985) without reshaping every network operation.
+// An IPv6 address as 16 octets in network order. Text parsing and zone-name
+// resolution are deliberately separate concerns; scope and flow fields are
+// deterministically zero at this socket-address boundary.
+pub struct Ipv6Addr {
+    bytes: [u8; 16],
+
+    fn new(bytes: [u8; 16]) -> Ipv6Addr {
+        Ipv6Addr { bytes: bytes }
+    }
+
+    // The loopback address ::1.
+    fn localhost() -> Ipv6Addr {
+        Ipv6Addr.new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    }
+
+    // The unspecified "any" address ::.
+    fn unspecified() -> Ipv6Addr {
+        Ipv6Addr.new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    }
+
+    fn octets(borrow self) -> [u8; 16] {
+        self.bytes
+    }
+}
+
+// An IP address. Adding V6 preserves the accepted ADR-0060 top-level shape.
 pub enum IpAddr {
     V4(Ipv4Addr),
+    V6(Ipv6Addr),
 }
 
 // A socket address: an IP address plus a TCP/UDP port.
@@ -81,6 +117,10 @@ pub struct SockAddr {
 
     fn v4(ip: Ipv4Addr, port: u16) -> SockAddr {
         SockAddr { ip: IpAddr.V4(ip), port: port }
+    }
+
+    fn v6(ip: Ipv6Addr, port: u16) -> SockAddr {
+        SockAddr { ip: IpAddr.V6(ip), port: port }
     }
 
     // Encode this address as the target `sockaddr_in` byte layout (ADR-0060
@@ -115,13 +155,14 @@ pub struct SockAddr {
                     0, 0, 0, 0, 0, 0, 0, 0,
                 ],
             },
+            IpAddr.V6(v6) => @panic("IPv6 address cannot be encoded as sockaddr_in"),
         }
     }
 
     // Decode a kernel-filled target `sockaddr_in`. Returns `None` unless the
     // target's family (and Darwin sin_len) is valid; the caller has already
     // validated the returned address length at the syscall boundary (ADR-0060
-    // §3). The trailing padding bytes are ignored.
+    // §3). Padding must be the canonical all-zero layout.
     fn from_sockaddr_in(b: [u8; 16]) -> option.Option(SockAddr) {
         let O = option.Option(SockAddr);
         match @target_os() {
@@ -133,10 +174,113 @@ pub struct SockAddr {
                 if b[0] != 16 || b[1] != @intCast(_af_inet()) { return O.None; }
             },
         }
+        if b[8] != 0 || b[9] != 0 || b[10] != 0 || b[11] != 0 {
+            return O.None;
+        }
+        if b[12] != 0 || b[13] != 0 || b[14] != 0 || b[15] != 0 {
+            return O.None;
+        }
         let port = binary.u16_from_be_bytes([b[2], b[3]]);
         let ip = Ipv4Addr.new(b[4], b[5], b[6], b[7]);
         O.Some(SockAddr.v4(ip, port))
     }
+
+    // Encode this address as the target `sockaddr_in6` layout. Both layouts
+    // use a big-endian port, zero flowinfo, 16 network-order address octets,
+    // and zero scope_id. Linux's family is native/little-endian; Darwin uses
+    // sin6_len=28 followed by its one-byte AF_INET6 value.
+    fn to_sockaddr_in6(self) -> [u8; 28] {
+        let pb = binary.u16_to_be_bytes(self.port);
+        match self.ip {
+            IpAddr.V4(v4) => @panic("IPv4 address cannot be encoded as sockaddr_in6"),
+            IpAddr.V6(v6) => {
+                let a = v6.bytes;
+                match @target_os() {
+                    Os.Linux => {
+                        let fam = binary.u16_to_le_bytes(_af_inet6());
+                        [
+                            fam[0], fam[1], pb[0], pb[1],
+                            0, 0, 0, 0,
+                            a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7],
+                            a[8], a[9], a[10], a[11], a[12], a[13], a[14], a[15],
+                            0, 0, 0, 0,
+                        ]
+                    },
+                    Os.Macos => [
+                        28, @intCast(_af_inet6()), pb[0], pb[1],
+                        0, 0, 0, 0,
+                        a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7],
+                        a[8], a[9], a[10], a[11], a[12], a[13], a[14], a[15],
+                        0, 0, 0, 0,
+                    ],
+                }
+            },
+        }
+    }
+
+    // Decode a complete target `sockaddr_in6`. Flowinfo and scope_id must be
+    // zero because the current public value has no fields that could preserve
+    // them; rejecting rather than silently discarding them is fail-closed.
+    fn from_sockaddr_in6(b: [u8; 28]) -> option.Option(SockAddr) {
+        let O = option.Option(SockAddr);
+        match @target_os() {
+            Os.Linux => {
+                let fam = binary.u16_from_le_bytes([b[0], b[1]]);
+                if fam != _af_inet6() { return O.None; }
+            },
+            Os.Macos => {
+                if b[0] != 28 || b[1] != @intCast(_af_inet6()) { return O.None; }
+            },
+        }
+        if b[4] != 0 || b[5] != 0 || b[6] != 0 || b[7] != 0 {
+            return O.None;
+        }
+        if b[24] != 0 || b[25] != 0 || b[26] != 0 || b[27] != 0 {
+            return O.None;
+        }
+        let port = binary.u16_from_be_bytes([b[2], b[3]]);
+        let ip = Ipv6Addr.new([
+            b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
+            b[16], b[17], b[18], b[19], b[20], b[21], b[22], b[23],
+        ]);
+        O.Some(SockAddr.v6(ip, port))
+    }
+
+    // The single syscall-boundary projection. It keeps the selected domain,
+    // byte image, and length together so they cannot disagree.
+    fn _to_kernel(self) -> _KernelSockAddr {
+        let port = self.port;
+        match self.ip {
+            IpAddr.V4(v4) => {
+                let b = SockAddr.v4(v4, port).to_sockaddr_in();
+                _KernelSockAddr {
+                    domain: @intCast(_af_inet()),
+                    len: sockaddr_in_len(),
+                    bytes: [
+                        b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+                        b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                }
+            },
+            IpAddr.V6(v6) => {
+                let b = SockAddr.v6(v6, port).to_sockaddr_in6();
+                _KernelSockAddr {
+                    domain: @intCast(_af_inet6()),
+                    len: sockaddr_in6_len(),
+                    bytes: b,
+                }
+            },
+        }
+    }
+}
+
+// Internal canonical socket-call address. The first `len` bytes are the exact
+// target sockaddr image; the remaining bytes are never passed to the kernel.
+struct _KernelSockAddr {
+    domain: u64,
+    len: u64,
+    bytes: [u8; 28],
 }
 
 // ===========================================================================
@@ -475,30 +619,27 @@ fn _normalize_macos_errno(e: i64) -> NetworkError {
     }
 }
 
-// Serialize a marshalled sockaddr_in value into a kernel-addressable 16-byte
-// heap buffer. A `[u8; 16]` VALUE lives in 8-byte logical slots (ADR-0040),
-// so its storage is not the contiguous byte image the kernel needs; this is
-// the one copy from value space into byte space. Caller frees with
-// `@free(buf, sockaddr_in_len(), 1)`.
-fn _sockaddr_to_kernel_buf(b: [u8; 16]) -> ptr mut u8 {
-    let buf: ptr mut u8 = checked { @alloc(sockaddr_in_len(), 1) };
+// Serialize the canonical address projection into a contiguous kernel buffer.
+// Rue array values live in 8-byte logical slots (ADR-0040), so their storage
+// is not itself a socket ABI byte image. Caller frees with `addr.len`.
+fn _sockaddr_to_kernel_buf(borrow addr: _KernelSockAddr) -> ptr mut u8 {
+    let buf: ptr mut u8 = checked { @alloc(addr.len, 1) };
     if checked { @ptr_to_int(buf) } == 0 {
         @panic("out of memory");
     }
     let mut i: u64 = 0;
-    while i < 16 {
-        checked { @ptr_write(@ptr_offset(buf, i), b[i]); };
+    while i < addr.len {
+        checked { @ptr_write(@ptr_offset(buf, i), addr.bytes[i]); };
         i += 1;
     }
     buf
 }
 
-// Create an AF_INET SOCK_STREAM socket, or the normalized error.
-fn _new_stream_socket() -> result.Result(i32, NetworkError) {
+// Create a stream socket in the address's selected domain.
+fn _new_stream_socket(domain: u64) -> result.Result(i32, NetworkError) {
     let R = result.Result(i32, NetworkError);
-    let af: u64 = @intCast(_af_inet());
     let proto: u64 = 0;
-    let ret: i64 = checked { @syscall(_sys_socket(), af, _sock_stream(), proto) };
+    let ret: i64 = checked { @syscall(_sys_socket(), domain, _sock_stream(), proto) };
     if ret < 0 {
         R.Err(_normalize_net_errno(0 - ret))
     } else {
@@ -531,16 +672,17 @@ pub struct TcpStream {
         if !_net_supported() {
             return R.Err(NetworkError.Unsupported);
         }
+        let kernel_addr = addr._to_kernel();
         let RS = result.Result(i32, NetworkError);
-        let fd = match _new_stream_socket() {
+        let fd = match _new_stream_socket(kernel_addr.domain) {
             RS.Ok(fd) => fd,
             RS.Err(e) => { return R.Err(e); },
         };
-        let buf = _sockaddr_to_kernel_buf(addr.to_sockaddr_in());
+        let buf = _sockaddr_to_kernel_buf(borrow kernel_addr);
         let baddr: u64 = checked { @ptr_to_int(buf) };
         let fd_u: u64 = @intCast(fd);
-        let ret: i64 = checked { @syscall(_sys_connect(), fd_u, baddr, sockaddr_in_len()) };
-        checked { @free(buf, sockaddr_in_len(), 1); };
+        let ret: i64 = checked { @syscall(_sys_connect(), fd_u, baddr, kernel_addr.len) };
+        checked { @free(buf, kernel_addr.len, 1); };
         if ret < 0 {
             _close_raw(fd);
             return R.Err(_normalize_net_errno(0 - ret));
@@ -720,16 +862,17 @@ pub struct TcpListener {
         if !_net_supported() {
             return R.Err(NetworkError.Unsupported);
         }
+        let kernel_addr = addr._to_kernel();
         let RS = result.Result(i32, NetworkError);
-        let fd = match _new_stream_socket() {
+        let fd = match _new_stream_socket(kernel_addr.domain) {
             RS.Ok(fd) => fd,
             RS.Err(e) => { return R.Err(e); },
         };
-        let buf = _sockaddr_to_kernel_buf(addr.to_sockaddr_in());
+        let buf = _sockaddr_to_kernel_buf(borrow kernel_addr);
         let baddr: u64 = checked { @ptr_to_int(buf) };
         let fd_u: u64 = @intCast(fd);
-        let bret: i64 = checked { @syscall(_sys_bind(), fd_u, baddr, sockaddr_in_len()) };
-        checked { @free(buf, sockaddr_in_len(), 1); };
+        let bret: i64 = checked { @syscall(_sys_bind(), fd_u, baddr, kernel_addr.len) };
+        checked { @free(buf, kernel_addr.len, 1); };
         if bret < 0 {
             _close_raw(fd);
             return R.Err(_normalize_net_errno(0 - bret));
@@ -748,17 +891,18 @@ pub struct TcpListener {
     // (ADR-0060 §3).
     fn local_addr(inout self) -> result.Result(SockAddr, NetworkError) {
         let R = result.Result(SockAddr, NetworkError);
-        let abuf: ptr mut u8 = checked { @alloc(sockaddr_in_len(), 1) };
+        let abuf: ptr mut u8 = checked { @alloc(sockaddr_in6_len(), 1) };
         if checked { @ptr_to_int(abuf) } == 0 {
             @panic("out of memory");
         }
-        // socklen_t in/out argument: starts at 16, kernel writes the actual
-        // length back (little-endian u32 on both v1 targets).
+        // socklen_t in/out argument: starts at the largest supported address,
+        // and the kernel writes the actual family-specific length back as a
+        // little-endian u32 on every supported target.
         let lbuf: ptr mut u8 = checked { @alloc(4, 1) };
         if checked { @ptr_to_int(lbuf) } == 0 {
             @panic("out of memory");
         }
-        checked { @ptr_write(@ptr_offset(lbuf, 0), 16); };
+        checked { @ptr_write(@ptr_offset(lbuf, 0), 28); };
         checked { @ptr_write(@ptr_offset(lbuf, 1), 0); };
         checked { @ptr_write(@ptr_offset(lbuf, 2), 0); };
         checked { @ptr_write(@ptr_offset(lbuf, 3), 0); };
@@ -767,7 +911,7 @@ pub struct TcpListener {
         let fd_u: u64 = @intCast(self.fd);
         let ret: i64 = checked { @syscall(_sys_getsockname(), fd_u, aaddr, laddr) };
         if ret < 0 {
-            checked { @free(abuf, sockaddr_in_len(), 1); };
+            checked { @free(abuf, sockaddr_in6_len(), 1); };
             checked { @free(lbuf, 4, 1); };
             return R.Err(_normalize_net_errno(0 - ret));
         }
@@ -777,8 +921,8 @@ pub struct TcpListener {
         let l3 = checked { @ptr_read(@ptr_offset(lbuf, 3)) };
         checked { @free(lbuf, 4, 1); };
         let written_len = binary.u32_from_le_bytes([l0, l1, l2, l3]);
-        if written_len != 16 {
-            checked { @free(abuf, sockaddr_in_len(), 1); };
+        if written_len != 16 && written_len != 28 {
+            checked { @free(abuf, sockaddr_in6_len(), 1); };
             return R.Err(NetworkError.InvalidInput);
         }
         let b0 = checked { @ptr_read(@ptr_offset(abuf, 0)) };
@@ -789,10 +933,48 @@ pub struct TcpListener {
         let b5 = checked { @ptr_read(@ptr_offset(abuf, 5)) };
         let b6 = checked { @ptr_read(@ptr_offset(abuf, 6)) };
         let b7 = checked { @ptr_read(@ptr_offset(abuf, 7)) };
-        checked { @free(abuf, sockaddr_in_len(), 1); };
-        let bytes: [u8; 16] = [b0, b1, b2, b3, b4, b5, b6, b7, 0, 0, 0, 0, 0, 0, 0, 0];
+        let b8 = checked { @ptr_read(@ptr_offset(abuf, 8)) };
+        let b9 = checked { @ptr_read(@ptr_offset(abuf, 9)) };
+        let b10 = checked { @ptr_read(@ptr_offset(abuf, 10)) };
+        let b11 = checked { @ptr_read(@ptr_offset(abuf, 11)) };
+        let b12 = checked { @ptr_read(@ptr_offset(abuf, 12)) };
+        let b13 = checked { @ptr_read(@ptr_offset(abuf, 13)) };
+        let b14 = checked { @ptr_read(@ptr_offset(abuf, 14)) };
+        let b15 = checked { @ptr_read(@ptr_offset(abuf, 15)) };
         let O = option.Option(SockAddr);
-        match SockAddr.from_sockaddr_in(bytes) {
+        if written_len == 16 {
+            checked { @free(abuf, sockaddr_in6_len(), 1); };
+            let bytes: [u8; 16] = [
+                b0, b1, b2, b3, b4, b5, b6, b7,
+                b8, b9, b10, b11, b12, b13, b14, b15,
+            ];
+            return match SockAddr.from_sockaddr_in(bytes) {
+                O.Some(a) => R.Ok(a),
+                O.None => R.Err(NetworkError.InvalidInput),
+            };
+        }
+        // Only a validated 28-byte result reaches these reads. In particular,
+        // an IPv4 result never reads the uninitialized tail of the buffer.
+        let b16 = checked { @ptr_read(@ptr_offset(abuf, 16)) };
+        let b17 = checked { @ptr_read(@ptr_offset(abuf, 17)) };
+        let b18 = checked { @ptr_read(@ptr_offset(abuf, 18)) };
+        let b19 = checked { @ptr_read(@ptr_offset(abuf, 19)) };
+        let b20 = checked { @ptr_read(@ptr_offset(abuf, 20)) };
+        let b21 = checked { @ptr_read(@ptr_offset(abuf, 21)) };
+        let b22 = checked { @ptr_read(@ptr_offset(abuf, 22)) };
+        let b23 = checked { @ptr_read(@ptr_offset(abuf, 23)) };
+        let b24 = checked { @ptr_read(@ptr_offset(abuf, 24)) };
+        let b25 = checked { @ptr_read(@ptr_offset(abuf, 25)) };
+        let b26 = checked { @ptr_read(@ptr_offset(abuf, 26)) };
+        let b27 = checked { @ptr_read(@ptr_offset(abuf, 27)) };
+        checked { @free(abuf, sockaddr_in6_len(), 1); };
+        let bytes: [u8; 28] = [
+            b0, b1, b2, b3, b4, b5, b6, b7,
+            b8, b9, b10, b11, b12, b13, b14, b15,
+            b16, b17, b18, b19, b20, b21, b22, b23,
+            b24, b25, b26, b27,
+        ];
+        match SockAddr.from_sockaddr_in6(bytes) {
             O.Some(a) => R.Ok(a),
             O.None => R.Err(NetworkError.InvalidInput),
         }


### PR DESCRIPTION
Adds IPv6 to the existing std.net address model and TCP paths.

- adds Ipv6Addr, IpAddr.V6, and SockAddr.v6
- marshals exact target-correct Linux and Darwin sockaddr_in6 layouts
- keeps socket domain, length, and bytes in one canonical syscall projection
- strictly rejects malformed family, length, flowinfo, scope, and padding inputs
- preserves IPv4 bytes and behavior
- adds exact-layout and native ::1 loopback coverage

Validation: focused std.net tests, quick, fmt, and premerge pass. The local oracle-diff action was attempted twice but could not spawn a query worker because the host returned EAGAIN; merge-queue CI remains authoritative for Linux and corpus execution.

Fixes RUE-985