### PR TITLE
RUE-1940: explain control-flow diagnostics

### DIFF
--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -457,6 +457,72 @@ compile_stdout_contains = ["E0499: Container element is linear", "Instantiate a 
 compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
+# The active control-flow tranche covers loop targets and the exact trusted
+# Option/Result rules for `?`. Invalid source pins every `explain` invocation
+# as a non-compiling metadata path.
+[[case]]
+name = "break_outside_loop_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0500"]
+compile_only = true
+compile_stdout_contains = ["E0500: Break outside loop", "Break from a function body:", "Break from an enclosing loop:", "docs/spec/src/04-expressions/08-loop-expressions.md (spec rule 4.8:9)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "continue_outside_loop_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0501"]
+compile_only = true
+compile_stdout_contains = ["E0501: Continue outside loop", "Continue from a function body:", "Continue an enclosing loop:", "docs/spec/src/04-expressions/08-loop-expressions.md (spec rule 4.8:9)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "break_with_value_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0502"]
+compile_only = true
+compile_stdout_contains = ["E0502: Break with value", "Break with a value operand:", "Store the value before breaking:", "docs/spec/src/04-expressions/08-loop-expressions.md (spec rule 4.8:22)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "question_outside_option_function_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0503"]
+compile_only = true
+compile_stdout_contains = ["E0503: Question outside option fn", "Propagate Option from a plain-value function:", "Return trusted Option before propagating:", "docs/spec/src/04-expressions/15-try-expressions.md (spec rule 4.15:4)", "docs/spec/src/04-expressions/15-try-expressions.md (spec rule 4.15:7)"]
+compile_stdout_not_contains = ["Compiled", "error conversion"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "question_on_non_option_or_result_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0504"]
+compile_only = true
+compile_stdout_contains = ["E0504: Question on non option", "neither an exact specialization", "Apply try to a plain integer:", "Apply try to a trusted Option:", "docs/spec/src/04-expressions/15-try-expressions.md (spec rule 4.15:3)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "question_outside_result_function_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0505"]
+compile_only = true
+compile_stdout_contains = ["E0505: Question outside result fn", "Propagate Result from a plain-value function:", "Return trusted Result before propagating:", "docs/spec/src/04-expressions/15-try-expressions.md (spec rule 4.15:4)"]
+compile_stdout_not_contains = ["Compiled", "error conversion"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "question_result_error_type_mismatch_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0506"]
+compile_only = true
+compile_stdout_contains = ["E0506: Question err type mismatch", "does not perform error conversion", "Propagate a different Result error type:", "Use the same Result error type:", "docs/spec/src/04-expressions/15-try-expressions.md (spec rule 4.15:4)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
 [[case]]
 name = "malformed_code_is_rejected"
 files = [{ path = "main.rue", source = "fn main() {}\n" }]

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -18,6 +18,7 @@ use ahash::{AHashMap, AHashSet};
 #[cfg(test)]
 mod integration_tests {
     use super::*;
+    use std::sync::Arc;
 
     const EXPLANATION_FILE_MARKER: &str = "// --- ";
 
@@ -81,6 +82,103 @@ mod integration_tests {
                     result.unwrap_or_else(|errors| {
                         panic!("example {:?} emitted {errors:?}", example.title)
                     });
+                }
+            }
+        }
+    }
+
+    fn trusted_try_explanation_snapshot(root_source: &str) -> SourceSnapshot {
+        let root = FileId::new(1);
+        let option = FileId::new(2);
+        let result = FileId::new(3);
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            root,
+            AHashMap::from([
+                (root, "/project/main.rue".to_owned()),
+                (option, "/project/std/option.rue".to_owned()),
+                (result, "/project/std/result.rue".to_owned()),
+            ]),
+            AHashMap::from([
+                (root, "main.rue".to_owned()),
+                (option, "\0rue-std/option.rue".to_owned()),
+                (result, "\0rue-std/result.rue".to_owned()),
+            ]),
+            AHashSet::from([option, result]),
+        )
+        .unwrap();
+        SourceSnapshot::new(
+            metadata,
+            vec![
+                (root, Arc::new(root_source.to_owned())),
+                (
+                    option,
+                    Arc::new(
+                        "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }"
+                            .to_owned(),
+                    ),
+                ),
+                (
+                    result,
+                    Arc::new(
+                        "pub fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }"
+                            .to_owned(),
+                    ),
+                ),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn control_flow_explanation_examples_have_the_declared_outcome() {
+        for metadata in rue_error::error_code_metadata()
+            .iter()
+            .filter(|metadata| (500..=506).contains(&metadata.code.0))
+        {
+            let explanation = rue_error::error_code_explanation(metadata.code)
+                .unwrap_or_else(|| panic!("{} must have an explanation", metadata.code));
+            for example in explanation.examples {
+                let snapshot = if (503..=506).contains(&metadata.code.0) {
+                    trusted_try_explanation_snapshot(example.source)
+                } else {
+                    SourceSnapshot::single("main.rue", example.source).unwrap()
+                };
+                let result = crate::test_compile_snapshot(&snapshot, &CompileOptions::default());
+                match example.outcome {
+                    rue_error::ErrorCodeExampleOutcome::EmitsThisCode => {
+                        let errors = match result {
+                            Ok(_) => panic!(
+                                "{} example {:?} compiled successfully",
+                                metadata.code, example.title
+                            ),
+                            Err(errors) => errors,
+                        };
+                        let codes = errors
+                            .iter()
+                            .map(|error| error.kind.code())
+                            .collect::<Vec<_>>();
+                        assert_eq!(
+                            codes.as_slice(),
+                            [metadata.code],
+                            "{} example {:?} must emit exactly its owning code; emitted {:?}: {errors:?}",
+                            metadata.code,
+                            example.title,
+                            codes,
+                        );
+                    }
+                    rue_error::ErrorCodeExampleOutcome::Compiles => {
+                        result.unwrap_or_else(|errors| {
+                            panic!(
+                                "{} example {:?} unexpectedly emitted {:?}",
+                                metadata.code,
+                                example.title,
+                                errors
+                                    .iter()
+                                    .map(|error| error.kind.code())
+                                    .collect::<Vec<_>>()
+                            )
+                        });
+                    }
                 }
             }
         }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1546,18 +1546,86 @@ define_error_codes! {
     // ========================================================================
     // Control flow errors (E0500-E0599)
     // ========================================================================
-    BREAK_OUTSIDE_LOOP = 500;
-    CONTINUE_OUTSIDE_LOOP = 501;
-    BREAK_WITH_VALUE = 502;
+    BREAK_OUTSIDE_LOOP = 500 => {
+        explanation: "A `break` expression exits the innermost enclosing `loop` or `while` loop. Outside a loop there is no control-flow target to exit, so Rue rejects the expression instead of assigning it a destination.",
+        likely_cause: "A `break` was placed in a function, conditional, or other block that is not nested inside a loop, or it was intended to leave a function. Put the expression inside the loop it should exit; use `return` when the intended target is the enclosing function.",
+        examples: [
+            ErrorCodeExample { title: "Break from a function body", source: "fn main() -> i32 {\n    break;\n    0\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Break from an enclosing loop", source: "fn main() -> i32 {\n    loop {\n        break;\n    }\n    0\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Break exits the innermost loop", path: "docs/spec/src/04-expressions/08-loop-expressions.md", rule: Some("4.8:7") },
+            ErrorCodeReference { title: "Break and continue require a loop", path: "docs/spec/src/04-expressions/08-loop-expressions.md", rule: Some("4.8:9") },
+        ],
+    };
+    CONTINUE_OUTSIDE_LOOP = 501 => {
+        explanation: "A `continue` expression skips the rest of the current iteration of the innermost enclosing `loop` or `while` loop. Outside a loop there is no next iteration to begin, so Rue rejects the expression.",
+        likely_cause: "A `continue` was placed in a function, conditional, or other block that is not nested inside a loop. Move it into the loop whose iteration should be skipped, or use another control-flow construct when execution should leave the function or conditional.",
+        examples: [
+            ErrorCodeExample { title: "Continue from a function body", source: "fn main() -> i32 {\n    continue;\n    0\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Continue an enclosing loop", source: "fn main() -> i32 {\n    let mut value = 0;\n    while value < 1 {\n        value = value + 1;\n        continue;\n    }\n    value\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Continue advances the innermost loop", path: "docs/spec/src/04-expressions/08-loop-expressions.md", rule: Some("4.8:8") },
+            ErrorCodeReference { title: "Break and continue require a loop", path: "docs/spec/src/04-expressions/08-loop-expressions.md", rule: Some("4.8:9") },
+        ],
+    };
+    BREAK_WITH_VALUE = 502 => {
+        explanation: "Rue loops currently produce only `()` when exited by `break`. A `break` therefore cannot carry a value operand: `break expression` is rejected even when the surrounding `loop` appears in a value position.",
+        likely_cause: "Code used `break value` expecting that value to become the result of a `loop`. Store the value in a mutable binding before a valueless `break`, or restructure the code so the desired value is produced after the loop.",
+        examples: [
+            ErrorCodeExample { title: "Break with a value operand", source: "fn main() -> i32 {\n    loop {\n        break 42;\n    }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Store the value before breaking", source: "fn main() -> i32 {\n    let mut answer = 0;\n    loop {\n        answer = 42;\n        break;\n    }\n    answer\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Loops exited by break produce unit", path: "docs/spec/src/04-expressions/08-loop-expressions.md", rule: Some("4.8:21") },
+            ErrorCodeReference { title: "Break has no value operand", path: "docs/spec/src/04-expressions/08-loop-expressions.md", rule: Some("4.8:22") },
+        ],
+    };
     /// The `?` operator was used in a function whose return type is not an
     /// `Option` (RUE-6, ADR-0038): `?` early-returns `None`, so the enclosing
     /// function must return an `Option`.
-    QUESTION_OUTSIDE_OPTION_FN = 503;
-    QUESTION_OUTSIDE_RESULT_FN = 505;
-    QUESTION_ERR_TYPE_MISMATCH = 506;
-    /// The `?` operator was applied to a value that is not an `Option`
-    /// (RUE-6, ADR-0038).
-    QUESTION_ON_NON_OPTION = 504;
+    QUESTION_OUTSIDE_OPTION_FN = 503 => {
+        explanation: "The operand of `?` is a trusted standard-library `Option`, but the enclosing function does not return a trusted standard-library `Option`. On `None`, `?` immediately returns `None` from that function, so its declared return type must be `std.option.Option(U)`. The success payload types may differ.",
+        likely_cause: "An Option-producing call was followed by `?` inside a function returning a plain value, `Result`, or a user-defined Option-shaped enum. Change the function to return the standard `Option`, handle `Some` and `None` explicitly with `match`, or remove `?`.",
+        examples: [
+            ErrorCodeExample { title: "Propagate Option from a plain-value function", source: "fn main() -> i32 {\n    let value = @parse_i32(\"42\")?;\n    value\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Return trusted Option before propagating", source: "const option = @import(\"std/option.rue\");\nfn parse() -> option.Option(i32) {\n    let O = option.Option(i32);\n    let value = @parse_i32(\"42\")?;\n    O.Some(value)\n}\nfn main() -> i32 {\n    parse();\n    0\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Try operand and enclosing producer compatibility", path: "docs/spec/src/04-expressions/15-try-expressions.md", rule: Some("4.15:4") },
+            ErrorCodeReference { title: "None returns from the enclosing function", path: "docs/spec/src/04-expressions/15-try-expressions.md", rule: Some("4.15:7") },
+        ],
+    };
+    /// The `?` operator was applied to a value that is neither a trusted
+    /// standard `Option` nor a trusted standard `Result` (RUE-6, ADR-0038).
+    QUESTION_ON_NON_OPTION = 504 => {
+        explanation: "The operand of `?` is neither an exact specialization of the trusted `std.option.Option` producer nor an exact specialization of the trusted `std.result.Result` producer. Only those two standard-library types have Rue's built-in try behavior; an enum with the same variants is still a distinct, ordinary type.",
+        likely_cause: "The operand is a plain value, another type, or a user-defined `Some`/`None` or `Ok`/`Err` lookalike. Apply `?` to a value produced by the standard `Option` or `Result`, or handle the operand's cases explicitly.",
+        examples: [
+            ErrorCodeExample { title: "Apply try to a plain integer", source: "fn main() -> i32 {\n    let value = 42?;\n    value\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Apply try to a trusted Option", source: "const option = @import(\"std/option.rue\");\nfn some_value() -> option.Option(i32) {\n    let O = option.Option(i32);\n    O.Some(42)\n}\nfn propagate() -> option.Option(i32) {\n    let O = option.Option(i32);\n    let value = some_value()?;\n    O.Some(value)\n}\nfn main() -> i32 {\n    propagate();\n    0\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [ErrorCodeReference { title: "Trusted try operand producers", path: "docs/spec/src/04-expressions/15-try-expressions.md", rule: Some("4.15:3") }],
+    };
+    QUESTION_OUTSIDE_RESULT_FN = 505 => {
+        explanation: "The operand of `?` is a trusted standard-library `Result`, but the enclosing function does not return a trusted standard-library `Result`. On `Err(e)`, `?` immediately returns an `Err(e)` constructed with the enclosing function's Result type, so that return type must be `std.result.Result(U, E)`.",
+        likely_cause: "A Result-producing call was followed by `?` inside a function returning a plain value, `Option`, or a user-defined Result-shaped enum. Change the function to return the standard `Result`, handle `Ok` and `Err` explicitly with `match`, or remove `?`.",
+        examples: [
+            ErrorCodeExample { title: "Propagate Result from a plain-value function", source: "const result = @import(\"std/result.rue\");\nfn fallible() -> result.Result(i32, i32) {\n    let R = result.Result(i32, i32);\n    R.Ok(42)\n}\nfn main() -> i32 {\n    fallible()?\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Return trusted Result before propagating", source: "const result = @import(\"std/result.rue\");\nfn fallible() -> result.Result(i32, i32) {\n    let R = result.Result(i32, i32);\n    R.Ok(42)\n}\nfn run() -> result.Result(i32, i32) {\n    let R = result.Result(i32, i32);\n    let value = fallible()?;\n    R.Ok(value)\n}\nfn main() -> i32 {\n    run();\n    0\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [ErrorCodeReference { title: "Try operand and enclosing producer compatibility", path: "docs/spec/src/04-expressions/15-try-expressions.md", rule: Some("4.15:4") }],
+    };
+    QUESTION_ERR_TYPE_MISMATCH = 506 => {
+        explanation: "The operand and enclosing function both use the trusted standard-library `Result`, but their error types are different. `?` returns the operand's `Err(e)` payload through the enclosing function's own Result producer, and Rue does not perform error conversion, so the two error types must be identical.",
+        likely_cause: "A called operation returns `Result(T, E1)` while its caller declares `Result(U, E2)` with a different error type. Make the error types match or explicitly map the error with `match` before propagating it; `?` does not invoke a conversion.",
+        examples: [
+            ErrorCodeExample { title: "Propagate a different Result error type", source: "const result = @import(\"std/result.rue\");\nfn fallible() -> result.Result(i32, i32) {\n    let R = result.Result(i32, i32);\n    R.Ok(42)\n}\nfn run() -> result.Result(i32, bool) {\n    let R = result.Result(i32, bool);\n    let value = fallible()?;\n    R.Ok(value)\n}\nfn main() -> i32 {\n    let R = result.Result(i32, bool);\n    match run() { R.Ok(value) => value, R.Err(_) => 0 }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Use the same Result error type", source: "const result = @import(\"std/result.rue\");\nfn fallible() -> result.Result(i32, i32) {\n    let R = result.Result(i32, i32);\n    R.Ok(42)\n}\nfn run() -> result.Result(i32, i32) {\n    let R = result.Result(i32, i32);\n    let value = fallible()?;\n    R.Ok(value)\n}\nfn main() -> i32 {\n    run();\n    0\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [ErrorCodeReference { title: "Result error types must be identical", path: "docs/spec/src/04-expressions/15-try-expressions.md", rule: Some("4.15:4") }],
+    };
 
     // ========================================================================
     // Match errors (E0600-E0699)
@@ -4087,6 +4155,42 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(actual, expected);
+        assert!(
+            expected
+                .into_iter()
+                .all(|code| error_code_explanation(code).is_some())
+        );
+    }
+
+    #[test]
+    fn active_control_flow_explanation_band_is_complete_and_bounded() {
+        let expected = [
+            ErrorCode::BREAK_OUTSIDE_LOOP,
+            ErrorCode::CONTINUE_OUTSIDE_LOOP,
+            ErrorCode::BREAK_WITH_VALUE,
+            ErrorCode::QUESTION_OUTSIDE_OPTION_FN,
+            ErrorCode::QUESTION_ON_NON_OPTION,
+            ErrorCode::QUESTION_OUTSIDE_RESULT_FN,
+            ErrorCode::QUESTION_ERR_TYPE_MISMATCH,
+        ];
+        let active = error_code_metadata()
+            .iter()
+            .filter_map(|metadata| {
+                (500..=506)
+                    .contains(&metadata.code.0)
+                    .then_some(metadata.code)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(active, expected);
+        let explained = ERROR_CODE_EXPLANATION_DECLARATIONS
+            .iter()
+            .filter_map(|declaration| {
+                (500..=506)
+                    .contains(&declaration.code.0)
+                    .then_some(declaration.code)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(explained, expected);
         assert!(
             expected
                 .into_iter()


### PR DESCRIPTION
## Summary

- add compiler-owned long-form explanations for E0500 through E0506
- validate failing and corrected examples through the compiler with trusted Option and Result provenance
- pin the exact active control-flow explanation set and CLI rendering

## Validation

- focused rue-error, compiler, spec, CLI, and UI tests
- scripts/rue quick
- scripts/rue fmt
- scripts/rue premerge
- git diff --check

Fixes RUE-1940