### PR TITLE
RUE-1951: keep comparison operands alive through the assertion report

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -1452,7 +1452,45 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Ok(AnalysisResult::new(block, Type::UNIT));
         }
 
-        let condition = self.build_comparison(air, failed, left, right, span, ctx)?;
+        // Give an owning operand a home that outlives the report.
+        //
+        // The comparison and the rendering must name one value, and that value
+        // has to still be alive when the report arm runs. A non-addressable
+        // operand — a call temporary such as `make()` or `s.clone()` — owns its
+        // resources with no place to own them from, so the aggregate comparison
+        // route materializes it into a frame slot in order to borrow it at all.
+        // Materializing it *here* instead is what keeps it alive (RUE-1951): a
+        // temp scope opened around the comparison alone ends with the block
+        // that computes the condition, so drop elaboration freed the temporary
+        // before the branch and the printer then read the freed heap block.
+        // Opening the scope around the whole intrinsic — comparison, branch,
+        // and report — puts that drop after the report instead. The report arm
+        // diverges, so on the failing path the drop never runs; on the passing
+        // path it runs exactly once, at the point the comparison's own scope
+        // used to run it.
+        //
+        // Only a value that owns something can be freed early, so only a type
+        // with drop glue needs the slot; a scalar rvalue stays a scalar rvalue
+        // and costs no frame storage.
+        let (left_value, mut temp_scope) =
+            self.materialize_comparison_operand(air, left.air_ref, left.ty, left_span, ctx)?;
+        let (right_value, right_scope) =
+            self.materialize_comparison_operand(air, right.air_ref, right.ty, right_span, ctx)?;
+        temp_scope.extend(right_scope);
+        let failed = if equality {
+            AirInstData::Ne(left_value, right_value)
+        } else {
+            AirInstData::Eq(left_value, right_value)
+        };
+
+        let condition = self.build_comparison(
+            air,
+            failed,
+            AnalysisResult::new(left_value, left.ty),
+            AnalysisResult::new(right_value, right.ty),
+            span,
+            ctx,
+        )?;
 
         // The report arm consumes nothing. Both operands were read as
         // projections above — the borrowing read `==` performs (4.3:3f) — and
@@ -1466,8 +1504,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             air,
             intrinsic_name,
             left.ty,
-            left.air_ref,
-            right.air_ref,
+            left_value,
+            right_value,
             span,
             ctx,
         )?;
@@ -1481,7 +1519,31 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: Type::UNIT,
             span,
         });
+        let branch = self.wrap_value_with_temp_scope(air, branch, Type::UNIT, span, temp_scope)?;
         Ok(AnalysisResult::new(branch, Type::UNIT))
+    }
+
+    /// Stage one `@assert_eq`/`@assert_ne` operand so the comparison and the
+    /// failure report read the same live value.
+    ///
+    /// An operand that already names addressable storage is returned unchanged:
+    /// a local, a field of a `borrow` parameter, or any other place is read as
+    /// the projection it is, never copied and never dropped here. An owning
+    /// rvalue gets the same StorageLive/Alloc/Load home a borrow argument gets,
+    /// and the returned prefix is the temp scope the caller must stretch across
+    /// the whole intrinsic.
+    fn materialize_comparison_operand(
+        &mut self,
+        air: &mut Air,
+        value: AirRef,
+        ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<(AirRef, Vec<AirRef>)> {
+        if !self.type_has_drop_glue(ty) {
+            return Ok((value, Vec::new()));
+        }
+        self.materialize_borrow_argument(air, value, ty, span, ctx)
     }
 
     /// The failing arm of a comparison assertion: render, stage the site,

--- a/crates/rue-cli-tests/cases/rue_test_assert.toml
+++ b/crates/rue-cli-tests/cases/rue_test_assert.toml
@@ -346,6 +346,176 @@ compile_stdout_contains = [
 ]
 
 # =============================================================================
+# Owning temporaries (RUE-1951).
+#
+# An operand with no place of its own — a call temporary such as `make()` or
+# `s.clone()` — is materialized into a hidden frame slot, and that slot's scope
+# has to reach past the branch. When it ended with the comparison instead, drop
+# elaboration freed the buffer before the report arm ran and the printer
+# rendered a freed heap block: the first eight bytes of every such rendering
+# came back as the allocator's own free-list header. The renderings pinned below
+# are therefore exact, on both sides, and the passing case proves the drop that
+# moved is still run exactly once.
+# =============================================================================
+
+[[case]]
+name = "a_returned_strbuf_renders_on_the_left"
+description = """
+The left operand is a call temporary and the right a literal, which takes the
+left's `StrBuf` type. Both renderings are the real bytes.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn rendered() -> StrBuf {
+    let mut s = StrBuf.new();
+    s.push_str("alpha");
+    s
+}
+
+test "compares a returned string on the left" {
+    @assert_eq(rendered(), "alpine");
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"diff":[{"op":"equal","text":"alp"},{"op":"delete","text":"ha"},{"op":"insert","text":"ine"}],"exit_code":101,"kind":"assert_eq","left":"alpha"',
+    '"message":"assertion failed: left == right","right":"alpine"',
+    '"verdict":"fail"',
+]
+
+[[case]]
+name = "a_returned_strbuf_renders_on_the_right"
+description = "The same operand on the other side: the slot and its scope are per operand, not per side."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn rendered() -> StrBuf {
+    let mut s = StrBuf.new();
+    s.push_str("alpha");
+    s
+}
+
+test "compares a returned string on the right" {
+    @assert_eq("alpine", rendered());
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"diff":[{"op":"equal","text":"alp"},{"op":"delete","text":"ine"},{"op":"insert","text":"ha"}],"exit_code":101,"kind":"assert_eq","left":"alpine"',
+    '"message":"assertion failed: left == right","right":"alpha"',
+    '"verdict":"fail"',
+]
+
+[[case]]
+name = "a_returned_struct_renders_its_owned_field"
+description = """
+A struct temporary owns its `StrBuf` field the same way, and the printer reaches
+that field's bytes through the same slot the comparison read.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Thing { name: StrBuf, size: i32 }
+
+fn built() -> Thing {
+    let mut s = StrBuf.new();
+    s.push_str("alpha");
+    Thing { name: s, size: 3 }
+}
+
+test "compares a returned struct" {
+    @assert_eq(built(), Thing { name: StrBuf.from_str(borrow "alpha"), size: 4 });
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"assert_eq"',
+    '"left":"{ name: alpha, size: 3 }"',
+    '"right":"{ name: alpha, size: 4 }"',
+]
+
+[[case]]
+name = "owning_temporaries_are_dropped_exactly_once"
+description = """
+The passing half. Ten thousand comparisons of two fresh `StrBuf` temporaries run
+to completion: the drop that moved past the branch still runs on the holding
+path, once per operand — a second one would free a live block and take the
+process down long before the loop ended.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn rendered() -> StrBuf {
+    let mut s = StrBuf.new();
+    s.push_str("alpha");
+    s
+}
+
+test "owning temporaries are dropped exactly once" {
+    let mut i: i32 = 0;
+    while i < 10000 {
+        @assert_eq(rendered(), rendered());
+        i = i + 1;
+    }
+    @assert_eq(i, 10000);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = [
+    '"verdict":"pass"',
+    '"crash":0,"event":"run_finished","failed":0,"passed":1',
+]
+
+# =============================================================================
 # The human rendering, built from the same values (ADR-0083 §2).
 # =============================================================================
 


### PR DESCRIPTION
Fixes RUE-1951.

A failing `@assert_eq` / `@assert_ne` rendered a call-temporary operand after it had been freed: the first eight bytes of the rendering came back as NULs or heap garbage, at every optimization level and on either side, while the comparison itself was correct. When the garbage was not UTF-8 the channel line was rejected and the verdict degraded to `exit` with a runner note, so the same test flipped between two failure shapes.

`analyze_assert_comparison_intrinsic` handed the same AirRefs to the comparison and to the report. For a `StrBuf` the comparison route materializes a non-addressable operand into a frame slot so `equals_borrowed` can borrow it and wraps the call in a temp scope; that scope ended with the block computing the condition, so drop elaboration freed the temporary before the branch, and the report arm's structural printer then read the released block.

The operands are now materialized once in the intrinsic, before the comparison, and the temp scope is stretched around the whole intrinsic (comparison, branch, report). Both the condition and the printer read the same load out of that slot, and the drop lands after the report. Only a type with drop glue gets a slot; an operand that already names addressable storage is returned untouched, so ownership rules for locals and borrowed fields are unchanged. The comptime-folded and divergent-operand paths are untouched.

Verification: the four repro shapes render exactly at -O0 and -O2; a 4,000,000-iteration passing loop shows byte-identical max RSS to the pre-fix baseline (drop exactly once, no leak); the CFG shows the drops on the holding path only; an ordinary executable keeps the pinned stderr message and exit 101. `scripts/rue cli rue_test` (49 passed, four new cases: temporary on the left, on the right, a struct temporary, and the passing loop), `scripts/rue spec 4.13` (213), `scripts/rue quick`, fmt clean. Rebased over RUE-1954 with the new cases re-derived against the `left`/`right` field names.