### PR TITLE
RUE-1918: add the declared test-candidate inventory and orphan warning

### DIFF
--- a/crates/rue-cli-tests/cases/test_candidates.toml
+++ b/crates/rue-cli-tests/cases/test_candidates.toml
@@ -1,0 +1,173 @@
+[section]
+id = "cli.test_candidates"
+name = "Declared test-candidate inventory"
+description = """
+RUE-1918 (ADR-0083 Phase 2b): `--test-candidates` is the one optional build
+integration the test runner takes — the set of files a build target declared,
+which powers the unimported-test-file warning.
+
+Two properties are pinned here. The flag is accepted and INERT in every other
+mode: a candidate list is not a read policy, does not join the module closure,
+and changes no byte of an ordinary build's output, even when it names a test
+file nothing imports. And the list is a build-system input, so an unreadable one
+is an ordinary driver error naming the path, never a silently empty inventory
+that would make the warning it powers quietly never fire.
+
+Reporting against the inventory is `rue test`'s job (RUE-1920); this phase
+validates the input and threads it through.
+"""
+
+[[case]]
+name = "declared_candidates_are_accepted_and_inert"
+description = "RUE-1918: an ordinary build with a candidate list compiles and runs unchanged."
+files = [
+    { path = "test-candidates.list", source = """
+# Declared by the build rule, one project-root-relative path per line.
+main.rue
+
+helper.rue
+orphan_tests.rue
+""" },
+    { path = "main.rue", source = """
+const helper = @import("helper.rue");
+
+fn main() -> i32 {
+    @dbg(helper.answer());
+    0
+}
+""" },
+    { path = "helper.rue", source = """
+pub fn answer() -> i32 {
+    42
+}
+""" },
+    # Declared, never imported, and full of tests: exactly the file the warning
+    # exists for. An ordinary build still says nothing about it.
+    { path = "orphan_tests.rue", source = """
+test "nothing imports this file" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["--test-candidates", "test-candidates.list", "main.rue", "-o", "prog"]
+stdout = "42\n"
+compile_stderr_not_contains = ["orphan_tests.rue", "test file", "warning"]
+
+[[case]]
+name = "declared_candidates_do_not_grant_a_source_read"
+description = """
+RUE-1918: declaring a candidate is not declaring a source. The manifest remains
+the sole read policy, so a file listed only as a candidate stays unreadable as
+an import.
+"""
+files = [
+    { path = "sources.manifest", source = """
+main.rue
+""" },
+    { path = "test-candidates.list", source = """
+main.rue
+helper.rue
+""" },
+    { path = "main.rue", source = """
+const helper = @import("helper.rue");
+
+fn main() -> i32 {
+    helper.answer()
+}
+""" },
+    { path = "helper.rue", source = """
+pub fn answer() -> i32 {
+    42
+}
+""" },
+]
+args = [
+    "--source-manifest",
+    "sources.manifest",
+    "--test-candidates",
+    "test-candidates.list",
+    "main.rue",
+    "-o",
+    "prog",
+]
+compile_fail = true
+error_contains = ["helper.rue"]
+
+[[case]]
+name = "unreadable_candidate_list_names_the_path"
+description = "RUE-1918: a missing candidate list fails the build and names the file."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" }]
+args = ["--test-candidates", "absent-candidates.list", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["Error reading test candidates", "absent-candidates.list"]
+
+[[case]]
+name = "the_candidate_list_may_be_given_only_once"
+description = """
+RUE-1918: two declared candidate sets describe two build targets. Last-wins
+would silently report against one of them, so a repeat is refused.
+"""
+files = [
+    { path = "one.list", source = "main.rue\n" },
+    { path = "two.list", source = "main.rue\n" },
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = [
+    "--test-candidates",
+    "one.list",
+    "--test-candidates",
+    "two.list",
+    "main.rue",
+    "-o",
+    "prog",
+]
+compile_fail = true
+error_contains = ["--test-candidates may be given at most once"]
+
+[[case]]
+name = "manifest_excluded_candidates_are_denied_not_read"
+description = """
+RUE-1918: acquisition obeys the source manifest. A declared candidate the
+manifest does not list is observed as unreadable rather than read from disk,
+and an ordinary build with such a candidate still succeeds and says nothing
+about it.
+"""
+files = [
+    { path = "sources.manifest", source = """
+main.rue
+""" },
+    { path = "test-candidates.list", source = """
+main.rue
+excluded_tests.rue
+""" },
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+    # Exists on disk, declared as a candidate, absent from the manifest.
+    { path = "excluded_tests.rue", source = """
+test "the manifest omits this file" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = [
+    "--source-manifest",
+    "sources.manifest",
+    "--test-candidates",
+    "test-candidates.list",
+    "main.rue",
+    "-o",
+    "prog",
+]
+exit_code = 0
+compile_stderr_not_contains = ["excluded_tests.rue", "warning"]

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1955,7 +1955,7 @@ fn glob_import_paths(source: &str) -> Vec<String> {
 // Manifest order is already pinned to the constructor invocation stream. Each
 // entry adds the exact raw source identity of that leaf, making the reviewed
 // registration operation one-shot rather than merely one syntactic call.
-const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 44] = [
+const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
     (1_608, 9_349_892_297_056_354_958),
     (2_319, 162_635_033_840_982_550),
     (2_335, 11_401_802_782_486_455_398),
@@ -1999,6 +1999,7 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 44] = [
     (8_756, 6_802_240_310_126_667_165),
     (14_038, 8_977_560_222_769_304_814),
     (380, 6_623_933_847_739_557_204),
+    (1_405, 15_935_800_678_319_035_612),
     (421, 8_838_427_880_540_066_171),
 ];
 
@@ -2012,26 +2013,30 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 44] = [
 // identity even when constructor, caller, and macro token counts do not.
 const CONSTRUCTION_TOKEN_STRUCT_IDENTITY: (usize, u64) = (80, 5_227_448_979_315_228_973);
 const CONSTRUCTION_TOKEN_IMPL_IDENTITY: (usize, u64) = (108, 2_765_439_612_714_245_239);
-const COMPILER_CRATE_ROOT_IDENTITY: (usize, u64) = (10_456, 13_393_868_787_617_733_612);
-const COMPILER_CRATE_ROOT_NAMESPACE_IDENTITY: (usize, u64, usize, u64) =
-    (110, 255_897_897_515_642_022, 223, 8_513_453_303_818_067_861);
+const COMPILER_CRATE_ROOT_IDENTITY: (usize, u64) = (10742, 6_981_258_935_585_704_258);
+const COMPILER_CRATE_ROOT_NAMESPACE_IDENTITY: (usize, u64, usize, u64) = (
+    112,
+    16_669_975_409_982_800_018,
+    227,
+    14_750_313_343_688_513_712,
+);
 const COMPILER_SESSION_ROOT_IDENTITY: (usize, u64) = (3_375, 11_197_616_651_825_656_461);
 const COMPILER_SESSION_CONSTRUCTOR_IDENTITY: (usize, u64) = (82, 10_721_269_354_679_246_675);
 const FRONTEND_DATABASE_CONSTRUCTION_IDENTITY: (usize, u64) = (268, 967_740_565_057_515_587);
 const DATABASE_INHERENT_CONSTRUCTOR_IDENTITY: (usize, u64) = (148, 15_840_470_727_822_522_148);
 const DATABASE_CANONICAL_CONSTRUCTOR_IDENTITY: (usize, u64) = (224, 1_314_571_707_455_964_487);
 const TEST_DEFAULT_DATABASE_ADAPTER_IDENTITY: (usize, u64) = (120, 3_163_599_038_660_274_771);
-const REGISTRATION_DATABASE_IMPL_IDENTITY: (usize, u64) = (34_847, 17_578_195_062_279_132_179);
+const REGISTRATION_DATABASE_IMPL_IDENTITY: (usize, u64) = (35_354, 9_236_865_163_121_593_081);
 const SHARED_FAMILY_FORWARDING_IDENTITY: (usize, u64) = (2_609, 9_595_658_320_490_175_466);
-const ORDERED_REGISTRATION_COMPOSER_IDENTITY: (usize, u64) = (33_364, 10_468_265_158_692_030_241);
+const ORDERED_REGISTRATION_COMPOSER_IDENTITY: (usize, u64) = (33_871, 17_019_997_086_940_479_461);
 // Macro imports, definitions, re-exports, and lexical ordering participate in
 // macro resolution. Seal the complete registrations authority and each wrapper
 // aggregate in addition to the executable identities inside them.
-const REGISTRATION_AUTHORITY_MODULE_IDENTITY: (usize, u64) = (44_597, 17_681_835_659_194_060_194);
+const REGISTRATION_AUTHORITY_MODULE_IDENTITY: (usize, u64) = (45_324, 8_202_842_852_626_878_117);
 const REGISTRATION_WRAPPER_MODULE_IDENTITIES: [(usize, u64); 5] = [
     (842, 17_134_465_730_999_135_202),
     (1_146, 9_973_452_843_887_101_603),
-    (1_118, 3_506_955_039_267_909_738),
+    (1_227, 377_303_397_680_888_843),
     (85, 9_154_658_544_330_042_432),
     (1_096, 1_461_060_759_810_744_828),
 ];
@@ -2584,7 +2589,7 @@ impl CompilerSession {
     let families = registered_revisioned_database_families();
     assert_eq!(
         families.len(),
-        44,
+        45,
         "the registered-family manifest is complete"
     );
     let invocations = registration_macro_invocations(registration_composer);
@@ -4309,7 +4314,7 @@ pub(super) use register_parse_import_parse;"#;
         (
             "revisioned_database::registrations".to_owned(),
             "runtime-field-macro-bare-identifier".to_owned(),
-            45,
+            46,
         ),
     ];
     assert_eq!(
@@ -4449,7 +4454,7 @@ pub(super) use register_parse_import_parse;"#;
     ));
     let nested_module_owners = module_owner_inventory(&compiler_module_sources);
     let nested_module_fingerprint = source_inventory_fingerprint(&nested_module_owners);
-    let expected_nested_module_identity = (154, 8_453_145_628_824_547_092);
+    let expected_nested_module_identity = (156, 2_667_001_902_368_665_969);
     assert_eq!(
         (nested_module_owners.len(), nested_module_fingerprint),
         expected_nested_module_identity,
@@ -4531,7 +4536,7 @@ pub(super) use register_parse_import_parse;"#;
             .iter()
             .map(|(_, count)| count)
             .sum::<usize>(),
-        44,
+        45,
         "the identifier inventory must derive from every manifested include leaf",
     );
     assert_eq!(
@@ -4875,7 +4880,7 @@ pub(super) use register_parse_import_parse;"#;
         });
     assert_eq!(
         (declarations.len(), fingerprint),
-        (210, 13_505_876_172_349_810_937),
+        (213, 209_895_908_114_665_903),
         "crate-visible declaration names, signatures, fields, or phase owners changed"
     );
 
@@ -5170,6 +5175,7 @@ struct:TestConstraintGenerationCancellationGuard
 struct:CompatibilityKey
 struct:RevisionedQueryDatabase
 fn:new
+struct:TestCandidateScanValue
 struct:TestCodegenEvaluatorGate
 fn:wait_until_entered
 fn:release
@@ -5308,7 +5314,9 @@ fn:clear_lineage_additions
 fn:exact_import_groups
 fn:publication_cone_retention_failures
 fn:stage_module_parses
+fn:test_candidate_scan
 fn:publish_import_batch
+fn:publish_test_candidate_inputs
 fn:publish_trusted_successor_view
 fn:import_ledger
 fn:current_import_view_state
@@ -5466,6 +5474,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("source_metadata", include_str!("source_metadata.rs")),
     ("source_snapshot", include_str!("source_snapshot.rs")),
     ("syntax", include_str!("syntax.rs")),
+    ("test_candidates", include_str!("test_candidates.rs")),
     ("test_dispatcher", include_str!("test_dispatcher.rs")),
     ("test_inventory", include_str!("test_inventory.rs")),
     (
@@ -7547,6 +7556,7 @@ fn unstable_views_do_not_alias_query_engine_records() {
         [
             "pubusecrate::diagnostic::{ColorChoice,DiagnosticFormatter,JsonDiagnostic,JsonDiagnosticFormatter,JsonSpan,JsonSuggestion,MultiFileFormatter,MultiFileJsonFormatter,SourceInfo,};",
             "pubusecrate::import_discovery::{AcceptedImportSource,DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportDiscoveryPlan,ImportDiscoveryRequest,ImportDiscoveryWave,ImportInputRevision,ImportObservation,ImportObservationLedger,ImportObservationStatus,};",
+            "pubusecrate::test_candidates::{TestCandidate,TestCandidateInventory,TestCandidateOutcome,UnimportedTestFile,};",
             "pubusecrate::warm_fresh_parity::ParityObservation;",
             "pubuserue_span::Span;",
             "pubusecrate::session::{ClosedDiscoveryContinuation,RootedCfgOutput,RootedCfgUnit,RootedParkOutcome,RootedPreOptimizationCfgOutput,RootedPreOptimizationCfgUnit,TrustedSuccessorDelta,};",

--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -1331,6 +1331,47 @@ mod tests {
         assert_eq!(json_warnings.matches("test.rue").count(), 3);
     }
 
+    /// The unimported-test-file warning has no source site: the file is outside
+    /// the closure, so the compiler holds no span inside it. Both the text and
+    /// JSON renderings must therefore carry the whole message and no location.
+    #[test]
+    fn unimported_test_file_warnings_render_without_a_source_site() {
+        let text = MultiFileFormatter::with_color_choice([], ColorChoice::Never);
+        let json = MultiFileJsonFormatter::new([]);
+
+        let counted = CompileWarning::without_span(WarningKind::UnimportedTestFile {
+            path: "app/parser_tests.rue".to_string(),
+            tests: 2,
+        });
+        let rendered = text.format_warning(&counted);
+        assert!(rendered.contains("app/parser_tests.rue"), "{rendered}");
+        assert!(rendered.contains("declares 2 tests"), "{rendered}");
+        assert!(
+            rendered.contains("no module in the compiled closure imports it"),
+            "{rendered}"
+        );
+        assert!(json.format_warning(&counted).spans.is_empty());
+
+        // One test is one test, not "1 tests".
+        let single = CompileWarning::without_span(WarningKind::UnimportedTestFile {
+            path: "app/one_test.rue".to_string(),
+            tests: 1,
+        });
+        assert!(
+            text.format_warning(&single).contains("declares 1 test but"),
+            "{}",
+            text.format_warning(&single)
+        );
+
+        let unparsable = CompileWarning::without_span(WarningKind::UnimportedTestFileUnparsable {
+            path: "app/broken.rue".to_string(),
+        });
+        let rendered = text.format_warning(&unparsable);
+        assert!(rendered.contains("app/broken.rue"), "{rendered}");
+        assert!(rendered.contains("could not be parsed"), "{rendered}");
+        assert!(json.format_warning(&unparsable).spans.is_empty());
+    }
+
     #[test]
     fn duplicate_file_ids_use_the_last_source_after_text_cache_deduplication() {
         let file_id = FileId::new(7);

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -73,6 +73,7 @@ mod source_identity;
 mod source_metadata;
 mod source_snapshot;
 mod syntax;
+mod test_candidates;
 mod test_dispatcher;
 mod test_inventory;
 mod toolchain_module_demand;
@@ -154,6 +155,11 @@ pub use source_identity::{
 };
 pub use source_metadata::SourceMetadata;
 pub use source_snapshot::{MAX_SOURCE_BYTES, MAX_SOURCE_FILES, SourceSnapshot};
+// The declared test-candidate inventory is a host protocol record, published
+// through `unstable` while `rue test` is still being built (ADR-0083 Phase 2).
+pub(crate) use test_candidates::{
+    TestCandidateInventory, TestCandidateOutcome, UnimportedTestFile,
+};
 pub use toolchain_module_demand::{
     OPTION_MODULE_LOGICAL_PATH, ParkedToolchainModules, STRBUF_MODULE_LOGICAL_PATH,
     TrustedToolchainModuleDemand,

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1331,6 +1331,9 @@ impl RetainedCharge for rue_error::WarningKind {
             Self::UnusedVariable(value)
             | Self::UnusedFunction(value)
             | Self::UnreachablePattern(value) => value.retained_charge(),
+            Self::UnimportedTestFile { path, .. } | Self::UnimportedTestFileUnparsable { path } => {
+                path.retained_charge()
+            }
             Self::UnreachableCode | Self::SentinelLookup => 0,
         }
     }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -122,6 +122,7 @@ pub(crate) const REVISIONED_DATABASE_SOURCE: &str = concat!(
     include_str!("revisioned_query_database/registrations/body/body_closures.rs"),
     include_str!("revisioned_query_database/registrations/body/body_closure_publications.rs"),
     include_str!("revisioned_query_database/registrations/parse_import/parse.rs"),
+    include_str!("revisioned_query_database/registrations/parse_import/test_candidate_scans.rs"),
     include_str!("revisioned_query_database/registrations/provider_probe.rs"),
     "\n#[cfg(test)]\npub(crate) mod test_support {\n",
     include_str!("revisioned_query_database/test_support.rs"),

--- a/crates/rue-compiler/src/revisioned_query_database/parse_import.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/parse_import.rs
@@ -2834,3 +2834,181 @@ impl RevisionedQueryDatabase {
         Ok(shells)
     }
 }
+
+// ---------------------------------------------------------------------------
+// Declared test candidates (ADR-0083 §1)
+//
+// A candidate is a file the build system declared but the compiler may never
+// have read: an orphaned `parser_tests.rue` is exactly the case the inventory
+// exists to find. Its bytes therefore cannot arrive through the module input
+// store — minting a module leaf for a candidate would put it in the closure
+// this scan is trying to prove it is OUTSIDE of.
+//
+// So candidates get their own input leaves, in their own revision namespace,
+// published by the same host that performs import reads and under the same
+// read policy. Two properties follow, and both are the point:
+//
+//   * the scan is revision-keyed, so editing one candidate re-scans exactly
+//     that candidate; and
+//   * publishing candidates cannot perturb the import namespace's certificate
+//     lineage, because candidate acquisition is an addition to the request
+//     rather than a new observation of the program's sources.
+// ---------------------------------------------------------------------------
+
+/// The key of one parse-only candidate scan: the candidate's identity under the
+/// read regime that acquired it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct TestCandidateScanKey(pub(super) crate::test_candidates::TestCandidateIdentity);
+
+impl QueryKey for TestCandidateScanKey {
+    fn stable_identity(&self) -> String {
+        self.0.runtime_input_key().to_string()
+    }
+
+    fn stable_hash(&self, hasher: &mut rue_query::StableHasher) {
+        self.0.hash(hasher);
+    }
+}
+
+/// The scan's published answer. Deliberately tiny: this query parses and counts,
+/// and anything richer would be a second semantic path into candidate files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TestCandidateScanValue(pub(crate) crate::test_candidates::TestCandidateScan);
+
+impl RetainedCharge for TestCandidateScanValue {
+    fn retained_charge(&self) -> u64 {
+        // Two scalars, published by value: the scan's whole answer is
+        // `{ tests, parse_failed }`.
+        (std::mem::size_of::<Self>() as u64).saturating_add(1)
+    }
+}
+
+pub(super) fn test_candidate_scan_value_equal(
+    left: &TestCandidateScanValue,
+    right: &TestCandidateScanValue,
+) -> bool {
+    left == right
+}
+
+/// One candidate's acquired bytes or typed non-read outcome, as an input leaf.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct TestCandidateLeaf {
+    pub(super) identity: crate::test_candidates::TestCandidateIdentity,
+    pub(super) outcome: crate::TestCandidateOutcome,
+}
+
+#[derive(Debug)]
+pub(super) struct TestCandidateInputView {
+    pub(super) revision: Revision,
+    pub(super) leaves: AHashMap<Arc<str>, TestCandidateLeaf>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct TestCandidateInputStore {
+    pub(super) revisions: VecDeque<Arc<TestCandidateInputView>>,
+    pub(super) next_stamp: u64,
+    pub(super) stamps: AHashMap<TestCandidateLeaf, u64>,
+}
+
+/// Retained candidate input views. Candidate acquisition happens once per
+/// reported request, so a short window is enough to keep the previous inventory
+/// available for red/green validation of an unchanged candidate.
+pub(super) const TEST_CANDIDATE_INPUT_REVISION_RETENTION: usize = 4;
+
+pub(super) fn test_candidate_input(
+    identity: &crate::test_candidates::TestCandidateIdentity,
+) -> InputIdentity {
+    InputIdentity::new("test-candidate", identity.runtime_input_key())
+}
+
+pub(super) fn test_candidate_view(
+    store: &Mutex<TestCandidateInputStore>,
+    revision: Revision,
+) -> Result<Arc<TestCandidateInputView>, QueryAbort> {
+    store
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .revisions
+        .iter()
+        .find(|view| view.revision == revision)
+        .cloned()
+        .ok_or(QueryAbort::UnpublishedRevision(revision))
+}
+
+impl RevisionedQueryDatabase {
+    /// Publish one declared candidate inventory as an immutable input revision
+    /// and return the revision its scan queries pin.
+    ///
+    /// The revision lives in the inventory's own regime namespace
+    /// (`TestCandidateInventory::regime_token`), so it neither extends nor
+    /// resets the import namespace's epoch head.
+    pub(crate) fn publish_test_candidate_inputs(
+        &mut self,
+        inventory: &crate::TestCandidateInventory,
+    ) -> CompileResult<Revision> {
+        let revision = Revision::new(self.next_revision, inventory.regime_token());
+        self.next_revision += 1;
+
+        let mut leaves = Vec::with_capacity(inventory.len());
+        let mut published = AHashMap::with_capacity(inventory.len());
+        {
+            let mut store = self
+                .test_candidate_store
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for candidate in inventory.candidates() {
+                let leaf = TestCandidateLeaf {
+                    identity: candidate.identity().clone(),
+                    outcome: candidate.outcome().clone(),
+                };
+                let TestCandidateInputStore {
+                    next_stamp, stamps, ..
+                } = &mut *store;
+                let stamp = *stamps.entry(leaf.clone()).or_insert_with(|| {
+                    let stamp = *next_stamp;
+                    *next_stamp += 1;
+                    stamp
+                });
+                leaves.push((test_candidate_input(&leaf.identity), stamp));
+                published.insert(leaf.identity.runtime_input_key(), leaf);
+            }
+        }
+
+        // An empty inventory still publishes: a revision with no leaves is a
+        // valid immutable view, and the caller's report is then trivially empty
+        // rather than a special case.
+        self.runtime
+            .publish_revision(revision, leaves)
+            .map_err(|error| {
+                import_input_error(format!("cannot publish test-candidate revision: {error:?}"))
+            })?;
+
+        let mut store = self
+            .test_candidate_store
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        store.revisions.push_back(Arc::new(TestCandidateInputView {
+            revision,
+            leaves: published,
+        }));
+        while store.revisions.len() > TEST_CANDIDATE_INPUT_REVISION_RETENTION {
+            store.revisions.pop_front();
+        }
+        Ok(revision)
+    }
+
+    /// Request one candidate's parse-only scan against a published candidate
+    /// revision.
+    pub(crate) fn test_candidate_scan(
+        &self,
+        revision: Revision,
+        identity: crate::test_candidates::TestCandidateIdentity,
+    ) -> QueryRequestAttempt<TestCandidateScanValue> {
+        self.runtime.request_registered(
+            &self.test_candidate_scans,
+            revision,
+            TestCandidateScanKey(identity),
+            CancellationToken::new(),
+        )
+    }
+}

--- a/crates/rue-compiler/src/revisioned_query_database/registrations.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations.rs
@@ -280,6 +280,12 @@ pub(crate) const REGISTRATION_MANIFEST: &[(&str, &str, &str, &str)] = &[
         include_str!("registrations/parse_import/parse.rs"),
     ),
     (
+        "parse_import",
+        concat!("compiler.", "test-candidate-scan"),
+        "register_parse_import_test_candidate_scans",
+        include_str!("registrations/parse_import/test_candidate_scans.rs"),
+    ),
+    (
         "body",
         concat!("compiler.", "body-fact-provider-probe"),
         "register_provider_probe",
@@ -883,6 +889,14 @@ impl RevisionedQueryDatabase {
         );
         let parse = register_parse_import_parse!(runtime);
         let parse_selection = parse.selection();
+        let test_candidate_store: Arc<Mutex<TestCandidateInputStore>> =
+            Arc::new(Mutex::new(TestCandidateInputStore {
+                next_stamp: 1,
+                ..TestCandidateInputStore::default()
+            }));
+        let test_candidate_store_for_scans = test_candidate_store.clone();
+        let test_candidate_scans =
+            register_parse_import_test_candidate_scans!(runtime, test_candidate_store_for_scans);
         Self {
             parse,
             parse_selection,
@@ -892,6 +906,7 @@ impl RevisionedQueryDatabase {
             source_stamps: VecDeque::new(),
             import_store,
             module_store,
+            test_candidate_store,
             cfg_collection_root,
             codegen_collection_root,
             publication_cone_retention_failures,
@@ -902,6 +917,7 @@ impl RevisionedQueryDatabase {
             declaration_body_plan_failure_injection,
             parse_modules,
             parse_module_batches,
+            test_candidate_scans,
             module_source_bases,
             module_indexes,
             declaration_occurrence_indexes,

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/parse_import.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/parse_import.rs
@@ -9,6 +9,7 @@ include!("parse_import/parse.rs");
 include!("parse_import/parse_module_batches.rs");
 include!("parse_import/parse_modules.rs");
 include!("parse_import/resolve_imports.rs");
+include!("parse_import/test_candidate_scans.rs");
 
 pub(super) use register_parse_import_declaration_imports;
 pub(super) use register_parse_import_declaration_occurrence_indexes;
@@ -21,3 +22,4 @@ pub(super) use register_parse_import_parse;
 pub(super) use register_parse_import_parse_module_batches;
 pub(super) use register_parse_import_parse_modules;
 pub(super) use register_parse_import_resolve_imports;
+pub(super) use register_parse_import_test_candidate_scans;

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/parse_import/test_candidate_scans.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/parse_import/test_candidate_scans.rs
@@ -1,0 +1,29 @@
+macro_rules! register_parse_import_test_candidate_scans {
+    ($runtime:ident, $test_candidate_store_for_scans:ident) => {{
+        $runtime
+            .family_with_equality_and_evaluator(
+                "compiler.test-candidate-scan",
+                MODULE_QUERY_MEMO_RETENTION,
+                test_candidate_scan_value_equal,
+                move |context, _, key: &TestCandidateScanKey| {
+                    // One declared input: this candidate's acquired bytes or
+                    // its typed absent/unreadable observation. Editing one
+                    // candidate therefore re-scans exactly that candidate.
+                    context.input(test_candidate_input(&key.0))?;
+                    let view =
+                        test_candidate_view(&$test_candidate_store_for_scans, context.revision())?;
+                    let leaf = view
+                        .leaves
+                        .get(&key.0.runtime_input_key())
+                        .ok_or(QueryAbort::Canceled)?;
+                    Ok(QueryOutput::success(TestCandidateScanValue(
+                        crate::test_candidates::scan_candidate_outcome(
+                            leaf.identity.path(),
+                            &leaf.outcome,
+                        ),
+                    )))
+                },
+            )
+            .expect("the TestCandidateScan family has one canonical name")
+    }};
+}

--- a/crates/rue-compiler/src/revisioned_query_database/shared.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/shared.rs
@@ -505,6 +505,10 @@ pub(crate) struct RevisionedQueryDatabase {
     pub(super) source_stamps: VecDeque<(crate::session::ExactSourceInput, u64)>,
     pub(super) import_store: Arc<Mutex<ImportInputStore>>,
     pub(super) module_store: Arc<Mutex<ModuleInputStore>>,
+    /// Declared test-candidate observations (ADR-0083 §1). Candidates are host
+    /// reads that never become modules, so they own an input store separate
+    /// from the module leaves the closure is built from.
+    pub(super) test_candidate_store: Arc<Mutex<TestCandidateInputStore>>,
     /// RUE-1576: the optimized-CFG and codegen collections' retained child
     /// cones, borrowed as fallback authority by the backend scopes that run
     /// after each within one rooted compile.
@@ -524,6 +528,9 @@ pub(crate) struct RevisionedQueryDatabase {
     pub(super) declaration_body_plan_failure_injection: DeclarationBodyPlanFailureInjection,
     pub(super) parse_modules: QueryFamily<ModuleQueryKey, ParseModuleValue>,
     pub(super) parse_module_batches: QueryFamily<ParseModuleBatchKey, ParseModuleBatchValue>,
+    /// Parse-only scan of one declared test candidate (ADR-0083 §1). It counts
+    /// `test` items and nothing else: no RIR, no semantics, no roots.
+    pub(super) test_candidate_scans: QueryFamily<TestCandidateScanKey, TestCandidateScanValue>,
     pub(super) module_source_bases:
         QueryFamily<ModuleQueryKey, Option<rue_air::DurableBodySourceLocator>>,
     pub(super) module_indexes: QueryFamily<ModuleQueryKey, ModuleIndexValue>,

--- a/crates/rue-compiler/src/session/program_artifacts.rs
+++ b/crates/rue-compiler/src/session/program_artifacts.rs
@@ -1049,6 +1049,114 @@ impl CompilerSession {
         self.refresh_retention_metrics();
         result
     }
+
+    /// Report the declared test candidates the request's module closure does
+    /// not contain (ADR-0083 §1).
+    ///
+    /// Discovery is the import closure, so a `parser_tests.rue` nothing imports
+    /// does not exist to any request — and forgetting the wiring produces
+    /// silence rather than a diagnostic. The declared candidate inventory is
+    /// what breaks that silence: every candidate outside the closure that
+    /// parses as containing test items, or that could not be parsed at all, is
+    /// reported here.
+    ///
+    /// Three properties are deliberate. Absent candidates are silent, because a
+    /// build target's `srcs` glob legitimately names files another root owns.
+    /// Candidates are never modules: scanning one publishes no module leaf,
+    /// joins no closure, and roots nothing. And the result is a report, not a
+    /// diagnostic — the caller decides whether this request wants the warning
+    /// (`rue test` does; an ordinary build does not).
+    ///
+    /// Closure membership is decided by comparing the candidate's normalized
+    /// logical path with each module's published identity as a string. A
+    /// candidate reached by the program under a different spelling than the
+    /// one the build declared — a symlink, or a path the resolver rewrote — is
+    /// therefore reported as unimported even though its file is in the closure.
+    /// Matching on canonical physical identity instead would need candidate
+    /// acquisition to return the canonical path; that is a small protocol
+    /// addition left for a real report of the false positive.
+    ///
+    /// The returned rows are ordered by path.
+    pub(crate) fn unimported_test_files(
+        &mut self,
+        candidates: &crate::TestCandidateInventory,
+    ) -> Result<Vec<crate::UnimportedTestFile>, CompileErrors> {
+        let committed = self.committed_import_discovery_artifact().ok_or_else(|| {
+            CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "reporting unimported test files requires a closed-valid import discovery revision"
+                    .into(),
+            )))
+        })?;
+        // An inventory acquired under one read regime cannot describe a closure
+        // discovered under another: the same spelling names a different file.
+        let context = committed.context();
+        if context.project_root() != candidates.project_root()
+            || context.std_root().unwrap_or("") != candidates.std_root().unwrap_or("")
+            || context.read_policy_revision() != candidates.read_policy_revision()
+        {
+            return Err(CompileErrors::from(CompileError::without_span(
+                ErrorKind::InvalidCompilerInput(
+                    "test candidates were declared under a different read policy than the \
+                     compiled closure"
+                        .into(),
+                ),
+            )));
+        }
+
+        let program = self
+            .published_owner()
+            .cloned()
+            .ok_or_else(no_published_program)?;
+        let closure = program
+            .modules()
+            .iter()
+            .map(|module| module.module_id().as_str().to_owned())
+            .collect::<std::collections::BTreeSet<_>>();
+
+        let revision = self
+            .queries
+            .revisioned
+            .publish_test_candidate_inputs(candidates)
+            .map_err(CompileErrors::from)?;
+
+        let mut reported = Vec::new();
+        for candidate in candidates.candidates() {
+            if closure.contains(candidate.path()) {
+                continue;
+            }
+            let attempt = self
+                .queries
+                .revisioned
+                .test_candidate_scan(revision, candidate.identity().clone());
+            let terminal = attempt.terminal().ok_or_else(|| {
+                CompileErrors::from(CompileError::without_span(ErrorKind::InternalError(
+                    format!(
+                        "test-candidate scan for '{}' published no terminal",
+                        candidate.path()
+                    ),
+                )))
+            })?;
+            let rue_query::QueryOutcome::Success(scan) = terminal.outcome() else {
+                return Err(CompileErrors::from(CompileError::without_span(
+                    ErrorKind::InternalError(format!(
+                        "test-candidate scan for '{}' failed",
+                        candidate.path()
+                    )),
+                )));
+            };
+            let scan = scan.0;
+            if scan.tests == 0 && !scan.parse_failed {
+                continue;
+            }
+            reported.push(crate::UnimportedTestFile {
+                path: candidate.path().to_owned(),
+                tests: scan.tests,
+                parse_failed: scan.parse_failed,
+            });
+        }
+        reported.sort();
+        Ok(reported)
+    }
 }
 
 fn programs_are_pointer_equivalent(left: &ParsedProgram, right: &ParsedProgram) -> bool {

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -6079,3 +6079,229 @@ fn cfg_transformation_oracle_fault_tolerates_a_test_request_without_main() {
     // acceptable as long as the request survives the missing `main`.
     let _ = session.rooted_cfg(&options);
 }
+
+// ---------------------------------------------------------------------------
+// Declared test candidates (ADR-0083 §1)
+// ---------------------------------------------------------------------------
+
+/// A committed two-module closure: `main.rue` imports `helper.rue`, and the
+/// helper is where the in-closure test declaration lives.
+fn committed_test_closure() -> CompilerSession {
+    let source = snapshot(
+        &[
+            (
+                1,
+                "/rue-fixture/main.rue",
+                "main.rue",
+                "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.value() }\n",
+            ),
+            (
+                2,
+                "/rue-fixture/helper.rue",
+                "helper.rue",
+                "pub fn value() -> i32 { 7 }\ntest \"helper answers\" { }\n",
+            ),
+        ],
+        1,
+    );
+    let mut session = CompilerSession::new();
+    publish_with_test_imports(&mut session, &source);
+    session
+}
+
+fn committed_candidate_inventory(session: &CompilerSession) -> crate::TestCandidateInventory {
+    let context = session
+        .committed_import_discovery_artifact()
+        .expect("the fixture commits a closed-valid discovery revision")
+        .context()
+        .clone();
+    crate::TestCandidateInventory::new(&context)
+}
+
+fn present(source: &str) -> crate::TestCandidateOutcome {
+    crate::TestCandidateOutcome::Present(Arc::from(source))
+}
+
+/// The whole point of the inventory: a declared file the closure never reached
+/// is reported when it declares tests, and a file the closure DID reach is not
+/// — its tests are already rooted by a test request.
+#[test]
+fn unimported_test_files_reports_only_declared_candidates_outside_the_closure() {
+    let mut session = committed_test_closure();
+    let mut candidates = committed_candidate_inventory(&session);
+    // In the closure, with a test: already discovered, so silent.
+    candidates
+        .declare(
+            "helper.rue",
+            present("pub fn value() -> i32 { 7 }\ntest \"helper answers\" { }\n"),
+        )
+        .unwrap();
+    // Outside the closure, with tests: the orphan the warning exists for.
+    candidates
+        .declare(
+            "orphan_tests.rue",
+            present("test \"a\" { }\ntest \"b\" { }\ntest \"c\" { }\n"),
+        )
+        .unwrap();
+    // Outside the closure, no tests: a plain unimported module is not this
+    // warning's business.
+    candidates
+        .declare("plain.rue", present("fn unused() -> i32 { 0 }\n"))
+        .unwrap();
+    // Declared but absent: a sibling target's glob entry, silent by design.
+    candidates
+        .declare("gone.rue", crate::TestCandidateOutcome::Absent)
+        .unwrap();
+
+    let reported = session.unimported_test_files(&candidates).unwrap();
+    assert_eq!(
+        reported,
+        vec![crate::UnimportedTestFile {
+            path: "orphan_tests.rue".to_owned(),
+            tests: 3,
+            parse_failed: false,
+        }]
+    );
+}
+
+/// A candidate that could not be read or parsed is reported with the count
+/// marked unknown rather than silently counted as zero.
+#[test]
+fn unreadable_and_unparsable_candidates_are_reported_and_ordered_by_path() {
+    let mut session = committed_test_closure();
+    let mut candidates = committed_candidate_inventory(&session);
+    candidates
+        .declare("z_orphan.rue", present("test \"z\" { }\n"))
+        .unwrap();
+    candidates
+        .declare("a_broken.rue", present("fn main( -> {\n"))
+        .unwrap();
+    candidates
+        .declare(
+            "m_denied.rue",
+            crate::TestCandidateOutcome::Unreadable(Arc::from("permission denied")),
+        )
+        .unwrap();
+
+    let reported = session.unimported_test_files(&candidates).unwrap();
+    assert_eq!(
+        reported,
+        vec![
+            crate::UnimportedTestFile {
+                path: "a_broken.rue".to_owned(),
+                tests: 0,
+                parse_failed: true,
+            },
+            crate::UnimportedTestFile {
+                path: "m_denied.rue".to_owned(),
+                tests: 0,
+                parse_failed: true,
+            },
+            crate::UnimportedTestFile {
+                path: "z_orphan.rue".to_owned(),
+                tests: 1,
+                parse_failed: false,
+            },
+        ]
+    );
+}
+
+/// An inventory acquired under a different read regime cannot describe this
+/// closure: the same spelling names a different file.
+#[test]
+fn candidates_declared_under_another_read_policy_are_refused() {
+    let mut session = committed_test_closure();
+    let foreign =
+        crate::ImportDiscoveryContext::new(1, "/rue-fixture", None, "a-different-source-manifest")
+            .unwrap();
+    let mut candidates = crate::TestCandidateInventory::new(&foreign);
+    candidates
+        .declare("orphan_tests.rue", present("test \"a\" { }\n"))
+        .unwrap();
+    let errors = session.unimported_test_files(&candidates).unwrap_err();
+    assert!(
+        errors.to_string().contains("different read policy"),
+        "{errors}"
+    );
+}
+
+/// The scan is revision-keyed: republishing an inventory in which exactly one
+/// candidate's bytes changed recomputes that candidate and reuses the rest.
+#[test]
+fn editing_one_candidate_rescans_only_that_candidate() {
+    let mut session = committed_test_closure();
+    let build = |session: &CompilerSession, edited: &str| {
+        let mut candidates = committed_candidate_inventory(session);
+        candidates.declare("edited.rue", present(edited)).unwrap();
+        candidates
+            .declare("stable.rue", present("test \"stable\" { }\n"))
+            .unwrap();
+        candidates
+    };
+
+    let first = build(&session, "test \"one\" { }\n");
+    let revision = session
+        .queries
+        .revisioned
+        .publish_test_candidate_inputs(&first)
+        .unwrap();
+    for candidate in first.candidates() {
+        assert_eq!(
+            session
+                .queries
+                .revisioned
+                .test_candidate_scan(revision, candidate.identity().clone())
+                .execution(),
+            rue_query::RequestExecution::Computed,
+            "the first inventory computes every scan"
+        );
+    }
+
+    let second = build(&session, "test \"one\" { }\ntest \"two\" { }\n");
+    let successor = session
+        .queries
+        .revisioned
+        .publish_test_candidate_inputs(&second)
+        .unwrap();
+    let executions = second
+        .candidates()
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.path().to_owned(),
+                session
+                    .queries
+                    .revisioned
+                    .test_candidate_scan(successor, candidate.identity().clone())
+                    .execution(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        executions,
+        vec![
+            (
+                "edited.rue".to_owned(),
+                rue_query::RequestExecution::Computed
+            ),
+            ("stable.rue".to_owned(), rue_query::RequestExecution::Reused),
+        ],
+        "only the edited candidate is rescanned"
+    );
+
+    assert_eq!(
+        session.unimported_test_files(&second).unwrap(),
+        vec![
+            crate::UnimportedTestFile {
+                path: "edited.rue".to_owned(),
+                tests: 2,
+                parse_failed: false,
+            },
+            crate::UnimportedTestFile {
+                path: "stable.rue".to_owned(),
+                tests: 1,
+                parse_failed: false,
+            },
+        ]
+    );
+}

--- a/crates/rue-compiler/src/test_candidates.rs
+++ b/crates/rue-compiler/src/test_candidates.rs
@@ -1,0 +1,510 @@
+//! Declared test-candidate inventory and the parse-only candidate scan
+//! (ADR-0083 §1, "discovery is the import closure").
+//!
+//! Discovery is the import closure, so a test-only file nothing imports does
+//! not exist to any request. The build system knows which files it declared —
+//! its `srcs` — and hands that set to the compiler as a *candidate inventory*
+//! (`--test-candidates`). A candidate is not a module: acquiring one never
+//! mints a [`ModuleId`](crate::ModuleId), never joins the module closure, and
+//! never creates a semantic root. It is a bounded host observation whose only
+//! consumer is the parse-only scan below.
+//!
+//! The acquisition contract mirrors import discovery exactly (ADR-0063 §2/§7):
+//! the host reads under the same read policy that governs imports and publishes
+//! each candidate's bytes — or a typed [`TestCandidateOutcome::Absent`] /
+//! [`TestCandidateOutcome::Unreadable`] observation — as a revisioned input
+//! leaf. Candidate reads are therefore recorded like any other host read and
+//! cannot become a second undeclared-read route.
+//!
+//! The scan itself is deliberately the smallest possible query: lex, parse,
+//! count `test` items. No RIR, no semantic analysis, no reachability. Its
+//! answer is `{ tests, parse_failed }` and nothing else.
+
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use crate::{CompileError, CompileResult, ErrorKind, ImportDiscoveryContext};
+
+/// What the host observed when it tried to acquire one declared candidate.
+///
+/// Missing, unreadable, and accepted stay distinguishable typed observations
+/// for the same reason import observations do (ADR-0063 §2.1): any transition
+/// between them must invalidate the dependent scan rather than be silently
+/// indistinguishable from "no tests here".
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TestCandidateOutcome {
+    /// The candidate was read and decoded as UTF-8 source text.
+    Present(Arc<str>),
+    /// The candidate does not exist. Absence is silent at the warning surface:
+    /// a build system may legitimately declare a file a sibling target owns.
+    Absent,
+    /// The candidate exists but could not be read or decoded, with the host's
+    /// reason retained for the diagnostic.
+    Unreadable(Arc<str>),
+}
+
+/// One declared candidate: its project-root-relative logical path plus the
+/// host's typed acquisition outcome.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TestCandidate {
+    identity: TestCandidateIdentity,
+    outcome: TestCandidateOutcome,
+}
+
+impl TestCandidate {
+    pub fn path(&self) -> &str {
+        self.identity.path()
+    }
+
+    pub fn outcome(&self) -> &TestCandidateOutcome {
+        &self.outcome
+    }
+
+    pub(crate) fn identity(&self) -> &TestCandidateIdentity {
+        &self.identity
+    }
+}
+
+/// Stable identity of one candidate observation.
+///
+/// The read regime travels with the path for the same reason it travels with
+/// an [`ImportDiscoveryRequest`](crate::ImportDiscoveryRequest): a candidate
+/// read observed under one project root, standard-library root, and read policy
+/// is not the same observation as a read of the same spelling under another.
+/// A regime change therefore mints new leaf identities instead of re-stamping
+/// the old ones.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct TestCandidateIdentity {
+    project_root: Arc<str>,
+    std_root: Arc<str>,
+    read_policy_revision: Arc<str>,
+    path: Arc<str>,
+}
+
+impl TestCandidateIdentity {
+    pub(crate) fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// The revisioned input key for this candidate, in the same length-prefixed
+    /// encoding `ImportDiscoveryRequest::runtime_input_key` uses so distinct
+    /// field boundaries cannot be forged by concatenation.
+    pub(crate) fn runtime_input_key(&self) -> Arc<str> {
+        use std::fmt::Write as _;
+
+        fn field(output: &mut String, value: &str) {
+            write!(output, "{}:{value}", value.len()).expect("string writes cannot fail");
+        }
+
+        let mut key = String::from("v1:");
+        field(&mut key, &self.project_root);
+        field(&mut key, &self.std_root);
+        field(&mut key, &self.read_policy_revision);
+        field(&mut key, &self.path);
+        key.into()
+    }
+}
+
+/// The declared candidate set for one request, together with the read regime it
+/// was acquired under.
+///
+/// Construction takes the request's [`ImportDiscoveryContext`] so the inventory
+/// cannot be assembled against a different read policy than the compile it is
+/// reported against.
+#[derive(Debug, Clone)]
+pub struct TestCandidateInventory {
+    project_root: Arc<str>,
+    std_root: Arc<str>,
+    read_policy_revision: Arc<str>,
+    candidates: Vec<TestCandidate>,
+}
+
+impl TestCandidateInventory {
+    /// Begin an inventory for the read regime `context` describes.
+    pub fn new(context: &ImportDiscoveryContext) -> Self {
+        Self {
+            project_root: Arc::from(context.project_root()),
+            std_root: Arc::from(context.std_root().unwrap_or("")),
+            read_policy_revision: Arc::from(context.read_policy_revision()),
+            candidates: Vec::new(),
+        }
+    }
+
+    /// Record one declared candidate's acquisition outcome.
+    ///
+    /// `path` is the project-root-relative spelling the build system declared.
+    /// It is normalized lexically to the logical path a module of that file
+    /// would carry, so closure membership can be decided by comparing strings
+    /// against published module identities.
+    ///
+    /// Declaring the same candidate twice keeps the first outcome: the
+    /// inventory is a set, and a repeated `srcs` entry is not two observations.
+    pub fn declare(
+        &mut self,
+        path: &str,
+        outcome: TestCandidateOutcome,
+    ) -> CompileResult<&TestCandidate> {
+        let normalized = self.normalize_candidate_path(path)?;
+        let identity = TestCandidateIdentity {
+            project_root: self.project_root.clone(),
+            std_root: self.std_root.clone(),
+            read_policy_revision: self.read_policy_revision.clone(),
+            path: normalized,
+        };
+        let index = match self
+            .candidates
+            .binary_search_by(|candidate| candidate.identity.cmp(&identity))
+        {
+            Ok(index) => index,
+            Err(index) => {
+                self.candidates
+                    .insert(index, TestCandidate { identity, outcome });
+                index
+            }
+        };
+        Ok(&self.candidates[index])
+    }
+
+    /// The declared candidates, ordered by logical path.
+    pub fn candidates(&self) -> &[TestCandidate] {
+        &self.candidates
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.candidates.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.candidates.len()
+    }
+
+    pub(crate) fn project_root(&self) -> &str {
+        &self.project_root
+    }
+
+    pub(crate) fn std_root(&self) -> Option<&str> {
+        (!self.std_root.is_empty()).then_some(&self.std_root)
+    }
+
+    pub(crate) fn read_policy_revision(&self) -> &str {
+        &self.read_policy_revision
+    }
+
+    /// Compatibility token for the candidate input namespace.
+    ///
+    /// Candidate leaves are published in their own revision namespace, keyed by
+    /// the same regime fields import discovery uses under a distinct domain tag.
+    /// Keeping the namespaces separate is what lets a candidate scan be
+    /// requested without perturbing the import namespace's certificate lineage:
+    /// candidate acquisition is an addition to the request, not a new
+    /// observation of the program's sources.
+    pub(crate) fn regime_token(&self) -> u64 {
+        use sha2::{Digest, Sha256};
+
+        let mut digest = Sha256::new();
+        let mut field = |bytes: &[u8]| {
+            digest.update((bytes.len() as u64).to_le_bytes());
+            digest.update(bytes);
+        };
+        field(b"rue-test-candidate-regime-v1");
+        field(self.project_root.as_bytes());
+        field(self.std_root.as_bytes());
+        field(self.read_policy_revision.as_bytes());
+        let bytes = digest.finalize();
+        u64::from_le_bytes(bytes[..8].try_into().expect("sha256 yields 32 bytes"))
+    }
+
+    /// Reduce a declared spelling to the logical path a module of that file
+    /// would carry, rejecting anything that cannot be a user module.
+    ///
+    /// Standard-library files are never candidates: the inventory exists to
+    /// find *unwired project files*, and std is reached through the toolchain
+    /// facade rather than through a build target's `srcs`.
+    fn normalize_candidate_path(&self, path: &str) -> CompileResult<Arc<str>> {
+        let trimmed = path.trim();
+        if trimmed.is_empty() {
+            return Err(invalid_candidate("a test candidate path cannot be empty"));
+        }
+        let project_root = Path::new(self.project_root.as_ref());
+        let requested = Path::new(trimmed);
+        let relative = if requested.is_absolute() {
+            requested.strip_prefix(project_root).map_err(|_| {
+                invalid_candidate(format!(
+                    "test candidate '{trimmed}' is outside the project root '{}'",
+                    self.project_root
+                ))
+            })?
+        } else {
+            requested
+        };
+        let normalized = normalize_relative(relative).ok_or_else(|| {
+            invalid_candidate(format!(
+                "test candidate '{trimmed}' escapes the project root '{}'",
+                self.project_root
+            ))
+        })?;
+        if let Some(std_root) = self.std_root() {
+            let absolute = project_root.join(&normalized);
+            if absolute.starts_with(Path::new(std_root)) {
+                return Err(invalid_candidate(format!(
+                    "test candidate '{trimmed}' resolves inside the standard-library root '{std_root}'; \
+                     standard-library files are never test candidates"
+                )));
+            }
+        }
+        let Some(normalized) = normalized.to_str() else {
+            return Err(invalid_candidate(format!(
+                "test candidate '{trimmed}' is not valid UTF-8"
+            )));
+        };
+        Ok(Arc::from(normalized))
+    }
+}
+
+/// One declared candidate the request's module closure does not contain, and
+/// which is worth telling the user about (ADR-0083 §1).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnimportedTestFile {
+    /// The candidate's project-root-relative logical path.
+    pub path: String,
+    /// Test declarations counted in the candidate.
+    pub tests: u32,
+    /// The candidate could not be read or parsed, so `tests` is not a count of
+    /// anything and the report says only that the answer is unknown.
+    pub parse_failed: bool,
+}
+
+/// The `compiler.test-candidate-scan` answer for one candidate revision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct TestCandidateScan {
+    pub(crate) tests: u32,
+    pub(crate) parse_failed: bool,
+}
+
+/// Count the test items one candidate's bytes declare.
+///
+/// Lex and parse only. A candidate that does not lex or parse reports
+/// `parse_failed` rather than a count: the file may or may not declare tests,
+/// and guessing either way would be worse than saying so.
+pub(crate) fn scan_candidate_outcome(
+    path: &str,
+    outcome: &TestCandidateOutcome,
+) -> TestCandidateScan {
+    let source = match outcome {
+        TestCandidateOutcome::Present(source) => source,
+        // Absence is not a failure; there is nothing to report about a file the
+        // host proved is not there.
+        TestCandidateOutcome::Absent => return TestCandidateScan::default(),
+        // An unreadable candidate is exactly as opaque as an unparsable one.
+        TestCandidateOutcome::Unreadable(_) => {
+            return TestCandidateScan {
+                tests: 0,
+                parse_failed: true,
+            };
+        }
+    };
+    let view = crate::queries::SourceView::new(path, source, rue_span::FileId::DEFAULT);
+    let outcome = crate::syntax::parse_file(view, lasso::ThreadedRodeo::new());
+    let Ok(ast) = outcome.result else {
+        return TestCandidateScan {
+            tests: 0,
+            parse_failed: true,
+        };
+    };
+    let tests = ast
+        .items
+        .iter()
+        .filter(|item| matches!(item, rue_parser::Item::Test(_)))
+        .count();
+    TestCandidateScan {
+        tests: u32::try_from(tests).unwrap_or(u32::MAX),
+        parse_failed: false,
+    }
+}
+
+/// Lexically reduce a relative path, refusing one that escapes its anchor.
+///
+/// This is a pure string reduction, deliberately: the candidate may not exist,
+/// and probing the filesystem to normalize it would be a read outside the
+/// declared policy.
+fn normalize_relative(path: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    (!normalized.as_os_str().is_empty()).then_some(normalized)
+}
+
+fn invalid_candidate(message: impl Into<String>) -> CompileError {
+    CompileError::without_span(ErrorKind::InvalidCompilerInput(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context(std_root: Option<&str>) -> ImportDiscoveryContext {
+        ImportDiscoveryContext::new(1, "/rue-fixture", std_root, "test-candidate-policy").unwrap()
+    }
+
+    fn inventory(std_root: Option<&str>) -> TestCandidateInventory {
+        TestCandidateInventory::new(&context(std_root))
+    }
+
+    fn present(source: &str) -> TestCandidateOutcome {
+        TestCandidateOutcome::Present(Arc::from(source))
+    }
+
+    #[test]
+    fn declared_paths_reduce_to_the_logical_path_a_module_would_carry() {
+        let mut candidates = inventory(None);
+        candidates
+            .declare("./app/./parser_tests.rue", present(""))
+            .unwrap();
+        candidates
+            .declare("/rue-fixture/app/other/../main.rue", present(""))
+            .unwrap();
+        assert_eq!(
+            candidates
+                .candidates()
+                .iter()
+                .map(TestCandidate::path)
+                .collect::<Vec<_>>(),
+            ["app/main.rue", "app/parser_tests.rue"]
+        );
+    }
+
+    /// A repeated `srcs` entry is one declared candidate, not two observations.
+    #[test]
+    fn declaring_the_same_candidate_twice_keeps_one_entry() {
+        let mut candidates = inventory(None);
+        candidates.declare("app/a.rue", present("")).unwrap();
+        candidates
+            .declare("./app/a.rue", present("fn f() {}"))
+            .unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates.candidates()[0].outcome(), &present(""));
+    }
+
+    /// Standard-library files are reached through the toolchain facade, never
+    /// through a build target's `srcs`. Accepting one as a candidate would make
+    /// the inventory report on files no project owns.
+    #[test]
+    fn standard_library_paths_are_refused() {
+        let mut candidates = inventory(Some("/rue-fixture/std"));
+        let error = candidates
+            .declare("std/option.rue", present(""))
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("standard-library root"),
+            "{error}"
+        );
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn paths_outside_the_project_root_are_refused() {
+        let mut candidates = inventory(None);
+        assert!(
+            candidates
+                .declare("../elsewhere/a.rue", present(""))
+                .is_err()
+        );
+        assert!(
+            candidates
+                .declare("/somewhere/else/a.rue", present(""))
+                .is_err()
+        );
+        assert!(candidates.declare("   ", present("")).is_err());
+        assert!(candidates.is_empty());
+    }
+
+    /// A candidate observed under one read regime is not the same observation
+    /// as the same spelling under another, so its input key differs.
+    #[test]
+    fn the_read_regime_travels_with_the_candidate_key() {
+        let mut open = inventory(None);
+        let mut sandboxed = TestCandidateInventory::new(
+            &ImportDiscoveryContext::new(1, "/rue-fixture", None, "manifest-abc").unwrap(),
+        );
+        open.declare("app/a.rue", present("")).unwrap();
+        sandboxed.declare("app/a.rue", present("")).unwrap();
+        assert_ne!(
+            open.candidates()[0].identity().runtime_input_key(),
+            sandboxed.candidates()[0].identity().runtime_input_key()
+        );
+        assert_ne!(open.regime_token(), sandboxed.regime_token());
+    }
+
+    #[test]
+    fn the_scan_counts_test_items_and_nothing_else() {
+        let scan = scan_candidate_outcome(
+            "app/parser_tests.rue",
+            &present(
+                "fn helper() -> i32 { 1 }\n\
+                 test \"first\" { }\n\
+                 test \"second\" { }\n",
+            ),
+        );
+        assert_eq!(
+            scan,
+            TestCandidateScan {
+                tests: 2,
+                parse_failed: false
+            }
+        );
+    }
+
+    #[test]
+    fn a_candidate_without_tests_scans_to_zero() {
+        let scan = scan_candidate_outcome("app/plain.rue", &present("fn main() -> i32 { 0 }\n"));
+        assert_eq!(
+            scan,
+            TestCandidateScan {
+                tests: 0,
+                parse_failed: false
+            }
+        );
+    }
+
+    /// An unparsable candidate reports that the answer is unknown rather than
+    /// guessing a count in either direction.
+    #[test]
+    fn an_unparsable_candidate_reports_parse_failure() {
+        let scan = scan_candidate_outcome("app/broken.rue", &present("fn main( -> { \n"));
+        assert!(scan.parse_failed);
+        assert_eq!(scan.tests, 0);
+    }
+
+    /// An unreadable candidate is exactly as opaque as an unparsable one; an
+    /// absent one is not a failure at all.
+    #[test]
+    fn absent_and_unreadable_outcomes_are_distinguishable() {
+        assert_eq!(
+            scan_candidate_outcome("app/gone.rue", &TestCandidateOutcome::Absent),
+            TestCandidateScan {
+                tests: 0,
+                parse_failed: false
+            }
+        );
+        assert_eq!(
+            scan_candidate_outcome(
+                "app/denied.rue",
+                &TestCandidateOutcome::Unreadable(Arc::from("permission denied"))
+            ),
+            TestCandidateScan {
+                tests: 0,
+                parse_failed: true
+            }
+        );
+    }
+}

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -19,6 +19,9 @@ pub use crate::import_discovery::{
     ImportDemandRoots, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave,
     ImportInputRevision, ImportObservation, ImportObservationLedger, ImportObservationStatus,
 };
+pub use crate::test_candidates::{
+    TestCandidate, TestCandidateInventory, TestCandidateOutcome, UnimportedTestFile,
+};
 pub use crate::warm_fresh_parity::ParityObservation;
 /// A diagnostic's source location, as the diagnostic types already hand it out.
 ///
@@ -664,6 +667,33 @@ pub fn oracle_executable(
     options: &crate::CompileOptions,
 ) -> crate::MultiErrorResult<crate::CompileOutput> {
     session.oracle_executable(snapshot, options)
+}
+
+/// Report the declared test candidates the compiled closure does not contain
+/// (ADR-0083 §1).
+///
+/// The build system declares which files a target owns; the compiler discovers
+/// which of them the root actually imports. A candidate outside that closure
+/// that declares tests is a file whose tests nothing will ever run, and the
+/// only way to notice is to look. Candidates whose bytes could not be read or
+/// parsed are reported the same way, with `parse_failed` set: the honest answer
+/// is that the count is unknown.
+///
+/// A candidate the host observed absent is silent — sibling build targets share
+/// `srcs` globs, so an unread declared file is routinely another root's tree.
+///
+/// This is a report, not a diagnostic: `rue test` renders it as the
+/// unimported-test-file warning, and an ordinary build ignores it.
+///
+/// Membership in the closure is by normalized logical path, so a file the
+/// program reaches under a different spelling than the build declared (a
+/// symlink, for instance) is reported as unimported; see the session method
+/// for the trade-off.
+pub fn unimported_test_files(
+    session: &mut crate::CompilerSession,
+    candidates: &crate::TestCandidateInventory,
+) -> Result<Vec<crate::UnimportedTestFile>, crate::CompileErrors> {
+    session.unimported_test_files(candidates)
 }
 
 /// Produce an executable inside a compile span owned by the filesystem

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -3600,6 +3600,22 @@ pub enum WarningKind {
     /// A lookup's fallback sentinel is compared with the same sentinel to test absence.
     #[error("integer sentinel used to test lookup absence")]
     SentinelLookup,
+    /// A declared test candidate outside the request's module closure declares
+    /// test items, so nothing roots them (ADR-0083 §1).
+    ///
+    /// This is a request-level warning with no source site: the file is not in
+    /// the closure, so the compiler holds no span inside it. It is never an
+    /// error — sibling build targets legitimately share a `srcs` glob, so an
+    /// unread candidate may belong to another root's tree.
+    #[error(
+        "test file '{path}' declares {tests} test{plural} but no module in the compiled closure imports it",
+        plural = if *tests == 1 { "" } else { "s" }
+    )]
+    UnimportedTestFile { path: String, tests: u32 },
+    /// A declared test candidate outside the request's module closure could not
+    /// be read or parsed, so whether it declares tests is unknown (ADR-0083 §1).
+    #[error("test file '{path}' is outside the compiled closure and could not be parsed")]
+    UnimportedTestFileUnparsable { path: String },
 }
 
 /// A compilation warning with optional source location information.

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -1,12 +1,13 @@
 use std::path::Path;
 
+use rue_compiler::unstable::TestCandidateInventory;
 use rue_compiler::unstable::{
     CancellableCompileOutcome, CodegenReady, CompilationCancellation, ObjectsReady,
     PresentationOutput, PresentationRequest, cancellable_executable_in_compile_scope,
     codegen_ready, executable_in_compile_scope, objects_ready, runnable_ready,
 };
 use rue_compiler::{
-    AcceptedReadManifest, CompileOptions, CompileOutput, ImportDiscoveryContext,
+    AcceptedReadManifest, CompileErrors, CompileOptions, CompileOutput, ImportDiscoveryContext,
     ImportDiscoveryStatus, ImportDiscoveryView, MultiErrorResult, RirView, SourceSnapshot,
 };
 
@@ -107,6 +108,40 @@ impl FilesystemCompilerHost {
 
     pub fn discovery_context(&self) -> &ImportDiscoveryContext {
         &self.state.resolution.context
+    }
+
+    /// Acquire the declared test-candidate inventory (ADR-0083 §1) under this
+    /// host's read policy.
+    ///
+    /// `declared` is the build system's `srcs` list as `--test-candidates`
+    /// spelled it: project-root-relative paths. Each is resolved against the
+    /// project root and observed the way an import candidate is observed —
+    /// with a `--source-manifest`, an undeclared spelling or a disallowed
+    /// canonical file is `Unreadable` rather than a filesystem read; a missing
+    /// file is `Absent`; an I/O or UTF-8 failure is `Unreadable` with its
+    /// reason. The inventory is built from this host's own discovery context,
+    /// so it can never be reported against a closure acquired under another
+    /// read regime.
+    ///
+    /// Candidate reads are deliberately not added to the accepted-read
+    /// manifest: they are not inputs of the program being built and must not
+    /// appear in `--emit deps` or the watch closure. The compiler publishes them
+    /// as their own revisioned input leaves when a request reports against the
+    /// inventory (`rue_compiler::unstable::unimported_test_files`).
+    pub fn acquire_test_candidates(
+        &self,
+        declared: &[String],
+    ) -> Result<TestCandidateInventory, CompileErrors> {
+        let context = self.discovery_context();
+        let project_root = Path::new(context.project_root());
+        let mut inventory = TestCandidateInventory::new(context);
+        for path in declared {
+            let outcome = self.state.read_test_candidate(&project_root.join(path));
+            inventory
+                .declare(path, outcome)
+                .map_err(CompileErrors::from)?;
+        }
+        Ok(inventory)
     }
 
     /// Return owned unstable instrumentation without exposing the retained
@@ -372,5 +407,141 @@ mod tests {
             host.cancellable_executable_in_compile_scope(&CompileOptions::default(), cancellation,),
             CancellableCompileOutcome::Canceled
         ));
+    }
+}
+
+#[cfg(test)]
+mod test_candidate_acquisition_tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use rue_compiler::unstable::TestCandidateOutcome;
+
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("rue-{name}-{}-{unique}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Acquisition observes each declared candidate under the host's read
+    /// policy, and the compiler reports exactly the unwired ones (ADR-0083 §1).
+    ///
+    /// Under a `--source-manifest` the policy order is the import loader's: a
+    /// spelling the manifest does not declare is denied before the filesystem
+    /// is probed, so an undeclared candidate is `Unreadable` whether or not a
+    /// file exists there — and, being unreadable, it is reported. Without a
+    /// manifest a missing file is observed `Absent` and stays silent. The root
+    /// itself is in the closure and is never reported.
+    #[test]
+    fn acquires_declared_candidates_under_the_read_policy_and_reports_orphans() {
+        let dir = scratch("test-candidate-acquisition");
+        let write = |name: &str, text: &str| {
+            fs::write(dir.join(name), text).unwrap();
+        };
+        write("main.rue", "fn main() -> i32 { 0 }\n");
+        write("orphan_tests.rue", "test \"nothing imports this\" { }\n");
+        write(
+            "excluded_tests.rue",
+            "test \"the manifest omits this\" { }\n",
+        );
+        write("sources.manifest", "main.rue\norphan_tests.rue\n");
+        let root = dir.join("main.rue");
+        let declared = [
+            "main.rue".to_owned(),
+            "orphan_tests.rue".to_owned(),
+            "excluded_tests.rue".to_owned(),
+            "absent_tests.rue".to_owned(),
+        ];
+        let outcome_of = |inventory: &TestCandidateInventory, path: &str| {
+            inventory
+                .candidates()
+                .iter()
+                .find(|candidate| candidate.path() == path)
+                .map(|candidate| candidate.outcome().clone())
+        };
+        let rows_of = |report: &[rue_compiler::unstable::UnimportedTestFile]| {
+            report
+                .iter()
+                .map(|row| (row.path.clone(), row.tests, row.parse_failed))
+                .collect::<Vec<_>>()
+        };
+
+        // With a manifest: declared files read, undeclared ones denied unprobed.
+        let manifest = dir.join("sources.manifest");
+        let mut host = FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: root.to_str().unwrap(),
+            source_manifest_path: Some(manifest.to_str().unwrap()),
+            std_root: None,
+        })
+        .unwrap();
+        let inventory = host.acquire_test_candidates(&declared).unwrap();
+        assert!(matches!(
+            outcome_of(&inventory, "main.rue"),
+            Some(TestCandidateOutcome::Present(_))
+        ));
+        assert!(matches!(
+            outcome_of(&inventory, "orphan_tests.rue"),
+            Some(TestCandidateOutcome::Present(_))
+        ));
+        for denied in ["excluded_tests.rue", "absent_tests.rue"] {
+            assert!(
+                matches!(
+                    outcome_of(&inventory, denied),
+                    Some(TestCandidateOutcome::Unreadable(ref reason)) if reason.contains("source manifest")
+                ),
+                "{denied}: a candidate the manifest omits is denied, not probed: {:?}",
+                outcome_of(&inventory, denied)
+            );
+        }
+        // Candidate reads never join the accepted-read manifest.
+        assert!(
+            !host
+                .accepted_reads()
+                .iter()
+                .any(|entry| entry.requested_path().ends_with("orphan_tests.rue")),
+            "candidate acquisition must not record an accepted source read"
+        );
+        let report =
+            rue_compiler::unstable::unimported_test_files(&mut host.state.session, &inventory)
+                .unwrap();
+        assert_eq!(
+            rows_of(&report),
+            vec![
+                ("absent_tests.rue".to_owned(), 0, true),
+                ("excluded_tests.rue".to_owned(), 0, true),
+                ("orphan_tests.rue".to_owned(), 1, false),
+            ]
+        );
+
+        // Without a manifest: a missing file is observed absent and stays silent.
+        let mut host = FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: root.to_str().unwrap(),
+            source_manifest_path: None,
+            std_root: None,
+        })
+        .unwrap();
+        let inventory = host
+            .acquire_test_candidates(&[
+                "orphan_tests.rue".to_owned(),
+                "absent_tests.rue".to_owned(),
+            ])
+            .unwrap();
+        assert!(matches!(
+            outcome_of(&inventory, "absent_tests.rue"),
+            Some(TestCandidateOutcome::Absent)
+        ));
+        let report =
+            rue_compiler::unstable::unimported_test_files(&mut host.state.session, &inventory)
+                .unwrap();
+        assert_eq!(
+            rows_of(&report),
+            vec![("orphan_tests.rue".to_owned(), 1, false)]
+        );
     }
 }

--- a/crates/rue/src/lib.rs
+++ b/crates/rue/src/lib.rs
@@ -7,9 +7,11 @@
 
 mod host;
 mod source_loader;
+mod test_candidates;
 
 pub use host::{FilesystemCompilerHost, HostOpenRequest};
 pub use source_loader::{
     HermeticDenialError, SourceLoadError, ToolchainIntegrityError, WatchFingerprint, WatchInput,
     watch_input_fingerprints, watch_inputs_changed, watch_inputs_changed_with_reader,
 };
+pub use test_candidates::load_declared_candidates;

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -203,6 +203,11 @@ struct Options {
     /// Optional build-system-facing manifest of source files the compiler may
     /// read while resolving the root module's import graph.
     source_manifest_path: Option<String>,
+    /// Optional build-system-facing list of files a target declared, used to
+    /// report test files nothing imports (ADR-0083 §1). Declaring a candidate
+    /// grants no read of it as a source: candidates never join the module
+    /// closure, and `--source-manifest` remains the sole source read policy.
+    test_candidates_path: Option<String>,
     output_path: String,
     emit_stages: Vec<EmitStage>,
     target: Target,
@@ -259,6 +264,10 @@ Options:
   -o, --output <path>  Set output path
   --source-manifest <path>
                        Restrict source imports to a line-oriented manifest
+  --test-candidates <path>
+                       Declare the files a build target owns, one project-root-
+                       relative path per line, so test files nothing imports can
+                       be reported (ADR-0083); never a source read policy
   --link-archive <path>
                        Link a static archive (.a) resolving extern \"C\" symbols
                        (ADR-0064 C FFI); can be repeated
@@ -384,6 +393,32 @@ fn refuse_extra_positional_sources(positional: &[String]) {
     );
 }
 
+/// Options that consume the argument after them.
+///
+/// Anything scanning the command line without `parse_args_from`'s own state —
+/// a later subcommand scan, argument classification, a shell completion — has
+/// to skip a value-taking option's value, or `rue --preview x prog.rue` reads
+/// `x` as a word of its own. This is that inventory, kept beside the arms that
+/// consume those values; a unit test holds it, the parser, and the help text in
+/// agreement.
+#[cfg(test)]
+const VALUE_TAKING_OPTIONS: &[&str] = &[
+    "--emit",
+    "--target",
+    "--linker",
+    "--preview",
+    "--log-level",
+    "--log-format",
+    "--error-format",
+    "--jobs",
+    "-j",
+    "-o",
+    "--output",
+    "--source-manifest",
+    "--link-archive",
+    "--test-candidates",
+];
+
 /// Parse arguments from a slice of strings (for testing).
 fn parse_args_from(args: &[&str]) -> ParseResult {
     if args.is_empty() {
@@ -424,6 +459,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     let mut watch = false;
     let mut jobs: Option<usize> = None;
     let mut source_manifest_path: Option<String> = None;
+    let mut test_candidates_path: Option<String> = None;
     let mut output_path: Option<String> = None;
     let mut link_archives: Vec<std::path::PathBuf> = Vec::new();
     let mut positional = Vec::new();
@@ -557,6 +593,21 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
                     return ParseResult::Error;
                 };
                 source_manifest_path = Some(path.to_string());
+            }
+            "--test-candidates" => {
+                let Some(path) = args_iter.next() else {
+                    eprintln!("Error: --test-candidates requires a path");
+                    return ParseResult::Error;
+                };
+                // Unlike the repeatable flags, a second list is refused rather
+                // than silently winning: two declared candidate sets describe
+                // two different build targets, and quietly reporting against
+                // one of them would be worse than saying so.
+                if test_candidates_path.is_some() {
+                    eprintln!("Error: --test-candidates may be given at most once");
+                    return ParseResult::Error;
+                }
+                test_candidates_path = Some(path.to_string());
             }
             "--link-archive" => {
                 let Some(path) = args_iter.next() else {
@@ -700,6 +751,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     ParseResult::Options(Box::new(Options {
         source_path,
         source_manifest_path,
+        test_candidates_path,
         output_path: final_output_path,
         emit_stages,
         target: final_target,
@@ -1974,6 +2026,29 @@ fn main() {
         options.benchmark_json,
     );
 
+    // A declared candidate list is accepted in every mode and read in every
+    // mode, so a build rule that writes a broken list fails the build it broke
+    // rather than only the `rue test` invocation that would have consumed it.
+    // Reporting against the list is `rue test`'s job (ADR-0083 §1); an ordinary
+    // build validates the input and carries it no further.
+    let declared_test_candidates = match options.test_candidates_path.as_deref() {
+        Some(path) => match rue_driver::load_declared_candidates(path) {
+            Ok(candidates) => {
+                tracing::debug!(
+                    path,
+                    declared_candidates = candidates.len(),
+                    "test candidate inventory declared"
+                );
+                Some(candidates)
+            }
+            Err(message) => {
+                eprintln!("{message}");
+                std::process::exit(1);
+            }
+        },
+        None => None,
+    };
+
     // Configure the compiler's shared structured-query budget before
     // dispatching to either the `--emit` path or the normal compile path, so
     // every driver path honors `-j`/`--jobs` (RUE-352).
@@ -2075,6 +2150,28 @@ fn main() {
         .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
         .collect();
     let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
+
+    // Acquire the declared inventory under the host's read policy so a test
+    // request can report against it (ADR-0083 §1). An ordinary build never
+    // reports; `rue test` (RUE-1920) is the consumer, and until it exists the
+    // acquisition is exercised here so a broken candidate path fails loudly
+    // rather than surfacing first inside the runner.
+    let _test_candidate_inventory = match declared_test_candidates.as_deref() {
+        Some(declared) => match compiler_host.acquire_test_candidates(declared) {
+            Ok(inventory) => {
+                tracing::debug!(
+                    acquired_candidates = inventory.len(),
+                    "test candidate inventory acquired"
+                );
+                Some(inventory)
+            }
+            Err(errors) => {
+                diagnostics.print_errors(&errors);
+                std::process::exit(1);
+            }
+        },
+        None => None,
+    };
 
     // Output-mode compatibility (including `--emit` + `--benchmark-json`) was
     // already validated before any I/O by `emit::validate_output_modes` (RUE-798).
@@ -2844,6 +2941,72 @@ mod tests {
             "source.rue",
             "--source-manifest",
         ])));
+    }
+
+    #[test]
+    fn parse_test_candidates() {
+        let opts = unwrap_options(parse_args_from(&[
+            "--test-candidates",
+            "test-candidates.list",
+            "source.rue",
+        ]));
+        assert_eq!(opts.source_path, "source.rue");
+        assert_eq!(
+            opts.test_candidates_path.as_deref(),
+            Some("test-candidates.list")
+        );
+    }
+
+    #[test]
+    fn parse_test_candidates_missing_value() {
+        assert!(is_error(&parse_args_from(&[
+            "source.rue",
+            "--test-candidates"
+        ])));
+    }
+
+    /// Two declared candidate sets describe two build targets. Last-wins would
+    /// silently report against one of them, so a repeat is refused.
+    #[test]
+    fn parse_test_candidates_rejects_a_repeat() {
+        assert!(is_error(&parse_args_from(&[
+            "--test-candidates",
+            "one.list",
+            "--test-candidates",
+            "two.list",
+            "source.rue",
+        ])));
+    }
+
+    /// A candidate list is inert outside test mode: it neither becomes a source
+    /// nor changes the compiled root or output.
+    #[test]
+    fn parse_test_candidates_leaves_the_rest_of_the_request_alone() {
+        let opts = unwrap_options(parse_args_from(&[
+            "--test-candidates",
+            "test-candidates.list",
+            "-o",
+            "prog",
+            "source.rue",
+        ]));
+        assert_eq!(opts.source_path, "source.rue");
+        assert_eq!(opts.output_path, "prog");
+        assert!(opts.emit_stages.is_empty());
+    }
+
+    #[test]
+    fn every_value_taking_option_is_documented_and_demands_a_value() {
+        let help = usage_text();
+        for option in VALUE_TAKING_OPTIONS {
+            assert!(
+                help.contains(option),
+                "value-taking option {option} is missing from the help text"
+            );
+            assert!(
+                is_error(&parse_args_from(&["source.rue", option])),
+                "value-taking option {option} accepted a missing value"
+            );
+        }
     }
 
     #[test]

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
 use ahash::{AHashMap, AHashSet};
+use rue_compiler::unstable::TestCandidateOutcome;
 use rue_compiler::unstable::{
     AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
     ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave, ImportInputRevision,
@@ -280,7 +281,7 @@ impl SourceManifest {
         self.allowed.contains(canonical)
     }
 
-    fn declares_path_without_probe(&self, path: &Path) -> bool {
+    pub(crate) fn declares_path_without_probe(&self, path: &Path) -> bool {
         self.declared_paths.contains(&normalize_lexical_path(path))
     }
 
@@ -951,6 +952,46 @@ pub(crate) struct SourceResolutionInputs {
 }
 
 impl ImportDiscoveryResult {
+    /// Observe one declared test candidate (ADR-0083 §1) under exactly the
+    /// read policy an import read obeys, without recording it as an accepted
+    /// read.
+    ///
+    /// The decision order mirrors `execute_import_request_uncancelled`: a
+    /// `--source-manifest` that does not declare the spelling denies the read
+    /// before the filesystem is touched; a missing file is `Absent`; a
+    /// canonical file the manifest does not allow, a non-file, an I/O failure,
+    /// or invalid UTF-8 is `Unreadable` with the reason. Nothing here joins the
+    /// accepted-read manifest or the watch closure: a candidate is not an input
+    /// of the program being built, so it must not appear in `--emit deps`, and
+    /// the compiler publishes it as its own revisioned input leaf instead.
+    pub(crate) fn read_test_candidate(&self, requested: &Path) -> TestCandidateOutcome {
+        let manifest = self.source_manifest.as_ref();
+        if manifest.is_some_and(|manifest| !manifest.declares_path_without_probe(requested)) {
+            return TestCandidateOutcome::Unreadable(Arc::from("outside the source manifest"));
+        }
+        match fs::canonicalize(requested) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                TestCandidateOutcome::Absent
+            }
+            Err(error) => TestCandidateOutcome::Unreadable(Arc::from(error.to_string())),
+            Ok(canonical)
+                if manifest.is_some_and(|manifest| !manifest.allows_canonical(&canonical)) =>
+            {
+                TestCandidateOutcome::Unreadable(Arc::from("outside the source manifest"))
+            }
+            Ok(canonical) if !canonical.is_file() => {
+                TestCandidateOutcome::Unreadable(Arc::from("not a regular file"))
+            }
+            Ok(canonical) => match fs::read(&canonical) {
+                Err(error) => TestCandidateOutcome::Unreadable(Arc::from(error.to_string())),
+                Ok(bytes) => match String::from_utf8(bytes) {
+                    Ok(text) => TestCandidateOutcome::Present(Arc::from(text)),
+                    Err(error) => TestCandidateOutcome::Unreadable(Arc::from(error.to_string())),
+                },
+            },
+        }
+    }
+
     pub(crate) fn watch_inputs(&self) -> Vec<WatchInput> {
         let mut paths =
             Vec::with_capacity(self.read_manifest.len() + self.observed_absent_paths.len() + 1);

--- a/crates/rue/src/test_candidates.rs
+++ b/crates/rue/src/test_candidates.rs
@@ -1,0 +1,114 @@
+//! The declared test-candidate list supplied by `--test-candidates`
+//! (ADR-0083, "The boundary").
+//!
+//! Everything about discovery, analysis, and execution lives in the compiler.
+//! Build integration adds exactly one optional input: the set of files a build
+//! target declared, which the `rue_program` rule writes from its `srcs`. It
+//! powers the unimported-test-file warning and nothing else — with no list, that
+//! warning degrades to a one-line notice and no other behavior changes.
+//!
+//! The derived source manifest cannot serve as this list. It omits files nothing
+//! read — exactly the orphans the warning is about — and it contains all of std.
+//! So the list is the declared `srcs` set, read here and handed to the compiler
+//! as candidates rather than as sources.
+//!
+//! The file is UTF-8 text, one project-root-relative path per line. Blank lines
+//! and `#` comments are ignored, matching `--source-manifest`'s line grammar so
+//! a build rule can write either file the same way.
+
+use std::fs;
+
+use crate::source_loader::parse_source_manifest_entry;
+
+/// Read the declared candidate paths from a `--test-candidates` file.
+///
+/// The list is a build-system input, so a missing or unreadable file is an
+/// ordinary driver error naming the path — never a silent empty list. Silently
+/// treating an unreadable list as "no candidates declared" would turn a broken
+/// build rule into a warning that never fires.
+pub fn load_declared_candidates(path: &str) -> Result<Vec<String>, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("Error reading test candidates '{}': {}", path, error))?;
+    let mut candidates = Vec::new();
+    for raw_line in content.lines() {
+        let entry = parse_source_manifest_entry(raw_line);
+        if entry.is_empty() {
+            continue;
+        }
+        candidates.push(entry);
+    }
+    // A repeated `srcs` entry is one declared candidate, not two observations.
+    candidates.sort();
+    candidates.dedup();
+    Ok(candidates)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("rue-{name}-{}-{unique}", std::process::id()));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write(dir: &Path, name: &str, contents: &str) -> String {
+        let path = dir.join(name);
+        fs::write(&path, contents).unwrap();
+        path.to_str().unwrap().to_owned()
+    }
+
+    #[test]
+    fn ignores_blank_lines_and_comments() {
+        let dir = scratch("candidate-list-comments");
+        let list = write(
+            &dir,
+            "test-candidates.list",
+            "# declared by //app:app\napp/main.rue\n\n  app/parser_tests.rue  \napp/x.rue # trailing\n",
+        );
+        assert_eq!(
+            load_declared_candidates(&list).unwrap(),
+            vec![
+                "app/main.rue".to_owned(),
+                "app/parser_tests.rue".to_owned(),
+                "app/x.rue".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn deduplicates_repeated_entries() {
+        let dir = scratch("candidate-list-dedup");
+        let list = write(
+            &dir,
+            "test-candidates.list",
+            "app/a.rue\napp/a.rue\napp/b.rue\n",
+        );
+        assert_eq!(
+            load_declared_candidates(&list).unwrap(),
+            vec!["app/a.rue".to_owned(), "app/b.rue".to_owned()]
+        );
+    }
+
+    #[test]
+    fn missing_file_names_the_path() {
+        let dir = scratch("candidate-list-missing");
+        let missing = dir.join("absent.list");
+        let error = load_declared_candidates(missing.to_str().unwrap()).unwrap_err();
+        assert!(
+            error.contains("absent.list"),
+            "the error must name the unreadable list: {error}"
+        );
+        assert!(
+            error.starts_with("Error reading test candidates"),
+            "{error}"
+        );
+    }
+}

--- a/rue_rules.bzl
+++ b/rue_rules.bzl
@@ -65,6 +65,11 @@ RueProgramInternalInfo = provider(fields = [
     "manifest",
     "deps_envelope",
     "srcs",
+    # The declared candidate inventory `rue test` reports against (ADR-0083).
+    # It is a LIST of the target's declared srcs, not a read policy: the
+    # compile action never receives it, so it cannot become a second
+    # undeclared-read route past the derive boundary above.
+    "test_candidates",
 ])
 
 
@@ -212,9 +217,20 @@ def _rue_program_impl(ctx: AnalysisContext) -> list[Provider]:
         identifier = ctx.label.name,
     )
 
+    # The declared candidate inventory (ADR-0083 §1). It is deliberately NOT a
+    # compile input: the compile action's read policy is `sources.manifest`,
+    # derived from what the scan actually read, and handing the compiler a
+    # second file of paths it may read would reopen the out-of-srcs hole the
+    # derive step exists to close. Consumers that want the inventory — the
+    # `rue test` driver mode — take it from the provider and pass it themselves.
+    #
+    # The content shape matches `srcs.list`: project-root-relative paths, one
+    # per line, which is exactly what `--test-candidates` parses.
+    test_candidates = ctx.actions.write("test-candidates.list", ctx.attrs.srcs)
+
     runs_natively = resolved_target == toolchain.native_target
     return [
-        DefaultInfo(default_output = executable, other_outputs = [manifest]),
+        DefaultInfo(default_output = executable, other_outputs = [manifest, test_candidates]),
         RunInfo(args = cmd_args(executable)),
         RueProgramInfo(
             executable = executable,
@@ -227,6 +243,7 @@ def _rue_program_impl(ctx: AnalysisContext) -> list[Provider]:
             manifest = manifest,
             deps_envelope = envelope,
             srcs = ctx.attrs.srcs,
+            test_candidates = test_candidates,
         ),
         ValidationInfo(validations = [ValidationSpec(
             name = "srcs-precision",


### PR DESCRIPTION
Closes RUE-1918. ADR-0083 Phase 2b: the one optional build-integration input the test runner takes, and the compiler machinery behind the unimported-test-file warning.

## What lands

- **`--test-candidates <file>`** on the driver: a UTF-8 list of project-root-relative paths, one per line, blank lines and `#` comments ignored, sharing the source manifest's line grammar so a build rule writes either file the same way. Missing or unreadable list is a driver error naming the path; a repeated flag is refused. Accepted and inert in every ordinary build.
- **Host acquisition.** `FilesystemCompilerHost::acquire_test_candidates` observes each declared candidate under exactly the read policy an import read obeys: with a `--source-manifest`, an undeclared spelling or a disallowed canonical file is `Unreadable` without a filesystem read; a missing file is `Absent`; an I/O or UTF-8 failure is `Unreadable` with its reason. Candidate reads are deliberately not added to the accepted-read manifest, so they never appear in `--emit deps` or the watch closure. The driver acquires the inventory after opening the host so a broken candidate fails loudly today; nothing reports against it until `rue test` (RUE-1920).
- **Compiler side.** `TestCandidateInventory` normalizes declared spellings to logical module paths, rejects std-root and root-escaping paths, and dedups. Candidate bytes are published as their own revisioned input leaves in a dedicated regime namespace (a digest over project root, std root, and read-policy revision), so publishing candidates cannot perturb the import namespace's certificate lineage: acquisition is an addition to the request, not a new observation of the program's sources. A new parse-only query family, `compiler.test-candidate-scan`, lexes and parses one candidate and counts `test` items; no RIR, no semantic analysis, no roots.
- **API.** `rue_compiler::unstable::unimported_test_files(session, &inventory)` reports every declared candidate outside the request's module closure that contains test items or could not be parsed, sorted by path. Absent candidates are silent, since sibling build targets legitimately share `srcs` globs. Closure membership is by normalized logical path; the doc comment records the symlink-spelling trade-off.
- **Warnings.** `WarningKind::UnimportedTestFile { path, tests }` and `UnimportedTestFileUnparsable { path }`, rendered without a span. They are request-level warnings that `rue test` will emit; they are not `@allow` names.
- **Build rule.** `rue_program` writes `test-candidates.list` from `srcs`, exposes it as `RueProgramInternalInfo.test_candidates`, and materializes it on a plain build. It is not yet passed to the compile action.

## Coverage

rue-compiler unit tests for the inventory (normalization, std rejection, dedup), the scan, closure-versus-candidate reporting, ordering, the read-regime mismatch, and revision-keyed re-scan; a rue-driver test that opens a real temp project with and without a manifest and asserts the outcome of each candidate class, that no accepted read is recorded, and the exact report rows; driver unit tests for the flag; five CLI cases including the manifest-excluded candidate; the structural gates (family count, identities, exports) updated; `//:repository-quality-gates` green. A `buck2 build` of a `rue_program` target produces the new list artifact.

Local: fmt, quick, driver and compiler unit suites, `scripts/rue cli test_candidates`, and repository-quality-gates green. The oracle-diff harness could not run on this host (thread-spawn EAGAIN, reproduced on unmodified trunk); the one executing CLI case is structurally identical to existing manifest cases, and the merge queue's oracle-diff lane is the authority.
