### PR TITLE
RUE-1620: add structured assertion payloads and machine diffs

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2312,7 +2312,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // `@panic` diverges: it aborts the process and never returns,
                     // so its expression type is `!` (never), a control-transfer
                     // form that participates in never coercion (spec 3.4:2,
-                    // 4.13:5b; formal core §5.7; RUE-512). Keeping it explicit
+                    // 4.13:5c; formal core §5.7; RUE-512). Keeping it explicit
                     // here — rather than leaning on the generic unit fallback —
                     // stops HM and semantic analysis from drifting apart.
                     for arg_ref in args.iter() {
@@ -2326,11 +2326,30 @@ impl<'a> ConstraintGenerator<'a> {
                     // `@assert` is NOT never-typed: on the success path it returns
                     // and evaluates to `()`. It only aborts when the condition is
                     // false, so its static type is unit on both paths (spec
-                    // 4.13:5b). Keep it explicit so HM and sema stay in lockstep.
+                    // 4.13:5d). Keep it explicit so HM and sema stay in lockstep.
                     for arg_ref in args.iter() {
                         // As with `@panic`, a literal message keeps the stable
                         // `str` default instead of requiring imported StrBuf.
                         generate_intrinsic_arg!(*arg_ref);
+                    }
+                    InferType::Concrete(Type::UNIT)
+                } else if intrinsic_name == "assert_eq" || intrinsic_name == "assert_ne" {
+                    // `@assert_eq(l, r)` / `@assert_ne(l, r)`: the two operands
+                    // share one type and the intrinsic evaluates to `()` on the
+                    // path that continues, exactly like `@assert` (spec
+                    // 4.13:5f). Unifying the operands here is what lets
+                    // `@assert_eq(port, 8080)` give the literal the other
+                    // side's type instead of the bare `i32` default; sema then
+                    // checks that type supports `==`.
+                    let operand_var = self.fresh_var();
+                    let operand_ty = InferType::Var(operand_var);
+                    for arg_ref in args.iter() {
+                        let info = generate_intrinsic_arg!(*arg_ref);
+                        self.add_constraint(Constraint::equal(
+                            info.ty,
+                            operand_ty.clone(),
+                            info.span,
+                        ));
                     }
                     InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "read_line" {
@@ -5256,6 +5275,52 @@ mod tests {
                     interner.resolve(&name)
                 );
             }
+        }
+    }
+
+    /// `@assert_eq`/`@assert_ne` are unit-typed like `@assert`, and their two
+    /// operands share one type — which is what lets a bare literal take the
+    /// other side's type instead of the `i32` default (ADR-0083 Phase 2.5,
+    /// spec 4.13:5f).
+    #[test]
+    fn comparison_assertions_are_unit_and_unify_their_operands_in_hm() {
+        for name in ["assert_eq", "assert_ne"] {
+            let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
+            let functions = AHashMap::new();
+            let structs = AHashMap::new();
+            let enums = AHashMap::new();
+            let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
+
+            let left = rir.add_inst(rue_rir::Inst {
+                data: InstData::BoolConst(true),
+                span: Span::new(1, 5),
+            });
+            let right = rir.add_inst(rue_rir::Inst {
+                data: InstData::IntConst(1),
+                span: Span::new(7, 8),
+            });
+            let name = interner.get_or_intern(name);
+            let intrinsic = rir
+                .add_intrinsic(name, &[left, right], Span::new(0, 9))
+                .unwrap();
+
+            let mut cgen = ConstraintGenerator::new(
+                &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+            );
+            let params = AHashMap::new();
+            let mut ctx = ConstraintContext::new(&params, Type::UNIT);
+            let info = cgen.generate(intrinsic, &mut ctx);
+            assert_eq!(
+                info.ty,
+                InferType::Concrete(Type::UNIT),
+                "@{} HM result contract",
+                interner.resolve(&name)
+            );
+            // Both operands are visited, and both are constrained to the same
+            // variable — the mismatch these two literals really are is reported
+            // when that variable is solved, not here.
+            assert!(cgen.expr_types().contains_key(&left));
+            assert!(cgen.expr_types().contains_key(&right));
         }
     }
 

--- a/crates/rue-air/src/intrinsic.rs
+++ b/crates/rue-air/src/intrinsic.rs
@@ -522,13 +522,17 @@ impl IntrinsicOperation {
             | RuntimeCallKind::StrPrintProjected
             | RuntimeCallKind::StrPrintlnAggregate
             | RuntimeCallKind::StrPrintlnProjected
-            // The ADR-0083 test channel is dispatcher and runner plumbing. No
-            // source spelling selects it, so it has no intrinsic identity —
-            // `@assert_eq` (Phase 2.5) is what will give `TestFail` one.
+            // The ADR-0083 test channel has no intrinsic identity. The
+            // dispatcher's own helpers are runner plumbing no source spelling
+            // selects; the reporting helpers are reached by a test body's `?`
+            // and by `@assert_eq`/`@assert_ne`, which emit the calls directly
+            // rather than through an `IntrinsicOperation` — a comparison is a
+            // branch around a pair of calls, not one conditional runtime call.
             | RuntimeCallKind::TestNormalizeProcess
             | RuntimeCallKind::TestComplete
             | RuntimeCallKind::TestFailureSite
             | RuntimeCallKind::TestFail
+            | RuntimeCallKind::TestFailComparison
             | RuntimeCallKind::TestUsageError => return None,
         })
     }
@@ -884,9 +888,9 @@ mod tests {
 
     // Every runtime call with no intrinsic spelling: the string and formatting
     // family, which sema selects from ordinary method calls, and the ADR-0083
-    // test channel, which only the synthesized dispatcher and the runner's own
-    // sugar reach.
-    const ORDINARY_CALL_ONLY: [RuntimeCallKind; 16] = [
+    // test channel, which the synthesized dispatcher and the assertion sugar
+    // emit as direct calls rather than through an `IntrinsicOperation`.
+    const ORDINARY_CALL_ONLY: [RuntimeCallKind; 17] = [
         RuntimeCallKind::StrByteAt,
         RuntimeCallKind::StrCharScalar,
         RuntimeCallKind::StrCharNext,
@@ -902,6 +906,7 @@ mod tests {
         RuntimeCallKind::TestComplete,
         RuntimeCallKind::TestFailureSite,
         RuntimeCallKind::TestFail,
+        RuntimeCallKind::TestFailComparison,
         RuntimeCallKind::TestUsageError,
     ];
 
@@ -1011,7 +1016,7 @@ mod tests {
             EXACT_RUNTIME_MAPPINGS.map(|(_, runtime)| runtime),
             "the exact intrinsic-to-runtime map drifted"
         );
-        assert_eq!(RuntimeCallKind::ALL.len(), 46);
+        assert_eq!(RuntimeCallKind::ALL.len(), 47);
         for kind in RuntimeCallKind::ALL {
             assert_eq!(
                 IntrinsicOperation::from_runtime_call(kind).is_some(),

--- a/crates/rue-air/src/runtime_call.rs
+++ b/crates/rue-air/src/runtime_call.rs
@@ -157,6 +157,10 @@ pub enum RuntimeCallKind {
     TestFailureSite,
     /// Report a structured failure on the §5.1 channel, then abort.
     TestFail,
+    /// Report a structured comparison failure — the two rendered operands as
+    /// `expected` and `actual` — on the §5.1 channel, then abort. What
+    /// `@assert_eq` and `@assert_ne` lower to (ADR-0083 Phase 2.5).
+    TestFailComparison,
     /// Write the pinned malformed-selector diagnostic and return.
     TestUsageError,
 }
@@ -326,7 +330,7 @@ const TEST_FAIL: &[RuntimeOperandOrigin] = &[
 ];
 
 impl RuntimeCallKind {
-    pub const ALL: [Self; 46] = [
+    pub const ALL: [Self; 47] = [
         Self::StrByteAt,
         Self::StrCharScalar,
         Self::StrCharNext,
@@ -372,6 +376,7 @@ impl RuntimeCallKind {
         Self::TestComplete,
         Self::TestFailureSite,
         Self::TestFail,
+        Self::TestFailComparison,
         Self::TestUsageError,
     ];
 
@@ -420,6 +425,7 @@ impl RuntimeCallKind {
             Self::TestComplete => RuntimeHelperId::TestComplete,
             Self::TestFailureSite => RuntimeHelperId::TestFailureSite,
             Self::TestFail => RuntimeHelperId::TestFail,
+            Self::TestFailComparison => RuntimeHelperId::TestFailComparison,
             Self::TestUsageError => RuntimeHelperId::TestUsageError,
         }
     }
@@ -463,7 +469,10 @@ impl RuntimeCallKind {
             Self::ByteCopy | Self::ByteMove => BYTE_COPY,
             Self::ByteSet => BYTE_SET,
             Self::TestFailureSite => TEST_FAILURE_SITE,
-            Self::TestFail => TEST_FAIL,
+            // The comparison form carries `kind`, `left`, and `right` where the
+            // open form carries `kind`, `message`, and `payload`: three byte
+            // views either way, so one operand plan serves both.
+            Self::TestFail | Self::TestFailComparison => TEST_FAIL,
         }
     }
 

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -182,6 +182,39 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ))
     }
 
+    /// Lower one comparison over two already-analyzed operands.
+    ///
+    /// This is the single comparison lowering. `==`/`!=`/`<`/… reach it from
+    /// `analyze_comparison` once their operands are analyzed, and
+    /// `@assert_eq`/`@assert_ne` reach it with the operands they evaluated once
+    /// for both the comparison and the rendering (ADR-0083 Phase 2.5). Sharing
+    /// it is what keeps `@assert_eq(a, b)` and `a == b` from being two answers
+    /// to the same question: the aggregate route (a `StrBuf`'s borrowed
+    /// `equals_borrowed`, 4.3:3) is reachable only here, so an intrinsic that
+    /// built its own `Eq` node would silently compare two string headers.
+    pub(super) fn build_comparison(
+        &mut self,
+        air: &mut Air,
+        comparison: AirInstData,
+        lhs: AnalysisResult,
+        rhs: AnalysisResult,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if matches!(comparison, AirInstData::Eq(..) | AirInstData::Ne(..))
+            && let Some(result) =
+                self.try_prepare_aggregate_equality(air, &comparison, lhs, rhs, span, ctx)?
+        {
+            return Ok(result);
+        }
+        let air_ref = air.add_inst(AirInst {
+            data: comparison,
+            ty: Type::BOOL,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::BOOL))
+    }
+
     /// Prepare source-defined aggregate equality when the aggregate provides
     /// the canonical borrowed equality method.
     pub(super) fn try_prepare_aggregate_equality(

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -442,25 +442,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         let comparison = make_data(lhs_result.air_ref, rhs_result.air_ref);
-        if matches!(comparison, AirInstData::Eq(..) | AirInstData::Ne(..))
-            && let Some(result) = self.try_prepare_aggregate_equality(
-                air,
-                &comparison,
-                lhs_result,
-                rhs_result,
-                span,
-                ctx,
-            )?
-        {
-            return Ok(result);
-        }
-
-        let air_ref = air.add_inst(AirInst {
-            data: comparison,
-            ty: Type::BOOL,
-            span,
-        });
-        Ok(AnalysisResult::new(air_ref, Type::BOOL))
+        self.build_comparison(air, comparison, lhs_result, rhs_result, span, ctx)
     }
 
     fn is_sentinel_lookup_test(&self, lhs: InstRef, rhs: InstRef) -> bool {

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -413,6 +413,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             self.analyze_panic_intrinsic(air, &args, span, ctx)
         } else if name == known.assert {
             self.analyze_assert_intrinsic(air, &args, span, ctx)
+        } else if name == known.assert_eq {
+            self.analyze_assert_comparison_intrinsic(air, "assert_eq", true, &args, span, ctx)
+        } else if name == known.assert_ne {
+            self.analyze_assert_comparison_intrinsic(air, "assert_ne", false, &args, span, ctx)
         } else if name == known.import {
             self.analyze_import_intrinsic(air, &args, span)
         } else if name == known.random_u32 {
@@ -1173,7 +1177,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // lower it to the `__rue_panic_no_msg` abort call instead of a
             // silent no-op. `@panic` has type `!` (never): it diverges and never
             // returns, so it participates in never coercion just like a `-> !`
-            // call, `return`, or `break` (spec 3.4:2, 4.13:5b; RUE-512).
+            // call, `return`, or `break` (spec 3.4:2, 4.13:5c; RUE-512).
             let air_ref = air.add_intrinsic(
                 crate::IntrinsicOperation::PanicNoMessage,
                 self.known_symbols().panic,
@@ -1312,6 +1316,280 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let air_ref =
             self.wrap_value_with_temp_scope(air, intrinsic_ref, Type::UNIT, span, temp_scope)?;
         Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
+    /// Analyze `@assert_eq(left, right)` and `@assert_ne(left, right)`
+    /// (ADR-0083 Phase 2.5, spec 4.13:5f).
+    ///
+    /// The family is `@assert` with a structured report. Both operands are read
+    /// once — equality borrows its operands (4.3:3f), so neither is consumed —
+    /// and compared through the one comparison lowering `==`/`!=` use, so
+    /// "supports `==`" here means exactly what it means there and a `StrBuf`
+    /// compares by content rather than by header. The failing arm renders each
+    /// operand with the same compiler-synthesized structural printer a test
+    /// body's `?` uses (ADR-0083 §1), stages the intrinsic's own site, and
+    /// calls the terminal comparison helper, which writes one frame carrying
+    /// `expected` and `actual` on the §5.1 channel and then takes the ordinary
+    /// panic path.
+    ///
+    /// The lowering is the same in a test image and in an ordinary executable.
+    /// Only the outcome differs, and only because the channel is a descriptor
+    /// an ordinary process does not have: the frame write fails with `EBADF`
+    /// and the pinned stderr message is the whole report. A build-mode-sensitive
+    /// lowering would make the same source mean two different things.
+    fn analyze_assert_comparison_intrinsic(
+        &mut self,
+        air: &mut Air,
+        intrinsic_name: &str,
+        equality: bool,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if args.len() != 2 {
+            // Analyze what was supplied anyway, so an error inside an operand is
+            // reported instead of being hidden behind the arity error.
+            for arg in args {
+                let _ = self.analyze_inst(air, arg.value, ctx);
+            }
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: intrinsic_name.to_string(),
+                    expected: 2,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let left_span = self.body_rir_ref().get(args[0].value).span;
+        let right_span = self.body_rir_ref().get(args[1].value).span;
+        let left = self.analyze_inst_for_projection(air, args[0].value, ctx)?;
+        let reachable_edges_after_left = ctx.ownership.loop_break_stack.clone();
+        let divergence_before_right = ctx.divergence_kinds;
+        // A bare literal on the right takes the left operand's text type, the
+        // same way `==` gives it one: without this, `@assert_eq(name, "rue")`
+        // would compare a `StrBuf` against a defaulted `str`.
+        let expected = (self.is_strbuf(left.ty) || self.is_str_like(left.ty)).then_some(left.ty);
+        let right = ctx.with_expected_type(expected, |ctx| {
+            self.analyze_inst_for_projection(air, args[1].value, ctx)
+        })?;
+        if !left.continues {
+            Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_left);
+            ctx.divergence_kinds = divergence_before_right;
+        }
+
+        // The condition the report is guarded by is the *failing* one, so the
+        // report is the then-arm of a branch with no else — the shape that says
+        // "nothing after this point is reachable from the report", which is
+        // what an arm ending in a `-> !` call means.
+        let failed = if equality {
+            AirInstData::Ne(left.air_ref, right.air_ref)
+        } else {
+            AirInstData::Eq(left.air_ref, right.air_ref)
+        };
+
+        // An operand that diverges means the assertion is never reached. Keep
+        // the comparison node so the operands are still lowered, and report the
+        // unreachable edge rather than a type error about a `!` operand.
+        if !left.continues || !right.continues {
+            let air_ref = air.add_inst(AirInst {
+                data: failed,
+                ty: Type::BOOL,
+                span,
+            });
+            return Ok(AnalysisResult::with_continues(air_ref, Type::UNIT, false));
+        }
+        if left.ty.is_never() || left.ty.is_error() || right.ty.is_error() {
+            let air_ref = air.add_inst(AirInst {
+                data: failed,
+                ty: Type::BOOL,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
+        }
+
+        // Both operands must be the same type. Inference constrains them to one
+        // type variable and so ordinarily reports a mismatch first; this is the
+        // guard that makes that a checked fact rather than an assumption,
+        // because one printer instance renders both operands and a printer
+        // built for the left type would read the right one's bytes by the wrong
+        // plan.
+        if !self.types_equivalent(left.ty, right.ty) {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: intrinsic_name.to_string(),
+                    expected: self.format_type_name(left.ty),
+                    found: self.format_type_name(right.ty),
+                })),
+                right_span,
+            ));
+        }
+        // …and that type must support `==` under the ordinary rules. This is
+        // the check `==` itself runs, so the two never disagree about which
+        // types are comparable.
+        self.validate_equality_operand_type(left.ty, left_span)?;
+
+        if let Some(fails) = Self::comptime_comparison(air, &failed) {
+            // Both operands are compile-time constants, so the comparison has
+            // an answer now and the intrinsic is exactly the `@assert` it could
+            // have been written as — no branch, no rendering, and no printer
+            // synthesized for a type nothing will render at run time.
+            let condition = air.add_inst(AirInst {
+                data: AirInstData::BoolConst(!fails),
+                ty: Type::BOOL,
+                span,
+            });
+            let assertion = air.add_intrinsic(
+                crate::IntrinsicOperation::AssertFailed,
+                self.known_symbols().assert,
+                &[condition],
+                Type::UNIT,
+                span,
+            )?;
+            let block =
+                air.add_block(&[left.air_ref, right.air_ref], assertion, Type::UNIT, span)?;
+            return Ok(AnalysisResult::new(block, Type::UNIT));
+        }
+
+        let condition = self.build_comparison(air, failed, left, right, span, ctx)?;
+
+        // The report arm consumes nothing. Both operands were read as
+        // projections above — the borrowing read `==` performs (4.3:3f) — and
+        // the printer call passes that already-read value, so an operand that
+        // is a field of a `borrow` parameter, a non-`Copy` field of a borrowed
+        // local, or a local still needed afterwards is legal here exactly as it
+        // is in `a == b`. What the printer receives by value is the read's
+        // result, not the place it came from; it never frees or drops it, and
+        // the process traps in the next call (ADR-0083 §1).
+        let report = self.build_comparison_report(
+            air,
+            intrinsic_name,
+            left.ty,
+            left.air_ref,
+            right.air_ref,
+            span,
+            ctx,
+        )?;
+
+        let branch = air.add_inst(AirInst {
+            data: AirInstData::Branch {
+                cond: condition.air_ref,
+                then_value: report,
+                else_value: None,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+        Ok(AnalysisResult::new(branch, Type::UNIT))
+    }
+
+    /// The failing arm of a comparison assertion: render, stage the site,
+    /// report, abort.
+    ///
+    /// The two channel calls are a pair by ABI — a failure record is more
+    /// arguments than a register-only helper can take — and the second adopts
+    /// whatever site the first staged, so nothing may run between them. Both
+    /// renderings are therefore materialized as statements *before* the site
+    /// call, exactly as the test-body `?` arm materializes its payload.
+    #[allow(clippy::too_many_arguments)]
+    fn build_comparison_report(
+        &mut self,
+        air: &mut Air,
+        intrinsic_name: &str,
+        operand_ty: Type,
+        left: AirRef,
+        right: AirRef,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AirRef> {
+        let str_ty = self.get_or_create_str_struct(span)?;
+        // One printer per type, named once per body: `@assert_eq` at two sites
+        // on the same type shares the instance a `?` on that type would use.
+        let printer = self.structural_printer_symbol(operand_ty, span, ctx)?;
+        let render = |air: &mut Air, value: AirRef| {
+            air.add_call(
+                None,
+                printer,
+                &[AirCallArg {
+                    value,
+                    mode: AirArgMode::Normal,
+                }],
+                str_ty,
+                span,
+            )
+        };
+        let left_text = render(air, left)?;
+        let right_text = render(air, right)?;
+
+        // A site the host cannot resolve is reported as the empty file at 0:0
+        // rather than as a compile error: the ABI accepts an absent location,
+        // and a report that cannot name its line is still a better failure than
+        // no report.
+        let (path, line, column) = self
+            .body_source_coordinate(span)
+            .unwrap_or_else(|| (std::sync::Arc::from(""), 0, 0));
+        let file = self.synthesized_string(air, ctx, &path, str_ty, span);
+        let line = air.add_inst(AirInst {
+            data: AirInstData::Const(u64::from(line)),
+            ty: Type::U32,
+            span,
+        });
+        let column = air.add_inst(AirInst {
+            data: AirInstData::Const(u64::from(column)),
+            ty: Type::U32,
+            span,
+        });
+        let site = self.runtime_channel_call(
+            air,
+            crate::RuntimeCallKind::TestFailureSite,
+            &[file, line, column],
+            Type::UNIT,
+            span,
+        )?;
+
+        // The message is pinned by the kind inside the runtime helper, which is
+        // what keeps this terminal call to the six registers every runtime
+        // helper is limited to while still carrying both renderings.
+        let kind = self.synthesized_string(air, ctx, intrinsic_name, str_ty, span);
+        let report = self.runtime_channel_call(
+            air,
+            crate::RuntimeCallKind::TestFailComparison,
+            &[kind, left_text, right_text],
+            Type::NEVER,
+            span,
+        )?;
+        Ok(air.add_block(
+            &[left_text, right_text, kind, site],
+            report,
+            Type::NEVER,
+            span,
+        )?)
+    }
+
+    /// Evaluate a comparison whose operands both analyzed to a compile-time
+    /// scalar, or `None` when at least one of them did not.
+    ///
+    /// Only the scalar constants fold. A byte string deliberately does not: two
+    /// identical literals are one interned run and would compare equal, but
+    /// equality on text is a content comparison the run-time lowering performs
+    /// (4.3:3), and answering it from the interning table would make the fold a
+    /// second, subtly different equality.
+    fn comptime_comparison(air: &Air, comparison: &AirInstData) -> Option<bool> {
+        let (left, right, equality) = match comparison {
+            AirInstData::Eq(left, right) => (*left, *right, true),
+            AirInstData::Ne(left, right) => (*left, *right, false),
+            _ => return None,
+        };
+        let equal = match (&air.get(left).data, &air.get(right).data) {
+            // The operands share one type by the time this runs, so equal bit
+            // patterns are equal values for every integer width and signedness.
+            (AirInstData::Const(left), AirInstData::Const(right)) => left == right,
+            (AirInstData::BoolConst(left), AirInstData::BoolConst(right)) => left == right,
+            (AirInstData::UnitConst, AirInstData::UnitConst) => true,
+            _ => return None,
+        };
+        Some(equal == equality)
     }
 
     /// Validate the shared message contract of `@panic` and `@assert`.

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -2038,7 +2038,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ty: err_ty,
                     span,
                 });
-                let printer = self.error_printer_symbol(err_ty, span, ctx)?;
+                let printer = self.structural_printer_symbol(err_ty, span, ctx)?;
                 air.add_call(
                     None,
                     printer,
@@ -2111,7 +2111,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     }
 
     /// Emit one ADR-0083 §5.1 failure-channel call by its manifest symbol.
-    fn runtime_channel_call(
+    ///
+    /// Shared with the comparison intrinsics (`@assert_eq`/`@assert_ne`,
+    /// ADR-0083 Phase 2.5), which report on the same channel.
+    pub(in crate::sema) fn runtime_channel_call(
         &mut self,
         air: &mut Air,
         runtime: crate::RuntimeCallKind,
@@ -2131,7 +2134,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     }
 
     /// Materialize one compiler-authored `str` run in this body.
-    fn synthesized_string(
+    pub(in crate::sema) fn synthesized_string(
         &mut self,
         air: &mut Air,
         ctx: &mut AnalysisContext,
@@ -2147,24 +2150,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         })
     }
 
-    /// The body-local call symbol naming `err_ty`'s structural printer.
+    /// The body-local call symbol naming `value_ty`'s structural printer.
     ///
-    /// The identity is the error type alone, so a second `?` site on the same
+    /// The identity is the rendered type alone, so a second site on the same
     /// type reuses this symbol and the request synthesizes one printer for both
-    /// (ADR-0083 §1).
-    fn error_printer_symbol(
+    /// (ADR-0083 §1). Sites are `?` failure arms and the operands of
+    /// `@assert_eq`/`@assert_ne` (Phase 2.5) alike: both render a value the
+    /// same way, so both name the same instance.
+    pub(in crate::sema) fn structural_printer_symbol(
         &mut self,
-        err_ty: Type,
+        value_ty: Type,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Spur> {
-        if let Some(symbol) = ctx.error_printer_symbols.get(&err_ty) {
+        if let Some(symbol) = ctx.error_printer_symbols.get(&value_ty) {
             return Ok(*symbol);
         }
-        let owner = self.canonical_type_instance(err_ty).map_err(|failure| {
+        let owner = self.canonical_type_instance(value_ty).map_err(|failure| {
             CompileError::new(
                 ErrorKind::InternalError(format!(
-                    "test-body `?` could not name its error type: {failure:?}"
+                    "a structural printer could not name its value type: {failure:?}"
                 )),
                 span,
             )
@@ -2175,7 +2180,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             symbol,
             crate::FunctionInstanceKey::ErrorPrinter(Node::new(owner)),
         );
-        ctx.error_printer_symbols.insert(err_ty, symbol);
+        ctx.error_printer_symbols.insert(value_ty, symbol);
         Ok(symbol)
     }
 

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -59,6 +59,11 @@ pub struct KnownSymbols {
     pub panic: Spur,
     /// The `assert` intrinsic symbol.
     pub assert: Spur,
+    /// The `assert_eq` intrinsic symbol — the comparison family's equality
+    /// form (ADR-0083 Phase 2.5, spec 4.13:5f).
+    pub assert_eq: Spur,
+    /// The `assert_ne` intrinsic symbol — the same family's inequality form.
+    pub assert_ne: Spur,
     /// The `read_line` intrinsic symbol.
     pub read_line: Spur,
     /// The `to_string` intrinsic symbol - formats an i64 as a decimal String.
@@ -223,6 +228,8 @@ impl KnownSymbols {
             cast: intern("cast")?,
             panic: intern("panic")?,
             assert: intern("assert")?,
+            assert_eq: intern("assert_eq")?,
+            assert_ne: intern("assert_ne")?,
             read_line: intern("read_line")?,
             to_string: intern("to_string")?,
             print: intern("print")?,
@@ -313,6 +320,8 @@ mod tests {
         assert_eq!(interner.resolve(&known.cast), "cast");
         assert_eq!(interner.resolve(&known.panic), "panic");
         assert_eq!(interner.resolve(&known.assert), "assert");
+        assert_eq!(interner.resolve(&known.assert_eq), "assert_eq");
+        assert_eq!(interner.resolve(&known.assert_ne), "assert_ne");
         assert_eq!(interner.resolve(&known.read_line), "read_line");
         assert_eq!(interner.resolve(&known.print), "print");
         assert_eq!(interner.resolve(&known.println), "println");

--- a/crates/rue-cli-tests/cases/rue_test_assert.toml
+++ b/crates/rue-cli-tests/cases/rue_test_assert.toml
@@ -1,0 +1,454 @@
+[section]
+id = "cli.rue_test_assert"
+name = "`@assert_eq` / `@assert_ne` through `rue test`"
+description = """
+RUE-1620 (ADR-0083 Phase 2.5, spec 4.13:5f): the comparison family reports both
+operands as structured data. These run the whole path through the real binary —
+compiler, linked test image, dispatched process, `__rue_test_fail_comparison`,
+failure channel, runner — so what is pinned here is what a consumer of the event
+stream actually sees: kind `assert_eq` or `assert_ne`, the intrinsic's own line
+and column, `expected` and `actual` rendered by the synthesized structural
+printer, and the `diff` the runner computes between them.
+
+`-j1` and `--format json` for the same reasons the sibling `cli.rue_test` cases
+give: whole-line interleaving is by design under parallel workers, and the event
+schema is a consumer contract (docs/process/test-events.md). Object keys are
+alphabetical, which is why `"actual"` precedes `"diff"` precedes `"expected"` in
+every expectation below.
+
+The last two cases leave `rue test` behind on purpose. The family lowers the
+same way in an ordinary executable — there is simply no descriptor 3 there — and
+an ordinary build's whole report is the pinned stderr message and status 101.
+"""
+
+# =============================================================================
+# The structured report: kind, site, operands, diff.
+# =============================================================================
+
+[[case]]
+name = "an_integer_comparison_reports_both_operands_and_a_character_diff"
+description = """
+Neither rendering contains a newline, so the diff is character-level and locates
+the single digit that differs. The site is the intrinsic's own position, not the
+test declaration's header: the declaration is on line 5 and the assertion on
+line 6.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+fn parse_port() -> i32 {
+    41
+}
+
+test "parses a port" {
+    @assert_eq(parse_port(), 42);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"assert_eq"',
+    '"message":"assertion failed: left == right"',
+    '"actual":"42","diff":[{"op":"equal","text":"4"},{"op":"delete","text":"1"},{"op":"insert","text":"2"}],"exit_code":101,"expected":"41"',
+    '"column":5,"file":',
+    '"line":6}',
+    '"verdict":"fail"',
+    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+]
+compile_stdout_not_contains = ['"payload"']
+
+[[case]]
+name = "a_strbuf_comparison_reports_its_bytes"
+description = """
+A `StrBuf` operand renders as its own bytes, and `==` on it is the content
+comparison 4.3:3 specifies — the family reuses that lowering rather than
+comparing two headers.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+test "compares two owned strings" {
+    let left = StrBuf.from_str(borrow "alpha");
+    let right = StrBuf.from_str(borrow "alpine");
+    @assert_eq(left, right);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"assert_eq"',
+    '"actual":"alpine"',
+    '"expected":"alpha"',
+    '{"op":"equal","text":"alp"}',
+    '"verdict":"fail"',
+]
+
+[[case]]
+name = "a_struct_comparison_renders_one_level_deep"
+description = """
+The rendering rules are the `?` failure arm's, unchanged: a struct renders as
+`{ field: value, … }` one level deep, with integers in decimal and `bool` as
+`true`/`false`.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+struct Point { x: i32, y: bool }
+
+fn origin() -> Point {
+    Point { x: 41, y: true }
+}
+
+test "compares two points" {
+    @assert_eq(origin(), Point { x: 42, y: false });
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"expected":"{ x: 41, y: true }"',
+    '"actual":"{ x: 42, y: false }"',
+    '"kind":"assert_eq"',
+]
+
+[[case]]
+name = "an_enum_comparison_renders_its_variant_and_payload"
+description = "A unit variant renders as its name, a payload variant as its name and its rendered payloads."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+enum Shape {
+    Dot,
+    Line(i32),
+}
+
+fn drawn() -> Shape {
+    Shape.Line(3)
+}
+
+test "compares two shapes" {
+    @assert_eq(drawn(), Shape.Dot);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"expected":"Line(3)"',
+    '"actual":"Dot"',
+    '"kind":"assert_eq"',
+]
+
+[[case]]
+name = "assert_ne_on_equal_values_reports_the_pair_it_rejected"
+description = """
+An `@assert_ne` failure has two identical renderings, so its diff is one `equal`
+hunk. Both fields stay present: the report is the pair the assertion demanded be
+different.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+fn parse_port() -> i32 {
+    41
+}
+
+test "rejects a duplicate port" {
+    @assert_ne(parse_port(), 41);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"assert_ne"',
+    '"message":"assertion failed: left != right"',
+    '"actual":"41","diff":[{"op":"equal","text":"41"}],"exit_code":101,"expected":"41"',
+]
+
+[[case]]
+name = "a_holding_comparison_reports_nothing"
+description = "A passing comparison has no effect, and the pass carries no failure record at all."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+fn parse_port() -> i32 {
+    8080
+}
+
+test "accepts a port" {
+    @assert_eq(parse_port(), 8080);
+    @assert_ne(parse_port(), 80);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = [
+    '"verdict":"pass"',
+    '"crash":0,"event":"run_finished","failed":0,"passed":1',
+]
+compile_stdout_not_contains = ['"failure"', '"expected"', '"diff"']
+
+# =============================================================================
+# Borrowed operands (spec 4.13:5f, 4.3:3f).
+#
+# The report arm renders each operand with a printer whose parameter is by
+# value, so the shape at risk is a place the body may only borrow: a field of a
+# `borrow` parameter, a non-`Copy` field of a borrowed local, a local still
+# needed afterwards. The comparison reads its operands the way `==` does and the
+# rendering passes that read's result, so none of these is a move — and the
+# failing case below proves the printer really does read through the borrow at
+# run time rather than rendering a corpse.
+# =============================================================================
+
+[[case]]
+name = "a_borrowed_strbuf_field_renders_on_the_failing_path"
+description = """
+The operand is `t.name`, where `t` is a `borrow` parameter and `name` is a
+`StrBuf`. The rendering has to reach the borrowed buffer's bytes, so the frame's
+`expected` is the real content rather than an empty or stale view.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Thing { name: StrBuf, size: i32 }
+
+fn check_name(borrow t: Thing, borrow expected: StrBuf) {
+    @assert_eq(t.name, expected);
+}
+
+test "compares a borrowed field" {
+    let thing = Thing { name: StrBuf.from_str(borrow "alpha"), size: 3 };
+    let expected = StrBuf.from_str(borrow "alpine");
+    check_name(borrow thing, borrow expected);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"assert_eq"',
+    '"expected":"alpha"',
+    '"actual":"alpine"',
+    '{"op":"equal","text":"alp"}',
+]
+
+[[case]]
+name = "borrowed_operands_hold_and_stay_usable"
+description = """
+The passing half of the same shape, plus the two remaining ones: a `Copy` field
+of a borrowed local, and locals used by value after the comparison. All of it
+must compile and run — the comparison consumes nothing.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Thing { name: StrBuf, size: i32 }
+
+fn check_name(borrow t: Thing, borrow expected: StrBuf) {
+    @assert_eq(t.name, expected);
+}
+
+fn check_size(borrow t: Thing) {
+    @assert_eq(t.size, 3);
+}
+
+fn consume(s: StrBuf) -> u64 { s.len() }
+
+test "borrowed operands are read, not taken" {
+    let thing = Thing { name: StrBuf.from_str(borrow "alpha"), size: 3 };
+    let expected = StrBuf.from_str(borrow "alpha");
+    check_name(borrow thing, borrow expected);
+    check_size(borrow thing);
+    // A non-`Copy` field of a borrowed local, compared in place, then still
+    // read through afterwards.
+    @assert_eq(thing.name, expected);
+    @assert_eq(thing.name.len(), expected.len());
+    // And locals the body consumes by value after comparing them.
+    let v = StrBuf.from_str(borrow "same");
+    let w = StrBuf.from_str(borrow "same");
+    @assert_eq(v, w);
+    @assert_eq(consume(v) + consume(w), 8);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = [
+    '"verdict":"pass"',
+    '"crash":0,"event":"run_finished","failed":0,"passed":1',
+]
+
+# =============================================================================
+# The human rendering, built from the same values (ADR-0083 §2).
+# =============================================================================
+
+[[case]]
+name = "the_human_rendering_puts_a_caret_under_the_first_difference"
+description = """
+A single-line pair prints both values aligned with a caret under the first
+character that differs. The caret's column comes out of the same `diff` the JSON
+stream publishes, so the two surfaces cannot disagree about where the difference
+is.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+fn parse_port() -> i32 {
+    41
+}
+
+test "parses a port" {
+    @assert_eq(parse_port(), 42);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    "assert_eq: assertion failed: left == right",
+    "  expected: 41\n  actual:   42\n             ^\n",
+]
+
+[[case]]
+name = "the_human_rendering_of_a_multi_line_pair_is_a_hunk_listing"
+description = """
+A multi-line pair gets the `-`/`+` listing instead of a caret, because a caret
+into a wall of text locates nothing.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+fn rendered() -> str {
+    "alpha\\nbeta\\ngamma\\n"
+}
+
+test "compares two documents" {
+    @assert_eq(rendered(), "alpha\\nBETA\\ngamma\\n");
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    "  expected:\n    alpha\n    beta\n    gamma\n",
+    "  actual:\n    alpha\n    BETA\n    gamma\n",
+    "  diff:\n      alpha\n    - beta\n    + BETA\n      gamma\n",
+]
+
+# =============================================================================
+# Outside a test image (spec 4.13:5f).
+# =============================================================================
+
+[[case]]
+name = "an_ordinary_build_traps_with_the_pinned_message"
+description = """
+The same source compiled as an ordinary executable takes the same lowering. The
+frame write finds no descriptor 3 and fails with `EBADF` by design, so what is
+left is the pinned message and status 101 — the whole report an ordinary program
+owes.
+"""
+files = [{ path = "main.rue", source = """
+fn parse_port() -> i32 {
+    41
+}
+
+fn main() -> i32 {
+    @assert_eq(parse_port(), 42);
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: assertion failed: left == right"]
+
+[[case]]
+name = "an_ordinary_build_names_the_inequality_it_checked"
+description = "`@assert_ne` pins its own message, so a reader can tell which comparison failed without the structured report."
+files = [{ path = "main.rue", source = """
+fn parse_port() -> i32 {
+    41
+}
+
+fn main() -> i32 {
+    @assert_ne(parse_port(), 41);
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: assertion failed: left != right"]

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -2013,12 +2013,12 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
 // identity even when constructor, caller, and macro token counts do not.
 const CONSTRUCTION_TOKEN_STRUCT_IDENTITY: (usize, u64) = (80, 5_227_448_979_315_228_973);
 const CONSTRUCTION_TOKEN_IMPL_IDENTITY: (usize, u64) = (108, 2_765_439_612_714_245_239);
-const COMPILER_CRATE_ROOT_IDENTITY: (usize, u64) = (10_799, 16_325_515_270_950_367_680);
+const COMPILER_CRATE_ROOT_IDENTITY: (usize, u64) = (10_841, 1_910_863_920_709_222_275);
 const COMPILER_CRATE_ROOT_NAMESPACE_IDENTITY: (usize, u64, usize, u64) = (
-    114,
-    11_273_416_965_168_702_126,
-    229,
-    2_753_161_391_832_661_620,
+    115,
+    16_786_415_244_923_993_326,
+    230,
+    6_981_227_682_883_627_572,
 );
 const COMPILER_SESSION_ROOT_IDENTITY: (usize, u64) = (3_375, 11_197_616_651_825_656_461);
 const COMPILER_SESSION_CONSTRUCTOR_IDENTITY: (usize, u64) = (82, 10_721_269_354_679_246_675);
@@ -4454,7 +4454,7 @@ pub(super) use register_parse_import_parse;"#;
     ));
     let nested_module_owners = module_owner_inventory(&compiler_module_sources);
     let nested_module_fingerprint = source_inventory_fingerprint(&nested_module_owners);
-    let expected_nested_module_identity = (159, 15_474_350_804_192_522_746);
+    let expected_nested_module_identity = (160, 14_291_932_838_853_825_352);
     assert_eq!(
         (nested_module_owners.len(), nested_module_fingerprint),
         expected_nested_module_identity,
@@ -7071,6 +7071,7 @@ fn facade_stays_small_and_session_centered() {
         .map(|(name, _)| *name)
         .chain([
             "api_inventory",
+            "assert_comparison_tests",
             "integration_tests",
             "pipeline_tests",
             "producer_nominal_acceptance_tests",

--- a/crates/rue-compiler/src/assert_comparison_tests.rs
+++ b/crates/rue-compiler/src/assert_comparison_tests.rs
@@ -1,0 +1,487 @@
+//! `@assert_eq` and `@assert_ne` (ADR-0083 Phase 2.5, spec 4.13:5f).
+//!
+//! These are the session-level half of the family's coverage: the lowered shape
+//! the runtime contract depends on, and the identity rule that makes the
+//! structural printer shared rather than per-site. What a failing comparison
+//! actually reports — the frame's `expected` and `actual`, the runner's diff,
+//! and the human rendering — is covered end to end by the `cli.rue_test_assert`
+//! cases, and the ordinary-build trap by `cli.rue_test_assert`'s executable
+//! case and the `4.13:5f` spec cases.
+//!
+//! The requests here are ordinary executable ones, deliberately. The family is
+//! usable anywhere `@assert` is, and lowering it identically in and out of a
+//! test image is the property worth pinning: nothing here mentions a test item.
+
+use crate::*;
+
+use ahash::AHashMap;
+
+/// Lower `source` as an ordinary executable request and return its
+/// pre-optimization CFGs.
+fn rooted_cfg(source: &str) -> Result<crate::session::RootedCfgOutput, CompileErrors> {
+    let snapshot = SourceSnapshot::single("main.rue", source).map_err(CompileErrors::from)?;
+    let (_, semantic, _) = crate::test_frontend_snapshot(&snapshot, &CompileOptions::default())?;
+    Ok(semantic)
+}
+
+/// Lower `source` as an ordinary executable request against the trusted
+/// standard-library fixtures, for the operand shapes that need a non-`Copy`
+/// type: `StrBuf` is where "read, don't consume" has observable consequences.
+fn rooted_cfg_with_std(source: &str) -> Result<crate::session::RootedCfgOutput, CompileErrors> {
+    let snapshot = crate::test_body_try_tests::trusted_snapshot(source);
+    let (_, semantic, _) = crate::test_frontend_snapshot(&snapshot, &CompileOptions::default())?;
+    Ok(semantic)
+}
+
+fn unit<'a>(
+    output: &'a crate::session::RootedCfgOutput,
+    name: &str,
+) -> &'a crate::session::RootedCfgUnit {
+    output
+        .functions()
+        .iter()
+        .find(|unit| unit.definition_source_name() == Some(name))
+        .unwrap_or_else(|| panic!("the request lowers `{name}`"))
+}
+
+fn printers(output: &crate::session::RootedCfgOutput) -> Vec<&crate::FunctionInstanceKey> {
+    output
+        .functions()
+        .iter()
+        .map(|function| &function.function)
+        .filter(|function| matches!(function, crate::FunctionInstanceKey::ErrorPrinter(_)))
+        .collect()
+}
+
+/// Every call one function makes, in block order then instruction order, named
+/// either by its runtime helper or by the callee symbol.
+fn call_sequence(unit: &crate::session::RootedCfgUnit) -> Vec<String> {
+    let mut names = AHashMap::new();
+    let mut sequence = Vec::new();
+    for block in unit.cfg().blocks() {
+        for value in &block.insts {
+            if let rue_cfg::CfgInstData::Call { runtime, name, .. } =
+                &unit.cfg().get_inst(*value).data
+            {
+                let label = match runtime {
+                    Some(runtime) => format!("{runtime:?}"),
+                    None => {
+                        let symbol = unit.interner().resolve(name).to_owned();
+                        let next = names.len();
+                        // Printer symbols carry a content digest, which is not
+                        // a stable thing to assert on; number them by first
+                        // appearance so two calls to one printer are visibly
+                        // the same callee.
+                        if symbol.contains("error_printer") {
+                            format!("printer#{}", *names.entry(symbol).or_insert(next))
+                        } else {
+                            symbol
+                        }
+                    }
+                };
+                sequence.push(label);
+            }
+        }
+    }
+    sequence
+}
+
+/// The failing arm's order is a contract with the runtime: both renderings
+/// first, then the staging call, then the terminal report — because the site
+/// the second call adopts is whatever the first staged, and nothing may run
+/// between them.
+#[test]
+fn the_failing_arm_renders_then_stages_then_reports() {
+    let output = rooted_cfg(
+        r#"
+fn value() -> i32 { 41 }
+fn check() {
+    @assert_eq(value(), 42);
+}
+fn main() -> i32 {
+    check();
+    0
+}
+"#,
+    )
+    .expect("`@assert_eq` is legal in an ordinary function");
+    assert_eq!(
+        call_sequence(unit(&output, "check")),
+        [
+            "__rue_fn_main_2erue__value",
+            "printer#0",
+            "printer#0",
+            "TestFailureSite",
+            "TestFailComparison",
+        ]
+    );
+}
+
+/// `@assert_ne` is the same lowering with the other comparison, and reports
+/// under its own kind.
+#[test]
+fn inequality_lowers_the_same_way() {
+    let output = rooted_cfg(
+        r#"
+fn value() -> i32 { 41 }
+fn check() {
+    @assert_ne(value(), 41);
+}
+fn main() -> i32 {
+    check();
+    0
+}
+"#,
+    )
+    .expect("`@assert_ne` is legal in an ordinary function");
+    let calls = call_sequence(unit(&output, "check"));
+    assert_eq!(
+        calls.last().map(String::as_str),
+        Some("TestFailComparison"),
+        "{calls:?}"
+    );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| call.starts_with("printer"))
+            .count(),
+        2,
+        "both operands are rendered: {calls:?}"
+    );
+}
+
+/// The staged site must be consumed by the very next instruction: a call
+/// between them would report against a location it did not stage.
+#[test]
+fn the_channel_pair_is_adjacent_in_the_lowered_cfg() {
+    let output = rooted_cfg(
+        r#"
+fn value() -> i32 { 41 }
+fn check() {
+    @assert_eq(value(), 42);
+}
+fn main() -> i32 {
+    check();
+    0
+}
+"#,
+    )
+    .expect("`@assert_eq` is legal in an ordinary function");
+    let unit = unit(&output, "check");
+    let runtime_of = |value: &rue_cfg::CfgValue| match &unit.cfg().get_inst(*value).data {
+        rue_cfg::CfgInstData::Call { runtime, .. } => *runtime,
+        _ => None,
+    };
+    let block =
+        unit.cfg()
+            .blocks()
+            .iter()
+            .find(|block| {
+                block.insts.iter().any(|value| {
+                    runtime_of(value) == Some(rue_air::RuntimeCallKind::TestFailureSite)
+                })
+            })
+            .expect("the failing arm stages a site");
+    let staged = block
+        .insts
+        .iter()
+        .position(|value| runtime_of(value) == Some(rue_air::RuntimeCallKind::TestFailureSite))
+        .expect("the staging call is in this block");
+    assert_eq!(
+        block.insts.get(staged + 1).and_then(runtime_of),
+        Some(rue_air::RuntimeCallKind::TestFailComparison),
+        "a staged site must be consumed by the very next instruction"
+    );
+}
+
+/// One printer per operand type, however many sites render it — the same
+/// identity rule a test body's `?` follows (ADR-0083 §1).
+#[test]
+fn two_sites_on_one_type_share_a_single_printer() {
+    let output = rooted_cfg(
+        r#"
+struct Point { x: i32, y: bool }
+fn origin() -> Point { Point { x: 0, y: false } }
+fn check() {
+    @assert_eq(origin(), Point { x: 1, y: true });
+    @assert_ne(origin(), Point { x: 0, y: false });
+}
+fn main() -> i32 {
+    check();
+    0
+}
+"#,
+    )
+    .expect("a struct operand supports `==` and is renderable");
+    let printers = printers(&output);
+    assert_eq!(
+        printers.len(),
+        1,
+        "an `@assert_eq` and an `@assert_ne` on one type share one printer: {printers:?}"
+    );
+    let calls = call_sequence(unit(&output, "check"));
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| call.as_str() == "printer#0")
+            .count(),
+        4,
+        "four operands, one printer: {calls:?}"
+    );
+}
+
+/// Two operand types are two printers, exactly as two error types are.
+#[test]
+fn two_operand_types_get_one_printer_each() {
+    let output = rooted_cfg(
+        r#"
+struct Point { x: i32 }
+struct Size { w: i32 }
+fn check(p: Point, s: Size) {
+    @assert_eq(p, Point { x: 1 });
+    @assert_eq(s, Size { w: 1 });
+}
+fn main() -> i32 {
+    check(Point { x: 0 }, Size { w: 0 });
+    0
+}
+"#,
+    )
+    .expect("two renderable operand types are legal");
+    assert_eq!(
+        printers(&output).len(),
+        2,
+        "two operand types are two printers: {:?}",
+        printers(&output)
+    );
+}
+
+/// A comparison both of whose operands are compile-time constants has its
+/// answer now, so it lowers to exactly the `@assert` it could have been written
+/// as: no branch to report from, no rendering, and no printer synthesized for a
+/// type nothing will render at run time.
+#[test]
+fn a_comptime_known_comparison_folds_to_a_plain_assert() {
+    let output = rooted_cfg(
+        r#"
+fn check() {
+    @assert_eq(1, 2);
+    @assert_ne(true, true);
+}
+fn main() -> i32 {
+    check();
+    0
+}
+"#,
+    )
+    .expect("a constant comparison is legal");
+    assert_eq!(
+        call_sequence(unit(&output, "check")),
+        Vec::<String>::new(),
+        "a folded comparison makes no channel or printer call"
+    );
+    assert!(
+        printers(&output).is_empty(),
+        "a folded comparison synthesizes no printer: {:?}",
+        printers(&output)
+    );
+    let intrinsics: Vec<rue_air::IntrinsicOperation> = unit(&output, "check")
+        .cfg()
+        .blocks()
+        .iter()
+        .flat_map(|block| block.insts.iter())
+        .filter_map(
+            |value| match &unit(&output, "check").cfg().get_inst(*value).data {
+                rue_cfg::CfgInstData::Intrinsic { operation, .. } => Some(*operation),
+                _ => None,
+            },
+        )
+        .collect();
+    assert_eq!(
+        intrinsics,
+        [
+            rue_air::IntrinsicOperation::AssertFailed,
+            rue_air::IntrinsicOperation::AssertFailed
+        ],
+        "the fold is the ordinary `@assert` lowering"
+    );
+}
+
+/// A byte string is deliberately not folded: `==` on text is a content
+/// comparison the run-time lowering performs, and answering it from the string
+/// interning table would be a second, subtly different equality.
+#[test]
+fn two_string_literals_are_not_folded() {
+    let output = rooted_cfg(
+        r#"
+fn check() {
+    @assert_eq("left", "right");
+}
+fn main() -> i32 {
+    check();
+    0
+}
+"#,
+    )
+    .expect("two string literals support `==`");
+    assert_eq!(
+        printers(&output).len(),
+        1,
+        "an unfolded comparison renders its operands"
+    );
+}
+
+/// The operands are *read*, not consumed — the borrowing read `==` performs
+/// (4.3:3f, spec 4.13:5f). The report arm passes what that read produced to the
+/// printer, so a place a body may only borrow is a legal operand: a field of a
+/// `borrow` parameter, a non-`Copy` field of a borrowed local, and a `Copy`
+/// field of one all analyze.
+///
+/// This is the shape most at risk from the report arm, because the printer's
+/// parameter is by value: an arm that read the *place* instead of the read's
+/// result would make every one of these a move out of a borrow.
+#[test]
+fn an_operand_may_be_a_place_the_body_may_only_borrow() {
+    let output = rooted_cfg_with_std(
+        r#"
+const sb = @import("std/strbuf.rue");
+
+struct Thing { name: sb.StrBuf, size: i32 }
+
+fn check_name(borrow t: Thing, borrow expected: sb.StrBuf) {
+    @assert_eq(t.name, expected);
+}
+
+fn check_size(borrow t: Thing) {
+    @assert_eq(t.size, 3);
+}
+
+fn main() -> i32 {
+    let thing = Thing { name: sb.owned("rue"), size: 3 };
+    let expected = sb.owned("rue");
+    check_name(borrow thing, borrow expected);
+    check_size(borrow thing);
+    // A non-`Copy` field of a borrowed local, compared in place, with both
+    // operands still live afterwards.
+    @assert_eq(thing.name, expected);
+    0
+}
+"#,
+    )
+    .expect("a borrowed place is a legal comparison operand");
+    // One printer per operand type, however the operands were reached.
+    assert_eq!(
+        printers(&output).len(),
+        2,
+        "the `StrBuf` operands and the `i32` one are two printers: {:?}",
+        printers(&output)
+    );
+}
+
+/// A local compared by `@assert_eq` is still owned afterwards, including by a
+/// later by-value use: the comparison reads it and the rendering reads it, and
+/// neither takes it.
+#[test]
+fn a_compared_local_survives_a_later_by_value_use() {
+    rooted_cfg_with_std(
+        r#"
+const sb = @import("std/strbuf.rue");
+
+fn consume(s: sb.StrBuf) -> i32 { 0 }
+
+fn main() -> i32 {
+    let v = sb.owned("same");
+    let w = sb.owned("same");
+    @assert_eq(v, w);
+    consume(v) + consume(w)
+}
+"#,
+    )
+    .expect("a compared local is not consumed by the comparison");
+}
+
+/// The operands must agree on a type. Inference constrains them to one type
+/// variable, so the mismatch is reported there rather than as a second
+/// intrinsic-shaped diagnostic.
+#[test]
+fn operands_of_different_types_are_rejected() {
+    let errors = rooted_cfg(
+        r#"
+fn main() -> i32 {
+    @assert_eq(1, true);
+    0
+}
+"#,
+    )
+    .expect_err("`@assert_eq` requires both operands to have one type");
+    let rendered = errors.to_string();
+    assert!(
+        rendered.contains("type mismatch") && rendered.contains("found bool"),
+        "unexpected diagnostics: {rendered}"
+    );
+}
+
+/// "Supports `==`" means exactly what it means for `==`, down to the wording: a
+/// raw pointer is not an equality operand, and the family reuses that one check
+/// rather than answering the question a second time.
+#[test]
+fn an_operand_type_without_equality_is_rejected_like_it_is_for_eq() {
+    let comparison = rooted_cfg(
+        r#"
+fn main() -> i32 {
+    let n: i32 = 1;
+    checked {
+        let p = @raw(n);
+        @assert_eq(p, p);
+    };
+    0
+}
+"#,
+    )
+    .expect_err("a raw pointer is not an equality operand")
+    .to_string();
+    let operator = rooted_cfg(
+        r#"
+fn main() -> i32 {
+    let n: i32 = 1;
+    checked {
+        let p = @raw(n);
+        @assert(p == p);
+    };
+    0
+}
+"#,
+    )
+    .expect_err("a raw pointer is not an equality operand")
+    .to_string();
+    assert!(
+        comparison.contains("integer, float, bool, string, unit, struct, array, or enum"),
+        "unexpected diagnostics: {comparison}"
+    );
+    assert!(
+        operator.contains("integer, float, bool, string, unit, struct, array, or enum"),
+        "unexpected diagnostics: {operator}"
+    );
+}
+
+/// The arity is exact, and the wrong one is the intrinsic's own diagnostic
+/// rather than a type error about a missing operand.
+#[test]
+fn a_wrong_operand_count_is_the_intrinsic_arity_error() {
+    let errors = rooted_cfg(
+        r#"
+fn main() -> i32 {
+    @assert_eq(1);
+    0
+}
+"#,
+    )
+    .expect_err("`@assert_eq` takes exactly two operands");
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(&error.kind, ErrorKind::IntrinsicWrongArgCount { name, expected, found }
+                if name == "assert_eq" && *expected == 2 && *found == 1)),
+        "unexpected diagnostics: {errors:?}"
+    );
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -96,6 +96,8 @@ mod producer_nominal_acceptance_tests;
 #[cfg(test)]
 mod api_inventory;
 #[cfg(test)]
+mod assert_comparison_tests;
+#[cfg(test)]
 mod integration_tests;
 #[cfg(test)]
 mod scaling_harness;

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -2465,7 +2465,7 @@ mod runtime_archive_validation_tests {
         inventory.symbols.push(marker("__rue_runtime_abi_v0", 1));
         let stale = error(&inventory, RuntimeTarget::Aarch64Linux);
         assert!(stale.contains(
-            "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v2`"
+            "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v3`"
         ));
 
         inventory
@@ -2619,7 +2619,7 @@ mod runtime_archive_validation_tests {
         let err = validation_error(&bytes);
         assert!(
             err.contains(
-                "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v2`"
+                "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v3`"
             ),
             "{err}"
         );

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -363,6 +363,25 @@ const ENTRIES: &[Entry] = &[
         external(ExternalDependencyKind::SystemCall),
         &["x86-64-linux"],
     ),
+    // A failing `@assert_eq` renders both operands first (ADR-0083 Phase 2.5),
+    // and the compiler-synthesized structural printer opens by taking a bounded
+    // buffer from the allocation helper — reached as a runtime call, since the
+    // printer is written directly in semantic-body form rather than in source
+    // that could spell `@alloc`. The interpreter stops there, before the
+    // failure-channel calls the rendering precedes, so `@alloc` is the whole
+    // gap. The passing comparisons in the same section never reach it.
+    Entry::new(
+        "cli.rue_test_assert",
+        "an_ordinary_build_names_the_inequality_it_checked",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.rue_test_assert",
+        "an_ordinary_build_traps_with_the_pinned_message",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
     Entry::new(
         "cli.slices",
         "slice_param_empty_array_len_zero",

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -87,6 +87,23 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::EmptySlicePointer),
         &[],
     ),
+    // A *failing* comparison assertion renders both operands first (spec
+    // 4.13:5f), and the compiler-synthesized structural printer opens by taking
+    // a bounded buffer from the allocation helper. The interpreter stops there;
+    // the holding cases beside these are modeled and agree, because a passing
+    // comparison renders nothing.
+    Entry::new(
+        "expressions.intrinsics",
+        "assert_eq_failing_aborts_with_its_pinned_message",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "expressions.intrinsics",
+        "assert_ne_failing_names_the_other_comparison",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
     // Source-defined StrBuf methods may still expose an unsupported target or
     // runtime boundary; their ordinary projection, allocation, pointer, and
     // inout representation paths are modeled.

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1253,13 +1253,18 @@ fn unsupported_runtime_call_kind(kind: RuntimeCallKind) -> Option<UnsupportedRun
         | RuntimeCallKind::ByteCopy
         | RuntimeCallKind::ByteMove
         | RuntimeCallKind::ByteSet
-        // The ADR-0083 test channel. No source construct spells these, and the
-        // oracle models ordinary compiled programs rather than test images, so
-        // a corpus program cannot reach one.
+        // The ADR-0083 test channel. The dispatcher's own helpers belong to a
+        // test image, which the oracle never compiles. The reporting helpers
+        // are reachable in an ordinary program — `@assert_eq` lowers to them —
+        // but only after the rendering that precedes them, and that rendering
+        // opens with the allocation helper below, so the interpreter has
+        // already stopped at a registered gap by the time a channel call is
+        // evaluated.
         | RuntimeCallKind::TestNormalizeProcess
         | RuntimeCallKind::TestComplete
         | RuntimeCallKind::TestFailureSite
         | RuntimeCallKind::TestFail
+        | RuntimeCallKind::TestFailComparison
         | RuntimeCallKind::TestUsageError => None,
     }
 }
@@ -3762,11 +3767,28 @@ impl<'a> Interp<'a> {
                     false
                 };
                 let missing_call_kind = if !is_string_builtin && runtime.is_some() {
+                    let runtime = runtime.expect("checked above");
+                    // A compiler-synthesized body reaches the memory helpers as
+                    // runtime calls rather than through the `@alloc` /
+                    // `@byte_copy` intrinsics that name them: drop glue and the
+                    // ADR-0083 §1 structural printer are written directly in
+                    // semantic-body form, and the printer is what a failing
+                    // `@assert_eq` calls before it reports. The interpreter's
+                    // gap is the same one either way, so it is reported as that
+                    // intrinsic's gap — which a corpus case can register —
+                    // rather than as a missing function body, which is a
+                    // harness failure. It stops here rather than joining the
+                    // output calls below, which are unmodeled *and* executable;
+                    // there is nothing to execute for an unmodeled allocation.
+                    if let Some(operation) = rue_air::IntrinsicOperation::from_runtime_call(runtime)
+                    {
+                        let borrowed = unsupported_intrinsic_kind_for_operation(operation);
+                        if borrowed.model_gap().is_some() {
+                            return Err(unsupported(borrowed, format!("call to '{fname}'")));
+                        }
+                    }
                     let kind = self.classify_unsupported_runtime_call_static(
-                        runtime.expect("checked above"),
-                        &arg_types,
-                        &arg_modes,
-                        ty,
+                        runtime, &arg_types, &arg_modes, ty,
                     );
                     if kind.model_gap().is_none() {
                         return Err(unsupported(kind, format!("call to '{fname}'")));

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -16,7 +16,7 @@ use core::fmt;
 #[macro_export]
 macro_rules! runtime_abi_version {
     ($callback:ident) => {
-        $callback!(2, __rue_runtime_abi_v2);
+        $callback!(3, __rue_runtime_abi_v3);
     };
 }
 
@@ -901,9 +901,10 @@ macro_rules! for_each_runtime_helper {
             safety: WRITABLE,
             returns: RETURNS
         },
-        // The ADR-0083 test channel (§3, §5.1). These four are runner plumbing
-        // called only from the synthesized test dispatcher and, later, from
-        // assertion sugar; no source-level intrinsic selects them yet.
+        // The ADR-0083 test channel (§3, §5.1). The dispatcher's own three are
+        // runner plumbing no source spelling selects; the reporting pair and
+        // its comparison form are what `@assert_eq`/`@assert_ne` and a test
+        // body's `?` lower to, in a test image and in an ordinary build alike.
         TestNormalizeProcess => safe __rue_test_normalize_process() {
             symbol: "__rue_test_normalize_process",
             parameters: params![],
@@ -952,6 +953,33 @@ macro_rules! for_each_runtime_helper {
             payload_len: u64,
         ) -> ! {
             symbol: "__rue_test_fail",
+            parameters: params![
+                BYTE_VIEW,
+                U64_VALUE,
+                BYTE_VIEW,
+                U64_VALUE,
+                BYTE_VIEW,
+                U64_VALUE,
+            ],
+            result: VOID,
+            safety: READABLE.union(TERMINATES),
+            returns: NEVER
+        },
+        // The comparison form of the same terminal call (ADR-0083 Phase 2.5).
+        // It carries the two rendered operands where `__rue_test_fail` carries
+        // one message and one open payload, so a consumer reads `expected` and
+        // `actual` as separate fields instead of parsing them back out of one
+        // string. The message is pinned by the kind rather than passed, which
+        // is what keeps this to the same six registers.
+        TestFailComparison => unsafe __rue_test_fail_comparison(
+            kind_ptr: *const u8,
+            kind_len: u64,
+            left_ptr: *const u8,
+            left_len: u64,
+            right_ptr: *const u8,
+            right_len: u64,
+        ) -> ! {
+            symbol: "__rue_test_fail_comparison",
             parameters: params![
                 BYTE_VIEW,
                 U64_VALUE,
@@ -1328,10 +1356,11 @@ const fn starts_with(value: &str, prefix: &str) -> bool {
 }
 
 const fn ends_with_decimal_version(symbol: &str, version: u32) -> bool {
-    // Version 2 added the ADR-0083 §5.1 test failure channel. This explicit
-    // check makes an ABI bump update both metadata values rather than silently
-    // retaining a stale symbol.
-    version == 2 && string_eq(symbol, "__rue_runtime_abi_v2")
+    // Version 2 added the ADR-0083 §5.1 test failure channel; version 3 added
+    // its comparison form, `__rue_test_fail_comparison` (Phase 2.5). This
+    // explicit check makes an ABI bump update both metadata values rather than
+    // silently retaining a stale symbol.
+    version == 3 && string_eq(symbol, "__rue_runtime_abi_v3")
 }
 
 /// Validate all table ordering, uniqueness, classification, and layout invariants.
@@ -1417,7 +1446,7 @@ mod tests {
     #[test]
     fn manifest_is_const_valid_and_exhaustive() {
         assert_eq!(validate_manifest(), Ok(()));
-        assert_eq!(RuntimeHelperId::ALL.len(), 51);
+        assert_eq!(RuntimeHelperId::ALL.len(), 52);
         assert_eq!(RuntimeHelperId::ALL.len(), RUNTIME_HELPERS.len());
         for (index, id) in RuntimeHelperId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, index);
@@ -1489,6 +1518,7 @@ mod tests {
             "__rue_test_complete",
             "__rue_test_failure_site",
             "__rue_test_fail",
+            "__rue_test_fail_comparison",
             "__rue_test_usage_error",
         ];
         assert_eq!(
@@ -1501,7 +1531,7 @@ mod tests {
     #[test]
     fn every_helper_has_the_exact_accepted_signature_and_contract() {
         fn check(
-            visited: &mut [bool; 51],
+            visited: &mut [bool; 52],
             ids: &[RuntimeHelperId],
             parameters: &[AbiParameter],
             result: AbiResult,
@@ -1522,7 +1552,7 @@ mod tests {
             }
         }
 
-        let mut visited = [false; 51];
+        let mut visited = [false; 52];
         check(
             &mut visited,
             &[RuntimeHelperId::Exit],
@@ -1772,7 +1802,10 @@ mod tests {
         );
         check(
             &mut visited,
-            &[RuntimeHelperId::TestFail],
+            &[
+                RuntimeHelperId::TestFail,
+                RuntimeHelperId::TestFailComparison,
+            ],
             &[
                 BYTE_VIEW, U64_VALUE, BYTE_VIEW, U64_VALUE, BYTE_VIEW, U64_VALUE,
             ],
@@ -1964,7 +1997,7 @@ mod tests {
 
     #[test]
     fn abi_version_metadata_is_a_one_byte_data_export() {
-        assert_eq!(RUNTIME_ABI_VERSION, 2);
+        assert_eq!(RUNTIME_ABI_VERSION, 3);
         assert_eq!(
             RUNTIME_ABI_VERSION_SYMBOL,
             format!("__rue_runtime_abi_v{RUNTIME_ABI_VERSION}")

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -215,6 +215,9 @@ macro_rules! call_runtime_helper_implementation {
     (__rue_test_fail($($argument:expr),*)) => {
         crate::test_channel::__rue_test_fail($($argument),*)
     };
+    (__rue_test_fail_comparison($($argument:expr),*)) => {
+        crate::test_channel::__rue_test_fail_comparison($($argument),*)
+    };
     (__rue_test_usage_error($($argument:expr),*)) => {
         crate::test_channel::__rue_test_usage_error($($argument),*)
     };

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -63,7 +63,21 @@ const LOCATION_FIELD: [u8; 22] = *b"\",\"location\":{\"file\":\"";
 const LINE_FIELD: [u8; 9] = *b"\",\"line\":";
 const COLUMN_FIELD: [u8; 10] = *b",\"column\":";
 const PAYLOAD_FIELD: [u8; 13] = *b"},\"payload\":\"";
+const EXPECTED_FIELD: [u8; 14] = *b"},\"expected\":\"";
+const ACTUAL_FIELD: [u8; 12] = *b"\",\"actual\":\"";
 const FRAME_TAIL: [u8; 3] = *b"\"}\n";
+
+/// The pinned message each comparison kind reports.
+///
+/// The message is chosen by the kind rather than passed, which is what keeps
+/// the comparison call to the six registers every runtime helper is limited to
+/// while still carrying both rendered operands. A kind this does not recognize
+/// gets the bare `assertion failed`, so an unknown kind is still a report.
+const ASSERT_EQ_KIND: [u8; 9] = *b"assert_eq";
+const ASSERT_NE_KIND: [u8; 9] = *b"assert_ne";
+const ASSERT_EQ_MESSAGE: [u8; 31] = *b"assertion failed: left == right";
+const ASSERT_NE_MESSAGE: [u8; 31] = *b"assertion failed: left != right";
+const ASSERT_MESSAGE: [u8; 16] = *b"assertion failed";
 
 /// The pinned malformed-selector diagnostic (ADR-0083 §3).
 const USAGE_MESSAGE: [u8; 50] = *b"rue-test: expected one 16-hex-digit test selector\n";
@@ -176,6 +190,28 @@ fn complete_frame(emit: &mut dyn FnMut(&[u8])) {
     writer.raw(&COMPLETE_FRAME);
 }
 
+/// Write every field both failure shapes share, through the open location
+/// object: the two differ only in what follows the column.
+fn failure_head(
+    writer: &mut FrameWriter<'_>,
+    kind: &[u8],
+    message: &[u8],
+    file: &[u8],
+    line: u32,
+    column: u32,
+) {
+    writer.raw(&FAILURE_HEAD);
+    writer.escaped(kind);
+    writer.raw(&MESSAGE_FIELD);
+    writer.escaped(message);
+    writer.raw(&LOCATION_FIELD);
+    writer.escaped(file);
+    writer.raw(&LINE_FIELD);
+    writer.number(line);
+    writer.raw(&COLUMN_FIELD);
+    writer.number(column);
+}
+
 /// Write one failure frame.
 ///
 /// `kind`, `message`, `file`, and `payload` are borrowed byte views; `payload`
@@ -191,19 +227,62 @@ fn failure_frame(
     payload: &[u8],
 ) {
     let mut writer = FrameWriter::new(emit);
-    writer.raw(&FAILURE_HEAD);
-    writer.escaped(kind);
-    writer.raw(&MESSAGE_FIELD);
-    writer.escaped(message);
-    writer.raw(&LOCATION_FIELD);
-    writer.escaped(file);
-    writer.raw(&LINE_FIELD);
-    writer.number(line);
-    writer.raw(&COLUMN_FIELD);
-    writer.number(column);
+    failure_head(&mut writer, kind, message, file, line, column);
     writer.raw(&PAYLOAD_FIELD);
     writer.escaped(payload);
     writer.raw(&FRAME_TAIL);
+}
+
+/// Write one comparison failure frame (ADR-0083 Phase 2.5).
+///
+/// It carries `expected` and `actual` where [`failure_frame`] carries the open
+/// `payload`, and no `payload` at all: two rendered operands are not one string
+/// a consumer has to split, and the runner computes the diff between them.
+/// `expected` is the left operand and `actual` the right — the order the source
+/// wrote them in, so `@assert_eq(want, got)` reads the way it is spelled.
+///
+/// The message is not a parameter: it is pinned by the kind, which is what
+/// keeps this call to the six registers a runtime helper is limited to while
+/// still carrying both operands.
+fn comparison_frame(
+    emit: &mut dyn FnMut(&[u8]),
+    kind: &[u8],
+    file: &[u8],
+    line: u32,
+    column: u32,
+    left: &[u8],
+    right: &[u8],
+) {
+    let mut writer = FrameWriter::new(emit);
+    failure_head(
+        &mut writer,
+        kind,
+        comparison_message(kind),
+        file,
+        line,
+        column,
+    );
+    writer.raw(&EXPECTED_FIELD);
+    writer.escaped(left);
+    writer.raw(&ACTUAL_FIELD);
+    writer.escaped(right);
+    writer.raw(&FRAME_TAIL);
+}
+
+/// The pinned message one comparison kind reports.
+///
+/// `assert_eq` and `assert_ne` are the only kinds the compiler emits. Another
+/// producer — §5.1 makes the channel an open protocol — gets the bare
+/// `assertion failed`, because a report with an unfamiliar kind is still a
+/// report.
+fn comparison_message(kind: &[u8]) -> &'static [u8] {
+    if kind == ASSERT_EQ_KIND {
+        &ASSERT_EQ_MESSAGE
+    } else if kind == ASSERT_NE_KIND {
+        &ASSERT_NE_MESSAGE
+    } else {
+        &ASSERT_MESSAGE
+    }
 }
 
 /// Best-effort write of already-framed bytes to the inherited channel.
@@ -346,6 +425,75 @@ crate::define_runtime_implementation! {
 }
 
 crate::define_runtime_implementation! {
+    /// Report a structured comparison failure, then abort like any other trap.
+    ///
+    /// The comparison form of [`__rue_test_fail`] (ADR-0083 Phase 2.5). It
+    /// writes a `failure` frame carrying the two rendered operands as
+    /// `expected` and `actual` — and no open `payload` — then takes the
+    /// ordinary panic path with the message its `kind` pins: `panic: assertion
+    /// failed: left == right` on stderr and exit 101.
+    ///
+    /// Both halves matter in different builds. Inside a test image the frame is
+    /// what the runner reads; in an ordinary executable there is no descriptor
+    /// 3, the frame write fails with `EBADF` as designed, and the pinned stderr
+    /// message is the whole report. `@assert_eq` therefore lowers the same way
+    /// wherever it is written.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_test_fail_comparison(
+    ///     kind_ptr: *const u8, kind_len: u64,
+    ///     left_ptr: *const u8, left_len: u64,
+    ///     right_ptr: *const u8, right_len: u64,
+    /// ) -> !
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// Each pointer/length pair must describe initialized bytes valid for the
+    /// call, or be null with a zero length.
+    pub unsafe extern "C" fn __rue_test_fail_comparison(
+        kind_ptr: *const u8,
+        kind_len: u64,
+        left_ptr: *const u8,
+        left_len: u64,
+        right_ptr: *const u8,
+        right_len: u64,
+    ) -> ! {
+        // SAFETY: the caller guarantees every pair describes readable bytes.
+        let (kind, left, right) = unsafe {
+            (
+                view(kind_ptr, kind_len),
+                view(left_ptr, left_len),
+                view(right_ptr, right_len),
+            )
+        };
+        let position = SITE_POSITION.load(Ordering::Relaxed);
+        // SAFETY: a staged site's bytes stay readable across the pair, and an
+        // unstaged one is the null-with-zero-length form `view` accepts.
+        let file = unsafe {
+            view(
+                SITE_FILE.load(Ordering::Relaxed) as *const u8,
+                SITE_FILE_LEN.load(Ordering::Relaxed),
+            )
+        };
+        comparison_frame(
+            &mut emit_to_channel,
+            kind,
+            file,
+            (position >> 32) as u32,
+            position as u32,
+            left,
+            right,
+        );
+        let message = comparison_message(kind);
+        // SAFETY: `message` is a `'static` run of this module's own bytes.
+        unsafe { crate::error::__rue_panic(message.as_ptr(), message.len() as u64) }
+    }
+}
+
+crate::define_runtime_implementation! {
     /// Write the pinned malformed-selector diagnostic to stderr and return.
     ///
     /// The dispatcher, not the runtime, owns the exit status for this case, so
@@ -404,6 +552,97 @@ mod tests {
              \"message\":\"assertion failed\",\
              \"location\":{\"file\":\"app/parser_tests.rue\",\"line\":7,\"column\":3},\
              \"payload\":\"\"}\n"
+        );
+    }
+
+    /// The comparison frame's field order, and the two fields that make it a
+    /// different shape rather than a payload convention: `expected` and
+    /// `actual` in place of `payload`, which is absent entirely.
+    #[test]
+    fn comparison_frame_carries_expected_and_actual_instead_of_a_payload() {
+        let bytes = frame_bytes(|emit| {
+            comparison_frame(
+                emit,
+                b"assert_eq",
+                b"app/parser_tests.rue",
+                7,
+                5,
+                b"41",
+                b"42",
+            )
+        });
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert_eq\",\
+             \"message\":\"assertion failed: left == right\",\
+             \"location\":{\"file\":\"app/parser_tests.rue\",\"line\":7,\"column\":5},\
+             \"expected\":\"41\",\"actual\":\"42\"}\n"
+        );
+    }
+
+    /// The message is pinned by the kind, not passed, which is what keeps the
+    /// comparison call inside the six-register helper budget.
+    #[test]
+    fn each_comparison_kind_pins_its_own_message() {
+        let ne =
+            frame_bytes(|emit| comparison_frame(emit, b"assert_ne", b"a.rue", 1, 1, b"7", b"7"));
+        assert!(
+            std::str::from_utf8(&ne)
+                .unwrap()
+                .contains("\"message\":\"assertion failed: left != right\""),
+            "{}",
+            std::str::from_utf8(&ne).unwrap()
+        );
+        // The channel is an open protocol (§5.1): a kind from somewhere else is
+        // still reported, with the bare assertion message.
+        let other = frame_bytes(|emit| comparison_frame(emit, b"lib_eq", b"a.rue", 1, 1, b"", b""));
+        assert!(
+            std::str::from_utf8(&other)
+                .unwrap()
+                .contains("\"kind\":\"lib_eq\",\"message\":\"assertion failed\""),
+            "{}",
+            std::str::from_utf8(&other).unwrap()
+        );
+    }
+
+    /// Both operands are escaped by the same rule the message is, so a rendered
+    /// value containing a quote, a backslash, or a newline cannot break the
+    /// frame it travels in.
+    #[test]
+    fn comparison_operands_are_escaped_like_every_other_string() {
+        let bytes = frame_bytes(|emit| {
+            comparison_frame(
+                emit,
+                b"assert_eq",
+                b"a.rue",
+                1,
+                1,
+                b"line one\nline two",
+                b"say \"hi\"\\",
+            )
+        });
+        let rendered = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            rendered.contains("\"expected\":\"line one\\u000aline two\""),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("\"actual\":\"say \\\"hi\\\"\\\\\"}"),
+            "{rendered}"
+        );
+    }
+
+    /// An empty rendering is a value, not an absent field: `@assert_eq` on two
+    /// empty strings must still publish both sides.
+    #[test]
+    fn empty_comparison_operands_stay_present_as_empty_strings() {
+        let bytes = frame_bytes(|emit| comparison_frame(emit, b"assert_eq", b"", 0, 0, b"", b""));
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert_eq\",\
+             \"message\":\"assertion failed: left == right\",\
+             \"location\":{\"file\":\"\",\"line\":0,\"column\":0},\
+             \"expected\":\"\",\"actual\":\"\"}\n"
         );
     }
 

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -70,7 +70,7 @@ fn main() -> i32 {
 compile_fail = true
 
 # =============================================================================
-# Intrinsic behavior and restrictions: @panic / @assert / @cast (4.13:5b-5e, RUE-319)
+# Intrinsic behavior and restrictions: @panic / @assert / @cast (4.13:5c-5e, RUE-319)
 #
 # @panic and @assert abort the process (message to stderr, exit 101), with the
 # same abort discipline as the @intCast overflow trap. @cast is rejected at
@@ -135,6 +135,139 @@ fn main() -> i32 {
 """
 exit_code = 101
 stderr_contains = "panic: one is not two"
+
+# =============================================================================
+# The comparison family: @assert_eq / @assert_ne (4.13:5f, ADR-0083 Phase 2.5)
+#
+# Same abort discipline as @assert, with a message that names which comparison
+# failed. The structured half of the report (expected/actual and the runner's
+# diff) needs a test image, so it is covered by the cli.rue_test_assert cases;
+# what an ordinary program observes is the pinned message and status 101.
+# =============================================================================
+
+[[case]]
+name = "assert_eq_holding_has_no_effect"
+spec = ["4.13:5f"]
+source = """
+fn main() -> i32 {
+    @assert_eq(1 + 1, 2);
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "assert_eq_failing_aborts_with_its_pinned_message"
+spec = ["4.13:5f"]
+source = """
+fn twice(n: i32) -> i32 { n * 2 }
+fn main() -> i32 {
+    @assert_eq(twice(20), 41);
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "panic: assertion failed: left == right"
+
+[[case]]
+name = "assert_ne_holding_has_no_effect"
+spec = ["4.13:5f"]
+source = """
+fn main() -> i32 {
+    @assert_ne(1, 2);
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "assert_ne_failing_names_the_other_comparison"
+spec = ["4.13:5f"]
+source = """
+fn twice(n: i32) -> i32 { n * 2 }
+fn main() -> i32 {
+    @assert_ne(twice(20), 40);
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "panic: assertion failed: left != right"
+
+# Each operand is evaluated exactly once, left before right (4.13:5f). Each
+# side announces itself, so the trace is both the count and the order — and the
+# assertion holds, so nothing after it is skipped.
+[[case]]
+name = "assert_eq_evaluates_each_operand_once_left_to_right"
+spec = ["4.13:5f"]
+source = """
+fn note(id: i32, value: i32) -> i32 {
+    @dbg(id);
+    value
+}
+fn main() -> i32 {
+    @assert_eq(note(1, 7), note(2, 7));
+    0
+}
+"""
+expected_stdout = "1\n2\n"
+exit_code = 0
+
+# The operands are read, not consumed: both are still usable afterwards,
+# exactly as `==` leaves them (4.3:3f).
+[[case]]
+name = "assert_eq_borrows_its_operands"
+spec = ["4.13:5f"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let left = Point { x: 20, y: 22 };
+    let right = Point { x: 20, y: 22 };
+    @assert_eq(left, right);
+    left.x + right.y
+}
+"""
+exit_code = 42
+
+# Both operands must have one type, and that type must be one `==` accepts.
+[[case]]
+name = "assert_eq_rejects_mismatched_operand_types"
+spec = ["4.13:5f"]
+source = """
+fn main() -> i32 {
+    @assert_eq(1, true);
+    0
+}
+"""
+compile_fail = true
+error_contains = "type mismatch"
+
+[[case]]
+name = "assert_eq_rejects_a_type_without_equality"
+spec = ["4.13:5f"]
+source = """
+fn main() -> i32 {
+    let n: i32 = 1;
+    checked {
+        let p = @raw(n);
+        @assert_eq(p, p);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "integer, float, bool, string, unit, struct, array, or enum"
+
+[[case]]
+name = "assert_eq_requires_exactly_two_operands"
+spec = ["4.13:5f"]
+source = """
+fn main() -> i32 {
+    @assert_eq(1);
+    0
+}
+"""
+compile_fail = true
+error_contains = "assert_eq"
 
 # @panic is `!`-typed (RUE-512): it diverges, so it participates in never
 # coercion (3.4:2) and may appear wherever a value of any type is expected — a

--- a/crates/rue-ui-tests/cases/diagnostics/assert_comparison.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/assert_comparison.toml
@@ -1,0 +1,96 @@
+[section]
+id = "diagnostics.assert_comparison"
+name = "Comparison-assertion diagnostics"
+description = """
+`@assert_eq` / `@assert_ne` reject exactly what `==` rejects (spec 4.13:5f,
+ADR-0083 Phase 2.5). Both operands must have one type and that type must be one
+`==` accepts, and the rendered wording is pinned here so the family cannot drift
+into a second, differently worded equality.
+"""
+
+[[case]]
+name = "operands_must_agree_on_a_type"
+description = "Inference constrains the two operands to one type, so a mismatch is reported at the second operand rather than as an intrinsic-shaped error of its own."
+source = """
+fn main() -> i32 {
+    @assert_eq(1, true);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0206", "type mismatch", "found bool"]
+
+[[case]]
+name = "inequality_agrees_on_a_type_too"
+description = "The other member of the family enforces the same rule."
+source = """
+fn main() -> i32 {
+    @assert_ne(true, 1);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]
+
+[[case]]
+name = "an_operand_type_must_support_equality"
+description = "A raw pointer is not an equality operand, and the family reuses `==`'s own check rather than answering the question a second time — so the wording is the one `p == p` produces."
+source = """
+fn main() -> i32 {
+    let n: i32 = 1;
+    checked {
+        let p = @raw(n);
+        @assert_eq(p, p);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0206",
+    "expected integer, float, bool, string, unit, struct, array, or enum",
+    "found ptr const i32",
+]
+
+[[case]]
+name = "the_comparison_operator_reports_the_same_wording"
+description = "The companion to the case above: `==` on the same operand produces the same diagnostic, which is what makes 'supports ==' one rule rather than two."
+source = """
+fn main() -> i32 {
+    let n: i32 = 1;
+    checked {
+        let ok = @raw(n) == @raw(n);
+        @assert(ok);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0206",
+    "expected integer, float, bool, string, unit, struct, array, or enum",
+]
+
+[[case]]
+name = "exactly_two_operands_are_required"
+description = "One operand is the intrinsic's own arity error, not a type error about a missing second value."
+source = """
+fn main() -> i32 {
+    @assert_eq(1);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0701", "intrinsic '@assert_eq' expects 2 arguments, found 1"]
+
+[[case]]
+name = "three_operands_are_rejected_as_well"
+description = "There is no message operand: a comparison failure's report is the two rendered values."
+source = """
+fn main() -> i32 {
+    @assert_ne(1, 2, 3);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0701", "intrinsic '@assert_ne' expects 2 arguments, found 3"]

--- a/crates/rue/src/test_mode/diff.rs
+++ b/crates/rue/src/test_mode/diff.rs
@@ -1,0 +1,379 @@
+//! The machine-computed diff between a comparison failure's two operands
+//! (ADR-0083 Phase 2.5).
+//!
+//! A `failure` frame carrying `expected` and `actual` says what the two values
+//! rendered to; it does not say where they differ. Computing that here — once,
+//! in the runner — is what lets the event stream and the human rendering agree,
+//! and what keeps a consumer from having to re-derive it from two strings.
+//!
+//! Three decisions shape it.
+//!
+//! - **Granularity follows the values.** A value containing a newline is diffed
+//!   line by line, because a character-level diff of two multi-line renderings
+//!   is unreadable and enormous; anything else is diffed character by
+//!   character, because that is what locates the one digit that changed.
+//! - **Hunks are exact, in order, and reconstruct both sides.** Concatenating
+//!   every `equal` and `delete` hunk's text yields `expected` exactly;
+//!   concatenating every `equal` and `insert` hunk's text yields `actual`. A
+//!   line unit therefore carries its own terminator, and the two invariants are
+//!   what make the encoding lossless rather than a rendering.
+//! - **It is dependency-free and bounded.** The renderings a compiler-synthesized
+//!   printer produces are bounded to 4 KiB, so an exact quadratic
+//!   longest-common-subsequence is affordable — but the channel is an open
+//!   protocol (§5.1) and another producer's values are not bounded by anything
+//!   the runner controls. A common prefix and suffix are removed first, and a
+//!   middle whose table would exceed [`CELL_BUDGET`] is reported as one
+//!   wholesale replacement instead of being refined. That keeps the work and
+//!   the memory bounded for *any* input, and a diff is still produced.
+//!
+//! Both operands are always valid UTF-8 by the time they arrive: they are JSON
+//! string fields, and a channel line that is not valid UTF-8 never becomes a
+//! frame at all — `parse_channel` records it as malformed and the verdict
+//! carries a `runner_note` saying the failure report could not be read. So a
+//! non-UTF-8 rendering is rejected upstream rather than re-encoded here.
+
+/// Largest longest-common-subsequence table the refinement will build, in
+/// cells. A 4 KiB rendering diffed by line stays far below it; two unrelated
+/// 1024-unit middles are exactly at it.
+const CELL_BUDGET: usize = 1 << 20;
+
+/// What one hunk says about the text it carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiffOp {
+    /// Present in both values.
+    Equal,
+    /// Present in `expected` and absent from `actual`.
+    Delete,
+    /// Present in `actual` and absent from `expected`.
+    Insert,
+}
+
+impl DiffOp {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Equal => "equal",
+            Self::Delete => "delete",
+            Self::Insert => "insert",
+        }
+    }
+}
+
+/// One run of text with one op. Adjacent runs sharing an op are always merged,
+/// so no two consecutive hunks have the same op and no hunk is empty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Hunk {
+    pub(crate) op: DiffOp,
+    pub(crate) text: String,
+}
+
+/// Whether a pair of values is diffed by line or by character.
+fn line_oriented(expected: &str, actual: &str) -> bool {
+    expected.contains('\n') || actual.contains('\n')
+}
+
+/// Split one value into the units it is diffed by.
+///
+/// A line keeps its own terminator, which is what makes the concatenation
+/// invariants hold for a value whose last line is unterminated as well as one
+/// whose last line is not.
+fn units(text: &str, by_line: bool) -> Vec<&str> {
+    if by_line {
+        text.split_inclusive('\n').collect()
+    } else {
+        text.char_indices()
+            .map(|(index, character)| &text[index..index + character.len_utf8()])
+            .collect()
+    }
+}
+
+/// The diff from `expected` to `actual`.
+pub(crate) fn diff(expected: &str, actual: &str) -> Vec<Hunk> {
+    let by_line = line_oriented(expected, actual);
+    let left = units(expected, by_line);
+    let right = units(actual, by_line);
+
+    let prefix = left
+        .iter()
+        .zip(right.iter())
+        .take_while(|(left, right)| left == right)
+        .count();
+    let suffix = left[prefix..]
+        .iter()
+        .rev()
+        .zip(right[prefix..].iter().rev())
+        .take_while(|(left, right)| left == right)
+        .count();
+
+    let mut hunks = Hunks::default();
+    hunks.extend(DiffOp::Equal, &left[..prefix]);
+    let left_middle = &left[prefix..left.len() - suffix];
+    let right_middle = &right[prefix..right.len() - suffix];
+    if left_middle.len().saturating_mul(right_middle.len()) > CELL_BUDGET {
+        // Past the budget the exact answer is not worth its cost, and a
+        // wholesale replacement is still a true diff: every unit of the middle
+        // really is absent from the other side's middle *as a subsequence
+        // alignment*, just not as coarsely as an exact run would report.
+        hunks.extend(DiffOp::Delete, left_middle);
+        hunks.extend(DiffOp::Insert, right_middle);
+    } else {
+        refine(&mut hunks, left_middle, right_middle);
+    }
+    hunks.extend(DiffOp::Equal, &left[left.len() - suffix..]);
+    hunks.0
+}
+
+/// Exact longest-common-subsequence alignment of the two middles.
+fn refine(hunks: &mut Hunks, left: &[&str], right: &[&str]) {
+    if left.is_empty() || right.is_empty() {
+        hunks.extend(DiffOp::Delete, left);
+        hunks.extend(DiffOp::Insert, right);
+        return;
+    }
+    let rows = left.len() + 1;
+    let columns = right.len() + 1;
+    let mut table = vec![0u32; rows * columns];
+    for row in (0..left.len()).rev() {
+        for column in (0..right.len()).rev() {
+            table[row * columns + column] = if left[row] == right[column] {
+                table[(row + 1) * columns + column + 1] + 1
+            } else {
+                table[(row + 1) * columns + column].max(table[row * columns + column + 1])
+            };
+        }
+    }
+
+    // Walk forward through the table, which emits a replacement as its deletes
+    // followed by its inserts — the order a reader expects, and the order the
+    // `-`/`+` rendering prints.
+    let (mut row, mut column) = (0, 0);
+    while row < left.len() || column < right.len() {
+        if row < left.len() && column < right.len() && left[row] == right[column] {
+            hunks.push(DiffOp::Equal, left[row]);
+            row += 1;
+            column += 1;
+        } else if column == right.len()
+            || (row < left.len()
+                && table[(row + 1) * columns + column] >= table[row * columns + column + 1])
+        {
+            hunks.push(DiffOp::Delete, left[row]);
+            row += 1;
+        } else {
+            hunks.push(DiffOp::Insert, right[column]);
+            column += 1;
+        }
+    }
+}
+
+/// Accumulator that merges adjacent units sharing an op into one hunk.
+#[derive(Default)]
+struct Hunks(Vec<Hunk>);
+
+impl Hunks {
+    fn push(&mut self, op: DiffOp, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        match self.0.last_mut() {
+            Some(last) if last.op == op => last.text.push_str(text),
+            _ => self.0.push(Hunk {
+                op,
+                text: text.to_owned(),
+            }),
+        }
+    }
+
+    fn extend(&mut self, op: DiffOp, units: &[&str]) {
+        for unit in units {
+            self.push(op, unit);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hunks(expected: &str, actual: &str) -> Vec<(&'static str, String)> {
+        diff(expected, actual)
+            .into_iter()
+            .map(|hunk| (hunk.op.as_str(), hunk.text))
+            .collect()
+    }
+
+    /// The two invariants the encoding rests on: the equal-and-delete hunks
+    /// rebuild `expected`, and the equal-and-insert hunks rebuild `actual`.
+    #[track_caller]
+    fn assert_reconstructs(expected: &str, actual: &str) {
+        let hunks = diff(expected, actual);
+        let mut left = String::new();
+        let mut right = String::new();
+        for hunk in &hunks {
+            match hunk.op {
+                DiffOp::Equal => {
+                    left.push_str(&hunk.text);
+                    right.push_str(&hunk.text);
+                }
+                DiffOp::Delete => left.push_str(&hunk.text),
+                DiffOp::Insert => right.push_str(&hunk.text),
+            }
+        }
+        assert_eq!(left, expected, "expected side of {hunks:?}");
+        assert_eq!(right, actual, "actual side of {hunks:?}");
+        for pair in hunks.windows(2) {
+            assert_ne!(pair[0].op, pair[1].op, "unmerged adjacent hunks: {hunks:?}");
+        }
+        assert!(
+            hunks.iter().all(|hunk| !hunk.text.is_empty()),
+            "empty hunk in {hunks:?}"
+        );
+    }
+
+    #[test]
+    fn identical_values_are_one_equal_hunk() {
+        assert_eq!(hunks("41", "41"), [("equal", "41".to_owned())]);
+        assert_reconstructs("41", "41");
+    }
+
+    #[test]
+    fn two_empty_values_have_no_hunks() {
+        assert_eq!(hunks("", ""), []);
+    }
+
+    #[test]
+    fn an_empty_side_is_a_single_delete_or_insert() {
+        assert_eq!(hunks("41", ""), [("delete", "41".to_owned())]);
+        assert_eq!(hunks("", "42"), [("insert", "42".to_owned())]);
+        assert_reconstructs("41", "");
+        assert_reconstructs("", "42");
+    }
+
+    /// The case the character granularity exists for: one digit changed, and
+    /// the diff says which one.
+    #[test]
+    fn a_single_changed_character_is_located_exactly() {
+        assert_eq!(
+            hunks("41", "42"),
+            [
+                ("equal", "4".to_owned()),
+                ("delete", "1".to_owned()),
+                ("insert", "2".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_pure_insertion_and_a_pure_deletion_keep_their_ops() {
+        assert_eq!(
+            hunks("ac", "abc"),
+            [
+                ("equal", "a".to_owned()),
+                ("insert", "b".to_owned()),
+                ("equal", "c".to_owned()),
+            ]
+        );
+        assert_eq!(
+            hunks("abc", "ac"),
+            [
+                ("equal", "a".to_owned()),
+                ("delete", "b".to_owned()),
+                ("equal", "c".to_owned()),
+            ]
+        );
+    }
+
+    /// The alignment prefers a deletion on a tie, so a substitution reports its
+    /// deletion before its insertion — the order the `-`/`+` rendering prints.
+    #[test]
+    fn a_substitution_reports_the_deletion_first() {
+        assert_eq!(
+            hunks("{ x: 1 }", "{ x: 2 }"),
+            [
+                ("equal", "{ x: ".to_owned()),
+                ("delete", "1".to_owned()),
+                ("insert", "2".to_owned()),
+                ("equal", " }".to_owned()),
+            ]
+        );
+        assert_reconstructs("{ x: 1, y: true }", "{ x: 2, y: false }");
+    }
+
+    /// A newline on either side switches the whole diff to lines, so a
+    /// multi-line rendering reports whole changed lines rather than a
+    /// character soup.
+    #[test]
+    fn a_newline_on_either_side_selects_line_granularity() {
+        assert_eq!(
+            hunks("a\nb\nc\n", "a\nB\nc\n"),
+            [
+                ("equal", "a\n".to_owned()),
+                ("delete", "b\n".to_owned()),
+                ("insert", "B\n".to_owned()),
+                ("equal", "c\n".to_owned()),
+            ]
+        );
+        // Only one side has a newline: still lines, so the single-line value is
+        // one unit that no line of the other side equals, rather than being
+        // diffed against every character of it.
+        assert_eq!(
+            hunks("a", "a\nb\n"),
+            [("delete", "a".to_owned()), ("insert", "a\nb\n".to_owned())]
+        );
+    }
+
+    /// A line unit carries its own terminator, so an unterminated last line and
+    /// a terminated one are different units and both reconstruct exactly.
+    #[test]
+    fn line_units_carry_their_terminators() {
+        assert_reconstructs("one\ntwo", "one\ntwo\n");
+        assert_eq!(
+            hunks("one\ntwo", "one\ntwo\n"),
+            [
+                ("equal", "one\n".to_owned()),
+                ("delete", "two".to_owned()),
+                ("insert", "two\n".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn multibyte_scalars_are_never_split() {
+        assert_reconstructs("héllo", "hallo");
+        assert_eq!(
+            hunks("é", "e"),
+            [("delete", "é".to_owned()), ("insert", "e".to_owned())]
+        );
+    }
+
+    /// Past the table budget the middle is reported as one wholesale
+    /// replacement rather than refined, and the result is still a diff that
+    /// reconstructs both sides.
+    #[test]
+    fn an_oversized_middle_falls_back_to_a_wholesale_replacement() {
+        let expected: String = std::iter::repeat_n("a\n", 2_000).collect();
+        let actual: String = std::iter::repeat_n("b\n", 2_000).collect();
+        let hunks = diff(&expected, &actual);
+        assert_eq!(
+            hunks.iter().map(|hunk| hunk.op).collect::<Vec<_>>(),
+            [DiffOp::Delete, DiffOp::Insert]
+        );
+        assert_reconstructs(&expected, &actual);
+    }
+
+    /// The shared prefix and suffix are removed before any table is built, so
+    /// two long values that differ in one line stay exact and cheap.
+    #[test]
+    fn a_long_pair_differing_in_one_line_stays_exact() {
+        let mut expected: String = std::iter::repeat_n("same\n", 3_000).collect();
+        let mut actual = expected.clone();
+        expected.push_str("left\n");
+        actual.push_str("right\n");
+        assert_eq!(
+            hunks(&expected, &actual)
+                .iter()
+                .map(|(op, _)| *op)
+                .collect::<Vec<_>>(),
+            ["equal", "delete", "insert"]
+        );
+        assert_reconstructs(&expected, &actual);
+    }
+}

--- a/crates/rue/src/test_mode/events.rs
+++ b/crates/rue/src/test_mode/events.rs
@@ -15,6 +15,7 @@
 
 use serde_json::{Map, Value};
 
+use super::diff;
 use super::verdict::Verdict;
 
 /// The event schema version, published in the stream's head event.
@@ -160,10 +161,40 @@ pub(crate) struct FailureRecord {
     pub(crate) signal: Option<i32>,
     pub(crate) location: Option<Location>,
     /// The open, versioned payload ADR-0083 §5.1 reserves for assertion
-    /// libraries. Empty until Phase 2.5's structured comparisons.
+    /// libraries. A comparison failure uses `expected`/`actual` instead.
     pub(crate) payload: Option<String>,
+    /// A comparison failure's two rendered operands and the diff between them
+    /// (ADR-0083 Phase 2.5). **Absent** on every other failure.
+    pub(crate) comparison: Option<Comparison>,
     /// The runner's own explanation, when it could not trust what it read.
     pub(crate) runner_note: Option<String>,
+}
+
+/// What a comparison assertion's failure frame carried, plus the runner's own
+/// diff of it.
+///
+/// The diff is computed here rather than by each consumer for the same reason
+/// every other field is: the event stream and the human rendering are one
+/// computation in one process, so a person and a tool can never be shown two
+/// different accounts of where two values differ.
+#[derive(Debug, Clone)]
+pub(crate) struct Comparison {
+    /// The left operand as the structural printer rendered it.
+    pub(crate) expected: String,
+    /// The right operand as the structural printer rendered it.
+    pub(crate) actual: String,
+    pub(crate) diff: Vec<diff::Hunk>,
+}
+
+impl Comparison {
+    pub(crate) fn new(expected: String, actual: String) -> Self {
+        let diff = diff::diff(&expected, &actual);
+        Self {
+            expected,
+            actual,
+            diff,
+        }
+    }
 }
 
 impl FailureRecord {
@@ -182,6 +213,34 @@ impl FailureRecord {
         }
         if let Some(payload) = &self.payload {
             object.insert("payload".to_owned(), Value::String(payload.clone()));
+        }
+        if let Some(comparison) = &self.comparison {
+            object.insert(
+                "expected".to_owned(),
+                Value::String(comparison.expected.clone()),
+            );
+            object.insert(
+                "actual".to_owned(),
+                Value::String(comparison.actual.clone()),
+            );
+            object.insert(
+                "diff".to_owned(),
+                Value::Array(
+                    comparison
+                        .diff
+                        .iter()
+                        .map(|hunk| {
+                            let mut entry = Map::new();
+                            entry.insert(
+                                "op".to_owned(),
+                                Value::String(hunk.op.as_str().to_owned()),
+                            );
+                            entry.insert("text".to_owned(), Value::String(hunk.text.clone()));
+                            Value::Object(entry)
+                        })
+                        .collect(),
+                ),
+            );
         }
         if let Some(note) = &self.runner_note {
             object.insert("runner_note".to_owned(), Value::String(note.clone()));
@@ -521,6 +580,65 @@ mod tests {
             line.contains("\"scratch_dir\":\"/tmp/rue-test-1-0\""),
             "{line}"
         );
+    }
+
+    /// A comparison failure publishes `expected`, `actual`, and the runner's
+    /// own `diff` — additive fields on the same `1.0` schema, in the same
+    /// alphabetical key order every other object uses (ADR-0083 Phase 2.5).
+    #[test]
+    fn a_comparison_failure_publishes_expected_actual_and_a_diff() {
+        let line = Event::TestFinished(Box::new(TestFinished {
+            id: "app/t.rue::bad".to_owned(),
+            verdict: Verdict::Fail(FailureKind::AssertEq),
+            duration_ms: 5,
+            failure: Some(FailureRecord {
+                kind: "assert_eq".to_owned(),
+                message: "assertion failed: left == right".to_owned(),
+                exit_code: Some(101),
+                comparison: Some(Comparison::new("41".to_owned(), "42".to_owned())),
+                ..FailureRecord::default()
+            }),
+            stdout: Capture::new(Vec::new(), 0, false),
+            stderr: Capture::new(Vec::new(), 0, false),
+            scratch_dir: None,
+            repro: Vec::new(),
+        }))
+        .to_ndjson();
+        assert!(
+            line.contains(
+                "\"failure\":{\"actual\":\"42\",\
+                 \"diff\":[{\"op\":\"equal\",\"text\":\"4\"},\
+                 {\"op\":\"delete\",\"text\":\"1\"},\
+                 {\"op\":\"insert\",\"text\":\"2\"}],\
+                 \"exit_code\":101,\"expected\":\"41\",\"kind\":\"assert_eq\","
+            ),
+            "{line}"
+        );
+        assert!(!line.contains("\"payload\""), "{line}");
+    }
+
+    /// Every other failure carries none of the three: a consumer distinguishes
+    /// a comparison by their presence, not by parsing the kind.
+    #[test]
+    fn a_non_comparison_failure_carries_no_comparison_fields() {
+        let line = Event::TestFinished(Box::new(TestFinished {
+            id: "app/t.rue::bad".to_owned(),
+            verdict: Verdict::Fail(FailureKind::Assert),
+            duration_ms: 1,
+            failure: Some(FailureRecord {
+                kind: "assert".to_owned(),
+                message: "assertion failed".to_owned(),
+                ..FailureRecord::default()
+            }),
+            stdout: Capture::new(Vec::new(), 0, false),
+            stderr: Capture::new(Vec::new(), 0, false),
+            scratch_dir: None,
+            repro: Vec::new(),
+        }))
+        .to_ndjson();
+        assert!(!line.contains("\"expected\""), "{line}");
+        assert!(!line.contains("\"actual\""), "{line}");
+        assert!(!line.contains("\"diff\""), "{line}");
     }
 
     /// Rue strings are arbitrary bytes written raw, so capture is lossless

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -17,6 +17,7 @@
 //!   exit 2 with diagnostics and an empty event stream, never a `run_started`
 //!   for a run that never began.
 
+pub(crate) mod diff;
 pub(crate) mod events;
 pub(crate) mod exec;
 pub(crate) mod render;
@@ -35,7 +36,8 @@ use rue_driver::FilesystemCompilerHost;
 use rue_target::Target;
 
 use events::{
-    CandidateSource, Capture, Event, FailureRecord, Location, TestFinished, UnimportedFile,
+    CandidateSource, Capture, Comparison, Event, FailureRecord, Location, TestFinished,
+    UnimportedFile,
 };
 use exec::{DEFAULT_STREAM_BUDGET, Dispatch};
 use selection::Shard;
@@ -608,8 +610,22 @@ fn failure_record(
         payload: frame
             .map(|frame| frame.payload.clone())
             .filter(|payload| !payload.is_empty()),
+        comparison: frame_comparison(frame),
         runner_note: execution.classification.runner_note.clone(),
     }
+}
+
+/// The comparison a failure frame carried, or `None` when it carried none
+/// (ADR-0083 Phase 2.5).
+///
+/// `expected` and `actual` travel together or not at all: a frame with one and
+/// not the other is a producer's mistake, and half a comparison is not a
+/// comparison. The diff between them is computed here, once, so the event
+/// stream and the human rendering read the same one.
+fn frame_comparison(frame: Option<&verdict::FailureFrame>) -> Option<Comparison> {
+    let frame = frame?;
+    let (expected, actual) = frame.expected.clone().zip(frame.actual.clone())?;
+    Some(Comparison::new(expected, actual))
 }
 
 fn failure_message(
@@ -630,7 +646,10 @@ fn failure_message(
             "a captured stream exceeded its {DEFAULT_STREAM_BUDGET}-byte retention budget; \
              the process group was killed"
         ),
-        FailureKind::Assert | FailureKind::Trap(_) => last_message_line(&execution.stderr),
+        FailureKind::Assert
+        | FailureKind::AssertEq
+        | FailureKind::AssertNe
+        | FailureKind::Trap(_) => last_message_line(&execution.stderr),
         FailureKind::Exit => match execution.exit_code {
             Some(code) => format!("the test exited with status {code}"),
             None => "the test did not exit normally".to_owned(),
@@ -787,6 +806,30 @@ mod tests {
                 "500",
             ]
         );
+    }
+
+    /// The comparison fields are one unit: both, or neither. A frame carrying
+    /// only one of them publishes nothing rather than half a report a consumer
+    /// would have to guess at.
+    #[test]
+    fn a_comparison_needs_both_of_its_operands() {
+        let frame = |expected: Option<&str>, actual: Option<&str>| verdict::FailureFrame {
+            kind: "assert_eq".to_owned(),
+            expected: expected.map(str::to_owned),
+            actual: actual.map(str::to_owned),
+            ..verdict::FailureFrame::default()
+        };
+        assert!(frame_comparison(None).is_none());
+        assert!(frame_comparison(Some(&frame(None, None))).is_none());
+        assert!(frame_comparison(Some(&frame(Some("41"), None))).is_none());
+        assert!(frame_comparison(Some(&frame(None, Some("42")))).is_none());
+        let both = frame_comparison(Some(&frame(Some("41"), Some("42")))).expect("a comparison");
+        assert_eq!(both.expected, "41");
+        assert_eq!(both.actual, "42");
+        assert_eq!(both.diff.len(), 3, "{:?}", both.diff);
+        // Two empty renderings are still a comparison: empty is a value.
+        let empty = frame_comparison(Some(&frame(Some(""), Some("")))).expect("a comparison");
+        assert!(empty.diff.is_empty());
     }
 
     #[test]

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -12,7 +12,8 @@
 
 use std::fmt::Write as _;
 
-use super::events::{CandidateSource, Capture, Event, TestFinished};
+use super::diff::{DiffOp, Hunk};
+use super::events::{CandidateSource, Capture, Comparison, Event, TestFinished};
 use super::verdict::Verdict;
 
 /// Render one event for a person, or `None` when a person is owed nothing by
@@ -125,6 +126,9 @@ fn render_failure(finished: &TestFinished) -> String {
                 let _ = write!(out, "\n  payload: {payload}");
             }
         }
+        if let Some(comparison) = &failure.comparison {
+            push_comparison(&mut out, comparison);
+        }
         if let Some(note) = &failure.runner_note {
             let _ = write!(out, "\n  note: {note}");
         }
@@ -136,6 +140,65 @@ fn render_failure(finished: &TestFinished) -> String {
     }
     let _ = write!(out, "\n  repro: {}", shell_command(repro));
     out
+}
+
+/// The two operands of a comparison assertion, and where they differ.
+///
+/// Both values are always printed, because "these two are not equal" is only
+/// half the report; the third element is what the runner computed about them,
+/// and it is drawn from the same `diff` the event stream publishes rather than
+/// recomputed here. A single-line pair gets a caret under the first differing
+/// character, which is the whole answer for the common case of one wrong digit;
+/// a multi-line pair gets the `-`/`+` listing, because a caret into a wall of
+/// text locates nothing.
+fn push_comparison(out: &mut String, comparison: &Comparison) {
+    let multi_line = comparison.expected.contains('\n') || comparison.actual.contains('\n');
+    if !multi_line {
+        let _ = write!(out, "\n  expected: {}", comparison.expected);
+        let _ = write!(out, "\n  actual:   {}", comparison.actual);
+        if let Some(column) = first_difference(&comparison.diff) {
+            let _ = write!(out, "\n  {}^", " ".repeat(LABEL_WIDTH - 2 + column));
+        }
+        return;
+    }
+    push_block(out, "expected", &comparison.expected);
+    push_block(out, "actual", &comparison.actual);
+    out.push_str("\n  diff:");
+    for hunk in &comparison.diff {
+        let marker = match hunk.op {
+            DiffOp::Equal => ' ',
+            DiffOp::Delete => '-',
+            DiffOp::Insert => '+',
+        };
+        for line in hunk.text.lines() {
+            let _ = write!(out, "\n    {marker} {line}");
+        }
+    }
+}
+
+/// Width of the `expected: ` / `actual:   ` labels, including the two-space
+/// indent every line of a failure carries.
+const LABEL_WIDTH: usize = 12;
+
+/// The character offset of the first difference, or `None` when the two values
+/// are identical — which is exactly how an `@assert_ne` failure looks.
+fn first_difference(diff: &[Hunk]) -> Option<usize> {
+    let mut offset = 0;
+    for hunk in diff {
+        if hunk.op != DiffOp::Equal {
+            return Some(offset);
+        }
+        offset += hunk.text.chars().count();
+    }
+    None
+}
+
+/// One labelled multi-line value, its lines indented under the label.
+fn push_block(out: &mut String, label: &str, value: &str) {
+    let _ = write!(out, "\n  {label}:");
+    for line in value.lines() {
+        let _ = write!(out, "\n    {line}");
+    }
 }
 
 /// A captured stream, indented under its failure, or nothing when it is empty.
@@ -180,7 +243,7 @@ fn shell_command(argv: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_mode::events::{FailureRecord, Location, UnimportedFile};
+    use crate::test_mode::events::{Comparison, FailureRecord, Location, UnimportedFile};
     use crate::test_mode::verdict::FailureKind;
 
     fn finished(verdict: Verdict, failure: Option<FailureRecord>) -> Event {
@@ -280,6 +343,77 @@ mod tests {
             rendered.contains("repro: rue test app/main.rue --filter 'app/t.rue::parses a port'"),
             "{rendered}"
         );
+    }
+
+    /// A single-line comparison prints both values aligned, and a caret under
+    /// the first character that differs. The caret's column comes out of the
+    /// same `diff` the event stream publishes, so the two surfaces cannot
+    /// disagree about where the difference is.
+    #[test]
+    fn a_single_line_comparison_prints_both_values_and_a_caret() {
+        let rendered = render(&finished(
+            Verdict::Fail(FailureKind::AssertEq),
+            Some(FailureRecord {
+                kind: "assert_eq".to_owned(),
+                message: "assertion failed: left == right".to_owned(),
+                exit_code: Some(101),
+                comparison: Some(Comparison::new("41".to_owned(), "42".to_owned())),
+                ..FailureRecord::default()
+            }),
+        ))
+        .expect("a failure renders");
+        assert!(
+            rendered.contains("\n  expected: 41\n  actual:   42\n             ^\n"),
+            "{rendered}"
+        );
+    }
+
+    /// An `@assert_ne` failure has two identical values, so there is no first
+    /// difference and no caret is drawn — the two values *are* the report.
+    #[test]
+    fn identical_values_print_no_caret() {
+        let rendered = render(&finished(
+            Verdict::Fail(FailureKind::AssertNe),
+            Some(FailureRecord {
+                kind: "assert_ne".to_owned(),
+                message: "assertion failed: left != right".to_owned(),
+                comparison: Some(Comparison::new("41".to_owned(), "41".to_owned())),
+                ..FailureRecord::default()
+            }),
+        ))
+        .expect("a failure renders");
+        assert!(
+            rendered.contains("\n  expected: 41\n  actual:   41\n  --- stdout"),
+            "{rendered}"
+        );
+    }
+
+    /// A multi-line pair gets the `-`/`+` listing instead: a caret into a wall
+    /// of text locates nothing.
+    #[test]
+    fn a_multi_line_comparison_prints_a_hunk_listing() {
+        let rendered = render(&finished(
+            Verdict::Fail(FailureKind::AssertEq),
+            Some(FailureRecord {
+                kind: "assert_eq".to_owned(),
+                message: "assertion failed: left == right".to_owned(),
+                comparison: Some(Comparison::new(
+                    "alpha\nbeta\ngamma\n".to_owned(),
+                    "alpha\nBETA\ngamma\n".to_owned(),
+                )),
+                ..FailureRecord::default()
+            }),
+        ))
+        .expect("a failure renders");
+        assert!(
+            rendered.contains(
+                "\n  expected:\n    alpha\n    beta\n    gamma\
+                 \n  actual:\n    alpha\n    BETA\n    gamma\
+                 \n  diff:\n      alpha\n    - beta\n    + BETA\n      gamma\n"
+            ),
+            "{rendered}"
+        );
+        assert!(!rendered.contains('^'), "{rendered}");
     }
 
     /// A runner-level note is never dropped from the human surface either: it

--- a/crates/rue/src/test_mode/verdict.rs
+++ b/crates/rue/src/test_mode/verdict.rs
@@ -61,6 +61,12 @@ pub(crate) enum FailureKind {
     Incomplete,
     /// A failed `@assert(cond)`.
     Assert,
+    /// A failed `@assert_eq(left, right)` (ADR-0083 Phase 2.5). Its frame is
+    /// the one that carries `expected` and `actual`.
+    AssertEq,
+    /// A failed `@assert_ne(left, right)`, whose frame carries the two values
+    /// the assertion demanded be different.
+    AssertNe,
     /// A runtime trap, named by its class.
     Trap(&'static str),
     /// A `?` in a test body whose failure arm reported through the channel.
@@ -79,6 +85,8 @@ impl FailureKind {
         match kind {
             "unhandled_error" => Self::UnhandledError,
             "assert" => Self::Assert,
+            "assert_eq" => Self::AssertEq,
+            "assert_ne" => Self::AssertNe,
             other => Self::Reported(other.to_owned()),
         }
     }
@@ -89,6 +97,8 @@ impl fmt::Display for FailureKind {
         match self {
             Self::Incomplete => f.write_str("incomplete"),
             Self::Assert => f.write_str("assert"),
+            Self::AssertEq => f.write_str("assert_eq"),
+            Self::AssertNe => f.write_str("assert_ne"),
             Self::Trap(class) => write!(f, "trap:{class}"),
             Self::UnhandledError => f.write_str("unhandled_error"),
             Self::Exit => f.write_str("exit"),
@@ -134,6 +144,16 @@ pub(crate) struct FailureFrame {
     pub(crate) line: u32,
     pub(crate) column: u32,
     pub(crate) payload: String,
+    /// The left operand of a comparison assertion, rendered (ADR-0083 Phase
+    /// 2.5). `None` when the frame carried no `expected` field at all, which is
+    /// what every non-comparison producer writes.
+    ///
+    /// Empty is a value, not an absence: `@assert_eq` over two empty strings
+    /// fails with two empty renderings, and dropping them would leave a
+    /// consumer unable to tell that case from an `@assert`.
+    pub(crate) expected: Option<String>,
+    /// The right operand, rendered. Present exactly when `expected` is.
+    pub(crate) actual: Option<String>,
 }
 
 /// What the channel carried, as the classifier needs it.
@@ -193,6 +213,8 @@ pub(crate) fn parse_channel(bytes: &[u8]) -> ChannelFrames {
                         line: location_number(&value, "line"),
                         column: location_number(&value, "column"),
                         payload: string_field(&value, "payload"),
+                        expected: optional_string_field(&value, "expected"),
+                        actual: optional_string_field(&value, "actual"),
                     });
                 }
             }
@@ -218,6 +240,14 @@ fn string_field(value: &serde_json::Value, key: &str) -> String {
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default()
         .to_owned()
+}
+
+/// A string field that may be absent, keeping absence distinct from empty.
+fn optional_string_field(value: &serde_json::Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
 }
 
 fn location_number(value: &serde_json::Value, key: &str) -> u32 {
@@ -489,6 +519,8 @@ mod tests {
                 line: 7,
                 column: 5,
                 payload: String::new(),
+                expected: None,
+                actual: None,
             }),
             ..ChannelFrames::default()
         };
@@ -583,6 +615,75 @@ mod tests {
         assert_eq!(failure.file, "a.rue");
         assert_eq!(failure.line, 3);
         assert_eq!(failure.column, 9);
+        assert_eq!(failure.expected, None);
+        assert_eq!(failure.actual, None);
+    }
+
+    /// A comparison frame carries `expected` and `actual` and no payload
+    /// (ADR-0083 Phase 2.5), and its kind is one the taxonomy names rather than
+    /// a verbatim one.
+    #[test]
+    fn a_comparison_frame_parses_its_two_operands() {
+        let bytes = concat!(
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert_eq\",",
+            "\"message\":\"assertion failed: left == right\",",
+            "\"location\":{\"file\":\"a.rue\",\"line\":3,\"column\":5},",
+            "\"expected\":\"41\",\"actual\":\"42\"}\n",
+        );
+        let frames = parse_channel(bytes.as_bytes());
+        assert!(frames.malformed.is_none());
+        let failure = frames.failure.expect("a failure frame");
+        assert_eq!(failure.expected.as_deref(), Some("41"));
+        assert_eq!(failure.actual.as_deref(), Some("42"));
+        assert_eq!(failure.payload, "");
+        assert_eq!(
+            FailureKind::reported(&failure.kind),
+            FailureKind::AssertEq,
+            "a built-in producer's kind is normalized, not published verbatim"
+        );
+    }
+
+    /// Empty is a value, not an absence: `@assert_eq` over two empty renderings
+    /// must still publish both sides, or a consumer cannot tell that failure
+    /// from a bare `@assert`.
+    #[test]
+    fn empty_operands_stay_distinct_from_absent_ones() {
+        let bytes = concat!(
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert_ne\",",
+            "\"message\":\"assertion failed: left != right\",",
+            "\"location\":{\"file\":\"a.rue\",\"line\":1,\"column\":1},",
+            "\"expected\":\"\",\"actual\":\"\"}\n",
+        );
+        let failure = parse_channel(bytes.as_bytes())
+            .failure
+            .expect("a failure frame");
+        assert_eq!(failure.expected.as_deref(), Some(""));
+        assert_eq!(failure.actual.as_deref(), Some(""));
+    }
+
+    /// A rendering that is not valid UTF-8 never becomes a frame at all: the
+    /// whole channel line is rejected upstream, and the verdict carries the
+    /// runner's note rather than a re-encoded operand. That is what keeps the
+    /// diff's inputs `str` all the way down, with no second encoding tag.
+    #[test]
+    fn a_non_utf8_channel_line_is_malformed_rather_than_re_encoded() {
+        let mut bytes = b"{\"record\":\"failure\",\"kind\":\"assert_eq\",\"expected\":\"".to_vec();
+        bytes.extend_from_slice(&[0xff, 0xfe]);
+        bytes.extend_from_slice(b"\",\"actual\":\"\"}\n");
+        let frames = parse_channel(&bytes);
+        assert!(frames.failure.is_none());
+        assert_eq!(
+            frames.malformed.as_deref(),
+            Some("a channel line was not valid UTF-8")
+        );
+        let classified = classify(Observation {
+            supervision: Supervision::Exited,
+            status: Ok(101),
+            stderr: b"",
+            frames: &frames,
+        });
+        assert_eq!(classified.verdict, Verdict::Fail(FailureKind::Exit));
+        assert!(classified.runner_note.is_some());
     }
 
     /// A blank channel is the ordinary shape for a test image run with no
@@ -598,6 +699,8 @@ mod tests {
     fn failure_kinds_render_their_published_spelling() {
         assert_eq!(FailureKind::Incomplete.to_string(), "incomplete");
         assert_eq!(FailureKind::Assert.to_string(), "assert");
+        assert_eq!(FailureKind::AssertEq.to_string(), "assert_eq");
+        assert_eq!(FailureKind::AssertNe.to_string(), "assert_ne");
         assert_eq!(FailureKind::Trap("panic").to_string(), "trap:panic");
         assert_eq!(FailureKind::UnhandledError.to_string(), "unhandled_error");
         assert_eq!(FailureKind::Exit.to_string(), "exit");

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -30,7 +30,7 @@ blocks (§1); discovery is the import closure for the MVP, with the
 unimported-test-file warning (§1); `--filter` narrows the run set and never
 the analysis root set (§2); and the structured failure channel is a
 dedicated inherited pipe (§5.1). Phases 1 through 2.5 (RUE-1618, RUE-1619,
-RUE-1620) are authorized to proceed on that basis.
+RUE-1620) are authorized to proceed on that basis, and are complete.
 
 Acceptance does not settle the lower-impact calls that Open Questions marks
 decidable within their phase — exit codes, `@assert` stabilization, the
@@ -329,14 +329,16 @@ $ rue test app/main.rue --filter parse_port      # run a subset
   per-test verdict, §3), `cached_pass`, and the `ice` failure kind are
   reserved in the schema for the deferred work (§6) and are unproducible in
   the MVP, whose whole-run compile failure is exit code `2`. A **failure
-  record** is data: kind (`assert` / `unhandled_error` / `trap:<class>` /
-  `exit` / `signal` / `timeout` / `output_overflow` / `incomplete` — the
-  last for exit 0 with no completion record, §3), the pinned runtime
-  message, exit code or signal, and a source location — the test
-  declaration's span, except `unhandled_error`, which carries the failing
-  `?` site (§1). Payload and location fields are extension points: richer
-  expected/actual payloads arrive through the failure channel (§5.1) as
-  additive minors, never by parsing prose. `capability_summary` is present
+  record** is data: kind (`assert` / `assert_eq` / `assert_ne` /
+  `unhandled_error` / `trap:<class>` / `exit` / `signal` / `timeout` /
+  `output_overflow` / `incomplete` — the last for exit 0 with no completion
+  record, §3), the pinned runtime message, exit code or signal, and a source
+  location — the test declaration's span, except `unhandled_error` and the
+  comparison kinds, which carry their own site (§1). Payload and location
+  fields are extension points, and Phase 2.5 used them: a comparison failure
+  carries `expected`, `actual`, and the runner's `diff` of the two as
+  additive minors on the same `1.0` schema, never as prose to be parsed.
+  `capability_summary` is present
   from v1.0 as `{"status": "unavailable"}` — zero claims, stated in-band —
   and is populated by the deferred capability ADR (§6) as an additive
   change inside a field consumers already handle.
@@ -501,10 +503,10 @@ eject-don't-degrade soundness posture the deferred capability ADR ratifies
 
 The channel through which a failing test reports structure — kind, message,
 expected/actual payload, failing-call-site location — is a documented
-runtime protocol. `@assert` today, `@assert_eq` in Phase 2.5, and the
-test-body `?` failure arm (§1) are sugar over the same channel any Rue
-function can invoke before aborting; user libraries emit the same records,
-and the stream carries them without knowing who produced them.
+runtime protocol. `@assert`, the comparison family `@assert_eq`/`@assert_ne`
+(Phase 2.5), and the test-body `?` failure arm (§1) are sugar over the same
+channel any Rue function can invoke before aborting; user libraries emit the
+same records, and the stream carries them without knowing who produced them.
 
 The mechanism — **ruled 2026-08-23** — is a **dedicated inherited pipe**:
 its own file descriptor, pinned in the §3 exec contract, written through a
@@ -664,10 +666,21 @@ companion project "rue test follow-ups" (§6).
       `main`), RUE-1918 (declared test-candidate inventory and the orphan
       warning), RUE-1920 (the `rue test` subcommand, runner, and event stream),
       RUE-1921 (`?` in test bodies with unwrap-and-report semantics).
-- [ ] **Phase 2.5: structured assertion payloads** - RUE-1620. `@assert_eq`
-      (and a minimal comparison family) as intrinsics producing
-      expected/actual through the §5.1 channel; machine-computed diffs in
-      `test_finished` events; human renderer built from the same payloads.
+- [x] **Phase 2.5: structured assertion payloads** - RUE-1620. `@assert_eq`
+      and `@assert_ne` as intrinsics producing expected/actual through the
+      §5.1 channel — one new runtime helper,
+      `__rue_test_fail_comparison` (ABI version 3), whose record carries the
+      two rendered operands where the open form carries a message and a
+      payload; machine-computed diffs in `test_finished` events, computed
+      once in the runner so the stream and the human rendering are one
+      computation; the human renderer built from those same values, with a
+      caret for a single-line pair and a `-`/`+` hunk listing for a
+      multi-line one. The family reuses the ordinary equality lowering and
+      the §1 structural printer rather than growing paths of its own, and
+      lowers identically inside and outside a test image. Settled the
+      `@assert` stabilization question below: the intrinsics are normative
+      (spec 4.13:5c - 4.13:5g) and assertion failure keeps exit 101,
+      distinguished by its pinned message.
       Pulled ahead of all deferred work deliberately: unstructured failure
       output is the primary agent token sink, and a runner that is
       agent-first in transport but prose in content has not met the bar.
@@ -810,10 +823,16 @@ site.
 
 ### Lower-impact decisions (decidable within their phase)
 
-- **Exit-code and `@assert` stabilization**: promote `@assert`/`@panic`
-  from the reserved intrinsic bucket (4.13:5b) to normative, and decide
-  whether assertion failure keeps exit 101 (recommended; distinguished by
-  pinned message) or gets a distinct code.
+- **Exit-code and `@assert` stabilization**: **settled in Phase 2.5
+  (RUE-1620)** as the recommendation. `@panic`, `@assert`, `@assert_eq`, and
+  `@assert_ne` left the reserved intrinsic bucket (4.13:5b) for normative
+  rules 4.13:5c - 4.13:5g, and assertion failure keeps exit **101**,
+  distinguished by its pinned message rather than by a status of its own. A
+  distinct code was rejected for the reason the taxonomy already relies on:
+  the runner classifies an abort by the last pinned stderr line, not by the
+  status, so a second status would add a number to branch on without adding
+  anything to distinguish — while costing every shell script that treats 101
+  as "the Rue program trapped" a special case.
 - **Exit-code contract** (§2): **settled in Phase 2c (RUE-1920)** as the
   0/1/2/3 proposal, empty-selection-as-error included, and published in
   `docs/process/test-events.md`. Everything that stops a `rue test` run from

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -2853,7 +2853,7 @@ witness of the dynamic semantics (RUE-50), cited inline in each §6 rule group.
 | §6.9 call / return / inout copy-out; nested-`return` unwind with scope drops | 6.1:4/5/18, 4.9:1/7, 3.4:5/6b, 3.9:18 |
 | §6.10 loop / break dynamics | 4.8:18/21/22, 3.4:2 |
 | §6.11 drop relation (active enum payload; skip moved; explicit `@drop`; residue order) | 3.9:1/2/4/13/15/18/28/37–39, 6.3:20 |
-| §6.12 overflow/bounds/div-zero/`@panic` traps + exit code | 3.1:6/13, 4.13:5b, 8.1, 8.2, 8.3, Appendix B |
+| §6.12 overflow/bounds/div-zero/`@panic` traps + exit code | 3.1:6/13, 4.13:5c, 8.1, 8.2, 8.3, Appendix B |
 | §6.13 allocation store: handles, views, container equations | 3.7, 3.9 (drop order), 4.3:2 (string content equality); design citations: the RUE-390 ruling, ADR-0035/0041/0043, the RUE-386 str ruling, the RUE-388 linear-element gate |
 | §7 soundness | the informal safety intent throughout ch. 3 and 8 |
 

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -83,19 +83,37 @@ A malformed selector is the image's own error: it writes
 ### The failure channel
 
 Descriptor 3 carries newline-delimited JSON, drained by the runner under its own
-budget. Two records exist in this version:
+budget. Two record kinds exist in this version, and `failure` has two shapes:
 
 ```json
 {"record":"complete","schema":"1.0"}
 {"record":"failure","schema":"1.0","kind":"...","message":"...","location":{"file":"...","line":0,"column":0},"payload":"..."}
+{"record":"failure","schema":"1.0","kind":"...","message":"...","location":{"file":"...","line":0,"column":0},"expected":"...","actual":"..."}
 ```
 
 The `complete` record is written by the dispatcher's epilogue alone, after the
 selected test body returns normally. `failure` records are written by assertion
 sugar and by the test-body `?` failure arm before aborting; `kind` is an open
 field, so a user assertion library's own kind is published verbatim rather than
-flattened (ADR-0083 §5.1). `payload` is the versioned extension point structured
-assertion payloads arrive through (Phase 2.5).
+flattened (ADR-0083 §5.1).
+
+A `failure` record carries **either** `payload` or the pair
+`expected`/`actual`, never both. `payload` is the open, versioned extension
+point §5.1 reserves for an assertion library with something structured to say
+in one string. `expected`/`actual` is the shape a **comparison** assertion
+writes: `expected` is the left operand and `actual` the right — the order the
+source spelled them, so `@assert_eq(want, got)` reads the way it is written —
+each rendered by the compiler-synthesized structural printer under the same
+rules and the same 4 KiB bound the test-body `?` payload uses. An empty
+rendering is a value and stays present as an empty string; a comparison is
+recognized by the fields' presence, not by parsing `kind`.
+
+`@assert_eq` and `@assert_ne` are the producers in this version, through the
+`__rue_test_fail_comparison` helper ([runtime-abi.md](../runtime-abi.md)). They
+are ordinary intrinsics, usable anywhere `@assert` is, and they lower the same
+way in a test image and in an ordinary executable — the only difference is that
+an ordinary process has no descriptor 3, so the frame write fails with `EBADF`
+as designed and the pinned stderr message is the whole report.
 
 Writes are best-effort by design: an image run by hand has no descriptor 3, and
 `EBADF` there is expected rather than exceptional. The channel is **not a
@@ -187,6 +205,9 @@ consumers already handle instead of adding one.
 | `signal` | integer | The signal that killed it. **Absent** otherwise. |
 | `location` | object | `{"file","line","column"}` — the test declaration's header, unless a failure frame carried its own site. |
 | `payload` | string | The channel's open payload. **Absent** when empty. |
+| `expected` | string | A comparison assertion's left operand, rendered. **Absent** on every other failure. |
+| `actual` | string | Its right operand, rendered. Present exactly when `expected` is. |
+| `diff` | array | The runner's diff from `expected` to `actual`. Present exactly when `expected` is. |
 | `runner_note` | string | The runner's own explanation. **Absent** unless the runner could not trust what it read. |
 
 `line` and `column` are both 1-based, and `column` counts Unicode scalars rather
@@ -199,6 +220,43 @@ operator's operand, so `location` names the failing expression rather than the
 
 `timeout` and `crash` verdicts also carry a failure record, with kind `timeout`
 and `signal` respectively.
+
+##### The comparison diff
+
+`diff` is computed by the runner, not carried on the channel, so the event
+stream and the human rendering are one computation and can never disagree about
+where two values differ. It is an array of hunks in order:
+
+```json
+"diff":[{"op":"equal","text":"4"},{"op":"delete","text":"1"},{"op":"insert","text":"2"}]
+```
+
+`op` is `equal` (present in both), `delete` (present in `expected`, absent from
+`actual`), or `insert` (the reverse). Two invariants make the encoding lossless
+rather than a rendering: concatenating every `equal` and `delete` hunk's `text`
+yields `expected` exactly, and concatenating every `equal` and `insert` hunk's
+yields `actual`. No two adjacent hunks share an `op`, and no hunk is empty, so
+two identical values are one `equal` hunk and two empty values are an empty
+array.
+
+Granularity follows the values: if either contains a newline the diff is
+line-by-line, and each line unit carries its own terminator; otherwise it is
+character-by-character, over Unicode scalar values. A common prefix and suffix
+are removed before any alignment, and a remaining middle large enough to make an
+exact longest-common-subsequence expensive is reported as one wholesale
+`delete` followed by one `insert` rather than refined — the invariants above
+hold either way.
+
+A rendering that is not valid UTF-8 never reaches the diff: `expected` and
+`actual` are JSON string fields, and a channel line that is not valid UTF-8 is
+rejected as malformed before it becomes a frame at all, yielding `fail` with
+kind `exit` and a `runner_note` (see Precedence below). There is no second
+encoding tag on these fields, unlike a capture record's.
+
+Under `--format human` the same values are printed as `expected:` and `actual:`
+lines. A single-line pair gets a caret under the first differing character; a
+multi-line pair gets a `-`/`+` hunk listing instead, because a caret into a wall
+of text locates nothing.
 
 #### Capture records
 
@@ -277,6 +335,8 @@ of stderr, and the frames read from the failure channel.
 | `pass` | — | Exit `0` **and** a `complete` frame was read. |
 | `fail` | `incomplete` | Exit `0` with no `complete` frame. |
 | `fail` | `assert` | The last stderr line is exactly `assertion failed`. |
+| `fail` | `assert_eq` | A `failure` frame from a failed `@assert_eq`, carrying `expected` and `actual`. |
+| `fail` | `assert_ne` | The same, from a failed `@assert_ne`. |
 | `fail` | `trap:<class>` | The last stderr line is another pinned runtime message. |
 | `fail` | `unhandled_error` | A `failure` frame with that kind — the test-body `?` failure arm. |
 | `fail` | *(verbatim)* | A `failure` frame with a kind the runner does not know (ADR-0083 §5.1). |
@@ -432,7 +492,10 @@ event of a run and in each `--list --format json` record.
 
 - **Additive changes are minors.** A new event kind, a new optional field, a new
   reserved value becoming producible, or a richer `payload` inside the failure
-  record. Consumers must ignore unknown fields and unknown event kinds.
+  record. Consumers must ignore unknown fields and unknown event kinds. The
+  failure record's `expected`, `actual`, and `diff` and the `assert_eq` /
+  `assert_ne` kinds arrived this way (ADR-0083 Phase 2.5): the version stays
+  `1.0` because nothing a `1.0` consumer already read changed.
 - **Removing or repurposing a field, renaming an event, or changing a field's
   type is a major.** So is producing a verdict this document reserves *out* of
   the taxonomy.

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -114,9 +114,10 @@ diagnostic and terminate the process with the runtime-error status.
 
 ## The test failure channel
 
-Five helpers exist only for `rue test` (ADR-0083 §3, §5.1). They are runner
-plumbing: no source spelling selects them, and the synthesized dispatcher `main`
-of a test image is their only caller in this revision.
+Six helpers implement the ADR-0083 §3 and §5.1 channel. Three are dispatcher
+plumbing no source spelling selects; the reporting helpers are what a test
+body's `?` and the comparison assertions lower to, in an ordinary executable as
+well as in a test image.
 
 - `__rue_test_normalize_process` narrows the captured argument count to one, so
   a test observes the pinned inventory rather than the selector it was
@@ -128,9 +129,23 @@ of a test image is their only caller in this revision.
   is register-only and x86-64 affords six. The first stages the location, the
   second emits the record and takes the ordinary panic path; nothing runs
   between them, and the staged file bytes must stay readable across both.
+- `__rue_test_fail_comparison` is the same terminal call for a comparison
+  assertion (Phase 2.5, ABI version 3): it carries the two rendered operands as
+  the record's `expected` and `actual` where `__rue_test_fail` carries a message
+  and the open payload. Its message is not a parameter — it is pinned by the
+  kind, `assertion failed: left == right` for `assert_eq` and
+  `assertion failed: left != right` for `assert_ne` — which is what keeps a
+  six-register call able to carry both operands. It pairs with
+  `__rue_test_failure_site` under the same adjacency rule.
 - `__rue_test_usage_error` writes one pinned diagnostic for a malformed
   selector and *returns*, unlike every other stderr-writing runtime path,
   because the dispatcher owns that case's exit status.
+
+`@assert_eq(l, r)` and `@assert_ne(l, r)` compile to the ordinary equality
+lowering plus, on the failing branch, the two rendering calls and this pair. The
+lowering does not depend on whether the request is a test one: an ordinary
+process simply has no descriptor 3, so the frame write fails with `EBADF` as
+designed and the pinned stderr message plus exit 101 is the whole report.
 
 The completion and failure records go to a dedicated inherited descriptor,
 number 3, one JSON object per line. Writes are best-effort: a test image run by

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -42,7 +42,8 @@ recognizes. The tables below group names that may appear in any expression
 position (expression intrinsics), only inside a `checked` block (unchecked
 intrinsics, specified in §9.2), or only as an internal checked bridge. Rule
 4.13:5b separately records frontend-reserved names and test infrastructure.
-The contracts for the reserved expression intrinsics are stated in 4.13:5c–e.
+The abort intrinsics `@panic`, `@assert`, `@assert_eq`, and `@assert_ne` are
+specified normatively in 4.13:5c–5g.
 This inventory is kept in sync with the compiler's
 source-intrinsic recognition paths: the RIR type-intrinsic forms, the
 pre-interned names in `crates/rue-air/src/sema/known_symbols.rs`, and the
@@ -55,6 +56,10 @@ Expression intrinsics (usable in any expression position):
 | Intrinsic | Purpose | Arguments | Return Type |
 |-----------|---------|-----------|-------------|
 | `@dbg` | Print debug output | 1 expression (int, bool, or string) | `()` |
+| `@panic` | Abort with a message (§4.13:5c) | 0–1 expressions (text message) | `!` |
+| `@assert` | Abort unless a condition holds (§4.13:5d) | 1 expression (`bool`), 1 optional expression (text message) | `()` |
+| `@assert_eq` | Abort unless two values are equal, reporting both (§4.13:5f) | 2 expressions (one type, comparable with `==`) | `()` |
+| `@assert_ne` | Abort unless two values differ, reporting both (§4.13:5f) | 2 expressions (one type, comparable with `==`) | `()` |
 | `@size_of` | Get type size in bytes | 1 type | `i32` |
 | `@align_of` | Get type alignment in bytes | 1 type | `i32` |
 | `@require_droppable` | Enforce the owning-container element-type gate | 1 type | `()` |
@@ -122,12 +127,11 @@ see rule [6.6:7](@/06-items/06-borrow-accessors.md)):
 
 {{ rule(id="4.13:5b", cat="informative") }}
 
-The compiler frontend reserves the names `@cast`, `@panic`, `@assert`, and
-`@test_preview_gate`. The expression contracts for `@panic`, `@assert`, and
-`@cast` are specified in 4.13:5c, 4.13:5d, and 4.13:5e respectively. The
-`@test_preview_gate()` intrinsic is a zero-argument no-op used only to test the
-preview-feature gating machinery (`--preview test_infra`); it is test
-infrastructure, not a language feature.
+The compiler frontend reserves the names `@cast` and `@test_preview_gate`.
+`@cast` is not a valid conversion intrinsic; its rejection is specified in
+4.13:5e. The `@test_preview_gate()` intrinsic is a zero-argument no-op used only
+to test the preview-feature gating machinery (`--preview test_infra`); it is
+test infrastructure, not a language feature.
 
 {{ rule(id="4.13:5c", cat="dynamic-semantics") }}
 
@@ -148,6 +152,40 @@ a true condition has no effect.
 `@cast` is reserved but not a valid conversion intrinsic. A call to it **MUST**
 be rejected at compile time with a diagnostic directing the programmer to
 `@intCast`.
+
+{{ rule(id="4.13:5f", cat="dynamic-semantics") }}
+
+`@assert_eq(left, right)` and `@assert_ne(left, right)` each take exactly two
+expressions and have type `()`. Both operands **MUST** have the same type, and
+that type **MUST** be one `==` accepts (4.3:3); it is a compile-time error
+otherwise. Each operand is evaluated exactly once, left before right, and read
+without being consumed — the same borrowing `==` performs (4.3:3f). The
+assertion holds when `left == right` does, for `@assert_eq`, and when
+`left != right` does, for `@assert_ne`. When it holds the intrinsic has no
+effect. When it does not, the program writes
+`panic: assertion failed: left == right` (for `@assert_eq`) or
+`panic: assertion failed: left != right` (for `@assert_ne`) to standard error
+and terminates with status 101, exactly as `@assert` does.
+
+{{ rule(id="4.13:5g", cat="informative") }}
+
+Inside a test image the same failure is additionally reported as structured
+data: a record naming the failing kind, the intrinsic's source location, and
+both operands rendered as `expected` and `actual`. Ordinary builds are
+unaffected — the report goes to a descriptor a test runner supplies, and its
+absence is not an error. See
+[docs/process/test-events.md](https://github.com/rue-language/rue/blob/trunk/docs/process/test-events.md)
+for that surface, which is a tooling contract rather than a language rule.
+
+{{ rule(id="4.13:5h") }}
+
+```rue
+fn main() -> i32 {
+    @assert_eq(1 + 1, 2);
+    @assert_ne(1, 2);
+    42
+}
+```
 
 ## `@dbg`
 


### PR DESCRIPTION
Closes RUE-1620. ADR-0083 Phase 2.5: `@assert_eq` and `@assert_ne` as intrinsics that report both operands as structured data, with machine-computed diffs in the event stream. This completes the rue test MVP (Phases 1, 2, and 2.5).

## Intrinsics

`@assert_eq(left, right)` and `@assert_ne(left, right)`: two operands of one type that `==` accepts, evaluated once each, left before right, read without being consumed exactly as `==` reads them. They reuse the ordinary equality lowering (one `build_comparison` shared with `==`) and the RUE-1921 structural printer, so no second comparison or rendering path exists. Inference unifies the operands on one type variable; a semantic `types_equivalent` guard backs that up because one printer instance renders both. Comptime-known operands fold to the existing `@assert` behavior. In ordinary builds a failure traps with `panic: assertion failed: left == right` (or `!=`) and exit 101; inside a test image the same failure additionally reaches the runner as structured data. Operands that are fields of `borrow` parameters, non-`Copy` fields through borrows, and locals used again afterwards all compile and render through the borrow, pinned by session tests and CLI cases.

## Runtime ABI v3

One new helper, `__rue_test_fail_comparison(kind, left, right) -> !`, writes a `failure` frame carrying `expected` and `actual` (the pinned message is chosen by kind inside the runtime, which keeps both byte views within six registers), prints the pinned message, and exits 101. Version 3, marker `__rue_runtime_abi_v3`, 52 helpers; manifest, runtime dispatch, archive validation, and `docs/runtime-abi.md` updated together per ADR-0055.

## Runner

`test_finished.failure` for kinds `assert_eq` and `assert_ne` gains `expected`, `actual`, and `diff`: ordered `{op: equal|insert|delete, text}` hunks, line-granular when either side contains a newline and character-granular otherwise, common prefix and suffix trimmed then exact LCS with a bounded middle that degrades to one delete plus insert. Two invariants make it lossless: equal plus delete concatenates to `expected`, equal plus insert to `actual`. The human renderer prints `expected:` and `actual:`, a caret under the first differing character for single-line pairs, and a `-`/`+` hunk listing for multi-line pairs. Non-UTF-8 channel lines are already rejected as malformed with a runner note, so the diff never sees them.

## Spec, docs, oracle

`@panic`, `@assert`, `@assert_eq`, and `@assert_ne` leave the reserved intrinsic bucket for normative rules 4.13:5c through 5g, settling the ADR's stabilization question: assertion failure keeps exit 101, distinguished by its pinned message. `docs/process/test-events.md` documents the new fields and produced kinds; ADR-0083 ticks Phase 2.5 and records the decision. The oracle now reports a runtime call that mirrors an unmodeled intrinsic as that intrinsic's registrable gap rather than a missing-body harness failure, which is how a synthesized printer's `@alloc` becomes a registered `Allocate` gap for the four failing-assertion corpus cases.

## Coverage

Twelve session tests (type mismatch and no-equality diagnostics, lowering order, comptime folding, one printer per type, borrowed-place operands, later use of compared locals); runtime frame tests; ABI pins; runner diff and extraction tests; twelve `rue test` CLI cases against real std (integers, `StrBuf`, struct, enum, `@assert_ne`, passing, ordinary-build trap, human rendering for single-line and multi-line, borrowed field failing and passing); spec cases for 4.13; six UI cases.

Local: fmt, quick, rue-air, rue-compiler, rue, rue-codegen, rue-test-runner, rue-runtime, rue-runtime-abi suites, `scripts/rue spec 4.13`, ui, `scripts/rue cli rue_test`, repository-quality-gates, the rue_program digest check, and a full `scripts/rue premerge` (211 pass, 0 fail) green on the pre-review hash; the post-review amendment re-ran the affected suites green. The oracle-diff harness cannot run on this host (thread exhaustion, reproduced without the change); the new cases were audited in isolation with the two registered gaps and the merge queue's oracle-diff lanes are the authority.
