### PR TITLE
RUE-1945: explain inference, ownership, and import diagnostics

### DIFF
--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -635,6 +635,72 @@ args = ["explain", "E0708"]
 compile_fail = true
 error_contains = ["unknown or retired error code E0708"]
 
+# The post-E0708 tranche spans context-directed inference, the by-copy
+# ownership gate, byte-allocation alignment, and import identity/provenance.
+# Invalid source pins each command as a deterministic metadata-only query.
+[[case]]
+name = "uninferrable_cast_target_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0709"]
+compile_only = true
+compile_stdout_contains = ["E0709: Cannot infer cast target", "those floating-point intrinsics are unavailable without that preview gate", "Leave an integer cast target unconstrained:", "Annotate the cast result:", "docs/spec/src/04-expressions/13-intrinsics.md (spec rule 4.13:27)", "docs/designs/0065-floating-point.md"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "uninferrable_pointee_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0710"]
+compile_only = true
+compile_stdout_contains = ["E0710: Cannot infer pointee type", "Discard a pointer with no inferred pointee:", "Annotate the pointer result:", "docs/spec/src/09-unchecked-code/02-intrinsics.md (spec rule 9.2:6d)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "nontrivial_container_element_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0711"]
+compile_only = true
+compile_stdout_contains = ["E0711: Container element not trivially droppable", "Copy an element that has drop glue:", "Copy a trivially droppable element:", "docs/spec/src/03-types/09-destructors.md (spec rule 3.9:7)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "invalid_intrinsic_alignment_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0712"]
+compile_only = true
+compile_stdout_contains = ["E0712: Intrinsic align not power of two", "Allocate with a three-byte alignment:", "Use a power-of-two alignment:", "docs/spec/src/09-unchecked-code/02-intrinsics.md (spec rule 9.2:13a)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "import_escape_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0713"]
+compile_only = true
+compile_stdout_contains = ["E0713: Import escapes root", "Import a file above the project root:", "Keep the imported file inside the project:", "// --- sub/helper.rue", "docs/spec/src/10-modules/02-import-resolution.md (spec rule 10.2:7)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "nonrelative_import_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0714"]
+compile_only = true
+compile_stdout_contains = ["E0714: Import specifier not relative", "Use an absolute import path:", "Use a relative import path:", "docs/spec/src/04-expressions/13-intrinsics.md (spec rule 4.13:133)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "physical_import_alias_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0715"]
+compile_only = true
+compile_stdout_contains = ["E0715: Import spellings same file", "Import hard-linked paths under different names:", "// --- b.rue", "Repeat one logical import spelling:", "docs/spec/src/10-modules/02-import-resolution.md (spec rule 10.2:4)", "docs/designs/0078-import-resolution-policy.md"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
 [[case]]
 name = "malformed_code_is_rejected"
 files = [{ path = "main.rue", source = "fn main() {}\n" }]

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -112,9 +112,10 @@ rue_rust_test(
 # consumer verifies the bounded documented lexer, parser, semantic-foundation,
 # struct-foundation, method/item, enum/place, place/borrow, and
 # const/item/ownership, single-file destructor/const, slice/string/container,
-# match, and single-file intrinsic tranches through the real one-shot compiler
-# path without copying the examples into a second fixture. Multi-file E0460 and
-# import/module examples are validated by compiler unit tests.
+# match, and single-file intrinsic/inference/ownership/alignment tranches
+# through the real one-shot compiler path without copying the examples into a
+# second fixture. Multi-file E0460 and import/module examples are validated by
+# compiler unit tests.
 rue_rust_test(
     name = "error-explanation-examples-test",
     srcs = ["tests/error_explanation_examples.rs"],

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -68,13 +68,26 @@ mod integration_tests {
             rue_error::ErrorCode::STD_LIB_NOT_FOUND,
             rue_error::ErrorCode::PRIVATE_MEMBER_ACCESS,
             rue_error::ErrorCode::UNKNOWN_MODULE_MEMBER,
+            rue_error::ErrorCode::IMPORT_ESCAPES_ROOT,
+            rue_error::ErrorCode::IMPORT_SPECIFIER_NOT_RELATIVE,
+            rue_error::ErrorCode::IMPORT_SPELLINGS_SAME_FILE,
         ] {
             let explanation = rue_error::error_code_explanation(code)
                 .unwrap_or_else(|| panic!("{code} explanation"));
             for example in explanation.examples {
                 let snapshot = explanation_example_snapshot(example.source);
                 let mut session = CompilerSession::new();
-                let published = crate::test_support::publish_test_snapshot(&mut session, &snapshot);
+                let published = if code == rue_error::ErrorCode::IMPORT_SPELLINGS_SAME_FILE
+                    && example.outcome == rue_error::ErrorCodeExampleOutcome::EmitsThisCode
+                {
+                    crate::test_support::publish_hard_link_explanation_snapshot(
+                        &mut session,
+                        &snapshot,
+                        ["a.rue", "b.rue"],
+                    )
+                } else {
+                    crate::test_support::publish_test_snapshot(&mut session, &snapshot)
+                };
                 let result = published
                     .and_then(|_| session.rooted_cfg(&CompileOptions::default()).map(|_| ()));
                 match example.outcome {

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -221,6 +221,28 @@ pub(crate) fn publish_test_snapshot(
     Ok(TestDiscoveryHost::new(snapshot)?.drive(session)?.snapshot)
 }
 
+/// Drive an explanation fixture whose two logical module paths are hard-link
+/// aliases for one physical file. This keeps E0715's executable example on the
+/// same compiler-owned discovery path as production while letting the
+/// presentation-neutral `// --- path` source format describe the logical tree.
+#[cfg(test)]
+pub(crate) fn publish_hard_link_explanation_snapshot(
+    session: &mut CompilerSession,
+    snapshot: &SourceSnapshot,
+    aliases: [&str; 2],
+) -> MultiErrorResult<SourceSnapshot> {
+    let mut host = TestDiscoveryHost::new(snapshot)?;
+    let shared_identity = PhysicalFileIdentity::new(7, 15);
+    for alias in aliases {
+        let requested = format!("{FIXTURE_PROJECT_ROOT}/{alias}");
+        host.files
+            .get_mut(&requested)
+            .unwrap_or_else(|| panic!("hard-link explanation fixture must contain {alias}"))
+            .identity = shared_identity;
+    }
+    Ok(host.drive(session)?.snapshot)
+}
+
 /// Whether `snapshot` declares any import directive, decided by a standalone
 /// parse so the answer costs the session nothing when discovery follows.
 pub(crate) fn fixture_has_imports(snapshot: &SourceSnapshot) -> MultiErrorResult<bool> {

--- a/crates/rue-compiler/tests/error_explanation_examples.rs
+++ b/crates/rue-compiler/tests/error_explanation_examples.rs
@@ -23,6 +23,7 @@ fn compiler_owned_explanation_examples_have_the_declared_outcome() {
                     | 499
                     | 600..=602
                     | 700..=702
+                    | 709..=712
             )
     }) {
         let explanation = error_code_explanation(metadata.code)

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1768,26 +1768,101 @@ define_error_codes! {
     // names the directory facade alone and a file module is spelled with its
     // extension, so the file/facade ambiguity no longer exists. Keep the
     // number retired rather than reusing it.
-    CANNOT_INFER_CAST_TARGET = 709;
-    CANNOT_INFER_POINTEE_TYPE = 710;
-    CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE = 711;
+    CANNOT_INFER_CAST_TARGET = 709 => {
+        explanation: "A context-directed numeric conversion has no target type to convert to. The stable `@intCast` and `@bitCast` intrinsics infer an integer result type from the surrounding annotation, parameter, or return position. When the `floats` preview is enabled, `@int_to_float`, `@float_to_int`, and `@float_cast` use the same contextual rule for their float or integer result; those floating-point intrinsics are unavailable without that preview gate.",
+        likely_cause: "The conversion result is discarded, stored in an unannotated binding, or passed only to a type-polymorphic operation such as `@dbg`, so no surrounding use requires the concrete integer or floating-point result type expected by that intrinsic.",
+        examples: [
+            ErrorCodeExample { title: "Leave an integer cast target unconstrained", source: "fn main() -> i32 {\n    let source: u64 = 5;\n    @dbg(@intCast(source));\n    0\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Annotate the cast result", source: "fn main() -> i32 {\n    let source: u64 = 5;\n    let converted: i32 = @intCast(source);\n    converted\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Context-inferred integer cast targets", path: "docs/spec/src/04-expressions/13-intrinsics.md", rule: Some("4.13:26") },
+            ErrorCodeReference { title: "Uninferrable cast targets", path: "docs/spec/src/04-expressions/13-intrinsics.md", rule: Some("4.13:27") },
+            ErrorCodeReference { title: "Preview floating-point conversion semantics (ADR-0065 §4)", path: "docs/designs/0065-floating-point.md", rule: None },
+        ],
+    };
+    CANNOT_INFER_POINTEE_TYPE = 710 => {
+        explanation: "`@int_to_ptr` converts a `u64` address to `ptr mut T`, but the address alone does not say what `T` is. Rue therefore takes the pointee type from the context in which the resulting pointer is used.",
+        likely_cause: "The pointer result is discarded or assigned to a binding without a pointer type annotation, and no later use constrains the pointer to one concrete pointee type.",
+        examples: [
+            ErrorCodeExample { title: "Discard a pointer with no inferred pointee", source: "fn main() {\n    checked {\n        let address: u64 = 0;\n        @int_to_ptr(address);\n    }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Annotate the pointer result", source: "fn main() {\n    checked {\n        let address: u64 = 0;\n        let pointer: ptr mut u8 = @int_to_ptr(address);\n    }\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Integer-to-pointer result type", path: "docs/spec/src/09-unchecked-code/02-intrinsics.md", rule: Some("9.2:6c") },
+            ErrorCodeReference { title: "Integer-to-pointer operand and inference", path: "docs/spec/src/09-unchecked-code/02-intrinsics.md", rule: Some("9.2:6d") },
+        ],
+    };
+    CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE = 711 => {
+        explanation: "A by-copy container read would duplicate an element while leaving the stored value live. When the element type has drop glue, both values would later clean up the same owned resources, so `@require_trivially_droppable(T)` rejects the read.",
+        likely_cause: "A container's by-copy accessor such as `get` or `get_or` was instantiated for an element type with a destructor or nested drop glue. Read the element in place through `get_ref`, or transfer its ownership with `pop` or `pop_or`.",
+        examples: [
+            ErrorCodeExample { title: "Copy an element that has drop glue", source: "struct Resource { value: i32 }\ndrop fn Resource(self) {}\nfn Reader(comptime T: type) -> type {\n    struct {\n        value: T,\n        fn first(borrow self) -> T {\n            @require_trivially_droppable(T);\n            self.value\n        }\n    }\n}\nfn main() -> i32 {\n    let R = Reader(Resource);\n    let reader = R { value: Resource { value: 42 } };\n    let value = reader.first();\n    value.value\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Copy a trivially droppable element", source: "fn Reader(comptime T: type) -> type {\n    struct {\n        value: T,\n        fn first(borrow self) -> T {\n            @require_trivially_droppable(T);\n            self.value\n        }\n    }\n}\nfn main() -> i32 {\n    let R = Reader(i32);\n    let reader = R { value: 42 };\n    reader.first()\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Trivially droppable types", path: "docs/spec/src/03-types/09-destructors.md", rule: Some("3.9:7") },
+            ErrorCodeReference { title: "By-value reads of borrowed resources", path: "docs/spec/src/06-items/06-borrow-accessors.md", rule: Some("6.6:11") },
+        ],
+    };
     /// A comptime-constant `align` argument to a byte-allocation intrinsic
     /// (`@alloc`/`@alloc_zeroed`/`@free`/`@realloc`/`@resize`, ADR-0059) was
     /// zero or not a power of two. Alignment must be a power of two.
-    INTRINSIC_ALIGN_NOT_POWER_OF_TWO = 712;
+    INTRINSIC_ALIGN_NOT_POWER_OF_TWO = 712 => {
+        explanation: "The byte-allocation family requires alignment to be a nonzero power-of-two byte count. Rue checks that contract at compile time whenever the `align` operand is a constant.",
+        likely_cause: "The constant alignment passed to `@alloc`, `@alloc_zeroed`, `@free`, `@realloc`, or `@resize` is zero or has more than one bit set, often because a size was used where an alignment was required. Use a valid alignment such as `@align_of(T)` converted to `u64`.",
+        examples: [
+            ErrorCodeExample { title: "Allocate with a three-byte alignment", source: "fn main() {\n    checked {\n        let block = @alloc(8, 3);\n    }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Use a power-of-two alignment", source: "fn main() {\n    checked {\n        let block = @alloc(8, 8);\n        @free(block, 8, 8);\n    }\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [ErrorCodeReference { title: "Allocation alignment contract", path: "docs/spec/src/09-unchecked-code/02-intrinsics.md", rule: Some("9.2:13a") }],
+    };
     /// A relative `@import` path resolves outside the project root (the root
     /// source file's directory), so it can receive no project-relative module
     /// identity (ADR-0078).
-    IMPORT_ESCAPES_ROOT = 713;
+    IMPORT_ESCAPES_ROOT = 713 => {
+        explanation: "A relative import normalized to a candidate outside the lexical identity boundary selected from the importing module's accepted provenance. That boundary is normally the project root (the root source file's directory); for a trusted standard-library importer it is the captured standard-library root. The candidate cannot receive an identity in the importer's namespace, so Rue rejects it before deriving any filesystem request.",
+        likely_cause: "A `..` component climbs above the importer's provenance-selected identity root, or a dependency was moved outside that root while its old relative import remained. Move the dependency back under the applicable project or captured standard-library root, or choose an in-root relative path.",
+        examples: [
+            ErrorCodeExample { title: "Import a file above the project root", source: "// --- main.rue\nconst outside = @import(\"../outside.rue\");\nfn main() -> i32 { 0 }", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Keep the imported file inside the project", source: "// --- main.rue\nconst helper = @import(\"sub/helper.rue\");\nfn main() -> i32 { helper.answer() }\n// --- sub/helper.rue\npub fn answer() -> i32 { 42 }", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Import escape diagnostic", path: "docs/spec/src/04-expressions/13-intrinsics.md", rule: Some("4.13:89") },
+            ErrorCodeReference { title: "Project-root module identity", path: "docs/spec/src/10-modules/02-import-resolution.md", rule: Some("10.2:7") },
+        ],
+    };
     /// An `@import` specifier is not a relative path: it is empty, or it is
     /// absolute. Resolution is defined for relative paths only (spec 10.2:1-2),
     /// and an absolute specifier would additionally bind the program to one
     /// machine's layout, which project-root-relative identity exists to avoid.
-    IMPORT_SPECIFIER_NOT_RELATIVE = 714;
+    IMPORT_SPECIFIER_NOT_RELATIVE = 714 => {
+        explanation: "An import path must be relative to the importing file. An empty path names no candidate, while an absolute path is anchored to one machine's filesystem instead of the source tree; Rue rejects either spelling before any filesystem probe. The reserved `std` specifier follows its own program-anchored rule.",
+        likely_cause: "The import string is empty, begins with `/`, or was generated as an absolute host path. Spell a source-tree dependency relative to the file containing the `@import` call.",
+        examples: [
+            ErrorCodeExample { title: "Use an absolute import path", source: "// --- main.rue\nconst helper = @import(\"/project/helper.rue\");\nfn main() -> i32 { 0 }", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Use a relative import path", source: "// --- main.rue\nconst helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n// --- helper.rue\npub fn answer() -> i32 { 42 }", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Non-relative import diagnostic", path: "docs/spec/src/04-expressions/13-intrinsics.md", rule: Some("4.13:133") },
+            ErrorCodeReference { title: "Relative import paths", path: "docs/spec/src/10-modules/02-import-resolution.md", rule: Some("10.2:8") },
+        ],
+    };
     /// Two logical import spellings resolve to one physical file. Importing a
     /// physical file under more than one logical identity would make the
     /// source graph ambiguous (RUE-1705).
-    IMPORT_SPELLINGS_SAME_FILE = 715;
+    IMPORT_SPELLINGS_SAME_FILE = 715 => {
+        explanation: "Two distinct logical import names reached the same physical file through non-symlink filesystem aliases, such as hard links or case variants on a case-insensitive filesystem. Giving one file multiple logical module identities within its applicable namespace would make declaration and provenance ownership ambiguous, so Rue reports the later import site. Repeating one logical spelling remains valid, and symlink routes canonicalize to one module.",
+        likely_cause: "The source tree contains hard-linked paths to one file, or two import strings differ only in spelling while the host filesystem treats them as the same file. Remove the alias and import the file consistently under one logical name in the applicable namespace.",
+        examples: [
+            ErrorCodeExample { title: "Import hard-linked paths under different names", source: "// --- main.rue\nconst first = @import(\"a.rue\");\nconst second = @import(\"b.rue\");\nfn main() -> i32 { 0 }\n// --- a.rue\npub fn value() -> i32 { 1 }\n// --- b.rue\npub fn value() -> i32 { 1 }", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Repeat one logical import spelling", source: "// --- main.rue\nconst first = @import(\"helper.rue\");\nconst second = @import(\"helper.rue\");\nfn main() -> i32 { first.value() + second.value() }\n// --- helper.rue\npub fn value() -> i32 { 1 }", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Canonical project-relative module identity", path: "docs/spec/src/10-modules/02-import-resolution.md", rule: Some("10.2:4") },
+            ErrorCodeReference { title: "Path normalization and physical-identity aliasing (ADR-0078 §3)", path: "docs/designs/0078-import-resolution-policy.md", rule: None },
+        ],
+    };
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -4237,9 +4312,13 @@ mod tests {
             }
             for reference in explanation.references {
                 assert!(!reference.title.is_empty());
-                assert!(reference.path.starts_with("docs/spec/src/"));
                 assert!(reference.path.ends_with(".md"));
-                assert!(reference.rule.is_some_and(|rule| !rule.is_empty()));
+                if reference.path.starts_with("docs/spec/src/") {
+                    assert!(reference.rule.is_some_and(|rule| !rule.is_empty()));
+                } else {
+                    assert!(reference.path.starts_with("docs/designs/"));
+                    assert_eq!(reference.rule, None);
+                }
             }
         }
 
@@ -4387,6 +4466,60 @@ mod tests {
 
         let retired = ErrorCode(708);
         assert!(RETIRED_ERROR_CODES.contains(&retired));
+        assert_eq!(error_code_explanation(retired), None);
+        assert_eq!(
+            retired.to_string().parse::<ErrorCode>(),
+            Err(ParseErrorCodeError::Unknown(retired))
+        );
+    }
+
+    #[test]
+    fn active_inference_ownership_alignment_and_import_explanation_band_is_complete_and_bounded() {
+        let expected = [
+            ErrorCode::CANNOT_INFER_CAST_TARGET,
+            ErrorCode::CANNOT_INFER_POINTEE_TYPE,
+            ErrorCode::CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE,
+            ErrorCode::INTRINSIC_ALIGN_NOT_POWER_OF_TWO,
+            ErrorCode::IMPORT_ESCAPES_ROOT,
+            ErrorCode::IMPORT_SPECIFIER_NOT_RELATIVE,
+            ErrorCode::IMPORT_SPELLINGS_SAME_FILE,
+        ];
+        let active = error_code_metadata()
+            .iter()
+            .filter(|metadata| (709..=715).contains(&metadata.code.0))
+            .map(|metadata| {
+                assert_eq!(metadata.source_path, "crates/rue-error/src/lib.rs");
+                metadata.code
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(active, expected);
+        let explained = ERROR_CODE_EXPLANATION_DECLARATIONS
+            .iter()
+            .filter_map(|declaration| {
+                (709..=715)
+                    .contains(&declaration.code.0)
+                    .then_some(declaration.code)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(explained, expected);
+        assert!(
+            expected
+                .into_iter()
+                .all(|code| error_code_explanation(code).is_some())
+        );
+
+        let retired = ErrorCode(708);
+        assert!(RETIRED_ERROR_CODES.contains(&retired));
+        assert!(
+            error_code_metadata()
+                .iter()
+                .all(|metadata| metadata.code != retired)
+        );
+        assert!(
+            ERROR_CODE_EXPLANATION_DECLARATIONS
+                .iter()
+                .all(|declaration| declaration.code != retired)
+        );
         assert_eq!(error_code_explanation(retired), None);
         assert_eq!(
             retired.to_string().parse::<ErrorCode>(),

--- a/crates/rue-spec/BUCK
+++ b/crates/rue-spec/BUCK
@@ -63,6 +63,7 @@ command_alias(
     exe = ":rue-spec",
     args = ["--error-pages"],
     env = {
+        "RUE_DESIGNS_DIR": "$(location //docs:designs)",
         "RUE_SPEC_DIR": "$(location //docs:spec-src)",
     },
     visibility = ["PUBLIC"],

--- a/crates/rue-spec/src/error_pages.rs
+++ b/crates/rue-spec/src/error_pages.rs
@@ -1,9 +1,9 @@
 //! Deterministic website pages projected from the compiler's error inventory.
 
-use crate::machine_index::canonical_spec_path;
-use crate::traceability::parse_spec_paragraphs;
-use rue_error::{error_code_explanation, error_code_metadata};
-use std::collections::BTreeSet;
+use crate::machine_index::{canonical_design_path, canonical_spec_path};
+use crate::traceability::{SpecParagraph, parse_spec_paragraphs};
+use rue_error::{ErrorCodeReference, error_code_explanation, error_code_metadata};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -37,7 +37,65 @@ fn front_matter_string(value: &str) -> String {
     escaped
 }
 
-pub fn generate(spec_dir: &Path) -> Result<Vec<GeneratedPage>, String> {
+fn render_reference(
+    reference: &ErrorCodeReference,
+    code: &str,
+    spec_dir: &Path,
+    designs_dir: &Path,
+    spec_paragraphs: &BTreeMap<String, SpecParagraph>,
+) -> Result<String, String> {
+    let href = if let Some(relative) = reference.path.strip_prefix("docs/spec/src/") {
+        let rule = reference.rule.ok_or_else(|| {
+            format!(
+                "error-code reference {:?} for {code} has no specification rule",
+                reference.title
+            )
+        })?;
+        if !spec_dir.join(relative).is_file() {
+            return Err(format!(
+                "error-code reference {:?} for {code} does not exist under {}",
+                reference.path,
+                spec_dir.display()
+            ));
+        }
+        let paragraph = spec_paragraphs.get(rule).ok_or_else(|| {
+            format!(
+                "error-code reference {:?} for {code} names unknown specification rule {rule}",
+                reference.title
+            )
+        })?;
+        if paragraph.source_path != relative {
+            return Err(format!(
+                "error-code reference {:?} for {code} places specification rule {rule} in {:?}, but its canonical source is {:?}",
+                reference.title, relative, paragraph.source_path
+            ));
+        }
+        canonical_spec_path(reference.path, rule)?
+    } else if let Some(relative) = reference.path.strip_prefix("docs/designs/") {
+        if let Some(rule) = reference.rule {
+            return Err(format!(
+                "design reference {:?} for {code} must not name specification rule {rule}",
+                reference.title
+            ));
+        }
+        if !designs_dir.join(relative).is_file() {
+            return Err(format!(
+                "error-code design reference {:?} for {code} does not exist under {}",
+                reference.path,
+                designs_dir.display()
+            ));
+        }
+        canonical_design_path(reference.path)?
+    } else {
+        return Err(format!(
+            "unsupported error-code reference path {:?} for {code}",
+            reference.path
+        ));
+    };
+    Ok(format!("\n- [{}]({href})\n", reference.title))
+}
+
+pub fn generate(spec_dir: &Path, designs_dir: &Path) -> Result<Vec<GeneratedPage>, String> {
     let metadata = error_code_metadata();
     let (spec_paragraphs, duplicate_spec_ids) = parse_spec_paragraphs(spec_dir)?;
     if !duplicate_spec_ids.is_empty() {
@@ -102,43 +160,13 @@ pub fn generate(spec_dir: &Path) -> Result<Vec<GeneratedPage>, String> {
             if !explanation.references.is_empty() {
                 page.push_str("\n## References\n");
                 for reference in explanation.references {
-                    let rule = reference.rule.ok_or_else(|| {
-                        format!(
-                            "error-code reference {:?} for {code} has no specification rule",
-                            reference.title
-                        )
-                    })?;
-                    let relative =
-                        reference
-                            .path
-                            .strip_prefix("docs/spec/src/")
-                            .ok_or_else(|| {
-                                format!(
-                                    "unsupported error-code reference path {:?} for {code}",
-                                    reference.path
-                                )
-                            })?;
-                    if !spec_dir.join(relative).is_file() {
-                        return Err(format!(
-                            "error-code reference {:?} for {code} does not exist under {}",
-                            reference.path,
-                            spec_dir.display()
-                        ));
-                    }
-                    let paragraph = spec_paragraphs.get(rule).ok_or_else(|| {
-                        format!(
-                            "error-code reference {:?} for {code} names unknown specification rule {rule}",
-                            reference.title
-                        )
-                    })?;
-                    if paragraph.source_path != relative {
-                        return Err(format!(
-                            "error-code reference {:?} for {code} places specification rule {rule} in {:?}, but its canonical source is {:?}",
-                            reference.title, relative, paragraph.source_path
-                        ));
-                    }
-                    let href = canonical_spec_path(reference.path, rule)?;
-                    page.push_str(&format!("\n- [{}]({href})\n", reference.title));
+                    page.push_str(&render_reference(
+                        reference,
+                        &code,
+                        spec_dir,
+                        designs_dir,
+                        &spec_paragraphs,
+                    )?);
                 }
             }
         } else {
@@ -190,8 +218,9 @@ fn write_to_paths(
     staging: &Path,
     backup: &Path,
     spec_dir: &Path,
+    designs_dir: &Path,
 ) -> Result<(), String> {
-    let pages = generate(spec_dir)?;
+    let pages = generate(spec_dir, designs_dir)?;
     remove_generated_directory(staging)?;
     fs::create_dir_all(staging)
         .map_err(|error| format!("failed to create {}: {error}", staging.display()))?;
@@ -227,12 +256,13 @@ fn write_to_paths(
     Ok(())
 }
 
-pub fn write(spec_dir: &Path) -> Result<(), String> {
+pub fn write(spec_dir: &Path, designs_dir: &Path) -> Result<(), String> {
     write_to_paths(
         Path::new(OUTPUT_DIR),
         Path::new(STAGING_DIR),
         Path::new(BACKUP_DIR),
         spec_dir,
+        designs_dir,
     )
 }
 
@@ -242,25 +272,33 @@ mod tests {
     use rue_error::RETIRED_ERROR_CODES;
     use std::collections::BTreeMap;
 
-    fn spec_fixture() -> tempfile::TempDir {
-        let directory = tempfile::tempdir().unwrap();
+    fn reference_fixture() -> (tempfile::TempDir, tempfile::TempDir) {
+        let spec_directory = tempfile::tempdir().unwrap();
+        let designs_directory = tempfile::tempdir().unwrap();
         let mut rules_by_path = BTreeMap::<&str, BTreeSet<&str>>::new();
         for metadata in error_code_metadata() {
             let Some(explanation) = error_code_explanation(metadata.code) else {
                 continue;
             };
             for reference in explanation.references {
-                rules_by_path
-                    .entry(reference.path)
-                    .or_default()
-                    .insert(reference.rule.expect("website references require a rule"));
+                if let Some(relative) = reference.path.strip_prefix("docs/spec/src/") {
+                    rules_by_path.entry(relative).or_default().insert(
+                        reference
+                            .rule
+                            .expect("specification references require a rule"),
+                    );
+                } else if let Some(relative) = reference.path.strip_prefix("docs/designs/") {
+                    assert_eq!(reference.rule, None, "design references are not spec rules");
+                    let fixture_path = designs_directory.path().join(relative);
+                    fs::create_dir_all(fixture_path.parent().unwrap()).unwrap();
+                    fs::write(fixture_path, "# Design fixture\n").unwrap();
+                } else {
+                    panic!("unsupported reference fixture path: {}", reference.path);
+                }
             }
         }
-        for (path, rules) in rules_by_path {
-            let relative = path
-                .strip_prefix("docs/spec/src/")
-                .expect("website references must name specification sources");
-            let fixture_path = directory.path().join(relative);
+        for (relative, rules) in rules_by_path {
+            let fixture_path = spec_directory.path().join(relative);
             fs::create_dir_all(fixture_path.parent().unwrap()).unwrap();
             let mut source = String::from("# Fixture\n");
             for rule in rules {
@@ -270,14 +308,14 @@ mod tests {
             }
             fs::write(fixture_path, source).unwrap();
         }
-        directory
+        (spec_directory, designs_directory)
     }
 
     #[test]
     fn pages_are_complete_unique_active_only_and_reproducible() {
-        let fixture = spec_fixture();
-        let first = generate(fixture.path()).unwrap();
-        let second = generate(fixture.path()).unwrap();
+        let (spec_fixture, designs_fixture) = reference_fixture();
+        let first = generate(spec_fixture.path(), designs_fixture.path()).unwrap();
+        let second = generate(spec_fixture.path(), designs_fixture.path()).unwrap();
         assert_eq!(first, second, "generation must be byte-reproducible");
         assert_eq!(first.len(), error_code_metadata().len() + 1);
 
@@ -316,18 +354,24 @@ mod tests {
 
     #[test]
     fn generated_internal_links_use_existing_routes() {
-        let fixture = spec_fixture();
-        let pages = generate(fixture.path()).unwrap();
-        let expected_spec_links = error_code_metadata()
+        let (spec_fixture, designs_fixture) = reference_fixture();
+        let pages = generate(spec_fixture.path(), designs_fixture.path()).unwrap();
+        let expected_reference_links = error_code_metadata()
             .iter()
             .filter_map(|metadata| error_code_explanation(metadata.code))
             .flat_map(|explanation| explanation.references)
             .map(|reference| {
-                canonical_spec_path(
-                    reference.path,
-                    reference.rule.expect("website references require a rule"),
-                )
-                .unwrap()
+                if reference.path.starts_with("docs/designs/") {
+                    canonical_design_path(reference.path).unwrap()
+                } else {
+                    canonical_spec_path(
+                        reference.path,
+                        reference
+                            .rule
+                            .expect("specification references require a rule"),
+                    )
+                    .unwrap()
+                }
             })
             .collect::<BTreeSet<_>>();
         for page in pages {
@@ -349,13 +393,95 @@ mod tests {
                     );
                 } else if href.starts_with("/spec/") {
                     assert!(
-                        expected_spec_links.contains(href),
+                        expected_reference_links.contains(href),
                         "explanation links only to declared specification references"
+                    );
+                } else if href
+                    .starts_with("https://github.com/rue-language/rue/blob/trunk/docs/designs/")
+                {
+                    assert!(
+                        expected_reference_links.contains(href),
+                        "explanation links only to declared design references"
                     );
                 } else {
                     panic!("unsupported generated internal link: {href}");
                 }
             }
+        }
+    }
+
+    #[test]
+    fn ruleless_design_references_render_as_repository_links() {
+        let spec_fixture = tempfile::tempdir().unwrap();
+        let designs_fixture = tempfile::tempdir().unwrap();
+        fs::write(
+            designs_fixture.path().join("0065-floating-point.md"),
+            "# ADR-0065\n",
+        )
+        .unwrap();
+        let rendered = render_reference(
+            &rue_error::ErrorCodeReference {
+                title: "Floating point",
+                path: "docs/designs/0065-floating-point.md",
+                rule: None,
+            },
+            "E0709",
+            spec_fixture.path(),
+            designs_fixture.path(),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            rendered,
+            "\n- [Floating point](https://github.com/rue-language/rue/blob/trunk/docs/designs/0065-floating-point.md)\n"
+        );
+    }
+
+    #[test]
+    fn malformed_reference_contracts_are_rejected() {
+        let spec_fixture = tempfile::tempdir().unwrap();
+        let designs_fixture = tempfile::tempdir().unwrap();
+        fs::write(designs_fixture.path().join("0065.md"), "# ADR\n").unwrap();
+        let paragraphs = BTreeMap::new();
+        let cases = [
+            (
+                rue_error::ErrorCodeReference {
+                    title: "Missing spec rule",
+                    path: "docs/spec/src/chapter.md",
+                    rule: None,
+                },
+                "has no specification rule",
+            ),
+            (
+                rue_error::ErrorCodeReference {
+                    title: "Design with spec rule",
+                    path: "docs/designs/0065.md",
+                    rule: Some("1.2:3"),
+                },
+                "must not name specification rule",
+            ),
+            (
+                rue_error::ErrorCodeReference {
+                    title: "Unsupported tree",
+                    path: "docs/process/ci.md",
+                    rule: None,
+                },
+                "unsupported error-code reference path",
+            ),
+        ];
+        for (reference, expected) in cases {
+            let error = render_reference(
+                &reference,
+                "E9999",
+                spec_fixture.path(),
+                designs_fixture.path(),
+                &paragraphs,
+            )
+            .unwrap_err();
+            assert!(
+                error.contains(expected),
+                "{error:?} does not contain {expected:?}"
+            );
         }
     }
 
@@ -388,7 +514,7 @@ mod tests {
 
     #[test]
     fn staged_write_replaces_only_after_every_page_is_ready() {
-        let fixture = spec_fixture();
+        let (spec_fixture, designs_fixture) = reference_fixture();
         let root = tempfile::tempdir().unwrap();
         let output = root.path().join("errors");
         let staging = root.path().join("staging");
@@ -396,7 +522,14 @@ mod tests {
         fs::create_dir(&output).unwrap();
         fs::write(output.join("stale.md"), "stale").unwrap();
 
-        write_to_paths(&output, &staging, &backup, fixture.path()).unwrap();
+        write_to_paths(
+            &output,
+            &staging,
+            &backup,
+            spec_fixture.path(),
+            designs_fixture.path(),
+        )
+        .unwrap();
 
         assert!(!output.join("stale.md").exists());
         assert!(output.join("_index.md").is_file());

--- a/crates/rue-spec/src/machine_index.rs
+++ b/crates/rue-spec/src/machine_index.rs
@@ -20,6 +20,7 @@ const SPEC_ROUTE_ROOT: &str = include_str!("spec-route-root.txt");
 #[derive(Debug)]
 struct WebsiteAuthorities {
     base_url: String,
+    github_url: String,
     anchor_prefix: String,
     spec_route_root: String,
 }
@@ -79,6 +80,13 @@ fn website_authorities() -> Result<WebsiteAuthorities, String> {
         .ok_or_else(|| "website/config.toml has no string base_url".to_string())?
         .trim_end_matches('/')
         .to_string();
+    let github_url = config
+        .get("extra")
+        .and_then(|value| value.get("github_url"))
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| "website/config.toml has no string extra.github_url".to_string())?
+        .trim_end_matches('/')
+        .to_string();
     let path_slugification = config
         .get("slugify")
         .and_then(|value| value.get("paths"))
@@ -112,6 +120,7 @@ fn website_authorities() -> Result<WebsiteAuthorities, String> {
     }
     Ok(WebsiteAuthorities {
         base_url,
+        github_url,
         anchor_prefix,
         spec_route_root: spec_route_root.to_string(),
     })
@@ -168,6 +177,35 @@ pub(crate) fn canonical_spec_path(source_path: &str, id: &str) -> Result<String,
         format!("{}/{page}/", authorities.spec_route_root)
     };
     Ok(format!("/{route}#{}{id}", authorities.anchor_prefix))
+}
+
+pub(crate) fn canonical_design_path(source_path: &str) -> Result<String, String> {
+    let relative = source_path.strip_prefix("docs/designs/").ok_or_else(|| {
+        format!("unsupported design reference path {source_path:?}: expected docs/designs/*.md")
+    })?;
+    let path = Path::new(relative);
+    // Interpolate only the conservative alphabet used by the checked-in ADR
+    // tree. These bytes are URL-path-safe as written; rejecting everything
+    // else avoids giving fragments, queries, escapes, platform separators, or
+    // non-ASCII spellings a second interpretation after filesystem validation.
+    let url_safe = relative
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'/'))
+        && relative.split('/').all(|component| !component.is_empty());
+    if !url_safe
+        || path.extension().and_then(|extension| extension.to_str()) != Some("md")
+        || path
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(format!(
+            "unsupported design reference path {source_path:?}: expected docs/designs/*.md"
+        ));
+    }
+    Ok(format!(
+        "{}/blob/trunk/{source_path}",
+        website_authorities()?.github_url
+    ))
 }
 
 fn canonical_url(
@@ -374,6 +412,10 @@ mod tests {
     fn canonical_urls_follow_the_spec_site_path_and_anchor_contract() {
         let authorities = website_authorities().unwrap();
         assert_eq!(authorities.base_url, "https://rue-lang.dev");
+        assert_eq!(
+            authorities.github_url,
+            "https://github.com/rue-language/rue"
+        );
         assert_eq!(authorities.anchor_prefix, "r-");
         assert_eq!(authorities.spec_route_root, "spec");
         assert_eq!(
@@ -388,6 +430,30 @@ mod tests {
             canonical_url(&authorities, "_index.md", "1.1:1").unwrap(),
             "https://rue-lang.dev/spec/#r-1.1:1",
         );
+        assert_eq!(
+            canonical_design_path("docs/designs/0065-floating-point.md").unwrap(),
+            "https://github.com/rue-language/rue/blob/trunk/docs/designs/0065-floating-point.md",
+        );
+    }
+
+    #[test]
+    fn design_paths_reject_url_significant_and_non_inventory_bytes() {
+        for path in [
+            "docs/designs/0065.md#fragment",
+            "docs/designs/0065.md?view=1",
+            "docs/designs/0065%2emd",
+            "docs/designs/nested\\0065.md",
+            "docs/designs/0065 floating-point.md",
+            "docs/designs/0065-flöating-point.md",
+            "docs/designs/../0065.md",
+            "docs/designs//0065.md",
+            "/docs/designs/0065.md",
+        ] {
+            assert!(
+                canonical_design_path(path).is_err(),
+                "unsafe design path was accepted: {path:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -62,6 +62,7 @@ mod traceability;
 
 /// Possible paths for the spec directory.
 const SPEC_DIR_PATHS: &[&str] = &["docs/spec/src", "../docs/spec/src", "../../docs/spec/src"];
+const DESIGNS_DIR_PATHS: &[&str] = &["docs/designs", "../docs/designs", "../../docs/designs"];
 
 /// Possible paths for the cases directory.
 const CASES_DIR_PATHS: &[&str] = &["crates/rue-spec/cases", "cases", "../rue-spec/cases"];
@@ -298,7 +299,8 @@ fn main() {
 
     if raw_args.iter().any(|argument| argument == "--error-pages") {
         let spec_dir = find_dir("RUE_SPEC_DIR", SPEC_DIR_PATHS, "docs/spec/src");
-        error_pages::write(&spec_dir).unwrap_or_else(|error| {
+        let designs_dir = find_dir("RUE_DESIGNS_DIR", DESIGNS_DIR_PATHS, "docs/designs");
+        error_pages::write(&spec_dir, &designs_dir).unwrap_or_else(|error| {
             eprintln!("error: {error}");
             std::process::exit(1);
         });

--- a/docs/BUCK
+++ b/docs/BUCK
@@ -21,7 +21,7 @@ filegroup(
 filegroup(
     name = "designs",
     srcs = dict([(path[len("designs/"):], path) for path in glob(["designs/**"])]),
-    visibility = ["//:"],
+    visibility = ["//:", "//crates/rue-spec:"],
 )
 
 # ADR-0071 phase 3: the note //:compiler-allocator-policy-validation reads.


### PR DESCRIPTION
## Summary

- add compiler-owned explanations and validated examples for the active E0709-E0715 diagnostic band
- validate single-file and import-discovery examples through canonical compiler paths, including physical-file alias provenance
- guard the exact active explanation set while keeping E0708 retired

## Validation

- focused rue-error, compiler explanation, inference, ownership, import, specification, and CLI explain tests
- scripts/rue quick
- scripts/rue premerge
- scripts/rue fmt
- git diff --check
- separate adversarial review

Closes RUE-1945