### PR TITLE
RUE-1911: reject value tails in never functions

### DIFF
--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -2408,6 +2408,23 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             }
         }
 
+        // Inference equality is intentionally symmetric: it joins operands and
+        // lets context-driven intrinsics acquire their semantic result type.
+        // Once AIR emission has resolved the actual body type, the function
+        // boundary is directional. A value cannot flow into declared `!`, even
+        // though `!` itself can flow into every value type. Enforce that before
+        // constructing the implicit Ret so malformed AIR never reaches CFG
+        // verification (RUE-1911).
+        if return_type.is_never() && !self.types_compatible(body_result.ty, return_type) {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: self.format_type_name(return_type),
+                    found: self.format_type_name(body_result.ty),
+                },
+                self.body_rir_ref().get(body).span,
+            ));
+        }
+
         // Add implicit return only if body doesn't already diverge (e.g., explicit return)
         if body_result.ty != Type::NEVER {
             // An accessor result cannot be the function's tail value: the

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -23,6 +23,56 @@ name = "ICE regressions"
 description = "Minimal programs that used to crash the compiler; each must now compile-or-cleanly-error with no signal (RUE-51)."
 
 [[case]]
+name = "loop_break_tail_in_never_function_rue1911"
+description = "RUE-1911: a reachable never-returning function whose loop can break must be rejected by semantic analysis before its unit return reaches CFG verification."
+files = [{ path = "main.rue", source = """
+fn stop() -> ! { loop { break } }
+fn main() -> i32 { stop() }
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected !, found ()"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification failed"]
+
+[[case]]
+name = "unconstrained_intrinsic_tail_in_never_function_rue1911"
+description = "RUE-1911: an unresolved context-driven intrinsic tail is not proof that a declared-never function diverges."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn stop() -> ! { @read_line() }
+fn main() -> i32 { stop() }
+""" }]
+compile_fail = true
+error_contains = ["E0702", "intrinsic '@read_line' expects Option(StrBuf), found !"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification failed"]
+
+[[case]]
+name = "comparison_value_left_never_right_remains_valid_rue1911"
+description = "RUE-1911 control: symmetric expression equality still accepts a diverging right operand."
+files = [{ path = "main.rue", source = """
+fn stop() -> ! { loop {} }
+fn compare(flag: bool) -> bool {
+    let value: i32 = 1;
+    if flag { value == stop() } else { false }
+}
+fn main() -> i32 { if compare(false) { 1 } else { 0 } }
+""" }]
+exit_code = 0
+
+[[case]]
+name = "comparison_never_left_value_right_remains_valid_rue1911"
+description = "RUE-1911 control: symmetric expression equality still accepts a diverging left operand."
+files = [{ path = "main.rue", source = """
+fn stop() -> ! { loop {} }
+fn compare(flag: bool) -> bool {
+    let value: i32 = 1;
+    if flag { stop() == value } else { false }
+}
+fn main() -> i32 { if compare(false) { 1 } else { 0 } }
+""" }]
+exit_code = 0
+
+[[case]]
 name = "nominal_type_adjacent_to_if_tail_rue1418"
 description = "RUE-1418: a named type adjacent to a block-like if became the function tail and reached CFG as a non-unit return without a runtime value."
 files = [{ path = "main.rue", source = """


### PR DESCRIPTION
## Summary
- enforce the declared-never function boundary after AIR body inference and before implicit return construction
- preserve symmetric bottom-type behavior inside expressions and canonical intrinsic diagnostics
- add durable CLI regressions for the minimized crash and both operand orders

## Validation
- `scripts/rue cli rue1911`
- focused AIR, CFG, compiler payload-schema, fuzz, and CLI tests
- `scripts/rue quick`
- `scripts/rue fmt`
- `scripts/rue premerge`
- oracle differential corpus passed within premerge

Fixes RUE-1911