### PR TITLE
RUE-1910: align comptime match inference pruning

### DIFF
--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -1113,7 +1113,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     if can_select {
                         canonical_evaluations = canonical_evaluations.saturating_add(1);
                         scope_materializations = scope_materializations.saturating_add(1);
-                        if let Some(arm) = self
+                        if let Some(selected_arm) = self
                             .select_comptime_match_with_resolved_types_and_membership(
                                 scrutinee,
                                 &arms,
@@ -1122,9 +1122,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                 value_subst,
                                 runtime_binding_membership_view(&bindings),
                             )?
+                            && crate::sema::comptime::prunable_match_body(
+                                self.body_rir_ref(),
+                                &arms,
+                                selected_arm,
+                            )
+                            .is_some()
                         {
-                            selections
-                                .insert(inst_ref, crate::sema::ComptimeSelection::Match { arm });
+                            selections.insert(
+                                inst_ref,
+                                crate::sema::ComptimeSelection::Match { arm: selected_arm },
+                            );
                         }
                     }
                 }

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -6,7 +6,8 @@
 
 use ahash::{AHashMap, AHashSet};
 use rue_rir::{
-    InstData, InstRef, RepeatCount, Rir, RirIntrinsicArgsRange, SymbolHandle, ValidatedRir,
+    InstData, InstRef, RepeatCount, Rir, RirIntrinsicArgsRange, RirMatchArmsRange, SymbolHandle,
+    ValidatedRir,
 };
 use rue_span::Span;
 use std::hash::Hash;
@@ -76,6 +77,41 @@ pub(crate) const COMPTIME_SOURCE: &str = concat!(
 /// Maximum propagated comptime call depth. Depth zero is the root call, and
 /// expression recursion does not spend this budget.
 pub const MAX_COMPTIME_CALL_DEPTH: usize = 64;
+
+/// Return the selected body only when a comptime-known match can use the
+/// pruned semantic path.
+///
+/// Inference and AIR analysis must agree on this boundary. In particular,
+/// integer matches without a wildcard are non-exhaustive and therefore take
+/// the ordinary all-arms path so sema can report that error. Recording a
+/// selection for such a match would make inference skip the unselected bodies
+/// even though AIR analysis still visits them.
+pub(crate) fn prunable_match_body(
+    rir: &Rir,
+    arms: &RirMatchArmsRange,
+    selected_arm: usize,
+) -> Option<InstRef> {
+    let arm_views = rir.match_arms(arms);
+    let selected = arm_views.get(selected_arm).map(|(_, body)| body)?;
+    let mut has_wildcard = false;
+    let mut bool_true_covered = false;
+    let mut bool_false_covered = false;
+    for (pattern, _) in arm_views.iter() {
+        match decode_comptime_match_pattern(&pattern, |_| ()) {
+            ComptimeMatchPattern::Wildcard => has_wildcard = true,
+            ComptimeMatchPattern::Bool(value) => {
+                if value {
+                    bool_true_covered = true;
+                } else {
+                    bool_false_covered = true;
+                }
+            }
+            ComptimeMatchPattern::Integer(_) => {}
+            ComptimeMatchPattern::Path { .. } => return None,
+        }
+    }
+    (has_wildcard || (bool_true_covered && bool_false_covered)).then_some(selected)
+}
 
 /// Convert the number of active ancestor calls into the propagated depth of a
 /// child call. Root evaluation is depth zero, so its first child is depth one.

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1033,121 +1033,89 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // then reports non-exhaustiveness).
         if let Some(crate::sema::ComptimeSelection::Match { arm: selected_arm }) =
             ctx.comptime_selections.get(&match_inst)
+            && let Some(selected) =
+                crate::sema::comptime::prunable_match_body(self.body_rir_ref(), arms, *selected_arm)
         {
             // These scans only read pattern shapes, so they iterate the
             // borrowed RIR view; nothing here needs the owned patterns the
             // old per-arm materialization allocated (RUE-1661).
             let arm_views = self.body_rir_ref().match_arms(arms);
-            let selected = arm_views.get(*selected_arm).map(|(_, body)| body);
-            let mut prunable = !arm_views.is_empty() && selected.is_some();
-            let mut has_wildcard = false;
-            let mut bool_true_covered = false;
-            let mut bool_false_covered = false;
+            // Pattern *legality* is independent of arm *selection*.
+            // Spec 4.14:19 exempts only the analysis of unselected arm
+            // *bodies* (and reaffirms exhaustiveness) — it does NOT
+            // exempt the per-pattern legality rules of 4.7. So before
+            // pruning we still range-check every integer pattern
+            // against the scrutinee's declared type, exactly as the
+            // normal path below does via check_pattern_int: E0800 for
+            // an out-of-range literal (4.7:23) and E0801 for a negative
+            // pattern on an unsigned scrutinee (4.7:24). The comptime
+            // value substituted for the scrutinee mistypes as i32 at
+            // AIR emission (a known limitation), so we take the
+            // scrutinee's true type from Hindley-Milner inference
+            // (RUE-215).
+            let scrutinee_type = Self::get_resolved_type(ctx, scrutinee, span, "match scrutinee")?;
+            // Validate every scalar pattern before pruning. The selected
+            // body is exempt from analysis, but a malformed later pattern
+            // remains a source error (for example `0 => ..., true => ...`
+            // on an integer scrutinee).
             for (pattern, _) in arm_views.iter() {
-                match pattern {
-                    RirPatternView::Wildcard(_) => has_wildcard = true,
-                    RirPatternView::Bool(b, _) => {
-                        if b {
-                            bool_true_covered = true;
-                        } else {
-                            bool_false_covered = true;
-                        }
+                match &pattern {
+                    RirPatternView::Int {
+                        value: magnitude,
+                        negative,
+                        ..
+                    } if scrutinee_type.is_integer() => {
+                        self.check_pattern_int(
+                            *magnitude,
+                            *negative,
+                            scrutinee_type,
+                            pattern.span(),
+                        )?;
                     }
-                    RirPatternView::Int { .. } => {}
-                    RirPatternView::Path { .. } => {
-                        prunable = false;
-                        break;
+                    RirPatternView::Int { .. } => {
+                        return Err(CompileError::new(
+                            ErrorKind::TypeMismatch {
+                                expected: self.format_type_name(scrutinee_type),
+                                found: "integer".to_string(),
+                            },
+                            pattern.span(),
+                        ));
                     }
+                    RirPatternView::Bool(_, _) if scrutinee_type != Type::BOOL => {
+                        return Err(CompileError::new(
+                            ErrorKind::TypeMismatch {
+                                expected: self.format_type_name(scrutinee_type),
+                                found: "bool".to_string(),
+                            },
+                            pattern.span(),
+                        ));
+                    }
+                    _ => {}
                 }
             }
-            // Exhaustiveness is a property of the pattern set, not of
-            // the arm bodies, so it stays checked even when the match
-            // value is comptime-known (spec 4.7:9): a wildcard, or
-            // both bool values for a bool scrutinee. A non-exhaustive
-            // match falls through to the normal path for the proper
-            // diagnostic (which also covers "no arm matched").
-            let exhaustive = has_wildcard || (bool_true_covered && bool_false_covered);
-            if prunable && exhaustive {
-                // Pattern *legality* is independent of arm *selection*.
-                // Spec 4.14:19 exempts only the analysis of unselected arm
-                // *bodies* (and reaffirms exhaustiveness) — it does NOT
-                // exempt the per-pattern legality rules of 4.7. So before
-                // pruning we still range-check every integer pattern
-                // against the scrutinee's declared type, exactly as the
-                // normal path below does via check_pattern_int: E0800 for
-                // an out-of-range literal (4.7:23) and E0801 for a negative
-                // pattern on an unsigned scrutinee (4.7:24). The comptime
-                // value substituted for the scrutinee mistypes as i32 at
-                // AIR emission (a known limitation), so we take the
-                // scrutinee's true type from Hindley-Milner inference
-                // (RUE-215).
-                let scrutinee_type =
-                    Self::get_resolved_type(ctx, scrutinee, span, "match scrutinee")?;
-                // Validate every scalar pattern before pruning. The selected
-                // body is exempt from analysis, but a malformed later pattern
-                // remains a source error (for example `0 => ..., true => ...`
-                // on an integer scrutinee).
-                for (pattern, _) in arm_views.iter() {
-                    match &pattern {
-                        RirPatternView::Int {
-                            value: magnitude,
-                            negative,
-                            ..
-                        } if scrutinee_type.is_integer() => {
-                            self.check_pattern_int(
-                                *magnitude,
-                                *negative,
-                                scrutinee_type,
-                                pattern.span(),
-                            )?;
-                        }
-                        RirPatternView::Int { .. } => {
-                            return Err(CompileError::new(
-                                ErrorKind::TypeMismatch {
-                                    expected: self.format_type_name(scrutinee_type),
-                                    found: "integer".to_string(),
-                                },
-                                pattern.span(),
-                            ));
-                        }
-                        RirPatternView::Bool(_, _) if scrutinee_type != Type::BOOL => {
-                            return Err(CompileError::new(
-                                ErrorKind::TypeMismatch {
-                                    expected: self.format_type_name(scrutinee_type),
-                                    found: "bool".to_string(),
-                                },
-                                pattern.span(),
-                            ));
-                        }
-                        _ => {}
-                    }
-                }
-                // Unreachable-pattern diagnostics (spec 4.7:20) are a
-                // property of the pattern *set*, not of which arm the
-                // comptime value selects, so they must still fire even
-                // though we prune to a single body below (RUE-555). The
-                // normal per-arm loop that would otherwise emit them is
-                // skipped by the early return, so run them here. Only
-                // pattern shapes are inspected — no arm body is analyzed,
-                // honoring 4.14:19.
-                self.warn_unreachable_pruned_arms(arm_views.iter(), scrutinee_type, ctx);
-                if let Some(body) = selected {
-                    ctx.push_scope();
-                    let boundary = ctx.ownership.enter_full_expression();
-                    let result = self.analyze_inst(air, body, ctx);
-                    let loans = ctx.ownership.nested_expression_loans(&boundary);
-                    ctx.ownership.exit_full_expression(boundary);
-                    let result = result?;
-                    let selected_divergence = ctx.divergence_kinds;
-                    ctx.pop_scope();
-                    ctx.divergence_kinds = prior_divergence.union(selected_divergence);
-                    // The selected arm is this `match`'s value, so loans
-                    // surviving its tail belong to the enclosing full
-                    // expression (RUE-1678).
-                    self.readmit_arm_accessor_loans(ctx, loans, result.continues)?;
-                    return Ok(result);
-                }
-            }
+            // Unreachable-pattern diagnostics (spec 4.7:20) are a
+            // property of the pattern *set*, not of which arm the
+            // comptime value selects, so they must still fire even
+            // though we prune to a single body below (RUE-555). The
+            // normal per-arm loop that would otherwise emit them is
+            // skipped by the early return, so run them here. Only
+            // pattern shapes are inspected — no arm body is analyzed,
+            // honoring 4.14:19.
+            self.warn_unreachable_pruned_arms(arm_views.iter(), scrutinee_type, ctx);
+            ctx.push_scope();
+            let boundary = ctx.ownership.enter_full_expression();
+            let result = self.analyze_inst(air, selected, ctx);
+            let loans = ctx.ownership.nested_expression_loans(&boundary);
+            ctx.ownership.exit_full_expression(boundary);
+            let result = result?;
+            let selected_divergence = ctx.divergence_kinds;
+            ctx.pop_scope();
+            ctx.divergence_kinds = prior_divergence.union(selected_divergence);
+            // The selected arm is this `match`'s value, so loans
+            // surviving its tail belong to the enclosing full
+            // expression (RUE-1678).
+            self.readmit_arm_accessor_loans(ctx, loans, result.continues)?;
+            return Ok(result);
         }
 
         // Derive the expected scrutinee type from the arm patterns, so a

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -23,6 +23,17 @@ name = "ICE regressions"
 description = "Minimal programs that used to crash the compiler; each must now compile-or-cleanly-error with no signal (RUE-51)."
 
 [[case]]
+name = "nonexhaustive_comptime_match_infers_all_arms_rue1910"
+description = "RUE-1910: a selected but non-exhaustive comptime match takes the ordinary semantic path, so inference must cover every arm that AIR analysis visits."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 { match n { 0 => 1, 0 => 1 } }
+fn main() -> i32 { f(0) }
+""" }]
+compile_fail = true
+error_contains = ["E0600", "match is not exhaustive"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "type inference did not resolve type"]
+
+[[case]]
 name = "loop_break_tail_in_never_function_rue1911"
 description = "RUE-1911: a reachable never-returning function whose loop can break must be rejected by semantic analysis before its unit return reaches CFG verification."
 files = [{ path = "main.rue", source = """

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -1807,6 +1807,28 @@ mod tests {
     }
 
     #[test]
+    fn compiler_targets_infer_every_arm_of_nonprunable_comptime_matches() {
+        // Saved compiler_aarch64 finding for RUE-1910. Comptime evaluation
+        // selects the first arm, but an integer match without a wildcard is
+        // non-exhaustive and therefore takes sema's ordinary all-arms path.
+        // Both compiler targets must infer the second arm before AIR visits it.
+        let source = "fn f(comptime n: i32) -> i32 { match n { 0 => 1, 0 => 1 } } \
+                      fn main() -> i32 { f(0) }";
+        for errors in [
+            CompilerAarch64Target::compile(source).expect_err("AArch64 compile rejects"),
+            CompilerX86_64O1Target::compile(source).expect_err("x86-64 compile rejects"),
+        ] {
+            assert_no_ice_errors(&errors);
+            assert!(
+                errors
+                    .iter()
+                    .any(|error| matches!(error.kind, rue_error::ErrorKind::NonExhaustiveMatch)),
+                "canonical non-exhaustive diagnostic was lost: {errors:?}"
+            );
+        }
+    }
+
+    #[test]
     fn compiler_x86_64_o1_target_selects_and_applies_basic_optimization() {
         let options = CompilerX86_64O1Target::options();
         assert_eq!(options.target, rue_compiler::Target::X86_64Linux);


### PR DESCRIPTION
Fixes RUE-1910

## Summary
- centralize comptime-match prunability in one semantic authority
- publish selection facts only when AIR may prune the same match
- add production CLI and cross-target fuzz regressions for the recovered nightly input

## Reproduction
The historical fresh corpus and recorded seed reproduced the exact unresolved-integer ICE at deterministic run 34,150 of 35,043. The minimized source is the new regression. Replaying the same 35,043-run sequence after the fix completed with zero crashes, panics, signals, or timeouts.

## Validation
- focused cross-target fuzz regression
- ICE regression CLI suite: 50/50
- rue-air: 842/842
- quick: 35 targets
- spec 4.7: 102/102
- spec 4.14: 224/224
- focused comptime and match CLI suites: 37/37
- AArch64 minimized case at O0/O1/O2/O3
- premerge: 213 passed, zero failures
- exact fixed historical replay: 35,043/35,043 crash-free

Local oracle-diff attempts were blocked before semantic execution by host EAGAIN thread-spawn exhaustion; CI is the oracle and native-AArch64 authority.