### PR TITLE
RUE-1954: rename comparison payload fields to left and right

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -1329,7 +1329,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// operand with the same compiler-synthesized structural printer a test
     /// body's `?` uses (ADR-0083 §1), stages the intrinsic's own site, and
     /// calls the terminal comparison helper, which writes one frame carrying
-    /// `expected` and `actual` on the §5.1 channel and then takes the ordinary
+    /// `left` and `right` on the §5.1 channel and then takes the ordinary
     /// panic path.
     ///
     /// The lowering is the same in a test image and in an ordinary executable.

--- a/crates/rue-cli-tests/cases/rue_test_assert.toml
+++ b/crates/rue-cli-tests/cases/rue_test_assert.toml
@@ -7,14 +7,14 @@ operands as structured data. These run the whole path through the real binary �
 compiler, linked test image, dispatched process, `__rue_test_fail_comparison`,
 failure channel, runner — so what is pinned here is what a consumer of the event
 stream actually sees: kind `assert_eq` or `assert_ne`, the intrinsic's own line
-and column, `expected` and `actual` rendered by the synthesized structural
+and column, `left` and `right` rendered by the synthesized structural
 printer, and the `diff` the runner computes between them.
 
 `-j1` and `--format json` for the same reasons the sibling `cli.rue_test` cases
 give: whole-line interleaving is by design under parallel workers, and the event
 schema is a consumer contract (docs/process/test-events.md). Object keys are
-alphabetical, which is why `"actual"` precedes `"diff"` precedes `"expected"` in
-every expectation below.
+alphabetical, which is why `"diff"` precedes `"kind"` precedes `"left"`
+precedes `"message"` precedes `"right"` in every expectation below.
 
 The last two cases leave `rue test` behind on purpose. The family lowers the
 same way in an ordinary executable — there is simply no descriptor 3 there — and
@@ -56,7 +56,8 @@ driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"assert_eq"',
     '"message":"assertion failed: left == right"',
-    '"actual":"42","diff":[{"op":"equal","text":"4"},{"op":"delete","text":"1"},{"op":"insert","text":"2"}],"exit_code":101,"expected":"41"',
+    '"diff":[{"op":"equal","text":"4"},{"op":"delete","text":"1"},{"op":"insert","text":"2"}],"exit_code":101,"kind":"assert_eq","left":"41"',
+    '"message":"assertion failed: left == right","right":"42"',
     '"column":5,"file":',
     '"line":6}',
     '"verdict":"fail"',
@@ -95,8 +96,8 @@ args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j
 driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"assert_eq"',
-    '"actual":"alpine"',
-    '"expected":"alpha"',
+    '"left":"alpha"',
+    '"right":"alpine"',
     '{"op":"equal","text":"alp"}',
     '"verdict":"fail"',
 ]
@@ -131,8 +132,8 @@ test "compares two points" {
 args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
-    '"expected":"{ x: 41, y: true }"',
-    '"actual":"{ x: 42, y: false }"',
+    '"left":"{ x: 41, y: true }"',
+    '"right":"{ x: 42, y: false }"',
     '"kind":"assert_eq"',
 ]
 
@@ -165,8 +166,8 @@ test "compares two shapes" {
 args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
-    '"expected":"Line(3)"',
-    '"actual":"Dot"',
+    '"left":"Line(3)"',
+    '"right":"Dot"',
     '"kind":"assert_eq"',
 ]
 
@@ -200,7 +201,8 @@ driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"assert_ne"',
     '"message":"assertion failed: left != right"',
-    '"actual":"41","diff":[{"op":"equal","text":"41"}],"exit_code":101,"expected":"41"',
+    '"diff":[{"op":"equal","text":"41"}],"exit_code":101,"kind":"assert_ne","left":"41"',
+    '"message":"assertion failed: left != right","right":"41"',
 ]
 
 [[case]]
@@ -231,7 +233,7 @@ compile_stdout_contains = [
     '"verdict":"pass"',
     '"crash":0,"event":"run_finished","failed":0,"passed":1',
 ]
-compile_stdout_not_contains = ['"failure"', '"expected"', '"diff"']
+compile_stdout_not_contains = ['"failure"', '"left":', '"diff"']
 
 # =============================================================================
 # Borrowed operands (spec 4.13:5f, 4.3:3f).
@@ -250,7 +252,7 @@ name = "a_borrowed_strbuf_field_renders_on_the_failing_path"
 description = """
 The operand is `t.name`, where `t` is a `borrow` parameter and `name` is a
 `StrBuf`. The rendering has to reach the borrowed buffer's bytes, so the frame's
-`expected` is the real content rather than an empty or stale view.
+`left` is the real content rather than an empty or stale view.
 """
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [
@@ -282,8 +284,8 @@ args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j
 driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"assert_eq"',
-    '"expected":"alpha"',
-    '"actual":"alpine"',
+    '"left":"alpha"',
+    '"right":"alpine"',
     '{"op":"equal","text":"alp"}',
 ]
 
@@ -377,7 +379,7 @@ args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j
 driver_exit_code = 1
 compile_stdout_contains = [
     "assert_eq: assertion failed: left == right",
-    "  expected: 41\n  actual:   42\n             ^\n",
+    "  left:  41\n  right: 42\n          ^\n",
 ]
 
 [[case]]
@@ -407,8 +409,8 @@ test "compares two documents" {
 args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
 driver_exit_code = 1
 compile_stdout_contains = [
-    "  expected:\n    alpha\n    beta\n    gamma\n",
-    "  actual:\n    alpha\n    BETA\n    gamma\n",
+    "  left:\n    alpha\n    beta\n    gamma\n",
+    "  right:\n    alpha\n    BETA\n    gamma\n",
     "  diff:\n      alpha\n    - beta\n    + BETA\n      gamma\n",
 ]
 

--- a/crates/rue-compiler/src/assert_comparison_tests.rs
+++ b/crates/rue-compiler/src/assert_comparison_tests.rs
@@ -3,7 +3,7 @@
 //! These are the session-level half of the family's coverage: the lowered shape
 //! the runtime contract depends on, and the identity rule that makes the
 //! structural printer shared rather than per-site. What a failing comparison
-//! actually reports — the frame's `expected` and `actual`, the runner's diff,
+//! actually reports — the frame's `left` and `right`, the runner's diff,
 //! and the human rendering — is covered end to end by the `cli.rue_test_assert`
 //! cases, and the ordinary-build trap by `cli.rue_test_assert`'s executable
 //! case and the `4.13:5f` spec cases.

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -967,8 +967,8 @@ macro_rules! for_each_runtime_helper {
         },
         // The comparison form of the same terminal call (ADR-0083 Phase 2.5).
         // It carries the two rendered operands where `__rue_test_fail` carries
-        // one message and one open payload, so a consumer reads `expected` and
-        // `actual` as separate fields instead of parsing them back out of one
+        // one message and one open payload, so a consumer reads `left` and
+        // `right` as separate fields instead of parsing them back out of one
         // string. The message is pinned by the kind rather than passed, which
         // is what keeps this to the same six registers.
         TestFailComparison => unsafe __rue_test_fail_comparison(

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -63,8 +63,8 @@ const LOCATION_FIELD: [u8; 22] = *b"\",\"location\":{\"file\":\"";
 const LINE_FIELD: [u8; 9] = *b"\",\"line\":";
 const COLUMN_FIELD: [u8; 10] = *b",\"column\":";
 const PAYLOAD_FIELD: [u8; 13] = *b"},\"payload\":\"";
-const EXPECTED_FIELD: [u8; 14] = *b"},\"expected\":\"";
-const ACTUAL_FIELD: [u8; 12] = *b"\",\"actual\":\"";
+const LEFT_FIELD: [u8; 10] = *b"},\"left\":\"";
+const RIGHT_FIELD: [u8; 11] = *b"\",\"right\":\"";
 const FRAME_TAIL: [u8; 3] = *b"\"}\n";
 
 /// The pinned message each comparison kind reports.
@@ -235,11 +235,11 @@ fn failure_frame(
 
 /// Write one comparison failure frame (ADR-0083 Phase 2.5).
 ///
-/// It carries `expected` and `actual` where [`failure_frame`] carries the open
+/// It carries `left` and `right` where [`failure_frame`] carries the open
 /// `payload`, and no `payload` at all: two rendered operands are not one string
 /// a consumer has to split, and the runner computes the diff between them.
-/// `expected` is the left operand and `actual` the right — the order the source
-/// wrote them in, so `@assert_eq(want, got)` reads the way it is spelled.
+/// `left` and `right` are the operands in the order the source wrote them, so
+/// `@assert_eq(want, got)` reads the way it is spelled.
 ///
 /// The message is not a parameter: it is pinned by the kind, which is what
 /// keeps this call to the six registers a runtime helper is limited to while
@@ -262,9 +262,9 @@ fn comparison_frame(
         line,
         column,
     );
-    writer.raw(&EXPECTED_FIELD);
+    writer.raw(&LEFT_FIELD);
     writer.escaped(left);
-    writer.raw(&ACTUAL_FIELD);
+    writer.raw(&RIGHT_FIELD);
     writer.escaped(right);
     writer.raw(&FRAME_TAIL);
 }
@@ -429,7 +429,7 @@ crate::define_runtime_implementation! {
     ///
     /// The comparison form of [`__rue_test_fail`] (ADR-0083 Phase 2.5). It
     /// writes a `failure` frame carrying the two rendered operands as
-    /// `expected` and `actual` — and no open `payload` — then takes the
+    /// `left` and `right` — and no open `payload` — then takes the
     /// ordinary panic path with the message its `kind` pins: `panic: assertion
     /// failed: left == right` on stderr and exit 101.
     ///
@@ -556,10 +556,10 @@ mod tests {
     }
 
     /// The comparison frame's field order, and the two fields that make it a
-    /// different shape rather than a payload convention: `expected` and
-    /// `actual` in place of `payload`, which is absent entirely.
+    /// different shape rather than a payload convention: `left` and
+    /// `right` in place of `payload`, which is absent entirely.
     #[test]
-    fn comparison_frame_carries_expected_and_actual_instead_of_a_payload() {
+    fn comparison_frame_carries_left_and_right_instead_of_a_payload() {
         let bytes = frame_bytes(|emit| {
             comparison_frame(
                 emit,
@@ -576,7 +576,7 @@ mod tests {
             "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert_eq\",\
              \"message\":\"assertion failed: left == right\",\
              \"location\":{\"file\":\"app/parser_tests.rue\",\"line\":7,\"column\":5},\
-             \"expected\":\"41\",\"actual\":\"42\"}\n"
+             \"left\":\"41\",\"right\":\"42\"}\n"
         );
     }
 
@@ -623,11 +623,11 @@ mod tests {
         });
         let rendered = std::str::from_utf8(&bytes).unwrap();
         assert!(
-            rendered.contains("\"expected\":\"line one\\u000aline two\""),
+            rendered.contains("\"left\":\"line one\\u000aline two\""),
             "{rendered}"
         );
         assert!(
-            rendered.contains("\"actual\":\"say \\\"hi\\\"\\\\\"}"),
+            rendered.contains("\"right\":\"say \\\"hi\\\"\\\\\"}"),
             "{rendered}"
         );
     }
@@ -642,7 +642,7 @@ mod tests {
             "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert_eq\",\
              \"message\":\"assertion failed: left == right\",\
              \"location\":{\"file\":\"\",\"line\":0,\"column\":0},\
-             \"expected\":\"\",\"actual\":\"\"}\n"
+             \"left\":\"\",\"right\":\"\"}\n"
         );
     }
 

--- a/crates/rue/src/test_mode/diff.rs
+++ b/crates/rue/src/test_mode/diff.rs
@@ -1,7 +1,7 @@
 //! The machine-computed diff between a comparison failure's two operands
 //! (ADR-0083 Phase 2.5).
 //!
-//! A `failure` frame carrying `expected` and `actual` says what the two values
+//! A `failure` frame carrying `left` and `right` says what the two values
 //! rendered to; it does not say where they differ. Computing that here — once,
 //! in the runner — is what lets the event stream and the human rendering agree,
 //! and what keeps a consumer from having to re-derive it from two strings.
@@ -13,8 +13,8 @@
 //!   is unreadable and enormous; anything else is diffed character by
 //!   character, because that is what locates the one digit that changed.
 //! - **Hunks are exact, in order, and reconstruct both sides.** Concatenating
-//!   every `equal` and `delete` hunk's text yields `expected` exactly;
-//!   concatenating every `equal` and `insert` hunk's text yields `actual`. A
+//!   every `equal` and `delete` hunk's text yields `left` exactly;
+//!   concatenating every `equal` and `insert` hunk's text yields `right`. A
 //!   line unit therefore carries its own terminator, and the two invariants are
 //!   what make the encoding lossless rather than a rendering.
 //! - **It is dependency-free and bounded.** The renderings a compiler-synthesized
@@ -42,9 +42,9 @@ const CELL_BUDGET: usize = 1 << 20;
 pub(crate) enum DiffOp {
     /// Present in both values.
     Equal,
-    /// Present in `expected` and absent from `actual`.
+    /// Present in `left` and absent from `right`.
     Delete,
-    /// Present in `actual` and absent from `expected`.
+    /// Present in `right` and absent from `left`.
     Insert,
 }
 
@@ -67,8 +67,8 @@ pub(crate) struct Hunk {
 }
 
 /// Whether a pair of values is diffed by line or by character.
-fn line_oriented(expected: &str, actual: &str) -> bool {
-    expected.contains('\n') || actual.contains('\n')
+fn line_oriented(left: &str, right: &str) -> bool {
+    left.contains('\n') || right.contains('\n')
 }
 
 /// Split one value into the units it is diffed by.
@@ -86,28 +86,28 @@ fn units(text: &str, by_line: bool) -> Vec<&str> {
     }
 }
 
-/// The diff from `expected` to `actual`.
-pub(crate) fn diff(expected: &str, actual: &str) -> Vec<Hunk> {
-    let by_line = line_oriented(expected, actual);
-    let left = units(expected, by_line);
-    let right = units(actual, by_line);
+/// The diff from `left` to `right`.
+pub(crate) fn diff(left: &str, right: &str) -> Vec<Hunk> {
+    let by_line = line_oriented(left, right);
+    let left_units = units(left, by_line);
+    let right_units = units(right, by_line);
 
-    let prefix = left
+    let prefix = left_units
         .iter()
-        .zip(right.iter())
+        .zip(right_units.iter())
         .take_while(|(left, right)| left == right)
         .count();
-    let suffix = left[prefix..]
+    let suffix = left_units[prefix..]
         .iter()
         .rev()
-        .zip(right[prefix..].iter().rev())
+        .zip(right_units[prefix..].iter().rev())
         .take_while(|(left, right)| left == right)
         .count();
 
     let mut hunks = Hunks::default();
-    hunks.extend(DiffOp::Equal, &left[..prefix]);
-    let left_middle = &left[prefix..left.len() - suffix];
-    let right_middle = &right[prefix..right.len() - suffix];
+    hunks.extend(DiffOp::Equal, &left_units[..prefix]);
+    let left_middle = &left_units[prefix..left_units.len() - suffix];
+    let right_middle = &right_units[prefix..right_units.len() - suffix];
     if left_middle.len().saturating_mul(right_middle.len()) > CELL_BUDGET {
         // Past the budget the exact answer is not worth its cost, and a
         // wholesale replacement is still a true diff: every unit of the middle
@@ -118,7 +118,7 @@ pub(crate) fn diff(expected: &str, actual: &str) -> Vec<Hunk> {
     } else {
         refine(&mut hunks, left_middle, right_middle);
     }
-    hunks.extend(DiffOp::Equal, &left[left.len() - suffix..]);
+    hunks.extend(DiffOp::Equal, &left_units[left_units.len() - suffix..]);
     hunks.0
 }
 
@@ -193,32 +193,32 @@ impl Hunks {
 mod tests {
     use super::*;
 
-    fn hunks(expected: &str, actual: &str) -> Vec<(&'static str, String)> {
-        diff(expected, actual)
+    fn hunks(left: &str, right: &str) -> Vec<(&'static str, String)> {
+        diff(left, right)
             .into_iter()
             .map(|hunk| (hunk.op.as_str(), hunk.text))
             .collect()
     }
 
     /// The two invariants the encoding rests on: the equal-and-delete hunks
-    /// rebuild `expected`, and the equal-and-insert hunks rebuild `actual`.
+    /// rebuild `left`, and the equal-and-insert hunks rebuild `right`.
     #[track_caller]
-    fn assert_reconstructs(expected: &str, actual: &str) {
-        let hunks = diff(expected, actual);
-        let mut left = String::new();
-        let mut right = String::new();
+    fn assert_reconstructs(left: &str, right: &str) {
+        let hunks = diff(left, right);
+        let mut rebuilt_left = String::new();
+        let mut rebuilt_right = String::new();
         for hunk in &hunks {
             match hunk.op {
                 DiffOp::Equal => {
-                    left.push_str(&hunk.text);
-                    right.push_str(&hunk.text);
+                    rebuilt_left.push_str(&hunk.text);
+                    rebuilt_right.push_str(&hunk.text);
                 }
-                DiffOp::Delete => left.push_str(&hunk.text),
-                DiffOp::Insert => right.push_str(&hunk.text),
+                DiffOp::Delete => rebuilt_left.push_str(&hunk.text),
+                DiffOp::Insert => rebuilt_right.push_str(&hunk.text),
             }
         }
-        assert_eq!(left, expected, "expected side of {hunks:?}");
-        assert_eq!(right, actual, "actual side of {hunks:?}");
+        assert_eq!(rebuilt_left, left, "left side of {hunks:?}");
+        assert_eq!(rebuilt_right, right, "right side of {hunks:?}");
         for pair in hunks.windows(2) {
             assert_ne!(pair[0].op, pair[1].op, "unmerged adjacent hunks: {hunks:?}");
         }
@@ -349,31 +349,31 @@ mod tests {
     /// reconstructs both sides.
     #[test]
     fn an_oversized_middle_falls_back_to_a_wholesale_replacement() {
-        let expected: String = std::iter::repeat_n("a\n", 2_000).collect();
-        let actual: String = std::iter::repeat_n("b\n", 2_000).collect();
-        let hunks = diff(&expected, &actual);
+        let left: String = std::iter::repeat_n("a\n", 2_000).collect();
+        let right: String = std::iter::repeat_n("b\n", 2_000).collect();
+        let hunks = diff(&left, &right);
         assert_eq!(
             hunks.iter().map(|hunk| hunk.op).collect::<Vec<_>>(),
             [DiffOp::Delete, DiffOp::Insert]
         );
-        assert_reconstructs(&expected, &actual);
+        assert_reconstructs(&left, &right);
     }
 
     /// The shared prefix and suffix are removed before any table is built, so
     /// two long values that differ in one line stay exact and cheap.
     #[test]
     fn a_long_pair_differing_in_one_line_stays_exact() {
-        let mut expected: String = std::iter::repeat_n("same\n", 3_000).collect();
-        let mut actual = expected.clone();
-        expected.push_str("left\n");
-        actual.push_str("right\n");
+        let mut left: String = std::iter::repeat_n("same\n", 3_000).collect();
+        let mut right = left.clone();
+        left.push_str("one\n");
+        right.push_str("two\n");
         assert_eq!(
-            hunks(&expected, &actual)
+            hunks(&left, &right)
                 .iter()
                 .map(|(op, _)| *op)
                 .collect::<Vec<_>>(),
             ["equal", "delete", "insert"]
         );
-        assert_reconstructs(&expected, &actual);
+        assert_reconstructs(&left, &right);
     }
 }

--- a/crates/rue/src/test_mode/events.rs
+++ b/crates/rue/src/test_mode/events.rs
@@ -161,7 +161,7 @@ pub(crate) struct FailureRecord {
     pub(crate) signal: Option<i32>,
     pub(crate) location: Option<Location>,
     /// The open, versioned payload ADR-0083 §5.1 reserves for assertion
-    /// libraries. A comparison failure uses `expected`/`actual` instead.
+    /// libraries. A comparison failure uses `left`/`right` instead.
     pub(crate) payload: Option<String>,
     /// A comparison failure's two rendered operands and the diff between them
     /// (ADR-0083 Phase 2.5). **Absent** on every other failure.
@@ -180,20 +180,16 @@ pub(crate) struct FailureRecord {
 #[derive(Debug, Clone)]
 pub(crate) struct Comparison {
     /// The left operand as the structural printer rendered it.
-    pub(crate) expected: String,
+    pub(crate) left: String,
     /// The right operand as the structural printer rendered it.
-    pub(crate) actual: String,
+    pub(crate) right: String,
     pub(crate) diff: Vec<diff::Hunk>,
 }
 
 impl Comparison {
-    pub(crate) fn new(expected: String, actual: String) -> Self {
-        let diff = diff::diff(&expected, &actual);
-        Self {
-            expected,
-            actual,
-            diff,
-        }
+    pub(crate) fn new(left: String, right: String) -> Self {
+        let diff = diff::diff(&left, &right);
+        Self { left, right, diff }
     }
 }
 
@@ -215,14 +211,8 @@ impl FailureRecord {
             object.insert("payload".to_owned(), Value::String(payload.clone()));
         }
         if let Some(comparison) = &self.comparison {
-            object.insert(
-                "expected".to_owned(),
-                Value::String(comparison.expected.clone()),
-            );
-            object.insert(
-                "actual".to_owned(),
-                Value::String(comparison.actual.clone()),
-            );
+            object.insert("left".to_owned(), Value::String(comparison.left.clone()));
+            object.insert("right".to_owned(), Value::String(comparison.right.clone()));
             object.insert(
                 "diff".to_owned(),
                 Value::Array(
@@ -582,11 +572,11 @@ mod tests {
         );
     }
 
-    /// A comparison failure publishes `expected`, `actual`, and the runner's
+    /// A comparison failure publishes `left`, `right`, and the runner's
     /// own `diff` — additive fields on the same `1.0` schema, in the same
     /// alphabetical key order every other object uses (ADR-0083 Phase 2.5).
     #[test]
-    fn a_comparison_failure_publishes_expected_actual_and_a_diff() {
+    fn a_comparison_failure_publishes_left_right_and_a_diff() {
         let line = Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::bad".to_owned(),
             verdict: Verdict::Fail(FailureKind::AssertEq),
@@ -606,11 +596,11 @@ mod tests {
         .to_ndjson();
         assert!(
             line.contains(
-                "\"failure\":{\"actual\":\"42\",\
-                 \"diff\":[{\"op\":\"equal\",\"text\":\"4\"},\
+                "\"failure\":{\"diff\":[{\"op\":\"equal\",\"text\":\"4\"},\
                  {\"op\":\"delete\",\"text\":\"1\"},\
                  {\"op\":\"insert\",\"text\":\"2\"}],\
-                 \"exit_code\":101,\"expected\":\"41\",\"kind\":\"assert_eq\","
+                 \"exit_code\":101,\"kind\":\"assert_eq\",\"left\":\"41\",\
+                 \"message\":\"assertion failed: left == right\",\"right\":\"42\"}"
             ),
             "{line}"
         );
@@ -636,8 +626,8 @@ mod tests {
             repro: Vec::new(),
         }))
         .to_ndjson();
-        assert!(!line.contains("\"expected\""), "{line}");
-        assert!(!line.contains("\"actual\""), "{line}");
+        assert!(!line.contains("\"left\""), "{line}");
+        assert!(!line.contains("\"right\""), "{line}");
         assert!(!line.contains("\"diff\""), "{line}");
     }
 

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -618,14 +618,14 @@ fn failure_record(
 /// The comparison a failure frame carried, or `None` when it carried none
 /// (ADR-0083 Phase 2.5).
 ///
-/// `expected` and `actual` travel together or not at all: a frame with one and
+/// `left` and `right` travel together or not at all: a frame with one and
 /// not the other is a producer's mistake, and half a comparison is not a
 /// comparison. The diff between them is computed here, once, so the event
 /// stream and the human rendering read the same one.
 fn frame_comparison(frame: Option<&verdict::FailureFrame>) -> Option<Comparison> {
     let frame = frame?;
-    let (expected, actual) = frame.expected.clone().zip(frame.actual.clone())?;
-    Some(Comparison::new(expected, actual))
+    let (left, right) = frame.left.clone().zip(frame.right.clone())?;
+    Some(Comparison::new(left, right))
 }
 
 fn failure_message(
@@ -813,10 +813,10 @@ mod tests {
     /// would have to guess at.
     #[test]
     fn a_comparison_needs_both_of_its_operands() {
-        let frame = |expected: Option<&str>, actual: Option<&str>| verdict::FailureFrame {
+        let frame = |left: Option<&str>, right: Option<&str>| verdict::FailureFrame {
             kind: "assert_eq".to_owned(),
-            expected: expected.map(str::to_owned),
-            actual: actual.map(str::to_owned),
+            left: left.map(str::to_owned),
+            right: right.map(str::to_owned),
             ..verdict::FailureFrame::default()
         };
         assert!(frame_comparison(None).is_none());
@@ -824,8 +824,8 @@ mod tests {
         assert!(frame_comparison(Some(&frame(Some("41"), None))).is_none());
         assert!(frame_comparison(Some(&frame(None, Some("42")))).is_none());
         let both = frame_comparison(Some(&frame(Some("41"), Some("42")))).expect("a comparison");
-        assert_eq!(both.expected, "41");
-        assert_eq!(both.actual, "42");
+        assert_eq!(both.left, "41");
+        assert_eq!(both.right, "42");
         assert_eq!(both.diff.len(), 3, "{:?}", both.diff);
         // Two empty renderings are still a comparison: empty is a value.
         let empty = frame_comparison(Some(&frame(Some(""), Some("")))).expect("a comparison");

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -152,17 +152,17 @@ fn render_failure(finished: &TestFinished) -> String {
 /// a multi-line pair gets the `-`/`+` listing, because a caret into a wall of
 /// text locates nothing.
 fn push_comparison(out: &mut String, comparison: &Comparison) {
-    let multi_line = comparison.expected.contains('\n') || comparison.actual.contains('\n');
+    let multi_line = comparison.left.contains('\n') || comparison.right.contains('\n');
     if !multi_line {
-        let _ = write!(out, "\n  expected: {}", comparison.expected);
-        let _ = write!(out, "\n  actual:   {}", comparison.actual);
+        let _ = write!(out, "\n  left:  {}", comparison.left);
+        let _ = write!(out, "\n  right: {}", comparison.right);
         if let Some(column) = first_difference(&comparison.diff) {
             let _ = write!(out, "\n  {}^", " ".repeat(LABEL_WIDTH - 2 + column));
         }
         return;
     }
-    push_block(out, "expected", &comparison.expected);
-    push_block(out, "actual", &comparison.actual);
+    push_block(out, "left", &comparison.left);
+    push_block(out, "right", &comparison.right);
     out.push_str("\n  diff:");
     for hunk in &comparison.diff {
         let marker = match hunk.op {
@@ -176,9 +176,9 @@ fn push_comparison(out: &mut String, comparison: &Comparison) {
     }
 }
 
-/// Width of the `expected: ` / `actual:   ` labels, including the two-space
-/// indent every line of a failure carries.
-const LABEL_WIDTH: usize = 12;
+/// Width of the `left:  ` / `right: ` labels, including the two-space indent
+/// every line of a failure carries.
+const LABEL_WIDTH: usize = 9;
 
 /// The character offset of the first difference, or `None` when the two values
 /// are identical — which is exactly how an `@assert_ne` failure looks.
@@ -363,7 +363,7 @@ mod tests {
         ))
         .expect("a failure renders");
         assert!(
-            rendered.contains("\n  expected: 41\n  actual:   42\n             ^\n"),
+            rendered.contains("\n  left:  41\n  right: 42\n          ^\n"),
             "{rendered}"
         );
     }
@@ -383,7 +383,7 @@ mod tests {
         ))
         .expect("a failure renders");
         assert!(
-            rendered.contains("\n  expected: 41\n  actual:   41\n  --- stdout"),
+            rendered.contains("\n  left:  41\n  right: 41\n  --- stdout"),
             "{rendered}"
         );
     }
@@ -407,8 +407,8 @@ mod tests {
         .expect("a failure renders");
         assert!(
             rendered.contains(
-                "\n  expected:\n    alpha\n    beta\n    gamma\
-                 \n  actual:\n    alpha\n    BETA\n    gamma\
+                "\n  left:\n    alpha\n    beta\n    gamma\
+                 \n  right:\n    alpha\n    BETA\n    gamma\
                  \n  diff:\n      alpha\n    - beta\n    + BETA\n      gamma\n"
             ),
             "{rendered}"

--- a/crates/rue/src/test_mode/verdict.rs
+++ b/crates/rue/src/test_mode/verdict.rs
@@ -62,7 +62,7 @@ pub(crate) enum FailureKind {
     /// A failed `@assert(cond)`.
     Assert,
     /// A failed `@assert_eq(left, right)` (ADR-0083 Phase 2.5). Its frame is
-    /// the one that carries `expected` and `actual`.
+    /// the one that carries `left` and `right`.
     AssertEq,
     /// A failed `@assert_ne(left, right)`, whose frame carries the two values
     /// the assertion demanded be different.
@@ -145,15 +145,15 @@ pub(crate) struct FailureFrame {
     pub(crate) column: u32,
     pub(crate) payload: String,
     /// The left operand of a comparison assertion, rendered (ADR-0083 Phase
-    /// 2.5). `None` when the frame carried no `expected` field at all, which is
+    /// 2.5). `None` when the frame carried no `left` field at all, which is
     /// what every non-comparison producer writes.
     ///
     /// Empty is a value, not an absence: `@assert_eq` over two empty strings
     /// fails with two empty renderings, and dropping them would leave a
     /// consumer unable to tell that case from an `@assert`.
-    pub(crate) expected: Option<String>,
-    /// The right operand, rendered. Present exactly when `expected` is.
-    pub(crate) actual: Option<String>,
+    pub(crate) left: Option<String>,
+    /// The right operand, rendered. Present exactly when `left` is.
+    pub(crate) right: Option<String>,
 }
 
 /// What the channel carried, as the classifier needs it.
@@ -213,8 +213,8 @@ pub(crate) fn parse_channel(bytes: &[u8]) -> ChannelFrames {
                         line: location_number(&value, "line"),
                         column: location_number(&value, "column"),
                         payload: string_field(&value, "payload"),
-                        expected: optional_string_field(&value, "expected"),
-                        actual: optional_string_field(&value, "actual"),
+                        left: optional_string_field(&value, "left"),
+                        right: optional_string_field(&value, "right"),
                     });
                 }
             }
@@ -519,8 +519,8 @@ mod tests {
                 line: 7,
                 column: 5,
                 payload: String::new(),
-                expected: None,
-                actual: None,
+                left: None,
+                right: None,
             }),
             ..ChannelFrames::default()
         };
@@ -615,11 +615,11 @@ mod tests {
         assert_eq!(failure.file, "a.rue");
         assert_eq!(failure.line, 3);
         assert_eq!(failure.column, 9);
-        assert_eq!(failure.expected, None);
-        assert_eq!(failure.actual, None);
+        assert_eq!(failure.left, None);
+        assert_eq!(failure.right, None);
     }
 
-    /// A comparison frame carries `expected` and `actual` and no payload
+    /// A comparison frame carries `left` and `right` and no payload
     /// (ADR-0083 Phase 2.5), and its kind is one the taxonomy names rather than
     /// a verbatim one.
     #[test]
@@ -628,13 +628,13 @@ mod tests {
             "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert_eq\",",
             "\"message\":\"assertion failed: left == right\",",
             "\"location\":{\"file\":\"a.rue\",\"line\":3,\"column\":5},",
-            "\"expected\":\"41\",\"actual\":\"42\"}\n",
+            "\"left\":\"41\",\"right\":\"42\"}\n",
         );
         let frames = parse_channel(bytes.as_bytes());
         assert!(frames.malformed.is_none());
         let failure = frames.failure.expect("a failure frame");
-        assert_eq!(failure.expected.as_deref(), Some("41"));
-        assert_eq!(failure.actual.as_deref(), Some("42"));
+        assert_eq!(failure.left.as_deref(), Some("41"));
+        assert_eq!(failure.right.as_deref(), Some("42"));
         assert_eq!(failure.payload, "");
         assert_eq!(
             FailureKind::reported(&failure.kind),
@@ -652,13 +652,13 @@ mod tests {
             "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert_ne\",",
             "\"message\":\"assertion failed: left != right\",",
             "\"location\":{\"file\":\"a.rue\",\"line\":1,\"column\":1},",
-            "\"expected\":\"\",\"actual\":\"\"}\n",
+            "\"left\":\"\",\"right\":\"\"}\n",
         );
         let failure = parse_channel(bytes.as_bytes())
             .failure
             .expect("a failure frame");
-        assert_eq!(failure.expected.as_deref(), Some(""));
-        assert_eq!(failure.actual.as_deref(), Some(""));
+        assert_eq!(failure.left.as_deref(), Some(""));
+        assert_eq!(failure.right.as_deref(), Some(""));
     }
 
     /// A rendering that is not valid UTF-8 never becomes a frame at all: the
@@ -667,9 +667,9 @@ mod tests {
     /// diff's inputs `str` all the way down, with no second encoding tag.
     #[test]
     fn a_non_utf8_channel_line_is_malformed_rather_than_re_encoded() {
-        let mut bytes = b"{\"record\":\"failure\",\"kind\":\"assert_eq\",\"expected\":\"".to_vec();
+        let mut bytes = b"{\"record\":\"failure\",\"kind\":\"assert_eq\",\"left\":\"".to_vec();
         bytes.extend_from_slice(&[0xff, 0xfe]);
-        bytes.extend_from_slice(b"\",\"actual\":\"\"}\n");
+        bytes.extend_from_slice(b"\",\"right\":\"\"}\n");
         let frames = parse_channel(&bytes);
         assert!(frames.failure.is_none());
         assert_eq!(

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -51,7 +51,7 @@ image per target plus one process per test, with the process's visible
 inventory pinned to exact values. Failures are structured data from day one:
 a documented failure channel that user assertion libraries share with the
 built-ins, `?` in test bodies with unwrap-and-report semantics, and
-structured assertion payloads (expected/actual with machine-computed diffs).
+structured assertion payloads (left/right with machine-computed diffs).
 
 The MVP claims nothing it cannot verify: it ships zero hermeticity claims,
 every test simply runs, and the event schema carries an explicit
@@ -336,7 +336,7 @@ $ rue test app/main.rue --filter parse_port      # run a subset
   location — the test declaration's span, except `unhandled_error` and the
   comparison kinds, which carry their own site (§1). Payload and location
   fields are extension points, and Phase 2.5 used them: a comparison failure
-  carries `expected`, `actual`, and the runner's `diff` of the two as
+  carries `left`, `right`, and the runner's `diff` of the two as
   additive minors on the same `1.0` schema, never as prose to be parsed.
   `capability_summary` is present
   from v1.0 as `{"status": "unavailable"}` — zero claims, stated in-band —
@@ -502,7 +502,7 @@ eject-don't-degrade soundness posture the deferred capability ADR ratifies
 #### 5.1 Assertion libraries are first-class by protocol, not by blessing
 
 The channel through which a failing test reports structure — kind, message,
-expected/actual payload, failing-call-site location — is a documented
+left/right payload, failing-call-site location — is a documented
 runtime protocol. `@assert`, the comparison family `@assert_eq`/`@assert_ne`
 (Phase 2.5), and the test-body `?` failure arm (§1) are sugar over the same
 channel any Rue function can invoke before aborting; user libraries emit the
@@ -667,7 +667,7 @@ companion project "rue test follow-ups" (§6).
       warning), RUE-1920 (the `rue test` subcommand, runner, and event stream),
       RUE-1921 (`?` in test bodies with unwrap-and-report semantics).
 - [x] **Phase 2.5: structured assertion payloads** - RUE-1620. `@assert_eq`
-      and `@assert_ne` as intrinsics producing expected/actual through the
+      and `@assert_ne` as intrinsics producing left/right through the
       §5.1 channel — one new runtime helper,
       `__rue_test_fail_comparison` (ABI version 3), whose record carries the
       two rendered operands where the open form carries a message and a

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -88,7 +88,7 @@ budget. Two record kinds exist in this version, and `failure` has two shapes:
 ```json
 {"record":"complete","schema":"1.0"}
 {"record":"failure","schema":"1.0","kind":"...","message":"...","location":{"file":"...","line":0,"column":0},"payload":"..."}
-{"record":"failure","schema":"1.0","kind":"...","message":"...","location":{"file":"...","line":0,"column":0},"expected":"...","actual":"..."}
+{"record":"failure","schema":"1.0","kind":"...","message":"...","location":{"file":"...","line":0,"column":0},"left":"...","right":"..."}
 ```
 
 The `complete` record is written by the dispatcher's epilogue alone, after the
@@ -97,16 +97,15 @@ sugar and by the test-body `?` failure arm before aborting; `kind` is an open
 field, so a user assertion library's own kind is published verbatim rather than
 flattened (ADR-0083 §5.1).
 
-A `failure` record carries **either** `payload` or the pair
-`expected`/`actual`, never both. `payload` is the open, versioned extension
-point §5.1 reserves for an assertion library with something structured to say
-in one string. `expected`/`actual` is the shape a **comparison** assertion
-writes: `expected` is the left operand and `actual` the right — the order the
-source spelled them, so `@assert_eq(want, got)` reads the way it is written —
-each rendered by the compiler-synthesized structural printer under the same
-rules and the same 4 KiB bound the test-body `?` payload uses. An empty
-rendering is a value and stays present as an empty string; a comparison is
-recognized by the fields' presence, not by parsing `kind`.
+A `failure` record carries **either** `payload` or the pair `left`/`right`,
+never both. `payload` is the open, versioned extension point §5.1 reserves for
+an assertion library with something structured to say in one string.
+`left`/`right` is the shape a **comparison** assertion writes: they are the two
+operands in the order the source spelled them, so `@assert_eq(want, got)` reads
+the way it is written — each rendered by the compiler-synthesized structural
+printer under the same rules and the same 4 KiB bound the test-body `?` payload
+uses. An empty rendering is a value and stays present as an empty string; a
+comparison is recognized by the fields' presence, not by parsing `kind`.
 
 `@assert_eq` and `@assert_ne` are the producers in this version, through the
 `__rue_test_fail_comparison` helper ([runtime-abi.md](../runtime-abi.md)). They
@@ -205,9 +204,9 @@ consumers already handle instead of adding one.
 | `signal` | integer | The signal that killed it. **Absent** otherwise. |
 | `location` | object | `{"file","line","column"}` — the test declaration's header, unless a failure frame carried its own site. |
 | `payload` | string | The channel's open payload. **Absent** when empty. |
-| `expected` | string | A comparison assertion's left operand, rendered. **Absent** on every other failure. |
-| `actual` | string | Its right operand, rendered. Present exactly when `expected` is. |
-| `diff` | array | The runner's diff from `expected` to `actual`. Present exactly when `expected` is. |
+| `left` | string | A comparison assertion's left operand, rendered. **Absent** on every other failure. |
+| `right` | string | Its right operand, rendered. Present exactly when `left` is. |
+| `diff` | array | The runner's diff from `left` to `right`. Present exactly when `left` is. |
 | `runner_note` | string | The runner's own explanation. **Absent** unless the runner could not trust what it read. |
 
 `line` and `column` are both 1-based, and `column` counts Unicode scalars rather
@@ -231,11 +230,11 @@ where two values differ. It is an array of hunks in order:
 "diff":[{"op":"equal","text":"4"},{"op":"delete","text":"1"},{"op":"insert","text":"2"}]
 ```
 
-`op` is `equal` (present in both), `delete` (present in `expected`, absent from
-`actual`), or `insert` (the reverse). Two invariants make the encoding lossless
+`op` is `equal` (present in both), `delete` (present in `left`, absent from
+`right`), or `insert` (the reverse). Two invariants make the encoding lossless
 rather than a rendering: concatenating every `equal` and `delete` hunk's `text`
-yields `expected` exactly, and concatenating every `equal` and `insert` hunk's
-yields `actual`. No two adjacent hunks share an `op`, and no hunk is empty, so
+yields `left` exactly, and concatenating every `equal` and `insert` hunk's
+yields `right`. No two adjacent hunks share an `op`, and no hunk is empty, so
 two identical values are one `equal` hunk and two empty values are an empty
 array.
 
@@ -247,13 +246,13 @@ exact longest-common-subsequence expensive is reported as one wholesale
 `delete` followed by one `insert` rather than refined — the invariants above
 hold either way.
 
-A rendering that is not valid UTF-8 never reaches the diff: `expected` and
-`actual` are JSON string fields, and a channel line that is not valid UTF-8 is
+A rendering that is not valid UTF-8 never reaches the diff: `left` and
+`right` are JSON string fields, and a channel line that is not valid UTF-8 is
 rejected as malformed before it becomes a frame at all, yielding `fail` with
 kind `exit` and a `runner_note` (see Precedence below). There is no second
 encoding tag on these fields, unlike a capture record's.
 
-Under `--format human` the same values are printed as `expected:` and `actual:`
+Under `--format human` the same values are printed as `left:` and `right:`
 lines. A single-line pair gets a caret under the first differing character; a
 multi-line pair gets a `-`/`+` hunk listing instead, because a caret into a wall
 of text locates nothing.
@@ -335,7 +334,7 @@ of stderr, and the frames read from the failure channel.
 | `pass` | — | Exit `0` **and** a `complete` frame was read. |
 | `fail` | `incomplete` | Exit `0` with no `complete` frame. |
 | `fail` | `assert` | The last stderr line is exactly `assertion failed`. |
-| `fail` | `assert_eq` | A `failure` frame from a failed `@assert_eq`, carrying `expected` and `actual`. |
+| `fail` | `assert_eq` | A `failure` frame from a failed `@assert_eq`, carrying `left` and `right`. |
 | `fail` | `assert_ne` | The same, from a failed `@assert_ne`. |
 | `fail` | `trap:<class>` | The last stderr line is another pinned runtime message. |
 | `fail` | `unhandled_error` | A `failure` frame with that kind — the test-body `?` failure arm. |
@@ -493,9 +492,13 @@ event of a run and in each `--list --format json` record.
 - **Additive changes are minors.** A new event kind, a new optional field, a new
   reserved value becoming producible, or a richer `payload` inside the failure
   record. Consumers must ignore unknown fields and unknown event kinds. The
-  failure record's `expected`, `actual`, and `diff` and the `assert_eq` /
+  failure record's `left`, `right`, and `diff` and the `assert_eq` /
   `assert_ne` kinds arrived this way (ADR-0083 Phase 2.5): the version stays
   `1.0` because nothing a `1.0` consumer already read changed.
+- The comparison operands were briefly named `expected`/`actual` and were
+  renamed to `left`/`right` in place, still at `1.0` (RUE-1954): the rename
+  landed before any consumer outside this repository existed, so it is the one
+  exception to the major-version rule below rather than a break in it.
 - **Removing or repurposing a field, renaming an event, or changing a field's
   type is a major.** So is producing a verdict this document reserves *out* of
   the taxonomy.

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -131,7 +131,7 @@ well as in a test image.
   between them, and the staged file bytes must stay readable across both.
 - `__rue_test_fail_comparison` is the same terminal call for a comparison
   assertion (Phase 2.5, ABI version 3): it carries the two rendered operands as
-  the record's `expected` and `actual` where `__rue_test_fail` carries a message
+  the record's `left` and `right` where `__rue_test_fail` carries a message
   and the open payload. Its message is not a parameter — it is pinned by the
   kind, `assertion failed: left == right` for `assert_eq` and
   `assertion failed: left != right` for `assert_ne` — which is what keeps a

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -171,7 +171,7 @@ and terminates with status 101, exactly as `@assert` does.
 
 Inside a test image the same failure is additionally reported as structured
 data: a record naming the failing kind, the intrinsic's source location, and
-both operands rendered as `expected` and `actual`. Ordinary builds are
+both operands rendered as `left` and `right`. Ordinary builds are
 unaffected — the report goes to a descriptor a test runner supplies, and its
 absence is not an error. See
 [docs/process/test-events.md](https://github.com/rue-language/rue/blob/trunk/docs/process/test-events.md)


### PR DESCRIPTION
Fixes RUE-1954.

The comparison failure record named its two operands `expected` and `actual`, which asserts an argument-order convention the compiler cannot know the author followed, and disagrees with the pinned message on the same record (`assertion failed: left == right`). Rename them to `left` and `right` everywhere they are consumer-visible: the channel frame the runtime writes, the parsed frame, the `test_finished` failure record, and the human renderer's labels, followed through `docs/process/test-events.md`, `docs/runtime-abi.md`, spec 4.13:5g, ADR-0083, and the pinned CLI cases.

The schema stays `1.0`: the fields were renamed in place before any consumer outside this repository existed, and the Versioning section now records that as the one exception rather than leaving the "renaming a field is a major" rule looking broken. No ABI shape change.

Verification: `scripts/rue cli rue_test` (45 passed), `//crates/rue:rue-test test_mode` (83), `scripts/rue unit runtime test_channel` (12), `scripts/rue quick`, `scripts/rue spec 4.13` (213), fmt and clippy clean.