### PR TITLE
RUE-1916: name RIR function declaration flags

### DIFF
--- a/crates/rue-rir/src/api_inventory.rs
+++ b/crates/rue-rir/src/api_inventory.rs
@@ -58,6 +58,55 @@ fn rir_instruction_layers_keep_their_canonical_owners() {
 }
 
 #[test]
+fn fn_decl_editor_api_keeps_flags_named() {
+    let editor = include_str!("inst/editor.rs");
+    let facade = include_str!("lib.rs");
+    let flags = source_region(editor, "pub struct FnDeclFlags {", "fn remap_call_args");
+    for field in [
+        "pub is_pub: bool,",
+        "pub is_unchecked: bool,",
+        "pub is_extern: bool,",
+        "pub is_c_export: bool,",
+        "pub is_test: bool,",
+        "pub has_self: bool,",
+        "pub self_mode: RirParamMode,",
+        "pub self_is_mut: bool,",
+        "pub returns_borrow: bool,",
+        "pub returns_inout: bool,",
+    ] {
+        assert!(flags.contains(field), "FnDeclFlags omits {field}");
+    }
+    assert!(editor.contains(
+        "#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]\npub struct FnDeclFlags {"
+    ));
+    assert!(facade.contains("FnDeclFlags, Inst, InstData"));
+
+    let constructor = source_region(
+        editor,
+        "pub fn add_fn_decl_with_return_modes(",
+        ") -> Result<InstRef, RirPayloadBuildError> {",
+    );
+    assert!(constructor.contains("flags: FnDeclFlags,"));
+    assert_eq!(constructor.matches("flags: FnDeclFlags,").count(), 1);
+    assert!(
+        !constructor.contains(": bool,"),
+        "function declaration flags became positional booleans again"
+    );
+
+    let _: fn(
+        &mut crate::RirEditor,
+        &[crate::RirDirective],
+        crate::FnDeclFlags,
+        lasso::Spur,
+        &[crate::RirParam],
+        crate::RirTypeSyntaxRef,
+        crate::InstRef,
+        rue_span::Span,
+    ) -> Result<crate::InstRef, crate::RirPayloadBuildError> =
+        crate::RirEditor::add_fn_decl_with_return_modes;
+}
+
+#[test]
 fn rir_payload_storage_and_raw_ranges_stay_owner_private() {
     let owner = include_str!("inst.rs");
     let payload = include_str!("inst/payload.rs");

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -18,9 +18,9 @@ use rue_parser::{
 };
 
 use crate::inst::{
-    Inst, InstData, InstRef, InternalIntrinsic, PayloadFallback, RepeatCount, Rir, RirArgMode,
-    RirCallArg, RirDeferredStructuralAnchor, RirDirective, RirEditor, RirParam, RirParamMode,
-    RirPattern,
+    FnDeclFlags, Inst, InstData, InstRef, InternalIntrinsic, PayloadFallback, RepeatCount, Rir,
+    RirArgMode, RirCallArg, RirDeferredStructuralAnchor, RirDirective, RirEditor, RirParam,
+    RirParamMode, RirPattern,
 };
 
 trait RecordPayloadFailure<T> {
@@ -835,22 +835,18 @@ impl<'a> AstGen<'a> {
             .rir
             .add_fn_decl_with_return_modes(
                 &directives,
-                false,
-                false,
-                false,
-                // Methods are never C exports.
-                false,
-                // Methods are never test declarations.
-                false,
+                FnDeclFlags {
+                    has_self,
+                    self_mode,
+                    self_is_mut,
+                    returns_borrow: method.place_return.is_some_and(|mode| mode.is_borrow()),
+                    returns_inout: method.place_return.is_some_and(|mode| mode.is_inout()),
+                    ..FnDeclFlags::default()
+                },
                 name,
                 &params,
                 return_type,
                 body,
-                has_self,
-                self_mode,
-                self_is_mut,
-                method.place_return.is_some_and(|mode| mode.is_borrow()),
-                method.place_return.is_some_and(|mode| mode.is_inout()),
                 method.span,
             )
             .record_failure(&mut self.payload_error);
@@ -931,20 +927,14 @@ impl<'a> AstGen<'a> {
         self.rir
             .add_fn_decl_with_return_modes(
                 &directives,
-                false,
-                false,
-                false,
-                false,
-                true,
+                FnDeclFlags {
+                    is_test: true,
+                    ..FnDeclFlags::default()
+                },
                 name,
                 &[],
                 return_type,
                 body,
-                false,
-                RirParamMode::Normal,
-                false,
-                false,
-                false,
                 test.span,
             )
             .record_failure(&mut self.payload_error)
@@ -986,22 +976,19 @@ impl<'a> AstGen<'a> {
             .rir
             .add_fn_decl_with_return_modes(
                 &directives,
-                func.visibility == Visibility::Public,
-                func.is_unchecked,
-                false,
-                // `pub extern "C" fn` marks a Rue-to-C export (ADR-0064 P4).
-                func.export_abi.is_some(),
-                // A `fn` is never a test declaration.
-                false,
+                FnDeclFlags {
+                    is_pub: func.visibility == Visibility::Public,
+                    is_unchecked: func.is_unchecked,
+                    // `pub extern "C" fn` marks a Rue-to-C export (ADR-0064 P4).
+                    is_c_export: func.export_abi.is_some(),
+                    returns_borrow: func.place_return.is_some_and(|mode| mode.is_borrow()),
+                    returns_inout: func.place_return.is_some_and(|mode| mode.is_inout()),
+                    ..FnDeclFlags::default()
+                },
                 name,
                 &params,
                 return_type,
                 body,
-                false,
-                RirParamMode::Normal,
-                false,
-                func.place_return.is_some_and(|mode| mode.is_borrow()),
-                func.place_return.is_some_and(|mode| mode.is_inout()),
                 func.span,
             )
             .record_failure(&mut self.payload_error);

--- a/crates/rue-rir/src/inst/editor.rs
+++ b/crates/rue-rir/src/inst/editor.rs
@@ -83,6 +83,25 @@ struct StructMethodsOverride<'a> {
     destination_methods: &'a [InstRef],
 }
 
+/// Named declaration, receiver, and return-mode flags for a function node.
+///
+/// Keeping these independent properties named at construction sites prevents
+/// positional boolean drift while preserving the canonical [`InstData::FnDecl`]
+/// representation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FnDeclFlags {
+    pub is_pub: bool,
+    pub is_unchecked: bool,
+    pub is_extern: bool,
+    pub is_c_export: bool,
+    pub is_test: bool,
+    pub has_self: bool,
+    pub self_mode: RirParamMode,
+    pub self_is_mut: bool,
+    pub returns_borrow: bool,
+    pub returns_inout: bool,
+}
+
 fn remap_call_args(
     args: RirSlice<'_, RirCallArg>,
     remap_ref: impl Fn(InstRef) -> InstRef,
@@ -295,7 +314,6 @@ impl RirEditor {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     pub fn add_fn_decl(
         &mut self,
         directives: &[RirDirective],
@@ -315,44 +333,47 @@ impl RirEditor {
     ) -> Result<InstRef, RirPayloadBuildError> {
         self.add_fn_decl_with_return_modes(
             directives,
-            is_pub,
-            is_unchecked,
-            is_extern,
-            is_c_export,
-            false,
+            FnDeclFlags {
+                is_pub,
+                is_unchecked,
+                is_extern,
+                is_c_export,
+                has_self,
+                self_mode,
+                self_is_mut,
+                returns_borrow,
+                ..FnDeclFlags::default()
+            },
             name,
             params,
             return_type,
             body,
-            has_self,
-            self_mode,
-            self_is_mut,
-            returns_borrow,
-            false,
             span,
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn add_fn_decl_with_return_modes(
         &mut self,
         directives: &[RirDirective],
-        is_pub: bool,
-        is_unchecked: bool,
-        is_extern: bool,
-        is_c_export: bool,
-        is_test: bool,
+        flags: FnDeclFlags,
         name: Spur,
         params: &[RirParam],
         return_type: RirTypeSyntaxRef,
         body: InstRef,
-        has_self: bool,
-        self_mode: RirParamMode,
-        self_is_mut: bool,
-        returns_borrow: bool,
-        returns_inout: bool,
         span: Span,
     ) -> Result<InstRef, RirPayloadBuildError> {
+        let FnDeclFlags {
+            is_pub,
+            is_unchecked,
+            is_extern,
+            is_c_export,
+            is_test,
+            has_self,
+            self_mode,
+            self_is_mut,
+            returns_borrow,
+            returns_inout,
+        } = flags;
         self.atomic(|rir| {
             let directives = rir.add_directives(directives)?;
             let params = rir.add_params(params)?;
@@ -1100,20 +1121,22 @@ impl RirEditor {
                             .collect::<Result<Vec<_>, RirSpanRemapError<E>>>()?;
                         self.add_fn_decl_with_return_modes(
                             &directives,
-                            *is_pub,
-                            *is_unchecked,
-                            *is_extern,
-                            *is_c_export,
-                            *is_test,
+                            FnDeclFlags {
+                                is_pub: *is_pub,
+                                is_unchecked: *is_unchecked,
+                                is_extern: *is_extern,
+                                is_c_export: *is_c_export,
+                                is_test: *is_test,
+                                has_self: *has_self,
+                                self_mode: *self_mode,
+                                self_is_mut: *self_is_mut,
+                                returns_borrow: *returns_borrow,
+                                returns_inout: *returns_inout,
+                            },
                             symbol(*name),
                             &params,
                             remap_type(*return_type),
                             remap_ref(*body),
-                            *has_self,
-                            *self_mode,
-                            *self_is_mut,
-                            *returns_borrow,
-                            *returns_inout,
                             span,
                         )?
                     }

--- a/crates/rue-rir/src/inst/packed.rs
+++ b/crates/rue-rir/src/inst/packed.rs
@@ -2998,20 +2998,22 @@ impl<
                 let self_mode = decode_param_mode(reader.byte()?)?;
                 self.destination.add_fn_decl_with_return_modes(
                     &directives,
-                    flags & 1 != 0,
-                    flags & 2 != 0,
-                    flags & 4 != 0,
-                    flags & 8 != 0,
-                    is_test,
+                    FnDeclFlags {
+                        is_pub: flags & 1 != 0,
+                        is_unchecked: flags & 2 != 0,
+                        is_extern: flags & 4 != 0,
+                        is_c_export: flags & 8 != 0,
+                        is_test,
+                        has_self: flags & 16 != 0,
+                        self_mode,
+                        self_is_mut: flags & 32 != 0,
+                        returns_borrow: flags & 64 != 0,
+                        returns_inout: flags & 128 != 0,
+                    },
                     name,
                     &params,
                     return_type,
                     body,
-                    flags & 16 != 0,
-                    self_mode,
-                    flags & 32 != 0,
-                    flags & 64 != 0,
-                    flags & 128 != 0,
                     span,
                 )?
             }
@@ -3795,20 +3797,14 @@ mod tests {
             let root = editor
                 .add_fn_decl_with_return_modes(
                     &[],
-                    false,
-                    false,
-                    false,
-                    false,
-                    is_test,
+                    FnDeclFlags {
+                        is_test,
+                        ..FnDeclFlags::default()
+                    },
                     name,
                     &[],
                     unit,
                     block,
-                    false,
-                    RirParamMode::Normal,
-                    false,
-                    false,
-                    false,
                     Span::new(0, 3),
                 )
                 .unwrap();
@@ -3838,6 +3834,231 @@ mod tests {
                 InstData::FnDecl { is_test: true, .. }
             ),
             "`is_test` must survive the round trip"
+        );
+    }
+
+    #[test]
+    fn fn_decl_named_flags_map_and_round_trip_independently() {
+        fn byte_deltas(left: &[u8], right: &[u8]) -> Vec<(usize, u8)> {
+            assert_eq!(left.len(), right.len());
+            left.iter()
+                .zip(right)
+                .enumerate()
+                .filter_map(|(index, (left, right))| {
+                    (left != right).then_some((index, left ^ right))
+                })
+                .collect()
+        }
+
+        fn flags_from(data: &InstData) -> FnDeclFlags {
+            let InstData::FnDecl {
+                is_pub,
+                is_unchecked,
+                is_extern,
+                is_c_export,
+                is_test,
+                has_self,
+                self_mode,
+                self_is_mut,
+                returns_borrow,
+                returns_inout,
+                ..
+            } = data
+            else {
+                panic!("expected function declaration")
+            };
+            FnDeclFlags {
+                is_pub: *is_pub,
+                is_unchecked: *is_unchecked,
+                is_extern: *is_extern,
+                is_c_export: *is_c_export,
+                is_test: *is_test,
+                has_self: *has_self,
+                self_mode: *self_mode,
+                self_is_mut: *self_is_mut,
+                returns_borrow: *returns_borrow,
+                returns_inout: *returns_inout,
+            }
+        }
+
+        let profiles = [
+            ("default", FnDeclFlags::default()),
+            (
+                "is_pub",
+                FnDeclFlags {
+                    is_pub: true,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "is_unchecked",
+                FnDeclFlags {
+                    is_unchecked: true,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "is_extern",
+                FnDeclFlags {
+                    is_extern: true,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "is_c_export",
+                FnDeclFlags {
+                    is_c_export: true,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "is_test",
+                FnDeclFlags {
+                    is_test: true,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "has_self",
+                FnDeclFlags {
+                    has_self: true,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "self_mode",
+                FnDeclFlags {
+                    self_mode: RirParamMode::Borrow,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "self_is_mut",
+                FnDeclFlags {
+                    self_is_mut: true,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "returns_borrow",
+                FnDeclFlags {
+                    returns_borrow: true,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "returns_inout",
+                FnDeclFlags {
+                    returns_inout: true,
+                    ..FnDeclFlags::default()
+                },
+            ),
+            (
+                "asymmetric",
+                FnDeclFlags {
+                    is_pub: true,
+                    is_unchecked: false,
+                    is_extern: true,
+                    is_c_export: false,
+                    is_test: true,
+                    has_self: false,
+                    self_mode: RirParamMode::Inout,
+                    self_is_mut: true,
+                    returns_borrow: false,
+                    returns_inout: true,
+                },
+            ),
+        ];
+
+        let mut packed_profiles = Vec::new();
+        for (label, expected) in profiles {
+            let symbols = ThreadedRodeo::new();
+            let name = symbols.get_or_intern("flags");
+            let mut editor = RirEditor::new();
+            let body = editor.add_inst(Inst {
+                data: InstData::UnitConst,
+                span: Span::new(1, 2),
+            });
+            let unit = editor.add_unit_type().unwrap();
+            let root = editor
+                .add_fn_decl_with_return_modes(
+                    &[],
+                    expected,
+                    name,
+                    &[],
+                    unit,
+                    body,
+                    Span::new(0, 3),
+                )
+                .unwrap();
+            assert_eq!(flags_from(&editor.get(root).data), expected, "{label}");
+
+            let context = RirValidationContext {
+                symbol_count: symbols.len(),
+                source_lengths: &[(FileId::DEFAULT, 3)],
+            };
+            let source = ValidatedRir::finish(editor, &context).unwrap();
+            let packed = pack(&source, &symbols, root);
+            let mut destination = RirEditor::new();
+            let appended = append(&packed, &mut destination).unwrap();
+            assert_eq!(
+                flags_from(&destination.get(appended.metadata.declaration).data),
+                expected,
+                "{label}"
+            );
+            let decoded = ValidatedRir::finish(destination, &context).unwrap();
+            assert!(source.exact_eq(&decoded), "{label}");
+            assert_eq!(
+                pack(&decoded, &symbols, appended.metadata.declaration).as_bytes(),
+                packed.as_bytes(),
+                "{label}"
+            );
+            packed_profiles.push((label, expected, packed.as_bytes().to_vec()));
+        }
+
+        let baseline = &packed_profiles[0].2;
+        let shared_flag_cases = [
+            (1, 1),
+            (2, 2),
+            (3, 4),
+            (4, 8),
+            (6, 16),
+            (8, 32),
+            (9, 64),
+            (10, 128),
+        ];
+        let shared_flag_offset = byte_deltas(baseline, &packed_profiles[1].2)[0].0;
+        for (profile, encoded_bit) in shared_flag_cases {
+            assert_eq!(
+                byte_deltas(baseline, &packed_profiles[profile].2),
+                [(shared_flag_offset, encoded_bit)],
+                "{} must retain its packed flag bit",
+                packed_profiles[profile].0
+            );
+        }
+
+        let test_delta = byte_deltas(baseline, &packed_profiles[5].2);
+        let self_mode_delta = byte_deltas(baseline, &packed_profiles[7].2);
+        assert_eq!(test_delta.len(), 1);
+        assert_eq!(test_delta[0].1, 1, "is_test retains its boolean byte");
+        assert_eq!(self_mode_delta.len(), 1);
+        assert_eq!(
+            self_mode_delta[0].1, 2,
+            "borrow self mode retains its encoded tag"
+        );
+        assert_ne!(test_delta[0].0, shared_flag_offset);
+        assert_ne!(self_mode_delta[0].0, shared_flag_offset);
+        assert_ne!(self_mode_delta[0].0, test_delta[0].0);
+
+        let asymmetric_delta = byte_deltas(baseline, &packed_profiles[11].2);
+        assert_eq!(
+            asymmetric_delta,
+            [
+                (shared_flag_offset, 1 | 4 | 32 | 128),
+                test_delta[0],
+                (self_mode_delta[0].0, 1),
+            ],
+            "asymmetric flags retain the exact packed byte layout"
         );
     }
 

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -34,11 +34,11 @@ pub use astgen::{
     AstGen, AstGenCandidate, AstGenDeclarationRoot, AstGenFinishError, AstGenItemRoots,
 };
 pub use inst::{
-    Inst, InstData, InstRef, InternalIntrinsic, MAX_RIR_ENTRIES_PER_PROGRAM, PackedRirAppend,
-    PackedRirAppendError, PackedRirAppendMetadata, PackedRirDecodeError, PackedRirEncodeError,
-    PackedRirMetadata, PackedRirMethodOwner, PackedRirProjection, PackedRirSymbols,
-    PackedValidatedRir, RIR_PAYLOAD_FAMILY_NAMES, RIR_SPAN_FIELD_FAMILY_NAMES, RepeatCount, Rir,
-    RirAnonEnumPayloadsRange, RirAnonEnumVariantsRange, RirAnonStructFieldsRange,
+    FnDeclFlags, Inst, InstData, InstRef, InternalIntrinsic, MAX_RIR_ENTRIES_PER_PROGRAM,
+    PackedRirAppend, PackedRirAppendError, PackedRirAppendMetadata, PackedRirDecodeError,
+    PackedRirEncodeError, PackedRirMetadata, PackedRirMethodOwner, PackedRirProjection,
+    PackedRirSymbols, PackedValidatedRir, RIR_PAYLOAD_FAMILY_NAMES, RIR_SPAN_FIELD_FAMILY_NAMES,
+    RepeatCount, Rir, RirAnonEnumPayloadsRange, RirAnonEnumVariantsRange, RirAnonStructFieldsRange,
     RirAnonStructMethodsRange, RirArgMode, RirArrayElemsRange, RirBlockInstsRange, RirCallArg,
     RirCallArgsRange, RirDirective, RirDirectiveView, RirDirectivesRange, RirEditor,
     RirEnumPayloads, RirEnumPayloadsRange, RirEnumVariantsRange, RirFallibleIntrinsic,


### PR DESCRIPTION
Fixes RUE-1916

Replace the positional function-declaration booleans on `RirEditor::add_fn_decl_with_return_modes` with a public `FnDeclFlags` value whose fields are named and defaultable. Keep `add_fn_decl` as the compatibility wrapper and migrate AstGen, owner-local remapping, and packed-RIR decoding without changing representation or behavior.

Add API-shape guards plus one-hot and asymmetric packed round-trip coverage that pins every flag mapping, exact equality, bit layout, and deterministic bytes.

Validation:
- `scripts/rue unit rir`
- `scripts/rue quick`
- `scripts/rue premerge`
- `scripts/rue fmt`
- `rue-rir-clippy`
- `git diff --check`