### PR TITLE
RUE-1957: report unimported test files once, on stderr

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -729,6 +729,55 @@ compile_stdout_contains = [
     '"test_candidates":"declared"',
     '"unimported_test_files":[{"parse_failed":false,"path":"orphan_tests.rue","tests":2}]',
 ]
+# The warning is stderr's, once (test-events.md, "Streams"). stdout carries the
+# same fact as `run_finished` data, never as a second warning line.
+compile_stdout_not_contains = ["warning:"]
+
+[[case]]
+name = "the_orphan_warning_is_stderrs_alone_under_the_human_format"
+description = """
+RUE-1957: the runner warns on stderr in every format, and the human renderer
+does not repeat it on stdout. On a terminal, which joins the two streams, a
+second copy read as two orphaned files.
+"""
+files = [
+    { path = "test-candidates.list", source = """
+main.rue
+tests.rue
+orphan_tests.rue
+""" },
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+    { path = "orphan_tests.rue", source = """
+test "nothing imports this file" {
+    @assert(1 == 1);
+}
+
+test "nor this one" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = [
+    "test", "main.rue", "--preview", "test_declarations",
+    "--test-candidates", "test-candidates.list", "--seed", "1", "-j1", "--format", "human",
+]
+driver_exit_code = 0
+compile_stderr_contains = [
+    "warning: test file 'orphan_tests.rue' declares 2 tests but no module in the compiled closure imports it",
+]
+compile_stdout_contains = ["1 passed"]
+compile_stdout_not_contains = ["warning:", "orphan_tests.rue"]
 
 [[case]]
 name = "without_an_inventory_a_multi_module_summary_says_orphans_are_not_detected"

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -48,29 +48,14 @@ pub(crate) fn render(event: &Event, context: Context) -> Option<String> {
             timeout,
             crash,
             wall_ms,
-            unimported_test_files,
+            // The unimported-test-file warnings are the runner's own, and
+            // stderr carries them once in every format (test-events.md,
+            // "Streams"). Rendering them here too would print a second copy
+            // on stdout whenever a terminal joins the streams.
+            unimported_test_files: _,
             test_candidates,
         } => {
-            let mut out = String::new();
-            if let Some(files) = unimported_test_files {
-                for file in files {
-                    if file.parse_failed {
-                        let _ = writeln!(
-                            out,
-                            "warning: test file '{}' is outside the compiled closure and could not be parsed",
-                            file.path
-                        );
-                    } else {
-                        let plural = if file.tests == 1 { "" } else { "s" };
-                        let _ = writeln!(
-                            out,
-                            "warning: test file '{}' declares {} test{plural} but no module in the compiled closure imports it",
-                            file.path, file.tests
-                        );
-                    }
-                }
-            }
-            out.push_str(&summary(*passed, *failed, *timeout, *crash, *wall_ms));
+            let mut out = summary(*passed, *failed, *timeout, *crash, *wall_ms);
             if *test_candidates == CandidateSource::None && context.multi_module_closure {
                 out.push('\n');
                 out.push_str(
@@ -611,8 +596,11 @@ mod tests {
         assert_eq!(rendered, "0 passed (0.1s)");
     }
 
+    /// The runner already warns about these on stderr, in both formats. The
+    /// human renderer writes to stdout, so repeating them here would show a
+    /// person two copies of one warning on a terminal that joins the streams.
     #[test]
-    fn orphaned_test_files_are_rendered_as_warnings() {
+    fn orphaned_test_files_are_left_to_the_stderr_warning() {
         let rendered = render_multi(&Event::RunFinished {
             passed: 1,
             failed: 0,
@@ -634,11 +622,10 @@ mod tests {
             test_candidates: CandidateSource::Declared,
         })
         .expect("a summary renders");
-        assert!(
-            rendered.contains("declares 1 test but no module in the compiled closure imports it"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("could not be parsed"), "{rendered}");
+        assert_eq!(rendered, "1 passed (0.0s)");
+        assert!(!rendered.contains("warning:"), "{rendered}");
+        assert!(!rendered.contains("app/orphan.rue"), "{rendered}");
+        assert!(!rendered.contains("could not be parsed"), "{rendered}");
         assert!(
             !rendered.contains("note: no --test-candidates"),
             "{rendered}"

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -29,7 +29,10 @@ while making `rue test` the first flag to bypass ADR-0005's explicit opt-in.
   events are rendered as text on stdout instead.
 - **stderr is the compiler's surface**, byte-for-byte as
   [diagnostics.md](diagnostics.md) pins it, plus the runner's own warnings
-  (unimported test files) and its one-line reason for a nonzero exit.
+  (unimported test files) and its one-line reason for a nonzero exit. Those
+  warnings are stderr's alone, once, in both formats: the human renderer does
+  not repeat them on stdout, where a terminal joining the streams would show
+  two copies of one warning.
 - **No event is emitted before the test image exists.** A compile failure is
   diagnostics on stderr, an empty event stream, and exit `2` — never a
   `run_started` for a run that never began.


### PR DESCRIPTION
Fixes RUE-1957.

With `--test-candidates`, an unimported test file was reported twice on a terminal: once on stderr by the runner and once more on stdout by the human renderer. test-events.md's "Streams" contract already makes the warning stderr's, so the human renderer no longer repeats it; stderr carries exactly one copy in both formats and `run_finished.unimported_test_files` is unchanged.

The renderer unit test is inverted to pin the absence, the existing JSON orphan case asserts no `warning:` reaches stdout, and a new human-format case pins the full line on stderr and nothing on stdout. The doc's "Streams" bullet states the rule.

Verification: `//crates/rue:rue-test test_mode` (83), `scripts/rue cli rue_test` (50), `scripts/rue quick`, fmt clean.