### PR TITLE
RUE-437: add compiler error explanations

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -594,8 +594,13 @@ _CLI_TEST_ABSOLUTIZE = _CLI_TEST_BASE_ABSOLUTIZE + ["RUE_CLI_STAGED_PROGRAMS"]
 #
 # Raised 3800 -> 3900 after later corpus growth pushed the linux-arm64 derived
 # deadline to 3805, preserving that same headroom policy.
-_CLI_TESTS_TIMEOUT_SECONDS = 3900
-_CLI_SHARD_TIMEOUT_SECONDS = 1200
+#
+# Raised 3900 -> 4000 and the shared shard bound 1200 -> 1300 when RUE-437's
+# CLI command cases pushed their derived deadlines to 3903s and 1201s. Both
+# bounds retain the established ~100s growth margin instead of immediately
+# becoming flush with the current corpus again.
+_CLI_TESTS_TIMEOUT_SECONDS = 4000
+_CLI_SHARD_TIMEOUT_SECONDS = 1300
 
 # The bounded premerge CLI corpus in one invocation: the canonical target that a
 # local `./test.sh` full run executes and that the RUE-924 corpus-omission audit

--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -1,0 +1,59 @@
+[section]
+id = "cli.explain"
+name = "Compiler-owned error explanations"
+description = """
+RUE-437: `rue explain E####` is a non-compiling CLI command backed by the
+canonical rue-error metadata identity. The deliberately invalid fixture proves
+the successful command returns before source loading or compilation.
+"""
+
+[[case]]
+name = "covered_code_is_explained_without_compiling"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0201"]
+compile_only = true
+compile_stdout_contains = [
+  "E0201: Undefined variable",
+  "Likely cause:",
+  "Undefined local:",
+  "Define the name before use:",
+  "docs/spec/src/10-modules/03-visibility.md (spec rule 10.3:8)",
+]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "malformed_code_is_rejected"
+files = [{ path = "main.rue", source = "fn main() {}\n" }]
+args = ["explain", "E201"]
+compile_fail = true
+error_contains = ["must have the form E followed by exactly four decimal digits"]
+compile_stdout_not_contains = ["E0201:"]
+
+[[case]]
+name = "unknown_code_is_rejected"
+files = [{ path = "main.rue", source = "fn main() {}\n" }]
+args = ["explain", "E9999"]
+compile_fail = true
+error_contains = ["unknown or retired error code E9999"]
+
+[[case]]
+name = "retired_code_is_rejected"
+files = [{ path = "main.rue", source = "fn main() {}\n" }]
+args = ["explain", "E0005"]
+compile_fail = true
+error_contains = ["unknown or retired error code E0005"]
+
+[[case]]
+name = "known_but_uncovered_code_is_rejected"
+files = [{ path = "main.rue", source = "fn main() {}\n" }]
+args = ["explain", "E0206"]
+compile_fail = true
+error_contains = ["no detailed explanation is available yet for E0206"]
+
+[[case]]
+name = "extra_argument_is_rejected"
+files = [{ path = "main.rue", source = "fn main() {}\n" }]
+args = ["explain", "E0201", "main.rue"]
+compile_fail = true
+error_contains = ["requires exactly one error code", "Usage: rue explain <E####>"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -98,6 +98,48 @@ pub struct ErrorCodeMetadata {
     pub source_path: &'static str,
 }
 
+/// A runnable example attached to an error-code explanation.
+///
+/// The fields are deliberately presentation-neutral so command-line and future
+/// machine-readable consumers can project the same compiler-owned record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ErrorCodeExample {
+    pub title: &'static str,
+    pub source: &'static str,
+}
+
+/// A canonical local reference attached to an error-code explanation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ErrorCodeReference {
+    pub title: &'static str,
+    pub path: &'static str,
+    pub rule: Option<&'static str>,
+}
+
+/// Compiler-owned long-form information for one public diagnostic code.
+///
+/// `metadata` points into [`error_code_metadata`], preserving the exact
+/// [`ErrorCode`] identity and symbolic name rather than copying them into a
+/// second registry. The remaining fields form a structured internal result
+/// that can be projected to other formats without scraping rendered prose.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorCodeExplanation {
+    pub metadata: &'static ErrorCodeMetadata,
+    pub explanation: &'static str,
+    pub likely_cause: &'static str,
+    pub examples: &'static [ErrorCodeExample],
+    pub references: &'static [ErrorCodeReference],
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ErrorCodeExplanationDeclaration {
+    code: ErrorCode,
+    explanation: &'static str,
+    likely_cause: &'static str,
+    examples: &'static [ErrorCodeExample],
+    references: &'static [ErrorCodeReference],
+}
+
 /// Maximum supported syntactic nesting depth.
 ///
 /// The parser (recursive-descent through bracketed constructs) and AstGen
@@ -110,7 +152,12 @@ pub struct ErrorCodeMetadata {
 pub const MAX_NESTING_DEPTH: usize = 256;
 
 macro_rules! define_error_codes {
-    ($( $(#[$meta:meta])* $name:ident = $value:literal; )*) => {
+    ($( $(#[$meta:meta])* $name:ident = $value:literal $(=> {
+        explanation: $explanation:literal,
+        likely_cause: $likely_cause:literal,
+        examples: [$($example:expr),* $(,)?],
+        references: [$($reference:expr),* $(,)?] $(,)?
+    })?; )*) => {
         impl ErrorCode {
             $(
                 $(#[$meta])*
@@ -120,6 +167,18 @@ macro_rules! define_error_codes {
 
         const ERROR_CODE_DECLARATIONS: &[(ErrorCode, &str)] = &[
             $((ErrorCode::$name, stringify!($name))),*
+        ];
+
+        const ERROR_CODE_EXPLANATION_DECLARATIONS: &[ErrorCodeExplanationDeclaration] = &[
+            $($(
+                ErrorCodeExplanationDeclaration {
+                    code: ErrorCode::$name,
+                    explanation: $explanation,
+                    likely_cause: $likely_cause,
+                    examples: &[$($example),*],
+                    references: &[$($reference),*],
+                },
+            )?)*
         ];
     };
 }
@@ -164,7 +223,27 @@ define_error_codes! {
     // Semantic errors (E0200-E0399)
     // ========================================================================
     NO_MAIN_FUNCTION = 200;
-    UNDEFINED_VARIABLE = 201;
+    UNDEFINED_VARIABLE = 201 => {
+        explanation: "Rue could not resolve a variable, constant, or enum type name used in an expression.",
+        likely_cause: "The name is misspelled, is outside its lexical scope, or belongs to another module and was used without that module's binding.",
+        examples: [
+            ErrorCodeExample {
+                title: "Undefined local",
+                source: "fn main() -> i32 {\n    answer\n}",
+            },
+            ErrorCodeExample {
+                title: "Define the name before use",
+                source: "fn main() -> i32 {\n    let answer = 42;\n    answer\n}",
+            },
+        ],
+        references: [
+            ErrorCodeReference {
+                title: "Module visibility and name resolution",
+                path: "docs/spec/src/10-modules/03-visibility.md",
+                rule: Some("10.3:8"),
+            },
+        ],
+    };
     UNDEFINED_FUNCTION = 202;
     ASSIGN_TO_IMMUTABLE = 203;
     UNKNOWN_TYPE = 204;
@@ -598,6 +677,35 @@ impl fmt::Display for ErrorCode {
     }
 }
 
+/// Error returned when parsing a public diagnostic code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum ParseErrorCodeError {
+    #[error("error code must have the form E followed by exactly four decimal digits")]
+    Malformed,
+    #[error("unknown or retired error code {0}")]
+    Unknown(ErrorCode),
+}
+
+impl std::str::FromStr for ErrorCode {
+    type Err = ParseErrorCodeError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let digits = value
+            .strip_prefix('E')
+            .filter(|digits| digits.len() == 4 && digits.bytes().all(|byte| byte.is_ascii_digit()))
+            .ok_or(ParseErrorCodeError::Malformed)?;
+        let code = ErrorCode(
+            digits
+                .parse::<u16>()
+                .expect("four decimal digits always fit in u16"),
+        );
+        error_code_metadata()
+            .binary_search_by_key(&code.0, |entry| entry.code.0)
+            .map(|_| code)
+            .map_err(|_| ParseErrorCodeError::Unknown(code))
+    }
+}
+
 /// Return every public compiler error code in numeric order.
 ///
 /// `define_error_codes!` remains the single structural authority: it emits the
@@ -627,6 +735,38 @@ pub fn error_code_metadata() -> &'static [ErrorCodeMetadata] {
         metadata.sort_by_key(|entry| entry.code.0);
         metadata
     })
+}
+
+/// Return the compiler-owned long-form explanation for `code`, when this
+/// production tranche covers it.
+///
+/// Explanation declarations are emitted by the same macro invocation as the
+/// [`ErrorCode`] constants. At initialization they are joined to the canonical
+/// metadata inventory, so consumers cannot observe a copied code identity or
+/// symbolic-name registry.
+pub fn error_code_explanation(code: ErrorCode) -> Option<&'static ErrorCodeExplanation> {
+    static EXPLANATIONS: std::sync::OnceLock<Vec<ErrorCodeExplanation>> =
+        std::sync::OnceLock::new();
+    EXPLANATIONS
+        .get_or_init(|| {
+            ERROR_CODE_EXPLANATION_DECLARATIONS
+                .iter()
+                .map(|declaration| {
+                    let metadata_index = error_code_metadata()
+                        .binary_search_by_key(&declaration.code.0, |entry| entry.code.0)
+                        .expect("explanation macro entry must have canonical metadata");
+                    ErrorCodeExplanation {
+                        metadata: &error_code_metadata()[metadata_index],
+                        explanation: declaration.explanation,
+                        likely_cause: declaration.likely_cause,
+                        examples: declaration.examples,
+                        references: declaration.references,
+                    }
+                })
+                .collect()
+        })
+        .iter()
+        .find(|explanation| explanation.metadata.code == code)
 }
 
 // ============================================================================
@@ -2739,6 +2879,51 @@ mod tests {
 
         assert_eq!(metadata.len(), ERROR_CODE_DECLARATIONS.len());
         assert_eq!(metadata, error_code_metadata(), "metadata must reproduce");
+    }
+
+    #[test]
+    fn error_code_parsing_uses_the_canonical_inventory() {
+        assert_eq!("E0201".parse(), Ok(ErrorCode::UNDEFINED_VARIABLE));
+        assert_eq!(
+            "E0005".parse::<ErrorCode>(),
+            Err(ParseErrorCodeError::Unknown(ErrorCode(5)))
+        );
+        assert_eq!(
+            "E9999".parse::<ErrorCode>(),
+            Err(ParseErrorCodeError::Unknown(ErrorCode(9999)))
+        );
+        for malformed in ["0201", "e0201", "E201", "E02010", "E02A1", ""] {
+            assert_eq!(
+                malformed.parse::<ErrorCode>(),
+                Err(ParseErrorCodeError::Malformed),
+                "{malformed:?} must not be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn explanations_are_macro_owned_and_retain_metadata_identity() {
+        let mut seen = HashSet::new();
+        for declaration in ERROR_CODE_EXPLANATION_DECLARATIONS {
+            assert!(seen.insert(declaration.code), "duplicate explanation code");
+            let explanation = error_code_explanation(declaration.code)
+                .expect("each macro explanation declaration must be queryable");
+            let metadata = error_code_metadata()
+                .iter()
+                .find(|entry| entry.code == declaration.code)
+                .expect("each explanation must reference declared metadata");
+            assert!(std::ptr::eq(explanation.metadata, metadata));
+            assert!(!explanation.explanation.is_empty());
+            assert!(!explanation.likely_cause.is_empty());
+            assert!((1..=2).contains(&explanation.examples.len()));
+            assert!(!explanation.references.is_empty());
+        }
+
+        let explanation = error_code_explanation(ErrorCode::UNDEFINED_VARIABLE)
+            .expect("E0201 is the bounded first production explanation");
+        assert_eq!(explanation.metadata.name, "UNDEFINED_VARIABLE");
+        assert_eq!(explanation.references[0].rule, Some("10.3:8"));
+        assert!(error_code_explanation(ErrorCode::TYPE_MISMATCH).is_none());
     }
 
     /// `ErrorKind::code()` must cover the compiler-declared ErrorCode constants without

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fmt::Write as _;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -39,7 +40,9 @@ use rue_compiler::{
 };
 #[cfg(test)]
 use rue_compiler::{CompilerSession, SourceMetadata, SourceSnapshot};
-use rue_error::{CompileError, DiagnosticWrapper, ErrorCode};
+use rue_error::{
+    CompileError, DiagnosticWrapper, ErrorCode, ErrorCodeExplanation, error_code_explanation,
+};
 use rue_perf_schema::{
     ArtifactHitEvidence, BuildBoundary, CompilerBoundaryEvidence, CompilerBuildProfile,
     CompilerConfigurationEvidence, CompilerCriticalPathEvidence, CompilerInputClass,
@@ -244,9 +247,13 @@ fn usage_text() -> String {
         "\
 Usage: rue [options] <root.rue> [output]
        rue [options] <root.rue> -o <output>
+       rue explain <E####>
 
 The compiler takes exactly one root source file and discovers every other
 file through its @import graph; pass build-system inputs with --source-manifest.
+
+Commands:
+  explain <E####>      Show the compiler-owned explanation for an error code
 
 Options:
   -o, --output <path>  Set output path
@@ -316,6 +323,8 @@ fn print_help() {
 enum ParseResult {
     /// Successfully parsed options (boxed: Options dwarfs the other variants).
     Options(Box<Options>),
+    /// Show compiler-owned information without entering the compile path.
+    Explain(ErrorCode),
     /// Parsing failed with an error.
     Error,
     /// User requested help or version (already printed, should exit 0).
@@ -380,6 +389,26 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     if args.is_empty() {
         print_usage();
         return ParseResult::Error;
+    }
+
+    if args[0] == "explain" {
+        let [_, code_text] = args else {
+            eprintln!("Error: `rue explain` requires exactly one error code");
+            eprintln!("Usage: rue explain <E####>");
+            return ParseResult::Error;
+        };
+        let code = match code_text.parse::<ErrorCode>() {
+            Ok(code) => code,
+            Err(error) => {
+                eprintln!("Error: {error}");
+                return ParseResult::Error;
+            }
+        };
+        if error_code_explanation(code).is_none() {
+            eprintln!("Error: no detailed explanation is available yet for {code}");
+            return ParseResult::Error;
+        }
+        return ParseResult::Explain(code);
     }
 
     let mut emit_stages = Vec::new();
@@ -688,15 +717,41 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     }))
 }
 
-fn parse_args() -> Option<Options> {
+fn parse_args() -> ParseResult {
     let args: Vec<String> = env::args().skip(1).collect();
     let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
-    match parse_args_from(&args_refs) {
-        ParseResult::Options(opts) => Some(*opts),
-        ParseResult::Error => None,
-        ParseResult::Exit => std::process::exit(0),
+    parse_args_from(&args_refs)
+}
+
+fn render_error_code_explanation(explanation: &ErrorCodeExplanation) -> String {
+    let metadata = explanation.metadata;
+    let mut output = format!(
+        "{}: {}\n\n{}\n",
+        metadata.code, metadata.title, explanation.explanation
+    );
+    writeln!(output, "\nLikely cause:\n{}", explanation.likely_cause)
+        .expect("writing to a String cannot fail");
+    output.push_str("\nExamples:\n");
+    for example in explanation.examples {
+        writeln!(output, "\n{}:", example.title).expect("writing to a String cannot fail");
+        for line in example.source.lines() {
+            writeln!(output, "    {line}").expect("writing to a String cannot fail");
+        }
     }
+    output.push_str("\nReferences:\n");
+    for reference in explanation.references {
+        match reference.rule {
+            Some(rule) => writeln!(
+                output,
+                "- {}: {} (spec rule {rule})",
+                reference.title, reference.path
+            ),
+            None => writeln!(output, "- {}: {}", reference.title, reference.path),
+        }
+        .expect("writing to a String cannot fail");
+    }
+    output
 }
 
 fn validate_watch_modes(options: &Options) -> Result<(), &'static str> {
@@ -1880,8 +1935,15 @@ fn main() {
     }));
 
     let options = match parse_args() {
-        Some(opts) => opts,
-        None => std::process::exit(1),
+        ParseResult::Options(options) => *options,
+        ParseResult::Explain(code) => {
+            let explanation = error_code_explanation(code)
+                .expect("argument parsing only accepts codes with explanations");
+            print!("{}", render_error_code_explanation(explanation));
+            return;
+        }
+        ParseResult::Error => std::process::exit(1),
+        ParseResult::Exit => return,
     };
 
     // The hook above is installed BEFORE argument parsing, so a panic inside
@@ -2729,6 +2791,7 @@ mod tests {
             ParseResult::Options(opts) => *opts,
             ParseResult::Error => panic!("Expected Options, got Error"),
             ParseResult::Exit => panic!("Expected Options, got Exit"),
+            ParseResult::Explain(_) => panic!("Expected Options, got Explain"),
         }
     }
 
@@ -3774,6 +3837,34 @@ mod tests {
     #[test]
     fn parse_version_short() {
         assert!(is_exit(&parse_args_from(&["-V"])));
+    }
+
+    #[test]
+    fn parse_explain_uses_the_compiler_owned_error_code() {
+        let ParseResult::Explain(code) = parse_args_from(&["explain", "E0201"]) else {
+            panic!("expected explain command");
+        };
+        assert_eq!(code, ErrorCode::UNDEFINED_VARIABLE);
+        let explanation = error_code_explanation(code).expect("E0201 explanation");
+        let rendered = render_error_code_explanation(explanation);
+        assert!(rendered.starts_with("E0201: Undefined variable\n"));
+        assert!(rendered.contains("Likely cause:"));
+        assert!(rendered.contains("docs/spec/src/10-modules/03-visibility.md"));
+        assert!(rendered.contains("spec rule 10.3:8"));
+    }
+
+    #[test]
+    fn parse_explain_rejects_bad_unknown_retired_and_uncovered_codes() {
+        for args in [
+            &["explain"][..],
+            &["explain", "E0201", "extra"][..],
+            &["explain", "0201"][..],
+            &["explain", "E9999"][..],
+            &["explain", "E0005"][..],
+            &["explain", "E0206"][..],
+        ] {
+            assert!(is_error(&parse_args_from(args)), "accepted {args:?}");
+        }
     }
 
     // ========== Unknown option tests ==========

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,15 @@ For direct compiler invocations, resolve the binary through `scripts/rue-bin`:
 RUE="$(scripts/rue-bin)"
 "$RUE" main.rue -o program
 "$RUE" --emit air --emit cfg main.rue
+"$RUE" explain E0201
 ```
+
+`rue explain E####` prints the compiler-owned long-form explanation for a
+covered diagnostic code. The explanation includes a likely cause, examples,
+and local specification or documentation references. This command performs no
+source discovery or compilation. A well-formed code may not have a long-form
+explanation yet; malformed, unknown, retired, and not-yet-covered codes exit
+unsuccessfully.
 
 The model is exactly one root source file per compile; additional files are
 reached through `@import` and discovered transitively from the root. The legacy


### PR DESCRIPTION
## Summary

- add a compiler-owned structured explanation record attached to the canonical ErrorCode declarations
- add the human-only `rue explain E####` command with deterministic malformed, unknown, retired, and uncovered-code failures
- document the command and cover metadata identity, non-compiling dispatch, CLI behavior, and timeout-policy integration

## Validation

- `scripts/rue fmt`
- `./buck2 test //crates/rue-error:rue-error-test //crates/rue:rue-test`
- `scripts/rue cli explain`
- `./buck2 test //:compiler-spec-machine-index`
- `./buck2 test //:cli-timeout-policy-validation //:cli-timeout-policy-tool-tests`
- `scripts/rue quick`
- `git diff --check`

A local standard-suite attempt reached the host process/thread ceiling in unrelated oracle corpus actions; the same run's affected tests and all patch-relevant targets passed, and isolated `rue-query` reran cleanly.

Fixes RUE-437
