### PR TITLE
RUE-1570: recover integer inference in malformed constructor heads

### DIFF
--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -333,7 +333,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // (RUE-596, spec 4.14:23): the head call reduces to a concrete type
             // at comptime; construct as if the type had been bound to a name
             // first (`let P = F(args); P { .. }`).
-            let head_result = self.analyze_inst(air, head_ref, ctx)?;
+            let recover_missing_arguments = ctx.resolved_type_of(head_ref).is_none();
+            let previous_recovery_scope = std::mem::replace(
+                &mut ctx.recover_missing_ctor_head_arguments,
+                recover_missing_arguments,
+            );
+            let head_result = self.analyze_inst(air, head_ref, ctx);
+            ctx.recover_missing_ctor_head_arguments = previous_recovery_scope;
+            let head_result = head_result?;
             continues &= head_result.continues;
             let AirInstData::TypeConst(reduced_ty) = air.get(head_result.air_ref).data else {
                 return Err(CompileError::new(

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -7147,8 +7147,31 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // literal-backed `cap == 0` header and an enum-typed fallible
             // intrinsic names its registry result — the same contextual
             // materialization a `let` with that annotation performs.
-            let prev_expected = if elaborates_borrow
-                && (param_ty.is_enum() || self.is_str_like(param_ty) || self.is_strbuf(param_ty))
+            // A malformed inline constructor head is intentionally absent
+            // from the inference walk when its comptime reduction fails. Its
+            // call operands can still be analyzed on the way to the stable
+            // "head is not a type" diagnostic. Give only such missing roots
+            // the callee's declared context, allowing integer literals (and
+            // literal expressions) to recover without changing ordinary
+            // inferred call arguments or repairing nested aggregate errors
+            // that have their own established diagnostics. Operator dispatch
+            // clears `expected_type`, so carry a separate integer context
+            // through the recovered subtree and restore it at this boundary.
+            let missing_inference_fact = ctx.recover_missing_ctor_head_arguments
+                && ctx.resolved_type_of(arg.value).is_none();
+            let previous_missing_integer_type = missing_inference_fact.then(|| {
+                let integer_type = if param_ty.is_integer() {
+                    param_ty
+                } else {
+                    Type::I32
+                };
+                ctx.missing_inference_integer_type.replace(integer_type)
+            });
+            let prev_expected = if missing_inference_fact
+                || (elaborates_borrow
+                    && (param_ty.is_enum()
+                        || self.is_str_like(param_ty)
+                        || self.is_strbuf(param_ty)))
             {
                 Some(ctx.expected_type.replace(param_ty))
             } else {
@@ -7157,6 +7180,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let arg_result = self.analyze_inst(air, arg.value, ctx);
             if let Some(previous) = prev_expected {
                 ctx.expected_type = previous;
+            }
+            if let Some(previous) = previous_missing_integer_type {
+                ctx.missing_inference_integer_type = previous;
             }
             ctx.ownership.byref_arg_root = prev_byref_root;
             let mut arg_result = arg_result?;

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -30,6 +30,25 @@ use crate::types::{Type, TypeKind};
 // ============================================================================
 
 impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
+    /// Resolve an integer expression through canonical inference, admitting
+    /// the narrowly scoped constructor-head recovery context when that walk
+    /// was deliberately skipped.
+    fn resolved_integer_type(
+        ctx: &AnalysisContext,
+        inst_ref: InstRef,
+        span: rue_span::Span,
+        context: &str,
+    ) -> CompileResult<Type> {
+        if let Some(ty) = ctx
+            .resolved_type_of(inst_ref)
+            .or(ctx.missing_inference_integer_type)
+        {
+            Ok(ty)
+        } else {
+            Self::get_resolved_type(ctx, inst_ref, span, context)
+        }
+    }
+
     // ========================================================================
     // Literals: IntConst, BoolConst, StringConst, UnitConst
     // ========================================================================
@@ -53,8 +72,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         match &inst.data {
             InstData::IntConst(value) => {
-                // Get the type from HM inference
-                let ty = Self::get_resolved_type(ctx, inst_ref, inst.span, "integer literal")?;
+                // Constructor-head recovery can make a call operand reachable
+                // to sema even though the unsuccessful head reduction kept it
+                // outside the ordinary inference walk. The call boundary
+                // supplies its declared parameter type as recovery context;
+                // use that integer type rather than turning the source-level
+                // "head is not a type" error into an unresolved-type ICE.
+                // Normal inferred literals still take the resolved-map path.
+                let ty = Self::resolved_integer_type(ctx, inst_ref, inst.span, "integer literal")?;
 
                 // Check if the literal value fits in the target type's range
                 if !ty.literal_fits(*value) {
@@ -179,7 +204,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         match &inst.data {
             InstData::Neg { operand } => {
                 // Get the resolved type from HM inference
-                let ty = Self::get_resolved_type(ctx, inst_ref, inst.span, "negation operator")?;
+                let ty =
+                    Self::resolved_integer_type(ctx, inst_ref, inst.span, "negation operator")?;
 
                 // Unary `-` requires a signed integer operand (i8/i16/i32/i64/
                 // isize). Reject unsigned integers (no negative range), bool, and
@@ -261,7 +287,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             InstData::BitNot { operand } => {
                 // Get the resolved type from HM inference
-                let ty = Self::get_resolved_type(ctx, inst_ref, inst.span, "bitwise NOT operator")?;
+                let ty =
+                    Self::resolved_integer_type(ctx, inst_ref, inst.span, "bitwise NOT operator")?;
 
                 // Bitwise NOT operates on integer types only
                 if !ty.is_integer() && !ty.is_error() && !ty.is_never() {

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -384,6 +384,19 @@ pub(crate) struct AnalysisContext<'a> {
     /// `Option(T)` (RUE-6, ADR-0038). Context never selects that nominal. Left
     /// `None` everywhere else, so no other analysis is affected.
     pub expected_type: Option<Type>,
+    /// Integer type supplied only while semantic recovery walks a call
+    /// argument whose root is absent from the inference result. This is
+    /// separate from `expected_type`: operator dispatch deliberately clears
+    /// ordinary result expectations before visiting operands, while every
+    /// integer node in a skipped malformed-constructor subtree still needs a
+    /// deterministic type. `None` on the canonical inferred path keeps a
+    /// genuinely missing inference fact classified as an internal error.
+    pub missing_inference_integer_type: Option<Type>,
+    /// Whether analysis is currently walking an inline constructor head that
+    /// inference deliberately skipped after comptime reduction failed. Only
+    /// call arguments reached inside this scope may synthesize the integer
+    /// recovery context above.
+    pub recover_missing_ctor_head_arguments: bool,
     /// The shared inference context for this body, threaded here so accessor
     /// call expansion (ADR-0062) can run type inference for the accessor's
     /// body on demand before splicing it into the caller.
@@ -706,6 +719,8 @@ impl<'a> AnalysisContext<'a> {
             referenced_functions: AHashSet::new(),
             referenced_methods: AHashSet::new(),
             expected_type: None,
+            missing_inference_integer_type: self.missing_inference_integer_type,
+            recover_missing_ctor_head_arguments: self.recover_missing_ctor_head_arguments,
             infer_ctx: self.infer_ctx,
             accessor_trailing_yield: self.accessor_trailing_yield,
             accessor_call_insts: self.accessor_call_insts.clone(),

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -2349,6 +2349,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             referenced_functions: AHashSet::new(),
             referenced_methods: AHashSet::new(),
             expected_type: None,
+            missing_inference_integer_type: None,
+            recover_missing_ctor_head_arguments: false,
             infer_ctx,
             accessor_trailing_yield: None,
             accessor_call_insts: AHashMap::new(),

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -23,6 +23,21 @@ name = "ICE regressions"
 description = "Minimal programs that used to crash the compiler; each must now compile-or-cleanly-error with no signal (RUE-51)."
 
 [[case]]
+name = "runtime_call_struct_head_literal_inference_rue1570"
+description = "RUE-1570: a runtime-valued call parsed as an inline struct-literal head skipped inference for its integer argument, so the intended type diagnostic became E9000."
+files = [{ path = "main.rue", source = """
+fn test(x: i32) -> i32 {
+    let y = if x > 5 { return 100 } else { x };
+    y * 2
+}
+fn main() -> i32 { test(3) { x };
+    y * 2}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected a type, found i32"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "type inference did not resolve type"]
+
+[[case]]
 name = "generic_array_value_length_unknown_element_type_rue407"
 description = "RUE-407 / GitHub #1225: a deferred generic array type `[i3; N]` validated only the `N` length, then specialization panicked when the unknown element type failed substitution. Now it is a clean E0204."
 files = [{ path = "main.rue", source = """

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -1868,6 +1868,151 @@ mod tests {
         );
     }
 
+    #[test]
+    fn sema_rejects_runtime_call_struct_heads_without_an_ice() {
+        // Saved sema-fuzzer finding for RUE-1570. The parser legitimately
+        // represents `test(3) { x }` as an inline constructor head; semantic
+        // analysis must reject the i32-returning head as a type without losing
+        // inference facts for the call's integer argument.
+        let saved = r#"
+fn test(x: i32) -> i32 {
+    let y = if x > 5 { return 100 } else { x };
+    y * 2
+}
+fn main() -> i32 { test(3) { x };
+    y * 2}
+"#;
+        let errors = query_semantics(saved).expect_err("runtime-valued constructor head rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        let primary = errors.iter().next().expect("one diagnostic was asserted");
+        assert!(
+            matches!(
+                &primary.kind,
+                rue_error::ErrorKind::TypeMismatch { expected, found }
+                    if expected == "a type" && found == "i32"
+            ),
+            "unexpected primary diagnostic: {primary:?}"
+        );
+
+        // Nearby recovered shapes cover contextual wide-literal inference,
+        // arithmetic and both integer unary operators. Logical `!` has a
+        // fixed bool type and confirms that recovery does not disturb it.
+        for source in [
+            "fn f(x: i64) -> i32 { 0 } fn main() -> i32 { f(2147483648) { missing }; 0 }",
+            "fn f(x: i64) -> i32 { 0 } fn main() -> i32 { f(-1) { missing }; 0 }",
+            "fn f(x: i64) -> i32 { 0 } fn main() -> i32 { f(~1) { missing }; 0 }",
+            "fn f(x: i64) -> i32 { 0 } fn main() -> i32 { f(1 + 2) { missing }; 0 }",
+            "fn f(x: i32) -> i32 { x } fn main() -> i32 { f(true) { missing }; 0 }",
+            "fn f(x: bool) -> i32 { 0 } fn main() -> i32 { f(3) { missing }; 0 }",
+            "fn f(x: bool) -> i32 { 0 } fn main() -> i32 { f(!false) { missing }; 0 }",
+        ] {
+            let errors = query_semantics(source).expect_err("malformed constructor head rejects");
+            assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+            let primary = errors.iter().next().expect("one diagnostic was asserted");
+            assert!(
+                matches!(
+                    &primary.kind,
+                    rue_error::ErrorKind::TypeMismatch { expected, found }
+                        if expected == "a type" && found == "i32"
+                ),
+                "unexpected primary diagnostic: {primary:?}"
+            );
+        }
+
+        // The recovered parameter type still governs unary legality; it is
+        // not merely a blanket i32 default for every skipped expression.
+        let errors =
+            query_semantics("fn f(x: u64) -> i32 { 0 } fn main() -> i32 { f(-1) { missing }; 0 }")
+                .expect_err("unsigned negation rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        assert!(
+            matches!(
+                errors.iter().next().map(|error| &error.kind),
+                Some(rue_error::ErrorKind::CannotNegate(found)) if found == "u64"
+            ),
+            "recovery lost the declared unsigned type: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn sema_constructor_head_recovery_survives_loop_recheck_forks() {
+        // Moving `p` changes the loop's back-edge ownership state and forces
+        // the scratch semantic pass. Its condition revisits the skipped `2`;
+        // recovery provenance must survive the context fork so the intended
+        // previous-iteration move error is not replaced by E9000.
+        let source = r#"
+struct P { x: i32 }
+fn consume(p: P) -> i32 { p.x }
+fn f(x: i32) -> i32 { x }
+fn main() -> i32 {
+    let p = P { x: 1 };
+    f({
+        let mut i = 0;
+        while i < 2 {
+            let _ = consume(p);
+            i = i + 1;
+        }
+        3
+    }) { missing };
+    0
+}
+"#;
+        let errors = query_semantics(source).expect_err("loop move on re-entry rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        let primary = errors.iter().next().expect("one diagnostic was asserted");
+        assert!(
+            matches!(primary.kind, rue_error::ErrorKind::UseAfterMove(_)),
+            "loop recheck lost constructor-head recovery provenance: {primary:?}"
+        );
+        assert!(
+            primary
+                .diagnostic()
+                .notes
+                .iter()
+                .any(|note| note.0.contains("previous iteration of the loop")),
+            "test did not exercise the loop recheck: {primary:?}"
+        );
+    }
+
+    #[test]
+    fn sema_constructor_head_recovery_preserves_valid_controls() {
+        for source in [
+            // Literal inference and diverging-if typing from the saved input.
+            "fn test(x: i32) -> i32 { let y = if x > 5 { return 100 } else { x }; y * 2 } fn main() -> i32 { test(3) }",
+            // A genuine inline type-constructor head with a literal comptime
+            // argument still reduces and constructs normally.
+            "fn Wrap(comptime n: i32) -> type { struct { value: i32 } } fn main() -> i32 { Wrap(3) { value: 42 }.value }",
+            // Operator roots retain canonical inference in successful inline
+            // constructor heads; recovery is never selected for these facts.
+            "fn Wrap(comptime n: i64) -> type { struct { value: i32 } } fn main() -> i32 { Wrap(-1) { value: 42 }.value }",
+            "fn Wrap(comptime n: i64) -> type { struct { value: i32 } } fn main() -> i32 { Wrap(~1) { value: 42 }.value }",
+            "fn Wrap(comptime n: i64) -> type { struct { value: i32 } } fn main() -> i32 { Wrap(1 + 2) { value: 42 }.value }",
+        ] {
+            let session = query_semantics(source).expect("valid control reaches semantic CFG");
+            assert_cfg_boundary_agreement(session);
+        }
+    }
+
+    #[test]
+    fn sema_constructor_head_recovery_preserves_array_diagnostic_order() {
+        let source = r#"
+const K: i32 = 3;
+fn Matrix(comptime T: type, comptime N: i32) -> type { struct { row: [T; N] } }
+fn sum(m: Matrix(i32, K)) -> i32 { m.row[0] + m.row[1] + m.row[2] }
+fn main() -> i32 {
+    let M = Matrix(i32, K);
+    sum(M { row: [40, 1, 1] }) { row: [T; N] }
+}
+"#;
+        let errors = query_semantics(source).expect_err("malformed generic construction rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        let primary = errors.iter().next().expect("one diagnostic was asserted");
+        assert!(
+            matches!(primary.kind, rue_error::ErrorKind::TypeAnnotationRequired),
+            "the established E0903 must precede the outer head error: {primary:?}"
+        );
+    }
+
     /// RUE-776: the `compiler` target must reach a strictly deeper boundary than
     /// `sema`. The sema query stops at the rooted CFG artifact; the compiler query
     /// must drive codegen and linking to a finished executable. If the compiler


### PR DESCRIPTION
## Summary
- scope integer-expression recovery to malformed inline constructor heads
- preserve ordinary inference invariants and malformed generic diagnostic ordering
- add sema fuzz and CLI regressions for the saved input and nearby expression forms

## Validation
- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue premerge` (207 passed, including oracle-diff)
- focused sema fuzz, CLI, and specification cases
- sema fuzz mutation sample: 6,074 runs, 0 crashes

Fixes RUE-1570