### PR TITLE
RUE-1934: shrink the storage guard and cache provisioning

### DIFF
--- a/.buckconfig.local.example
+++ b/.buckconfig.local.example
@@ -1,9 +1,16 @@
 # BuildBuddy remote cache + remote execution — opt-in local config (RUE-316).
 #
-# Copy this file to `.buckconfig.local` (gitignored) and paste your BuildBuddy
-# API key. buck2 reads `.buckconfig.local` automatically and layers it over
-# `.buckconfig`, so the shared config stays cache-agnostic — nobody without a key
-# is affected.
+# The recommended setup is `scripts/rue cache install`: it writes this same
+# configuration once, privately, to ${XDG_CONFIG_HOME:-~/.config}/rue/
+# buildbuddy.buckconfig, and the repository `./buck2` wrapper links
+# `.buckconfig.local` to that file in any worktree on the first
+# build/test/run/install there (see docs/process/build-cache.md).
+#
+# This file documents the knobs, and remains the hand-written alternative for
+# one checkout, which the wrapper never replaces: copy it to `.buckconfig.local`
+# (gitignored) and paste your BuildBuddy API key. buck2 reads `.buckconfig.local`
+# automatically and layers it over `.buckconfig`, so the shared config stays
+# cache-agnostic — nobody without a key is affected.
 #
 #   cp .buckconfig.local.example .buckconfig.local
 #   # then replace <YOUR_BUILDBUDDY_API_KEY> below

--- a/.claude/skills/integrate-worker/SKILL.md
+++ b/.claude/skills/integrate-worker/SKILL.md
@@ -114,9 +114,12 @@ in the same hot lane go in consecutive cycles, not the same one.
   dangling changes (safe: git protects checked-out branches; only unbookmarked
   non-`@` heads are abandoned). Without it, `jj log` fills with dozens of dead
   heads within a session.
-- For disk pressure, run **`scripts/rue storage clean`** (guard-gated, reclaims
-  stale Buck outputs host-wide; it never deletes worktrees or source files) —
-  never blanket `rm -rf .claude/worktrees`, which races running workers.
+- For disk pressure, remove worktrees whose work is finished (`git worktree
+  remove <path>`) or run **`scripts/rue storage clean`** (Buck's own stale
+  cleanup in every registered worktree; it never deletes worktrees or source
+  files) — never blanket `rm -rf .claude/worktrees`, which races running
+  workers. The `./buck2` wrapper refuses to start a build below 4 GiB free and
+  cleans nothing itself.
 
 ## Worker-prompt invariants this protocol assumes
 

--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -61,7 +61,6 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Cold release build (populates the remote cache)
         run: |
@@ -161,7 +160,6 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Check rue_program warm cache across relocated roots
         run: scripts/check-rue-program-warm-cache.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       # Materialize the planner output once. `narrowed=true` is valid only with
       # a non-empty live impacted closure and verified selection/gate state; an
@@ -260,7 +259,6 @@ jobs:
             exit 1
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Build compiler remotely
         env:
@@ -309,10 +307,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         # A depth-1 checkout is enough for this lane: nothing it runs reads git
-        # history. Two of its steps do shell out to git — `provision-build-cache`
-        # lists worktrees, and `affected-targets build-scope` prunes them in its
-        # exit trap — but both ask only about the checkout in front of them, and
-        # the pin gate below is decided from file contents. The gate that does
+        # history. One of its steps does shell out to git — `affected-targets
+        # build-scope` prunes worktrees in its exit trap — but it asks only
+        # about the checkout in front of it, and the pin gate below is decided
+        # from file contents. The gate that does
         # count commits is the `performance-staleness` job, which takes its own
         # `fetch-depth: 0` checkout for the purpose (RUE-1258, RUE-1504).
 
@@ -332,7 +330,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       # RUE-1130: materialize the determinator's impacted-target closure so the
       # heavy steps below can run exactly it. `narrowed` is the determinator's
@@ -644,7 +641,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Check the performance series is still advancing
         # Is the series *already* stalled? A repository-wide condition, so this
@@ -843,7 +839,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Build native compiler and linker
         if: steps.sel.outputs.run == 'true'
@@ -999,7 +994,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Check rue_program digest sensitivity
         if: steps.sel.outputs.run == 'true'
@@ -1081,7 +1075,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Decide affected corpus targets
         # Fail-open: the script always exits 0 with a decision (full on any
@@ -1156,7 +1149,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Run ${{ matrix.name }} corpus
         if: steps.sel.outputs.run == 'true'
@@ -1223,7 +1215,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       # Direct RUE-277 guard: inspect Buck's analyzed rustc_cfg actions instead
       # of inferring optimization from complete binary bytes. This performs no
@@ -1276,7 +1267,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Install valgrind
         if: steps.sel.outputs.run == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       # //:cli-tests owns the premerge shards' complete union; //:cli-tests-slow
       # owns declarative slow sections. Exclude the CI-only shards so the
@@ -114,7 +113,6 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
-          scripts/provision-build-cache apply
 
       - name: Run scheduled slow program
         if: steps.select.outputs.run == 'true' && (github.event_name == 'schedule' || inputs.tier == 'slow')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,11 +84,10 @@ scripts/rue cli abi                  # filtered CLI integration tests
 scripts/rue test [pattern]           # broad/full suite
 scripts/rue fmt                      # format changed Rust files
 scripts/rue storage status           # inventory Buck disk use across worktrees
-scripts/rue storage plan             # dry-run host-wide stale cleanup
+scripts/rue storage plan             # dry-run stale cleanup in every registered worktree
 scripts/rue storage clean            # reclaim stale Buck2 artifacts host-wide
-scripts/rue storage reclaim-finished RUE_ROOT [RUE_ROOT ...] # explicit finished-root output reclaim
-scripts/rue cache install            # securely install the shared cache config
-scripts/rue cache apply --all        # provision current Git/Codex worktrees
+scripts/rue storage reset RUE_ROOT   # full Buck reset of one registered worktree
+scripts/rue cache install            # securely install the private cache config
 ```
 
 When corpus-affecting cases change, use this focused check:
@@ -260,10 +259,13 @@ build actions; `weight_percentage = 100` keeps two corpus actions from running
 together within one Buck daemon/worktree while still allowing corpus work to
 overlap non-corpus actions such as unit tests and compiles. There is no
 full-suite host lock or cross-worktree test serialization, so sibling worktrees
-may run concurrently. The cross-worktree coordination relevant here is the
-`buck2` wrapper's `scripts/rue-storage` disk-pressure guard. The optional
-BuildBuddy action cache uses one private user config and ignored per-worktree
-symlinks; see `docs/process/build-cache.md`. Never commit or print its
+may run concurrently. There is no cross-worktree coordination: the `buck2`
+wrapper only refuses to start a build below a 4 GiB free-space floor, and a
+finished worktree's `buck-out` is reclaimed by removing the worktree. The
+optional BuildBuddy action cache is one private user config
+(`scripts/rue cache install`) that the wrapper links as `.buckconfig.local` in
+a worktree on the first build there; `RUE_NO_REMOTE_CACHE=1` skips that for
+one command. See `docs/process/build-cache.md`. Never commit or print its
 credential. Full remote execution is supported (RUE-320, Done 2026-07-18): the
 repository wrapper defaults to `--prefer-local`, and `--prefer-remote` is an
 explicit opt-in for cache-population or RE-debugging runs, not the default

--- a/BUCK
+++ b/BUCK
@@ -1658,12 +1658,15 @@ rue_test_suite(
     tests = ["//crates/rue-rir:rue-rir[doc]"],
 )
 
-# Maintenance scripts with deletion behavior. Their fail-closed contract is
-# pinned by scripts/test-cleanup-scripts.sh (RUE-567, RUE-1225), which runs
+# Maintenance scripts with deletion behavior, plus the ./buck2 wrapper's
+# free-space floor. Their fail-closed contracts are pinned by
+# scripts/test-cleanup-scripts.sh (RUE-567, RUE-1225, RUE-1934), which runs
 # copies against fake tools — no real repo, remote, or Buck output is touched.
 filegroup(
     name = "cleanup-script-inputs",
     srcs = [
+        "buck2",
+        "buck2-bin",
         "scripts/jj-tidy",
         "scripts/rue-storage",
     ],
@@ -1777,7 +1780,6 @@ filegroup(
         "buck2-bin",
         "scripts/ci-heavy-suite",
         "scripts/provision-build-cache",
-        "scripts/rue-storage",
         "test.sh",
     ],
 )

--- a/buck2
+++ b/buck2
@@ -5,23 +5,6 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 args=("$@")
 
-# A previously installed private config follows newly created worktrees on
-# their first direct Buck invocation as well as through scripts/rue.
-if [[ -x "$repo_root/scripts/provision-build-cache" ]]; then
-    (cd "$repo_root" && scripts/provision-build-cache auto)
-fi
-
-# The remote-cache execution platform must set remote_enabled for OSS Buck2 to
-# connect to the action cache. Its limited-hybrid default otherwise prefers
-# remote execution, which Rue cannot rely on until RUE-320 fixes remote linking.
-# Force cache lookup followed by local execution unless the caller explicitly
-# selected an execution mode.
-uses_remote_cache=0
-if [[ -r "$repo_root/.buckconfig.local" ]] &&
-   grep -Eq '^[[:space:]]*execution_platforms[[:space:]]*=[[:space:]]*root//platforms:remote_cache([[:space:]]|$)' "$repo_root/.buckconfig.local"; then
-    uses_remote_cache=1
-fi
-
 execution_command=0
 explicit_preference=0
 if [[ "${#args[@]}" -gt 0 ]]; then
@@ -33,17 +16,70 @@ if [[ "${#args[@]}" -gt 0 ]]; then
     done
 fi
 
-# Starting another disk-heavy command while the host is near ENOSPC is unsafe.
-# The guard is normally just one portable `df` read. When free space is both at
-# or below 10% of the device and below the cleanup floor, it asks Buck to
-# reclaim eligible outputs from every registered Rue worktree, preserving
-# materializer state and active artifacts; it refuses the build only below the
-# hard floor, and warns-but-proceeds in between (RUE-1331 — active sibling
-# worktrees legitimately pin the host between the floors). `clean` itself is
-# not an execution command, so the host-wide guard cannot recurse through this
-# wrapper.
-if [[ "$execution_command" -eq 1 ]] && [[ -x "$repo_root/scripts/rue-storage" ]]; then
-    (cd "$repo_root" && scripts/rue-storage guard)
+# Starting another disk-heavy command near ENOSPC is unsafe, but nothing this
+# wrapper could delete on a build's behalf is safe either: the cross-worktree
+# cleanup that used to run here caused RUE-1331 and RUE-1683 and did not
+# prevent RUE-1790. The guard is therefore one portable `df` read and a
+# refusal below an absolute floor. An incremental build fits in 4 GiB; a cold
+# full build may not, and fails loudly with ENOSPC rather than corrupting
+# anything. Reclaiming space is a per-worktree decision made by a person.
+# `clean` is not an execution command, so it stays available below the floor.
+floor_gib=4
+if [[ "$execution_command" -eq 1 ]]; then
+    free_kib="$(df -Pk "$repo_root" 2>/dev/null | awk 'NR == 2 { print $4 }' || true)"
+    if [[ ! "$free_kib" =~ ^[0-9]+$ ]]; then
+        echo "error: cannot measure free space under $repo_root; refusing to start a build that could hit ENOSPC" >&2
+        exit 1
+    fi
+    if [[ "$free_kib" -lt $((floor_gib * 1048576)) ]]; then
+        free_gib="$(awk -v kib="$free_kib" 'BEGIN { printf "%.1f", kib / 1048576 }')"
+        cat >&2 <<NOTICE
+error: ${free_gib} GiB free under $repo_root is below the ${floor_gib} GiB floor; build stopped before risking ENOSPC.
+To reclaim space: remove worktrees whose work is finished
+('git worktree remove <path>'), reset one registered worktree's Buck outputs
+('scripts/rue storage reset <root>'), or remove stale tracked outputs from
+every registered worktree ('scripts/rue storage clean').
+NOTICE
+        exit 1
+    fi
+fi
+
+# The optional BuildBuddy action cache. `scripts/rue cache install` writes one
+# private config per user; the first execution command in a checkout links
+# .buckconfig.local (gitignored) to it, and that is the whole provisioning
+# step. The link, not a per-command --config-file, is the delivery mechanism
+# because [buck2] digest_algorithms and [buck2_re_client] are daemon-startup
+# settings: a --config-file leaves `buck2 status` at digest_algorithms null
+# (SHA1, which BuildBuddy's CAS rejects) and the daemon with no RE engine
+# address, while a changed .buckconfig.local restarts the daemon with both
+# applied. RUE_NO_REMOTE_CACHE=1 skips the link for one command
+# (scripts/check-reproducible-compiler.sh). Any existing .buckconfig.local,
+# symlink or file, belongs to the user and is left alone, and a config another
+# account can read is refused with a warning rather than linked; neither ever
+# blocks a local build.
+central_config="${RUE_BUILDBUDDY_CONFIG:-${XDG_CONFIG_HOME:-${HOME:-}/.config}/rue/buildbuddy.buckconfig}"
+local_config="$repo_root/.buckconfig.local"
+if [[ "$execution_command" -eq 1 ]] && [[ "${RUE_NO_REMOTE_CACHE:-}" != 1 ]] &&
+   [[ -f "$central_config" ]] && [[ ! -e "$local_config" ]] && [[ ! -L "$local_config" ]]; then
+    # GNU stat first, then the BSD spelling.
+    mode="$(stat -c '%a' "$central_config" 2>/dev/null || stat -f '%Lp' "$central_config" 2>/dev/null || true)"
+    if [[ ! "$mode" =~ ^[0-7]+$ ]] || (( (8#$mode & 077) != 0 )); then
+        echo "warning: $central_config is readable by other accounts; chmod 600 it or re-run 'scripts/rue cache install'. Continuing without the remote cache." >&2
+    elif ! ln -s "$central_config" "$local_config" 2>/dev/null; then
+        echo "warning: could not link $local_config to the installed BuildBuddy config; continuing without the remote cache" >&2
+    fi
+fi
+
+# The remote-cache execution platform must set remote_enabled for OSS Buck2 to
+# connect to the action cache. Its limited-hybrid default otherwise prefers
+# remote execution, which Rue cannot rely on until RUE-320 fixes remote linking.
+# Force cache lookup followed by local execution unless the caller explicitly
+# selected an execution mode. This runs after the link step so the first build
+# in a new worktree gets the preference too.
+uses_remote_cache=0
+if [[ -r "$local_config" ]] &&
+   grep -Eq '^[[:space:]]*execution_platforms[[:space:]]*=[[:space:]]*root//platforms:remote_cache([[:space:]]|$)' "$local_config"; then
+    uses_remote_cache=1
 fi
 
 if [[ "$uses_remote_cache" -eq 1 ]] && [[ "$execution_command" -eq 1 ]] && [[ "$explicit_preference" -eq 0 ]]; then

--- a/docs/designs/0082-buck2-build-system.md
+++ b/docs/designs/0082-buck2-build-system.md
@@ -9,7 +9,7 @@ accepted: 2026-08-27
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["ADR-0069", "ADR-0070", "RUE-1819", "RUE-1118", "RUE-316", "RUE-320", "RUE-1505", "RUE-1523", "RUE-1790", "RUE-1818"]
+relates: ["ADR-0069", "ADR-0070", "RUE-1819", "RUE-1118", "RUE-316", "RUE-320", "RUE-1505", "RUE-1523", "RUE-1790", "RUE-1818", "RUE-1934"]
 ---
 
 # ADR-0082: Buck2 as the build system
@@ -106,9 +106,12 @@ needed.
   broken twice by the same shape (RUE-1511, RUE-1788). The expressiveness
   that enables the caching also generates this bug class.
 - OSS Buck2 has no persistent cross-daemon cache, so each worktree carries
-  its own `buck-out`; the disk-pressure guard and storage tooling exist to
-  manage that. The current age-based reclaim policy fails under fix-cycle
-  load and is being redesigned (RUE-1790).
+  its own `buck-out`, and that disk is reclaimed by a person removing finished
+  worktrees (or `scripts/rue storage reset`). The `./buck2` wrapper only
+  refuses to start a build below a 4 GiB free-space floor. An age-based
+  cross-worktree reclaim guard was tried first; it caused more incidents than
+  it prevented (RUE-1331, RUE-1683) and could not help under fix-cycle load
+  (RUE-1790), so RUE-1934 removed it.
 - The contributor on-ramp is steeper than a cargo workspace. With the current
   contributor base this cost is small; it grows if the project seeks outside
   contributors, and re-evaluation should weigh it then.
@@ -122,8 +125,9 @@ makes the on-ramp cost primary.
 
 ## Future Work
 
-- RUE-1790: replace age-based storage reclaim with finishedness-based
-  reclaim.
+- RUE-1790 asked for finishedness-based storage reclaim in place of the
+  age-based guard. RUE-1934 settled it the other way: the guard is gone, and
+  a finished worktree's output is reclaimed by removing the worktree.
 - RUE-1818: the interpreter-baseline validator question is deliberately out
   of scope here and tracked as its own decision.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,10 +27,10 @@ scripts/rue spec 4.2                 # filtered specification cases
 scripts/rue cli abi                  # filtered CLI integration cases
 scripts/rue fmt                      # format first-party Rust
 scripts/rue storage status           # inventory Buck usage across worktrees
-scripts/rue storage plan             # dry-run host-wide stale cleanup
+scripts/rue storage plan             # dry-run stale cleanup in every registered worktree
 scripts/rue storage clean            # remove stale Buck artifacts host-wide
-scripts/rue storage guard            # run the emergency low-disk preflight now
-scripts/rue storage reclaim-finished /exact/root # reclaim outputs for a finished root
+scripts/rue storage reset /exact/root # full Buck reset of one registered worktree
+scripts/rue cache install            # install the private BuildBuddy cache config
 ```
 
 For direct compiler invocations, resolve the binary through `scripts/rue-bin`:

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -26,101 +26,75 @@ Tracking: RUE-316 (groundwork), RUE-320 (platform-scoped linker).
 
 ```bash
 scripts/rue cache install       # prompts without echo for the BuildBuddy key
-scripts/rue cache apply --all   # primary checkout + current Git/Codex worktrees
 ```
 
-`install` writes one user-owned configuration at
-`${XDG_CONFIG_HOME:-~/.config}/rue/buildbuddy.buckconfig`, with mode `0600`.
-`apply` places only an ignored `.buckconfig.local` symlink in each checkout, so
-the credential is neither copied between worktrees nor stored in Git. It refuses
-to replace an existing local config and refuses a central config readable by
-another account. Commands never print the key. A secure config installed before
-the Rust upload gate existed is upgraded atomically in place, preserving its
-credential; an explicit `default_allow_cache_upload = false` remains an error
-instead of being silently overridden.
+`install` atomically writes one user-owned configuration at
+`${XDG_CONFIG_HOME:-~/.config}/rue/buildbuddy.buckconfig` with mode `0600`;
+re-run it to replace the file, and it never prints the key. That is the only
+step: the repository `./buck2` wrapper links `.buckconfig.local` (gitignored)
+to that file in any worktree on the first `build`, `test`, `run`, or `install`
+there, so the credential is never copied between worktrees or stored in Git.
+The link, rather than a per-command `--config-file`, is the delivery mechanism
+because `[buck2] digest_algorithms` and `[buck2_re_client]` are daemon-startup
+settings: a `--config-file` leaves the daemon on SHA1 digests (which
+BuildBuddy's CAS rejects) with no RE engine address, while a changed
+`.buckconfig.local` restarts the daemon with both applied.
 
-Once installed, direct `./buck2`, `scripts/rue ...`, and `test.sh` runs
-automatically link a new worktree on first use. If the central config is absent,
-Rue simply uses its ordinary local Buck configuration. If it is malformed or
-insecure, Rue warns and continues without provisioning it. Existing local paths,
-including broken or unrelated symlinks, are left untouched. This keeps cache
-setup opt-in and prevents a credential problem from making local builds unusable.
+If the file is absent, Rue uses its ordinary local Buck configuration. An
+existing `.buckconfig.local`, symlink or file, is never replaced, and a config
+readable by another account is refused with a warning rather than linked;
+neither ever blocks a local build. `RUE_NO_REMOTE_CACHE=1` skips the link for
+one command, which is how the deliberately cache-free
+`scripts/check-reproducible-compiler.sh` declines it (moving an existing
+wrapper link aside for the duration), and `RUE_BUILDBUDDY_CONFIG` names a
+different path for both `install` and the wrapper. A hand-written
+`.buckconfig.local` (see `.buckconfig.local.example`) is left alone and still
+makes the wrapper default to `--prefer-local`.
 
 ## Host-wide disk lifecycle
 
 Every worktree has its own `buck-out`; a large primary checkout and many smaller
 worktrees therefore share one host budget even though Buck daemons cannot share
 their local materializer state. Rue configures Buck's deferred materializer to
-persist that state, defer write actions, and continuously remove outputs that
-have not been used for one week. Cleanup starts twelve hours after daemon startup
-and repeats daily. Buck coordinates those deletions with active builds; Rue does
-not infer that a worktree is disposable from its age or directory name.
+persist that state, defer write actions, and remove outputs that have not been
+used for one week; cleanup starts twelve hours after daemon startup and repeats
+daily, and Buck coordinates the deletions with active builds. That policy is
+what keeps a long-lived checkout bounded. It cannot help a worker worktree: a
+short-lived daemon never reaches the twelve-hour offset, and output from work
+still in flight is in use and must stay.
 
-The background cleaner also watches the host filesystem. At 20% free space or
-lower it adaptively promotes the oldest non-active outputs until Buck projects
-that 20% will be free again. Outputs accessed in the last twelve hours remain
-protected even under pressure. This threshold is host-wide—the worktrees have
-separate materializer databases, but they consume the same filesystem budget.
-
-Use the host-wide storage command from any current Rue checkout:
+Per-worktree output is therefore reclaimed by a person, per worktree: remove a
+worktree whose work is finished (`git worktree remove <path>`), or reset one
+that stays. From any current Rue checkout:
 
 ```bash
 scripts/rue storage status            # sizes, source state, and cache state
 scripts/rue storage plan [AGE]        # Buck dry-run in every registered worktree
-scripts/rue storage clean [AGE]       # stale + adaptive cleanup; default 1w
-scripts/rue storage guard             # run the build preflight explicitly
-scripts/rue storage guard --finished-root /exact/root # name caller-confirmed finished output
+scripts/rue storage clean [AGE]       # Buck's tracked stale cleanup; default 1w
 scripts/rue storage reset /exact/root # full Buck reset of an explicit target
-scripts/rue storage reclaim-finished /exact/root # reclaim a caller-confirmed finished root
 ```
 
-Every `./buck2 build`, `test`, `run`, or `install` invocation runs the same
-portable free-space preflight. Above 10% free it is only a `df` read. At 10% or
-lower it synchronously requests adaptive cleanup from every registered Rue
-worktree before allowing more disk-heavy work. If inventory or cleanup fails,
-the command stops with recovery guidance instead of proceeding toward ENOSPC.
-If tracked cleanup cannot escape the emergency threshold, the guard may fully
-reset the largest legacy `buck-out` trees whose checked-out revisions predate
-deferred materializer state. It uses the coordinator checkout's pinned Buck and
-refuses to reset a root with an active command. Dirty source state is unrelated
-and remains untouched. Between 10% and 20%, Buck's ordinary background policy
-restores headroom without putting every build behind a host-wide scan.
+The inventory comes from `git worktree list` and fails closed: if the
+registered set cannot be read, no cleanup runs. `plan` and `clean` are Buck's
+own `clean --stale AGE --tracked-only` in every registered worktree and nothing
+more. `reset` validates every named path as a registered Rue worktree before it
+resets any of them. Neither command removes source files or worktrees, and
+`scripts/rue gc` remains a compatibility alias for the one-week `clean`.
 
-The inventory comes from `git worktree list` and fails closed: if the registered
-set cannot be read, no cleanup runs. `clean` removes stale or untracked Buck
-outputs and may promote older tracked, non-active outputs when the host is below
-the 20% target. `reset` is the migration escape hatch for an older worktree whose
-artifacts predate persisted materializer state; it validates every named path as
-a registered Rue worktree before it resets any of them. Neither command removes
-source files or worktrees. `reclaim-finished` is the explicit lifecycle handoff
-for a root whose caller knows its work is finished: it accepts only exact
-registered Rue worktree roots, verifies their live Git identity belongs to the
-coordinator's worktree family, refuses the current checkout and ambiguous
-inventory entries, and uses Buck's `clean --exit-when notidle` liveness check
-for every existing isolation. Dirty source is valid and does not influence the
-finishedness decision. A root with no existing Buck isolation entries succeeds
-without invoking destructive cleanup. When pressure remains after ordinary TTL cleanup, `guard` may name
-caller-supplied `--finished-root` values that still have output and pass a
-non-destructive Buck probe, but never reclaims them automatically; run the
-printed command explicitly. If a later named root refuses its destructive
-liveness check, earlier roots may already have been reclaimed; the command
-stops immediately and never continues to later roots.
-Current, active, and zero-output roots are not reported as eligible. Reclaim
-stops on a changed output root or isolation set; residual Buck-owned metadata
-in a cleaned isolation is reported honestly rather than treated as a failed
-cleanup. A new isolation can leave an earlier isolation reclaimed while the
-command stops for review, just as a later named root can stop a multi-root
-command after earlier roots succeeded. Per-isolation liveness rechecks can
-similarly reclaim earlier isolations in the same root before a later isolation
-refuses and stops the command.
-`scripts/rue gc` remains a compatibility alias for the host-wide one-week
-stale cleanup.
+Every `./buck2 build`, `test`, `run`, or `install` invocation reads free space
+once (`df -Pk`) and refuses to start below 4 GiB, naming the remedies above; an
+incremental build fits in that headroom, and a cold full build that does not
+fails loudly with ENOSPC rather than corrupting anything. Above the floor the
+wrapper does nothing, and no build ever cleans another worktree's output on its
+own behalf: the earlier guard's cross-worktree cleanup caused RUE-1331 and
+RUE-1683 and did not prevent RUE-1790 (123 MB free), because an age-based
+policy cannot reclaim output the same cycle is still producing.
 
 The default setup is for the shared **action cache**. Normal commands stay on
 `--prefer-local`; add `--prefer-remote` explicitly when remote execution is the
-intended experiment. The checked-in `.buckconfig.local.example` remains a
-reference for the generated configuration, not the recommended per-worktree
-setup.
+intended experiment. The checked-in `.buckconfig.local.example` documents the
+same knobs for a hand-written per-checkout config; the installed user config
+is the recommended setup.
 
 ## Full-suite host coordination
 
@@ -204,7 +178,7 @@ path.
 
 CI reads the key from the `BUILDBUDDY_API_KEY` repo secret (never from a file).
 The cache is provisioned (RUE-1006/RUE-1019) via
-`scripts/provision-build-cache install && apply`, gated on secret presence, in
+`scripts/provision-build-cache install`, gated on secret presence, in
 every `CI` job whose cost is a build — ten of them as of RUE-1504: `clippy`,
 `linux-premerge`, `native-platforms`, `platform-corpus`, `affected-targets`,
 `rue-program-digests`, `remote-execution`, `performance-staleness`, `release`,
@@ -222,9 +196,11 @@ Availability rules, which the workflow steps must respect:
   already-approved, queued code, which is also why letting them write to the
   shared cache (`allow_cache_uploads`) is acceptable.
 - **The dedicated compiler-reproducibility job is intentionally cache-free.**
-  It runs `scripts/check-reproducible-compiler.sh` (RUE-617), which hard-errors
-  on a `.buckconfig.local`: the reference and relocated candidate builds must be
-  identically configured for the byte comparison to indict path/scheduling/
+  It runs `scripts/check-reproducible-compiler.sh` (RUE-617), which moves a
+  wrapper-created `.buckconfig.local` link aside for the duration, refuses a
+  hand-written one, and exports `RUE_NO_REMOTE_CACHE=1` so the wrapper does not
+  relink: the reference and relocated candidate builds must be identically
+  configured for the byte comparison to indict path/scheduling/
   environment leaks rather than configuration drift. Keeping that proof in an
   independent job lets the ordinary linux-x64 build and tests use the shared
   cache without changing the reproducibility contract.
@@ -238,8 +214,9 @@ and builds `//crates/rue:rue` with `--local-only` and
 `.buckconfig.local`; every Buck wrapper invocation also points
 `RUE_BUILDBUDDY_CONFIG` at a verified-nonexistent root-local path and removes
 `BUILDBUDDY_API_KEY` from its environment. The sentinel is checked before and
-after every build, query, ownership audit, and daemon shutdown. Thus wrapper
-auto-provisioning cannot copy, read, or activate the central cache credential.
+after every build, query, ownership audit, and daemon shutdown. Thus the
+wrapper finds no installed config to link, and would not replace the sentinel
+anyway, so it cannot activate the central cache credential.
 The resulting configured graph is rejected if it selects the remote-cache
 platform. A configured `deps(//crates/rue:rue)` query scopes the
 inventory: Rust library `.rlib`/`.rmeta` outputs, `rust_library` targets whose

--- a/platforms/BUCK
+++ b/platforms/BUCK
@@ -48,7 +48,9 @@ platform(
     visibility = ["PUBLIC"],
 )
 
-# Cache-only EXECUTION platform (RUE-316) — opt-in via .buckconfig.local.
+# Cache-only EXECUTION platform (RUE-316) — opt-in via .buckconfig.local, which
+# the ./buck2 wrapper links to the installed cache config (scripts/rue cache
+# install) or the user writes by hand.
 # Unused by default; select with `[build] execution_platforms = root//platforms:remote_cache`.
 remote_cache_platform(
     name = "remote_cache",

--- a/scripts/check-reproducible-compiler.sh
+++ b/scripts/check-reproducible-compiler.sh
@@ -25,6 +25,17 @@ rm -f \
     "$artifact_dir/reference-readelf.txt" \
     "$artifact_dir/candidate-readelf.txt"
 
+# Both builds must be cache-free. The ./buck2 wrapper links .buckconfig.local
+# to an installed BuildBuddy config on a checkout's first execution command;
+# such a link is moved aside for the duration (restored on exit, after a
+# failure too) and the opt-out keeps the wrapper from recreating it. A
+# hand-written .buckconfig.local is refused: the reference and the relocated
+# candidate would build under different configuration. Toggling the file
+# restarts the Buck daemon, which is expected here.
+central_config="${RUE_BUILDBUDDY_CONFIG:-${XDG_CONFIG_HOME:-${HOME:-}/.config}/rue/buildbuddy.buckconfig}"
+local_config="$repo_root/.buckconfig.local"
+aside_config=""
+
 cleanup() {
     if [ -x "$candidate_root/buck2" ]; then
         (
@@ -32,15 +43,22 @@ cleanup() {
             ./buck2 --isolation-dir compiler-repro kill >/dev/null 2>&1 || true
         )
     fi
+    if [ -n "$aside_config" ] && [ -L "$aside_config" ]; then
+        mv "$aside_config" "$local_config"
+    fi
     rm -rf "$scratch"
 }
 trap cleanup EXIT
 
-if [ -e "$repo_root/.buckconfig.local" ]; then
+if [ -L "$local_config" ] && [ "$(readlink "$local_config")" = "$central_config" ]; then
+    aside_config="$scratch/buckconfig.local.aside"
+    mv "$local_config" "$aside_config"
+elif [ -e "$local_config" ] || [ -L "$local_config" ]; then
     printf 'error: .buckconfig.local would make the reference and archived candidate use different configuration\n' >&2
     printf '       move it aside before running the reproducibility check\n' >&2
     exit 1
 fi
+export RUE_NO_REMOTE_CACHE=1
 
 materialize_source_tree() {
     if git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/scripts/check-rue-program-warm-cache.sh
+++ b/scripts/check-rue-program-warm-cache.sh
@@ -61,8 +61,14 @@ SCENARIOS=(
     //:large-example-meridian-canary-workdir
 )
 
-if ! grep -Eq '^[[:space:]]*execution_platforms[[:space:]]*=[[:space:]]*root//platforms:remote_cache([[:space:]]|$)' .buckconfig.local 2>/dev/null; then
-    echo "FAIL: no provisioned remote cache (.buckconfig.local); a warm-cache check without one is vacuous" >&2
+# The ./buck2 wrapper links .buckconfig.local to the installed config on the
+# first execution command in any checkout, including the relocated clone
+# below, unless the opt-out is set; so the config's presence is the whole
+# precondition.
+central_config="${RUE_BUILDBUDDY_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/rue/buildbuddy.buckconfig}"
+if [[ "${RUE_NO_REMOTE_CACHE:-}" == 1 ]] ||
+    ! grep -Eq '^[[:space:]]*execution_platforms[[:space:]]*=[[:space:]]*root//platforms:remote_cache([[:space:]]|$)' "$central_config" 2>/dev/null; then
+    echo "FAIL: no installed remote cache config ($central_config); a warm-cache check without one is vacuous" >&2
     exit 1
 fi
 
@@ -100,15 +106,9 @@ echo "  ok: $(wc -l <<<"$cold_lines") rue_* action(s) executed cold"
 
 echo "warm-cache: (2) relocated checkout stages the CLI programs and runs the canary scenarios"
 git clone --quiet --no-hardlinks . "$reloc"
-# .buckconfig.local is private and untracked, so the clone starts without a
-# remote cache; provision it explicitly rather than relying on the wrapper's
-# auto-follow, and fail here — not at the misleading cache-miss assertion —
-# if the relocated root still has no cache config.
-scripts/provision-build-cache apply "$reloc" >/dev/null
-if ! grep -Eq '^[[:space:]]*execution_platforms[[:space:]]*=[[:space:]]*root//platforms:remote_cache([[:space:]]|$)' "$reloc/.buckconfig.local" 2>/dev/null; then
-    echo "FAIL: relocated checkout has no provisioned remote cache" >&2
-    exit 1
-fi
+# The clone needs no provisioning: its ./buck2 wrapper links the same
+# installed user config checked above on its first build, so a cache miss
+# below is a real one.
 # `buck2 log what-ran` reports the LAST invocation, so the two consumer shapes
 # are driven separately and their logs are collected as each finishes. The two
 # invocations name disjoint programs, so neither hides the other's actions.

--- a/scripts/provision-build-cache
+++ b/scripts/provision-build-cache
@@ -1,99 +1,24 @@
 #!/usr/bin/env bash
-# Install one private BuildBuddy Buck config and share it with Rue worktrees.
+# Install one private BuildBuddy Buck config for the current user. The
+# repository ./buck2 wrapper links .buckconfig.local to that file in any
+# worktree on the first execution command there, so installing it is the whole
+# provisioning step.
 set -euo pipefail
 
 config_home="${XDG_CONFIG_HOME:-${HOME:?HOME must be set}/.config}"
 central_config="${RUE_BUILDBUDDY_CONFIG:-$config_home/rue/buildbuddy.buckconfig}"
 
 usage() {
-    cat <<'EOF'
+    cat <<'USAGE'
 usage: scripts/provision-build-cache install
-       scripts/provision-build-cache apply [--all] [RUE_ROOT ...]
-       scripts/provision-build-cache status [RUE_ROOT ...]
 
 install reads BUILDBUDDY_API_KEY, or prompts without echo on a terminal, and
-writes the central config with mode 0600. apply links .buckconfig.local in the
-current checkout (or named roots) to that config. --all also discovers Git and
-Codex worktrees. A private config from before the Rust upload gate was added is
-upgraded in place without replacing or printing its credential.
-EOF
-}
-
-validate_private_config() {
-    if [[ ! -f "$central_config" ]] || [[ ! -r "$central_config" ]]; then
-        echo "error: BuildBuddy config is unavailable; run scripts/provision-build-cache install" >&2
-        return 1
-    fi
-    if [[ ! -O "$central_config" ]]; then
-        echo "error: BuildBuddy config is not owned by the current user" >&2
-        return 1
-    fi
-    local mode
-    # Try GNU stat first. GNU accepts -f with unrelated filesystem-reporting
-    # semantics, so probing the BSD form first can succeed with unusable output.
-    mode="$(stat -c '%a' "$central_config" 2>/dev/null || stat -f '%Lp' "$central_config" 2>/dev/null || true)"
-    if [[ -z "$mode" ]] || (( (8#$mode & 077) != 0 )); then
-        echo "error: BuildBuddy config permissions must deny group and other access (use chmod 600)" >&2
-        return 1
-    fi
-    if grep -q '<YOUR_BUILDBUDDY_API_KEY>' "$central_config" ||
-       ! grep -Eq '^[[:space:]]*http_headers[[:space:]]*=[[:space:]]*x-buildbuddy-api-key:.+' "$central_config"; then
-        echo "error: BuildBuddy config does not contain a configured API key" >&2
-        return 1
-    fi
-}
-
-migrate_config() {
-    validate_private_config || return 1
-    if grep -Eq '^[[:space:]]*default_allow_cache_upload[[:space:]]*=' "$central_config"; then
-        if ! grep -Eq '^[[:space:]]*default_allow_cache_upload[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$central_config"; then
-            echo "error: BuildBuddy config explicitly disables Rust action uploads" >&2
-            return 1
-        fi
-        return 0
-    fi
-
-    # This is the one recognized legacy shape: a secure, user-owned config
-    # with a configured credential but no upload gate. Preserve every existing
-    # byte (especially the credential) and atomically add only the public knob.
-    umask 077
-    local tmp="${central_config}.tmp.$$"
-    if ! awk '
-        BEGIN { in_buck2 = 0; saw_buck2 = 0; inserted = 0 }
-        /^\[buck2\][[:space:]]*$/ { in_buck2 = 1; saw_buck2 = 1; print; next }
-        /^\[/ && in_buck2 && !inserted {
-            print "default_allow_cache_upload = true"
-            inserted = 1
-            in_buck2 = 0
-        }
-        { print }
-        END {
-            if (saw_buck2 && !inserted) print "default_allow_cache_upload = true"
-            if (!saw_buck2) {
-                print ""
-                print "[buck2]"
-                print "default_allow_cache_upload = true"
-            }
-        }
-    ' "$central_config" >"$tmp"; then
-        rm -f "$tmp"
-        echo "error: could not prepare BuildBuddy config migration" >&2
-        return 1
-    fi
-    if ! chmod 600 "$tmp" || ! mv "$tmp" "$central_config"; then
-        rm -f "$tmp"
-        echo "error: could not install BuildBuddy config migration" >&2
-        return 1
-    fi
-    echo "Upgraded private BuildBuddy config with the Rust upload gate"
-}
-
-validate_config() {
-    migrate_config || return 1
-    if ! grep -Eq '^[[:space:]]*default_allow_cache_upload[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$central_config"; then
-        echo "error: BuildBuddy config does not enable Rust action uploads" >&2
-        return 1
-    fi
+atomically writes the private config with mode 0600 to
+${XDG_CONFIG_HOME:-~/.config}/rue/buildbuddy.buckconfig (RUE_BUILDBUDDY_CONFIG
+names another path). Re-run it to replace an existing config. The credential
+is never printed. Remove the file to stop using the remote cache, or set
+RUE_NO_REMOTE_CACHE=1 to keep one command cache-free.
+USAGE
 }
 
 install_config() {
@@ -112,15 +37,15 @@ install_config() {
     local tmp="${central_config}.tmp.$$"
     trap 'rm -f "$tmp"' EXIT
     {
-        cat <<'EOF'
+        cat <<'CONFIG'
 [buck2_re_client]
 engine_address = grpc://remote.buildbuddy.io
 action_cache_address = grpc://remote.buildbuddy.io
 cas_address = grpc://remote.buildbuddy.io
 tls = true
-EOF
+CONFIG
         printf 'http_headers = x-buildbuddy-api-key:%s\n' "$key"
-        cat <<'EOF'
+        cat <<'CONFIG'
 
 [buck2]
 digest_algorithms = SHA256
@@ -130,7 +55,7 @@ default_allow_cache_upload = true
 
 [build]
 execution_platforms = root//platforms:remote_cache
-EOF
+CONFIG
     } >"$tmp"
     chmod 600 "$tmp"
     mv "$tmp" "$central_config"
@@ -138,104 +63,13 @@ EOF
     echo "Installed private BuildBuddy config at $central_config"
 }
 
-is_rue_root() {
-    [[ -f "$1/.buckconfig" ]] && [[ -x "$1/buck2" ]] && [[ -f "$1/platforms/remote_cache.bzl" ]]
-}
-
-apply_root() {
-    local root="$1" destination="$1/.buckconfig.local"
-    if ! is_rue_root "$root"; then
-        echo "error: not a Rue checkout: $root" >&2
-        return 1
-    fi
-    if [[ -L "$destination" ]]; then
-        if [[ "$(cd "$(dirname "$destination")" && readlink "$destination")" == "$central_config" ]]; then
-            echo "BuildBuddy cache already configured: $root"
-            return 0
-        fi
-        echo "error: refusing to replace an unrelated symlink: $destination" >&2
-        return 1
-    fi
-    if [[ -e "$destination" ]]; then
-        echo "error: refusing to replace existing config: $destination" >&2
-        return 1
-    fi
-    ln -s "$central_config" "$destination"
-    echo "Configured BuildBuddy cache: $root"
-}
-
-auto_apply() {
-    # Recommended wrappers call this so newly created worktrees adopt an
-    # already-installed central config on first use. Absence is an intentional
-    # cache-off state; an invalid config is ignored with a credential-free
-    # warning so local builds remain usable.
-    # Any existing path, including a broken symlink, belongs to the user. Do
-    # not replace it and do not let an opt-in cache feature break local builds.
-    [[ -e "$PWD/.buckconfig.local" || -L "$PWD/.buckconfig.local" ]] && return 0
-    [[ -f "$central_config" ]] || return 0
-    if ! validate_config; then
-        echo "warning: BuildBuddy cache config is invalid; continuing without remote cache" >&2
-        return 0
-    fi
-    if ! apply_root "$PWD" >/dev/null; then
-        echo "warning: could not provision BuildBuddy cache; continuing without changing local config" >&2
-    fi
-    return 0
-}
-
-collect_all_roots() {
-    printf '%s\n' "$PWD"
-    if command -v git >/dev/null 2>&1; then
-        git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' || true
-    fi
-    local codex_home="${CODEX_HOME:-${HOME:-}/.codex}" root
-    for root in "$codex_home"/worktrees/*/rue; do
-        [[ -d "$root" ]] && printf '%s\n' "$root"
-    done
-}
-
-command="${1:-}"
-shift || true
-case "$command" in
+case "${1:-}" in
     install)
-        [[ $# -eq 0 ]] || { usage >&2; exit 2; }
+        [[ $# -eq 1 ]] || { usage >&2; exit 2; }
         install_config
         ;;
-    apply)
-        validate_config
-        all=0
-        if [[ "${1:-}" == "--all" ]]; then all=1; shift; fi
-        roots=("$@")
-        if [[ "$all" -eq 1 ]]; then
-            while IFS= read -r root; do roots+=("$root"); done < <(collect_all_roots)
-        elif [[ ${#roots[@]} -eq 0 ]]; then
-            roots=("$PWD")
-        fi
-        # Sort/unique avoids duplicate output when the current checkout also
-        # appears in Git's worktree inventory.
-        failed=0
-        while IFS= read -r root; do
-            [[ -n "$root" ]] || continue
-            if ! apply_root "$root"; then failed=1; fi
-        done < <(printf '%s\n' "${roots[@]}" | sort -u)
-        [[ "$failed" -eq 0 ]]
-        ;;
-    auto)
-        [[ $# -eq 0 ]] || { usage >&2; exit 2; }
-        auto_apply
-        ;;
-    status)
-        validate_config
-        roots=("$@")
-        [[ ${#roots[@]} -gt 0 ]] || roots=("$PWD")
-        for root in "${roots[@]}"; do
-            if [[ -L "$root/.buckconfig.local" ]] && [[ "$(readlink "$root/.buckconfig.local")" == "$central_config" ]]; then
-                echo "BuildBuddy cache configured: $root"
-            else
-                echo "BuildBuddy cache not configured: $root" >&2
-                exit 1
-            fi
-        done
+    -h|--help|help)
+        usage
         ;;
     *)
         usage >&2

--- a/scripts/rue
+++ b/scripts/rue
@@ -23,10 +23,9 @@
 #   scripts/rue frontend-manifest  Refresh the audited frontend corpus manifest
 #   scripts/rue fmt                Format the code (./fmt.sh)
 #   scripts/rue storage [args...]  Inspect or reclaim Buck outputs across worktrees
-#   scripts/rue storage reclaim-finished ROOT ...
-#                                  Explicitly reclaim outputs for finished roots
+#                                  (status | plan [age] | clean [age] | reset ROOT ...)
 #   scripts/rue gc [age]           Compatibility alias for host-wide stale cleanup
-#   scripts/rue cache [args...]    Provision the shared BuildBuddy action cache
+#   scripts/rue cache install      Install the private BuildBuddy cache config
 #   scripts/rue path               Print the absolute binary path (build if needed)
 #
 set -euo pipefail
@@ -39,13 +38,6 @@ set -euo pipefail
 caller_pwd="$PWD"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
-
-# Once a private central cache config has been installed, make new worktrees
-# adopt it on first use. Missing/invalid credentials never enter the repository
-# and never prevent a local build.
-if [[ -x scripts/provision-build-cache ]]; then
-    scripts/provision-build-cache auto
-fi
 
 cmd="${1:-}"
 shift || true

--- a/scripts/rue-storage
+++ b/scripts/rue-storage
@@ -4,65 +4,43 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+central_config="${RUE_BUILDBUDDY_CONFIG:-${XDG_CONFIG_HOME:-${HOME:-}/.config}/rue/buildbuddy.buckconfig}"
 
 usage() {
-    cat <<'EOF'
+    cat <<'USAGE'
 usage: scripts/rue-storage status
        scripts/rue-storage plan [STALE_AGE]
        scripts/rue-storage clean [STALE_AGE]
-       scripts/rue-storage guard [--finished-root RUE_ROOT ...]
-       scripts/rue-storage reclaim-finished RUE_ROOT [RUE_ROOT ...]
        scripts/rue-storage reset RUE_ROOT [RUE_ROOT ...]
 
-status inventories every registered Rue worktree and its buck-out size. plan
-asks Buck what tracked stale output it would remove. clean performs that
-coordinated tracked stale cleanup (default age: 1w) and, below 20% host free
-space, adaptively removes the oldest eligible tracked output while preserving a
-12-hour minimum TTL. guard is the build preflight: when free space is at or below 10%
-of the device AND below the cleanup floor (16 GiB), it runs that cleanup
-across every worktree before allowing more disk-heavy work; a build is
-refused only when free space also sits at or below the hard floor (4 GiB),
-where ENOSPC is a real risk — between the floors the guard warns and
-proceeds, because on a busy multi-worktree host the free space held by
-active sibling builds is not reclaimable and blocking every build there
-starves the host without protecting it (RUE-1331). reset fully removes Buck
-outputs only from the exact registered roots named by the caller. reclaim-finished
-does the same for caller-authorized finished roots, using Buck's non-preempting
-liveness check for each existing Buck isolation and preserving tracked and
-untracked source content. Source worktrees are never removed.
-EOF
+status inventories every registered Rue worktree with its buck-out size,
+source state, and remote-cache state. plan asks Buck, in every registered
+worktree, which tracked output unused for STALE_AGE (default 1w) it would
+remove; clean removes it. Both are Buck's own `clean --stale --tracked-only`,
+which coordinates with active builds, and nothing more. reset removes all
+Buck output from the exact registered roots named by the caller. Output that
+belongs to finished work is reclaimed by removing its worktree
+(`git worktree remove <path>`). Source worktrees and files are never removed.
+USAGE
 }
 
-adaptive_target_percent=20
-adaptive_min_ttl=12h
-emergency_trigger_percent=10
-# Percent-of-total free space misleads wherever writable capacity is not the
-# device size: allowance-capped cloud containers report a large device with a
-# small quota (so the fraction reads permanently "low" while tens of GiB are
-# usable), and very large disks make 10% an enormous absolute reserve. The
-# emergency path therefore requires BOTH a low free fraction AND less absolute
-# headroom than a cold full build plus test outputs could consume.
-emergency_free_floor_gib=16
-# Below the cleanup floor the guard tries to reclaim space; it refuses to
-# build only below this hard floor. The gap exists because several active
-# worktrees legitimately hold the host between the two floors for hours (their
-# artifacts are live, so no cleanup can help), and a chronic refusal in that
-# band blocks all verification while inviting guard bypasses (RUE-1331). An
-# incremental build fits comfortably in 4 GiB; a cold full build may not, and
-# fails loudly with ENOSPC rather than silently corrupting anything.
-hard_floor_gib=4
-
-collect_roots() {
-    local inventory
-    if ! inventory="$(git_reclaim -C "$repo_root" worktree list --porcelain 2>/dev/null)"; then
+# The inventory is `git worktree list`, and it fails closed: an unreadable
+# inventory means no cleanup anywhere, never a guess at which roots exist.
+registered_roots() {
+    local inventory root
+    if ! inventory="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null)"; then
         echo "error: cannot inventory registered worktrees; refusing cleanup (fail-closed)" >&2
         return 1
     fi
-    awk '/^worktree / { sub(/^worktree /, ""); print }' <<<"$inventory"
-}
-
-is_rue_root() {
-    [[ -f "$1/.buckconfig" && -x "$1/buck2" ]]
+    while IFS= read -r root; do
+        [[ "$root" == "worktree "* ]] || continue
+        root="${root#worktree }"
+        if [[ -f "$root/.buckconfig" && -x "$root/buck2" ]]; then
+            printf '%s\n' "$root"
+        else
+            echo "warning: registered worktree is not a usable Rue checkout: $root" >&2
+        fi
+    done <<<"$inventory"
 }
 
 size_kib() {
@@ -83,7 +61,7 @@ human_kib() {
 
 source_state() {
     local out
-    if ! out="$(git_reclaim -C "$1" status --porcelain 2>/dev/null)"; then
+    if ! out="$(git -C "$1" status --porcelain 2>/dev/null)"; then
         printf 'unknown'
     elif [[ -n "$out" ]]; then
         printf 'dirty'
@@ -92,40 +70,17 @@ source_state() {
     fi
 }
 
-# Reclaim decisions must use the repository selected by each explicit -C
-# root, never ambient Git environment that could redirect inventory, identity,
-# or source-state probes to an unrelated checkout. Keep ordinary Git commands
-# on the same safe path as well; unsetting the object/config selectors closes
-# the remaining ways for a caller's environment to change repository meaning.
-git_reclaim() {
-    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_INDEX_FILE \
-        -u GIT_OBJECT_DIRECTORY -u GIT_ALTERNATE_OBJECT_DIRECTORIES \
-        -u GIT_CEILING_DIRECTORIES -u GIT_DISCOVERY_ACROSS_FILESYSTEM \
-        -u GIT_NAMESPACE git "$@"
-}
-
+# `central` is the link to the installed user config that the ./buck2 wrapper
+# creates on a checkout's first build; `local` is any other .buckconfig.local.
 cache_state() {
     local destination="$1/.buckconfig.local"
-    if [[ -L "$destination" && -e "$destination" ]]; then
-        printf 'shared'
+    if [[ -L "$destination" && "$(readlink "$destination")" == "$central_config" ]]; then
+        printf 'central'
     elif [[ -e "$destination" || -L "$destination" ]]; then
-        printf 'custom'
+        printf 'local'
     else
         printf 'off'
     fi
-}
-
-registered_roots() {
-    local root roots
-    roots="$(collect_roots)" || return 1
-    while IFS= read -r root; do
-        [[ -n "$root" ]] || continue
-        if is_rue_root "$root"; then
-            printf '%s\n' "$root"
-        else
-            echo "warning: registered worktree is not a usable Rue checkout: $root" >&2
-        fi
-    done <<<"$roots"
 }
 
 status_all() {
@@ -133,6 +88,7 @@ status_all() {
     roots="$(registered_roots)" || return 1
     printf 'BUCK-OUT\tSOURCE\tCACHE\tWORKTREE\n'
     while IFS= read -r root; do
+        [[ -n "$root" ]] || continue
         kib="$(size_kib "$root")"
         total=$((total + kib))
         count=$((count + 1))
@@ -140,199 +96,24 @@ status_all() {
     done <<<"$roots"
     printf 'Total: %s in %d registered Rue worktree(s)\n' "$(human_kib "$total")" "$count"
     df -Pk "$repo_root" | awk 'NR == 2 { printf "Host filesystem: %s used, %.1f GiB available\n", $5, $4 / 1048576 }'
-    printf 'Policy: adaptive cleanup targets %d%% free (minimum TTL %s); emergency cleanup starts at %d%% only below %d GiB absolute free; builds are refused only below %d GiB\n' \
-        "$adaptive_target_percent" "$adaptive_min_ttl" "$emergency_trigger_percent" "$emergency_free_floor_gib" "$hard_floor_gib"
+    printf 'Policy: Buck removes tracked output unused for one week (.buckconfig); ./buck2 refuses build/test/run/install below 4 GiB free; remove finished worktrees to reclaim their output\n'
 }
 
 stale_all() {
     local mode="$1" age="$2" root roots failed=0
-    local args=(
-        clean --stale "$age"
-        --tracked-only
-        --adaptive-low-disk-threshold "$adaptive_target_percent"
-        --adaptive-min-ttl "$adaptive_min_ttl"
-    )
-    [[ "$mode" == plan ]] && args+=(--dry-run)
+    local args=(clean --stale "$age" --tracked-only)
+    if [[ "$mode" == plan ]]; then
+        args+=(--dry-run)
+    fi
     roots="$(registered_roots)" || return 1
     while IFS= read -r root; do
+        [[ -n "$root" ]] || continue
         printf '\n%s: %s\n' "$mode" "$root"
-        # Use the coordinator checkout's pinned Buck. A registered worktree may
-        # be on an older revision whose wrapper predates adaptive cleanup, but
-        # clean still operates on the project selected by this subshell's cwd.
+        # The coordinator checkout's pinned Buck; clean still operates on the
+        # project selected by this subshell's cwd.
         (cd "$root" && "$repo_root/buck2" "${args[@]}") || failed=1
     done <<<"$roots"
     return "$failed"
-}
-
-free_basis_points() {
-    local basis_points
-    if ! basis_points="$(df -Pk "$repo_root" 2>/dev/null | awk '
-        NR == 2 && $2 > 0 { printf "%d\n", ($4 * 10000) / $2; found = 1 }
-        END { if (!found) exit 1 }
-    ')"; then
-        echo "error: cannot determine host free space; refusing disk-pressure preflight" >&2
-        return 1
-    fi
-    printf '%s\n' "$basis_points"
-}
-
-format_basis_points() {
-    local basis_points="$1"
-    printf '%d.%02d' "$((basis_points / 100))" "$((basis_points % 100))"
-}
-
-free_kib() {
-    local kib
-    if ! kib="$(df -Pk "$repo_root" 2>/dev/null | awk '
-        NR == 2 { print $4; found = 1 }
-        END { if (!found) exit 1 }
-    ')"; then
-        echo "error: cannot determine host free space; refusing disk-pressure preflight" >&2
-        return 1
-    fi
-    printf '%s\n' "$kib"
-}
-
-# Prints "low" when both emergency signals are low, "ok" otherwise. Fails (and
-# callers fail closed) when free space cannot be measured at all.
-emergency_pressure() {
-    local basis_points kib
-    basis_points="$(free_basis_points)" || return 1
-    kib="$(free_kib)" || return 1
-    if (( basis_points <= emergency_trigger_percent * 100 )) &&
-        (( kib <= emergency_free_floor_gib * 1048576 )); then
-        printf 'low\n'
-    else
-        printf 'ok\n'
-    fi
-}
-
-# The refusal decision: "low" only when free space sits at or below the hard
-# floor (same fraction gate as the cleanup trigger). Fails closed like
-# emergency_pressure.
-hard_pressure() {
-    local basis_points kib
-    basis_points="$(free_basis_points)" || return 1
-    kib="$(free_kib)" || return 1
-    if (( basis_points <= emergency_trigger_percent * 100 )) &&
-        (( kib <= hard_floor_gib * 1048576 )); then
-        printf 'low\n'
-    else
-        printf 'ok\n'
-    fi
-}
-
-# One shared remediation notice so the refusal and the warn-and-proceed paths
-# name the same sanctioned moves. Editing or bypassing the guard is not one of
-# them.
-remediation_notice() {
-    cat >&2 <<EOF
-To reclaim space safely: remove worktrees whose work is finished
-('git worktree remove <path>'), reclaim stale Buck outputs host-wide with
-'scripts/rue storage clean', or reset a specific registered root's Buck
-outputs with 'scripts/rue storage reset <root>'.
-Do not edit or bypass this guard; it protects every worktree on the host.
-EOF
-}
-
-# "X.YZ% (N.M GiB)" for guard messages: the fraction alone reads as nonsense on
-# hosts where the device is much larger than the writable allowance.
-describe_free() {
-    local basis_points kib
-    basis_points="$(free_basis_points)" || return 1
-    kib="$(free_kib)" || return 1
-    printf '%s%% (%s)' "$(format_basis_points "$basis_points")" "$(human_kib "$kib")"
-}
-
-tracking_state() {
-    local root="$1" config
-    if ! config="$(cd "$root" && "$repo_root/buck2" audit config \
-        buck2.defer_write_actions --output-format json 2>/dev/null)"; then
-        echo "error: cannot inspect Buck materializer policy for $root" >&2
-        return 1
-    fi
-    if grep -q '"buck2.defer_write_actions":"true"' <<<"$config"; then
-        printf 'tracked\n'
-    else
-        printf 'legacy\n'
-    fi
-}
-
-reset_legacy_under_pressure() {
-    local roots root state kib entries="" now failed=0
-    roots="$(registered_roots)" || return 1
-    while IFS= read -r root; do
-        state="$(tracking_state "$root")" || return 1
-        if [[ "$state" == legacy ]]; then
-            kib="$(size_kib "$root")"
-            (( kib > 0 )) && entries+="${kib}"$'\t'"${root}"$'\n'
-        fi
-    done <<<"$roots"
-
-    while IFS=$'\t' read -r kib root; do
-        [[ -n "$root" ]] || continue
-        echo "warning: resetting legacy Buck state ($(human_kib "$kib")) in inactive worktree: $root" >&2
-        # A legacy checkout cannot participate in tracked stale cleanup. A full
-        # Buck reset is the only materializer-consistent migration. The
-        # not-idle guard refuses to interrupt an active command.
-        if ! (cd "$root" && "$repo_root/buck2" clean --exit-when notidle); then
-            echo "warning: could not reset legacy Buck state in $root (it may be active)" >&2
-            failed=1
-            continue
-        fi
-        now="$(emergency_pressure)" || return 1
-        if [[ "$now" == ok ]]; then
-            return 0
-        fi
-    done <<<"$(printf '%s' "$entries" | sort -rn)"
-
-    (( failed == 0 )) || return 1
-    return 1
-}
-
-guard_low_disk() {
-    local pressure before after after_basis_points
-    pressure="$(emergency_pressure)" || return 1
-    if [[ "$pressure" == ok ]]; then
-        return 0
-    fi
-    before="$(describe_free)" || return 1
-
-    echo "warning: host filesystem has ${before} free; running Rue's host-wide adaptive cleanup before building" >&2
-    # A cleanup error is not by itself fatal: with sibling worktrees mid-build,
-    # their busy Buck daemons legitimately refuse `clean`, which is the same
-    # contention RUE-1331's middle band exists for. The hard floor below still
-    # makes the refusal decision; only measurement failures stay fail-closed.
-    if ! stale_all clean 1w; then
-        echo "warning: host-wide cleanup could not run to completion (a sibling worktree's Buck daemon may be busy); deciding on the hard floor instead" >&2
-    fi
-
-    pressure="$(emergency_pressure)" || return 1
-    after="$(describe_free)" || return 1
-    if [[ "$pressure" == low ]]; then
-        if (( ${#FINISHED_EVIDENCE_ROOTS[@]} > 0 )); then
-            report_finished_evidence
-        fi
-        echo "warning: host filesystem still has only ${after} free; trying largest legacy Buck roots while preserving active work" >&2
-        # Escalation is best-effort; the hard floor below makes the decision.
-        reset_legacy_under_pressure || true
-        pressure="$(hard_pressure)" || return 1
-        after="$(describe_free)" || return 1
-        if [[ "$pressure" == low ]]; then
-            echo "error: host filesystem has ${after} free, at or below the ${hard_floor_gib} GiB hard floor; build stopped before risking ENOSPC" >&2
-            remediation_notice
-            return 1
-        fi
-        echo "warning: host filesystem has ${after} free — below the ${emergency_free_floor_gib} GiB cleanup floor but above the ${hard_floor_gib} GiB hard floor; proceeding. Incremental builds fit here; a cold full build may fail with ENOSPC." >&2
-        remediation_notice
-        return 0
-    fi
-    after_basis_points="$(free_basis_points)" || return 1
-    if (( after_basis_points < adaptive_target_percent * 100 )); then
-        echo "warning: cleanup raised host free space to ${after}, below the ${adaptive_target_percent}% adaptive target but above the emergency threshold" >&2
-    else
-        echo "Host free space after Rue cleanup: ${after}" >&2
-    fi
 }
 
 canonical_registered_root() {
@@ -343,654 +124,11 @@ canonical_registered_root() {
     fi
     roots="$(registered_roots)" || return 1
     while IFS= read -r root; do
+        [[ -n "$root" ]] || continue
         [[ "$(cd "$root" && pwd -P)" == "$canonical" ]] && { printf '%s\n' "$root"; return 0; }
     done <<<"$roots"
     echo "error: reset target is not a registered Rue worktree: $requested" >&2
     return 1
-}
-
-# The explicit reclaim path has a stricter inventory contract than the
-# host-wide status/TTL commands. Every entry must be a usable Rue checkout and
-# every canonical path must be unique; otherwise an alias could make the
-# caller authorize a different checkout than the one inspected.
-canonical_reclaim_root() {
-    local requested="$1" canonical root root_canonical roots seen=""
-    if ! canonical="$(cd "$requested" 2>/dev/null && pwd -P)"; then
-        echo "error: reclaim-finished target is not a directory: $requested" >&2
-        return 1
-    fi
-    if [[ "$canonical" == *$'\n'* ]]; then
-        echo "error: reclaim-finished target path is ambiguous; refusing reclaim: $requested" >&2
-        return 1
-    fi
-    roots="$(collect_roots)" || return 1
-    while IFS= read -r root; do
-        [[ -n "$root" ]] || continue
-        if ! is_rue_root "$root"; then
-            echo "error: registered worktree is not a usable Rue checkout; refusing reclaim: $root" >&2
-            return 1
-        fi
-        if ! root_canonical="$(cd "$root" 2>/dev/null && pwd -P)"; then
-            echo "error: cannot canonicalize registered worktree; refusing reclaim: $root" >&2
-            return 1
-        fi
-        if [[ "$root_canonical" == *$'\n'* ]]; then
-            echo "error: registered worktree path is ambiguous; refusing reclaim: $root" >&2
-            return 1
-        fi
-        if [[ "$seen" == *$'\n'"$root_canonical"$'\n'* ]]; then
-            echo "error: registered worktree inventory has ambiguous duplicate root: $root_canonical" >&2
-            return 1
-        fi
-        seen+=$'\n'"$root_canonical"$'\n'
-        if [[ "$root_canonical" == "$canonical" ]]; then
-            verify_reclaim_git_identity "$root_canonical" || return 1
-            printf '%s\n' "$root_canonical"
-        fi
-    done <<<"$roots"
-    if [[ "$seen" != *$'\n'"$canonical"$'\n'* ]]; then
-        echo "error: reclaim-finished target is not a registered Rue worktree: $requested" >&2
-        return 1
-    fi
-}
-
-canonical_git_path() {
-    local base="$1" path="$2"
-    if [[ "$path" == /* ]]; then
-        cd "$path" 2>/dev/null && pwd -P
-    else
-        cd "$base/$path" 2>/dev/null && pwd -P
-    fi
-}
-
-verify_reclaim_git_identity() {
-    local root="$1" coordinator_common candidate_common candidate_git_dir candidate_top pointer expected_pointer
-    if ! coordinator_common="$(git_reclaim -C "$repo_root" rev-parse --git-common-dir 2>/dev/null)" ||
-        ! coordinator_common="$(canonical_git_path "$repo_root" "$coordinator_common")"; then
-        echo "error: cannot inspect coordinator Git identity; refusing reclaim for $root" >&2
-        return 1
-    fi
-    if ! candidate_common="$(git_reclaim -C "$root" rev-parse --git-common-dir 2>/dev/null)" ||
-        ! candidate_common="$(canonical_git_path "$root" "$candidate_common")" ||
-        [[ "$candidate_common" != "$coordinator_common" ]]; then
-        echo "error: target is not in the coordinator's Git worktree family; refusing reclaim for $root" >&2
-        return 1
-    fi
-    if ! candidate_git_dir="$(git_reclaim -C "$root" rev-parse --git-dir 2>/dev/null)" ||
-        ! candidate_git_dir="$(canonical_git_path "$root" "$candidate_git_dir")"; then
-        echo "error: cannot inspect target Git worktree admin directory; refusing reclaim for $root" >&2
-        return 1
-    fi
-    if [[ "$candidate_git_dir" != "$coordinator_common" ]]; then
-        case "$candidate_git_dir/" in
-            "$coordinator_common/worktrees/"*) ;;
-            *)
-                echo "error: target Git worktree admin directory is outside the coordinator mapping; refusing reclaim for $root" >&2
-                return 1
-                ;;
-        esac
-        if [[ -L "$candidate_git_dir/gitdir" || ! -f "$candidate_git_dir/gitdir" ]] ||
-            ! IFS= read -r pointer <"$candidate_git_dir/gitdir" ||
-            [[ -z "$pointer" || "$pointer" == gitdir:* ]]; then
-            echo "error: target Git worktree admin back-pointer is missing; refusing reclaim for $root" >&2
-            return 1
-        fi
-        if [[ -L "$root/.git" || ! -f "$root/.git" ]]; then
-            echo "error: target Git worktree link file is missing; refusing reclaim for $root" >&2
-            return 1
-        fi
-        expected_pointer="$(canonical_file_path "$root" "$root/.git")" || return 1
-        # Git may write a relative back-pointer when the worktree uses
-        # --relative-paths; it is relative to the admin directory, not root.
-        if ! pointer="$(canonical_file_path "$candidate_git_dir" "$pointer")" ||
-            [[ "$pointer" != "$expected_pointer" ]]; then
-            echo "error: target Git worktree admin back-pointer does not match its registered root; refusing reclaim for $root" >&2
-            return 1
-        fi
-    else
-        # A linked worktree has a .git file, while the coordinator's main
-        # checkout has a real .git directory. Do not accept a main-looking
-        # candidate whose .git merely points at the coordinator metadata.
-        if [[ -L "$root/.git" || ! -d "$root/.git" ]] ||
-            ! candidate_git_dir="$(cd "$root/.git" 2>/dev/null && pwd -P)" ||
-            [[ "$candidate_git_dir" != "$coordinator_common" ]]; then
-            echo "error: target main-worktree Git metadata does not match the coordinator; refusing reclaim for $root" >&2
-            return 1
-        fi
-    fi
-    if ! candidate_top="$(git_reclaim -C "$root" rev-parse --show-toplevel 2>/dev/null)" ||
-        ! candidate_top="$(cd "$candidate_top" 2>/dev/null && pwd -P)" ||
-        [[ "$candidate_top" != "$root" ]]; then
-        echo "error: target Git top-level does not match its registered root; refusing reclaim for $root" >&2
-        return 1
-    fi
-    if [[ "${2:-}" == print-admin ]]; then
-        printf '%s\n' "$candidate_git_dir"
-    fi
-}
-
-filesystem_identity() {
-    local path="$1" identity
-    # GNU stat's -f means filesystem statistics (not file dev:inode), so try
-    # its exact file form first. BSD/macOS rejects -c and then provides the
-    # equivalent fields through -f.
-    if identity="$(stat -c '%d:%i' "$path" 2>/dev/null)" &&
-        [[ "$identity" =~ ^[0-9]+:[0-9]+$ ]]; then
-        printf '%s\n' "$identity"
-        return 0
-    fi
-    if identity="$(stat -f '%d:%i' "$path" 2>/dev/null)" &&
-        [[ "$identity" =~ ^[0-9]+:[0-9]+$ ]]; then
-        printf '%s\n' "$identity"
-        return 0
-    fi
-    echo "error: cannot inspect filesystem identity for $path; refusing reclaim" >&2
-    return 1
-}
-
-canonical_file_path() {
-    local base="$1" path="$2" directory filename canonical_directory
-    if [[ "$path" == /* ]]; then
-        directory="${path%/*}"
-        filename="${path##*/}"
-    else
-        directory="$base/${path%/*}"
-        filename="${path##*/}"
-    fi
-    [[ -n "$directory" ]] || directory=/
-    if ! canonical_directory="$(cd "$directory" 2>/dev/null && pwd -P)"; then
-        return 1
-    fi
-    printf '%s/%s\n' "$canonical_directory" "$filename"
-}
-
-# `du` is part of the validation boundary for explicit cleanup. A failed or
-# malformed size probe must not be interpreted as an empty buck-out.
-reclaim_size_kib() {
-    local root="$1" kib
-    if [[ ! -e "$root/buck-out" && ! -L "$root/buck-out" ]]; then
-        printf '0\n'
-        return 0
-    fi
-    if [[ -L "$root/buck-out" || ! -d "$root/buck-out" ]]; then
-        echo "error: Buck output root is not a directory; refusing reclaim for $root" >&2
-        return 1
-    fi
-    if ! kib="$(du -sk "$root/buck-out" 2>/dev/null | awk 'NR == 1 && $1 ~ /^[0-9]+$/ { print $1; found = 1 } END { if (!found) exit 1 }')" ||
-        [[ ! "$kib" =~ ^[0-9]+$ ]]; then
-        echo "error: cannot inspect Buck output size for $root; refusing reclaim" >&2
-        return 1
-    fi
-    printf '%s\n' "$kib"
-}
-
-# Enumerate only the isolation directories that already exist under this
-# root. Each Buck operation is scoped to one such isolation, so a newly-created
-# alternate isolation is never swept by a broad default clean. Every
-# directory, including Buck's default v2 isolation, is passed explicitly as
-# --isolation-dir so inherited isolation settings cannot retarget cleanup.
-run_isolation_clean() {
-    local root="$1" path="$2" mode="$3" expected_admin="${4:-}" expected_admin_identity="${5:-}" expected_identity="${6:-}" expected_output_identity="${7:-}" expected_isolation_identity="${8:-}" isolation
-    local current_admin current_admin_identity current_identity
-    local -a args=()
-    (
-        cd "$root" 2>/dev/null || return 1
-        validate_isolation_path "$root" "$path" || return 1
-        validate_pinned_output_identity "$root" "$expected_output_identity" || return 1
-        validate_pinned_path_identity "$path" "$expected_isolation_identity" || return 1
-        if [[ "$mode" == destructive ]]; then
-            verify_registered_reclaim_root "$root" || return 1
-            current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
-            current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
-            current_identity="$(filesystem_identity "$root")" || return 1
-            if [[ "$current_admin" != "$expected_admin" ||
-                "$current_admin_identity" != "$expected_admin_identity" ||
-                "$current_identity" != "$expected_identity" ]]; then
-                echo "error: registered worktree identity changed since reclaim validation; refusing reclaim for $root" >&2
-                return 1
-            fi
-        fi
-        if [[ "$path" == "$root/buck-out" ]]; then
-            isolation=v2
-        else
-            isolation="${path##*/}"
-        fi
-        args=(--isolation-dir "$isolation" clean)
-        if [[ "$mode" == preflight ]]; then
-            args+=(--dry-run --exit-when notidle)
-            "$repo_root/buck2" "${args[@]}" >/dev/null
-        elif [[ "$mode" == evidence ]]; then
-            args+=(--stale 1w --tracked-only --dry-run --exit-when notidle)
-            "$repo_root/buck2" "${args[@]}" >/dev/null
-        else
-            args+=(--exit-when notidle)
-            "$repo_root/buck2" "${args[@]}"
-        fi
-    )
-}
-
-validate_isolation_path() {
-    local root="$1" path="$2"
-    if [[ -L "$root/buck-out" || ! -d "$root/buck-out" ]]; then
-        echo "error: Buck output root changed while reclaiming; refusing reclaim for $root" >&2
-        return 1
-    fi
-    if [[ "$path" != "$root/buck-out" && "$path" != "$root/buck-out/"* ]]; then
-        echo "error: Buck isolation path is outside buck-out; refusing reclaim for $root: $path" >&2
-        return 1
-    fi
-    if [[ -L "$path" || ! -d "$path" ]]; then
-        echo "error: Buck isolation changed while reclaiming; refusing reclaim for $root: $path" >&2
-        return 1
-    fi
-}
-
-reclaim_output_identity() {
-    local root="$1"
-    if [[ ! -e "$root/buck-out" && ! -L "$root/buck-out" ]]; then
-        printf 'absent\n'
-    else
-        filesystem_identity "$root/buck-out"
-    fi
-}
-
-validate_pinned_output_identity() {
-    local root="$1" expected="$2" current
-    current="$(reclaim_output_identity "$root")" || return 1
-    if [[ "$current" != "$expected" ]]; then
-        echo "error: Buck output root identity changed during reclaim; refusing reclaim for $root" >&2
-        return 1
-    fi
-}
-
-validate_pinned_path_identity() {
-    local path="$1" expected="$2" current
-    current="$(filesystem_identity "$path")" || return 1
-    if [[ "$current" != "$expected" ]]; then
-        echo "error: Buck isolation identity changed during reclaim; refusing reclaim for $path" >&2
-        return 1
-    fi
-}
-
-isolation_identity_snapshot() {
-    local snapshot="$1" path
-    while IFS= read -r path; do
-        [[ -n "$path" ]] || continue
-        filesystem_identity "$path" || return 1
-    done <<<"$snapshot"
-}
-
-snapshot_identity_at() {
-    local identities="$1" wanted="$2" index=0 identity
-    while IFS= read -r identity; do
-        if (( index == wanted )); then
-            printf '%s\n' "$identity"
-            return 0
-        fi
-        index=$((index + 1))
-    done <<<"$identities"
-    return 1
-}
-
-verify_registered_reclaim_root() {
-    local target="$1" roots root canonical found=0 seen=""
-    roots="$(collect_roots)" || return 1
-    while IFS= read -r root; do
-        [[ -n "$root" ]] || continue
-        if ! is_rue_root "$root" ||
-            ! canonical="$(cd "$root" 2>/dev/null && pwd -P)"; then
-            echo "error: registered worktree inventory changed or became unusable; refusing reclaim for $target" >&2
-            return 1
-        fi
-        if [[ "$canonical" == *$'\n'* ]]; then
-            echo "error: registered worktree path became ambiguous; refusing reclaim for $target" >&2
-            return 1
-        fi
-        if [[ "$seen" == *$'\n'"$canonical"$'\n'* ]]; then
-            echo "error: registered worktree inventory became ambiguous; refusing reclaim for $target" >&2
-            return 1
-        fi
-        seen+=$'\n'"$canonical"$'\n'
-        [[ "$canonical" == "$target" ]] && found=1
-    done <<<"$roots"
-    if (( found == 0 )); then
-        echo "error: reclaim target is no longer a registered Rue worktree; refusing reclaim for $target" >&2
-        return 1
-    fi
-}
-
-validate_isolation_snapshot() {
-    local root="$1" snapshot="$2" current
-    if ! current="$(snapshot_isolations "$root")" || [[ "$current" != "$snapshot" ]]; then
-        echo "error: Buck isolation set changed since liveness preflight; refusing reclaim for $root" >&2
-        return 1
-    fi
-}
-
-validate_post_reclaim_snapshot() {
-    local root="$1" initial="$2" current path residual
-    if ! current="$(snapshot_isolations "$root")"; then
-        return 1
-    fi
-    while IFS= read -r path; do
-        [[ -n "$path" ]] || continue
-        case $'\n'"$initial"$'\n' in
-            *$'\n'"$path"$'\n'*) ;;
-            *)
-                echo "error: new Buck isolation appeared during reclaim; refusing to continue for $root: $path" >&2
-                return 1
-                ;;
-        esac
-        if ! residual="$(find "$path" ! -type d -print -quit 2>/dev/null)"; then
-            echo "error: cannot inspect residual Buck output after reclaiming $root" >&2
-            return 1
-        fi
-        if [[ -n "$residual" ]]; then
-            echo "warning: Buck retained output in the cleaned isolation for $root: $residual" >&2
-        fi
-    done <<<"$current"
-}
-
-# Output a newline-separated snapshot of direct isolation paths. Direct files
-# are retained as a compatibility fixture for the default v2 isolation; a
-# mixture of files and directories, or any symlink, is ambiguous and refused.
-snapshot_isolations() {
-    local root="$1" path snapshot="" default_path="" found=0 direct=0
-    if [[ -L "$root/buck-out" ]]; then
-        echo "error: Buck output root is a symlink; refusing reclaim for $root" >&2
-        return 1
-    fi
-    if [[ ! -e "$root/buck-out" ]]; then
-        return 0
-    fi
-    if [[ ! -d "$root/buck-out" ]]; then
-        echo "error: Buck output root is not a directory; refusing reclaim for $root" >&2
-        return 1
-    fi
-    for path in "$root"/buck-out/* "$root"/buck-out/.[!.]* "$root"/buck-out/..?*; do
-        [[ -e "$path" || -L "$path" ]] || continue
-        if [[ "$path" == *$'\n'* ]]; then
-            echo "error: Buck isolation path contains a newline; refusing reclaim for $root" >&2
-            return 1
-        fi
-        if [[ -L "$path" ]]; then
-            echo "error: Buck isolation is a symlink; refusing reclaim for $root: $path" >&2
-            return 1
-        elif [[ -d "$path" ]]; then
-            found=1
-            if [[ "${path##*/}" == v2 ]]; then
-                default_path="$path"
-            else
-                snapshot+="${snapshot:+$'\n'}${path}"
-            fi
-        elif [[ -f "$path" ]]; then
-            direct=1
-        else
-            echo "error: unknown direct Buck output entry; refusing reclaim for $root: $path" >&2
-            return 1
-        fi
-    done
-    if (( found > 0 && direct > 0 )); then
-        echo "error: Buck output mixes direct files and isolation directories; refusing reclaim for $root" >&2
-        return 1
-    fi
-    if (( found == 0 && direct > 0 )); then
-        snapshot="$root/buck-out"
-    elif [[ -n "$default_path" ]]; then
-        snapshot="${default_path}${snapshot:+$'\n'}${snapshot}"
-    fi
-    printf '%s\n' "$snapshot"
-}
-
-clean_isolation_snapshot() {
-    local root="$1" mode="$2" snapshot="$3" expected_admin="${4:-}" expected_admin_identity="${5:-}" expected_identity="${6:-}" expected_output_identity="${7:-}" expected_isolation_identities="${8:-}" path path_index=0 expected_path_identity
-    validate_isolation_snapshot "$root" "$snapshot" || return 1
-    [[ -n "$snapshot" ]] || return 0
-    while IFS= read -r path; do
-        [[ -n "$path" ]] || continue
-        expected_path_identity="$(snapshot_identity_at "$expected_isolation_identities" "$path_index")" || return 1
-        run_isolation_clean "$root" "$path" "$mode" "$expected_admin" "$expected_admin_identity" "$expected_identity" "$expected_output_identity" "$expected_path_identity" || return 1
-        path_index=$((path_index + 1))
-    done <<<"$snapshot"
-}
-
-reclaim_finished_roots() {
-    local requested root state kib before after reclaimed existing index snapshot admin identity current_admin current_identity current_admin_identity output_identity isolation_identities initial_snapshot initial_output_identity initial_isolation_identities current_snapshot current_isolation_identities
-    local -a roots=() states=() sizes=() isolation_snapshots=() isolation_identity_snapshots=() output_identities=() admin_dirs=() admin_identities=() root_identities=()
-    # Resolve and inspect every requested root before invoking Buck for any
-    # root. The caller's explicit list is the finishedness signal; clean and
-    # dirty source states are both accepted.
-    for requested in "$@"; do
-        root="$(canonical_reclaim_root "$requested")" || return 1
-        if [[ "$root" == "$repo_root" ]]; then
-            echo "error: refusing reclaim-finished for the current coordinator worktree: $requested" >&2
-            return 1
-        fi
-        if (( ${#roots[@]} > 0 )); then
-            for existing in "${roots[@]}"; do
-                if [[ "$existing" == "$root" ]]; then
-                    echo "error: reclaim-finished target was named more than once: $requested" >&2
-                    return 1
-                fi
-            done
-        fi
-        # Pin the registered Git/root identity and output generation before any
-        # source, size, or isolation probes. A replacement during those probes
-        # must not become the new accepted baseline.
-        admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
-        admin_identity="$(filesystem_identity "$admin")" || return 1
-        identity="$(filesystem_identity "$root")" || return 1
-        initial_output_identity="$(reclaim_output_identity "$root")" || return 1
-        initial_snapshot="$(snapshot_isolations "$root")" || return 1
-        initial_isolation_identities="$(isolation_identity_snapshot "$initial_snapshot")" || return 1
-        state="$(source_state "$root")"
-        if [[ "$state" == unknown ]]; then
-            echo "error: cannot inspect source state for $root; refusing reclaim" >&2
-            return 1
-        fi
-        kib="$(reclaim_size_kib "$root")" || return 1
-        output_identity="$(reclaim_output_identity "$root")" || return 1
-        if [[ "$output_identity" != "$initial_output_identity" ]]; then
-            echo "error: Buck output generation changed during initial reclaim validation; refusing reclaim for $root" >&2
-            return 1
-        fi
-        current_snapshot="$(snapshot_isolations "$root")" || return 1
-        current_isolation_identities="$(isolation_identity_snapshot "$current_snapshot")" || return 1
-        if [[ "$current_snapshot" != "$initial_snapshot" ||
-            "$current_isolation_identities" != "$initial_isolation_identities" ]]; then
-            echo "error: Buck isolation generation changed during initial reclaim validation; refusing reclaim for $root" >&2
-            return 1
-        fi
-        current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
-        current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
-        current_identity="$(filesystem_identity "$root")" || return 1
-        if [[ "$current_admin" != "$admin" ||
-            "$current_admin_identity" != "$admin_identity" ||
-            "$current_identity" != "$identity" ]]; then
-            echo "error: registered worktree identity changed during initial reclaim validation; refusing reclaim for $root" >&2
-            return 1
-        fi
-        snapshot="$initial_snapshot"
-        isolation_identities="$initial_isolation_identities"
-        roots+=("$root")
-        states+=("$state")
-        sizes+=("$kib")
-        isolation_snapshots+=("$snapshot")
-        isolation_identity_snapshots+=("$isolation_identities")
-        output_identities+=("$output_identity")
-        admin_dirs+=("$admin")
-        admin_identities+=("$admin_identity")
-        root_identities+=("$identity")
-    done
-
-    # Probe every snapshotted target while all targets are still untouched. This
-    # closes the common multi-root case where a later active daemon would
-    # otherwise be discovered only after an earlier root had been reclaimed.
-    # The destructive call below repeats the authority check because a daemon
-    # can become active between this harmless probe and cleanup.
-    for index in "${!roots[@]}"; do
-        root="${roots[$index]}"
-        [[ -n "${isolation_snapshots[$index]}" ]] || continue
-        if ! clean_isolation_snapshot "$root" preflight "${isolation_snapshots[$index]}" "" "" "" "${output_identities[$index]}" "${isolation_identity_snapshots[$index]}"; then
-            echo "error: Buck refused reclaim-finished preflight for $root (the worktree may be active); no roots reclaimed" >&2
-            return 1
-        fi
-    done
-
-    for index in "${!roots[@]}"; do
-        root="${roots[$index]}"
-        if ! validate_isolation_snapshot "$root" "${isolation_snapshots[$index]}"; then
-            return 1
-        fi
-        validate_pinned_output_identity "$root" "${output_identities[$index]}" || return 1
-        verify_registered_reclaim_root "$root" || return 1
-        current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
-        current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
-        current_identity="$(filesystem_identity "$root")" || return 1
-        if [[ "$current_admin" != "${admin_dirs[$index]}" ||
-            "$current_admin_identity" != "${admin_identities[$index]}" ||
-            "$current_identity" != "${root_identities[$index]}" ]]; then
-            echo "error: registered worktree identity changed since reclaim validation; refusing reclaim for $root" >&2
-            return 1
-        fi
-        if [[ -z "${isolation_snapshots[$index]}" ]]; then
-            printf 'reclaim-finished: %s — zero Buck output; reclaimed 0 KiB\n' "$root"
-            continue
-        fi
-        before="$(reclaim_size_kib "$root")" || return 1
-        printf 'reclaim-finished: %s (caller-authorized finished root; source %s)\n' "$root" "${states[$index]}"
-        # Buck owns the liveness decision for this exact isolation.
-        current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
-        current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
-        current_identity="$(filesystem_identity "$root")" || return 1
-        if [[ "$current_admin" != "${admin_dirs[$index]}" ||
-            "$current_admin_identity" != "${admin_identities[$index]}" ||
-            "$current_identity" != "${root_identities[$index]}" ]]; then
-            echo "error: registered worktree identity changed since reclaim validation; refusing reclaim for $root" >&2
-            return 1
-        fi
-        if ! clean_isolation_snapshot "$root" destructive "${isolation_snapshots[$index]}" "${admin_dirs[$index]}" "${admin_identities[$index]}" "${root_identities[$index]}" "${output_identities[$index]}" "${isolation_identity_snapshots[$index]}"; then
-            echo "error: Buck refused reclaim-finished for $root (the worktree may be active); no further roots reclaimed" >&2
-            return 1
-        fi
-        verify_registered_reclaim_root "$root" || return 1
-        current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
-        current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
-        current_identity="$(filesystem_identity "$root")" || return 1
-        if [[ "$current_admin" != "${admin_dirs[$index]}" ||
-            "$current_admin_identity" != "${admin_identities[$index]}" ||
-            "$current_identity" != "${root_identities[$index]}" ]]; then
-            echo "error: registered worktree identity changed during reclaim; refusing terminal success for $root" >&2
-            return 1
-        fi
-        after="$(reclaim_size_kib "$root")" || return 1
-        if ! validate_post_reclaim_snapshot "$root" "${isolation_snapshots[$index]}"; then
-            return 1
-        fi
-        reclaimed=$((before - after))
-        if (( reclaimed < 0 )); then
-            printf 'reclaim-finished: %s — observed output growth of %s (residual %s)\n' "$root" "$(human_kib "$((-reclaimed))")" "$(human_kib "$after")"
-        elif (( after > 0 )); then
-            printf 'reclaim-finished: %s — reclaimed %s (residual %s)\n' "$root" "$(human_kib "$reclaimed")" "$(human_kib "$after")"
-        else
-            printf 'reclaim-finished: %s — reclaimed %s\n' "$root" "$(human_kib "$reclaimed")"
-        fi
-    done
-}
-
-validate_finished_evidence() {
-    local requested root state existing admin admin_identity root_identity
-    local -a evidence_roots=() evidence_admin_dirs=() evidence_admin_identities=() evidence_root_identities=()
-    for requested in "$@"; do
-        root="$(canonical_reclaim_root "$requested")" || return 1
-        if [[ "$root" == "$repo_root" ]]; then
-            echo "error: --finished-root cannot name the current coordinator worktree: $requested" >&2
-            return 1
-        fi
-        if (( ${#evidence_roots[@]} > 0 )); then
-            for existing in "${evidence_roots[@]}"; do
-                if [[ "$existing" == "$root" ]]; then
-                    echo "error: --finished-root named the same registered root more than once: $requested" >&2
-                    return 1
-                fi
-            done
-        fi
-        state="$(source_state "$root")"
-        [[ "$state" != unknown ]] || {
-            echo "error: cannot inspect --finished-root source state for $root; refusing guard evidence" >&2
-            return 1
-        }
-        admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
-        admin_identity="$(filesystem_identity "$admin")" || return 1
-        root_identity="$(filesystem_identity "$root")" || return 1
-        evidence_roots+=("$root")
-        evidence_admin_dirs+=("$admin")
-        evidence_admin_identities+=("$admin_identity")
-        evidence_root_identities+=("$root_identity")
-    done
-    FINISHED_EVIDENCE_ROOTS=("${evidence_roots[@]}")
-    FINISHED_EVIDENCE_ADMIN_DIRS=("${evidence_admin_dirs[@]}")
-    FINISHED_EVIDENCE_ADMIN_IDENTITIES=("${evidence_admin_identities[@]}")
-    FINISHED_EVIDENCE_ROOT_IDENTITIES=("${evidence_root_identities[@]}")
-}
-
-validate_finished_evidence_identity() {
-    local index="$1" root current_admin current_admin_identity current_identity
-    root="${FINISHED_EVIDENCE_ROOTS[$index]}"
-    verify_registered_reclaim_root "$root" || return 1
-    current_admin="$(verify_reclaim_git_identity "$root" print-admin)" || return 1
-    current_admin_identity="$(filesystem_identity "$current_admin")" || return 1
-    current_identity="$(filesystem_identity "$root")" || return 1
-    if [[ "$current_admin" != "${FINISHED_EVIDENCE_ADMIN_DIRS[$index]}" ||
-        "$current_admin_identity" != "${FINISHED_EVIDENCE_ADMIN_IDENTITIES[$index]}" ||
-        "$current_identity" != "${FINISHED_EVIDENCE_ROOT_IDENTITIES[$index]}" ]]; then
-        echo "error: caller-supplied finished-root identity changed; refusing guard evidence for $root" >&2
-        return 1
-    fi
-}
-
-report_finished_evidence() {
-    local index root kib snapshot quoted_root output_identity isolation_identities
-    for index in "${!FINISHED_EVIDENCE_ROOTS[@]}"; do
-        root="${FINISHED_EVIDENCE_ROOTS[$index]}"
-        validate_finished_evidence_identity "$index" || return 1
-        kib="$(reclaim_size_kib "$root")" || return 1
-        (( kib > 0 )) || continue
-        # This non-destructive probe lets Buck reject a live daemon and shows
-        # whether the normal one-week tracked cleanup still has output to
-        # consider. A successful probe plus nonzero output is caller evidence;
-        # it is never auto-reclaimed here.
-        snapshot="$(snapshot_isolations "$root")" || return 1
-        output_identity="$(reclaim_output_identity "$root")" || return 1
-        isolation_identities="$(isolation_identity_snapshot "$snapshot")" || return 1
-        if ! clean_isolation_snapshot "$root" evidence "$snapshot" "" "" "" "$output_identity" "$isolation_identities" >/dev/null 2>&1; then
-            continue
-        fi
-        validate_finished_evidence_identity "$index" || return 1
-        kib="$(reclaim_size_kib "$root")" || return 1
-        (( kib > 0 )) || continue
-        quoted_root="$(printf '%q' "$root")"
-        printf 'warning: caller-supplied finished root is eligible for reclaim-finished: %s\n' "$root" >&2
-        printf 'warning: reclaim it explicitly with: scripts/rue storage reclaim-finished %s\n' "$quoted_root" >&2
-    done
-}
-
-FINISHED_EVIDENCE_ROOTS=()
-FINISHED_EVIDENCE_ADMIN_DIRS=()
-FINISHED_EVIDENCE_ADMIN_IDENTITIES=()
-FINISHED_EVIDENCE_ROOT_IDENTITIES=()
-
-guard_command() {
-    local -a finished_evidence=()
-    while [[ $# -gt 0 ]]; do
-        [[ "$1" == --finished-root && $# -ge 2 && -n "$2" ]] || { usage >&2; return 2; }
-        finished_evidence+=("$2")
-        shift 2
-    done
-    if (( ${#finished_evidence[@]} > 0 )); then
-        validate_finished_evidence "${finished_evidence[@]}"
-    fi
-    guard_low_disk
 }
 
 reset_roots() {
@@ -1017,13 +155,6 @@ case "$command" in
     plan|clean)
         [[ $# -le 1 ]] || { usage >&2; exit 2; }
         stale_all "$command" "${1:-1w}"
-        ;;
-    guard)
-        guard_command "$@"
-        ;;
-    reclaim-finished)
-        [[ $# -gt 0 ]] || { usage >&2; exit 2; }
-        reclaim_finished_roots "$@"
         ;;
     reset)
         [[ $# -gt 0 ]] || { usage >&2; exit 2; }

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Hermetic regression tests for cache provisioning and full-suite scheduling.
+# Hermetic regression tests for cache provisioning, the ./buck2 wrapper's
+# remote-cache handling, and full-suite scheduling.
 set -uo pipefail
 
 if [[ -n "${RUE_BUILD_SHARING_ROOT:-}" ]]; then
@@ -17,160 +18,45 @@ check() {
     if [[ "$2" -eq 0 ]]; then pass "$1"; else fail "$1"; fi
 }
 
-make_rue_root() {
-    local root="$1"
-    mkdir -p "$root/platforms"
-    : >"$root/.buckconfig"
-    : >"$root/platforms/remote_cache.bzl"
-    printf '#!/bin/sh\nexit 0\n' >"$root/buck2"
-    chmod +x "$root/buck2"
-}
-
-test_cache_provisioning() {
-    local sb key config out rc mode
-    sb="$(mktemp -d)"
-    key='test-secret-that-must-not-be-printed'
-    config="$sb/config/rue/buildbuddy.buckconfig"
-    make_rue_root "$sb/primary"
-    make_rue_root "$sb/worktree"
-
-    mkdir -p "$(dirname "$config")"
-    cat >"$config" <<EOF
-[buck2_re_client]
-http_headers = x-buildbuddy-api-key:$key
-EOF
-    chmod 600 "$config"
-    rc=0
-    out="$(HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
-        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/primary" "$sb/worktree" 2>&1)" || rc=$?
-    check "cache: private pre-upload-gate config migrates automatically" \
-        "$([ "$rc" -eq 0 ] && grep -Eq '^default_allow_cache_upload = true$' "$config" && echo 0 || echo 1)"
-    check "cache: migration preserves the credential without printing it" \
-        "$(grep -Fq "x-buildbuddy-api-key:$key" "$config" && [[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
-    mode="$(stat -c '%a' "$config" 2>/dev/null || stat -f '%Lp' "$config")"
-    check "cache: migrated config remains private" "$([ $((8#$mode & 077)) -eq 0 ] && echo 0 || echo 1)"
-
-    rc=0
-    out="$(HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
-        "$SRC_ROOT/scripts/provision-build-cache" install 2>&1)" || rc=$?
-    check "cache: install succeeds" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
-    check "cache: install never prints the key" "$([[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
-    mode="$(stat -c '%a' "$config" 2>/dev/null || stat -f '%Lp' "$config")"
-    check "cache: central config is private" "$([ $((8#$mode & 077)) -eq 0 ] && echo 0 || echo 1)"
-    check "cache: Rust action uploads are enabled" \
-        "$(grep -Eq '^default_allow_cache_upload = true$' "$config" && echo 0 || echo 1)"
-
-    rc=0
-    out="$(HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
-        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/primary" "$sb/worktree" 2>&1)" || rc=$?
-    check "cache: one command provisions multiple worktrees" \
-        "$([ "$rc" -eq 0 ] && [[ -L "$sb/primary/.buckconfig.local" ]] && [[ -L "$sb/worktree/.buckconfig.local" ]] && echo 0 || echo 1)"
-    check "cache: worktrees share the central config" \
-        "$([ "$(readlink "$sb/primary/.buckconfig.local")" = "$config" ] && [ "$(readlink "$sb/worktree/.buckconfig.local")" = "$config" ] && echo 0 || echo 1)"
-    check "cache: provisioning never prints the key" "$([[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
-
-    make_rue_root "$sb/future-worktree"
-    rc=0
-    (cd "$sb/future-worktree" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
-        "$SRC_ROOT/scripts/provision-build-cache" auto) >/dev/null 2>&1 || rc=$?
-    check "cache: a future worktree adopts the installed config on first use" \
-        "$([ "$rc" -eq 0 ] && [[ -L "$sb/future-worktree/.buckconfig.local" ]] && echo 0 || echo 1)"
-
-    rm -f "$sb/worktree/.buckconfig.local"
-    printf 'local config that must survive\n' >"$sb/worktree/.buckconfig.local"
-    rc=0
-    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
-        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/worktree" >/dev/null 2>&1 || rc=$?
-    check "cache: existing per-worktree config is preserved" \
-        "$([ "$rc" -ne 0 ] && grep -q 'must survive' "$sb/worktree/.buckconfig.local" && echo 0 || echo 1)"
-
-    chmod 644 "$config"
-    rc=0
-    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
-        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/primary" >/dev/null 2>&1 || rc=$?
-    check "cache: insecure central permissions fail closed" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
-
-    chmod 600 "$config"
-    sed 's/default_allow_cache_upload = true/default_allow_cache_upload = false/' "$config" >"$config.disabled"
-    mv "$config.disabled" "$config"
-    chmod 600 "$config"
-    rc=0
-    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
-        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/primary" >/dev/null 2>&1 || rc=$?
-    check "cache: an explicit upload opt-out is never rewritten" \
-        "$([ "$rc" -ne 0 ] && grep -Eq '^default_allow_cache_upload = false$' "$config" && echo 0 || echo 1)"
-    rm -rf "$sb"
-}
-
-test_buck_wrapper_prefers_local_cache_misses() {
-    local sb guard_calls rc
-    sb="$(mktemp -d)"
-    mkdir -p "$sb/fakebin" "$sb/scripts"
+# The real ./buck2 and its DotSlash manifest, a fake dotslash that records the
+# argv it would have run, and a fake `df -Pk` reporting ample free space so
+# the wrapper's free-space floor (pinned by test-cleanup-scripts.sh) never
+# decides these tests.
+make_wrapper_sandbox() {
+    local sb="$1"
+    mkdir -p "$sb/fakebin" "$sb/config"
     cp "$SRC_ROOT/buck2" "$sb/buck2"
     cp "$SRC_ROOT/buck2-bin" "$sb/buck2-bin"
     chmod +x "$sb/buck2"
-    cat >"$sb/scripts/rue-storage" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >>"$STORAGE_ARGS"
-EOF
-    chmod +x "$sb/scripts/rue-storage"
-    cat >"$sb/.buckconfig.local" <<'EOF'
-[build]
-execution_platforms = root//platforms:remote_cache
-EOF
+    # The first argument is the DotSlash manifest; the log holds Buck's argv.
     cat >"$sb/fakebin/dotslash" <<'EOF'
 #!/usr/bin/env bash
+shift
 printf '%s\n' "$@" >"$DOTSLASH_ARGS"
 EOF
-    chmod +x "$sb/fakebin/dotslash"
-
-    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/build.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" build //:probe
-    check "buck wrapper: cache misses prefer local execution" \
-        "$(grep -Fxq -- '--prefer-local' "$sb/build.args" && echo 0 || echo 1)"
-
-    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/remote.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" build --prefer-remote //:probe
-    check "buck wrapper: explicit execution preference is preserved" \
-        "$(! grep -Fxq -- '--prefer-local' "$sb/remote.args" && grep -Fxq -- '--prefer-remote' "$sb/remote.args" && echo 0 || echo 1)"
-
-    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/run.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" run //:probe -- program-arg
-    local local_line separator_line
-    local_line="$(grep -nFx -- '--prefer-local' "$sb/run.args" | cut -d: -f1)"
-    separator_line="$(grep -nFx -- '--' "$sb/run.args" | cut -d: -f1)"
-    check "buck wrapper: preference stays before executable arguments" \
-        "$([ "$local_line" -lt "$separator_line" ] && echo 0 || echo 1)"
-    guard_calls="$(grep -c '^guard$' "$sb/storage.args")"
-    check "buck wrapper: every execution command runs the disk-pressure guard" \
-        "$([ "$guard_calls" -eq 3 ] && echo 0 || echo 1)"
-
-    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/clean.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" clean
-    check "buck wrapper: cleanup commands do not recurse through the guard" \
-        "$([ "$(grep -c '^guard$' "$sb/storage.args")" -eq "$guard_calls" ] && echo 0 || echo 1)"
-
-    cat >"$sb/scripts/rue-storage" <<'EOF'
+    cat >"$sb/fakebin/df" <<'EOF'
 #!/usr/bin/env bash
-exit 1
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf '/dev/fake 100000000 1000 50000000 1%% /\n'
 EOF
-    chmod +x "$sb/scripts/rue-storage"
-    rc=0
-    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/blocked.args" PATH="$sb/fakebin:$PATH" \
-        "$sb/buck2" test //:probe || rc=$?
-    check "buck wrapper: a failed pressure guard blocks disk-heavy work" \
-        "$([ "$rc" -ne 0 ] && [ ! -e "$sb/blocked.args" ] && echo 0 || echo 1)"
-    rm -rf "$sb"
+    chmod +x "$sb/fakebin/dotslash" "$sb/fakebin/df"
 }
 
-test_buck_wrapper_auto_provisions() {
-    local sb config
-    sb="$(mktemp -d)"
-    config="$sb/config/rue/buildbuddy.buckconfig"
-    mkdir -p "$sb/scripts" "$sb/platforms" "$sb/fakebin" "$(dirname "$config")"
-    cp "$SRC_ROOT/buck2" "$sb/buck2"
-    cp "$SRC_ROOT/buck2-bin" "$sb/buck2-bin"
-    cp "$SRC_ROOT/scripts/provision-build-cache" "$sb/scripts/provision-build-cache"
-    : >"$sb/.buckconfig"
-    : >"$sb/platforms/remote_cache.bzl"
-    chmod +x "$sb/buck2" "$sb/scripts/provision-build-cache"
-    cat >"$config" <<'EOF'
+# run_wrapper <sandbox> <argv-log> [buck2 args...]. HOME and XDG_CONFIG_HOME
+# point into the sandbox and the override variables are cleared, so nothing
+# installed on the host reaches the argv under test; WRAPPER_ENV adds
+# assignments for one call.
+run_wrapper() {
+    local sb="$1" log="$2"
+    shift 2
+    ( cd "$sb" && unset RUE_BUILDBUDDY_CONFIG RUE_NO_REMOTE_CACHE &&
+      env HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" DOTSLASH_ARGS="$sb/$log" \
+          PATH="$sb/fakebin:$PATH" ${WRAPPER_ENV:-} ./buck2 "$@" ) >"$sb/$log.out" 2>&1
+}
+
+write_central_config() {
+    mkdir -p "$(dirname "$1")"
+    cat >"$1" <<'EOF'
 [buck2_re_client]
 http_headers = x-buildbuddy-api-key:test-secret
 [buck2]
@@ -178,26 +64,154 @@ default_allow_cache_upload = true
 [build]
 execution_platforms = root//platforms:remote_cache
 EOF
-    chmod 600 "$config"
-    cat >"$sb/fakebin/dotslash" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$@" >"$DOTSLASH_ARGS"
-EOF
-    chmod +x "$sb/fakebin/dotslash"
+    chmod 600 "$1"
+}
 
-    (cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
-        DOTSLASH_ARGS="$sb/args" PATH="$sb/fakebin:$PATH" ./buck2 build //:probe)
-    check "buck wrapper: direct use provisions a future worktree" \
+# 1-based line number of the first argv entry equal to $2 in log $1, or empty.
+argv_line() {
+    awk -v want="$2" '$0 == want { print NR; exit }' "$1"
+}
+
+test_cache_install() {
+    local sb key config out rc mode
+    sb="$(mktemp -d)"
+    key='test-secret-that-must-not-be-printed'
+    config="$sb/config/rue/buildbuddy.buckconfig"
+    mkdir -p "$sb/checkout"
+
+    rc=0
+    out="$(cd "$sb/checkout" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
+        "$SRC_ROOT/scripts/provision-build-cache" install 2>&1)" || rc=$?
+    check "cache: install succeeds" "$([ "$rc" -eq 0 ] && [[ -f "$config" ]] && echo 0 || echo 1)"
+    check "cache: install never prints the key" "$([[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
+    mode="$(stat -c '%a' "$config" 2>/dev/null || stat -f '%Lp' "$config")"
+    check "cache: central config is private" "$([ $((8#$mode & 077)) -eq 0 ] && echo 0 || echo 1)"
+    check "cache: the credential is stored as the BuildBuddy header" \
+        "$(grep -q "^http_headers = x-buildbuddy-api-key:$key\$" "$config" && echo 0 || echo 1)"
+    check "cache: Rust action uploads are enabled" \
+        "$(grep -Eq '^default_allow_cache_upload = true$' "$config" && echo 0 || echo 1)"
+    check "cache: the remote-cache execution platform is selected" \
+        "$(grep -Eq '^execution_platforms = root//platforms:remote_cache$' "$config" && echo 0 || echo 1)"
+    check "cache: install writes nothing into the checkout" \
+        "$([ ! -e "$sb/checkout/.buckconfig.local" ] && echo 0 || echo 1)"
+
+    rc=0
+    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key-rotated" \
+        "$SRC_ROOT/scripts/provision-build-cache" install >/dev/null 2>&1 || rc=$?
+    check "cache: re-running install replaces the config in place" \
+        "$([ "$rc" -eq 0 ] && grep -q "x-buildbuddy-api-key:$key-rotated\$" "$config" && ! grep -q "x-buildbuddy-api-key:$key\$" "$config" && echo 0 || echo 1)"
+    mode="$(stat -c '%a' "$config" 2>/dev/null || stat -f '%Lp' "$config")"
+    check "cache: the replacement is private and leaves no temporary file" \
+        "$([ $((8#$mode & 077)) -eq 0 ] && [ "$(ls "$sb/config/rue" | wc -l | tr -d ' ')" -eq 1 ] && echo 0 || echo 1)"
+
+    rc=0
+    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY= \
+        "$SRC_ROOT/scripts/provision-build-cache" install </dev/null >/dev/null 2>&1 || rc=$?
+    check "cache: an empty key without a terminal is refused" \
+        "$([ "$rc" -ne 0 ] && grep -q "x-buildbuddy-api-key:$key-rotated\$" "$config" && echo 0 || echo 1)"
+
+    rc=0
+    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        "$SRC_ROOT/scripts/provision-build-cache" apply >/dev/null 2>&1 || rc=$?
+    check "cache: install is the only subcommand" "$([ "$rc" -eq 2 ] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+test_buck_wrapper_prefers_local_cache_misses() {
+    local sb local_line separator_line
+    sb="$(mktemp -d)"
+    make_wrapper_sandbox "$sb"
+    # A hand-written per-checkout config, which buck2 reads on its own; the
+    # wrapper still recognizes it as a cache configuration.
+    cat >"$sb/.buckconfig.local" <<'EOF'
+[build]
+execution_platforms = root//platforms:remote_cache
+EOF
+
+    run_wrapper "$sb" build.args build //:probe
+    check "buck wrapper: cache misses prefer local execution" \
+        "$(grep -Fxq -- '--prefer-local' "$sb/build.args" && echo 0 || echo 1)"
+    check "buck wrapper: a per-checkout config is left as the user wrote it" \
+        "$([ ! -L "$sb/.buckconfig.local" ] && grep -q 'remote_cache' "$sb/.buckconfig.local" && echo 0 || echo 1)"
+
+    run_wrapper "$sb" remote.args build --prefer-remote //:probe
+    check "buck wrapper: explicit execution preference is preserved" \
+        "$(! grep -Fxq -- '--prefer-local' "$sb/remote.args" && grep -Fxq -- '--prefer-remote' "$sb/remote.args" && echo 0 || echo 1)"
+
+    run_wrapper "$sb" run.args run //:probe -- program-arg
+    local_line="$(argv_line "$sb/run.args" --prefer-local)"
+    separator_line="$(argv_line "$sb/run.args" --)"
+    check "buck wrapper: preference stays before executable arguments" \
+        "$([ -n "$local_line" ] && [ "$local_line" -lt "$separator_line" ] && echo 0 || echo 1)"
+
+    run_wrapper "$sb" clean.args clean
+    check "buck wrapper: non-execution commands receive no execution preference" \
+        "$(! grep -Fxq -- '--prefer-local' "$sb/clean.args" && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+# The installed config reaches buck2 through a .buckconfig.local symlink, not
+# a per-command --config-file: [buck2] digest_algorithms and [buck2_re_client]
+# are daemon-startup settings that only a project config applies.
+test_buck_wrapper_links_installed_config() {
+    local sb config alt
+    sb="$(mktemp -d)"
+    make_wrapper_sandbox "$sb"
+    config="$sb/config/rue/buildbuddy.buckconfig"
+    write_central_config "$config"
+
+    run_wrapper "$sb" audit.args audit config build.execution_platforms
+    check "buck wrapper: non-execution commands never provision" \
+        "$([ ! -e "$sb/.buckconfig.local" ] && [ ! -L "$sb/.buckconfig.local" ] && echo 0 || echo 1)"
+
+    run_wrapper "$sb" build.args build //:probe
+    check "buck wrapper: the first execution command links .buckconfig.local to the installed config" \
         "$([[ -L "$sb/.buckconfig.local" ]] && [ "$(readlink "$sb/.buckconfig.local")" = "$config" ] && echo 0 || echo 1)"
-    check "buck wrapper: newly adopted cache prefers local misses" \
-        "$(grep -Fxq -- '--prefer-local' "$sb/args" && echo 0 || echo 1)"
+    check "buck wrapper: that first build already prefers local execution for misses" \
+        "$(grep -Fxq -- '--prefer-local' "$sb/build.args" && echo 0 || echo 1)"
+    check "buck wrapper: the config is never passed on the command line" \
+        "$(! grep -Fxq -- '--config-file' "$sb/build.args" && echo 0 || echo 1)"
+
+    run_wrapper "$sb" again.args test //:probe
+    check "buck wrapper: an existing link is left as is" \
+        "$([[ -L "$sb/.buckconfig.local" ]] && [ "$(readlink "$sb/.buckconfig.local")" = "$config" ] && grep -Fxq -- '--prefer-local' "$sb/again.args" && echo 0 || echo 1)"
+
+    rm "$sb/.buckconfig.local"
+    printf 'local config that must survive\n' >"$sb/.buckconfig.local"
+    run_wrapper "$sb" keep.args build //:probe
+    check "buck wrapper: an existing per-checkout config is never replaced" \
+        "$([ ! -L "$sb/.buckconfig.local" ] && grep -q 'must survive' "$sb/.buckconfig.local" && [ "$(head -n 1 "$sb/keep.args")" = build ] && echo 0 || echo 1)"
 
     rm "$sb/.buckconfig.local"
     ln -s "$sb/missing-user-config" "$sb/.buckconfig.local"
-    (cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
-        DOTSLASH_ARGS="$sb/broken.args" PATH="$sb/fakebin:$PATH" ./buck2 build //:probe)
-    check "buck wrapper: a broken user symlink never blocks local builds" \
-        "$([[ -L "$sb/.buckconfig.local" ]] && [ "$(readlink "$sb/.buckconfig.local")" = "$sb/missing-user-config" ] && echo 0 || echo 1)"
+    run_wrapper "$sb" broken.args build //:probe
+    check "buck wrapper: a broken user symlink is left alone and never blocks local builds" \
+        "$([[ -L "$sb/.buckconfig.local" ]] && [ "$(readlink "$sb/.buckconfig.local")" = "$sb/missing-user-config" ] && [ "$(head -n 1 "$sb/broken.args")" = build ] && echo 0 || echo 1)"
+    rm "$sb/.buckconfig.local"
+
+    WRAPPER_ENV="RUE_NO_REMOTE_CACHE=1" run_wrapper "$sb" optout.args build //:probe
+    check "buck wrapper: RUE_NO_REMOTE_CACHE=1 links nothing and adds no preference" \
+        "$([ ! -e "$sb/.buckconfig.local" ] && [ ! -L "$sb/.buckconfig.local" ] && [ "$(tr '\n' ' ' <"$sb/optout.args")" = 'build //:probe ' ] && echo 0 || echo 1)"
+
+    chmod 644 "$config"
+    run_wrapper "$sb" insecure.args build //:probe
+    check "buck wrapper: a config readable by other accounts is not linked, with a warning" \
+        "$([ ! -L "$sb/.buckconfig.local" ] && grep -q 'readable by other accounts' "$sb/insecure.args.out" && echo 0 || echo 1)"
+    check "buck wrapper: refusing the config never blocks the build" \
+        "$([ "$(tr '\n' ' ' <"$sb/insecure.args")" = 'build //:probe ' ] && echo 0 || echo 1)"
+    chmod 600 "$config"
+
+    alt="$sb/alt.buckconfig"
+    write_central_config "$alt"
+    WRAPPER_ENV="RUE_BUILDBUDDY_CONFIG=$alt" run_wrapper "$sb" alt.args build //:probe
+    check "buck wrapper: RUE_BUILDBUDDY_CONFIG names the config to link" \
+        "$([[ -L "$sb/.buckconfig.local" ]] && [ "$(readlink "$sb/.buckconfig.local")" = "$alt" ] && echo 0 || echo 1)"
+    rm "$sb/.buckconfig.local"
+
+    rm -f "$config"
+    run_wrapper "$sb" absent.args build //:probe
+    check "buck wrapper: without an installed config nothing is linked and the argv is unchanged" \
+        "$([ ! -e "$sb/.buckconfig.local" ] && [ ! -L "$sb/.buckconfig.local" ] && [ "$(tr '\n' ' ' <"$sb/absent.args")" = 'build //:probe ' ] && echo 0 || echo 1)"
     rm -rf "$sb"
 }
 
@@ -248,9 +262,9 @@ EOF
     rm -rf "$sb"
 }
 
-test_cache_provisioning
+test_cache_install
 test_buck_wrapper_prefers_local_cache_misses
-test_buck_wrapper_auto_provisions
+test_buck_wrapper_links_installed_config
 test_full_suite_orchestration
 
 echo "--------------------------------------------------"

--- a/scripts/test-cleanup-scripts.sh
+++ b/scripts/test-cleanup-scripts.sh
@@ -1,22 +1,27 @@
 #!/usr/bin/env bash
-# test-cleanup-scripts.sh — fail-closed regression tests for maintenance
-# scripts jj-tidy and rue-storage (RUE-567, RUE-1225).
+# test-cleanup-scripts.sh — fail-closed regression tests for the maintenance
+# scripts jj-tidy and rue-storage (RUE-567, RUE-1225) and for the ./buck2
+# wrapper's free-space floor (RUE-1934).
 #
 # jj-tidy performs remote branch deletion. rue-storage only deletes rebuildable
 # Buck outputs, but it still refuses to infer targets from a failed inventory.
+# The wrapper refuses to start a build below an absolute free-space floor and
+# never cleans anything on a build's behalf: the cross-worktree cleanup it used
+# to run caused RUE-1331 and RUE-1683 and did not prevent RUE-1790.
 #
 # Each test runs a copy of the real script in a throwaway sandbox with fake
 # tools, so no real repo, remote, or Buck output is touched.
 set -uo pipefail
 
-# Directory holding the scripts under test. Under buck2 sh_test this is the
+# Root holding the scripts under test. Under buck2 sh_test this is the
 # materialized `:cleanup-script-inputs` filegroup (RUE_CLEANUP_SCRIPTS_ROOT);
-# run directly from a checkout it defaults to the repo's scripts/ dir.
+# run directly from a checkout it defaults to the repository root.
 if [ -n "${RUE_CLEANUP_SCRIPTS_ROOT:-}" ]; then
-  SCRIPTS_DIR="$RUE_CLEANUP_SCRIPTS_ROOT/scripts"
+  ROOT_DIR="$RUE_CLEANUP_SCRIPTS_ROOT"
 else
-  SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+  ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 fi
+SCRIPTS_DIR="$ROOT_DIR/scripts"
 FAILURES=0
 TESTS=0
 
@@ -78,14 +83,6 @@ run_script() { # run_script <sandbox> <name> [args...]
 }
 
 calls() { cat "$1/calls.log" 2>/dev/null; }
-
-# reclaim-finished now scopes even Buck's default v2 isolation explicitly;
-# recognize both that argv shape and the legacy host-wide `clean` form. Keep
-# reset/TTL assertions on their original matchers because those paths retain
-# their distinct contracts.
-has_reclaim_buck_destructive_call() {
-  grep -Eq '(^|:)((--isolation-dir [^[:space:]]+ )?clean) --exit-when notidle([[:space:]]|$)' "$1/calls.log" 2>/dev/null
-}
 
 # ===========================================================================
 # jj-tidy — remote branch deletion must be fail-closed
@@ -208,6 +205,26 @@ EOF
   chmod +x "$root/buck2"
 }
 
+# A fake git whose worktree inventory lists the named sandbox roots.
+setup_storage_inventory() {
+  local sb="$1"
+  shift
+  local listing="" root
+  for root in "$@"; do
+    listing+="worktree $sb/$root\\n\\n"
+  done
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+printf 'git ' >>"\$CALLS"; printf '%s\n' "\$*" >>"\$CALLS"
+if [[ "\$*" == *"worktree list --porcelain"* ]]; then
+  printf '$listing'
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sb/fakebin/git"
+}
+
 test_storage_git_failure_is_fail_closed() {
   local sb rc=0; sb="$(make_sandbox rue-storage)"
   : >"$sb/.buckconfig"
@@ -220,7 +237,7 @@ EOF
   chmod +x "$sb/fakebin/git"
   run_script "$sb" rue-storage clean || rc=$?
   check "storage: failed inventory refuses cleanup" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
-  check "storage: failed inventory invokes no Buck cleaner" "$(! grep -q ':clean ' "$sb/calls.log" && echo 0 || echo 1)"
+  check "storage: failed inventory invokes no Buck cleaner" "$(! grep -q ':clean' "$sb/calls.log" && echo 0 || echo 1)"
   grep -q 'fail-closed' "$sb/out.log" || fail "storage: expected fail-closed notice on git failure"
   rm -rf "$sb"
 }
@@ -229,296 +246,24 @@ test_storage_plans_every_registered_root() {
   local sb; sb="$(make_sandbox rue-storage)"
   setup_storage_root "$sb/root-1"
   setup_storage_root "$sb/root-2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-printf 'git ' >>"\$CALLS"; printf '%s\n' "\$*" >>"\$CALLS"
-if [[ "\$*" == *"worktree list --porcelain"* ]]; then
-  printf 'worktree %s/root-1\n\nworktree %s/root-2\n' "$sb" "$sb"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$sb/fakebin/git"
+  setup_storage_inventory "$sb" root-1 root-2
   run_script "$sb" rue-storage plan 2d
   check "storage: dry-run covers every registered Rue worktree" \
-    "$([ "$(grep -c ':clean --stale 2d' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
-  check "storage: plan never applies its cleanup" \
-    "$([ "$(grep -c -- '--dry-run' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
-  check "storage: dry-run includes the adaptive host-free target" \
-    "$([ "$(grep -c -- '--adaptive-low-disk-threshold 20' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
-  check "storage: dry-run considers tracked artifacts only" \
-    "$([ "$(grep -c -- '--tracked-only' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
-  check "storage: dry-run protects the minimum TTL" \
-    "$([ "$(grep -c -- '--adaptive-min-ttl 12h' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
-  check "storage: dry-run never performs a full reset" \
-    "$(! grep -Eq ':clean$' "$sb/calls.log" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_guard_is_host_wide_only_under_pressure() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  setup_storage_root "$sb/root-2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"worktree list --porcelain"* ]]; then
-  printf 'worktree %s/root-1\n\nworktree %s/root-2\n' "$sb" "$sb"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$sb/fakebin/git"
-
-  # First probe is below the 10% emergency threshold; the post-clean probe is
-  # above the 20% target.
-  cat >"$sb/fakebin/df" <<EOF
-#!/usr/bin/env bash
-count=0
-[[ -f "$sb/df-count" ]] && count=\$(cat "$sb/df-count")
-printf '%d\n' \$((count + 1)) >"$sb/df-count"
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-if [[ \$count -eq 0 ]]; then
-  printf 'disk 100000 95000 5000 95%% /\n'
-else
-  printf 'disk 100000 75000 25000 75%% /\n'
-fi
-EOF
-  chmod +x "$sb/fakebin/df"
-  run_script "$sb" rue-storage guard || rc=$?
-  check "storage: pressure guard succeeds after recovering headroom" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
-  check "storage: pressure guard cleans every registered worktree" \
-    "$([ "$(grep -c ':clean --stale 1w' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
-  check "storage: pressure guard uses adaptive materializer cleanup" \
-    "$([ "$(grep -c -- '--adaptive-low-disk-threshold 20 --adaptive-min-ttl 12h' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
-  check "storage: pressure guard considers tracked artifacts only" \
-    "$([ "$(grep -c -- '--tracked-only' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+    "$([ "$(grep -c ':clean --stale 2d --tracked-only --dry-run$' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+  check "storage: plan is Buck's own tracked stale cleanup and nothing more" \
+    "$(! grep -q -- '--adaptive' "$sb/calls.log" && ! grep -Eq ':clean$' "$sb/calls.log" && echo 0 || echo 1)"
 
   : >"$sb/calls.log"
-  cat >"$sb/fakebin/df" <<'EOF'
-#!/usr/bin/env bash
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-printf 'disk 100000 89500 10500 89.5%% /\n'
-EOF
-  chmod +x "$sb/fakebin/df"
-  rc=0
-  run_script "$sb" rue-storage guard || rc=$?
-  check "storage: healthy guard succeeds without cleanup" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
-  check "storage: healthy guard starts no Buck cleanup" \
-    "$(! grep -q ':clean ' "$sb/calls.log" 2>/dev/null && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_guard_preserves_incremental_rustc_scaffolding() {
-  # RUE-1683: adaptive stale cleanup must not remove untracked rustc out-dir
-  # scaffolding from a live sibling worktree. The fake Buck coordinator models
-  # the old behavior by deleting that directory unless --tracked-only is set,
-  # then models a subsequent incremental build that requires it.
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  setup_storage_root "$sb/root-2"
-  mkdir -p "$sb/root-2/buck-out/v2/gen/extras/rue-codegen"
-
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-case "$1" in
-  clean)
-    if [[ "$*" == *"--stale"* && "$*" != *"--tracked-only"* ]]; then
-      rmdir "$PWD/buck-out/v2/gen/extras/rue-codegen" 2>/dev/null || true
-    fi
-    ;;
-  build)
-    [[ -d "$PWD/buck-out/v2/gen/extras/rue-codegen" ]]
-    ;;
-esac
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"worktree list --porcelain"* ]]; then
-  printf 'worktree %s/root-1\n\nworktree %s/root-2\n' "$sb" "$sb"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$sb/fakebin/git"
-  # Start below the emergency threshold, then recover above the adaptive
-  # target after cleanup. No host-wide disk state is touched.
-  cat >"$sb/fakebin/df" <<EOF
-#!/usr/bin/env bash
-count=0
-[[ -f "$sb/df-count" ]] && count=\$(cat "$sb/df-count")
-printf '%d\n' \$((count + 1)) >"$sb/df-count"
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-if [[ \$count -eq 0 ]]; then
-  printf 'disk 100000 95000 5000 95%% /\n'
-else
-  printf 'disk 100000 75000 25000 75%% /\n'
-fi
-EOF
-  chmod +x "$sb/fakebin/df"
-
-  run_script "$sb" rue-storage guard || rc=$?
-  check "storage: guard preserves a sibling's rustc out-dir scaffolding" \
-    "$([ -d "$sb/root-2/buck-out/v2/gen/extras/rue-codegen" ] && echo 0 || echo 1)"
-  (cd "$sb/root-2" && CALLS="$sb/calls.log" PATH="$sb/fakebin:$PATH" \
-    "$sb/buck2" build --incremental) || rc=1
-  check "storage: subsequent sibling incremental build remains viable" \
-    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_guard_blocks_when_pressure_remains_critical() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf 'legacy output\n' >"$sb/root-1/buck-out/legacy"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"worktree list --porcelain"* ]]; then
-  printf 'worktree %s/root-1\n' "$sb"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$sb/fakebin/git"
-  cat >"$sb/fakebin/df" <<'EOF'
-#!/usr/bin/env bash
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-printf 'disk 100000 95000 5000 95%% /\n'
-EOF
-  chmod +x "$sb/fakebin/df"
-  run_script "$sb" rue-storage guard || rc=$?
-  check "storage: guard refuses a build when cleanup cannot escape critical pressure" \
-    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
-  check "storage: critical guard tries a materializer-consistent legacy reset" \
-    "$(grep -q ':clean --exit-when notidle' "$sb/calls.log" && echo 0 || echo 1)"
-  check "storage: coordinator never trusts a worktree-local Buck wrapper" \
-    "$(! grep -q 'unexpected worktree-local' "$sb/calls.log" && echo 0 || echo 1)"
-  grep -q 'stopped before risking ENOSPC\|still has only' "$sb/out.log" || \
-    fail "storage: expected actionable ENOSPC prevention notice"
-  rm -rf "$sb"
-}
-
-test_storage_guard_proceeds_between_cleanup_and_hard_floors() {
-  # RUE-1331: several active worktrees legitimately pin a large host between
-  # the 16 GiB cleanup floor and the 4 GiB hard floor for hours. Cleanup finds
-  # nothing reclaimable there (the artifacts are live), and a refusal starves
-  # every build without protecting the host — the guard must warn and proceed.
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"worktree list --porcelain"* ]]; then
-  printf 'worktree %s/root-1\n' "$sb"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$sb/fakebin/git"
-  # 15 GiB free of 200 GiB: 7.5%, below the cleanup floor, above the hard
-  # floor. Constant across probes — cleanup reclaims nothing, as on a host
-  # whose space is held by active sibling builds.
-  cat >"$sb/fakebin/df" <<'EOF'
-#!/usr/bin/env bash
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-printf 'disk 209715200 193986560 15728640 93%% /\n'
-EOF
-  chmod +x "$sb/fakebin/df"
-  run_script "$sb" rue-storage guard || rc=$?
-  check "storage: guard proceeds between the cleanup and hard floors" \
-    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
-  check "storage: between-floors guard still attempts cleanup first" \
-    "$(grep -q ':clean --stale 1w' "$sb/calls.log" && echo 0 || echo 1)"
-  grep -q 'above the 4 GiB hard floor; proceeding' "$sb/out.log" || \
-    fail "storage: expected the warn-and-proceed notice between floors"
-  grep -q 'Do not edit or bypass this guard' "$sb/out.log" || \
-    fail "storage: expected the sanctioned-remediation notice"
-  rm -rf "$sb"
-}
-
-test_storage_guard_survives_cleanup_failure_between_floors() {
-  # RUE-1331 follow-up: sibling worktrees mid-build make their Buck daemons
-  # refuse `clean`. A cleanup ERROR must not be fatal in the middle band —
-  # the hard floor decides. Observed live: three cycle-5 workers building
-  # blocked the coordinator's build through this exact path.
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-exit 1
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"worktree list --porcelain"* ]]; then
-  printf 'worktree %s/root-1\n' "$sb"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$sb/fakebin/git"
-  # 15 GiB free of 200 GiB: middle band, constant across probes.
-  cat >"$sb/fakebin/df" <<'EOF'
-#!/usr/bin/env bash
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-printf 'disk 209715200 193986560 15728640 93%% /\n'
-EOF
-  chmod +x "$sb/fakebin/df"
-  run_script "$sb" rue-storage guard || rc=$?
-  check "storage: cleanup failure between floors still proceeds" \
-    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
-  grep -q 'deciding on the hard floor instead' "$sb/out.log" || \
-    fail "storage: expected the cleanup-failure demotion notice"
-  rm -rf "$sb"
-}
-
-test_storage_guard_still_refuses_below_hard_floor_when_cleanup_fails() {
-  # The safety property survives the demotion: a cleanup error below the hard
-  # floor is still a refusal.
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-exit 1
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"worktree list --porcelain"* ]]; then
-  printf 'worktree %s/root-1\n' "$sb"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$sb/fakebin/git"
-  cat >"$sb/fakebin/df" <<'EOF'
-#!/usr/bin/env bash
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-printf 'disk 100000 95000 5000 95%% /\n'
-EOF
-  chmod +x "$sb/fakebin/df"
-  run_script "$sb" rue-storage guard || rc=$?
-  check "storage: cleanup failure below the hard floor still refuses" \
-    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
-  grep -q 'hard floor; build stopped before risking ENOSPC' "$sb/out.log" || \
-    fail "storage: expected the hard-floor refusal notice"
+  run_script "$sb" rue-storage clean 3d
+  check "storage: clean applies the same cleanup to every registered root" \
+    "$([ "$(grep -c ':clean --stale 3d --tracked-only$' "$sb/calls.log")" -eq 2 ] && ! grep -q -- '--dry-run' "$sb/calls.log" && echo 0 || echo 1)"
   rm -rf "$sb"
 }
 
 test_storage_reset_validates_all_targets_first() {
   local sb rc=0; sb="$(make_sandbox rue-storage)"
   setup_storage_root "$sb/root-1"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"worktree list --porcelain"* ]]; then
-  printf 'worktree %s/root-1\n' "$sb"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$sb/fakebin/git"
+  setup_storage_inventory "$sb" root-1
   run_script "$sb" rue-storage reset "$sb/root-1" "$sb/not-registered" || rc=$?
   check "storage: reset rejects an unregistered target" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
   check "storage: reset validates every target before deleting output" \
@@ -527,1052 +272,79 @@ EOF
   : >"$sb/calls.log"
   run_script "$sb" rue-storage reset "$sb/root-1"
   check "storage: exact registered target can be reset" \
-    "$(grep -Eq ':clean$' "$sb/calls.log" && echo 0 || echo 1)"
+    "$(grep -Eq "^$sb/root-1:clean$" "$sb/calls.log" && echo 0 || echo 1)"
   rm -rf "$sb"
 }
 
-test_storage_reclaim_finished_preserves_dirty_and_clean_sources() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  setup_storage_root "$sb/root-2"
-  setup_storage_root "$sb/root-3"
-  printf '../../../root-1/.git\n' >"$sb/.git/worktrees/root-1/gitdir"
-  printf 'dirty source\n' >"$sb/root-1/dirty.rue"
-  printf 'clean source\n' >"$sb/root-2/clean.rue"
-  printf 'output\n' >"$sb/root-1/buck-out/artifact"
-  printf 'output\n' >"$sb/root-2/buck-out/artifact"
-  printf 'sibling output\n' >"$sb/root-3/buck-out/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then rm -rf "$PWD/buck-out"; fi
-EOF
+# ===========================================================================
+# ./buck2 wrapper — the free-space floor refuses, and never cleans
+# ===========================================================================
+
+# The real wrapper and its DotSlash manifest, a fake dotslash that records the
+# argv it would have run, and a fake `df -Pk` reporting FAKE_FREE_KIB free (or
+# failing outright under FAKE_DF_FAIL=1).
+make_wrapper_sandbox() {
+  local sb
+  sb="$(mktemp -d)"
+  mkdir -p "$sb/fakebin" "$sb/config"
+  cp "$ROOT_DIR/buck2" "$sb/buck2"
+  cp "$ROOT_DIR/buck2-bin" "$sb/buck2-bin"
   chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
+  # The first argument is the DotSlash manifest; the log holds Buck's argv.
+  cat >"$sb/fakebin/dotslash" <<'EOF'
 #!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n\\nworktree %s/root-3\\n' "$sb" "$sb" "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; *root-3*) printf '%s/.git/worktrees/root-3\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) if [[ "\$*" == *root-1* ]]; then printf ' M dirty.rue\\n'; fi ;;
-  *) exit 1 ;;
-esac
+shift
+printf '%s\n' "$@" >"$DOTSLASH_ARGS"
 EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/root-2" || rc=$?
-  check "storage: reclaim-finished covers dirty and clean roots" "$([ "$rc" -eq 0 ] && [ "$(grep -c 'clean --exit-when notidle$' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
-  check "storage: dirty source survives reclaim byte-for-byte" "$([ -f "$sb/root-1/dirty.rue" ] && [ "$(cat "$sb/root-1/dirty.rue")" = 'dirty source' ] && echo 0 || echo 1)"
-  check "storage: clean source survives reclaim byte-for-byte" "$([ -f "$sb/root-2/clean.rue" ] && [ "$(cat "$sb/root-2/clean.rue")" = 'clean source' ] && echo 0 || echo 1)"
-  check "storage: unnamed sibling output survives reclaim" "$([ -f "$sb/root-3/buck-out/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_invalid_and_current_targets() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf output >"$sb/root-1/buck-out/artifact"
-  mkdir -p "$sb/counterfeit/buck-out"
-  : >"$sb/counterfeit/.buckconfig"
-  printf '#!/bin/sh\n' >"$sb/counterfeit/buck2"; chmod +x "$sb/counterfeit/buck2"
-  : >"$sb/.buckconfig"
-  ln -s "$sb" "$sb/current-alias"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s\\n\\nworktree %s/root-1\\n' "$sb" "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/counterfeit" || rc=$?
-  check "storage: counterfeit target is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  rc=0; : >"$sb/calls.log"
-  run_script "$sb" rue-storage reclaim-finished "$sb" || rc=$?
-  check "storage: current coordinator root is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  rc=0; : >"$sb/calls.log"
-  run_script "$sb" rue-storage reclaim-finished "$sb/current-alias" || rc=$?
-  check "storage: current coordinator symlink alias is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_replacement_clone_identity() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf output >"$sb/root-1/buck-out/artifact"
-  mkdir -p "$sb/other.git"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) if [[ "\$*" == *root-1* ]]; then printf '%s/other.git\\n' "$sb"; else printf '%s/.git\\n' "$sb"; fi ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: replacement clone at registered path is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_ignores_ambient_git_selection() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf output >"$sb/root-1/buck-out/artifact"
-  mkdir -p "$sb/foreign.git" "$sb/foreign-root"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ -n "\${GIT_DIR:-}" || -n "\${GIT_WORK_TREE:-}" || -n "\${GIT_COMMON_DIR:-}" || -n "\${GIT_INDEX_FILE:-}" ]]; then
-  case "\$*" in
-    *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-    *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-    *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-    *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-    *"status --porcelain"*) : ;;
-    *) exit 1 ;;
-  esac
-else
-  case "\$*" in
-    *"worktree list --porcelain"*) printf 'worktree %s\\n' "$sb" ;;
-    *) exit 1 ;;
-  esac
-fi
-EOF
-  chmod +x "$sb/fakebin/git"
-  GIT_DIR="$sb/foreign.git" GIT_WORK_TREE="$sb/foreign-root" GIT_COMMON_DIR="$sb/foreign.git" GIT_INDEX_FILE="$sb/foreign-index" \
-    run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: ambient Git selection cannot authorize a foreign root" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/root-1/buck-out/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_main_metadata_counterfeit() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf output >"$sb/root-1/buck-out/artifact"
-  rm -f "$sb/root-1/.git"
-  ln -s "$sb/.git" "$sb/root-1/.git"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: main-worktree metadata counterfeit is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/root-1/buck-out/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_same_common_counterfeit() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf output >"$sb/root-1/buck-out/artifact"
-  mkdir -p "$sb/.git/other-admin"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/other-admin\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: same-common-dir counterfeit with wrong worktree admin is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/root-1/buck-out/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_isolation_symlink_escape() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/outside"
-  printf outside >"$sb/outside/artifact"
-  ln -s "$sb/outside" "$sb/root-1/buck-out/escape"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: symlinked direct isolation is refused without Buck cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/outside/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_non_directory_output_root() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  rm -rf "$sb/root-1/buck-out"
-  printf 'not a directory' >"$sb/root-1/buck-out"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: non-directory Buck output root is refused" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ "$(cat "$sb/root-1/buck-out")" = 'not a directory' ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_output_root_swap() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/outside"
-  printf output >"$sb/root-1/buck-out/artifact"
-  printf outside >"$sb/outside/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *--dry-run* ]]; then
-  mv "$PWD/buck-out" "$PWD/buck-out-saved"
-  ln -s "$PWD/../outside" "$PWD/buck-out"
-fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  : >"$CALLS.destructive"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: swapped Buck output root is refused before destructive clean" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out-saved/artifact" ] && [ "$(cat "$sb/outside/artifact")" = outside ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_regular_output_root_replacement() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf original >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *--dry-run* ]]; then
-  mv "$PWD/buck-out" "$PWD/buck-out-saved"
-  mkdir -p "$PWD/buck-out/v2"
-  printf replacement >"$PWD/buck-out/v2/artifact"
-fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  : >"$CALLS.destructive"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: same-path output-root generation replacement is refused" "$([ "$rc" -ne 0 ] && grep -q 'output root identity changed' "$sb/out.log" && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && [ -f "$sb/root-1/buck-out-saved/v2/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_initial_probe_replacement() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf original >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"status --porcelain"* && ! -e "\$CALLS.probed" ]]; then
-  : >"\$CALLS.probed"
-  mv "$sb/root-1" "$sb/root-1-probed"
-  mkdir "$sb/root-1"
-  cp "$sb/root-1-probed/.git" "$sb/root-1/.git"
-  cp "$sb/root-1-probed/.buckconfig" "$sb/root-1/.buckconfig"
-  cp "$sb/root-1-probed/buck2" "$sb/root-1/buck2"
-  mv "$sb/root-1-probed/buck-out" "$sb/root-1/buck-out"
-  printf '%s/.git\\n' "$sb/root-1" >"$sb/.git/worktrees/root-1/gitdir"
-fi
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: initial probe root replacement is refused" "$([ "$rc" -ne 0 ] && [ -e "$sb/calls.log.probed" ] && [ -d "$sb/root-1-probed" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && grep -q 'registered worktree identity changed during initial reclaim validation' "$sb/out.log" && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_initial_probe_isolation_replacement() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf original >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"status --porcelain"* && ! -e "\$CALLS.child-probed" ]]; then
-  : >"\$CALLS.child-probed"
-  mv "$sb/root-1/buck-out/v2" "$sb/root-1/v2-probed"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf replacement >"$sb/root-1/buck-out/v2/artifact"
-fi
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: initial probe isolation replacement is refused" "$([ "$rc" -ne 0 ] && [ -e "$sb/calls.log.child-probed" ] && [ -f "$sb/root-1/v2-probed/artifact" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && grep -q 'Buck isolation generation changed during initial reclaim validation' "$sb/out.log" && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_initial_probe_new_isolation() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf original >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *"status --porcelain"* && ! -e "\$CALLS.new-isolation" ]]; then
-  : >"\$CALLS.new-isolation"
-  mkdir -p "$sb/root-1/buck-out/compiler-repro"
-  printf new >"$sb/root-1/buck-out/compiler-repro/artifact"
-fi
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: initial probe new isolation is refused" "$([ "$rc" -ne 0 ] && [ -e "$sb/calls.log.new-isolation" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && [ -f "$sb/root-1/buck-out/compiler-repro/artifact" ] && grep -q 'Buck isolation generation changed during initial reclaim validation' "$sb/out.log" && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_regular_isolation_replacement() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf original >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *--dry-run* ]]; then
-  mv "$PWD/buck-out/v2" "$PWD/v2-saved"
-  mkdir -p "$PWD/buck-out/v2"
-  printf replacement >"$PWD/buck-out/v2/artifact"
-fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  : >"$CALLS.destructive"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: same-path isolation generation replacement is refused" "$([ "$rc" -ne 0 ] && grep -q 'isolation identity changed' "$sb/out.log" && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && [ -f "$sb/root-1/v2-saved/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_worktree_replacement() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf output >"$sb/root-1/buck-out/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *--dry-run* ]]; then
-  mv "$PWD" "$PWD-replaced"
-  mkdir "$PWD"
-  cp "$PWD-replaced/.buckconfig" "$PWD/.buckconfig"
-  cp "$PWD-replaced/buck2" "$PWD/buck2"
-  mkdir "$PWD/buck-out"
-fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  : >"$CALLS.destructive"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: replaced registered worktree is refused before destructive clean" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1-replaced/buck-out/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_valid_same_path_replacement() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf original >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-set -e
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *--dry-run* ]]; then
-  test_sb="${CALLS%/calls.log}"
-  mv "$PWD" "$PWD-replaced"
-  mkdir -p "$PWD/buck-out/v2" "$test_sb/.git/worktrees/replacement"
-  : >"$PWD/.buckconfig"
-  cp "$PWD-replaced/buck2" "$PWD/buck2"
-  printf 'gitdir: %s/.git/worktrees/replacement\n' "$test_sb" >"$PWD/.git"
-  printf '%s/.git\n' "$PWD" >"$test_sb/.git/worktrees/replacement/gitdir"
-  printf replacement >"$PWD/buck-out/v2/artifact"
-  : >"$CALLS.replaced"
-fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  : >"$CALLS.destructive"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) if [[ -f "\$CALLS.replaced" ]]; then printf '%s/.git/worktrees/replacement\\n' "$sb"; else printf '%s/.git/worktrees/root-1\\n' "$sb"; fi ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: valid same-path Git worktree replacement is refused before destructive clean" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_handles_empty_isolation_that_gains_output() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  setup_storage_root "$sb/root-2"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf output >"$sb/root-2/buck-out/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$PWD" == *'/root-1' && "$*" == *--dry-run* ]]; then
-  printf gained >"$PWD/buck-out/v2/artifact"
-fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  rm -rf "$PWD/buck-out/v2" "$PWD/buck-out/artifact"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; esac ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/root-2" || rc=$?
-  check "storage: empty isolation is preflighted and reclaimed after gaining output" "$([ "$rc" -eq 0 ] && grep -q 'clean --exit-when notidle$' "$sb/calls.log" && [ ! -e "$sb/root-1/buck-out/v2" ] && [ ! -e "$sb/root-2/buck-out/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_cleans_zero_byte_output_entry() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  : >"$sb/root-1/buck-out/v2/zero-byte"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  rm -f "$PWD/buck-out/v2/zero-byte"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: zero-byte output entry is preflighted and reclaimed" "$([ "$rc" -eq 0 ] && [ ! -e "$sb/root-1/buck-out/v2/zero-byte" ] && [ "$(grep -c -- '--isolation-dir v2 clean --dry-run --exit-when notidle' "$sb/calls.log")" -eq 1 ] && [ "$(grep -c -- '--isolation-dir v2 clean --exit-when notidle' "$sb/calls.log")" -eq 1 ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rechecks_empty_root_after_later_preflight() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  setup_storage_root "$sb/root-2"
-  printf root2 >"$sb/root-2/buck-out/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$PWD" == *'/root-2' && "$*" == *--dry-run* ]]; then
-  mkdir -p "$PWD/../root-1/buck-out/v2"
-  printf appeared >"$PWD/../root-1/buck-out/v2/artifact"
-fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  : >"$CALLS.destructive"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; esac ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/root-2" || rc=$?
-  check "storage: later preflight growth of an empty root is refused before all destructive cleanup" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/calls.log.destructive" ] && [ -f "$sb/root-1/buck-out/v2/artifact" ] && ! grep -q 'zero Buck output' "$sb/out.log" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_new_isolation_after_clean() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf output >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  rm -rf "$PWD/buck-out/v2"
-  mkdir -p "$PWD/buck-out/new-isolation"
-  printf new >"$PWD/buck-out/new-isolation/artifact"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: new isolation after clean is refused and remains for review" "$([ "$rc" -ne 0 ] && [ -f "$sb/root-1/buck-out/new-isolation/artifact" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_reports_buck_owned_residual() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf output >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  rm -f "$PWD/buck-out/v2/artifact"
-  printf buck-log >"$PWD/buck-out/v2/log"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: Buck-owned residual is reported after successful exact-isolation clean" "$([ "$rc" -eq 0 ] && grep -q 'residual' "$sb/out.log" && [ -f "$sb/root-1/buck-out/v2/log" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_reports_non_directory_residual() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf output >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  rm -f "$PWD/buck-out/v2/artifact"
-  mkfifo "$PWD/buck-out/v2/buck-fifo"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: non-directory Buck residual is reported" "$([ "$rc" -eq 0 ] && grep -q 'buck-fifo' "$sb/out.log" && [ -p "$sb/root-1/buck-out/v2/buck-fifo" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_rejects_root_replacement_after_clean() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2"
-  printf output >"$sb/root-1/buck-out/v2/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  mv "$PWD" "$PWD-replaced"
-  mkdir -p "$PWD/buck-out/v2"
-  : >"$PWD/.buckconfig"
-  cp "$PWD-replaced/buck2" "$PWD/buck2"
-  printf replacement >"$PWD/buck-out/v2/artifact"
-  : >"$CALLS.replaced"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) if [[ -f "\$CALLS.replaced" ]]; then printf '%s/.git/worktrees/replacement\\n' "$sb"; else printf '%s/.git/worktrees/root-1\\n' "$sb"; fi ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: root replacement after clean suppresses terminal success" "$([ "$rc" -ne 0 ] && ! grep -q 'reclaimed' "$sb/out.log" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_explicitly_scopes_v2_with_environment_override() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2" "$sb/root-1/buck-out/compiler-repro"
-  printf v2 >"$sb/root-1/buck-out/v2/artifact"
-  printf repro >"$sb/root-1/buck-out/compiler-repro/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ -f "$CALLS.active-v2" && "$*" == *'--isolation-dir v2 clean'* && "$*" == *--dry-run* ]]; then exit 7; fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  if [[ "$*" == *'--isolation-dir compiler-repro'* ]]; then rm -rf "$PWD/buck-out/compiler-repro"; else rm -rf "$PWD/buck-out/v2"; fi
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  : >"$sb/calls.log.active-v2"
-  BUCK_ISOLATION_DIR=compiler-repro run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: active explicit v2 isolation blocks every cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && [ -f "$sb/root-1/buck-out/v2/artifact" ] && [ -f "$sb/root-1/buck-out/compiler-repro/artifact" ] && echo 0 || echo 1)"
-  rm -f "$sb/calls.log.active-v2"; : >"$sb/calls.log"; rc=0
-  BUCK_ISOLATION_DIR=compiler-repro run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: environment override cannot retarget explicit isolation cleanup" "$([ "$rc" -eq 0 ] && [ "$(grep -c -- '--isolation-dir v2 clean --dry-run --exit-when notidle' "$sb/calls.log")" -eq 1 ] && [ "$(grep -c -- '--isolation-dir v2 clean --exit-when notidle' "$sb/calls.log")" -eq 1 ] && [ "$(grep -c -- '--isolation-dir compiler-repro clean --dry-run --exit-when notidle' "$sb/calls.log")" -eq 1 ] && [ "$(grep -c -- '--isolation-dir compiler-repro clean --exit-when notidle' "$sb/calls.log")" -eq 1 ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_alias_active_and_zero_output() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  setup_storage_root "$sb/root-2"
-  printf output >"$sb/root-1/buck-out/artifact"
-  ln -s "$sb/root-1" "$sb/root-1-alias"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$PWD" == *'/root-1' ]]; then exit 7; fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1-alias" || rc=$?
-  check "storage: active Buck root is refused" "$([ "$rc" -ne 0 ] && grep -q 'root-1' "$sb/out.log" && echo 0 || echo 1)"
-  : >"$sb/calls.log"; rc=0
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-2" || rc=$?
-  check "storage: zero-output root succeeds without destructive Buck cleanup" "$([ "$rc" -eq 0 ] && ! has_reclaim_buck_destructive_call "$sb" && grep -q 'zero Buck output' "$sb/out.log" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_alias_and_preflight_validate_all() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  setup_storage_root "$sb/root-2"
-  printf one >"$sb/root-1/buck-out/artifact"
-  printf two >"$sb/root-2/buck-out/artifact"
-  ln -s "$sb/root-1" "$sb/root-1-alias"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$PWD" == *'/root-2' && "$*" == *--dry-run* ]]; then exit 7; fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then rm -rf "$PWD/buck-out"; fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1-alias" "$sb/root-2" || rc=$?
-  check "storage: later active preflight prevents all destructive cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  check "storage: earlier output survives later preflight refusal" "$([ -f "$sb/root-1/buck-out/artifact" ] && echo 0 || echo 1)"
-  check "storage: later output survives its preflight refusal" "$([ -f "$sb/root-2/buck-out/artifact" ] && echo 0 || echo 1)"
-
-  : >"$sb/calls.log"; rc=0
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1-alias" || rc=$?
-  check "storage: symlink alias reclaims its canonical registered root" "$([ "$rc" -eq 0 ] && [ ! -e "$sb/root-1/buck-out" ] && [ "$(grep -c 'clean --exit-when notidle$' "$sb/calls.log")" -eq 1 ] && echo 0 || echo 1)"
-
-  mkdir -p "$sb/root-1/buck-out"; printf one >"$sb/root-1/buck-out/artifact"
-  : >"$sb/calls.log"; rc=0
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" "$sb/root-1-alias" || rc=$?
-  check "storage: canonical and alias duplicate is refused before cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_reclaim_finished_scopes_every_isolation() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  mkdir -p "$sb/root-1/buck-out/v2" "$sb/root-1/buck-out/compiler-repro"
-  printf default >"$sb/root-1/buck-out/v2/artifact"
-  printf alternate >"$sb/root-1/buck-out/compiler-repro/artifact"
-cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ -f "$CALLS.active-alternate" && "$*" == *--isolation-dir*compiler-repro* && "$*" == *--dry-run* ]]; then exit 7; fi
-if [[ -f "$CALLS.activate-on-destructive" && "$*" == *--isolation-dir*compiler-repro* && "$*" != *--dry-run* ]]; then exit 7; fi
-if [[ "$*" == *clean* && "$*" != *--dry-run* ]]; then
-  if [[ "$*" == *'--isolation-dir compiler-repro'* ]]; then rm -rf "$PWD/buck-out/compiler-repro"; else rm -rf "$PWD/buck-out/v2"; fi
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-chmod +x "$sb/fakebin/git"
-: >"$sb/calls.log.active-alternate"
-run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: active alternate isolation prevents all cleanup" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  check "storage: default isolation survives alternate refusal" "$([ -f "$sb/root-1/buck-out/v2/artifact" ] && echo 0 || echo 1)"
-  check "storage: alternate isolation survives its refusal" "$([ -f "$sb/root-1/buck-out/compiler-repro/artifact" ] && echo 0 || echo 1)"
-
-  rm -f "$sb/calls.log.active-alternate"
-  : >"$sb/calls.log.activate-on-destructive"
-  : >"$sb/calls.log"; rc=0
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: destructive alternate refusal stops within-root cleanup" "$([ "$rc" -ne 0 ] && [ ! -e "$sb/root-1/buck-out/v2" ] && [ -f "$sb/root-1/buck-out/compiler-repro/artifact" ] && echo 0 || echo 1)"
-  rm -f "$sb/calls.log.activate-on-destructive"
-  : >"$sb/calls.log"; rc=0
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: idle alternate isolation can reclaim after refusal" "$([ "$rc" -eq 0 ] && [ ! -e "$sb/root-1/buck-out/compiler-repro" ] && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
-
-test_storage_guard_finished_evidence_rechecks_output_after_ttl_cleanup() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf output >"$sb/root-1/buck-out/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$1" == audit ]]; then printf '{"buck2.defer_write_actions":"true"}\n'; fi
-if [[ "$1" == clean && "$*" == *--stale* && "$*" != *--dry-run* ]]; then rm -rf "$PWD/buck-out"; fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
   cat >"$sb/fakebin/df" <<'EOF'
 #!/usr/bin/env bash
+if [ "${FAKE_DF_FAIL:-0}" = 1 ]; then exit 1; fi
 printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-printf 'disk 100000 95000 5000 95%% /\n'
+printf '/dev/fake 100000000 1000 %s 1%% /\n' "$FAKE_FREE_KIB"
 EOF
-  chmod +x "$sb/fakebin/df"
-  run_script "$sb" rue-storage guard --finished-root "$sb/root-1" || rc=$?
-  check "storage: guard does not advertise output removed by ordinary TTL cleanup" "$(! grep -q 'reclaim-finished' "$sb/out.log" && echo 0 || echo 1)"
-  rm -rf "$sb"
+  chmod +x "$sb/fakebin/dotslash" "$sb/fakebin/df"
+  printf '%s\n' "$sb"
 }
 
-test_storage_guard_finished_evidence_rejects_root_replacement() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf output >"$sb/root-1/buck-out/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$1" == audit ]]; then printf '{"buck2.defer_write_actions":"true"}\n'; fi
-if [[ "$*" == *--stale* && "$*" == *--dry-run* ]]; then
-  mv "$PWD" "$PWD-replaced"
-  mkdir -p "$PWD"
-  cp "$PWD-replaced/.buckconfig" "$PWD/.buckconfig"
-  cp "$PWD-replaced/buck2" "$PWD/buck2"
-  cp "$PWD-replaced/.git" "$PWD/.git"
-  mkdir -p "$PWD/buck-out"
-  printf replacement >"$PWD/buck-out/artifact"
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  cat >"$sb/fakebin/df" <<'EOF'
-#!/usr/bin/env bash
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-printf 'disk 100000 95000 5000 95%% /\n'
-EOF
-  chmod +x "$sb/fakebin/df"
-  run_script "$sb" rue-storage guard --finished-root "$sb/root-1" || rc=$?
-  check "storage: guard rejects finished evidence after root replacement" "$([ "$rc" -ne 0 ] && [ -d "$sb/root-1-replaced" ] && [ "$(cat "$sb/root-1/buck-out/artifact")" = replacement ] && ! grep -q 'eligible for reclaim-finished' "$sb/out.log" && echo 0 || echo 1)"
-  rm -rf "$sb"
+# run_wrapper <sandbox> <free-kib> <argv-log> [buck2 args...]. The config
+# lookups point into the empty sandbox so no installed cache config on the
+# host can reach the argv under test.
+run_wrapper() {
+  local sb="$1" free="$2" log="$3"
+  shift 3
+  ( cd "$sb" && FAKE_FREE_KIB="$free" DOTSLASH_ARGS="$sb/$log" \
+      HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" RUE_BUILDBUDDY_CONFIG="$sb/absent-config" \
+      PATH="$sb/fakebin:$PATH" ./buck2 "$@" ) >"$sb/out.log" 2>&1
 }
 
-test_storage_guard_rejects_malformed_evidence_and_reclaim_rejects_unknown_source() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  : >"$sb/.buckconfig"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s\\n' "$sb" ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  run_script "$sb" rue-storage guard --finished-root || rc=$?
-  check "storage: malformed finished-root option fails with usage" "$([ "$rc" -eq 2 ] && grep -q '^usage:' "$sb/out.log" && echo 0 || echo 1)"
-  check "storage: malformed finished-root option invokes no cleanup" "$(! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
+test_wrapper_refuses_below_free_space_floor() {
+  local sb rc gib=1048576; sb="$(make_wrapper_sandbox)"
 
-  setup_storage_root "$sb/root-1"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) exit 1 ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"; : >"$sb/calls.log"; rc=0
-  run_script "$sb" rue-storage reclaim-finished "$sb/root-1" || rc=$?
-  check "storage: unknown source state refuses reclaim" "$([ "$rc" -ne 0 ] && ! has_reclaim_buck_destructive_call "$sb" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
+  rc=0; run_wrapper "$sb" $((1 * gib)) refused.args build //:probe || rc=$?
+  check "wrapper: a build below the 4 GiB floor is refused before Buck runs" \
+    "$([ "$rc" -ne 0 ] && [ ! -e "$sb/refused.args" ] && echo 0 || echo 1)"
+  check "wrapper: the refusal names worktree removal, storage reset, and storage clean" \
+    "$(grep -q 'git worktree remove' "$sb/out.log" && grep -q 'storage reset' "$sb/out.log" && grep -q 'storage clean' "$sb/out.log" && echo 0 || echo 1)"
 
-test_storage_guard_names_only_caller_supplied_finished_evidence() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  printf output >"$sb/root-1/buck-out/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$1" == audit ]]; then
-  printf '{"buck2.defer_write_actions":"true"}\n'
-fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n' "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  cat >"$sb/fakebin/df" <<'EOF'
-#!/usr/bin/env bash
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-printf 'disk 100000 95000 5000 95%% /\n'
-EOF
-  chmod +x "$sb/fakebin/df"
-  run_script "$sb" rue-storage guard --finished-root "$sb/root-1" || rc=$?
-  check "storage: guard accepts caller-supplied finished evidence" "$([ "$rc" -ne 0 ] && grep -q 'reclaim-finished' "$sb/out.log" && echo 0 || echo 1)"
-  check "storage: guard evidence does not auto-reclaim" "$(! grep -q 'clean --exit-when notidle$' "$sb/calls.log" && echo 0 || echo 1)"
-  rm -rf "$sb"
-}
+  rc=0; run_wrapper "$sb" $((1 * gib)) clean.args clean || rc=$?
+  check "wrapper: clean stays available below the floor" \
+    "$([ "$rc" -eq 0 ] && [ "$(head -n 1 "$sb/clean.args")" = clean ] && echo 0 || echo 1)"
 
-test_storage_guard_skips_active_evidence_and_names_idle_evidence() {
-  local sb rc=0; sb="$(make_sandbox rue-storage)"
-  setup_storage_root "$sb/root-1"
-  setup_storage_root "$sb/root-2"
-  printf active >"$sb/root-1/buck-out/artifact"
-  printf idle >"$sb/root-2/buck-out/artifact"
-  cat >"$sb/buck2" <<'EOF'
-#!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
-if [[ "$1" == audit ]]; then printf '{"buck2.defer_write_actions":"true"}\n'; fi
-if [[ "$PWD" == *'/root-1' && "$*" == *--dry-run* ]]; then exit 7; fi
-EOF
-  chmod +x "$sb/buck2"
-  cat >"$sb/fakebin/git" <<EOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"worktree list --porcelain"*) printf 'worktree %s/root-1\\n\\nworktree %s/root-2\\n' "$sb" "$sb" ;;
-  *"rev-parse --git-common-dir"*) printf '%s/.git\\n' "$sb" ;;
-  *"rev-parse --git-dir"*) case "\$*" in *root-1*) printf '%s/.git/worktrees/root-1\\n' "$sb" ;; *root-2*) printf '%s/.git/worktrees/root-2\\n' "$sb" ;; *) printf '%s/.git\\n' "$sb" ;; esac ;;
-  *"rev-parse --show-toplevel"*) printf '%s\\n' "\$2" ;;
-  *"status --porcelain"*) : ;;
-  *) exit 1 ;;
-esac
-EOF
-  chmod +x "$sb/fakebin/git"
-  cat >"$sb/fakebin/df" <<'EOF'
-#!/usr/bin/env bash
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-printf 'disk 100000 95000 5000 95%% /\n'
-EOF
-  chmod +x "$sb/fakebin/df"
-  run_script "$sb" rue-storage guard --finished-root "$sb/root-1" --finished-root "$sb/root-2" || rc=$?
-  check "storage: active evidence is skipped while idle evidence is named" "$([ "$rc" -ne 0 ] && grep -q "root-2" "$sb/out.log" && ! grep -q "root-1.*eligible" "$sb/out.log" && echo 0 || echo 1)"
+  rc=0; run_wrapper "$sb" $((1 * gib)) targets.args targets //:probe || rc=$?
+  check "wrapper: non-execution commands are never refused" \
+    "$([ "$rc" -eq 0 ] && [ -e "$sb/targets.args" ] && echo 0 || echo 1)"
+
+  rc=0; run_wrapper "$sb" $((4 * gib)) floor.args test //:probe || rc=$?
+  check "wrapper: exactly 4 GiB free passes the floor" \
+    "$([ "$rc" -eq 0 ] && [ "$(head -n 1 "$sb/floor.args")" = test ] && echo 0 || echo 1)"
+
+  rc=0; run_wrapper "$sb" $((8 * gib)) above.args build //:probe || rc=$?
+  check "wrapper: above the floor the build runs with its argv unchanged" \
+    "$([ "$rc" -eq 0 ] && [ "$(tr '\n' ' ' <"$sb/above.args")" = 'build //:probe ' ] && echo 0 || echo 1)"
+
+  rc=0; FAKE_DF_FAIL=1 run_wrapper "$sb" 0 nodf.args build //:probe || rc=$?
+  check "wrapper: an unmeasurable filesystem fails closed" \
+    "$([ "$rc" -ne 0 ] && [ ! -e "$sb/nodf.args" ] && echo 0 || echo 1)"
   rm -rf "$sb"
 }
 
@@ -1582,45 +354,8 @@ test_jjtidy_gh_failure_deletes_nothing
 test_jjtidy_only_deletes_proven_merged
 test_storage_git_failure_is_fail_closed
 test_storage_plans_every_registered_root
-test_storage_guard_is_host_wide_only_under_pressure
-test_storage_guard_preserves_incremental_rustc_scaffolding
-test_storage_guard_blocks_when_pressure_remains_critical
-test_storage_guard_proceeds_between_cleanup_and_hard_floors
-test_storage_guard_survives_cleanup_failure_between_floors
-test_storage_guard_still_refuses_below_hard_floor_when_cleanup_fails
 test_storage_reset_validates_all_targets_first
-test_storage_reclaim_finished_preserves_dirty_and_clean_sources
-test_storage_reclaim_finished_rejects_invalid_and_current_targets
-test_storage_reclaim_finished_rejects_replacement_clone_identity
-test_storage_reclaim_finished_ignores_ambient_git_selection
-test_storage_reclaim_finished_rejects_main_metadata_counterfeit
-test_storage_reclaim_finished_rejects_same_common_counterfeit
-test_storage_reclaim_finished_rejects_isolation_symlink_escape
-test_storage_reclaim_finished_rejects_non_directory_output_root
-test_storage_reclaim_finished_rejects_output_root_swap
-test_storage_reclaim_finished_rejects_regular_output_root_replacement
-test_storage_reclaim_finished_rejects_initial_probe_replacement
-test_storage_reclaim_finished_rejects_initial_probe_isolation_replacement
-test_storage_reclaim_finished_rejects_initial_probe_new_isolation
-test_storage_reclaim_finished_rejects_regular_isolation_replacement
-test_storage_reclaim_finished_rejects_worktree_replacement
-test_storage_reclaim_finished_rejects_valid_same_path_replacement
-test_storage_reclaim_finished_handles_empty_isolation_that_gains_output
-test_storage_reclaim_finished_cleans_zero_byte_output_entry
-test_storage_reclaim_finished_rechecks_empty_root_after_later_preflight
-test_storage_reclaim_finished_rejects_new_isolation_after_clean
-test_storage_reclaim_finished_reports_buck_owned_residual
-test_storage_reclaim_finished_reports_non_directory_residual
-test_storage_reclaim_finished_rejects_root_replacement_after_clean
-test_storage_reclaim_finished_explicitly_scopes_v2_with_environment_override
-test_storage_reclaim_finished_alias_active_and_zero_output
-test_storage_reclaim_finished_alias_and_preflight_validate_all
-test_storage_reclaim_finished_scopes_every_isolation
-test_storage_guard_finished_evidence_rechecks_output_after_ttl_cleanup
-test_storage_guard_finished_evidence_rejects_root_replacement
-test_storage_guard_rejects_malformed_evidence_and_reclaim_rejects_unknown_source
-test_storage_guard_names_only_caller_supplied_finished_evidence
-test_storage_guard_skips_active_evidence_and_names_idle_evidence
+test_wrapper_refuses_below_free_space_floor
 
 echo "--------------------------------------------------"
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -528,10 +528,6 @@ def clippy_workflow_errors(workflow: str) -> list[str]:
             "scripts/provision-build-cache install",
             "clippy must preserve remote-cache provisioning",
         ),
-        (
-            "scripts/provision-build-cache apply",
-            "clippy must preserve remote-cache provisioning",
-        ),
     ):
         if required not in executable:
             errors.append(message)

--- a/test.sh
+++ b/test.sh
@@ -71,12 +71,6 @@ if [[ $# -gt 0 && -n "$requested_test_tier" ]]; then
     exit 2
 fi
 
-# Direct full-suite invocations also bootstrap an already-installed private
-# cache config. This is a no-op when the user has not opted in.
-if [[ -x scripts/provision-build-cache ]]; then
-    scripts/provision-build-cache auto
-fi
-
 # Always print the result sentinel, even on an early `set -e` exit, so a piped
 # or captured run is self-describing (RUE-579).
 #


### PR DESCRIPTION
Closes RUE-1934.

## What was deleted, and why

- **`scripts/rue-storage`: `guard`'s cleanup escalation, `reset_legacy_under_pressure`, `reclaim-finished`, `--finished-root`, and the finished-evidence machinery.** `reclaim-finished` and the evidence path (~1,700 lines with their tests) had no caller outside tests and docs. `reset_legacy_under_pressure` only acted on checkouts lacking `defer_write_actions`, which none has had since RUE-1225 — dead code. The guard's cross-worktree cleanup caused RUE-1331 and RUE-1683 and did not prevent RUE-1790 (host at 123 MB free): an age-based TTL cannot reclaim same-cycle output, and `.buckconfig`'s background cleaner never runs in a worker worktree because of `clean_stale_start_offset_hours = 12`. Most of the remaining script validated its own inputs against a same-UID directory-swap threat with no privilege boundary. What stays: `status`, `plan`, `clean` (Buck's own `clean --stale AGE --tracked-only` per registered worktree, no adaptive/low-disk flags), and `reset ROOT` (validate every named path is a registered worktree first, then `buck2 clean`), plus the fail-closed `git worktree list` inventory. `scripts/rue storage ...` and `scripts/rue gc` keep working. `status`'s CACHE column reports `central` for a wrapper link to the installed config, `local` for any other `.buckconfig.local`, `off` for none.
- **`scripts/provision-build-cache`: `apply`, `auto`, `--all`, `status`, Codex worktree discovery, and `migrate_config`.** Only `install` remains (prompt without echo, 0600, atomic write). Re-running `install` replaces the file; there is no in-place migration.
- **The `provision-build-cache auto` calls** in `buck2`, `scripts/rue`, and `test.sh`, and the `provision-build-cache apply` step in every CI job (`ci.yml` ×10, `release.yml` ×2, `cache-probe.yml` ×2). `validate-ci-gate.py` pinned the clippy job's `apply` line; that pin is removed (the `install` pin stays). `scripts/test-validate-ci-gate.py` had no test on the `apply` pin, so it is unchanged.

## The new wrapper contract (`./buck2`)

1. **Free-space floor.** For `build`/`test`/`run`/`install`, one portable `df -Pk` read; below 4 GiB free the command is refused with a message naming `git worktree remove <path>`, `scripts/rue storage reset <root>`, and `scripts/rue storage clean`. An unmeasurable filesystem also refuses (fail-closed, as before). Above the floor the wrapper does nothing; `clean`, `targets`, `audit`, etc. are never refused. No cleanup is ever triggered from a build.
2. **Cache provisioning is install plus one link.** For execution commands, when `RUE_NO_REMOTE_CACHE` ≠ 1, `${RUE_BUILDBUDDY_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/rue/buildbuddy.buckconfig}` is a regular file with no group/other bits, and `$repo_root/.buckconfig.local` does not exist (neither file nor symlink), the wrapper creates `.buckconfig.local` as a symlink to the central config — the ~10 lines that were the whole of the old `apply`/`auto`. An existing `.buckconfig.local` (symlink or file, including a broken one) is never touched; a group/world-readable config is refused with a warning; a failed `ln` warns; none of those blocks a local build. The `uses_remote_cache` grep of `.buckconfig.local` (which drives `--prefer-local`) runs **after** the link step, so the first build in a new worktree gets `--prefer-local` too. The `--prefer-local` insertion logic is unchanged.

   Why the link and not a per-command `--config-file` (an earlier revision of this PR tried that, and review caught it against a real daemon): `[buck2] digest_algorithms` and `[buck2_re_client]` are daemon-startup settings. A `--config-file` leaves `buck2 status` at `digest_algorithms: null` (SHA1, which BuildBuddy's CAS rejects) and the daemon with no RE engine address (`Error: (No engine address)` on a real rustc action), while a changed `.buckconfig.local` restarts the daemon with both applied. Verified below.
3. `scripts/check-reproducible-compiler.sh` must be cache-free: if `.buckconfig.local` is a symlink to the central config it is moved aside for the duration and restored from the EXIT trap (on failure too); a hand-written `.buckconfig.local` (regular file, or symlink elsewhere) is still refused; `RUE_NO_REMOTE_CACHE=1` is exported so the wrapper does not relink. Toggling the file restarts the daemon, which is expected. `scripts/check-rue-program-warm-cache.sh` requires the installed config instead of grepping `.buckconfig.local`, and no longer provisions the relocated clone (its wrapper links the same file on its first build). `scripts/check-reproducible-build-metadata.py` needs no change: it points `RUE_BUILDBUDDY_CONFIG` at an absent path and writes its own `.buckconfig.local` sentinel, which the wrapper leaves alone.

## Tests

- `scripts/test-cleanup-scripts.sh`: jj-tidy tests unchanged; storage tests are fail-closed inventory, plan/clean cover every registered root (and carry no adaptive flags), reset refuses an unregistered path and cleans a registered one; new wrapper-floor test (refuse at 1 GiB with the remedies, `clean`/`targets` still allowed, pass at exactly 4 GiB and at 8 GiB with argv unchanged, `df` failure fails closed). `//:cleanup-script-inputs` now includes `buck2` and `buck2-bin`.
- `scripts/test-build-sharing.sh`: `install` contract (private, key never printed, replace in place, empty key refused, writes nothing into the checkout, `install` is the only subcommand); `--prefer-local` checks kept; link contract (non-execution commands never provision; first execution command links `.buckconfig.local` to the central config and already gets `--prefer-local`; nothing on the command line; an existing link is left as is; an existing per-checkout file is never replaced; a broken user symlink is left alone and the build still runs; `RUE_NO_REMOTE_CACHE=1` links nothing; 0644 config is not linked, with a warning, build still runs; `RUE_BUILDBUDDY_CONFIG` override honored; absent config → nothing linked, argv unchanged); full-suite orchestration kept. `//:build-sharing-test-inputs` drops `rue-storage`.
- `scripts/test-wrapper-scripts.sh` does not reference `provision-build-cache` or `rue-storage`; it needed no change and still passes.
- The real-daemon digest check is done as a manual verification step (below) rather than inside the sh_test sandbox.

## Line counts

| file | before | after |
| --- | ---: | ---: |
| `scripts/rue-storage` | 1,039 | 170 |
| `scripts/provision-build-cache` | 244 | 78 |
| `buck2` | 67 | 103 |
| `scripts/test-cleanup-scripts.sh` | 1,632 | 367 |
| `scripts/test-build-sharing.sh` | 262 | 276 |

## Docs

`docs/process/build-cache.md` ("Local development across worktrees", "Host-wide disk lifecycle", CI section, metadata-diagnostic paragraph), ADR-0082's accepted-cost bullet and its RUE-1790 future-work bullet (plus `RUE-1934` in `relates`), `AGENTS.md` quickstart and the "Testing strategy" sentence, `docs/development.md`, `.claude/skills/integrate-worker/SKILL.md`, `.buckconfig.local.example`'s header, `scripts/rue` help, the `ci.yml` checkout comment that said `provision-build-cache` shells out to git, and the `platforms/BUCK` comment.

## Verification (re-run after the review change)

| command | result |
| --- | --- |
| `bash scripts/test-cleanup-scripts.sh` | all 18 checks passed |
| `bash scripts/test-build-sharing.sh` | all 34 checks passed |
| `bash scripts/test-wrapper-scripts.sh` | all 168 checks passed |
| `./buck2 test //:cleanup-script-tests //:build-sharing-tests //:wrapper-script-tests //:corpus-action-tests //:shell-bash-baseline-tool-tests //:python-baseline-tool-tests //:doc-link-validation //:adr-registry-validation //:ci-gate-validation //:dotslash-bootstrap-validation` | Pass 10, Fail 0 |
| `python3 scripts/validate-shell-bash-baseline.py` | valid (59 scanned, 52 parsed) |
| `python3 scripts/validate-python-baseline.py` | valid (93 files against 3.9) |
| `python3 scripts/validate-shell-pipefail-pipelines.py` | valid (52 scripts) |
| `python3 scripts/validate-doc-links.py` | valid, no dead references |
| `python3 scripts/validate-ci-gate.py .github/workflows/ci.yml --test-runner-source crates/rue-test-runner/src/lib.rs --buck BUCK --structural-only` | CI gate valid |
| `./buck2 bxl //test_tiers.bxl:validate` | valid: 218 premerge, 20 slow, 3 stress |
| **Real daemon check**: temp `XDG_CONFIG_HOME` with a 0600 config containing only `[buck2] digest_algorithms = SHA256`; in this checkout with no `.buckconfig.local`: `./buck2 status` → `"digest_algorithms":null`; `XDG_CONFIG_HOME=<tmp> ./buck2 build //std:std` → "Connected to new buck2 daemon", BUILD SUCCEEDED, `.buckconfig.local -> <tmp>/rue/buildbuddy.buckconfig` created; `./buck2 audit config buck2.digest_algorithms` → `SHA256`; `./buck2 status` → `"digest_algorithms":"SHA256"`; `rm .buckconfig.local`; `./buck2 status` → `null` again | daemon picks up the linked config |
| `./buck2 targets //std:std` with no installed config on this host | `root//std:std`, rc 0 |
