### PR TITLE
RUE-1071/RUE-1072: add scalar float codegen

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -114,7 +114,7 @@ pub use sema::{
     DurableReducedComptimeCall, DurableSignatureParameter, DurableTryProducer, FunctionInfo,
     ImplicitDropDependencySourceEvent, ImplicitNamedDestructorDependencyEvent, ImportResolution,
     MAX_COMPTIME_CALL_DEPTH, MemberCandidate, MemberKind, MethodInfo, NameCandidate,
-    NameResolution, NamedConstDependencyEvent, NamedConstDependencyTargetEvent,
+    NameResolution, NamedConstDependencyEvent, NamedConstDependencyTargetEvent, NativeArgClass,
     NominalWellFormedness, OperatorMemberCandidate, OperatorName, ParamSlotModes,
     ProviderAggregateFacts, ProviderAnonymousBody, ProviderBodyAnalysisState, ProviderBodyWork,
     ProviderCallFacts, ProviderDefinitionKind, ProviderEndpointFacts, ProviderIdentityContext,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -103,7 +103,7 @@ pub use output::{
     DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
     DeclarationTypeDependencyTargetKind, ImplicitDropDependencySourceEvent,
     ImplicitNamedDestructorDependencyEvent, NamedConstDependencyEvent,
-    NamedConstDependencyTargetEvent, ParamSlotModes, SourceParamAbi,
+    NamedConstDependencyTargetEvent, NativeArgClass, ParamSlotModes, SourceParamAbi,
 };
 pub use provider::{
     BodyFactProvider, DropCopyMetadata, ImportResolution, MemberCandidate, MemberKind,

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -245,6 +245,13 @@ pub struct ImplicitNamedDestructorDependencyEvent {
 /// `arg_class.crossing_slots() == slot_count`, so the plumbing is behaviourally
 /// inert and the emitted prologue is byte-identical.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeArgClass {
+    Gp,
+    Fp32,
+    Fp64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceParamAbi {
     /// First parameter ABI slot this source parameter occupies.
     pub start_slot: u32,
@@ -258,6 +265,9 @@ pub struct SourceParamAbi {
     /// `crossing_regs < slot_count` distinguishes exactly the by-value indirect
     /// aggregate the callee must unmarshal.
     pub crossing_regs: u32,
+    /// Register-bank class of each crossing slot, in source order. Pointer
+    /// transports are GP; direct scalar float leaves retain their width.
+    pub crossing_classes: Vec<NativeArgClass>,
     /// The aggregate type — carried *only* for a by-value indirect parameter, so
     /// code generation can build its compact memory image; `None` for every
     /// direct parameter and every by-reference pointer. Withholding the type

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -7,8 +7,8 @@ use ahash::{AHashMap, AHashSet};
 use lasso::{Spur, ThreadedRodeo};
 use rue_air::{
     AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
-    AnalyzedCallableKind, ArgConvention, FrozenTypeInternPool, NativeCallAbi, ParamSlotModes,
-    SourceParamAbi, StructId, Type, TypeKind, ValidatedAir,
+    AnalyzedCallableKind, ArgConvention, FrozenTypeInternPool, NativeArgClass, NativeCallAbi,
+    ParamSlotModes, SourceParamAbi, StructId, Type, TypeKind, ValidatedAir,
 };
 use rue_error::{CompileError, CompileWarning, ErrorKind, WarningKind};
 use std::cell::RefCell;
@@ -789,10 +789,10 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
     let mut slot = 0u32;
     while slot < num_params {
         let is_by_ref = by_ref.get(slot as usize).copied().unwrap_or(false);
-        let (slot_count, crossing_regs, ty) = if is_by_ref {
+        let (slot_count, crossing_regs, ty, crossing_classes) = if is_by_ref {
             // A by-reference parameter is always one pointer slot; its type is
             // never consulted by code generation.
-            (1, 1, None)
+            (1, 1, None, vec![NativeArgClass::Gp])
         } else if let Some(&ty) = ty_at.get(&slot) {
             let width = type_pool.abi_slot_count(ty).max(1);
             let crossing = if direct_slot_abi {
@@ -808,21 +808,66 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
             // pointer over a multi-slot span), so a direct parameter's CFG stays
             // layout-independent.
             let carried_ty = (crossing < width).then_some(ty);
-            (width, crossing, carried_ty)
+            let crossing_classes = if crossing < width {
+                vec![NativeArgClass::Gp]
+            } else {
+                let mut classes = native_arg_leaf_classes(type_pool, ty);
+                classes.reverse();
+                // Unit occupies one historical parameter slot even though it
+                // has no ABI leaf. Keep that synthetic slot in the GP bank so
+                // the parameter metadata remains a total description of the
+                // existing slot-oriented CFG contract.
+                if classes.is_empty() && crossing == 1 {
+                    classes.push(NativeArgClass::Gp);
+                }
+                classes
+            };
+            (width, crossing, carried_ty, crossing_classes)
         } else {
             // No recorded type for a by-value slot: a single direct slot, which
             // homes exactly as the historical prologue.
-            (1, 1, None)
+            (1, 1, None, vec![NativeArgClass::Gp])
         };
         descriptors.push(SourceParamAbi {
             start_slot: slot,
             slot_count,
             crossing_regs,
+            crossing_classes,
             ty,
         });
         slot += slot_count;
     }
     descriptors
+}
+
+fn native_arg_leaf_classes(type_pool: &FrozenTypeInternPool, ty: Type) -> Vec<NativeArgClass> {
+    fn push(type_pool: &FrozenTypeInternPool, ty: Type, out: &mut Vec<NativeArgClass>) {
+        match ty.kind() {
+            TypeKind::Unit | TypeKind::Never => {}
+            TypeKind::F32 => out.push(NativeArgClass::Fp32),
+            TypeKind::F64 => out.push(NativeArgClass::Fp64),
+            TypeKind::Struct(id) => {
+                for field in &type_pool.struct_def(id).fields {
+                    push(type_pool, field.ty, out);
+                }
+            }
+            TypeKind::Array(id) => {
+                let (element, len) = type_pool.array_def(id);
+                for _ in 0..len {
+                    push(type_pool, element, out);
+                }
+            }
+            // Enums always carry an integer tag and may overlay unlike payload
+            // classes, so their stable internal call image remains GP-shaped.
+            TypeKind::Enum(_) => {
+                out.extend((0..type_pool.abi_slot_count(ty)).map(|_| NativeArgClass::Gp));
+            }
+            _ => out.push(NativeArgClass::Gp),
+        }
+    }
+    let mut out = Vec::new();
+    push(type_pool, ty, &mut out);
+    out
 }
 
 impl<'a> CfgBuilder<'a> {
@@ -1090,18 +1135,6 @@ impl<'a> CfgBuilder<'a> {
         let inst = self.air.get(air_ref);
         let span = inst.span;
         let ty = inst.ty;
-
-        // ADR-0065 Phase 4 deliberately stops at typed AIR. Until both
-        // backends implement float register classes and operations, reject a
-        // concrete float before it can be represented by the integer-oriented
-        // CFG and silently miscompiled.
-        if ty.is_float() {
-            self.errors
-                .push(CompileError::new(ErrorKind::FloatNotYetImplemented, span));
-            self.cfg
-                .set_terminator(self.current_block, Terminator::Unreachable);
-            return Self::diverged();
-        }
 
         match &inst.data {
             AirInstData::Const(v) => {
@@ -1724,6 +1757,26 @@ impl<'a> CfgBuilder<'a> {
                 name,
                 args,
             } => {
+                // ADR-0065 Phase 8 owns total ordering, and Phases 5/6 cover
+                // signed integer conversions only. Keep the existing
+                // fail-closed diagnostic for later phases while supported
+                // scalar operations proceed into the target backends.
+                let unsupported_float_intrinsic = *operation
+                    == rue_air::IntrinsicOperation::TotalCmp
+                    || (*operation == rue_air::IntrinsicOperation::FloatToInt && !ty.is_signed())
+                    || (*operation == rue_air::IntrinsicOperation::IntToFloat
+                        && self
+                            .air
+                            .get_intrinsic_args(args)
+                            .next()
+                            .is_some_and(|arg| !self.air.get(arg).ty.is_signed()));
+                if unsupported_float_intrinsic {
+                    self.errors
+                        .push(CompileError::new(ErrorKind::FloatNotYetImplemented, span));
+                    self.cfg
+                        .set_terminator(self.current_block, Terminator::Unreachable);
+                    return Self::diverged();
+                }
                 let arguments = self
                     .air
                     .get_intrinsic_args(args)
@@ -2523,11 +2576,23 @@ impl<'a> CfgBuilder<'a> {
                 // Unit has no runtime value. Keeping a path-local synthetic
                 // unit value on Return makes that operand appear to cross a
                 // join without a block parameter and violates SSA dominance.
-                let val = if self.cfg.return_type() == Type::UNIT {
+                let mut val = if self.cfg.return_type() == Type::UNIT {
                     None
                 } else {
                     val
                 };
+
+                // A named comptime-float constant retains its exact semantic
+                // identity in AIR. Materialize it at the function's declared
+                // float width before CFG verification and machine lowering.
+                let return_type = self.cfg.return_type();
+                if return_type.is_float()
+                    && let Some(value) = val
+                    && self.cfg.get_inst(value).ty == Type::COMPTIME_FLOAT
+                    && let CfgInstData::Const(bits) = self.cfg.get_inst(value).data
+                {
+                    val = Some(self.emit(CfgInstData::Const(bits), return_type, span));
+                }
 
                 self.branch_through_return_cleanup(val, span);
 

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -2411,6 +2411,7 @@ mod tests {
                 start_slot: 0,
                 slot_count: 2,
                 crossing_regs: 2,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp; 2],
                 ty: None,
             }]);
             let entry = cfg.new_block();
@@ -3139,6 +3140,7 @@ mod tests {
                 start_slot: 0,
                 slot_count: 2,
                 crossing_regs: 2,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp; 2],
                 ty: None,
             }]);
             let entry = cfg.new_block();

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -1163,6 +1163,7 @@ impl Cfg {
                     start_slot: param.start_slot,
                     slot_count: param.slot_count,
                     crossing_regs: param.crossing_regs,
+                    crossing_classes: param.crossing_classes.clone(),
                     ty: match param.ty {
                         Some(t) => Some(ty(t).map_err(CfgRemapError::Domain)?),
                         None => None,

--- a/crates/rue-cli-tests/cases/float_codegen.toml
+++ b/crates/rue-cli-tests/cases/float_codegen.toml
@@ -1,0 +1,429 @@
+[section]
+id = "cli.float_codegen"
+name = "Scalar float code generation"
+description = "ADR-0065 Phases 5 and 6: scalar float lowering, FP ABI registers, IEEE comparisons, and checked conversions on both native backends."
+
+[[case]]
+name = "x86_64_scalar_arithmetic_and_fp_abi"
+files = [{ path = "main.rue", source = """
+fn sum9(a: f64, b: f64, c: f64, d: f64, e: f64, f: f64, g: f64, h: f64, i: f64) -> f64 {
+    a + b + c + d + e + f + g + h + i
+}
+fn main() -> i32 {
+    @float_to_int(sum9(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0))
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+exit_code = 45
+
+[[case]]
+name = "aarch64_scalar_arithmetic_and_fp_abi"
+files = [{ path = "main.rue", source = """
+fn sum9(a: f64, b: f64, c: f64, d: f64, e: f64, f: f64, g: f64, h: f64, i: f64) -> f64 {
+    a + b + c + d + e + f + g + h + i
+}
+fn main() -> i32 {
+    @float_to_int(sum9(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0))
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 45
+
+[[case]]
+name = "native_width_conversions_and_arithmetic"
+files = [{ path = "main.rue", source = """
+fn f32_value() -> f32 { @int_to_float(6) / 4.0 }
+fn main() -> i32 {
+    let widened: f64 = @float_cast(f32_value());
+    let narrowed: f32 = @float_cast(widened + 2.25);
+    @float_to_int(narrowed)
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+exit_code = 3
+
+[[case]]
+name = "native_float_value_survives_a_call_via_spill"
+files = [{ path = "main.rue", source = """
+fn identity(value: f64) -> f64 { value }
+fn main() -> i32 {
+    let across_call: f64 = 1.5;
+    let returned: f64 = identity(2.5);
+    @float_to_int(across_call + returned)
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+exit_code = 4
+
+[[case]]
+name = "native_nan_comparisons_are_unordered"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let zero: f64 = 0.0;
+    let nan: f64 = zero / zero;
+    if nan != nan && !(nan == nan) && !(nan < zero) && !(nan <= zero)
+        && !(nan > zero) && !(nan >= zero) { 7 } else { 99 }
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+exit_code = 7
+
+[[case]]
+name = "native_nan_to_int_traps"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let zero: f64 = 0.0;
+    @float_to_int(zero / zero)
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+runtime_error_contains = ["integer overflow"]
+exit_code = 101
+
+[[case]]
+name = "native_float_to_i32_upper_boundary_traps"
+files = [{ path = "main.rue", source = "fn main() -> i32 { @float_to_int(2147483648.0) }" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+runtime_error_contains = ["integer overflow"]
+exit_code = 101
+
+[[case]]
+name = "native_float_to_i32_lower_boundary_is_inclusive"
+files = [{ path = "main.rue", source = "fn main() -> i32 { @float_to_int(-2147483648.0) }" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "x86_64_float_block_parameter"
+files = [{ path = "main.rue", source = """
+fn choose(flag: bool) -> f64 { if flag { 3.0 } else { 9.0 } }
+fn main() -> i32 { @float_to_int(choose(true)) }
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+exit_code = 3
+
+[[case]]
+name = "aarch64_float_block_parameter"
+files = [{ path = "main.rue", source = """
+fn choose(flag: bool) -> f64 { if flag { 3.0 } else { 9.0 } }
+fn main() -> i32 { @float_to_int(choose(true)) }
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 3
+
+[[case]]
+name = "x86_64_mixed_argument_banks_are_independent"
+files = [{ path = "main.rue", source = """
+fn pick(_left: f64, right: i32, a: f32, b: i32, c: f64) -> i32 {
+    right + b + @float_to_int(a) + @float_to_int(c)
+}
+fn main() -> i32 { pick(1.0, 32, 2.0, 3, 5.0) }
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+exit_code = 42
+
+[[case]]
+name = "aarch64_mixed_argument_banks_are_independent"
+files = [{ path = "main.rue", source = """
+fn pick(_left: f64, right: i32, a: f32, b: i32, c: f64) -> i32 {
+    right + b + @float_to_int(a) + @float_to_int(c)
+}
+fn main() -> i32 { pick(1.0, 32, 2.0, 3, 5.0) }
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 42
+
+[[case]]
+name = "native_float_pointer_widths_preserve_neighbor_bytes"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut value: f32 = 1.0;
+    let mut wide: f64 = 2.0;
+    let neighbor: u8 = 77;
+    checked {
+        let pf: ptr mut f32 = @raw_mut(value);
+        @ptr_write(pf, 3.5);
+        let f: f32 = @ptr_read(pf);
+        let pd: ptr mut f64 = @raw_mut(wide);
+        @ptr_write(pd, 6.0);
+        let d: f64 = @ptr_read(pd);
+        if @float_to_int(f) == 3 && @float_to_int(d) == 6 && neighbor == 77 { 9 } else { 99 }
+    }
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+exit_code = 9
+
+[[case]]
+name = "x86_64_mixed_argument_banks_overflow_independently"
+files = [{ path = "main.rue", source = """
+fn tail(i0:i32,f0:f64,i1:i32,f1:f64,i2:i32,f2:f64,i3:i32,f3:f64,i4:i32,f4:f64,
+    i5:i32,f5:f64,i6:i32,f6:f64,i7:i32,f7:f64,ix8:i32,fx8:f64) -> i32 {
+    ix8 + @float_to_int(fx8)
+}
+fn main() -> i32 {
+    tail(1,1.0,2,2.0,3,3.0,4,4.0,5,5.0,6,6.0,7,7.0,8,8.0,19,23.0)
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+exit_code = 42
+
+[[case]]
+name = "aarch64_mixed_argument_banks_overflow_independently"
+files = [{ path = "main.rue", source = """
+fn tail(i0:i32,f0:f64,i1:i32,f1:f64,i2:i32,f2:f64,i3:i32,f3:f64,i4:i32,f4:f64,
+    i5:i32,f5:f64,i6:i32,f6:f64,i7:i32,f7:f64,ix8:i32,fx8:f64) -> i32 {
+    ix8 + @float_to_int(fx8)
+}
+fn main() -> i32 {
+    tail(1,1.0,2,2.0,3,3.0,4,4.0,5,5.0,6,6.0,7,7.0,8,8.0,19,23.0)
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 42
+
+[[case]]
+name = "native_float_fields_arrays_and_inout"
+files = [{ path = "main.rue", source = """
+struct Pair { small: f32, wide: f64 }
+fn set32(inout value: f32) { value = 4.0; }
+fn set64(inout value: f64) { value = 8.0; }
+fn main() -> i32 {
+    let mut pair = Pair { small: 1.0, wide: 2.0 };
+    let mut values: [f64; 2] = [3.0, 5.0];
+    set32(inout pair.small);
+    set64(inout values[1]);
+    @float_to_int(@float_cast(pair.small) + pair.wide + values[0] + values[1])
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+exit_code = 17
+
+[[case]]
+name = "aarch64_float_large_frame_offsets"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let values: [f64; 40] = [
+        7.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,
+        10.0,11.0,12.0,13.0,14.0,15.0,16.0,17.0,18.0,19.0,
+        20.0,21.0,22.0,23.0,24.0,25.0,26.0,27.0,28.0,29.0,
+        30.0,31.0,32.0,33.0,34.0,35.0,36.0,37.0,38.0,39.0
+    ];
+    @float_to_int(values[0])
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 7
+
+[[case]]
+name = "native_aggregate_float_equality_is_ieee"
+files = [{ path = "main.rue", source = """
+struct Inner { x: f32, y: f64 }
+struct Outer { tag: i32, inner: Inner }
+fn main() -> i32 {
+    let a = Outer { tag: 1, inner: Inner { x: 2.0, y: 3.0 } };
+    let b = Outer { tag: 1, inner: Inner { x: 2.0, y: 3.0 } };
+    let zero: f64 = 0.0;
+    let nan = zero / zero;
+    let n = Outer { tag: 1, inner: Inner { x: 2.0, y: nan } };
+    if a == b && !(a != b) && n != n && !(n == n) { 11 } else { 99 }
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+exit_code = 11
+
+[[case]]
+name = "x86_64_float_enums_preserve_slot_classes"
+files = [{ path = "main.rue", source = """
+enum Small { Some(f32), None }
+enum Wide { Some(f64), None }
+fn read_wide(value: Wide) -> f64 {
+    match value { Wide.Some(x) => x, Wide.None => 0.0 }
+}
+fn main() -> i32 {
+    let small = Small.Some(2.0);
+    let local: f32 = match small { Small.Some(x) => x, Small.None => 0.0 };
+    let zero: f64 = 0.0;
+    let nan = Wide.Some(zero / zero);
+    let sum = @float_cast(local) + read_wide(Wide.Some(5.0));
+    @float_to_int(sum) + if nan != nan { 1 } else { 90 }
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+exit_code = 8
+
+[[case]]
+name = "aarch64_float_enums_preserve_slot_classes"
+files = [{ path = "main.rue", source = """
+enum Small { Some(f32), None }
+enum Wide { Some(f64), None }
+fn read_wide(value: Wide) -> f64 {
+    match value { Wide.Some(x) => x, Wide.None => 0.0 }
+}
+fn main() -> i32 {
+    let small = Small.Some(2.0);
+    let local: f32 = match small { Small.Some(x) => x, Small.None => 0.0 };
+    let zero: f64 = 0.0;
+    let nan = Wide.Some(zero / zero);
+    let sum = @float_cast(local) + read_wide(Wide.Some(5.0));
+    @float_to_int(sum) + if nan != nan { 1 } else { 90 }
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 8
+
+[[case]]
+name = "x86_64_borrow_and_inout_float_transport_is_gp"
+files = [{ path = "main.rue", source = """
+fn read32(borrow value: f32) -> f32 { value }
+fn read64(borrow value: f64) -> f64 { value }
+fn bump32(inout value: f32) { value = value + 1.5; }
+fn bump64(inout value: f64) { value = value + 2.0; }
+fn main() -> i32 {
+    let mut small: f32 = 2.0;
+    let mut wide: f64 = 3.0;
+    let before = @float_cast(read32(borrow small)) + read64(borrow wide);
+    bump32(inout small);
+    bump64(inout wide);
+    @float_to_int(before + @float_cast(small) + wide)
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+exit_code = 13
+
+[[case]]
+name = "aarch64_borrow_and_inout_float_transport_is_gp"
+files = [{ path = "main.rue", source = """
+fn read32(borrow value: f32) -> f32 { value }
+fn read64(borrow value: f64) -> f64 { value }
+fn bump32(inout value: f32) { value = value + 1.5; }
+fn bump64(inout value: f64) { value = value + 2.0; }
+fn main() -> i32 {
+    let mut small: f32 = 2.0;
+    let mut wide: f64 = 3.0;
+    let before = @float_cast(read32(borrow small)) + read64(borrow wide);
+    bump32(inout small);
+    bump64(inout wide);
+    @float_to_int(before + @float_cast(small) + wide)
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 13
+
+[[case]]
+name = "x86_64_mixed_enum_payload_carriers_are_tag_typed"
+files = [{ path = "main.rue", source = """
+enum Mixed { Small(f32), Wide(f64), Empty }
+enum Overlay { Float(f64), Integer(i64), Empty }
+fn read_mixed(value: Mixed) -> f64 {
+    match value {
+        Mixed.Small(x) => @float_cast(x),
+        Mixed.Wide(x) => x,
+        Mixed.Empty => 0.0,
+    }
+}
+fn read_float(value: Overlay) -> f64 {
+    match value { Overlay.Float(x) => x, Overlay.Integer(_) => 0.0, Overlay.Empty => 0.0 }
+}
+fn read_integer(value: Overlay) -> i64 {
+    match value { Overlay.Integer(x) => x, Overlay.Float(_) => 0, Overlay.Empty => 0 }
+}
+fn main() -> i32 {
+    let zero: f64 = 0.0;
+    let nan = Mixed.Wide(zero / zero);
+    let floats = read_mixed(Mixed.Small(3.0)) + read_mixed(Mixed.Wide(4.0));
+    let overlay = read_float(Overlay.Float(5.0));
+    let memory = checked {
+        let pm: ptr mut Mixed = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Mixed)), @intCast(@align_of(Mixed)))));
+        @ptr_write(pm, Mixed.Small(6.0));
+        let m = @ptr_read(pm);
+        let po: ptr mut Overlay = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Overlay)), @intCast(@align_of(Overlay)))));
+        @ptr_write(po, Overlay.Float(7.0));
+        let f = @ptr_read(po);
+        @ptr_write(po, Overlay.Integer(8));
+        let i = @ptr_read(po);
+        let result = @float_to_int(read_mixed(m) + read_float(f)) + @intCast(read_integer(i));
+        @free(@int_to_ptr(@ptr_to_int(pm)), @intCast(@size_of(Mixed)), @intCast(@align_of(Mixed)));
+        @free(@int_to_ptr(@ptr_to_int(po)), @intCast(@size_of(Overlay)), @intCast(@align_of(Overlay)));
+        result
+    };
+    @float_to_int(floats + overlay) + @intCast(read_integer(Overlay.Integer(9)))
+        + memory + if nan != nan && !(nan == nan) { 1 } else { 90 }
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+exit_code = 43
+
+[[case]]
+name = "aarch64_mixed_enum_payload_carriers_are_tag_typed"
+files = [{ path = "main.rue", source = """
+enum Mixed { Small(f32), Wide(f64), Empty }
+enum Overlay { Float(f64), Integer(i64), Empty }
+fn read_mixed(value: Mixed) -> f64 {
+    match value {
+        Mixed.Small(x) => @float_cast(x),
+        Mixed.Wide(x) => x,
+        Mixed.Empty => 0.0,
+    }
+}
+fn read_float(value: Overlay) -> f64 {
+    match value { Overlay.Float(x) => x, Overlay.Integer(_) => 0.0, Overlay.Empty => 0.0 }
+}
+fn read_integer(value: Overlay) -> i64 {
+    match value { Overlay.Integer(x) => x, Overlay.Float(_) => 0, Overlay.Empty => 0 }
+}
+fn main() -> i32 {
+    let zero: f64 = 0.0;
+    let nan = Mixed.Wide(zero / zero);
+    let floats = read_mixed(Mixed.Small(3.0)) + read_mixed(Mixed.Wide(4.0));
+    let overlay = read_float(Overlay.Float(5.0));
+    let memory = checked {
+        let pm: ptr mut Mixed = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Mixed)), @intCast(@align_of(Mixed)))));
+        @ptr_write(pm, Mixed.Small(6.0));
+        let m = @ptr_read(pm);
+        let po: ptr mut Overlay = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Overlay)), @intCast(@align_of(Overlay)))));
+        @ptr_write(po, Overlay.Float(7.0));
+        let f = @ptr_read(po);
+        @ptr_write(po, Overlay.Integer(8));
+        let i = @ptr_read(po);
+        let result = @float_to_int(read_mixed(m) + read_float(f)) + @intCast(read_integer(i));
+        @free(@int_to_ptr(@ptr_to_int(pm)), @intCast(@size_of(Mixed)), @intCast(@align_of(Mixed)));
+        @free(@int_to_ptr(@ptr_to_int(po)), @intCast(@size_of(Overlay)), @intCast(@align_of(Overlay)));
+        result
+    };
+    @float_to_int(floats + overlay) + @intCast(read_integer(Overlay.Integer(9)))
+        + memory + if nan != nan && !(nan == nan) { 1 } else { 90 }
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 43

--- a/crates/rue-cli-tests/cases/float_literals.toml
+++ b/crates/rue-cli-tests/cases/float_literals.toml
@@ -2,12 +2,11 @@
 id = "cli.float_literals"
 name = "Float literal grammar and the floats preview gate"
 description = """
-ADR-0065 Phases 2-4 (RUE-1068 through RUE-1070): the lexer produces a float
+ADR-0065 Phases 2-6 (RUE-1068 through RUE-1072): the lexer produces a float
 literal token, the parser and RIR carry it untyped, and AIR gives it an exact
-comptime value plus contextual f32/f64 typing. The whole feature sits behind
-`--preview floats`; E1100 fires without the flag, while E1109 is the explicit
-fail-closed boundary before the Phase 5/6 backends. These cases pin both
-directions and the spelling rules.
+comptime value plus contextual f32/f64 typing. Scalar lowering now reaches both
+backends, while the whole feature remains behind `--preview floats`; E1100
+fires without the flag. These cases pin both directions and the spelling rules.
 """
 
 # ---------------------------------------------------------------------------
@@ -33,8 +32,8 @@ error_contains = [
 ]
 
 [[case]]
-name = "float_literal_with_preview_reaches_the_phase_marker"
-description = "With the flag the literal is typed and stops at the explicit pre-backend marker (E1109), not an ICE."
+name = "float_literal_with_preview_compiles"
+description = "With the flag a typed float literal reaches the scalar backends."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let x = 1.5;
@@ -42,13 +41,8 @@ fn main() -> i32 {
 }
 """ }]
 args = ["--preview", "floats", "main.rue", "-o", "prog"]
-compile_fail = true
-error_contains = [
-    "E1109",
-    "floating-point lowering is not yet implemented after typed AIR",
-    "ADR-0065 Phase 4 boundary, RUE-1070",
-]
-compile_stderr_not_contains = ["internal compiler error", "E1100"]
+exit_code = 0
+compile_stderr_not_contains = ["internal compiler error", "E1100", "E1109"]
 
 [[case]]
 name = "float_in_an_operand_position_is_gated_not_ignored"
@@ -66,8 +60,8 @@ error_contains = ["E0206", "expected comptime_float, found i32"]
 compile_stderr_not_contains = ["internal compiler error"]
 
 [[case]]
-name = "float_diagnostic_is_one_clean_json_diagnostic"
-description = "The typed literal produces one well-formed lowering-boundary diagnostic, not a cascade."
+name = "float_literal_compiles_with_json_diagnostics_enabled"
+description = "The diagnostic output mode does not disturb successful float lowering."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let x = 6.022e23;
@@ -75,10 +69,8 @@ fn main() -> i32 {
 }
 """ }]
 args = ["--error-format", "json", "--preview", "floats", "main.rue", "-o", "prog"]
-compile_fail = true
-error_contains = ["E1109"]
-json_diagnostics = true
-json_diagnostic_order = ["error E1109 main.rue:2:5"]
+exit_code = 0
+compile_stderr_not_contains = ["internal compiler error", "E1100", "E1109"]
 
 # ---------------------------------------------------------------------------
 # The literal reaches RIR untyped (Phase 3's actual deliverable).

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -10,7 +10,7 @@ use rue_cfg::{BlockId, Cfg, CfgValue, Type, ValidatedCfg};
 use rue_error::CompileResult;
 use rue_target::Target;
 
-use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
+use super::mir::{Aarch64Inst, Aarch64Mir, Cond, FloatWidth, LabelId, Operand, Reg, VReg};
 use crate::agg_slots::SlotBackend;
 use crate::allocation;
 use crate::cfg_lower::CfgLowerContext;
@@ -31,6 +31,16 @@ pub(super) const ARG_REGS: [Reg; 8] = [
     Reg::X5,
     Reg::X6,
     Reg::X7,
+];
+pub(super) const FP_ARG_REGS: [Reg; 8] = [
+    Reg::V0,
+    Reg::V1,
+    Reg::V2,
+    Reg::V3,
+    Reg::V4,
+    Reg::V5,
+    Reg::V6,
+    Reg::V7,
 ];
 
 /// Return value registers for the internal Rue convention (AAPCS64 only
@@ -498,12 +508,38 @@ impl<'a> CfgLower<'a> {
     /// into the entry block). A register-only by-ref pointer seeds the
     /// by-ref cache directly.
     fn materialize_register_params(&mut self) {
-        for (param_slot, abi_index) in self.ctx.param_entry_copies() {
-            let vreg = self.mir.alloc_vreg();
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Virtual(vreg),
-                src: Operand::Physical(ARG_REGS[abi_index as usize]),
-            });
+        for (param_slot, class, location) in self.ctx.param_entry_copies() {
+            let (vreg, copy) = match (class, location) {
+                (
+                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::call_plan::AbiSlotLocation::GpReg(class_index),
+                ) => {
+                    let vreg = self.mir.alloc_vreg();
+                    (
+                        vreg,
+                        Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Physical(ARG_REGS[class_index]),
+                        },
+                    )
+                }
+                (
+                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::call_plan::AbiSlotLocation::FpReg(class_index),
+                ) => {
+                    let vreg = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                    (
+                        vreg,
+                        Aarch64Inst::FloatMov {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Physical(FP_ARG_REGS[class_index]),
+                            width,
+                        },
+                    )
+                }
+                _ => unreachable!("register-only parameter class and ABI bank must agree"),
+            };
+            self.mir.push(copy);
             if self.ctx.cfg.is_param_by_ref(param_slot) {
                 self.by_ref_param_ptrs.insert(param_slot, vreg);
             } else {
@@ -527,7 +563,10 @@ impl<'a> CfgLower<'a> {
         let plan = crate::call_plan::CallPlan::from_slot_values(
             crate::call_plan::CallTarget::rue(symbol),
             arg_vregs,
-            ARG_REGS.len(),
+            crate::call_plan::AbiRegisterBanks {
+                gp: ARG_REGS.len(),
+                fp: FP_ARG_REGS.len(),
+            },
         );
         let _ = self.lower_call_plan(plan);
     }
@@ -633,6 +672,36 @@ impl<'a> CfgLower<'a> {
         let div_by_zero_call = plan.div_by_zero_call;
         let wrap = plan.wrap;
         let vreg = match plan.operation {
+            ArithmeticOperation::FloatAdd { lhs, rhs, width }
+            | ArithmeticOperation::FloatSub { lhs, rhs, width }
+            | ArithmeticOperation::FloatMul { lhs, rhs, width }
+            | ArithmeticOperation::FloatDiv { lhs, rhs, width } => {
+                let op = match plan.operation {
+                    ArithmeticOperation::FloatAdd { .. } => super::mir::FloatBinOp::Add,
+                    ArithmeticOperation::FloatSub { .. } => super::mir::FloatBinOp::Sub,
+                    ArithmeticOperation::FloatMul { .. } => super::mir::FloatBinOp::Mul,
+                    ArithmeticOperation::FloatDiv { .. } => super::mir::FloatBinOp::Div,
+                    _ => unreachable!(),
+                };
+                let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(Aarch64Inst::FloatBin {
+                    op,
+                    dst: Operand::Virtual(dst),
+                    lhs: Operand::Virtual(lhs),
+                    rhs: Operand::Virtual(rhs),
+                    width,
+                });
+                dst
+            }
+            ArithmeticOperation::FloatNeg { value, width } => {
+                let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(Aarch64Inst::FloatNeg {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(value),
+                    width,
+                });
+                dst
+            }
             ArithmeticOperation::Add { lhs, rhs, width } => {
                 let vreg = self.mir.alloc_vreg();
                 self.mir.push(if width.bits == 64 {
@@ -903,7 +972,6 @@ impl<'a> CfgLower<'a> {
     ) -> crate::value_plan::MaterializedValue {
         use crate::call_plan::ReturnPlan;
         let primary = plan.result.unwrap_or_else(|| self.mir.alloc_vreg());
-        let num_reg_args = plan.abi_slots.len().min(ARG_REGS.len());
         if plan.stack_bytes > 0 {
             self.mir.push(Aarch64Inst::SubImm {
                 dst: Operand::Physical(Reg::Sp),
@@ -912,19 +980,56 @@ impl<'a> CfgLower<'a> {
                     .expect("call stack area must fit displacement"),
             });
         }
-        for (index, arg) in plan.abi_slots.iter().skip(ARG_REGS.len()).enumerate() {
-            self.mir.push(Aarch64Inst::Str {
-                src: Operand::Virtual(*arg),
-                base: Reg::Sp,
-                offset: checked_cell_byte_offset(index as u64)
-                    .expect("call stack slot offset must fit displacement"),
-            });
+        for ((arg, class), location) in plan
+            .abi_slots
+            .iter()
+            .zip(&plan.abi_classes)
+            .zip(&plan.abi_locations)
+        {
+            let crate::call_plan::AbiSlotLocation::Stack(index) = location else {
+                continue;
+            };
+            let offset = checked_cell_byte_offset(*index as u64)
+                .expect("call stack slot offset must fit displacement");
+            if let crate::call_plan::AbiSlotClass::Fp(width) = class {
+                self.mir.push(Aarch64Inst::FloatStore {
+                    src: Operand::Virtual(*arg),
+                    base: Reg::Sp,
+                    offset,
+                    width: *width,
+                });
+            } else {
+                self.mir.push(Aarch64Inst::Str {
+                    src: Operand::Virtual(*arg),
+                    base: Reg::Sp,
+                    offset,
+                });
+            }
         }
-        for (index, arg) in plan.abi_slots.iter().take(num_reg_args).enumerate() {
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Physical(ARG_REGS[index]),
-                src: Operand::Virtual(*arg),
-            });
+        for ((arg, class), location) in plan
+            .abi_slots
+            .iter()
+            .zip(&plan.abi_classes)
+            .zip(&plan.abi_locations)
+        {
+            match (class, location) {
+                (
+                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::call_plan::AbiSlotLocation::FpReg(index),
+                ) => self.mir.push(Aarch64Inst::FloatMov {
+                    dst: Operand::Physical(FP_ARG_REGS[*index]),
+                    src: Operand::Virtual(*arg),
+                    width: *width,
+                }),
+                (
+                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::call_plan::AbiSlotLocation::GpReg(index),
+                ) => self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Physical(ARG_REGS[*index]),
+                    src: Operand::Virtual(*arg),
+                }),
+                _ => {}
+            }
         }
         let symbol_id = self.intern_symbol(plan.target.symbol());
         self.mir.push(Aarch64Inst::call(symbol_id));
@@ -1011,10 +1116,20 @@ impl<'a> CfgLower<'a> {
                 src: Operand::Virtual(slot),
             });
         } else if matches!(plan.return_plan, ReturnPlan::Scalar) {
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Virtual(primary),
-                src: Operand::Physical(Reg::X0),
-            });
+            self.mir.push(
+                if self.mir.vreg_class(primary) == crate::reg_class::RegClass::Fp {
+                    Aarch64Inst::FloatMov {
+                        dst: Operand::Virtual(primary),
+                        src: Operand::Physical(Reg::V0),
+                        width: plan.result_float_width.expect("FP call result width"),
+                    }
+                } else {
+                    Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(primary),
+                        src: Operand::Physical(Reg::X0),
+                    }
+                },
+            );
         } else if matches!(plan.return_plan, ReturnPlan::ZeroSized) {
             self.mir.push(Aarch64Inst::MovImm {
                 dst: Operand::Virtual(primary),
@@ -1114,6 +1229,18 @@ impl<'a> CfgLower<'a> {
         let mut slots = Vec::new();
         let primary = match plan.value {
             ResidualValuePlan::Const { value } => {
+                if let Some(float_width) = crate::value_plan::float_width(ty) {
+                    let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                    self.mir.push(Aarch64Inst::FloatConst {
+                        dst: Operand::Virtual(dst),
+                        bits: value,
+                        width: float_width,
+                    });
+                    return ValueResult::Materialized(crate::value_plan::MaterializedValue {
+                        primary: dst,
+                        slots: Vec::new(),
+                    });
+                }
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovImm {
                     dst: Operand::Virtual(dst),
@@ -1296,34 +1423,66 @@ impl<'a> CfgLower<'a> {
                 op,
                 lhs,
                 rhs,
-                leaf_types,
+                equality_leaves,
                 runtime_call,
-            } => self.lower_comparison(op, lhs, rhs, plan.policy, &leaf_types, runtime_call),
+            } => self.lower_comparison(op, lhs, rhs, plan.policy, &equality_leaves, runtime_call),
             ResidualValuePlan::Alloc {
                 slot,
                 init,
                 init_shape,
+                float_width,
+                leaf_types,
             } => {
                 if init_shape.slot_count() == 0 {
                     return ValueResult::SideEffect;
                 } else if init.slots.is_empty() {
-                    self.emit_store_slot(init.primary, slot);
+                    if let Some(width) = float_width {
+                        self.mir.push(Aarch64Inst::FloatStore {
+                            base: Reg::Fp,
+                            offset: self.ctx.local_offset(slot),
+                            src: Operand::Virtual(init.primary),
+                            width,
+                        });
+                    } else {
+                        self.emit_store_slot(init.primary, slot);
+                    }
                 } else {
-                    crate::agg_slots::store_slots(self, &init.slots, slot);
+                    crate::agg_slots::store_slots_typed(self, &init.slots, slot, &leaf_types);
                 }
                 return ValueResult::SideEffect;
             }
-            ResidualValuePlan::Load { slot } => {
+            ResidualValuePlan::Load {
+                slot,
+                float_width,
+                leaf_types,
+            } => {
                 let count = plan.policy.shape.slot_count();
                 if count == 0 {
                     self.mir.alloc_vreg()
                 } else if count > 1 {
-                    slots = crate::agg_slots::load_slots_at_low(self, slot + count - 1, count);
+                    slots = crate::agg_slots::load_slots_at_low_typed(
+                        self,
+                        slot + count - 1,
+                        &leaf_types,
+                    );
                     let dst = slots[0];
                     dst
                 } else {
-                    let dst = self.mir.alloc_vreg();
-                    self.emit_load_slot(dst, slot);
+                    let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
+                    });
+                    if let Some(width) = float_width {
+                        self.mir.push(Aarch64Inst::FloatLoad {
+                            dst: Operand::Virtual(dst),
+                            base: Reg::Fp,
+                            offset: self.ctx.local_offset(slot),
+                            width,
+                        });
+                    } else {
+                        self.emit_load_slot(dst, slot);
+                    }
                     dst
                 }
             }
@@ -1331,6 +1490,8 @@ impl<'a> CfgLower<'a> {
                 destination,
                 value,
                 value_shape,
+                float_width,
+                leaf_types,
             } => {
                 if value_shape.slot_count() == 0 {
                     return ValueResult::SideEffect;
@@ -1338,17 +1499,37 @@ impl<'a> CfgLower<'a> {
                 if value.slots.is_empty() {
                     match destination {
                         crate::value_plan::StoreDestination::FrameSlot(slot) => {
-                            self.emit_store_slot(value.primary, slot)
+                            if let Some(width) = float_width {
+                                self.mir.push(Aarch64Inst::FloatStore {
+                                    base: Reg::Fp,
+                                    offset: self.ctx.local_offset(slot),
+                                    src: Operand::Virtual(value.primary),
+                                    width,
+                                });
+                            } else {
+                                self.emit_store_slot(value.primary, slot);
+                            }
                         }
                         crate::value_plan::StoreDestination::ByRefParam(param_slot) => {
                             let ptr = self.ensure_by_ref_param_ptr(param_slot);
-                            self.emit_store_ptr_base(value.primary, ptr);
+                            if let Some(width) = float_width {
+                                <Self as crate::agg_slots::SlotBackend>::emit_float_store_through_ptr(
+                                    self, value.primary, ptr, 0, width,
+                                );
+                            } else {
+                                self.emit_store_ptr_base(value.primary, ptr);
+                            }
                         }
                     }
                 } else {
                     match destination {
                         crate::value_plan::StoreDestination::FrameSlot(slot) => {
-                            crate::agg_slots::store_slots(self, &value.slots, slot)
+                            crate::agg_slots::store_slots_typed(
+                                self,
+                                &value.slots,
+                                slot,
+                                &leaf_types,
+                            )
                         }
                         crate::value_plan::StoreDestination::ByRefParam(param_slot) => {
                             let ptr = self.ensure_by_ref_param_ptr(param_slot);
@@ -1362,6 +1543,8 @@ impl<'a> CfgLower<'a> {
                 param_slot,
                 value,
                 value_shape,
+                float_width,
+                leaf_types,
             } => {
                 if value_shape.slot_count() == 0 {
                     return ValueResult::SideEffect;
@@ -1369,7 +1552,17 @@ impl<'a> CfgLower<'a> {
                 if self.ctx.cfg.is_param_by_ref(param_slot) {
                     let ptr = self.ensure_by_ref_param_ptr(param_slot);
                     if value.slots.is_empty() {
-                        self.emit_store_ptr_base(value.primary, ptr);
+                        if let Some(width) = float_width {
+                            <Self as crate::agg_slots::SlotBackend>::emit_float_store_through_ptr(
+                                self,
+                                value.primary,
+                                ptr,
+                                0,
+                                width,
+                            );
+                        } else {
+                            self.emit_store_ptr_base(value.primary, ptr);
+                        }
                     } else {
                         crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
                     }
@@ -1384,11 +1577,23 @@ impl<'a> CfgLower<'a> {
                     } else {
                         value.slots
                     };
-                    crate::agg_slots::store_slots(
-                        self,
-                        &vals,
-                        self.ctx.param_frame_slot(param_slot),
-                    );
+                    if vals.len() == 1
+                        && let Some(width) = float_width
+                    {
+                        <Self as crate::place_lower::PlaceLowerBackend>::emit_float_store_slot(
+                            self,
+                            vals[0],
+                            self.ctx.param_frame_slot(param_slot),
+                            width,
+                        );
+                    } else {
+                        crate::agg_slots::store_slots_typed(
+                            self,
+                            &vals,
+                            self.ctx.param_frame_slot(param_slot),
+                            &leaf_types,
+                        );
+                    }
                 }
                 return ValueResult::SideEffect;
             }
@@ -1401,7 +1606,11 @@ impl<'a> CfgLower<'a> {
                     let dst = slots[0];
                     dst
                 } else {
-                    let dst = self.mir.alloc_vreg();
+                    let dst = self.mir.alloc_vreg_in(if ty.is_float() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
+                    });
                     crate::place_lower::lower_place_read_plan(self, dst, &place, ty);
                     dst
                 }
@@ -1410,6 +1619,7 @@ impl<'a> CfgLower<'a> {
                 place,
                 value,
                 value_shape,
+                float_width,
             } => {
                 let vals = if matches!(
                     value_shape,
@@ -1422,7 +1632,7 @@ impl<'a> CfgLower<'a> {
                 } else {
                     value.slots
                 };
-                crate::place_lower::lower_place_write_plan(self, &place, &vals);
+                crate::place_lower::lower_place_write_plan(self, &place, &vals, float_width);
                 return ValueResult::SideEffect;
             }
             ResidualValuePlan::StructInit { fields, .. }
@@ -1469,16 +1679,28 @@ impl<'a> CfgLower<'a> {
                 variant_index,
                 payload,
                 total_slots,
+                leaf_types,
                 zero_unused_payload,
                 ..
             } => {
-                slots = (0..total_slots).map(|_| self.mir.alloc_vreg()).collect();
+                assert_eq!(leaf_types.len(), total_slots as usize);
+                slots = leaf_types
+                    .iter()
+                    .map(|ty| {
+                        self.mir
+                            .alloc_vreg_in(if crate::value_plan::float_width(*ty).is_some() {
+                                crate::reg_class::RegClass::Fp
+                            } else {
+                                crate::reg_class::RegClass::Gp
+                            })
+                    })
+                    .collect();
                 self.mir.push(Aarch64Inst::MovImm {
                     dst: Operand::Virtual(slots[0]),
                     imm: variant_index as i64,
                 });
                 let mut offset = 1;
-                for (value, shape) in payload {
+                for (value, shape, value_leaf_types) in payload {
                     if shape.slot_count() == 0 {
                         continue;
                     }
@@ -1487,12 +1709,31 @@ impl<'a> CfgLower<'a> {
                     } else {
                         value.slots
                     };
-                    for value in values {
+                    assert_eq!(values.len(), value_leaf_types.len());
+                    for (value, value_ty) in values.into_iter().zip(value_leaf_types) {
                         if offset < slots.len() {
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Virtual(slots[offset]),
-                                src: Operand::Virtual(value),
-                            });
+                            if let Some(width) = crate::value_plan::float_width(value_ty) {
+                                assert_eq!(
+                                    self.mir.vreg_class(value),
+                                    crate::reg_class::RegClass::Fp,
+                                    "float enum payload source must use the FP class"
+                                );
+                                self.mir.push(Aarch64Inst::FloatToBits {
+                                    dst: Operand::Virtual(slots[offset]),
+                                    src: Operand::Virtual(value),
+                                    width,
+                                });
+                            } else {
+                                assert_eq!(
+                                    self.mir.vreg_class(value),
+                                    crate::reg_class::RegClass::Gp,
+                                    "enum payload slot class must match its canonical leaf type"
+                                );
+                                self.mir.push(Aarch64Inst::MovRR {
+                                    dst: Operand::Virtual(slots[offset]),
+                                    src: Operand::Virtual(value),
+                                });
+                            }
                             offset += 1;
                         }
                     }
@@ -1501,11 +1742,19 @@ impl<'a> CfgLower<'a> {
                 // compact memory image marshalled from the value carries no residue
                 // from a wider variant (ADR-0052 ruling 5). Only under the gate.
                 if zero_unused_payload {
-                    for slot in slots.iter().skip(offset) {
-                        self.mir.push(Aarch64Inst::MovImm {
-                            dst: Operand::Virtual(*slot),
-                            imm: 0,
-                        });
+                    for (index, slot) in slots.iter().enumerate().skip(offset) {
+                        if let Some(width) = crate::value_plan::float_width(leaf_types[index]) {
+                            self.mir.push(Aarch64Inst::FloatConst {
+                                dst: Operand::Virtual(*slot),
+                                bits: 0,
+                                width,
+                            });
+                        } else {
+                            self.mir.push(Aarch64Inst::MovImm {
+                                dst: Operand::Virtual(*slot),
+                                imm: 0,
+                            });
+                        }
                     }
                 }
                 let dst = slots[0];
@@ -1515,14 +1764,31 @@ impl<'a> CfgLower<'a> {
                 base_slots,
                 field_offset,
                 field_slots,
+                field_types,
             } => {
+                assert_eq!(field_types.len(), field_slots as usize);
                 slots.clear();
                 for index in 0..field_slots {
-                    let dst = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(dst),
-                        src: Operand::Virtual(base_slots[(field_offset + index) as usize]),
+                    let ty = field_types[index as usize];
+                    let width = crate::value_plan::float_width(ty);
+                    let dst = self.mir.alloc_vreg_in(if width.is_some() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
                     });
+                    let src = base_slots[(field_offset + index) as usize];
+                    if let Some(width) = width {
+                        self.mir.push(Aarch64Inst::BitsToFloat {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(src),
+                            width,
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(src),
+                        });
+                    }
                     slots.push(dst);
                 }
                 let dst = slots
@@ -1568,10 +1834,15 @@ impl<'a> CfgLower<'a> {
     fn lower_param_value(
         &mut self,
         index: u32,
-        _ty: Type,
+        ty: Type,
         policy: crate::value_plan::ValuePlan,
     ) -> (VReg, Vec<VReg>) {
-        let dst = self.mir.alloc_vreg();
+        let float_width = crate::value_plan::float_width(ty);
+        let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
+            crate::reg_class::RegClass::Fp
+        } else {
+            crate::reg_class::RegClass::Gp
+        });
         let count = policy.shape.slot_count();
         if count == 0 {
             self.mir.push(Aarch64Inst::MovImm {
@@ -1597,20 +1868,41 @@ impl<'a> CfgLower<'a> {
                     .collect();
                 return (slots[0], slots);
             }
-            self.mir.push(Aarch64Inst::LdrIndexed {
-                dst: Operand::Virtual(dst),
-                base: ptr,
-            });
+            if let Some(width) = float_width {
+                <Self as crate::place_lower::PlaceLowerBackend>::emit_load_ptr_base(
+                    self,
+                    dst,
+                    ptr,
+                    Some(width),
+                );
+            } else {
+                self.mir.push(Aarch64Inst::LdrIndexed {
+                    dst: Operand::Virtual(dst),
+                    base: ptr,
+                });
+            }
         } else if count > 1 {
+            let leaf_types = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty);
             let slots: Vec<_> = (0..count)
                 .map(|slot| {
-                    let v = self.mir.alloc_vreg();
-                    let frame_slot = self.ctx.param_frame_slot(index) + count - 1 - slot;
-                    self.mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Virtual(v),
-                        base: Reg::Fp,
-                        offset: self.ctx.local_offset(frame_slot),
+                    let width = crate::value_plan::float_width(leaf_types[slot as usize]);
+                    let v = self.mir.alloc_vreg_in(if width.is_some() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
                     });
+                    let frame_slot = self.ctx.param_frame_slot(index) + count - 1 - slot;
+                    if let Some(width) = width {
+                        <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
+                            self, v, frame_slot, width,
+                        );
+                    } else {
+                        self.mir.push(Aarch64Inst::Ldr {
+                            dst: Operand::Virtual(v),
+                            base: Reg::Fp,
+                            offset: self.ctx.local_offset(frame_slot),
+                        });
+                    }
                     v
                 })
                 .collect();
@@ -1619,6 +1911,13 @@ impl<'a> CfgLower<'a> {
             // Register-only scalar (RUE-1170): the entry preamble copied the
             // argument register into one read-only vreg shared by every read.
             return (vreg, Vec::new());
+        } else if let Some(width) = float_width {
+            <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
+                self,
+                dst,
+                self.ctx.param_frame_slot(index),
+                width,
+            );
         } else {
             self.mir.push(Aarch64Inst::Ldr {
                 dst: Operand::Virtual(dst),
@@ -1692,12 +1991,33 @@ impl<'a> CfgLower<'a> {
         lhs: crate::value_plan::MaterializedValue,
         rhs: crate::value_plan::MaterializedValue,
         policy: crate::value_plan::ValuePlan,
-        leaf_types: &[Type],
+        equality_leaves: &[crate::aggregate_eq::EqualityLeaf],
         runtime_call: Option<crate::runtime_call_plan::RuntimeCallPlan>,
     ) -> VReg {
         match policy.comparison.expect("comparison plan") {
             crate::value_plan::ComparisonPreparation::Scalar { .. } => {
                 self.lower_scalar_comparison(op, lhs.primary, rhs.primary, policy)
+            }
+            crate::value_plan::ComparisonPreparation::Float { width } => {
+                self.mir.push(Aarch64Inst::FloatCmp {
+                    lhs: Operand::Virtual(lhs.primary),
+                    rhs: Operand::Virtual(rhs.primary),
+                    width,
+                });
+                let dst = self.mir.alloc_vreg();
+                let cond = match op {
+                    crate::value_plan::ComparisonOp::Eq => Cond::Eq,
+                    crate::value_plan::ComparisonOp::Ne => Cond::Ne,
+                    crate::value_plan::ComparisonOp::Lt => Cond::Lo,
+                    crate::value_plan::ComparisonOp::Gt => Cond::Gt,
+                    crate::value_plan::ComparisonOp::Le => Cond::Ls,
+                    crate::value_plan::ComparisonOp::Ge => Cond::Ge,
+                };
+                self.mir.push(Aarch64Inst::Cset {
+                    dst: Operand::Virtual(dst),
+                    cond,
+                });
+                dst
             }
             crate::value_plan::ComparisonPreparation::Unit => {
                 let dst = self.mir.alloc_vreg();
@@ -1725,7 +2045,7 @@ impl<'a> CfgLower<'a> {
                     self,
                     &lhs.slots,
                     &rhs.slots,
-                    leaf_types,
+                    equality_leaves,
                     matches!(op, crate::value_plan::ComparisonOp::Ne),
                 )
             }
@@ -1859,12 +2179,28 @@ impl<'a> CfgLower<'a> {
                     slots = crate::agg_slots::load_slots_through_ptr(self, ptr, count);
                     slots[0]
                 } else {
-                    let dst = self.mir.alloc_vreg();
+                    let float_width = crate::value_plan::float_width(plan.result_ty);
+                    let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
+                    });
                     if count != 0 {
                         // A narrow scalar pointee reads 1/2/4 physical bytes and
                         // extends into the slot-shaped vreg (RUE-989); a full-slot
                         // pointee keeps the eight-byte load.
-                        if let Some(narrow) = plan.narrow_access {
+                        if let Some(width) = float_width {
+                            self.mir.push(Aarch64Inst::MovRR {
+                                dst: Operand::Physical(Reg::X9),
+                                src: Operand::Virtual(ptr),
+                            });
+                            self.mir.push(Aarch64Inst::FloatLoad {
+                                dst: Operand::Virtual(dst),
+                                base: Reg::X9,
+                                offset: 0,
+                                width,
+                            });
+                        } else if let Some(narrow) = plan.narrow_access {
                             self.mir.push(Aarch64Inst::NarrowLoadIndexed {
                                 dst: Operand::Virtual(dst),
                                 base: ptr,
@@ -1919,6 +2255,17 @@ impl<'a> CfgLower<'a> {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
                     crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
+                } else if let Some(width) = crate::value_plan::float_width(plan.args[1].ty) {
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(Reg::X9),
+                        src: Operand::Virtual(ptr),
+                    });
+                    self.mir.push(Aarch64Inst::FloatStore {
+                        base: Reg::X9,
+                        offset: 0,
+                        src: Operand::Virtual(value.primary),
+                        width,
+                    });
                 } else if let Some(narrow) = plan.narrow_access {
                     // A narrow scalar truncates to 1/2/4 physical bytes (RUE-989).
                     self.mir.push(Aarch64Inst::NarrowStoreIndexed {
@@ -2127,12 +2474,70 @@ impl<'a> CfgLower<'a> {
             | rue_air::IntrinsicOperation::BoundsCheck => {
                 unreachable!("trap handled above")
             }
-            rue_air::IntrinsicOperation::IntToFloat
-            | rue_air::IntrinsicOperation::FloatToInt
-            | rue_air::IntrinsicOperation::FloatCast
-            | rue_air::IntrinsicOperation::TotalCmp => {
-                unreachable!("ADR-0065 Phase 4 rejects float operations at CFG construction")
+            rue_air::IntrinsicOperation::IntToFloat => {
+                let width = crate::value_plan::float_width(plan.result_ty).expect("float result");
+                let int =
+                    crate::value_plan::integer_width(plan.args[0].ty).expect("integer source");
+                let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(Aarch64Inst::IntToFloat {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(plan.args[0].primary),
+                    int_bits: int.bits.max(32),
+                    width,
+                });
+                dst
             }
+            rue_air::IntrinsicOperation::FloatToInt => {
+                let width = crate::value_plan::float_width(plan.args[0].ty).expect("float source");
+                let int = crate::value_plan::integer_width(plan.result_ty).expect("integer result");
+                let check = crate::value_plan::checked_float_to_int_plan(width, int);
+                for guard in check.guards {
+                    let bound = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                    self.mir.push(Aarch64Inst::FloatConst {
+                        dst: Operand::Virtual(bound),
+                        bits: guard.bound_bits,
+                        width,
+                    });
+                    self.mir.push(Aarch64Inst::FloatCmp {
+                        lhs: Operand::Virtual(plan.args[0].primary),
+                        rhs: Operand::Virtual(bound),
+                        width,
+                    });
+                    let ok = self.mir.alloc_label();
+                    self.mir.push(Aarch64Inst::BCond {
+                        cond: match guard.success {
+                            crate::value_plan::FloatToIntGuardRelation::OrderedGreaterEqual => {
+                                Cond::Ge
+                            }
+                            crate::value_plan::FloatToIntGuardRelation::OrderedLess => Cond::Lo,
+                        },
+                        label: ok,
+                    });
+                    let _ = self.lower_runtime_call(check.trap_call.clone());
+                    self.mir.push(Aarch64Inst::Label { id: ok });
+                }
+                let dst = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::FloatToInt {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(plan.args[0].primary),
+                    int_bits: int.bits.max(32),
+                    width,
+                });
+                dst
+            }
+            rue_air::IntrinsicOperation::FloatCast => {
+                let from = crate::value_plan::float_width(plan.args[0].ty).expect("float source");
+                let to = crate::value_plan::float_width(plan.result_ty).expect("float result");
+                let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(Aarch64Inst::FloatCast {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(plan.args[0].primary),
+                    from,
+                    to,
+                });
+                dst
+            }
+            rue_air::IntrinsicOperation::TotalCmp => unreachable!("total_cmp is ADR-0065 phase 8"),
         };
         crate::value_plan::MaterializedValue { primary, slots }
     }
@@ -2919,11 +3324,21 @@ impl<'a> CfgLower<'a> {
                 }
                 ReturnMode::Function { value } => match value {
                     ReturnValuePlan::ZeroSized => self.mir.push(Aarch64Inst::Ret),
-                    ReturnValuePlan::Scalar { value } => {
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Physical(Reg::X0),
-                            src: Operand::Virtual(value),
-                        });
+                    ReturnValuePlan::Scalar { value, float_width } => {
+                        self.mir.push(
+                            if self.mir.vreg_class(value) == crate::reg_class::RegClass::Fp {
+                                Aarch64Inst::FloatMov {
+                                    dst: Operand::Physical(Reg::V0),
+                                    src: Operand::Virtual(value),
+                                    width: float_width.expect("FP return width"),
+                                }
+                            } else {
+                                Aarch64Inst::MovRR {
+                                    dst: Operand::Physical(Reg::X0),
+                                    src: Operand::Virtual(value),
+                                }
+                            },
+                        );
                         self.mir.push(Aarch64Inst::Ret);
                     }
                     ReturnValuePlan::Aggregate { slots, return_plan } => {
@@ -2974,9 +3389,17 @@ impl<'a> CfgLower<'a> {
 
     fn emit_edge_moves(&mut self, edge: &crate::terminator_plan::EdgePlan) {
         for movement in &edge.moves {
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Virtual(movement.destination),
-                src: Operand::Virtual(movement.source),
+            self.mir.push(if let Some(width) = movement.float_width {
+                Aarch64Inst::FloatMov {
+                    dst: Operand::Virtual(movement.destination),
+                    src: Operand::Virtual(movement.source),
+                    width,
+                }
+            } else {
+                Aarch64Inst::MovRR {
+                    dst: Operand::Virtual(movement.destination),
+                    src: Operand::Virtual(movement.source),
+                }
             });
         }
     }
@@ -3063,7 +3486,17 @@ impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
     }
 
     fn prepare_block_param(&mut self, block: BlockId, index: u32, value: CfgValue, ty: Type) {
-        let vreg = self.mir.alloc_vreg();
+        let primary_ty = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty)
+            .first()
+            .copied()
+            .unwrap_or(ty);
+        let vreg =
+            self.mir
+                .alloc_vreg_in(if crate::value_plan::float_width(primary_ty).is_some() {
+                    crate::reg_class::RegClass::Fp
+                } else {
+                    crate::reg_class::RegClass::Gp
+                });
         self.block_param_vregs.insert((block, index), vreg);
         self.value_map.insert(value, vreg);
         crate::agg_slots::preallocate_block_param_slots(self, value, ty, vreg);
@@ -3123,6 +3556,13 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn reserve_value_result(&mut self) -> VReg {
         self.mir.alloc_vreg()
     }
+    fn reserve_typed_value_result(&mut self, ty: Type) -> VReg {
+        self.mir.alloc_vreg_in(if ty.is_float() {
+            crate::reg_class::RegClass::Fp
+        } else {
+            crate::reg_class::RegClass::Gp
+        })
+    }
     fn resolve_symbol(&self, symbol: lasso::Spur) -> String {
         self.symbols.resolve(self.interner.resolve(&symbol))
     }
@@ -3135,8 +3575,11 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
         rue_air::TargetCAbiFlavor::Aapcs64
     }
-    fn call_arg_register_budget(&self) -> usize {
-        ARG_REGS.len()
+    fn call_arg_register_banks(&self) -> crate::call_plan::AbiRegisterBanks {
+        crate::call_plan::AbiRegisterBanks {
+            gp: ARG_REGS.len(),
+            fp: FP_ARG_REGS.len(),
+        }
     }
     fn return_register_budget(&self) -> u32 {
         RET_REGS.len() as u32
@@ -3481,15 +3924,35 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn alloc_vreg(&mut self) -> VReg {
         self.mir.alloc_vreg()
     }
+    fn alloc_float_vreg(&mut self) -> VReg {
+        self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp)
+    }
     fn get_vreg(&mut self, value: CfgValue) -> VReg {
         CfgLower::get_vreg(self, value)
     }
     fn emit_load_slot(&mut self, dst: VReg, slot: u32) {
         let offset = self.ctx.local_offset(slot);
-        self.mir.push(Aarch64Inst::Ldr {
+        if self.mir.vreg_class(dst) == crate::reg_class::RegClass::Fp {
+            self.mir.push(Aarch64Inst::FloatLoad {
+                dst: Operand::Virtual(dst),
+                base: Reg::Fp,
+                offset,
+                width: FloatWidth::F64,
+            });
+        } else {
+            self.mir.push(Aarch64Inst::Ldr {
+                dst: Operand::Virtual(dst),
+                base: Reg::Fp,
+                offset,
+            });
+        }
+    }
+    fn emit_typed_float_load_slot(&mut self, dst: VReg, slot: u32, width: FloatWidth) {
+        self.mir.push(Aarch64Inst::FloatLoad {
             dst: Operand::Virtual(dst),
             base: Reg::Fp,
-            offset,
+            offset: self.ctx.local_offset(slot),
+            width,
         });
     }
     fn emit_reg_move(&mut self, dst: VReg, src: VReg) {
@@ -3500,10 +3963,27 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     }
     fn emit_store_slot(&mut self, src: VReg, slot: u32) {
         let offset = self.ctx.local_offset(slot);
-        self.mir.push(Aarch64Inst::Str {
-            src: Operand::Virtual(src),
+        if self.mir.vreg_class(src) == crate::reg_class::RegClass::Fp {
+            self.mir.push(Aarch64Inst::FloatStore {
+                base: Reg::Fp,
+                offset,
+                src: Operand::Virtual(src),
+                width: FloatWidth::F64,
+            });
+        } else {
+            self.mir.push(Aarch64Inst::Str {
+                src: Operand::Virtual(src),
+                base: Reg::Fp,
+                offset,
+            });
+        }
+    }
+    fn emit_typed_float_store_slot(&mut self, src: VReg, slot: u32, width: FloatWidth) {
+        self.mir.push(Aarch64Inst::FloatStore {
             base: Reg::Fp,
-            offset,
+            offset: self.ctx.local_offset(slot),
+            src: Operand::Virtual(src),
+            width,
         });
     }
     fn emit_store_through_ptr(&mut self, src: VReg, ptr: VReg, byte_offset: i32) {
@@ -3518,6 +3998,56 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             dst: Operand::Virtual(dst),
             base: ptr,
             offset: byte_offset,
+        });
+    }
+    fn emit_float_store_through_ptr(
+        &mut self,
+        src: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        width: FloatWidth,
+    ) {
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Physical(Reg::X9),
+            src: Operand::Virtual(ptr),
+        });
+        self.mir.push(Aarch64Inst::FloatStore {
+            base: Reg::X9,
+            offset: byte_offset,
+            src: Operand::Virtual(src),
+            width,
+        });
+    }
+    fn emit_float_load_through_ptr(
+        &mut self,
+        dst: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        width: FloatWidth,
+    ) {
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Physical(Reg::X9),
+            src: Operand::Virtual(ptr),
+        });
+        self.mir.push(Aarch64Inst::FloatLoad {
+            dst: Operand::Virtual(dst),
+            base: Reg::X9,
+            offset: byte_offset,
+            width,
+        });
+    }
+    fn emit_float_to_bits(&mut self, dst: VReg, src: VReg, width: FloatWidth) {
+        self.mir.push(Aarch64Inst::FloatToBits {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(src),
+            width,
+        });
+    }
+    fn emit_bits_to_float(&mut self, dst: VReg, src: VReg, width: FloatWidth) {
+        self.mir.push(Aarch64Inst::BitsToFloat {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(src),
+            width,
         });
     }
     fn emit_narrow_store_through_ptr(
@@ -3589,6 +4119,13 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             imm: 0,
         });
     }
+    fn emit_set_float_zero(&mut self, dst: VReg, width: FloatWidth) {
+        self.mir.push(Aarch64Inst::FloatConst {
+            dst: Operand::Virtual(dst),
+            bits: 0,
+            width,
+        });
+    }
     fn alloc_marshal_label(&mut self) -> LabelId {
         self.mir.alloc_label()
     }
@@ -3652,10 +4189,41 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
         });
     }
 
-    fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg) {
-        self.mir.push(Aarch64Inst::LdrIndexed {
+    fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg, float_width: Option<FloatWidth>) {
+        if let Some(width) = float_width {
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X9),
+                src: Operand::Virtual(ptr),
+            });
+            self.mir.push(Aarch64Inst::FloatLoad {
+                dst: Operand::Virtual(dst),
+                base: Reg::X9,
+                offset: 0,
+                width,
+            });
+        } else {
+            self.mir.push(Aarch64Inst::LdrIndexed {
+                dst: Operand::Virtual(dst),
+                base: ptr,
+            });
+        }
+    }
+
+    fn emit_float_load_slot(&mut self, dst: VReg, slot: u32, width: FloatWidth) {
+        self.mir.push(Aarch64Inst::FloatLoad {
             dst: Operand::Virtual(dst),
-            base: ptr,
+            base: Reg::Fp,
+            offset: self.ctx.local_offset(slot),
+            width,
+        });
+    }
+
+    fn emit_float_store_slot(&mut self, src: VReg, slot: u32, width: FloatWidth) {
+        self.mir.push(Aarch64Inst::FloatStore {
+            base: Reg::Fp,
+            offset: self.ctx.local_offset(slot),
+            src: Operand::Virtual(src),
+            width,
         });
     }
 }
@@ -3810,7 +4378,43 @@ impl crate::aggregate_eq::AggregateEqPlanBackend for CfgLower<'_> {
             imm: value as i64,
         });
     }
-    fn emit_slot_eq(&mut self, dst: VReg, lhs: VReg, rhs: VReg, wide: bool) {
+    fn emit_slot_eq(
+        &mut self,
+        dst: VReg,
+        mut lhs: VReg,
+        mut rhs: VReg,
+        leaf_ty: Type,
+        bit_carrier: bool,
+    ) {
+        if let Some(width) = crate::value_plan::float_width(leaf_ty) {
+            if bit_carrier {
+                let lhs_fp = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                let rhs_fp = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(Aarch64Inst::BitsToFloat {
+                    dst: Operand::Virtual(lhs_fp),
+                    src: Operand::Virtual(lhs),
+                    width,
+                });
+                self.mir.push(Aarch64Inst::BitsToFloat {
+                    dst: Operand::Virtual(rhs_fp),
+                    src: Operand::Virtual(rhs),
+                    width,
+                });
+                lhs = lhs_fp;
+                rhs = rhs_fp;
+            }
+            self.mir.push(Aarch64Inst::FloatCmp {
+                lhs: Operand::Virtual(lhs),
+                rhs: Operand::Virtual(rhs),
+                width,
+            });
+            self.mir.push(Aarch64Inst::Cset {
+                dst: Operand::Virtual(dst),
+                cond: Cond::Eq,
+            });
+            return;
+        }
+        let wide = crate::types::slot_needs_wide_compare(leaf_ty);
         self.mir.push(if wide {
             Aarch64Inst::Cmp64RR {
                 src1: Operand::Virtual(lhs),
@@ -3821,6 +4425,16 @@ impl crate::aggregate_eq::AggregateEqPlanBackend for CfgLower<'_> {
                 src1: Operand::Virtual(lhs),
                 src2: Operand::Virtual(rhs),
             }
+        });
+        self.mir.push(Aarch64Inst::Cset {
+            dst: Operand::Virtual(dst),
+            cond: Cond::Eq,
+        });
+    }
+    fn emit_tag_eq(&mut self, dst: VReg, tag: VReg, discriminant: u32) {
+        self.mir.push(Aarch64Inst::CmpImm {
+            src: Operand::Virtual(tag),
+            imm: discriminant as i32,
         });
         self.mir.push(Aarch64Inst::Cset {
             dst: Operand::Virtual(dst),
@@ -4035,6 +4649,7 @@ mod tests {
                 start_slot: slot,
                 slot_count: 1,
                 crossing_regs: 1,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()
@@ -5276,6 +5891,7 @@ mod tests {
                 start_slot: 0,
                 slot_count: 3,
                 crossing_regs: 1,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: Some(padded_ty),
             }],
             &pool,

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -544,8 +544,12 @@ impl<'a> Emitter<'a> {
             (0..self.num_params)
                 .map(|slot| crate::codegen_pipeline::ParamHoming {
                     start_slot: slot,
-                    reg_count: 1,
-                    abi_start: slot + abi_shift,
+                    class: crate::call_plan::AbiSlotClass::Gp,
+                    location: if (slot + abi_shift) < 8 {
+                        crate::call_plan::AbiSlotLocation::GpReg((slot + abi_shift) as usize)
+                    } else {
+                        crate::call_plan::AbiSlotLocation::Stack((slot + abi_shift - 8) as usize)
+                    },
                 })
                 .collect()
         } else {
@@ -812,6 +816,16 @@ impl<'a> Emitter<'a> {
             Reg::X6,
             Reg::X7,
         ];
+        let fp_param_regs = [
+            Reg::V0,
+            Reg::V1,
+            Reg::V2,
+            Reg::V3,
+            Reg::V4,
+            Reg::V5,
+            Reg::V6,
+            Reg::V7,
+        ];
         // Home incoming argument registers into the frame parameter area. Each
         // source parameter consumes `reg_count` consecutive incoming registers
         // (RUE-1005): a by-value indirect compact aggregate arrives as one
@@ -822,27 +836,43 @@ impl<'a> Emitter<'a> {
         // all; their frame slots are likewise compacted away, which
         // `start_slot` already reflects.
         for homing in self.param_homing_or_per_slot() {
-            for k in 0..homing.reg_count {
-                // Use frame_local_slots (not num_locals, which includes spill
-                // slots): CfgLower generated the body's param reads against the
-                // pre-spill count. (RUE-129)
-                let slot = self.frame_local_slots + homing.start_slot + k;
-                // Slot location past the callee-saved area — the single
-                // AArch64 authority shared with the `--emit stackframe`
-                // reporter (RUE-774).
-                let offset =
-                    crate::frame_layout::aarch64_slot_offset(self.callee_saved.len(), slot);
+            // Use frame_local_slots (not num_locals, which includes spill
+            // slots): CfgLower generated the body's param reads against the
+            // pre-spill count. (RUE-129)
+            let slot = self.frame_local_slots + homing.start_slot;
+            // Slot location past the callee-saved area — the single
+            // AArch64 authority shared with the `--emit stackframe`
+            // reporter (RUE-774).
+            let offset = crate::frame_layout::aarch64_slot_offset(self.callee_saved.len(), slot);
 
-                let abi_index = (homing.abi_start + k) as usize;
-                if abi_index < param_regs.len() {
+            match (homing.class, homing.location) {
+                (
+                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::call_plan::AbiSlotLocation::GpReg(abi_index),
+                ) => {
                     self.begin_inst();
                     self.emit_str(param_regs[abi_index], Reg::Fp, offset);
                     end_inst!(self, "str {}, [x29, #{}]", param_regs[abi_index], offset);
-                } else {
+                }
+                (
+                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::call_plan::AbiSlotLocation::FpReg(abi_index),
+                ) => {
+                    self.begin_inst();
+                    self.emit_float_mem(false, fp_param_regs[abi_index], Reg::Fp, offset, width);
+                    end_inst!(
+                        self,
+                        "str float {}, [x29, #{}]",
+                        fp_param_regs[abi_index],
+                        offset
+                    );
+                }
+                (_, crate::call_plan::AbiSlotLocation::Stack(stack_index)) => {
                     // Stack-passed arg: copy from above the frame into the param area
                     let src_offset = crate::frame_layout::checked_incoming_stack_arg_offset(
                         16,
-                        u32::try_from(abi_index).expect("ABI index must fit u32"),
+                        u32::try_from(param_regs.len() + stack_index)
+                            .expect("ABI index must fit u32"),
                         u32::try_from(param_regs.len())
                             .expect("argument register count must fit u32"),
                     )
@@ -854,6 +884,7 @@ impl<'a> Emitter<'a> {
                     self.emit_str(Reg::X9, Reg::Fp, offset);
                     end_inst!(self, "str x9, [x29, #{}]", offset);
                 }
+                _ => unreachable!("parameter ABI class/location mismatch"),
             }
         }
 
@@ -871,7 +902,114 @@ impl<'a> Emitter<'a> {
 
     /// Emit a single instruction.
     fn emit_inst(&mut self, inst: &Aarch64Inst) -> CompileResult<()> {
+        Self::assert_float_operand_classes(inst);
         match inst {
+            Aarch64Inst::FloatConst { dst, bits, width } => {
+                self.begin_inst();
+                self.emit_mov_imm(Reg::X9, *bits as i64);
+                self.emit_float_from_gp(dst.as_physical(), Reg::X9, *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatMov { dst, src, width } => {
+                self.begin_inst();
+                self.emit_float_unary(0x1e204000, dst.as_physical(), src.as_physical(), *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatToBits { dst, src, width } => {
+                self.begin_inst();
+                self.emit_float_to_gp(dst.as_physical(), src.as_physical(), *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::BitsToFloat { dst, src, width } => {
+                self.begin_inst();
+                self.emit_float_from_gp(dst.as_physical(), src.as_physical(), *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatNeg { dst, src, width } => {
+                self.begin_inst();
+                self.emit_float_unary(0x1e214000, dst.as_physical(), src.as_physical(), *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatSqrt { dst, src, width } => {
+                self.begin_inst();
+                self.emit_float_unary(0x1e21c000, dst.as_physical(), src.as_physical(), *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatLoad {
+                dst,
+                base,
+                offset,
+                width,
+            } => {
+                let offset = self.adjust_fp_offset(*base, i64::from(*offset)) as i32;
+                self.begin_inst();
+                self.emit_float_mem(true, dst.as_physical(), *base, offset, *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatStore {
+                base,
+                offset,
+                src,
+                width,
+            } => {
+                let offset = self.adjust_fp_offset(*base, i64::from(*offset)) as i32;
+                self.begin_inst();
+                self.emit_float_mem(false, src.as_physical(), *base, offset, *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatBin {
+                op,
+                dst,
+                lhs,
+                rhs,
+                width,
+            } => {
+                let base = match op {
+                    super::mir::FloatBinOp::Add => 0x1e202800,
+                    super::mir::FloatBinOp::Sub => 0x1e203800,
+                    super::mir::FloatBinOp::Mul => 0x1e200800,
+                    super::mir::FloatBinOp::Div => 0x1e201800,
+                };
+                self.begin_inst();
+                self.emit_float_binary(
+                    base,
+                    dst.as_physical(),
+                    lhs.as_physical(),
+                    rhs.as_physical(),
+                    *width,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatCmp { lhs, rhs, width } => {
+                self.begin_inst();
+                self.emit_float_cmp(lhs.as_physical(), rhs.as_physical(), *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::IntToFloat {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => {
+                self.begin_inst();
+                self.emit_scvtf(dst.as_physical(), src.as_physical(), *int_bits, *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatToInt {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => {
+                self.begin_inst();
+                self.emit_fcvtzs(dst.as_physical(), src.as_physical(), *int_bits, *width);
+                end_inst!(self, "{}", inst);
+            }
+            Aarch64Inst::FloatCast { dst, src, from, to } => {
+                self.begin_inst();
+                self.emit_fcvt(dst.as_physical(), src.as_physical(), *from, *to);
+                end_inst!(self, "{}", inst);
+            }
             Aarch64Inst::MovImm { dst, imm } => {
                 let rd = dst.as_physical();
                 self.begin_inst();
@@ -1614,6 +1752,67 @@ impl<'a> Emitter<'a> {
         Ok(())
     }
 
+    fn assert_float_operand_classes(inst: &Aarch64Inst) {
+        let fp = |operand: &super::mir::Operand| {
+            assert_eq!(
+                operand.as_physical().class(),
+                crate::reg_class::RegClass::Fp,
+                "{inst:?}"
+            )
+        };
+        let gp = |operand: &super::mir::Operand| {
+            assert_eq!(
+                operand.as_physical().class(),
+                crate::reg_class::RegClass::Gp,
+                "{inst:?}"
+            )
+        };
+        match inst {
+            Aarch64Inst::FloatConst { dst, .. } => fp(dst),
+            Aarch64Inst::FloatMov { dst, src, .. }
+            | Aarch64Inst::FloatNeg { dst, src, .. }
+            | Aarch64Inst::FloatSqrt { dst, src, .. }
+            | Aarch64Inst::FloatCast { dst, src, .. } => {
+                fp(dst);
+                fp(src);
+            }
+            Aarch64Inst::FloatToBits { dst, src, .. } => {
+                gp(dst);
+                fp(src);
+            }
+            Aarch64Inst::BitsToFloat { dst, src, .. } => {
+                fp(dst);
+                gp(src);
+            }
+            Aarch64Inst::FloatLoad { dst, base, .. } => {
+                fp(dst);
+                assert_eq!(base.class(), crate::reg_class::RegClass::Gp);
+            }
+            Aarch64Inst::FloatStore { base, src, .. } => {
+                assert_eq!(base.class(), crate::reg_class::RegClass::Gp);
+                fp(src);
+            }
+            Aarch64Inst::FloatBin { dst, lhs, rhs, .. } => {
+                fp(dst);
+                fp(lhs);
+                fp(rhs);
+            }
+            Aarch64Inst::FloatCmp { lhs, rhs, .. } => {
+                fp(lhs);
+                fp(rhs);
+            }
+            Aarch64Inst::IntToFloat { dst, src, .. } => {
+                fp(dst);
+                gp(src);
+            }
+            Aarch64Inst::FloatToInt { dst, src, .. } => {
+                gp(dst);
+                fp(src);
+            }
+            _ => {}
+        }
+    }
+
     /// Emit function epilogue (restore SP from FP, restore callee-saved, LDP FP/LR).
     fn emit_epilogue(&mut self) {
         self.record_comment("epilogue");
@@ -1754,6 +1953,176 @@ impl<'a> Emitter<'a> {
     }
 
     // ========== Instruction encoding helpers ==========
+
+    fn emit_float_unary(
+        &mut self,
+        base: u32,
+        dst: Reg,
+        src: Reg,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        let width_bit = if width == crate::value_plan::FloatWidth::F64 {
+            1 << 22
+        } else {
+            0
+        };
+        self.emit_u32(base | width_bit | ((src.encoding() as u32) << 5) | dst.encoding() as u32);
+    }
+
+    fn emit_float_binary(
+        &mut self,
+        base: u32,
+        dst: Reg,
+        lhs: Reg,
+        rhs: Reg,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        let width_bit = if width == crate::value_plan::FloatWidth::F64 {
+            1 << 22
+        } else {
+            0
+        };
+        self.emit_u32(
+            base | width_bit
+                | ((rhs.encoding() as u32) << 16)
+                | ((lhs.encoding() as u32) << 5)
+                | dst.encoding() as u32,
+        );
+    }
+
+    fn emit_float_cmp(&mut self, lhs: Reg, rhs: Reg, width: crate::value_plan::FloatWidth) {
+        let width_bit = if width == crate::value_plan::FloatWidth::F64 {
+            1 << 22
+        } else {
+            0
+        };
+        self.emit_u32(
+            0x1e202000
+                | width_bit
+                | ((rhs.encoding() as u32) << 16)
+                | ((lhs.encoding() as u32) << 5),
+        );
+    }
+
+    fn emit_float_from_gp(&mut self, dst: Reg, src: Reg, width: crate::value_plan::FloatWidth) {
+        let base = if width == crate::value_plan::FloatWidth::F64 {
+            0x9e670000
+        } else {
+            0x1e270000
+        };
+        self.emit_u32(base | ((src.encoding() as u32) << 5) | dst.encoding() as u32);
+    }
+
+    fn emit_float_to_gp(&mut self, dst: Reg, src: Reg, width: crate::value_plan::FloatWidth) {
+        let base = if width == crate::value_plan::FloatWidth::F64 {
+            0x9e660000
+        } else {
+            0x1e260000
+        };
+        self.emit_u32(base | ((src.encoding() as u32) << 5) | dst.encoding() as u32);
+    }
+
+    fn emit_float_mem(
+        &mut self,
+        load: bool,
+        reg: Reg,
+        base: Reg,
+        offset: i32,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        let scale = if width == crate::value_plan::FloatWidth::F32 {
+            4
+        } else {
+            8
+        };
+        let scaled_opcode = match (load, width) {
+            (true, crate::value_plan::FloatWidth::F32) => 0xbd400000,
+            (false, crate::value_plan::FloatWidth::F32) => 0xbd000000,
+            (true, crate::value_plan::FloatWidth::F64) => 0xfd400000,
+            (false, crate::value_plan::FloatWidth::F64) => 0xfd000000,
+        };
+        if offset >= 0 && offset % scale == 0 && offset / scale < 4096 {
+            self.emit_u32(
+                scaled_opcode
+                    | (((offset / scale) as u32) << 10)
+                    | ((base.encoding() as u32) << 5)
+                    | reg.encoding() as u32,
+            );
+            return;
+        }
+        if (-256..=255).contains(&offset) {
+            let unscaled_opcode = match (load, width) {
+                (true, crate::value_plan::FloatWidth::F32) => 0xbc400000,
+                (false, crate::value_plan::FloatWidth::F32) => 0xbc000000,
+                (true, crate::value_plan::FloatWidth::F64) => 0xfc400000,
+                (false, crate::value_plan::FloatWidth::F64) => 0xfc000000,
+            };
+            self.emit_u32(
+                unscaled_opcode
+                    | (((offset as u32) & 0x1ff) << 12)
+                    | ((base.encoding() as u32) << 5)
+                    | reg.encoding() as u32,
+            );
+            return;
+        }
+
+        assert!(
+            base != Reg::Sp && base != SCRATCH_ADDRESS,
+            "large float offset needs a general base register"
+        );
+        self.emit_mov_imm(SCRATCH_ADDRESS, offset as i64);
+        self.emit_add_rr(SCRATCH_ADDRESS, base, SCRATCH_ADDRESS, false);
+        self.emit_u32(
+            scaled_opcode | ((SCRATCH_ADDRESS.encoding() as u32) << 5) | reg.encoding() as u32,
+        );
+    }
+
+    fn emit_scvtf(
+        &mut self,
+        dst: Reg,
+        src: Reg,
+        int_bits: u32,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        let base = match (int_bits, width) {
+            (64, crate::value_plan::FloatWidth::F32) => 0x9e220000,
+            (64, crate::value_plan::FloatWidth::F64) => 0x9e620000,
+            (_, crate::value_plan::FloatWidth::F32) => 0x1e220000,
+            (_, crate::value_plan::FloatWidth::F64) => 0x1e620000,
+        };
+        self.emit_u32(base | ((src.encoding() as u32) << 5) | dst.encoding() as u32);
+    }
+
+    fn emit_fcvtzs(
+        &mut self,
+        dst: Reg,
+        src: Reg,
+        int_bits: u32,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        let base = match (int_bits, width) {
+            (64, crate::value_plan::FloatWidth::F32) => 0x9e380000,
+            (64, crate::value_plan::FloatWidth::F64) => 0x9e780000,
+            (_, crate::value_plan::FloatWidth::F32) => 0x1e380000,
+            (_, crate::value_plan::FloatWidth::F64) => 0x1e780000,
+        };
+        self.emit_u32(base | ((src.encoding() as u32) << 5) | dst.encoding() as u32);
+    }
+
+    fn emit_fcvt(
+        &mut self,
+        dst: Reg,
+        src: Reg,
+        from: crate::value_plan::FloatWidth,
+        to: crate::value_plan::FloatWidth,
+    ) {
+        let base = match (from, to) {
+            (crate::value_plan::FloatWidth::F32, crate::value_plan::FloatWidth::F64) => 0x1e22c000,
+            (crate::value_plan::FloatWidth::F64, crate::value_plan::FloatWidth::F32) => 0x1e624000,
+            _ => 0x1e204000,
+        };
+        self.emit_u32(base | ((src.encoding() as u32) << 5) | dst.encoding() as u32);
+    }
 
     fn emit_u32(&mut self, inst: u32) {
         self.code.extend_from_slice(&inst.to_le_bytes());
@@ -2623,6 +2992,137 @@ impl<'a> Emitter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::aarch64::mir::{FloatBinOp, FloatWidth};
+
+    #[test]
+    fn scalar_float_arithmetic_and_compare_encodings() {
+        assert_eq!(
+            emit_single(Aarch64Inst::FloatBin {
+                op: FloatBinOp::Add,
+                dst: Operand::Physical(Reg::V0),
+                lhs: Operand::Physical(Reg::V1),
+                rhs: Operand::Physical(Reg::V2),
+                width: FloatWidth::F64,
+            }),
+            0x1e622820_u32.to_le_bytes()
+        );
+        assert_eq!(
+            emit_single(Aarch64Inst::FloatCmp {
+                lhs: Operand::Physical(Reg::V0),
+                rhs: Operand::Physical(Reg::V1),
+                width: FloatWidth::F64,
+            }),
+            0x1e612000_u32.to_le_bytes()
+        );
+        assert_eq!(
+            emit_single(Aarch64Inst::FloatSqrt {
+                dst: Operand::Physical(Reg::V0),
+                src: Operand::Physical(Reg::V1),
+                width: FloatWidth::F32,
+            }),
+            0x1e21c020_u32.to_le_bytes()
+        );
+        assert_eq!(
+            emit_single(Aarch64Inst::FloatSqrt {
+                dst: Operand::Physical(Reg::V0),
+                src: Operand::Physical(Reg::V1),
+                width: FloatWidth::F64,
+            }),
+            0x1e61c020_u32.to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn scalar_float_signed_conversion_encodings() {
+        assert_eq!(
+            emit_single(Aarch64Inst::IntToFloat {
+                dst: Operand::Physical(Reg::V0),
+                src: Operand::Physical(Reg::X1),
+                int_bits: 64,
+                width: FloatWidth::F64,
+            }),
+            0x9e620020_u32.to_le_bytes()
+        );
+        assert_eq!(
+            emit_single(Aarch64Inst::FloatToInt {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::V1),
+                int_bits: 32,
+                width: FloatWidth::F32,
+            }),
+            0x1e380020_u32.to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn scalar_float_bit_carrier_moves_cover_both_widths_and_classes() {
+        assert_eq!(
+            emit_single(Aarch64Inst::FloatToBits {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::V1),
+                width: FloatWidth::F32,
+            }),
+            0x1e260020_u32.to_le_bytes()
+        );
+        assert_eq!(
+            emit_single(Aarch64Inst::BitsToFloat {
+                dst: Operand::Physical(Reg::V0),
+                src: Operand::Physical(Reg::X1),
+                width: FloatWidth::F32,
+            }),
+            0x1e270020_u32.to_le_bytes()
+        );
+        assert_eq!(
+            emit_single(Aarch64Inst::FloatToBits {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::V1),
+                width: FloatWidth::F64,
+            }),
+            0x9e660020_u32.to_le_bytes()
+        );
+        assert_eq!(
+            emit_single(Aarch64Inst::BitsToFloat {
+                dst: Operand::Physical(Reg::V0),
+                src: Operand::Physical(Reg::X1),
+                width: FloatWidth::F64,
+            }),
+            0x9e670020_u32.to_le_bytes()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "FloatCmp")]
+    fn float_encoder_rejects_gp_operands() {
+        let _ = emit_single(Aarch64Inst::FloatCmp {
+            lhs: Operand::Physical(Reg::V0),
+            rhs: Operand::Physical(Reg::X1),
+            width: FloatWidth::F64,
+        });
+    }
+
+    #[test]
+    fn scalar_float_memory_supports_scaled_and_large_frame_offsets() {
+        assert_eq!(
+            emit_single(Aarch64Inst::FloatLoad {
+                dst: Operand::Physical(Reg::V0),
+                base: Reg::X1,
+                offset: 16,
+                width: FloatWidth::F32,
+            }),
+            (0xbd401020_u32).to_le_bytes()
+        );
+        let code = emit_single(Aarch64Inst::FloatStore {
+            base: Reg::X1,
+            offset: -2048,
+            src: Operand::Physical(Reg::V1),
+            width: FloatWidth::F64,
+        });
+        assert_eq!(code.len(), 12);
+        let last = u32::from_le_bytes(code[8..12].try_into().unwrap());
+        assert_eq!(last & 0xffc00000, 0xfd000000);
+        assert_eq!((last >> 5) & 0x1f, SCRATCH_ADDRESS.encoding() as u32);
+        assert_eq!((last >> 10) & 0xfff, 0);
+    }
 
     /// Encode `mov rd, #imm` through the real encoder (via [`Aarch64Inst::MovImm`])
     /// and return the emitted bytes.
@@ -2757,8 +3257,8 @@ mod tests {
         let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
             .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                 start_slot: 0,
-                reg_count: 1,
-                abi_start: 8,
+                class: crate::call_plan::AbiSlotClass::Gp,
+                location: crate::call_plan::AbiSlotLocation::Stack(0),
             }])
             .emit_all()
             .expect("stack argument homing must emit");

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -153,6 +153,20 @@ fn uses(inst: &Aarch64Inst) -> VRegList {
     };
 
     match inst {
+        Aarch64Inst::FloatConst { .. } | Aarch64Inst::FloatLoad { .. } => {}
+        Aarch64Inst::FloatMov { src, .. }
+        | Aarch64Inst::FloatToBits { src, .. }
+        | Aarch64Inst::BitsToFloat { src, .. }
+        | Aarch64Inst::FloatNeg { src, .. }
+        | Aarch64Inst::FloatSqrt { src, .. }
+        | Aarch64Inst::IntToFloat { src, .. }
+        | Aarch64Inst::FloatToInt { src, .. }
+        | Aarch64Inst::FloatCast { src, .. }
+        | Aarch64Inst::FloatStore { src, .. } => add_if_virtual(src, &mut result),
+        Aarch64Inst::FloatBin { lhs, rhs, .. } | Aarch64Inst::FloatCmp { lhs, rhs, .. } => {
+            add_if_virtual(lhs, &mut result);
+            add_if_virtual(rhs, &mut result);
+        }
         Aarch64Inst::MovImm { .. } => {
             // Only defines
         }
@@ -303,6 +317,18 @@ pub(crate) fn defs(inst: &Aarch64Inst) -> VRegList {
     };
 
     match inst {
+        Aarch64Inst::FloatConst { dst, .. }
+        | Aarch64Inst::FloatMov { dst, .. }
+        | Aarch64Inst::FloatToBits { dst, .. }
+        | Aarch64Inst::BitsToFloat { dst, .. }
+        | Aarch64Inst::FloatLoad { dst, .. }
+        | Aarch64Inst::FloatBin { dst, .. }
+        | Aarch64Inst::FloatNeg { dst, .. }
+        | Aarch64Inst::FloatSqrt { dst, .. }
+        | Aarch64Inst::IntToFloat { dst, .. }
+        | Aarch64Inst::FloatToInt { dst, .. }
+        | Aarch64Inst::FloatCast { dst, .. } => add_if_virtual(dst, &mut result),
+        Aarch64Inst::FloatStore { .. } | Aarch64Inst::FloatCmp { .. } => {}
         Aarch64Inst::MovImm { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
@@ -423,6 +449,23 @@ pub(crate) fn defs(inst: &Aarch64Inst) -> VRegList {
 mod tests {
     use super::*;
     use crate::aarch64::mir::Cond;
+    use crate::vreg::VReg;
+
+    #[test]
+    fn scalar_float_binary_op_reads_sources_and_defines_destination() {
+        let dst = VReg::new(0);
+        let lhs = VReg::new(1);
+        let rhs = VReg::new(2);
+        let inst = Aarch64Inst::FloatBin {
+            op: super::super::mir::FloatBinOp::Div,
+            dst: Operand::Virtual(dst),
+            lhs: Operand::Virtual(lhs),
+            rhs: Operand::Virtual(rhs),
+            width: crate::value_plan::FloatWidth::F32,
+        };
+        assert_eq!(uses(&inst).into_iter().collect::<Vec<_>>(), vec![lhs, rhs]);
+        assert_eq!(defs(&inst).into_iter().collect::<Vec<_>>(), vec![dst]);
+    }
 
     #[test]
     fn clobbers_are_borrowed_static_slices() {
@@ -469,6 +512,30 @@ mod tests {
                 Reg::X16,
                 Reg::X17,
                 Reg::Lr,
+                Reg::V0,
+                Reg::V1,
+                Reg::V2,
+                Reg::V3,
+                Reg::V4,
+                Reg::V5,
+                Reg::V6,
+                Reg::V7,
+                Reg::V16,
+                Reg::V17,
+                Reg::V18,
+                Reg::V19,
+                Reg::V20,
+                Reg::V21,
+                Reg::V22,
+                Reg::V23,
+                Reg::V24,
+                Reg::V25,
+                Reg::V26,
+                Reg::V27,
+                Reg::V28,
+                Reg::V29,
+                Reg::V30,
+                Reg::V31,
             ]
         );
         assert!(!call_clobbers.contains(&Reg::X18));

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -40,8 +40,17 @@ pub use rue_runtime_abi::ReturnBehavior;
 const _: () = assert!(std::mem::size_of::<Aarch64Inst>() <= 48);
 
 pub use crate::reg_class::{RegClass, VRegClasses};
+pub use crate::value_plan::FloatWidth;
 use crate::vreg::MirState;
 pub use crate::vreg::{BLOCK_LABEL_BASE, LabelId, VReg};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloatBinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
 
 /// A physical AArch64 register.
 ///
@@ -96,6 +105,38 @@ pub enum Reg {
     Sp = 31,
     /// Zero register (reads as zero, writes discarded)
     Xzr = 32,
+    V0 = 33,
+    V1,
+    V2,
+    V3,
+    V4,
+    V5,
+    V6,
+    V7,
+    V8,
+    V9,
+    V10,
+    V11,
+    V12,
+    V13,
+    V14,
+    V15,
+    V16,
+    V17,
+    V18,
+    V19,
+    V20,
+    V21,
+    V22,
+    V23,
+    V24,
+    V25,
+    V26,
+    V27,
+    V28,
+    V29,
+    V30,
+    V31,
 }
 
 // ============================================================================
@@ -155,6 +196,16 @@ pub(crate) const RESERVED_REGS: &[Reg] = &[
     Reg::Lr,  // link register (x30)
     Reg::Sp,  // stack pointer
     Reg::Xzr, // zero register
+    Reg::V0,
+    Reg::V1,
+    Reg::V2,
+    Reg::V3,
+    Reg::V4,
+    Reg::V5,
+    Reg::V6,
+    Reg::V7,
+    Reg::V16,
+    Reg::V17,
 ];
 
 /// Scratch register for a rewritten instruction's value: the destination when
@@ -177,6 +228,8 @@ pub(crate) const SCRATCH_SOURCE_C: Reg = Reg::X12;
 /// Distinct from every allocation scratch because emission happens after
 /// rewriting, with allocated values already live in registers.
 pub(crate) const SCRATCH_ADDRESS: Reg = Reg::X15;
+pub(crate) const SCRATCH_FP_VALUE: Reg = Reg::V16;
+pub(crate) const SCRATCH_FP_SOURCE: Reg = Reg::V17;
 
 /// Largest immediate encoded by the two-instruction ADD/SUB immediate form.
 /// Values above this limit are materialized by the emitter.
@@ -214,7 +267,11 @@ impl Reg {
     /// without special-casing a target that has only one class (RUE-1067).
     #[inline]
     pub const fn class(self) -> RegClass {
-        RegClass::Gp
+        if (self as u8) >= Reg::V0 as u8 {
+            RegClass::Fp
+        } else {
+            RegClass::Gp
+        }
     }
 
     /// Get the register encoding for instruction fields (0-30 for X0-X30, 31 for SP/XZR).
@@ -254,6 +311,7 @@ impl Reg {
             Reg::Lr => 30,
             Reg::Sp => 31,
             Reg::Xzr => 31, // Same encoding as SP, context determines meaning
+            _ => (self as u8) - (Reg::V0 as u8),
         }
     }
 
@@ -274,6 +332,14 @@ impl Reg {
                 | Reg::X28
                 | Reg::Fp
                 | Reg::Lr
+                | Reg::V8
+                | Reg::V9
+                | Reg::V10
+                | Reg::V11
+                | Reg::V12
+                | Reg::V13
+                | Reg::V14
+                | Reg::V15
         )
     }
 
@@ -313,6 +379,38 @@ impl Reg {
             Reg::Lr => "lr",
             Reg::Sp => "sp",
             Reg::Xzr => "xzr",
+            Reg::V0 => "v0",
+            Reg::V1 => "v1",
+            Reg::V2 => "v2",
+            Reg::V3 => "v3",
+            Reg::V4 => "v4",
+            Reg::V5 => "v5",
+            Reg::V6 => "v6",
+            Reg::V7 => "v7",
+            Reg::V8 => "v8",
+            Reg::V9 => "v9",
+            Reg::V10 => "v10",
+            Reg::V11 => "v11",
+            Reg::V12 => "v12",
+            Reg::V13 => "v13",
+            Reg::V14 => "v14",
+            Reg::V15 => "v15",
+            Reg::V16 => "v16",
+            Reg::V17 => "v17",
+            Reg::V18 => "v18",
+            Reg::V19 => "v19",
+            Reg::V20 => "v20",
+            Reg::V21 => "v21",
+            Reg::V22 => "v22",
+            Reg::V23 => "v23",
+            Reg::V24 => "v24",
+            Reg::V25 => "v25",
+            Reg::V26 => "v26",
+            Reg::V27 => "v27",
+            Reg::V28 => "v28",
+            Reg::V29 => "v29",
+            Reg::V30 => "v30",
+            Reg::V31 => "v31",
         }
     }
 
@@ -352,6 +450,7 @@ impl Reg {
             Reg::Lr => "w30",
             Reg::Sp => "wsp",
             Reg::Xzr => "wzr",
+            _ => self.name64(),
         }
     }
 
@@ -529,6 +628,78 @@ impl fmt::Display for Cond {
 /// An AArch64 MIR instruction.
 #[derive(Debug, Clone)]
 pub enum Aarch64Inst {
+    FloatConst {
+        dst: Operand,
+        bits: u64,
+        width: FloatWidth,
+    },
+    FloatMov {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatToBits {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    BitsToFloat {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatLoad {
+        dst: Operand,
+        base: Reg,
+        offset: i32,
+        width: FloatWidth,
+    },
+    FloatStore {
+        base: Reg,
+        offset: i32,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatBin {
+        op: FloatBinOp,
+        dst: Operand,
+        lhs: Operand,
+        rhs: Operand,
+        width: FloatWidth,
+    },
+    FloatNeg {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatSqrt {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatCmp {
+        lhs: Operand,
+        rhs: Operand,
+        width: FloatWidth,
+    },
+    IntToFloat {
+        dst: Operand,
+        src: Operand,
+        int_bits: u32,
+        width: FloatWidth,
+    },
+    FloatToInt {
+        dst: Operand,
+        src: Operand,
+        int_bits: u32,
+        width: FloatWidth,
+    },
+    FloatCast {
+        dst: Operand,
+        src: Operand,
+        from: FloatWidth,
+        to: FloatWidth,
+    },
     // === Move instructions ===
     /// `mov dst, #imm` - Move immediate to register (MOVZ/MOVN/MOVK sequence).
     MovImm { dst: Operand, imm: i64 },
@@ -1011,6 +1182,7 @@ impl Aarch64Inst {
     /// virtual registers to physical registers that would be clobbered.
     pub fn clobbers(&self) -> &'static [Reg] {
         match self {
+            Aarch64Inst::FloatConst { .. } => &[Reg::X9],
             // Function calls clobber all caller-saved registers per AAPCS64
             Aarch64Inst::Bl { .. } => &[
                 Reg::X0,
@@ -1032,6 +1204,30 @@ impl Aarch64Inst {
                 Reg::X16,
                 Reg::X17,
                 Reg::Lr,
+                Reg::V0,
+                Reg::V1,
+                Reg::V2,
+                Reg::V3,
+                Reg::V4,
+                Reg::V5,
+                Reg::V6,
+                Reg::V7,
+                Reg::V16,
+                Reg::V17,
+                Reg::V18,
+                Reg::V19,
+                Reg::V20,
+                Reg::V21,
+                Reg::V22,
+                Reg::V23,
+                Reg::V24,
+                Reg::V25,
+                Reg::V26,
+                Reg::V27,
+                Reg::V28,
+                Reg::V29,
+                Reg::V30,
+                Reg::V31,
             ],
             // Syscall returns in X0. On macOS, X16 carries the syscall
             // number; on Linux, X8 does — clobber both to cover either target.
@@ -1099,6 +1295,62 @@ pub(crate) fn narrow_store_mnemonic(width: u8) -> &'static str {
 impl fmt::Display for Aarch64Inst {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Aarch64Inst::FloatConst { dst, bits, width } => {
+                write!(f, "fconst.{width:?} {dst}, 0x{bits:x}")
+            }
+            Aarch64Inst::FloatMov { dst, src, width } => write!(f, "fmov.{width:?} {dst}, {src}"),
+            Aarch64Inst::FloatToBits { dst, src, width } => {
+                write!(f, "fmov.bits.{width:?} {dst}, {src}")
+            }
+            Aarch64Inst::BitsToFloat { dst, src, width } => {
+                write!(f, "fmov.float.{width:?} {dst}, {src}")
+            }
+            Aarch64Inst::FloatLoad {
+                dst,
+                base,
+                offset,
+                width,
+            } => write!(f, "ldr.{width:?} {dst}, [{base}, #{offset}]"),
+            Aarch64Inst::FloatStore {
+                base,
+                offset,
+                src,
+                width,
+            } => write!(f, "str.{width:?} {src}, [{base}, #{offset}]"),
+            Aarch64Inst::FloatBin {
+                op,
+                dst,
+                lhs,
+                rhs,
+                width,
+            } => write!(
+                f,
+                "{}.{width:?} {dst}, {lhs}, {rhs}",
+                match op {
+                    FloatBinOp::Add => "fadd",
+                    FloatBinOp::Sub => "fsub",
+                    FloatBinOp::Mul => "fmul",
+                    FloatBinOp::Div => "fdiv",
+                }
+            ),
+            Aarch64Inst::FloatNeg { dst, src, width } => write!(f, "fneg.{width:?} {dst}, {src}"),
+            Aarch64Inst::FloatSqrt { dst, src, width } => write!(f, "fsqrt.{width:?} {dst}, {src}"),
+            Aarch64Inst::FloatCmp { lhs, rhs, width } => write!(f, "fcmp.{width:?} {lhs}, {rhs}"),
+            Aarch64Inst::IntToFloat {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => write!(f, "scvtf.{width:?}.{int_bits} {dst}, {src}"),
+            Aarch64Inst::FloatToInt {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => write!(f, "fcvtzs.{int_bits}.{width:?} {dst}, {src}"),
+            Aarch64Inst::FloatCast { dst, src, from, to } => {
+                write!(f, "fcvt.{to:?}.{from:?} {dst}, {src}")
+            }
             Aarch64Inst::MovImm { dst, imm } => write!(f, "mov {}, #{}", dst, imm),
             Aarch64Inst::MovRR { dst, src } => write!(f, "mov {}, {}", dst, src),
             Aarch64Inst::Ldr { dst, base, offset } => {
@@ -1408,10 +1660,8 @@ impl Aarch64Mir {
 
     /// Allocate a new general-purpose virtual register.
     ///
-    /// This is the whole of lowering today: no Rue type lowers to a
-    /// floating-point value yet, so every value a function computes lives in a
-    /// general-purpose register. Sites that later hold a floating-point value
-    /// call [`Aarch64Mir::alloc_vreg_in`] with [`RegClass::Fp`] instead (RUE-1067).
+    /// Integer values and addresses use this default. Scalar float lowering
+    /// calls [`Aarch64Mir::alloc_vreg_in`] with [`RegClass::Fp`].
     pub fn alloc_vreg(&mut self) -> VReg {
         self.alloc_vreg_in(RegClass::Gp)
     }
@@ -1605,8 +1855,10 @@ mod tests {
     }
 
     #[test]
-    fn every_physical_register_is_general_purpose() {
+    fn physical_registers_report_their_register_class() {
         assert_eq!(Reg::X19.class(), RegClass::Gp);
+        assert_eq!(Reg::V0.class(), RegClass::Fp);
+        assert_eq!(Reg::V31.class(), RegClass::Fp);
     }
 
     #[test]
@@ -1617,6 +1869,8 @@ mod tests {
         assert_eq!(Reg::Lr.encoding(), 30);
         assert_eq!(Reg::Sp.encoding(), 31);
         assert_eq!(Reg::Xzr.encoding(), 31);
+        assert_eq!(Reg::V0.encoding(), 0);
+        assert_eq!(Reg::V31.encoding(), 31);
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -66,6 +66,7 @@ impl Backend for Aarch64CodegenBackend {
 
     const ARCH: rue_target::Arch = rue_target::Arch::Aarch64;
     const ARG_REG_COUNT: u32 = cfg_lower::ARG_REGS.len() as u32;
+    const FP_ARG_REG_COUNT: u32 = cfg_lower::FP_ARG_REGS.len() as u32;
     const RETURN_REG_COUNT: u32 = cfg_lower::RET_REGS.len() as u32;
     const SAVED_REG_SCHEME: crate::frame_layout::SavedRegScheme =
         crate::frame_layout::SavedRegScheme::Aarch64;

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -16,8 +16,8 @@ use super::liveness;
 use super::mir;
 use super::mir::VReg;
 use super::mir::{
-    Aarch64Inst, Aarch64Mir, Operand, Reg, SCRATCH_SOURCE_A, SCRATCH_SOURCE_B, SCRATCH_SOURCE_C,
-    SCRATCH_VALUE,
+    Aarch64Inst, Aarch64Mir, Operand, Reg, SCRATCH_FP_SOURCE, SCRATCH_FP_VALUE, SCRATCH_SOURCE_A,
+    SCRATCH_SOURCE_B, SCRATCH_SOURCE_C, SCRATCH_VALUE,
 };
 use crate::alloc_dst;
 use crate::regalloc::{
@@ -33,6 +33,22 @@ use crate::regalloc::{
 /// X14. See [`mir::RESERVED_REGS`] for the per-register reasoning; the
 /// assertion below keeps the two in agreement.
 const CALLER_SAVED_REGS: &[Reg] = &[Reg::X13, Reg::X14];
+const FP_CALLER_SAVED_REGS: &[Reg] = &[
+    Reg::V18,
+    Reg::V19,
+    Reg::V20,
+    Reg::V21,
+    Reg::V22,
+    Reg::V23,
+    Reg::V24,
+    Reg::V25,
+    Reg::V26,
+    Reg::V27,
+    Reg::V28,
+    Reg::V29,
+    Reg::V30,
+    Reg::V31,
+];
 
 /// Callee-saved registers, the only home for a value that must survive a call.
 ///
@@ -165,6 +181,225 @@ impl RegAlloc {
         inst: Aarch64Inst,
     ) -> CompileResult<()> {
         match inst {
+            Aarch64Inst::FloatConst { dst, bits, width } => {
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(Aarch64Inst::FloatConst {
+                    dst: out,
+                    bits,
+                    width,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(Aarch64Inst::FloatStore {
+                        base: Reg::Fp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            Aarch64Inst::FloatMov { dst, src, width }
+            | Aarch64Inst::FloatNeg { dst, src, width }
+            | Aarch64Inst::FloatSqrt { dst, src, width } => {
+                let is_neg = matches!(inst, Aarch64Inst::FloatNeg { .. });
+                let is_sqrt = matches!(inst, Aarch64Inst::FloatSqrt { .. });
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_SOURCE, width)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(if is_sqrt {
+                    Aarch64Inst::FloatSqrt {
+                        dst: out,
+                        src,
+                        width,
+                    }
+                } else if is_neg {
+                    Aarch64Inst::FloatNeg {
+                        dst: out,
+                        src,
+                        width,
+                    }
+                } else {
+                    Aarch64Inst::FloatMov {
+                        dst: out,
+                        src,
+                        width,
+                    }
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(Aarch64Inst::FloatStore {
+                        base: Reg::Fp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            Aarch64Inst::FloatToBits { dst, src, width } => {
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_VALUE, width)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::FloatToBits { dst: dst_op, src, width });
+                    },
+                    store |spill_offset| {
+                        mir.push_after(Aarch64Inst::Str {
+                            base: Reg::Fp,
+                            offset: spill_offset,
+                            src: Operand::Physical(SCRATCH_VALUE),
+                        });
+                    },
+                );
+            }
+            Aarch64Inst::BitsToFloat { dst, src, width } => {
+                let src = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(Aarch64Inst::BitsToFloat {
+                    dst: out,
+                    src,
+                    width,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(Aarch64Inst::FloatStore {
+                        base: Reg::Fp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            Aarch64Inst::FloatBin {
+                op,
+                dst,
+                lhs,
+                rhs,
+                width,
+            } => {
+                let lhs = Self::load_float_operand(context, mir, lhs, SCRATCH_FP_VALUE, width)?;
+                let rhs = Self::load_float_operand(context, mir, rhs, SCRATCH_FP_SOURCE, width)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(Aarch64Inst::FloatBin {
+                    op,
+                    dst: out,
+                    lhs,
+                    rhs,
+                    width,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(Aarch64Inst::FloatStore {
+                        base: Reg::Fp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            Aarch64Inst::FloatCmp { lhs, rhs, width } => {
+                let lhs = Self::load_float_operand(context, mir, lhs, SCRATCH_FP_VALUE, width)?;
+                let rhs = Self::load_float_operand(context, mir, rhs, SCRATCH_FP_SOURCE, width)?;
+                mir.push(Aarch64Inst::FloatCmp { lhs, rhs, width });
+            }
+            Aarch64Inst::FloatLoad {
+                dst,
+                base,
+                offset,
+                width,
+            } => {
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(Aarch64Inst::FloatLoad {
+                    dst: out,
+                    base,
+                    offset,
+                    width,
+                });
+                if let Some(spill_offset) = spill {
+                    mir.push_after(Aarch64Inst::FloatStore {
+                        base: Reg::Fp,
+                        offset: spill_offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            Aarch64Inst::FloatStore {
+                base,
+                offset,
+                src,
+                width,
+            } => {
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_VALUE, width)?;
+                mir.push(Aarch64Inst::FloatStore {
+                    base,
+                    offset,
+                    src,
+                    width,
+                });
+            }
+            Aarch64Inst::IntToFloat {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => {
+                let src = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(Aarch64Inst::IntToFloat {
+                    dst: out,
+                    src,
+                    int_bits,
+                    width,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(Aarch64Inst::FloatStore {
+                        base: Reg::Fp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            Aarch64Inst::FloatToInt {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => {
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_VALUE, width)?;
+                let dst_alloc = Self::get_allocation(context, dst);
+                let out = match dst_alloc {
+                    Some(Allocation::Register(r)) => Operand::Physical(r),
+                    Some(Allocation::Spill(_)) => Operand::Physical(SCRATCH_VALUE),
+                    None => dst,
+                    Some(Allocation::Rematerialize(_)) => unreachable!(),
+                };
+                mir.push(Aarch64Inst::FloatToInt {
+                    dst: out,
+                    src,
+                    int_bits,
+                    width,
+                });
+                if let Some(Allocation::Spill(offset)) = dst_alloc {
+                    mir.push_after(Aarch64Inst::Str {
+                        src: out,
+                        base: Reg::Fp,
+                        offset,
+                    });
+                }
+            }
+            Aarch64Inst::FloatCast { dst, src, from, to } => {
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_SOURCE, from)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(Aarch64Inst::FloatCast {
+                    dst: out,
+                    src,
+                    from,
+                    to,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(Aarch64Inst::FloatStore {
+                        base: Reg::Fp,
+                        offset,
+                        src: out,
+                        width: to,
+                    });
+                }
+            }
             Aarch64Inst::MovImm { dst, imm } => {
                 alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
@@ -1109,6 +1344,49 @@ impl RegAlloc {
         }
     }
 
+    fn float_output(
+        context: &AllocationContext<'_, Reg>,
+        operand: Operand,
+        scratch: Reg,
+    ) -> (Operand, Option<i32>) {
+        match Self::get_allocation(context, operand) {
+            Some(Allocation::Register(reg)) => (Operand::Physical(reg), None),
+            Some(Allocation::Spill(offset)) => (Operand::Physical(scratch), Some(offset)),
+            Some(Allocation::Rematerialize(_)) => {
+                unreachable!("destination cannot be rematerializable")
+            }
+            None => (operand, None),
+        }
+    }
+
+    fn load_float_operand(
+        context: &AllocationContext<'_, Reg>,
+        mir: &mut RewriteBuffer<Aarch64Inst>,
+        operand: Operand,
+        scratch: Reg,
+        width: crate::value_plan::FloatWidth,
+    ) -> CompileResult<Operand> {
+        match operand {
+            Operand::Virtual(vreg) => match context.allocation(vreg) {
+                Some(Allocation::Register(reg)) => Ok(Operand::Physical(reg)),
+                Some(Allocation::Spill(offset)) => {
+                    mir.push_before(Aarch64Inst::FloatLoad {
+                        dst: Operand::Physical(scratch),
+                        base: Reg::Fp,
+                        offset,
+                        width,
+                    });
+                    Ok(Operand::Physical(scratch))
+                }
+                Some(Allocation::Rematerialize(_)) => {
+                    unreachable!("float values are not rematerialized")
+                }
+                None => Ok(operand),
+            },
+            Operand::Physical(_) => Ok(operand),
+        }
+    }
+
     /// Load an operand into a physical register, inserting a load if spilled
     /// or rematerializing if marked for rematerialization.
     /// Returns the operand to use (either the allocated register or the scratch register).
@@ -1358,19 +1636,19 @@ impl RegAllocBackend for Aarch64Backend {
     }
 
     fn register_file() -> RegisterFile<'static, Self::Reg> {
-        // General-purpose only: `Reg` names no floating-point register yet, so
-        // the `Fp` class of the file is empty and no interval can select it
-        // (RUE-1067). The floats series adds the V/D registers here.
-        RegisterFile::gp_only(SaveClasses {
-            caller_saved: CALLER_SAVED_REGS,
-            callee_saved: CALLEE_SAVED_REGS,
-            // AArch64 instructions are a fixed four bytes and encode every
-            // general register in the same five-bit field, so no allocatable
-            // register is cheaper to address than another and the RUE-1227
-            // preference has nothing to trade. Reusing a callee-saved register
-            // in place of a caller-saved one here would only add pressure.
-            compact_callee_saved: &[],
-        })
+        // Keep scalar floating-point values in a disjoint vector register class.
+        RegisterFile::new([
+            SaveClasses {
+                caller_saved: CALLER_SAVED_REGS,
+                callee_saved: CALLEE_SAVED_REGS,
+                compact_callee_saved: &[],
+            },
+            SaveClasses {
+                caller_saved: FP_CALLER_SAVED_REGS,
+                callee_saved: &[],
+                compact_callee_saved: &[],
+            },
+        ])
     }
 
     fn for_each_physical_operand<F>(inst: &Self::Inst, mut visit: F)
@@ -1419,20 +1697,15 @@ mod tests {
     use super::Aarch64Backend;
     use super::liveness;
     use super::{
-        ALLOCATABLE_REGS, Aarch64Inst, Aarch64Mir, CALLEE_SAVED_REGS, CALLER_SAVED_REGS, Operand,
-        Reg, RegAlloc, SCRATCH_SOURCE_A, SCRATCH_VALUE, VReg,
+        ALLOCATABLE_REGS, Aarch64Inst, Aarch64Mir, CALLEE_SAVED_REGS, CALLER_SAVED_REGS,
+        FP_CALLER_SAVED_REGS, Operand, Reg, RegAlloc, SCRATCH_SOURCE_A, SCRATCH_VALUE, VReg,
     };
     use crate::reg_class::RegClass;
     use crate::regalloc::{Allocation, RegAllocBackend, RematerializeOp};
     use ahash::AHashSet;
 
     #[test]
-    fn the_register_file_is_general_purpose_only() {
-        // The whole of RUE-1067's claim on this backend: the class dimension
-        // exists, and the floating-point half of it is empty. A change that
-        // populates `Fp` here without the rest of the floats series would make
-        // allocation hand out registers no instruction can encode, so this
-        // guard fails loudly instead.
+    fn the_register_file_keeps_gp_and_fp_registers_separate() {
         let file = <Aarch64Backend as RegAllocBackend>::register_file();
         let gp = file.class(RegClass::Gp);
         let fp = file.class(RegClass::Fp);
@@ -1440,12 +1713,16 @@ mod tests {
         assert_eq!(gp.caller_saved, CALLER_SAVED_REGS);
         assert_eq!(gp.callee_saved, CALLEE_SAVED_REGS);
         assert!(!gp.is_empty());
-        assert!(
-            fp.is_empty(),
-            "no floating-point register is allocatable yet"
+        assert_eq!(fp.caller_saved, FP_CALLER_SAVED_REGS);
+        assert!(fp.callee_saved.is_empty());
+        assert!(!fp.is_empty());
+        assert_eq!(
+            file.len(),
+            ALLOCATABLE_REGS.len() + FP_CALLER_SAVED_REGS.len()
         );
-        assert_eq!(file.len(), ALLOCATABLE_REGS.len());
-        assert_eq!(file.caller_saved_flattened(), CALLER_SAVED_REGS.to_vec());
+        let mut expected = CALLER_SAVED_REGS.to_vec();
+        expected.extend_from_slice(FP_CALLER_SAVED_REGS);
+        assert_eq!(file.caller_saved_flattened(), expected);
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -85,6 +85,23 @@ impl SchedulerAdapter for Aarch64Scheduler {
 /// They represent the number of cycles until the result is ready.
 fn get_latency(inst: &Aarch64Inst) -> u32 {
     match inst {
+        Aarch64Inst::FloatLoad { .. } => 4,
+        Aarch64Inst::FloatBin {
+            op: super::mir::FloatBinOp::Div,
+            ..
+        } => 12,
+        Aarch64Inst::FloatBin { .. }
+        | Aarch64Inst::FloatNeg { .. }
+        | Aarch64Inst::FloatSqrt { .. }
+        | Aarch64Inst::FloatCast { .. }
+        | Aarch64Inst::IntToFloat { .. }
+        | Aarch64Inst::FloatToInt { .. } => 4,
+        Aarch64Inst::FloatConst { .. }
+        | Aarch64Inst::FloatMov { .. }
+        | Aarch64Inst::FloatToBits { .. }
+        | Aarch64Inst::BitsToFloat { .. }
+        | Aarch64Inst::FloatStore { .. }
+        | Aarch64Inst::FloatCmp { .. } => 1,
         // Register moves: 1 cycle (may be eliminated by renaming)
         Aarch64Inst::MovRR { .. } | Aarch64Inst::MovImm { .. } => 1,
 
@@ -231,6 +248,8 @@ fn accesses_memory(inst: &Aarch64Inst) -> bool {
         inst,
         Aarch64Inst::Ldr { .. }
             | Aarch64Inst::Str { .. }
+            | Aarch64Inst::FloatLoad { .. }
+            | Aarch64Inst::FloatStore { .. }
             | Aarch64Inst::LdrIndexed { .. }
             | Aarch64Inst::StrIndexed { .. }
             | Aarch64Inst::LdrIndexedOffset { .. }
@@ -255,6 +274,24 @@ pub(super) fn regs_read(inst: &Aarch64Inst) -> RegList<Reg> {
     };
 
     match inst {
+        Aarch64Inst::FloatConst { .. } => {}
+        Aarch64Inst::FloatLoad { base, .. } => result.push(*base),
+        Aarch64Inst::FloatMov { src, .. }
+        | Aarch64Inst::FloatToBits { src, .. }
+        | Aarch64Inst::BitsToFloat { src, .. }
+        | Aarch64Inst::FloatNeg { src, .. }
+        | Aarch64Inst::FloatSqrt { src, .. }
+        | Aarch64Inst::IntToFloat { src, .. }
+        | Aarch64Inst::FloatToInt { src, .. }
+        | Aarch64Inst::FloatCast { src, .. } => add_if_phys(src, &mut result),
+        Aarch64Inst::FloatStore { base, src, .. } => {
+            result.push(*base);
+            add_if_phys(src, &mut result);
+        }
+        Aarch64Inst::FloatBin { lhs, rhs, .. } | Aarch64Inst::FloatCmp { lhs, rhs, .. } => {
+            add_if_phys(lhs, &mut result);
+            add_if_phys(rhs, &mut result);
+        }
         Aarch64Inst::MovImm { .. } => {}
         Aarch64Inst::MovRR { src, .. } => add_if_phys(src, &mut result),
         Aarch64Inst::Ldr { base, .. } | Aarch64Inst::NarrowLoad { base, .. } => result.push(*base),
@@ -385,6 +422,18 @@ pub(super) fn regs_written(inst: &Aarch64Inst) -> RegList<Reg> {
     };
 
     match inst {
+        Aarch64Inst::FloatConst { dst, .. }
+        | Aarch64Inst::FloatMov { dst, .. }
+        | Aarch64Inst::FloatToBits { dst, .. }
+        | Aarch64Inst::BitsToFloat { dst, .. }
+        | Aarch64Inst::FloatLoad { dst, .. }
+        | Aarch64Inst::FloatBin { dst, .. }
+        | Aarch64Inst::FloatNeg { dst, .. }
+        | Aarch64Inst::FloatSqrt { dst, .. }
+        | Aarch64Inst::IntToFloat { dst, .. }
+        | Aarch64Inst::FloatToInt { dst, .. }
+        | Aarch64Inst::FloatCast { dst, .. } => add_if_phys(dst, &mut result),
+        Aarch64Inst::FloatStore { .. } | Aarch64Inst::FloatCmp { .. } => {}
         Aarch64Inst::MovImm { dst, .. }
         | Aarch64Inst::MovRR { dst, .. }
         | Aarch64Inst::Ldr { dst, .. }
@@ -505,6 +554,7 @@ pub(super) fn writes_flags(inst: &Aarch64Inst) -> bool {
             | Aarch64Inst::Cmp64RR { .. }
             | Aarch64Inst::CmpImm { .. }
             | Aarch64Inst::TstRR { .. }
+            | Aarch64Inst::FloatCmp { .. }
     )
 }
 

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -43,11 +43,20 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
     /// Allocate a fresh virtual register.
     fn alloc_vreg(&mut self) -> VReg;
 
+    fn alloc_float_vreg(&mut self) -> VReg;
+
     /// Get (or lazily create) the primary vreg for a CFG value.
     fn get_vreg(&mut self, value: CfgValue) -> VReg;
 
     /// Emit a load of frame slot `slot` into `dst`.
     fn emit_load_slot(&mut self, dst: VReg, slot: u32);
+
+    fn emit_typed_float_load_slot(
+        &mut self,
+        dst: VReg,
+        slot: u32,
+        width: crate::value_plan::FloatWidth,
+    );
 
     /// Emit a register-to-register move.
     fn emit_reg_move(&mut self, dst: VReg, src: VReg);
@@ -55,11 +64,38 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
     /// Emit a store of `src` to frame slot `slot`.
     fn emit_store_slot(&mut self, src: VReg, slot: u32);
 
+    fn emit_typed_float_store_slot(
+        &mut self,
+        src: VReg,
+        slot: u32,
+        width: crate::value_plan::FloatWidth,
+    );
+
     /// Emit a store of `src` through pointer `ptr` at `byte_offset` from it.
     fn emit_store_through_ptr(&mut self, src: VReg, ptr: VReg, byte_offset: i32);
 
     /// Emit a load of the value at `byte_offset` from pointer `ptr` into `dst`.
     fn emit_load_through_ptr(&mut self, dst: VReg, ptr: VReg, byte_offset: i32);
+
+    fn emit_float_store_through_ptr(
+        &mut self,
+        src: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        width: crate::value_plan::FloatWidth,
+    );
+
+    fn emit_float_load_through_ptr(
+        &mut self,
+        dst: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        width: crate::value_plan::FloatWidth,
+    );
+
+    fn emit_float_to_bits(&mut self, dst: VReg, src: VReg, width: crate::value_plan::FloatWidth);
+
+    fn emit_bits_to_float(&mut self, dst: VReg, src: VReg, width: crate::value_plan::FloatWidth);
 
     /// Emit a narrow (1/2/4-byte) store of the low `access.width` bytes of `src`
     /// through pointer `ptr` at `byte_offset` from it (RUE-1000).
@@ -90,6 +126,8 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
     /// does not write, so the loaded value matches the zeroed decomposition of a
     /// shorter variant.
     fn emit_set_zero(&mut self, dst: VReg);
+
+    fn emit_set_float_zero(&mut self, dst: VReg, width: crate::value_plan::FloatWidth);
 
     /// Allocate a fresh label for a tag-dispatch marshalling edge (RUE-1037).
     fn alloc_marshal_label(&mut self) -> crate::vreg::LabelId;
@@ -177,9 +215,17 @@ pub(crate) fn store_enum_slots_through_ptr<B: SlotBackend>(
     // byte, so the whole image is initialized regardless of prior memory contents.
     zero_padding_through_ptr(b, ptr, padding);
     for (val, slot) in vals.iter().zip(map.iter()) {
-        match slot.access {
-            None => b.emit_store_through_ptr(*val, ptr, slot.byte_offset),
-            Some(access) => b.emit_narrow_store_through_ptr(*val, ptr, slot.byte_offset, access),
+        match (slot.float_width, slot.access) {
+            (Some(width), _) if slot.bit_carrier => {
+                let fp = b.alloc_float_vreg();
+                b.emit_bits_to_float(fp, *val, width);
+                b.emit_float_store_through_ptr(fp, ptr, slot.byte_offset, width);
+            }
+            (Some(width), _) => b.emit_float_store_through_ptr(*val, ptr, slot.byte_offset, width),
+            (None, None) => b.emit_store_through_ptr(*val, ptr, slot.byte_offset),
+            (None, Some(access)) => {
+                b.emit_narrow_store_through_ptr(*val, ptr, slot.byte_offset, access)
+            }
         }
     }
 }
@@ -196,10 +242,22 @@ pub(crate) fn load_enum_slots_through_ptr<B: SlotBackend>(
 ) -> Vec<VReg> {
     let mut vregs = Vec::with_capacity(map.len());
     for slot in map {
-        let dst = b.alloc_vreg();
-        match slot.access {
-            None => b.emit_load_through_ptr(dst, ptr, slot.byte_offset),
-            Some(access) => b.emit_narrow_load_through_ptr(dst, ptr, slot.byte_offset, access),
+        let dst = if slot.float_width.is_some() && !slot.bit_carrier {
+            b.alloc_float_vreg()
+        } else {
+            b.alloc_vreg()
+        };
+        match (slot.float_width, slot.access) {
+            (Some(width), _) if slot.bit_carrier => {
+                let fp = b.alloc_float_vreg();
+                b.emit_float_load_through_ptr(fp, ptr, slot.byte_offset, width);
+                b.emit_float_to_bits(dst, fp, width);
+            }
+            (Some(width), _) => b.emit_float_load_through_ptr(dst, ptr, slot.byte_offset, width),
+            (None, None) => b.emit_load_through_ptr(dst, ptr, slot.byte_offset),
+            (None, Some(access)) => {
+                b.emit_narrow_load_through_ptr(dst, ptr, slot.byte_offset, access)
+            }
         }
         vregs.push(dst);
     }
@@ -314,12 +372,19 @@ pub(crate) fn preallocate_block_param_slots<B: SlotBackend>(
     }
 
     let slot_count = b.ctx().type_slot_count(ty);
+    let leaf_types = crate::types::aggregate_leaf_types(b.ctx().type_pool, ty);
     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
     if slot_count > 0 {
         slot_vregs.push(primary_vreg);
     }
-    for _ in 1..slot_count {
-        slot_vregs.push(b.alloc_vreg());
+    for slot in 1..slot_count {
+        slot_vregs.push(
+            if crate::value_plan::float_width(leaf_types[slot as usize]).is_some() {
+                b.alloc_float_vreg()
+            } else {
+                b.alloc_vreg()
+            },
+        );
     }
     b.slot_cache().insert(param_value, slot_vregs);
 }
@@ -343,6 +408,23 @@ pub(crate) fn store_slots<B: SlotBackend>(b: &mut B, vals: &[VReg], base_slot: u
 pub(crate) fn store_slots_at_low<B: SlotBackend>(b: &mut B, vals: &[VReg], low_slot: u32) {
     for (k, val) in vals.iter().enumerate() {
         b.emit_store_slot(*val, low_slot - k as u32);
+    }
+}
+
+pub(crate) fn store_slots_typed<B: SlotBackend>(
+    b: &mut B,
+    vals: &[VReg],
+    base_slot: u32,
+    leaf_types: &[Type],
+) {
+    assert_eq!(vals.len(), leaf_types.len());
+    let low_slot = base_slot + (vals.len() as u32).saturating_sub(1);
+    for (k, (val, ty)) in vals.iter().zip(leaf_types).enumerate() {
+        if let Some(width) = crate::value_plan::float_width(*ty) {
+            b.emit_typed_float_store_slot(*val, low_slot - k as u32, width);
+        } else {
+            b.emit_store_slot(*val, low_slot - k as u32);
+        }
     }
 }
 
@@ -430,7 +512,7 @@ pub(crate) fn store_dispatch_image<B: SlotBackend>(
             end: u64::from(image.image_size),
         }],
     );
-    store_image_segs(b, vals, ptr, &image.segs);
+    store_image_segs(b, vals, ptr, &image.segs, false);
 }
 
 fn store_image_segs<B: SlotBackend>(
@@ -438,11 +520,12 @@ fn store_image_segs<B: SlotBackend>(
     vals: &[VReg],
     ptr: VReg,
     segs: &[crate::types::ImageSeg],
+    carrier: bool,
 ) {
     for seg in segs {
         match seg {
             crate::types::ImageSeg::Leaf { slot, phys } => {
-                store_leaf(b, vals[*slot as usize], ptr, phys);
+                store_leaf(b, vals[*slot as usize], ptr, phys, carrier);
             }
             crate::types::ImageSeg::Switch(region) => {
                 let tag = vals[region.tag_slot as usize];
@@ -452,7 +535,7 @@ fn store_image_segs<B: SlotBackend>(
                 for arm in &region.arms {
                     let next = b.alloc_marshal_label();
                     b.emit_marshal_branch_if_tag_ne(tag, arm.discriminant, next);
-                    store_image_segs(b, vals, ptr, &arm.segs);
+                    store_image_segs(b, vals, ptr, &arm.segs, true);
                     b.emit_marshal_jump(end);
                     b.emit_marshal_label(next);
                 }
@@ -467,10 +550,17 @@ fn store_leaf<B: SlotBackend>(
     val: VReg,
     ptr: VReg,
     phys: &crate::types::PhysicalEnumSlot,
+    carrier: bool,
 ) {
-    match phys.access {
-        None => b.emit_store_through_ptr(val, ptr, phys.byte_offset),
-        Some(access) => b.emit_narrow_store_through_ptr(val, ptr, phys.byte_offset, access),
+    match (phys.float_width, phys.access) {
+        (Some(width), _) if carrier || phys.bit_carrier => {
+            let fp = b.alloc_float_vreg();
+            b.emit_bits_to_float(fp, val, width);
+            b.emit_float_store_through_ptr(fp, ptr, phys.byte_offset, width);
+        }
+        (Some(width), _) => b.emit_float_store_through_ptr(val, ptr, phys.byte_offset, width),
+        (None, None) => b.emit_store_through_ptr(val, ptr, phys.byte_offset),
+        (None, Some(access)) => b.emit_narrow_store_through_ptr(val, ptr, phys.byte_offset, access),
     }
 }
 
@@ -484,21 +574,60 @@ pub(crate) fn load_dispatch_image<B: SlotBackend>(
     ptr: VReg,
     image: &crate::types::DispatchImage,
 ) -> Vec<VReg> {
-    let result: Vec<VReg> = (0..image.total_slots).map(|_| b.alloc_vreg()).collect();
-    load_image_segs(b, ptr, &result, &image.segs);
+    let mut float_widths = vec![None; image.total_slots as usize];
+    collect_dispatch_float_widths(&image.segs, &mut float_widths);
+    let result: Vec<VReg> = float_widths
+        .iter()
+        .map(|width| {
+            if width.is_some() {
+                b.alloc_float_vreg()
+            } else {
+                b.alloc_vreg()
+            }
+        })
+        .collect();
+    load_image_segs(b, ptr, &result, &float_widths, &image.segs, false);
     result
+}
+
+fn collect_dispatch_float_widths(
+    segs: &[crate::types::ImageSeg],
+    widths: &mut [Option<crate::value_plan::FloatWidth>],
+) {
+    for seg in segs {
+        match seg {
+            crate::types::ImageSeg::Leaf { slot, phys } => {
+                if phys.bit_carrier {
+                    continue;
+                }
+                let entry = &mut widths[*slot as usize];
+                assert!(
+                    entry.is_none() || *entry == phys.float_width,
+                    "one aggregate slot cannot have conflicting FP widths"
+                );
+                if phys.float_width.is_some() {
+                    *entry = phys.float_width;
+                }
+            }
+            // Slots below a switch are enum union payload bit carriers, so their
+            // class cannot be inferred from any one variant's semantic type.
+            crate::types::ImageSeg::Switch(_) => {}
+        }
+    }
 }
 
 fn load_image_segs<B: SlotBackend>(
     b: &mut B,
     ptr: VReg,
     result: &[VReg],
+    float_widths: &[Option<crate::value_plan::FloatWidth>],
     segs: &[crate::types::ImageSeg],
+    carrier: bool,
 ) {
     for seg in segs {
         match seg {
             crate::types::ImageSeg::Leaf { slot, phys } => {
-                load_leaf(b, result[*slot as usize], ptr, phys);
+                load_leaf(b, result[*slot as usize], ptr, phys, carrier);
             }
             crate::types::ImageSeg::Switch(region) => {
                 let tag = result[region.tag_slot as usize];
@@ -507,13 +636,17 @@ fn load_image_segs<B: SlotBackend>(
                 // read back zero on every path (matching the value model, and
                 // giving every result slot a definition on all branches).
                 for slot in (region.tag_slot + 1)..(region.tag_slot + region.span) {
-                    b.emit_set_zero(result[slot as usize]);
+                    if let Some(width) = float_widths[slot as usize] {
+                        b.emit_set_float_zero(result[slot as usize], width);
+                    } else {
+                        b.emit_set_zero(result[slot as usize]);
+                    }
                 }
                 let end = b.alloc_marshal_label();
                 for arm in &region.arms {
                     let next = b.alloc_marshal_label();
                     b.emit_marshal_branch_if_tag_ne(tag, arm.discriminant, next);
-                    load_image_segs(b, ptr, result, &arm.segs);
+                    load_image_segs(b, ptr, result, float_widths, &arm.segs, true);
                     b.emit_marshal_jump(end);
                     b.emit_marshal_label(next);
                 }
@@ -528,10 +661,17 @@ fn load_leaf<B: SlotBackend>(
     dst: VReg,
     ptr: VReg,
     phys: &crate::types::PhysicalEnumSlot,
+    carrier: bool,
 ) {
-    match phys.access {
-        None => b.emit_load_through_ptr(dst, ptr, phys.byte_offset),
-        Some(access) => b.emit_narrow_load_through_ptr(dst, ptr, phys.byte_offset, access),
+    match (phys.float_width, phys.access) {
+        (Some(width), _) if carrier || phys.bit_carrier => {
+            let fp = b.alloc_float_vreg();
+            b.emit_float_load_through_ptr(fp, ptr, phys.byte_offset, width);
+            b.emit_float_to_bits(dst, fp, width);
+        }
+        (Some(width), _) => b.emit_float_load_through_ptr(dst, ptr, phys.byte_offset, width),
+        (None, None) => b.emit_load_through_ptr(dst, ptr, phys.byte_offset),
+        (None, Some(access)) => b.emit_narrow_load_through_ptr(dst, ptr, phys.byte_offset, access),
     }
 }
 
@@ -585,14 +725,26 @@ pub(crate) fn load_slots_through_ptr<B: SlotBackend>(
 /// Load `count` logical slots (slot 0 first) from the frame with the value's
 /// low-end (slot 0) at frame slot `low_slot`; logical slot `k` is read from
 /// frame slot `low_slot - k` (ascending, ADR-0040).
-pub(crate) fn load_slots_at_low<B: SlotBackend>(b: &mut B, low_slot: u32, count: u32) -> Vec<VReg> {
-    let mut vregs = Vec::with_capacity(count as usize);
-    for k in 0..count {
-        let vreg = b.alloc_vreg();
-        b.emit_load_slot(vreg, low_slot - k);
-        vregs.push(vreg);
-    }
-    vregs
+pub(crate) fn load_slots_at_low_typed<B: SlotBackend>(
+    b: &mut B,
+    low_slot: u32,
+    leaf_types: &[Type],
+) -> Vec<VReg> {
+    leaf_types
+        .iter()
+        .enumerate()
+        .map(|(k, ty)| {
+            if let Some(width) = crate::value_plan::float_width(*ty) {
+                let vreg = b.alloc_float_vreg();
+                b.emit_typed_float_load_slot(vreg, low_slot - k as u32, width);
+                vreg
+            } else {
+                let vreg = b.alloc_vreg();
+                b.emit_load_slot(vreg, low_slot - k as u32);
+                vreg
+            }
+        })
+        .collect()
 }
 
 /// Load `count` slots through `addr_vreg` at ASCENDING byte offsets (slot k at

--- a/crates/rue-codegen/src/aggregate_eq.rs
+++ b/crates/rue-codegen/src/aggregate_eq.rs
@@ -1,21 +1,120 @@
 //! Shared aggregate equality lowering.
 //!
-//! Structural equality for multi-slot aggregates is target-independent at the
-//! algorithm level: flatten both operands into storage slots, compare each slot
-//! using the leaf type's compare width, AND the per-slot results, and optionally
-//! invert for `!=`. Backends provide only the scalar instruction emission.
+//! The plan preserves semantic leaf comparisons independently of the physical
+//! slot carrier. Enum union payload slots are GP bit carriers because their
+//! active variant may change register class or FP width; guards select the
+//! active variant before its payload comparison contributes to the result.
 
-use rue_cfg::Type;
+use rue_air::{FrozenTypeInternPool, Type, TypeKind};
 
-use crate::types;
 use crate::vreg::VReg;
 
-/// Target hooks used after shared CFG lowering has flattened the operands.
-/// This interface deliberately has no CFG handles or type-pool access.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TagGuard {
+    pub slot: u32,
+    pub discriminant: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EqualityLeaf {
+    pub slot: u32,
+    pub ty: Type,
+    pub bit_carrier: bool,
+    pub guards: Vec<TagGuard>,
+}
+
+pub fn equality_leaves(type_pool: &FrozenTypeInternPool, ty: Type) -> Vec<EqualityLeaf> {
+    let mut leaves = Vec::new();
+    push_equality_leaves(type_pool, ty, 0, false, &[], &mut leaves);
+    leaves
+}
+
+fn push_equality_leaves(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+    base: u32,
+    bit_carrier: bool,
+    guards: &[TagGuard],
+    out: &mut Vec<EqualityLeaf>,
+) -> u32 {
+    match ty.kind() {
+        TypeKind::Unit | TypeKind::Never => 0,
+        TypeKind::Struct(id) => {
+            let mut offset = 0;
+            for field in &type_pool.struct_def(id).fields {
+                offset += push_equality_leaves(
+                    type_pool,
+                    field.ty,
+                    base + offset,
+                    bit_carrier,
+                    guards,
+                    out,
+                );
+            }
+            offset
+        }
+        TypeKind::Array(id) => {
+            let (element, length) = type_pool.array_def(id);
+            let mut offset = 0;
+            for _ in 0..length {
+                offset += push_equality_leaves(
+                    type_pool,
+                    element,
+                    base + offset,
+                    bit_carrier,
+                    guards,
+                    out,
+                );
+            }
+            offset
+        }
+        TypeKind::Enum(id) => {
+            out.push(EqualityLeaf {
+                slot: base,
+                ty: Type::I32,
+                bit_carrier,
+                guards: guards.to_vec(),
+            });
+            let def = type_pool.enum_def(id);
+            let mut max_payload = 0;
+            for variant in 0..def.variant_count() {
+                let mut variant_guards = guards.to_vec();
+                variant_guards.push(TagGuard {
+                    slot: base,
+                    discriminant: variant as u32,
+                });
+                let mut offset = 0;
+                for &payload_ty in def.variant_payload(variant) {
+                    offset += push_equality_leaves(
+                        type_pool,
+                        payload_ty,
+                        base + 1 + offset,
+                        true,
+                        &variant_guards,
+                        out,
+                    );
+                }
+                max_payload = max_payload.max(offset);
+            }
+            1 + max_payload
+        }
+        _ => {
+            out.push(EqualityLeaf {
+                slot: base,
+                ty,
+                bit_carrier,
+                guards: guards.to_vec(),
+            });
+            1
+        }
+    }
+}
+
 pub trait AggregateEqPlanBackend {
     fn alloc_vreg(&mut self) -> VReg;
     fn emit_bool_const(&mut self, dst: VReg, value: bool);
-    fn emit_slot_eq(&mut self, dst: VReg, lhs: VReg, rhs: VReg, wide: bool);
+    fn emit_slot_eq(&mut self, dst: VReg, lhs: VReg, rhs: VReg, leaf_ty: Type, bit_carrier: bool);
+    fn emit_tag_eq(&mut self, dst: VReg, tag: VReg, discriminant: u32);
     fn emit_bool_and(&mut self, acc: VReg, rhs: VReg);
     fn emit_bool_not(&mut self, value: VReg);
 }
@@ -24,25 +123,47 @@ pub fn emit_aggregate_equality_plan<B: AggregateEqPlanBackend>(
     b: &mut B,
     lhs_slots: &[VReg],
     rhs_slots: &[VReg],
-    leaf_types: &[Type],
+    leaves: &[EqualityLeaf],
     invert: bool,
 ) -> VReg {
-    assert_eq!(
-        lhs_slots.len(),
-        leaf_types.len(),
-        "normalized aggregate lhs slot count mismatch"
-    );
-    assert_eq!(
-        rhs_slots.len(),
-        leaf_types.len(),
-        "normalized aggregate rhs slot count mismatch"
-    );
+    assert_eq!(lhs_slots.len(), rhs_slots.len());
     let result = b.alloc_vreg();
     b.emit_bool_const(result, true);
-    for ((lhs, rhs), leaf_ty) in lhs_slots.iter().zip(rhs_slots).zip(leaf_types) {
+    for leaf in leaves {
+        let slot = leaf.slot as usize;
+        assert!(
+            slot < lhs_slots.len(),
+            "aggregate equality slot out of range"
+        );
         let cmp = b.alloc_vreg();
-        b.emit_slot_eq(cmp, *lhs, *rhs, types::slot_needs_wide_compare(*leaf_ty));
-        b.emit_bool_and(result, cmp);
+        b.emit_slot_eq(
+            cmp,
+            lhs_slots[slot],
+            rhs_slots[slot],
+            leaf.ty,
+            leaf.bit_carrier,
+        );
+        if leaf.guards.is_empty() {
+            b.emit_bool_and(result, cmp);
+            continue;
+        }
+
+        let active = b.alloc_vreg();
+        b.emit_bool_const(active, true);
+        for guard in &leaf.guards {
+            let guard_result = b.alloc_vreg();
+            b.emit_tag_eq(
+                guard_result,
+                lhs_slots[guard.slot as usize],
+                guard.discriminant,
+            );
+            b.emit_bool_and(active, guard_result);
+        }
+        // (!active || cmp), expressed using the existing boolean primitives.
+        b.emit_bool_not(cmp);
+        b.emit_bool_and(active, cmp);
+        b.emit_bool_not(active);
+        b.emit_bool_and(result, active);
     }
     if invert {
         b.emit_bool_not(result);

--- a/crates/rue-codegen/src/backend.rs
+++ b/crates/rue-codegen/src/backend.rs
@@ -33,6 +33,7 @@ pub(crate) trait Backend {
     /// before validating or lowering a CFG, including in release builds.
     const ARCH: rue_target::Arch;
     const ARG_REG_COUNT: u32;
+    const FP_ARG_REG_COUNT: u32;
     const RETURN_REG_COUNT: u32;
     const SAVED_REG_SCHEME: SavedRegScheme;
     const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor;

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -127,6 +127,96 @@ pub struct UserArgPlan {
     pub slots: Vec<VReg>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AbiRegisterBanks {
+    pub gp: usize,
+    pub fp: usize,
+}
+
+impl From<usize> for AbiRegisterBanks {
+    fn from(gp: usize) -> Self {
+        Self { gp, fp: 0 }
+    }
+}
+
+impl From<u32> for AbiRegisterBanks {
+    fn from(gp: u32) -> Self {
+        Self {
+            gp: gp as usize,
+            fp: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+impl From<i32> for AbiRegisterBanks {
+    fn from(gp: i32) -> Self {
+        Self {
+            gp: gp as usize,
+            fp: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbiSlotClass {
+    Gp,
+    Fp(crate::value_plan::FloatWidth),
+}
+
+impl From<rue_air::NativeArgClass> for AbiSlotClass {
+    fn from(value: rue_air::NativeArgClass) -> Self {
+        match value {
+            rue_air::NativeArgClass::Gp => Self::Gp,
+            rue_air::NativeArgClass::Fp32 => Self::Fp(crate::value_plan::FloatWidth::F32),
+            rue_air::NativeArgClass::Fp64 => Self::Fp(crate::value_plan::FloatWidth::F64),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbiSlotLocation {
+    GpReg(usize),
+    FpReg(usize),
+    Stack(usize),
+}
+
+pub fn assign_abi_slots(
+    classes: impl IntoIterator<Item = AbiSlotClass>,
+    banks: AbiRegisterBanks,
+) -> Vec<AbiSlotLocation> {
+    let mut gp = 0usize;
+    let mut fp = 0usize;
+    let mut stack = 0usize;
+    classes
+        .into_iter()
+        .map(|class| match class {
+            AbiSlotClass::Gp if gp < banks.gp => {
+                let index = gp;
+                gp += 1;
+                AbiSlotLocation::GpReg(index)
+            }
+            AbiSlotClass::Fp(_) if fp < banks.fp => {
+                let index = fp;
+                fp += 1;
+                AbiSlotLocation::FpReg(index)
+            }
+            AbiSlotClass::Gp => {
+                gp += 1;
+                let index = stack;
+                stack += 1;
+                AbiSlotLocation::Stack(index)
+            }
+            AbiSlotClass::Fp(_) => {
+                fp += 1;
+                let index = stack;
+                stack += 1;
+                AbiSlotLocation::Stack(index)
+            }
+        })
+        .collect()
+}
+
 /// The hidden caller-provided return storage, when the return uses sret.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HiddenSretPlan {
@@ -178,6 +268,8 @@ pub struct CallPlan {
     /// Complete logical ABI slots, including the hidden sret pointer when
     /// present.  This is the only slot vector the adapters may marshal.
     pub abi_slots: Vec<VReg>,
+    pub abi_classes: Vec<AbiSlotClass>,
+    pub abi_locations: Vec<AbiSlotLocation>,
     pub return_plan: ReturnPlan,
     /// For a compact aggregate returned via sret under `aggregate_layout`
     /// (ADR-0052 phase 5.7, RUE-1004), the internal-slot → physical-byte image
@@ -193,6 +285,7 @@ pub struct CallPlan {
     /// Result vreg reserved by the shared dispatcher before argument leaves
     /// materialize, preserving the canonical event allocation order.
     pub result: Option<VReg>,
+    pub result_float_width: Option<crate::value_plan::FloatWidth>,
     pub stack_slot_count: usize,
     pub stack_bytes: u32,
     /// Total bytes of caller-owned compact-image buffers reserved for by-value
@@ -221,6 +314,7 @@ pub enum CallArgInput {
         value: rue_cfg::CfgValue,
         slot_count: u32,
         is_multislot_aggregate: bool,
+        slot_types: Vec<Type>,
     },
     /// A by-value non-slot-identical compact aggregate the classifier forces
     /// indirect under `aggregate_layout` (RUE-976/RUE-1005): the caller writes
@@ -329,6 +423,11 @@ impl CallInputs {
                     arg.value,
                     types::type_slot_count(type_pool, arg_ty),
                     types::is_multislot_aggregate(type_pool, arg_ty),
+                    if types::is_multislot_aggregate(type_pool, arg_ty) {
+                        types::aggregate_leaf_types(type_pool, arg_ty)
+                    } else {
+                        vec![arg_ty]
+                    },
                     by_ref_plan.clone(),
                 )
                 .unwrap_or_else(|message| panic!("{message}"))
@@ -363,6 +462,7 @@ fn normalize_call_arg(
     value: rue_cfg::CfgValue,
     slot_count: u32,
     is_multislot_aggregate: bool,
+    slot_types: Vec<Type>,
     by_ref_plan: Option<crate::value_plan::ByRefAddressPlan>,
 ) -> Result<CallArgInput, &'static str> {
     match (mode, by_ref_plan) {
@@ -370,6 +470,7 @@ fn normalize_call_arg(
             value,
             slot_count,
             is_multislot_aggregate,
+            slot_types,
         }),
         (CfgArgMode::Inout, Some(address)) => Ok(CallArgInput::ByRef {
             mode: ByRefMode::Inout,
@@ -429,7 +530,7 @@ impl CallPlan {
         target: CallTarget,
         return_plan: ReturnPlan,
         args: &[CallArgInput],
-        arg_reg_budget: usize,
+        arg_register_banks: impl Into<AbiRegisterBanks>,
         materializer: &mut M,
     ) -> Self {
         Self::from_inputs_with_result(
@@ -438,7 +539,7 @@ impl CallPlan {
             None,
             None,
             args,
-            arg_reg_budget,
+            arg_register_banks.into(),
             materializer,
             None,
         )
@@ -450,13 +551,14 @@ impl CallPlan {
         compact_return_image: Option<Vec<crate::types::PhysicalEnumSlot>>,
         compact_return_dispatch: Option<crate::types::DispatchImage>,
         args: &[CallArgInput],
-        arg_reg_budget: usize,
+        arg_register_banks: impl Into<AbiRegisterBanks>,
         materializer: &mut M,
         result: Option<VReg>,
     ) -> Self {
         let callee_abi = CalleeAbi::for_target(&target);
         let mut hidden_sret = None;
         let mut abi_slots = Vec::new();
+        let mut abi_classes = Vec::new();
 
         if let ReturnPlan::Sret {
             slot_count,
@@ -471,17 +573,19 @@ impl CallPlan {
                 storage_bytes,
             });
             abi_slots.push(pointer);
+            abi_classes.push(AbiSlotClass::Gp);
         }
 
         let mut user_args = Vec::with_capacity(args.len());
         let mut caller_indirect_bytes = 0u32;
         for arg in args {
-            let (mode, slots) = match arg {
+            let (mode, slots, classes) = match arg {
                 CallArgInput::ByRef { mode, address } => (
                     (*mode).into(),
                     // A reference is an ABI pointer even when the pointee has
                     // no storage slots. This branch precedes ZST omission.
                     vec![materializer.materialize_by_ref(address)],
+                    vec![AbiSlotClass::Gp],
                 ),
                 CallArgInput::IndirectValue {
                     value,
@@ -502,7 +606,7 @@ impl CallPlan {
                         padding,
                         *storage_bytes,
                     );
-                    (UserArgMode::Value, vec![pointer])
+                    (UserArgMode::Value, vec![pointer], vec![AbiSlotClass::Gp])
                 }
                 CallArgInput::IndirectValueDispatch {
                     value,
@@ -519,12 +623,13 @@ impl CallPlan {
                         image,
                         *storage_bytes,
                     );
-                    (UserArgMode::Value, vec![pointer])
+                    (UserArgMode::Value, vec![pointer], vec![AbiSlotClass::Gp])
                 }
                 CallArgInput::Value {
                     value,
                     slot_count,
                     is_multislot_aggregate,
+                    slot_types,
                 } => {
                     let slots = if *slot_count == 0 {
                         Vec::new()
@@ -543,15 +648,31 @@ impl CallPlan {
                     } else {
                         vec![materializer.materialize_scalar(*value)]
                     };
-                    (UserArgMode::Value, slots)
+                    let mut classes = slot_types
+                        .iter()
+                        .map(|ty| match crate::value_plan::float_width(*ty) {
+                            Some(width) => AbiSlotClass::Fp(width),
+                            None => AbiSlotClass::Gp,
+                        })
+                        .collect::<Vec<_>>();
+                    if *is_multislot_aggregate && callee_abi == CalleeAbi::Rue {
+                        classes.reverse();
+                    }
+                    (UserArgMode::Value, slots, classes)
                 }
             };
 
             abi_slots.extend(slots.iter().copied());
+            abi_classes.extend(classes);
             user_args.push(UserArgPlan { mode, slots });
         }
 
-        let stack_slot_count = abi_slots.len().saturating_sub(arg_reg_budget);
+        let abi_locations =
+            assign_abi_slots(abi_classes.iter().copied(), arg_register_banks.into());
+        let stack_slot_count = abi_locations
+            .iter()
+            .filter(|location| matches!(location, AbiSlotLocation::Stack(_)))
+            .count();
         let stack_bytes = checked_aligned_cell_region_bytes(
             u64::try_from(stack_slot_count).expect("call stack slot count must fit u64"),
         )
@@ -563,10 +684,13 @@ impl CallPlan {
             hidden_sret,
             user_args,
             abi_slots,
+            abi_classes,
+            abi_locations,
             return_plan,
             compact_return_image,
             compact_return_dispatch,
             result,
+            result_float_width: None,
             stack_slot_count,
             stack_bytes,
             caller_indirect_bytes,
@@ -578,8 +702,18 @@ impl CallPlan {
 
     /// Build the same normalized shape for drop/glue calls whose slots have
     /// already been materialized by the canonical aggregate leaves.
-    pub fn from_slot_values(target: CallTarget, slots: &[VReg], arg_reg_budget: usize) -> Self {
-        let stack_slot_count = slots.len().saturating_sub(arg_reg_budget);
+    pub fn from_slot_values(
+        target: CallTarget,
+        slots: &[VReg],
+        arg_register_banks: impl Into<AbiRegisterBanks>,
+    ) -> Self {
+        let abi_classes = vec![AbiSlotClass::Gp; slots.len()];
+        let abi_locations =
+            assign_abi_slots(abi_classes.iter().copied(), arg_register_banks.into());
+        let stack_slot_count = abi_locations
+            .iter()
+            .filter(|location| matches!(location, AbiSlotLocation::Stack(_)))
+            .count();
         Self {
             callee_abi: CalleeAbi::for_target(&target),
             target,
@@ -589,10 +723,13 @@ impl CallPlan {
                 slots: slots.to_vec(),
             }],
             abi_slots: slots.to_vec(),
+            abi_classes,
+            abi_locations,
             return_plan: ReturnPlan::ZeroSized,
             compact_return_image: None,
             compact_return_dispatch: None,
             result: None,
+            result_float_width: None,
             stack_slot_count,
             stack_bytes: checked_aligned_cell_region_bytes(
                 u64::try_from(stack_slot_count).expect("call stack slot count must fit u64"),
@@ -677,6 +814,7 @@ mod tests {
             rue_cfg::CfgValue::from_raw(1),
             1,
             false,
+            vec![Type::I32],
             None,
         )
         .expect("normal values should normalize without an address plan");
@@ -687,6 +825,7 @@ mod tests {
             rue_cfg::CfgValue::from_raw(2),
             1,
             false,
+            vec![Type::I32],
             Some(address.clone()),
         )
         .expect("borrow arguments should normalize with an address plan");
@@ -704,6 +843,7 @@ mod tests {
                 rue_cfg::CfgValue::from_raw(3),
                 1,
                 false,
+                vec![Type::I32],
                 Some(address.clone()),
             )
             .is_err()
@@ -714,6 +854,7 @@ mod tests {
                 rue_cfg::CfgValue::from_raw(4),
                 1,
                 false,
+                vec![Type::I32],
                 None,
             )
             .is_err()
@@ -729,6 +870,29 @@ mod tests {
         assert_eq!(plan.stack_slot_count, 3);
         assert_eq!(plan.stack_bytes, 32);
         assert_eq!(plan.return_plan, ReturnPlan::ZeroSized);
+    }
+
+    #[test]
+    fn abi_register_banks_fill_independently_and_share_stack_order() {
+        let classes = [
+            AbiSlotClass::Fp(crate::value_plan::FloatWidth::F32),
+            AbiSlotClass::Gp,
+            AbiSlotClass::Gp,
+            AbiSlotClass::Fp(crate::value_plan::FloatWidth::F64),
+            AbiSlotClass::Gp,
+            AbiSlotClass::Fp(crate::value_plan::FloatWidth::F32),
+        ];
+        assert_eq!(
+            assign_abi_slots(classes, AbiRegisterBanks { gp: 2, fp: 2 }),
+            vec![
+                AbiSlotLocation::FpReg(0),
+                AbiSlotLocation::GpReg(0),
+                AbiSlotLocation::GpReg(1),
+                AbiSlotLocation::FpReg(1),
+                AbiSlotLocation::Stack(0),
+                AbiSlotLocation::Stack(1),
+            ]
+        );
     }
 
     #[test]
@@ -749,10 +913,13 @@ mod tests {
                 },
             ],
             abi_slots: slots.clone(),
+            abi_classes: vec![AbiSlotClass::Gp],
+            abi_locations: vec![AbiSlotLocation::GpReg(0)],
             return_plan: ReturnPlan::ZeroSized,
             compact_return_image: None,
             compact_return_dispatch: None,
             result: None,
+            result_float_width: None,
             stack_slot_count: 0,
             stack_bytes: 0,
             caller_indirect_bytes: 0,
@@ -787,6 +954,7 @@ mod tests {
                 value: rue_cfg::CfgValue::from_raw(1),
                 slot_count: 2,
                 is_multislot_aggregate: true,
+                slot_types: vec![Type::I32, Type::I32],
             },
             CallArgInput::ByRef {
                 mode: ByRefMode::Borrow,
@@ -799,6 +967,7 @@ mod tests {
                 value: rue_cfg::CfgValue::from_raw(3),
                 slot_count: 0,
                 is_multislot_aggregate: false,
+                slot_types: Vec::new(),
             },
         ];
         let mut materializer = TestMaterializer;
@@ -830,6 +999,7 @@ mod tests {
             value: rue_cfg::CfgValue::from_raw(1),
             slot_count: 2,
             is_multislot_aggregate: true,
+            slot_types: vec![Type::I32, Type::I32],
         }];
 
         let mut materializer = TestMaterializer;

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -648,16 +648,28 @@ impl CallPlan {
                     } else {
                         vec![materializer.materialize_scalar(*value)]
                     };
-                    let mut classes = slot_types
-                        .iter()
-                        .map(|ty| match crate::value_plan::float_width(*ty) {
-                            Some(width) => AbiSlotClass::Fp(width),
-                            None => AbiSlotClass::Gp,
-                        })
-                        .collect::<Vec<_>>();
+                    // A zero-sized normal argument has no ABI slot. Its
+                    // semantic type can still appear in `slot_types`, but it
+                    // must not consume a register-bank index or a stack slot.
+                    let mut classes = if slots.is_empty() {
+                        Vec::new()
+                    } else {
+                        slot_types
+                            .iter()
+                            .map(|ty| match crate::value_plan::float_width(*ty) {
+                                Some(width) => AbiSlotClass::Fp(width),
+                                None => AbiSlotClass::Gp,
+                            })
+                            .collect::<Vec<_>>()
+                    };
                     if *is_multislot_aggregate && callee_abi == CalleeAbi::Rue {
                         classes.reverse();
                     }
+                    assert_eq!(
+                        slots.len(),
+                        classes.len(),
+                        "value argument ABI slots and classes must have equal cardinality"
+                    );
                     (UserArgMode::Value, slots, classes)
                 }
             };
@@ -667,8 +679,18 @@ impl CallPlan {
             user_args.push(UserArgPlan { mode, slots });
         }
 
+        assert_eq!(
+            abi_slots.len(),
+            abi_classes.len(),
+            "call ABI slots and classes must have equal cardinality"
+        );
         let abi_locations =
             assign_abi_slots(abi_classes.iter().copied(), arg_register_banks.into());
+        assert_eq!(
+            abi_slots.len(),
+            abi_locations.len(),
+            "call ABI slots and locations must have equal cardinality"
+        );
         let stack_slot_count = abi_locations
             .iter()
             .filter(|location| matches!(location, AbiSlotLocation::Stack(_)))
@@ -929,6 +951,59 @@ mod tests {
         assert!(plan.user_args[0].slots.is_empty());
         assert_eq!(plan.user_args[1].slots, slots);
         assert_eq!(plan.abi_slots.len(), 1);
+    }
+
+    #[test]
+    fn zero_sized_normal_arguments_do_not_consume_abi_locations() {
+        let mut args = Vec::new();
+        for value in 1..=9 {
+            if value == 4 {
+                // Semantic lowering retains the unit type even though the
+                // value has no physical ABI slot.
+                args.push(CallArgInput::Value {
+                    value: rue_cfg::CfgValue::from_raw(100),
+                    slot_count: 0,
+                    is_multislot_aggregate: false,
+                    slot_types: vec![Type::UNIT],
+                });
+            }
+            args.push(CallArgInput::Value {
+                value: rue_cfg::CfgValue::from_raw(value),
+                slot_count: 1,
+                is_multislot_aggregate: false,
+                slot_types: vec![Type::I32],
+            });
+        }
+
+        let mut materializer = TestMaterializer;
+        let plan = CallPlan::from_inputs(
+            CallTarget::rue("callee"),
+            ReturnPlan::ZeroSized,
+            &args,
+            AbiRegisterBanks { gp: 6, fp: 8 },
+            &mut materializer,
+        );
+
+        assert_eq!(plan.user_args[3].slots, Vec::<VReg>::new());
+        assert_eq!(plan.abi_slots.len(), 9);
+        assert_eq!(plan.abi_classes.len(), 9);
+        assert_eq!(plan.abi_locations.len(), 9);
+        assert_eq!(
+            plan.abi_locations,
+            vec![
+                AbiSlotLocation::GpReg(0),
+                AbiSlotLocation::GpReg(1),
+                AbiSlotLocation::GpReg(2),
+                AbiSlotLocation::GpReg(3),
+                AbiSlotLocation::GpReg(4),
+                AbiSlotLocation::GpReg(5),
+                AbiSlotLocation::Stack(0),
+                AbiSlotLocation::Stack(1),
+                AbiSlotLocation::Stack(2),
+            ]
+        );
+        assert_eq!(plan.stack_slot_count, 3);
+        assert_eq!(plan.stack_bytes, 32);
     }
 
     #[test]

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -379,7 +379,13 @@ impl<'a> CfgLowerContext<'a> {
     /// Register-only parameters needing an entry copy, as
     /// `(param ABI slot, incoming ABI index)` (RUE-1170). Empty without a
     /// pipeline plan: the historical layout homes everything.
-    pub(crate) fn param_entry_copies(&self) -> Vec<(u32, u32)> {
+    pub(crate) fn param_entry_copies(
+        &self,
+    ) -> Vec<(
+        u32,
+        crate::call_plan::AbiSlotClass,
+        crate::call_plan::AbiSlotLocation,
+    )> {
         match self.param_storage {
             None => Vec::new(),
             Some(plan) => plan.entry_copies(self.cfg).collect(),

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -30,8 +30,8 @@ use crate::frame_layout::{FrameLayout, FramePointer, SavedRegScheme};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ParamHoming {
     pub(crate) start_slot: u32,
-    pub(crate) reg_count: u32,
-    pub(crate) abi_start: u32,
+    pub(crate) class: crate::call_plan::AbiSlotClass,
+    pub(crate) location: crate::call_plan::AbiSlotLocation,
 }
 
 /// Decide whether the final frame needs a frame pointer and a slot region, or
@@ -222,8 +222,15 @@ pub(crate) fn prepare_mir_with_backend<B: crate::backend::Backend>(
         B::TARGET_C_FLAVOR,
         &|name| symbols.is_foreign(&symbols.resolve(interner.resolve(&name))),
     )?;
-    let param_storage =
-        crate::param_storage::ParamStoragePlan::plan(cfg, type_pool, has_sret, B::ARG_REG_COUNT);
+    let param_storage = crate::param_storage::ParamStoragePlan::plan(
+        cfg,
+        type_pool,
+        has_sret,
+        crate::call_plan::AbiRegisterBanks {
+            gp: B::ARG_REG_COUNT as usize,
+            fp: B::FP_ARG_REG_COUNT as usize,
+        },
+    );
     let param_homing = param_storage.homing().to_vec();
     let homed_param_slots = param_storage.homed_area_slots();
     let local_storage = crate::local_storage::LocalSlotPlan::plan(cfg, type_pool, interner);
@@ -380,6 +387,7 @@ mod tests {
 
         const ARCH: Arch = Arch::X86_64;
         const ARG_REG_COUNT: u32 = 6;
+        const FP_ARG_REG_COUNT: u32 = 8;
         const RETURN_REG_COUNT: u32 = 6;
         const SAVED_REG_SCHEME: SavedRegScheme = SavedRegScheme::X86_64;
         const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor = rue_air::TargetCAbiFlavor::SysVAmd64;

--- a/crates/rue-codegen/src/param_storage.rs
+++ b/crates/rue-codegen/src/param_storage.rs
@@ -43,7 +43,10 @@ pub(crate) enum ParamSlotStorage {
     Frame { area_slot: u32 },
     /// Register-only: the slot arrives in incoming ABI argument register
     /// `abi_index` (sret shift included) and has no frame home.
-    Register { abi_index: u32 },
+    Register {
+        class: crate::call_plan::AbiSlotClass,
+        location: crate::call_plan::AbiSlotLocation,
+    },
 }
 
 /// The complete per-function parameter storage decision.
@@ -66,8 +69,21 @@ impl ParamStoragePlan {
     /// index and every slot is treated as used. This is both the fallback
     /// for synthetic CFGs without source-parameter descriptors and the
     /// baseline the planned path must shrink from.
-    pub(crate) fn all_homed(num_params: u32, has_sret: bool) -> Self {
-        let abi_shift = has_sret as u32;
+    pub(crate) fn all_homed(
+        num_params: u32,
+        has_sret: bool,
+        register_banks: crate::call_plan::AbiRegisterBanks,
+    ) -> Self {
+        let mut classes = Vec::with_capacity(num_params as usize + has_sret as usize);
+        if has_sret {
+            classes.push(crate::call_plan::AbiSlotClass::Gp);
+        }
+        classes.extend(std::iter::repeat_n(
+            crate::call_plan::AbiSlotClass::Gp,
+            num_params as usize,
+        ));
+        let locations = crate::call_plan::assign_abi_slots(classes, register_banks);
+        let abi_shift = has_sret as usize;
         Self {
             slots: (0..num_params)
                 .map(|slot| ParamSlotStorage::Frame { area_slot: slot })
@@ -77,8 +93,8 @@ impl ParamStoragePlan {
             homing: (0..num_params)
                 .map(|slot| ParamHoming {
                     start_slot: slot,
-                    reg_count: 1,
-                    abi_start: slot + abi_shift,
+                    class: crate::call_plan::AbiSlotClass::Gp,
+                    location: locations[slot as usize + abi_shift],
                 })
                 .collect(),
         }
@@ -90,13 +106,20 @@ impl ParamStoragePlan {
         cfg: &Cfg,
         type_pool: &FrozenTypeInternPool,
         has_sret: bool,
-        arg_reg_count: u32,
+        register_banks: impl Into<crate::call_plan::AbiRegisterBanks>,
     ) -> Self {
+        let register_banks = register_banks.into();
         let num_params = cfg.num_params();
         let descriptors = cfg.source_param_abi();
         if descriptors.is_empty() {
-            return Self::all_homed(num_params, has_sret);
+            return Self::all_homed(num_params, has_sret, register_banks);
         }
+        assert!(
+            descriptors
+                .iter()
+                .all(|d| d.crossing_classes.len() == d.crossing_regs as usize),
+            "parameter ABI class metadata must classify every crossing slot"
+        );
         // Defensive: the descriptors must tile the parameter area exactly;
         // anything else falls back to the historical all-homed plan rather
         // than planning against inconsistent metadata.
@@ -108,13 +131,26 @@ impl ParamStoragePlan {
                 .any(|(a, b)| a.start_slot + a.slot_count != b.start_slot)
             || descriptors.first().is_some_and(|d| d.start_slot != 0)
         {
-            return Self::all_homed(num_params, has_sret);
+            return Self::all_homed(num_params, has_sret, register_banks);
         }
 
         let scan = scan_param_references(cfg, type_pool);
         let mut slots = Vec::with_capacity(num_params as usize);
         let mut homing = Vec::new();
-        let mut abi = has_sret as u32;
+        let mut classes = Vec::new();
+        if has_sret {
+            classes.push(crate::call_plan::AbiSlotClass::Gp);
+        }
+        for d in descriptors {
+            classes.extend(
+                d.crossing_classes
+                    .iter()
+                    .copied()
+                    .map(crate::call_plan::AbiSlotClass::from),
+            );
+        }
+        let locations = crate::call_plan::assign_abi_slots(classes.iter().copied(), register_banks);
+        let mut crossing_index = has_sret as usize;
         let mut area = 0u32;
         for d in descriptors {
             let slot = d.start_slot;
@@ -124,28 +160,40 @@ impl ParamStoragePlan {
             // pointer, which nothing may address (every consumer goes through
             // `ensure_by_ref_param_ptr`); a by-value slot must additionally
             // be immutable and never addressed.
+            let parameter_locations =
+                &locations[crossing_index..crossing_index + d.crossing_regs as usize];
+            let parameter_classes =
+                &classes[crossing_index..crossing_index + d.crossing_regs as usize];
             let eligible = d.slot_count == 1
                 && d.crossing_regs == 1
-                && abi < arg_reg_count
+                && !matches!(
+                    parameter_locations[0],
+                    crate::call_plan::AbiSlotLocation::Stack(_)
+                )
                 && !scan.needs_home[slot as usize]
                 && (cfg.is_param_by_ref(slot)
                     || (!cfg.is_param_writable(slot) && !cfg.is_param_address_taken(slot)));
             if eligible {
-                slots.push(ParamSlotStorage::Register { abi_index: abi });
+                slots.push(ParamSlotStorage::Register {
+                    class: parameter_classes[0],
+                    location: parameter_locations[0],
+                });
             } else {
                 for j in 0..d.slot_count {
                     slots.push(ParamSlotStorage::Frame {
                         area_slot: area + j,
                     });
                 }
-                homing.push(ParamHoming {
-                    start_slot: area,
-                    reg_count: d.crossing_regs,
-                    abi_start: abi,
-                });
+                for j in 0..d.crossing_regs {
+                    homing.push(ParamHoming {
+                        start_slot: area + j,
+                        class: parameter_classes[j as usize],
+                        location: parameter_locations[j as usize],
+                    });
+                }
                 area += d.slot_count;
             }
-            abi += d.crossing_regs;
+            crossing_index += d.crossing_regs as usize;
         }
         Self {
             slots,
@@ -194,17 +242,23 @@ impl ParamStoragePlan {
     pub(crate) fn entry_copies<'a>(
         &'a self,
         cfg: &'a Cfg,
-    ) -> impl Iterator<Item = (u32, u32)> + 'a {
+    ) -> impl Iterator<
+        Item = (
+            u32,
+            crate::call_plan::AbiSlotClass,
+            crate::call_plan::AbiSlotLocation,
+        ),
+    > + 'a {
         self.slots
             .iter()
             .enumerate()
             .filter_map(move |(slot, storage)| {
                 let slot = slot as u32;
                 match storage {
-                    ParamSlotStorage::Register { abi_index }
+                    ParamSlotStorage::Register { class, location }
                         if cfg.is_param_by_ref(slot) || self.used[slot as usize] =>
                     {
-                        Some((slot, *abi_index))
+                        Some((slot, *class, *location))
                     }
                     _ => None,
                 }
@@ -385,6 +439,7 @@ mod tests {
                 start_slot: slot,
                 slot_count: 1,
                 crossing_regs: 1,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()
@@ -409,7 +464,45 @@ mod tests {
         assert_eq!(plan.slot(0), ParamSlotStorage::Frame { area_slot: 0 });
         assert_eq!(plan.slot(1), ParamSlotStorage::Frame { area_slot: 1 });
         assert_eq!(plan.homing().len(), 2);
-        assert_eq!(plan.homing()[1].abi_start, 1);
+        assert_eq!(
+            plan.homing()[1].location,
+            crate::call_plan::AbiSlotLocation::GpReg(1)
+        );
+    }
+
+    #[test]
+    fn descriptorless_fallback_uses_target_gp_bank_width() {
+        let cfg = Cfg::new(Type::UNIT, 1, 8, "synthetic-arm".into(), vec![false; 8]);
+        let arm = ParamStoragePlan::plan(
+            &cfg,
+            &pool(),
+            false,
+            crate::call_plan::AbiRegisterBanks { gp: 8, fp: 8 },
+        );
+        assert_eq!(arm.homing().len(), 8);
+        assert_eq!(
+            arm.homing()[6].location,
+            crate::call_plan::AbiSlotLocation::GpReg(6)
+        );
+        assert_eq!(
+            arm.homing()[7].location,
+            crate::call_plan::AbiSlotLocation::GpReg(7)
+        );
+
+        let x86 = ParamStoragePlan::plan(
+            &cfg,
+            &pool(),
+            false,
+            crate::call_plan::AbiRegisterBanks { gp: 6, fp: 8 },
+        );
+        assert_eq!(
+            x86.homing()[6].location,
+            crate::call_plan::AbiSlotLocation::Stack(0)
+        );
+        assert_eq!(
+            x86.homing()[7].location,
+            crate::call_plan::AbiSlotLocation::Stack(1)
+        );
     }
 
     #[test]
@@ -422,13 +515,16 @@ mod tests {
         push_param(&mut cfg, entry, 0);
 
         let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
-        assert_eq!(plan.slot(0), ParamSlotStorage::Register { abi_index: 0 });
-        assert_eq!(plan.slot(1), ParamSlotStorage::Register { abi_index: 1 });
+        assert!(matches!(plan.slot(0), ParamSlotStorage::Register { .. }));
+        assert!(matches!(plan.slot(1), ParamSlotStorage::Register { .. }));
         assert!(plan.is_used(0));
         assert!(!plan.is_used(1));
         assert_eq!(plan.homed_area_slots(), 0);
         assert!(plan.homing().is_empty());
-        assert_eq!(plan.entry_copies(&cfg).collect::<Vec<_>>(), [(0, 0)]);
+        assert_eq!(
+            plan.entry_copies(&cfg).next().unwrap().2,
+            crate::call_plan::AbiSlotLocation::GpReg(0)
+        );
     }
 
     #[test]
@@ -440,7 +536,13 @@ mod tests {
         push_param(&mut cfg, entry, 0);
 
         let plan = ParamStoragePlan::plan(&cfg, &pool(), true, 6);
-        assert_eq!(plan.slot(0), ParamSlotStorage::Register { abi_index: 1 });
+        assert!(matches!(
+            plan.slot(0),
+            ParamSlotStorage::Register {
+                location: crate::call_plan::AbiSlotLocation::GpReg(1),
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -469,8 +571,14 @@ mod tests {
         assert_eq!(plan.slot(7), ParamSlotStorage::Frame { area_slot: 1 });
         assert_eq!(plan.homed_area_slots(), 2);
         // The homed entries still name their original incoming ABI indices.
-        assert_eq!(plan.homing()[0].abi_start, 6);
-        assert_eq!(plan.homing()[1].abi_start, 7);
+        assert_eq!(
+            plan.homing()[0].location,
+            crate::call_plan::AbiSlotLocation::Stack(0)
+        );
+        assert_eq!(
+            plan.homing()[1].location,
+            crate::call_plan::AbiSlotLocation::Stack(1)
+        );
 
         // With eight argument registers (AArch64) everything is register-only.
         let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 8);
@@ -523,7 +631,13 @@ mod tests {
         let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
         assert_eq!(plan.slot(0), ParamSlotStorage::Frame { area_slot: 0 });
         assert_eq!(plan.slot(1), ParamSlotStorage::Frame { area_slot: 1 });
-        assert_eq!(plan.slot(2), ParamSlotStorage::Register { abi_index: 2 });
+        assert!(matches!(
+            plan.slot(2),
+            ParamSlotStorage::Register {
+                location: crate::call_plan::AbiSlotLocation::GpReg(2),
+                ..
+            }
+        ));
         assert_eq!(plan.homed_area_slots(), 2);
     }
 
@@ -583,9 +697,18 @@ mod tests {
         );
 
         let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
-        assert_eq!(plan.slot(0), ParamSlotStorage::Register { abi_index: 0 });
+        assert!(matches!(
+            plan.slot(0),
+            ParamSlotStorage::Register {
+                location: crate::call_plan::AbiSlotLocation::GpReg(0),
+                ..
+            }
+        ));
         // The pointer is copied at entry whether or not a Param inst exists.
-        assert_eq!(plan.entry_copies(&cfg).collect::<Vec<_>>(), [(0, 0)]);
+        assert_eq!(
+            plan.entry_copies(&cfg).next().unwrap().2,
+            crate::call_plan::AbiSlotLocation::GpReg(0)
+        );
     }
 
     /// The direct-slot cleanup convention (destructors, drop glue) describes
@@ -660,12 +783,14 @@ mod tests {
                 start_slot: 0,
                 slot_count: 2,
                 crossing_regs: 2,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp; 2],
                 ty: None,
             },
             SourceParamAbi {
                 start_slot: 2,
                 slot_count: 1,
                 crossing_regs: 1,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             },
         ]);
@@ -685,6 +810,6 @@ mod tests {
         assert_eq!(plan.slot(1), ParamSlotStorage::Frame { area_slot: 1 });
         assert_eq!(plan.slot(2), ParamSlotStorage::Frame { area_slot: 2 });
         assert_eq!(plan.homed_area_slots(), 3);
-        assert_eq!(plan.homing().len(), 2);
+        assert_eq!(plan.homing().len(), 3);
     }
 }

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -75,7 +75,14 @@ pub(crate) trait PlaceLowerBackend: SlotBackend {
     /// AArch64 has separate base-only and base-plus-zero MIR variants. Keeping
     /// this leaf preserves the pre-extraction choice at simple and dynamically
     /// addressed place reads.
-    fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg);
+    fn emit_load_ptr_base(
+        &mut self,
+        dst: VReg,
+        ptr: VReg,
+        float_width: Option<crate::value_plan::FloatWidth>,
+    );
+    fn emit_float_load_slot(&mut self, dst: VReg, slot: u32, width: crate::value_plan::FloatWidth);
+    fn emit_float_store_slot(&mut self, src: VReg, slot: u32, width: crate::value_plan::FloatWidth);
 }
 
 fn resolved_offsets<B: PlaceLowerBackend + ?Sized>(
@@ -261,6 +268,7 @@ pub(crate) fn lower_place_read_plan<B: PlaceLowerBackend>(
     place: &ResolvedPlace,
     ty: Type,
 ) {
+    let float_width = crate::value_plan::float_width(ty);
     if b.ctx().type_slot_count(ty) == 0 {
         resolved_offsets(b, place, true);
         b.emit_zero_sized_place(dst);
@@ -268,25 +276,45 @@ pub(crate) fn lower_place_read_plan<B: PlaceLowerBackend>(
     }
     if place.projections.is_empty() {
         match place.base {
-            crate::value_plan::PlaceBasePlan::Local(slot) => b.emit_load_slot(dst, slot),
+            crate::value_plan::PlaceBasePlan::Local(slot) => match float_width {
+                Some(width) => b.emit_float_load_slot(dst, slot, width),
+                None => b.emit_load_slot(dst, slot),
+            },
             crate::value_plan::PlaceBasePlan::Param { slot, by_ref: true } => {
                 let ptr = b.ensure_by_ref_param_ptr(slot);
-                b.emit_load_ptr_base(dst, ptr);
+                b.emit_load_ptr_base(dst, ptr, float_width);
             }
             crate::value_plan::PlaceBasePlan::Param {
                 slot,
                 by_ref: false,
-            } => b.emit_load_slot(dst, b.ctx().param_frame_slot(slot)),
-            crate::value_plan::PlaceBasePlan::Pointer(ptr) => b.emit_load_ptr_base(dst, ptr),
+            } => match float_width {
+                Some(width) => b.emit_float_load_slot(dst, b.ctx().param_frame_slot(slot), width),
+                None => b.emit_load_slot(dst, b.ctx().param_frame_slot(slot)),
+            },
+            crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
+                b.emit_load_ptr_base(dst, ptr, float_width)
+            }
         }
         return;
     }
     let offsets = resolved_offsets(b, place, true);
     match resolved_access(b, place, offsets) {
-        ProjectedAccess::FrameSlot(slot) => b.emit_load_slot(dst, slot),
-        ProjectedAccess::PointerAddr(ptr) => b.emit_load_ptr_base(dst, ptr),
+        ProjectedAccess::FrameSlot(slot) => match float_width {
+            Some(width) => b.emit_float_load_slot(dst, slot, width),
+            None => b.emit_load_slot(dst, slot),
+        },
+        ProjectedAccess::PointerAddr(ptr) => b.emit_load_ptr_base(dst, ptr, float_width),
         ProjectedAccess::PointerOffset { ptr, byte_offset } => {
-            b.emit_load_through_ptr(dst, ptr, byte_offset)
+            if let Some(width) = float_width {
+                let addr = b.alloc_vreg();
+                b.emit_reg_move(addr, ptr);
+                if byte_offset != 0 {
+                    b.emit_addr_add_imm(addr, byte_offset);
+                }
+                b.emit_load_ptr_base(dst, addr, Some(width));
+            } else {
+                b.emit_load_through_ptr(dst, ptr, byte_offset)
+            }
         }
     }
 }
@@ -295,6 +323,7 @@ pub(crate) fn lower_place_write_plan<B: PlaceLowerBackend>(
     b: &mut B,
     place: &ResolvedPlace,
     vals: &[VReg],
+    float_width: Option<crate::value_plan::FloatWidth>,
 ) {
     if vals.is_empty() {
         resolved_offsets(b, place, true);
@@ -302,27 +331,64 @@ pub(crate) fn lower_place_write_plan<B: PlaceLowerBackend>(
     }
     if place.projections.is_empty() {
         match place.base {
+            crate::value_plan::PlaceBasePlan::Local(slot)
+                if vals.len() == 1 && float_width.is_some() =>
+            {
+                b.emit_float_store_slot(vals[0], slot, float_width.unwrap())
+            }
             crate::value_plan::PlaceBasePlan::Local(slot) => agg_slots::store_slots(b, vals, slot),
             crate::value_plan::PlaceBasePlan::Param { slot, by_ref: true } => {
                 let ptr = b.ensure_by_ref_param_ptr(slot);
-                agg_slots::store_slots_through_ptr(b, vals, ptr, 0);
+                if vals.len() == 1
+                    && let Some(width) = float_width
+                {
+                    b.emit_float_store_through_ptr(vals[0], ptr, 0, width);
+                } else {
+                    agg_slots::store_slots_through_ptr(b, vals, ptr, 0);
+                }
             }
+            crate::value_plan::PlaceBasePlan::Param {
+                slot,
+                by_ref: false,
+            } if vals.len() == 1 && float_width.is_some() => b.emit_float_store_slot(
+                vals[0],
+                b.ctx().param_frame_slot(slot),
+                float_width.unwrap(),
+            ),
             crate::value_plan::PlaceBasePlan::Param {
                 slot,
                 by_ref: false,
             } => agg_slots::store_slots(b, vals, b.ctx().param_frame_slot(slot)),
             crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
-                agg_slots::store_slots_through_ptr(b, vals, ptr, 0)
+                if vals.len() == 1
+                    && let Some(width) = float_width
+                {
+                    b.emit_float_store_through_ptr(vals[0], ptr, 0, width)
+                } else {
+                    agg_slots::store_slots_through_ptr(b, vals, ptr, 0)
+                }
             }
         }
         return;
     }
     let offsets = resolved_offsets(b, place, true);
     match resolved_access(b, place, offsets) {
+        ProjectedAccess::FrameSlot(slot) if vals.len() == 1 && float_width.is_some() => {
+            b.emit_float_store_slot(vals[0], slot, float_width.unwrap())
+        }
         ProjectedAccess::FrameSlot(slot) => agg_slots::store_slots_at_low(b, vals, slot),
+        ProjectedAccess::PointerAddr(ptr) if vals.len() == 1 && float_width.is_some() => {
+            b.emit_float_store_through_ptr(vals[0], ptr, 0, float_width.unwrap())
+        }
         ProjectedAccess::PointerAddr(ptr) => agg_slots::store_slots_through_ptr(b, vals, ptr, 0),
         ProjectedAccess::PointerOffset { ptr, byte_offset } => {
-            agg_slots::store_slots_through_ptr(b, vals, ptr, byte_offset)
+            if vals.len() == 1
+                && let Some(width) = float_width
+            {
+                b.emit_float_store_through_ptr(vals[0], ptr, byte_offset, width)
+            } else {
+                agg_slots::store_slots_through_ptr(b, vals, ptr, byte_offset)
+            }
         }
     }
 }
@@ -562,6 +628,7 @@ mod tests {
                 start_slot: slot,
                 slot_count: 1,
                 crossing_regs: 1,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()

--- a/crates/rue-codegen/src/runtime_call_plan.rs
+++ b/crates/rue-codegen/src/runtime_call_plan.rs
@@ -239,6 +239,7 @@ impl RuntimeCallPlan {
                     value,
                     slot_count,
                     is_multislot_aggregate,
+                    ..
                 } => {
                     if *slot_count == 0 {
                         continue;

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -737,6 +737,7 @@ mod tests {
                 start_slot: slot,
                 slot_count: 1,
                 crossing_regs: 1,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()
@@ -1607,6 +1608,7 @@ mod tests {
             start_slot: 0,
             slot_count: 3,
             crossing_regs: 1,
+            crossing_classes: vec![rue_air::NativeArgClass::Gp],
             ty: Some(shape_ty),
         }]);
         let entry = cfg.new_block();
@@ -1780,6 +1782,7 @@ mod tests {
             start_slot: 0,
             slot_count: 2,
             crossing_regs: 1,
+            crossing_classes: vec![rue_air::NativeArgClass::Gp],
             ty: Some(pair_ty),
         }]);
         let entry = cfg.new_block();

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -24,6 +24,7 @@ pub struct SlotMove {
     pub slot_index: u32,
     pub source: VReg,
     pub destination: VReg,
+    pub float_width: Option<crate::value_plan::FloatWidth>,
 }
 
 /// Normalized work for one CFG successor edge.
@@ -49,6 +50,7 @@ pub enum ReturnValuePlan {
     ZeroSized,
     Scalar {
         value: VReg,
+        float_width: Option<crate::value_plan::FloatWidth>,
     },
     Aggregate {
         slots: Vec<VReg>,
@@ -328,11 +330,14 @@ fn moves_for_edge<A: TerminatorAdapter>(
                     slot_index: 0,
                     source: source.primary,
                     destination: destination.primary,
+                    float_width: crate::value_plan::float_width(ctx.cfg.get_inst(value).ty),
                 });
             }
             ValueShape::CompleteAggregate { slot_count } => {
                 assert_eq!(source.slots.len(), slot_count as usize);
                 assert_eq!(destination.slots.len(), slot_count as usize);
+                let leaf_types =
+                    crate::types::aggregate_leaf_types(ctx.type_pool, ctx.cfg.get_inst(value).ty);
                 moves.extend(
                     source
                         .slots
@@ -345,6 +350,7 @@ fn moves_for_edge<A: TerminatorAdapter>(
                             slot_index: slot_index as u32,
                             source,
                             destination,
+                            float_width: crate::value_plan::float_width(leaf_types[slot_index]),
                         }),
                 );
             }
@@ -385,6 +391,7 @@ fn return_value<A: TerminatorAdapter>(
         ValueShape::ZeroSized => ReturnValuePlan::ZeroSized,
         ValueShape::Scalar => ReturnValuePlan::Scalar {
             value: materialized.primary,
+            float_width: crate::value_plan::float_width(ctx.cfg.get_inst(value).ty),
         },
         ValueShape::CompleteAggregate { slot_count } => {
             assert_eq!(materialized.slots.len(), slot_count as usize);
@@ -1475,6 +1482,7 @@ mod tests {
                     slot_index: 0,
                     source: VReg::new(1),
                     destination: VReg::new(2),
+                    float_width: None,
                 }],
                 fallthrough: true,
             },

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -140,11 +140,12 @@ pub fn slot_needs_wide_compare(ty: Type) -> bool {
 /// - **array**: the element leaf types repeated `length` times
 /// - **payload enum**: slot 0 is the discriminant (a narrow tag), followed by
 ///   the payload area sized to the widest variant. For each payload slot we
-///   pick a representative leaf type that is wide if *any* variant places a
-///   wide leaf there, so a mixed `i64`/`i32` payload slot is compared at 64
-///   bits (narrow values are zero-extended in their slot, so a wide compare of
-///   a narrow value is still correct). Padding slots beyond every variant's
-///   payload are zero and compare as narrow.
+///   use a canonical 64-bit GP bit carrier. A union slot may hold values from
+///   different register classes or FP widths depending on the active variant,
+///   so choosing any variant's semantic leaf type here would make the value's
+///   register class order-dependent. Construction and extraction perform the
+///   explicit class-safe bit moves, while equality uses the active variant's
+///   semantic payload types.
 /// - **unit / never**: zero slots (no entries)
 pub fn aggregate_leaf_types(type_pool: &FrozenTypeInternPool, ty: Type) -> Vec<Type> {
     let mut out = Vec::new();
@@ -172,25 +173,19 @@ fn push_leaf_types(type_pool: &FrozenTypeInternPool, ty: Type, out: &mut Vec<Typ
             // tag and any padding are materialized as clean (zero-extended)
             // values, so a narrow compare of the tag is correct.
             out.push(Type::I32);
-            // Payload area sized to the widest variant. For each slot position,
-            // prefer a wide leaf type if any variant carries one there.
+            // Payload area sized to the widest variant. Every union position is
+            // represented by a GP bit carrier; its semantic interpretation is
+            // selected by the runtime tag.
             let enum_def = type_pool.enum_def(enum_id);
-            let mut per_slot: Vec<Type> = Vec::new();
+            let mut payload_slots = 0usize;
             for v in 0..enum_def.variant_count() {
                 let mut variant_leaves: Vec<Type> = Vec::new();
                 for &pty in enum_def.variant_payload(v) {
                     push_leaf_types(type_pool, pty, &mut variant_leaves);
                 }
-                for (i, leaf) in variant_leaves.into_iter().enumerate() {
-                    if i >= per_slot.len() {
-                        per_slot.push(leaf);
-                    } else if slot_needs_wide_compare(leaf) && !slot_needs_wide_compare(per_slot[i])
-                    {
-                        per_slot[i] = leaf;
-                    }
-                }
+                payload_slots = payload_slots.max(variant_leaves.len());
             }
-            out.extend(per_slot);
+            out.extend(std::iter::repeat_n(Type::I64, payload_slots));
         }
         _ => out.push(ty),
     }
@@ -316,16 +311,18 @@ pub(crate) fn narrow_scalar_access(
 /// the compact gate. Full eight-byte leaves (`i64`/`u64`/pointers) report width
 /// 8; a load of them needs no narrowing. Returns `None` for aggregate,
 /// zero-sized, or compile-time-only types, which have no scalar leaf.
-fn scalar_physical_access(ty: Type) -> Option<(u8, bool)> {
+fn scalar_physical_access(ty: Type) -> Option<(u8, bool, Option<crate::value_plan::FloatWidth>)> {
     match ty.kind() {
-        TypeKind::I8 => Some((1, true)),
-        TypeKind::U8 | TypeKind::Bool => Some((1, false)),
-        TypeKind::I16 => Some((2, true)),
-        TypeKind::U16 => Some((2, false)),
-        TypeKind::I32 => Some((4, true)),
-        TypeKind::U32 => Some((4, false)),
+        TypeKind::I8 => Some((1, true, None)),
+        TypeKind::U8 | TypeKind::Bool => Some((1, false, None)),
+        TypeKind::I16 => Some((2, true, None)),
+        TypeKind::U16 => Some((2, false, None)),
+        TypeKind::I32 => Some((4, true, None)),
+        TypeKind::U32 => Some((4, false, None)),
+        TypeKind::F32 => Some((4, false, Some(crate::value_plan::FloatWidth::F32))),
+        TypeKind::F64 => Some((8, false, Some(crate::value_plan::FloatWidth::F64))),
         TypeKind::I64 | TypeKind::U64 | TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => {
-            Some((8, false))
+            Some((8, false, None))
         }
         _ => None,
     }
@@ -348,6 +345,10 @@ pub struct PhysicalEnumSlot {
     pub byte_offset: i32,
     /// Narrow (1/2/4-byte) access, or `None` for a full eight-byte slot.
     pub access: Option<NarrowScalar>,
+    pub float_width: Option<crate::value_plan::FloatWidth>,
+    /// This leaf occupies an enum union payload slot whose register value is a
+    /// canonical GP bit carrier, regardless of the active variant's semantics.
+    pub bit_carrier: bool,
 }
 
 /// The internal-slot → physical-byte map for whole-enum memory marshalling under
@@ -398,6 +399,8 @@ pub(crate) fn enum_physical_slot_map(
             width: tag_width,
             signed: false,
         }),
+        float_width: None,
+        bit_carrier: false,
     }];
 
     // Payload union positions, one per flattened scalar LEAF position across all
@@ -415,6 +418,7 @@ pub(crate) fn enum_physical_slot_map(
         offset: i32,
         width: u8,
         signed: bool,
+        float_width: Option<crate::value_plan::FloatWidth>,
     }
     let def = type_pool.enum_def(enum_id);
     let mut positions: Vec<Position> = Vec::new();
@@ -441,14 +445,25 @@ pub(crate) fn enum_physical_slot_map(
                     // Variant-dependent leaf offset: not a single memory image.
                     return None;
                 }
+                // FP width and register-class interpretation are semantic, not
+                // a widest-storage property. A mixed f32/f64 or float/integer
+                // union therefore requires tag-dispatched marshalling.
+                if pos.float_width != leaf.float_width {
+                    return None;
+                }
                 match width.cmp(&pos.width) {
                     std::cmp::Ordering::Greater => {
                         pos.width = width;
                         pos.signed = signed;
+                        pos.float_width = leaf.float_width;
                     }
                     // Equal widest widths must agree on signedness, or the load
                     // extension of the union slot would be ambiguous.
-                    std::cmp::Ordering::Equal if pos.signed != signed => return None,
+                    std::cmp::Ordering::Equal
+                        if pos.signed != signed || pos.float_width != leaf.float_width =>
+                    {
+                        return None;
+                    }
                     _ => {}
                 }
             } else {
@@ -456,6 +471,7 @@ pub(crate) fn enum_physical_slot_map(
                     offset,
                     width,
                     signed,
+                    float_width: leaf.float_width,
                 });
             }
         }
@@ -479,6 +495,8 @@ pub(crate) fn enum_physical_slot_map(
                     signed: pos.signed,
                 })
             },
+            float_width: pos.float_width,
+            bit_carrier: true,
         });
     }
 
@@ -556,6 +574,8 @@ fn push_physical_slots(
                 out.push(PhysicalEnumSlot {
                     byte_offset: base_offset + slot.byte_offset,
                     access: slot.access,
+                    float_width: slot.float_width,
+                    bit_carrier: slot.bit_carrier,
                 });
             }
             Some(())
@@ -575,10 +595,12 @@ fn push_physical_slots(
             Some(())
         }
         _ => {
-            let (width, signed) = scalar_physical_access(ty)?;
+            let (width, signed, float_width) = scalar_physical_access(ty)?;
             out.push(PhysicalEnumSlot {
                 byte_offset: base_offset,
                 access: (width != 8).then_some(NarrowScalar { width, signed }),
+                float_width,
+                bit_carrier: false,
             });
             Some(())
         }
@@ -773,6 +795,8 @@ fn push_image_segments(
                         phys: PhysicalEnumSlot {
                             byte_offset: base_offset + slot.byte_offset,
                             access: slot.access,
+                            float_width: slot.float_width,
+                            bit_carrier: slot.bit_carrier,
                         },
                     });
                     *slot_cursor += 1;
@@ -840,12 +864,14 @@ fn push_image_segments(
             Some(())
         }
         _ => {
-            let (width, signed) = scalar_physical_access(ty)?;
+            let (width, signed, float_width) = scalar_physical_access(ty)?;
             out.push(ImageSeg::Leaf {
                 slot: *slot_cursor,
                 phys: PhysicalEnumSlot {
                     byte_offset: base_offset,
                     access: (width != 8).then_some(NarrowScalar { width, signed }),
+                    float_width,
+                    bit_carrier: false,
                 },
             });
             *slot_cursor += 1;

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -79,7 +79,7 @@ pub enum ResidualValuePlan {
         op: ComparisonOp,
         lhs: MaterializedValue,
         rhs: MaterializedValue,
-        leaf_types: Vec<Type>,
+        equality_leaves: Vec<crate::aggregate_eq::EqualityLeaf>,
         runtime_call: Option<crate::runtime_call_plan::RuntimeCallPlan>,
     },
     Bitwise {
@@ -103,19 +103,27 @@ pub enum ResidualValuePlan {
         slot: u32,
         init: MaterializedValue,
         init_shape: ValueShape,
+        float_width: Option<FloatWidth>,
+        leaf_types: Vec<Type>,
     },
     Load {
         slot: u32,
+        float_width: Option<FloatWidth>,
+        leaf_types: Vec<Type>,
     },
     Store {
         destination: StoreDestination,
         value: MaterializedValue,
         value_shape: ValueShape,
+        float_width: Option<FloatWidth>,
+        leaf_types: Vec<Type>,
     },
     ParamStore {
         param_slot: u32,
         value: MaterializedValue,
         value_shape: ValueShape,
+        float_width: Option<FloatWidth>,
+        leaf_types: Vec<Type>,
     },
     StructInit {
         struct_id: StructId,
@@ -127,8 +135,12 @@ pub enum ResidualValuePlan {
     EnumVariant {
         enum_id: EnumId,
         variant_index: u32,
-        payload: Vec<(MaterializedValue, ValueShape)>,
+        payload: Vec<(MaterializedValue, ValueShape, Vec<Type>)>,
         total_slots: u32,
+        /// Canonical type of every decomposed enum slot. The discriminant and
+        /// union payload are GP values; payload floats cross the class boundary
+        /// through explicit bit-carrier moves selected by the active variant.
+        leaf_types: Vec<Type>,
         /// Under the compact layout (ADR-0052 ruling 5, RUE-1007/RUE-1014), the
         /// payload slots not written by this (shorter) variant are zeroed so a
         /// variant-independent memory image marshalled from this value carries no
@@ -140,6 +152,7 @@ pub enum ResidualValuePlan {
         base_slots: Vec<VReg>,
         field_offset: u32,
         field_slots: u32,
+        field_types: Vec<Type>,
     },
     IntCast {
         value: VReg,
@@ -164,6 +177,7 @@ pub enum ResidualValuePlan {
         place: PlacePlan,
         value: MaterializedValue,
         value_shape: ValueShape,
+        float_width: Option<FloatWidth>,
     },
 }
 
@@ -199,6 +213,30 @@ pub struct ArithmeticPlan {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArithmeticOperation {
+    FloatAdd {
+        lhs: VReg,
+        rhs: VReg,
+        width: FloatWidth,
+    },
+    FloatSub {
+        lhs: VReg,
+        rhs: VReg,
+        width: FloatWidth,
+    },
+    FloatMul {
+        lhs: VReg,
+        rhs: VReg,
+        width: FloatWidth,
+    },
+    FloatDiv {
+        lhs: VReg,
+        rhs: VReg,
+        width: FloatWidth,
+    },
+    FloatNeg {
+        value: VReg,
+        width: FloatWidth,
+    },
     Add {
         lhs: VReg,
         rhs: VReg,
@@ -250,6 +288,7 @@ pub struct IntrinsicArgPlan {
     pub integer_extension: IntegerExtension,
     pub place: Option<PlacePlan>,
     pub debug: DebugValuePlan,
+    pub ty: Type,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -395,6 +434,7 @@ pub trait ValueLowerAdapter:
 {
     fn value_is_lowered(&self, value: CfgValue) -> bool;
     fn reserve_value_result(&mut self) -> VReg;
+    fn reserve_typed_value_result(&mut self, ty: Type) -> VReg;
     fn resolve_symbol(&self, symbol: Spur) -> String;
     /// Whether `machine_symbol` (already resolved via
     /// [`resolve_symbol`](Self::resolve_symbol)) names an `extern "C"` foreign
@@ -404,7 +444,7 @@ pub trait ValueLowerAdapter:
     /// on AArch64. Names the classifier that governs a foreign-call boundary.
     fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor;
     fn resolve_named_symbol(&self, symbol: &str) -> String;
-    fn call_arg_register_budget(&self) -> usize;
+    fn call_arg_register_banks(&self) -> crate::call_plan::AbiRegisterBanks;
     fn return_register_budget(&self) -> u32;
     fn emit_value(&mut self, plan: ValueEmissionPlan) -> ValueResult;
     fn emit_call(&mut self, plan: CallPlan) -> ValueResult;
@@ -461,6 +501,76 @@ impl ValueShape {
 pub struct IntegerWidth {
     pub bits: u32,
     pub signed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloatWidth {
+    F32,
+    F64,
+}
+
+pub fn float_width(ty: Type) -> Option<FloatWidth> {
+    match ty.kind() {
+        TypeKind::F32 => Some(FloatWidth::F32),
+        TypeKind::F64 => Some(FloatWidth::F64),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloatToIntGuardRelation {
+    OrderedGreaterEqual,
+    OrderedLess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FloatToIntGuard {
+    pub bound_bits: u64,
+    pub success: FloatToIntGuardRelation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedFloatToIntPlan {
+    pub guards: [FloatToIntGuard; 2],
+    pub trap_call: crate::runtime_call_plan::RuntimeCallPlan,
+}
+
+/// Plan the ordered guard sequence required before a truncating float-to-int
+/// instruction. The lower guard rejects NaN and values below the inclusive
+/// minimum; the upper guard rejects NaN and values at or above the exclusive
+/// maximum. Targets only select their branch spelling for these relations.
+pub fn checked_float_to_int_plan(
+    width: FloatWidth,
+    integer: IntegerWidth,
+) -> CheckedFloatToIntPlan {
+    assert!(
+        integer.signed,
+        "ADR-0065 phases 5-6 support signed integer conversion"
+    );
+    let lower = -(2.0f64).powi((integer.bits - 1) as i32);
+    let upper = (2.0f64).powi((integer.bits - 1) as i32);
+    let bounds = match width {
+        FloatWidth::F32 => (
+            (lower as f32).to_bits() as u64,
+            (upper as f32).to_bits() as u64,
+        ),
+        FloatWidth::F64 => (lower.to_bits(), upper.to_bits()),
+    };
+    CheckedFloatToIntPlan {
+        guards: [
+            FloatToIntGuard {
+                bound_bits: bounds.0,
+                success: FloatToIntGuardRelation::OrderedGreaterEqual,
+            },
+            FloatToIntGuard {
+                bound_bits: bounds.1,
+                success: FloatToIntGuardRelation::OrderedLess,
+            },
+        ],
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+            rue_runtime_abi::RuntimeHelperId::Overflow,
+        ),
+    }
 }
 
 impl From<IntegerType> for IntegerWidth {
@@ -540,6 +650,7 @@ pub enum MaterializationRequirement {
 pub enum ComparisonPreparation {
     Unit,
     Scalar { width: IntegerWidth },
+    Float { width: FloatWidth },
     Aggregate { slot_count: u32 },
     StringContent { slot_count: u32 },
 }
@@ -642,6 +753,8 @@ impl ValuePlan {
                     })
                 } else if lhs_ty == Type::UNIT {
                     Some(ComparisonPreparation::Unit)
+                } else if let Some(width) = float_width(lhs_ty) {
+                    Some(ComparisonPreparation::Float { width })
                 } else {
                     Some(ComparisonPreparation::Scalar {
                         width: comparison_integer_width(lhs_ty),
@@ -752,8 +865,8 @@ fn comparison_plan<A: ValueLowerAdapter>(
     rhs: CfgValue,
 ) -> ResidualValuePlan {
     let lhs_ty = ctx.cfg.get_inst(lhs).ty;
-    let leaf_types = if ctx.is_multislot_aggregate(lhs_ty) {
-        crate::types::aggregate_leaf_types(ctx.type_pool, lhs_ty)
+    let equality_leaves = if ctx.is_multislot_aggregate(lhs_ty) {
+        crate::aggregate_eq::equality_leaves(ctx.type_pool, lhs_ty)
     } else {
         Vec::new()
     };
@@ -786,7 +899,7 @@ fn comparison_plan<A: ValueLowerAdapter>(
         op,
         lhs,
         rhs,
-        leaf_types,
+        equality_leaves,
         runtime_call,
     }
 }
@@ -1060,19 +1173,39 @@ fn residual_plan<A: ValueLowerAdapter>(
             slot: ctx.frame_slot(slot),
             init: operand(ctx, adapter, init),
             init_shape: ValuePlan::for_value(ctx, init).shape,
+            float_width: float_width(ctx.cfg.get_inst(init).ty),
+            leaf_types: crate::types::aggregate_leaf_types(
+                ctx.type_pool,
+                ctx.cfg.get_inst(init).ty,
+            ),
         },
         ResidualInput::Load { slot } => ResidualValuePlan::Load {
             slot: ctx.frame_slot(slot),
+            float_width: float_width(ctx.cfg.get_inst(value).ty),
+            leaf_types: crate::types::aggregate_leaf_types(
+                ctx.type_pool,
+                ctx.cfg.get_inst(value).ty,
+            ),
         },
         ResidualInput::Store { slot, value } => ResidualValuePlan::Store {
             destination: store_destination(ctx, slot),
             value: operand(ctx, adapter, value),
             value_shape: ValuePlan::for_value(ctx, value).shape,
+            float_width: float_width(ctx.cfg.get_inst(value).ty),
+            leaf_types: crate::types::aggregate_leaf_types(
+                ctx.type_pool,
+                ctx.cfg.get_inst(value).ty,
+            ),
         },
         ResidualInput::ParamStore { param_slot, value } => ResidualValuePlan::ParamStore {
             param_slot,
             value: operand(ctx, adapter, value),
             value_shape: ValuePlan::for_value(ctx, value).shape,
+            float_width: float_width(ctx.cfg.get_inst(value).ty),
+            leaf_types: crate::types::aggregate_leaf_types(
+                ctx.type_pool,
+                ctx.cfg.get_inst(value).ty,
+            ),
         },
         ResidualInput::StructInit { struct_id } => ResidualValuePlan::StructInit {
             struct_id,
@@ -1118,10 +1251,18 @@ fn residual_plan<A: ValueLowerAdapter>(
                     (
                         operand(ctx, adapter, field),
                         ValuePlan::for_value(ctx, field).shape,
+                        crate::types::aggregate_leaf_types(
+                            ctx.type_pool,
+                            ctx.cfg.get_inst(field).ty,
+                        ),
                     )
                 })
                 .collect(),
             total_slots: ctx.type_slot_count(ctx.cfg.get_inst(value).ty),
+            leaf_types: crate::types::aggregate_leaf_types(
+                ctx.type_pool,
+                ctx.cfg.get_inst(value).ty,
+            ),
             // ADR-0052 ruling 5: the compact image zeroes padding and unused
             // payload bytes deterministically on construction.
             zero_unused_payload: true,
@@ -1142,6 +1283,10 @@ fn residual_plan<A: ValueLowerAdapter>(
                     field_index,
                 ),
                 field_slots: ctx.type_slot_count(ctx.cfg.get_inst(value).ty),
+                field_types: crate::types::aggregate_leaf_types(
+                    ctx.type_pool,
+                    ctx.cfg.get_inst(value).ty,
+                ),
             }
         }
         ResidualInput::IntCast { value, from_ty } => ResidualValuePlan::IntCast {
@@ -1173,6 +1318,7 @@ fn residual_plan<A: ValueLowerAdapter>(
             },
             value: operand(ctx, adapter, stored),
             value_shape: ValuePlan::for_value(ctx, stored).shape,
+            float_width: float_width(ctx.cfg.get_inst(stored).ty),
         },
     }
 }
@@ -1247,11 +1393,19 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
     }
     match &inst.data {
         CfgInstData::Add(lhs, rhs) => {
-            let width = policy.integer_width.expect("add width");
             let lhs = operand(ctx, adapter, *lhs).primary;
             let rhs = operand(ctx, adapter, *rhs).primary;
+            let operation = if let Some(width) = float_width(inst.ty) {
+                ArithmeticOperation::FloatAdd { lhs, rhs, width }
+            } else {
+                ArithmeticOperation::Add {
+                    lhs,
+                    rhs,
+                    width: policy.integer_width.expect("add width"),
+                }
+            };
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation: ArithmeticOperation::Add { lhs, rhs, width },
+                operation,
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
                     RuntimeHelperId::Overflow,
                 ),
@@ -1264,11 +1418,19 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             Some(ValueKind::BinaryArithmetic)
         }
         CfgInstData::Sub(lhs, rhs) => {
-            let width = policy.integer_width.expect("sub width");
             let lhs = operand(ctx, adapter, *lhs).primary;
             let rhs = operand(ctx, adapter, *rhs).primary;
+            let operation = if let Some(width) = float_width(inst.ty) {
+                ArithmeticOperation::FloatSub { lhs, rhs, width }
+            } else {
+                ArithmeticOperation::Sub {
+                    lhs,
+                    rhs,
+                    width: policy.integer_width.expect("sub width"),
+                }
+            };
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation: ArithmeticOperation::Sub { lhs, rhs, width },
+                operation,
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
                     RuntimeHelperId::Overflow,
                 ),
@@ -1281,9 +1443,27 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             Some(ValueKind::BinaryArithmetic)
         }
         CfgInstData::Mul(lhs, rhs) => {
-            let width = policy.integer_width.expect("mul width");
             let lhs_result = operand(ctx, adapter, *lhs);
             let rhs_result = operand(ctx, adapter, *rhs);
+            if let Some(width) = float_width(inst.ty) {
+                let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
+                    operation: ArithmeticOperation::FloatMul {
+                        lhs: lhs_result.primary,
+                        rhs: rhs_result.primary,
+                        width,
+                    },
+                    overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                        RuntimeHelperId::Overflow,
+                    ),
+                    div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                        RuntimeHelperId::DivByZero,
+                    ),
+                    wrap: false,
+                });
+                cache_result(adapter, value, result);
+                return Some(ValueKind::BinaryArithmetic);
+            }
+            let width = policy.integer_width.expect("mul width");
             let shift = if width.bits >= 32 {
                 power_of_two_shift(ctx, *lhs)
                     .map(|shift| (rhs_result.primary, shift))
@@ -1372,11 +1552,19 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             Some(ValueKind::BinaryArithmetic)
         }
         CfgInstData::Div(lhs, rhs) => {
-            let width = policy.integer_width.expect("div width");
             let lhs = operand(ctx, adapter, *lhs).primary;
             let rhs = operand(ctx, adapter, *rhs).primary;
+            let operation = if let Some(width) = float_width(inst.ty) {
+                ArithmeticOperation::FloatDiv { lhs, rhs, width }
+            } else {
+                ArithmeticOperation::Div {
+                    lhs,
+                    rhs,
+                    width: policy.integer_width.expect("div width"),
+                }
+            };
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation: ArithmeticOperation::Div { lhs, rhs, width },
+                operation,
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
                     RuntimeHelperId::Overflow,
                 ),
@@ -1406,13 +1594,20 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             Some(ValueKind::BinaryArithmetic)
         }
         CfgInstData::Neg(operand_value) => {
-            let width = policy.integer_width.expect("neg width");
             let operand_vreg = operand(ctx, adapter, *operand_value).primary;
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation: ArithmeticOperation::Neg {
+            let operation = if let Some(width) = float_width(inst.ty) {
+                ArithmeticOperation::FloatNeg {
                     value: operand_vreg,
                     width,
-                },
+                }
+            } else {
+                ArithmeticOperation::Neg {
+                    value: operand_vreg,
+                    width: policy.integer_width.expect("neg width"),
+                }
+            };
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
+                operation,
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
                     RuntimeHelperId::Overflow,
                 ),
@@ -1481,7 +1676,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         call_args,
                         adapter.target_c_flavor(),
                     );
-                    let result_vreg = adapter.reserve_value_result();
+                    let result_vreg = adapter.reserve_typed_value_result(inst.ty);
                     adapter.emit_foreign_call(foreign_inputs, result_vreg)
                 } else {
                     // An `extern "C"` scalar/pointer call (ADR-0064 P2): a scalar
@@ -1498,17 +1693,18 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     } else {
                         None
                     };
-                    let result_vreg = adapter.reserve_value_result();
+                    let result_vreg = adapter.reserve_typed_value_result(inst.ty);
                     let mut plan = crate::call_plan::CallPlan::from_inputs_with_result(
                         crate::call_plan::CallTarget::rue(symbol),
                         inputs.return_plan,
                         inputs.compact_return_image.clone(),
                         inputs.compact_return_dispatch.clone(),
                         &inputs.args,
-                        adapter.call_arg_register_budget(),
+                        adapter.call_arg_register_banks(),
                         adapter,
                         Some(result_vreg),
                     );
+                    plan.result_float_width = float_width(inst.ty);
                     plan.foreign_return_extension = foreign_return_extension;
                     adapter.emit_call(plan)
                 }
@@ -1535,6 +1731,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         integer_extension: integer_extension(ctx.cfg.get_inst(arg).ty),
                         place: place_from_value(ctx, adapter, arg),
                         debug: debug_value_plan(ctx.cfg.get_inst(arg).ty),
+                        ty: ctx.cfg.get_inst(arg).ty,
                     }
                 })
                 .collect();
@@ -3284,6 +3481,7 @@ mod tests {
             integer_extension: IntegerExtension::None,
             place: None,
             debug: DebugValuePlan::Bool,
+            ty: Type::I32,
         };
         let string_arg = IntrinsicArgPlan {
             slots: vec![crate::vreg::VReg::new(0), crate::vreg::VReg::new(1)],

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -31,7 +31,7 @@ use rue_air::{FrozenTypeInternPool, TypeKind};
 use rue_cfg::{BlockId, Cfg, CfgValue, Type, ValidatedCfg};
 use rue_error::CompileResult;
 
-use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
+use super::mir::{FloatWidth, LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 use crate::agg_slots::SlotBackend;
 use crate::allocation;
 use crate::cfg_lower::CfgLowerContext;
@@ -46,6 +46,16 @@ use crate::vreg::BLOCK_LABEL_BASE;
 /// in the callee); the callee prologue copies them into its frame param area
 /// so the body addresses every param slot uniformly (see `emit_prologue`).
 pub(super) const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9];
+pub(super) const FP_ARG_REGS: [Reg; 8] = [
+    Reg::Xmm0,
+    Reg::Xmm1,
+    Reg::Xmm2,
+    Reg::Xmm3,
+    Reg::Xmm4,
+    Reg::Xmm5,
+    Reg::Xmm6,
+    Reg::Xmm7,
+];
 
 /// Return value registers for the internal Rue convention (SysV only defines
 /// rax/rdx; the rest are caller-saved scratch regs we extend the convention
@@ -506,12 +516,38 @@ impl<'a> CfgLower<'a> {
     /// into the entry block). A register-only by-ref pointer seeds the
     /// by-ref cache directly.
     fn materialize_register_params(&mut self) {
-        for (param_slot, abi_index) in self.ctx.param_entry_copies() {
-            let vreg = self.mir.alloc_vreg();
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(vreg),
-                src: Operand::Physical(ARG_REGS[abi_index as usize]),
-            });
+        for (param_slot, class, location) in self.ctx.param_entry_copies() {
+            let (vreg, copy) = match (class, location) {
+                (
+                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::call_plan::AbiSlotLocation::GpReg(class_index),
+                ) => {
+                    let vreg = self.mir.alloc_vreg();
+                    (
+                        vreg,
+                        X86Inst::MovRR {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Physical(ARG_REGS[class_index]),
+                        },
+                    )
+                }
+                (
+                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::call_plan::AbiSlotLocation::FpReg(class_index),
+                ) => {
+                    let vreg = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                    (
+                        vreg,
+                        X86Inst::FloatMov {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Physical(FP_ARG_REGS[class_index]),
+                            width,
+                        },
+                    )
+                }
+                _ => unreachable!("register-only parameter class and ABI bank must agree"),
+            };
+            self.mir.push(copy);
             if self.ctx.cfg.is_param_by_ref(param_slot) {
                 self.by_ref_param_ptrs.insert(param_slot, vreg);
             } else {
@@ -535,7 +571,10 @@ impl<'a> CfgLower<'a> {
         let plan = crate::call_plan::CallPlan::from_slot_values(
             crate::call_plan::CallTarget::rue(symbol),
             arg_vregs,
-            ARG_REGS.len(),
+            crate::call_plan::AbiRegisterBanks {
+                gp: ARG_REGS.len(),
+                fp: FP_ARG_REGS.len(),
+            },
         );
         let _ = self.lower_call_plan(plan);
     }
@@ -804,6 +843,40 @@ impl<'a> CfgLower<'a> {
         let div_by_zero_call = plan.div_by_zero_call;
         let wrap = plan.wrap;
         let vreg = match plan.operation {
+            ArithmeticOperation::FloatAdd { lhs, rhs, width }
+            | ArithmeticOperation::FloatSub { lhs, rhs, width }
+            | ArithmeticOperation::FloatMul { lhs, rhs, width }
+            | ArithmeticOperation::FloatDiv { lhs, rhs, width } => {
+                let op = match plan.operation {
+                    ArithmeticOperation::FloatAdd { .. } => super::mir::FloatBinOp::Add,
+                    ArithmeticOperation::FloatSub { .. } => super::mir::FloatBinOp::Sub,
+                    ArithmeticOperation::FloatMul { .. } => super::mir::FloatBinOp::Mul,
+                    ArithmeticOperation::FloatDiv { .. } => super::mir::FloatBinOp::Div,
+                    _ => unreachable!(),
+                };
+                let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(X86Inst::FloatMov {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(lhs),
+                    width,
+                });
+                self.mir.push(X86Inst::FloatBin {
+                    op,
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(rhs),
+                    width,
+                });
+                dst
+            }
+            ArithmeticOperation::FloatNeg { value, width } => {
+                let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(X86Inst::FloatNeg {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(value),
+                    width,
+                });
+                dst
+            }
             ArithmeticOperation::Add { lhs, rhs, width } => {
                 let vreg = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRR {
@@ -1088,14 +1161,53 @@ impl<'a> CfgLower<'a> {
     ) -> crate::value_plan::MaterializedValue {
         use crate::call_plan::ReturnPlan;
         let primary = plan.result.unwrap_or_else(|| self.mir.alloc_vreg());
-        let num_reg_args = plan.abi_slots.len().min(ARG_REGS.len());
         let num_stack_args = plan.stack_slot_count;
+        let has_fp_stack_arg =
+            plan.abi_classes
+                .iter()
+                .zip(&plan.abi_locations)
+                .any(|(class, location)| {
+                    matches!(class, crate::call_plan::AbiSlotClass::Fp(_))
+                        && matches!(location, crate::call_plan::AbiSlotLocation::Stack(_))
+                });
         let stack_cell_bytes = checked_cell_region_bytes(
             u64::try_from(num_stack_args).expect("call stack slot count must fit u64"),
         )
         .expect("call stack area must fit displacement");
         let needs_alignment = plan.stack_bytes > stack_cell_bytes;
-        if needs_alignment {
+        if has_fp_stack_arg {
+            self.mir.push(X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: -checked_displacement_bytes(u64::from(plan.stack_bytes))
+                    .expect("call stack area must fit displacement"),
+            });
+            for ((arg, class), location) in plan
+                .abi_slots
+                .iter()
+                .zip(&plan.abi_classes)
+                .zip(&plan.abi_locations)
+            {
+                let crate::call_plan::AbiSlotLocation::Stack(index) = location else {
+                    continue;
+                };
+                let offset = checked_cell_byte_offset(*index as u64)
+                    .expect("call stack slot offset must fit displacement");
+                if let crate::call_plan::AbiSlotClass::Fp(width) = class {
+                    self.mir.push(X86Inst::FloatStore {
+                        base: Reg::Rsp,
+                        offset,
+                        src: Operand::Virtual(*arg),
+                        width: *width,
+                    });
+                } else {
+                    self.mir.push(X86Inst::MovMR {
+                        base: Reg::Rsp,
+                        offset,
+                        src: Operand::Virtual(*arg),
+                    });
+                }
+            }
+        } else if needs_alignment {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
                 imm: -i32::try_from(
@@ -1107,7 +1219,43 @@ impl<'a> CfgLower<'a> {
                 .expect("call stack alignment padding must fit i32"),
             });
         }
-        for arg in plan.abi_slots.iter().skip(ARG_REGS.len()).rev() {
+        if !has_fp_stack_arg {
+            for (arg, location) in plan.abi_slots.iter().zip(&plan.abi_locations).rev() {
+                if !matches!(location, crate::call_plan::AbiSlotLocation::Stack(_)) {
+                    continue;
+                }
+                self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Physical(Reg::Rax),
+                    src: Operand::Virtual(*arg),
+                });
+                self.mir.push(X86Inst::Push {
+                    src: Operand::Physical(Reg::Rax),
+                });
+            }
+        }
+        let gp_args: Vec<_> = plan
+            .abi_slots
+            .iter()
+            .zip(&plan.abi_locations)
+            .filter_map(|(arg, location)| match location {
+                crate::call_plan::AbiSlotLocation::GpReg(index) => Some((*index, *arg)),
+                _ => None,
+            })
+            .collect();
+        let fp_args: Vec<_> = plan
+            .abi_slots
+            .iter()
+            .zip(&plan.abi_classes)
+            .zip(&plan.abi_locations)
+            .filter_map(|((arg, class), location)| match (class, location) {
+                (
+                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::call_plan::AbiSlotLocation::FpReg(index),
+                ) => Some((*index, *arg, *width)),
+                _ => None,
+            })
+            .collect();
+        for (_, arg) in gp_args.iter().rev() {
             self.mir.push(X86Inst::MovRR {
                 dst: Operand::Physical(Reg::Rax),
                 src: Operand::Virtual(*arg),
@@ -1116,18 +1264,16 @@ impl<'a> CfgLower<'a> {
                 src: Operand::Physical(Reg::Rax),
             });
         }
-        for arg in plan.abi_slots.iter().take(num_reg_args).rev() {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Physical(Reg::Rax),
-                src: Operand::Virtual(*arg),
-            });
-            self.mir.push(X86Inst::Push {
-                src: Operand::Physical(Reg::Rax),
-            });
-        }
-        for (index, _) in plan.abi_slots.iter().take(num_reg_args).enumerate() {
+        for (index, _) in &gp_args {
             self.mir.push(X86Inst::Pop {
-                dst: Operand::Physical(ARG_REGS[index]),
+                dst: Operand::Physical(ARG_REGS[*index]),
+            });
+        }
+        for (index, arg, width) in fp_args {
+            self.mir.push(X86Inst::FloatMov {
+                dst: Operand::Physical(FP_ARG_REGS[index]),
+                src: Operand::Virtual(arg),
+                width,
             });
         }
         let symbol_id = self.intern_symbol(plan.target.symbol());
@@ -1213,10 +1359,20 @@ impl<'a> CfgLower<'a> {
                 src: Operand::Virtual(slot),
             });
         } else if matches!(plan.return_plan, ReturnPlan::Scalar) {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(primary),
-                src: Operand::Physical(Reg::Rax),
-            });
+            self.mir.push(
+                if self.mir.vreg_class(primary) == crate::reg_class::RegClass::Fp {
+                    X86Inst::FloatMov {
+                        dst: Operand::Virtual(primary),
+                        src: Operand::Physical(Reg::Xmm0),
+                        width: plan.result_float_width.expect("FP call result width"),
+                    }
+                } else {
+                    X86Inst::MovRR {
+                        dst: Operand::Virtual(primary),
+                        src: Operand::Physical(Reg::Rax),
+                    }
+                },
+            );
         } else if matches!(plan.return_plan, ReturnPlan::ZeroSized) {
             self.mir.push(X86Inst::MovRI32 {
                 dst: Operand::Virtual(primary),
@@ -1315,6 +1471,18 @@ impl<'a> CfgLower<'a> {
         let mut slots = Vec::new();
         let primary = match plan.value {
             ResidualValuePlan::Const { value } => {
+                if let Some(float_width) = crate::value_plan::float_width(ty) {
+                    let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                    self.mir.push(X86Inst::FloatConst {
+                        dst: Operand::Virtual(dst),
+                        bits: value,
+                        width: float_width,
+                    });
+                    return ValueResult::Materialized(crate::value_plan::MaterializedValue {
+                        primary: dst,
+                        slots: Vec::new(),
+                    });
+                }
                 let dst = self.mir.alloc_vreg();
                 if value <= u32::MAX as u64 {
                     self.mir.push(X86Inst::MovRI32 {
@@ -1522,34 +1690,66 @@ impl<'a> CfgLower<'a> {
                 op,
                 lhs,
                 rhs,
-                leaf_types,
+                equality_leaves,
                 runtime_call,
-            } => self.lower_comparison(op, lhs, rhs, plan.policy, &leaf_types, runtime_call),
+            } => self.lower_comparison(op, lhs, rhs, plan.policy, &equality_leaves, runtime_call),
             ResidualValuePlan::Alloc {
                 slot,
                 init,
                 init_shape,
+                float_width,
+                leaf_types,
             } => {
                 if init_shape.slot_count() == 0 {
                     return ValueResult::SideEffect;
                 } else if init.slots.is_empty() {
-                    self.emit_store_slot(init.primary, slot);
+                    if let Some(width) = float_width {
+                        self.mir.push(X86Inst::FloatStore {
+                            base: Reg::Rbp,
+                            offset: self.ctx.local_offset(slot),
+                            src: Operand::Virtual(init.primary),
+                            width,
+                        });
+                    } else {
+                        self.emit_store_slot(init.primary, slot);
+                    }
                 } else {
-                    crate::agg_slots::store_slots(self, &init.slots, slot);
+                    crate::agg_slots::store_slots_typed(self, &init.slots, slot, &leaf_types);
                 }
                 return ValueResult::SideEffect;
             }
-            ResidualValuePlan::Load { slot } => {
+            ResidualValuePlan::Load {
+                slot,
+                float_width,
+                leaf_types,
+            } => {
                 let count = plan.policy.shape.slot_count();
                 if count == 0 {
                     self.mir.alloc_vreg()
                 } else if count > 1 {
-                    slots = crate::agg_slots::load_slots_at_low(self, slot + count - 1, count);
+                    slots = crate::agg_slots::load_slots_at_low_typed(
+                        self,
+                        slot + count - 1,
+                        &leaf_types,
+                    );
                     let dst = slots[0];
                     dst
                 } else {
-                    let dst = self.mir.alloc_vreg();
-                    self.emit_load_slot(dst, slot);
+                    let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
+                    });
+                    if let Some(width) = float_width {
+                        self.mir.push(X86Inst::FloatLoad {
+                            dst: Operand::Virtual(dst),
+                            base: Reg::Rbp,
+                            offset: self.ctx.local_offset(slot),
+                            width,
+                        });
+                    } else {
+                        self.emit_load_slot(dst, slot);
+                    }
                     dst
                 }
             }
@@ -1557,6 +1757,8 @@ impl<'a> CfgLower<'a> {
                 destination,
                 value,
                 value_shape,
+                float_width,
+                leaf_types,
             } => {
                 if value_shape.slot_count() == 0 {
                     return ValueResult::SideEffect;
@@ -1564,17 +1766,37 @@ impl<'a> CfgLower<'a> {
                 if value.slots.is_empty() {
                     match destination {
                         crate::value_plan::StoreDestination::FrameSlot(slot) => {
-                            self.emit_store_slot(value.primary, slot)
+                            if let Some(width) = float_width {
+                                self.mir.push(X86Inst::FloatStore {
+                                    base: Reg::Rbp,
+                                    offset: self.ctx.local_offset(slot),
+                                    src: Operand::Virtual(value.primary),
+                                    width,
+                                });
+                            } else {
+                                self.emit_store_slot(value.primary, slot);
+                            }
                         }
                         crate::value_plan::StoreDestination::ByRefParam(param_slot) => {
                             let ptr = self.ensure_by_ref_param_ptr(param_slot);
-                            self.emit_store_ptr_base(value.primary, ptr);
+                            if let Some(width) = float_width {
+                                <Self as crate::agg_slots::SlotBackend>::emit_float_store_through_ptr(
+                                    self, value.primary, ptr, 0, width,
+                                );
+                            } else {
+                                self.emit_store_ptr_base(value.primary, ptr);
+                            }
                         }
                     }
                 } else {
                     match destination {
                         crate::value_plan::StoreDestination::FrameSlot(slot) => {
-                            crate::agg_slots::store_slots(self, &value.slots, slot)
+                            crate::agg_slots::store_slots_typed(
+                                self,
+                                &value.slots,
+                                slot,
+                                &leaf_types,
+                            )
                         }
                         crate::value_plan::StoreDestination::ByRefParam(param_slot) => {
                             let ptr = self.ensure_by_ref_param_ptr(param_slot);
@@ -1588,6 +1810,8 @@ impl<'a> CfgLower<'a> {
                 param_slot,
                 value,
                 value_shape,
+                float_width,
+                leaf_types,
             } => {
                 if value_shape.slot_count() == 0 {
                     return ValueResult::SideEffect;
@@ -1595,7 +1819,17 @@ impl<'a> CfgLower<'a> {
                 if self.ctx.cfg.is_param_by_ref(param_slot) {
                     let ptr = self.ensure_by_ref_param_ptr(param_slot);
                     if value.slots.is_empty() {
-                        self.emit_store_ptr_base(value.primary, ptr);
+                        if let Some(width) = float_width {
+                            <Self as crate::agg_slots::SlotBackend>::emit_float_store_through_ptr(
+                                self,
+                                value.primary,
+                                ptr,
+                                0,
+                                width,
+                            );
+                        } else {
+                            self.emit_store_ptr_base(value.primary, ptr);
+                        }
                     } else {
                         crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
                     }
@@ -1610,11 +1844,23 @@ impl<'a> CfgLower<'a> {
                     } else {
                         value.slots
                     };
-                    crate::agg_slots::store_slots(
-                        self,
-                        &vals,
-                        self.ctx.param_frame_slot(param_slot),
-                    );
+                    if vals.len() == 1
+                        && let Some(width) = float_width
+                    {
+                        <Self as crate::place_lower::PlaceLowerBackend>::emit_float_store_slot(
+                            self,
+                            vals[0],
+                            self.ctx.param_frame_slot(param_slot),
+                            width,
+                        );
+                    } else {
+                        crate::agg_slots::store_slots_typed(
+                            self,
+                            &vals,
+                            self.ctx.param_frame_slot(param_slot),
+                            &leaf_types,
+                        );
+                    }
                 }
                 return ValueResult::SideEffect;
             }
@@ -1627,7 +1873,11 @@ impl<'a> CfgLower<'a> {
                     let dst = slots[0];
                     dst
                 } else {
-                    let dst = self.mir.alloc_vreg();
+                    let dst = self.mir.alloc_vreg_in(if ty.is_float() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
+                    });
                     crate::place_lower::lower_place_read_plan(self, dst, &place, ty);
                     dst
                 }
@@ -1636,6 +1886,7 @@ impl<'a> CfgLower<'a> {
                 place,
                 value,
                 value_shape,
+                float_width,
             } => {
                 let vals = if matches!(
                     value_shape,
@@ -1648,7 +1899,7 @@ impl<'a> CfgLower<'a> {
                 } else {
                     value.slots
                 };
-                crate::place_lower::lower_place_write_plan(self, &place, &vals);
+                crate::place_lower::lower_place_write_plan(self, &place, &vals, float_width);
                 return ValueResult::SideEffect;
             }
             ResidualValuePlan::StructInit { fields, .. }
@@ -1695,16 +1946,28 @@ impl<'a> CfgLower<'a> {
                 variant_index,
                 payload,
                 total_slots,
+                leaf_types,
                 zero_unused_payload,
                 ..
             } => {
-                slots = (0..total_slots).map(|_| self.mir.alloc_vreg()).collect();
+                assert_eq!(leaf_types.len(), total_slots as usize);
+                slots = leaf_types
+                    .iter()
+                    .map(|ty| {
+                        self.mir
+                            .alloc_vreg_in(if crate::value_plan::float_width(*ty).is_some() {
+                                crate::reg_class::RegClass::Fp
+                            } else {
+                                crate::reg_class::RegClass::Gp
+                            })
+                    })
+                    .collect();
                 self.mir.push(X86Inst::MovRI32 {
                     dst: Operand::Virtual(slots[0]),
                     imm: variant_index as i32,
                 });
                 let mut offset = 1;
-                for (value, shape) in payload {
+                for (value, shape, value_leaf_types) in payload {
                     if shape.slot_count() == 0 {
                         continue;
                     }
@@ -1713,12 +1976,31 @@ impl<'a> CfgLower<'a> {
                     } else {
                         value.slots
                     };
-                    for value in values {
+                    assert_eq!(values.len(), value_leaf_types.len());
+                    for (value, value_ty) in values.into_iter().zip(value_leaf_types) {
                         if offset < slots.len() {
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Virtual(slots[offset]),
-                                src: Operand::Virtual(value),
-                            });
+                            if let Some(width) = crate::value_plan::float_width(value_ty) {
+                                assert_eq!(
+                                    self.mir.vreg_class(value),
+                                    crate::reg_class::RegClass::Fp,
+                                    "float enum payload source must use the FP class"
+                                );
+                                self.mir.push(X86Inst::FloatToBits {
+                                    dst: Operand::Virtual(slots[offset]),
+                                    src: Operand::Virtual(value),
+                                    width,
+                                });
+                            } else {
+                                assert_eq!(
+                                    self.mir.vreg_class(value),
+                                    crate::reg_class::RegClass::Gp,
+                                    "enum payload slot class must match its canonical leaf type"
+                                );
+                                self.mir.push(X86Inst::MovRR {
+                                    dst: Operand::Virtual(slots[offset]),
+                                    src: Operand::Virtual(value),
+                                });
+                            }
                             offset += 1;
                         }
                     }
@@ -1727,11 +2009,19 @@ impl<'a> CfgLower<'a> {
                 // compact memory image marshalled from the value carries no residue
                 // from a wider variant (ADR-0052 ruling 5). Only under the gate.
                 if zero_unused_payload {
-                    for slot in slots.iter().skip(offset) {
-                        self.mir.push(X86Inst::MovRI32 {
-                            dst: Operand::Virtual(*slot),
-                            imm: 0,
-                        });
+                    for (index, slot) in slots.iter().enumerate().skip(offset) {
+                        if let Some(width) = crate::value_plan::float_width(leaf_types[index]) {
+                            self.mir.push(X86Inst::FloatConst {
+                                dst: Operand::Virtual(*slot),
+                                bits: 0,
+                                width,
+                            });
+                        } else {
+                            self.mir.push(X86Inst::MovRI32 {
+                                dst: Operand::Virtual(*slot),
+                                imm: 0,
+                            });
+                        }
                     }
                 }
                 let dst = slots[0];
@@ -1741,14 +2031,31 @@ impl<'a> CfgLower<'a> {
                 base_slots,
                 field_offset,
                 field_slots,
+                field_types,
             } => {
+                assert_eq!(field_types.len(), field_slots as usize);
                 slots.clear();
                 for index in 0..field_slots {
-                    let dst = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(dst),
-                        src: Operand::Virtual(base_slots[(field_offset + index) as usize]),
+                    let ty = field_types[index as usize];
+                    let width = crate::value_plan::float_width(ty);
+                    let dst = self.mir.alloc_vreg_in(if width.is_some() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
                     });
+                    let src = base_slots[(field_offset + index) as usize];
+                    if let Some(width) = width {
+                        self.mir.push(X86Inst::BitsToFloat {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(src),
+                            width,
+                        });
+                    } else {
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(src),
+                        });
+                    }
                     slots.push(dst);
                 }
                 let dst = slots
@@ -1797,7 +2104,12 @@ impl<'a> CfgLower<'a> {
         ty: Type,
         policy: crate::value_plan::ValuePlan,
     ) -> (VReg, Vec<VReg>) {
-        let dst = self.mir.alloc_vreg();
+        let float_width = crate::value_plan::float_width(ty);
+        let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
+            crate::reg_class::RegClass::Fp
+        } else {
+            crate::reg_class::RegClass::Gp
+        });
         let count = policy.shape.slot_count();
         if count == 0 {
             self.mir.push(X86Inst::MovRI32 {
@@ -1823,21 +2135,42 @@ impl<'a> CfgLower<'a> {
                     .collect();
                 return (slots[0], slots);
             }
-            self.mir.push(X86Inst::MovRMIndexed {
-                dst: Operand::Virtual(dst),
-                base: ptr,
-                offset: 0,
-            });
+            if let Some(width) = float_width {
+                <Self as crate::place_lower::PlaceLowerBackend>::emit_load_ptr_base(
+                    self,
+                    dst,
+                    ptr,
+                    Some(width),
+                );
+            } else {
+                self.mir.push(X86Inst::MovRMIndexed {
+                    dst: Operand::Virtual(dst),
+                    base: ptr,
+                    offset: 0,
+                });
+            }
         } else if count > 1 {
+            let leaf_types = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty);
             let slots: Vec<_> = (0..count)
                 .map(|slot| {
-                    let v = self.mir.alloc_vreg();
-                    let frame_slot = self.ctx.param_frame_slot(index) + count - 1 - slot;
-                    self.mir.push(X86Inst::MovRM {
-                        dst: Operand::Virtual(v),
-                        base: Reg::Rbp,
-                        offset: self.ctx.local_offset(frame_slot),
+                    let width = crate::value_plan::float_width(leaf_types[slot as usize]);
+                    let v = self.mir.alloc_vreg_in(if width.is_some() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
                     });
+                    let frame_slot = self.ctx.param_frame_slot(index) + count - 1 - slot;
+                    if let Some(width) = width {
+                        <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
+                            self, v, frame_slot, width,
+                        );
+                    } else {
+                        self.mir.push(X86Inst::MovRM {
+                            dst: Operand::Virtual(v),
+                            base: Reg::Rbp,
+                            offset: self.ctx.local_offset(frame_slot),
+                        });
+                    }
                     v
                 })
                 .collect();
@@ -1847,6 +2180,13 @@ impl<'a> CfgLower<'a> {
             // argument register into one read-only vreg shared by every read.
             let _ = ty;
             return (vreg, Vec::new());
+        } else if let Some(width) = float_width {
+            <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
+                self,
+                dst,
+                self.ctx.param_frame_slot(index),
+                width,
+            );
         } else {
             self.mir.push(X86Inst::MovRM {
                 dst: Operand::Virtual(dst),
@@ -1854,7 +2194,6 @@ impl<'a> CfgLower<'a> {
                 offset: self.ctx.local_offset(self.ctx.param_frame_slot(index)),
             });
         }
-        let _ = ty;
         (dst, Vec::new())
     }
 
@@ -1949,12 +2288,15 @@ impl<'a> CfgLower<'a> {
         lhs: crate::value_plan::MaterializedValue,
         rhs: crate::value_plan::MaterializedValue,
         policy: crate::value_plan::ValuePlan,
-        leaf_types: &[Type],
+        equality_leaves: &[crate::aggregate_eq::EqualityLeaf],
         runtime_call: Option<crate::runtime_call_plan::RuntimeCallPlan>,
     ) -> VReg {
         match policy.comparison.expect("comparison plan") {
             crate::value_plan::ComparisonPreparation::Scalar { .. } => {
                 self.lower_scalar_comparison(op, lhs.primary, rhs.primary, policy)
+            }
+            crate::value_plan::ComparisonPreparation::Float { width } => {
+                self.lower_float_comparison(op, lhs.primary, rhs.primary, width)
             }
             crate::value_plan::ComparisonPreparation::Unit => {
                 let dst = self.mir.alloc_vreg();
@@ -1981,11 +2323,75 @@ impl<'a> CfgLower<'a> {
                     self,
                     &lhs.slots,
                     &rhs.slots,
-                    leaf_types,
+                    equality_leaves,
                     matches!(op, crate::value_plan::ComparisonOp::Ne),
                 )
             }
         }
+    }
+
+    fn lower_float_comparison(
+        &mut self,
+        op: crate::value_plan::ComparisonOp,
+        lhs: VReg,
+        rhs: VReg,
+        width: crate::value_plan::FloatWidth,
+    ) -> VReg {
+        self.mir.push(X86Inst::FloatCmp {
+            lhs: Operand::Virtual(lhs),
+            rhs: Operand::Virtual(rhs),
+            width,
+        });
+        let dst = self.mir.alloc_vreg();
+        self.mir.push(match op {
+            crate::value_plan::ComparisonOp::Eq => X86Inst::Sete {
+                dst: Operand::Virtual(dst),
+            },
+            crate::value_plan::ComparisonOp::Ne => X86Inst::Setne {
+                dst: Operand::Virtual(dst),
+            },
+            crate::value_plan::ComparisonOp::Lt => X86Inst::Setb {
+                dst: Operand::Virtual(dst),
+            },
+            crate::value_plan::ComparisonOp::Gt => X86Inst::Seta {
+                dst: Operand::Virtual(dst),
+            },
+            crate::value_plan::ComparisonOp::Le => X86Inst::Setbe {
+                dst: Operand::Virtual(dst),
+            },
+            crate::value_plan::ComparisonOp::Ge => X86Inst::Setae {
+                dst: Operand::Virtual(dst),
+            },
+        });
+        if matches!(
+            op,
+            crate::value_plan::ComparisonOp::Eq
+                | crate::value_plan::ComparisonOp::Lt
+                | crate::value_plan::ComparisonOp::Le
+        ) {
+            let ordered = self.mir.alloc_vreg();
+            self.mir.push(X86Inst::Setnp {
+                dst: Operand::Virtual(ordered),
+            });
+            self.mir.push(X86Inst::AndRR {
+                dst: Operand::Virtual(dst),
+                src: Operand::Virtual(ordered),
+            });
+        } else if matches!(op, crate::value_plan::ComparisonOp::Ne) {
+            let unordered = self.mir.alloc_vreg();
+            self.mir.push(X86Inst::Setp {
+                dst: Operand::Virtual(unordered),
+            });
+            self.mir.push(X86Inst::OrRR {
+                dst: Operand::Virtual(dst),
+                src: Operand::Virtual(unordered),
+            });
+        }
+        self.mir.push(X86Inst::Movzx {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(dst),
+        });
+        dst
     }
 
     fn lower_trap(
@@ -2116,12 +2522,28 @@ impl<'a> CfgLower<'a> {
                     slots = crate::agg_slots::load_slots_through_ptr(self, ptr, count);
                     slots[0]
                 } else {
-                    let dst = self.mir.alloc_vreg();
+                    let float_width = crate::value_plan::float_width(plan.result_ty);
+                    let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
+                        crate::reg_class::RegClass::Fp
+                    } else {
+                        crate::reg_class::RegClass::Gp
+                    });
                     if count != 0 {
                         // A narrow scalar pointee reads 1/2/4 physical bytes and
                         // extends into the slot-shaped vreg (RUE-989); a full-slot
                         // pointee keeps the eight-byte load.
-                        if let Some(narrow) = plan.narrow_access {
+                        if let Some(width) = float_width {
+                            self.mir.push(X86Inst::MovRR {
+                                dst: Operand::Physical(Reg::Rax),
+                                src: Operand::Virtual(ptr),
+                            });
+                            self.mir.push(X86Inst::FloatLoad {
+                                dst: Operand::Virtual(dst),
+                                base: Reg::Rax,
+                                offset: 0,
+                                width,
+                            });
+                        } else if let Some(narrow) = plan.narrow_access {
                             self.mir.push(X86Inst::NarrowLoadIndexed {
                                 dst: Operand::Virtual(dst),
                                 base: ptr,
@@ -2177,6 +2599,17 @@ impl<'a> CfgLower<'a> {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
                     crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
+                } else if let Some(width) = crate::value_plan::float_width(plan.args[1].ty) {
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rax),
+                        src: Operand::Virtual(ptr),
+                    });
+                    self.mir.push(X86Inst::FloatStore {
+                        base: Reg::Rax,
+                        offset: 0,
+                        src: Operand::Virtual(value.primary),
+                        width,
+                    });
                 } else if let Some(narrow) = plan.narrow_access {
                     // A narrow scalar truncates to 1/2/4 physical bytes (RUE-989).
                     self.mir.push(X86Inst::NarrowStoreIndexed {
@@ -2334,12 +2767,69 @@ impl<'a> CfgLower<'a> {
             | rue_air::IntrinsicOperation::BoundsCheck => {
                 unreachable!("trap handled above")
             }
-            rue_air::IntrinsicOperation::IntToFloat
-            | rue_air::IntrinsicOperation::FloatToInt
-            | rue_air::IntrinsicOperation::FloatCast
-            | rue_air::IntrinsicOperation::TotalCmp => {
-                unreachable!("ADR-0065 Phase 4 rejects float operations at CFG construction")
+            rue_air::IntrinsicOperation::IntToFloat => {
+                let width = crate::value_plan::float_width(plan.result_ty).expect("float result");
+                let int =
+                    crate::value_plan::integer_width(plan.args[0].ty).expect("integer source");
+                let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(X86Inst::IntToFloat {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(plan.args[0].primary),
+                    int_bits: int.bits.max(32),
+                    width,
+                });
+                dst
             }
+            rue_air::IntrinsicOperation::FloatToInt => {
+                let width = crate::value_plan::float_width(plan.args[0].ty).expect("float source");
+                let int = crate::value_plan::integer_width(plan.result_ty).expect("integer result");
+                let check = crate::value_plan::checked_float_to_int_plan(width, int);
+                for guard in check.guards {
+                    let bound = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                    self.mir.push(X86Inst::FloatConst {
+                        dst: Operand::Virtual(bound),
+                        bits: guard.bound_bits,
+                        width,
+                    });
+                    self.mir.push(X86Inst::FloatCmp {
+                        lhs: Operand::Virtual(plan.args[0].primary),
+                        rhs: Operand::Virtual(bound),
+                        width,
+                    });
+                    let ok = self.new_label();
+                    self.mir.push(match guard.success {
+                        crate::value_plan::FloatToIntGuardRelation::OrderedGreaterEqual => {
+                            X86Inst::Jae { label: ok }
+                        }
+                        crate::value_plan::FloatToIntGuardRelation::OrderedLess => {
+                            X86Inst::Jb { label: ok }
+                        }
+                    });
+                    let _ = self.lower_runtime_call(check.trap_call.clone());
+                    self.mir.push(X86Inst::Label { id: ok });
+                }
+                let dst = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::FloatToInt {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(plan.args[0].primary),
+                    int_bits: int.bits.max(32),
+                    width,
+                });
+                dst
+            }
+            rue_air::IntrinsicOperation::FloatCast => {
+                let from = crate::value_plan::float_width(plan.args[0].ty).expect("float source");
+                let to = crate::value_plan::float_width(plan.result_ty).expect("float result");
+                let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(X86Inst::FloatCast {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(plan.args[0].primary),
+                    from,
+                    to,
+                });
+                dst
+            }
+            rue_air::IntrinsicOperation::TotalCmp => unreachable!("total_cmp is ADR-0065 phase 8"),
         };
         crate::value_plan::MaterializedValue { primary, slots }
     }
@@ -2738,11 +3228,21 @@ impl<'a> CfgLower<'a> {
                 }
                 ReturnMode::Function { value } => match value {
                     ReturnValuePlan::ZeroSized => self.mir.push(X86Inst::Ret),
-                    ReturnValuePlan::Scalar { value } => {
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Physical(Reg::Rax),
-                            src: Operand::Virtual(value),
-                        });
+                    ReturnValuePlan::Scalar { value, float_width } => {
+                        self.mir.push(
+                            if self.mir.vreg_class(value) == crate::reg_class::RegClass::Fp {
+                                X86Inst::FloatMov {
+                                    dst: Operand::Physical(Reg::Xmm0),
+                                    src: Operand::Virtual(value),
+                                    width: float_width.expect("FP return width"),
+                                }
+                            } else {
+                                X86Inst::MovRR {
+                                    dst: Operand::Physical(Reg::Rax),
+                                    src: Operand::Virtual(value),
+                                }
+                            },
+                        );
                         self.mir.push(X86Inst::Ret);
                     }
                     ReturnValuePlan::Aggregate { slots, return_plan } => {
@@ -2793,9 +3293,17 @@ impl<'a> CfgLower<'a> {
 
     fn emit_edge_moves(&mut self, edge: &crate::terminator_plan::EdgePlan) {
         for movement in &edge.moves {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(movement.destination),
-                src: Operand::Virtual(movement.source),
+            self.mir.push(if let Some(width) = movement.float_width {
+                X86Inst::FloatMov {
+                    dst: Operand::Virtual(movement.destination),
+                    src: Operand::Virtual(movement.source),
+                    width,
+                }
+            } else {
+                X86Inst::MovRR {
+                    dst: Operand::Virtual(movement.destination),
+                    src: Operand::Virtual(movement.source),
+                }
             });
         }
     }
@@ -2882,7 +3390,17 @@ impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
     }
 
     fn prepare_block_param(&mut self, block: BlockId, index: u32, value: CfgValue, ty: Type) {
-        let vreg = self.mir.alloc_vreg();
+        let primary_ty = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty)
+            .first()
+            .copied()
+            .unwrap_or(ty);
+        let vreg =
+            self.mir
+                .alloc_vreg_in(if crate::value_plan::float_width(primary_ty).is_some() {
+                    crate::reg_class::RegClass::Fp
+                } else {
+                    crate::reg_class::RegClass::Gp
+                });
         self.block_param_vregs.insert((block, index), vreg);
         self.value_map.insert(value, vreg);
         crate::agg_slots::preallocate_block_param_slots(self, value, ty, vreg);
@@ -2944,6 +3462,13 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn reserve_value_result(&mut self) -> VReg {
         self.mir.alloc_vreg()
     }
+    fn reserve_typed_value_result(&mut self, ty: Type) -> VReg {
+        self.mir.alloc_vreg_in(if ty.is_float() {
+            crate::reg_class::RegClass::Fp
+        } else {
+            crate::reg_class::RegClass::Gp
+        })
+    }
     fn resolve_symbol(&self, symbol: lasso::Spur) -> String {
         self.symbols.resolve(self.interner.resolve(&symbol))
     }
@@ -2956,8 +3481,11 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
         rue_air::TargetCAbiFlavor::SysVAmd64
     }
-    fn call_arg_register_budget(&self) -> usize {
-        ARG_REGS.len()
+    fn call_arg_register_banks(&self) -> crate::call_plan::AbiRegisterBanks {
+        crate::call_plan::AbiRegisterBanks {
+            gp: ARG_REGS.len(),
+            fp: FP_ARG_REGS.len(),
+        }
     }
     fn return_register_budget(&self) -> u32 {
         RET_REGS.len() as u32
@@ -3244,15 +3772,35 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn alloc_vreg(&mut self) -> VReg {
         self.mir.alloc_vreg()
     }
+    fn alloc_float_vreg(&mut self) -> VReg {
+        self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp)
+    }
     fn get_vreg(&mut self, value: CfgValue) -> VReg {
         CfgLower::get_vreg(self, value)
     }
     fn emit_load_slot(&mut self, dst: VReg, slot: u32) {
         let offset = self.ctx.local_offset(slot);
-        self.mir.push(X86Inst::MovRM {
+        if self.mir.vreg_class(dst) == crate::reg_class::RegClass::Fp {
+            self.mir.push(X86Inst::FloatLoad {
+                dst: Operand::Virtual(dst),
+                base: Reg::Rbp,
+                offset,
+                width: FloatWidth::F64,
+            });
+        } else {
+            self.mir.push(X86Inst::MovRM {
+                dst: Operand::Virtual(dst),
+                base: Reg::Rbp,
+                offset,
+            });
+        }
+    }
+    fn emit_typed_float_load_slot(&mut self, dst: VReg, slot: u32, width: FloatWidth) {
+        self.mir.push(X86Inst::FloatLoad {
             dst: Operand::Virtual(dst),
             base: Reg::Rbp,
-            offset,
+            offset: self.ctx.local_offset(slot),
+            width,
         });
     }
     fn emit_reg_move(&mut self, dst: VReg, src: VReg) {
@@ -3263,10 +3811,27 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     }
     fn emit_store_slot(&mut self, src: VReg, slot: u32) {
         let offset = self.ctx.local_offset(slot);
-        self.mir.push(X86Inst::MovMR {
+        if self.mir.vreg_class(src) == crate::reg_class::RegClass::Fp {
+            self.mir.push(X86Inst::FloatStore {
+                base: Reg::Rbp,
+                offset,
+                src: Operand::Virtual(src),
+                width: FloatWidth::F64,
+            });
+        } else {
+            self.mir.push(X86Inst::MovMR {
+                base: Reg::Rbp,
+                offset,
+                src: Operand::Virtual(src),
+            });
+        }
+    }
+    fn emit_typed_float_store_slot(&mut self, src: VReg, slot: u32, width: FloatWidth) {
+        self.mir.push(X86Inst::FloatStore {
             base: Reg::Rbp,
-            offset,
+            offset: self.ctx.local_offset(slot),
             src: Operand::Virtual(src),
+            width,
         });
     }
     fn emit_store_through_ptr(&mut self, src: VReg, ptr: VReg, byte_offset: i32) {
@@ -3281,6 +3846,56 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             dst: Operand::Virtual(dst),
             base: ptr,
             offset: byte_offset,
+        });
+    }
+    fn emit_float_store_through_ptr(
+        &mut self,
+        src: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        width: FloatWidth,
+    ) {
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Virtual(ptr),
+        });
+        self.mir.push(X86Inst::FloatStore {
+            base: Reg::Rax,
+            offset: byte_offset,
+            src: Operand::Virtual(src),
+            width,
+        });
+    }
+    fn emit_float_load_through_ptr(
+        &mut self,
+        dst: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        width: FloatWidth,
+    ) {
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Virtual(ptr),
+        });
+        self.mir.push(X86Inst::FloatLoad {
+            dst: Operand::Virtual(dst),
+            base: Reg::Rax,
+            offset: byte_offset,
+            width,
+        });
+    }
+    fn emit_float_to_bits(&mut self, dst: VReg, src: VReg, width: FloatWidth) {
+        self.mir.push(X86Inst::FloatToBits {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(src),
+            width,
+        });
+    }
+    fn emit_bits_to_float(&mut self, dst: VReg, src: VReg, width: FloatWidth) {
+        self.mir.push(X86Inst::BitsToFloat {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(src),
+            width,
         });
     }
     fn emit_narrow_store_through_ptr(
@@ -3328,6 +3943,13 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         self.mir.push(X86Inst::MovRI32 {
             dst: Operand::Virtual(dst),
             imm: 0,
+        });
+    }
+    fn emit_set_float_zero(&mut self, dst: VReg, width: FloatWidth) {
+        self.mir.push(X86Inst::FloatConst {
+            dst: Operand::Virtual(dst),
+            bits: 0,
+            width,
         });
     }
     fn alloc_marshal_label(&mut self) -> LabelId {
@@ -3396,11 +4018,42 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
         });
     }
 
-    fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg) {
-        self.mir.push(X86Inst::MovRMIndexed {
+    fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg, float_width: Option<FloatWidth>) {
+        if let Some(width) = float_width {
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Virtual(ptr),
+            });
+            self.mir.push(X86Inst::FloatLoad {
+                dst: Operand::Virtual(dst),
+                base: Reg::Rax,
+                offset: 0,
+                width,
+            });
+        } else {
+            self.mir.push(X86Inst::MovRMIndexed {
+                dst: Operand::Virtual(dst),
+                base: ptr,
+                offset: 0,
+            });
+        }
+    }
+
+    fn emit_float_load_slot(&mut self, dst: VReg, slot: u32, width: FloatWidth) {
+        self.mir.push(X86Inst::FloatLoad {
             dst: Operand::Virtual(dst),
-            base: ptr,
-            offset: 0,
+            base: Reg::Rbp,
+            offset: self.ctx.local_offset(slot),
+            width,
+        });
+    }
+
+    fn emit_float_store_slot(&mut self, src: VReg, slot: u32, width: FloatWidth) {
+        self.mir.push(X86Inst::FloatStore {
+            base: Reg::Rbp,
+            offset: self.ctx.local_offset(slot),
+            src: Operand::Virtual(src),
+            width,
         });
     }
 }
@@ -3591,7 +4244,54 @@ impl crate::aggregate_eq::AggregateEqPlanBackend for CfgLower<'_> {
             imm: value as i32,
         });
     }
-    fn emit_slot_eq(&mut self, dst: VReg, lhs: VReg, rhs: VReg, wide: bool) {
+    fn emit_slot_eq(
+        &mut self,
+        dst: VReg,
+        mut lhs: VReg,
+        mut rhs: VReg,
+        leaf_ty: Type,
+        bit_carrier: bool,
+    ) {
+        if let Some(width) = crate::value_plan::float_width(leaf_ty) {
+            if bit_carrier {
+                let lhs_fp = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                let rhs_fp = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                self.mir.push(X86Inst::BitsToFloat {
+                    dst: Operand::Virtual(lhs_fp),
+                    src: Operand::Virtual(lhs),
+                    width,
+                });
+                self.mir.push(X86Inst::BitsToFloat {
+                    dst: Operand::Virtual(rhs_fp),
+                    src: Operand::Virtual(rhs),
+                    width,
+                });
+                lhs = lhs_fp;
+                rhs = rhs_fp;
+            }
+            self.mir.push(X86Inst::FloatCmp {
+                lhs: Operand::Virtual(lhs),
+                rhs: Operand::Virtual(rhs),
+                width,
+            });
+            self.mir.push(X86Inst::Sete {
+                dst: Operand::Virtual(dst),
+            });
+            let ordered = self.mir.alloc_vreg();
+            self.mir.push(X86Inst::Setnp {
+                dst: Operand::Virtual(ordered),
+            });
+            self.mir.push(X86Inst::AndRR {
+                dst: Operand::Virtual(dst),
+                src: Operand::Virtual(ordered),
+            });
+            self.mir.push(X86Inst::Movzx {
+                dst: Operand::Virtual(dst),
+                src: Operand::Virtual(dst),
+            });
+            return;
+        }
+        let wide = crate::types::slot_needs_wide_compare(leaf_ty);
         self.mir.push(if wide {
             X86Inst::Cmp64RR {
                 src1: Operand::Virtual(lhs),
@@ -3602,6 +4302,19 @@ impl crate::aggregate_eq::AggregateEqPlanBackend for CfgLower<'_> {
                 src1: Operand::Virtual(lhs),
                 src2: Operand::Virtual(rhs),
             }
+        });
+        self.mir.push(X86Inst::Sete {
+            dst: Operand::Virtual(dst),
+        });
+        self.mir.push(X86Inst::Movzx {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(dst),
+        });
+    }
+    fn emit_tag_eq(&mut self, dst: VReg, tag: VReg, discriminant: u32) {
+        self.mir.push(X86Inst::CmpRI {
+            src: Operand::Virtual(tag),
+            imm: discriminant as i32,
         });
         self.mir.push(X86Inst::Sete {
             dst: Operand::Virtual(dst),
@@ -3813,6 +4526,7 @@ mod tests {
                 start_slot: slot,
                 slot_count: 1,
                 crossing_regs: 1,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()
@@ -4961,6 +5675,7 @@ mod tests {
                 start_slot: 0,
                 slot_count: 3,
                 crossing_regs: 1,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: Some(padded_ty),
             }],
             &pool,
@@ -5098,12 +5813,14 @@ mod tests {
                     start_slot: 0,
                     slot_count: 3,
                     crossing_regs: 1,
+                    crossing_classes: vec![rue_air::NativeArgClass::Gp],
                     ty: Some(padded_ty),
                 },
                 SourceParamAbi {
                     start_slot: 3,
                     slot_count: 1,
                     crossing_regs: 1,
+                    crossing_classes: vec![rue_air::NativeArgClass::Gp],
                     ty: None,
                 },
             ],
@@ -5137,13 +5854,16 @@ mod tests {
             plan.homing(),
             [crate::codegen_pipeline::ParamHoming {
                 start_slot: 0,
-                reg_count: 1,
-                abi_start: 0,
+                class: crate::call_plan::AbiSlotClass::Gp,
+                location: crate::call_plan::AbiSlotLocation::GpReg(0),
             }]
         );
         assert_eq!(
             plan.slot(3),
-            crate::param_storage::ParamSlotStorage::Register { abi_index: 1 }
+            crate::param_storage::ParamSlotStorage::Register {
+                class: crate::call_plan::AbiSlotClass::Gp,
+                location: crate::call_plan::AbiSlotLocation::GpReg(1),
+            }
         );
     }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1269,7 +1269,11 @@ impl<'a> CfgLower<'a> {
                 dst: Operand::Physical(ARG_REGS[*index]),
             });
         }
-        for (index, arg, width) in fp_args {
+        // Regalloc reloads a spilled FloatMov source through xmm0. Populate
+        // the FP argument bank from high to low so such a reload happens
+        // before xmm0 receives its final ABI value. The allocator reserves
+        // xmm0-xmm7, so no other source can alias a destination in this bank.
+        for (index, arg, width) in fp_args.into_iter().rev() {
             self.mir.push(X86Inst::FloatMov {
                 dst: Operand::Physical(FP_ARG_REGS[index]),
                 src: Operand::Virtual(arg),
@@ -6093,6 +6097,93 @@ mod tests {
                 }
             )
         }));
+    }
+
+    #[test]
+    fn spilled_fp_call_argument_is_reloaded_before_xmm0_is_populated() {
+        // Nine simultaneously-live f64 arguments exceed the eight allocatable
+        // FP registers. A spill reload uses xmm0 as its reserved scratch, so
+        // the ABI moves must run from xmm7 down through xmm0.
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let mut fixture = FixtureCfg::new(
+            Type::F64,
+            0,
+            "caller",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let args = (1..=9)
+            .map(|value| CfgCallArg {
+                value: fixture.konst((value as f64).to_bits(), Type::F64),
+                mode: CfgArgMode::Normal,
+            })
+            .collect();
+        let result = fixture.call("sum9", args, Type::F64);
+        fixture.ret(Some(result));
+
+        let allocated = crate::x86_64::regalloc::RegAlloc::new(
+            fixture.lower().expect("float call must lower"),
+            0,
+        )
+        .allocate()
+        .expect("float call must allocate");
+        let call_index = allocated
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, X86Inst::CallRel { .. }))
+            .expect("float call must emit a call");
+        let call_setup = &allocated.instructions()[..call_index];
+        let fp_destinations: Vec<_> = call_setup
+            .iter()
+            .filter_map(|inst| match inst {
+                X86Inst::FloatMov {
+                    dst: Operand::Physical(dst),
+                    ..
+                } if FP_ARG_REGS.contains(dst) => Some(*dst),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            fp_destinations,
+            vec![
+                Reg::Xmm7,
+                Reg::Xmm6,
+                Reg::Xmm5,
+                Reg::Xmm4,
+                Reg::Xmm3,
+                Reg::Xmm2,
+                Reg::Xmm1,
+                Reg::Xmm0,
+            ]
+        );
+        let spill_reload = call_setup
+            .iter()
+            .position(|inst| {
+                matches!(
+                    inst,
+                    X86Inst::FloatLoad {
+                        dst: Operand::Physical(Reg::Xmm0),
+                        ..
+                    }
+                )
+            })
+            .expect("register pressure must reload one FP argument through xmm0");
+        let final_xmm0 = call_setup
+            .iter()
+            .rposition(|inst| {
+                matches!(
+                    inst,
+                    X86Inst::FloatMov {
+                        dst: Operand::Physical(Reg::Xmm0),
+                        ..
+                    }
+                )
+            })
+            .expect("the first FP argument must populate xmm0");
+        assert!(spill_reload < final_xmm0);
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -593,8 +593,12 @@ impl<'a> Emitter<'a> {
             (0..self.num_params)
                 .map(|slot| crate::codegen_pipeline::ParamHoming {
                     start_slot: slot,
-                    reg_count: 1,
-                    abi_start: slot + abi_shift,
+                    class: crate::call_plan::AbiSlotClass::Gp,
+                    location: if (slot + abi_shift) < 6 {
+                        crate::call_plan::AbiSlotLocation::GpReg((slot + abi_shift) as usize)
+                    } else {
+                        crate::call_plan::AbiSlotLocation::Stack((slot + abi_shift) as usize - 6)
+                    },
                 })
                 .collect()
         } else {
@@ -667,6 +671,16 @@ impl<'a> Emitter<'a> {
         // When the function returns via sret, the hidden buffer pointer is
         // the first ABI argument, shifting every user param by one slot.
         const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9];
+        const FP_ARG_REGS: [Reg; 8] = [
+            Reg::Xmm0,
+            Reg::Xmm1,
+            Reg::Xmm2,
+            Reg::Xmm3,
+            Reg::Xmm4,
+            Reg::Xmm5,
+            Reg::Xmm6,
+            Reg::Xmm7,
+        ];
 
         let callee_saved_size = self.callee_saved_size();
 
@@ -680,25 +694,47 @@ impl<'a> Emitter<'a> {
         // argument registers without appearing here at all; their frame slots
         // are likewise compacted away, which `start_slot` already reflects.
         for homing in self.param_homing_or_per_slot() {
-            for k in 0..homing.reg_count {
-                // Use frame_local_slots (not num_locals which includes spills)
-                // because CfgLower generates param offsets based on the original count
-                let slot = self.frame_local_slots + homing.start_slot + k;
-                // Skip past callee-saved registers in the offset calculation
-                let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
+            // Use frame_local_slots (not num_locals which includes spills)
+            // because CfgLower generates param offsets based on the original count
+            let slot = self.frame_local_slots + homing.start_slot;
+            // Skip past callee-saved registers in the offset calculation
+            let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
 
-                let abi_index = homing.abi_start + k;
-                if (abi_index as usize) < ARG_REGS.len() {
-                    let reg = ARG_REGS[abi_index as usize];
+            match (homing.class, homing.location) {
+                (
+                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::call_plan::AbiSlotLocation::GpReg(index),
+                ) => {
+                    let reg = ARG_REGS[index];
                     // Emit: mov [rbp + offset], reg
                     self.begin_inst();
                     self.emit_mov_mr(Reg::Rbp, offset, reg);
                     end_inst!(self, "mov [rbp{}], {}", offset, reg);
-                } else {
+                }
+                (
+                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::call_plan::AbiSlotLocation::FpReg(index),
+                ) => {
+                    self.begin_inst();
+                    self.emit_sse_rm(
+                        if width == crate::value_plan::FloatWidth::F32 {
+                            0xF3
+                        } else {
+                            0xF2
+                        },
+                        0x11,
+                        FP_ARG_REGS[index],
+                        Reg::Rbp,
+                        offset,
+                    );
+                    end_inst!(self, "mov float [rbp{}], {}", offset, FP_ARG_REGS[index]);
+                }
+                (_, crate::call_plan::AbiSlotLocation::Stack(stack_index)) => {
                     // Stack-passed arg: copy from above the frame into the param area
                     let src_offset = crate::frame_layout::checked_incoming_stack_arg_offset(
                         16,
-                        abi_index,
+                        u32::try_from(ARG_REGS.len() + stack_index)
+                            .expect("incoming stack argument index must fit u32"),
                         u32::try_from(ARG_REGS.len())
                             .expect("argument register count must fit u32"),
                     )
@@ -710,6 +746,7 @@ impl<'a> Emitter<'a> {
                     self.emit_mov_mr(Reg::Rbp, offset, Reg::Rax);
                     end_inst!(self, "mov [rbp{}], rax", offset);
                 }
+                _ => unreachable!("parameter ABI class/location mismatch"),
             }
         }
 
@@ -806,7 +843,208 @@ impl<'a> Emitter<'a> {
 
     /// Emit a single instruction.
     fn emit_inst(&mut self, inst: &X86Inst) -> CompileResult<()> {
+        Self::assert_float_operand_classes(inst);
         match inst {
+            X86Inst::FloatConst { dst, bits, width } => {
+                self.begin_inst();
+                self.emit_float_const(dst.as_physical(), *bits, *width);
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatMov { dst, src, width } => {
+                self.begin_inst();
+                self.emit_sse_rr(
+                    if *width == crate::value_plan::FloatWidth::F32 {
+                        0xF3
+                    } else {
+                        0xF2
+                    },
+                    0x10,
+                    dst.as_physical(),
+                    src.as_physical(),
+                    false,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatToBits { dst, src, width } => {
+                self.begin_inst();
+                self.emit_sse_rr(
+                    0x66,
+                    0x7e,
+                    src.as_physical(),
+                    dst.as_physical(),
+                    *width == crate::value_plan::FloatWidth::F64,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::BitsToFloat { dst, src, width } => {
+                self.begin_inst();
+                self.emit_sse_rr(
+                    0x66,
+                    0x6e,
+                    dst.as_physical(),
+                    src.as_physical(),
+                    *width == crate::value_plan::FloatWidth::F64,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatLoad {
+                dst,
+                base,
+                offset,
+                width,
+            } => {
+                let offset = self.adjust_fp_offset(*base, *offset);
+                self.begin_inst();
+                self.emit_sse_rm(
+                    if *width == crate::value_plan::FloatWidth::F32 {
+                        0xF3
+                    } else {
+                        0xF2
+                    },
+                    0x10,
+                    dst.as_physical(),
+                    *base,
+                    offset,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatStore {
+                base,
+                offset,
+                src,
+                width,
+            } => {
+                let offset = self.adjust_fp_offset(*base, *offset);
+                self.begin_inst();
+                self.emit_sse_rm(
+                    if *width == crate::value_plan::FloatWidth::F32 {
+                        0xF3
+                    } else {
+                        0xF2
+                    },
+                    0x11,
+                    src.as_physical(),
+                    *base,
+                    offset,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatBin {
+                op,
+                dst,
+                src,
+                width,
+            } => {
+                let opcode = match op {
+                    super::mir::FloatBinOp::Add => 0x58,
+                    super::mir::FloatBinOp::Sub => 0x5c,
+                    super::mir::FloatBinOp::Mul => 0x59,
+                    super::mir::FloatBinOp::Div => 0x5e,
+                };
+                self.begin_inst();
+                self.emit_sse_rr(
+                    if *width == crate::value_plan::FloatWidth::F32 {
+                        0xF3
+                    } else {
+                        0xF2
+                    },
+                    opcode,
+                    dst.as_physical(),
+                    src.as_physical(),
+                    false,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatNeg { dst, src, width } => {
+                self.begin_inst();
+                self.emit_float_neg(dst.as_physical(), src.as_physical(), *width);
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatSqrt { dst, src, width } => {
+                self.begin_inst();
+                self.emit_sse_rr(
+                    if *width == crate::value_plan::FloatWidth::F32 {
+                        0xF3
+                    } else {
+                        0xF2
+                    },
+                    0x51,
+                    dst.as_physical(),
+                    src.as_physical(),
+                    false,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatCmp { lhs, rhs, width } => {
+                self.begin_inst();
+                self.emit_sse_rr(
+                    if *width == crate::value_plan::FloatWidth::F32 {
+                        0x00
+                    } else {
+                        0x66
+                    },
+                    0x2e,
+                    lhs.as_physical(),
+                    rhs.as_physical(),
+                    false,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::IntToFloat {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => {
+                self.begin_inst();
+                self.emit_sse_rr(
+                    if *width == crate::value_plan::FloatWidth::F32 {
+                        0xF3
+                    } else {
+                        0xF2
+                    },
+                    0x2a,
+                    dst.as_physical(),
+                    src.as_physical(),
+                    *int_bits == 64,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatToInt {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => {
+                self.begin_inst();
+                self.emit_sse_rr(
+                    if *width == crate::value_plan::FloatWidth::F32 {
+                        0xF3
+                    } else {
+                        0xF2
+                    },
+                    0x2c,
+                    dst.as_physical(),
+                    src.as_physical(),
+                    *int_bits == 64,
+                );
+                end_inst!(self, "{}", inst);
+            }
+            X86Inst::FloatCast { dst, src, from, .. } => {
+                self.begin_inst();
+                self.emit_sse_rr(
+                    if *from == crate::value_plan::FloatWidth::F32 {
+                        0xF3
+                    } else {
+                        0xF2
+                    },
+                    0x5a,
+                    dst.as_physical(),
+                    src.as_physical(),
+                    false,
+                );
+                end_inst!(self, "{}", inst);
+            }
             X86Inst::MovRI32 { dst, imm } => {
                 self.begin_inst();
                 self.emit_mov_ri32(dst.as_physical(), *imm);
@@ -1106,6 +1344,16 @@ impl<'a> Emitter<'a> {
                 self.begin_inst();
                 self.emit_setcc(0x94, dst.as_physical());
                 end_inst!(self, "sete {}", dst.as_physical());
+            }
+            X86Inst::Setp { dst } => {
+                self.begin_inst();
+                self.emit_setcc(0x9A, dst.as_physical());
+                end_inst!(self, "setp {}", dst.as_physical());
+            }
+            X86Inst::Setnp { dst } => {
+                self.begin_inst();
+                self.emit_setcc(0x9B, dst.as_physical());
+                end_inst!(self, "setnp {}", dst.as_physical());
             }
             X86Inst::Setne { dst } => {
                 self.begin_inst();
@@ -1415,6 +1663,66 @@ impl<'a> Emitter<'a> {
         Ok(())
     }
 
+    fn assert_float_operand_classes(inst: &X86Inst) {
+        let fp = |operand: &super::mir::Operand| {
+            assert_eq!(
+                operand.as_physical().class(),
+                crate::reg_class::RegClass::Fp,
+                "{inst:?}"
+            )
+        };
+        let gp = |operand: &super::mir::Operand| {
+            assert_eq!(
+                operand.as_physical().class(),
+                crate::reg_class::RegClass::Gp,
+                "{inst:?}"
+            )
+        };
+        match inst {
+            X86Inst::FloatConst { dst, .. } => fp(dst),
+            X86Inst::FloatMov { dst, src, .. }
+            | X86Inst::FloatNeg { dst, src, .. }
+            | X86Inst::FloatSqrt { dst, src, .. }
+            | X86Inst::FloatCast { dst, src, .. } => {
+                fp(dst);
+                fp(src);
+            }
+            X86Inst::FloatToBits { dst, src, .. } => {
+                gp(dst);
+                fp(src);
+            }
+            X86Inst::BitsToFloat { dst, src, .. } => {
+                fp(dst);
+                gp(src);
+            }
+            X86Inst::FloatLoad { dst, base, .. } => {
+                fp(dst);
+                assert_eq!(base.class(), crate::reg_class::RegClass::Gp);
+            }
+            X86Inst::FloatStore { base, src, .. } => {
+                assert_eq!(base.class(), crate::reg_class::RegClass::Gp);
+                fp(src);
+            }
+            X86Inst::FloatBin { dst, src, .. } => {
+                fp(dst);
+                fp(src);
+            }
+            X86Inst::FloatCmp { lhs, rhs, .. } => {
+                fp(lhs);
+                fp(rhs);
+            }
+            X86Inst::IntToFloat { dst, src, .. } => {
+                fp(dst);
+                gp(src);
+            }
+            X86Inst::FloatToInt { dst, src, .. } => {
+                gp(dst);
+                fp(src);
+            }
+            _ => {}
+        }
+    }
+
     /// Emit LEA with simple [base + disp] addressing.
     fn emit_lea_simple(&mut self, dst: Reg, base: Reg, disp: i32) {
         let dst_enc = dst.encoding();
@@ -1544,6 +1852,67 @@ impl<'a> Emitter<'a> {
     /// - REX.R = 1 if src is r8-r15
     /// - REX.B = 1 if dst is r8-r15
     /// - ModR/M byte: mod=11 (register), reg=src, r/m=dst
+    fn emit_sse_rr(&mut self, prefix: u8, opcode: u8, reg: Reg, rm: Reg, rex_w: bool) {
+        if prefix != 0 {
+            self.code.push(prefix);
+        }
+        let rex = 0x40
+            | if rex_w { 8 } else { 0 }
+            | if reg.needs_rex() { 4 } else { 0 }
+            | if rm.needs_rex() { 1 } else { 0 };
+        if rex != 0x40 {
+            self.code.push(rex);
+        }
+        self.code.extend_from_slice(&[
+            0x0f,
+            opcode,
+            0xc0 | ((reg.encoding() & 7) << 3) | (rm.encoding() & 7),
+        ]);
+    }
+
+    fn emit_sse_rm(&mut self, prefix: u8, opcode: u8, reg: Reg, base: Reg, offset: i32) {
+        if prefix != 0 {
+            self.code.push(prefix);
+        }
+        let rex = 0x40 | if reg.needs_rex() { 4 } else { 0 } | if base.needs_rex() { 1 } else { 0 };
+        if rex != 0x40 {
+            self.code.push(rex);
+        }
+        self.code.extend_from_slice(&[0x0f, opcode]);
+        self.emit_modrm_memory(reg.encoding(), base.encoding(), offset);
+    }
+
+    fn emit_float_const(&mut self, dst: Reg, bits: u64, width: crate::value_plan::FloatWidth) {
+        self.emit_mov_ri64(Reg::Rax, bits as i64);
+        self.emit_sse_rr(
+            0x66,
+            0x6e,
+            dst,
+            Reg::Rax,
+            width == crate::value_plan::FloatWidth::F64,
+        );
+    }
+
+    fn emit_float_neg(&mut self, dst: Reg, src: Reg, width: crate::value_plan::FloatWidth) {
+        let sign = if width == crate::value_plan::FloatWidth::F32 {
+            1u64 << 31
+        } else {
+            1u64 << 63
+        };
+        self.emit_float_const(dst, sign, width);
+        self.emit_sse_rr(
+            if width == crate::value_plan::FloatWidth::F64 {
+                0x66
+            } else {
+                0
+            },
+            0x57,
+            dst,
+            src,
+            false,
+        );
+    }
+
     fn emit_mov_rr(&mut self, dst: Reg, src: Reg) {
         let dst_enc = dst.encoding();
         let src_enc = src.encoding();
@@ -3025,7 +3394,7 @@ impl<'a> Emitter<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::mir::Operand;
+    use super::super::mir::{FloatBinOp, FloatWidth, Operand};
     use super::*;
     use crate::LabelId;
 
@@ -3052,14 +3421,119 @@ mod tests {
     }
 
     #[test]
+    fn scalar_sse2_float_encodings_cover_widths_and_extended_registers() {
+        assert_eq!(
+            emit_single(X86Inst::FloatBin {
+                op: FloatBinOp::Add,
+                dst: Operand::Physical(Reg::Xmm0),
+                src: Operand::Physical(Reg::Xmm1),
+                width: FloatWidth::F32,
+            }),
+            vec![0xf3, 0x0f, 0x58, 0xc1]
+        );
+        assert_eq!(
+            emit_single(X86Inst::FloatMov {
+                dst: Operand::Physical(Reg::Xmm8),
+                src: Operand::Physical(Reg::Xmm9),
+                width: FloatWidth::F64,
+            }),
+            vec![0xf2, 0x45, 0x0f, 0x10, 0xc1]
+        );
+        assert_eq!(
+            emit_single(X86Inst::FloatCmp {
+                lhs: Operand::Physical(Reg::Xmm0),
+                rhs: Operand::Physical(Reg::Xmm1),
+                width: FloatWidth::F64,
+            }),
+            vec![0x66, 0x0f, 0x2e, 0xc1]
+        );
+        assert_eq!(
+            emit_single(X86Inst::FloatSqrt {
+                dst: Operand::Physical(Reg::Xmm0),
+                src: Operand::Physical(Reg::Xmm1),
+                width: FloatWidth::F32,
+            }),
+            vec![0xf3, 0x0f, 0x51, 0xc1]
+        );
+        assert_eq!(
+            emit_single(X86Inst::FloatSqrt {
+                dst: Operand::Physical(Reg::Xmm8),
+                src: Operand::Physical(Reg::Xmm9),
+                width: FloatWidth::F64,
+            }),
+            vec![0xf2, 0x45, 0x0f, 0x51, 0xc1]
+        );
+    }
+
+    #[test]
+    fn scalar_float_bit_carrier_moves_cover_both_widths_and_classes() {
+        assert_eq!(
+            emit_single(X86Inst::FloatToBits {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Physical(Reg::Xmm1),
+                width: FloatWidth::F32,
+            }),
+            vec![0x66, 0x0f, 0x7e, 0xc8]
+        );
+        assert_eq!(
+            emit_single(X86Inst::BitsToFloat {
+                dst: Operand::Physical(Reg::Xmm1),
+                src: Operand::Physical(Reg::Rax),
+                width: FloatWidth::F32,
+            }),
+            vec![0x66, 0x0f, 0x6e, 0xc8]
+        );
+        assert_eq!(
+            emit_single(X86Inst::FloatToBits {
+                dst: Operand::Physical(Reg::R10),
+                src: Operand::Physical(Reg::Xmm9),
+                width: FloatWidth::F64,
+            }),
+            vec![0x66, 0x4d, 0x0f, 0x7e, 0xca]
+        );
+        assert_eq!(
+            emit_single(X86Inst::BitsToFloat {
+                dst: Operand::Physical(Reg::Xmm9),
+                src: Operand::Physical(Reg::R10),
+                width: FloatWidth::F64,
+            }),
+            vec![0x66, 0x4d, 0x0f, 0x6e, 0xca]
+        );
+    }
+
+    #[test]
+    fn scalar_sse2_signed_conversion_encoding() {
+        assert_eq!(
+            emit_single(X86Inst::FloatToInt {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Physical(Reg::Xmm0),
+                int_bits: 64,
+                width: FloatWidth::F64,
+            }),
+            vec![0xf2, 0x48, 0x0f, 0x2c, 0xc0]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "FloatBin")]
+    fn float_encoder_rejects_gp_operands() {
+        let _ = emit_single(X86Inst::FloatBin {
+            op: FloatBinOp::Add,
+            dst: Operand::Physical(Reg::Xmm0),
+            src: Operand::Physical(Reg::Rax),
+            width: FloatWidth::F64,
+        });
+    }
+
+    #[test]
     fn incoming_stack_argument_homing_uses_sysv_entry_offset() {
         let mut mir = X86Mir::new();
         mir.push(X86Inst::Ret);
         let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
             .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                 start_slot: 0,
-                reg_count: 1,
-                abi_start: 6,
+                class: crate::call_plan::AbiSlotClass::Gp,
+                location: crate::call_plan::AbiSlotLocation::Stack(0),
             }])
             .emit_all()
             .expect("stack argument homing must emit");

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -155,6 +155,24 @@ pub fn uses(inst: &X86Inst) -> VRegList {
     };
 
     match inst {
+        X86Inst::FloatConst { .. } | X86Inst::FloatLoad { .. } => {}
+        X86Inst::FloatMov { src, .. }
+        | X86Inst::FloatToBits { src, .. }
+        | X86Inst::BitsToFloat { src, .. }
+        | X86Inst::FloatNeg { src, .. }
+        | X86Inst::FloatSqrt { src, .. }
+        | X86Inst::IntToFloat { src, .. }
+        | X86Inst::FloatToInt { src, .. }
+        | X86Inst::FloatCast { src, .. }
+        | X86Inst::FloatStore { src, .. } => add_if_virtual(src, &mut result),
+        X86Inst::FloatBin { dst, src, .. } => {
+            add_if_virtual(dst, &mut result);
+            add_if_virtual(src, &mut result);
+        }
+        X86Inst::FloatCmp { lhs, rhs, .. } => {
+            add_if_virtual(lhs, &mut result);
+            add_if_virtual(rhs, &mut result);
+        }
         X86Inst::MovRI32 { .. } | X86Inst::MovRI64 { .. } => {
             // Only defines, no uses
         }
@@ -243,6 +261,8 @@ pub fn uses(inst: &X86Inst) -> VRegList {
             add_if_virtual(src, &mut result);
         }
         X86Inst::Sete { .. }
+        | X86Inst::Setp { .. }
+        | X86Inst::Setnp { .. }
         | X86Inst::Setne { .. }
         | X86Inst::Setl { .. }
         | X86Inst::Setg { .. }
@@ -338,6 +358,18 @@ pub fn defs(inst: &X86Inst) -> VRegList {
     };
 
     match inst {
+        X86Inst::FloatConst { dst, .. }
+        | X86Inst::FloatMov { dst, .. }
+        | X86Inst::FloatToBits { dst, .. }
+        | X86Inst::BitsToFloat { dst, .. }
+        | X86Inst::FloatLoad { dst, .. }
+        | X86Inst::FloatBin { dst, .. }
+        | X86Inst::FloatNeg { dst, .. }
+        | X86Inst::FloatSqrt { dst, .. }
+        | X86Inst::IntToFloat { dst, .. }
+        | X86Inst::FloatToInt { dst, .. }
+        | X86Inst::FloatCast { dst, .. } => add_if_virtual(dst, &mut result),
+        X86Inst::FloatStore { .. } | X86Inst::FloatCmp { .. } => {}
         X86Inst::MovRI32 { dst, .. } | X86Inst::MovRI64 { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
@@ -402,6 +434,8 @@ pub fn defs(inst: &X86Inst) -> VRegList {
             // Only sets flags, no register def
         }
         X86Inst::Sete { dst }
+        | X86Inst::Setp { dst }
+        | X86Inst::Setnp { dst }
         | X86Inst::Setne { dst }
         | X86Inst::Setl { dst }
         | X86Inst::Setg { dst }
@@ -479,6 +513,21 @@ pub fn defs(inst: &X86Inst) -> VRegList {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vreg::VReg;
+
+    #[test]
+    fn scalar_float_binary_op_reads_both_operands_and_defines_destination() {
+        let dst = VReg::new(0);
+        let src = VReg::new(1);
+        let inst = X86Inst::FloatBin {
+            op: super::super::mir::FloatBinOp::Mul,
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(src),
+            width: crate::value_plan::FloatWidth::F64,
+        };
+        assert_eq!(uses(&inst).into_iter().collect::<Vec<_>>(), vec![dst, src]);
+        assert_eq!(defs(&inst).into_iter().collect::<Vec<_>>(), vec![dst]);
+    }
 
     #[test]
     fn clobbers_are_borrowed_static_slices() {
@@ -513,6 +562,22 @@ mod tests {
                 Reg::R9,
                 Reg::R10,
                 Reg::R11,
+                Reg::Xmm0,
+                Reg::Xmm1,
+                Reg::Xmm2,
+                Reg::Xmm3,
+                Reg::Xmm4,
+                Reg::Xmm5,
+                Reg::Xmm6,
+                Reg::Xmm7,
+                Reg::Xmm8,
+                Reg::Xmm9,
+                Reg::Xmm10,
+                Reg::Xmm11,
+                Reg::Xmm12,
+                Reg::Xmm13,
+                Reg::Xmm14,
+                Reg::Xmm15,
             ]
         );
         assert!(!call_clobbers.contains(&Reg::Rsp));

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -18,8 +18,17 @@ pub use rue_runtime_abi::ReturnBehavior;
 const _: () = assert!(std::mem::size_of::<X86Inst>() <= 40);
 
 pub use crate::reg_class::{RegClass, VRegClasses};
+pub use crate::value_plan::FloatWidth;
 use crate::vreg::MirState;
 pub use crate::vreg::{LabelId, VReg};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloatBinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
 
 /// A physical x86-64 register.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -41,6 +50,22 @@ pub enum Reg {
     R13 = 13,
     R14 = 14,
     R15 = 15,
+    Xmm0 = 16,
+    Xmm1,
+    Xmm2,
+    Xmm3,
+    Xmm4,
+    Xmm5,
+    Xmm6,
+    Xmm7,
+    Xmm8,
+    Xmm9,
+    Xmm10,
+    Xmm11,
+    Xmm12,
+    Xmm13,
+    Xmm14,
+    Xmm15,
 }
 
 // ============================================================================
@@ -89,6 +114,14 @@ pub(crate) const RESERVED_REGS: &[Reg] = &[
     Reg::R8,  // ARG_REGS[4], RET_REGS[3]
     Reg::R9,  // ARG_REGS[5], RET_REGS[4]
     Reg::R10, // RET_REGS[5], SCRATCH_SOURCE
+    Reg::Xmm0,
+    Reg::Xmm1,
+    Reg::Xmm2,
+    Reg::Xmm3,
+    Reg::Xmm4,
+    Reg::Xmm5,
+    Reg::Xmm6,
+    Reg::Xmm7,
 ];
 
 /// Scratch register for a rewritten instruction's value: the destination when
@@ -109,6 +142,8 @@ pub(crate) const SCRATCH_ADDR_BASE: Reg = Reg::Rdx;
 /// SIB address rewrite already occupies. (`rsp` cannot encode as a SIB index,
 /// which is one more reason it is reserved.)
 pub(crate) const SCRATCH_ADDR_INDEX: Reg = Reg::Rcx;
+pub(crate) const SCRATCH_FP_VALUE: Reg = Reg::Xmm0;
+pub(crate) const SCRATCH_FP_SOURCE: Reg = Reg::Xmm1;
 
 /// The register a variable-count shift takes its count in: `cl`, the low byte
 /// of `rcx`. This is a fixed machine operand, not a choice, so the allocator
@@ -147,19 +182,23 @@ impl Reg {
     /// special-casing a target that has only one class (RUE-1067).
     #[inline]
     pub const fn class(self) -> RegClass {
-        RegClass::Gp
+        if (self as u8) >= Reg::Xmm0 as u8 {
+            RegClass::Fp
+        } else {
+            RegClass::Gp
+        }
     }
 
     /// Get the register encoding for ModR/M and SIB bytes.
     #[inline]
     pub const fn encoding(self) -> u8 {
-        self as u8
+        (self as u8) & 15
     }
 
     /// Whether this register requires a REX prefix (R8-R15).
     #[inline]
     pub const fn needs_rex(self) -> bool {
-        (self as u8) >= 8
+        self.encoding() >= 8
     }
 
     /// The 32-bit version of this register's name.
@@ -181,6 +220,7 @@ impl Reg {
             Reg::R13 => "r13d",
             Reg::R14 => "r14d",
             Reg::R15 => "r15d",
+            _ => self.name64(),
         }
     }
 
@@ -203,6 +243,22 @@ impl Reg {
             Reg::R13 => "r13",
             Reg::R14 => "r14",
             Reg::R15 => "r15",
+            Reg::Xmm0 => "xmm0",
+            Reg::Xmm1 => "xmm1",
+            Reg::Xmm2 => "xmm2",
+            Reg::Xmm3 => "xmm3",
+            Reg::Xmm4 => "xmm4",
+            Reg::Xmm5 => "xmm5",
+            Reg::Xmm6 => "xmm6",
+            Reg::Xmm7 => "xmm7",
+            Reg::Xmm8 => "xmm8",
+            Reg::Xmm9 => "xmm9",
+            Reg::Xmm10 => "xmm10",
+            Reg::Xmm11 => "xmm11",
+            Reg::Xmm12 => "xmm12",
+            Reg::Xmm13 => "xmm13",
+            Reg::Xmm14 => "xmm14",
+            Reg::Xmm15 => "xmm15",
         }
     }
 }
@@ -279,14 +335,94 @@ impl From<Reg> for Operand {
 /// An x86-64 MIR instruction.
 #[derive(Debug, Clone)]
 pub enum X86Inst {
+    FloatConst {
+        dst: Operand,
+        bits: u64,
+        width: FloatWidth,
+    },
+    FloatMov {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatToBits {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    BitsToFloat {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatLoad {
+        dst: Operand,
+        base: Reg,
+        offset: i32,
+        width: FloatWidth,
+    },
+    FloatStore {
+        base: Reg,
+        offset: i32,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatBin {
+        op: FloatBinOp,
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatNeg {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatSqrt {
+        dst: Operand,
+        src: Operand,
+        width: FloatWidth,
+    },
+    FloatCmp {
+        lhs: Operand,
+        rhs: Operand,
+        width: FloatWidth,
+    },
+    IntToFloat {
+        dst: Operand,
+        src: Operand,
+        int_bits: u32,
+        width: FloatWidth,
+    },
+    FloatToInt {
+        dst: Operand,
+        src: Operand,
+        int_bits: u32,
+        width: FloatWidth,
+    },
+    FloatCast {
+        dst: Operand,
+        src: Operand,
+        from: FloatWidth,
+        to: FloatWidth,
+    },
     /// `mov dst, imm32` - Move 32-bit immediate to register.
-    MovRI32 { dst: Operand, imm: i32 },
+    MovRI32 {
+        dst: Operand,
+        imm: i32,
+    },
 
     /// `mov dst, imm64` - Move 64-bit immediate to register.
-    MovRI64 { dst: Operand, imm: i64 },
+    MovRI64 {
+        dst: Operand,
+        imm: i64,
+    },
 
     /// `mov dst, src` - Move register to register.
-    MovRR { dst: Operand, src: Operand },
+    MovRR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `mov dst, [base + offset]` - Load from memory (stack local).
     MovRM {
@@ -304,105 +440,185 @@ pub enum X86Inst {
 
     // Arithmetic instructions
     /// `add dst, src` - Add src to dst (dst = dst + src).
-    AddRR { dst: Operand, src: Operand },
+    AddRR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `add dst, src` (64-bit) - Add src to dst treating operands as 64-bit.
     ///
     /// Used for 64-bit arithmetic where 32-bit truncation would give incorrect overflow detection.
-    AddRR64 { dst: Operand, src: Operand },
+    AddRR64 {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `sub dst, src` - Subtract src from dst (dst = dst - src).
-    SubRR { dst: Operand, src: Operand },
+    SubRR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `sub dst, src` (64-bit) - Subtract src from dst treating operands as 64-bit.
     ///
     /// Used for pointer arithmetic where 32-bit truncation would break addresses.
-    SubRR64 { dst: Operand, src: Operand },
+    SubRR64 {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `add dst, imm` - Add immediate to register (dst = dst + imm).
-    AddRI { dst: Operand, imm: i32 },
+    AddRI {
+        dst: Operand,
+        imm: i32,
+    },
 
     /// `imul dst, src` - Signed multiply (dst = dst * src).
-    ImulRR { dst: Operand, src: Operand },
+    ImulRR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `imul dst, src` (64-bit) - Signed multiply treating operands as 64-bit.
     ///
     /// Used for 64-bit multiplication where 32-bit truncation would give incorrect overflow detection.
-    ImulRR64 { dst: Operand, src: Operand },
+    ImulRR64 {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `neg dst` - Two's complement negation (dst = -dst).
-    Neg { dst: Operand },
+    Neg {
+        dst: Operand,
+    },
 
     /// `neg dst` (64-bit) - Two's complement negation treating operand as 64-bit.
     ///
     /// Used for 64-bit negation where 32-bit truncation would give incorrect overflow detection.
-    Neg64 { dst: Operand },
+    Neg64 {
+        dst: Operand,
+    },
 
     /// `xor dst, imm` - XOR with immediate (dst = dst ^ imm).
-    XorRI { dst: Operand, imm: i32 },
+    XorRI {
+        dst: Operand,
+        imm: i32,
+    },
 
     /// `and dst, src` - Bitwise AND, 32-bit (dst = dst & src).
-    AndRR { dst: Operand, src: Operand },
+    AndRR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `or dst, src` - Bitwise OR, 32-bit (dst = dst | src).
-    OrRR { dst: Operand, src: Operand },
+    OrRR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `xor dst, src` - Bitwise XOR, 32-bit (dst = dst ^ src).
-    XorRR { dst: Operand, src: Operand },
+    XorRR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `and dst, src` - Bitwise AND, 64-bit (dst = dst & src).
-    And64RR { dst: Operand, src: Operand },
+    And64RR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `or dst, src` - Bitwise OR, 64-bit (dst = dst | src).
-    Or64RR { dst: Operand, src: Operand },
+    Or64RR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `xor dst, src` - Bitwise XOR, 64-bit (dst = dst ^ src).
-    Xor64RR { dst: Operand, src: Operand },
+    Xor64RR {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `not dst` - Bitwise NOT, 32-bit (dst = ~dst).
-    NotR { dst: Operand },
+    NotR {
+        dst: Operand,
+    },
 
     /// `not dst` (64-bit) - Bitwise NOT treating operand as 64-bit (dst = ~dst).
     ///
     /// Used for i64/u64 BitNot where the 32-bit form would zero the high
     /// 32 bits of the result (RUE-59).
-    Not64R { dst: Operand },
+    Not64R {
+        dst: Operand,
+    },
 
     /// `shl dst, cl` - Shift left 64-bit by count in CL register (dst = dst << CL).
-    ShlRCl { dst: Operand },
+    ShlRCl {
+        dst: Operand,
+    },
 
     /// `shl dst, cl` - Shift left 32-bit by count in CL register (dst = dst << CL).
-    Shl32RCl { dst: Operand },
+    Shl32RCl {
+        dst: Operand,
+    },
 
     /// `shl dst, imm` - Shift left 64-bit by immediate (dst = dst << imm).
-    ShlRI { dst: Operand, imm: u8 },
+    ShlRI {
+        dst: Operand,
+        imm: u8,
+    },
 
     /// `shl dst, imm` - Shift left 32-bit by immediate (dst = dst << imm).
-    Shl32RI { dst: Operand, imm: u8 },
+    Shl32RI {
+        dst: Operand,
+        imm: u8,
+    },
 
     /// `shr dst, cl` - Logical shift right 64-bit by count in CL register (dst = dst >> CL).
-    ShrRCl { dst: Operand },
+    ShrRCl {
+        dst: Operand,
+    },
 
     /// `shr dst, cl` - Logical shift right 32-bit by count in CL register (dst = dst >> CL).
-    Shr32RCl { dst: Operand },
+    Shr32RCl {
+        dst: Operand,
+    },
 
     /// `shr dst, imm` - Logical shift right 64-bit by immediate (dst = dst >> imm).
-    ShrRI { dst: Operand, imm: u8 },
+    ShrRI {
+        dst: Operand,
+        imm: u8,
+    },
 
     /// `shr dst, imm` - Logical shift right 32-bit by immediate (dst = dst >> imm).
-    Shr32RI { dst: Operand, imm: u8 },
+    Shr32RI {
+        dst: Operand,
+        imm: u8,
+    },
 
     /// `sar dst, cl` - Arithmetic shift right 64-bit by count in CL register.
-    SarRCl { dst: Operand },
+    SarRCl {
+        dst: Operand,
+    },
 
     /// `sar dst, cl` - Arithmetic shift right 32-bit by count in CL register.
-    Sar32RCl { dst: Operand },
+    Sar32RCl {
+        dst: Operand,
+    },
 
     /// `sar dst, imm` - Arithmetic shift right 64-bit by immediate.
-    SarRI { dst: Operand, imm: u8 },
+    SarRI {
+        dst: Operand,
+        imm: u8,
+    },
 
     /// `sar dst, imm` - Arithmetic shift right 32-bit by immediate.
-    Sar32RI { dst: Operand, imm: u8 },
+    Sar32RI {
+        dst: Operand,
+        imm: u8,
+    },
 
     /// `cdq` - Sign-extend EAX into EDX:EAX (for signed division).
     Cdq,
@@ -412,136 +628,235 @@ pub enum X86Inst {
 
     /// `idiv src` - Signed divide EDX:EAX by src.
     /// Quotient in EAX, remainder in EDX.
-    IdivR { src: Operand },
+    IdivR {
+        src: Operand,
+    },
 
     /// `div src` - Unsigned divide EDX:EAX by src.
     /// Quotient in EAX, remainder in EDX.
-    DivR { src: Operand },
+    DivR {
+        src: Operand,
+    },
 
     /// `idiv src` - Signed divide RDX:RAX by src (64-bit).
     /// Quotient in RAX, remainder in RDX.
-    Idiv64R { src: Operand },
+    Idiv64R {
+        src: Operand,
+    },
 
     /// `div src` - Unsigned divide RDX:RAX by src (64-bit).
     /// Quotient in RAX, remainder in RDX.
-    Div64R { src: Operand },
+    Div64R {
+        src: Operand,
+    },
 
     /// `mul src` - Unsigned multiply EAX by src (32-bit).
     /// Product in EDX:EAX; CF and OF are set iff EDX (the high half) is
     /// non-zero, i.e. exactly on unsigned overflow (RUE-148).
-    MulR { src: Operand },
+    MulR {
+        src: Operand,
+    },
 
     /// `mul src` - Unsigned multiply RAX by src (64-bit).
     /// Product in RDX:RAX; CF and OF are set iff RDX (the high half) is
     /// non-zero, i.e. exactly on unsigned overflow (RUE-148).
-    Mul64R { src: Operand },
+    Mul64R {
+        src: Operand,
+    },
 
     // Comparison and control flow
     /// `cmp src1, src2` - Compare 32-bit (subtract and set flags, discard result).
-    CmpRR { src1: Operand, src2: Operand },
+    CmpRR {
+        src1: Operand,
+        src2: Operand,
+    },
 
     /// `cmp src1, src2` - Compare 64-bit (subtract and set flags, discard result).
-    Cmp64RR { src1: Operand, src2: Operand },
+    Cmp64RR {
+        src1: Operand,
+        src2: Operand,
+    },
 
     /// `cmp src, imm` - Compare register with immediate (32-bit).
-    CmpRI { src: Operand, imm: i32 },
+    CmpRI {
+        src: Operand,
+        imm: i32,
+    },
 
     /// `cmp src, imm` - Compare register with immediate (64-bit).
-    Cmp64RI { src: Operand, imm: i32 },
+    Cmp64RI {
+        src: Operand,
+        imm: i32,
+    },
 
     /// `sete dst` - Set byte if equal (ZF=1).
-    Sete { dst: Operand },
+    Sete {
+        dst: Operand,
+    },
+    Setp {
+        dst: Operand,
+    },
+    Setnp {
+        dst: Operand,
+    },
 
     /// `setne dst` - Set byte if not equal (ZF=0).
-    Setne { dst: Operand },
+    Setne {
+        dst: Operand,
+    },
 
     /// `setl dst` - Set byte if less (signed: SF!=OF).
-    Setl { dst: Operand },
+    Setl {
+        dst: Operand,
+    },
 
     /// `setg dst` - Set byte if greater (signed: ZF=0 and SF=OF).
-    Setg { dst: Operand },
+    Setg {
+        dst: Operand,
+    },
 
     /// `setle dst` - Set byte if less or equal (signed: ZF=1 or SF!=OF).
-    Setle { dst: Operand },
+    Setle {
+        dst: Operand,
+    },
 
     /// `setge dst` - Set byte if greater or equal (signed: SF=OF).
-    Setge { dst: Operand },
+    Setge {
+        dst: Operand,
+    },
 
     /// `setb dst` - Set byte if below (unsigned: CF=1).
-    Setb { dst: Operand },
+    Setb {
+        dst: Operand,
+    },
 
     /// `seta dst` - Set byte if above (unsigned: CF=0 and ZF=0).
-    Seta { dst: Operand },
+    Seta {
+        dst: Operand,
+    },
 
     /// `setbe dst` - Set byte if below or equal (unsigned: CF=1 or ZF=1).
-    Setbe { dst: Operand },
+    Setbe {
+        dst: Operand,
+    },
 
     /// `setae dst` - Set byte if above or equal (unsigned: CF=0).
-    Setae { dst: Operand },
+    Setae {
+        dst: Operand,
+    },
 
     /// `movzx dst, src` - Move with zero-extend (byte to dword).
-    Movzx { dst: Operand, src: Operand },
+    Movzx {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `movsx dst, src` - Sign-extend 8-bit to 64-bit.
-    Movsx8To64 { dst: Operand, src: Operand },
+    Movsx8To64 {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `movsx dst, src` - Sign-extend 16-bit to 64-bit.
-    Movsx16To64 { dst: Operand, src: Operand },
+    Movsx16To64 {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `movsxd dst, src` - Sign-extend 32-bit to 64-bit.
-    Movsx32To64 { dst: Operand, src: Operand },
+    Movsx32To64 {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `mov dst32, src32` - Zero-extend 32-bit to 64-bit via a 32-bit write.
     ///
     /// In 64-bit mode, any write to a 32-bit general-purpose register clears
     /// the destination's upper half. This is the canonical register-to-register
     /// u32-to-u64 normalization instruction.
-    Movzx32To64 { dst: Operand, src: Operand },
+    Movzx32To64 {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `movzx dst, src` - Zero-extend 8-bit to 64-bit.
-    Movzx8To64 { dst: Operand, src: Operand },
+    Movzx8To64 {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `movzx dst, src` - Zero-extend 16-bit to 64-bit.
-    Movzx16To64 { dst: Operand, src: Operand },
+    Movzx16To64 {
+        dst: Operand,
+        src: Operand,
+    },
 
     /// `test src1, src2` - Bitwise AND, set flags, discard result.
-    TestRR { src1: Operand, src2: Operand },
+    TestRR {
+        src1: Operand,
+        src2: Operand,
+    },
 
     /// `test src1, src2` - Bitwise AND (64-bit), set flags, discard result.
-    Test64RR { src1: Operand, src2: Operand },
+    Test64RR {
+        src1: Operand,
+        src2: Operand,
+    },
 
     /// `jz label` - Jump if zero flag is set.
-    Jz { label: LabelId },
+    Jz {
+        label: LabelId,
+    },
 
     /// `jnz label` - Jump if zero flag is not set.
-    Jnz { label: LabelId },
+    Jnz {
+        label: LabelId,
+    },
 
     /// `jo label` - Jump if overflow flag is set.
-    Jo { label: LabelId },
+    Jo {
+        label: LabelId,
+    },
 
     /// `jno label` - Jump if overflow flag is not set.
-    Jno { label: LabelId },
+    Jno {
+        label: LabelId,
+    },
 
     /// `jb label` - Jump if below (unsigned: CF=1).
-    Jb { label: LabelId },
+    Jb {
+        label: LabelId,
+    },
 
     /// `jae label` - Jump if above or equal (unsigned: CF=0).
-    Jae { label: LabelId },
+    Jae {
+        label: LabelId,
+    },
 
     /// `jbe label` - Jump if below or equal (unsigned: CF=1 or ZF=1).
-    Jbe { label: LabelId },
+    Jbe {
+        label: LabelId,
+    },
 
     /// `jge label` - Jump if greater or equal (signed: SF=OF).
-    Jge { label: LabelId },
+    Jge {
+        label: LabelId,
+    },
 
     /// `jle label` - Jump if less or equal (signed: ZF=1 or SF≠OF).
-    Jle { label: LabelId },
+    Jle {
+        label: LabelId,
+    },
 
     /// `jmp label` - Unconditional jump.
-    Jmp { label: LabelId },
+    Jmp {
+        label: LabelId,
+    },
 
     /// Label marker (not a real instruction).
-    Label { id: LabelId },
+    Label {
+        id: LabelId,
+    },
 
     /// `call symbol` - Call a function by symbol name (PC-relative).
     ///
@@ -573,18 +888,29 @@ pub enum X86Inst {
     Ud2,
 
     /// `pop dst` - Pop value from stack into register.
-    Pop { dst: Operand },
+    Pop {
+        dst: Operand,
+    },
 
     /// `push src` - Push value from register onto stack.
-    Push { src: Operand },
+    Push {
+        src: Operand,
+    },
 
     /// `lea dst, [base + disp]` - Load effective address.
-    Lea { dst: Operand, base: Reg, disp: i32 },
+    Lea {
+        dst: Operand,
+        base: Reg,
+        disp: i32,
+    },
 
     /// `shl dst, count` - Pre-register-allocation variable left-shift pseudo.
     /// Register allocation loads `count` into `cl` and lowers this to
     /// [`X86Inst::ShlRCl`] before scheduling.
-    Shl { dst: Operand, count: Operand },
+    Shl {
+        dst: Operand,
+        count: Operand,
+    },
 
     /// `mov dst, [base]` - Load from memory via a virtual base register.
     ///
@@ -682,14 +1008,23 @@ pub enum X86Inst {
     },
 
     /// Load pointer to string constant (pseudo-instruction resolved during emission)
-    StringConstPtr { dst: Operand, string_id: u32 },
+    StringConstPtr {
+        dst: Operand,
+        string_id: u32,
+    },
 
     /// Load string length (pseudo-instruction resolved during emission)
-    StringConstLen { dst: Operand, string_id: u32 },
+    StringConstLen {
+        dst: Operand,
+        string_id: u32,
+    },
 
     /// Load string capacity (pseudo-instruction resolved during emission)
     /// For string literals, this is always 0 (indicating rodata, not heap)
-    StringConstCap { dst: Operand, string_id: u32 },
+    StringConstCap {
+        dst: Operand,
+        string_id: u32,
+    },
 }
 
 impl X86Inst {
@@ -733,6 +1068,7 @@ impl X86Inst {
             | X86Inst::Mul64R { .. } => &[Reg::Rax, Reg::Rdx],
             // CDQ/CQO sign-extends (E/R)AX into (E/R)DX, clobbering RDX
             X86Inst::Cdq | X86Inst::Cqo => &[Reg::Rdx],
+            X86Inst::FloatConst { .. } | X86Inst::FloatNeg { .. } => &[Reg::Rax],
             // Function calls clobber all caller-saved registers per System V AMD64 ABI
             X86Inst::CallRel { .. } => &[
                 Reg::Rax,
@@ -744,6 +1080,22 @@ impl X86Inst {
                 Reg::R9,
                 Reg::R10,
                 Reg::R11,
+                Reg::Xmm0,
+                Reg::Xmm1,
+                Reg::Xmm2,
+                Reg::Xmm3,
+                Reg::Xmm4,
+                Reg::Xmm5,
+                Reg::Xmm6,
+                Reg::Xmm7,
+                Reg::Xmm8,
+                Reg::Xmm9,
+                Reg::Xmm10,
+                Reg::Xmm11,
+                Reg::Xmm12,
+                Reg::Xmm13,
+                Reg::Xmm14,
+                Reg::Xmm15,
             ],
             // Syscall clobbers RAX (return value), RCX (saved RIP), R11 (saved RFLAGS)
             X86Inst::Syscall => &[Reg::Rax, Reg::Rcx, Reg::R11],
@@ -774,6 +1126,88 @@ fn fmt_disp(offset: i32) -> String {
 impl fmt::Display for X86Inst {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            X86Inst::FloatConst { dst, bits, width } => {
+                write!(f, "fconst.{width:?} {dst}, 0x{bits:x}")
+            }
+            X86Inst::FloatMov { dst, src, width } => write!(
+                f,
+                "movs{} {dst}, {src}",
+                if *width == FloatWidth::F32 { "s" } else { "d" }
+            ),
+            X86Inst::FloatToBits { dst, src, width } => {
+                write!(f, "float_to_bits.{width:?} {dst}, {src}")
+            }
+            X86Inst::BitsToFloat { dst, src, width } => {
+                write!(f, "bits_to_float.{width:?} {dst}, {src}")
+            }
+            X86Inst::FloatLoad {
+                dst,
+                base,
+                offset,
+                width,
+            } => write!(
+                f,
+                "movs{} {dst}, [{base}{}]",
+                if *width == FloatWidth::F32 { "s" } else { "d" },
+                fmt_disp(*offset)
+            ),
+            X86Inst::FloatStore {
+                base,
+                offset,
+                src,
+                width,
+            } => write!(
+                f,
+                "movs{} [{base}{}], {src}",
+                if *width == FloatWidth::F32 { "s" } else { "d" },
+                fmt_disp(*offset)
+            ),
+            X86Inst::FloatBin {
+                op,
+                dst,
+                src,
+                width,
+            } => write!(
+                f,
+                "{}s{} {dst}, {src}",
+                match op {
+                    FloatBinOp::Add => "add",
+                    FloatBinOp::Sub => "sub",
+                    FloatBinOp::Mul => "mul",
+                    FloatBinOp::Div => "div",
+                },
+                if *width == FloatWidth::F32 { "s" } else { "d" }
+            ),
+            X86Inst::FloatNeg { dst, src, width } => write!(f, "fneg.{width:?} {dst}, {src}"),
+            X86Inst::FloatSqrt { dst, src, width } => write!(f, "fsqrt.{width:?} {dst}, {src}"),
+            X86Inst::FloatCmp { lhs, rhs, width } => write!(
+                f,
+                "ucomis{} {lhs}, {rhs}",
+                if *width == FloatWidth::F32 { "s" } else { "d" }
+            ),
+            X86Inst::IntToFloat {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => write!(
+                f,
+                "cvtsi{int_bits}2s{} {dst}, {src}",
+                if *width == FloatWidth::F32 { "s" } else { "d" }
+            ),
+            X86Inst::FloatToInt {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => write!(
+                f,
+                "cvtts{}2si{int_bits} {dst}, {src}",
+                if *width == FloatWidth::F32 { "s" } else { "d" }
+            ),
+            X86Inst::FloatCast { dst, src, from, to } => {
+                write!(f, "cvt{from:?}2{to:?} {dst}, {src}")
+            }
             X86Inst::MovRI32 { dst, imm } => write!(f, "mov {}, {}", dst, imm),
             X86Inst::MovRI64 { dst, imm } => write!(f, "mov {}, {}", dst, imm),
             X86Inst::MovRR { dst, src } => write!(f, "mov {}, {}", dst, src),
@@ -834,6 +1268,8 @@ impl fmt::Display for X86Inst {
             X86Inst::CmpRI { src, imm } => write!(f, "cmp {}, {}", src, imm),
             X86Inst::Cmp64RI { src, imm } => write!(f, "cmpq {}, {}", src, imm),
             X86Inst::Sete { dst } => write!(f, "sete {}", dst),
+            X86Inst::Setp { dst } => write!(f, "setp {}", dst),
+            X86Inst::Setnp { dst } => write!(f, "setnp {}", dst),
             X86Inst::Setne { dst } => write!(f, "setne {}", dst),
             X86Inst::Setl { dst } => write!(f, "setl {}", dst),
             X86Inst::Setg { dst } => write!(f, "setg {}", dst),
@@ -1073,10 +1509,8 @@ impl X86Mir {
 
     /// Allocate a new general-purpose virtual register.
     ///
-    /// This is the whole of lowering today: no Rue type lowers to a
-    /// floating-point value yet, so every value a function computes lives in a
-    /// general-purpose register. Sites that later hold a floating-point value
-    /// call [`X86Mir::alloc_vreg_in`] with [`RegClass::Fp`] instead (RUE-1067).
+    /// Integer values and addresses use this default. Scalar float lowering
+    /// calls [`X86Mir::alloc_vreg_in`] with [`RegClass::Fp`].
     pub fn alloc_vreg(&mut self) -> VReg {
         self.alloc_vreg_in(RegClass::Gp)
     }
@@ -1253,8 +1687,10 @@ mod tests {
     }
 
     #[test]
-    fn every_physical_register_is_general_purpose() {
+    fn physical_registers_report_their_register_class() {
         assert_eq!(Reg::Rbx.class(), RegClass::Gp);
+        assert_eq!(Reg::Xmm0.class(), RegClass::Fp);
+        assert_eq!(Reg::Xmm15.class(), RegClass::Fp);
     }
 
     #[test]
@@ -1263,6 +1699,8 @@ mod tests {
         assert_eq!(Reg::Rdi.encoding(), 7);
         assert_eq!(Reg::R8.encoding(), 8);
         assert_eq!(Reg::R15.encoding(), 15);
+        assert_eq!(Reg::Xmm0.encoding(), 0);
+        assert_eq!(Reg::Xmm15.encoding(), 15);
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -63,6 +63,7 @@ impl Backend for X86CodegenBackend {
 
     const ARCH: rue_target::Arch = rue_target::Arch::X86_64;
     const ARG_REG_COUNT: u32 = cfg_lower::ARG_REGS.len() as u32;
+    const FP_ARG_REG_COUNT: u32 = cfg_lower::FP_ARG_REGS.len() as u32;
     const RETURN_REG_COUNT: u32 = cfg_lower::RET_REGS.len() as u32;
     const SAVED_REG_SCHEME: crate::frame_layout::SavedRegScheme =
         crate::frame_layout::SavedRegScheme::X86_64;

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -17,8 +17,8 @@ use super::liveness;
 use super::mir;
 use super::mir::VReg;
 use super::mir::{
-    Operand, Reg, SCRATCH_ADDR_BASE, SCRATCH_ADDR_INDEX, SCRATCH_SOURCE, SCRATCH_VALUE,
-    SHIFT_COUNT, X86Inst, X86Mir,
+    Operand, Reg, SCRATCH_ADDR_BASE, SCRATCH_ADDR_INDEX, SCRATCH_FP_SOURCE, SCRATCH_FP_VALUE,
+    SCRATCH_SOURCE, SCRATCH_VALUE, SHIFT_COUNT, X86Inst, X86Mir,
 };
 use crate::alloc_dst;
 use crate::regalloc::{
@@ -68,6 +68,16 @@ const CALLEE_SAVED_REGS: &[Reg] = &[Reg::Rbx, Reg::R13, Reg::R14, Reg::R15, Reg:
 /// would give up a register and buy nothing. See
 /// [`RegisterClasses::compact_callee_saved`].
 const COMPACT_CALLEE_SAVED_REGS: &[Reg] = &[Reg::Rbx];
+const FP_CALLER_SAVED_REGS: &[Reg] = &[
+    Reg::Xmm8,
+    Reg::Xmm9,
+    Reg::Xmm10,
+    Reg::Xmm11,
+    Reg::Xmm12,
+    Reg::Xmm13,
+    Reg::Xmm14,
+    Reg::Xmm15,
+];
 
 /// Every allocatable register, in preference order: caller-saved first.
 ///
@@ -196,6 +206,230 @@ impl RegAlloc {
         inst: X86Inst,
     ) -> CompileResult<()> {
         match inst {
+            X86Inst::FloatConst { dst, bits, width } => {
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(X86Inst::FloatConst {
+                    dst: out,
+                    bits,
+                    width,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(X86Inst::FloatStore {
+                        base: Reg::Rbp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            X86Inst::FloatMov { dst, src, width } => {
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_VALUE, width)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(X86Inst::FloatMov {
+                    dst: out,
+                    src,
+                    width,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(X86Inst::FloatStore {
+                        base: Reg::Rbp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            X86Inst::FloatToBits { dst, src, width } => {
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_VALUE, width)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::FloatToBits { dst: dst_op, src, width });
+                    },
+                    store |spill_offset| {
+                        mir.push_after(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset: spill_offset,
+                            src: Operand::Physical(SCRATCH_VALUE),
+                        });
+                    },
+                );
+            }
+            X86Inst::BitsToFloat { dst, src, width } => {
+                let src = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(X86Inst::BitsToFloat {
+                    dst: out,
+                    src,
+                    width,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(X86Inst::FloatStore {
+                        base: Reg::Rbp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            X86Inst::FloatBin {
+                op,
+                dst,
+                src,
+                width,
+            } => {
+                let out = Self::load_float_operand(context, mir, dst, SCRATCH_FP_VALUE, width)?;
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_SOURCE, width)?;
+                mir.push(X86Inst::FloatBin {
+                    op,
+                    dst: out,
+                    src,
+                    width,
+                });
+                if let Some(Allocation::Spill(offset)) = Self::get_allocation(context, dst) {
+                    mir.push_after(X86Inst::FloatStore {
+                        base: Reg::Rbp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            X86Inst::FloatNeg { dst, src, width } | X86Inst::FloatSqrt { dst, src, width } => {
+                let is_sqrt = matches!(inst, X86Inst::FloatSqrt { .. });
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_SOURCE, width)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(if is_sqrt {
+                    X86Inst::FloatSqrt {
+                        dst: out,
+                        src,
+                        width,
+                    }
+                } else {
+                    X86Inst::FloatNeg {
+                        dst: out,
+                        src,
+                        width,
+                    }
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(X86Inst::FloatStore {
+                        base: Reg::Rbp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            X86Inst::FloatCmp { lhs, rhs, width } => {
+                let lhs = Self::load_float_operand(context, mir, lhs, SCRATCH_FP_VALUE, width)?;
+                let rhs = Self::load_float_operand(context, mir, rhs, SCRATCH_FP_SOURCE, width)?;
+                mir.push(X86Inst::FloatCmp { lhs, rhs, width });
+            }
+            X86Inst::FloatLoad {
+                dst,
+                base,
+                offset,
+                width,
+            } => {
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(X86Inst::FloatLoad {
+                    dst: out,
+                    base,
+                    offset,
+                    width,
+                });
+                if let Some(spill_offset) = spill {
+                    mir.push_after(X86Inst::FloatStore {
+                        base: Reg::Rbp,
+                        offset: spill_offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            X86Inst::FloatStore {
+                base,
+                offset,
+                src,
+                width,
+            } => {
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_VALUE, width)?;
+                mir.push(X86Inst::FloatStore {
+                    base,
+                    offset,
+                    src,
+                    width,
+                });
+            }
+            X86Inst::IntToFloat {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => {
+                let src = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(X86Inst::IntToFloat {
+                    dst: out,
+                    src,
+                    int_bits,
+                    width,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(X86Inst::FloatStore {
+                        base: Reg::Rbp,
+                        offset,
+                        src: out,
+                        width,
+                    });
+                }
+            }
+            X86Inst::FloatToInt {
+                dst,
+                src,
+                int_bits,
+                width,
+            } => {
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_VALUE, width)?;
+                let dst_alloc = Self::get_allocation(context, dst);
+                let out = match dst_alloc {
+                    Some(Allocation::Register(r)) => Operand::Physical(r),
+                    Some(Allocation::Spill(_)) => Operand::Physical(SCRATCH_VALUE),
+                    None => dst,
+                    Some(Allocation::Rematerialize(_)) => unreachable!(),
+                };
+                mir.push(X86Inst::FloatToInt {
+                    dst: out,
+                    src,
+                    int_bits,
+                    width,
+                });
+                if let Some(Allocation::Spill(offset)) = dst_alloc {
+                    mir.push_after(X86Inst::MovMR {
+                        base: Reg::Rbp,
+                        offset,
+                        src: out,
+                    });
+                }
+            }
+            X86Inst::FloatCast { dst, src, from, to } => {
+                let src = Self::load_float_operand(context, mir, src, SCRATCH_FP_SOURCE, from)?;
+                let (out, spill) = Self::float_output(context, dst, SCRATCH_FP_VALUE);
+                mir.push(X86Inst::FloatCast {
+                    dst: out,
+                    src,
+                    from,
+                    to,
+                });
+                if let Some(offset) = spill {
+                    mir.push_after(X86Inst::FloatStore {
+                        base: Reg::Rbp,
+                        offset,
+                        src: out,
+                        width: to,
+                    });
+                }
+            }
             X86Inst::MovRI32 { dst, imm } => {
                 alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
@@ -542,6 +776,12 @@ impl RegAlloc {
 
             X86Inst::Sete { dst } => {
                 Self::emit_setcc(context, mir, dst, |d| X86Inst::Sete { dst: d });
+            }
+            X86Inst::Setp { dst } => {
+                Self::emit_setcc(context, mir, dst, |d| X86Inst::Setp { dst: d })
+            }
+            X86Inst::Setnp { dst } => {
+                Self::emit_setcc(context, mir, dst, |d| X86Inst::Setnp { dst: d })
             }
 
             X86Inst::Setne { dst } => {
@@ -1075,6 +1315,49 @@ impl RegAlloc {
         }
     }
 
+    fn float_output(
+        context: &AllocationContext<'_, Reg>,
+        operand: Operand,
+        scratch: Reg,
+    ) -> (Operand, Option<i32>) {
+        match Self::get_allocation(context, operand) {
+            Some(Allocation::Register(reg)) => (Operand::Physical(reg), None),
+            Some(Allocation::Spill(offset)) => (Operand::Physical(scratch), Some(offset)),
+            Some(Allocation::Rematerialize(_)) => {
+                unreachable!("destination cannot be rematerializable")
+            }
+            None => (operand, None),
+        }
+    }
+
+    fn load_float_operand(
+        context: &AllocationContext<'_, Reg>,
+        mir: &mut RewriteBuffer<X86Inst>,
+        operand: Operand,
+        scratch: Reg,
+        width: crate::value_plan::FloatWidth,
+    ) -> CompileResult<Operand> {
+        match operand {
+            Operand::Virtual(vreg) => match context.allocation(vreg) {
+                Some(Allocation::Register(reg)) => Ok(Operand::Physical(reg)),
+                Some(Allocation::Spill(offset)) => {
+                    mir.push_before(X86Inst::FloatLoad {
+                        dst: Operand::Physical(scratch),
+                        base: Reg::Rbp,
+                        offset,
+                        width,
+                    });
+                    Ok(Operand::Physical(scratch))
+                }
+                Some(Allocation::Rematerialize(_)) => {
+                    unreachable!("float values are not rematerialized")
+                }
+                None => Ok(operand),
+            },
+            Operand::Physical(_) => Ok(operand),
+        }
+    }
+
     /// Load an operand into a physical register, inserting a load if spilled
     /// or rematerializing if marked for rematerialization.
     /// Returns the operand to use (either the allocated register or the scratch register).
@@ -1408,14 +1691,19 @@ impl RegAllocBackend for X86Backend {
     }
 
     fn register_file() -> RegisterFile<'static, Self::Reg> {
-        // General-purpose only: `Reg` names no XMM register yet, so the `Fp`
-        // class of the file is empty and no interval can select it
-        // (RUE-1067). The floats series adds the XMM registers here.
-        RegisterFile::gp_only(SaveClasses {
-            caller_saved: CALLER_SAVED_REGS,
-            callee_saved: CALLEE_SAVED_REGS,
-            compact_callee_saved: COMPACT_CALLEE_SAVED_REGS,
-        })
+        // Keep scalar floating-point values in a disjoint XMM register class.
+        RegisterFile::new([
+            SaveClasses {
+                caller_saved: CALLER_SAVED_REGS,
+                callee_saved: CALLEE_SAVED_REGS,
+                compact_callee_saved: COMPACT_CALLEE_SAVED_REGS,
+            },
+            SaveClasses {
+                caller_saved: FP_CALLER_SAVED_REGS,
+                callee_saved: &[],
+                compact_callee_saved: &[],
+            },
+        ])
     }
 
     fn for_each_physical_operand<F>(inst: &Self::Inst, mut visit: F)
@@ -1464,20 +1752,15 @@ mod tests {
     use super::X86Backend;
     use super::liveness;
     use super::{
-        ALLOCATABLE_REGS, CALLEE_SAVED_REGS, CALLER_SAVED_REGS, COMPACT_CALLEE_SAVED_REGS, Operand,
-        Reg, RegAlloc, SCRATCH_VALUE, VReg, X86Inst, X86Mir,
+        ALLOCATABLE_REGS, CALLEE_SAVED_REGS, CALLER_SAVED_REGS, COMPACT_CALLEE_SAVED_REGS,
+        FP_CALLER_SAVED_REGS, Operand, Reg, RegAlloc, SCRATCH_VALUE, VReg, X86Inst, X86Mir,
     };
     use crate::reg_class::RegClass;
     use crate::regalloc::{Allocation, RegAllocBackend, RematerializeOp};
     use ahash::AHashSet;
 
     #[test]
-    fn the_register_file_is_general_purpose_only() {
-        // The whole of RUE-1067's claim on this backend: the class dimension
-        // exists, and the floating-point half of it is empty. A change that
-        // populates `Fp` here without the rest of the floats series would make
-        // allocation hand out registers no instruction can encode, so this
-        // guard fails loudly instead.
+    fn the_register_file_keeps_gp_and_fp_registers_separate() {
         let file = <X86Backend as RegAllocBackend>::register_file();
         let gp = file.class(RegClass::Gp);
         let fp = file.class(RegClass::Fp);
@@ -1485,12 +1768,16 @@ mod tests {
         assert_eq!(gp.caller_saved, CALLER_SAVED_REGS);
         assert_eq!(gp.callee_saved, CALLEE_SAVED_REGS);
         assert!(!gp.is_empty());
-        assert!(
-            fp.is_empty(),
-            "no floating-point register is allocatable yet"
+        assert_eq!(fp.caller_saved, FP_CALLER_SAVED_REGS);
+        assert!(fp.callee_saved.is_empty());
+        assert!(!fp.is_empty());
+        assert_eq!(
+            file.len(),
+            ALLOCATABLE_REGS.len() + FP_CALLER_SAVED_REGS.len()
         );
-        assert_eq!(file.len(), ALLOCATABLE_REGS.len());
-        assert_eq!(file.caller_saved_flattened(), CALLER_SAVED_REGS.to_vec());
+        let mut expected = CALLER_SAVED_REGS.to_vec();
+        expected.extend_from_slice(FP_CALLER_SAVED_REGS);
+        assert_eq!(file.caller_saved_flattened(), expected);
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -85,6 +85,23 @@ impl SchedulerAdapter for X86Scheduler {
 /// They represent the number of cycles until the result is ready.
 fn get_latency(inst: &X86Inst) -> u32 {
     match inst {
+        X86Inst::FloatLoad { .. } => 4,
+        X86Inst::FloatBin {
+            op: super::mir::FloatBinOp::Div,
+            ..
+        } => 12,
+        X86Inst::FloatBin { .. }
+        | X86Inst::FloatNeg { .. }
+        | X86Inst::FloatSqrt { .. }
+        | X86Inst::FloatCast { .. }
+        | X86Inst::IntToFloat { .. }
+        | X86Inst::FloatToInt { .. } => 4,
+        X86Inst::FloatConst { .. }
+        | X86Inst::FloatMov { .. }
+        | X86Inst::FloatToBits { .. }
+        | X86Inst::BitsToFloat { .. }
+        | X86Inst::FloatStore { .. }
+        | X86Inst::FloatCmp { .. } => 1,
         // Register moves: 0-1 cycle (often eliminated by renaming)
         X86Inst::MovRR { .. } => 1,
         X86Inst::MovRI32 { .. } | X86Inst::MovRI64 { .. } => 1,
@@ -162,6 +179,8 @@ fn get_latency(inst: &X86Inst) -> u32 {
 
         // Setcc: 1 cycle
         X86Inst::Sete { .. }
+        | X86Inst::Setp { .. }
+        | X86Inst::Setnp { .. }
         | X86Inst::Setne { .. }
         | X86Inst::Setl { .. }
         | X86Inst::Setg { .. }
@@ -249,6 +268,8 @@ fn accesses_memory(inst: &X86Inst) -> bool {
         inst,
         X86Inst::MovRM { .. }
             | X86Inst::MovMR { .. }
+            | X86Inst::FloatLoad { .. }
+            | X86Inst::FloatStore { .. }
             | X86Inst::MovRMIndexed { .. }
             | X86Inst::MovMRIndexed { .. }
             | X86Inst::MovRMSib { .. }
@@ -273,6 +294,28 @@ pub(super) fn regs_read(inst: &X86Inst) -> RegList<Reg> {
     };
 
     match inst {
+        X86Inst::FloatConst { .. } => {}
+        X86Inst::FloatLoad { base, .. } => result.push(*base),
+        X86Inst::FloatMov { src, .. }
+        | X86Inst::FloatToBits { src, .. }
+        | X86Inst::BitsToFloat { src, .. }
+        | X86Inst::FloatNeg { src, .. }
+        | X86Inst::FloatSqrt { src, .. }
+        | X86Inst::IntToFloat { src, .. }
+        | X86Inst::FloatToInt { src, .. }
+        | X86Inst::FloatCast { src, .. } => add_if_phys(src, &mut result),
+        X86Inst::FloatStore { base, src, .. } => {
+            result.push(*base);
+            add_if_phys(src, &mut result);
+        }
+        X86Inst::FloatBin { dst, src, .. } => {
+            add_if_phys(dst, &mut result);
+            add_if_phys(src, &mut result);
+        }
+        X86Inst::FloatCmp { lhs, rhs, .. } => {
+            add_if_phys(lhs, &mut result);
+            add_if_phys(rhs, &mut result);
+        }
         X86Inst::MovRI32 { .. } | X86Inst::MovRI64 { .. } => {}
         X86Inst::MovRR { src, .. } => add_if_phys(src, &mut result),
         X86Inst::MovRM { base, .. } | X86Inst::NarrowLoadRM { base, .. } => result.push(*base),
@@ -346,6 +389,8 @@ pub(super) fn regs_read(inst: &X86Inst) -> RegList<Reg> {
             add_if_phys(src, &mut result);
         }
         X86Inst::Sete { .. }
+        | X86Inst::Setp { .. }
+        | X86Inst::Setnp { .. }
         | X86Inst::Setne { .. }
         | X86Inst::Setl { .. }
         | X86Inst::Setg { .. }
@@ -434,6 +479,18 @@ pub(super) fn regs_written(inst: &X86Inst) -> RegList<Reg> {
     };
 
     match inst {
+        X86Inst::FloatConst { dst, .. }
+        | X86Inst::FloatMov { dst, .. }
+        | X86Inst::FloatToBits { dst, .. }
+        | X86Inst::BitsToFloat { dst, .. }
+        | X86Inst::FloatLoad { dst, .. }
+        | X86Inst::FloatBin { dst, .. }
+        | X86Inst::FloatNeg { dst, .. }
+        | X86Inst::FloatSqrt { dst, .. }
+        | X86Inst::IntToFloat { dst, .. }
+        | X86Inst::FloatToInt { dst, .. }
+        | X86Inst::FloatCast { dst, .. } => add_if_phys(dst, &mut result),
+        X86Inst::FloatStore { .. } | X86Inst::FloatCmp { .. } => {}
         X86Inst::MovRI32 { dst, .. }
         | X86Inst::MovRI64 { dst, .. }
         | X86Inst::MovRR { dst, .. }
@@ -487,6 +544,8 @@ pub(super) fn regs_written(inst: &X86Inst) -> RegList<Reg> {
         }
         X86Inst::Cdq | X86Inst::Cqo => result.push(Reg::Rdx),
         X86Inst::Sete { dst }
+        | X86Inst::Setp { dst }
+        | X86Inst::Setnp { dst }
         | X86Inst::Setne { dst }
         | X86Inst::Setl { dst }
         | X86Inst::Setg { dst }
@@ -606,6 +665,7 @@ pub(super) fn writes_flags(inst: &X86Inst) -> bool {
             | X86Inst::Cmp64RI { .. }
             | X86Inst::TestRR { .. }
             | X86Inst::Test64RR { .. }
+            | X86Inst::FloatCmp { .. }
     )
 }
 
@@ -636,6 +696,8 @@ pub(super) fn reads_flags(inst: &X86Inst) -> bool {
             | X86Inst::Seta { .. }
             | X86Inst::Setbe { .. }
             | X86Inst::Setae { .. }
+            | X86Inst::Setp { .. }
+            | X86Inst::Setnp { .. }
             // Conditional jumps
             | X86Inst::Jz { .. }
             | X86Inst::Jnz { .. }

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -809,7 +809,18 @@ impl RetainedCharge for rue_cfg::ValidatedCfg {
             .saturating_add(self.fn_name().len() as u64)
             .saturating_add((self.param_modes().len() * 2 * std::mem::size_of::<bool>()) as u64)
             .saturating_add(std::mem::size_of_val(self.source_param_abi()) as u64)
+            .saturating_add(source_param_abi_nested_retained_charge(
+                self.source_param_abi(),
+            ))
     }
+}
+
+fn source_param_abi_nested_retained_charge(params: &[rue_air::SourceParamAbi]) -> u64 {
+    params.iter().fold(0u64, |charge, param| {
+        charge.saturating_add(
+            (param.crossing_classes.len() * std::mem::size_of::<rue_air::NativeArgClass>()) as u64,
+        )
+    })
 }
 
 impl RetainedCharge for rue_air::FrozenTypeInternPool {
@@ -3639,6 +3650,30 @@ fn resolve_splice_block(
 #[cfg(test)]
 mod accessor_graph_tests {
     use super::*;
+
+    #[test]
+    fn source_param_abi_charges_nested_crossing_class_vectors() {
+        let params = vec![
+            rue_air::SourceParamAbi {
+                start_slot: 0,
+                slot_count: 2,
+                crossing_regs: 2,
+                crossing_classes: vec![rue_air::NativeArgClass::Gp, rue_air::NativeArgClass::Fp64],
+                ty: None,
+            },
+            rue_air::SourceParamAbi {
+                start_slot: 2,
+                slot_count: 1,
+                crossing_regs: 1,
+                crossing_classes: vec![rue_air::NativeArgClass::Fp32],
+                ty: None,
+            },
+        ];
+        assert_eq!(
+            source_param_abi_nested_retained_charge(&params),
+            (3 * std::mem::size_of::<rue_air::NativeArgClass>()) as u64
+        );
+    }
 
     #[test]
     fn accessor_interner_copy_preserves_ordinals_without_mutating_the_source() {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1772,8 +1772,8 @@ define_error_codes! {
     /// beside the other `extern "C"` rules, and is the import-side mirror of
     /// E1106's rejection of a `pub extern "C" fn` export named `main`.
     FOREIGN_ENTRY_POINT_DECLARATION = 1108;
-    /// A typed float reached the explicit ADR-0065 Phase 4 lowering boundary.
-    /// The source feature is enabled, but architecture lowering is not yet.
+    /// A typed float operation reached an ADR-0065 phase that remains outside
+    /// the currently implemented scalar backend subset.
     FLOAT_NOT_YET_IMPLEMENTED = 1109;
 
     // ========================================================================
@@ -2064,8 +2064,9 @@ pub enum PreviewFeature {
     /// literals (ADR-0065, RUE-714). Gated until every phase of the M9 rollout
     /// — types and inference, both backends, the dtoa runtime — is complete
     /// (ADR-0065 Phase 10). The lexer and parser accept a float literal only
-    /// with this flag; Phase 4 types it, while executable builds still stop at
-    /// [`ErrorKind::FloatNotYetImplemented`] until backend phases land.
+    /// with this flag; Phases 5-6 lower scalar arithmetic and signed integer
+    /// conversions, while later-phase operations still stop at
+    /// [`ErrorKind::FloatNotYetImplemented`].
     Floats,
     /// Public enums may promise that importing matches include a wildcard.
     NonExhaustiveEnums,
@@ -3417,12 +3418,11 @@ pub enum ErrorKind {
     #[error("`@repr(c)` struct `{}` is not FFI-eligible: {}", .0.struct_name, .0.reason)]
     ReprCStructIneligible(Box<ReprCIneligibleError>),
 
-    /// A typed float reached CFG construction before architecture-specific
-    /// lowering exists. Rejecting here prevents integer-oriented lowering from
-    /// silently reinterpreting its bits.
+    /// A typed float operation is assigned to a later ADR-0065 phase. Rejecting
+    /// it here prevents integer-oriented lowering from reinterpreting its bits.
     #[error(
-        "floating-point lowering is not yet implemented after typed AIR \
-         (ADR-0065 Phase 4 boundary, RUE-1070)"
+        "this floating-point operation is reserved for a later ADR-0065 phase \
+         and is not yet supported after typed AIR"
     )]
     FloatNotYetImplemented,
 
@@ -5252,9 +5252,8 @@ mod tests {
 
     #[test]
     fn test_float_literal_error_codes() {
-        // The two halves of the float gate: E1100 without `--preview floats`
-        // (the shared preview-gate kind), E1109 with it, plus the E0011
-        // spelling rule from ADR-0065 §3.
+        // E1100 is the preview gate, E1109 marks float operations assigned to
+        // later ADR-0065 phases, and E0011 covers the spelling rules in §3.
         assert_eq!(
             ErrorKind::FloatNotYetImplemented.code(),
             ErrorCode::FLOAT_NOT_YET_IMPLEMENTED

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -74,6 +74,63 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::PointerWrite),
         &[],
     ),
+    // ADR-0065 phases 5 and 6 expose scalar float operations that the CFG
+    // oracle does not model yet. Keep each accepted gap tied to the first
+    // exact semantic boundary reached by that case.
+    Entry::new(
+        "cli.float_codegen",
+        "native_width_conversions_and_arithmetic",
+        intrinsic(UnsupportedIntrinsicKind::IntToFloat),
+        &[],
+    ),
+    Entry::new(
+        "cli.float_codegen",
+        "native_float_value_survives_a_call_via_spill",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "cli.float_codegen",
+        "native_nan_comparisons_are_unordered",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "cli.float_codegen",
+        "native_nan_to_int_traps",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "cli.float_codegen",
+        "native_float_to_i32_upper_boundary_traps",
+        intrinsic(UnsupportedIntrinsicKind::FloatToInt),
+        &[],
+    ),
+    Entry::new(
+        "cli.float_codegen",
+        "native_float_to_i32_lower_boundary_is_inclusive",
+        intrinsic(UnsupportedIntrinsicKind::FloatToInt),
+        &[],
+    ),
+    Entry::new(
+        "cli.float_codegen",
+        "native_float_pointer_widths_preserve_neighbor_bytes",
+        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
+        &[],
+    ),
+    Entry::new(
+        "cli.float_codegen",
+        "native_float_fields_arrays_and_inout",
+        intrinsic(UnsupportedIntrinsicKind::FloatCast),
+        &[],
+    ),
+    Entry::new(
+        "cli.float_codegen",
+        "native_aggregate_float_equality_is_ieee",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
     // std.fs File IO v0 (RUE-712, ADR-0057): pure-Rue fs over @syscall. The
     // oracle models the StrBuf/ArrayBuf and raw-pointer representation setup;
     // these cases remain debt because the host syscall effect is external.
@@ -563,6 +620,9 @@ fn render_kind(kind: ModelGapKind) -> String {
         ModelGapKind::Semantic(SemanticGapKind::TextProjectionRead) => {
             "semantic(SemanticGapKind::TextProjectionRead)".to_string()
         }
+        ModelGapKind::Semantic(SemanticGapKind::FloatArithmetic) => {
+            "semantic(SemanticGapKind::FloatArithmetic)".to_string()
+        }
         ModelGapKind::ExternalDependency(kind) => {
             format!("external(ExternalDependencyKind::{kind:?})")
         }
@@ -574,6 +634,10 @@ fn render_kind(kind: ModelGapKind) -> String {
 
 const fn intrinsic(kind: UnsupportedIntrinsicKind) -> ModelGapKind {
     ModelGapKind::Semantic(SemanticGapKind::Intrinsic(kind))
+}
+
+const fn semantic(kind: SemanticGapKind) -> ModelGapKind {
+    ModelGapKind::Semantic(kind)
 }
 
 const fn external(kind: ExternalDependencyKind) -> ModelGapKind {

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -390,6 +390,9 @@ fn render_kind(kind: ModelGapKind) -> String {
         ModelGapKind::Semantic(SemanticGapKind::TextProjectionRead) => {
             "semantic(SemanticGapKind::TextProjectionRead)".to_string()
         }
+        ModelGapKind::Semantic(SemanticGapKind::FloatArithmetic) => {
+            "semantic(SemanticGapKind::FloatArithmetic)".to_string()
+        }
         ModelGapKind::ExternalDependency(kind) => {
             format!("external(ExternalDependencyKind::{kind:?})")
         }

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -351,6 +351,9 @@ pub enum UnsupportedIntrinsicKind {
     ByteCopy,
     ByteMove,
     ByteSet,
+    IntToFloat,
+    FloatToInt,
+    FloatCast,
 }
 
 /// A compiler-emitted runtime call whose deterministic semantics are not
@@ -368,6 +371,7 @@ pub enum SemanticGapKind {
     RuntimeCall(UnsupportedRuntimeCallKind),
     FlattenedParameterSlot,
     TextProjectionRead,
+    FloatArithmetic,
 }
 
 /// A dependency whose value comes from outside deterministic Rue semantics.
@@ -1156,6 +1160,15 @@ fn unsupported_intrinsic_kind_for_operation(
         rue_air::IntrinsicOperation::ByteSet => {
             UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteSet))
         }
+        rue_air::IntrinsicOperation::IntToFloat => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::IntToFloat))
+        }
+        rue_air::IntrinsicOperation::FloatToInt => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::FloatToInt))
+        }
+        rue_air::IntrinsicOperation::FloatCast => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::FloatCast))
+        }
         rue_air::IntrinsicOperation::ReadLine => {
             UnsupportedKind::ExternalDependency(External::StandardInput)
         }
@@ -1198,9 +1211,6 @@ fn unsupported_intrinsic_kind_for_operation(
         | rue_air::IntrinsicOperation::DebugU64
         | rue_air::IntrinsicOperation::DebugBool
         | rue_air::IntrinsicOperation::DebugStr
-        | rue_air::IntrinsicOperation::IntToFloat
-        | rue_air::IntrinsicOperation::FloatToInt
-        | rue_air::IntrinsicOperation::FloatCast
         | rue_air::IntrinsicOperation::TotalCmp
         | rue_air::IntrinsicOperation::BitCast => {
             UnsupportedKind::ContractViolation(ContractViolationKind::UnexpectedIntrinsic)
@@ -2260,6 +2270,16 @@ impl<'a> Interp<'a> {
                     ty == Type::U64 || ty == Type::NEVER
                 }) && result_ty == Type::I64
             }
+            rue_air::IntrinsicOperation::IntToFloat => {
+                (ty(0).is_integer() || ty(0) == Type::NEVER) && result_ty.is_float()
+            }
+            rue_air::IntrinsicOperation::FloatToInt => {
+                (ty(0).is_float() || ty(0) == Type::NEVER) && result_ty.is_integer()
+            }
+            rue_air::IntrinsicOperation::FloatCast => {
+                (ty(0) == Type::NEVER && result_ty.is_float())
+                    || (ty(0).is_float() && result_ty.is_float() && ty(0) != result_ty)
+            }
             rue_air::IntrinsicOperation::PanicNoMessage
             | rue_air::IntrinsicOperation::Panic
             | rue_air::IntrinsicOperation::AssertFailed
@@ -2269,9 +2289,6 @@ impl<'a> Interp<'a> {
             | rue_air::IntrinsicOperation::DebugU64
             | rue_air::IntrinsicOperation::DebugBool
             | rue_air::IntrinsicOperation::DebugStr
-            | rue_air::IntrinsicOperation::IntToFloat
-            | rue_air::IntrinsicOperation::FloatToInt
-            | rue_air::IntrinsicOperation::FloatCast
             | rue_air::IntrinsicOperation::TotalCmp
             | rue_air::IntrinsicOperation::BitCast => false,
         };
@@ -3390,6 +3407,109 @@ impl<'a> Interp<'a> {
         self.type_pool().abi_slot_count(ty) == 0
     }
 
+    /// Whether equality for `ty` would eventually compare a float leaf.
+    ///
+    /// The oracle stores scalar values as integer bit patterns, so letting a
+    /// float-bearing comparison reach `cmp` would silently model bit equality
+    /// instead of IEEE equality. Detect the complete aggregate shape before
+    /// evaluating either operand and report the same typed float semantic gap
+    /// as scalar float operations.
+    fn type_contains_float(&self, ty: Type) -> bool {
+        if ty.is_float() {
+            return true;
+        }
+        match ty.kind() {
+            TypeKind::Struct(id) => self
+                .type_pool()
+                .struct_def(id)
+                .fields
+                .iter()
+                .any(|field| self.type_contains_float(field.ty)),
+            TypeKind::Array(id) => {
+                let (element, len) = self.type_pool().array_def(id);
+                len != 0 && self.type_contains_float(element)
+            }
+            TypeKind::Enum(id) => self
+                .type_pool()
+                .enum_def(id)
+                .variant_payloads
+                .iter()
+                .flatten()
+                .copied()
+                .any(|payload| self.type_contains_float(payload)),
+            _ => false,
+        }
+    }
+
+    /// Classify a CFG operation as a well-typed float operation without
+    /// evaluating its operands. Any instruction shape involving a float must
+    /// satisfy the CFG typing contract before it can become registrable model
+    /// debt; malformed mixed-class or result shapes remain hard failures.
+    fn is_well_typed_float_operation(
+        &self,
+        cfg: &Cfg,
+        data: &CfgInstData,
+        result_ty: Type,
+    ) -> Step<bool> {
+        let binary_arithmetic = match data {
+            CfgInstData::Add(a, b)
+            | CfgInstData::Sub(a, b)
+            | CfgInstData::Mul(a, b)
+            | CfgInstData::Div(a, b) => Some((*a, *b)),
+            _ => None,
+        };
+        let (involves_float, valid) = if let Some((a, b)) = binary_arithmetic {
+            let a_ty = cfg.get_inst(a).ty;
+            let b_ty = cfg.get_inst(b).ty;
+            (
+                result_ty.is_float() || a_ty.is_float() || b_ty.is_float(),
+                result_ty.is_float() && a_ty == result_ty && b_ty == result_ty,
+            )
+        } else if let CfgInstData::Neg(value) = data {
+            let value_ty = cfg.get_inst(*value).ty;
+            (
+                result_ty.is_float() || value_ty.is_float(),
+                result_ty.is_float() && value_ty == result_ty,
+            )
+        } else {
+            let comparison = match data {
+                CfgInstData::Eq(a, b)
+                | CfgInstData::Ne(a, b)
+                | CfgInstData::Lt(a, b)
+                | CfgInstData::Gt(a, b)
+                | CfgInstData::Le(a, b)
+                | CfgInstData::Ge(a, b) => Some((*a, *b)),
+                _ => None,
+            };
+            let Some((a, b)) = comparison else {
+                return Ok(false);
+            };
+            let a_ty = cfg.get_inst(a).ty;
+            let b_ty = cfg.get_inst(b).ty;
+            let equality = matches!(data, CfgInstData::Eq(..) | CfgInstData::Ne(..));
+            let operand_has_float =
+                self.type_contains_float(a_ty) || self.type_contains_float(b_ty);
+            (
+                result_ty.is_float() || operand_has_float,
+                result_ty == Type::BOOL
+                    && a_ty == b_ty
+                    && if equality {
+                        self.type_contains_float(a_ty)
+                    } else {
+                        a_ty.is_float()
+                    },
+            )
+        };
+
+        if involves_float && !valid {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::NonIntegerOperationType),
+                "malformed float operation signature",
+            ));
+        }
+        Ok(involves_float)
+    }
+
     /// Materialize the (unique) value of a zero-sized type, preserving the
     /// aggregate shape so field/element projections still line up.
     fn zero_sized_value(&self, ty: Type) -> Value {
@@ -3421,6 +3541,12 @@ impl<'a> Interp<'a> {
         }
         let inst = cfg.get_inst(v);
         let ty = inst.ty;
+        if self.is_well_typed_float_operation(cfg, &inst.data, ty)? {
+            return Err(unsupported(
+                UnsupportedKind::SemanticGap(SemanticGapKind::FloatArithmetic),
+                "scalar or aggregate float operation",
+            ));
+        }
         let result = match &inst.data {
             CfgInstData::Const(n) => {
                 if *n == 0 && ty.is_ptr_const() && self.is_empty_slice_pointer(cfg, v) {

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -98,7 +98,11 @@ fn run_test_preview(src: &str) -> Outcome {
 }
 
 fn expect_unsupported(src: &str) -> Unsupported {
-    match run_source(src) {
+    expect_unsupported_with_preview(src, &PreviewFeatures::new())
+}
+
+fn expect_unsupported_with_preview(src: &str, preview_features: &PreviewFeatures) -> Unsupported {
+    match run_source_with_preview_features(src, preview_features) {
         Err(RunSourceError::Unsupported(unsupported)) => unsupported,
         Err(RunSourceError::Compile(errors)) => {
             panic!("expected oracle-unsupported source, but it failed to compile: {errors:#?}")
@@ -902,6 +906,9 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
         (Operation::ByteMove, Intrinsic::ByteMove),
         (Operation::ByteCopy, Intrinsic::ByteCopy),
         (Operation::ByteSet, Intrinsic::ByteSet),
+        (Operation::IntToFloat, Intrinsic::IntToFloat),
+        (Operation::FloatToInt, Intrinsic::FloatToInt),
+        (Operation::FloatCast, Intrinsic::FloatCast),
     ] {
         let expected = UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(intrinsic));
         assert_eq!(
@@ -944,9 +951,6 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
         Operation::DebugU64,
         Operation::DebugBool,
         Operation::DebugStr,
-        Operation::IntToFloat,
-        Operation::FloatToInt,
-        Operation::FloatCast,
         Operation::TotalCmp,
         Operation::BitCast,
     ] {
@@ -958,6 +962,164 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
     }
 
     assert_eq!(Operation::ALL.len(), 46);
+}
+
+#[test]
+fn float_arithmetic_is_a_typed_model_gap() {
+    let unsupported = expect_unsupported_with_preview(
+        r#"fn main() -> i32 {
+            let zero: f64 = 0.0;
+            if zero / zero == zero { 0 } else { 1 }
+        }"#,
+        &PreviewFeatures::from([PreviewFeature::Floats]),
+    );
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::SemanticGap(SemanticGapKind::FloatArithmetic)
+    );
+}
+
+#[test]
+fn scalar_float_comparison_is_a_typed_model_gap() {
+    let unsupported = expect_unsupported_with_preview(
+        "fn main() -> i32 { let left: f64 = 1.0; let right: f64 = 2.0; if left < right { 0 } else { 1 } }",
+        &PreviewFeatures::from([PreviewFeature::Floats]),
+    );
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::SemanticGap(SemanticGapKind::FloatArithmetic)
+    );
+}
+
+#[test]
+fn aggregate_float_equality_is_a_typed_model_gap() {
+    let unsupported = expect_unsupported_with_preview(
+        r#"struct Outer { nested: [f64; 1] }
+        fn main() -> i32 {
+            let left = Outer { nested: [1.0] };
+            let right = Outer { nested: [1.0] };
+            if left == right { 0 } else { 1 }
+        }"#,
+        &PreviewFeatures::from([PreviewFeature::Floats]),
+    );
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::SemanticGap(SemanticGapKind::FloatArithmetic)
+    );
+}
+
+#[test]
+fn zero_length_float_array_equality_remains_modeled() {
+    let source = r#"struct EmptyFloats { values: [f64; 0] }
+        fn main() -> i32 {
+            let left = EmptyFloats { values: [] };
+            let right = EmptyFloats { values: [] };
+            if left == right { 0 } else { 1 }
+        }"#;
+    let outcome =
+        run_source_with_preview_features(source, &PreviewFeatures::from([PreviewFeature::Floats]))
+            .expect("zero-length arrays have no reachable float value to compare");
+    assert_eq!(outcome.exit_code, 0);
+}
+
+#[test]
+fn malformed_float_arithmetic_shape_is_a_contract_violation() {
+    let state = query_cfg_state(
+        "fn add(left: i32, right: i32) -> i32 { left + right } fn main() -> i32 { add(1, 2) }",
+    )
+    .expect("integer addition probe compiles");
+    let cfg = &state
+        .functions
+        .iter()
+        .find(|function| function.is_source_named("add"))
+        .expect("add function remains reachable")
+        .cfg;
+    let (left, right) = cfg
+        .blocks()
+        .iter()
+        .flat_map(|block| block.insts.iter().copied())
+        .find_map(|value| match cfg.get_inst(value).data {
+            CfgInstData::Add(left, right) => Some((left, right)),
+            _ => None,
+        })
+        .expect("integer Add remains in the parameterized function");
+    let interp = Interp {
+        state: &state,
+        stdout_trace: Vec::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+        heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
+        heap_metadata_bytes: 0,
+    };
+    let error = interp
+        .is_well_typed_float_operation(cfg, &CfgInstData::Add(left, right), Type::F64)
+        .expect_err("integer operands with a float result violate the CFG contract");
+    assert!(matches!(
+        error,
+        Flow::Unsupported(Unsupported {
+            kind: UnsupportedKind::ContractViolation(
+                ContractViolationKind::NonIntegerOperationType
+            ),
+            ..
+        })
+    ));
+}
+
+#[test]
+fn malformed_float_aggregate_ordering_is_a_contract_violation() {
+    let previews = PreviewFeatures::from([PreviewFeature::Floats]);
+    let state = query_cfg_state_with_preview_features(
+        r#"struct Boxed { value: f64 }
+        fn equal(left: Boxed, right: Boxed) -> bool { left == right }
+        fn main() -> i32 {
+            if equal(Boxed { value: 1.0 }, Boxed { value: 1.0 }) { 0 } else { 1 }
+        }"#,
+        &previews,
+    )
+    .expect("aggregate equality probe compiles");
+    let cfg = &state
+        .functions
+        .iter()
+        .find(|function| function.is_source_named("equal"))
+        .expect("equal function remains reachable")
+        .cfg;
+    let (left, right) = cfg
+        .blocks()
+        .iter()
+        .flat_map(|block| block.insts.iter().copied())
+        .find_map(|value| match cfg.get_inst(value).data {
+            CfgInstData::Eq(left, right) => Some((left, right)),
+            _ => None,
+        })
+        .expect("aggregate Eq remains in the parameterized function");
+    let interp = Interp {
+        state: &state,
+        stdout_trace: Vec::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+        heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
+        heap_metadata_bytes: 0,
+    };
+    let error = interp
+        .is_well_typed_float_operation(cfg, &CfgInstData::Lt(left, right), Type::BOOL)
+        .expect_err("ordering a float-bearing aggregate violates the CFG contract");
+    assert!(matches!(
+        error,
+        Flow::Unsupported(Unsupported {
+            kind: UnsupportedKind::ContractViolation(
+                ContractViolationKind::NonIntegerOperationType
+            ),
+            ..
+        })
+    ));
 }
 
 #[test]

--- a/crates/rue-ui-tests/cases/diagnostics/float-literals.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/float-literals.toml
@@ -2,11 +2,11 @@
 id = "diagnostics.float-literals"
 name = "Float literal diagnostics"
 description = """
-ADR-0065 Phases 2-4 (RUE-1068 through RUE-1070). Two families live here: the spelling
+ADR-0065 Phases 2-6 (RUE-1068 through RUE-1072). Two families live here: the spelling
 rules for the literal itself (`.5` / `5.` / `1e`), which are lexical or
 grammatical and fire regardless of the preview flag, and the two-sided
-`floats` preview gate — E1100 without `--preview floats`, and the explicit
-Phase-4 E1109 lowering boundary after typed AIR.
+`floats` preview gate — E1100 without `--preview floats` — plus the Phase 8
+E1109 boundary for `@total_cmp`.
 """
 
 [[case]]
@@ -26,8 +26,8 @@ error_contains = [
 ]
 
 [[case]]
-name = "enabled_reaches_the_typed_lowering_boundary"
-description = "With the flag the literal is typed and stops at the explicit production-inert Phase-4 lowering boundary."
+name = "enabled_reaches_scalar_codegen"
+description = "With the flag the literal is typed and accepted by scalar code generation."
 source = """
 fn main() -> i32 {
     let x = 1.5;
@@ -35,12 +35,7 @@ fn main() -> i32 {
 }
 """
 preview = "floats"
-compile_fail = true
-error_contains = [
-    "E1109",
-    "floating-point lowering is not yet implemented after typed AIR",
-    "ADR-0065 Phase 4 boundary, RUE-1070",
-]
+exit_code = 0
 
 [[case]]
 name = "float_in_a_comptime_block_names_the_real_reason"
@@ -52,8 +47,7 @@ fn main() -> i32 {
 }
 """
 preview = "floats"
-compile_fail = true
-error_contains = ["E1109", "floating-point lowering is not yet implemented after typed AIR"]
+exit_code = 0
 
 [[case]]
 name = "float_as_a_call_argument"
@@ -77,8 +71,7 @@ fn value() -> f32 { 1.5 }
 fn main() -> i32 { @float_to_int(value()) }
 """
 preview = "floats"
-compile_fail = true
-error_contains = ["E1109", "typed AIR"]
+exit_code = 1
 
 [[case]]
 name = "unconstrained_literal_defaults_to_f64"
@@ -101,8 +94,7 @@ fn main() -> i32 {
 }
 """
 preview = "floats"
-compile_fail = true
-error_contains = ["E1109", "typed AIR"]
+exit_code = 1
 
 [[case]]
 name = "integer_literal_is_admitted_by_float_context"
@@ -111,8 +103,7 @@ fn value() -> f64 { 42 }
 fn main() -> i32 { @float_to_int(value()) }
 """
 preview = "floats"
-compile_fail = true
-error_contains = ["E1109", "typed AIR"]
+exit_code = 42
 
 [[case]]
 name = "integer_literals_are_admitted_by_each_direct_float_destination"
@@ -127,8 +118,7 @@ fn value() -> f64 {
 fn main() -> i32 { @float_to_int(value()) }
 """
 preview = "floats"
-compile_fail = true
-error_contains = ["E1109", "typed AIR"]
+exit_code = 6
 
 [[case]]
 name = "finite_range_overflow_is_rejected_before_lowering"
@@ -178,6 +168,20 @@ compile_fail = true
 error_contains = ["E0701", "float_to_int", "expects 1 argument"]
 
 [[case]]
+name = "unsigned_float_to_int_remains_fail_closed"
+source = "fn value() -> u32 { @float_to_int(1.0) }\nfn main() -> i32 { @intCast(value()) }"
+preview = "floats"
+compile_fail = true
+error_contains = ["E1109"]
+
+[[case]]
+name = "unsigned_int_to_float_remains_fail_closed"
+source = "fn value() -> f64 { let x: u32 = 1; @int_to_float(x) }\nfn main() -> i32 { @float_to_int(value()) }"
+preview = "floats"
+compile_fail = true
+error_contains = ["E1109"]
+
+[[case]]
 name = "total_cmp_requires_matching_float_widths"
 source = """
 fn a() -> f32 { 1.0 }
@@ -196,8 +200,7 @@ fn main() -> i32 { @float_to_int(dep.value()) }
 """
 aux_files = { "dep.rue" = "pub fn value() -> f64 { 1.25 }\n" }
 preview = "floats"
-compile_fail = true
-error_contains = ["E1109", "typed AIR"]
+exit_code = 1
 
 [[case]]
 name = "leading_dot_names_the_replacement"

--- a/scripts/planted-miscompile-study.py
+++ b/scripts/planted-miscompile-study.py
@@ -30,7 +30,7 @@ PATCH_TARGETS = {
 PATCH_PREIMAGE_SHA256 = {
     "RUE-348": "3d680149390b5dbd19d71ab1bc3fcff5cfc0a65525684ca8fafbc357f81004d2",
     "RUE-914": "cc00b46e5840e02b80095ae9e121a39ab66bcf6b25d17e9bc37d7fe996b72fb1",
-    "RUE-1758": "cdb907ba09b8f17243aa6671d249f4f72b24cec00ac33854d3b0e07a83ad13cf",
+    "RUE-1758": "e77acda1180060fdb48bf17c644a822fac86030997161042de06404b623efb88",
 }
 FOCUSED_CLI = {
     "RUE-348": "enum_payload_equality_across_opt_levels",


### PR DESCRIPTION
## Summary
- lower scalar f32/f64 arithmetic, comparisons, square root, and signed integer conversions on x86-64 and AArch64
- add FP-aware register allocation, spills, memory access, block parameters, calls, returns, and mixed aggregate/enum transport
- preserve IEEE equality and unordered-NaN behavior, with checked float-to-integer traps
- retain the floats preview gate and fail closed for later-phase operations

## Validation
- scripts/rue unit codegen (828 passed)
- scripts/rue cli float_codegen (24 passed)
- scripts/rue quick (35 targets passed)
- scripts/rue premerge (211 passed)

Fixes RUE-1071
Fixes RUE-1072