### PR TITLE
RUE-1418: align nominal value inference

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -182,7 +182,7 @@ pub struct MethodSig {
 
 /// Demand-population seam for the inference context (RUE-1091 slice r5b).
 ///
-/// Constraint generation consults the thirteen declaration-universe families
+/// Constraint generation consults the fourteen declaration-universe families
 /// purely by key. Rather than eagerly project the whole universe into owned
 /// `AHashMap`s before any body is analyzed (the O(universe)-per-body term
 /// RUE-1083 removes), the production path implements this trait over the frozen
@@ -202,6 +202,7 @@ pub(crate) trait LazyInferenceFacts {
     fn struct_type_by_file(&self, key: (FileId, Spur)) -> Option<Type>;
     fn builtin_enum_type(&self, name: Spur) -> Option<Type>;
     fn enum_type_by_file(&self, key: (FileId, Spur)) -> Option<Type>;
+    fn nominal_type_accessible(&self, accessing_file: FileId, ty: Type) -> bool;
     fn const_type(&self, key: (FileId, Spur)) -> Option<Type>;
     fn const_type_alias(&self, key: (FileId, Spur)) -> Option<Type>;
     fn const_value(&self, key: (FileId, Spur)) -> Option<i128>;
@@ -372,7 +373,7 @@ pub struct ConstraintGenerator<'a> {
     /// lazy provider (see `functions`).
     methods: Option<&'a AHashMap<(StructId, Spur), MethodSig>>,
     /// Demand-population provider (RUE-1091 slice r5b). When present, the
-    /// thirteen declaration-universe families are materialized on first consult
+    /// fourteen declaration-universe families are materialized on first consult
     /// through this seam instead of read from eager maps. `None` in unit tests,
     /// which construct the generator from literal maps.
     lazy: Option<&'a dyn LazyInferenceFacts>,
@@ -696,7 +697,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// Create a generator driven by a demand-population provider (RUE-1091
     /// slice r5b).
     ///
-    /// The eager family maps stay `None`; every keyed consult of the thirteen
+    /// The eager family maps stay `None`; every keyed consult of the fourteen
     /// declaration-universe families routes through `lazy`, which materializes
     /// only the signatures and types the body actually names. This is the
     /// production body-analysis path — the eager `new`/`with_type_subst`
@@ -1305,6 +1306,21 @@ impl<'a> ConstraintGenerator<'a> {
             .and_then(|map| map.get(&key).copied())
     }
 
+    fn nominal_type_accessible(&self, accessing_file: FileId, ty: Type) -> bool {
+        if let Some(lazy) = self.lazy {
+            return lazy.nominal_type_accessible(accessing_file, ty);
+        }
+        if let Some(id) = ty.as_struct() {
+            let def = self.type_pool.struct_def(id);
+            return def.is_pub || def.file_id == accessing_file;
+        }
+        if let Some(id) = ty.as_enum() {
+            let def = self.type_pool.enum_def(id);
+            return def.is_pub || def.file_id == accessing_file;
+        }
+        false
+    }
+
     /// Look up a file-level constant's declared type by (declaring file, name).
     fn const_type(&self, key: (FileId, Spur)) -> Option<Type> {
         if let Some(lazy) = self.lazy {
@@ -1744,6 +1760,18 @@ impl<'a> ConstraintGenerator<'a> {
                     // anchors expressions like `N + 1` and `m.go() + 1` to the
                     // declaration's concrete type (RUE-142).
                     self.type_to_infer(const_ty)
+                } else if self.struct_type_for(name, span.file_id).is_some()
+                    || self.enum_type_for(name, span.file_id).is_some()
+                {
+                    // Named nominal types parse as `VarRef` when they appear
+                    // in value position. Sema materializes them as compile-time
+                    // `TypeConst` values, so inference must publish the same
+                    // type instead of treating the name like an unresolved
+                    // runtime variable. In particular, this keeps a type name
+                    // used as an implicit function result from passing through
+                    // the error-type compatibility escape hatch and reaching
+                    // CFG construction without a runtime return value.
+                    InferType::Concrete(Type::COMPTIME_TYPE)
                 } else {
                     // Unknown variable - will be caught during semantic analysis
                     InferType::Concrete(Type::ERROR)
@@ -3353,6 +3381,26 @@ impl<'a> ConstraintGenerator<'a> {
                 match self.known_field_type(&base_info.ty, *field) {
                     Some(field_ty) => self.type_to_infer(field_ty),
                     None => {
+                        // Sema resolves module members in nominal-before-const
+                        // order. Mirror the nominal part here: `m.S` and `m.E`
+                        // are compile-time type values, not unconstrained
+                        // runtime fields. Visibility remains owned by sema;
+                        // this lookup only supplies the value category needed
+                        // by surrounding inference constraints.
+                        let member_nominal_ty = match &base_info.ty {
+                            InferType::Concrete(ty) if ty.is_module() => ty
+                                .as_module()
+                                .and_then(|module_id| self.module_file_id(module_id))
+                                .and_then(|file_id| {
+                                    self.struct_type_by_file((file_id, *field))
+                                        .or_else(|| self.enum_type_by_file((file_id, *field)))
+                                })
+                                .filter(|member_ty| {
+                                    self.nominal_type_accessible(span.file_id, *member_ty)
+                                })
+                                .map(|_| Type::COMPTIME_TYPE),
+                            _ => None,
+                        };
                         // Module receiver: `m.CONST` resolves to a module
                         // member value-constant; yield its declared type so
                         // uses like `m.CONST + 1` are anchored (RUE-160).
@@ -3384,7 +3432,7 @@ impl<'a> ConstraintGenerator<'a> {
                                 .and_then(|file_id| self.module_binding_type((file_id, *field))),
                             _ => None,
                         };
-                        match member_const_ty.or(member_module_ty) {
+                        match member_nominal_ty.or(member_const_ty).or(member_module_ty) {
                             Some(member_ty) => self.type_to_infer(member_ty),
                             None => InferType::Var(self.fresh_var()),
                         }

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -37,6 +37,7 @@ pub(super) trait InferenceFactSource {
     fn inference_struct_type_by_file(&self, key: (FileId, Spur)) -> Option<Type>;
     fn inference_builtin_enum_type(&self, name: Spur) -> Option<Type>;
     fn inference_enum_type_by_file(&self, key: (FileId, Spur)) -> Option<Type>;
+    fn inference_nominal_type_accessible(&self, accessing_file: FileId, ty: Type) -> bool;
     fn inference_const_type(&self, key: (FileId, Spur)) -> Option<Type>;
     fn inference_const_type_alias(&self, key: (FileId, Spur)) -> Option<Type>;
     fn inference_const_value(&self, key: (FileId, Spur)) -> Option<i128>;
@@ -48,7 +49,7 @@ pub(super) trait InferenceFactSource {
 
 /// Demand-population cache for constraint generation (RUE-1091 slice r5b).
 ///
-/// Constraint generation consults the thirteen declaration-universe families
+/// Constraint generation consults the fourteen declaration-universe families
 /// purely by key. Rather than convert every function/method signature and
 /// project every struct/enum/const into owned `HashMap`s before a single body
 /// is analyzed — the O(universe)-per-body term RUE-1083 removes — this context
@@ -195,6 +196,11 @@ impl<H: BodyAnalysisReadHost> LazyInferenceFacts for HostInferenceFacts<'_, H> {
         self.host
             .inference_enum_type_by_file(key)
             .or_else(|| self.ctx.gen_enum_types_by_file.get(&key).copied())
+    }
+
+    fn nominal_type_accessible(&self, accessing_file: FileId, ty: Type) -> bool {
+        self.host
+            .inference_nominal_type_accessible(accessing_file, ty)
     }
 
     fn const_type(&self, key: (FileId, Spur)) -> Option<Type> {

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -3705,6 +3705,23 @@ where
         self.nominal_type_for_symbol(key.0, key.1)
             .filter(|ty| ty.as_enum().is_some())
     }
+    fn inference_nominal_type_accessible(&self, accessing_file: FileId, ty: Type) -> bool {
+        let (defining_file, is_pub) = if let Some(id) = ty.as_struct() {
+            let def = self.type_pool.struct_def(id);
+            (def.file_id, def.is_pub)
+        } else if let Some(id) = ty.as_enum() {
+            let def = self.type_pool.enum_def(id);
+            (def.file_id, def.is_pub)
+        } else {
+            return false;
+        };
+        crate::sema::aggregate_resolution::is_accessible(
+            self,
+            accessing_file,
+            defining_file,
+            is_pub,
+        )
+    }
     fn inference_const_type(&self, key: (FileId, Spur)) -> Option<Type> {
         self.call_value_const(key.0, key.1)
             .map(|info| match info.value {

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -23,6 +23,204 @@ name = "ICE regressions"
 description = "Minimal programs that used to crash the compiler; each must now compile-or-cleanly-error with no signal (RUE-51)."
 
 [[case]]
+name = "nominal_type_adjacent_to_if_tail_rue1418"
+description = "RUE-1418: a named type adjacent to a block-like if became the function tail and reached CFG as a non-unit return without a runtime value."
+files = [{ path = "main.rue", source = """
+struct S { v: [i32; 3] }
+
+fn main() -> i32 {
+    let a = S { v: [1, 2, 3] };
+    let b = S { v: [1, 2, 3] };
+    let c = S { v: [1, 2, 4] };
+    if a == b && a != c { 1 } else { 0 }S
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found type"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
+name = "qualified_struct_type_adjacent_to_if_tail_rue1418"
+description = "RUE-1418: a module-qualified struct type tail is a compile-time type value and must be rejected before CFG publication."
+files = [
+    { path = "main.rue", source = """
+const m = @import("types.rue");
+fn main() -> i32 {
+    if true { 1 } else { 0 }m.S
+}
+""" },
+    { path = "types.rue", source = """
+pub struct S { value: i32 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found type"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
+name = "private_qualified_struct_type_tail_keeps_privacy_rue1418"
+description = "RUE-1418 privacy control: an inaccessible qualified struct tail remains owned by sema's E0706 visibility check."
+files = [
+    { path = "main.rue", source = """
+const m = @import("sub/types.rue");
+fn main() -> i32 {
+    if true { 1 } else { 0 }m.S
+}
+""" },
+    { path = "sub/types.rue", source = """
+struct S { value: i32 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0706", "struct `S` is private"]
+compile_stderr_not_contains = ["E0206", "E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
+name = "same_directory_private_qualified_struct_tail_rue1418"
+description = "RUE-1418 visibility control: a same-directory private struct is accessible but remains a compile-time type value."
+files = [
+    { path = "main.rue", source = """
+const m = @import("types.rue");
+fn main() -> i32 {
+    if true { 1 } else { 0 }m.S
+}
+""" },
+    { path = "types.rue", source = """
+struct S { value: i32 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found type"]
+compile_stderr_not_contains = ["E0706", "E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
+name = "same_directory_private_qualified_enum_tail_rue1418"
+description = "RUE-1418 visibility control: a same-directory private enum follows the accessible compile-time type path."
+files = [
+    { path = "main.rue", source = """
+const m = @import("types.rue");
+fn main() -> i32 {
+    if true { 1 } else { 0 }m.E
+}
+""" },
+    { path = "types.rue", source = """
+enum E { A }
+""" },
+]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found type"]
+compile_stderr_not_contains = ["E0706", "E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
+name = "private_qualified_enum_type_tail_keeps_privacy_rue1418"
+description = "RUE-1418 privacy control: inaccessible qualified enums follow the same E0706 visibility path."
+files = [
+    { path = "main.rue", source = """
+const m = @import("sub/types.rue");
+fn main() -> i32 {
+    if true { 1 } else { 0 }m.E
+}
+""" },
+    { path = "sub/types.rue", source = """
+enum E { A }
+""" },
+]
+compile_fail = true
+error_contains = ["E0706", "enum `E` is private"]
+compile_stderr_not_contains = ["E0206", "E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
+name = "qualified_enum_type_adjacent_to_if_tail_rue1418"
+description = "RUE-1418: a module-qualified enum type tail follows the same compile-time type path as a qualified struct."
+files = [
+    { path = "main.rue", source = """
+const m = @import("types.rue");
+fn main() -> i32 {
+    if true { 1 } else { 0 }m.E
+}
+""" },
+    { path = "types.rue", source = """
+pub enum E { A }
+""" },
+]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found type"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
+name = "nominal_type_statement_after_if_rue1418"
+description = "RUE-1418 nearby recovery: whitespace and a semicolon make the named type a discarded statement and leave an ordinary unit-valued function body."
+files = [{ path = "main.rue", source = """
+struct S { v: [i32; 3] }
+fn main() -> i32 {
+    let a = S { v: [1, 2, 3] };
+    let b = S { v: [1, 2, 3] };
+    let c = S { v: [1, 2, 4] };
+    if a == b && a != c { 1 } else { 0 } S;
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found ()"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
+name = "missing_else_value_after_struct_equality_rue1418"
+description = "RUE-1418 nearby recovery: a missing else value retains the branch-join diagnostic ahead of CFG publication."
+files = [{ path = "main.rue", source = """
+struct S { v: [i32; 3] }
+fn main() -> i32 {
+    let a = S { v: [1, 2, 3] };
+    let b = S { v: [1, 2, 3] };
+    let c = S { v: [1, 2, 4] };
+    if a == b && a != c { 1 } else { }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected integer type, found ()"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
+name = "struct_array_equality_if_tail_control_rue1418"
+description = "RUE-1418 control: struct and array equality, short-circuiting, and an implicit if result remain valid."
+files = [{ path = "main.rue", source = """
+struct S { v: [i32; 3] }
+fn main() -> i32 {
+    let a = S { v: [1, 2, 3] };
+    let b = S { v: [1, 2, 3] };
+    let c = S { v: [1, 2, 4] };
+    if a == b && a != c { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "struct_array_equality_explicit_return_control_rue1418"
+description = "RUE-1418 control: the same branch result remains valid through an explicit return."
+files = [{ path = "main.rue", source = """
+struct S { v: [i32; 3] }
+fn main() -> i32 {
+    let a = S { v: [1, 2, 3] };
+    let b = S { v: [1, 2, 3] };
+    let c = S { v: [1, 2, 4] };
+    return if a == b && a != c { 1 } else { 0 };
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "nominal_type_explicit_return_rue1418"
+description = "RUE-1418 control: an explicitly returned type value retains the ordinary wrong-return-type diagnostic."
+files = [{ path = "main.rue", source = """
+struct S { v: [i32; 3] }
+fn main() -> i32 {
+    return S;
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found type"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification failed", "has no value"]
+
+[[case]]
 name = "runtime_call_struct_head_literal_inference_rue1570"
 description = "RUE-1570: a runtime-valued call parsed as an inline struct-literal head skipped inference for its integer argument, so the intended type diagnostic became E9000."
 files = [{ path = "main.rue", source = """

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -1869,6 +1869,114 @@ mod tests {
     }
 
     #[test]
+    fn sema_nominal_type_tail_is_an_ordinary_return_diagnostic() {
+        // Saved sema-fuzzer finding for RUE-1418. A block-like `if` is a
+        // complete statement, so the adjacent `S` is the function body's tail
+        // expression. Named types are compile-time values: inference must
+        // reject that tail against `-> i32` before CFG construction rather
+        // than publishing a return with no runtime value.
+        const PREFIX: &str = r#"struct S { v: [i32; 3] }
+
+fn main() -> i32 {
+    let a = S { v: [1, 2, 3] };
+    let b = S { v: [1, 2, 3] };
+    let c = S { v: [1, 2, 4] };
+"#;
+        // Keep this literal byte-for-byte identical to the saved reproducer,
+        // including the blank line after the declaration and final newline.
+        let saved = r#"struct S { v: [i32; 3] }
+
+fn main() -> i32 {
+    let a = S { v: [1, 2, 3] };
+    let b = S { v: [1, 2, 3] };
+    let c = S { v: [1, 2, 4] };
+    if a == b && a != c { 1 } else { 0 }S
+}
+"#;
+        let errors = query_semantics(saved).expect_err("type-valued tail rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        assert!(
+            matches!(
+                errors.iter().next().map(|error| &error.kind),
+                Some(rue_error::ErrorKind::TypeMismatch { expected, found })
+                    if expected == "i32" && found == "type"
+            ),
+            "unexpected saved-input diagnostic: {errors:?}"
+        );
+        SemaTarget.fuzz(saved.as_bytes());
+
+        // Whitespace does not change the statement boundary. A semicolon after
+        // the type value instead makes the whole body unit-valued; both shapes
+        // remain ordinary, deterministic return-type diagnostics.
+        let spaced = format!("{PREFIX}    if a == b && a != c {{ 1 }} else {{ 0 }} S\n}}");
+        let errors = query_semantics(&spaced).expect_err("spaced type-valued tail rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        assert!(
+            matches!(
+                errors.iter().next().map(|error| &error.kind),
+                Some(rue_error::ErrorKind::TypeMismatch { expected, found })
+                    if expected == "i32" && found == "type"
+            ),
+            "unexpected spaced-tail diagnostic: {errors:?}"
+        );
+        SemaTarget.fuzz(spaced.as_bytes());
+
+        let terminated = format!("{PREFIX}    if a == b && a != c {{ 1 }} else {{ 0 }} S;\n}}");
+        let errors = query_semantics(&terminated).expect_err("unit-valued body rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        assert!(
+            matches!(
+                errors.iter().next().map(|error| &error.kind),
+                Some(rue_error::ErrorKind::TypeMismatch { expected, found })
+                    if expected == "i32" && found == "()"
+            ),
+            "unexpected terminated-tail diagnostic: {errors:?}"
+        );
+        SemaTarget.fuzz(terminated.as_bytes());
+
+        // A branch missing its value is rejected at the branch join before
+        // the enclosing return constraint. This pins the established primary
+        // diagnostic order for the nearby recovery shape.
+        let missing_expression = format!("{PREFIX}    if a == b && a != c {{ 1 }} else {{ }}\n}}");
+        let errors =
+            query_semantics(&missing_expression).expect_err("missing branch expression rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        assert!(
+            matches!(
+                errors.iter().next().map(|error| &error.kind),
+                Some(rue_error::ErrorKind::TypeMismatch { expected, found })
+                    if expected == "integer type" && found == "()"
+            ),
+            "unexpected missing-expression diagnostic: {errors:?}"
+        );
+        SemaTarget.fuzz(missing_expression.as_bytes());
+
+        // Keep aggregate equality, short-circuiting, branch-result inference,
+        // and both implicit and explicit i32 returns live at this boundary.
+        for valid in [
+            format!("{PREFIX}    if a == b && a != c {{ 1 }} else {{ 0 }}\n}}"),
+            format!("{PREFIX}    return if a == b && a != c {{ 1 }} else {{ 0 }};\n}}"),
+        ] {
+            let session = query_semantics(&valid).expect("valid control reaches semantic CFG");
+            assert_cfg_boundary_agreement(session);
+        }
+
+        let wrong_explicit_return = format!("{PREFIX}    return S;\n}}");
+        let errors =
+            query_semantics(&wrong_explicit_return).expect_err("explicit type return rejects");
+        assert_eq!(errors.len(), 1, "diagnostic order changed: {errors:?}");
+        assert!(
+            matches!(
+                errors.iter().next().map(|error| &error.kind),
+                Some(rue_error::ErrorKind::TypeMismatch { expected, found })
+                    if expected == "i32" && found == "type"
+            ),
+            "unexpected explicit-return diagnostic: {errors:?}"
+        );
+        SemaTarget.fuzz(wrong_explicit_return.as_bytes());
+    }
+
+    #[test]
     fn sema_string_len_wrong_return_is_an_ordinary_diagnostic() {
         // Saved sema-fuzzer finding for RUE-1513. The intrinsic-looking text
         // belongs to the string literal; reassignment is valid, and `len()`


### PR DESCRIPTION
Fixes RUE-1418.

Aligns inference with semantic lowering for bare and module-qualified nominal type values so invalid runtime return CFGs are rejected as ordinary diagnostics. Qualified lookup reuses the canonical visibility policy, preserving E0706 for inaccessible private members.

Adds the exact saved sema-fuzzer input, nearby tail and missing-expression controls, valid aggregate equality and return controls, qualified struct/enum coverage, and privacy regressions.

Validation:
- saved-input sema replay: 5,000 runs, zero crashes
- fuzz tests: 125/125
- CLI ICE regressions: 45/45
- quick suite: 34 targets, zero failures
- premerge: 207 targets, zero failures
- focused changed-corpus oracle audit: O1/O2/O3 agree, zero disagreements
- formatting and diff checks clean

The broad standard suite was also attempted; its full oracle workers hit host thread-spawn EAGAIN before semantic results, while all completed targets were green.