### PR TITLE
RUE-1796: validate nightly fuzz target scheduling

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -141,8 +141,8 @@ jobs:
       # Guard against RUE-515 recurring: `emitter_aarch64` was registered in the
       # fuzzer but never invoked here, so aarch64 codegen got no nightly
       # byte-mutation budget. Fail fast if any target the fuzzer advertises via
-      # --list has no `--max-time` step in this file. A target intentionally kept
-      # off the nightly budget must be listed in NIGHTLY_EXEMPT with a reason.
+      # --list lacks its complete execution, cache, aggregation, or reporting
+      # contract. An intentional nightly exemption must include a reason here.
       - name: Verify every registered fuzz target is scheduled
         run: |
           NIGHTLY_EXEMPT=""   # none currently exempt
@@ -155,21 +155,13 @@ jobs:
           if [ "${#targets[@]}" -eq 0 ]; then
             echo "::error::could not enumerate fuzz targets from --list"; exit 1
           fi
-          missing=()
+          scheduled=()
           for t in "${targets[@]}"; do
             case " $NIGHTLY_EXEMPT " in *" $t "*) continue ;; esac
-            grep -qF -- "--mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/${t} ${t} crates/rue-fuzz/nightly-input/${t}" .github/workflows/fuzz.yml || missing+=("$t")
-            grep -qF -- "path: crates/rue-fuzz/nightly-restored/${t}" .github/workflows/fuzz.yml || missing+=("${t}:restore-path")
-            restored_paths="$(grep -cF -- "path: crates/rue-fuzz/nightly-restored/${t}" .github/workflows/fuzz.yml || true)"
-            [ "$restored_paths" -ge 2 ] || missing+=("${t}:save-path")
-            grep -qF -- "key: rue-fuzz-corpus-v3-${t}-${{ github.run_id }}-${{ github.run_attempt }}" .github/workflows/fuzz.yml || missing+=("${t}:generation-key")
-            grep -qF -- "restore-keys: rue-fuzz-corpus-v3-${t}-" .github/workflows/fuzz.yml || missing+=("${t}:restore-prefix")
+            scheduled[${#scheduled[@]}]="$t"
           done
-          if [ "${#missing[@]}" -ne 0 ]; then
-            echo "::error::registered fuzz target(s) not scheduled with an isolated five-minute corpus step: ${missing[*]}"
-            echo "Add the exact '--max-time=300' step (plus aggregation, reporting, and cache save entries), or add the target to NIGHTLY_EXEMPT."
-            exit 1
-          fi
+          python3 scripts/validate-fuzz-workflow.py \
+            .github/workflows/fuzz.yml "${scheduled[@]}"
           echo "All ${#targets[@]} registered fuzz targets are scheduled: ${targets[*]}"
 
       # Each fuzz step is continue-on-error so one crashing target no longer

--- a/BUCK
+++ b/BUCK
@@ -1649,7 +1649,10 @@ rue_sh_test(
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_FUZZ_REPORT_ROOT": "$(location :fuzz-report-test-inputs)",
     },
-    resources = ["scripts/fuzz-report-failure.py"] +
+    resources = [
+        "scripts/fuzz-report-failure.py",
+        "scripts/validate-fuzz-workflow.py",
+    ] +
         [":gatelib-sources"],
 )
 

--- a/scripts/test-fuzz-report-failure.py
+++ b/scripts/test-fuzz-report-failure.py
@@ -38,6 +38,7 @@ sys.path.insert(0, str(SCRIPTS))
 from gatelib import load_script
 
 fr = load_script("fuzz-report-failure.py", __file__)
+fw = load_script("validate-fuzz-workflow.py", __file__)
 
 
 class MockTransport(fr.Transport):
@@ -603,6 +604,7 @@ class WorkflowContractTests(unittest.TestCase):
             "emitter_sequence_aarch64",
         )
         for target in targets:
+            self.assertEqual(fw.validate_target(self.workflow, target), [])
             self.assertIn(
                 f"path: crates/rue-fuzz/nightly-restored/{target}", self.workflow
             )
@@ -652,22 +654,118 @@ class WorkflowContractTests(unittest.TestCase):
         )
 
     def test_live_target_guard_checks_cache_wiring(self):
-        guard = self.workflow.split("- name: Verify every registered fuzz target is scheduled", 1)[1]
+        guard = fw.matching_block(
+            fw.step_blocks(self.workflow),
+            "- name: Verify every registered fuzz target is scheduled",
+            6,
+        )
+        self.assertIsNotNone(guard)
         self.assertIn(
-            'grep -qF -- "path: crates/rue-fuzz/nightly-restored/${t}"', guard
+            "python3 scripts/validate-fuzz-workflow.py", guard
+        )
+        self.assertNotIn(
+            "${{ github.run_id }}", guard
+        )
+        self.assertNotIn(
+            "${{ github.run_attempt }}", guard
         )
         self.assertIn(
-            'grep -cF -- "path: crates/rue-fuzz/nightly-restored/${t}"', guard
-        )
-        self.assertIn(
-            'key: rue-fuzz-corpus-v3-${t}-${{ github.run_id }}-${{ github.run_attempt }}',
-            guard,
-        )
-        self.assertIn(
-            'restore-keys: rue-fuzz-corpus-v3-${t}-',
+            '.github/workflows/fuzz.yml "${scheduled[@]}"',
             guard,
         )
         self.assertNotRegex(self.workflow, r"\b(?:find|cp)\s+.*nightly-(?:restored|corpus)")
+
+    def test_live_target_validator_rejects_expression_interpolation_drift(self):
+        target = "lexer"
+        generation_key = (
+            f"key: rue-fuzz-corpus-v3-{target}-"
+            "${{ github.run_id }}-${{ github.run_attempt }}"
+        )
+        drifted = self.workflow.replace(
+            generation_key,
+            f"key: rue-fuzz-corpus-v3-{target}-12345-1",
+        )
+        self.assertEqual(
+            fw.validate_target(drifted, target),
+            [
+                "lexer:restore-generation-key",
+                "lexer:save-generation-key",
+            ],
+        )
+
+    def test_live_target_validator_rejects_a_missing_target_field(self):
+        target = "lexer"
+        missing_aggregation = self.workflow.replace(
+            "steps.fuzz-lexer.outcome == 'failure' ||", "", 1
+        )
+        self.assertEqual(
+            fw.validate_target(missing_aggregation, target),
+            ["lexer:failure-aggregation"],
+        )
+
+    def test_live_target_validator_ignores_a_commented_out_mutation_command(self):
+        target = "lexer"
+        command = (
+            "./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 "
+            "--evolve-corpus=crates/rue-fuzz/nightly-corpus/lexer lexer "
+            "crates/rue-fuzz/nightly-input/lexer"
+        )
+        commented = self.workflow.replace(
+            f"        run: {command}",
+            f"        run: |\n          # {command}",
+        )
+        self.assertEqual(
+            fw.validate_target(commented, target),
+            ["lexer:five-minute-step"],
+        )
+
+    def test_live_target_validator_ignores_aggregation_shell_comments(self):
+        target = "lexer"
+        camouflaged = self.workflow.replace(
+            "          steps.fuzz-lexer.outcome == 'failure' ||\n", "", 1
+        ).replace(
+            '          echo "One or more fuzz targets found crashes (see step outcomes above)."',
+            "          # steps.fuzz-lexer.outcome == 'failure'\n"
+            '          echo "One or more fuzz targets found crashes (see step outcomes above)."',
+            1,
+        )
+        self.assertEqual(
+            fw.validate_target(camouflaged, target),
+            ["lexer:failure-aggregation"],
+        )
+
+    def test_live_target_validator_rejects_a_disabled_mutation_step(self):
+        disabled = self.workflow.replace(
+            "        id: fuzz-lexer\n",
+            "        id: fuzz-lexer\n        if: false\n",
+            1,
+        )
+        self.assertEqual(
+            fw.validate_target(disabled, "lexer"),
+            ["lexer:five-minute-step"],
+        )
+
+    def test_live_target_validator_rejects_a_dead_aggregation_clause(self):
+        dead_clause = self.workflow.replace(
+            "          steps.fuzz-lexer.outcome == 'failure' ||",
+            "          false && steps.fuzz-lexer.outcome == 'failure' ||",
+            1,
+        )
+        self.assertEqual(
+            fw.validate_target(dead_clause, "lexer"),
+            ["lexer:failure-aggregation"],
+        )
+
+    def test_live_target_validator_rejects_a_folded_dead_aggregation_clause(self):
+        dead_clause = self.workflow.replace(
+            "          steps.fuzz-lexer.outcome == 'failure' ||",
+            "          false &&\n          steps.fuzz-lexer.outcome == 'failure' ||",
+            1,
+        )
+        self.assertEqual(
+            fw.validate_target(dead_clause, "lexer"),
+            ["lexer:failure-aggregation"],
+        )
 
     def test_every_aggregated_target_is_also_named_to_the_reporter(self):
         """A target the reporter does not name degrades to `(job-level failure)`.

--- a/scripts/validate-fuzz-workflow.py
+++ b/scripts/validate-fuzz-workflow.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Validate the per-target contracts in the nightly fuzz workflow."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+STEP_HEADER = re.compile(r"^      - name: ", re.MULTILINE)
+AGGREGATED_TARGET = re.compile(
+    r"steps\.fuzz-[a-z0-9-]+\.outcome == 'failure' \|\|"
+)
+
+
+def step_blocks(workflow: str) -> list[str]:
+    """Return workflow step blocks without requiring a YAML dependency."""
+    starts = [match.start() for match in STEP_HEADER.finditer(workflow)]
+    return [
+        workflow[start : starts[index + 1] if index + 1 < len(starts) else None]
+        for index, start in enumerate(starts)
+    ]
+
+
+def matching_block(blocks: list[str], line: str, indent: int = 8) -> Optional[str]:
+    matches = [block for block in blocks if has_line(block, line, indent)]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def has_line(block: str, line: str, indent: int) -> bool:
+    return f"{' ' * indent}{line}" in block.splitlines()
+
+
+def has_step_field(block: str, field: str) -> bool:
+    prefix = f"        {field}:"
+    return any(line.startswith(prefix) for line in block.splitlines())
+
+
+def scalar_lines(block: str, field: str) -> list[str]:
+    """Return one top-level step block scalar without adjacent YAML fields."""
+    lines = block.splitlines()
+    marker = f"        {field}: |"
+    folded_marker = f"        {field}: >-"
+    starts = [
+        index
+        for index, line in enumerate(lines)
+        if line in (marker, folded_marker)
+    ]
+    if len(starts) != 1:
+        return []
+    body = []
+    for line in lines[starts[0] + 1 :]:
+        if line.startswith("        ") and not line.startswith("          "):
+            break
+        if line.startswith("          "):
+            body.append(line[10:])
+    return body
+
+
+def matching_line_block(blocks: list[str], line: str, indent: int) -> Optional[str]:
+    matches = [block for block in blocks if has_line(block, line, indent)]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def validate_target(workflow: str, target: str) -> list[str]:
+    """Return missing or ambiguous nightly contracts for one fuzz target."""
+    blocks = step_blocks(workflow)
+    step_id = f"fuzz-{target.replace('_', '-')}"
+    generation_key = (
+        f"key: rue-fuzz-corpus-v3-{target}-"
+        "${{ github.run_id }}-${{ github.run_attempt }}"
+    )
+    errors = []
+
+    command = (
+        "--mutate --max-time=300 "
+        f"--evolve-corpus=crates/rue-fuzz/nightly-corpus/{target} "
+        f"{target} crates/rue-fuzz/nightly-input/{target}"
+    )
+    mutation = matching_block(blocks, f"run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- {command}")
+    if (
+        mutation is None
+        or has_step_field(mutation, "if")
+        or not all(
+            has_line(mutation, field, 8)
+            for field in (
+                f"id: {step_id}",
+                "continue-on-error: true",
+                "timeout-minutes: 10",
+            )
+        )
+    ):
+        errors.append(f"{target}:five-minute-step")
+
+    restore_path = f"path: crates/rue-fuzz/nightly-restored/{target}"
+    restore = matching_line_block(
+        [block for block in blocks if has_line(block, "uses: actions/cache/restore@v5", 8)],
+        restore_path,
+        10,
+    )
+    if restore is None or has_step_field(restore, "if"):
+        errors.append(f"{target}:restore-path")
+    else:
+        if not has_line(restore, generation_key, 10):
+            errors.append(f"{target}:restore-generation-key")
+        if not has_line(restore, f"restore-keys: rue-fuzz-corpus-v3-{target}-", 10):
+            errors.append(f"{target}:restore-prefix")
+
+    save = matching_line_block(
+        [block for block in blocks if has_line(block, "uses: actions/cache/save@v5", 8)],
+        restore_path,
+        10,
+    )
+    if save is None:
+        errors.append(f"{target}:save-path")
+    else:
+        if not has_line(save, generation_key, 10):
+            errors.append(f"{target}:save-generation-key")
+        if not has_line(
+            save, "if: always() && steps.publish_clean_corpus.outcome == 'success'", 8
+        ):
+            errors.append(f"{target}:save-condition")
+        if not has_line(save, "continue-on-error: true", 8):
+            errors.append(f"{target}:save-error-policy")
+
+    aggregation = matching_block(
+        blocks, "- name: Fail if any fuzz step found crashes", 6
+    )
+    aggregation_line = f"steps.{step_id}.outcome == 'failure' ||"
+    aggregation_body = [] if aggregation is None else scalar_lines(aggregation, "if")
+    aggregation_body = [line for line in aggregation_body if line]
+    canonical_aggregation = (
+        len(aggregation_body) >= 2
+        and all(AGGREGATED_TARGET.fullmatch(line) for line in aggregation_body[:-1])
+        and aggregation_body[-1] == "steps.fuzz-differential.outcome == 'failure'"
+    )
+    if not canonical_aggregation or aggregation_line not in aggregation_body:
+        errors.append(f"{target}:failure-aggregation")
+
+    reporting = matching_block(
+        blocks, "- name: Report crashes (Linear, GitHub Issues fallback)", 6
+    )
+    report_line = f"record {target} '${{{{ steps.{step_id}.outcome }}}}'"
+    if (
+        reporting is None
+        or not has_line(reporting, "if: failure()", 8)
+        or report_line not in scalar_lines(reporting, "run")
+    ):
+        errors.append(f"{target}:reporting")
+
+    return errors
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workflow", type=Path)
+    parser.add_argument("targets", nargs="+")
+    args = parser.parse_args(argv)
+
+    workflow = args.workflow.read_text()
+    errors = []
+    for target in args.targets:
+        errors.extend(validate_target(workflow, target))
+    if errors:
+        print(
+            "registered fuzz target contract(s) missing or ambiguous: "
+            + " ".join(errors),
+            file=sys.stderr,
+        )
+        return 1
+    print(f"validated {len(args.targets)} registered nightly fuzz target(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- replace interpolation-prone inline workflow greps with a Python 3.9-compatible contract validator
- verify every registered target has its exact mutation, cache restore/save, aggregation, and reporting wiring
- add adversarial regressions for expression interpolation, missing fields, inert comments, disabled steps, and folded dead conditions

## Testing

- `./buck2 test //:fuzz-report-tool-tests`
- `scripts/rue quick`
- `scripts/rue premerge`
- `python3 scripts/validate-python-baseline.py`
- `python3 scripts/validate-shell-bash-baseline.py`

Fixes RUE-1796