### PR TITLE
RUE-1073: add runtime float formatting

### DIFF
--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -2465,7 +2465,7 @@ mod runtime_archive_validation_tests {
         inventory.symbols.push(marker("__rue_runtime_abi_v0", 1));
         let stale = error(&inventory, RuntimeTarget::Aarch64Linux);
         assert!(stale.contains(
-            "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v3`"
+            "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v4`"
         ));
 
         inventory
@@ -2619,7 +2619,7 @@ mod runtime_archive_validation_tests {
         let err = validation_error(&bytes);
         assert!(
             err.contains(
-                "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v3`"
+                "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v4`"
             ),
             "{err}"
         );

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -16,7 +16,7 @@ use core::fmt;
 #[macro_export]
 macro_rules! runtime_abi_version {
     ($callback:ident) => {
-        $callback!(3, __rue_runtime_abi_v3);
+        $callback!(4, __rue_runtime_abi_v4);
     };
 }
 
@@ -48,6 +48,15 @@ pub enum AbiType {
     /// The target C ABI's `usize`, used only by compiler-built memory routines.
     Usize,
 }
+
+/// Width discriminants accepted by `__rue_to_string_float`.
+///
+/// The value travels as a `u32`, not as a Rust or C enum, so an invalid caller
+/// value cannot create undefined behavior at the boundary. The runtime traps
+/// on any value other than these two constants. For [`FLOAT_WIDTH_F32`], only
+/// the low 32 bits of the adjacent `u64` bit-pattern parameter may be set.
+pub const FLOAT_WIDTH_F32: u32 = 32;
+pub const FLOAT_WIDTH_F64: u32 = 64;
 
 /// How a parameter crosses the C boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -714,6 +723,17 @@ macro_rules! for_each_runtime_helper {
             safety: WRITABLE,
             returns: RETURNS
         },
+        ToStringFloat => unsafe __rue_to_string_float(
+            out: *mut $crate::StrBufResult,
+            bits: u64,
+            width: u32,
+        ) {
+            symbol: "__rue_to_string_float",
+            parameters: params![STR_BUF_OUT, U64_VALUE, U32_VALUE],
+            result: VOID,
+            safety: WRITABLE,
+            returns: RETURNS
+        },
         Print => unsafe __rue_print(ptr: *const u8, len: u64, cap: u64) {
             symbol: "__rue_print",
             parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
@@ -1356,11 +1376,11 @@ const fn starts_with(value: &str, prefix: &str) -> bool {
 }
 
 const fn ends_with_decimal_version(symbol: &str, version: u32) -> bool {
-    // Version 2 added the ADR-0083 §5.1 test failure channel; version 3 added
-    // its comparison form, `__rue_test_fail_comparison` (Phase 2.5). This
-    // explicit check makes an ABI bump update both metadata values rather than
-    // silently retaining a stale symbol.
-    version == 3 && string_eq(symbol, "__rue_runtime_abi_v3")
+    // Version 3 added the ADR-0083 §5.1 comparison failure channel; version 4
+    // added width-explicit float formatting. This explicit check makes an ABI
+    // bump update both metadata values rather than silently retaining a stale
+    // symbol.
+    version == 4 && string_eq(symbol, "__rue_runtime_abi_v4")
 }
 
 /// Validate all table ordering, uniqueness, classification, and layout invariants.
@@ -1446,7 +1466,7 @@ mod tests {
     #[test]
     fn manifest_is_const_valid_and_exhaustive() {
         assert_eq!(validate_manifest(), Ok(()));
-        assert_eq!(RuntimeHelperId::ALL.len(), 52);
+        assert_eq!(RuntimeHelperId::ALL.len(), 53);
         assert_eq!(RuntimeHelperId::ALL.len(), RUNTIME_HELPERS.len());
         for (index, id) in RuntimeHelperId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, index);
@@ -1493,6 +1513,7 @@ mod tests {
             "__rue_str_char_next_lossy",
             "__rue_to_string",
             "__rue_to_string_unsigned",
+            "__rue_to_string_float",
             "__rue_print",
             "__rue_println",
             "__rue_str_print",
@@ -1531,7 +1552,7 @@ mod tests {
     #[test]
     fn every_helper_has_the_exact_accepted_signature_and_contract() {
         fn check(
-            visited: &mut [bool; 52],
+            visited: &mut [bool; 53],
             ids: &[RuntimeHelperId],
             parameters: &[AbiParameter],
             result: AbiResult,
@@ -1552,7 +1573,7 @@ mod tests {
             }
         }
 
-        let mut visited = [false; 52];
+        let mut visited = [false; 53];
         check(
             &mut visited,
             &[RuntimeHelperId::Exit],
@@ -1683,6 +1704,14 @@ mod tests {
             &mut visited,
             &[RuntimeHelperId::ToStringUnsigned],
             &[STR_BUF_OUT, U64_VALUE],
+            VOID,
+            WRITABLE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::ToStringFloat],
+            &[STR_BUF_OUT, U64_VALUE, U32_VALUE],
             VOID,
             WRITABLE,
             RETURNS,
@@ -1910,6 +1939,11 @@ mod tests {
             ParameterMode::OutPointer(AggregateShapeId::StrBufResult)
         );
         assert_eq!(
+            RuntimeHelperId::ToStringFloat.helper().parameters,
+            [STR_BUF_OUT, U64_VALUE, U32_VALUE],
+            "float bits and width must cross the ABI explicitly"
+        );
+        assert_eq!(
             RuntimeHelperId::ParseI64.helper().parameters[0].mode,
             ParameterMode::OutPointer(AggregateShapeId::OptionIntResult)
         );
@@ -1997,7 +2031,7 @@ mod tests {
 
     #[test]
     fn abi_version_metadata_is_a_one_byte_data_export() {
-        assert_eq!(RUNTIME_ABI_VERSION, 3);
+        assert_eq!(RUNTIME_ABI_VERSION, 4);
         assert_eq!(
             RUNTIME_ABI_VERSION_SYMBOL,
             format!("__rue_runtime_abi_v{RUNTIME_ABI_VERSION}")

--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -18,6 +18,7 @@ rue_crate(
     deps = [
         "//crates/rue-allocator:rue-allocator",
         "//crates/rue-runtime-abi:rue-runtime-abi",
+        "//third-party:zmij",
     ],
     # Force static linkage to ensure the [staticlib] subtarget is available
     preferred_linkage = "static",
@@ -99,6 +100,7 @@ rue_rust_test(
     deps = [
         "//crates/rue-allocator:rue-allocator",
         "//crates/rue-runtime-abi:rue-runtime-abi",
+        "//third-party:zmij",
     ],
 )
 

--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -65,6 +65,11 @@ export_file(
     src = "src/lib.rs",
 )
 
+export_file(
+    name = "runtime-build-rule-source",
+    src = "runtime.bzl",
+)
+
 rue_sh_test(
     name = "runtime-archives-test",
     platform = "native",
@@ -74,6 +79,7 @@ rue_sh_test(
         "RUNTIME_X86_64_LINUX": "$(location :rue-runtime-x86_64-unknown-linux-gnu)",
         "RUNTIME_AARCH64_LINUX": "$(location :rue-runtime-aarch64-unknown-linux-gnu)",
         "RUNTIME_AARCH64_MACOS": "$(location :rue-runtime-aarch64-apple-darwin)",
+        "RUNTIME_BUILD_RULE_SOURCE": "$(location :runtime-build-rule-source)",
         "RUNTIME_STRING_SOURCE": "$(location :runtime-str-eq-source)",
     },
 )
@@ -83,6 +89,7 @@ rue_sh_test(
     test = "tests/test_validate_runtime_archives.py",
     resources = ["tests/validate_runtime_archives.py", "src/lib.rs"],
     env = {
+        "RUNTIME_BUILD_RULE_SOURCE": "$(location :runtime-build-rule-source)",
         "RUNTIME_LIB_SOURCE": "$(location :runtime-lib-source)",
     },
 )

--- a/crates/rue-runtime/runtime.bzl
+++ b/crates/rue-runtime/runtime.bzl
@@ -35,7 +35,7 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
         "zmij-src-{}".format(target),
         {
             "lib.rs": ctx.attrs.zmij_crate_root,
-            "traits.rs": ctx.attrs.zmij_srcs[0],
+            "traits.rs": ctx.attrs.zmij_traits_source,
         },
     )
     zmij_crate_root = zmij_source_dir.project("lib.rs")
@@ -121,7 +121,10 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
             format = "{}=/rue/third-party/vendor/zmij-0.1.7/src/lib.rs",
         ),
     )
-    zmij_args.add(zmij_crate_root)
+    # `project("lib.rs")` alone lets remote execution materialize only that
+    # projection. Keep the complete module-relative source tree as an explicit
+    # action input so rustc can resolve `mod traits` in a clean sandbox.
+    zmij_args.add(cmd_args(zmij_crate_root, hidden = [zmij_source_dir]))
     zmij_args.add("-o", zmij_rlib.as_output())
 
     ctx.actions.run(
@@ -178,7 +181,7 @@ _runtime_staticlib = rule(
         "target_triple": attrs.string(),
         "rustc_flags": attrs.list(attrs.arg()),
         "zmij_crate_root": attrs.source(),
-        "zmij_srcs": attrs.list(attrs.source()),
+        "zmij_traits_source": attrs.source(),
         "_rust_toolchain": attrs.toolchain_dep(default = "toolchains//:rust"),
     },
 )
@@ -199,8 +202,6 @@ def runtime_staticlib(name: str, target_triple: str, target_std: str, visibility
         target_triple = target_triple,
         rustc_flags = flags,
         zmij_crate_root = "//third-party:zmij-0.1.7-lib.rs",
-        zmij_srcs = [
-            "//third-party:zmij-0.1.7-traits.rs",
-        ],
+        zmij_traits_source = "//third-party:zmij-0.1.7-traits.rs",
         visibility = visibility,
     )

--- a/crates/rue-runtime/runtime.bzl
+++ b/crates/rue-runtime/runtime.bzl
@@ -29,7 +29,16 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
     target_sysroot = target_std.project("rust-std-{}".format(target))
     abi_rlib = ctx.actions.declare_output("librue_runtime_abi-{}.rlib".format(target))
     allocator_rlib = ctx.actions.declare_output("librue_allocator-{}.rlib".format(target))
+    zmij_rlib = ctx.actions.declare_output("libzmij-{}.rlib".format(target))
     archive = ctx.actions.declare_output("librue_runtime-{}.a".format(target))
+    zmij_source_dir = ctx.actions.symlinked_dir(
+        "zmij-src-{}".format(target),
+        {
+            "lib.rs": ctx.attrs.zmij_crate_root,
+            "traits.rs": ctx.attrs.zmij_srcs[0],
+        },
+    )
+    zmij_crate_root = zmij_source_dir.project("lib.rs")
 
     abi_args = cmd_args(toolchain.compiler)
     abi_args.add(
@@ -91,6 +100,36 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
         identifier = target,
     )
 
+    zmij_args = cmd_args(toolchain.compiler)
+    zmij_args.add(
+        "--crate-name",
+        "zmij",
+        "--crate-type",
+        "rlib",
+        "--edition",
+        "2021",
+        "--target",
+        target,
+        "--sysroot",
+        target_sysroot,
+    )
+    zmij_args.add(ctx.attrs.rustc_flags)
+    zmij_args.add(
+        "--remap-path-prefix",
+        cmd_args(
+            zmij_crate_root,
+            format = "{}=/rue/third-party/vendor/zmij-0.1.7/src/lib.rs",
+        ),
+    )
+    zmij_args.add(zmij_crate_root)
+    zmij_args.add("-o", zmij_rlib.as_output())
+
+    ctx.actions.run(
+        zmij_args,
+        category = "runtime_zmij_rlib",
+        identifier = target,
+    )
+
     args = cmd_args(toolchain.compiler)
     args.add(
         "--crate-name",
@@ -113,6 +152,10 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
         "--extern",
         cmd_args("rue_runtime_abi=", abi_rlib, delimiter = ""),
     )
+    args.add(
+        "--extern",
+        cmd_args("zmij=", zmij_rlib, delimiter = ""),
+    )
     args.add(cmd_args(ctx.attrs.crate_root, hidden = ctx.attrs.srcs))
     args.add("-o", archive.as_output())
 
@@ -134,6 +177,8 @@ _runtime_staticlib = rule(
         "target_std": attrs.dep(),
         "target_triple": attrs.string(),
         "rustc_flags": attrs.list(attrs.arg()),
+        "zmij_crate_root": attrs.source(),
+        "zmij_srcs": attrs.list(attrs.source()),
         "_rust_toolchain": attrs.toolchain_dep(default = "toolchains//:rust"),
     },
 )
@@ -153,5 +198,9 @@ def runtime_staticlib(name: str, target_triple: str, target_std: str, visibility
         target_std = target_std,
         target_triple = target_triple,
         rustc_flags = flags,
+        zmij_crate_root = "//third-party:zmij-0.1.7-lib.rs",
+        zmij_srcs = [
+            "//third-party:zmij-0.1.7-traits.rs",
+        ],
         visibility = visibility,
     )

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -182,6 +182,7 @@ macro_rules! call_runtime_helper_implementation {
     (__rue_str_char_next_lossy($($argument:expr),*)) => { crate::string::__rue_str_char_next_lossy($($argument),*) };
     (__rue_to_string($($argument:expr),*)) => { crate::string::__rue_to_string($($argument),*) };
     (__rue_to_string_unsigned($($argument:expr),*)) => { crate::string::__rue_to_string_unsigned($($argument),*) };
+    (__rue_to_string_float($($argument:expr),*)) => { crate::string::__rue_to_string_float($($argument),*) };
     (__rue_print($($argument:expr),*)) => { crate::io::__rue_print($($argument),*) };
     (__rue_println($($argument:expr),*)) => { crate::io::__rue_println($($argument),*) };
     (__rue_str_print($($argument:expr),*)) => { crate::io::__rue_str_print($($argument),*) };

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -6,7 +6,7 @@
 //! results returned through the `StrBuf` three-word representation.
 
 use crate::heap;
-pub use rue_runtime_abi::StrBufResult;
+pub use rue_runtime_abi::{FLOAT_WIDTH_F32, FLOAT_WIDTH_F64, StrBufResult};
 
 /// Minimum capacity for runtime-produced `StrBuf` values.
 pub const STRING_MIN_CAPACITY: u64 = 16;
@@ -62,6 +62,36 @@ crate::define_runtime_implementation! {
         // SAFETY: Equal lengths and the caller's contract make both ranges
         // valid for the comparison.
         (unsafe { crate::memory::bcmp(ptr1, ptr2, len1 as usize) == 0 }) as u64
+    }
+}
+
+/// Copy formatter-owned bytes into a fresh allocation with the canonical
+/// runtime-produced `StrBuf` capacity and ownership contract.
+///
+/// # Safety
+///
+/// `out` must point to valid, aligned, exclusive result storage.
+unsafe fn publish_owned_strbuf(out: *mut StrBufResult, bytes: &[u8]) {
+    let len = bytes.len() as u64;
+    let cap = if len < STRING_MIN_CAPACITY {
+        STRING_MIN_CAPACITY
+    } else {
+        len
+    };
+    let ptr = heap::alloc(cap, 1);
+    if ptr.is_null() {
+        crate::error::allocation_failure();
+    }
+
+    // SAFETY: `ptr` is a fresh allocation of `cap >= len` bytes, `bytes`
+    // contains exactly `len` initialized bytes, and the caller provides valid
+    // result storage. Publishing happens only after allocation succeeds, so a
+    // trap cannot leave a partially initialized owner behind.
+    unsafe {
+        core::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
+        (*out).ptr = ptr;
+        (*out).cap = cap;
+        (*out).len = len;
     }
 }
 
@@ -621,6 +651,49 @@ crate::define_runtime_implementation! {
     }
 }
 
+crate::define_runtime_implementation! {
+    /// Format an IEEE-754 `f32` or `f64` to its shortest round-trip decimal
+    /// representation through the vendored `zmij` implementation.
+    ///
+    /// # ABI (sret convention)
+    ///
+    /// ```text
+    /// extern "C" fn __rue_to_string_float(
+    ///     out: *mut StrBufResult,
+    ///     bits: u64,
+    ///     width: u32,
+    /// )
+    /// ```
+    ///
+    /// `bits` carries the input's raw IEEE representation. `width` is exactly
+    /// `FLOAT_WIDTH_F32` or `FLOAT_WIDTH_F64`; an f32 encoding must have its
+    /// upper 32 bits clear. Using integer boundary types makes width and NaN
+    /// payload preservation independent of target C floating-point ABIs. Any
+    /// invalid encoding traps before allocation rather than guessing a width.
+    /// The returned `StrBuf` owns a fresh heap buffer.
+    ///
+    /// # Safety
+    ///
+    /// `out` must point to valid, aligned, exclusive result storage.
+    pub unsafe extern "C" fn __rue_to_string_float(
+        out: *mut StrBufResult,
+        bits: u64,
+        width: u32,
+    ) {
+        let mut formatter = zmij::Buffer::new();
+        let formatted = match width {
+            FLOAT_WIDTH_F32 if bits <= u32::MAX as u64 => {
+                formatter.format(f32::from_bits(bits as u32))
+            }
+            FLOAT_WIDTH_F64 => formatter.format(f64::from_bits(bits)),
+            _ => crate::error::__rue_panic_no_msg(),
+        };
+
+        // SAFETY: inherited from this function's caller contract.
+        unsafe { publish_owned_strbuf(out, formatted.as_bytes()) };
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate std;
@@ -641,6 +714,44 @@ mod tests {
         // SAFETY: Formatting functions publish at least `len` initialized
         // bytes in a live allocation.
         unsafe { core::slice::from_raw_parts(result.ptr, result.len as usize) }
+    }
+
+    fn free_result(result: &mut StrBufResult) {
+        // SAFETY: Formatting returned this live allocation with exactly the
+        // published capacity and byte alignment. Clear the header so tests
+        // cannot accidentally inspect or free the released owner again.
+        unsafe { heap::free(result.ptr, result.cap, 1) };
+        *result = blank_result();
+    }
+
+    fn assert_f32(value: f32, expected: &str) {
+        let mut out = blank_result();
+        // SAFETY: `out` is valid, aligned, exclusive result storage and the
+        // zero-extended raw bits match the explicit f32 width.
+        unsafe { __rue_to_string_float(&mut out, value.to_bits() as u64, FLOAT_WIDTH_F32) };
+        assert_eq!(result_bytes(&out), expected.as_bytes());
+        assert!(out.cap >= out.len);
+        if value.is_finite() {
+            let rendered = self::std::str::from_utf8(result_bytes(&out)).unwrap();
+            let parsed: f32 = rendered.parse().unwrap();
+            assert_eq!(parsed.to_bits(), value.to_bits(), "{value:?} -> {rendered}");
+        }
+        free_result(&mut out);
+    }
+
+    fn assert_f64(value: f64, expected: &str) {
+        let mut out = blank_result();
+        // SAFETY: `out` is valid, aligned, exclusive result storage and the raw
+        // bits match the explicit f64 width.
+        unsafe { __rue_to_string_float(&mut out, value.to_bits(), FLOAT_WIDTH_F64) };
+        assert_eq!(result_bytes(&out), expected.as_bytes());
+        assert!(out.cap >= out.len);
+        if value.is_finite() {
+            let rendered = self::std::str::from_utf8(result_bytes(&out)).unwrap();
+            let parsed: f64 = rendered.parse().unwrap();
+            assert_eq!(parsed.to_bits(), value.to_bits(), "{value:?} -> {rendered}");
+        }
+        free_result(&mut out);
     }
 
     #[test]
@@ -767,9 +878,74 @@ mod tests {
         // SAFETY: `out` is valid, aligned, exclusive result storage.
         unsafe { __rue_to_string(&mut out, i64::MIN) };
         assert_eq!(result_bytes(&out), b"-9223372036854775808");
+        free_result(&mut out);
 
         unsafe { __rue_to_string_unsigned(&mut out, u64::MAX) };
         assert_eq!(result_bytes(&out), b"18446744073709551615");
+        free_result(&mut out);
+    }
+
+    #[test]
+    fn float_formatting_is_shortest_round_trip_for_f32() {
+        assert_f32(-0.0, "-0.0");
+        assert_f32(f32::INFINITY, "inf");
+        assert_f32(f32::NEG_INFINITY, "-inf");
+        assert_f32(f32::NAN, "NaN");
+        assert_f32(f32::from_bits(1), "1e-45");
+        assert_f32(f32::from_bits(0x007f_ffff), "1.1754942e-38");
+        assert_f32(f32::MIN_POSITIVE, "1.1754944e-38");
+        assert_f32(0.1, "0.1");
+        assert_f32(1.234_567_8, "1.2345678");
+        assert_f32(f32::MAX, "3.4028235e+38");
+        assert_f32(f32::MIN, "-3.4028235e+38");
+    }
+
+    #[test]
+    fn float_formatting_is_shortest_round_trip_for_f64() {
+        assert_f64(-0.0, "-0.0");
+        assert_f64(f64::INFINITY, "inf");
+        assert_f64(f64::NEG_INFINITY, "-inf");
+        assert_f64(f64::NAN, "NaN");
+        assert_f64(f64::from_bits(1), "5e-324");
+        assert_f64(
+            f64::from_bits(0x000f_ffff_ffff_ffff),
+            "2.225073858507201e-308",
+        );
+        assert_f64(f64::MIN_POSITIVE, "2.2250738585072014e-308");
+        assert_f64(0.1, "0.1");
+        assert_f64(1.234_567_890_123_456_7, "1.2345678901234567");
+        assert_f64(f64::MAX, "1.7976931348623157e+308");
+        assert_f64(f64::MIN, "-1.7976931348623157e+308");
+    }
+
+    #[test]
+    fn float_formatting_rejects_ambiguous_width_encodings() {
+        const CHILD_ENV: &str = "RUE_FLOAT_WIDTH_CHILD";
+        if let Some(mode) = self::std::env::var_os(CHILD_ENV) {
+            let mut out = blank_result();
+            unsafe {
+                match mode.to_string_lossy().as_ref() {
+                    "unknown-width" => __rue_to_string_float(&mut out, 0, 0),
+                    "wide-f32-bits" => __rue_to_string_float(&mut out, 1 << 32, FLOAT_WIDTH_F32),
+                    other => panic!("unknown float-width failure mode: {other}"),
+                }
+            }
+            unreachable!();
+        }
+
+        for mode in ["unknown-width", "wide-f32-bits"] {
+            let output = Command::new(self::std::env::current_exe().expect("current test binary"))
+                .args([
+                    "--exact",
+                    "string::tests::float_formatting_rejects_ambiguous_width_encodings",
+                    "--nocapture",
+                ])
+                .env(CHILD_ENV, mode)
+                .output()
+                .expect("spawn invalid-float-width child");
+            assert_eq!(output.status.code(), Some(101), "mode {mode}");
+            assert_eq!(output.stderr, b"panic\n", "mode {mode}");
+        }
     }
 
     #[test]
@@ -782,13 +958,14 @@ mod tests {
                 match mode.to_string_lossy().as_ref() {
                     "signed" => __rue_to_string(&mut out, 1),
                     "unsigned" => __rue_to_string_unsigned(&mut out, 1),
+                    "float" => __rue_to_string_float(&mut out, 1.0f64.to_bits(), FLOAT_WIDTH_F64),
                     other => panic!("unknown allocation failure mode: {other}"),
                 }
             }
             unreachable!();
         }
 
-        for mode in ["signed", "unsigned"] {
+        for mode in ["signed", "unsigned", "float"] {
             let output = Command::new(self::std::env::current_exe().expect("current test binary"))
                 .args([
                     "--exact",

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -274,6 +274,67 @@ class TestConfigurationTests(unittest.TestCase):
             finally:
                 path.unlink()
 
+    def test_float_format_source_requires_one_width_explicit_zmij_authority(self):
+        import tempfile
+
+        positive = """
+        fn __rue_to_string_float(out: *mut StrBufResult, bits: u64, width: u32) {
+            let mut formatter = zmij::Buffer::new();
+            let formatted = match width {
+                FLOAT_WIDTH_F32 => formatter.format(f32::from_bits(bits as u32)),
+                FLOAT_WIDTH_F64 => formatter.format(f64::from_bits(bits)),
+                _ => trap(),
+            };
+            publish_owned_strbuf(out, formatted.as_bytes());
+        }
+        """
+        with tempfile.NamedTemporaryFile("w", delete=False) as file:
+            file.write(positive)
+            path = Path(file.name)
+        try:
+            validator.validate_float_format_source(path)
+        finally:
+            path.unlink()
+
+    def test_float_format_source_rejects_peer_or_independent_formatters(self):
+        import tempfile
+
+        sources = [
+            """
+            fn __rue_to_string_float(out: *mut StrBufResult, bits: u64, width: u32) {
+                let mut formatter = zmij::Buffer::new();
+                let formatted = match width {
+                    FLOAT_WIDTH_F32 => formatter.format(f32::from_bits(bits as u32)),
+                    FLOAT_WIDTH_F64 => formatter.format(f64::from_bits(bits)),
+                    _ => trap(),
+                };
+                while false {}
+                publish_owned_strbuf(out, formatted.as_bytes());
+            }
+            """,
+            """
+            fn __rue_to_string_float(out: *mut StrBufResult, bits: u64, width: u32) {
+                let mut formatter = zmij::Buffer::new();
+                let formatted = match width {
+                    FLOAT_WIDTH_F32 => formatter.format(f32::from_bits(bits as u32)),
+                    FLOAT_WIDTH_F64 => formatter.format(f64::from_bits(bits)),
+                    _ => trap(),
+                };
+                publish_owned_strbuf(out, formatted.as_bytes());
+            }
+            fn __rue_to_string_float_f32() {}
+            """,
+        ]
+        for source in sources:
+            with tempfile.NamedTemporaryFile("w", delete=False) as file:
+                file.write(source)
+                path = Path(file.name)
+            try:
+                with self.assertRaises(AssertionError):
+                    validator.validate_float_format_source(path)
+            finally:
+                path.unlink()
+
     def test_elf_fixture_skips_undefined_then_keeps_defined_function(self):
         sections = [{}, {"flags": 0x4, "name": ".text.memcpy"}]
         entries = [

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -145,6 +145,36 @@ class BodyValidationTests(unittest.TestCase):
 
 
 class TestConfigurationTests(unittest.TestCase):
+    def test_zmij_action_hermetically_materializes_its_module_tree(self):
+        declared_source = os.environ.get("RUNTIME_BUILD_RULE_SOURCE")
+        source_path = Path(declared_source) if declared_source else None
+        if source_path is None or not source_path.is_file():
+            source_path = Path(__file__).parents[1] / "runtime.bzl"
+        validator.validate_zmij_action_source(source_path)
+
+    def test_zmij_action_guard_rejects_a_projected_root_without_hidden_tree(self):
+        import tempfile
+
+        incomplete = """
+        zmij_source_dir = ctx.actions.symlinked_dir(
+            "zmij-src",
+            {
+                "lib.rs": ctx.attrs.zmij_crate_root,
+                "traits.rs": ctx.attrs.zmij_traits_source,
+            },
+        )
+        zmij_crate_root = zmij_source_dir.project("lib.rs")
+        zmij_args.add(zmij_crate_root)
+        """
+        with tempfile.NamedTemporaryFile("w", delete=False) as file:
+            file.write(incomplete)
+            path = Path(file.name)
+        try:
+            with self.assertRaisesRegex(AssertionError, "hermetically stage"):
+                validator.validate_zmij_action_source(path)
+        finally:
+            path.unlink()
+
     def test_libtest_disables_libc_shaped_reserved_exports(self):
         declared_source = os.environ.get("RUNTIME_LIB_SOURCE")
         source_path = Path(declared_source) if declared_source else None

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -17,6 +17,7 @@ N_SECT = 0x0E
 N_PEXT = 0x10
 CHUNKED_SYMBOLS = ("memcpy", "memmove", "memset", "memcmp", "bcmp", "__rue_str_eq")
 RESERVED_SYMBOLS = ("memcpy", "memmove", "memset", "memcmp", "bcmp")
+FLOAT_FORMAT_SYMBOL = "__rue_to_string_float"
 ELF_SHT_RELA = 4
 ELF_SHT_REL = 9
 ELF_SHT_SYMTAB = 2
@@ -194,6 +195,41 @@ def validate_str_eq_source(path: Path):
         raise AssertionError(f"{path}: bcmp result is not the returned equality")
     if re.search(r"\b(?:while|for)\b|read_chunk|write_chunk|read_unaligned|write_unaligned", body):
         raise AssertionError(f"{path}: __rue_str_eq contains an independent comparison loop")
+
+
+def validate_float_format_source(path: Path):
+    """Require one width-explicit helper that delegates both widths to zmij."""
+    code = _strip_rust_comments(path.read_text())
+    declarations = re.findall(r"\bfn\s+__rue_to_string_float\s*\(", code)
+    if len(declarations) != 1:
+        raise AssertionError(
+            f"{path}: expected one __rue_to_string_float implementation, "
+            f"found {len(declarations)}"
+        )
+    body = _function_body(code, FLOAT_FORMAT_SYMBOL)
+    required = (
+        r"zmij::Buffer::new\s*\(",
+        r"FLOAT_WIDTH_F32",
+        r"f32::from_bits\s*\(",
+        r"FLOAT_WIDTH_F64",
+        r"f64::from_bits\s*\(",
+        r"publish_owned_strbuf\s*\(",
+    )
+    for pattern in required:
+        if not re.search(pattern, body):
+            raise AssertionError(
+                f"{path}: __rue_to_string_float is missing required source shape {pattern}"
+            )
+    if len(re.findall(r"\.format\s*\(", body)) != 2:
+        raise AssertionError(
+            f"{path}: __rue_to_string_float must delegate both widths directly to zmij"
+        )
+    if re.search(r"\b(?:while|for)\b|format!|\.to_string\s*\(", body):
+        raise AssertionError(
+            f"{path}: __rue_to_string_float contains an independent formatter"
+        )
+    if re.search(r"\bfn\s+__rue_to_string_float_(?:f32|f64)\s*\(", code):
+        raise AssertionError(f"{path}: width-specific float formatter authority is forbidden")
 
 
 def parse_elf_object(payload: bytes):
@@ -770,6 +806,29 @@ def validate_chunked_primitives(path: Path, expected_format: str, expected_machi
         )
 
 
+def validate_float_format_symbol(path: Path, expected_format: str, expected_machine: int):
+    """Require exactly one canonical float-format export and no width peers."""
+    definitions = []
+    forbidden = []
+    for member, payload in archive_members(path):
+        machine = elf_machine(payload) if expected_format == "elf" else macho_cpu(payload)
+        if machine != expected_machine:
+            continue
+        bodies = parse_elf_object(payload) if expected_format == "elf" else parse_macho_object(payload)
+        for name in bodies:
+            normalized = _normalized_target(name, expected_format)
+            if normalized == FLOAT_FORMAT_SYMBOL:
+                definitions.append(member)
+            elif normalized.startswith(FLOAT_FORMAT_SYMBOL + "_"):
+                forbidden.append((member, normalized))
+    if len(definitions) != 1:
+        raise AssertionError(
+            f"{path}: expected one {FLOAT_FORMAT_SYMBOL} definition, found {len(definitions)}"
+        )
+    if forbidden:
+        raise AssertionError(f"{path}: forbidden width-specific float formatter exports: {forbidden}")
+
+
 def _collect_archive_definitions(path: Path, objects, expected_format: str):
     """Collect every required definition so duplicate members fail closed."""
     definitions = {symbol: [] for symbol in CHUNKED_SYMBOLS}
@@ -840,12 +899,14 @@ def validate_archive(path: Path, expected_format: str, expected_machine: int):
             )
 
     validate_chunked_primitives(path, expected_format, expected_machine)
+    validate_float_format_symbol(path, expected_format, expected_machine)
 
 
 def main():
     source = os.environ.get("RUNTIME_STRING_SOURCE")
     if source:
         validate_str_eq_source(Path(source))
+        validate_float_format_source(Path(source))
     validate_archive(Path(os.environ["RUNTIME_X86_64_LINUX"]), "elf", 62)
     validate_archive(Path(os.environ["RUNTIME_AARCH64_LINUX"]), "elf", 183)
     validate_archive(Path(os.environ["RUNTIME_AARCH64_MACOS"]), "macho", 0x0100000C)

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -232,6 +232,23 @@ def validate_float_format_source(path: Path):
         raise AssertionError(f"{path}: width-specific float formatter authority is forbidden")
 
 
+def validate_zmij_action_source(path: Path):
+    """Require the custom rustc action to carry zmij's complete module tree."""
+    code = _strip_rust_comments(path.read_text())
+    required = (
+        r'"lib\.rs"\s*:\s*ctx\.attrs\.zmij_crate_root',
+        r'"traits\.rs"\s*:\s*ctx\.attrs\.zmij_traits_source',
+        r"zmij_args\.add\s*\(\s*cmd_args\s*\(\s*zmij_crate_root\s*,"
+        r"\s*hidden\s*=\s*\[\s*zmij_source_dir\s*\]\s*\)\s*\)",
+    )
+    for pattern in required:
+        if not re.search(pattern, code, re.DOTALL):
+            raise AssertionError(
+                f"{path}: runtime_zmij_rlib does not hermetically stage required source "
+                f"shape {pattern}"
+            )
+
+
 def parse_elf_object(payload: bytes):
     """Parse the ELF64 sections, symbols, and relocations needed by the guard."""
     if len(payload) < 64 or not payload.startswith(ELF_MAGIC) or payload[4] != 2:
@@ -903,6 +920,9 @@ def validate_archive(path: Path, expected_format: str, expected_machine: int):
 
 
 def main():
+    build_rule = os.environ.get("RUNTIME_BUILD_RULE_SOURCE")
+    if build_rule:
+        validate_zmij_action_source(Path(build_rule))
     source = os.environ.get("RUNTIME_STRING_SOURCE")
     if source:
         validate_str_eq_source(Path(source))

--- a/docs/designs/0065-floating-point.md
+++ b/docs/designs/0065-floating-point.md
@@ -287,7 +287,7 @@ register-class pre-work (Phase 1) is a hard prerequisite for Phases 5–6.
   diagnostic naming the tracking issue and the `std.math.rem` path (§9). RUE-1070
 - [ ] **Phase 5: x86-64 backend** — SSE2 scalar ops, XMM regs, SysV FP ABI. RUE-NNN
 - [ ] **Phase 6: aarch64 backend** — FP/NEON scalar ops, V-regs, AAPCS64 FP ABI. RUE-NNN
-- [ ] **Phase 7: Runtime dtoa** — wire `zmij` as `__rue_to_string_float`. RUE-NNN
+- [x] **Phase 7: Runtime dtoa** — wire `zmij` as `__rue_to_string_float`. RUE-1073
 - [ ] **Phase 8: std.math / std.fmt / @dbg** — hardware-instruction math, float
   formatting, `@total_cmp` lowering (§8). RUE-NNN
 - [ ] **Phase 9: Spec + spec tests** — a `03-types/` float chapter, division-divergence

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -100,6 +100,21 @@ Core `str` remains a non-owning packed-byte view. `std.strbuf.StrBuf` is the
 source-defined growable string type. Its algorithms and destructor are ordinary
 Rue code, not runtime ABI exports.
 
+## Width-explicit float formatting
+
+The runtime has one float-to-text authority and one production symbol,
+`__rue_to_string_float`. Its scalar inputs are the raw IEEE-754 bits in a
+`u64` and a separate `u32` width discriminator. The canonical discriminator
+values are `FLOAT_WIDTH_F32` (32) and `FLOAT_WIDTH_F64` (64); an f32 encoding
+must also have its upper 32 bits clear. Invalid encodings trap before allocation
+instead of selecting a width implicitly.
+
+The helper delegates both widths to the vendored no-std `zmij` formatter and
+then copies the shortest-round-trip spelling into a fresh runtime allocation.
+The ordinary `StrBufResult` out-pointer contract transfers that allocation to
+the caller. Language-level formatting and debug exposure are separate compiler
+and standard-library concerns.
+
 ## Safety and termination
 
 Manifest pointer modes distinguish readable inputs, writable inputs, mutable

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -5523,6 +5523,12 @@ buildscript_run(
     version = "0.8.31",
 )
 
+rue_alias(
+    name = "zmij",
+    actual = ":zmij-0.1.7",
+    visibility = ["PUBLIC"],
+)
+
 rue_rust_library(
     name = "zmij-0.1.7",
     srcs = [

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "zmij",
 ]
 
 [[package]]

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -34,6 +34,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 rayon = "1.10"
 fixedbitset = "0.5"
 itoa = "1.0"
+zmij = "=0.1.7"
 proptest = "1.5"
 smallvec = "1.15"
 syn = { version = "2.0.111", features = ["full", "visit", "extra-traits"] }

--- a/third-party/reindeer_rules.bzl
+++ b/third-party/reindeer_rules.bzl
@@ -111,6 +111,21 @@ def _libtest2_scheduler_test():
         ],
     )
 
+def _zmij_runtime_sources():
+    # The freestanding runtime compiles fixed cross-target rlibs directly with
+    # the hermetic rustc, so preserve module-relative source paths as explicit
+    # exported inputs beside Reindeer's generated library.
+    native.export_file(
+        name = "zmij-0.1.7-lib.rs",
+        src = "vendor/zmij-0.1.7/src/lib.rs",
+        visibility = ["//crates/rue-runtime:"],
+    )
+    native.export_file(
+        name = "zmij-0.1.7-traits.rs",
+        src = "vendor/zmij-0.1.7/src/traits.rs",
+        visibility = ["//crates/rue-runtime:"],
+    )
+
 def _is_linux_mimalloc_target(name):
     return name == "libmimalloc-sys" or name == "libmimalloc-sys-0.1.49" or name == "mimalloc" or name == "mimalloc-0.1.52"
 
@@ -132,3 +147,5 @@ def rue_rust_library(name, **kwargs):
         _mimalloc_native_targets()
     elif name == "libtest2-harness-0.0.3":
         _libtest2_scheduler_test()
+    elif name == "zmij-0.1.7":
+        _zmij_runtime_sources()


### PR DESCRIPTION
## Summary

- add one width-explicit runtime float formatter backed by vendored zmij 0.1.7
- preserve raw f32/f64 bits through the ABI and return an owned StrBuf allocation
- validate the symbol inventory and all supported runtime archives
- cover shortest round trips, signed zero, infinities, NaN, subnormals, normal boundaries, invalid encodings, release, and OOM behavior

## Validation

- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- focused runtime ABI, runtime, archive parser, three-target archive, and native-link tests

The canonical broad suite completed its premerge work but the slow oracle corpus could not start query workers on this host due persistent EAGAIN process pressure; dedicated CI is authoritative for that lane and Linux sanitizer coverage.

Fixes RUE-1073.