### PR TITLE
RUE-1933: give examples and docs their own Buck packages

### DIFF
--- a/.claude/skills/integrate-worker/SKILL.md
+++ b/.claude/skills/integrate-worker/SKILL.md
@@ -34,7 +34,7 @@ Each step exists because skipping it once caused a real failure.
    one night, individually-green workers were jointly wrong (double-drops).
 
 5. **A tightening change compiles the example corpus BEFORE the suite.**
-   `./buck2 build //:cli-staged-programs` builds all ten multi-file example
+   `./buck2 build //examples:cli-staged-programs` builds all ten multi-file example
    programs. Any change that makes the compiler reject, trap, or error where it
    previously accepted needs this, and canaries are not enough: a RUE-1786
    over-rejection passed `examples/harbor` *and* its own mutation check, and was

--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -128,7 +128,7 @@ jobs:
   # ADR-0070's positive warm-cache control (RUE-1405, extended by RUE-1406).
   # Cold-builds the two canary rue_programs and the nine staged CLI programs
   # under a fresh nonce, then from a relocated checkout root re-runs the
-  # canaries' four consuming scenarios and rebuilds //:cli-staged-programs,
+  # canaries' four consuming scenarios and rebuilds //examples:cli-staged-programs,
   # failing unless the scan/derive/compile actions were all served by the
   # remote cache. The nonce keys the Rust toolchain, so the cold half also
   # rebuilds the compiler — that is what makes "cold" provable, and it is why

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,14 +120,14 @@ jobs:
         if: steps.select.outputs.run == 'true' && (github.event_name == 'schedule' || inputs.tier == 'slow')
         run: >-
           scripts/ci-timed "${{ matrix.program }} slow" --
-          ./buck2 test "//:large-example-${{ matrix.program }}-slow"
+          ./buck2 test "//examples:large-example-${{ matrix.program }}-slow"
           --target-platforms //platforms:release
 
       - name: Run manual stress program
         if: steps.select.outputs.run == 'true' && github.event_name == 'workflow_dispatch' && inputs.tier == 'stress'
         run: >-
           scripts/ci-timed "${{ matrix.program }} stress" --
-          ./buck2 test "//:large-example-${{ matrix.program }}-stress"
+          ./buck2 test "//examples:large-example-${{ matrix.program }}-stress"
           --target-platforms //platforms:release
 
       # See the release job's rationale. Named per program so a scheduled run

--- a/BUCK
+++ b/BUCK
@@ -1,7 +1,7 @@
 # Repo-root test-suite targets (RUE-144 / RUE-132).
 #
 # Each suite ties a test-harness binary to the rue compiler and the on-disk
-# inputs it actually reads (cases/, std/, docs/), so Buck owns the binary
+# inputs it actually reads (cases/, std/, examples/, docs/), so Buck owns the binary
 # handoff and keys each suite on its real inputs:
 #
 #   buck2 test //...        # runs unit tests + spec/UI/CLI suites + repo gates
@@ -31,7 +31,6 @@
 # files so that `buck2 test //crates/...` (quick-test.sh, test.sh's filtered
 # path) still means "unit tests only".
 
-load("//:rue_rules.bzl", "rue_program", "rue_program_family", "rue_program_staging", "rue_program_test")
 load("//:test_defs.bzl", "rue_sh_test", "rue_test_suite", "rue_tool_test")
 
 load(":corpus.bzl", "cached_corpus_suite")
@@ -41,15 +40,10 @@ rue_sh_test(
     test = "scripts/check-compiler-allocator-policy.sh",
     env = {
         "RUE_ALLOCATOR_CRATE_ROOT": "$(location //crates/rue:allocator-policy-inputs)",
-        "RUE_ALLOCATOR_POLICY_NOTE": "$(location :compiler-allocator-policy-note)",
+        "RUE_ALLOCATOR_POLICY_NOTE": "$(location //docs:adr-0071-phase-3-note)",
         "RUE_ALLOCATOR_THIRD_PARTY_ROOT": "$(location //third-party:allocator-policy-inputs)",
         "RUE_ALLOCATOR_ZIG_ROOT": "$(location toolchains//zig:policy-inputs)",
     },
-)
-
-export_file(
-    name = "compiler-allocator-policy-note",
-    src = "docs/notes/adr-0071-phase-3-linux-compiler-allocator.md",
 )
 
 # Versioned configuration anchors for the repository's Rust quality gates.
@@ -226,28 +220,21 @@ rue_sh_test(
     labels = ["rue_not_quick"],
 )
 
-# The example programs are runtime inputs to the CLI integration tests: the
-# suite compiles+runs every examples/*.rue through the real driver (RUE-48),
-# so an edit under examples/ MUST re-run the CLI suite (declared here as an
-# input, resolved to an absolute path via RUE_EXAMPLES_DIR below).
-filegroup(
-    name = "examples",
-    srcs = glob(["examples/**"]),
-    visibility = ["PUBLIC"],
-)
-
 # Syntax-valid, checked-in Rue programs compared by the independent stage-1
 # frontend differential. Keeping the selection explicit excludes intentionally
 # malformed UI/spec/CLI fixtures without a filename heuristic.
-# `std/` is its own package, so a root glob cannot reach it; the std tree is
-# mounted at the `std/` key instead, which keeps the corpus manifest's
-# `std/<file>.rue` paths unchanged. The harness follows the directory symlink.
+# `examples/` and `std/` are their own packages, so a root glob cannot reach
+# them; each tree is mounted at its directory key instead, which keeps the
+# corpus manifest's `examples/<...>.rue` and `std/<file>.rue` paths unchanged.
+# The harness follows the directory symlinks.
 filegroup(
     name = "frontend-diff-corpus",
     srcs = dict([(path, path) for path in glob([
-        "examples/**/*.rue",
         "reproducibility/**/*.rue",
-    ])]) | {"std": "//std:std"},
+    ])]) | {
+        "examples": "//examples:rue-sources",
+        "std": "//std:std",
+    },
     visibility = ["PUBLIC"],
 )
 
@@ -285,17 +272,6 @@ filegroup(
         "scripts/check-tutorial-snippets.py",
         "test.sh",
     ],
-)
-
-filegroup(
-    name = "spec-docs",
-    srcs = glob(["docs/spec/src/**"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "adr-designs",
-    srcs = glob(["docs/designs/**"]),
 )
 
 # Required pull-request and merge-group CI must not execute a moving container
@@ -355,7 +331,7 @@ rue_sh_test(
     args = ["--traceability"],
     env = {
         "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
-        "RUE_SPEC_DIR": "$(location :spec-docs)/docs/spec/src",
+        "RUE_SPEC_DIR": "$(location //docs:spec-src)",
     },
 )
 
@@ -365,7 +341,7 @@ rue_sh_test(
     args = ["--check-machine-index"],
     env = {
         "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
-        "RUE_SPEC_DIR": "$(location :spec-docs)/docs/spec/src",
+        "RUE_SPEC_DIR": "$(location //docs:spec-src)",
     },
 )
 
@@ -393,84 +369,6 @@ cached_corpus_suite(
     ],
 )
 
-# ADR-0070 Phase 2 (RUE-1406): the CLI cases that name a checked-in root stop
-# compiling it inside the harness. Each root is one `rue_program` build action —
-# keyed on its real inputs, uploadable, and shared by every scenario naming it —
-# and the corpus actions below declare the staged executables the way they
-# declare every other input, through `$(location ...)` in their `attrs.arg()`
-# env. The weld this breaks is not a speed problem but a coverage one: the only
-# way to run Meridian's sixth scenario was to compile 36k lines a sixth time,
-# so RUE-1083 disabled all six rather than pay for them.
-#
-# 64 of the 73 cases naming a checked-in root migrate, over 9 roots. Only 8 are
-# new: `examples/meridian/main.rue` is already a Phase 1 large-example program,
-# so one artifact serves both suites — the "many scenarios, one compile"
-# property reaching across two suites.
-#
-# What stays compile-in-harness, all of it deliberate: the 6 cross-target
-# `cli-test-fixtures` cases (each (root, target) tuple has exactly one consumer
-# and compiles in milliseconds), the repo-relative `source_path` fixture case
-# (whose subject IS the TOML resolution mechanism it would be leaving), the one
-# `differential_opt` calculator case (four compiles by design, at opt levels the
-# runner drives), and the one-scenario wordfreq root. The harness decides this
-# structurally rather than from a list — see `case_runs_prebuilt_program`.
-#
-# The RUE-48 automatic example smokes are untouched: `run_example` still
-# compiles each root it discovers through the ordinary driver, so every example
-# still proves it compiles the way a user compiles it.
-#
-# `examples/first/` holds three sibling roots, so `first-stats` names its one
-# file instead of globbing the directory; every other root owns its directory
-# and takes the directory-bounded glob ADR-0070's over-declaration audit
-# documents.
-[
-    rue_program(
-        name = _name,
-        root = "examples/{}.rue".format(_root),
-        srcs = _srcs,
-    )
-    for _name, _root, _srcs in [
-        ("first-stats", "first/stats", ["examples/first/stats.rue"]),
-        ("gazette", "gazette/main", glob(["examples/gazette/**/*.rue"])),
-        ("harbor", "harbor/main", glob(["examples/harbor/**/*.rue"])),
-        ("jsonfmt", "jsonfmt/main", glob(["examples/jsonfmt/**/*.rue"])),
-        ("lattice", "lattice/main", glob(["examples/lattice/**/*.rue"])),
-        ("mosaic", "mosaic/main", glob(["examples/mosaic/**/*.rue"])),
-        ("rill", "rill/main", glob(["examples/rill/**/*.rue"])),
-        ("ruelex", "ruelex/main", glob(["examples/ruelex/**/*.rue"])),
-        ("second-calculator", "second/calculator", glob(["examples/second/**/*.rue"])),
-    ]
-]
-
-# The ten artifacts as one directory keyed by root path, so a corpus action
-# declares a single `$(location ...)` and the harness's lookup key is the
-# case's own `source_path` string. Consumed by //:cli-tests, //:cli-tests-slow
-# and the four shards.
-#
-# Every consumer declares all ten even though no single corpus target runs
-# cases against all ten — mosaic's section is slow-tier, so the premerge
-# targets carry it for nothing. That is the simplest correct form ADR-0070
-# chose deliberately: it is a mild over-declaration of each action's key (an
-# edit to any root already re-runs every CLI corpus action today, since the
-# roots live inside the declared `:examples` filegroup) and it fails closed,
-# because a case whose program is absent from the staging environment cannot
-# silently run a stale one.
-rue_program_staging(
-    name = "cli-staged-programs",
-    programs = [
-        ":first-stats",
-        ":gazette",
-        ":harbor",
-        ":jsonfmt",
-        ":lattice",
-        ":meridian",
-        ":mosaic",
-        ":rill",
-        ":ruelex",
-        ":second-calculator",
-    ],
-)
-
 # Shared verbatim by //:cli-tests and its shards so a slice runs exactly the
 # same cases the monolithic target would. What the two skips exclude is the
 # automatic RUE-48 smoke over each large application's full root, which still
@@ -492,7 +390,7 @@ _CLI_TEST_ARGS = [
 _CLI_TEST_BASE_ENV = {
     "RUE_BINARY": "$(exe_target //crates/rue:rue)",
     "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
-    "RUE_EXAMPLES_DIR": "$(location :examples)/examples",
+    "RUE_EXAMPLES_DIR": "$(location //examples:examples)",
     "RUE_REPO_DIR": "$(location :cli-test-fixtures)",
     "RUE_STD_DIR": "$(location //std:std)",
 }
@@ -505,7 +403,7 @@ _CLI_TEST_BASE_ENV = {
 # release-configured program compiles to a deliberately bounded lane (RUE-1129)
 # in exchange for nothing.
 _CLI_STAGED_PROGRAMS_ENV = {
-    "RUE_CLI_STAGED_PROGRAMS": "$(location :cli-staged-programs)",
+    "RUE_CLI_STAGED_PROGRAMS": "$(location //examples:cli-staged-programs)",
 }
 
 _CLI_TEST_ENV = dict(
@@ -663,141 +561,6 @@ CLI_TEST_SHARD_COUNT = 4
     for _shard in range(CLI_TEST_SHARD_COUNT)
 ]
 
-# ADR-0070 Phase 1 (RUE-1405): each large maintained application compiles
-# once as a `rue_program` build action — cached, shared across lanes — and
-# every runtime scenario below is its own `rue_program_test` consuming that
-# executable. A test execution never reaches the action cache, so the compile
-# must not live inside one.
-#
-# Each sibling pair shares a directory glob (main does not import canary.rue,
-# or vice versa): the precision trade ADR-0070's over-declaration audit
-# documents. The executor's 600s default (RUE-1156) now bounds only a runtime
-# scenario, which finishes in seconds even at stress scale.
-rue_program_family(
-    name = "large-example-caldera",
-    srcs = glob(["examples/caldera/**/*.rue"]),
-    programs = {
-        "caldera": {"root": "examples/caldera/main.rue"},
-        "caldera-canary": {"root": "examples/caldera/canary.rue"},
-    },
-)
-
-# `:meridian` is the ninth staged CLI program as well as the slow-tier
-# large-example root (ADR-0070 Phase 2): one compile, consumed by the six
-# scheduled scenarios below AND by the six CLI corpus scenarios of
-# cases/examples_meridian.toml.
-rue_program_family(
-    name = "large-example-meridian",
-    srcs = glob(["examples/meridian/**/*.rue"]),
-    programs = {
-        "meridian": {"root": "examples/meridian/main.rue"},
-        "meridian-canary": {"root": "examples/meridian/canary.rue"},
-    },
-)
-
-# The required pre-merge canaries compile a reduced root from each maintained
-# application and execute its core path. They are intentionally honest about
-# their scope: neither claims to compile the complete generated graph. Each
-# canary executable deliberately has two consuming scenarios — the core-path
-# check, and a staged-cwd run — which is the "one compile, many scenarios"
-# shape scripts/check-rue-program-warm-cache.sh asserts is cache-served.
-[
-    rue_program_test(
-        name = "large-example-{}-canary".format(_program),
-        program = ":{}-canary".format(_program),
-    )
-    for _program in ["caldera", "meridian"]
-]
-
-[
-    rue_program_test(
-        name = "large-example-{}-canary-workdir".format(_program),
-        program = ":{}-canary".format(_program),
-        files = [{"path": "data/staged.txt", "source": "staged\n"}],
-    )
-    for _program in ["caldera", "meridian"]
-]
-
-# Scheduled slow coverage: the complete application graphs, one compile each,
-# reused by every scenario. Every marker lands on stdout.
-_LARGE_EXAMPLE_SLOW_SCENARIOS = {
-    "caldera": [
-        ("selftest", [], ["selftest checks=23", "valid=true"], {}),
-        ("demo", ["demo"], ["entities=8", "valid=true"], {}),
-        (
-            "scenario",
-            ["run", "demo.caldera"],
-            ["script_oracle=true", "valid=true"],
-            {"demo.caldera": "examples/caldera/demo.caldera"},
-        ),
-        ("stress1", ["stress1"], ["stress scale=1", "valid=true"], {}),
-        ("benchmark", ["benchmark"], ["benchmark tiers=2", "valid=true"], {}),
-    ],
-    "meridian": [
-        ("help", [], ["usage: meridian"], {}),
-        ("demo", ["demo"], ["database=meridian", "result_valid=true"], {}),
-        (
-            "workload",
-            ["run", "demo.sql"],
-            ["plan_valid=true", "result_valid=true"],
-            {"demo.sql": "examples/meridian/demo.sql"},
-        ),
-        ("selftest", ["selftest"], ["selftest checks=24", "valid=true"], {}),
-        ("stress1", ["stress1"], ["stress scale=1", "valid=true"], {}),
-        (
-            "benchmark",
-            ["benchmark"],
-            ["benchmark=meridian-complete", "valid=true"],
-            {},
-        ),
-    ],
-}
-
-[
-    rue_program_test(
-        name = "large-example-{}-{}".format(_program, _scenario),
-        tier = "slow",
-        labels = ["rue_scheduled_large_example"],
-        program = ":{}".format(_program),
-        program_args = _args,
-        stdout_contains = _markers,
-        data = _data,
-    )
-    for _program, _scenarios in _LARGE_EXAMPLE_SLOW_SCENARIOS.items()
-    for _scenario, _args, _markers, _data in _scenarios
-]
-
-# The release workflow's matrix selects one application per job by these
-# names, exactly as it selected the retired monolithic sh_tests; each suite
-# fans out to the per-scenario tests above, which share one compiled artifact.
-[
-    rue_test_suite(
-        name = "large-example-{}-slow".format(_program),
-        tier = "slow",
-        labels = ["rue_scheduled_large_example"],
-        tests = [
-            ":large-example-{}-{}".format(_program, _scenario)
-            for _scenario, _args, _markers, _data in _scenarios
-        ],
-    )
-    for _program, _scenarios in _LARGE_EXAMPLE_SLOW_SCENARIOS.items()
-]
-
-# The 4x generated workload is an extreme scaling experiment rather than a
-# correctness smoke, so it has explicit stress-tier ownership. It consumes
-# the same compiled artifact as the slow tier.
-[
-    rue_program_test(
-        name = "large-example-{}-stress".format(_program),
-        tier = "stress",
-        labels = ["rue_scheduled_large_example"],
-        program = ":{}".format(_program),
-        program_args = ["stress4"],
-        stdout_contains = ["stress scale=4", "valid=true"],
-    )
-    for _program in ["caldera", "meridian"]
-]
-
 # RUE-1083: `examples/` is a declared input because this suite now also checks a
 # real maintained program (rill) for byte-stable output, not just the
 # purpose-built fixture. An edit under examples/ must therefore re-run it.
@@ -825,7 +588,7 @@ cached_corpus_suite(
     harness = ":reproducible-programs-harness",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
-        "RUE_EXAMPLES_DIR": "$(location :examples)/examples",
+        "RUE_EXAMPLES_DIR": "$(location //examples:examples)",
         "RUE_REPRO_FIXTURE": "$(location :reproducibility-fixture)/reproducibility/fixture",
         "RUE_STD_DIR": "$(location //std:std)",
     },
@@ -983,7 +746,7 @@ rue_sh_test(
     test = "scripts/validate-adrs.py",
     args = [
         "--adr-dir",
-        "$(location :adr-designs)/docs/designs",
+        "$(location //docs:designs)",
     ],
 )
 
@@ -996,12 +759,12 @@ rue_tool_test(
 # RUE-1531: the notes index (docs/notes/README.md) must list every note, and
 # every relative link or bare docs/crates/scripts path reference under
 # docs/**/*.md must name a real file. The docs tree is a declared resource so
-# a docs edit re-runs the gate instead of being served a stale pass; docs/
-# holds no nested Buck packages, so the root glob reaches all of it.
+# a docs edit re-runs the gate instead of being served a stale pass; `docs/`
+# is its own package, so the tree arrives through its filegroup.
 rue_sh_test(
     name = "doc-link-validation",
     test = "scripts/validate-doc-links.py",
-    resources = [":gatelib-sources"] + glob(["docs/**"]),
+    resources = [":gatelib-sources", "//docs:all"],
 )
 
 rue_tool_test(
@@ -1200,9 +963,7 @@ rue_tool_test(
 rue_tool_test(
     name = "caldera-generator-check",
     test = "scripts/test-caldera-generator.py",
-    resources = ["scripts/generate-caldera.py"] + glob([
-        "examples/caldera/**",
-    ]),
+    resources = ["scripts/generate-caldera.py", "//examples:caldera-sources"],
     gatelib = False,
 )
 
@@ -1441,7 +1202,7 @@ genrule(
         "RUE_CLI_EMIT_SHARD_LOADS={} ".format(CLI_TEST_SHARD_COUNT) +
         "RUE_CLI_CASE_TIER=premerge " +
         "RUE_CLI_CASES=$(location //crates/rue-cli-tests:cases)/cases " +
-        "RUE_EXAMPLES_DIR=$(location :examples)/examples " +
+        "RUE_EXAMPLES_DIR=$(location //examples:examples) " +
         "RUE_CLI_SHARD_WEIGHTS=$(location //crates/rue-cli-tests:shard-weights) " +
         "$(exe //crates/rue-cli-tests:rue-cli-tests) > $OUT",
 )
@@ -1475,7 +1236,7 @@ rue_sh_test(
     env = {
         "RUE_CLI_HARNESS": "$(exe_target //crates/rue-cli-tests:rue-cli-tests)",
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
-        "RUE_EXAMPLES_DIR": "$(location :examples)/examples",
+        "RUE_EXAMPLES_DIR": "$(location //examples:examples)",
         "RUE_REPO_DIR": "$(location :cli-test-fixtures)",
         "RUE_STD_DIR": "$(location //std:std)",
     },
@@ -1729,7 +1490,7 @@ rue_sh_test(
         "RUE_UI_CASES": "$(location //crates/rue-ui-tests:cases)/cases",
         "RUE_CLI_HARNESS": "$(exe_target //crates/rue-cli-tests:rue-cli-tests)",
         "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
-        "RUE_EXAMPLES_DIR": "$(location root//:examples)/examples",
+        "RUE_EXAMPLES_DIR": "$(location //examples:examples)",
         "RUE_REPO_DIR": "$(location root//:cli-test-fixtures)",
         "RUE_STD_DIR": "$(location //std:std)",
     },

--- a/crates/rue-cli-tests/BUCK
+++ b/crates/rue-cli-tests/BUCK
@@ -58,7 +58,7 @@ command_alias(
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_CLI_CASES": "$(location :cases)/cases",
-        "RUE_EXAMPLES_DIR": "$(location root//:examples)/examples",
+        "RUE_EXAMPLES_DIR": "$(location //examples:examples)",
         "RUE_REPO_DIR": "$(location root//:cli-test-fixtures)",
         "RUE_STD_DIR": "$(location //std:std)",
     },

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -2024,7 +2024,7 @@ fn run_phase_with_timeout(
 
 /// Directory of prebuilt `rue_program` executables, keyed by the repo-relative
 /// root each was compiled from (ADR-0070 Phase 2 / RUE-1406). Buck stages it
-/// for the CLI corpus actions through `$(location //:cli-staged-programs)`;
+/// for the CLI corpus actions through `$(location //examples:cli-staged-programs)`;
 /// a developer entry point that runs this harness outside Buck simply leaves
 /// it unset, and every case compiles its own root as before.
 const STAGED_PROGRAMS_ENV: &str = "RUE_CLI_STAGED_PROGRAMS";

--- a/crates/rue-mcp/BUCK
+++ b/crates/rue-mcp/BUCK
@@ -21,7 +21,7 @@ command_alias(
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_SPEC_BINARY": "$(exe_target //crates/rue-spec:rue-spec)",
         "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
-        "RUE_SPEC_DIR": "$(location root//:spec-docs)/docs/spec/src",
+        "RUE_SPEC_DIR": "$(location //docs:spec-src)",
     },
     visibility = ["PUBLIC"],
 )
@@ -40,6 +40,6 @@ rue_sh_test(
         "RUE_MCP_BINARY": "$(exe_target :rue-mcp)",
         "RUE_SPEC_BINARY": "$(exe_target //crates/rue-spec:rue-spec)",
         "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
-        "RUE_SPEC_DIR": "$(location root//:spec-docs)/docs/spec/src",
+        "RUE_SPEC_DIR": "$(location //docs:spec-src)",
     },
 )

--- a/crates/rue-spec/BUCK
+++ b/crates/rue-spec/BUCK
@@ -51,7 +51,7 @@ command_alias(
     args = ["--machine-index"],
     env = {
         "RUE_SPEC_CASES": "$(location :cases)/cases",
-        "RUE_SPEC_DIR": "$(location root//:spec-docs)/docs/spec/src",
+        "RUE_SPEC_DIR": "$(location //docs:spec-src)",
     },
     visibility = ["PUBLIC"],
 )
@@ -63,7 +63,7 @@ command_alias(
     exe = ":rue-spec",
     args = ["--error-pages"],
     env = {
-        "RUE_SPEC_DIR": "$(location root//:spec-docs)/docs/spec/src",
+        "RUE_SPEC_DIR": "$(location //docs:spec-src)",
     },
     visibility = ["PUBLIC"],
 )

--- a/docs/BUCK
+++ b/docs/BUCK
@@ -1,0 +1,32 @@
+# Documentation trees as Buck inputs. A root-package `glob()` cannot reach
+# into this package, so the gates and harnesses that read docs depend on the
+# targets here. The dict-form filegroups strip their subdirectory prefix, so
+# `$(location //docs:spec-src)` IS the specification source root and
+# `$(location //docs:designs)` IS the ADR directory, with no path suffix at
+# the consumer.
+
+# The whole tree, for the doc-link gate (RUE-1531): any docs edit re-runs it.
+filegroup(
+    name = "all",
+    srcs = glob(["**"]),
+    visibility = ["//:"],
+)
+
+filegroup(
+    name = "spec-src",
+    srcs = dict([(path[len("spec/src/"):], path) for path in glob(["spec/src/**"])]),
+    visibility = ["PUBLIC"],
+)
+
+filegroup(
+    name = "designs",
+    srcs = dict([(path[len("designs/"):], path) for path in glob(["designs/**"])]),
+    visibility = ["//:"],
+)
+
+# ADR-0071 phase 3: the note //:compiler-allocator-policy-validation reads.
+export_file(
+    name = "adr-0071-phase-3-note",
+    src = "notes/adr-0071-phase-3-linux-compiler-allocator.md",
+    visibility = ["//:"],
+)

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -302,7 +302,7 @@ control (RUE-1405, extended by RUE-1406;
 `scripts/check-rue-program-warm-cache.sh`). It cold-builds the two canary
 `rue_program` targets and the nine staged CLI programs under the same nonce
 mechanism, then from a *relocated* checkout root runs the canaries' four
-consuming scenarios and rebuilds `//:cli-staged-programs`, failing unless every
+consuming scenarios and rebuilds `//examples:cli-staged-programs`, failing unless every
 scan/derive/compile action was a cache hit. Cross-root service is the property
 the derive step's manifest re-anchoring exists to guarantee, and it is what
 lets a `pull_request` run's compile be consumed by the `merge_group` run. Both

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -394,10 +394,10 @@ application instead compiles as a `rue_program` build action (ADR-0070 /
 RUE-1405) — a real cached artifact keyed on its declared read closure, served
 by the remote action cache across invocations and lanes — and every runtime
 scenario is its own `rue_program_test` consuming that artifact. The required
-broad pass runs the `//:large-example-{caldera,meridian}-canary` scenarios
+broad pass runs the `//examples:large-example-{caldera,meridian}-canary` scenarios
 over reduced roots that exercise each application's core compiler/runtime
 path without claiming full-program coverage. Nightly
-`//:large-example-{caldera,meridian}-slow` suites fan out to the per-scenario
+`//examples:large-example-{caldera,meridian}-slow` suites fan out to the per-scenario
 tests over the complete real roots, and the `stress4` configurations live
 only in the corresponding `-stress` scenarios, which reuse the same compiled
 artifact instead of recompiling it. The positive warm-cache control
@@ -413,7 +413,7 @@ apply to it.
 
 The CLI cases that name a checked-in root do not compile it. ADR-0070 Phase 2
 (RUE-1406) declares each of the nine such roots as a `rue_program`, collects
-them into `//:cli-staged-programs`, and gives every CLI corpus action that
+them into `//examples:cli-staged-programs`, and gives every CLI corpus action that
 directory as a declared input; the harness runs the prebuilt executable a case
 names. 64 cases work this way. What still compiles inside the harness is
 deliberate and structural — the harness stages a case only when the case says
@@ -583,7 +583,7 @@ coverage remains and that case cannot return as an accidental substring match.
 Cost, measured on a 4-core-class host with the binaries already built: **0.29s
 wall for 73 `--list` invocations**, 1.6s of process time run concurrently. The
 gate materializes only what a listing consults, which deliberately excludes
-`RUE_CLI_STAGED_PROGRAMS`: `//:cli-staged-programs` stages ten `rue_program`
+`RUE_CLI_STAGED_PROGRAMS`: `//examples:cli-staged-programs` stages ten `rue_program`
 compiles that discovery never reads, the premerge lane does not otherwise build
 it, and the shards that do consume it run on other runners. The step is skipped
 on a narrowed pull-request run, where it would have to build unimpacted test

--- a/examples/BUCK
+++ b/examples/BUCK
@@ -1,0 +1,257 @@
+# The example programs: runtime inputs of the CLI corpus, and the
+# `rue_program` build actions of ADR-0070 (one compile per checked-in root,
+# consumed by many scenarios). Every `root` below is a PROJECT-relative path,
+# as `rue_program` requires; `srcs` and `data` are package-relative.
+#
+# A root-package `glob()` cannot reach into this package, so anything at the
+# root that needs example files depends on a target declared here.
+
+load("//:rue_rules.bzl", "rue_program", "rue_program_family", "rue_program_staging", "rue_program_test")
+load("//:test_defs.bzl", "rue_test_suite")
+
+# The example programs are runtime inputs to the CLI integration tests: the
+# suite compiles+runs every examples/*.rue through the real driver (RUE-48),
+# so an edit under examples/ MUST re-run the CLI suite (declared here as an
+# input, resolved to an absolute path via RUE_EXAMPLES_DIR in the root
+# package's corpus suites). This package exists so `$(location
+# //examples:examples)` IS the examples root, and so the `rue_program`
+# declarations below sit beside the programs they build.
+filegroup(
+    name = "examples",
+    srcs = glob(["**"]),
+    visibility = ["PUBLIC"],
+)
+
+# Only the Rue sources, for the frontend differential's corpus (//:frontend-
+# diff-corpus mounts this at its `examples/` key so the corpus manifest's
+# paths are unchanged).
+filegroup(
+    name = "rue-sources",
+    srcs = glob(["**/*.rue"]),
+    visibility = ["//:"],
+)
+
+# The committed Caldera capacity corpus is generator output;
+# //:caldera-generator-check declares it through this target because a root
+# glob cannot descend into this package.
+filegroup(
+    name = "caldera-sources",
+    srcs = glob(["caldera/**"]),
+    visibility = ["//:"],
+)
+
+
+# ADR-0070 Phase 2 (RUE-1406): the CLI cases that name a checked-in root stop
+# compiling it inside the harness. Each root is one `rue_program` build action —
+# keyed on its real inputs, uploadable, and shared by every scenario naming it —
+# and the corpus actions below declare the staged executables the way they
+# declare every other input, through `$(location ...)` in their `attrs.arg()`
+# env. The weld this breaks is not a speed problem but a coverage one: the only
+# way to run Meridian's sixth scenario was to compile 36k lines a sixth time,
+# so RUE-1083 disabled all six rather than pay for them.
+#
+# 64 of the 73 cases naming a checked-in root migrate, over 9 roots. Only 8 are
+# new: `examples/meridian/main.rue` is already a Phase 1 large-example program,
+# so one artifact serves both suites — the "many scenarios, one compile"
+# property reaching across two suites.
+#
+# What stays compile-in-harness, all of it deliberate: the 6 cross-target
+# `cli-test-fixtures` cases (each (root, target) tuple has exactly one consumer
+# and compiles in milliseconds), the repo-relative `source_path` fixture case
+# (whose subject IS the TOML resolution mechanism it would be leaving), the one
+# `differential_opt` calculator case (four compiles by design, at opt levels the
+# runner drives), and the one-scenario wordfreq root. The harness decides this
+# structurally rather than from a list — see `case_runs_prebuilt_program`.
+#
+# The RUE-48 automatic example smokes are untouched: `run_example` still
+# compiles each root it discovers through the ordinary driver, so every example
+# still proves it compiles the way a user compiles it.
+#
+# `examples/first/` holds three sibling roots, so `first-stats` names its one
+# file instead of globbing the directory; every other root owns its directory
+# and takes the directory-bounded glob ADR-0070's over-declaration audit
+# documents.
+[
+    rue_program(
+        name = _name,
+        root = "examples/{}.rue".format(_root),
+        srcs = _srcs,
+    )
+    for _name, _root, _srcs in [
+        ("first-stats", "first/stats", ["first/stats.rue"]),
+        ("gazette", "gazette/main", glob(["gazette/**/*.rue"])),
+        ("harbor", "harbor/main", glob(["harbor/**/*.rue"])),
+        ("jsonfmt", "jsonfmt/main", glob(["jsonfmt/**/*.rue"])),
+        ("lattice", "lattice/main", glob(["lattice/**/*.rue"])),
+        ("mosaic", "mosaic/main", glob(["mosaic/**/*.rue"])),
+        ("rill", "rill/main", glob(["rill/**/*.rue"])),
+        ("ruelex", "ruelex/main", glob(["ruelex/**/*.rue"])),
+        ("second-calculator", "second/calculator", glob(["second/**/*.rue"])),
+    ]
+]
+
+# The ten artifacts as one directory keyed by root path, so a corpus action
+# declares a single `$(location ...)` and the harness's lookup key is the
+# case's own `source_path` string. Consumed by //:cli-tests, //:cli-tests-slow
+# and the four shards in the root package.
+#
+# Every consumer declares all ten even though no single corpus target runs
+# cases against all ten — mosaic's section is slow-tier, so the premerge
+# targets carry it for nothing. That is the simplest correct form ADR-0070
+# chose deliberately: it is a mild over-declaration of each action's key (an
+# edit to any root already re-runs every CLI corpus action today, since the
+# roots live inside the declared `:examples` filegroup) and it fails closed,
+# because a case whose program is absent from the staging environment cannot
+# silently run a stale one.
+rue_program_staging(
+    name = "cli-staged-programs",
+    visibility = ["//:"],
+    programs = [
+        ":first-stats",
+        ":gazette",
+        ":harbor",
+        ":jsonfmt",
+        ":lattice",
+        ":meridian",
+        ":mosaic",
+        ":rill",
+        ":ruelex",
+        ":second-calculator",
+    ],
+)
+
+
+# ADR-0070 Phase 1 (RUE-1405): each large maintained application compiles
+# once as a `rue_program` build action — cached, shared across lanes — and
+# every runtime scenario below is its own `rue_program_test` consuming that
+# executable. A test execution never reaches the action cache, so the compile
+# must not live inside one.
+#
+# Each sibling pair shares a directory glob (main does not import canary.rue,
+# or vice versa): the precision trade ADR-0070's over-declaration audit
+# documents. The executor's 600s default (RUE-1156) now bounds only a runtime
+# scenario, which finishes in seconds even at stress scale.
+rue_program_family(
+    name = "large-example-caldera",
+    srcs = glob(["caldera/**/*.rue"]),
+    programs = {
+        "caldera": {"root": "examples/caldera/main.rue"},
+        "caldera-canary": {"root": "examples/caldera/canary.rue"},
+    },
+)
+
+# `:meridian` is the ninth staged CLI program as well as the slow-tier
+# large-example root (ADR-0070 Phase 2): one compile, consumed by the six
+# scheduled scenarios below AND by the six CLI corpus scenarios of
+# cases/examples_meridian.toml.
+rue_program_family(
+    name = "large-example-meridian",
+    srcs = glob(["meridian/**/*.rue"]),
+    programs = {
+        "meridian": {"root": "examples/meridian/main.rue"},
+        "meridian-canary": {"root": "examples/meridian/canary.rue"},
+    },
+)
+
+# The required pre-merge canaries compile a reduced root from each maintained
+# application and execute its core path. They are intentionally honest about
+# their scope: neither claims to compile the complete generated graph. Each
+# canary executable deliberately has two consuming scenarios — the core-path
+# check, and a staged-cwd run — which is the "one compile, many scenarios"
+# shape scripts/check-rue-program-warm-cache.sh asserts is cache-served.
+[
+    rue_program_test(
+        name = "large-example-{}-canary".format(_program),
+        program = ":{}-canary".format(_program),
+    )
+    for _program in ["caldera", "meridian"]
+]
+
+[
+    rue_program_test(
+        name = "large-example-{}-canary-workdir".format(_program),
+        program = ":{}-canary".format(_program),
+        files = [{"path": "data/staged.txt", "source": "staged\n"}],
+    )
+    for _program in ["caldera", "meridian"]
+]
+
+# Scheduled slow coverage: the complete application graphs, one compile each,
+# reused by every scenario. Every marker lands on stdout.
+_LARGE_EXAMPLE_SLOW_SCENARIOS = {
+    "caldera": [
+        ("selftest", [], ["selftest checks=23", "valid=true"], {}),
+        ("demo", ["demo"], ["entities=8", "valid=true"], {}),
+        (
+            "scenario",
+            ["run", "demo.caldera"],
+            ["script_oracle=true", "valid=true"],
+            {"demo.caldera": "caldera/demo.caldera"},
+        ),
+        ("stress1", ["stress1"], ["stress scale=1", "valid=true"], {}),
+        ("benchmark", ["benchmark"], ["benchmark tiers=2", "valid=true"], {}),
+    ],
+    "meridian": [
+        ("help", [], ["usage: meridian"], {}),
+        ("demo", ["demo"], ["database=meridian", "result_valid=true"], {}),
+        (
+            "workload",
+            ["run", "demo.sql"],
+            ["plan_valid=true", "result_valid=true"],
+            {"demo.sql": "meridian/demo.sql"},
+        ),
+        ("selftest", ["selftest"], ["selftest checks=24", "valid=true"], {}),
+        ("stress1", ["stress1"], ["stress scale=1", "valid=true"], {}),
+        (
+            "benchmark",
+            ["benchmark"],
+            ["benchmark=meridian-complete", "valid=true"],
+            {},
+        ),
+    ],
+}
+
+[
+    rue_program_test(
+        name = "large-example-{}-{}".format(_program, _scenario),
+        tier = "slow",
+        labels = ["rue_scheduled_large_example"],
+        program = ":{}".format(_program),
+        program_args = _args,
+        stdout_contains = _markers,
+        data = _data,
+    )
+    for _program, _scenarios in _LARGE_EXAMPLE_SLOW_SCENARIOS.items()
+    for _scenario, _args, _markers, _data in _scenarios
+]
+
+# The release workflow's matrix selects one application per job by these
+# names, exactly as it selected the retired monolithic sh_tests; each suite
+# fans out to the per-scenario tests above, which share one compiled artifact.
+[
+    rue_test_suite(
+        name = "large-example-{}-slow".format(_program),
+        tier = "slow",
+        labels = ["rue_scheduled_large_example"],
+        tests = [
+            ":large-example-{}-{}".format(_program, _scenario)
+            for _scenario, _args, _markers, _data in _scenarios
+        ],
+    )
+    for _program, _scenarios in _LARGE_EXAMPLE_SLOW_SCENARIOS.items()
+]
+
+# The 4x generated workload is an extreme scaling experiment rather than a
+# correctness smoke, so it has explicit stress-tier ownership. It consumes
+# the same compiled artifact as the slow tier.
+[
+    rue_program_test(
+        name = "large-example-{}-stress".format(_program),
+        tier = "stress",
+        labels = ["rue_scheduled_large_example"],
+        program = ":{}".format(_program),
+        program_args = ["stress4"],
+        stdout_contains = ["stress scale=4", "valid=true"],
+    )
+    for _program in ["caldera", "meridian"]
+]

--- a/scripts/check-rue-program-warm-cache.sh
+++ b/scripts/check-rue-program-warm-cache.sh
@@ -9,7 +9,7 @@
 # Two consumer shapes are covered, because ADR-0070 has two:
 #   * the large-example canaries, each consumed by two `rue_program_test`
 #     scenarios (Phase 1);
-#   * the nine CLI roots in //:cli-staged-programs, consumed by the CLI corpus
+#   * the nine CLI roots in //examples:cli-staged-programs, consumed by the CLI corpus
 #     ACTIONS — //:cli-tests, //:cli-tests-slow and the four shards all declare
 #     that one directory, and the 64 TOML cases naming those roots run the
 #     staged executables instead of compiling them (Phase 2).
@@ -53,12 +53,12 @@ PROGRAMS=(
     ruelex
     second-calculator
 )
-BUILD_TARGETS=(//:caldera-canary //:meridian-canary //:cli-staged-programs)
+BUILD_TARGETS=(//examples:caldera-canary //examples:meridian-canary //examples:cli-staged-programs)
 SCENARIOS=(
-    //:large-example-caldera-canary
-    //:large-example-caldera-canary-workdir
-    //:large-example-meridian-canary
-    //:large-example-meridian-canary-workdir
+    //examples:large-example-caldera-canary
+    //examples:large-example-caldera-canary-workdir
+    //examples:large-example-meridian-canary
+    //examples:large-example-meridian-canary-workdir
 )
 
 if ! grep -Eq '^[[:space:]]*execution_platforms[[:space:]]*=[[:space:]]*root//platforms:remote_cache([[:space:]]|$)' .buckconfig.local 2>/dev/null; then
@@ -112,7 +112,7 @@ fi
 # `buck2 log what-ran` reports the LAST invocation, so the two consumer shapes
 # are driven separately and their logs are collected as each finishes. The two
 # invocations name disjoint programs, so neither hides the other's actions.
-(cd "$reloc" && "${RUE_BUCK2:-./buck2}" build "${NONCE_ARGS[@]}" //:cli-staged-programs >/dev/null 2>&1) || {
+(cd "$reloc" && "${RUE_BUCK2:-./buck2}" build "${NONCE_ARGS[@]}" //examples:cli-staged-programs >/dev/null 2>&1) || {
     echo "FAIL: staging the CLI programs failed in the relocated checkout" >&2
     exit 1
 }

--- a/scripts/test-validate-tier-ci-selectors.py
+++ b/scripts/test-validate-tier-ci-selectors.py
@@ -70,7 +70,7 @@ jobs:
     steps:
       - name: Run manual stress program
         if: github.event_name == 'workflow_dispatch' && inputs.tier == 'stress'
-        run: ./buck2 test "//:large-example-${{ matrix.program }}-stress"
+        run: ./buck2 test "//examples:large-example-${{ matrix.program }}-stress"
 """
 
 
@@ -205,7 +205,7 @@ class TierCiSelectorTests(unittest.TestCase):
             "      - name: Run manual stress program\n"
             "        if: github.event_name == 'workflow_dispatch'"
             " && inputs.tier == 'stress'\n"
-            '        run: ./buck2 test "//:large-example-${{ matrix.program }}-stress"\n',
+            '        run: ./buck2 test "//examples:large-example-${{ matrix.program }}-stress"\n',
             "",
         )
         self.assertIn("//... toolchains//...", release)

--- a/scripts/validate-test-duplication.py
+++ b/scripts/validate-test-duplication.py
@@ -740,7 +740,7 @@ def resolve_inventory(buck: Buck, targets: set[str]) -> Inventory:
 # listing consults.
 #
 # `RUE_CLI_STAGED_PROGRAMS` is the whole reason this exists.
-# `//:cli-staged-programs` stages ten `rue_program` executables, Meridian's
+# `//examples:cli-staged-programs` stages ten `rue_program` executables, Meridian's
 # among them at 80.7s in ADR-0070's own table, and the premerge lane never
 # builds it: that job builds `//crates/...`, and root corpus targets are
 # deliberately excluded (`ci.yml`, "Build all targets"). The CLI shards that do

--- a/scripts/validate-tier-ci-selectors.py
+++ b/scripts/validate-tier-ci-selectors.py
@@ -99,7 +99,7 @@ TIER_SELECTORS: dict[str, tuple[Selector, ...]] = {
             job="large-program",
             evidence=(
                 "inputs.tier == 'stress'",
-                '//:large-example-${{ matrix.program }}-stress',
+                '//examples:large-example-${{ matrix.program }}-stress',
             ),
             why="the manually dispatched 4x large-program stress matrix",
         ),


### PR DESCRIPTION
Closes RUE-1933.

Follow-up to the `std/` move in RUE-1915. The root BUCK file globbed 1,438 files under `examples/` and 206 under `docs/`, so an edit to either re-parsed the root package, and the `rue_program` declarations for the example roots lived at the repository root rather than beside the programs they build.

## What moved

- `examples/BUCK` owns the `examples` filegroup, the nine staged CLI programs, the two large-example families, the canary and slow scenarios, and `cli-staged-programs`. `root` stays a project-relative path as the rule requires; `srcs` and `data` are package-relative.
- `docs/BUCK` owns the spec sources, the ADR directory, the whole-tree resource for the doc-link gate, and the ADR-0071 note the allocator policy gate reads. The dict-form filegroups strip their subdirectory prefix, so `$(location //docs:spec-src)` is the specification root and `$(location //docs:designs)` the ADR directory, with no path suffix at any consumer.
- Every root target that used to glob into either directory now depends on a target declared there (a root glob cannot descend into a package): the frontend-diff corpus mounts `//examples:rue-sources` at its `examples/` key so the corpus manifest's paths are unchanged, and the Caldera generator check declares `//examples:caldera-sources`.
- Labels follow: `release.yml`, `scripts/check-rue-program-warm-cache.sh`, the tier-selector evidence string and its test, `docs/process/ci.md`, `docs/process/build-cache.md`, the integrate-worker skill, and two comments.

## Verification

- Whole-graph `buck2 targets --json` diff before/after: 39 root targets reappear under `//examples:` or `//docs:` with only package-relative path and label differences; 22 shared targets change only in the labels they reference; six new filegroups/exports.
- `buck2 cquery "set(//... toolchains//...)"` configures every node; `buck2 bxl //test_tiers.bxl:validate`: 218 premerge, 20 slow, 3 stress.
- Tier selector, CI gate (structural), doc links, ADR registry, python/bash/pipefail baselines: all pass.
- `buck2 test` over `//examples:` (canaries and slow scenarios, stress excluded), `//docs:`, the frontend-diff corpus, CLI shard 0, spec traceability and machine index, allocator policy, tutorial snippets, known-bug markers, zero-filter harness, reproducible programs, the rue-mcp and rue-spec packages, and the CI-timeout, CI-gate, and tier-selector gates: 40 targets pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmNTj9stFgZSNZihSxoTDS)_