### PR TITLE
RUE-1513: rebaseline sema fuzz regression

### DIFF
--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -591,3 +591,64 @@ args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0411", "no method named 'len' found for type 'str'"]
 compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]
+
+# --- Saved sema-fuzzer return mismatch (RUE-1513) ---------------------------
+
+[[case]]
+name = "saved_string_len_wrong_return_is_e0206"
+description = "The exact saved sema-fuzzer input keeps intrinsic-looking text inside the reassigned string and reports one ordinary u64-to-i32 return mismatch."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s: str = "hello";
+    s = "hi @intCast   ";
+(s.len())
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0206 main.rue:1:18"]
+error_contains = ['"message":"type mismatch: expected i32, found u64"']
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]
+
+[[case]]
+name = "string_assignment_intrinsic_token_adjacency_is_parse_error"
+description = "Control: moving `@intCast` immediately outside the closing quote is one parser diagnostic, so token adjacency cannot be confused with the saved literal contents."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s: str = "hello";
+    s = "hi" @intCast;
+(s.len())
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0100 main.rue:3:14"]
+error_contains = ["\"message\":\"expected ';', found '@'\""]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]
+
+[[case]]
+name = "string_reassignment_len_u64_and_intcast_succeed"
+description = "Control: the saved assignment shape is valid, `len()` remains u64, and an explicit integer cast returns the reassigned string's byte length."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s: str = "hello";
+    s = "hi @intCast   ";
+    let n: u64 = s.len();
+    @intCast(n)
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 14
+
+[[case]]
+name = "ordinary_u64_wrong_return_is_e0206"
+description = "Control: the same return mismatch without strings remains the ordinary E0206 baseline."
+files = [{ path = "main.rue", source = "fn main() -> i32 { let n: u64 = 2; n }" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0206 main.rue:1:18"]
+error_contains = ['"message":"type mismatch: expected i32, found u64"']
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -1869,6 +1869,75 @@ mod tests {
     }
 
     #[test]
+    fn sema_string_len_wrong_return_is_an_ordinary_diagnostic() {
+        // Saved sema-fuzzer finding for RUE-1513. The intrinsic-looking text
+        // belongs to the string literal; reassignment is valid, and `len()`
+        // has its ordinary u64 result type. Returning it from `main` must stop
+        // at E0206 rather than reaching CFG verification with an i32/u64 slot
+        // disagreement.
+        let saved = r#"fn main() -> i32 {
+    let mut s: str = "hello";
+    s = "hi @intCast   ";
+(s.len())
+}"#;
+        let errors = query_semantics(saved).expect_err("u64 return rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        assert!(
+            matches!(
+                errors.iter().next().map(|error| &error.kind),
+                Some(rue_error::ErrorKind::TypeMismatch { expected, found })
+                    if expected == "i32" && found == "u64"
+            ),
+            "unexpected saved-input diagnostic: {errors:?}"
+        );
+        SemaTarget.fuzz(saved.as_bytes());
+
+        // Moving the intrinsic outside the closing quote is a parser error,
+        // not a second semantic path for the saved input.
+        let malformed = r#"fn main() -> i32 {
+    let mut s: str = "hello";
+    s = "hi" @intCast;
+(s.len())
+}"#;
+        let errors = query_semantics(malformed).expect_err("adjacent token rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        assert!(
+            matches!(
+                errors.iter().next().map(|error| &error.kind),
+                Some(rue_error::ErrorKind::UnexpectedToken { expected, found })
+                    if expected == "';'" && found == "'@'"
+            ),
+            "unexpected adjacent-token diagnostic: {errors:?}"
+        );
+        SemaTarget.fuzz(malformed.as_bytes());
+
+        // Nearby controls keep reassignment, len typing, and the explicit
+        // narrowing route live in the production target.
+        let valid = r#"fn main() -> i32 {
+    let mut s: str = "hello";
+    s = "hi @intCast   ";
+    let n: u64 = s.len();
+    @intCast(n)
+}"#;
+        query_semantics(valid).expect("valid assignment, len, and cast reach CFG");
+        SemaTarget.fuzz(valid.as_bytes());
+
+        let ordinary_wrong_return = "fn main() -> i32 { let n: u64 = 2; n }";
+        let errors =
+            query_semantics(ordinary_wrong_return).expect_err("ordinary u64 return rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        assert!(
+            matches!(
+                errors.iter().next().map(|error| &error.kind),
+                Some(rue_error::ErrorKind::TypeMismatch { expected, found })
+                    if expected == "i32" && found == "u64"
+            ),
+            "unexpected wrong-return diagnostic: {errors:?}"
+        );
+        SemaTarget.fuzz(ordinary_wrong_return.as_bytes());
+    }
+
+    #[test]
     fn sema_rejects_runtime_call_struct_heads_without_an_ice() {
         // Saved sema-fuzzer finding for RUE-1570. The parser legitimately
         // represents `test(3) { x }` as an inline constructor head; semantic


### PR DESCRIPTION
## Summary

- preserve the exact saved sema-fuzzer input as a production-path regression
- pin the transformed result to one ordered E0206 diagnostic instead of an internal error
- cover malformed token adjacency, valid string reassignment and length, explicit narrowing, and an ordinary wrong-return control

The historical crash is already absent on current trunk: the canonical string-view length inference path now publishes `u64` before CFG construction. This change records that no-churn outcome in the CLI corpus and registered sema fuzz target.

## Validation

- `scripts/rue fmt`
- `scripts/rue cli str_type` (34/34)
- `scripts/rue unit fuzz sema_string_len_wrong_return_is_an_ordinary_diagnostic`
- `scripts/rue quick`
- `scripts/rue premerge` (207/207)
- focused O1/O2/O3 oracle corpus (1 modeled agreement, 3 expected compile failures)
- independent adversarial parser/inference/CFG/fuzz review: no findings

A standard-suite attempt reached the authoritative full O1 oracle corpus but the local host repeatedly refused query worker creation with OS 35 `WouldBlock`; focused O1/O2/O3 coverage for every added case is green.

Fixes RUE-1513.