### PR TITLE
RUE-1949: retry truncated Zig cache materialization

### DIFF
--- a/buck2
+++ b/buck2
@@ -7,11 +7,15 @@ args=("$@")
 
 execution_command=0
 explicit_preference=0
+remote_cache_disabled=0
 if [[ "${#args[@]}" -gt 0 ]]; then
     for arg in "${args[@]}"; do
+        [[ "$arg" == "--" ]] && break
         case "$arg" in
             build|test|run|install) execution_command=1 ;;
-            --prefer-local|--prefer-remote|--local-only|--remote-only) explicit_preference=1 ;;
+            --prefer-local|--prefer-remote|--remote-only) explicit_preference=1 ;;
+            --local-only) explicit_preference=1; remote_cache_disabled=1 ;;
+            --no-remote-cache) remote_cache_disabled=1 ;;
         esac
     done
 fi
@@ -96,7 +100,91 @@ if [[ "$uses_remote_cache" -eq 1 ]] && [[ "$execution_command" -eq 1 ]] && [[ "$
     [[ "$inserted" -eq 1 ]] || args+=(--prefer-local)
 fi
 
+# BuildBuddy occasionally terminates a large BatchReadBlobs response while
+# Buck is materializing the Zig executable. The failure happens before the
+# requested action runs, and immediately replaying the same command has proved
+# sufficient. Keep the exception deliberately narrower than a general remote
+# cache retry: every observed invariant must be present in the first attempt's
+# stderr, and the replay calls DotSlash directly so there can only be one retry.
+is_truncated_zig_materialization() {
+    local line previous_is_zig_failure=0
+    local zig_failure_re='Internal error \(stage: materialize_inputs_failed\): Error materializing artifact at path `buck-out/[^[:space:]`]+/toolchains/[^[:space:]`]+/zig/[^[:space:]`]+/zig`'
+
+    # Buck emits the materialization failure and its transport cause as two
+    # adjacent stderr diagnostics. Requiring that structure prevents ordinary
+    # action/program output from assembling the classifier out of unrelated
+    # lines after the requested action has already run.
+    while IFS= read -r line; do
+        if [[ "$previous_is_zig_failure" -eq 1 ]] &&
+           [[ "$line" == *'Error: (Failed to make BatchReadBlobs request:'* ]] &&
+           { [[ "$line" == *'missing grpc-status trailer, stream was terminated without a final status (possible truncation by a proxy or load balancer)'* ]] ||
+             [[ "$line" == *'Unexpected EOF decoding stream'* ]]; }; then
+            return 0
+        fi
+        if [[ "$line" =~ $zig_failure_re ]]; then
+            previous_is_zig_failure=1
+        else
+            previous_is_zig_failure=0
+        fi
+    done <"$1"
+    return 1
+}
+
 if [[ "${#args[@]}" -gt 0 ]]; then
+    if [[ "${GITHUB_ACTIONS:-}" == true ]] &&
+       [[ "$uses_remote_cache" -eq 1 ]] && [[ "$execution_command" -eq 1 ]] &&
+       [[ "$remote_cache_disabled" -eq 0 ]] && [[ "${RUE_NO_REMOTE_CACHE:-}" != 1 ]]; then
+        retry_dir="$(mktemp -d "${TMPDIR:-/tmp}/rue-buck2-materialization.XXXXXX")"
+        retry_stdout="$retry_dir/stdout"
+        retry_stderr="$retry_dir/stderr"
+        retry_stdout_pipe="$retry_dir/stdout.pipe"
+        retry_stderr_pipe="$retry_dir/stderr.pipe"
+        cleanup_retry_capture() {
+            rm -f "$retry_stdout" "$retry_stderr" "$retry_stdout_pipe" "$retry_stderr_pipe"
+            rmdir "$retry_dir" 2>/dev/null || true
+        }
+        trap cleanup_retry_capture EXIT
+        mkfifo "$retry_stdout_pipe" "$retry_stderr_pipe"
+
+        # Required GitHub CI is non-interactive. Preserve stdout and stderr as
+        # separate streaming channels because rue-bin and other callers parse
+        # Buck's stdout; only stderr is classified.
+        tee "$retry_stdout" <"$retry_stdout_pipe" &
+        stdout_tee_pid=$!
+        tee "$retry_stderr" <"$retry_stderr_pipe" >&2 &
+        stderr_tee_pid=$!
+        set +e
+        dotslash "$repo_root/buck2-bin" "${args[@]}" >"$retry_stdout_pipe" 2>"$retry_stderr_pipe"
+        first_status=$?
+        wait "$stdout_tee_pid"
+        stdout_tee_status=$?
+        wait "$stderr_tee_pid"
+        stderr_tee_status=$?
+        set -e
+
+        if [[ "$first_status" -ne 0 ]] && [[ "$stdout_tee_status" -eq 0 ]] &&
+           [[ "$stderr_tee_status" -eq 0 ]] &&
+           is_truncated_zig_materialization "$retry_stderr"; then
+            echo "note: retrying Buck once after a truncated BuildBuddy Zig materialization" >&2
+            cleanup_retry_capture
+            trap - EXIT
+            set +e
+            dotslash "$repo_root/buck2-bin" "${args[@]}"
+            retry_status=$?
+            set -e
+            if [[ "$retry_status" -eq 0 ]]; then
+                exit 0
+            fi
+            # The retry is mitigation for one transport incident, not a new
+            # authority over the command's failure contract. If it also fails,
+            # keep the first attempt's status as well as both attempts' output.
+            exit "$first_status"
+        fi
+
+        cleanup_retry_capture
+        trap - EXIT
+        exit "$first_status"
+    fi
     exec dotslash "$repo_root/buck2-bin" "${args[@]}"
 else
     exec dotslash "$repo_root/buck2-bin"

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -97,6 +97,44 @@ intended experiment. The checked-in `.buckconfig.local.example` documents the
 same knobs for a hand-written per-checkout config; the installed user config
 is the recommended setup.
 
+### Bounded Zig materialization retry
+
+On 2026-09-03 and 2026-09-04 UTC, first attempts of CI runs
+33814662565 and 33824226528 intermittently failed before their requested tests
+ran. Buck reported `materialize_inputs_failed` for the Zig executable under
+`buck-out/.../toolchains/.../zig/.../zig`; BuildBuddy's `BatchReadBlobs`
+response ended without its final `grpc-status` trailer and the diagnostic
+called out possible proxy/load-balancer truncation. The same incident record
+also includes one `BatchReadBlobs` `Unexpected EOF decoding stream` failure for
+that stage and artifact. Plain failed-job reruns passed.
+
+The repository `./buck2` wrapper therefore makes one bounded replay of the
+exact same DotSlash/Buck argv only in GitHub Actions, when those facts occur as
+an adjacent pair of Buck stderr diagnostics on a failed execution command using
+the configured remote-cache platform. The first attempt remains in the log and
+the replay streams normally. A successful replay returns success; a failed
+replay preserves the first failure's status and both attempts' output. A
+matching second failure is not retried again. Successful
+commands, compiler/test/semantic failures, other remote errors, non-Zig
+materialization failures, ordinary local configurations, and
+`RUE_NO_REMOTE_CACHE=1`, `--no-remote-cache`, and `--local-only` retain
+fail-fast behavior. Other explicit local/remote preferences are replayed
+unchanged, so this applies equally to cache-only and intentionally remote
+execution without changing either mode's semantics.
+
+This policy is centralized in the wrapper used by CI rather than duplicated in
+workflow jobs. Interactive and other local commands still directly `exec`
+DotSlash without capture. Fork jobs without the secret never acquire the
+installed config and remain ineligible. The wrapper does not read config
+contents into the capture or print argv, configuration, or credentials; the
+temporary captures hold only the first attempt's output that was already
+streamed to the caller.
+Hermetic synthetic tests pin the exact classifier, argv replay, one-retry
+ceiling, and exit propagation. Those tests prove the repository policy, not
+that the intermittent service-side truncation has disappeared; that conclusion
+requires continued operational evidence from ordinary pull-request and
+merge-group runs.
+
 ## Full-suite host coordination
 
 `scripts/rue test` with no filter takes a user-scoped lock under `/tmp`, shared by

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -29,9 +29,23 @@ make_wrapper_sandbox() {
     cp "$SRC_ROOT/buck2-bin" "$sb/buck2-bin"
     chmod +x "$sb/buck2"
     # The first argument is the DotSlash manifest; the log holds Buck's argv.
+    # Retry tests provide numbered output/status fixtures and retain each
+    # invocation's argv separately.
     cat >"$sb/fakebin/dotslash" <<'EOF'
 #!/usr/bin/env bash
 shift
+if [[ -n "${DOTSLASH_ATTEMPT_PREFIX:-}" ]]; then
+    count=0
+    [[ -f "${DOTSLASH_ATTEMPT_PREFIX}.count" ]] && count="$(cat "${DOTSLASH_ATTEMPT_PREFIX}.count")"
+    count=$((count + 1))
+    printf '%s\n' "$count" >"${DOTSLASH_ATTEMPT_PREFIX}.count"
+    printf '%s\n' "$@" >"$DOTSLASH_ARGS.$count"
+    [[ ! -f "${DOTSLASH_ATTEMPT_PREFIX}.output.$count" ]] || cat "${DOTSLASH_ATTEMPT_PREFIX}.output.$count"
+    [[ ! -f "${DOTSLASH_ATTEMPT_PREFIX}.stderr.$count" ]] || cat "${DOTSLASH_ATTEMPT_PREFIX}.stderr.$count" >&2
+    status=0
+    [[ ! -f "${DOTSLASH_ATTEMPT_PREFIX}.status.$count" ]] || status="$(cat "${DOTSLASH_ATTEMPT_PREFIX}.status.$count")"
+    exit "$status"
+fi
 printf '%s\n' "$@" >"$DOTSLASH_ARGS"
 EOF
     cat >"$sb/fakebin/df" <<'EOF'
@@ -40,6 +54,45 @@ printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
 printf '/dev/fake 100000000 1000 50000000 1%% /\n'
 EOF
     chmod +x "$sb/fakebin/dotslash" "$sb/fakebin/df"
+}
+
+write_retry_attempt() {
+    local sb="$1" attempt="$2" status="$3" output="$4"
+    printf '%s\n' "$status" >"$sb/attempt.status.$attempt"
+    printf '%s\n' "$output" >"$sb/attempt.output.$attempt"
+}
+
+write_retry_stderr_attempt() {
+    local sb="$1" attempt="$2" output="$3"
+    printf '%s\n' "$output" >"$sb/attempt.stderr.$attempt"
+}
+
+write_retry_failure() {
+    local sb="$1" attempt="$2" status="$3" output="$4"
+    write_retry_attempt "$sb" "$attempt" "$status" ""
+    write_retry_stderr_attempt "$sb" "$attempt" "$output"
+}
+
+grpc_failure() {
+    cat <<'EOF'
+Internal error (stage: materialize_inputs_failed): Error materializing artifact at path `buck-out/v2/art/toolchains/01d1977e3655e393/zig/__dist-linux-x86_64__/dist-linux-x86_64/zig`
+Error: (Failed to make BatchReadBlobs request: code: 'Unknown error', message: "protocol error: missing grpc-status trailer, stream was terminated without a final status (possible truncation by a proxy or load balancer)")
+EOF
+}
+
+eof_failure() {
+    cat <<'EOF'
+Internal error (stage: materialize_inputs_failed): Error materializing artifact at path `buck-out/v2/art/toolchains/01d1977e3655e393/zig/__dist-linux-x86_64__/dist-linux-x86_64/zig`
+Error: (Failed to make BatchReadBlobs request: Unexpected EOF decoding stream)
+EOF
+}
+
+disjoint_grpc_failure() {
+    cat <<'EOF'
+Internal error (stage: materialize_inputs_failed): Error materializing artifact at path `buck-out/v2/art/toolchains/01d1977e3655e393/zig/__dist-linux-x86_64__/dist-linux-x86_64/zig`
+unrelated action output separates the two diagnostics
+Error: (Failed to make BatchReadBlobs request: code: 'Unknown error', message: "protocol error: missing grpc-status trailer, stream was terminated without a final status (possible truncation by a proxy or load balancer)")
+EOF
 }
 
 # run_wrapper <sandbox> <argv-log> [buck2 args...]. HOME and XDG_CONFIG_HOME
@@ -52,6 +105,14 @@ run_wrapper() {
     ( cd "$sb" && unset RUE_BUILDBUDDY_CONFIG RUE_NO_REMOTE_CACHE &&
       env HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" DOTSLASH_ARGS="$sb/$log" \
           PATH="$sb/fakebin:$PATH" ${WRAPPER_ENV:-} ./buck2 "$@" ) >"$sb/$log.out" 2>&1
+}
+
+run_wrapper_split() {
+    local sb="$1" log="$2"
+    shift 2
+    ( cd "$sb" && unset RUE_BUILDBUDDY_CONFIG RUE_NO_REMOTE_CACHE &&
+      env HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" DOTSLASH_ARGS="$sb/$log" \
+          PATH="$sb/fakebin:$PATH" ${WRAPPER_ENV:-} ./buck2 "$@" ) >"$sb/$log.stdout" 2>"$sb/$log.stderr"
 }
 
 write_central_config() {
@@ -215,6 +276,171 @@ test_buck_wrapper_links_installed_config() {
     rm -rf "$sb"
 }
 
+test_buck_wrapper_retries_only_truncated_zig_materialization() {
+    local sb out rc fixture variant missing preference_ok status_ok expected_output
+    sb="$(mktemp -d)"
+    make_wrapper_sandbox "$sb"
+    cat >"$sb/.buckconfig.local" <<'EOF'
+[build]
+execution_platforms = root//platforms:remote_cache
+EOF
+
+    # Both transport endings observed for this incident classify, and a clean
+    # replay returns success while retaining both attempts' output.
+    for variant in grpc eof; do
+        rm -f "$sb"/attempt.* "$sb"/retry.args.*
+        if [[ "$variant" == grpc ]]; then fixture="$(grpc_failure)"; else fixture="$(eof_failure)"; fi
+        write_retry_attempt "$sb" 1 41 "first attempt stdout ($variant)"
+        write_retry_stderr_attempt "$sb" 1 "$fixture"
+        write_retry_attempt "$sb" 2 0 "second attempt succeeded ($variant)"
+        rc=0
+        if [[ "$variant" == grpc ]]; then
+            WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args build --prefer-remote //:probe --config cli.test=value || rc=$?
+        else
+            WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args build //:probe --config cli.test=value || rc=$?
+        fi
+        out="$(cat "$sb/retry.args.out")"
+        check "buck wrapper: $variant truncation retries and succeeds" \
+            "$([ "$rc" -eq 0 ] && [ "$(cat "$sb/attempt.count")" -eq 2 ] && echo 0 || echo 1)"
+        check "buck wrapper: $variant retry keeps both attempts visible" \
+            "$([[ "$out" == *"materialize_inputs_failed"* ]] && [[ "$out" == *"second attempt succeeded ($variant)"* ]] && [[ "$out" == *"retrying Buck once"* ]] && echo 0 || echo 1)"
+        if [[ "$variant" == grpc ]]; then
+            preference_ok="$(grep -Fxq -- '--prefer-remote' "$sb/retry.args.1" && ! grep -Fxq -- '--prefer-local' "$sb/retry.args.1" && echo 0 || echo 1)"
+        else
+            preference_ok="$(grep -Fxq -- '--prefer-local' "$sb/retry.args.1" && echo 0 || echo 1)"
+        fi
+        check "buck wrapper: $variant retry replays exact post-wrapper argv" \
+            "$(cmp -s "$sb/retry.args.1" "$sb/retry.args.2" && [ "$preference_ok" -eq 0 ] && grep -Fxq -- '--config' "$sb/retry.args.1" && grep -Fxq -- 'cli.test=value' "$sb/retry.args.1" && echo 0 || echo 1)"
+    done
+
+    # Capturing eligible commands must not merge streams: rue-bin parses
+    # --show-output on stdout while forwarding Buck progress from stderr.
+    rm -f "$sb"/attempt.* "$sb"/split.args.*
+    write_retry_attempt "$sb" 1 0 "crates/rue:rue buck-out/v2/gen/root/rue"
+    write_retry_stderr_attempt "$sb" 1 "BUILD SUCCEEDED"
+    rc=0
+    WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper_split "$sb" split.args build //crates/rue:rue --show-output || rc=$?
+    check "buck wrapper: eligible capture preserves stdout and stderr channels" \
+        "$([ "$rc" -eq 0 ] && grep -Fxq 'crates/rue:rue buck-out/v2/gen/root/rue' "$sb/split.args.stdout" && grep -Fxq 'BUILD SUCCEEDED' "$sb/split.args.stderr" && ! grep -Fq 'BUILD SUCCEEDED' "$sb/split.args.stdout" && ! grep -Fq 'crates/rue:rue' "$sb/split.args.stderr" && echo 0 || echo 1)"
+
+    # Local commands retain direct exec behavior even with a cache config. A
+    # program cannot trigger the CI-only retry by printing the signature.
+    rm -f "$sb"/attempt.* "$sb"/local.args.*
+    write_retry_failure "$sb" 1 26 "$(grpc_failure)"
+    rc=0
+    WRAPPER_ENV="DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" local.args run //:probe || rc=$?
+    check "buck wrapper: configured local commands are never captured or retried" \
+        "$([ "$rc" -eq 26 ] && [ "$(cat "$sb/attempt.count")" -eq 1 ] && echo 0 || echo 1)"
+
+    # Classification is one adjacent Buck stderr diagnostic pair, not an
+    # order-independent bag of words from program output or unrelated lines.
+    for variant in stdout disjoint; do
+        rm -f "$sb"/attempt.* "$sb"/retry.args.*
+        if [[ "$variant" == stdout ]]; then
+            write_retry_attempt "$sb" 1 27 "$(grpc_failure)"
+        else
+            write_retry_failure "$sb" 1 28 "$(disjoint_grpc_failure)"
+        fi
+        rc=0
+        WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args run //:probe || rc=$?
+        check "buck wrapper: $variant signature is not retried" \
+            "$([ "$(cat "$sb/attempt.count")" -eq 1 ] && { [ "$rc" -eq 27 ] || [ "$rc" -eq 28 ]; } && echo 0 || echo 1)"
+    done
+
+    # Program arguments after `--` are not Buck flags. They cannot disable the
+    # retry or suppress the wrapper's default --prefer-local insertion.
+    rm -f "$sb"/attempt.* "$sb"/separator.args.*
+    write_retry_failure "$sb" 1 29 "$(grpc_failure)"
+    write_retry_attempt "$sb" 2 0 "separator retry succeeded"
+    rc=0
+    WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" separator.args run //:probe -- --no-remote-cache --local-only --prefer-remote || rc=$?
+    check "buck wrapper: program arguments after separator do not change retry policy" \
+        "$([ "$rc" -eq 0 ] && [ "$(cat "$sb/attempt.count")" -eq 2 ] && grep -Fxq -- '--prefer-local' "$sb/separator.args.1" && cmp -s "$sb/separator.args.1" "$sb/separator.args.2" && echo 0 || echo 1)"
+
+    # A matching second failure is returned directly, proving both failure
+    # propagation and the hard ceiling of one replay.
+    rm -f "$sb"/attempt.* "$sb"/retry.args.*
+    write_retry_failure "$sb" 1 42 "$(eof_failure)"
+    write_retry_failure "$sb" 2 73 "$(grpc_failure)"
+    rc=0
+    WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args test //:probe || rc=$?
+    check "buck wrapper: retry failure preserves the original status" "$([ "$rc" -eq 42 ] && echo 0 || echo 1)"
+    check "buck wrapper: a matching retry is never retried again" \
+        "$([ "$(cat "$sb/attempt.count")" -eq 2 ] && [[ "$(cat "$sb/retry.args.out")" == *"Failed to make BatchReadBlobs request"* ]] && echo 0 || echo 1)"
+
+    # Success and ordinary compiler/test failures retain their original one-run
+    # behavior even while the remote cache is configured.
+    for variant in success compiler; do
+        rm -f "$sb"/attempt.* "$sb"/retry.args.*
+        if [[ "$variant" == success ]]; then
+            write_retry_attempt "$sb" 1 0 "BUILD SUCCEEDED"
+            expected_output="BUILD SUCCEEDED"
+        else
+            write_retry_attempt "$sb" 1 19 "Action failed: rustc\nerror[E0308]: mismatched types\ntest result: FAILED"
+            expected_output="error[E0308]"
+        fi
+        rc=0
+        WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args build //:probe || rc=$?
+        if [[ "$variant" == success ]]; then status_ok="$([ "$rc" -eq 0 ] && echo 0 || echo 1)"; else status_ok="$([ "$rc" -eq 19 ] && echo 0 || echo 1)"; fi
+        check "buck wrapper: $variant output is not retried" \
+            "$([ "$status_ok" -eq 0 ] && [ "$(cat "$sb/attempt.count")" -eq 1 ] && grep -Fq "$expected_output" "$sb/retry.args.out" && echo 0 || echo 1)"
+    done
+
+    # Removing any one invariant from the conjunction fails closed.
+    for missing in stage zig batch transport; do
+        rm -f "$sb"/attempt.* "$sb"/retry.args.*
+        fixture="$(grpc_failure)"
+        case "$missing" in
+            stage) fixture="${fixture/materialize_inputs_failed/materialize_failed}" ;;
+            zig) fixture="${fixture/toolchains\/01d1977e3655e393\/zig/toolchains\/01d1977e3655e393\/rust}" ;;
+            batch) fixture="${fixture/BatchReadBlobs/ReadBlob}" ;;
+            transport) fixture="${fixture/missing grpc-status trailer, stream was terminated without a final status (possible truncation by a proxy or load balancer)/connection reset by peer}" ;;
+        esac
+        write_retry_failure "$sb" 1 31 "$fixture"
+        rc=0
+        WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args build //:probe || rc=$?
+        check "buck wrapper: signature without $missing is not retried" \
+            "$([ "$rc" -eq 31 ] && [ "$(cat "$sb/attempt.count")" -eq 1 ] && echo 0 || echo 1)"
+    done
+
+    # The same diagnostic is not eligible without an active cache config or
+    # under the per-command cache opt-out.
+    rm "$sb/.buckconfig.local"
+    rm -f "$sb"/attempt.* "$sb"/retry.args.*
+    write_retry_failure "$sb" 1 51 "$(grpc_failure)"
+    rc=0
+    WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args build //:probe || rc=$?
+    check "buck wrapper: matching output without cache configuration is not retried" \
+        "$([ "$rc" -eq 51 ] && [ "$(cat "$sb/attempt.count")" -eq 1 ] && echo 0 || echo 1)"
+
+    cat >"$sb/.buckconfig.local" <<'EOF'
+[build]
+execution_platforms = root//platforms:remote_cache
+EOF
+    rm -f "$sb"/attempt.* "$sb"/retry.args.*
+    write_retry_failure "$sb" 1 52 "$(eof_failure)"
+    rc=0
+    WRAPPER_ENV="GITHUB_ACTIONS=true RUE_NO_REMOTE_CACHE=1 DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args build //:probe || rc=$?
+    check "buck wrapper: cache opt-out is not retried" \
+        "$([ "$rc" -eq 52 ] && [ "$(cat "$sb/attempt.count")" -eq 1 ] && echo 0 || echo 1)"
+
+    rm -f "$sb"/attempt.* "$sb"/retry.args.*
+    write_retry_failure "$sb" 1 53 "$(grpc_failure)"
+    rc=0
+    WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args build --no-remote-cache //:probe || rc=$?
+    check "buck wrapper: Buck's no-remote-cache flag is not retried" \
+        "$([ "$rc" -eq 53 ] && [ "$(cat "$sb/attempt.count")" -eq 1 ] && echo 0 || echo 1)"
+
+    rm -f "$sb"/attempt.* "$sb"/retry.args.*
+    write_retry_failure "$sb" 1 54 "$(eof_failure)"
+    rc=0
+    WRAPPER_ENV="GITHUB_ACTIONS=true DOTSLASH_ATTEMPT_PREFIX=$sb/attempt" run_wrapper "$sb" retry.args build --local-only //:probe || rc=$?
+    check "buck wrapper: local-only execution is not retried" \
+        "$([ "$rc" -eq 54 ] && [ "$(cat "$sb/attempt.count")" -eq 1 ] && echo 0 || echo 1)"
+
+    rm -rf "$sb"
+}
+
 test_full_suite_orchestration() {
     local sb out rc=0
     sb="$(mktemp -d)"
@@ -265,6 +491,7 @@ EOF
 test_cache_install
 test_buck_wrapper_prefers_local_cache_misses
 test_buck_wrapper_links_installed_config
+test_buck_wrapper_retries_only_truncated_zig_materialization
 test_full_suite_orchestration
 
 echo "--------------------------------------------------"

--- a/scripts/test-dotslash-bootstrap.py
+++ b/scripts/test-dotslash-bootstrap.py
@@ -146,6 +146,20 @@ class DotslashBootstrapTests(unittest.TestCase):
         self.assertEqual(len(errors), 1)
         self.assertIn("later.yaml:4", errors[0])
 
+    def test_rejects_direct_buck_manifest_in_a_second_workflow(self) -> None:
+        errors = self.validate(
+            {
+                "ci.yml": CALLER,
+                "release.yml": (
+                    "jobs:\n  release:\n    steps:\n"
+                    "      - run: dotslash ./buck2-bin build //crates/rue:rue\n"
+                ),
+            }
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("release.yml:4", errors[0])
+        self.assertIn("must reach Buck through repository `./buck2`", errors[0])
+
     def test_reports_every_offending_site(self) -> None:
         errors = self.validate(
             {

--- a/scripts/validate-dotslash-bootstrap.py
+++ b/scripts/validate-dotslash-bootstrap.py
@@ -28,6 +28,11 @@ and never saves the freshly downloaded one back -- every job re-downloads tens
 of megabytes, indefinitely and silently, because dotslash succeeds either
 way. So every `dotslash-` key in the action must hash `buck2-bin` and must
 not hash `buck2`.
+
+The wrapper also owns the bounded GitHub-Actions-only remote-cache retry from
+RUE-1949. Every workflow must therefore invoke Buck through `./buck2`, never
+run the `buck2-bin` manifest directly; otherwise the pin is correct but the
+repository's cache failure policy is silently absent.
 """
 
 from __future__ import annotations
@@ -51,6 +56,9 @@ HASH_FILES = re.compile(r"hashFiles\((?P<arguments>[^)]*)\)")
 QUOTED = re.compile(r"""['"](?P<name>[^'"]*)['"]""")
 PINNED_MANIFEST = "buck2-bin"
 WRAPPER = "buck2"
+DIRECT_PINNED_MANIFEST = re.compile(
+    r"(?:^|\s)(?:dotslash\s+)?(?:\./)?buck2-bin(?:\s|$)"
+)
 
 
 def workflows_in(directory: Path) -> list[Path]:
@@ -80,6 +88,15 @@ def check_workflows(workflows: list[Path]) -> tuple[list[str], int]:
                 errors.append(
                     f"{path}:{number}: declares its own dotslash cache key; "
                     f"{ACTION_REFERENCE} owns the store paths and key policy"
+                )
+            if (
+                not line.lstrip().startswith("#")
+                and DIRECT_PINNED_MANIFEST.search(line)
+            ):
+                errors.append(
+                    f"{path}:{number}: invokes {PINNED_MANIFEST} directly; "
+                    "CI must reach Buck through repository `./buck2` so "
+                    "centralized wrapper policy cannot be bypassed"
                 )
     return errors, callers
 


### PR DESCRIPTION
## Summary

- retry one narrowly classified GitHub Actions failure while Buck materializes the cached Zig toolchain
- keep ordinary local and non-matching failures on the direct execution path
- add deterministic wrapper and workflow-policy coverage, plus incident documentation

## Validation

- focused Buck policy targets (6 targets)
- scripts/rue quick (35 passed)
- scripts/rue premerge (211 passed)
- scripts/rue fmt
- git diff --check

Fixes RUE-1949