### PR TITLE
RUE-1917: add the test failure channel, test image, and dispatcher main

### DIFF
--- a/crates/rue-air/src/intrinsic.rs
+++ b/crates/rue-air/src/intrinsic.rs
@@ -509,7 +509,15 @@ impl IntrinsicOperation {
             | RuntimeCallKind::StrPrintAggregate
             | RuntimeCallKind::StrPrintProjected
             | RuntimeCallKind::StrPrintlnAggregate
-            | RuntimeCallKind::StrPrintlnProjected => return None,
+            | RuntimeCallKind::StrPrintlnProjected
+            // The ADR-0083 test channel is dispatcher and runner plumbing. No
+            // source spelling selects it, so it has no intrinsic identity —
+            // `@assert_eq` (Phase 2.5) is what will give `TestFail` one.
+            | RuntimeCallKind::TestNormalizeProcess
+            | RuntimeCallKind::TestComplete
+            | RuntimeCallKind::TestFailureSite
+            | RuntimeCallKind::TestFail
+            | RuntimeCallKind::TestUsageError => return None,
         })
     }
 
@@ -834,7 +842,11 @@ mod tests {
         (IntrinsicOperation::EnvLen, RuntimeCallKind::EnvLen),
     ];
 
-    const ORDINARY_CALL_ONLY: [RuntimeCallKind; 11] = [
+    // Every runtime call with no intrinsic spelling: the string and formatting
+    // family, which sema selects from ordinary method calls, and the ADR-0083
+    // test channel, which only the synthesized dispatcher and the runner's own
+    // sugar reach.
+    const ORDINARY_CALL_ONLY: [RuntimeCallKind; 16] = [
         RuntimeCallKind::StrByteAt,
         RuntimeCallKind::StrCharScalar,
         RuntimeCallKind::StrCharNext,
@@ -846,6 +858,11 @@ mod tests {
         RuntimeCallKind::StrPrintProjected,
         RuntimeCallKind::StrPrintlnAggregate,
         RuntimeCallKind::StrPrintlnProjected,
+        RuntimeCallKind::TestNormalizeProcess,
+        RuntimeCallKind::TestComplete,
+        RuntimeCallKind::TestFailureSite,
+        RuntimeCallKind::TestFail,
+        RuntimeCallKind::TestUsageError,
     ];
 
     #[test]
@@ -950,7 +967,7 @@ mod tests {
             EXACT_RUNTIME_MAPPINGS.map(|(_, runtime)| runtime),
             "the exact intrinsic-to-runtime map drifted"
         );
-        assert_eq!(RuntimeCallKind::ALL.len(), 41);
+        assert_eq!(RuntimeCallKind::ALL.len(), 46);
         for kind in RuntimeCallKind::ALL {
             assert_eq!(
                 IntrinsicOperation::from_runtime_call(kind).is_some(),

--- a/crates/rue-air/src/runtime_call.rs
+++ b/crates/rue-air/src/runtime_call.rs
@@ -149,6 +149,16 @@ pub enum RuntimeCallKind {
     ByteCopy,
     ByteMove,
     ByteSet,
+    /// Present the pinned test-visible process inventory (ADR-0083 §3).
+    TestNormalizeProcess,
+    /// Write the dispatcher's terminal completion frame (ADR-0083 §3).
+    TestComplete,
+    /// Stage the source location the next failure record carries.
+    TestFailureSite,
+    /// Report a structured failure on the §5.1 channel, then abort.
+    TestFail,
+    /// Write the pinned malformed-selector diagnostic and return.
+    TestUsageError,
 }
 
 const STR_BYTE_AT: &[RuntimeOperandOrigin] = &[
@@ -290,8 +300,33 @@ const BYTE_SET: &[RuntimeOperandOrigin] = &[
     },
 ];
 
+// The ADR-0083 §5.1 failure record, in the two calls a register-only helper
+// budget affords: `__rue_test_failure_site(file, line, column)` stages the
+// location, then `__rue_test_fail(kind, message, payload)` emits the record and
+// aborts. `payload` is the open, versioned field an assertion library fills in.
+const TEST_FAILURE_SITE: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::TextPointer(0),
+    RuntimeOperandOrigin::TextLength(0),
+    RuntimeOperandOrigin::ValueArgument {
+        index: 1,
+        ty: AbiType::U32,
+    },
+    RuntimeOperandOrigin::ValueArgument {
+        index: 2,
+        ty: AbiType::U32,
+    },
+];
+const TEST_FAIL: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::TextPointer(0),
+    RuntimeOperandOrigin::TextLength(0),
+    RuntimeOperandOrigin::TextPointer(1),
+    RuntimeOperandOrigin::TextLength(1),
+    RuntimeOperandOrigin::TextPointer(2),
+    RuntimeOperandOrigin::TextLength(2),
+];
+
 impl RuntimeCallKind {
-    pub const ALL: [Self; 41] = [
+    pub const ALL: [Self; 46] = [
         Self::StrByteAt,
         Self::StrCharScalar,
         Self::StrCharNext,
@@ -333,6 +368,11 @@ impl RuntimeCallKind {
         Self::ByteCopy,
         Self::ByteMove,
         Self::ByteSet,
+        Self::TestNormalizeProcess,
+        Self::TestComplete,
+        Self::TestFailureSite,
+        Self::TestFail,
+        Self::TestUsageError,
     ];
 
     pub const fn helper(self) -> RuntimeHelperId {
@@ -376,6 +416,11 @@ impl RuntimeCallKind {
             Self::ByteCopy => RuntimeHelperId::ByteCopy,
             Self::ByteMove => RuntimeHelperId::ByteMove,
             Self::ByteSet => RuntimeHelperId::ByteSet,
+            Self::TestNormalizeProcess => RuntimeHelperId::TestNormalizeProcess,
+            Self::TestComplete => RuntimeHelperId::TestComplete,
+            Self::TestFailureSite => RuntimeHelperId::TestFailureSite,
+            Self::TestFail => RuntimeHelperId::TestFail,
+            Self::TestUsageError => RuntimeHelperId::TestUsageError,
         }
     }
 
@@ -405,7 +450,10 @@ impl RuntimeCallKind {
             | Self::RandomU32
             | Self::RandomU64
             | Self::ArgCount
-            | Self::EnvCount => NONE,
+            | Self::EnvCount
+            | Self::TestNormalizeProcess
+            | Self::TestComplete
+            | Self::TestUsageError => NONE,
             Self::ArgPtr | Self::ArgLen | Self::EnvPtr | Self::EnvLen => PROCESS_INDEX,
             Self::ReadLine => READ_LINE,
             Self::ParseI32 | Self::ParseI64 | Self::ParseU32 | Self::ParseU64 => PARSE,
@@ -414,6 +462,8 @@ impl RuntimeCallKind {
             Self::Realloc | Self::Resize => RESIZE_LAYOUT,
             Self::ByteCopy | Self::ByteMove => BYTE_COPY,
             Self::ByteSet => BYTE_SET,
+            Self::TestFailureSite => TEST_FAILURE_SITE,
+            Self::TestFail => TEST_FAIL,
         }
     }
 

--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -92,6 +92,8 @@ pub(crate) fn anonymous_producer_root(
             F::Definition(value) => Some(*value),
             F::Specialization { base, .. } => function_root(base),
             F::AnonymousMember { owner, .. } | F::DropGlue(owner) => type_root(owner),
+            // Synthesized by the request, not rooted at any declaration.
+            F::TestDispatcher => None,
         }
     }
     match producer {

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -2221,6 +2221,8 @@ pub(in crate::sema) fn semantic_import_type_mentions_generic_parameter<K, M>(
             } => function_instance(base) || arguments(args),
             crate::FunctionInstanceKey::AnonymousMember { owner, .. }
             | crate::FunctionInstanceKey::DropGlue(owner) => type_instance(owner),
+            // No type arguments at all, so nothing generic can hide here.
+            crate::FunctionInstanceKey::TestDispatcher => false,
         }
     }
 

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -4236,13 +4236,15 @@ where
                             base_definition(base)
                         }
                         crate::FunctionInstanceKey::AnonymousMember { .. }
-                        | crate::FunctionInstanceKey::DropGlue(_) => None,
+                        | crate::FunctionInstanceKey::DropGlue(_)
+                        | crate::FunctionInstanceKey::TestDispatcher => None,
                     }
                 }
                 base_definition(base)?
             }
             crate::FunctionInstanceKey::AnonymousMember { .. }
-            | crate::FunctionInstanceKey::DropGlue(_) => return None,
+            | crate::FunctionInstanceKey::DropGlue(_)
+            | crate::FunctionInstanceKey::TestDispatcher => return None,
         };
         let name = self.source.definition_name(definition)?;
         let signature = self.source.function(definition)?;
@@ -6139,6 +6141,9 @@ where
         }
         crate::FunctionInstanceKey::DropGlue(_) => {
             Err("drop glue cannot produce an anonymous member body")
+        }
+        crate::FunctionInstanceKey::TestDispatcher => {
+            Err("the test dispatcher cannot produce an anonymous member body")
         }
     }
 }

--- a/crates/rue-air/src/semantic_identity.rs
+++ b/crates/rue-air/src/semantic_identity.rs
@@ -424,7 +424,8 @@ impl<D, M> AnonymousNominalKey<D, M> {
                 FunctionInstanceKey::Specialization { arguments, .. } => Some(arguments),
                 FunctionInstanceKey::Definition(_)
                 | FunctionInstanceKey::AnonymousMember { .. }
-                | FunctionInstanceKey::DropGlue(_) => None,
+                | FunctionInstanceKey::DropGlue(_)
+                | FunctionInstanceKey::TestDispatcher => None,
             },
         }
     }
@@ -489,6 +490,15 @@ pub enum FunctionInstanceKey<D, M> {
         member: AnonymousMemberKey,
     },
     DropGlue(Node<TypeInstanceKey<D, M>>),
+    /// The synthesized `main` of a test image (ADR-0083 §3).
+    ///
+    /// A test request has exactly one, and it carries no payload: the ordered
+    /// test table it dispatches on is a property of the request's closure, not
+    /// of this identity, so the identity stays the same while the closure
+    /// grows. Dispatcher code is runner plumbing — the capability summaries and
+    /// closure fingerprints the deferred ADRs compute exclude it by
+    /// construction.
+    TestDispatcher,
 }
 
 impl<D, M> CanonicalArgumentValue<D, M> {
@@ -699,6 +709,9 @@ impl<D, M> FunctionInstanceKey<D, M> {
             Self::DropGlue(value) => FunctionInstanceKey::DropGlue(Node::new(
                 value.try_map_identities(definition, module)?,
             )),
+            // The dispatcher carries no definition or module identity, so
+            // relocating it into another issuer's vocabulary is the identity.
+            Self::TestDispatcher => FunctionInstanceKey::TestDispatcher,
         })
     }
 }

--- a/crates/rue-air/src/stable_digest.rs
+++ b/crates/rue-air/src/stable_digest.rs
@@ -254,6 +254,7 @@ impl DurableEncode for crate::FunctionInstanceKey<String, String> {
                 encode_variant(state, 3);
                 owner.durable_encode(state);
             }
+            Self::TestDispatcher => encode_variant(state, 4),
         }
     }
 }

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1976,7 +1976,7 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 44] = [
     (8_573, 4_124_823_810_140_583_654),
     (753, 3_150_885_663_910_159_936),
     (2_598, 10_270_973_964_375_394_836),
-    (11_514, 1_556_117_829_400_373_530),
+    (11_583, 5_315_119_467_923_005_516),
     (103_771, 11_567_462_448_468_948_481),
     (3_254, 11_949_940_325_034_004_149),
     (5_552, 14_658_861_127_087_730_967),
@@ -2012,13 +2012,9 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 44] = [
 // identity even when constructor, caller, and macro token counts do not.
 const CONSTRUCTION_TOKEN_STRUCT_IDENTITY: (usize, u64) = (80, 5_227_448_979_315_228_973);
 const CONSTRUCTION_TOKEN_IMPL_IDENTITY: (usize, u64) = (108, 2_765_439_612_714_245_239);
-const COMPILER_CRATE_ROOT_IDENTITY: (usize, u64) = (10_380, 4_871_274_390_997_435_514);
-const COMPILER_CRATE_ROOT_NAMESPACE_IDENTITY: (usize, u64, usize, u64) = (
-    107,
-    10_929_233_963_061_401_561,
-    220,
-    6_174_496_129_237_532_836,
-);
+const COMPILER_CRATE_ROOT_IDENTITY: (usize, u64) = (10_456, 13_393_868_787_617_733_612);
+const COMPILER_CRATE_ROOT_NAMESPACE_IDENTITY: (usize, u64, usize, u64) =
+    (110, 255_897_897_515_642_022, 223, 8_513_453_303_818_067_861);
 const COMPILER_SESSION_ROOT_IDENTITY: (usize, u64) = (3_375, 11_197_616_651_825_656_461);
 const COMPILER_SESSION_CONSTRUCTOR_IDENTITY: (usize, u64) = (82, 10_721_269_354_679_246_675);
 const FRONTEND_DATABASE_CONSTRUCTION_IDENTITY: (usize, u64) = (268, 967_740_565_057_515_587);
@@ -4453,7 +4449,7 @@ pub(super) use register_parse_import_parse;"#;
     ));
     let nested_module_owners = module_owner_inventory(&compiler_module_sources);
     let nested_module_fingerprint = source_inventory_fingerprint(&nested_module_owners);
-    let expected_nested_module_identity = (151, 14_424_826_081_772_489_333);
+    let expected_nested_module_identity = (154, 8_453_145_628_824_547_092);
     assert_eq!(
         (nested_module_owners.len(), nested_module_fingerprint),
         expected_nested_module_identity,
@@ -5470,6 +5466,8 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("source_metadata", include_str!("source_metadata.rs")),
     ("source_snapshot", include_str!("source_snapshot.rs")),
     ("syntax", include_str!("syntax.rs")),
+    ("test_dispatcher", include_str!("test_dispatcher.rs")),
+    ("test_inventory", include_str!("test_inventory.rs")),
     (
         "toolchain_module_demand",
         include_str!("toolchain_module_demand.rs"),
@@ -7069,6 +7067,7 @@ fn facade_stays_small_and_session_centered() {
             "retained_charge",
             "scaling_harness",
             "supported_api_inventory",
+            "test_image_tests",
             "test_support",
         ])
         .collect::<Vec<_>>();

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -52,6 +52,18 @@ pub(crate) enum CfgSemanticInput {
         materialization: Arc<crate::local_semantic_materialization::LocalMaterializationFacts>,
         body_span: Span,
     },
+    /// The synthesized `main` of a test image (ADR-0083 §3).
+    ///
+    /// The table is the request's tests in inventory order, so the ordinal a
+    /// selector names is an index into it. It is the whole semantic input:
+    /// the body is a pure function of the ordered table, so two requests with
+    /// the same tests in the same order share one CFG terminal, and adding or
+    /// renaming a test invalidates it exactly as it should.
+    TestDispatcher {
+        table: Arc<[crate::FunctionInstanceKey]>,
+        materialization: Arc<crate::local_semantic_materialization::LocalMaterializationFacts>,
+        body_span: Span,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -114,6 +126,18 @@ impl PartialEq for CfgSemanticInput {
                     && left_facts == right_facts
                     && left_materialization == right_materialization
             }
+            (
+                Self::TestDispatcher {
+                    table: left_table,
+                    materialization: left_materialization,
+                    ..
+                },
+                Self::TestDispatcher {
+                    table: right_table,
+                    materialization: right_materialization,
+                    ..
+                },
+            ) => left_table == right_table && left_materialization == right_materialization,
             _ => false,
         }
     }
@@ -340,7 +364,9 @@ pub(crate) fn accessor_source_name(identity: &crate::FunctionInstanceKey) -> Str
         crate::FunctionInstanceKey::Definition(definition) => definition.name().to_owned(),
         crate::FunctionInstanceKey::Specialization { base, .. } => accessor_source_name(base),
         crate::FunctionInstanceKey::AnonymousMember { member, .. } => member.name.to_string(),
-        crate::FunctionInstanceKey::DropGlue(_) => "<accessor>".to_owned(),
+        crate::FunctionInstanceKey::DropGlue(_) | crate::FunctionInstanceKey::TestDispatcher => {
+            "<accessor>".to_owned()
+        }
     }
 }
 
@@ -364,7 +390,9 @@ pub(crate) fn accessor_cfg_subgraph(
                         _ => None,
                     })
                     .collect(),
-                CfgSemanticInput::DropGlue { .. } => Vec::new(),
+                CfgSemanticInput::DropGlue { .. } | CfgSemanticInput::TestDispatcher { .. } => {
+                    Vec::new()
+                }
             };
             (function.clone(), callees)
         })
@@ -389,7 +417,7 @@ pub(crate) fn accessor_cfg_subgraph(
             CfgSemanticInput::Body {
                 materialization, ..
             } => Some(materialization),
-            CfgSemanticInput::DropGlue { .. } => None,
+            CfgSemanticInput::DropGlue { .. } | CfgSemanticInput::TestDispatcher { .. } => None,
         }
     }
     fn with_facts(
@@ -401,7 +429,9 @@ pub(crate) fn accessor_cfg_subgraph(
                 input: input.clone(),
                 materialization,
             },
-            CfgSemanticInput::DropGlue { .. } => key.semantic_input.clone(),
+            CfgSemanticInput::DropGlue { .. } | CfgSemanticInput::TestDispatcher { .. } => {
+                key.semantic_input.clone()
+            }
         };
         CfgQueryKey::new(
             key.function.clone(),
@@ -817,6 +847,13 @@ impl RetainedCharge for CfgSemanticInput {
                 .retained_charge()
                 .saturating_add(facts.retained_charge())
                 .saturating_add(materialization.retained_charge()),
+            Self::TestDispatcher {
+                table,
+                materialization,
+                ..
+            } => table
+                .retained_charge()
+                .saturating_add(materialization.retained_charge()),
         }
     }
 }
@@ -933,7 +970,8 @@ pub(crate) fn import_accessor_failure(
         .find(|dependency| dependency.function == origin.accessor)
         .map(|dependency| match &dependency.semantic_input {
             CfgSemanticInput::Body { input, .. } => input.body_span,
-            CfgSemanticInput::DropGlue { body_span, .. } => *body_span,
+            CfgSemanticInput::DropGlue { body_span, .. }
+            | CfgSemanticInput::TestDispatcher { body_span, .. } => *body_span,
         })
         .expect("published accessor failure must name a dependency");
     import_errors(errors, origin.body_span, current_accessor_span)
@@ -1251,6 +1289,18 @@ fn materialize_and_build_cfg(
                 };
             (&synthesized, *body_span, materialization.as_ref())
         }
+        CfgSemanticInput::TestDispatcher {
+            table,
+            materialization,
+            body_span,
+        } => {
+            // Unlike drop glue, the dispatcher needs no layout prerequisite:
+            // its body is a pure function of the ordered table, so it can be
+            // synthesized directly. Fact selection built the same body from the
+            // same table when it chose this key's materialization facts.
+            synthesized = crate::test_dispatcher::synthesize_test_dispatcher(table);
+            (&synthesized, *body_span, materialization.as_ref())
+        }
     };
     let mut builtin_facts = Vec::with_capacity(facts.builtin_nominals.len());
     let builtin_terminals = context.query_registered_adaptive_batch(
@@ -1286,7 +1336,7 @@ fn materialize_and_build_cfg(
     #[cfg(test)]
     let local_interner_limit = match &key.semantic_input {
         CfgSemanticInput::Body { input, .. } => input.interner_limit,
-        CfgSemanticInput::DropGlue { .. } => None,
+        CfgSemanticInput::DropGlue { .. } | CfgSemanticInput::TestDispatcher { .. } => None,
     };
     // The local semantic epoch owns the actual insertion path. Tests inject
     // their request-local ceiling into that owner so a regression to an
@@ -1303,11 +1353,24 @@ fn materialize_and_build_cfg(
             rue_rir::SharedSymbolSpace::private()
         }
     };
-    // Both CFG inputs use the exact fact-side indexes prepared during
-    // selection, keeping canonical-body and drop-glue materialization on one
-    // indexed path.
-    let materialized = match &key.semantic_input {
-        CfgSemanticInput::Body { input, .. } => {
+    // Every CFG input uses the exact fact-side indexes prepared during
+    // selection, keeping canonical-body and synthesized-body materialization on
+    // one indexed path each. A synthesized input's identity is the only thing
+    // that distinguishes drop glue from the test dispatcher here: both bodies
+    // were already built above, and the local epoch just needs to know whose
+    // they are.
+    let synthesized_identity = match &key.semantic_input {
+        CfgSemanticInput::Body { .. } => None,
+        CfgSemanticInput::DropGlue { owner, .. } => Some(crate::FunctionInstanceKey::DropGlue(
+            Node::new(owner.clone()),
+        )),
+        CfgSemanticInput::TestDispatcher { .. } => Some(crate::FunctionInstanceKey::TestDispatcher),
+    };
+    let materialized = match synthesized_identity {
+        None => {
+            let CfgSemanticInput::Body { input, .. } = &key.semantic_input else {
+                unreachable!("only a canonical source body has no synthesized identity")
+            };
             crate::local_semantic_materialization::materialize_canonical_body_with_indexes_in_space(
                 &input.canonical,
                 body_span,
@@ -1322,9 +1385,9 @@ fn materialize_and_build_cfg(
                 materialization_symbol_space,
             )
         }
-        CfgSemanticInput::DropGlue { owner, .. } => {
+        Some(identity) => {
             crate::local_semantic_materialization::materialize_semantic_body_with_indexes_in_space(
-                crate::FunctionInstanceKey::DropGlue(Node::new(owner.clone())),
+                identity,
                 body,
                 body_span,
                 &facts.declarations,
@@ -1742,7 +1805,8 @@ fn build_cfg(
 fn semantic_input_body_span(input: &CfgSemanticInput) -> Span {
     match input {
         CfgSemanticInput::Body { input, .. } => input.body_span,
-        CfgSemanticInput::DropGlue { body_span, .. } => *body_span,
+        CfgSemanticInput::DropGlue { body_span, .. }
+        | CfgSemanticInput::TestDispatcher { body_span, .. } => *body_span,
     }
 }
 
@@ -3216,7 +3280,8 @@ fn is_true_free_function(function: &crate::FunctionInstanceKey) -> bool {
             definition
         }
         crate::FunctionInstanceKey::AnonymousMember { .. }
-        | crate::FunctionInstanceKey::DropGlue(_) => return false,
+        | crate::FunctionInstanceKey::DropGlue(_)
+        | crate::FunctionInstanceKey::TestDispatcher => return false,
     };
     definition.kind() == crate::StableDefinitionKind::Function
 }

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -301,7 +301,8 @@ fn foreign_callable_symbol(callable: &crate::FunctionInstanceKey) -> Option<Stri
         crate::FunctionInstanceKey::Definition(definition) => Some(definition.name().to_owned()),
         crate::FunctionInstanceKey::Specialization { base, .. } => foreign_callable_symbol(base),
         crate::FunctionInstanceKey::AnonymousMember { .. }
-        | crate::FunctionInstanceKey::DropGlue(_) => None,
+        | crate::FunctionInstanceKey::DropGlue(_)
+        | crate::FunctionInstanceKey::TestDispatcher => None,
     }
 }
 

--- a/crates/rue-compiler/src/durable_comptime/projection.rs
+++ b/crates/rue-compiler/src/durable_comptime/projection.rs
@@ -206,7 +206,8 @@ fn durable_type_diagnostic_name_kernel(ty: &DurableType) -> String {
             crate::FunctionInstanceKey::Definition(key) => Some(key.name()),
             crate::FunctionInstanceKey::Specialization { base, .. } => function_name(base),
             crate::FunctionInstanceKey::AnonymousMember { .. }
-            | crate::FunctionInstanceKey::DropGlue(_) => None,
+            | crate::FunctionInstanceKey::DropGlue(_)
+            | crate::FunctionInstanceKey::TestDispatcher => None,
         }
     }
 
@@ -308,13 +309,15 @@ pub(crate) fn durable_type_diagnostic_name_with_parameters(
                         base_definition(base)
                     }
                     crate::FunctionInstanceKey::AnonymousMember { .. }
-                    | crate::FunctionInstanceKey::DropGlue(_) => None,
+                    | crate::FunctionInstanceKey::DropGlue(_)
+                    | crate::FunctionInstanceKey::TestDispatcher => None,
                 }
             }
             base_definition(base)
         }
         crate::FunctionInstanceKey::AnonymousMember { .. }
-        | crate::FunctionInstanceKey::DropGlue(_) => None,
+        | crate::FunctionInstanceKey::DropGlue(_)
+        | crate::FunctionInstanceKey::TestDispatcher => None,
     };
     let Some(definition) = definition else {
         return durable_type_diagnostic_name(ty);

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -73,6 +73,8 @@ mod source_identity;
 mod source_metadata;
 mod source_snapshot;
 mod syntax;
+mod test_dispatcher;
+mod test_inventory;
 mod toolchain_module_demand;
 mod type_queries;
 mod typed_query_store;
@@ -97,6 +99,8 @@ mod integration_tests;
 mod scaling_harness;
 #[cfg(test)]
 mod supported_api_inventory;
+#[cfg(test)]
+mod test_image_tests;
 mod warm_fresh_parity;
 
 // Supported source, identity, option, session, and diagnostic surface.

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -2465,7 +2465,7 @@ mod runtime_archive_validation_tests {
         inventory.symbols.push(marker("__rue_runtime_abi_v0", 1));
         let stale = error(&inventory, RuntimeTarget::Aarch64Linux);
         assert!(stale.contains(
-            "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v1`"
+            "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v2`"
         ));
 
         inventory
@@ -2619,7 +2619,7 @@ mod runtime_archive_validation_tests {
         let err = validation_error(&bytes);
         assert!(
             err.contains(
-                "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v1`"
+                "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v2`"
             ),
             "{err}"
         );

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -767,6 +767,12 @@ fn live_callable_symbol(identity: &FunctionInstanceKey) -> Option<String> {
         FunctionInstanceKey::DropGlue(owner) => {
             Some(format!("__rue_drop_{}", drop_glue_type_name(owner)?))
         }
+        // The test image's entry point. The loader looks up `main` by that
+        // exact unmangled spelling (`entry.rs`), so the dispatcher's symbol is
+        // not a naming preference — it is the ABI. Spelling it here rather than
+        // as a second special case beside the executable's `main` keeps one
+        // symbol authority for every rooted callable.
+        FunctionInstanceKey::TestDispatcher => Some("main".to_owned()),
     }
 }
 
@@ -1536,6 +1542,10 @@ pub(crate) fn select_materialization_facts(
                 }
                 FunctionInstanceKey::AnonymousMember { owner, .. }
                 | FunctionInstanceKey::DropGlue(owner) => self.instance_type(owner),
+                // The dispatcher names no declaration and no type, so it
+                // contributes no module or nominal fact of its own; the tests
+                // it calls contribute theirs through the same walk.
+                FunctionInstanceKey::TestDispatcher => {}
             }
         }
 

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -1054,8 +1054,8 @@ mod tests {
             target: Target::X86_64Linux,
             object_format: ProgramObjectFormat::Elf,
             entry_point: "_start",
-            runtime_abi_version: 1,
-            runtime_abi_symbol: "__rue_runtime_abi_v1",
+            runtime_abi_version: rue_runtime_abi::RUNTIME_ABI_VERSION,
+            runtime_abi_symbol: rue_runtime_abi::RUNTIME_ABI_VERSION_SYMBOL,
             runtime_archive: RuntimeArchiveIdentity::for_target(Target::X86_64Linux),
             required_runtime_symbols: vec!["_start".to_owned()],
         }

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -630,6 +630,7 @@ impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::FunctionI
                 .retained_charge()
                 .saturating_add(member.retained_charge()),
             Self::DropGlue(value) => value.retained_charge(),
+            Self::TestDispatcher => 0,
         }
     }
 }

--- a/crates/rue-compiler/src/revisioned_query_database/body/closure_nucleus.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/closure_nucleus.rs
@@ -420,6 +420,7 @@ pub(in crate::revisioned_query_database) fn visit_instance_anonymous_nominals<'a
             }
             crate::FunctionInstanceKey::AnonymousMember { owner, .. }
             | crate::FunctionInstanceKey::DropGlue(owner) => instance_type(owner, seen, visit),
+            crate::FunctionInstanceKey::TestDispatcher => {}
         }
     }
 

--- a/crates/rue-compiler/src/revisioned_query_database/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/provider.rs
@@ -789,7 +789,8 @@ impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
                 }
                 rue_air::FunctionInstanceKey::Specialization { base, .. } => function_module(base),
                 rue_air::FunctionInstanceKey::AnonymousMember { .. }
-                | rue_air::FunctionInstanceKey::DropGlue(_) => None,
+                | rue_air::FunctionInstanceKey::DropGlue(_)
+                | rue_air::FunctionInstanceKey::TestDispatcher => None,
             }
         }
         match &identity.producer {

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_produced_anonymous.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_produced_anonymous.rs
@@ -18,7 +18,8 @@ $runtime
                         }
                         crate::FunctionInstanceKey::Specialization { .. } => false,
                         crate::FunctionInstanceKey::AnonymousMember { .. }
-                        | crate::FunctionInstanceKey::DropGlue(_) => true,
+                        | crate::FunctionInstanceKey::DropGlue(_)
+                        | crate::FunctionInstanceKey::TestDispatcher => true,
                     };
                     if transaction_only {
                         let transaction = context

--- a/crates/rue-compiler/src/revisioned_query_database/semantic.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/semantic.rs
@@ -292,7 +292,8 @@ pub(crate) fn function_definition_key(
         crate::FunctionInstanceKey::Definition(key) => Some(key),
         crate::FunctionInstanceKey::Specialization { base, .. } => function_definition_key(base),
         crate::FunctionInstanceKey::AnonymousMember { .. }
-        | crate::FunctionInstanceKey::DropGlue(_) => None,
+        | crate::FunctionInstanceKey::DropGlue(_)
+        | crate::FunctionInstanceKey::TestDispatcher => None,
     }
 }
 
@@ -323,7 +324,9 @@ pub(super) fn function_body_source_definition_key(
             };
             producer_body_source_definition_key(&owner.producer)
         }
-        crate::FunctionInstanceKey::DropGlue(_) => None,
+        crate::FunctionInstanceKey::DropGlue(_) | crate::FunctionInstanceKey::TestDispatcher => {
+            None
+        }
     }
 }
 

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -718,6 +718,7 @@ fn encode_function(value: &FunctionInstanceKey, output: &mut String) {
             tag(output, 3);
             encode_type(value, output);
         }
+        FunctionInstanceKey::TestDispatcher => tag(output, 4),
     }
 }
 

--- a/crates/rue-compiler/src/session/rooted_artifacts.rs
+++ b/crates/rue-compiler/src/session/rooted_artifacts.rs
@@ -282,10 +282,25 @@ pub(super) struct RootedBodyGraph {
     /// consumers use instead of re-deriving roots from `main` and
     /// `c_export_roots`.
     pub(super) roots: Arc<[crate::FunctionInstanceKey]>,
+    /// The request's tests in stable-ID order, empty unless this is a
+    /// `RootSelection::Tests` graph (ADR-0083 §2).
+    ///
+    /// Computed once here so the `--list` surface and the test image's
+    /// dispatcher ordinals are the same table rather than two sorts of the
+    /// same declarations.
+    pub(super) test_inventory: Arc<[crate::test_inventory::RootedTest]>,
     pub(super) closure: crate::body_query::BodyClosureOutput,
     pub(super) work: crate::CanonicalSemanticWork,
 }
 
+/// The C-ABI export thunks a request's image must carry.
+///
+/// `extern "C"` exports are executable-only. The nucleus records them for every
+/// request, but only `RootSelection::Executable` roots them (ADR-0083 §1), so a
+/// test request produces no CFG unit for one and this intersection is empty by
+/// construction. A test image is entered through the synthesized dispatcher and
+/// exposes nothing else; if a future selection should link exports alongside
+/// tests, that belongs in the root-set authority, not here.
 pub(super) fn collect_rooted_exports(
     graph: &RootedBodyGraph,
     cfgs: &[RootedCfgUnit],

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -338,6 +338,11 @@ impl CompilerSession {
             c_export_roots: projection.c_export_roots,
             modules: program.modules().to_vec().into(),
             main,
+            test_inventory: crate::test_inventory::collect_test_inventory(
+                program.modules(),
+                &root_identities,
+            )
+            .into(),
             roots: root_identities,
             closure: closure.clone(),
             work,
@@ -536,6 +541,32 @@ impl CompilerSession {
         }
     }
 
+    /// The request's ordered test inventory, analyzed but not lowered.
+    ///
+    /// This stops at the body graph deliberately (ADR-0083 §2: `--list` does
+    /// semantic analysis of the test closure and no codegen), so it is the one
+    /// entry point that answers a listing without building a CFG.
+    pub(crate) fn rooted_test_inventory(
+        &mut self,
+        options: &CompileOptions,
+    ) -> Result<Vec<crate::unstable::TestInventoryEntry>, CompileErrors> {
+        match self.rooted_body_graph_with_cancellation(options, rue_query::CancellationToken::new())
+        {
+            Ok(graph) => Ok(graph
+                .test_inventory
+                .iter()
+                .map(|test| test.entry.clone())
+                .collect()),
+            Err(SemanticRequestControl::Compile(errors)) => Err(errors),
+            Err(SemanticRequestControl::Abort(abort)) => {
+                Err(pipeline_abort_errors("rooted test inventory", abort))
+            }
+            Err(SemanticRequestControl::Parked(park)) => {
+                Err(unresolved_toolchain_park_errors(&park))
+            }
+        }
+    }
+
     pub(crate) fn rooted_pre_optimization_cfg(
         &mut self,
         options: &CompileOptions,
@@ -607,6 +638,21 @@ impl CompilerSession {
                 .cloned()
                 .map(|owner| crate::FunctionInstanceKey::DropGlue(Node::new(owner))),
         );
+        // A test image needs an entry point, and only a request that lowers one
+        // synthesizes it: `rooted_test_inventory` stops at the body graph, so a
+        // listing never builds a dispatcher it would not link (ADR-0083 §2,
+        // §3). The table is the inventory verbatim, so ordinal `n` here is the
+        // same `n` a listing published.
+        let dispatches_tests = options.root_selection == crate::RootSelection::Tests;
+        let test_dispatcher_table: Arc<[crate::FunctionInstanceKey]> = graph
+            .test_inventory
+            .iter()
+            .map(|test| test.identity.clone())
+            .collect::<Vec<_>>()
+            .into();
+        if dispatches_tests {
+            identities.insert(crate::FunctionInstanceKey::TestDispatcher);
+        }
         // Only an executable request has a `main`, and only its symbol is
         // spelled unmangled (ADR-0083 §1: a test request has no entry point).
         let main_identity = graph
@@ -815,6 +861,49 @@ impl CompilerSession {
                 crate::cfg_query::CfgSemanticInput::DropGlue {
                     owner: owner.clone(),
                     facts: Box::new(facts.clone()),
+                    materialization: Arc::new(materialization),
+                    body_span: fallback_span,
+                },
+                fallback_span,
+            ));
+        }
+        if dispatches_tests {
+            work.cfg.materialization_fact_selections += 1;
+            // Fact selection walks the same body the CFG evaluator will
+            // synthesize, so the callables the dispatcher names are exactly the
+            // tests in the table.
+            let body = crate::test_dispatcher::synthesize_test_dispatcher(&test_dispatcher_table);
+            let materialization =
+                crate::local_semantic_materialization::select_materialization_facts(
+                    &crate::FunctionInstanceKey::TestDispatcher,
+                    &body,
+                    &materialization_index,
+                    &callable_symbols,
+                    &mut fact_closures,
+                )
+                .map_err(|error| {
+                    CompileError::new(
+                        ErrorKind::InternalError(format!(
+                            "test-dispatcher materialization fact selection failed: {error:?}"
+                        )),
+                        fallback_span,
+                    )
+                })?;
+            work.cfg.materialization_declarations_selected += materialization.declarations.len();
+            work.cfg.materialization_anonymous_nominals_selected +=
+                materialization.anonymous_nominals.len();
+            work.cfg.materialization_callables_selected += materialization.callables.len();
+            work.cfg.materialization_nominal_metadata_selected +=
+                materialization.nominal_metadata.len();
+            work.cfg.materialization_modules_selected += materialization.modules.len();
+            work.cfg.materialization_builtin_nominals_selected +=
+                materialization.builtin_nominals.len();
+            work.cfg.materialization_required_types_selected +=
+                materialization.required_types.len();
+            cfg_inputs.push((
+                crate::FunctionInstanceKey::TestDispatcher,
+                crate::cfg_query::CfgSemanticInput::TestDispatcher {
+                    table: Arc::clone(&test_dispatcher_table),
                     materialization: Arc::new(materialization),
                     body_span: fallback_span,
                 },
@@ -2129,6 +2218,7 @@ pub(super) fn stable_function_definition_root(
         F::Definition(value) => Some(value),
         F::Specialization { base, .. } => stable_function_definition_root(base),
         F::AnonymousMember { owner, .. } | F::DropGlue(owner) => stable_type_definition_root(owner),
+        F::TestDispatcher => None,
     }
 }
 
@@ -2192,7 +2282,8 @@ fn rooted_unused_function_warnings(
             crate::FunctionInstanceKey::Definition(definition) => Some(definition),
             crate::FunctionInstanceKey::Specialization { base, .. } => source_definition(base),
             crate::FunctionInstanceKey::AnonymousMember { .. }
-            | crate::FunctionInstanceKey::DropGlue(_) => None,
+            | crate::FunctionInstanceKey::DropGlue(_)
+            | crate::FunctionInstanceKey::TestDispatcher => None,
         }
     }
 

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -5704,6 +5704,233 @@ fn executable_cfg_closure_excludes_test_units() {
     );
 }
 
+/// Two modules' tests share one inventory, ordered by the whole stable ID.
+///
+/// The ordering is what binds a listing to the image's selectors, so this pins
+/// both the ID spelling and that an ordinal is its index (ADR-0083 §2, §3).
+#[test]
+fn test_inventory_orders_every_module_by_stable_id() {
+    let source = snapshot(
+        &[
+            (
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn main() -> i32 { let h = @import(\"helper.rue\"); 0 }\n\
+                 test \"zulu\" { }\n\
+                 test \"alpha\" { }\n",
+            ),
+            (
+                2,
+                "/p/helper.rue",
+                "helper.rue",
+                "pub fn used() -> i32 { 3 }\n\
+                 test \"beta\" { let x = used(); }\n",
+            ),
+        ],
+        1,
+    );
+    let mut session = CompilerSession::new();
+    publish_with_test_imports(&mut session, &source);
+
+    let inventory = crate::unstable::test_inventory(
+        &mut session,
+        &test_declaration_options(crate::RootSelection::Tests),
+    )
+    .expect("the test closure analyzes");
+
+    let ids = inventory
+        .entries
+        .iter()
+        .map(|entry| entry.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ids,
+        vec!["helper.rue::beta", "main.rue::alpha", "main.rue::zulu"],
+        "the inventory is byte order over the whole `<module>::<name>` ID"
+    );
+    for (index, entry) in inventory.entries.iter().enumerate() {
+        assert_eq!(entry.ordinal as usize, index, "{entry:?}");
+        assert_eq!(entry.id, format!("{}::{}", entry.module, entry.name));
+        assert!(entry.line > 0 && entry.column > 0, "{entry:?}");
+        assert!(entry.file.ends_with(&entry.module), "{entry:?}");
+    }
+    let alpha = &inventory.entries[1];
+    assert_eq!(alpha.module, "main.rue");
+    assert_eq!(alpha.name, "alpha");
+    // `test "alpha"` is the third line of `main.rue`, at its first column.
+    assert_eq!((alpha.line, alpha.column), (3, 1));
+}
+
+/// A listing analyzes the closure and stops (ADR-0083 §2): no codegen, no
+/// object projection.
+#[test]
+fn test_inventory_performs_no_codegen() {
+    let source = SourceSnapshot::single(
+        "main.rue",
+        "fn helper() -> i32 { 7 }\ntest \"lists\" { let x = helper(); }",
+    )
+    .unwrap();
+    let mut session = CompilerSession::new();
+    session.update(&source).into_result().unwrap();
+
+    let options = test_declaration_options(crate::RootSelection::Tests);
+    let inventory =
+        crate::unstable::test_inventory(&mut session, &options).expect("the closure analyzes");
+    assert_eq!(inventory.entries.len(), 1);
+    assert_eq!(inventory.entries[0].id, "main.rue::lists");
+    assert!(
+        session.codegen_executions().is_empty(),
+        "a listing must not reach codegen: {:?}",
+        session.codegen_executions()
+    );
+    assert_eq!(session.codegen_collections(), 0);
+    assert!(session.object_projection_executions().is_empty());
+    assert_eq!(session.object_projection_collections(), 0);
+}
+
+/// The facade refuses a request whose roots are not tests: answering an
+/// executable request with an empty inventory would report "no tests" for a
+/// program full of them.
+#[test]
+fn test_requests_require_the_tests_root_selection() {
+    let source =
+        SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }\ntest \"present\" { }").unwrap();
+    let mut session = CompilerSession::new();
+    session.update(&source).into_result().unwrap();
+
+    let options = test_declaration_options(crate::RootSelection::Executable);
+    let listing = crate::unstable::test_inventory(&mut session, &options)
+        .err()
+        .expect("a listing refuses an executable root selection");
+    let image = crate::unstable::test_image_in_compile_scope(&mut session, &options)
+        .map(|_| ())
+        .err()
+        .expect("an image refuses an executable root selection");
+    for errors in [listing, image] {
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(error.kind, ErrorKind::InvalidCompilerInput(_))),
+            "unexpected diagnostics: {errors:?}"
+        );
+    }
+}
+
+/// The dispatcher joins a test request's CFG closure under the unmangled
+/// `main`, and an executable request's closure is unchanged (ADR-0083 §3).
+#[test]
+fn the_test_dispatcher_is_the_test_image_entry_point() {
+    let source = SourceSnapshot::single(
+        "main.rue",
+        "fn main() -> i32 { 0 }\ntest \"dispatched\" { }",
+    )
+    .unwrap();
+    let mut session = CompilerSession::new();
+    session.update(&source).into_result().unwrap();
+
+    let executable = session
+        .rooted_cfg(&test_declaration_options(crate::RootSelection::Executable))
+        .expect("the executable program compiles");
+    assert!(
+        !executable
+            .functions()
+            .iter()
+            .any(|unit| unit.function == crate::FunctionInstanceKey::TestDispatcher),
+        "an executable request synthesizes no dispatcher"
+    );
+    let executable_symbols = defined_symbols(&executable);
+    assert!(executable_symbols.iter().any(|symbol| symbol == "main"));
+
+    let tests = session
+        .rooted_cfg(&test_declaration_options(crate::RootSelection::Tests))
+        .expect("the test image compiles");
+    let dispatchers = tests
+        .functions()
+        .iter()
+        .filter(|unit| unit.function == crate::FunctionInstanceKey::TestDispatcher)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        dispatchers.len(),
+        1,
+        "exactly one dispatcher per test image"
+    );
+    assert_eq!(
+        dispatchers[0].record.codegen.defined_symbol.as_ref(),
+        "main",
+        "the loader looks the entry point up by that exact spelling"
+    );
+
+    // The executable graph is identical to what it was before a test request
+    // ran: the two root sets are disjoint (ADR-0083 §1).
+    let executable_again = session
+        .rooted_cfg(&test_declaration_options(crate::RootSelection::Executable))
+        .expect("the executable program still compiles");
+    assert_eq!(defined_symbols(&executable_again), executable_symbols);
+}
+
+/// `extern "C"` exports are executable-only (ADR-0083 §1). A test image links
+/// no export thunk, because a test request roots no c-export.
+#[test]
+fn a_test_request_roots_no_c_export() {
+    let source = SourceSnapshot::single(
+        "main.rue",
+        "pub extern \"C\" fn rue_add(a: i32, b: i32) -> i32 { a + b }\n\
+         fn main() -> i32 { 0 }\n\
+         test \"present\" { }",
+    )
+    .unwrap();
+    let options = |root_selection| CompileOptions {
+        preview_features: PreviewFeatures::from([
+            PreviewFeature::TestDeclarations,
+            PreviewFeature::CFfi,
+        ]),
+        root_selection,
+        ..CompileOptions::default()
+    };
+    let mut session = CompilerSession::new();
+    session.update(&source).into_result().unwrap();
+
+    let executable = session
+        .rooted_cfg(&options(crate::RootSelection::Executable))
+        .expect("the executable program compiles");
+    let exported = crate::session::collect_rooted_exports(&executable.graph, &executable.cfgs);
+    assert_eq!(
+        exported
+            .iter()
+            .map(|thunk| thunk.exported_symbol.as_str())
+            .collect::<Vec<_>>(),
+        vec!["rue_add"],
+        "an executable request links its c-export thunk"
+    );
+
+    let tests = session
+        .rooted_cfg(&options(crate::RootSelection::Tests))
+        .expect("the test image compiles");
+    assert!(
+        crate::session::collect_rooted_exports(&tests.graph, &tests.cfgs).is_empty(),
+        "a test image exposes only its dispatcher entry point"
+    );
+    assert!(
+        !tests
+            .functions()
+            .iter()
+            .any(|unit| unit.source_name() == "rue_add"),
+        "an unreferenced c-export is not even reached by a test request"
+    );
+}
+
+/// The defined machine symbols of a rooted CFG closure, sorted.
+fn defined_symbols(output: &crate::session::RootedCfgOutput) -> Vec<String> {
+    let mut symbols = output
+        .functions()
+        .iter()
+        .map(|unit| unit.record.codegen.defined_symbol.to_string())
+        .collect::<Vec<_>>();
+    symbols.sort();
+    symbols
+}
+
 /// A test body's calls are whole-program references, so a helper called only
 /// from a test does not warn as unused in an executable build (ADR-0083 §1).
 #[test]

--- a/crates/rue-compiler/src/test_dispatcher.rs
+++ b/crates/rue-compiler/src/test_dispatcher.rs
@@ -1,0 +1,392 @@
+//! The synthesized `main` of a test image (ADR-0083 §3).
+//!
+//! A test image links every test in the request's closure plus one generated
+//! entry point that reads a selector from `argv` and calls exactly one test
+//! body. Like drop glue, the dispatcher is produced as a [`rue_air::SemanticBody`]
+//! and materialized through the ordinary CFG path, so both backends, the
+//! optimizer, and the memo database get it without a line of per-backend code.
+//! Unlike the C export thunk, it is not hand-assembled per target.
+//!
+//! # The shape it generates
+//!
+//! ```text
+//! fn main() -> i32 {
+//!     if @arg_count() != 2 { __rue_test_usage_error(); return 2; }
+//!     let entry = @arg_ptr(1);
+//!     if @arg_len(1) != 16 { __rue_test_usage_error(); return 2; }
+//!     // sixteen unrolled hex digits, accumulating the value and an OR of
+//!     // every digit — see `hex digits` below
+//!     if flags >= 16 { __rue_test_usage_error(); return 2; }
+//!     if ordinal >= <test count> { __rue_test_usage_error(); return 2; }
+//!     __rue_test_normalize_process();
+//!     match ordinal { 0 => test_0(), 1 => test_1(), ..., _ => () }
+//!     __rue_test_complete();
+//!     return 0;
+//! }
+//! ```
+//!
+//! # Why it imports nothing
+//!
+//! The parse is written out of raw pointer reads and wrapping arithmetic rather
+//! than `std.env` and `std.parse`. A test image's closure is whatever the tests
+//! import, and a suite that imports no standard library must still link: making
+//! the entry point depend on `std` would put a module in every test closure
+//! that the request never asked for, changing what is analyzed and what the
+//! deferred cache (§6) would key on.
+//!
+//! # hex digits
+//!
+//! The selector is exactly sixteen lowercase hex digits, so each digit maps to
+//! `byte - 48` for `'0'..='9'` and `byte - 87` for `'a'..='f'`. Both use
+//! wrapping subtraction: every other byte then lands far above 15 rather than
+//! trapping on underflow, and the loop needs no per-digit range test. Validity
+//! is the bitwise OR of all sixteen digits — a value stays below 16 exactly
+//! when every digit did — which is also what rejects the uppercase digits and
+//! the bytes 0x57 through 0x60, which a bare subtraction would otherwise
+//! decode as 0 through 9.
+//!
+//! The value is accumulated with wrapping multiply and add because sixteen hex
+//! digits fill a `u64` exactly: the last shift is a legitimate overflow of the
+//! trapping operators, not an error.
+//!
+//! # Exclusion
+//!
+//! Dispatcher code is runner plumbing. It is excluded by construction from the
+//! capability summaries and closure fingerprints the deferred ADRs compute
+//! (ADR-0083 §3), which is why it carries no source span of its own and roots
+//! nothing beyond the tests already in the request's root set.
+
+use std::sync::Arc;
+
+use rue_air::{
+    AirArgMode, SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg, SemanticBodyInst,
+    SemanticBodyInstData, SemanticBodyMatchArm, SemanticBodyPattern,
+};
+
+type Ty = rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>;
+type Body = SemanticBody<crate::StableDefinitionKey, crate::ModuleId>;
+type Inst = SemanticBodyInst<crate::StableDefinitionKey, crate::ModuleId>;
+type Data = SemanticBodyInstData<crate::StableDefinitionKey, crate::ModuleId>;
+
+/// Digits in a selector, and therefore the exec contract's fixed selector
+/// width (ADR-0083 §3). Sixteen lowercase hex digits are one `u64`.
+const SELECTOR_DIGITS: u32 = 16;
+
+/// Exit status for a malformed or out-of-range selector (ADR-0083 §2: `2` is
+/// "compilation or runner error", and a dispatcher that cannot understand its
+/// own argv is the latter).
+const SELECTOR_ERROR_STATUS: u64 = 2;
+
+/// `'9'`: the last byte that decodes through the decimal offset.
+const LAST_DECIMAL_BYTE: u64 = 57;
+/// `'0'`.
+const DECIMAL_OFFSET: u64 = 48;
+/// `'a' - 10`, the offset that maps `'a'..='f'` onto `10..=15`.
+const LOWERCASE_OFFSET: u64 = 87;
+/// One past the last valid digit value.
+const RADIX: u64 = 16;
+
+/// Local slot holding the selector's first byte address.
+const ENTRY_SLOT: u32 = 0;
+/// First of the sixteen slots holding one widened selector byte each.
+const BYTE_SLOT_BASE: u32 = 1;
+/// First of the sixteen slots holding one decoded digit each.
+const DIGIT_SLOT_BASE: u32 = BYTE_SLOT_BASE + SELECTOR_DIGITS;
+/// Local slot holding the decoded ordinal.
+const ORDINAL_SLOT: u32 = DIGIT_SLOT_BASE + SELECTOR_DIGITS;
+/// Total local slots the body declares.
+const LOCAL_SLOTS: u32 = ORDINAL_SLOT + 1;
+
+/// Build the canonical dispatcher body for one ordered test table.
+///
+/// `table` is the request's tests in inventory order (`test_inventory`), so
+/// element `n` is the body selector `n` runs. This function is pure and cheap:
+/// the CFG evaluator and the fact selector that prepares its inputs both call
+/// it rather than passing an already-built body through a memo key.
+pub(crate) fn synthesize_test_dispatcher(table: &[crate::FunctionInstanceKey]) -> Body {
+    let mut builder = Builder::default();
+    let mut statements = Vec::new();
+
+    // argc: the runner always execs with exactly the image name and one
+    // selector, so anything else is a hand-run image or a broken runner.
+    let arg_count = builder.add(
+        Data::RuntimeCall {
+            runtime: rue_air::RuntimeCallKind::ArgCount,
+            args: Arc::new([]),
+        },
+        Ty::U64,
+    );
+    let expected_argc = builder.constant(2, Ty::U64);
+    let wrong_argc = builder.add(Data::Ne(arg_count, expected_argc), Ty::Bool);
+    statements.push(builder.selector_error_guard(wrong_argc));
+
+    // The selector's bytes. `entry` is bound once and read sixteen times.
+    let selector_index = builder.constant(1, Ty::U64);
+    let entry = builder.add(
+        Data::RuntimeCall {
+            runtime: rue_air::RuntimeCallKind::ArgPtr,
+            args: Arc::new([argument(selector_index)]),
+        },
+        pointer_type(),
+    );
+    statements.push(builder.bind(ENTRY_SLOT, entry, pointer_type()));
+
+    let length_index = builder.constant(1, Ty::U64);
+    let selector_length = builder.add(
+        Data::RuntimeCall {
+            runtime: rue_air::RuntimeCallKind::ArgLen,
+            args: Arc::new([argument(length_index)]),
+        },
+        Ty::U64,
+    );
+    let expected_length = builder.constant(u64::from(SELECTOR_DIGITS), Ty::U64);
+    let wrong_length = builder.add(Data::Ne(selector_length, expected_length), Ty::Bool);
+    statements.push(builder.selector_error_guard(wrong_length));
+
+    // Sixteen unrolled digits. Unrolled rather than looped because the width is
+    // fixed by the exec contract: a loop would need its own induction slot and
+    // bound check to express a constant the contract already pins.
+    let mut ordinal = builder.constant(0, Ty::U64);
+    let mut flags = builder.constant(0, Ty::U64);
+    for digit in 0..SELECTOR_DIGITS {
+        let byte_slot = BYTE_SLOT_BASE + digit;
+        let digit_slot = DIGIT_SLOT_BASE + digit;
+
+        let base = builder.load(ENTRY_SLOT, pointer_type());
+        let offset = builder.constant(u64::from(digit), Ty::U64);
+        let address = builder.add(
+            Data::Intrinsic {
+                operation: rue_air::IntrinsicOperation::PtrOffset,
+                name: Arc::from(rue_air::IntrinsicOperation::PtrOffset.expected_spelling()),
+                args: Arc::new([argument(base), argument(offset)]),
+            },
+            pointer_type(),
+        );
+        let byte = builder.add(
+            Data::Intrinsic {
+                operation: rue_air::IntrinsicOperation::PtrRead,
+                name: Arc::from(rue_air::IntrinsicOperation::PtrRead.expected_spelling()),
+                args: Arc::new([argument(address)]),
+            },
+            Ty::U8,
+        );
+        let widened = builder.add(
+            Data::IntCast {
+                value: byte,
+                from_ty: Ty::U8,
+            },
+            Ty::U64,
+        );
+        statements.push(builder.bind(byte_slot, widened, Ty::U64));
+
+        let classify = builder.load(byte_slot, Ty::U64);
+        let last_decimal = builder.constant(LAST_DECIMAL_BYTE, Ty::U64);
+        let is_decimal = builder.add(Data::Le(classify, last_decimal), Ty::Bool);
+        let decimal_source = builder.load(byte_slot, Ty::U64);
+        let decimal_offset = builder.constant(DECIMAL_OFFSET, Ty::U64);
+        let decimal = builder.add(Data::WrappingSub(decimal_source, decimal_offset), Ty::U64);
+        let lowercase_source = builder.load(byte_slot, Ty::U64);
+        let lowercase_offset = builder.constant(LOWERCASE_OFFSET, Ty::U64);
+        let lowercase = builder.add(
+            Data::WrappingSub(lowercase_source, lowercase_offset),
+            Ty::U64,
+        );
+        let decoded = builder.add(
+            Data::Branch {
+                cond: is_decimal,
+                then_value: decimal,
+                else_value: Some(lowercase),
+            },
+            Ty::U64,
+        );
+        statements.push(builder.bind(digit_slot, decoded, Ty::U64));
+
+        let value = builder.load(digit_slot, Ty::U64);
+        let radix = builder.constant(RADIX, Ty::U64);
+        let shifted = builder.add(Data::WrappingMul(ordinal, radix), Ty::U64);
+        ordinal = builder.add(Data::WrappingAdd(shifted, value), Ty::U64);
+
+        let validity = builder.load(digit_slot, Ty::U64);
+        flags = builder.add(Data::BitOr(flags, validity), Ty::U64);
+    }
+    statements.push(builder.bind(ORDINAL_SLOT, ordinal, Ty::U64));
+
+    let radix = builder.constant(RADIX, Ty::U64);
+    let malformed = builder.add(Data::Ge(flags, radix), Ty::Bool);
+    statements.push(builder.selector_error_guard(malformed));
+
+    // Out of range, which an empty table makes true for every selector.
+    let selected = builder.load(ORDINAL_SLOT, Ty::U64);
+    let count = builder.constant(table.len() as u64, Ty::U64);
+    let out_of_range = builder.add(Data::Ge(selected, count), Ty::Bool);
+    statements.push(builder.selector_error_guard(out_of_range));
+
+    // Normalization runs before the body so the test observes the pinned
+    // inventory (§3) and never the selector that varies per test.
+    statements.push(builder.add(
+        Data::RuntimeCall {
+            runtime: rue_air::RuntimeCallKind::TestNormalizeProcess,
+            args: Arc::new([]),
+        },
+        Ty::Unit,
+    ));
+
+    let scrutinee = builder.load(ORDINAL_SLOT, Ty::U64);
+    let mut arms = Vec::with_capacity(table.len() + 1);
+    for (ordinal, function) in table.iter().enumerate() {
+        let call = builder.add(
+            Data::Call {
+                function: function.clone(),
+                args: Arc::new([]),
+            },
+            Ty::Unit,
+        );
+        arms.push(SemanticBodyMatchArm {
+            pattern: SemanticBodyPattern::Int(ordinal as i64),
+            body: call,
+        });
+    }
+    // The range guard above already rejected every ordinal without an arm, so
+    // this one exists to make the match exhaustive rather than to be taken.
+    let unreached = builder.add(Data::UnitConst, Ty::Unit);
+    arms.push(SemanticBodyMatchArm {
+        pattern: SemanticBodyPattern::Wildcard,
+        body: unreached,
+    });
+    statements.push(builder.add(
+        Data::Match {
+            scrutinee,
+            arms: arms.into(),
+        },
+        Ty::Unit,
+    ));
+
+    // The terminal completion frame, written only here: exit 0 without it is
+    // how the runner detects a body that exited before its assertions ran.
+    statements.push(builder.add(
+        Data::RuntimeCall {
+            runtime: rue_air::RuntimeCallKind::TestComplete,
+            args: Arc::new([]),
+        },
+        Ty::Unit,
+    ));
+
+    let success = builder.constant(0, Ty::I32);
+    let ret = builder.add(Data::Ret(Some(success)), Ty::Never);
+    builder.add(
+        Data::Block {
+            statements: statements.into(),
+            value: ret,
+        },
+        Ty::Never,
+    );
+
+    Body {
+        is_accessor: false,
+        return_type: Ty::I32,
+        instructions: builder.instructions.into(),
+        places: Arc::new([]),
+        strings: Arc::new([]),
+        local_atoms: Arc::new([]),
+        param_drops: Arc::new([]),
+        borrow_slots: Arc::new([]),
+        num_locals: LOCAL_SLOTS,
+        num_param_slots: 0,
+        param_by_ref: Arc::new([]),
+        param_writable: Arc::new([]),
+        allow_unreachable_code: false,
+        warnings: Arc::new([]),
+        method_references: Arc::new([]),
+    }
+}
+
+/// The dispatcher's only pointer type: the raw `argv` entry it reads bytes
+/// from. `std.env` builds owned copies on top of the same accessors; the
+/// dispatcher reads through them directly because it must not import `std`.
+fn pointer_type() -> Ty {
+    Ty::PtrMut(Arc::new(Ty::U8))
+}
+
+fn argument(value: u32) -> SemanticBodyCallArg {
+    SemanticBodyCallArg {
+        value,
+        mode: AirArgMode::Normal,
+    }
+}
+
+/// Instruction accumulator for the generated body.
+///
+/// Every reference is to an earlier index, which the importer enforces, so the
+/// builder only ever appends. Values are never shared across a branch boundary:
+/// anything read more than once is bound to a local slot and reloaded, exactly
+/// as an ordinary source body does.
+#[derive(Default)]
+struct Builder {
+    instructions: Vec<Inst>,
+}
+
+impl Builder {
+    fn add(&mut self, data: Data, ty: Ty) -> u32 {
+        let index = u32::try_from(self.instructions.len()).expect("dispatcher body fits u32");
+        self.instructions.push(SemanticBodyInst {
+            data,
+            ty,
+            anchor: SemanticBodyAnchor { start: 0, end: 0 },
+        });
+        index
+    }
+
+    fn constant(&mut self, value: u64, ty: Ty) -> u32 {
+        self.add(Data::Const(value), ty)
+    }
+
+    /// Introduce a local slot holding `value`, as one statement.
+    fn bind(&mut self, slot: u32, value: u32, ty: Ty) -> u32 {
+        let live = self.add(Data::StorageLive { slot }, ty);
+        let allocation = self.add(Data::Alloc { slot, init: value }, Ty::Unit);
+        self.add(
+            Data::Block {
+                statements: Arc::new([live]),
+                value: allocation,
+            },
+            Ty::Unit,
+        )
+    }
+
+    fn load(&mut self, slot: u32, ty: Ty) -> u32 {
+        self.add(Data::Load { slot }, ty)
+    }
+
+    /// `if <condition> { __rue_test_usage_error(); return 2; }` as one
+    /// statement.
+    ///
+    /// The diagnostic is one pinned runtime message rather than compiler-built
+    /// text: the dispatcher has no string constants of its own, and the message
+    /// is part of the exec contract rather than of any one image.
+    fn selector_error_guard(&mut self, condition: u32) -> u32 {
+        let report = self.add(
+            Data::RuntimeCall {
+                runtime: rue_air::RuntimeCallKind::TestUsageError,
+                args: Arc::new([]),
+            },
+            Ty::Unit,
+        );
+        let status = self.constant(SELECTOR_ERROR_STATUS, Ty::I32);
+        let ret = self.add(Data::Ret(Some(status)), Ty::Never);
+        let taken = self.add(
+            Data::Block {
+                statements: Arc::new([report]),
+                value: ret,
+            },
+            Ty::Never,
+        );
+        self.add(
+            Data::Branch {
+                cond: condition,
+                then_value: taken,
+                else_value: None,
+            },
+            Ty::Unit,
+        )
+    }
+}

--- a/crates/rue-compiler/src/test_image_tests.rs
+++ b/crates/rue-compiler/src/test_image_tests.rs
@@ -1,0 +1,309 @@
+//! End-to-end coverage for the test image and its exec contract (ADR-0083 §3).
+//!
+//! These link a real image through the ADR-0061 facade and run it the way the
+//! runner will: `argv = ["rue-test", "<16 hex digits>"]`, `envp =
+//! ["RUE_TEST=1"]`, a private working directory, `/dev/null` on stdin, and the
+//! write end of the failure-channel pipe on descriptor 3. Nothing below reads
+//! compiler internals — the assertions are on exit status, the two byte
+//! streams, and the channel — because those are what the runner will observe.
+//!
+//! They are host-native (`platform_native_`, `#[ignore]`) and run through
+//! `rue-compiler-platform-native-test`: a linked image only executes on the
+//! target it was built for, and the default target is the host.
+
+#![cfg(all(test, unix))]
+
+use crate::{CompileOptions, CompilerSession, RootSelection};
+use rue_error::{PreviewFeature, PreviewFeatures};
+
+/// The exact completion frame the dispatcher's epilogue writes.
+const COMPLETE_FRAME: &str = "{\"record\":\"complete\",\"schema\":\"1.0\"}\n";
+
+/// The pinned malformed-selector diagnostic.
+const USAGE_MESSAGE: &str = "rue-test: expected one 16-hex-digit test selector\n";
+
+/// The host's `exit` syscall number, matching `std._exit_syscall_number`.
+///
+/// Spelled here rather than imported so the fixture needs no standard library:
+/// a test image's closure is whatever its tests import, and this one imports
+/// nothing.
+const EXIT_SYSCALL: u64 = if cfg!(target_os = "macos") {
+    1
+} else if cfg!(target_arch = "aarch64") {
+    93
+} else {
+    60
+};
+
+/// What one dispatched test process produced.
+struct DispatchedRun {
+    status: Option<i32>,
+    stdout: String,
+    stderr: String,
+    channel: String,
+}
+
+fn test_options() -> CompileOptions {
+    CompileOptions {
+        preview_features: PreviewFeatures::from([PreviewFeature::TestDeclarations]),
+        root_selection: RootSelection::Tests,
+        ..CompileOptions::default()
+    }
+}
+
+/// Link the three-test fixture and return its image plus its inventory.
+///
+/// One image serves every case below: the marginal cost of another verdict is
+/// one more `test` item, while another image is another link.
+fn dispatch_fixture() -> (Vec<u8>, crate::unstable::TestInventory) {
+    let source = crate::SourceSnapshot::single(
+        "main.rue",
+        &format!(
+            "test \"alpha passes\" {{ println(\"ran alpha\"); }}\n\
+             test \"bravo exits early\" {{ checked {{ @syscall({EXIT_SYSCALL}, 0); }}; }}\n\
+             test \"charlie traps\" {{ @panic(\"boom\"); }}\n"
+        ),
+    )
+    .unwrap();
+    let mut session = CompilerSession::new();
+    crate::test_support::TestDiscoveryHost::new(&source)
+        .unwrap()
+        .drive(&mut session)
+        .unwrap();
+    let (image, inventory) =
+        crate::unstable::test_image_in_compile_scope(&mut session, &test_options())
+            .expect("the test image links");
+    (image.elf, inventory)
+}
+
+/// Run `image` under the exec contract with `selector`.
+fn run_test_image(image: &[u8], label: &str, selector: &str) -> DispatchedRun {
+    use std::io::Read;
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::io::FromRawFd;
+    use std::os::unix::process::CommandExt;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_IMAGE: AtomicU64 = AtomicU64::new(0);
+    let unique = NEXT_IMAGE.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "rue-test-image-{label}-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::write(&path, image).expect("write linked test image");
+    let mut permissions = std::fs::metadata(&path)
+        .expect("read linked test image metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&path, permissions).expect("make the linked test image runnable");
+    #[cfg(target_os = "macos")]
+    {
+        let signing = std::process::Command::new("codesign")
+            .args([
+                "-f",
+                "-s",
+                "-",
+                "--identifier",
+                "dev.rue-lang.test-image",
+                "--timestamp=none",
+            ])
+            .arg(&path)
+            .output()
+            .expect("run ad-hoc codesign for the linked test image");
+        assert!(
+            signing.status.success(),
+            "codesign linked test image: {}",
+            String::from_utf8_lossy(&signing.stderr)
+        );
+    }
+
+    // The failure channel. The runner inherits its write end on descriptor 3;
+    // this stands in for that, including the parent holding the read end open
+    // until the child exits.
+    let mut channel_fds = [0 as libc::c_int; 2];
+    // SAFETY: `channel_fds` is a two-element array, exactly what `pipe` writes.
+    assert_eq!(unsafe { libc::pipe(channel_fds.as_mut_ptr()) }, 0);
+    let [channel_read, channel_write] = channel_fds;
+
+    let scratch = tempfile::tempdir().expect("per-test scratch directory");
+    let mut command = std::process::Command::new(&path);
+    command
+        .arg0("rue-test")
+        .arg(selector)
+        .env_clear()
+        .env("RUE_TEST", "1")
+        .current_dir(scratch.path())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    // SAFETY: the hook calls only `dup2` and `close`, both async-signal-safe,
+    // and touches no memory the fork shares with another thread.
+    unsafe {
+        command.pre_exec(move || {
+            // The read end goes first. `pipe` hands back the lowest free
+            // descriptors, so it is frequently descriptor 3 itself — closing it
+            // after the `dup2` below would close the write end that had just
+            // replaced it, and the channel would silently carry nothing.
+            libc::close(channel_read);
+            if libc::dup2(channel_write, 3) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if channel_write != 3 {
+                libc::close(channel_write);
+            }
+            Ok(())
+        });
+    }
+    let child = command.spawn().expect("spawn the dispatched test process");
+    // The parent's own write end must go before the read reaches end of stream.
+    // SAFETY: this descriptor is owned here and closed exactly once.
+    unsafe { libc::close(channel_write) };
+    let output = child
+        .wait_with_output()
+        .expect("collect the dispatched test process output");
+    // SAFETY: `channel_read` is a live descriptor this call takes ownership of.
+    let mut reader = unsafe { std::fs::File::from_raw_fd(channel_read) };
+    let mut channel = Vec::new();
+    reader
+        .read_to_end(&mut channel)
+        .expect("drain the failure channel");
+    std::fs::remove_file(&path).expect("remove the linked test image");
+
+    DispatchedRun {
+        status: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        channel: String::from_utf8_lossy(&channel).into_owned(),
+    }
+}
+
+/// A selected test runs, and only the dispatcher's epilogue writes the
+/// completion frame (ADR-0083 §3).
+#[test]
+#[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+fn platform_native_test_image_runs_the_selected_test_and_completes() {
+    let (image, inventory) = dispatch_fixture();
+    assert_eq!(
+        inventory
+            .entries
+            .iter()
+            .map(|entry| entry.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "main.rue::alpha passes",
+            "main.rue::bravo exits early",
+            "main.rue::charlie traps",
+        ]
+    );
+
+    let run = run_test_image(&image, "pass", "0000000000000000");
+    assert_eq!(run.status, Some(0), "{run:?}", run = run.stderr);
+    assert_eq!(run.stdout, "ran alpha\n");
+    assert_eq!(run.stderr, "");
+    assert_eq!(run.channel, COMPLETE_FRAME);
+}
+
+/// A body that exits before returning writes no completion frame, which is the
+/// evidence the runner turns into the `incomplete` verdict (ADR-0083 §3).
+#[test]
+#[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+fn platform_native_an_early_exit_produces_no_completion_frame() {
+    let (image, _) = dispatch_fixture();
+    let run = run_test_image(&image, "early-exit", "0000000000000001");
+    assert_eq!(run.status, Some(0), "an early `exit(0)` still exits zero");
+    assert_eq!(
+        run.channel, "",
+        "exit 0 with no completion frame is exactly the `incomplete` hazard"
+    );
+}
+
+/// A trapping body takes the ordinary runtime abort path and writes no frame.
+#[test]
+#[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+fn platform_native_a_trapping_test_exits_101_without_a_frame() {
+    let (image, _) = dispatch_fixture();
+    let run = run_test_image(&image, "trap", "0000000000000002");
+    assert_eq!(run.status, Some(101));
+    assert_eq!(run.stderr, "panic: boom\n");
+    assert_eq!(run.channel, "");
+}
+
+/// Every malformed or out-of-range selector is one pinned diagnostic and exit
+/// 2 (ADR-0083 §3): a dispatcher that cannot read its own argv is a runner
+/// error, not a test failure.
+#[test]
+#[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+fn platform_native_a_bad_selector_is_the_pinned_usage_error() {
+    let (image, _) = dispatch_fixture();
+    for (label, selector) in [
+        ("out-of-range", "0000000000000003"),
+        ("saturated", "ffffffffffffffff"),
+        ("too-short", "0"),
+        ("non-hex", "00000000000000zz"),
+        ("uppercase", "000000000000000A"),
+    ] {
+        let run = run_test_image(&image, label, selector);
+        assert_eq!(run.status, Some(2), "{label}: {}", run.stderr);
+        assert_eq!(run.stderr, USAGE_MESSAGE, "{label}");
+        assert_eq!(run.stdout, "", "{label}");
+        assert_eq!(run.channel, "", "{label}");
+    }
+}
+
+/// The test-visible inventory after normalization is the pinned one
+/// (ADR-0083 §3): one argument spelled `rue-test`, and one environment entry.
+///
+/// The fixture reads the process accessors directly rather than through
+/// `std.env`, for the same reason the dispatcher does: a test image's closure
+/// is whatever its tests import, and this one imports nothing. It reports by
+/// trapping, so a wrong inventory names which field was wrong.
+#[test]
+#[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+fn platform_native_a_test_observes_the_pinned_process_inventory() {
+    let source = crate::SourceSnapshot::single(
+        "main.rue",
+        "fn byte_at(p: ptr mut u8, i: u64) -> u64 {\n\
+        \x20   let b: u8 = checked { @ptr_read(@ptr_offset(p, i)) };\n\
+        \x20   @intCast(b)\n\
+         }\n\
+         test \"observes its inventory\" {\n\
+        \x20   let argc: u64 = checked { @arg_count() };\n\
+        \x20   if argc != 1 { @panic(\"arg_count\"); }\n\
+        \x20   let envc: u64 = checked { @env_count() };\n\
+        \x20   if envc != 1 { @panic(\"env_count\"); }\n\
+        \x20   let name_len: u64 = checked { @arg_len(0) };\n\
+        \x20   if name_len != 8 { @panic(\"arg(0) length\"); }\n\
+        \x20   let name: ptr mut u8 = checked { @arg_ptr(0) };\n\
+        \x20   if byte_at(name, 0) != 114 { @panic(\"arg(0) bytes\"); }\n\
+        \x20   if byte_at(name, 1) != 117 { @panic(\"arg(0) bytes\"); }\n\
+        \x20   if byte_at(name, 2) != 101 { @panic(\"arg(0) bytes\"); }\n\
+        \x20   if byte_at(name, 3) != 45 { @panic(\"arg(0) bytes\"); }\n\
+        \x20   if byte_at(name, 4) != 116 { @panic(\"arg(0) bytes\"); }\n\
+        \x20   if byte_at(name, 5) != 101 { @panic(\"arg(0) bytes\"); }\n\
+        \x20   if byte_at(name, 6) != 115 { @panic(\"arg(0) bytes\"); }\n\
+        \x20   if byte_at(name, 7) != 116 { @panic(\"arg(0) bytes\"); }\n\
+        \x20   let entry_len: u64 = checked { @env_len(0) };\n\
+        \x20   if entry_len != 10 { @panic(\"env(0) length\"); }\n\
+        \x20   println(\"inventory ok\");\n\
+         }\n",
+    )
+    .unwrap();
+    let mut session = CompilerSession::new();
+    crate::test_support::TestDiscoveryHost::new(&source)
+        .unwrap()
+        .drive(&mut session)
+        .unwrap();
+    let (image, inventory) =
+        crate::unstable::test_image_in_compile_scope(&mut session, &test_options())
+            .expect("the test image links");
+    assert_eq!(inventory.entries.len(), 1);
+
+    let run = run_test_image(&image.elf, "inventory", "0000000000000000");
+    assert_eq!(run.status, Some(0), "{}", run.stderr);
+    assert_eq!(
+        run.stdout, "inventory ok\n",
+        "the selector must be invisible to the test: {}",
+        run.stderr
+    );
+    assert_eq!(run.channel, COMPLETE_FRAME);
+}

--- a/crates/rue-compiler/src/test_inventory.rs
+++ b/crates/rue-compiler/src/test_inventory.rs
@@ -1,0 +1,132 @@
+//! The one place a test closure's ordered inventory is computed (ADR-0083 §2).
+//!
+//! Two consumers read this order, and they must never disagree: the `--list`
+//! surface a runner publishes, and the ordinal each test is dispatched by
+//! inside the test image. A selector is an index into this table, so two
+//! independent sorts would silently run the wrong body. Both therefore call
+//! [`collect_test_inventory`], and the dispatcher's table is built from its
+//! result rather than from a second pass over the same declarations.
+//!
+//! The stable ID is `<module>::<name>`. `<module>` is the module's published
+//! identity — project-root-relative for user modules; a standard-library module
+//! reports its requested path instead of the internal trusted spelling, the
+//! same guard `import_discovery` applies when it renders a module path for a
+//! consumer. `<name>` is the test's string literal verbatim, which may contain
+//! spaces and punctuation and is never mangled here (the linker symbol, which
+//! cannot carry those bytes, is a separate concern with its own digest).
+//!
+//! Ordering is byte order over the whole ID. It is deliberately not
+//! declaration order, module order, or symbol order: only a property of the
+//! source text itself keeps a filtered run's ordinals equal to a full run's.
+
+use std::sync::Arc;
+
+use crate::parsed_modules::ParsedModule;
+use crate::unstable::TestInventoryEntry;
+
+/// One inventoried test: what a consumer is shown, and what the image calls.
+///
+/// The two travel together so a consumer of the ordering never has to recover
+/// an identity from a rendered ID. Recovering it would have to parse a display
+/// path back into a `ModuleId`, and a standard-library module's display path is
+/// deliberately not its `ModuleId`.
+#[derive(Debug, Clone)]
+pub(crate) struct RootedTest {
+    pub(crate) entry: TestInventoryEntry,
+    pub(crate) identity: crate::FunctionInstanceKey,
+}
+
+/// Build the ordered inventory for a request's rooted test declarations.
+///
+/// `roots` is the request's root set exactly as the root-set authority
+/// published it; every `StableDefinitionKind::Test` definition in it becomes
+/// one entry, and nothing else does — so an executable request, whose root set
+/// holds no tests, yields an empty inventory without a special case.
+/// `modules` supplies the source locations, which the semantic identities do
+/// not carry.
+///
+/// A test whose declaration cannot be located in its module's AST still gets an
+/// entry, at line and column zero. Dropping it would renumber every later
+/// ordinal and silently dispatch the wrong body; the inventory's job is to be
+/// complete and stably ordered, not to diagnose.
+pub(crate) fn collect_test_inventory(
+    modules: &[Arc<ParsedModule>],
+    roots: &[crate::FunctionInstanceKey],
+) -> Vec<RootedTest> {
+    let mut entries = Vec::new();
+    for root in roots {
+        let crate::FunctionInstanceKey::Definition(key) = root else {
+            continue;
+        };
+        if key.kind() != crate::StableDefinitionKind::Test {
+            continue;
+        }
+        let module = modules
+            .iter()
+            .find(|module| module.module_id() == key.module());
+        let name = key.name().to_owned();
+        let module_path = match module {
+            Some(module) => module_display_path(module),
+            None => key.module().as_str().to_owned(),
+        };
+        let (file, line, column) = match module {
+            Some(module) => {
+                let file = module.physical_path().to_owned();
+                match declaration_header_start(module, &name) {
+                    Some(offset) => {
+                        let index = rue_span::LineIndex::new(module.source_text());
+                        let (line, column) = index.line_col(offset);
+                        (file, line, column)
+                    }
+                    None => (file, 0, 0),
+                }
+            }
+            None => (String::new(), 0, 0),
+        };
+        entries.push(RootedTest {
+            entry: TestInventoryEntry {
+                id: format!("{module_path}::{name}"),
+                module: module_path,
+                name,
+                file,
+                line,
+                column,
+                ordinal: 0,
+            },
+            identity: root.clone(),
+        });
+    }
+    entries.sort_by(|left, right| left.entry.id.cmp(&right.entry.id));
+    for (ordinal, test) in entries.iter_mut().enumerate() {
+        test.entry.ordinal = u32::try_from(ordinal).unwrap_or(u32::MAX);
+    }
+    entries
+}
+
+/// The module identity a consumer is shown.
+///
+/// A standard-library module's `ModuleId` carries the internal trusted
+/// namespace, which is not a path anyone can type. Reporting its requested path
+/// keeps a `std` test's ID and a user test's ID the same kind of thing.
+fn module_display_path(module: &ParsedModule) -> String {
+    if module.module_id().is_trusted_standard_library() {
+        module.physical_path().to_owned()
+    } else {
+        module.module_id().as_str().to_owned()
+    }
+}
+
+/// Byte offset of `test "name"` in its module's source.
+///
+/// The header span rather than the whole declaration: a failure points a reader
+/// at the test that failed, not at the first byte of a body that may be pages
+/// long. Names are unique within a module (a duplicate is a compile error), so
+/// the first match is the only match.
+fn declaration_header_start(module: &ParsedModule, name: &str) -> Option<u32> {
+    module.ast().items.iter().find_map(|item| match item {
+        rue_parser::ast::Item::Test(test) => (module.try_resolve_raw_symbol(test.name.value)
+            == Some(name))
+        .then_some(test.header_span.start),
+        _ => None,
+    })
+}

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -676,6 +676,83 @@ pub fn executable_in_compile_scope(
     session.executable_in_compile_scope(options)
 }
 
+/// One test declaration in a request's ordered inventory (ADR-0083 §2).
+///
+/// `id` is the stable identity `<module>::<name>` every other surface refers to
+/// a test by — filters, event streams, and repro argv. `ordinal` is its
+/// position in this inventory and, equivalently, the selector the test image
+/// dispatches it on; the two can never disagree because one computation
+/// produces both.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestInventoryEntry {
+    pub id: String,
+    pub module: String,
+    pub name: String,
+    pub file: String,
+    /// 1-based line of the `test "name"` header, or `0` when the declaration
+    /// could not be located in its module's syntax tree.
+    pub line: u32,
+    /// 1-based column of that header, on the same terms as `line`.
+    pub column: u32,
+    pub ordinal: u32,
+}
+
+/// Every test in a request's closure, in stable-ID order.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TestInventory {
+    pub entries: Vec<TestInventoryEntry>,
+}
+
+/// Analyze a test closure and publish its ordered inventory, without codegen.
+///
+/// This is the discovery half of ADR-0083 §2's `--list`: semantic analysis of
+/// every test body in the closure, and nothing after it. No CFG is built, no
+/// object is produced, and no image is linked — a listing must never pay for
+/// terminal artifacts it does not show.
+///
+/// `options.root_selection` must be [`crate::RootSelection::Tests`]. An
+/// executable request has no test roots at all, so answering it with an empty
+/// inventory would report "no tests" for a program full of them.
+pub fn test_inventory(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+) -> crate::MultiErrorResult<TestInventory> {
+    require_test_root_selection(options)?;
+    Ok(TestInventory {
+        entries: session.rooted_test_inventory(options)?,
+    })
+}
+
+/// Link the test image for a request's closure and publish its inventory.
+///
+/// The image is an ordinary executable produced through the ordinary image
+/// path: every test in the closure plus the synthesized dispatcher `main`
+/// (ADR-0083 §3), which the runner execs once per test with that test's
+/// ordinal as its selector. The returned inventory is what assigns those
+/// ordinals, so a caller never has to re-derive them.
+///
+/// `options.root_selection` must be [`crate::RootSelection::Tests`].
+pub fn test_image_in_compile_scope(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+) -> crate::MultiErrorResult<(crate::CompileOutput, TestInventory)> {
+    require_test_root_selection(options)?;
+    let entries = session.rooted_test_inventory(options)?;
+    let image = session.executable_in_compile_scope(options)?;
+    Ok((image, TestInventory { entries }))
+}
+
+fn require_test_root_selection(options: &crate::CompileOptions) -> crate::MultiErrorResult<()> {
+    match options.root_selection {
+        crate::RootSelection::Tests => Ok(()),
+        other => Err(crate::CompileErrors::from(
+            crate::CompileError::without_span(crate::ErrorKind::InvalidCompilerInput(format!(
+                "a test request requires RootSelection::Tests, not {other:?}"
+            ))),
+        )),
+    }
+}
+
 /// Cloneable cancellation authority for one retained-host compile cycle.
 ///
 /// This deliberately hides query-runtime identities and keys. Canceling a

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1248,7 +1248,15 @@ fn unsupported_runtime_call_kind(kind: RuntimeCallKind) -> Option<UnsupportedRun
         | RuntimeCallKind::EnvLen
         | RuntimeCallKind::ByteCopy
         | RuntimeCallKind::ByteMove
-        | RuntimeCallKind::ByteSet => None,
+        | RuntimeCallKind::ByteSet
+        // The ADR-0083 test channel. No source construct spells these, and the
+        // oracle models ordinary compiled programs rather than test images, so
+        // a corpus program cannot reach one.
+        | RuntimeCallKind::TestNormalizeProcess
+        | RuntimeCallKind::TestComplete
+        | RuntimeCallKind::TestFailureSite
+        | RuntimeCallKind::TestFail
+        | RuntimeCallKind::TestUsageError => None,
     }
 }
 

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -16,7 +16,7 @@ use core::fmt;
 #[macro_export]
 macro_rules! runtime_abi_version {
     ($callback:ident) => {
-        $callback!(1, __rue_runtime_abi_v1);
+        $callback!(2, __rue_runtime_abi_v2);
     };
 }
 
@@ -356,6 +356,7 @@ macro_rules! params {
 
 const I32_VALUE: AbiParameter = AbiParameter::value(AbiType::I32);
 const I64_VALUE: AbiParameter = AbiParameter::value(AbiType::I64);
+const U32_VALUE: AbiParameter = AbiParameter::value(AbiType::U32);
 const U64_VALUE: AbiParameter = AbiParameter::value(AbiType::U64);
 const BOOL_WORD_VALUE: AbiParameter = AbiParameter::value(AbiType::BoolWordI64);
 const BYTE_VIEW: AbiParameter = AbiParameter::const_pointer(AbiType::Byte);
@@ -899,6 +900,78 @@ macro_rules! for_each_runtime_helper {
             // which must denote that many writable bytes.
             safety: WRITABLE,
             returns: RETURNS
+        },
+        // The ADR-0083 test channel (§3, §5.1). These four are runner plumbing
+        // called only from the synthesized test dispatcher and, later, from
+        // assertion sugar; no source-level intrinsic selects them yet.
+        TestNormalizeProcess => safe __rue_test_normalize_process() {
+            symbol: "__rue_test_normalize_process",
+            parameters: params![],
+            result: VOID,
+            // Rewrites the runtime's own captured argument count; the caller
+            // supplies nothing and owes nothing.
+            safety: SafetyContract::NONE,
+            returns: RETURNS
+        },
+        TestComplete => safe __rue_test_complete() {
+            symbol: "__rue_test_complete",
+            parameters: params![],
+            result: VOID,
+            // Writes the terminal completion frame to the inherited failure
+            // channel; the write is best-effort and takes no caller pointer.
+            safety: SafetyContract::NONE,
+            returns: RETURNS
+        },
+        // A failure record carries more than a register-only call can take:
+        // three byte views plus a file, a line, and a column is ten arguments,
+        // and every runtime helper is register-only (six on x86-64). The record
+        // is therefore assembled by two calls. This one stages the failing
+        // source location, and the terminal call below emits the record and
+        // aborts. Nothing may run between them.
+        TestFailureSite => unsafe __rue_test_failure_site(
+            file_ptr: *const u8,
+            file_len: u64,
+            line: u32,
+            column: u32,
+        ) {
+            symbol: "__rue_test_failure_site",
+            parameters: params![BYTE_VIEW, U64_VALUE, U32_VALUE, U32_VALUE],
+            result: VOID,
+            // The file bytes are borrowed, not copied: they must stay readable
+            // until the `__rue_test_fail` that consumes this site has written
+            // its record.
+            safety: READABLE,
+            returns: RETURNS
+        },
+        TestFail => unsafe __rue_test_fail(
+            kind_ptr: *const u8,
+            kind_len: u64,
+            message_ptr: *const u8,
+            message_len: u64,
+            payload_ptr: *const u8,
+            payload_len: u64,
+        ) -> ! {
+            symbol: "__rue_test_fail",
+            parameters: params![
+                BYTE_VIEW,
+                U64_VALUE,
+                BYTE_VIEW,
+                U64_VALUE,
+                BYTE_VIEW,
+                U64_VALUE,
+            ],
+            result: VOID,
+            safety: READABLE.union(TERMINATES),
+            returns: NEVER
+        },
+        TestUsageError => safe __rue_test_usage_error() {
+            symbol: "__rue_test_usage_error",
+            parameters: params![],
+            result: VOID,
+            // Writes one pinned diagnostic to stderr and returns so the
+            // dispatcher can choose its own exit status.
+            safety: SafetyContract::NONE,
+            returns: RETURNS
         }
             }
     };
@@ -1255,9 +1328,10 @@ const fn starts_with(value: &str, prefix: &str) -> bool {
 }
 
 const fn ends_with_decimal_version(symbol: &str, version: u32) -> bool {
-    // Version 1 is the initial ABI. This explicit check makes an ABI bump update
-    // both metadata values rather than silently retaining a stale symbol.
-    version == 1 && string_eq(symbol, "__rue_runtime_abi_v1")
+    // Version 2 added the ADR-0083 §5.1 test failure channel. This explicit
+    // check makes an ABI bump update both metadata values rather than silently
+    // retaining a stale symbol.
+    version == 2 && string_eq(symbol, "__rue_runtime_abi_v2")
 }
 
 /// Validate all table ordering, uniqueness, classification, and layout invariants.
@@ -1343,7 +1417,7 @@ mod tests {
     #[test]
     fn manifest_is_const_valid_and_exhaustive() {
         assert_eq!(validate_manifest(), Ok(()));
-        assert_eq!(RuntimeHelperId::ALL.len(), 46);
+        assert_eq!(RuntimeHelperId::ALL.len(), 51);
         assert_eq!(RuntimeHelperId::ALL.len(), RUNTIME_HELPERS.len());
         for (index, id) in RuntimeHelperId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, index);
@@ -1411,6 +1485,11 @@ mod tests {
             "__rue_byte_copy",
             "__rue_byte_move",
             "__rue_byte_set",
+            "__rue_test_normalize_process",
+            "__rue_test_complete",
+            "__rue_test_failure_site",
+            "__rue_test_fail",
+            "__rue_test_usage_error",
         ];
         assert_eq!(
             RUNTIME_HELPERS.map(|helper| helper.symbol),
@@ -1422,7 +1501,7 @@ mod tests {
     #[test]
     fn every_helper_has_the_exact_accepted_signature_and_contract() {
         fn check(
-            visited: &mut [bool; 46],
+            visited: &mut [bool; 51],
             ids: &[RuntimeHelperId],
             parameters: &[AbiParameter],
             result: AbiResult,
@@ -1443,7 +1522,7 @@ mod tests {
             }
         }
 
-        let mut visited = [false; 46];
+        let mut visited = [false; 51];
         check(
             &mut visited,
             &[RuntimeHelperId::Exit],
@@ -1671,6 +1750,36 @@ mod tests {
             WRITABLE,
             RETURNS,
         );
+        check(
+            &mut visited,
+            &[
+                RuntimeHelperId::TestNormalizeProcess,
+                RuntimeHelperId::TestComplete,
+                RuntimeHelperId::TestUsageError,
+            ],
+            &[],
+            VOID,
+            SafetyContract::NONE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::TestFailureSite],
+            &[BYTE_VIEW, U64_VALUE, U32_VALUE, U32_VALUE],
+            VOID,
+            READABLE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::TestFail],
+            &[
+                BYTE_VIEW, U64_VALUE, BYTE_VIEW, U64_VALUE, BYTE_VIEW, U64_VALUE,
+            ],
+            VOID,
+            READABLE.union(TERMINATES),
+            NEVER,
+        );
         assert!(visited.into_iter().all(|was_visited| was_visited));
     }
 
@@ -1855,7 +1964,7 @@ mod tests {
 
     #[test]
     fn abi_version_metadata_is_a_one_byte_data_export() {
-        assert_eq!(RUNTIME_ABI_VERSION, 1);
+        assert_eq!(RUNTIME_ABI_VERSION, 2);
         assert_eq!(
             RUNTIME_ABI_VERSION_SYMBOL,
             format!("__rue_runtime_abi_v{RUNTIME_ABI_VERSION}")

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -154,6 +154,7 @@ pub mod parse;
 pub mod process;
 pub mod random;
 pub mod string;
+pub mod test_channel;
 
 macro_rules! call_runtime_helper_implementation {
     (__rue_exit($($argument:expr),*)) => { crate::entry::__rue_exit($($argument),*) };
@@ -202,6 +203,21 @@ macro_rules! call_runtime_helper_implementation {
     (__rue_byte_copy($($argument:expr),*)) => { crate::memory::__rue_byte_copy($($argument),*) };
     (__rue_byte_move($($argument:expr),*)) => { crate::memory::__rue_byte_move($($argument),*) };
     (__rue_byte_set($($argument:expr),*)) => { crate::memory::__rue_byte_set($($argument),*) };
+    (__rue_test_normalize_process($($argument:expr),*)) => {
+        crate::process::__rue_test_normalize_process($($argument),*)
+    };
+    (__rue_test_complete($($argument:expr),*)) => {
+        crate::test_channel::__rue_test_complete($($argument),*)
+    };
+    (__rue_test_failure_site($($argument:expr),*)) => {
+        crate::test_channel::__rue_test_failure_site($($argument),*)
+    };
+    (__rue_test_fail($($argument:expr),*)) => {
+        crate::test_channel::__rue_test_fail($($argument),*)
+    };
+    (__rue_test_usage_error($($argument:expr),*)) => {
+        crate::test_channel::__rue_test_usage_error($($argument),*)
+    };
 }
 
 macro_rules! declare_runtime_helper {

--- a/crates/rue-runtime/src/process.rs
+++ b/crates/rue-runtime/src/process.rs
@@ -151,6 +151,26 @@ pub fn __rue_env_len(index: u64) -> u64 {
     vector_len(&ENV_VECTOR, &ENV_COUNT, index)
 }
 
+/// Present the pinned test-visible process inventory (ADR-0083 §3).
+///
+/// The runner execs a test image as `argv = ["rue-test", "<selector>"]` with
+/// `envp = ["RUE_TEST=1"]`, and the loader lays those strings on the initial
+/// stack before any Rue code runs — so `capture` has already recorded the
+/// selector by the time the dispatcher starts. Dropping the captured argument
+/// count to one is what hides it: `std.env` reads through these accessors, so
+/// after this call a test observes `arg_count() == 1`, `arg(0) == "rue-test"`,
+/// and the single `RUE_TEST=1` environment entry, and never the selector that
+/// varies per test.
+///
+/// Only the count moves. The vector pointers stay exactly as the loader left
+/// them — nothing is copied, nothing is freed — so this is a pure narrowing of
+/// what the accessors will report.
+///
+/// The dispatcher calls this once, before the selected test body runs.
+pub fn __rue_test_normalize_process() {
+    ARG_COUNT.store(1, Ordering::Relaxed);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,5 +229,36 @@ mod tests {
         assert_eq!(__rue_env_count(), 0);
         assert!(__rue_env_ptr(0).is_null());
         assert_eq!(__rue_env_len(0), 0);
+
+        // The ADR-0083 §3 test-visible inventory, from the exact vectors the
+        // runner execs with. Normalization hides the selector by narrowing the
+        // count; the surviving `argv[0]` and the environment are untouched.
+        let program = b"rue-test\0";
+        let selector = b"0000000000000003\0";
+        let argv3: [*const u8; 3] = [program.as_ptr(), selector.as_ptr(), core::ptr::null()];
+        let marker = b"RUE_TEST=1\0";
+        let envp3: [*const u8; 2] = [marker.as_ptr(), core::ptr::null()];
+        // SAFETY: argv3/envp3 are valid terminated vectors.
+        unsafe { capture(2, argv3.as_ptr(), envp3.as_ptr()) };
+        assert_eq!(__rue_arg_count(), 2);
+
+        __rue_test_normalize_process();
+        assert_eq!(__rue_arg_count(), 1);
+        assert_eq!(__rue_arg_len(0), 8);
+        // SAFETY: index 0 is in range and addresses 8 readable bytes.
+        unsafe {
+            let ptr = __rue_arg_ptr(0);
+            assert_eq!(core::slice::from_raw_parts(ptr, 8), b"rue-test");
+        }
+        // The selector is out of range once normalized, so no test can read it.
+        assert!(__rue_arg_ptr(1).is_null());
+        assert_eq!(__rue_arg_len(1), 0);
+        assert_eq!(__rue_env_count(), 1);
+        assert_eq!(__rue_env_len(0), 10);
+        // SAFETY: index 0 is in range and addresses 10 readable bytes.
+        unsafe {
+            let ptr = __rue_env_ptr(0);
+            assert_eq!(core::slice::from_raw_parts(ptr, 10), b"RUE_TEST=1");
+        }
     }
 }

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -1,0 +1,504 @@
+//! The `rue test` structured failure channel (ADR-0083 §3 and §5.1).
+//!
+//! A dispatched test process inherits one dedicated descriptor, [`CHANNEL_FD`],
+//! whose write end the runner drains with its own budget. The channel carries
+//! newline-delimited JSON records: the dispatcher's terminal `complete` frame
+//! and the `failure` frames assertion sugar emits before aborting. It is not a
+//! security boundary — it exists so an accidental collision with a test's own
+//! stdout or stderr cannot forge or truncate a verdict.
+//!
+//! Two properties are load-bearing:
+//!
+//! - **Writes are best-effort.** A test run by hand has no descriptor 3, so
+//!   `EBADF` is expected rather than exceptional; a runner that closed its read
+//!   end yields `EPIPE`. Both are discarded. (`SIGPIPE` keeps its default
+//!   disposition here exactly as it does for stdout, spec §8.5, so a closed
+//!   reader terminates the process before `write` returns at all. The runner
+//!   holds its read end open until the child exits precisely for this reason.)
+//! - **No allocation, and no staging buffer.** A record is emitted as runs
+//!   borrowed straight from the caller's own bytes, so an arbitrarily long
+//!   message needs no heap and no bound on its own length.
+//!
+//! Records reserved by §5.1 and §5.2 — `promotion` payloads and per-case
+//! `sub_result` identities — are named by the schema and produced by nothing in
+//! this version.
+
+use core::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
+
+use crate::platform;
+
+/// Inherited failure-channel descriptor, pinned by the §3 exec contract.
+pub const CHANNEL_FD: u64 = 3;
+
+/// The failing source location staged by the most recent
+/// [`__rue_test_failure_site`] call.
+///
+/// A failure record carries three byte views plus a file, a line, and a column
+/// — ten arguments, where every runtime helper is register-only and x86-64
+/// affords six. The record is therefore assembled by two calls, and this holds
+/// the first one's result until the second consumes it. Generated code emits
+/// the pair adjacently with nothing in between, and the process aborts inside
+/// the second, so the window is a straight line with no other Rue code in it.
+///
+/// The pointer is borrowed rather than copied: the runtime allocates nothing,
+/// and the caller's obligation to keep those bytes readable across the pair is
+/// exactly what the manifest's `READABLE_BYTES` contract records.
+static SITE_FILE: AtomicPtr<u8> = AtomicPtr::new(core::ptr::null_mut());
+static SITE_FILE_LEN: AtomicU64 = AtomicU64::new(0);
+/// Line in the high half, column in the low half. One word rather than two
+/// keeps the staged site to three statics, and neither field is meaningful
+/// without the other.
+static SITE_POSITION: AtomicU64 = AtomicU64::new(0);
+
+/// The literal frame text, in field order. Every record carries the schema
+/// version inline, so a reader never has to infer it.
+///
+/// These are value constants rather than `&'static [u8]` statics: the runtime's
+/// message paths deliberately avoid static byte-string relocations, which have
+/// misbuilt on the macOS linker before (see `error.rs`).
+const COMPLETE_FRAME: [u8; 37] = *b"{\"record\":\"complete\",\"schema\":\"1.0\"}\n";
+const FAILURE_HEAD: [u8; 43] = *b"{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"";
+const MESSAGE_FIELD: [u8; 13] = *b"\",\"message\":\"";
+const LOCATION_FIELD: [u8; 22] = *b"\",\"location\":{\"file\":\"";
+const LINE_FIELD: [u8; 9] = *b"\",\"line\":";
+const COLUMN_FIELD: [u8; 10] = *b",\"column\":";
+const PAYLOAD_FIELD: [u8; 13] = *b"},\"payload\":\"";
+const FRAME_TAIL: [u8; 3] = *b"\"}\n";
+
+/// The pinned malformed-selector diagnostic (ADR-0083 §3).
+const USAGE_MESSAGE: [u8; 50] = *b"rue-test: expected one 16-hex-digit test selector\n";
+
+/// Emitter for one channel frame.
+///
+/// `emit` receives already-escaped bytes in order, and the frame is assembled
+/// as a series of runs borrowed straight from the caller's own bytes — there is
+/// no staging buffer. That is a size decision as much as an allocation one: a
+/// buffer large enough to hold a frame would be zero-initialized through a
+/// `memset`-family libcall the freestanding runtime does not export (on Darwin,
+/// `bzero`), and the link would fail. Runs cost one `write(2)` each, which for
+/// a record written once per failing test is not worth a buffer.
+///
+/// Production passes the descriptor writer; tests pass a collector, which is
+/// what lets the exact frame bytes be asserted without a real pipe.
+struct FrameWriter<'a> {
+    emit: &'a mut dyn FnMut(&[u8]),
+}
+
+impl<'a> FrameWriter<'a> {
+    fn new(emit: &'a mut dyn FnMut(&[u8])) -> Self {
+        Self { emit }
+    }
+
+    fn raw(&mut self, bytes: &[u8]) {
+        if !bytes.is_empty() {
+            (self.emit)(bytes);
+        }
+    }
+
+    /// Emit `bytes` as the body of a JSON string.
+    ///
+    /// Rue strings are arbitrary byte sequences, not guaranteed UTF-8, so this
+    /// escapes exactly what JSON requires and nothing else: the quote, the
+    /// backslash, and every control byte below `0x20` as a `\u00xx` escape.
+    /// Bytes at or above `0x80` are emitted raw, which keeps a valid UTF-8
+    /// message byte-identical on the wire and leaves an invalid one to the
+    /// runner's encoding tag (§2) rather than corrupting it here.
+    ///
+    /// Unescaped stretches are emitted as one run, so a message that needs no
+    /// escaping costs exactly one write.
+    fn escaped(&mut self, bytes: &[u8]) {
+        const HEX: [u8; 16] = *b"0123456789abcdef";
+        let mut run_start = 0;
+        for (index, byte) in bytes.iter().enumerate() {
+            let mut escape = [0u8; 6];
+            let escape_len = match *byte {
+                b'"' => {
+                    escape[0] = b'\\';
+                    escape[1] = b'"';
+                    2
+                }
+                b'\\' => {
+                    escape[0] = b'\\';
+                    escape[1] = b'\\';
+                    2
+                }
+                value if value < 0x20 => {
+                    escape[0] = b'\\';
+                    escape[1] = b'u';
+                    escape[2] = b'0';
+                    escape[3] = b'0';
+                    escape[4] = HEX[usize::from(value >> 4)];
+                    escape[5] = HEX[usize::from(value & 0x0f)];
+                    6
+                }
+                _ => 0,
+            };
+            if escape_len > 0 {
+                self.raw(&bytes[run_start..index]);
+                self.raw(&escape[..escape_len]);
+                run_start = index + 1;
+            }
+        }
+        self.raw(&bytes[run_start..]);
+    }
+
+    /// Emit `value` as a JSON number.
+    fn number(&mut self, value: u32) {
+        // Ten digits hold every `u32`; the array is small enough to initialize
+        // inline rather than through a `memset` libcall.
+        let mut digits = [0u8; 10];
+        let mut written = 0;
+        let mut remaining = value;
+        loop {
+            digits[written] = b'0' + (remaining % 10) as u8;
+            written += 1;
+            remaining /= 10;
+            if remaining == 0 {
+                break;
+            }
+        }
+        // The loop produced least-significant digit first.
+        let mut reversed = [0u8; 10];
+        for (index, digit) in digits[..written].iter().rev().enumerate() {
+            reversed[index] = *digit;
+        }
+        self.raw(&reversed[..written]);
+    }
+}
+
+/// Write the terminal completion frame.
+///
+/// The dispatcher's epilogue is the only producer: exit 0 with end of stream
+/// and no completion frame is how the runner detects a test body that called
+/// `std.exit(0)` before its assertions ran (§3, failure kind `incomplete`).
+fn complete_frame(emit: &mut dyn FnMut(&[u8])) {
+    let mut writer = FrameWriter::new(emit);
+    writer.raw(&COMPLETE_FRAME);
+}
+
+/// Write one failure frame.
+///
+/// `kind`, `message`, `file`, and `payload` are borrowed byte views; `payload`
+/// is the open, versioned extension point §5.1 reserves for assertion
+/// libraries, and is empty when a producer has nothing structured to say.
+fn failure_frame(
+    emit: &mut dyn FnMut(&[u8]),
+    kind: &[u8],
+    message: &[u8],
+    file: &[u8],
+    line: u32,
+    column: u32,
+    payload: &[u8],
+) {
+    let mut writer = FrameWriter::new(emit);
+    writer.raw(&FAILURE_HEAD);
+    writer.escaped(kind);
+    writer.raw(&MESSAGE_FIELD);
+    writer.escaped(message);
+    writer.raw(&LOCATION_FIELD);
+    writer.escaped(file);
+    writer.raw(&LINE_FIELD);
+    writer.number(line);
+    writer.raw(&COLUMN_FIELD);
+    writer.number(column);
+    writer.raw(&PAYLOAD_FIELD);
+    writer.escaped(payload);
+    writer.raw(&FRAME_TAIL);
+}
+
+/// Best-effort write of already-framed bytes to the inherited channel.
+fn emit_to_channel(bytes: &[u8]) {
+    // Discarded deliberately: `EBADF` when the program was run by hand without
+    // a channel, `EPIPE` when the runner is gone. Neither is recoverable and
+    // neither should disturb the test's own result.
+    let _ = platform::write_all(CHANNEL_FD, bytes);
+}
+
+/// Borrow `len` bytes at `ptr`, tolerating the null-with-zero-length form the
+/// ABI permits for an absent view.
+///
+/// # Safety
+///
+/// When `len > 0`, `ptr` must address `len` initialized bytes that stay valid
+/// for the call.
+unsafe fn view<'a>(ptr: *const u8, len: u64) -> &'a [u8] {
+    if len == 0 {
+        return &[];
+    }
+    // SAFETY: the caller guarantees `len` readable bytes at a non-null `ptr`.
+    unsafe { core::slice::from_raw_parts(ptr, len as usize) }
+}
+
+crate::define_runtime_implementation! {
+    /// Write the terminal completion frame to the failure channel.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_test_complete()
+    /// ```
+    ///
+    /// Called only from the synthesized dispatcher's epilogue, after the
+    /// selected test body returns normally.
+    pub extern "C" fn __rue_test_complete() {
+        complete_frame(&mut emit_to_channel);
+    }
+}
+
+crate::define_runtime_implementation! {
+    /// Stage the source location the next failure record will carry.
+    ///
+    /// Paired with [`__rue_test_fail`], which consumes it. Nothing clears the
+    /// staging afterwards, because nothing runs afterwards: the consumer aborts
+    /// the process. A site staged without a following failure would be adopted
+    /// by the next one, which generated code never allows — it emits the two
+    /// calls together.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_test_failure_site(
+    ///     file_ptr: *const u8, file_len: u64, line: u32, column: u32,
+    /// )
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// `file_ptr`/`file_len` must describe initialized bytes that stay valid
+    /// until the paired `__rue_test_fail` has written its record, or be null
+    /// with a zero length.
+    pub unsafe extern "C" fn __rue_test_failure_site(
+        file_ptr: *const u8,
+        file_len: u64,
+        line: u32,
+        column: u32,
+    ) {
+        SITE_FILE.store(file_ptr as *mut u8, Ordering::Relaxed);
+        SITE_FILE_LEN.store(file_len, Ordering::Relaxed);
+        SITE_POSITION.store(
+            (u64::from(line) << 32) | u64::from(column),
+            Ordering::Relaxed,
+        );
+    }
+}
+
+crate::define_runtime_implementation! {
+    /// Report a structured test failure, then abort like any other trap.
+    ///
+    /// Writes one `failure` frame to the channel — carrying whatever location
+    /// [`__rue_test_failure_site`] staged, or none — and then takes the
+    /// ordinary panic path: `panic: {message}\n` on stderr and exit 101. The
+    /// frame goes first so a failure is recorded even if the stderr write is
+    /// lost.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_test_fail(
+    ///     kind_ptr: *const u8, kind_len: u64,
+    ///     message_ptr: *const u8, message_len: u64,
+    ///     payload_ptr: *const u8, payload_len: u64,
+    /// ) -> !
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// Each pointer/length pair must describe initialized bytes valid for the
+    /// call, or be null with a zero length.
+    pub unsafe extern "C" fn __rue_test_fail(
+        kind_ptr: *const u8,
+        kind_len: u64,
+        message_ptr: *const u8,
+        message_len: u64,
+        payload_ptr: *const u8,
+        payload_len: u64,
+    ) -> ! {
+        // SAFETY: the caller guarantees every pair describes readable bytes.
+        let message = unsafe { view(message_ptr, message_len) };
+        // SAFETY: as above.
+        let (kind, payload) = unsafe {
+            (
+                view(kind_ptr, kind_len),
+                view(payload_ptr, payload_len),
+            )
+        };
+        let position = SITE_POSITION.load(Ordering::Relaxed);
+        // SAFETY: a staged site's bytes stay readable across the pair, and an
+        // unstaged one is the null-with-zero-length form `view` accepts.
+        let file = unsafe {
+            view(
+                SITE_FILE.load(Ordering::Relaxed) as *const u8,
+                SITE_FILE_LEN.load(Ordering::Relaxed),
+            )
+        };
+        failure_frame(
+            &mut emit_to_channel,
+            kind,
+            message,
+            file,
+            (position >> 32) as u32,
+            position as u32,
+            payload,
+        );
+        // SAFETY: `message` is a live borrow of the caller's bytes.
+        unsafe { crate::error::__rue_panic(message.as_ptr(), message.len() as u64) }
+    }
+}
+
+crate::define_runtime_implementation! {
+    /// Write the pinned malformed-selector diagnostic to stderr and return.
+    ///
+    /// The dispatcher, not the runtime, owns the exit status for this case, so
+    /// unlike every other stderr-writing runtime path this one returns rather
+    /// than terminating (ADR-0083 §3: a malformed selector is exit 2).
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_test_usage_error()
+    /// ```
+    pub extern "C" fn __rue_test_usage_error() {
+        platform::write_stderr(&USAGE_MESSAGE);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use std::vec::Vec;
+
+    fn frame_bytes(build: impl FnOnce(&mut dyn FnMut(&[u8]))) -> Vec<u8> {
+        let mut collected = Vec::new();
+        let mut emit = |bytes: &[u8]| collected.extend_from_slice(bytes);
+        build(&mut emit);
+        collected
+    }
+
+    #[test]
+    fn completion_frame_is_the_pinned_bytes() {
+        let bytes = frame_bytes(complete_frame);
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"record\":\"complete\",\"schema\":\"1.0\"}\n"
+        );
+    }
+
+    #[test]
+    fn failure_frame_is_the_pinned_field_order() {
+        let bytes = frame_bytes(|emit| {
+            failure_frame(
+                emit,
+                b"assert",
+                b"assertion failed",
+                b"app/parser_tests.rue",
+                7,
+                3,
+                b"",
+            )
+        });
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert\",\
+             \"message\":\"assertion failed\",\
+             \"location\":{\"file\":\"app/parser_tests.rue\",\"line\":7,\"column\":3},\
+             \"payload\":\"\"}\n"
+        );
+    }
+
+    #[test]
+    fn strings_escape_quotes_backslashes_and_control_bytes_only() {
+        let bytes = frame_bytes(|emit| {
+            failure_frame(
+                emit,
+                b"assert",
+                b"say \"hi\"\\\n\t\x00",
+                b"a.rue",
+                1,
+                1,
+                b"expected \x1f",
+            )
+        });
+        let rendered = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            rendered.contains("\"message\":\"say \\\"hi\\\"\\\\\\u000a\\u0009\\u0000\""),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("\"payload\":\"expected \\u001f\""),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn bytes_at_or_above_0x80_are_written_raw() {
+        let bytes = frame_bytes(|emit| {
+            failure_frame(
+                emit,
+                b"assert",
+                &[0xe2, 0x9c, 0x93, 0xff],
+                b"a.rue",
+                1,
+                1,
+                b"",
+            )
+        });
+        // The message field body appears verbatim, invalid UTF-8 included.
+        let needle: &[u8] = &[
+            b'"', b'm', b'e', b's', b's', b'a', b'g', b'e', b'"', b':', b'"',
+        ];
+        let start = bytes
+            .windows(needle.len())
+            .position(|window| window == needle)
+            .unwrap()
+            + needle.len();
+        assert_eq!(&bytes[start..start + 4], &[0xe2, 0x9c, 0x93, 0xff]);
+    }
+
+    #[test]
+    fn a_long_message_is_emitted_in_order_across_runs() {
+        let long = std::vec![b'x'; 4_096];
+        let bytes = frame_bytes(|emit| failure_frame(emit, b"assert", &long, b"a.rue", 1, 1, b""));
+        let rendered = std::str::from_utf8(&bytes).unwrap();
+        assert!(rendered.starts_with("{\"record\":\"failure\","));
+        assert!(rendered.ends_with("\"payload\":\"\"}\n"));
+        assert_eq!(rendered.matches('x').count(), long.len());
+    }
+
+    #[test]
+    fn numbers_render_without_padding() {
+        let bytes = frame_bytes(|emit| failure_frame(emit, b"k", b"m", b"f", 0, u32::MAX, b""));
+        let rendered = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            rendered.contains("\"line\":0,\"column\":4294967295"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn a_staged_site_round_trips_through_the_packed_position() {
+        let file = b"app/parser_tests.rue";
+        // SAFETY: `file` outlives the read below.
+        unsafe { __rue_test_failure_site(file.as_ptr(), file.len() as u64, 7, 3) };
+        let position = SITE_POSITION.load(Ordering::Relaxed);
+        assert_eq!(((position >> 32) as u32, position as u32), (7, 3));
+        assert_eq!(SITE_FILE_LEN.load(Ordering::Relaxed), file.len() as u64);
+        // SAFETY: the staged pointer is `file`, still live here.
+        let staged = unsafe {
+            view(
+                SITE_FILE.load(Ordering::Relaxed) as *const u8,
+                SITE_FILE_LEN.load(Ordering::Relaxed),
+            )
+        };
+        assert_eq!(staged, file);
+    }
+
+    #[test]
+    fn writing_to_a_closed_descriptor_is_tolerated() {
+        // The channel is absent whenever a test image is run by hand, so an
+        // `EBADF` write must return rather than abort. A descriptor far above
+        // anything the harness opens stands in for that.
+        let _ = platform::write_all(1_000_000, b"{}\n");
+    }
+}

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -112,6 +112,37 @@ The manifest also distinguishes returning helpers from traps and process
 termination. Rue does not unwind across this boundary. Runtime traps report the
 diagnostic and terminate the process with the runtime-error status.
 
+## The test failure channel
+
+Five helpers exist only for `rue test` (ADR-0083 §3, §5.1). They are runner
+plumbing: no source spelling selects them, and the synthesized dispatcher `main`
+of a test image is their only caller in this revision.
+
+- `__rue_test_normalize_process` narrows the captured argument count to one, so
+  a test observes the pinned inventory rather than the selector it was
+  dispatched by.
+- `__rue_test_complete` writes the terminal completion record.
+- `__rue_test_failure_site` and `__rue_test_fail` report one structured failure
+  and abort. They are a pair because a failure record carries three byte views
+  plus a file, a line, and a column — ten arguments, where every runtime helper
+  is register-only and x86-64 affords six. The first stages the location, the
+  second emits the record and takes the ordinary panic path; nothing runs
+  between them, and the staged file bytes must stay readable across both.
+- `__rue_test_usage_error` writes one pinned diagnostic for a malformed
+  selector and *returns*, unlike every other stderr-writing runtime path,
+  because the dispatcher owns that case's exit status.
+
+The completion and failure records go to a dedicated inherited descriptor,
+number 3, one JSON object per line. Writes are best-effort: a test image run by
+hand has no such descriptor, so `EBADF` is expected rather than exceptional.
+The channel is not a security boundary — it prevents accidental collision with
+a test's own stdout, which is all its consumers are promised.
+
+Its capability class is **hermetic-compatible, on the same grounds as stdout**:
+runner-pinned, fully captured, and budgeted. ADR-0083 §5.1 records that
+classification in prose until the machine-checked manifest capability field
+arrives with the deferred capability ADR.
+
 ## Export classes
 
 The reserved `__rue_` namespace contains several deliberately distinct kinds


### PR DESCRIPTION
Closes RUE-1917. ADR-0083 Phase 2a: everything below the `rue test` driver. The runtime gains the dedicated failure channel and completion record (§3, §5.1), and the compiler gains the test image with its synthesized dispatcher `main`. No subcommand yet; that is RUE-1920.

## Runtime ABI v2

`RUNTIME_ABI_VERSION` moves to 2 (`__rue_runtime_abi_v2`), per ADR-0055's rule that helper additions update manifest, implementation, validation, and version together. Five helpers join the manifest (46 → 51), all runner plumbing with no source spelling:

- `__rue_test_normalize_process` narrows the captured argc to one, so a test observes `argv = ["rue-test"]` and `RUE_TEST=1` and never the selector it was dispatched by.
- `__rue_test_complete` writes the terminal `{"record":"complete","schema":"1.0"}` frame to the inherited channel on fd 3.
- `__rue_test_failure_site` and `__rue_test_fail` report one structured failure and abort. They are a pair because a failure record is ten arguments and helpers are register-only: the first stages the source location, the second writes the `failure` frame, prints `panic: <message>` to stderr, and exits 101.
- `__rue_test_usage_error` writes the pinned malformed-selector diagnostic and returns, so the dispatcher owns that case's exit status (2).

Channel writes are best-effort: a hand-run image has no fd 3 and `EBADF` is expected. Frames are emitted as runs borrowed from the caller's bytes with JSON escaping for quote, backslash, and control bytes only; bytes at or above 0x80 pass through raw for the runner's encoding tag. There is no staging buffer, because one lowered to a `bzero` libcall the freestanding runtime does not export on Darwin. `docs/runtime-abi.md` documents the channel and its hermetic-compatible capability class.

## Test image and dispatcher

- **Inventory** (`test_inventory.rs`) is the single ordering authority: tests sorted by stable ID `<module>::<name>` in byte order, with source location and ordinal. Both the `--list` surface and the dispatcher table read it, so a selector can never name the wrong body.
- **Dispatcher** (`test_dispatcher.rs`) is a `rue_air::SemanticBody` fed through a new `CfgSemanticInput::TestDispatcher`, following the drop-glue precedent, so both backends get it with no per-backend code. It validates `argc == 2` and a sixteen-lowercase-hex-digit selector using wrapping arithmetic over raw argv bytes (it imports nothing, so a suite that never imports std still links), normalizes the process, dispatches by ordinal, writes the completion frame, and returns 0. A malformed or out-of-range selector prints the pinned message and returns 2.
- **Identity**: `FunctionInstanceKey::TestDispatcher`, symbol `main`. Only a `RootSelection::Tests` request that lowers an image synthesizes it; `rooted_test_inventory` stops at the body graph, so a listing never builds a dispatcher it would not link. `extern "C"` exports remain executable-only and a test image links no thunk, asserted by test.
- **Facade** (`rue_compiler::unstable`): `test_inventory(session, options)` and `test_image_in_compile_scope(session, options) -> (CompileOutput, TestInventory)`, both requiring `RootSelection::Tests`.

## Coverage

Runtime unit tests for frame bytes, escaping, packed site staging, and closed-descriptor tolerance; ABI manifest and archive pins; rue-air `RuntimeCallKind` pins; rue-oracle marks the new call kinds unreachable from corpus programs; rue-compiler session tests for inventory order across modules, no-codegen listing, dispatcher entry point, c-export exclusion, and Executable graphs unchanged; platform-native end-to-end tests (`test_image_tests.rs`) that link an image and exec it with the pinned argv, env, and fd 3, covering the selected test completing, the pinned process inventory, a bad selector, a trapping test (exit 101, no frame), and an early `std.exit(0)` producing no completion frame.

Local: fmt, quick, unit suites for rue-runtime, rue-runtime-abi, rue-air, rue-codegen, rue-compiler, the platform-native target, repository-quality-gates, the ABI CLI cases, and the rue_program digest check all green. CI's ARM64 and macOS legs are the authority for the second backend.
