### PR TITLE
RUE-1920: add the rue test subcommand, runner, and event stream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,9 @@ scripts/rue all                      # canonical union of all tiers
 scripts/rue unit compiler durable_   # one compiler unit test
 scripts/rue spec 4.2                 # filtered specification tests
 scripts/rue cli abi                  # filtered CLI integration tests
-scripts/rue test [pattern]           # broad/full suite
+scripts/rue test [pattern]           # broad/full suite (the maintainers' compiler-suite
+                                     # wrapper — unrelated to the language's own
+                                     # `rue test` subcommand, docs/process/test-events.md)
 scripts/rue fmt                      # format changed Rust files
 scripts/rue storage status           # inventory Buck disk use across worktrees
 scripts/rue storage plan             # dry-run stale cleanup in every registered worktree

--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -1,0 +1,835 @@
+[section]
+id = "cli.rue_test"
+name = "The rue test subcommand, runner, and event stream"
+description = """
+RUE-1920 (ADR-0083 Phase 2c): `rue test` end to end through the real binary —
+subcommand dispatch, the verdict taxonomy against the real runtime, the exit-code
+contract, and the NDJSON event stream.
+
+Two things are pinned here that nothing else can pin. The verdict classification
+reads the runtime's own pinned abort messages, so these cases run real programs
+down each trap path: a runtime that reworded `assertion failed` or
+`error: division by zero` fails a case rather than silently reclassifying a trap
+as a bare `exit`. And the event schema is a consumer contract
+(docs/process/test-events.md), so the JSON cases assert exact object text —
+alphabetical keys included — which a field rename or a dropped field breaks.
+
+Cases that assert the event stream pass `-j1`: parallel workers interleave whole
+lines by design, and the schema promises the content of each line rather than an
+order across concurrent tests.
+"""
+
+# ========================= verdicts =========================
+
+[[case]]
+name = "a_passing_test_exits_zero_and_reports_a_count"
+description = "ADR-0083 §2: passes are a count, not a wall of green."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "arithmetic still works" {
+    @assert(2 + 2 == 4);
+}
+
+test "so does comparison" {
+    @assert(1 < 2);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+driver_exit_code = 0
+compile_stdout_contains = ["2 passed ("]
+compile_stdout_not_contains = ["FAIL", "PASS "]
+
+[[case]]
+name = "a_failed_assert_is_kind_assert_and_exits_one"
+description = """
+The pinned `assertion failed` message from `__rue_assert_failed` is what the
+`assert` kind is classified from; this case runs the real runtime path.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "two plus two is five" {
+    @assert(2 + 2 == 5);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"assert"',
+    '"message":"assertion failed"',
+    '"verdict":"fail"',
+    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+]
+
+[[case]]
+name = "a_panicking_test_is_kind_trap_panic"
+description = "`@panic(msg)` writes the pinned `panic: <msg>` prefix and exits 101."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "gives up" {
+    @panic("boom");
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = ['"kind":"trap:panic"', '"message":"panic: boom"']
+
+[[case]]
+name = "a_trapping_test_is_classified_by_its_runtime_message"
+description = """
+ADR-0083 §2's `trap:<class>` names come from the runtime's own pinned messages.
+This runs the division trap so `error: division by zero` is matched against the
+real `__rue_div_by_zero`, not against a retyped copy.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "divides by zero" {
+    let d: i32 = 0;
+    let n: i32 = 1;
+    @assert(n / d == 0);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = ['"kind":"trap:div_by_zero"', '"message":"error: division by zero"']
+
+[[case]]
+name = "an_early_exit_before_the_epilogue_is_incomplete"
+description = """
+ADR-0083 §3: a body calling `std.exit(0)` before its assertions must not report
+as a pass — that is false-positive test evidence. The dispatcher's completion
+record is what distinguishes them, and its absence is the `incomplete` kind.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+test "leaves before it checks anything" {
+    std.exit(0);
+    @assert(1 == 2);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"incomplete"',
+    "\"message\":\"the test exited 0 without the dispatcher's completion record\"",
+    '"verdict":"fail"',
+]
+
+[[case]]
+name = "a_hanging_test_times_out_and_is_its_own_verdict"
+description = """
+ADR-0083 §3: the per-test budget kills the process group and yields the
+`timeout` verdict, which is distinct from a failure so a suite can tell a wrong
+answer from a wedged one.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "never finishes" {
+    let mut i: i32 = 0;
+    while i >= 0 {
+        if i > 0 {
+            i = i - 1;
+        }
+    }
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--timeout-ms", "500", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"verdict":"timeout"',
+    '"kind":"timeout"',
+    'the process group was killed',
+    '"crash":0,"event":"run_finished","failed":0,"passed":0',
+    '"timeout":1',
+]
+
+[[case]]
+name = "a_flooding_test_is_killed_with_kind_output_overflow"
+description = """
+ADR-0083 §2: capture is bounded as bytes arrive, and exceeding a stream's budget
+kills the process group and yields `output_overflow` with the retained prefix
+attached. This writes past the 1 MiB default in 4 KiB lines.
+"""
+contract = "heavyweight_long"
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "floods its own stdout" {
+    let mut i: u64 = 0;
+    while i < 4096 {
+        @dbg("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+        i = i + 1;
+    }
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = ['"kind":"output_overflow"', '"verdict":"fail"']
+
+# ========================= listing and selection =========================
+
+[[case]]
+name = "list_prints_the_inventory_in_stable_id_order"
+description = "ADR-0083 §2: `--list` is discovery — no codegen, no linking, no execution."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "beta" {
+    @assert(1 == 1);
+}
+
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--list"]
+driver_exit_code = 0
+compile_stdout_contains = ["tests.rue::alpha\ntests.rue::beta\n"]
+
+[[case]]
+name = "list_json_emits_one_record_per_test_and_nothing_else"
+description = """
+The listing stream is inventory records only: no `run_started`, no
+`run_finished`, and every key alphabetical (docs/process/test-events.md).
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--list", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = [
+    '{"column":1,"event":"test","file":"tests.rue","id":"tests.rue::alpha","line":1,"module":"tests.rue","name":"alpha","schema":"1.0"}',
+]
+compile_stdout_not_contains = ["run_started", "run_finished", "test_finished"]
+
+[[case]]
+name = "a_filter_narrows_the_run_set_by_substring"
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "parse_port accepts" {
+    @assert(1 == 1);
+}
+
+test "parse_port rejects" {
+    @assert(1 == 1);
+}
+
+test "lexer eats spaces" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--list", "--filter", "parse_port"]
+driver_exit_code = 0
+compile_stdout_contains = ["tests.rue::parse_port accepts\ntests.rue::parse_port rejects\n"]
+compile_stdout_not_contains = ["lexer"]
+
+[[case]]
+name = "repeated_filters_union_rather_than_intersect"
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "parse_port accepts" {
+    @assert(1 == 1);
+}
+
+test "lexer eats spaces" {
+    @assert(1 == 1);
+}
+
+test "unrelated" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = [
+    "test", "main.rue", "--preview", "test_declarations", "--list",
+    "--filter", "parse_port", "--filter", "lexer",
+]
+driver_exit_code = 0
+compile_stdout_contains = ["tests.rue::lexer eats spaces\ntests.rue::parse_port accepts\n"]
+compile_stdout_not_contains = ["unrelated"]
+
+[[case]]
+name = "a_filter_matching_nothing_is_exit_three"
+description = """
+ADR-0083 §2: an empty selection is how a typo becomes false evidence, so it is
+its own exit code rather than a vacuous success.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--filter", "no_such_test", "-j1"]
+driver_exit_code = 3
+compile_stderr_contains = ["no tests matched the selection"]
+
+[[case]]
+name = "shard_one_of_two_takes_part_of_the_inventory"
+description = """
+`--shard K/N` partitions by the FNV-1a hash of the stable id, which
+docs/process/test-events.md specifies so an external scheduler computes the same
+partition. This case and the next assert the two halves are disjoint and
+together are the whole.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+
+test "beta" {
+    @assert(1 == 1);
+}
+
+test "gamma" {
+    @assert(1 == 1);
+}
+
+test "delta" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--list", "--shard", "1/2"]
+driver_exit_code = 0
+compile_stdout_contains = ["tests.rue::alpha\ntests.rue::beta\ntests.rue::delta\n"]
+compile_stdout_not_contains = ["gamma"]
+
+[[case]]
+name = "shard_two_of_two_takes_the_rest"
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+
+test "beta" {
+    @assert(1 == 1);
+}
+
+test "gamma" {
+    @assert(1 == 1);
+}
+
+test "delta" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--list", "--shard", "2/2"]
+driver_exit_code = 0
+compile_stdout_contains = ["tests.rue::gamma\n"]
+compile_stdout_not_contains = ["alpha", "beta", "delta"]
+
+# ========================= the event stream =========================
+
+[[case]]
+name = "the_event_stream_pins_its_schema_and_key_order"
+description = """
+docs/process/test-events.md is a consumer contract. Object keys are serialized
+in alphabetical order — the same determinism stance docs/process/diagnostics.md
+takes — so these are exact object fragments rather than field-presence checks.
+`capability_summary` is present from v1.0 with an explicit `unavailable` status,
+which is what lets the deferred capability ADR populate it additively.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "424242", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = [
+    '{"event":"run_started","jobs":1,"opt_level":"0",',
+    '"plan":{"selected":1,"total":1},"root":"main.rue","schema":"1.0","seed":424242,',
+    '{"event":"test_started","id":"tests.rue::alpha"}',
+    '{"capability_summary":{"status":"unavailable"},',
+    '"stderr":{"bytes_total":0,"digest":"sha256:',
+    '"stdout":{"bytes_total":0,"digest":"sha256:',
+    '"verdict":"pass"',
+    '{"crash":0,"event":"run_finished","failed":0,"passed":1,"test_candidates":"none","timeout":0,',
+]
+# A pass carries digests, never inline bytes, and retains no scratch directory.
+compile_stdout_not_contains = ['"data"', "scratch_dir", '"shard"']
+
+[[case]]
+name = "a_failure_carries_its_bytes_scratch_directory_and_repro_argv"
+description = """
+ADR-0083 §3: every non-pass carries the exact argv that reproduces that one
+test — selected by the full stable id, never the bare name, and carrying the
+seed and the compile flags so the same image is rebuilt. Running that argv is
+the round trip the repro promises.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "fails on purpose" {
+    @assert(1 == 2);
+}
+""" },
+]
+args = [
+    "test", "main.rue", "--preview", "test_declarations", "--seed", "9",
+    "-j1", "--timeout-ms", "9000", "--format", "json",
+]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"repro":["rue","test","main.rue","--filter","tests.rue::fails on purpose","--seed","9",',
+    '"-O0","--preview","test_declarations","--timeout-ms","9000"]',
+    '"stderr":{"bytes_total":17,"data":"assertion failed\n","encoding":"utf8"}',
+    '"scratch_dir":"',
+]
+
+[[case]]
+name = "the_repro_argv_reproduces_the_same_verdict_alone"
+description = """
+The repro from the previous case, run as its own invocation: the same one test,
+the same `assert` verdict, and no other test in the run. A repro that selected
+by the bare name would also re-run the passing homonym below it.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "fails on purpose" {
+    @assert(1 == 2);
+}
+""" },
+    { path = "other.rue", source = """
+test "fails on purpose" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = [
+    "test", "main.rue", "--filter", "tests.rue::fails on purpose", "--seed", "9",
+    "-O0", "--preview", "test_declarations", "--timeout-ms", "9000",
+    "-j1", "--format", "json",
+]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"plan":{"selected":1,"total":1}',
+    '"kind":"assert"',
+    '"id":"tests.rue::fails on purpose"',
+    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+]
+
+[[case]]
+name = "an_explicit_seed_is_honored_and_reported"
+description = """
+The seed is published in `run_started` and repeated in every repro argv, so a
+shuffle-dependent failure comes back. Determinism of the order it produces is
+pinned by the runner's own unit tests, which can run the planner twice.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+
+test "beta" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "7", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = ['"seed":7,', '"--seed","7"']
+
+[[case]]
+name = "a_shard_is_reported_in_the_head_event"
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+
+test "beta" {
+    @assert(1 == 1);
+}
+
+test "gamma" {
+    @assert(1 == 1);
+}
+
+test "delta" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = [
+    "test", "main.rue", "--preview", "test_declarations", "--seed", "1",
+    "-j1", "--shard", "2/2", "--format", "json",
+]
+driver_exit_code = 0
+compile_stdout_contains = ['"shard":"2/2"', '"plan":{"selected":1,"total":4}']
+
+# ========================= the preview gate and the candidate inventory =========================
+
+[[case]]
+name = "test_mode_does_not_enable_the_preview_gate_for_you"
+description = """
+ADR-0083 §1, ruled: `--preview test_declarations` is required exactly as for a
+build. Auto-enabling it in test mode would make `rue test` the first flag to
+bypass ADR-0005's explicit opt-in while leaving the same files failing ordinary
+builds. A program that will not compile is the runner-error status.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue"]
+driver_exit_code = 2
+compile_stderr_contains = ["E1100", "test_declarations"]
+compile_stdout_not_contains = ["run_started"]
+
+[[case]]
+name = "an_orphaned_test_file_is_warned_about_and_reported_in_run_finished"
+description = """
+ADR-0083 §1: with a declared candidate inventory, a test file the closure never
+imports is reported — on stderr as a warning and in `run_finished` as data. It
+stays a warning: sibling build targets legitimately share a `srcs` glob.
+"""
+files = [
+    { path = "test-candidates.list", source = """
+main.rue
+tests.rue
+orphan_tests.rue
+""" },
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+    { path = "orphan_tests.rue", source = """
+test "nothing imports this file" {
+    @assert(1 == 1);
+}
+
+test "nor this one" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = [
+    "test", "main.rue", "--preview", "test_declarations",
+    "--test-candidates", "test-candidates.list", "--seed", "1", "-j1", "--format", "json",
+]
+driver_exit_code = 0
+compile_stderr_contains = [
+    "orphan_tests.rue",
+    "declares 2 tests but no module in the compiled closure imports it",
+]
+compile_stdout_contains = [
+    '"test_candidates":"declared"',
+    '"unimported_test_files":[{"parse_failed":false,"path":"orphan_tests.rue","tests":2}]',
+]
+
+[[case]]
+name = "without_an_inventory_the_summary_says_orphans_are_not_detected"
+description = """
+Silence would be read as "no orphans found". The run says instead that it did
+not look.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+driver_exit_code = 0
+compile_stdout_contains = [
+    "note: no --test-candidates inventory; unimported test files are not detected",
+]
+
+# ========================= dispatch and flag combinations =========================
+
+[[case]]
+name = "an_output_named_test_is_still_an_ordinary_build"
+description = """
+ADR-0083 §2's dispatch rule is value-aware over the eleven value-taking options
+precisely so this keeps meaning "output named `test`". If the scan regressed,
+this case would become a test run and stop producing an executable.
+"""
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    42
+}
+""" },
+]
+args = ["-o", "test", "main.rue"]
+output = "test"
+exit_code = 42
+compile_stdout_contains = ["Compiled main.rue -> test"]
+
+[[case]]
+name = "a_root_module_named_test_is_spelled_with_a_relative_path"
+description = "The documented disambiguation for a file literally named `test`."
+files = [
+    { path = "test", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "./test", "--preview", "test_declarations", "--list"]
+driver_exit_code = 0
+compile_stdout_contains = ["tests.rue::alpha"]
+
+[[case]]
+name = "test_mode_refuses_emit"
+description = "ADR-0083 §2: `--emit` owns stdout, which is the event stream's."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = ["test", "main.rue", "--emit", "ast"]
+driver_exit_code = 2
+compile_stderr_contains = ["`rue test` cannot be combined with --emit"]
+
+[[case]]
+name = "test_mode_refuses_an_output_path"
+description = "A test run publishes no executable to the user's output path."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = ["test", "main.rue", "-o", "prog"]
+driver_exit_code = 2
+compile_stderr_contains = ["`rue test` cannot be combined with -o/--output"]
+
+[[case]]
+name = "test_mode_refuses_watch_and_the_timing_surfaces"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = ["test", "main.rue", "--watch"]
+driver_exit_code = 2
+compile_stderr_contains = ["`rue test` cannot be combined with --watch"]
+
+[[case]]
+name = "a_test_only_flag_outside_test_mode_is_refused_by_name"
+description = """
+The reverse direction. Ignoring `rue --filter x main.rue` would let a mistyped
+invocation look like it worked.
+"""
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = ["--filter", "x", "main.rue"]
+compile_fail = true
+error_contains = ["--filter is only valid with the `rue test` subcommand"]
+
+[[case]]
+name = "a_test_run_takes_exactly_one_root_source"
+description = "ADR-0046 / RUE-767's one-root rule holds in test mode too."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "other.rue", source = """
+fn other() -> i32 {
+    0
+}
+""" },
+]
+args = ["test", "main.rue", "other.rue"]
+compile_fail = true
+error_contains = ["unexpected extra source file 'other.rue'"]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -80,6 +80,8 @@
 //! - `stdin`: piped to the compiled program when it runs
 //! - `compile_fail` + `error_contains`: expect compilation failure
 //! - `compile_only`: don't run the produced binary
+//! - `driver_exit_code`: exact exit status of a driver subcommand invocation
+//!   that produces no program to run, such as `rue test` (ADR-0083)
 //! - `executable_target`: validate the produced executable's bounded ELF or
 //!   Mach-O structure, architecture, load commands, entry point, and resolved
 //!   entry relocation against this Rue target
@@ -1304,6 +1306,20 @@ struct Case {
     /// Incompatible with `compile_fail` and `symbols_contain`.
     #[serde(default)]
     no_symbol_table: bool,
+    /// Exact expected exit status of the DRIVER invocation itself, for a
+    /// subcommand that neither compiles-and-runs nor fails to compile.
+    ///
+    /// `rue test` (ADR-0083) is the case this exists for: its exit status is a
+    /// documented four-way contract (0 passed / 1 failures / 2 runner error /
+    /// 3 empty selection) that agents branch on, and `compile_fail`'s
+    /// "nonzero" cannot tell 1 from 3. Setting it also declares that the
+    /// invocation produces no executable to run, so the case ends after the
+    /// compiler's own stdout, stderr, and status are checked — assert the
+    /// driver's output with `compile_stdout_contains` and
+    /// `compile_stderr_contains`. Incompatible with `compile_fail`, whose
+    /// contract is exactly the weaker one this replaces.
+    #[serde(default)]
+    driver_exit_code: Option<i32>,
 }
 
 /// What running one case produced: the compiled program's exit code and
@@ -2079,6 +2095,9 @@ fn case_runs_prebuilt_program(case: &Case) -> bool {
         executable_target: None,
         compile_fail: false,
         compile_only: false,
+        // A driver subcommand runs no produced program at all, so no staged
+        // executable can answer for it.
+        driver_exit_code: None,
         execute_if_native: false,
         differential_opt: false,
         ffi_answer_archive: false,
@@ -2379,6 +2398,18 @@ fn run_case(
                 forbidden, compile_stdout
             )));
         }
+    }
+
+    // A driver subcommand's own exit status, checked before the
+    // build-and-run expectations that do not apply to it (ADR-0083 §2).
+    if let Some(expected) = case.driver_exit_code {
+        let actual = compile_output.status.code();
+        if actual != Some(expected) {
+            return Err(TestFailure::assertion(format!(
+                "driver exit mismatch: expected {expected}, actual {actual:?}\n--- stdout ---\n{compile_stdout}\n--- stderr ---\n{compile_stderr}"
+            )));
+        }
+        return Ok(RunOutcome::default());
     }
 
     let compile_succeeded = compile_output.status.success();
@@ -3499,11 +3530,20 @@ fn compile_fail_has_exit_code(case: &Case) -> bool {
     case.compile_fail && case.exit_code.is_some()
 }
 
-/// Return produced-program fields that are meaningless when `compile_only`
-/// stops the case before the program runs. Keep this list aligned with the
-/// assertions and inputs consumed exclusively by `run_case_program`.
+/// `driver_exit_code` asserts an exact status; `compile_fail` asserts only
+/// "nonzero". Declaring both means the case's author wanted one of them, and
+/// the harness cannot tell which — so it says so rather than silently
+/// honouring the stricter one.
+fn driver_exit_code_conflicts_with_compile_fail(case: &Case) -> bool {
+    case.driver_exit_code.is_some() && case.compile_fail
+}
+
+/// Return produced-program fields that are meaningless when `compile_only` or
+/// `driver_exit_code` stops the case before a program runs. Keep this list
+/// aligned with the assertions and inputs consumed exclusively by
+/// `run_case_program`.
 fn compile_only_runtime_fields(case: &Case) -> Vec<&'static str> {
-    if !case.compile_only {
+    if !case.compile_only && case.driver_exit_code.is_none() {
         return Vec::new();
     }
     [
@@ -3643,10 +3683,18 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                 // load time so the doc comment's promise is enforced, not merely
                 // documented (RUE-132).
                 for case in &tf.cases {
+                    if driver_exit_code_conflicts_with_compile_fail(case) {
+                        eprintln!(
+                            "error: {}: case '{}' declares both `driver_exit_code` and `compile_fail` — the first asserts an exact status and the second only a nonzero one; keep one",
+                            path.display(),
+                            case.name,
+                        );
+                        std::process::exit(1);
+                    }
                     let compile_only_fields = compile_only_runtime_fields(case);
                     if !compile_only_fields.is_empty() {
                         eprintln!(
-                            "error: {}: case '{}' is `compile_only` but declares produced-program field(s) {} — remove those fields",
+                            "error: {}: case '{}' runs no program but declares produced-program field(s) {} — remove those fields",
                             path.display(),
                             case.name,
                             compile_only_fields
@@ -5392,7 +5440,7 @@ mod tests {
         // the compiler's environment, or asserts something about a compile the
         // staged path never runs. ADR-0070 keeps every one of these cases
         // compile-in-harness.
-        let overrides: [(&str, fn(&mut Case)); 16] = [
+        let overrides: [(&str, fn(&mut Case)); 17] = [
             // The one differential_opt calculator case: four compiles by
             // design, at opt levels the runner drives.
             ("differential_opt", |case| case.differential_opt = true),
@@ -5411,6 +5459,7 @@ mod tests {
             }),
             ("compile_fail", |case| case.compile_fail = true),
             ("compile_only", |case| case.compile_only = true),
+            ("driver_exit_code", |case| case.driver_exit_code = Some(3)),
             ("execute_if_native", |case| case.execute_if_native = true),
             ("ffi_answer_archive", |case| case.ffi_answer_archive = true),
             ("json_diagnostics", |case| case.json_diagnostics = true),
@@ -5620,6 +5669,56 @@ mod tests {
             ..Default::default()
         };
         assert!(compile_only_runtime_fields(&valid).is_empty());
+    }
+
+    /// `driver_exit_code` stops a case before any program runs, exactly as
+    /// `compile_only` does, so the same produced-program fields are meaningless
+    /// with it (ADR-0083's `rue test` is the subcommand this exists for).
+    #[test]
+    fn driver_exit_code_case_rejects_runtime_fields() {
+        let case = Case {
+            name: "driver".to_string(),
+            driver_exit_code: Some(3),
+            exit_code: Some(0),
+            stdout: Some("out".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            compile_only_runtime_fields(&case),
+            vec!["stdout", "exit_code"]
+        );
+
+        let valid = Case {
+            name: "driver".to_string(),
+            driver_exit_code: Some(1),
+            compile_stdout_contains: vec!["run_finished".to_string()],
+            compile_stderr_contains: vec!["warning".to_string()],
+            ..Default::default()
+        };
+        assert!(compile_only_runtime_fields(&valid).is_empty());
+    }
+
+    /// One asserts an exact status and the other only "nonzero"; a case
+    /// declaring both has not said which it meant.
+    #[test]
+    fn driver_exit_code_and_compile_fail_cannot_be_combined() {
+        assert!(driver_exit_code_conflicts_with_compile_fail(&Case {
+            name: "both".to_string(),
+            driver_exit_code: Some(2),
+            compile_fail: true,
+            ..Default::default()
+        }));
+        assert!(!driver_exit_code_conflicts_with_compile_fail(&Case {
+            name: "one".to_string(),
+            driver_exit_code: Some(2),
+            ..Default::default()
+        }));
+        assert!(!driver_exit_code_conflicts_with_compile_fail(&Case {
+            name: "other".to_string(),
+            compile_fail: true,
+            error_contains: vec!["E0206".to_string()],
+            ..Default::default()
+        }));
     }
 
     #[test]

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -3,6 +3,9 @@
 //! This crate provides common functionality for running compiler tests,
 //! including test case parsing, execution, and output comparison.
 
+pub mod pipe_drain;
+
+use pipe_drain::{PIPE_DRAIN_FINISH_TIMEOUT, spawn_pipe_drain};
 use rue_error::{PreviewFeature, error_code_metadata};
 use rue_target::Target;
 use serde::{Deserialize, Deserializer};
@@ -17,10 +20,9 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 10_000;
 pub const RUNTIME_ERROR_EXIT_CODE: i32 = 101;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
-use std::io::{Read as IoRead, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
-use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 /// The coordinates of one slice in a sharded test corpus (RUE-1116).
@@ -2619,122 +2621,6 @@ fn run_golden_ir_test(
     check_golden(&actual, expected, header_name)
 }
 
-enum DrainMessage {
-    Bytes(Vec<u8>),
-    Overflow,
-    Done,
-}
-
-struct PipeDrain {
-    rx: mpsc::Receiver<DrainMessage>,
-    bytes: Vec<u8>,
-    done: bool,
-    overflowed: bool,
-}
-
-impl PipeDrain {
-    fn poll(&mut self) {
-        // Bound work per child-status poll. An unbounded producer must not keep
-        // the timeout loop inside `try_recv` forever.
-        for _ in 0..64 {
-            match self.rx.try_recv() {
-                Ok(message) => self.handle(message),
-                Err(mpsc::TryRecvError::Empty) => return,
-                Err(mpsc::TryRecvError::Disconnected) => {
-                    self.done = true;
-                    return;
-                }
-            }
-        }
-    }
-
-    fn finish(&mut self, timeout: Duration) {
-        let deadline = Instant::now() + timeout;
-        while !self.done {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                return;
-            }
-            match self.rx.recv_timeout(remaining) {
-                Ok(message) => self.handle(message),
-                Err(_) => {
-                    self.done = true;
-                    return;
-                }
-            }
-        }
-    }
-
-    fn handle(&mut self, message: DrainMessage) {
-        match message {
-            DrainMessage::Bytes(chunk) => self.bytes.extend(chunk),
-            DrainMessage::Overflow => self.overflowed = true,
-            DrainMessage::Done => self.done = true,
-        }
-    }
-}
-
-/// How long `run_with_timeout` waits for pipe-drain helpers after the child has
-/// exited or been killed.
-///
-/// A well-behaved child closes stdout/stderr promptly, so this normally just
-/// observes `DrainMessage::Done`. If a descendant process inherited a pipe fd
-/// and keeps it open, the reader thread may block forever; bounding collection
-/// keeps the harness moving and returns whatever bytes were already drained.
-const PIPE_DRAIN_FINISH_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// Drain a pipe on a helper thread, sending chunks as they arrive.
-///
-/// Sending chunks incrementally matters: if the reader never reaches EOF
-/// because a daemonized descendant inherited the write end, the caller can
-/// still recover the bytes that were already read instead of blocking on a
-/// thread join.
-fn spawn_pipe_drain<R: IoRead + Send + 'static>(
-    pipe: Option<R>,
-    output_limit: Option<usize>,
-) -> PipeDrain {
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        if let Some(mut reader) = pipe {
-            let mut buf = [0; 8192];
-            let mut retained = 0usize;
-            let mut overflowed = false;
-            loop {
-                match reader.read(&mut buf) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        if !overflowed {
-                            let keep = output_limit
-                                .map(|limit| n.min(limit.saturating_sub(retained)))
-                                .unwrap_or(n);
-                            if keep > 0
-                                && tx.send(DrainMessage::Bytes(buf[..keep].to_vec())).is_err()
-                            {
-                                return;
-                            }
-                            retained += keep;
-                            if keep < n {
-                                overflowed = true;
-                                if tx.send(DrainMessage::Overflow).is_err() {
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                    Err(_) => break,
-                }
-            }
-        }
-        let _ = tx.send(DrainMessage::Done);
-    });
-    PipeDrain {
-        rx,
-        bytes: Vec::new(),
-        done: false,
-        overflowed: false,
-    }
-}
-
 /// Marker prefix identifying a timeout failure. A timed-out run is a distinct
 /// failure class (like an ICE): the process ran past its wall-clock budget and
 /// was killed, rather than producing a wrong-but-finite result. Both this
@@ -2883,9 +2769,9 @@ fn run_with_timeout_impl(
     loop {
         stdout_drain.poll();
         stderr_drain.poll();
-        if stdout_drain.overflowed || stderr_drain.overflowed {
+        if stdout_drain.overflowed() || stderr_drain.overflowed() {
             kill_process_group(&mut child);
-            let stream = match (stdout_drain.overflowed, stderr_drain.overflowed) {
+            let stream = match (stdout_drain.overflowed(), stderr_drain.overflowed()) {
                 (true, true) => "stdout and stderr",
                 (true, false) => "stdout",
                 (false, true) => "stderr",
@@ -2904,8 +2790,8 @@ fn run_with_timeout_impl(
                 stdout_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
                 stderr_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
                 drop(stdin_writer);
-                if stdout_drain.overflowed || stderr_drain.overflowed {
-                    let stream = match (stdout_drain.overflowed, stderr_drain.overflowed) {
+                if stdout_drain.overflowed() || stderr_drain.overflowed() {
+                    let stream = match (stdout_drain.overflowed(), stderr_drain.overflowed()) {
                         (true, true) => "stdout and stderr",
                         (true, false) => "stdout",
                         (false, true) => "stderr",
@@ -2918,8 +2804,8 @@ fn run_with_timeout_impl(
                 }
                 return Ok(Output {
                     status,
-                    stdout: stdout_drain.bytes,
-                    stderr: stderr_drain.bytes,
+                    stdout: stdout_drain.into_bytes(),
+                    stderr: stderr_drain.into_bytes(),
                 });
             }
             Ok(None) => {

--- a/crates/rue-test-runner/src/pipe_drain.rs
+++ b/crates/rue-test-runner/src/pipe_drain.rs
@@ -1,0 +1,246 @@
+//! Bounded, non-blocking draining of a child process's pipes.
+//!
+//! One implementation serves every harness in the tree and the `rue test`
+//! runner in the compiler driver (ADR-0083 §3, which adopts these mechanics as
+//! contract). It lives in its own module because a second copy is exactly the
+//! kind of duplicate that drifts: the budget arithmetic, the incremental
+//! hand-off, and the bounded finish are each load-bearing for a different
+//! failure mode, and a copy that loses one of them fails only under load.
+//!
+//! Three properties are why this is not `read_to_end` on a joined thread:
+//!
+//! - **Chunks are handed over incrementally**, not at EOF. If a daemonized
+//!   descendant inherits the write end, the reader never sees EOF, and a
+//!   caller that joined the thread would block forever instead of reporting
+//!   the bytes it already has.
+//! - **The retention budget is enforced as bytes arrive**, not after. A test
+//!   that writes a gigabyte must cost a bounded amount of the runner's memory,
+//!   which checking `Output::stdout.len()` afterwards cannot deliver.
+//! - **The true byte count is tracked separately from what is retained.** A
+//!   consumer publishing capture metadata needs to say how much the process
+//!   actually wrote, which is not the size of the prefix that was kept.
+
+use std::io::Read as IoRead;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+/// How long a caller should wait for a drain helper after the child has exited
+/// or been killed.
+///
+/// A well-behaved child closes its streams promptly, so this normally just
+/// observes [`DrainMessage::Done`]. If a descendant process inherited a pipe fd
+/// and keeps it open, the reader thread may block forever; bounding collection
+/// keeps the caller moving and returns whatever bytes were already drained.
+pub const PIPE_DRAIN_FINISH_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Bytes read from the pipe in one `read(2)`, and how many of them were kept.
+///
+/// `read` is the true size of the chunk and `retained` the prefix that fit
+/// inside the budget; the two differ only once the budget is exhausted.
+enum DrainMessage {
+    Chunk { retained: Vec<u8>, read: usize },
+    Overflow,
+    Done,
+}
+
+/// A pipe being drained on a helper thread.
+///
+/// Created by [`spawn_pipe_drain`]. The owner calls [`PipeDrain::poll`] while
+/// waiting on the child, then [`PipeDrain::finish`] once it has exited.
+pub struct PipeDrain {
+    rx: mpsc::Receiver<DrainMessage>,
+    bytes: Vec<u8>,
+    bytes_total: u64,
+    done: bool,
+    overflowed: bool,
+}
+
+impl PipeDrain {
+    /// Collect whatever the reader thread has already produced, without
+    /// blocking.
+    pub fn poll(&mut self) {
+        // Bound work per child-status poll. An unbounded producer must not keep
+        // the caller's wait loop inside `try_recv` forever.
+        for _ in 0..64 {
+            match self.rx.try_recv() {
+                Ok(message) => self.handle(message),
+                Err(mpsc::TryRecvError::Empty) => return,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.done = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Collect the remaining output, giving up after `timeout`.
+    ///
+    /// The bound is the whole point: an escaped descendant holding the write
+    /// end open means EOF never arrives, and the caller still owes its own
+    /// caller an answer.
+    pub fn finish(&mut self, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        while !self.done {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return;
+            }
+            match self.rx.recv_timeout(remaining) {
+                Ok(message) => self.handle(message),
+                Err(_) => {
+                    self.done = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    /// The retained prefix: at most the configured budget.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Take the retained prefix, consuming the drain.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    /// Every byte the process wrote to this stream, budget or no budget.
+    ///
+    /// This is the count a capture record publishes; `bytes().len()` is only
+    /// what was kept.
+    pub fn bytes_total(&self) -> u64 {
+        self.bytes_total
+    }
+
+    /// Whether the stream exceeded its retention budget.
+    pub fn overflowed(&self) -> bool {
+        self.overflowed
+    }
+
+    /// Whether the reader thread reached end of stream.
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    fn handle(&mut self, message: DrainMessage) {
+        match message {
+            DrainMessage::Chunk { retained, read } => {
+                self.bytes.extend(retained);
+                self.bytes_total = self.bytes_total.saturating_add(read as u64);
+            }
+            DrainMessage::Overflow => self.overflowed = true,
+            DrainMessage::Done => self.done = true,
+        }
+    }
+}
+
+/// Drain a pipe on a helper thread, sending chunks as they arrive.
+///
+/// `output_limit` bounds the bytes retained, not the bytes read: reading
+/// continues past the budget so the caller learns the true size and so the
+/// child never blocks in `write(2)` against a full pipe while the caller is
+/// deciding what to do about the overflow.
+pub fn spawn_pipe_drain<R: IoRead + Send + 'static>(
+    pipe: Option<R>,
+    output_limit: Option<usize>,
+) -> PipeDrain {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        if let Some(mut reader) = pipe {
+            let mut buf = [0; 8192];
+            let mut retained = 0usize;
+            let mut overflowed = false;
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let keep = if overflowed {
+                            0
+                        } else {
+                            output_limit
+                                .map(|limit| n.min(limit.saturating_sub(retained)))
+                                .unwrap_or(n)
+                        };
+                        if tx
+                            .send(DrainMessage::Chunk {
+                                retained: buf[..keep].to_vec(),
+                                read: n,
+                            })
+                            .is_err()
+                        {
+                            return;
+                        }
+                        retained += keep;
+                        if keep < n && !overflowed {
+                            overflowed = true;
+                            if tx.send(DrainMessage::Overflow).is_err() {
+                                return;
+                            }
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+        let _ = tx.send(DrainMessage::Done);
+    });
+    PipeDrain {
+        rx,
+        bytes: Vec::new(),
+        bytes_total: 0,
+        done: false,
+        overflowed: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The budget bounds what is kept, never what is counted: a consumer must
+    /// be able to report how much the process actually wrote.
+    #[test]
+    fn retains_a_prefix_while_counting_every_byte() {
+        let payload = vec![b'x'; 5000];
+        let mut drain = spawn_pipe_drain(Some(std::io::Cursor::new(payload)), Some(1000));
+        drain.finish(Duration::from_secs(5));
+        assert!(drain.overflowed());
+        assert_eq!(drain.bytes().len(), 1000);
+        assert_eq!(drain.bytes_total(), 5000);
+    }
+
+    /// A stream inside its budget reports no overflow and a total equal to what
+    /// it retained.
+    #[test]
+    fn a_stream_within_budget_never_reports_overflow() {
+        let mut drain = spawn_pipe_drain(Some(std::io::Cursor::new(b"hello".to_vec())), Some(1000));
+        drain.finish(Duration::from_secs(5));
+        assert!(!drain.overflowed());
+        assert_eq!(drain.bytes(), b"hello");
+        assert_eq!(drain.bytes_total(), 5);
+        assert!(drain.is_done());
+    }
+
+    /// No budget means everything is retained.
+    #[test]
+    fn an_unbounded_drain_retains_everything() {
+        let payload = vec![b'y'; 20_000];
+        let mut drain = spawn_pipe_drain(Some(std::io::Cursor::new(payload)), None);
+        drain.finish(Duration::from_secs(5));
+        assert!(!drain.overflowed());
+        assert_eq!(drain.bytes().len(), 20_000);
+        assert_eq!(drain.bytes_total(), 20_000);
+    }
+
+    /// An absent pipe is not an error: a caller that did not redirect a stream
+    /// still gets a drain it can poll and finish.
+    #[test]
+    fn an_absent_pipe_finishes_empty() {
+        let mut drain = spawn_pipe_drain(None::<std::io::Cursor<Vec<u8>>>, Some(16));
+        drain.finish(Duration::from_secs(5));
+        assert!(drain.is_done());
+        assert!(drain.bytes().is_empty());
+        assert_eq!(drain.bytes_total(), 0);
+    }
+}

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -63,6 +63,11 @@ rue_binary(
     crate_root = "src/main.rs",
     deps = _DEPS + _COMPILER_ALLOCATOR_DEPS + [
         ":rue-driver",
+        # `rue test` supervises one process per test with the same bounded
+        # pipe-drain, process-group, and timeout mechanics the harnesses use
+        # (ADR-0083 §3 adopts them as contract). One implementation, in
+        # //crates/rue-test-runner:pipe_drain, rather than a second copy here.
+        "//crates/rue-test-runner:rue-test-runner",
     ],
     test_deps = [
         "//crates/rue-query:rue-query",
@@ -81,6 +86,7 @@ rue_binary(
     crate_root = "src/main.rs",
     deps = _DEPS + [
         ":rue-driver",
+        "//crates/rue-test-runner:rue-test-runner",
     ],
     rustc_flags = [
         "--cfg=rue_benchmark_allocations",

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -3,8 +3,10 @@ use std::path::Path;
 use rue_compiler::unstable::TestCandidateInventory;
 use rue_compiler::unstable::{
     CancellableCompileOutcome, CodegenReady, CompilationCancellation, ObjectsReady,
-    PresentationOutput, PresentationRequest, cancellable_executable_in_compile_scope,
-    codegen_ready, executable_in_compile_scope, objects_ready, runnable_ready,
+    PresentationOutput, PresentationRequest, TestInventory, UnimportedTestFile,
+    cancellable_executable_in_compile_scope, codegen_ready, executable_in_compile_scope,
+    objects_ready, runnable_ready, test_image_in_compile_scope, test_inventory,
+    unimported_test_files,
 };
 use rue_compiler::{
     AcceptedReadManifest, CompileErrors, CompileOptions, CompileOutput, ImportDiscoveryContext,
@@ -177,6 +179,33 @@ impl FilesystemCompilerHost {
         cancellation: CompilationCancellation,
     ) -> CancellableCompileOutcome {
         cancellable_executable_in_compile_scope(&mut self.state.session, options, cancellation)
+    }
+
+    /// Analyze the request's test closure and publish its ordered inventory
+    /// (ADR-0083 §2's `--list`), without codegen or linking.
+    pub fn test_inventory(&mut self, options: &CompileOptions) -> MultiErrorResult<TestInventory> {
+        test_inventory(&mut self.state.session, options)
+    }
+
+    /// Link the test image for the request's closure and publish the inventory
+    /// that assigned its dispatch ordinals (ADR-0083 §3).
+    pub fn test_image_in_compile_scope(
+        &mut self,
+        options: &CompileOptions,
+    ) -> MultiErrorResult<(CompileOutput, TestInventory)> {
+        test_image_in_compile_scope(&mut self.state.session, options)
+    }
+
+    /// Report the declared candidates the compiled closure does not contain
+    /// (ADR-0083 §1).
+    ///
+    /// Takes an inventory this same host acquired, so the report can never be
+    /// made against a closure observed under a different read regime.
+    pub fn unimported_test_files(
+        &mut self,
+        candidates: &TestCandidateInventory,
+    ) -> Result<Vec<UnimportedTestFile>, CompileErrors> {
+        unimported_test_files(&mut self.state.session, candidates)
     }
 
     /// Reach ADR-0068's codegen-ready endpoint without projecting objects.

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -19,6 +19,7 @@ mod compiler_allocator;
 mod emit;
 mod output;
 mod platform_signing;
+mod test_mode;
 mod timing;
 mod watch;
 
@@ -225,6 +226,22 @@ struct Options {
     watch: bool,
     /// Number of parallel jobs (0 = auto-detect, use all cores).
     jobs: usize,
+    /// Which subcommand the command line selected (ADR-0083 §2). Test mode is
+    /// the driver's first subcommand, so it is a mode rather than another
+    /// boolean beside `watch`: the modes are mutually exclusive by
+    /// construction, which is what `validate_mode_combinations` then only has
+    /// to state for the flags.
+    mode: DriverMode,
+    /// The test-mode flags. Parsed in every mode so an unsupported combination
+    /// is reported as such rather than as an unknown option, and rejected
+    /// outside test mode by `validate_mode_combinations`.
+    test: test_mode::TestOptions,
+    /// Whether a test-only flag appeared at all, which is what lets compile
+    /// mode reject one by name instead of ignoring it.
+    test_flags_given: Vec<&'static str>,
+    /// Whether `-o`/`--output` named the output explicitly. Compile mode warns
+    /// when `--emit` ignores it; test mode refuses it outright.
+    explicit_output: bool,
 }
 
 /// Version string for the rue compiler (single-sourced from rue-error so the
@@ -252,6 +269,7 @@ fn usage_text() -> String {
         "\
 Usage: rue [options] <root.rue> [output]
        rue [options] <root.rue> -o <output>
+       rue test [options] <root.rue>
        rue explain <E####>
 
 The compiler takes exactly one root source file and discovers every other
@@ -259,6 +277,25 @@ file through its @import graph; pass build-system inputs with --source-manifest.
 
 Commands:
   explain <E####>      Show the compiler-owned explanation for an error code
+  test <root.rue>      Build the root's test image and run its tests
+
+`rue test` options (see docs/process/test-events.md for the event schema):
+  --list               List the inventory; no codegen, no linking, no execution
+  --filter <pattern>   Run only tests whose stable id contains <pattern>
+                       Can be repeated; repeated filters union
+  --format <fmt>       Report as human text or as the NDJSON event stream
+                       Formats: human, json (default: human)
+  --timeout-ms <N>     Per-test wall-clock budget (default: {default_timeout})
+  --shard <K/N>        Run shard K of N, partitioned by stable-id hash
+  --seed <N>           Seed the run-order shuffle (default: fresh and reported)
+  --test-candidates <path>
+                       Report declared test files nothing imports
+  Test mode reuses --target, -O<n>, --preview, --jobs, --source-manifest,
+  --link-archive, --error-format, and the logging options. It cannot be
+  combined with --emit, --watch, --benchmark-json, --time-passes, or -o.
+  Exit codes: 0 all passed, 1 failures, 2 compilation or runner error,
+  3 empty selection.
+  A root module actually named `test` is spelled `./test`.
 
 Options:
   -o, --output <path>  Set output path
@@ -309,6 +346,7 @@ Options:
         log_levels = LogLevel::all_names(),
         log_formats = LogFormat::all_names(),
         error_formats = ErrorFormat::all_names(),
+        default_timeout = test_mode::DEFAULT_TIMEOUT_MS,
     )
 }
 
@@ -396,12 +434,11 @@ fn refuse_extra_positional_sources(positional: &[String]) {
 /// Options that consume the argument after them.
 ///
 /// Anything scanning the command line without `parse_args_from`'s own state —
-/// a later subcommand scan, argument classification, a shell completion — has
+/// the subcommand scan below, argument classification, a shell completion — has
 /// to skip a value-taking option's value, or `rue --preview x prog.rue` reads
 /// `x` as a word of its own. This is that inventory, kept beside the arms that
 /// consume those values; a unit test holds it, the parser, and the help text in
 /// agreement.
-#[cfg(test)]
 const VALUE_TAKING_OPTIONS: &[&str] = &[
     "--emit",
     "--target",
@@ -417,7 +454,53 @@ const VALUE_TAKING_OPTIONS: &[&str] = &[
     "--source-manifest",
     "--link-archive",
     "--test-candidates",
+    "--filter",
+    "--format",
+    "--timeout-ms",
+    "--shard",
+    "--seed",
 ];
+
+/// The driver's subcommand, decided before anything else is parsed.
+///
+/// ADR-0083 §2's dispatch rule: the driver enters test mode when the first
+/// argument that is neither a flag nor a flag's value is exactly `test`. The
+/// scan has to be value-aware because eleven existing options take a following
+/// value — without that, `rue -o test prog.rue` would stop meaning "output
+/// named `test`", silently turning an ordinary build into a test run. A root
+/// module literally named `test` is spelled `./test`, which is the same
+/// disambiguation every subcommand-bearing CLI uses.
+///
+/// Returns the index of the `test` token so the caller can drop it before the
+/// ordinary parse, which then needs no knowledge of subcommands at all.
+fn test_subcommand_index(args: &[&str]) -> Option<usize> {
+    let mut index = 0;
+    while index < args.len() {
+        let arg = args[index];
+        if VALUE_TAKING_OPTIONS.contains(&arg) {
+            // Skip the option AND its value. A missing value is a parse error
+            // the ordinary loop reports; here it simply ends the scan.
+            index += 2;
+            continue;
+        }
+        if arg.starts_with('-') {
+            index += 1;
+            continue;
+        }
+        return (arg == "test").then_some(index);
+    }
+    None
+}
+
+/// Which driver mode the command line selected.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+enum DriverMode {
+    /// Compile a root module to an executable (or an `--emit` artifact).
+    #[default]
+    Compile,
+    /// `rue test`: build the test image and run its tests (ADR-0083 §2).
+    Test,
+}
 
 /// Parse arguments from a slice of strings (for testing).
 fn parse_args_from(args: &[&str]) -> ParseResult {
@@ -446,6 +529,21 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         return ParseResult::Explain(code);
     }
 
+    // Decide the subcommand first and drop its token, so the option loop below
+    // parses one flat command line in either mode (ADR-0083 §2).
+    let without_subcommand: Vec<&str>;
+    let (mode, args) = match test_subcommand_index(args) {
+        Some(index) => {
+            without_subcommand = args
+                .iter()
+                .enumerate()
+                .filter_map(|(position, arg)| (position != index).then_some(*arg))
+                .collect();
+            (DriverMode::Test, without_subcommand.as_slice())
+        }
+        None => (DriverMode::Compile, args),
+    };
+
     let mut emit_stages = Vec::new();
     let mut target: Option<Target> = None;
     let mut linker: Option<LinkerMode> = None;
@@ -462,6 +560,8 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     let mut test_candidates_path: Option<String> = None;
     let mut output_path: Option<String> = None;
     let mut link_archives: Vec<std::path::PathBuf> = Vec::new();
+    let mut test = test_mode::TestOptions::default();
+    let mut test_flags_given: Vec<&'static str> = Vec::new();
     let mut positional = Vec::new();
     let mut args_iter = args.iter().peekable();
 
@@ -616,6 +716,82 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
                 };
                 link_archives.push(std::path::PathBuf::from(path));
             }
+            "--list" => {
+                test.list = true;
+                test_flags_given.push("--list");
+            }
+            "--filter" => {
+                let Some(pattern) = args_iter.next() else {
+                    eprintln!("Error: --filter requires a pattern");
+                    return ParseResult::Error;
+                };
+                // Repeatable and unioned: narrowing a run to two unrelated
+                // areas is the ordinary case, and a second --filter replacing
+                // the first would make that impossible to spell.
+                test.filters.push((*pattern).to_string());
+                test_flags_given.push("--filter");
+            }
+            "--format" => {
+                let Some(format_str) = args_iter.next() else {
+                    eprintln!("Error: --format requires a value");
+                    eprintln!("Valid formats: human, json");
+                    return ParseResult::Error;
+                };
+                match format_str.parse::<test_mode::OutputFormat>() {
+                    Ok(format) => test.format = format,
+                    Err(error) => {
+                        eprintln!("Error: {error}");
+                        return ParseResult::Error;
+                    }
+                }
+                test_flags_given.push("--format");
+            }
+            "--timeout-ms" => {
+                let Some(value) = args_iter.next() else {
+                    eprintln!("Error: --timeout-ms requires a value");
+                    return ParseResult::Error;
+                };
+                match value.parse::<u64>() {
+                    Ok(0) => {
+                        eprintln!("Error: --timeout-ms must be at least 1");
+                        return ParseResult::Error;
+                    }
+                    Ok(millis) => test.timeout_ms = millis,
+                    Err(_) => {
+                        eprintln!("Error: --timeout-ms value must be a positive integer");
+                        return ParseResult::Error;
+                    }
+                }
+                test_flags_given.push("--timeout-ms");
+            }
+            "--shard" => {
+                let Some(value) = args_iter.next() else {
+                    eprintln!("Error: --shard requires a K/N value");
+                    return ParseResult::Error;
+                };
+                match test_mode::selection::Shard::parse(value) {
+                    Ok(shard) => test.shard = Some(shard),
+                    Err(error) => {
+                        eprintln!("Error: {error}");
+                        return ParseResult::Error;
+                    }
+                }
+                test_flags_given.push("--shard");
+            }
+            "--seed" => {
+                let Some(value) = args_iter.next() else {
+                    eprintln!("Error: --seed requires a value");
+                    return ParseResult::Error;
+                };
+                match value.parse::<u64>() {
+                    Ok(seed) => test.seed = Some(seed),
+                    Err(_) => {
+                        eprintln!("Error: --seed value must be an unsigned 64-bit integer");
+                        return ParseResult::Error;
+                    }
+                }
+                test_flags_given.push("--seed");
+            }
             "--time-passes" => {
                 time_passes = true;
             }
@@ -675,7 +851,18 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     // @import (ADR-0046 / RUE-767). Additional positional .rue arguments are
     // the removed flat-mode input surface and are refused.
     let explicit_output = output_path.is_some();
-    let (source_path, final_output_path) = if let Some(out) = output_path {
+    let (source_path, final_output_path) = if mode == DriverMode::Test {
+        // Test mode publishes no executable at the user's path — the image is
+        // the runner's own artifact — so there is no output positional and
+        // every positional is a source. Exactly one root, as everywhere else.
+        match single_root_source(&positional) {
+            Some(root) => (root, "a.out".to_string()),
+            None => {
+                refuse_extra_positional_sources(&positional);
+                return ParseResult::Error;
+            }
+        }
+    } else if let Some(out) = output_path {
         // -o names the output explicitly, so every positional is a source.
         match single_root_source(&positional) {
             Some(root) => (root, out),
@@ -766,7 +953,98 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         benchmark_json,
         watch,
         jobs: jobs.unwrap_or(0),
+        mode,
+        test,
+        test_flags_given,
+        explicit_output,
     }))
+}
+
+/// Reject the flag combinations the driver's modes cannot honor.
+///
+/// Test mode joins the same validation path `--watch` uses (ADR-0083 §2). Each
+/// refusal is a real conflict over one resource rather than a taste: `--emit`
+/// and `--benchmark-json` own stdout, which is the event stream's; `--watch`
+/// owns the process's lifetime, which the run does; `-o` names an executable
+/// destination a test run never publishes to; and `--time-passes` writes an
+/// unstructured timing report into the same stream.
+///
+/// The reverse direction matters just as much: a test-only flag in compile
+/// mode is refused by name. Silently ignoring `rue --filter x main.rue` would
+/// let a mistyped invocation look like it worked.
+fn validate_mode_combinations(options: &Options) -> Result<(), String> {
+    if options.mode != DriverMode::Test {
+        if let Some(flag) = options.test_flags_given.first() {
+            return Err(format!(
+                "Error: {flag} is only valid with the `rue test` subcommand"
+            ));
+        }
+        return Ok(());
+    }
+    let conflict = if !options.emit_stages.is_empty() {
+        Some("--emit")
+    } else if options.watch {
+        Some("--watch")
+    } else if options.benchmark_json {
+        Some("--benchmark-json")
+    } else if options.time_passes {
+        Some("--time-passes")
+    } else if options.explicit_output {
+        Some("-o/--output")
+    } else {
+        None
+    };
+    match conflict {
+        Some(flag) => Err(format!("Error: `rue test` cannot be combined with {flag}")),
+        None => Ok(()),
+    }
+}
+
+/// Worker count for a test run.
+///
+/// `--jobs` is shared with compilation and keeps its spelling, but its zero
+/// default means something different here: compilation reads it as "use the
+/// shared query budget's own auto-detection", while a test run has to name a
+/// concrete number of concurrent processes. ADR-0083 §3's default is every
+/// test in parallel, so zero resolves to available parallelism.
+fn test_mode_jobs(jobs: usize) -> usize {
+    if jobs > 0 {
+        return jobs;
+    }
+    std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1)
+}
+
+/// The compile-mode flags a repro argv repeats (ADR-0083 §3).
+///
+/// A repro must reconstruct the same image, so the target, optimization level,
+/// preview set, per-test budget, and any build-system inputs travel with it.
+/// The target and opt level are emitted even when they were defaulted: a repro
+/// is run later, possibly elsewhere, and "whatever the host was" is not a
+/// reproduction. `--filter` and `--seed` are added by the runner, which owns
+/// the identity being reproduced.
+fn test_repro_flags(options: &Options) -> Vec<String> {
+    let mut flags = vec![
+        "--target".to_string(),
+        options.target.to_string(),
+        format!("-{}", options.opt_level.name()),
+    ];
+    for feature in options.preview_features.iter() {
+        flags.push("--preview".to_string());
+        flags.push(feature.to_string());
+    }
+    flags.push("--timeout-ms".to_string());
+    flags.push(options.test.timeout_ms.to_string());
+    if let Some(manifest) = &options.source_manifest_path {
+        flags.push("--source-manifest".to_string());
+        flags.push(manifest.clone());
+    }
+    for archive in &options.link_archives {
+        flags.push("--link-archive".to_string());
+        flags.push(archive.display().to_string());
+    }
+    flags
 }
 
 fn parse_args() -> ParseResult {
@@ -2016,6 +2294,17 @@ fn main() {
         eprintln!("{message}");
         std::process::exit(1);
     }
+    // A `rue test` invocation that cannot run reports the runner-error status
+    // rather than the compile-mode argument status, so an agent branching on
+    // the exit code sees "the run did not happen" for every reason it did not
+    // (ADR-0083 §2). Compile mode's own argument errors keep exiting `1`.
+    if let Err(message) = validate_mode_combinations(&options) {
+        eprintln!("{message}");
+        std::process::exit(match options.mode {
+            DriverMode::Test => test_mode::TestExitCode::RunnerError.code(),
+            DriverMode::Compile => 1,
+        });
+    }
 
     // Initialize tracing based on CLI options
     // Returns timing data if --time-passes or --benchmark-json was specified
@@ -2090,9 +2379,14 @@ fn main() {
         opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
         link_archives: options.link_archives.clone(),
-        // The driver has no test-mode spelling yet; `rue test` arrives with
-        // ADR-0083 Phase 2 (RUE-1619).
-        root_selection: rue_compiler::RootSelection::Executable,
+        // A test request roots every test item in the closure; an executable
+        // request roots none of them (ADR-0083 §1). This is the only place the
+        // two differ, so `rue test` is one root set away from an ordinary
+        // build all the way down.
+        root_selection: match options.mode {
+            DriverMode::Test => rue_compiler::RootSelection::Tests,
+            DriverMode::Compile => rue_compiler::RootSelection::Executable,
+        },
     };
 
     // Acquire any trusted toolchain modules a reached fallible intrinsic requires
@@ -2152,11 +2446,11 @@ fn main() {
     let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
 
     // Acquire the declared inventory under the host's read policy so a test
-    // request can report against it (ADR-0083 §1). An ordinary build never
-    // reports; `rue test` (RUE-1920) is the consumer, and until it exists the
-    // acquisition is exercised here so a broken candidate path fails loudly
-    // rather than surfacing first inside the runner.
-    let _test_candidate_inventory = match declared_test_candidates.as_deref() {
+    // request can report against it (ADR-0083 §1). `rue test` is the consumer;
+    // an ordinary build validates the input and carries it no further, so a
+    // build rule writing a broken list fails the build it broke rather than
+    // only the test run that would have read it.
+    let test_candidate_inventory = match declared_test_candidates.as_deref() {
         Some(declared) => match compiler_host.acquire_test_candidates(declared) {
             Ok(inventory) => {
                 tracing::debug!(
@@ -2208,7 +2502,41 @@ fn main() {
         diagnostics.print_errors(&with_import_migration_helps(
             compiler_host.discovery_revision().diagnostics(),
         ));
-        std::process::exit(1);
+        // Compile mode's rejected-program status is `1` and stays that way.
+        // For `rue test` a program that will not compile is the same outcome as
+        // a link failure or a runner error — the run could not be performed —
+        // and ADR-0083 §2 gives that one code, so an agent branching on the
+        // exit status never has to also parse stderr to tell them apart.
+        std::process::exit(match options.mode {
+            DriverMode::Test => test_mode::TestExitCode::RunnerError.code(),
+            DriverMode::Compile => 1,
+        });
+    }
+
+    // `rue test` owns the rest of this process: it links the test image, runs
+    // one process per selected test, and publishes the event stream on stdout
+    // (ADR-0083 §2). It is placed after toolchain acquisition and before the
+    // `--emit` and executable paths because it shares every step above and
+    // none below — in particular it publishes no executable to the user's
+    // output path, so the destination preflight below does not apply to it.
+    if options.mode == DriverMode::Test {
+        let exit = {
+            let _compile = compile_span.enter();
+            test_mode::run(test_mode::TestRequest {
+                host: &mut compiler_host,
+                compile_options: compile_options.clone(),
+                options: options.test.clone(),
+                diagnostics: &diagnostics,
+                root: options.source_path.clone(),
+                repro_flags: test_repro_flags(&options),
+                jobs: test_mode_jobs(options.jobs),
+                target: options.target,
+                opt_level: options.opt_level,
+                candidates: test_candidate_inventory,
+            })
+        };
+        let _ = std::io::stdout().flush();
+        std::process::exit(exit.code());
     }
 
     // Closed discovery fixes the complete source identity set. Validate the
@@ -3012,6 +3340,283 @@ mod tests {
     #[test]
     fn parse_no_args_returns_error() {
         assert!(is_error(&parse_args_from(&[])));
+    }
+
+    // ========== `rue test` subcommand dispatch (ADR-0083 §2) ==========
+    //
+    // The dispatch rule is "the first argument that is neither a flag nor a
+    // flag's value is exactly `test`". Every case below is one way that scan
+    // can go wrong, and the value-aware half is what keeps an ordinary build
+    // from silently becoming a test run.
+
+    #[test]
+    fn test_is_the_subcommand_when_it_leads_the_command_line() {
+        assert_eq!(test_subcommand_index(&["test", "main.rue"]), Some(0));
+        let options = unwrap_options(parse_args_from(&["test", "main.rue"]));
+        assert_eq!(options.mode, DriverMode::Test);
+        assert_eq!(options.source_path, "main.rue");
+    }
+
+    /// Flags may precede the subcommand: `rue --preview x test main.rue` is a
+    /// test run, and `x` is the preview's value rather than a word of its own.
+    #[test]
+    fn flags_before_the_subcommand_do_not_hide_it() {
+        assert_eq!(
+            test_subcommand_index(&["--preview", "test_declarations", "test", "main.rue"]),
+            Some(2)
+        );
+        let options = unwrap_options(parse_args_from(&[
+            "--preview",
+            "test_declarations",
+            "-O2",
+            "--jobs",
+            "3",
+            "test",
+            "main.rue",
+        ]));
+        assert_eq!(options.mode, DriverMode::Test);
+        assert_eq!(options.source_path, "main.rue");
+        assert_eq!(options.jobs, 3);
+        assert_eq!(options.opt_level, OptLevel::O2);
+    }
+
+    #[test]
+    fn flags_after_the_subcommand_parse_as_usual() {
+        let options = unwrap_options(parse_args_from(&[
+            "test",
+            "main.rue",
+            "--filter",
+            "parse",
+            "--filter",
+            "lex",
+            "--format",
+            "json",
+            "--seed",
+            "417",
+            "--timeout-ms",
+            "500",
+            "--shard",
+            "1/4",
+            "--list",
+        ]));
+        assert_eq!(options.mode, DriverMode::Test);
+        assert_eq!(options.test.filters, vec!["parse", "lex"]);
+        assert_eq!(options.test.format, test_mode::OutputFormat::Json);
+        assert_eq!(options.test.seed, Some(417));
+        assert_eq!(options.test.timeout_ms, 500);
+        assert_eq!(
+            options.test.shard,
+            Some(test_mode::selection::Shard { index: 1, count: 4 })
+        );
+        assert!(options.test.list);
+    }
+
+    /// The reason the scan has to be value-aware at all: `-o` takes a value,
+    /// so `test` here is an output name and the invocation stays an ordinary
+    /// build.
+    #[test]
+    fn an_output_named_test_is_not_the_subcommand() {
+        assert_eq!(test_subcommand_index(&["-o", "test", "prog.rue"]), None);
+        let options = unwrap_options(parse_args_from(&["-o", "test", "prog.rue"]));
+        assert_eq!(options.mode, DriverMode::Compile);
+        assert_eq!(options.output_path, "test");
+        assert_eq!(options.source_path, "prog.rue");
+    }
+
+    /// The same trap for every other value-taking option, checked
+    /// mechanically so a new one cannot be added without joining the scan.
+    #[test]
+    fn no_value_taking_option_lets_its_value_become_the_subcommand() {
+        for option in VALUE_TAKING_OPTIONS {
+            assert_eq!(
+                test_subcommand_index(&[option, "test", "prog.rue"]),
+                None,
+                "{option}'s value was read as the subcommand"
+            );
+        }
+    }
+
+    /// A root module actually named `test` is spelled `./test`, which the scan
+    /// does not match because it compares the whole argument.
+    #[test]
+    fn a_root_named_test_is_reachable_as_a_relative_path() {
+        assert_eq!(test_subcommand_index(&["./test"]), None);
+        let options = unwrap_options(parse_args_from(&["./test"]));
+        assert_eq!(options.mode, DriverMode::Compile);
+        assert_eq!(options.source_path, "./test");
+
+        assert_eq!(test_subcommand_index(&["test", "./test"]), Some(0));
+        let options = unwrap_options(parse_args_from(&["test", "./test"]));
+        assert_eq!(options.mode, DriverMode::Test);
+        assert_eq!(options.source_path, "./test");
+    }
+
+    /// `test` only dispatches in first position among non-flags: a second
+    /// positional is an extra source, which the one-root rule refuses.
+    #[test]
+    fn test_after_another_positional_is_not_the_subcommand() {
+        assert_eq!(test_subcommand_index(&["main.rue", "test"]), None);
+        assert!(is_error(&parse_args_from(&["main.rue", "test", "extra"])));
+    }
+
+    #[test]
+    fn a_test_run_takes_exactly_one_root_source() {
+        assert!(is_error(&parse_args_from(&["test"])));
+        assert!(is_error(&parse_args_from(&["test", "a.rue", "b.rue"])));
+    }
+
+    #[test]
+    fn test_mode_defaults_match_the_documented_ones() {
+        let options = unwrap_options(parse_args_from(&["test", "main.rue"]));
+        assert!(!options.test.list);
+        assert!(options.test.filters.is_empty());
+        assert_eq!(options.test.format, test_mode::OutputFormat::Human);
+        assert_eq!(options.test.timeout_ms, test_mode::DEFAULT_TIMEOUT_MS);
+        assert_eq!(options.test.shard, None);
+        // No seed until the run derives and reports one.
+        assert_eq!(options.test.seed, None);
+    }
+
+    /// Test mode joins the driver's mode validation rather than growing its
+    /// own; every conflict is over one resource the two modes both want.
+    #[test]
+    fn test_mode_refuses_every_incompatible_flag() {
+        let conflicts: &[(&[&str], &str)] = &[
+            (&["test", "main.rue", "--emit", "ast"], "--emit"),
+            (&["test", "main.rue", "--watch"], "--watch"),
+            (
+                &["test", "main.rue", "--benchmark-json"],
+                "--benchmark-json",
+            ),
+            (&["test", "main.rue", "--time-passes"], "--time-passes"),
+            (&["test", "main.rue", "-o", "prog"], "-o/--output"),
+            (&["test", "main.rue", "--output", "prog"], "-o/--output"),
+        ];
+        for (args, flag) in conflicts {
+            let options = unwrap_options(parse_args_from(args));
+            let error = validate_mode_combinations(&options)
+                .expect_err(&format!("{flag} must conflict with `rue test`"));
+            assert!(error.contains(flag), "{error}");
+        }
+    }
+
+    /// The reverse direction: a test-only flag outside test mode is refused by
+    /// name. Ignoring it would let a mistyped invocation look like it worked.
+    #[test]
+    fn compile_mode_refuses_a_test_only_flag_by_name() {
+        for flag in [
+            vec!["--list"],
+            vec!["--filter", "x"],
+            vec!["--format", "json"],
+            vec!["--timeout-ms", "10"],
+            vec!["--shard", "1/2"],
+            vec!["--seed", "1"],
+        ] {
+            let mut args = vec!["main.rue"];
+            args.extend(flag.iter().copied());
+            let options = unwrap_options(parse_args_from(&args));
+            let error = validate_mode_combinations(&options)
+                .expect_err(&format!("{:?} must be test-only", flag[0]));
+            assert!(error.contains(flag[0]), "{error}");
+            assert!(error.contains("rue test"), "{error}");
+        }
+    }
+
+    /// `--test-candidates` is not test-only: an ordinary build validates the
+    /// list so a broken build rule fails the build it broke (ADR-0083 §1).
+    #[test]
+    fn test_candidates_stays_valid_outside_test_mode() {
+        let options = unwrap_options(parse_args_from(&[
+            "--test-candidates",
+            "c.list",
+            "main.rue",
+        ]));
+        assert!(validate_mode_combinations(&options).is_ok());
+    }
+
+    #[test]
+    fn a_valid_test_invocation_passes_mode_validation() {
+        let options = unwrap_options(parse_args_from(&[
+            "test",
+            "main.rue",
+            "--preview",
+            "test_declarations",
+            "--target",
+            "x86-64-linux",
+            "-O1",
+            "--jobs",
+            "2",
+            "--error-format",
+            "json",
+        ]));
+        assert!(validate_mode_combinations(&options).is_ok());
+    }
+
+    #[test]
+    fn malformed_test_flag_values_are_rejected() {
+        assert!(is_error(&parse_args_from(&[
+            "test", "main.rue", "--format", "ndjson"
+        ])));
+        assert!(is_error(&parse_args_from(&[
+            "test",
+            "main.rue",
+            "--timeout-ms",
+            "0"
+        ])));
+        assert!(is_error(&parse_args_from(&[
+            "test",
+            "main.rue",
+            "--timeout-ms",
+            "soon"
+        ])));
+        assert!(is_error(&parse_args_from(&[
+            "test", "main.rue", "--seed", "-1"
+        ])));
+        assert!(is_error(&parse_args_from(&[
+            "test", "main.rue", "--shard", "3/2"
+        ])));
+    }
+
+    /// A test request roots the closure's test items; an executable request
+    /// roots none of them. This is the only place the two differ.
+    #[test]
+    fn the_repro_flags_reconstruct_the_image_configuration() {
+        let options = unwrap_options(parse_args_from(&[
+            "test",
+            "main.rue",
+            "--target",
+            "x86-64-linux",
+            "-O2",
+            "--preview",
+            "test_declarations",
+            "--timeout-ms",
+            "500",
+            "--source-manifest",
+            "sources.manifest",
+        ]));
+        let flags = test_repro_flags(&options);
+        assert_eq!(
+            flags,
+            vec![
+                "--target",
+                "x86-64-linux",
+                "-O2",
+                "--preview",
+                "test_declarations",
+                "--timeout-ms",
+                "500",
+                "--source-manifest",
+                "sources.manifest",
+            ]
+        );
+    }
+
+    /// `--jobs 0` means "auto" in both modes, but a test run needs a concrete
+    /// process count rather than the query budget's own auto-detection.
+    #[test]
+    fn test_mode_jobs_resolves_auto_to_available_parallelism() {
+        assert_eq!(test_mode_jobs(4), 4);
+        assert!(test_mode_jobs(0) >= 1);
     }
 
     // ========== Positional source acceptance tests ==========

--- a/crates/rue/src/test_mode/events.rs
+++ b/crates/rue/src/test_mode/events.rs
@@ -1,0 +1,605 @@
+//! The `rue test` event stream (ADR-0083 §2), schema `1.0`.
+//!
+//! Events are produced as ordinary Rust values first and serialized second.
+//! That ordering is the point: the human renderer consumes the same values in
+//! the same process rather than re-parsing NDJSON, so a field the machine
+//! surface publishes and a field a person is shown can never come from two
+//! different computations. `docs/process/test-events.md` is the schema's
+//! normative description.
+//!
+//! Object keys are serialized in alphabetical order, matching the determinism
+//! stance `docs/process/diagnostics.md` takes for `--error-format json`: two
+//! runs over the same inputs owe a consumer byte-identical output. That falls
+//! out of `serde_json::Map` being a `BTreeMap` here, which is also how the
+//! diagnostic formatter gets it.
+
+use serde_json::{Map, Value};
+
+use super::verdict::Verdict;
+
+/// The event schema version, published in the stream's head event.
+pub(crate) const SCHEMA_VERSION: &str = "1.0";
+
+/// The `capability_summary` every `test_finished` carries.
+///
+/// ADR-0083 ships zero hermeticity claims and says so in-band rather than by
+/// omitting the field: consumers handle the shape from v1.0, and the deferred
+/// capability ADR populates it as an additive change.
+const CAPABILITY_UNAVAILABLE: &str = "unavailable";
+
+/// How captured bytes are carried.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Encoding {
+    Utf8,
+    Base64,
+}
+
+impl Encoding {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Utf8 => "utf8",
+            Self::Base64 => "base64",
+        }
+    }
+}
+
+/// One captured stream's published record.
+///
+/// `bytes_total` is what the process wrote; `data` is the retained prefix, and
+/// is present only for a non-pass. A pass carries `digest` instead — a passing
+/// test's output is evidence a consumer may want to compare, not read, and
+/// inlining it for every green test is exactly the wall of green ADR-0083 §2
+/// rejects. A pass can never have overflowed its budget (an overflow is a
+/// failure verdict), so its digest always covers the whole stream.
+#[derive(Debug, Clone)]
+pub(crate) struct Capture {
+    pub(crate) encoding: Encoding,
+    pub(crate) bytes_total: u64,
+    pub(crate) retained: Vec<u8>,
+    /// `true` for a pass: publish a digest rather than the bytes.
+    pub(crate) digest_only: bool,
+}
+
+impl Capture {
+    fn to_json(&self) -> Value {
+        let mut object = Map::new();
+        object.insert(
+            "encoding".to_owned(),
+            Value::String(self.encoding.as_str().to_owned()),
+        );
+        object.insert("bytes_total".to_owned(), Value::from(self.bytes_total));
+        if self.digest_only {
+            object.insert("digest".to_owned(), Value::String(self.digest()));
+        } else {
+            object.insert("data".to_owned(), Value::String(self.encoded_data()));
+        }
+        Value::Object(object)
+    }
+
+    /// The retained bytes as the `encoding` tag describes them.
+    pub(crate) fn encoded_data(&self) -> String {
+        match self.encoding {
+            Encoding::Utf8 => String::from_utf8_lossy(&self.retained).into_owned(),
+            Encoding::Base64 => base64(&self.retained),
+        }
+    }
+
+    /// `sha256:<hex>` over the retained bytes.
+    fn digest(&self) -> String {
+        use sha2::{Digest, Sha256};
+        format!("sha256:{:x}", Sha256::digest(&self.retained))
+    }
+
+    /// Build a record from drained bytes. Rue strings are arbitrary byte
+    /// sequences written raw, so the encoding is decided by inspection rather
+    /// than assumed.
+    pub(crate) fn new(retained: Vec<u8>, bytes_total: u64, digest_only: bool) -> Self {
+        let encoding = if std::str::from_utf8(&retained).is_ok() {
+            Encoding::Utf8
+        } else {
+            Encoding::Base64
+        };
+        Self {
+            encoding,
+            bytes_total,
+            retained,
+            digest_only,
+        }
+    }
+}
+
+/// Standard base64 with padding, for capture that is not valid UTF-8.
+fn base64(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ALPHABET[(triple >> 18) as usize & 63] as char);
+        out.push(ALPHABET[(triple >> 12) as usize & 63] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHABET[(triple >> 6) as usize & 63] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[triple as usize & 63] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+/// A failure's source location.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Location {
+    pub(crate) file: String,
+    pub(crate) line: u32,
+    pub(crate) column: u32,
+}
+
+impl Location {
+    fn to_json(&self) -> Value {
+        let mut object = Map::new();
+        object.insert("file".to_owned(), Value::String(self.file.clone()));
+        object.insert("line".to_owned(), Value::from(self.line));
+        object.insert("column".to_owned(), Value::from(self.column));
+        Value::Object(object)
+    }
+}
+
+/// The structured failure record (ADR-0083 §2).
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FailureRecord {
+    pub(crate) kind: String,
+    pub(crate) message: String,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) signal: Option<i32>,
+    pub(crate) location: Option<Location>,
+    /// The open, versioned payload ADR-0083 §5.1 reserves for assertion
+    /// libraries. Empty until Phase 2.5's structured comparisons.
+    pub(crate) payload: Option<String>,
+    /// The runner's own explanation, when it could not trust what it read.
+    pub(crate) runner_note: Option<String>,
+}
+
+impl FailureRecord {
+    fn to_json(&self) -> Value {
+        let mut object = Map::new();
+        object.insert("kind".to_owned(), Value::String(self.kind.clone()));
+        object.insert("message".to_owned(), Value::String(self.message.clone()));
+        if let Some(code) = self.exit_code {
+            object.insert("exit_code".to_owned(), Value::from(code));
+        }
+        if let Some(signal) = self.signal {
+            object.insert("signal".to_owned(), Value::from(signal));
+        }
+        if let Some(location) = &self.location {
+            object.insert("location".to_owned(), location.to_json());
+        }
+        if let Some(payload) = &self.payload {
+            object.insert("payload".to_owned(), Value::String(payload.clone()));
+        }
+        if let Some(note) = &self.runner_note {
+            object.insert("runner_note".to_owned(), Value::String(note.clone()));
+        }
+        Value::Object(object)
+    }
+}
+
+/// A declared test file outside the compiled closure (ADR-0083 §1).
+#[derive(Debug, Clone)]
+pub(crate) struct UnimportedFile {
+    pub(crate) path: String,
+    pub(crate) tests: u32,
+    pub(crate) parse_failed: bool,
+}
+
+/// Whether a declared candidate inventory was supplied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CandidateSource {
+    Declared,
+    None,
+}
+
+impl CandidateSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Declared => "declared",
+            Self::None => "none",
+        }
+    }
+}
+
+/// One event of the stream.
+#[derive(Debug, Clone)]
+pub(crate) enum Event {
+    RunStarted {
+        root: String,
+        target: String,
+        opt_level: String,
+        seed: u64,
+        jobs: usize,
+        shard: Option<String>,
+        selected: usize,
+        total: usize,
+    },
+    TestStarted {
+        id: String,
+    },
+    TestFinished(Box<TestFinished>),
+    RunFinished {
+        passed: usize,
+        failed: usize,
+        timeout: usize,
+        crash: usize,
+        wall_ms: u64,
+        unimported_test_files: Option<Vec<UnimportedFile>>,
+        test_candidates: CandidateSource,
+    },
+    /// A `--list --format json` inventory record. The listing stream carries
+    /// no `run_started`, so this record carries the schema version itself —
+    /// ADR-0061 §6 wants every published stream to name its version in-band.
+    Test {
+        id: String,
+        module: String,
+        name: String,
+        file: String,
+        line: u32,
+        column: u32,
+    },
+}
+
+/// The `test_finished` payload, boxed out of [`Event`] because it dwarfs the
+/// other variants.
+#[derive(Debug, Clone)]
+pub(crate) struct TestFinished {
+    pub(crate) id: String,
+    pub(crate) verdict: Verdict,
+    pub(crate) duration_ms: u64,
+    pub(crate) failure: Option<FailureRecord>,
+    pub(crate) stdout: Capture,
+    pub(crate) stderr: Capture,
+    pub(crate) scratch_dir: Option<String>,
+    pub(crate) repro: Vec<String>,
+}
+
+impl Event {
+    /// This event as one NDJSON line, without its terminator.
+    pub(crate) fn to_ndjson(&self) -> String {
+        serde_json::to_string(&self.to_json()).expect("event values are always serializable")
+    }
+
+    fn to_json(&self) -> Value {
+        let mut object = Map::new();
+        match self {
+            Self::RunStarted {
+                root,
+                target,
+                opt_level,
+                seed,
+                jobs,
+                shard,
+                selected,
+                total,
+            } => {
+                object.insert("event".to_owned(), Value::String("run_started".to_owned()));
+                object.insert(
+                    "schema".to_owned(),
+                    Value::String(SCHEMA_VERSION.to_owned()),
+                );
+                object.insert("root".to_owned(), Value::String(root.clone()));
+                object.insert("target".to_owned(), Value::String(target.clone()));
+                object.insert("opt_level".to_owned(), Value::String(opt_level.clone()));
+                object.insert("seed".to_owned(), Value::from(*seed));
+                object.insert("jobs".to_owned(), Value::from(*jobs));
+                if let Some(shard) = shard {
+                    object.insert("shard".to_owned(), Value::String(shard.clone()));
+                }
+                let mut plan = Map::new();
+                plan.insert("selected".to_owned(), Value::from(*selected));
+                plan.insert("total".to_owned(), Value::from(*total));
+                object.insert("plan".to_owned(), Value::Object(plan));
+            }
+            Self::TestStarted { id } => {
+                object.insert("event".to_owned(), Value::String("test_started".to_owned()));
+                object.insert("id".to_owned(), Value::String(id.clone()));
+            }
+            Self::TestFinished(finished) => {
+                let TestFinished {
+                    id,
+                    verdict,
+                    duration_ms,
+                    failure,
+                    stdout,
+                    stderr,
+                    scratch_dir,
+                    repro,
+                } = finished.as_ref();
+                object.insert(
+                    "event".to_owned(),
+                    Value::String("test_finished".to_owned()),
+                );
+                object.insert("id".to_owned(), Value::String(id.clone()));
+                object.insert(
+                    "verdict".to_owned(),
+                    Value::String(verdict.as_str().to_owned()),
+                );
+                object.insert("duration_ms".to_owned(), Value::from(*duration_ms));
+                let mut capability = Map::new();
+                capability.insert(
+                    "status".to_owned(),
+                    Value::String(CAPABILITY_UNAVAILABLE.to_owned()),
+                );
+                object.insert("capability_summary".to_owned(), Value::Object(capability));
+                if let Some(failure) = failure {
+                    object.insert("failure".to_owned(), failure.to_json());
+                }
+                object.insert("stdout".to_owned(), stdout.to_json());
+                object.insert("stderr".to_owned(), stderr.to_json());
+                if let Some(scratch) = scratch_dir {
+                    object.insert("scratch_dir".to_owned(), Value::String(scratch.clone()));
+                }
+                object.insert(
+                    "repro".to_owned(),
+                    Value::Array(repro.iter().cloned().map(Value::String).collect()),
+                );
+            }
+            Self::RunFinished {
+                passed,
+                failed,
+                timeout,
+                crash,
+                wall_ms,
+                unimported_test_files,
+                test_candidates,
+            } => {
+                object.insert("event".to_owned(), Value::String("run_finished".to_owned()));
+                object.insert("passed".to_owned(), Value::from(*passed));
+                object.insert("failed".to_owned(), Value::from(*failed));
+                object.insert("timeout".to_owned(), Value::from(*timeout));
+                object.insert("crash".to_owned(), Value::from(*crash));
+                object.insert("wall_ms".to_owned(), Value::from(*wall_ms));
+                if let Some(files) = unimported_test_files {
+                    object.insert(
+                        "unimported_test_files".to_owned(),
+                        Value::Array(
+                            files
+                                .iter()
+                                .map(|file| {
+                                    let mut entry = Map::new();
+                                    entry.insert(
+                                        "path".to_owned(),
+                                        Value::String(file.path.clone()),
+                                    );
+                                    entry.insert("tests".to_owned(), Value::from(file.tests));
+                                    entry.insert(
+                                        "parse_failed".to_owned(),
+                                        Value::Bool(file.parse_failed),
+                                    );
+                                    Value::Object(entry)
+                                })
+                                .collect(),
+                        ),
+                    );
+                }
+                object.insert(
+                    "test_candidates".to_owned(),
+                    Value::String(test_candidates.as_str().to_owned()),
+                );
+            }
+            Self::Test {
+                id,
+                module,
+                name,
+                file,
+                line,
+                column,
+            } => {
+                object.insert("event".to_owned(), Value::String("test".to_owned()));
+                object.insert(
+                    "schema".to_owned(),
+                    Value::String(SCHEMA_VERSION.to_owned()),
+                );
+                object.insert("id".to_owned(), Value::String(id.clone()));
+                object.insert("module".to_owned(), Value::String(module.clone()));
+                object.insert("name".to_owned(), Value::String(name.clone()));
+                object.insert("file".to_owned(), Value::String(file.clone()));
+                object.insert("line".to_owned(), Value::from(*line));
+                object.insert("column".to_owned(), Value::from(*column));
+            }
+        }
+        Value::Object(object)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_mode::verdict::FailureKind;
+
+    /// Alphabetical key order is a determinism promise, not an accident of the
+    /// struct's field order — the same stance `diagnostics.md` takes.
+    #[test]
+    fn keys_are_serialized_in_alphabetical_order() {
+        let line = Event::RunStarted {
+            root: "app/main.rue".to_owned(),
+            target: "aarch64-macos".to_owned(),
+            opt_level: "0".to_owned(),
+            seed: 417,
+            jobs: 4,
+            shard: Some("1/2".to_owned()),
+            selected: 3,
+            total: 8,
+        }
+        .to_ndjson();
+        assert_eq!(
+            line,
+            "{\"event\":\"run_started\",\"jobs\":4,\"opt_level\":\"0\",\
+             \"plan\":{\"selected\":3,\"total\":8},\"root\":\"app/main.rue\",\
+             \"schema\":\"1.0\",\"seed\":417,\"shard\":\"1/2\",\"target\":\"aarch64-macos\"}"
+        );
+    }
+
+    #[test]
+    fn an_absent_shard_is_omitted_rather_than_null() {
+        let line = Event::RunStarted {
+            root: "m.rue".to_owned(),
+            target: "x86-64-linux".to_owned(),
+            opt_level: "1".to_owned(),
+            seed: 1,
+            jobs: 1,
+            shard: None,
+            selected: 1,
+            total: 1,
+        }
+        .to_ndjson();
+        assert!(!line.contains("shard"), "{line}");
+    }
+
+    #[test]
+    fn a_passing_test_publishes_digests_and_no_scratch_directory() {
+        let line = Event::TestFinished(Box::new(TestFinished {
+            id: "app/t.rue::ok".to_owned(),
+            verdict: Verdict::Pass,
+            duration_ms: 2,
+            failure: None,
+            stdout: Capture::new(b"hi\n".to_vec(), 3, true),
+            stderr: Capture::new(Vec::new(), 0, true),
+            scratch_dir: None,
+            repro: vec!["rue".to_owned(), "test".to_owned()],
+        }))
+        .to_ndjson();
+        assert!(line.contains("\"verdict\":\"pass\""), "{line}");
+        assert!(line.contains("\"digest\":\"sha256:"), "{line}");
+        assert!(!line.contains("\"data\""), "{line}");
+        assert!(!line.contains("scratch_dir"), "{line}");
+        assert!(
+            line.contains("\"capability_summary\":{\"status\":\"unavailable\"}"),
+            "{line}"
+        );
+    }
+
+    #[test]
+    fn a_failing_test_carries_its_bytes_scratch_directory_and_repro() {
+        let line = Event::TestFinished(Box::new(TestFinished {
+            id: "app/t.rue::bad".to_owned(),
+            verdict: Verdict::Fail(FailureKind::Assert),
+            duration_ms: 5,
+            failure: Some(FailureRecord {
+                kind: "assert".to_owned(),
+                message: "assertion failed".to_owned(),
+                exit_code: Some(101),
+                location: Some(Location {
+                    file: "app/t.rue".to_owned(),
+                    line: 4,
+                    column: 5,
+                }),
+                ..FailureRecord::default()
+            }),
+            stdout: Capture::new(Vec::new(), 0, false),
+            stderr: Capture::new(b"assertion failed\n".to_vec(), 17, false),
+            scratch_dir: Some("/tmp/rue-test-1-0".to_owned()),
+            repro: vec![
+                "rue".to_owned(),
+                "test".to_owned(),
+                "app/main.rue".to_owned(),
+            ],
+        }))
+        .to_ndjson();
+        assert!(line.contains("\"verdict\":\"fail\""), "{line}");
+        assert!(line.contains("\"data\":\"assertion failed\\n\""), "{line}");
+        assert!(line.contains("\"exit_code\":101"), "{line}");
+        assert!(
+            line.contains("\"location\":{\"column\":5,\"file\":\"app/t.rue\",\"line\":4}"),
+            "{line}"
+        );
+        assert!(
+            line.contains("\"scratch_dir\":\"/tmp/rue-test-1-0\""),
+            "{line}"
+        );
+    }
+
+    /// Rue strings are arbitrary bytes written raw, so capture is lossless
+    /// within its window rather than lossy-UTF-8.
+    #[test]
+    fn invalid_utf8_capture_is_tagged_and_base64_encoded() {
+        let capture = Capture::new(vec![0xff, 0xfe, 0x00], 3, false);
+        assert_eq!(capture.encoding, Encoding::Base64);
+        assert_eq!(capture.encoded_data(), "//4A");
+    }
+
+    #[test]
+    fn base64_pads_every_chunk_length() {
+        assert_eq!(base64(b""), "");
+        assert_eq!(base64(b"f"), "Zg==");
+        assert_eq!(base64(b"fo"), "Zm8=");
+        assert_eq!(base64(b"foo"), "Zm9v");
+        assert_eq!(base64(b"foob"), "Zm9vYg==");
+        assert_eq!(base64(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn a_listing_record_names_its_schema_version() {
+        let line = Event::Test {
+            id: "app/t.rue::ok".to_owned(),
+            module: "app/t.rue".to_owned(),
+            name: "ok".to_owned(),
+            file: "/w/app/t.rue".to_owned(),
+            line: 1,
+            column: 1,
+        }
+        .to_ndjson();
+        assert_eq!(
+            line,
+            "{\"column\":1,\"event\":\"test\",\"file\":\"/w/app/t.rue\",\
+             \"id\":\"app/t.rue::ok\",\"line\":1,\"module\":\"app/t.rue\",\
+             \"name\":\"ok\",\"schema\":\"1.0\"}"
+        );
+    }
+
+    #[test]
+    fn run_finished_states_the_candidate_source_either_way() {
+        let declared = Event::RunFinished {
+            passed: 1,
+            failed: 0,
+            timeout: 0,
+            crash: 0,
+            wall_ms: 12,
+            unimported_test_files: Some(vec![UnimportedFile {
+                path: "app/orphan.rue".to_owned(),
+                tests: 2,
+                parse_failed: false,
+            }]),
+            test_candidates: CandidateSource::Declared,
+        }
+        .to_ndjson();
+        assert!(
+            declared.contains("\"test_candidates\":\"declared\""),
+            "{declared}"
+        );
+        assert!(
+            declared.contains(
+                "\"unimported_test_files\":[{\"parse_failed\":false,\"path\":\"app/orphan.rue\",\"tests\":2}]"
+            ),
+            "{declared}"
+        );
+
+        let none = Event::RunFinished {
+            passed: 0,
+            failed: 0,
+            timeout: 0,
+            crash: 0,
+            wall_ms: 0,
+            unimported_test_files: None,
+            test_candidates: CandidateSource::None,
+        }
+        .to_ndjson();
+        assert!(none.contains("\"test_candidates\":\"none\""), "{none}");
+        assert!(!none.contains("unimported_test_files"), "{none}");
+    }
+}

--- a/crates/rue/src/test_mode/exec.rs
+++ b/crates/rue/src/test_mode/exec.rs
@@ -1,0 +1,502 @@
+//! One test, one process (ADR-0083 §3).
+//!
+//! The exec contract this implements is the image's published interface, fixed
+//! by RUE-1917 and restated in `docs/process/test-events.md`: `argv` is
+//! `["rue-test", "<ordinal as 16 lowercase hex digits>"]`, `envp` is exactly
+//! `["RUE_TEST=1"]`, the working directory is a fresh private scratch
+//! directory, stdin is an immediate EOF, and descriptor 3 is the write end of
+//! the structured failure channel. Those are contract values, not conveniences:
+//! ADR-0083 §3 pins them because the loader lays the real strings on the
+//! initial process stack, so their sizes are stack consumption no later pointer
+//! swap can undo — which is what will make a keyed configuration's stack
+//! consumption deterministic when the deferred verdict cache (§6) needs it.
+//!
+//! The supervision mechanics — the process group, the SIGKILL on expiry, the
+//! bounded concurrent drains, the post-exit group kill — are `rue-test-runner`'s
+//! and are used from there rather than reimplemented, so the harness and the
+//! product runner cannot drift on the deadlock class RUE-338 closed.
+
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use rue_test_runner::pipe_drain::{PIPE_DRAIN_FINISH_TIMEOUT, PipeDrain, spawn_pipe_drain};
+use rue_test_runner::{configure_process_group, kill_process_group};
+
+use super::verdict::{ChannelFrames, Classification, Observation, Supervision, classify};
+
+/// The failure channel's descriptor, pinned by the ADR-0083 §3 exec contract
+/// and by `crates/rue-runtime/src/test_channel.rs`, which writes to it.
+const CHANNEL_FD: i32 = 3;
+
+/// `argv[0]` every test process observes. Constant by contract: the image path
+/// varies per run and the test-visible inventory must not.
+const LOGICAL_ARGV0: &str = "rue-test";
+
+/// The one environment entry a test process inherits.
+const TEST_ENV_VAR: &str = "RUE_TEST";
+const TEST_ENV_VALUE: &str = "1";
+
+/// Default retention budget for each of stdout and stderr.
+pub(crate) const DEFAULT_STREAM_BUDGET: usize = 1024 * 1024;
+
+/// The failure channel's own budget, separate from the streams' by design: a
+/// test that floods stdout must not be able to truncate its own failure record
+/// (ADR-0083 §2).
+pub(crate) const CHANNEL_BUDGET: usize = 256 * 1024;
+
+/// How often the supervision loop wakes to poll the drains and the child.
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+/// What one test process produced, as the event builder needs it.
+pub(crate) struct Execution {
+    pub(crate) classification: Classification,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) signal: Option<i32>,
+    pub(crate) frames: ChannelFrames,
+    pub(crate) stdout: Vec<u8>,
+    pub(crate) stdout_total: u64,
+    pub(crate) stderr: Vec<u8>,
+    pub(crate) stderr_total: u64,
+    pub(crate) duration: Duration,
+    pub(crate) scratch_dir: PathBuf,
+}
+
+/// Everything one dispatch needs.
+pub(crate) struct Dispatch<'a> {
+    pub(crate) image: &'a Path,
+    /// The run's private directory, which every scratch directory sits inside.
+    pub(crate) run_root: &'a Path,
+    pub(crate) ordinal: u32,
+    pub(crate) seed: u64,
+    pub(crate) timeout: Duration,
+    pub(crate) stream_budget: usize,
+}
+
+/// Render a selector exactly as the dispatcher parses it: sixteen lowercase
+/// hex digits, fixed width (ADR-0083 §3).
+pub(crate) fn selector(ordinal: u32) -> String {
+    format!("{:016x}", u64::from(ordinal))
+}
+
+/// The private directory one run owns, holding its image and every scratch
+/// directory.
+///
+/// The process id is what makes it private. Two runs launched with the same
+/// explicit `--seed` — a repro next to the run that produced it, or two CLI
+/// cases in a parallel suite — would otherwise name the same scratch
+/// directories, and one run's fresh-directory setup would delete the other
+/// run's working directory out from under a live test.
+pub(crate) fn run_root(seed: u64) -> PathBuf {
+    std::env::temp_dir().join(format!("rue-test-{seed}-{}", std::process::id()))
+}
+
+/// The scratch directory one test runs in.
+///
+/// Named from the seed and the ordinal so a retained directory can be tied back
+/// to the run and the test that produced it from the event stream alone. It is
+/// removed first when a stale one is present: "fresh" is the contract, and a
+/// leftover from an interrupted earlier run would otherwise be a test's
+/// starting state.
+pub(crate) fn scratch_path(run_root: &Path, seed: u64, ordinal: u32) -> PathBuf {
+    run_root.join(format!("rue-test-{seed}-{ordinal}"))
+}
+
+/// Holds descriptor 3 open for the life of the process so nothing else can be
+/// allocated there.
+///
+/// `None` means this static holds nothing: either the descriptor was already
+/// occupied when we looked — which establishes the same invariant, by someone
+/// else's ownership — or claiming it failed, which is best-effort and leaves
+/// the runner exactly as correct as it was before the reservation existed.
+static CHANNEL_RESERVATION: OnceLock<Option<OwnedFd>> = OnceLock::new();
+
+/// Claim descriptor 3 before any test is spawned.
+///
+/// The child's `pre_exec` puts the channel's write end on descriptor 3, but a
+/// `dup2` onto 3 silently replaces whatever the *parent* had there — and the
+/// parent does not control descriptor 3 on its own. `Command::spawn` opens its
+/// own close-on-exec pipe at spawn time, on the lowest free descriptors, to
+/// report a failed `exec` back to the parent. This runner spawns from several
+/// threads at once, so if that pipe's write end lands on 3 for one spawn, that
+/// child's `dup2` destroys it: an `exec` failure would then be written into our
+/// failure channel as a malformed frame while the parent read EOF from the real
+/// pipe and concluded the spawn had succeeded.
+///
+/// Pinning a placeholder on 3 for the whole process closes that window at its
+/// source. No later `open` or `pipe` can be given descriptor 3 while it is
+/// occupied, so the child's `dup2` always replaces this placeholder and never a
+/// live descriptor of the runner's own.
+///
+/// Idempotent, and safe to call from anywhere: the first caller wins and the
+/// descriptor is never released.
+pub(crate) fn reserve_channel_descriptor() {
+    CHANNEL_RESERVATION.get_or_init(|| {
+        // SAFETY: a bare query of a descriptor's flags.
+        if unsafe { libc::fcntl(CHANNEL_FD, libc::F_GETFD) } >= 0 {
+            // Already open — our own parent handed us something on 3. Leave it
+            // alone: it is not ours to close, and an occupied descriptor is
+            // exactly the invariant this function exists to establish.
+            return None;
+        }
+        let placeholder = std::fs::File::open("/dev/null").ok()?;
+        if placeholder.as_raw_fd() == CHANNEL_FD {
+            // `open` was handed 3 directly, which is the common case. Rust
+            // opens with `O_CLOEXEC`, so it is already close-on-exec.
+            return Some(OwnedFd::from(placeholder));
+        }
+        // SAFETY: both descriptors are open; `dup2` closes nothing we own,
+        // because the branch above proved 3 was free.
+        if unsafe { libc::dup2(placeholder.as_raw_fd(), CHANNEL_FD) } < 0 {
+            return None;
+        }
+        // `dup2` clears close-on-exec on the new descriptor. Restore it so the
+        // placeholder never leaks into an unrelated child — the test image's
+        // own descriptor 3 is installed by `pre_exec`, not inherited from here.
+        // SAFETY: descriptor 3 is now open and owned by this process.
+        unsafe {
+            libc::fcntl(CHANNEL_FD, libc::F_SETFD, libc::FD_CLOEXEC);
+        }
+        // Dropping `placeholder` closes its original descriptor; 3 survives as
+        // the duplicate, owned from here on by this static.
+        // SAFETY: `dup2` succeeded, so descriptor 3 is open and unowned.
+        Some(unsafe { OwnedFd::from_raw_fd(CHANNEL_FD) })
+    });
+}
+
+/// Run one test to a verdict.
+///
+/// Errors are runner errors — the image could not be executed at all — and are
+/// distinct from a test that ran and failed.
+pub(crate) fn run_one(dispatch: Dispatch<'_>) -> io::Result<Execution> {
+    let scratch = scratch_path(dispatch.run_root, dispatch.seed, dispatch.ordinal);
+    if scratch.exists() {
+        let _ = std::fs::remove_dir_all(&scratch);
+    }
+    std::fs::create_dir_all(&scratch)?;
+
+    let (channel_read, channel_write) = channel_pipe()?;
+    let channel_write_fd = channel_write.as_raw_fd();
+    let channel_read_fd = channel_read.as_raw_fd();
+
+    let mut command = Command::new(dispatch.image);
+    {
+        use std::os::unix::process::CommandExt;
+        command
+            .arg0(LOGICAL_ARGV0)
+            .arg(selector(dispatch.ordinal))
+            .env_clear()
+            .env(TEST_ENV_VAR, TEST_ENV_VALUE)
+            .current_dir(&scratch)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        // SAFETY: the closure runs between fork and exec in the child. It calls
+        // only async-signal-safe syscalls (`dup2`, `fcntl`, `close`) and
+        // allocates nothing, which is the whole obligation `pre_exec` imposes.
+        unsafe {
+            command.pre_exec(move || install_channel(channel_write_fd, channel_read_fd));
+        }
+    }
+    configure_process_group(&mut command);
+
+    let start = Instant::now();
+    let mut child = command.spawn()?;
+    // The parent's copy of the write end must go now: while it is open, the
+    // reader below can never see end of stream.
+    drop(channel_write);
+    let pid = child.id() as i32;
+
+    let mut stdout_drain = spawn_pipe_drain(child.stdout.take(), Some(dispatch.stream_budget));
+    let mut stderr_drain = spawn_pipe_drain(child.stderr.take(), Some(dispatch.stream_budget));
+    // Ownership of the read end moves to the drain thread, which closes it at
+    // end of stream. The runner holds it open until then on purpose: a test
+    // writing to a channel whose reader had closed would die of SIGPIPE.
+    let mut channel_drain = spawn_pipe_drain(
+        Some(std::fs::File::from(channel_read)),
+        Some(CHANNEL_BUDGET),
+    );
+
+    let mut supervision = Supervision::Exited;
+    let status = loop {
+        stdout_drain.poll();
+        stderr_drain.poll();
+        channel_drain.poll();
+
+        if stdout_drain.overflowed() || stderr_drain.overflowed() {
+            supervision = Supervision::OutputOverflow;
+            kill_process_group(&mut child);
+            break None;
+        }
+
+        match child.try_wait()? {
+            Some(status) => break Some(status),
+            None => {
+                if start.elapsed() > dispatch.timeout {
+                    supervision = Supervision::TimedOut;
+                    kill_process_group(&mut child);
+                    break None;
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+        }
+    };
+    let duration = start.elapsed();
+
+    // Post-exit group SIGKILL for stragglers: hygiene, not containment
+    // (ADR-0083 §3). A descendant that outlived its parent would otherwise keep
+    // a pipe open and stall the bounded finish below for no useful reason.
+    reap_process_group(pid);
+
+    finish(&mut stdout_drain);
+    finish(&mut stderr_drain);
+    finish(&mut channel_drain);
+
+    // The budget is enforced by the drain threads, which hand their verdict
+    // over a channel — so a test that floods its stdout and then exits
+    // immediately can be reaped before the overflow message arrives. Reading
+    // the flag again after the bounded finish is what keeps such a test from
+    // reporting as a pass whose digest silently covers a truncated prefix.
+    if supervision == Supervision::Exited
+        && (stdout_drain.overflowed() || stderr_drain.overflowed())
+    {
+        supervision = Supervision::OutputOverflow;
+    }
+
+    let (exit_code, signal) = match &status {
+        Some(status) => {
+            use std::os::unix::process::ExitStatusExt;
+            (status.code(), status.signal())
+        }
+        None => (None, None),
+    };
+    let frames = super::verdict::parse_channel(channel_drain.bytes());
+    let status_for_classification = match (exit_code, signal) {
+        (Some(code), _) => Ok(code),
+        (None, Some(signal)) => Err(signal),
+        // The runner killed the group, so there is no self-reported status.
+        // Supervision decides these, ahead of the status, in `classify`.
+        (None, None) => Err(libc::SIGKILL),
+    };
+    let classification = classify(Observation {
+        supervision,
+        status: status_for_classification,
+        stderr: stderr_drain.bytes(),
+        frames: &frames,
+    });
+
+    Ok(Execution {
+        classification,
+        exit_code,
+        signal,
+        frames,
+        stdout_total: stdout_drain.bytes_total(),
+        stderr_total: stderr_drain.bytes_total(),
+        stdout: stdout_drain.into_bytes(),
+        stderr: stderr_drain.into_bytes(),
+        duration,
+        scratch_dir: scratch,
+    })
+}
+
+fn finish(drain: &mut PipeDrain) {
+    drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
+}
+
+/// A fresh pipe for one test's failure channel.
+///
+/// Both ends are marked close-on-exec immediately: this runner spawns from
+/// several threads at once, and a descriptor without the flag would be
+/// inherited by whichever unrelated test happened to fork next, keeping that
+/// test's channel from ever reaching end of stream. The child's own descriptor
+/// 3 has the flag cleared inside `pre_exec`, where it is the one descriptor
+/// meant to survive.
+fn channel_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
+    let mut fds = [0 as libc::c_int; 2];
+    // SAFETY: `fds` is a valid two-element array for `pipe` to fill.
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `pipe` succeeded, so both descriptors are open and unowned.
+    let ends = unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) };
+    for end in [&ends.0, &ends.1] {
+        // SAFETY: the descriptor is owned and open.
+        if unsafe { libc::fcntl(end.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(ends)
+}
+
+/// Put the channel's write end on descriptor 3 in the forked child.
+///
+/// Runs between `fork` and `exec`, so it may call nothing but
+/// async-signal-safe syscalls.
+///
+/// The `== CHANNEL_FD` branches below cannot be taken once
+/// [`reserve_channel_descriptor`] has run: descriptor 3 is occupied by the
+/// placeholder for the life of the process, so neither end of a pipe created
+/// afterwards can be allocated there. They are kept as belt and braces — a
+/// future caller that spawns without reserving first would otherwise get a
+/// `dup2` onto itself, which is a no-op that leaves close-on-exec set and would
+/// hand the image a channel that closes at `exec`.
+fn install_channel(write_fd: i32, read_fd: i32) -> io::Result<()> {
+    if write_fd == CHANNEL_FD {
+        // SAFETY: async-signal-safe, on a descriptor this child owns.
+        if unsafe { libc::fcntl(CHANNEL_FD, libc::F_SETFD, 0) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    } else {
+        // `dup2` clears close-on-exec on the new descriptor, which is exactly
+        // what makes descriptor 3 survive into the image. What it replaces is
+        // the reserved placeholder, never a live descriptor of the runner's.
+        // SAFETY: async-signal-safe, on descriptors this child owns.
+        if unsafe { libc::dup2(write_fd, CHANNEL_FD) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    if read_fd != CHANNEL_FD {
+        // SAFETY: async-signal-safe; the child has no use for the read end and
+        // holding it open would keep the runner from seeing end of stream if
+        // the image ever forked.
+        unsafe {
+            libc::close(read_fd);
+        }
+    }
+    Ok(())
+}
+
+/// Best-effort teardown of anything the test left running in its group.
+fn reap_process_group(pid: i32) {
+    // SAFETY: a negative pid names the process group led by `pid`. Failure
+    // (an already-empty group) is the ordinary case and carries no obligation.
+    unsafe {
+        libc::kill(-pid, libc::SIGKILL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The dispatcher parses a fixed-width, lowercase, sixteen-digit selector
+    /// and rejects everything else, so this rendering is contract.
+    #[test]
+    fn selectors_are_sixteen_lowercase_hex_digits() {
+        assert_eq!(selector(0), "0000000000000000");
+        assert_eq!(selector(1), "0000000000000001");
+        assert_eq!(selector(255), "00000000000000ff");
+        assert_eq!(selector(u32::MAX), "00000000ffffffff");
+        for ordinal in [0, 1, 41, 1000, u32::MAX] {
+            let rendered = selector(ordinal);
+            assert_eq!(rendered.len(), 16);
+            assert!(
+                rendered
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+                "{rendered}"
+            );
+        }
+    }
+
+    /// The scratch name ties a retained directory back to the run and the test
+    /// from the event stream alone.
+    #[test]
+    fn a_scratch_directory_is_named_from_the_seed_and_ordinal() {
+        let root = run_root(417);
+        let path = scratch_path(&root, 417, 3);
+        assert_eq!(
+            path.file_name().unwrap().to_str().unwrap(),
+            "rue-test-417-3"
+        );
+        assert_eq!(path.parent().unwrap(), root);
+    }
+
+    /// Two runs sharing an explicit seed must not share scratch paths: one
+    /// run's fresh-directory setup would delete the other's live working
+    /// directory. The run root is what keeps them disjoint.
+    #[test]
+    fn a_run_root_is_private_to_its_process() {
+        let root = run_root(417);
+        assert_eq!(root.parent().unwrap(), std::env::temp_dir());
+        assert!(
+            root.file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .ends_with(&format!("-{}", std::process::id())),
+            "{root:?}"
+        );
+    }
+
+    /// The channel's budget is separate from the streams' so a test that floods
+    /// stdout cannot truncate its own failure record (ADR-0083 §2).
+    #[test]
+    fn the_channel_budget_is_independent_of_the_stream_budget() {
+        assert_eq!(DEFAULT_STREAM_BUDGET, 1024 * 1024);
+        assert_eq!(CHANNEL_BUDGET, 256 * 1024);
+        assert_ne!(DEFAULT_STREAM_BUDGET, CHANNEL_BUDGET);
+    }
+
+    /// A pipe both of whose ends leaked into an unrelated concurrent spawn
+    /// would keep that test's channel from ever reaching end of stream.
+    #[test]
+    fn both_channel_ends_are_close_on_exec_in_the_parent() {
+        reserve_channel_descriptor();
+        let (read, write) = channel_pipe().expect("a pipe");
+        for end in [&read, &write] {
+            // SAFETY: the descriptor is owned and open.
+            let flags = unsafe { libc::fcntl(end.as_raw_fd(), libc::F_GETFD) };
+            assert!(flags >= 0);
+            assert_eq!(flags & libc::FD_CLOEXEC, libc::FD_CLOEXEC);
+        }
+    }
+
+    /// The reservation's whole purpose: once descriptor 3 is held, nothing the
+    /// process opens afterwards can be allocated there. If a pipe end could
+    /// still land on 3, a child's `dup2` onto the channel would destroy it —
+    /// and for `Command::spawn`'s own exec-reporting pipe that means an exec
+    /// failure written into the failure channel while the parent reads EOF from
+    /// the real pipe and believes the spawn succeeded.
+    #[test]
+    fn nothing_is_allocated_at_the_channel_descriptor_after_reserving_it() {
+        reserve_channel_descriptor();
+
+        // SAFETY: a bare query of a descriptor's flags.
+        assert!(
+            unsafe { libc::fcntl(CHANNEL_FD, libc::F_GETFD) } >= 0,
+            "descriptor {CHANNEL_FD} must be occupied after reserving it"
+        );
+
+        // Several pipes, because the first free descriptor moves as they stack
+        // up: none of their ends may be the reserved one.
+        let mut held = Vec::new();
+        for _ in 0..8 {
+            let (read, write) = channel_pipe().expect("a pipe");
+            assert_ne!(read.as_raw_fd(), CHANNEL_FD);
+            assert_ne!(write.as_raw_fd(), CHANNEL_FD);
+            held.push((read, write));
+        }
+
+        // An ordinary file open is allocated from the same descriptor space.
+        let file = std::fs::File::open("/dev/null").expect("/dev/null");
+        assert_ne!(file.as_raw_fd(), CHANNEL_FD);
+    }
+
+    /// Reserving twice is not an error and does not change what is held: the
+    /// runner calls it once per invocation and tests call it freely.
+    #[test]
+    fn reserving_the_channel_descriptor_is_idempotent() {
+        reserve_channel_descriptor();
+        // SAFETY: a bare query of a descriptor's flags.
+        let first = unsafe { libc::fcntl(CHANNEL_FD, libc::F_GETFD) };
+        reserve_channel_descriptor();
+        // SAFETY: a bare query of a descriptor's flags.
+        let second = unsafe { libc::fcntl(CHANNEL_FD, libc::F_GETFD) };
+        assert!(first >= 0);
+        assert_eq!(first, second);
+    }
+}

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -1,0 +1,821 @@
+//! `rue test`: the driver's test mode (ADR-0083 §2, §3).
+//!
+//! One image is linked for the request's whole test closure, and one process is
+//! spawned per selected test. Everything the run produces is an event
+//! (`events`), decided by one classifier (`verdict`), ordered by one planner
+//! (`selection`), executed by one dispatcher (`exec`), and shown to a person by
+//! one consumer of those same events (`render`).
+//!
+//! The schema is `docs/process/test-events.md`. Two stream rules are settled
+//! here and stated there because they are easy to get subtly wrong:
+//!
+//! - **stdout is the runner's surface and stderr is the compiler's.** Compiler
+//!   diagnostics keep going where `docs/process/diagnostics.md` puts them,
+//!   `--error-format json` included and unchanged, so a consumer can read the
+//!   whole of stdout as the event stream.
+//! - **No event is emitted before the image exists.** A compile failure is
+//!   exit 2 with diagnostics and an empty event stream, never a `run_started`
+//!   for a run that never began.
+
+pub(crate) mod events;
+pub(crate) mod exec;
+pub(crate) mod render;
+pub(crate) mod selection;
+pub(crate) mod verdict;
+
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use rue_compiler::unstable::{TestCandidateInventory, TestInventoryEntry};
+use rue_compiler::{CompileOptions, OptLevel};
+use rue_driver::FilesystemCompilerHost;
+use rue_target::Target;
+
+use events::{
+    CandidateSource, Capture, Event, FailureRecord, Location, TestFinished, UnimportedFile,
+};
+use exec::{DEFAULT_STREAM_BUDGET, Dispatch};
+use selection::Shard;
+use verdict::{FailureKind, Verdict};
+
+/// The default per-test wall-clock budget, matching `rue-test-runner`'s
+/// (ADR-0083 §3).
+pub(crate) const DEFAULT_TIMEOUT_MS: u64 = rue_test_runner::DEFAULT_TIMEOUT_MS;
+
+/// `rue test`'s exit statuses (ADR-0083 §2).
+///
+/// Agents branch on these, so they are one enum with one documented mapping
+/// rather than scattered `exit` calls. The compile-mode driver's own exit paths
+/// are untouched: this is a new surface, not a change to the old one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TestExitCode {
+    /// Every selected test passed.
+    AllPassed = 0,
+    /// At least one selected test failed, timed out, or crashed.
+    Failures = 1,
+    /// The run could not be performed: a compile failure, a link failure, an
+    /// ICE, a bad flag combination, or a runner error.
+    RunnerError = 2,
+    /// The selection was empty. A filter that matches nothing is how a typo
+    /// becomes false evidence, so it is an outcome of its own rather than a
+    /// vacuous success.
+    EmptySelection = 3,
+}
+
+impl TestExitCode {
+    pub(crate) fn code(self) -> i32 {
+        self as i32
+    }
+}
+
+/// How the run reports itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum OutputFormat {
+    #[default]
+    Human,
+    Json,
+}
+
+impl std::str::FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        match text {
+            "human" => Ok(Self::Human),
+            "json" => Ok(Self::Json),
+            other => Err(format!(
+                "invalid --format '{other}' (valid formats: human, json)"
+            )),
+        }
+    }
+}
+
+/// The test-mode flags, as parsed.
+#[derive(Debug, Clone)]
+pub(crate) struct TestOptions {
+    pub(crate) list: bool,
+    pub(crate) filters: Vec<String>,
+    pub(crate) format: OutputFormat,
+    pub(crate) timeout_ms: u64,
+    pub(crate) shard: Option<Shard>,
+    /// `None` until the run derives one from a fresh random source and reports
+    /// it in `run_started`.
+    pub(crate) seed: Option<u64>,
+}
+
+impl Default for TestOptions {
+    fn default() -> Self {
+        Self {
+            list: false,
+            filters: Vec::new(),
+            format: OutputFormat::default(),
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+            shard: None,
+            seed: None,
+        }
+    }
+}
+
+/// Everything one `rue test` invocation needs from the driver.
+pub(crate) struct TestRequest<'a, 'diagnostics> {
+    pub(crate) host: &'a mut FilesystemCompilerHost,
+    pub(crate) compile_options: CompileOptions,
+    pub(crate) options: TestOptions,
+    pub(crate) diagnostics: &'a crate::DiagnosticOutput<'diagnostics>,
+    /// The root source exactly as the command line spelled it, which is what a
+    /// repro argv must repeat.
+    pub(crate) root: String,
+    /// The compile-mode flags a repro argv repeats after the filter and seed.
+    pub(crate) repro_flags: Vec<String>,
+    pub(crate) jobs: usize,
+    pub(crate) target: Target,
+    pub(crate) opt_level: OptLevel,
+    pub(crate) candidates: Option<TestCandidateInventory>,
+}
+
+/// Derive a seed from a fresh random source.
+///
+/// `RandomState` is seeded by the OS, which is the only entropy the standard
+/// library exposes without a dependency. The value is published in
+/// `run_started` and repeated in every repro argv, so a shuffle that surfaced a
+/// bug is re-runnable.
+fn fresh_seed() -> u64 {
+    use std::hash::{BuildHasher, Hasher};
+    std::collections::hash_map::RandomState::new()
+        .build_hasher()
+        .finish()
+}
+
+/// Serializes the run's output so concurrent workers cannot interleave a line,
+/// and routes each event to the surface the invocation asked for.
+struct Reporter {
+    format: OutputFormat,
+    stdout: Mutex<()>,
+}
+
+impl Reporter {
+    fn new(format: OutputFormat) -> Self {
+        Self {
+            format,
+            stdout: Mutex::new(()),
+        }
+    }
+
+    fn emit(&self, event: &Event) {
+        let _guard = self
+            .stdout
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let mut out = std::io::stdout().lock();
+        match self.format {
+            OutputFormat::Json => {
+                let _ = writeln!(out, "{}", event.to_ndjson());
+            }
+            OutputFormat::Human => {
+                if let Some(text) = render::render(event) {
+                    let _ = writeln!(out, "{text}");
+                }
+            }
+        }
+        let _ = out.flush();
+    }
+}
+
+/// Run `rue test` to an exit status.
+pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
+    let TestRequest {
+        host,
+        compile_options,
+        options,
+        diagnostics,
+        root,
+        repro_flags,
+        jobs,
+        target,
+        opt_level,
+        candidates,
+    } = request;
+
+    // Before anything can spawn: pin descriptor 3 shut for the life of the
+    // process, so no pipe the standard library opens for its own bookkeeping
+    // can be allocated there and then be destroyed by a child's `dup2` onto
+    // the channel. See `exec::reserve_channel_descriptor`.
+    exec::reserve_channel_descriptor();
+
+    let seed = options.seed.unwrap_or_else(fresh_seed);
+    let reporter = Reporter::new(options.format);
+
+    if options.list {
+        return list(host, &compile_options, &options, diagnostics, &reporter);
+    }
+
+    // Nothing is published before the image exists: a compile failure is
+    // diagnostics on stderr and exit 2, with an empty event stream.
+    let (image, inventory) = match host.test_image_in_compile_scope(&compile_options) {
+        Ok(output) => output,
+        Err(errors) => {
+            diagnostics.print_errors(&crate::with_import_migration_helps(&errors));
+            return TestExitCode::RunnerError;
+        }
+    };
+    diagnostics.print_warnings(&image.warnings);
+
+    let total = inventory.entries.len();
+    let plan = selection::plan(&inventory.entries, &options.filters, options.shard, seed);
+    let started = Instant::now();
+
+    reporter.emit(&Event::RunStarted {
+        root: root.clone(),
+        target: target.to_string(),
+        opt_level: opt_level_digit(opt_level),
+        seed,
+        jobs,
+        shard: options.shard.map(|shard| shard.to_string()),
+        selected: plan.len(),
+        total,
+    });
+
+    if plan.is_empty() {
+        let unimported = report_unimported(host, candidates.as_ref(), diagnostics);
+        let Ok(unimported) = unimported else {
+            return TestExitCode::RunnerError;
+        };
+        // Said before the terminal event, so a reader of an interleaved
+        // terminal sees the reason ahead of the vacuous "0 passed" summary.
+        eprintln!("{}", empty_selection_reason(total));
+        reporter.emit(&Event::RunFinished {
+            passed: 0,
+            failed: 0,
+            timeout: 0,
+            crash: 0,
+            wall_ms: elapsed_ms(started),
+            unimported_test_files: unimported,
+            test_candidates: candidate_source(candidates.as_ref()),
+        });
+        return TestExitCode::EmptySelection;
+    }
+
+    let run_root = exec::run_root(seed);
+    let image_path = match publish_image(&image.elf, target, &run_root) {
+        Ok(path) => path,
+        Err(message) => {
+            eprintln!("{message}");
+            return TestExitCode::RunnerError;
+        }
+    };
+
+    let outcome = execute_plan(ExecutionRequest {
+        plan: &plan,
+        image: &image_path,
+        run_root: &run_root,
+        seed,
+        timeout: Duration::from_millis(options.timeout_ms),
+        jobs,
+        root: &root,
+        repro_flags: &repro_flags,
+        reporter: &reporter,
+    });
+    // The image is the runner's own artifact and is never retained; the run
+    // root goes with it unless a failing test left a scratch directory behind,
+    // in which case the non-recursive removal fails and the evidence survives.
+    let _ = std::fs::remove_file(&image_path);
+    let _ = std::fs::remove_dir(&run_root);
+
+    if let Some(error) = outcome.runner_error {
+        eprintln!("error: {error}");
+        return TestExitCode::RunnerError;
+    }
+
+    let Ok(unimported) = report_unimported(host, candidates.as_ref(), diagnostics) else {
+        return TestExitCode::RunnerError;
+    };
+    reporter.emit(&Event::RunFinished {
+        passed: outcome.passed,
+        failed: outcome.failed,
+        timeout: outcome.timeout,
+        crash: outcome.crash,
+        wall_ms: elapsed_ms(started),
+        unimported_test_files: unimported,
+        test_candidates: candidate_source(candidates.as_ref()),
+    });
+
+    if outcome.failed + outcome.timeout + outcome.crash > 0 {
+        TestExitCode::Failures
+    } else {
+        TestExitCode::AllPassed
+    }
+}
+
+/// The `opt_level` field: the digit alone, so a consumer reads `"2"` rather
+/// than having to strip the `-O` a command line spells it with.
+fn opt_level_digit(level: OptLevel) -> String {
+    level.name().trim_start_matches('O').to_owned()
+}
+
+/// Why exit 3 happened, distinguishing the two ways a selection can be empty.
+///
+/// "Your filter matched nothing" and "this root declares no tests" are
+/// different mistakes with different fixes, and a run that says only the first
+/// sends a reader looking for a typo in a correct pattern.
+fn empty_selection_reason(total: usize) -> &'static str {
+    if total == 0 {
+        "error: the compiled closure declares no tests; a test-only file must be reached by an @import"
+    } else {
+        "error: no tests matched the selection"
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn candidate_source(candidates: Option<&TestCandidateInventory>) -> CandidateSource {
+    match candidates {
+        Some(_) => CandidateSource::Declared,
+        None => CandidateSource::None,
+    }
+}
+
+/// `--list`: the inventory, with no codegen, no linking, and no execution.
+///
+/// Filtering and sharding apply — a listing answers "what would this
+/// invocation run" — but the shuffle does not. A listing is an inventory, and
+/// stable-ID order is the property that makes two listings comparable.
+fn list(
+    host: &mut FilesystemCompilerHost,
+    compile_options: &CompileOptions,
+    options: &TestOptions,
+    diagnostics: &crate::DiagnosticOutput<'_>,
+    reporter: &Reporter,
+) -> TestExitCode {
+    let inventory = match host.test_inventory(compile_options) {
+        Ok(inventory) => inventory,
+        Err(errors) => {
+            diagnostics.print_errors(&crate::with_import_migration_helps(&errors));
+            return TestExitCode::RunnerError;
+        }
+    };
+    let selected: Vec<&TestInventoryEntry> = inventory
+        .entries
+        .iter()
+        .filter(|entry| selection::matches_filters(&entry.id, &options.filters))
+        .filter(|entry| {
+            options.shard.is_none_or(|shard| {
+                selection::shard_hash(&entry.id) % shard.count == shard.index - 1
+            })
+        })
+        .collect();
+    if selected.is_empty() {
+        eprintln!("{}", empty_selection_reason(inventory.entries.len()));
+        return TestExitCode::EmptySelection;
+    }
+    for entry in selected {
+        reporter.emit(&Event::Test {
+            id: entry.id.clone(),
+            module: entry.module.clone(),
+            name: entry.name.clone(),
+            file: entry.file.clone(),
+            line: entry.line,
+            column: entry.column,
+        });
+    }
+    TestExitCode::AllPassed
+}
+
+/// Write the linked image where it can be executed.
+///
+/// This goes through the driver's ordinary publication path rather than a bare
+/// `fs::write`, because publication is where target-specific finalization
+/// happens — notably ad-hoc Mach-O signing, without which the image would not
+/// run at all on Apple silicon.
+fn publish_image(
+    elf: &[u8],
+    target: Target,
+    run_root: &std::path::Path,
+) -> Result<PathBuf, String> {
+    std::fs::create_dir_all(run_root)
+        .map_err(|error| format!("error: could not create the test run directory: {error}"))?;
+    let path = run_root.join("rue-test-image");
+    let destination = crate::output::preflight_destination(&path, std::iter::empty())
+        .map_err(|error| publish_failure("stage", error))?;
+    crate::output::publish_executable(crate::output::PublishRequest {
+        destination,
+        bytes: elf,
+        target,
+    })
+    .map_err(|error| publish_failure("publish", error))?;
+    Ok(path)
+}
+
+/// A staging failure, rendered through the same message a publication failure
+/// carries on the compile path.
+fn publish_failure(verb: &str, error: crate::output::PublishError) -> String {
+    format!(
+        "error: could not {verb} the test image: {}",
+        error.into_compile_error().kind
+    )
+}
+
+struct ExecutionRequest<'a> {
+    plan: &'a [TestInventoryEntry],
+    image: &'a std::path::Path,
+    run_root: &'a std::path::Path,
+    seed: u64,
+    timeout: Duration,
+    jobs: usize,
+    root: &'a str,
+    repro_flags: &'a [String],
+    reporter: &'a Reporter,
+}
+
+#[derive(Default)]
+struct ExecutionOutcome {
+    passed: usize,
+    failed: usize,
+    timeout: usize,
+    crash: usize,
+    runner_error: Option<String>,
+}
+
+/// Run the plan across a bounded pool of workers.
+///
+/// Work is claimed from a shared cursor rather than partitioned up front:
+/// tests have wildly different durations and the MVP has no duration history
+/// to bin-pack with (that arrives with the deferred scheduling ADR), so a
+/// static split would leave workers idle behind one slow test.
+fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
+    let cursor = AtomicUsize::new(0);
+    let passed = AtomicUsize::new(0);
+    let failed = AtomicUsize::new(0);
+    let timed_out = AtomicUsize::new(0);
+    let crashed = AtomicUsize::new(0);
+    let runner_error: Mutex<Option<String>> = Mutex::new(None);
+
+    std::thread::scope(|scope| {
+        for _ in 0..request.jobs.max(1) {
+            let cursor = &cursor;
+            let passed = &passed;
+            let failed = &failed;
+            let timed_out = &timed_out;
+            let crashed = &crashed;
+            let runner_error = &runner_error;
+            let request = &request;
+            scope.spawn(move || {
+                loop {
+                    let index = cursor.fetch_add(1, Ordering::SeqCst);
+                    let Some(entry) = request.plan.get(index) else {
+                        return;
+                    };
+                    if runner_error
+                        .lock()
+                        .unwrap_or_else(|error| error.into_inner())
+                        .is_some()
+                    {
+                        return;
+                    }
+                    request.reporter.emit(&Event::TestStarted {
+                        id: entry.id.clone(),
+                    });
+                    let execution = exec::run_one(Dispatch {
+                        image: request.image,
+                        run_root: request.run_root,
+                        ordinal: entry.ordinal,
+                        seed: request.seed,
+                        timeout: request.timeout,
+                        stream_budget: DEFAULT_STREAM_BUDGET,
+                    });
+                    let execution = match execution {
+                        Ok(execution) => execution,
+                        Err(error) => {
+                            let mut slot = runner_error
+                                .lock()
+                                .unwrap_or_else(|error| error.into_inner());
+                            if slot.is_none() {
+                                *slot = Some(format!("could not run test '{}': {error}", entry.id));
+                            }
+                            return;
+                        }
+                    };
+                    match &execution.classification.verdict {
+                        Verdict::Pass => passed.fetch_add(1, Ordering::Relaxed),
+                        Verdict::Fail(_) => failed.fetch_add(1, Ordering::Relaxed),
+                        Verdict::Timeout => timed_out.fetch_add(1, Ordering::Relaxed),
+                        Verdict::Crash(_) => crashed.fetch_add(1, Ordering::Relaxed),
+                    };
+                    let event = finish_event(
+                        entry,
+                        execution,
+                        request.root,
+                        request.repro_flags,
+                        request.seed,
+                        request.timeout,
+                    );
+                    request.reporter.emit(&event);
+                }
+            });
+        }
+    });
+
+    ExecutionOutcome {
+        passed: passed.into_inner(),
+        failed: failed.into_inner(),
+        timeout: timed_out.into_inner(),
+        crash: crashed.into_inner(),
+        runner_error: runner_error
+            .into_inner()
+            .unwrap_or_else(|error| error.into_inner()),
+    }
+}
+
+/// Turn one finished process into its `test_finished` event.
+///
+/// The scratch directory is deleted on a pass and retained on anything else,
+/// with its path in the event: the abort-only runtime means destructors do not
+/// run on a failing path, so the directory plus process death is what
+/// teardown-on-failure amounts to (ADR-0083 §5.4).
+fn finish_event(
+    entry: &TestInventoryEntry,
+    execution: exec::Execution,
+    root: &str,
+    repro_flags: &[String],
+    seed: u64,
+    timeout: Duration,
+) -> Event {
+    let verdict = execution.classification.verdict.clone();
+    let passed = verdict.is_pass();
+    if passed {
+        let _ = std::fs::remove_dir_all(&execution.scratch_dir);
+    }
+    let failure = (!passed).then(|| failure_record(entry, &verdict, &execution, timeout));
+    Event::TestFinished(Box::new(TestFinished {
+        id: entry.id.clone(),
+        verdict,
+        duration_ms: u64::try_from(execution.duration.as_millis()).unwrap_or(u64::MAX),
+        failure,
+        stdout: Capture::new(execution.stdout, execution.stdout_total, passed),
+        stderr: Capture::new(execution.stderr, execution.stderr_total, passed),
+        scratch_dir: (!passed).then(|| execution.scratch_dir.display().to_string()),
+        repro: repro_argv(root, &entry.id, seed, repro_flags),
+    }))
+}
+
+fn failure_record(
+    entry: &TestInventoryEntry,
+    verdict: &Verdict,
+    execution: &exec::Execution,
+    timeout: Duration,
+) -> FailureRecord {
+    let frame = execution.frames.failure.as_ref();
+    let (kind, message) = match verdict {
+        Verdict::Pass => unreachable!("a pass carries no failure record"),
+        Verdict::Timeout => (
+            "timeout".to_owned(),
+            format!(
+                "the test exceeded its {} ms budget; the process group was killed",
+                timeout.as_millis()
+            ),
+        ),
+        Verdict::Crash(signal) => (
+            "signal".to_owned(),
+            format!("the test was killed by signal {signal}"),
+        ),
+        Verdict::Fail(kind) => (kind.to_string(), failure_message(kind, execution, frame)),
+    };
+    // The declaration's span is the default location; a frame that carries its
+    // own site (the `?` failure arm, or an assertion library reporting its
+    // caller) supersedes it.
+    let location = match frame.filter(|frame| !frame.file.is_empty()) {
+        Some(frame) => Location {
+            file: frame.file.clone(),
+            line: frame.line,
+            column: frame.column,
+        },
+        None => Location {
+            file: entry.file.clone(),
+            line: entry.line,
+            column: entry.column,
+        },
+    };
+    FailureRecord {
+        kind,
+        message,
+        exit_code: execution.exit_code,
+        signal: execution.signal,
+        location: Some(location),
+        payload: frame
+            .map(|frame| frame.payload.clone())
+            .filter(|payload| !payload.is_empty()),
+        runner_note: execution.classification.runner_note.clone(),
+    }
+}
+
+fn failure_message(
+    kind: &FailureKind,
+    execution: &exec::Execution,
+    frame: Option<&verdict::FailureFrame>,
+) -> String {
+    if let Some(frame) = frame {
+        if !frame.message.is_empty() {
+            return frame.message.clone();
+        }
+    }
+    match kind {
+        FailureKind::Incomplete => {
+            "the test exited 0 without the dispatcher's completion record".to_owned()
+        }
+        FailureKind::OutputOverflow => format!(
+            "a captured stream exceeded its {DEFAULT_STREAM_BUDGET}-byte retention budget; \
+             the process group was killed"
+        ),
+        FailureKind::Assert | FailureKind::Trap(_) => last_message_line(&execution.stderr),
+        FailureKind::Exit => match execution.exit_code {
+            Some(code) => format!("the test exited with status {code}"),
+            None => "the test did not exit normally".to_owned(),
+        },
+        FailureKind::UnhandledError | FailureKind::Reported(_) => {
+            last_message_line(&execution.stderr)
+        }
+    }
+}
+
+/// The last non-empty line of a trapping test's stderr: the pinned runtime
+/// message the verdict was classified from.
+fn last_message_line(stderr: &[u8]) -> String {
+    String::from_utf8_lossy(stderr)
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_default()
+        .trim_end()
+        .to_owned()
+}
+
+/// The argv that reproduces exactly this one test (ADR-0083 §3).
+///
+/// It selects by the full stable ID, never the bare name: two modules may
+/// declare tests with the same name, and a repro that re-runs both is not a
+/// repro. The seed travels with it so a shuffle-dependent failure comes back.
+fn repro_argv(root: &str, id: &str, seed: u64, flags: &[String]) -> Vec<String> {
+    let mut argv = vec![
+        "rue".to_owned(),
+        "test".to_owned(),
+        root.to_owned(),
+        "--filter".to_owned(),
+        id.to_owned(),
+        "--seed".to_owned(),
+        seed.to_string(),
+    ];
+    argv.extend(flags.iter().cloned());
+    argv
+}
+
+/// Render the unimported-test-file warnings and collect them for the event.
+///
+/// Returns `Err(())` when the report itself failed; its diagnostics have
+/// already been presented.
+fn report_unimported(
+    host: &mut FilesystemCompilerHost,
+    candidates: Option<&TestCandidateInventory>,
+    diagnostics: &crate::DiagnosticOutput<'_>,
+) -> Result<Option<Vec<UnimportedFile>>, ()> {
+    let Some(candidates) = candidates else {
+        return Ok(None);
+    };
+    let files = match host.unimported_test_files(candidates) {
+        Ok(files) => files,
+        Err(errors) => {
+            diagnostics.print_errors(&errors);
+            return Err(());
+        }
+    };
+    let warnings: Vec<rue_compiler::CompileWarning> = files
+        .iter()
+        .map(|file| {
+            let kind = if file.parse_failed {
+                rue_error::WarningKind::UnimportedTestFileUnparsable {
+                    path: file.path.clone(),
+                }
+            } else {
+                rue_error::WarningKind::UnimportedTestFile {
+                    path: file.path.clone(),
+                    tests: file.tests,
+                }
+            };
+            rue_compiler::CompileWarning::without_span(kind)
+        })
+        .collect();
+    if !warnings.is_empty() {
+        diagnostics.print_warnings(&warnings);
+    }
+    Ok(Some(
+        files
+            .into_iter()
+            .map(|file| UnimportedFile {
+                path: file.path,
+                tests: file.tests,
+                parse_failed: file.parse_failed,
+            })
+            .collect(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Agents branch on these numbers; they are pinned rather than implied.
+    #[test]
+    fn exit_codes_are_the_documented_mapping() {
+        assert_eq!(TestExitCode::AllPassed.code(), 0);
+        assert_eq!(TestExitCode::Failures.code(), 1);
+        assert_eq!(TestExitCode::RunnerError.code(), 2);
+        assert_eq!(TestExitCode::EmptySelection.code(), 3);
+    }
+
+    #[test]
+    fn formats_parse_their_two_spellings_and_nothing_else() {
+        assert_eq!(
+            "human".parse::<OutputFormat>().unwrap(),
+            OutputFormat::Human
+        );
+        assert_eq!("json".parse::<OutputFormat>().unwrap(), OutputFormat::Json);
+        assert!(
+            "ndjson"
+                .parse::<OutputFormat>()
+                .unwrap_err()
+                .contains("human, json")
+        );
+    }
+
+    /// The repro selects by the full stable ID and repeats the run's seed and
+    /// compile flags, so re-running it lands on the same one test.
+    #[test]
+    fn a_repro_argv_names_the_stable_id_the_seed_and_the_flags() {
+        let argv = repro_argv(
+            "app/main.rue",
+            "app/t.rue::parses a port",
+            417,
+            &[
+                "--target".to_owned(),
+                "x86-64-linux".to_owned(),
+                "-O1".to_owned(),
+                "--preview".to_owned(),
+                "test_declarations".to_owned(),
+                "--timeout-ms".to_owned(),
+                "500".to_owned(),
+            ],
+        );
+        assert_eq!(
+            argv,
+            vec![
+                "rue",
+                "test",
+                "app/main.rue",
+                "--filter",
+                "app/t.rue::parses a port",
+                "--seed",
+                "417",
+                "--target",
+                "x86-64-linux",
+                "-O1",
+                "--preview",
+                "test_declarations",
+                "--timeout-ms",
+                "500",
+            ]
+        );
+    }
+
+    #[test]
+    fn the_last_stderr_line_is_the_message_a_trap_reports() {
+        assert_eq!(
+            last_message_line(b"working\nassertion failed\n"),
+            "assertion failed"
+        );
+        assert_eq!(last_message_line(b""), "");
+    }
+
+    /// A fresh seed is genuinely fresh: two runs in one process must not agree.
+    #[test]
+    fn fresh_seeds_differ_between_runs() {
+        assert_ne!(fresh_seed(), fresh_seed());
+    }
+
+    /// A wrong filter and a root with no tests are different mistakes.
+    #[test]
+    fn an_empty_selection_names_which_emptiness_it_was() {
+        assert!(empty_selection_reason(0).contains("declares no tests"));
+        assert!(empty_selection_reason(0).contains("@import"));
+        assert!(empty_selection_reason(7).contains("no tests matched the selection"));
+    }
+
+    /// The digit alone, so a consumer reads `"2"` rather than stripping `-O`.
+    #[test]
+    fn the_opt_level_field_is_the_bare_digit() {
+        assert_eq!(opt_level_digit(OptLevel::O0), "0");
+        assert_eq!(opt_level_digit(OptLevel::O3), "3");
+    }
+}

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -1,0 +1,429 @@
+//! The human renderer, as a consumer of the event stream (ADR-0083 §2).
+//!
+//! It reads the same `Event` values the NDJSON writer serializes, in the same
+//! process — never re-parsed text, and never a second computation of what to
+//! say. It is deliberately stateless: every number in the summary comes out of
+//! the `run_finished` event's own fields rather than a private tally, so a
+//! person and a tool cannot be shown two different counts of the same run.
+//!
+//! Verbosity is asymmetric on purpose. A failure prints whole — structure,
+//! location, captured output, the retained scratch directory, and the argv that
+//! reproduces it alone — and a pass prints nothing at all. No wall of green.
+
+use std::fmt::Write as _;
+
+use super::events::{CandidateSource, Capture, Event, TestFinished};
+use super::verdict::Verdict;
+
+/// Render one event for a person, or `None` when a person is owed nothing by
+/// it.
+pub(crate) fn render(event: &Event) -> Option<String> {
+    match event {
+        Event::RunStarted { .. } | Event::TestStarted { .. } => None,
+        Event::Test { id, .. } => Some(id.clone()),
+        Event::TestFinished(finished) => {
+            (!finished.verdict.is_pass()).then(|| render_failure(finished))
+        }
+        Event::RunFinished {
+            passed,
+            failed,
+            timeout,
+            crash,
+            wall_ms,
+            unimported_test_files,
+            test_candidates,
+        } => {
+            let mut out = String::new();
+            if let Some(files) = unimported_test_files {
+                for file in files {
+                    if file.parse_failed {
+                        let _ = writeln!(
+                            out,
+                            "warning: test file '{}' is outside the compiled closure and could not be parsed",
+                            file.path
+                        );
+                    } else {
+                        let plural = if file.tests == 1 { "" } else { "s" };
+                        let _ = writeln!(
+                            out,
+                            "warning: test file '{}' declares {} test{plural} but no module in the compiled closure imports it",
+                            file.path, file.tests
+                        );
+                    }
+                }
+            }
+            out.push_str(&summary(*passed, *failed, *timeout, *crash, *wall_ms));
+            if *test_candidates == CandidateSource::None {
+                out.push('\n');
+                out.push_str(
+                    "note: no --test-candidates inventory; unimported test files are not detected",
+                );
+            }
+            Some(out)
+        }
+    }
+}
+
+/// `41 passed, 1 failed (0.9s)`, naming the classes that occurred.
+///
+/// A zero count for timeouts or crashes is left out rather than printed as
+/// `0 timed out`: those are not ordinary outcomes, and a line that always
+/// mentions them trains a reader to stop seeing them.
+fn summary(passed: usize, failed: usize, timeout: usize, crash: usize, wall_ms: u64) -> String {
+    let mut parts = vec![format!("{passed} passed")];
+    if failed > 0 {
+        parts.push(format!("{failed} failed"));
+    }
+    if timeout > 0 {
+        parts.push(format!("{timeout} timed out"));
+    }
+    if crash > 0 {
+        parts.push(format!("{crash} crashed"));
+    }
+    format!("{} ({})", parts.join(", "), seconds(wall_ms))
+}
+
+/// A duration a person reads, to a tenth of a second.
+fn seconds(millis: u64) -> String {
+    format!("{}.{}s", millis / 1000, (millis % 1000) / 100)
+}
+
+/// One non-passing test, whole.
+fn render_failure(finished: &TestFinished) -> String {
+    let TestFinished {
+        id,
+        verdict,
+        failure,
+        stdout,
+        stderr,
+        scratch_dir,
+        repro,
+        ..
+    } = finished;
+    let banner = match verdict {
+        Verdict::Pass => "PASS",
+        Verdict::Fail(_) => "FAIL",
+        Verdict::Timeout => "TIMEOUT",
+        Verdict::Crash(_) => "CRASH",
+    };
+    let mut out = format!("{banner} {id}");
+    if let Some(failure) = failure {
+        out.push_str("\n  ");
+        out.push_str(&failure.kind);
+        if !failure.message.is_empty() {
+            let _ = write!(out, ": {}", failure.message);
+        }
+        if let Some(location) = &failure.location {
+            let _ = write!(
+                out,
+                "  ({}:{}:{})",
+                location.file, location.line, location.column
+            );
+        }
+        if let Some(payload) = &failure.payload {
+            if !payload.is_empty() {
+                let _ = write!(out, "\n  payload: {payload}");
+            }
+        }
+        if let Some(note) = &failure.runner_note {
+            let _ = write!(out, "\n  note: {note}");
+        }
+    }
+    push_capture(&mut out, "stdout", stdout);
+    push_capture(&mut out, "stderr", stderr);
+    if let Some(scratch) = scratch_dir {
+        let _ = write!(out, "\n  scratch: {scratch}");
+    }
+    let _ = write!(out, "\n  repro: {}", shell_command(repro));
+    out
+}
+
+/// A captured stream, indented under its failure, or nothing when it is empty.
+fn push_capture(out: &mut String, label: &str, capture: &Capture) {
+    if capture.bytes_total == 0 {
+        return;
+    }
+    let _ = write!(out, "\n  --- {label} ({} bytes) ---", capture.bytes_total);
+    for line in capture.encoded_data().lines() {
+        let _ = write!(out, "\n  {line}");
+    }
+    if capture.bytes_total > capture.retained.len() as u64 {
+        let _ = write!(
+            out,
+            "\n  ... {} further bytes were not retained",
+            capture.bytes_total - capture.retained.len() as u64
+        );
+    }
+}
+
+/// The repro argv as a line a person can paste.
+///
+/// Quoting is presentation only: the argv the event stream publishes is the
+/// authoritative form, because a test name may contain any byte a shell would
+/// argue about and a consumer should never have to unquote to re-execute.
+fn shell_command(argv: &[String]) -> String {
+    argv.iter()
+        .map(|argument| {
+            let safe = argument.bytes().all(|byte| {
+                matches!(byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'/' | b'=' | b':')
+            });
+            if argument.is_empty() || !safe {
+                format!("'{}'", argument.replace('\'', "'\\''"))
+            } else {
+                argument.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_mode::events::{FailureRecord, Location, UnimportedFile};
+    use crate::test_mode::verdict::FailureKind;
+
+    fn finished(verdict: Verdict, failure: Option<FailureRecord>) -> Event {
+        Event::TestFinished(Box::new(TestFinished {
+            id: "app/t.rue::parses a port".to_owned(),
+            verdict,
+            duration_ms: 3,
+            failure,
+            stdout: Capture::new(b"checking\n".to_vec(), 9, false),
+            stderr: Capture::new(b"assertion failed\n".to_vec(), 17, false),
+            scratch_dir: Some("/tmp/rue-test-417-2".to_owned()),
+            repro: vec![
+                "rue".to_owned(),
+                "test".to_owned(),
+                "app/main.rue".to_owned(),
+                "--filter".to_owned(),
+                "app/t.rue::parses a port".to_owned(),
+            ],
+        }))
+    }
+
+    fn run_finished(passed: usize, failed: usize, timeout: usize, crash: usize) -> Event {
+        Event::RunFinished {
+            passed,
+            failed,
+            timeout,
+            crash,
+            wall_ms: 900,
+            unimported_test_files: Some(Vec::new()),
+            test_candidates: CandidateSource::Declared,
+        }
+    }
+
+    /// No wall of green: a pass prints nothing.
+    #[test]
+    fn a_pass_prints_nothing() {
+        assert!(render(&finished(Verdict::Pass, None)).is_none());
+    }
+
+    /// The head events are machine bookkeeping; a person is shown failures and
+    /// a summary, not a running commentary.
+    #[test]
+    fn run_and_test_start_print_nothing() {
+        assert!(
+            render(&Event::TestStarted {
+                id: "app/t.rue::ok".to_owned()
+            })
+            .is_none()
+        );
+        assert!(
+            render(&Event::RunStarted {
+                root: "m.rue".to_owned(),
+                target: "x86-64-linux".to_owned(),
+                opt_level: "0".to_owned(),
+                seed: 1,
+                jobs: 1,
+                shard: None,
+                selected: 1,
+                total: 1,
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn a_failure_prints_structure_output_scratch_and_repro() {
+        let rendered = render(&finished(
+            Verdict::Fail(FailureKind::Assert),
+            Some(FailureRecord {
+                kind: "assert".to_owned(),
+                message: "assertion failed".to_owned(),
+                exit_code: Some(101),
+                location: Some(Location {
+                    file: "app/t.rue".to_owned(),
+                    line: 7,
+                    column: 5,
+                }),
+                ..FailureRecord::default()
+            }),
+        ))
+        .expect("a failure renders");
+        assert!(
+            rendered.starts_with("FAIL app/t.rue::parses a port"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("assert: assertion failed  (app/t.rue:7:5)"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("--- stdout (9 bytes) ---"), "{rendered}");
+        assert!(rendered.contains("--- stderr (17 bytes) ---"), "{rendered}");
+        assert!(
+            rendered.contains("scratch: /tmp/rue-test-417-2"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("repro: rue test app/main.rue --filter 'app/t.rue::parses a port'"),
+            "{rendered}"
+        );
+    }
+
+    /// A runner-level note is never dropped from the human surface either: it
+    /// is the only account of a failure report the runner could not read.
+    #[test]
+    fn a_runner_note_is_printed_with_its_failure() {
+        let rendered = render(&finished(
+            Verdict::Fail(FailureKind::Exit),
+            Some(FailureRecord {
+                kind: "exit".to_owned(),
+                message: "the test exited with status 101".to_owned(),
+                runner_note: Some("the test failure channel could not be read".to_owned()),
+                ..FailureRecord::default()
+            }),
+        ))
+        .expect("a failure renders");
+        assert!(
+            rendered.contains("note: the test failure channel could not be read"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn timeouts_and_crashes_carry_their_own_banners() {
+        let timeout = render(&finished(Verdict::Timeout, None)).expect("a timeout renders");
+        assert!(timeout.starts_with("TIMEOUT "), "{timeout}");
+        let crash = render(&finished(Verdict::Crash(11), None)).expect("a crash renders");
+        assert!(crash.starts_with("CRASH "), "{crash}");
+    }
+
+    /// Every number a person reads comes from the event, so the two surfaces
+    /// cannot report different counts for the same run.
+    #[test]
+    fn the_summary_names_only_the_classes_that_occurred() {
+        assert!(
+            render(&run_finished(2, 0, 0, 0))
+                .unwrap()
+                .starts_with("2 passed (0.9s)")
+        );
+        assert!(
+            render(&run_finished(2, 1, 0, 0))
+                .unwrap()
+                .starts_with("2 passed, 1 failed (0.9s)")
+        );
+        assert!(
+            render(&run_finished(2, 1, 1, 1))
+                .unwrap()
+                .starts_with("2 passed, 1 failed, 1 timed out, 1 crashed (0.9s)")
+        );
+    }
+
+    /// Without an inventory the runner cannot detect orphaned test files, and
+    /// says so rather than leaving silence to be read as "none found".
+    #[test]
+    fn a_run_without_a_candidate_inventory_says_so() {
+        let rendered = render(&Event::RunFinished {
+            passed: 0,
+            failed: 0,
+            timeout: 0,
+            crash: 0,
+            wall_ms: 100,
+            unimported_test_files: None,
+            test_candidates: CandidateSource::None,
+        })
+        .expect("a summary renders");
+        assert!(rendered.contains("0 passed (0.1s)"), "{rendered}");
+        assert!(
+            rendered.contains(
+                "note: no --test-candidates inventory; unimported test files are not detected"
+            ),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn orphaned_test_files_are_rendered_as_warnings() {
+        let rendered = render(&Event::RunFinished {
+            passed: 1,
+            failed: 0,
+            timeout: 0,
+            crash: 0,
+            wall_ms: 0,
+            unimported_test_files: Some(vec![
+                UnimportedFile {
+                    path: "app/orphan.rue".to_owned(),
+                    tests: 1,
+                    parse_failed: false,
+                },
+                UnimportedFile {
+                    path: "app/broken.rue".to_owned(),
+                    tests: 0,
+                    parse_failed: true,
+                },
+            ]),
+            test_candidates: CandidateSource::Declared,
+        })
+        .expect("a summary renders");
+        assert!(
+            rendered.contains("declares 1 test but no module in the compiled closure imports it"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("could not be parsed"), "{rendered}");
+        assert!(
+            !rendered.contains("note: no --test-candidates"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn a_listing_entry_renders_as_its_bare_identity() {
+        assert_eq!(
+            render(&Event::Test {
+                id: "app/t.rue::ok".to_owned(),
+                module: "app/t.rue".to_owned(),
+                name: "ok".to_owned(),
+                file: "app/t.rue".to_owned(),
+                line: 1,
+                column: 1,
+            }),
+            Some("app/t.rue::ok".to_owned())
+        );
+    }
+
+    #[test]
+    fn repro_quoting_survives_a_name_with_a_quote_in_it() {
+        assert_eq!(
+            shell_command(&["rue".to_owned(), "it's fine".to_owned()]),
+            "rue 'it'\\''s fine'"
+        );
+        assert_eq!(
+            shell_command(&["--seed".to_owned(), "417".to_owned()]),
+            "--seed 417"
+        );
+    }
+
+    #[test]
+    fn truncated_capture_says_how_much_was_dropped() {
+        let mut out = String::new();
+        push_capture(
+            &mut out,
+            "stdout",
+            &Capture::new(b"kept".to_vec(), 1000, false),
+        );
+        assert!(out.contains("--- stdout (1000 bytes) ---"), "{out}");
+        assert!(out.contains("996 further bytes were not retained"), "{out}");
+    }
+}

--- a/crates/rue/src/test_mode/selection.rs
+++ b/crates/rue/src/test_mode/selection.rs
@@ -1,0 +1,289 @@
+//! Turning an inventory into a run order (ADR-0083 §2).
+//!
+//! Three stages, always in this order: filter, then shard, then shuffle.
+//!
+//! The order is not arbitrary. Sharding a filtered set is what makes
+//! `--shard K/N` partition *the run*, so the N shards of a filtered run
+//! reconstitute exactly that run. Shuffling last is what keeps the shuffle from
+//! changing which tests a shard owns — order is a scheduling decision, and
+//! membership is not.
+//!
+//! Both the shard assignment and the shuffle are pure functions of values the
+//! event stream publishes (the stable ID, and the seed), so a reader of an
+//! event stream can reproduce the run order without asking the runner anything.
+
+use std::num::NonZeroU64;
+
+use rue_compiler::unstable::TestInventoryEntry;
+
+/// FNV-1a over the stable ID's bytes, which is what `--shard` partitions on.
+///
+/// A named, fully specified hash rather than `DefaultHasher`: `SipHash`'s
+/// `DefaultHasher` is explicitly not stable across Rust releases, and a shard
+/// assignment that moves when the compiler is rebuilt would silently drop tests
+/// from a sharded CI run. FNV-1a is two lines, has no dependency, and is
+/// documented in `docs/process/test-events.md` so an external scheduler can
+/// compute the same partition.
+pub(crate) fn shard_hash(id: &str) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET_BASIS;
+    for byte in id.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+/// SplitMix64: the shuffle's PRNG.
+///
+/// Chosen for the same reason as the shard hash — it is a documented, seven-line
+/// algorithm an external tool can reimplement from the schema doc, so `--seed`
+/// reproduces an order outside this binary and not merely inside it.
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    /// A uniform value in `0..bound`, by rejection so the modulo bias that
+    /// would quietly favour low indices never enters the shuffle.
+    ///
+    /// `bound` is a [`NonZeroU64`] rather than a checked `u64`: the only
+    /// unusable input is zero, and taking it in the type means the caller's
+    /// obligation is discharged where the value is built instead of re-checked
+    /// here on every draw.
+    fn below(&mut self, bound: NonZeroU64) -> u64 {
+        let bound = bound.get();
+        let zone = u64::MAX - (u64::MAX % bound);
+        loop {
+            let draw = self.next();
+            if draw < zone {
+                return draw % bound;
+            }
+        }
+    }
+}
+
+/// A `--shard K/N` selector: 1-based `index` of `count`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Shard {
+    pub(crate) index: u64,
+    pub(crate) count: u64,
+}
+
+impl Shard {
+    /// Parse the `K/N` spelling, rejecting the off-by-one traps directly.
+    pub(crate) fn parse(text: &str) -> Result<Self, String> {
+        let (index, count) = text
+            .split_once('/')
+            .ok_or_else(|| format!("--shard value '{text}' must be spelled K/N"))?;
+        let index = index
+            .parse::<u64>()
+            .map_err(|_| format!("--shard index '{index}' must be a positive integer"))?;
+        let count = count
+            .parse::<u64>()
+            .map_err(|_| format!("--shard count '{count}' must be a positive integer"))?;
+        if count == 0 {
+            return Err("--shard count must be at least 1".to_owned());
+        }
+        if index == 0 || index > count {
+            return Err(format!(
+                "--shard index {index} is out of range for {count} shards (indices are 1-based)"
+            ));
+        }
+        Ok(Self { index, count })
+    }
+
+    fn owns(self, id: &str) -> bool {
+        shard_hash(id) % self.count == self.index - 1
+    }
+}
+
+impl std::fmt::Display for Shard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.index, self.count)
+    }
+}
+
+/// Keep the entries at least one filter matches.
+///
+/// Matching is a substring test against the stable ID, and repeated filters
+/// union — the rule `docs/process/test-events.md` states normatively. Substring
+/// rather than glob or regex because the ID's own shape (`<module>::<name>`)
+/// already gives a user the two prefixes they reach for, and a filter language
+/// is a compatibility surface this ADR does not need.
+pub(crate) fn matches_filters(id: &str, filters: &[String]) -> bool {
+    filters.is_empty() || filters.iter().any(|filter| id.contains(filter.as_str()))
+}
+
+/// Filter, shard, and shuffle one inventory into the order tests will run in.
+pub(crate) fn plan(
+    entries: &[TestInventoryEntry],
+    filters: &[String],
+    shard: Option<Shard>,
+    seed: u64,
+) -> Vec<TestInventoryEntry> {
+    let mut selected: Vec<TestInventoryEntry> = entries
+        .iter()
+        .filter(|entry| matches_filters(&entry.id, filters))
+        .filter(|entry| shard.is_none_or(|shard| shard.owns(&entry.id)))
+        .cloned()
+        .collect();
+    shuffle(&mut selected, seed);
+    selected
+}
+
+/// Fisher-Yates over a SplitMix64 stream seeded by `--seed`.
+///
+/// The loop starts at index 1, so each draw's exclusive bound is at least two
+/// and the `NonZeroU64` below is built from a value the range itself
+/// guarantees.
+fn shuffle(entries: &mut [TestInventoryEntry], seed: u64) {
+    let mut rng = SplitMix64(seed);
+    for position in (1..entries.len()).rev() {
+        let bound = NonZeroU64::new(position as u64 + 1).expect("position >= 1, so bound >= 2");
+        entries.swap(position, rng.below(bound) as usize);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str) -> TestInventoryEntry {
+        TestInventoryEntry {
+            id: id.to_owned(),
+            module: "m.rue".to_owned(),
+            name: id.to_owned(),
+            file: "m.rue".to_owned(),
+            line: 1,
+            column: 1,
+            ordinal: 0,
+        }
+    }
+
+    fn inventory(count: usize) -> Vec<TestInventoryEntry> {
+        (0..count)
+            .map(|index| entry(&format!("app/m.rue::test {index}")))
+            .collect()
+    }
+
+    fn ids(entries: &[TestInventoryEntry]) -> Vec<String> {
+        entries.iter().map(|entry| entry.id.clone()).collect()
+    }
+
+    /// The hash is a published contract: an external scheduler computes the
+    /// same partition from the schema doc, so its values are pinned here.
+    #[test]
+    fn the_shard_hash_is_pinned_fnv_1a() {
+        assert_eq!(shard_hash(""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(shard_hash("a"), 0xaf63_dc4c_8601_ec8c);
+        assert_eq!(shard_hash("foobar"), 0x8594_4171_f739_67e8);
+    }
+
+    #[test]
+    fn no_filter_selects_everything() {
+        assert!(matches_filters("app/m.rue::anything", &[]));
+    }
+
+    #[test]
+    fn filters_match_substrings_of_the_stable_id_and_union() {
+        let filters = vec!["parse_port".to_owned(), "lexer".to_owned()];
+        assert!(matches_filters("app/p.rue::parse_port accepts", &filters));
+        assert!(matches_filters("app/l.rue::lexer eats spaces", &filters));
+        assert!(!matches_filters("app/x.rue::something else", &filters));
+        // The module half of the ID is matchable too, which is how a whole
+        // file's tests are selected without naming each one.
+        assert!(matches_filters(
+            "app/lexer_tests.rue::whatever",
+            &["app/lexer_tests.rue".to_owned()]
+        ));
+    }
+
+    /// A run's shards partition it: every test in exactly one shard.
+    #[test]
+    fn shards_partition_the_selection() {
+        let entries = inventory(40);
+        let mut union: Vec<String> = Vec::new();
+        for index in 1..=4 {
+            let shard = Shard { index, count: 4 };
+            union.extend(ids(&plan(&entries, &[], Some(shard), 0)));
+        }
+        union.sort();
+        let mut all = ids(&entries);
+        all.sort();
+        assert_eq!(union, all);
+    }
+
+    /// Sharding happens after filtering, so the shards of a filtered run
+    /// reconstitute that run and not the whole inventory.
+    #[test]
+    fn shards_partition_the_filtered_run_not_the_inventory() {
+        let entries = inventory(40);
+        let filters = vec!["test 1".to_owned()];
+        let mut union: Vec<String> = Vec::new();
+        for index in 1..=2 {
+            union.extend(ids(&plan(
+                &entries,
+                &filters,
+                Some(Shard { index, count: 2 }),
+                7,
+            )));
+        }
+        union.sort();
+        let mut expected = ids(&plan(&entries, &filters, None, 7));
+        expected.sort();
+        assert_eq!(union, expected);
+        assert!(expected.len() < 40, "the filter must actually narrow");
+    }
+
+    #[test]
+    fn a_seed_reproduces_an_order_and_different_seeds_generally_differ() {
+        let entries = inventory(24);
+        assert_eq!(
+            ids(&plan(&entries, &[], None, 417)),
+            ids(&plan(&entries, &[], None, 417))
+        );
+        assert_ne!(
+            ids(&plan(&entries, &[], None, 417)),
+            ids(&plan(&entries, &[], None, 418))
+        );
+    }
+
+    /// Shuffling never changes membership, only order.
+    #[test]
+    fn the_shuffle_is_a_permutation() {
+        let entries = inventory(31);
+        let mut shuffled = ids(&plan(&entries, &[], None, 99));
+        shuffled.sort();
+        let mut all = ids(&entries);
+        all.sort();
+        assert_eq!(shuffled, all);
+    }
+
+    #[test]
+    fn shard_parsing_rejects_the_off_by_one_traps() {
+        assert_eq!(Shard::parse("1/2").unwrap(), Shard { index: 1, count: 2 });
+        assert!(Shard::parse("0/2").unwrap_err().contains("1-based"));
+        assert!(Shard::parse("3/2").unwrap_err().contains("out of range"));
+        assert!(Shard::parse("1/0").unwrap_err().contains("at least 1"));
+        assert!(Shard::parse("1").unwrap_err().contains("K/N"));
+        assert!(
+            Shard::parse("a/2")
+                .unwrap_err()
+                .contains("positive integer")
+        );
+    }
+
+    #[test]
+    fn an_empty_or_single_selection_shuffles_without_panicking() {
+        assert!(plan(&[], &[], None, 5).is_empty());
+        assert_eq!(plan(&inventory(1), &[], None, 5).len(), 1);
+    }
+}

--- a/crates/rue/src/test_mode/verdict.rs
+++ b/crates/rue/src/test_mode/verdict.rs
@@ -1,0 +1,614 @@
+//! The verdict taxonomy and its one classification function (ADR-0083 §2).
+//!
+//! Every published verdict is decided here, from an observation of one finished
+//! test process: its exit status, its stderr, the frames it wrote on the §5.1
+//! failure channel, and whether the runner killed it. Keeping the decision in
+//! one total function is what makes the taxonomy testable without spawning
+//! anything, and what keeps the human renderer and the event stream from
+//! disagreeing — both read the same `Verdict`.
+//!
+//! Reserved and unproduced in this version, per ADR-0083 §6: the `skipped`
+//! verdict (settled OUT of the v1 taxonomy — filtering removes tests from the
+//! selection rather than reporting them, and `@skip` is deferred with directive
+//! grammar), the `compile_error` and `cached_pass` verdicts, and the `ice`
+//! failure kind. `docs/process/test-events.md` documents each as reserved.
+
+use std::fmt;
+
+/// The pinned stderr message of a runtime trap, and the `trap:<class>` name the
+/// event stream publishes for it.
+///
+/// The messages are the ones `crates/rue-runtime/src/error.rs` and
+/// `entry.rs` write byte-by-byte before `exit(101)`. They are a contract with
+/// the runtime, not a heuristic: `cases/rue_test.toml` runs real programs that
+/// take each of these paths through the real runtime, so a runtime that
+/// reworded one fails those cases rather than silently reclassifying a trap as
+/// a bare `exit`.
+const TRAP_MESSAGES: &[(&str, &str)] = &[
+    // `__rue_panic_no_msg`. The message-carrying `__rue_panic` writes
+    // `panic: <msg>`, which is matched by prefix below.
+    ("panic", "panic"),
+    ("error: division by zero", "div_by_zero"),
+    ("error: integer overflow", "overflow"),
+    ("error: integer cast overflow", "intcast_overflow"),
+    ("error: index out of bounds", "bounds_check"),
+    ("error: invalid UTF-8", "invalid_utf8"),
+    ("stack overflow", "stack_overflow"),
+];
+
+/// `__rue_assert_failed`'s pinned message.
+const ASSERT_MESSAGE: &str = "assertion failed";
+
+/// `__rue_panic`'s prefix, ahead of the user's message text.
+const PANIC_PREFIX: &str = "panic: ";
+
+/// The runtime's abort status. Every trap, `@panic`, and failed `@assert`
+/// exits with it (ADR-0083 Context: the failure model is abort-only).
+const RUNTIME_ERROR_EXIT_CODE: i32 = rue_test_runner::RUNTIME_ERROR_EXIT_CODE;
+
+/// Why a test failed.
+///
+/// `Reported` carries a kind a failure frame supplied verbatim. ADR-0083 §5.1
+/// makes the channel an open protocol — user assertion libraries emit the same
+/// records as the built-ins — so a kind the runner does not recognize is
+/// published rather than flattened into `exit`. The built-in producers use
+/// `unhandled_error`, which is normalized to its own variant on construction so
+/// there is exactly one spelling of it in the taxonomy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FailureKind {
+    /// Exit 0 with no completion record: the body called `std.exit(0)` before
+    /// reaching the dispatcher's epilogue (ADR-0083 §3).
+    Incomplete,
+    /// A failed `@assert(cond)`.
+    Assert,
+    /// A runtime trap, named by its class.
+    Trap(&'static str),
+    /// A `?` in a test body whose failure arm reported through the channel.
+    UnhandledError,
+    /// Any other nonzero exit.
+    Exit,
+    /// A capture budget was exhausted and the process group was killed.
+    OutputOverflow,
+    /// A kind a failure frame supplied verbatim (ADR-0083 §5.1).
+    Reported(String),
+}
+
+impl FailureKind {
+    /// Build the kind a failure frame named, normalizing the built-in spelling.
+    pub(crate) fn reported(kind: &str) -> Self {
+        match kind {
+            "unhandled_error" => Self::UnhandledError,
+            "assert" => Self::Assert,
+            other => Self::Reported(other.to_owned()),
+        }
+    }
+}
+
+impl fmt::Display for FailureKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Incomplete => f.write_str("incomplete"),
+            Self::Assert => f.write_str("assert"),
+            Self::Trap(class) => write!(f, "trap:{class}"),
+            Self::UnhandledError => f.write_str("unhandled_error"),
+            Self::Exit => f.write_str("exit"),
+            Self::OutputOverflow => f.write_str("output_overflow"),
+            Self::Reported(kind) => f.write_str(kind),
+        }
+    }
+}
+
+/// What one test process produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Verdict {
+    Pass,
+    Fail(FailureKind),
+    /// The per-test wall-clock budget expired and the process group was killed.
+    Timeout,
+    /// Killed by a signal, SIGPIPE included.
+    Crash(i32),
+}
+
+impl Verdict {
+    /// The `verdict` field's published value.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail(_) => "fail",
+            Self::Timeout => "timeout",
+            Self::Crash(_) => "crash",
+        }
+    }
+
+    pub(crate) fn is_pass(&self) -> bool {
+        matches!(self, Self::Pass)
+    }
+}
+
+/// One frame read from the failure channel.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct FailureFrame {
+    pub(crate) kind: String,
+    pub(crate) message: String,
+    pub(crate) file: String,
+    pub(crate) line: u32,
+    pub(crate) column: u32,
+    pub(crate) payload: String,
+}
+
+/// What the channel carried, as the classifier needs it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ChannelFrames {
+    /// The dispatcher's terminal completion record was observed.
+    pub(crate) complete: bool,
+    /// The first well-formed `failure` frame. Later ones are additional
+    /// reports from the same aborting process; the first is the one that
+    /// caused the abort.
+    pub(crate) failure: Option<FailureFrame>,
+    /// A line on the channel that was not a well-formed frame, with the reason.
+    ///
+    /// Never discarded: a channel the runner cannot read is a runner defect,
+    /// and swallowing it would turn a broken failure report into a bare exit.
+    pub(crate) malformed: Option<String>,
+}
+
+/// Parse the bytes drained from the failure channel.
+///
+/// The channel is newline-delimited JSON. A line that is not valid JSON, or
+/// carries no known `record`, is recorded as malformed rather than skipped.
+pub(crate) fn parse_channel(bytes: &[u8]) -> ChannelFrames {
+    let mut frames = ChannelFrames::default();
+    for line in bytes.split(|byte| *byte == b'\n') {
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        let text = match std::str::from_utf8(line) {
+            Ok(text) => text,
+            Err(_) => {
+                note_malformed(&mut frames, "a channel line was not valid UTF-8");
+                continue;
+            }
+        };
+        let value: serde_json::Value = match serde_json::from_str(text) {
+            Ok(value) => value,
+            Err(error) => {
+                note_malformed(
+                    &mut frames,
+                    &format!("a channel line was not JSON: {error}"),
+                );
+                continue;
+            }
+        };
+        match value.get("record").and_then(serde_json::Value::as_str) {
+            Some("complete") => frames.complete = true,
+            Some("failure") => {
+                if frames.failure.is_none() {
+                    frames.failure = Some(FailureFrame {
+                        kind: string_field(&value, "kind"),
+                        message: string_field(&value, "message"),
+                        file: value
+                            .get("location")
+                            .map(|location| string_field(location, "file"))
+                            .unwrap_or_default(),
+                        line: location_number(&value, "line"),
+                        column: location_number(&value, "column"),
+                        payload: string_field(&value, "payload"),
+                    });
+                }
+            }
+            Some(other) => note_malformed(
+                &mut frames,
+                &format!("a channel line named an unknown record '{other}'"),
+            ),
+            None => note_malformed(&mut frames, "a channel line carried no 'record' field"),
+        }
+    }
+    frames
+}
+
+fn note_malformed(frames: &mut ChannelFrames, reason: &str) {
+    if frames.malformed.is_none() {
+        frames.malformed = Some(reason.to_owned());
+    }
+}
+
+fn string_field(value: &serde_json::Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_owned()
+}
+
+fn location_number(value: &serde_json::Value, key: &str) -> u32 {
+    value
+        .get("location")
+        .and_then(|location| location.get(key))
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|number| u32::try_from(number).ok())
+        .unwrap_or(0)
+}
+
+/// How the runner's own supervision ended a test, before its exit status is
+/// consulted at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Supervision {
+    /// The process exited on its own.
+    Exited,
+    /// The wall-clock budget expired; the group was killed.
+    TimedOut,
+    /// A capture budget was exhausted; the group was killed.
+    OutputOverflow,
+}
+
+/// Everything the classifier reads about one finished test process.
+#[derive(Debug, Clone)]
+pub(crate) struct Observation<'a> {
+    pub(crate) supervision: Supervision,
+    /// `Ok(code)` for an ordinary exit, `Err(signal)` for a signal death.
+    pub(crate) status: Result<i32, i32>,
+    pub(crate) stderr: &'a [u8],
+    pub(crate) frames: &'a ChannelFrames,
+}
+
+/// The verdict, and the runner's own note when it has one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Classification {
+    pub(crate) verdict: Verdict,
+    /// A runner-level explanation attached to the failure record. Present when
+    /// the runner itself could not trust what it read.
+    pub(crate) runner_note: Option<String>,
+}
+
+/// Decide one test's verdict.
+///
+/// The order of the arms is the taxonomy's precedence and is deliberate.
+/// Supervision outcomes come first because the runner's own kill is what
+/// produced the signal death that would otherwise read as a crash. A malformed
+/// channel is next: an unreadable failure report must never be reported as a
+/// pass or as a bare exit with no explanation. Only then is the process's own
+/// account of itself consulted — a failure frame ahead of the exit status,
+/// since the frame carries structure the status cannot.
+pub(crate) fn classify(observation: Observation<'_>) -> Classification {
+    let frames = observation.frames;
+    match observation.supervision {
+        Supervision::TimedOut => {
+            return Classification {
+                verdict: Verdict::Timeout,
+                runner_note: None,
+            };
+        }
+        Supervision::OutputOverflow => {
+            return Classification {
+                verdict: Verdict::Fail(FailureKind::OutputOverflow),
+                runner_note: None,
+            };
+        }
+        Supervision::Exited => {}
+    }
+
+    if let Some(reason) = &frames.malformed {
+        return Classification {
+            verdict: Verdict::Fail(FailureKind::Exit),
+            runner_note: Some(format!(
+                "the test failure channel could not be read: {reason}"
+            )),
+        };
+    }
+
+    if let Some(failure) = &frames.failure {
+        return Classification {
+            verdict: Verdict::Fail(FailureKind::reported(&failure.kind)),
+            runner_note: None,
+        };
+    }
+
+    let code = match observation.status {
+        Ok(code) => code,
+        Err(signal) => {
+            return Classification {
+                verdict: Verdict::Crash(signal),
+                runner_note: None,
+            };
+        }
+    };
+
+    if code == 0 {
+        return if frames.complete {
+            Classification {
+                verdict: Verdict::Pass,
+                runner_note: None,
+            }
+        } else {
+            Classification {
+                verdict: Verdict::Fail(FailureKind::Incomplete),
+                runner_note: None,
+            }
+        };
+    }
+
+    if code == RUNTIME_ERROR_EXIT_CODE {
+        if let Some(kind) = classify_runtime_message(observation.stderr) {
+            return Classification {
+                verdict: Verdict::Fail(kind),
+                runner_note: None,
+            };
+        }
+    }
+
+    Classification {
+        verdict: Verdict::Fail(FailureKind::Exit),
+        runner_note: None,
+    }
+}
+
+/// Recognize a pinned runtime abort message on a trapping process's stderr.
+///
+/// The last non-empty line is what is matched, not the whole stream: a test
+/// that printed diagnostics of its own before tripping an assertion still
+/// trapped, and classifying it as a bare `exit` because it was chatty would
+/// lose the one piece of structure the abort-only runtime gives us. The match
+/// against that line is exact (or, for `@panic("msg")`, exact on the pinned
+/// prefix), so a reworded runtime message is a failed CLI case rather than a
+/// silent reclassification.
+fn classify_runtime_message(stderr: &[u8]) -> Option<FailureKind> {
+    let text = String::from_utf8_lossy(stderr);
+    let last = text.lines().rev().find(|line| !line.trim().is_empty())?;
+    let last = last.trim_end();
+    if last == ASSERT_MESSAGE {
+        return Some(FailureKind::Assert);
+    }
+    if last.starts_with(PANIC_PREFIX) {
+        return Some(FailureKind::Trap("panic"));
+    }
+    TRAP_MESSAGES
+        .iter()
+        .find(|(message, _)| *message == last)
+        .map(|(_, class)| FailureKind::Trap(class))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn observe(status: Result<i32, i32>, stderr: &str, frames: &ChannelFrames) -> Classification {
+        classify(Observation {
+            supervision: Supervision::Exited,
+            status,
+            stderr: stderr.as_bytes(),
+            frames,
+        })
+    }
+
+    fn complete() -> ChannelFrames {
+        ChannelFrames {
+            complete: true,
+            ..ChannelFrames::default()
+        }
+    }
+
+    #[test]
+    fn exit_zero_with_a_completion_record_passes() {
+        assert_eq!(observe(Ok(0), "", &complete()).verdict, Verdict::Pass);
+    }
+
+    /// The `std.exit(0)`-before-the-epilogue case: a clean exit that never
+    /// reached the dispatcher's completion record is false evidence, not a
+    /// pass (ADR-0083 §3).
+    #[test]
+    fn exit_zero_without_a_completion_record_is_incomplete() {
+        assert_eq!(
+            observe(Ok(0), "", &ChannelFrames::default()).verdict,
+            Verdict::Fail(FailureKind::Incomplete)
+        );
+    }
+
+    #[test]
+    fn a_failed_assert_is_classified_from_its_pinned_message() {
+        assert_eq!(
+            observe(Ok(101), "assertion failed\n", &ChannelFrames::default()).verdict,
+            Verdict::Fail(FailureKind::Assert)
+        );
+    }
+
+    #[test]
+    fn every_pinned_trap_message_names_its_class() {
+        let expected = [
+            ("panic\n", "panic"),
+            ("panic: boom\n", "panic"),
+            ("error: division by zero\n", "div_by_zero"),
+            ("error: integer overflow\n", "overflow"),
+            ("error: integer cast overflow\n", "intcast_overflow"),
+            ("error: index out of bounds\n", "bounds_check"),
+            ("error: invalid UTF-8\n", "invalid_utf8"),
+            ("stack overflow\n", "stack_overflow"),
+        ];
+        for (stderr, class) in expected {
+            assert_eq!(
+                observe(Ok(101), stderr, &ChannelFrames::default()).verdict,
+                Verdict::Fail(FailureKind::Trap(class)),
+                "stderr {stderr:?}"
+            );
+        }
+    }
+
+    /// A test that printed before it trapped still trapped.
+    #[test]
+    fn output_before_a_trap_does_not_hide_its_class() {
+        assert_eq!(
+            observe(
+                Ok(101),
+                "checking the parser\nassertion failed\n",
+                &ChannelFrames::default()
+            )
+            .verdict,
+            Verdict::Fail(FailureKind::Assert)
+        );
+    }
+
+    /// Exit 101 is not enough on its own: an unrecognized message is an
+    /// ordinary nonzero exit, never a fabricated trap class.
+    #[test]
+    fn an_unrecognized_message_at_the_runtime_status_is_an_exit() {
+        assert_eq!(
+            observe(
+                Ok(101),
+                "something else entirely\n",
+                &ChannelFrames::default()
+            )
+            .verdict,
+            Verdict::Fail(FailureKind::Exit)
+        );
+    }
+
+    #[test]
+    fn any_other_nonzero_exit_is_an_exit_failure() {
+        assert_eq!(
+            observe(Ok(3), "", &ChannelFrames::default()).verdict,
+            Verdict::Fail(FailureKind::Exit)
+        );
+    }
+
+    #[test]
+    fn a_signal_death_is_a_crash_carrying_its_signal() {
+        assert_eq!(
+            observe(Err(13), "", &ChannelFrames::default()).verdict,
+            Verdict::Crash(13)
+        );
+    }
+
+    /// A failure frame outranks the exit status: it carries structure the
+    /// status cannot, and the abort path behind it is the same 101.
+    #[test]
+    fn a_failure_frame_outranks_the_exit_classification() {
+        let frames = ChannelFrames {
+            failure: Some(FailureFrame {
+                kind: "unhandled_error".to_owned(),
+                message: "Err(NotFound)".to_owned(),
+                file: "app/tests.rue".to_owned(),
+                line: 7,
+                column: 5,
+                payload: String::new(),
+            }),
+            ..ChannelFrames::default()
+        };
+        assert_eq!(
+            observe(Ok(101), "panic: unhandled error\n", &frames).verdict,
+            Verdict::Fail(FailureKind::UnhandledError)
+        );
+    }
+
+    /// ADR-0083 §5.1 makes the channel an open protocol, so a kind the runner
+    /// does not know is published verbatim rather than flattened.
+    #[test]
+    fn a_library_supplied_kind_is_published_verbatim() {
+        let frames = ChannelFrames {
+            failure: Some(FailureFrame {
+                kind: "expect_eq".to_owned(),
+                ..FailureFrame::default()
+            }),
+            ..ChannelFrames::default()
+        };
+        let verdict = observe(Ok(101), "", &frames).verdict;
+        assert_eq!(
+            verdict,
+            Verdict::Fail(FailureKind::Reported("expect_eq".to_owned()))
+        );
+        let Verdict::Fail(kind) = verdict else {
+            unreachable!()
+        };
+        assert_eq!(kind.to_string(), "expect_eq");
+    }
+
+    #[test]
+    fn supervision_outcomes_precede_the_exit_status() {
+        let timed_out = classify(Observation {
+            supervision: Supervision::TimedOut,
+            status: Err(9),
+            stderr: b"",
+            frames: &ChannelFrames::default(),
+        });
+        assert_eq!(timed_out.verdict, Verdict::Timeout);
+
+        let overflowed = classify(Observation {
+            supervision: Supervision::OutputOverflow,
+            status: Err(9),
+            stderr: b"",
+            frames: &ChannelFrames::default(),
+        });
+        assert_eq!(
+            overflowed.verdict,
+            Verdict::Fail(FailureKind::OutputOverflow)
+        );
+    }
+
+    /// A channel the runner could not read is never silently ignored — least
+    /// of all when the process otherwise looks like a pass.
+    #[test]
+    fn a_malformed_frame_fails_the_test_with_a_runner_note() {
+        let frames = parse_channel(b"{\"record\":\"complete\"\n");
+        assert!(frames.malformed.is_some());
+        let classification = observe(Ok(0), "", &frames);
+        assert_eq!(classification.verdict, Verdict::Fail(FailureKind::Exit));
+        let note = classification.runner_note.expect("a note is required");
+        assert!(note.contains("failure channel"), "{note}");
+    }
+
+    #[test]
+    fn a_line_with_no_record_field_is_malformed() {
+        let frames = parse_channel(b"{\"schema\":\"1.0\"}\n");
+        assert!(
+            frames
+                .malformed
+                .as_deref()
+                .is_some_and(|note| note.contains("no 'record' field")),
+            "{frames:?}"
+        );
+    }
+
+    #[test]
+    fn frames_parse_completion_and_failure_records() {
+        let bytes = concat!(
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"unhandled_error\",",
+            "\"message\":\"Err(NotFound)\",\"location\":{\"file\":\"a.rue\",\"line\":3,",
+            "\"column\":9},\"payload\":\"\"}\n",
+            "{\"record\":\"complete\",\"schema\":\"1.0\"}\n",
+        );
+        let frames = parse_channel(bytes.as_bytes());
+        assert!(frames.complete);
+        assert!(frames.malformed.is_none());
+        let failure = frames.failure.expect("a failure frame");
+        assert_eq!(failure.kind, "unhandled_error");
+        assert_eq!(failure.message, "Err(NotFound)");
+        assert_eq!(failure.file, "a.rue");
+        assert_eq!(failure.line, 3);
+        assert_eq!(failure.column, 9);
+    }
+
+    /// A blank channel is the ordinary shape for a test image run with no
+    /// descriptor 3 at all, and must not be mistaken for a broken one.
+    #[test]
+    fn an_empty_channel_is_not_malformed() {
+        let frames = parse_channel(b"");
+        assert_eq!(frames, ChannelFrames::default());
+        assert_eq!(parse_channel(b"\n\n"), ChannelFrames::default());
+    }
+
+    #[test]
+    fn failure_kinds_render_their_published_spelling() {
+        assert_eq!(FailureKind::Incomplete.to_string(), "incomplete");
+        assert_eq!(FailureKind::Assert.to_string(), "assert");
+        assert_eq!(FailureKind::Trap("panic").to_string(), "trap:panic");
+        assert_eq!(FailureKind::UnhandledError.to_string(), "unhandled_error");
+        assert_eq!(FailureKind::Exit.to_string(), "exit");
+        assert_eq!(FailureKind::OutputOverflow.to_string(), "output_overflow");
+    }
+
+    #[test]
+    fn verdicts_render_their_published_spelling() {
+        assert_eq!(Verdict::Pass.as_str(), "pass");
+        assert_eq!(Verdict::Fail(FailureKind::Exit).as_str(), "fail");
+        assert_eq!(Verdict::Timeout.as_str(), "timeout");
+        assert_eq!(Verdict::Crash(11).as_str(), "crash");
+    }
+}

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -645,9 +645,12 @@ companion project "rue test follow-ups" (§6).
       `--test-candidates` and its bounded candidate-acquisition step (§1);
       `--list`, `--filter` (run-set semantics, as ruled), `--jobs`,
       `--shard`, `--timeout-ms`, `--seed` (shuffle), exit codes; NDJSON
-      event stream v1.0 with schema doc (a new `test-events.md` under
-      `docs/process/`) covering encoding, budgets, payload asymmetry, and
-      the `capability_summary` unavailable state (§2); the test-body `?`
+      event stream v1.0 with schema doc — landed as
+      `docs/process/test-events.md` (RUE-1920), covering the exec contract,
+      encoding, budgets, payload asymmetry, the verdict taxonomy and its
+      reserved values, the `--filter` rule, the shard hash and shuffle
+      PRNG, and the `capability_summary` unavailable state (§2); the
+      test-body `?`
       rule whole — legality and failure-arm lowering together (§1); the
       dispatcher completion record and its `incomplete` failure kind (§3);
       the failure-channel contract with reserved promotion and
@@ -807,19 +810,27 @@ site.
   from the reserved intrinsic bucket (4.13:5b) to normative, and decide
   whether assertion failure keeps exit 101 (recommended; distinguished by
   pinned message) or gets a distinct code.
-- **Exit-code contract** (§2): the 0/1/2/3 proposal, in particular
-  empty-selection-as-error. How a future per-test `compile_error` verdict
-  maps onto exit codes is deferred with that verdict (§6, RUE-1622), but
-  agents will branch on these codes, so they need sign-off before Phase 2
-  ships.
-- **The `skipped` verdict has no producing mechanism**: `@skip` is
-  deferred with directive-grammar work, and filtering removes tests from
-  the selection rather than reporting them. Name a v1 producer (platform
-  scoping is the natural candidate) or reserve `skipped` out of the v1
-  taxonomy — an unproducible verdict in a published enum is a consumer
-  trap.
-- **The `scripts/rue test` homonym**: rename the wrapper subcommand (e.g.
-  `scripts/rue suite`) or accept the distinction and fix docs.
+- **Exit-code contract** (§2): **settled in Phase 2c (RUE-1920)** as the
+  0/1/2/3 proposal, empty-selection-as-error included, and published in
+  `docs/process/test-events.md`. Everything that stops a `rue test` run from
+  happening — a compile failure, a failing image link, an ICE, a bad flag
+  combination — is `2`, so an agent branching on the status never has to
+  also parse stderr to tell those apart. How a future per-test
+  `compile_error` verdict maps onto exit codes is deferred with that verdict
+  (§6, RUE-1622).
+- **The `skipped` verdict has no producing mechanism**: **settled in Phase 2c
+  (RUE-1920)** by reserving `skipped` **out** of the v1 taxonomy. `@skip` is
+  deferred with directive-grammar work, and filtering removes tests from the
+  selection rather than reporting them, so v1 has no producer — and an
+  unproducible verdict in a published enum is a consumer trap. It is
+  documented as reserved in the schema doc and emitted by nothing; naming a
+  producer (platform scoping is the natural candidate) is an additive minor.
+- **The `scripts/rue test` homonym**: the rename remains open. Phase 2c took
+  the interim half of the choice — the quickstart entry now says the wrapper
+  is the maintainers' compiler-suite runner and points at
+  `docs/process/test-events.md` for the language's own subcommand — so the
+  rename (e.g. `scripts/rue suite`) is a maintainer call that no longer
+  blocks anything.
 - **Naming**: `test_declarations` preview flag; `--test-candidates`; a new
   `test-events.md` under `docs/process/` as the schema doc home.
 

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -17,6 +17,12 @@ The flag is orthogonal to `--log-format` (see [logging.md](logging.md)):
 `--error-format` controls *program diagnostics*. Setting one does not change
 the other.
 
+It is orthogonal to the third machine surface as well.
+[test-events.md](test-events.md) owns the `rue test` event stream, which is
+NDJSON on **stdout**; program diagnostics keep this document's framing on
+stderr in test mode exactly as in a build, so a consumer can read one stream
+for each.
+
 ## Stream and framing
 
 Under `--error-format json`:

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -1,0 +1,444 @@
+# The `rue test` Event Stream
+
+`rue test <root.rue>` builds one test image for the root module's `@import`
+closure and runs one process per selected test. Its **primary output is a
+versioned NDJSON event stream on stdout**; the human rendering is a consumer of
+that same stream in the same process, never a separate computation.
+
+This document is the schema's normative description (ADR-0083 §2). It is the
+companion of [diagnostics.md](diagnostics.md), which owns the *other* machine
+surface: `--error-format json` compiler diagnostics on stderr. The two are
+orthogonal and stay on their own streams.
+
+```bash
+rue test app/main.rue --preview test_declarations
+rue test app/main.rue --preview test_declarations --format json
+rue test app/main.rue --preview test_declarations --list --format json
+```
+
+`--preview test_declarations` is required exactly as it is for a build. `rue
+test` does not enable it implicitly: any request whose closure contains test
+items — ordinary executable builds included — needs the flag to compile at all,
+so auto-enabling it here would leave those same files failing ordinary builds
+while making `rue test` the first flag to bypass ADR-0005's explicit opt-in.
+
+## Streams
+
+- **stdout is the runner's surface.** Every line is one event, so a consumer
+  can read the whole of stdout as the stream. Under `--format human` the same
+  events are rendered as text on stdout instead.
+- **stderr is the compiler's surface**, byte-for-byte as
+  [diagnostics.md](diagnostics.md) pins it, plus the runner's own warnings
+  (unimported test files) and its one-line reason for a nonzero exit.
+- **No event is emitted before the test image exists.** A compile failure is
+  diagnostics on stderr, an empty event stream, and exit `2` — never a
+  `run_started` for a run that never began.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Every selected test passed. |
+| `1` | At least one selected test failed, timed out, or crashed. |
+| `2` | The run could not be performed: a compile failure, a failing image link, an ICE, a bad flag combination, or a runner error. |
+| `3` | The selection was empty. |
+
+`3` is a distinct outcome rather than a vacuous success because an empty
+selection is how a typo becomes false evidence. A run whose selection is empty
+still emits `run_started` and `run_finished` (with zero counts) so a machine
+consumer sees a complete stream, and names on stderr which emptiness it was —
+`error: no tests matched the selection` when the closure has tests that nothing
+selected, or `error: the compiled closure declares no tests; a test-only file
+must be reached by an @import` when it has none at all. Those are different
+mistakes with different fixes. `--list` reports the same two on stderr and emits
+no records.
+
+## The exec contract
+
+The image's interface is public by commitment (ADR-0083 §5.4): an alternative
+runner may enumerate with `--list --format json` and execute through exactly
+this contract. See [runtime-abi.md](../runtime-abi.md) for the runtime helpers
+that implement its channel half.
+
+| Aspect | Value |
+|--------|-------|
+| `argv` | `["rue-test", "<ordinal as 16 lowercase hex digits>"]` |
+| `envp` | exactly `["RUE_TEST=1"]` |
+| working directory | a fresh private scratch directory |
+| stdin | `/dev/null` (immediate EOF) |
+| descriptor 3 | the write end of the structured failure channel |
+| process group | its own; the runner kills the group on expiry and again after exit |
+
+These are pinned values, not conveniences. The loader lays the real `argv` and
+`envp` strings on the initial process stack before any Rue code runs, so their
+sizes are stack consumption no later pointer swap can undo; pinning them is what
+will make a keyed configuration's stack consumption deterministic for the
+deferred verdict cache (ADR-0083 §6). The dispatcher consumes the selector and
+then narrows the visible argument count to one, so a test observes
+`argv[0] == "rue-test"` and never the selector it was dispatched by.
+
+A malformed selector is the image's own error: it writes
+`rue-test: expected one 16-hex-digit test selector` to stderr and exits `2`.
+
+### The failure channel
+
+Descriptor 3 carries newline-delimited JSON, drained by the runner under its own
+budget. Two records exist in this version:
+
+```json
+{"record":"complete","schema":"1.0"}
+{"record":"failure","schema":"1.0","kind":"...","message":"...","location":{"file":"...","line":0,"column":0},"payload":"..."}
+```
+
+The `complete` record is written by the dispatcher's epilogue alone, after the
+selected test body returns normally. `failure` records are written by assertion
+sugar and by the test-body `?` failure arm before aborting; `kind` is an open
+field, so a user assertion library's own kind is published verbatim rather than
+flattened (ADR-0083 §5.1). `payload` is the versioned extension point structured
+assertion payloads arrive through (Phase 2.5).
+
+Writes are best-effort by design: an image run by hand has no descriptor 3, and
+`EBADF` there is expected rather than exceptional. The channel is **not a
+security boundary** — it prevents accidental collision with a test's own stdout,
+which is all its consumers are promised.
+
+Reserved by ADR-0083 §5.1 and §5.2, and produced by nothing in this version:
+`promotion` payloads (a machine-applicable suggested fix, for a future
+`rue test --accept`) and `sub_result` records (named child results attributed as
+`<test-id>/<sub-name>`).
+
+## Stable test identity
+
+A test's stable ID is `<module>::<name>`.
+
+- `<module>` is the module's published identity: project-root-relative for a
+  user module. A standard-library module reports its requested path rather than
+  the internal trusted spelling.
+- `<name>` is the test's string literal verbatim. It may contain spaces and
+  punctuation and is never mangled.
+
+The inventory is sorted by byte order over the whole ID — deliberately not
+declaration order, module order, or symbol order, because only a property of the
+source text keeps a filtered run's ordinals equal to a full run's. A test's
+`ordinal` is its index in that order, and equivalently the selector the image
+dispatches it on.
+
+## Events
+
+Every event is one JSON object on one line. **Object keys are serialized in
+alphabetical order**; consumers must not depend on key order, but the ordering
+is fixed so two runs over the same inputs produce byte-identical output — the
+same determinism stance [diagnostics.md](diagnostics.md) takes.
+
+Under `--jobs N` with `N > 1`, whole lines from concurrent tests interleave. The
+schema promises the content of each line, not an order across concurrent tests;
+`test_started` always precedes its own `test_finished`.
+
+### `run_started`
+
+The head event, and the only one carrying the schema version for a run.
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `event` | `"run_started"` | |
+| `schema` | string | Schema version, `"1.0"`. |
+| `root` | string | The root source exactly as the command line spelled it. |
+| `target` | string | The Rue target the image was built for. |
+| `opt_level` | string | The optimization level's digit: `"0"`–`"3"`. |
+| `seed` | integer | The run's shuffle seed (see `--seed`). |
+| `jobs` | integer | Concurrent test processes. |
+| `shard` | string | `"K/N"`. **Absent** when `--shard` was not given. |
+| `plan` | object | `{"selected": integer, "total": integer}` — tests selected, and tests in the closure. |
+
+### `test_started`
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `event` | `"test_started"` | |
+| `id` | string | The stable test ID. |
+
+### `test_finished`
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `event` | `"test_finished"` | |
+| `id` | string | The stable test ID. |
+| `verdict` | string | `"pass"`, `"fail"`, `"timeout"`, or `"crash"`. |
+| `duration_ms` | integer | Wall time from spawn to reap. |
+| `capability_summary` | object | `{"status":"unavailable"}` — see below. |
+| `failure` | object | The failure record. **Absent** on a pass. |
+| `stdout` | object | Capture record. |
+| `stderr` | object | Capture record. |
+| `scratch_dir` | string | The retained scratch directory. **Absent** on a pass, whose directory is deleted. |
+| `repro` | array of strings | The argv that reproduces this one test. Always present. |
+
+`capability_summary` is present from v1.0 with an explicit `unavailable` status
+rather than omitted. The MVP verifies no hermeticity claim for any test and says
+so in-band, so the deferred capability ADR (ADR-0083 §6) can populate a field
+consumers already handle instead of adding one.
+
+#### The failure record
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `kind` | string | See the taxonomy below. |
+| `message` | string | The pinned runtime message, the frame's message, or the runner's description. |
+| `exit_code` | integer | The process's exit status. **Absent** when it did not exit normally. |
+| `signal` | integer | The signal that killed it. **Absent** otherwise. |
+| `location` | object | `{"file","line","column"}` — the test declaration's header, unless a failure frame carried its own site. |
+| `payload` | string | The channel's open payload. **Absent** when empty. |
+| `runner_note` | string | The runner's own explanation. **Absent** unless the runner could not trust what it read. |
+
+`timeout` and `crash` verdicts also carry a failure record, with kind `timeout`
+and `signal` respectively.
+
+#### Capture records
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `encoding` | `"utf8"` \| `"base64"` | How `data` is encoded. |
+| `bytes_total` | integer | Every byte the process wrote to this stream — not the size of what was kept. |
+| `data` | string | The retained prefix. Present on a **non-pass**. |
+| `digest` | string | `sha256:<hex>` over the retained bytes. Present on a **pass**. |
+
+Rue strings are arbitrary byte sequences written raw, so capture is lossless
+within its retained window rather than lossy-UTF-8: `encoding` is `utf8` when
+the retained bytes are valid UTF-8 and `base64` (standard alphabet, padded)
+otherwise.
+
+The asymmetry is deliberate (ADR-0083 §2): a failing test's output is what a
+reader needs, and inlining every passing test's output is the wall of green the
+design rejects. A pass can never have overflowed its budget — an overflow is a
+failure verdict — so a pass's digest always covers the whole stream.
+
+**Budgets.** 1 MiB retained per stream for stdout and stderr; 256 KiB for the
+failure channel, deliberately separate so a test that floods its streams cannot
+truncate its own failure record. Exceeding a *stream* budget kills the process
+group and yields `fail` with kind `output_overflow`, retained prefix attached.
+Reading continues past the budget so `bytes_total` is the true count.
+
+### `run_finished`
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `event` | `"run_finished"` | |
+| `passed` / `failed` / `timeout` / `crash` | integer | Counts by verdict. |
+| `wall_ms` | integer | Wall time for the whole run. |
+| `unimported_test_files` | array | Declared test files outside the closure. **Absent** without `--test-candidates`. |
+| `test_candidates` | `"declared"` \| `"none"` | Whether an inventory was supplied. |
+
+Each `unimported_test_files` entry is `{"path": string, "tests": integer,
+"parse_failed": boolean}`. `parse_failed` means the candidate could not be read
+or parsed, so `tests` counts nothing and the honest answer is that the count is
+unknown. Without `--test-candidates`, the human summary appends
+`note: no --test-candidates inventory; unimported test files are not detected` —
+silence would be read as "none found".
+
+### `test` (listing records)
+
+`--list --format json` emits one of these per inventory entry **and nothing
+else**: no `run_started`, no `run_finished`. Because there is no head event to
+carry it, each record names the schema version itself.
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `event` | `"test"` | |
+| `schema` | string | `"1.0"`. |
+| `id` | string | The stable test ID. |
+| `module` | string | The module half of the ID. |
+| `name` | string | The test's name, verbatim. |
+| `file` | string | The declaring file as the compiler observed it. |
+| `line` / `column` | integer | 1-indexed position of the `test "name"` header, or `0` when the declaration could not be located in its module's syntax tree. |
+
+`--list --format human` prints one ID per line.
+
+`--list` performs semantic analysis of the test closure and stops: no CFG, no
+codegen, no linking, no execution. Two additive surfaces are reserved rather
+than shipped (ADR-0083 §2): `--list --cache-status`, which arrives with the
+deferred verdict cache and would have to materialize closure terminal
+artifacts the default listing must never pay for, and `--list --reaches <item>`.
+
+## The verdict taxonomy
+
+One classifier decides every verdict from one observation of a finished process:
+the runner's own supervision outcome, the exit status, the last non-empty line
+of stderr, and the frames read from the failure channel.
+
+| Verdict | Failure kind | Produced when |
+|---------|--------------|---------------|
+| `pass` | — | Exit `0` **and** a `complete` frame was read. |
+| `fail` | `incomplete` | Exit `0` with no `complete` frame. |
+| `fail` | `assert` | The last stderr line is exactly `assertion failed`. |
+| `fail` | `trap:<class>` | The last stderr line is another pinned runtime message. |
+| `fail` | `unhandled_error` | A `failure` frame with that kind — the test-body `?` failure arm. |
+| `fail` | *(verbatim)* | A `failure` frame with a kind the runner does not know (ADR-0083 §5.1). |
+| `fail` | `exit` | Any other nonzero exit. |
+| `fail` | `output_overflow` | A stream budget was exhausted; the group was killed. |
+| `timeout` | `timeout` | The per-test budget expired; the group was killed. |
+| `crash` | `signal` | Killed by a signal, SIGPIPE included. The `signal` field carries the number. |
+
+`trap:<class>` classes are `panic`, `div_by_zero`, `overflow`,
+`intcast_overflow`, `bounds_check`, `invalid_utf8`, and `stack_overflow`. The
+messages they match are the ones `crates/rue-runtime/src/error.rs` and `entry.rs`
+write before `exit(101)`; `crates/rue-cli-tests/cases/rue_test.toml` runs real
+programs down those paths, so a reworded runtime message fails a case rather than
+silently reclassifying a trap as a bare `exit`.
+
+Precedence, in order:
+
+1. **The runner's own supervision** — a timeout or an output overflow — because
+   the runner's kill is what produced the signal death that would otherwise read
+   as a crash.
+2. **A malformed channel line.** An unreadable failure report is never silently
+   ignored: the verdict is `fail` with kind `exit` and a `runner_note` saying so,
+   even when the process otherwise looks like a pass.
+3. **A well-formed `failure` frame**, which carries structure the exit status
+   cannot.
+4. **The exit status**, and for the runtime's abort status `101`, the pinned
+   message on the last non-empty line of stderr. The last line rather than the
+   whole stream, so a test that printed diagnostics of its own before tripping an
+   assertion is still classified by the trap it took; the comparison against that
+   line is exact.
+
+### Reserved values
+
+Published in this taxonomy, produced by nothing in this version, and named here
+so a consumer can handle them when they arrive:
+
+- **`skipped`** is reserved **out** of the v1 verdict set. It has no producing
+  mechanism: `--filter` removes tests from the selection rather than reporting
+  them, and `@skip` is deferred with directive-argument grammar. An unproducible
+  verdict in a published enum is a consumer trap, so it is documented rather
+  than emitted (this settles ADR-0083's open question).
+- **`compile_error`** — a per-test verdict, deferred with ADR-0083 §6. The MVP's
+  whole-run compile failure is exit `2`.
+- **`cached_pass`** — deferred with the hermetic verdict cache.
+- **`ice`** — a reserved failure kind.
+
+## Selection
+
+Three stages, always in this order: **filter, then shard, then shuffle**.
+Sharding after filtering is what makes the N shards of a filtered run
+reconstitute exactly that run; shuffling last is what keeps the shuffle from
+changing which tests a shard owns.
+
+Filtering narrows the **run set, never the analysis root set** (ruled,
+ADR-0083 §2): the request still roots every test in the closure, so a filtered
+run's verdicts are identical to the same tests' verdicts in a full run.
+
+### `--filter`
+
+**Matching rule:** a test is selected when its stable ID *contains* the pattern
+as a substring. `--filter` is repeatable and repeated filters **union**. Matching
+is over the whole ID, so `--filter app/lexer_tests.rue` selects one file's tests
+and `--filter "parse_port"` selects by name fragment.
+
+### `--shard K/N`
+
+`K` is 1-based. A test belongs to shard `K` when
+`fnv1a64(id) % N == K - 1`, where `fnv1a64` is 64-bit **FNV-1a** over the ID's
+UTF-8 bytes:
+
+```text
+hash = 0xcbf29ce484222325
+for byte in id: hash = (hash XOR byte) * 0x100000001b3   (mod 2^64)
+```
+
+FNV-1a rather than the standard library's `DefaultHasher`, whose values are
+explicitly not stable across Rust releases — a shard assignment that moved when
+the compiler was rebuilt would silently drop tests from a sharded CI run. It is
+specified here so an external scheduler computes the same partition.
+
+Duration-aware bin-packing is deferred with the scheduling ADR; it needs
+recorded-duration history the MVP does not keep.
+
+### `--seed`
+
+The run order is a Fisher-Yates shuffle over a **SplitMix64** stream seeded by
+`--seed`:
+
+```text
+state += 0x9e3779b97f4a7c15
+z = state
+z = (z XOR (z >> 30)) * 0xbf58476d1ce4e5b9
+z = (z XOR (z >> 27)) * 0x94d049bb133111eb
+return z XOR (z >> 31)
+```
+
+Indices are drawn by rejection sampling so the modulo bias that would quietly
+favour low indices never enters the shuffle. With no `--seed`, the runner derives
+one from a fresh OS-seeded random source and reports it in `run_started`, so a
+shuffle that surfaced a bug is re-runnable.
+
+`--list` applies `--filter` and `--shard` but **not** the shuffle: a listing is
+an inventory, and stable-ID order is what makes two listings comparable.
+
+## Reproduction as data
+
+Every `test_finished` carries the exact argv that reproduces that one test:
+
+```json
+["rue","test","app/main.rue","--filter","app/t.rue::parses a port","--seed","417",
+ "--target","x86-64-linux","-O0","--preview","test_declarations","--timeout-ms","10000"]
+```
+
+It selects by the **full stable ID, never the bare name** — two modules may
+declare tests with the same name, and a repro that re-runs both is not a repro.
+The seed, target, optimization level, preview set, and per-test budget travel
+with it so the same image is rebuilt, and `--source-manifest` and
+`--link-archive` are repeated when they were given. The target and optimization
+level are emitted even when they were defaulted: a repro is run later, possibly
+elsewhere, and "whatever the host was" is not a reproduction.
+
+The argv array is the authoritative form. The human renderer's `repro:` line is
+the same argv shell-quoted for pasting; a consumer should re-execute the array
+rather than parse the line.
+
+## Scratch directories and isolation
+
+Each test starts in a fresh private scratch directory, which is **deleted on a
+pass and retained on anything else**, with its path in the event. The abort-only
+runtime means destructors do not run on a failing path, so the retained
+directory plus process death is what teardown-on-failure amounts to
+(ADR-0083 §5.4).
+
+Directories live under a per-run directory named for the seed and the runner's
+process id, and are themselves named `rue-test-<seed>-<ordinal>`. The run
+directory is what keeps two runs that share an explicit `--seed` — a repro next
+to the run that produced it, or two suites in parallel — from deleting each
+other's live working directories.
+
+**What isolation does and does not promise.** Each test observes fresh process
+state, has an independent lifecycle the runner enforces, gets its output
+captured and attributed exactly, and receives best-effort process-tree cleanup.
+Noninterference is *not* promised: a test doing raw syscalls or FFI can signal
+arbitrary processes or contend on shared OS state, and a process group is not
+containment. ADR-0083 §3 scopes that clause to verified-hermetic tests, which
+the deferred capability ADR introduces; the MVP verifies nothing and claims it
+for no test.
+
+## Versioning
+
+This schema follows ADR-0061 §6. The version is `1.0`, published in the head
+event of a run and in each `--list --format json` record.
+
+- **Additive changes are minors.** A new event kind, a new optional field, a new
+  reserved value becoming producible, or a richer `payload` inside the failure
+  record. Consumers must ignore unknown fields and unknown event kinds.
+- **Removing or repurposing a field, renaming an event, or changing a field's
+  type is a major.** So is producing a verdict this document reserves *out* of
+  the taxonomy.
+- Changing a field here is a consumer-visible break: update this document and
+  the `cli.rue_test` cases in `crates/rue-cli-tests/cases/rue_test.toml` in the
+  same change, the way [diagnostics.md](diagnostics.md) and its
+  `json_diagnostics` cases move together.
+
+## Testing this surface
+
+`crates/rue-cli-tests/cases/rue_test.toml` runs the real binary end to end: each
+verdict against the real runtime, the exit-code contract, the dispatch rule, the
+orphan warning, and exact object text for the events — alphabetical keys
+included, so a field rename or a dropped field fails a case. A case asserting a
+driver subcommand's status uses the harness's `driver_exit_code` field, which
+pins an exact status where `compile_fail` can only say "nonzero" and so cannot
+tell `1` from `3`.


### PR DESCRIPTION
Closes RUE-1920. ADR-0083 Phase 2c: the `rue test` subcommand, the process-per-test runner, and the NDJSON event stream. With RUE-1917 (image and channel) and RUE-1918 (candidate inventory) already on trunk, this is the first user-facing `rue test`.

## Driver

- `rue test <root.rue> [flags]`. The driver enters test mode when the first argument that is neither a flag nor a flag's value is exactly `test`, using a value-aware scan over every value-taking option, so `rue -o test prog.rue` still names an output and a root literally called `test` is spelled `./test`. Test mode joins the mode validation: it cannot combine with `--emit`, `--watch`, `--benchmark-json`, `--time-passes`, or `-o`.
- Flags: `--list`, `--filter <pattern>` (repeatable, union, substring on the stable ID), `--format human|json`, `--timeout-ms N` (default 10000), `--shard K/N` (FNV-1a over the stable ID), `--seed N` (SplitMix64 shuffle; fresh and reported when omitted), `--test-candidates <file>`. Compile-mode flags keep their spellings.
- Exit codes: 0 all selected passed; 1 failures, timeouts, or crashes; 2 compilation or runner error, including bad flag combinations; 3 empty selection.

## Runner

- One image per run, one process per test in its own process group. Each test gets a fresh scratch directory under a per-run parent (seed plus pid, so two runs sharing a seed cannot delete each other's live directories), stdin from `/dev/null`, `argv[0]` `rue-test`, exactly `RUE_TEST=1` in the environment, and the failure channel's write end on descriptor 3 via a `pre_exec` dup2. Descriptor 3 is reserved in the runner process at start with a close-on-exec `/dev/null` placeholder, so the standard library's own spawn-reporting pipe can never occupy it under concurrent spawns.
- The limited-drain machinery moves out of `rue-test-runner`'s private code into a public `pipe_drain` module used by both the harness and the runner, extended with a true `bytes_total` counter. Streams have a 1 MiB budget each and the channel its own 256 KiB budget; overflow kills the group. Timeouts SIGKILL the group; a post-exit group kill reaps stragglers; pipes stay open until exit.
- Verdicts: `pass` requires exit 0 and a `complete` frame; `fail` kinds `incomplete`, `assert`, `trap:<class>`, `unhandled_error` (from a `failure` frame, or any frame kind verbatim per the open protocol), `exit`, `output_overflow`; `timeout` and `crash` are their own verdicts. Trap matching compares the last non-empty stderr line against the runtime's pinned messages, pinned end to end by CLI cases. `skipped` is reserved out of the v1 taxonomy; `compile_error`, `cached_pass`, and `ice` are reserved and unproducible. The ADR's open questions for exit codes and `skipped` are recorded as settled.

## Event stream

NDJSON on stdout with alphabetical keys, schema `1.0`: `run_started`, `test_started`, `test_finished` (verdict, duration, `capability_summary: {"status":"unavailable"}`, failure record with location and payload, captured output inline for non-passes and as `bytes_total` plus a SHA-256 digest for passes, scratch directory when retained, and repro argv selecting by the full stable ID), `run_finished` (counts, wall time, unimported test files, candidate inventory status), and `test` listing records. Compiler diagnostics stay on stderr with `--error-format json` orthogonal. The human renderer consumes the same event structs and prints failures in full and passes as a count. The schema lives in the new `docs/process/test-events.md`, cross-linked from `docs/process/diagnostics.md`; `AGENTS.md` disambiguates the `scripts/rue test` homonym.

## Coverage

Driver unit tests for the dispatch scan and every invalid combination; runner unit tests for classification, frame parsing including malformed JSON, selection and sharding, the seeded shuffle, event encoding, the renderer, the exec contract values, and the descriptor reservation; a new `driver_exit_code` field in the CLI harness; 29 end-to-end CLI cases in `cases/rue_test.toml` covering pass, assert, panic, `std.exit(0)` incompleteness, timeout, output overflow, listing in both formats, filters including empty selection, sharding, seed reporting, schema pins, repro round trip, the preview gate, the orphan warning, and invalid combinations.

Local: fmt, quick, the driver, runner, and CLI-harness unit suites, `scripts/rue cli rue_test`, `//:cli-tests`, `//:repository-quality-gates`, and a full `scripts/rue premerge` (211 pass, 0 fail) green. The oracle-diff harness cannot run on this host (thread-spawn EAGAIN, reproduced on unmodified trunk); the merge queue's oracle-diff lane is the authority.
