### PR TITLE
RUE-1941: explain match diagnostics

### DIFF
--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -523,6 +523,36 @@ compile_stdout_contains = ["E0506: Question err type mismatch", "does not perfor
 compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
+# The active match band documents exhaustiveness, the zero-arm exception, and
+# the scrutinee types accepted by semantic analysis. Invalid source pins each
+# invocation as a non-compiling metadata path.
+[[case]]
+name = "non_exhaustive_match_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0600"]
+compile_only = true
+compile_stdout_contains = ["E0600: Non exhaustive match", "Omit one boolean case:", "Cover both boolean cases:", "docs/spec/src/04-expressions/07-match-expressions.md (spec rule 4.7:9)", "docs/spec/src/04-expressions/07-match-expressions.md (spec rule 4.7:10)", "docs/spec/src/06-items/03-enums.md (spec rule 6.3:21)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "empty_match_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0601"]
+compile_only = true
+compile_stdout_contains = ["E0601: Empty match", "Leave an integer match empty:", "Add an exhaustive wildcard arm:", "docs/spec/src/04-expressions/07-match-expressions.md (spec rule 4.7:26)", "docs/spec/src/04-expressions/07-match-expressions.md (spec rule 4.7:27)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "invalid_match_type_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0602"]
+compile_only = true
+compile_stdout_contains = ["E0602: Invalid match type", "Match a string value:", "Match a supported integer value:", "docs/spec/src/04-expressions/07-match-expressions.md (spec rule 4.7:2)", "docs/spec/src/04-expressions/07-match-expressions.md (spec rule 4.7:13)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
 [[case]]
 name = "malformed_code_is_rejected"
 files = [{ path = "main.rue", source = "fn main() {}\n" }]

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -111,10 +111,10 @@ rue_rust_test(
 # Compiler-owned error explanations carry executable examples. This external
 # consumer verifies the bounded documented lexer, parser, semantic-foundation,
 # struct-foundation, method/item, enum/place, place/borrow, and
-# const/item/ownership, single-file destructor/const, and slice/string/container
-# tranches through the real one-shot compiler path without copying the examples
-# into a second fixture. The multi-file E0460 example is validated by the
-# compiler unit test.
+# const/item/ownership, single-file destructor/const, slice/string/container,
+# and match tranches through the real one-shot compiler path without copying
+# the examples into a second fixture. The multi-file E0460 example is validated
+# by the compiler unit test.
 rue_rust_test(
     name = "error-explanation-examples-test",
     srcs = ["tests/error_explanation_examples.rs"],

--- a/crates/rue-compiler/tests/error_explanation_examples.rs
+++ b/crates/rue-compiler/tests/error_explanation_examples.rs
@@ -21,6 +21,7 @@ fn compiler_owned_explanation_examples_have_the_declared_outcome() {
                     | 478
                     | 480..=497
                     | 499
+                    | 600..=602
             )
     }) {
         let explanation = error_code_explanation(metadata.code)

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1630,9 +1630,43 @@ define_error_codes! {
     // ========================================================================
     // Match errors (E0600-E0699)
     // ========================================================================
-    NON_EXHAUSTIVE_MATCH = 600;
-    EMPTY_MATCH = 601;
-    INVALID_MATCH_TYPE = 602;
+    NON_EXHAUSTIVE_MATCH = 600 => {
+        explanation: "A `match` must cover every possible value of its scrutinee type. Boolean matches need both literal cases, enum matches need every variant, and integer matches need an irrefutable wildcard arm; a wildcard also makes a boolean or enum match exhaustive.",
+        likely_cause: "One boolean literal or enum variant is missing, an integer match lists only specific values, or a match on an externally non-exhaustive enum omits the wildcard needed to cover variants that may be added outside the current module.",
+        examples: [
+            ErrorCodeExample { title: "Omit one boolean case", source: "fn main() -> i32 {\n    match true {\n        true => 1,\n    }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Cover both boolean cases", source: "fn main() -> i32 {\n    match true {\n        true => 1,\n        false => 0,\n    }\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Match patterns must be exhaustive", path: "docs/spec/src/04-expressions/07-match-expressions.md", rule: Some("4.7:9") },
+            ErrorCodeReference { title: "Exhaustiveness rules by scrutinee type", path: "docs/spec/src/04-expressions/07-match-expressions.md", rule: Some("4.7:10") },
+            ErrorCodeReference { title: "External non-exhaustive enums require a wildcard", path: "docs/spec/src/06-items/03-enums.md", rule: Some("6.3:21") },
+        ],
+    };
+    EMPTY_MATCH = 601 => {
+        explanation: "A `match` with no arms is valid only when its scrutinee is an enum with zero variants. Every inhabited type has at least one possible value, so an empty arm list cannot cover it.",
+        likely_cause: "A match body was left empty while being drafted, or code attempted to use an empty match with an integer, boolean, or enum that has one or more variants. Add arms covering the scrutinee or reserve the empty form for a zero-variant enum.",
+        examples: [
+            ErrorCodeExample { title: "Leave an integer match empty", source: "fn main() -> i32 {\n    match 0 {}\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Add an exhaustive wildcard arm", source: "fn main() -> i32 {\n    match 0 {\n        _ => 0,\n    }\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Empty matches require a zero-variant enum", path: "docs/spec/src/04-expressions/07-match-expressions.md", rule: Some("4.7:26") },
+            ErrorCodeReference { title: "Empty matches have never type", path: "docs/spec/src/04-expressions/07-match-expressions.md", rule: Some("4.7:27") },
+        ],
+    };
+    INVALID_MATCH_TYPE = 602 => {
+        explanation: "Rue supports `match` scrutinees whose type is an integer, `bool`, or an enum. A value of any other type has no supported pattern domain, so the match is rejected before its arms are analyzed.",
+        likely_cause: "Code tries to match a string, struct, array, pointer, or another unsupported value directly. Match a supported field or discriminating value instead, or express the condition with another construct.",
+        examples: [
+            ErrorCodeExample { title: "Match a string value", source: "fn main() -> i32 {\n    match \"hello\" {\n        _ => 0,\n    }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Match a supported integer value", source: "fn main() -> i32 {\n    match 1 {\n        _ => 0,\n    }\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Supported match pattern forms", path: "docs/spec/src/04-expressions/07-match-expressions.md", rule: Some("4.7:2") },
+            ErrorCodeReference { title: "Patterns must match the scrutinee type", path: "docs/spec/src/04-expressions/07-match-expressions.md", rule: Some("4.7:13") },
+        ],
+    };
 
     // ========================================================================
     // Intrinsic errors (E0700-E0799)
@@ -4186,6 +4220,38 @@ mod tests {
             .iter()
             .filter_map(|declaration| {
                 (500..=506)
+                    .contains(&declaration.code.0)
+                    .then_some(declaration.code)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(explained, expected);
+        assert!(
+            expected
+                .into_iter()
+                .all(|code| error_code_explanation(code).is_some())
+        );
+    }
+
+    #[test]
+    fn active_match_explanation_band_is_complete_and_bounded() {
+        let expected = [
+            ErrorCode::NON_EXHAUSTIVE_MATCH,
+            ErrorCode::EMPTY_MATCH,
+            ErrorCode::INVALID_MATCH_TYPE,
+        ];
+        let active = error_code_metadata()
+            .iter()
+            .filter_map(|metadata| {
+                (600..=699)
+                    .contains(&metadata.code.0)
+                    .then_some(metadata.code)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(active, expected);
+        let explained = ERROR_CODE_EXPLANATION_DECLARATIONS
+            .iter()
+            .filter_map(|declaration| {
+                (600..=699)
                     .contains(&declaration.code.0)
                     .then_some(declaration.code)
             })


### PR DESCRIPTION
## Summary

- document the active E0600-E0602 match-diagnostic band with causes, examples, and stable specification references
- validate failing and corrected examples through the real compiler
- guard the exact active match band and cover explain output through the CLI

## Testing

- scripts/rue unit error
- scripts/rue unit compiler:error-explanation-examples-test
- scripts/rue cli code_is_explained
- scripts/rue spec match
- scripts/rue ui match
- scripts/rue cli match
- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test (243 tests passed; six oracle corpus actions hit host thread exhaustion without a semantic failure)

Fixes RUE-1941