### PR TITLE
RUE-1959: print the candidates notice only for a multi-module closure

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -731,10 +731,11 @@ compile_stdout_contains = [
 ]
 
 [[case]]
-name = "without_an_inventory_the_summary_says_orphans_are_not_detected"
+name = "without_an_inventory_a_multi_module_summary_says_orphans_are_not_detected"
 description = """
-Silence would be read as "no orphans found". The run says instead that it did
-not look.
+Silence would be read as "no orphans found". This root imports a second module,
+so an orphan is a thing that could exist here, and the run says instead that it
+did not look.
 """
 files = [
     { path = "main.rue", source = """
@@ -755,6 +756,54 @@ driver_exit_code = 0
 compile_stdout_contains = [
     "note: no --test-candidates inventory; unimported test files are not detected",
 ]
+
+[[case]]
+name = "a_single_module_run_is_owed_no_note_about_candidates"
+description = """
+RUE-1959: a closure of one user module has no second module that could have
+failed to import a test file, so there is nothing for the note to be about. It
+was noise under every filtered rerun pasted from a `repro:` line. The JSON
+`test_candidates` field is unaffected — this is the human summary only.
+"""
+files = [
+    { path = "main.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+driver_exit_code = 0
+compile_stdout_contains = ["1 passed"]
+compile_stdout_not_contains = ["note: no --test-candidates inventory"]
+
+[[case]]
+name = "a_single_module_run_still_reports_test_candidates_none_in_json"
+description = """
+RUE-1959 changed the human summary only. `run_finished.test_candidates` is a
+published field and answers `"none"` for the same run.
+"""
+files = [
+    { path = "main.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = [
+    "test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1",
+    "--format", "json",
+]
+driver_exit_code = 0
+compile_stdout_contains = ['"test_candidates":"none"']
 
 # ========================= dispatch and flag combinations =========================
 

--- a/crates/rue-compiler/src/session/program_artifacts.rs
+++ b/crates/rue-compiler/src/session/program_artifacts.rs
@@ -1077,6 +1077,24 @@ impl CompilerSession {
     /// addition left for a real report of the false positive.
     ///
     /// The returned rows are ordered by path.
+    /// How many caller-authored modules the published closure holds.
+    ///
+    /// Standard-library modules are excluded because they can never be the
+    /// subject of an unimported-test-file report: a candidate inventory names
+    /// project files, and closure membership above is decided against those
+    /// same logical paths. A single-file program therefore answers 1 here even
+    /// though its closure carries whatever of `std` it reached.
+    ///
+    /// Zero means nothing is published yet, which is not a closure of one.
+    pub(crate) fn published_user_module_count(&self) -> usize {
+        self.published_owner().map_or(0, |program| {
+            program
+                .modules_iter()
+                .filter(|module| !module.module_id().is_trusted_standard_library())
+                .count()
+        })
+    }
+
     pub(crate) fn unimported_test_files(
         &mut self,
         candidates: &crate::TestCandidateInventory,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -696,6 +696,16 @@ pub fn unimported_test_files(
     session.unimported_test_files(candidates)
 }
 
+/// How many caller-authored modules the published closure holds, excluding the
+/// standard library.
+///
+/// `rue test` uses it as presentation policy: a closure of one user module has
+/// nothing that another module could have failed to import, so there is nothing
+/// for the missing-candidate-inventory notice to be about (RUE-1959).
+pub fn published_user_module_count(session: &crate::CompilerSession) -> usize {
+    session.published_user_module_count()
+}
+
 /// Produce an executable inside a compile span owned by the filesystem
 /// driver. Stable callers use `compile_snapshot`, which owns its tracing
 /// root.

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -208,6 +208,11 @@ impl FilesystemCompilerHost {
         unimported_test_files(&mut self.state.session, candidates)
     }
 
+    /// How many caller-authored modules the published closure holds (RUE-1959).
+    pub fn published_user_module_count(&self) -> usize {
+        rue_compiler::unstable::published_user_module_count(&self.state.session)
+    }
+
     /// Reach ADR-0068's codegen-ready endpoint without projecting objects.
     pub fn codegen_ready(&mut self, options: &CompileOptions) -> MultiErrorResult<CodegenReady> {
         codegen_ready(&mut self.state.session, options)

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -155,13 +155,17 @@ fn fresh_seed() -> u64 {
 /// and routes each event to the surface the invocation asked for.
 struct Reporter {
     format: OutputFormat,
+    /// Presentation policy the human renderer needs and the event schema does
+    /// not carry. See `render::Context`.
+    context: render::Context,
     stdout: Mutex<()>,
 }
 
 impl Reporter {
-    fn new(format: OutputFormat) -> Self {
+    fn new(format: OutputFormat, context: render::Context) -> Self {
         Self {
             format,
+            context,
             stdout: Mutex::new(()),
         }
     }
@@ -177,7 +181,7 @@ impl Reporter {
                 let _ = writeln!(out, "{}", event.to_ndjson());
             }
             OutputFormat::Human => {
-                if let Some(text) = render::render(event) {
+                if let Some(text) = render::render(event, self.context) {
                     let _ = writeln!(out, "{text}");
                 }
             }
@@ -208,9 +212,10 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
     exec::reserve_channel_descriptor();
 
     let seed = options.seed.unwrap_or_else(fresh_seed);
-    let reporter = Reporter::new(options.format);
 
     if options.list {
+        // A listing emits no `run_finished`, so it is owed no closure context.
+        let reporter = Reporter::new(options.format, render::Context::default());
         return list(host, &compile_options, &options, diagnostics, &reporter);
     }
 
@@ -223,6 +228,15 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
             return TestExitCode::RunnerError;
         }
     };
+    // Built here rather than above because the closure is only published once
+    // the image is: nothing before this point could answer how many modules the
+    // program has.
+    let reporter = Reporter::new(
+        options.format,
+        render::Context {
+            multi_module_closure: host.published_user_module_count() > 1,
+        },
+    );
     diagnostics.print_warnings(&image.warnings);
 
     let total = inventory.entries.len();

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -16,9 +16,26 @@ use super::diff::{DiffOp, Hunk};
 use super::events::{CandidateSource, Capture, Comparison, Event, TestFinished};
 use super::verdict::Verdict;
 
+/// What the human renderer is told out of band.
+///
+/// The event schema is a published surface (`test-events.md`), so presentation
+/// policy that is not run data does not become a field on an event. It reaches
+/// the renderer here instead, and the NDJSON stream is byte-identical with or
+/// without it.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct Context {
+    /// Whether the compiled closure holds more than one user module.
+    ///
+    /// A closure of one has no second module that could have failed to import a
+    /// test file, so the missing-inventory note would answer a question this run
+    /// cannot raise. `run_finished.test_candidates` still says `"none"` either
+    /// way (RUE-1959).
+    pub(crate) multi_module_closure: bool,
+}
+
 /// Render one event for a person, or `None` when a person is owed nothing by
 /// it.
-pub(crate) fn render(event: &Event) -> Option<String> {
+pub(crate) fn render(event: &Event, context: Context) -> Option<String> {
     match event {
         Event::RunStarted { .. } | Event::TestStarted { .. } => None,
         Event::Test { id, .. } => Some(id.clone()),
@@ -54,7 +71,7 @@ pub(crate) fn render(event: &Event) -> Option<String> {
                 }
             }
             out.push_str(&summary(*passed, *failed, *timeout, *crash, *wall_ms));
-            if *test_candidates == CandidateSource::None {
+            if *test_candidates == CandidateSource::None && context.multi_module_closure {
                 out.push('\n');
                 out.push_str(
                     "note: no --test-candidates inventory; unimported test files are not detected",
@@ -320,6 +337,18 @@ mod tests {
     use crate::test_mode::events::{Comparison, FailureRecord, Location, UnimportedFile};
     use crate::test_mode::verdict::FailureKind;
 
+    /// Render as an ordinary multi-module program, which is what every case
+    /// that is not about the closure size wants: the closure-size policy only
+    /// governs the missing-inventory note.
+    fn render_multi(event: &Event) -> Option<String> {
+        super::render(
+            event,
+            Context {
+                multi_module_closure: true,
+            },
+        )
+    }
+
     fn finished(verdict: Verdict, failure: Option<FailureRecord>) -> Event {
         Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::parses a port".to_owned(),
@@ -354,7 +383,7 @@ mod tests {
     /// No wall of green: a pass prints nothing.
     #[test]
     fn a_pass_prints_nothing() {
-        assert!(render(&finished(Verdict::Pass, None)).is_none());
+        assert!(render_multi(&finished(Verdict::Pass, None)).is_none());
     }
 
     /// The head events are machine bookkeeping; a person is shown failures and
@@ -362,13 +391,13 @@ mod tests {
     #[test]
     fn run_and_test_start_print_nothing() {
         assert!(
-            render(&Event::TestStarted {
+            render_multi(&Event::TestStarted {
                 id: "app/t.rue::ok".to_owned()
             })
             .is_none()
         );
         assert!(
-            render(&Event::RunStarted {
+            render_multi(&Event::RunStarted {
                 root: "m.rue".to_owned(),
                 target: "x86-64-linux".to_owned(),
                 opt_level: "0".to_owned(),
@@ -384,7 +413,7 @@ mod tests {
 
     #[test]
     fn a_failure_prints_structure_output_scratch_and_repro() {
-        let rendered = render(&finished(
+        let rendered = render_multi(&finished(
             Verdict::Fail(FailureKind::Assert),
             Some(FailureRecord {
                 kind: "assert".to_owned(),
@@ -425,7 +454,7 @@ mod tests {
     /// disagree about where the difference is.
     #[test]
     fn a_single_line_comparison_prints_both_values_and_a_caret() {
-        let rendered = render(&finished(
+        let rendered = render_multi(&finished(
             Verdict::Fail(FailureKind::AssertEq),
             Some(FailureRecord {
                 kind: "assert_eq".to_owned(),
@@ -446,7 +475,7 @@ mod tests {
     /// difference and no caret is drawn — the two values *are* the report.
     #[test]
     fn identical_values_print_no_caret() {
-        let rendered = render(&finished(
+        let rendered = render_multi(&finished(
             Verdict::Fail(FailureKind::AssertNe),
             Some(FailureRecord {
                 kind: "assert_ne".to_owned(),
@@ -466,7 +495,7 @@ mod tests {
     /// of text locates nothing.
     #[test]
     fn a_multi_line_comparison_prints_a_hunk_listing() {
-        let rendered = render(&finished(
+        let rendered = render_multi(&finished(
             Verdict::Fail(FailureKind::AssertEq),
             Some(FailureRecord {
                 kind: "assert_eq".to_owned(),
@@ -494,7 +523,7 @@ mod tests {
     /// is the only account of a failure report the runner could not read.
     #[test]
     fn a_runner_note_is_printed_with_its_failure() {
-        let rendered = render(&finished(
+        let rendered = render_multi(&finished(
             Verdict::Fail(FailureKind::Exit),
             Some(FailureRecord {
                 kind: "exit".to_owned(),
@@ -512,9 +541,9 @@ mod tests {
 
     #[test]
     fn timeouts_and_crashes_carry_their_own_banners() {
-        let timeout = render(&finished(Verdict::Timeout, None)).expect("a timeout renders");
+        let timeout = render_multi(&finished(Verdict::Timeout, None)).expect("a timeout renders");
         assert!(timeout.starts_with("TIMEOUT "), "{timeout}");
-        let crash = render(&finished(Verdict::Crash(11), None)).expect("a crash renders");
+        let crash = render_multi(&finished(Verdict::Crash(11), None)).expect("a crash renders");
         assert!(crash.starts_with("CRASH "), "{crash}");
     }
 
@@ -523,27 +552,24 @@ mod tests {
     #[test]
     fn the_summary_names_only_the_classes_that_occurred() {
         assert!(
-            render(&run_finished(2, 0, 0, 0))
+            render_multi(&run_finished(2, 0, 0, 0))
                 .unwrap()
                 .starts_with("2 passed (0.9s)")
         );
         assert!(
-            render(&run_finished(2, 1, 0, 0))
+            render_multi(&run_finished(2, 1, 0, 0))
                 .unwrap()
                 .starts_with("2 passed, 1 failed (0.9s)")
         );
         assert!(
-            render(&run_finished(2, 1, 1, 1))
+            render_multi(&run_finished(2, 1, 1, 1))
                 .unwrap()
                 .starts_with("2 passed, 1 failed, 1 timed out, 1 crashed (0.9s)")
         );
     }
 
-    /// Without an inventory the runner cannot detect orphaned test files, and
-    /// says so rather than leaving silence to be read as "none found".
-    #[test]
-    fn a_run_without_a_candidate_inventory_says_so() {
-        let rendered = render(&Event::RunFinished {
+    fn no_inventory() -> Event {
+        Event::RunFinished {
             passed: 0,
             failed: 0,
             timeout: 0,
@@ -551,8 +577,15 @@ mod tests {
             wall_ms: 100,
             unimported_test_files: None,
             test_candidates: CandidateSource::None,
-        })
-        .expect("a summary renders");
+        }
+    }
+
+    /// Where an orphan is possible, the runner cannot detect one without an
+    /// inventory and says so, rather than leaving silence to be read as "none
+    /// found".
+    #[test]
+    fn a_multi_module_run_without_a_candidate_inventory_says_so() {
+        let rendered = render_multi(&no_inventory()).expect("a summary renders");
         assert!(rendered.contains("0 passed (0.1s)"), "{rendered}");
         assert!(
             rendered.contains(
@@ -562,9 +595,25 @@ mod tests {
         );
     }
 
+    /// A closure of one user module has no second module that could have failed
+    /// to import a test file, so the note would answer a question this run
+    /// cannot raise — noise under every filtered rerun pasted from a `repro:`
+    /// line. The event's `test_candidates` is unchanged.
+    #[test]
+    fn a_single_module_run_is_owed_no_note_about_candidates() {
+        let rendered = super::render(
+            &no_inventory(),
+            Context {
+                multi_module_closure: false,
+            },
+        )
+        .expect("a summary renders");
+        assert_eq!(rendered, "0 passed (0.1s)");
+    }
+
     #[test]
     fn orphaned_test_files_are_rendered_as_warnings() {
-        let rendered = render(&Event::RunFinished {
+        let rendered = render_multi(&Event::RunFinished {
             passed: 1,
             failed: 0,
             timeout: 0,
@@ -599,7 +648,7 @@ mod tests {
     #[test]
     fn a_listing_entry_renders_as_its_bare_identity() {
         assert_eq!(
-            render(&Event::Test {
+            render_multi(&Event::Test {
                 id: "app/t.rue::ok".to_owned(),
                 module: "app/t.rue".to_owned(),
                 name: "ok".to_owned(),

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -304,7 +304,13 @@ Each `unimported_test_files` entry is `{"path": string, "tests": integer,
 or parsed, so `tests` counts nothing and the honest answer is that the count is
 unknown. Without `--test-candidates`, the human summary appends
 `note: no --test-candidates inventory; unimported test files are not detected` —
-silence would be read as "none found".
+silence would be read as "none found" — but only when the compiled closure holds
+more than one user module (the standard library does not count). A closure of
+one has no second module that could have failed to import a test file, so the
+note would answer a question that run cannot raise; it was noise under every
+filtered rerun pasted from a `repro:` line. The condition is presentation only:
+`test_candidates` still answers `"none"` for such a run, and no event carries the
+closure size.
 
 ### `test` (listing records)
 


### PR DESCRIPTION
Fixes RUE-1959.

Every `--format human` run without `--test-candidates` ended with `note: no --test-candidates inventory; unimported test files are not detected`, including a single-file program and every filtered rerun pasted from a `repro:` line. The note is honest (silence would read as "none found") but a single-module closure has nothing to be unimported, so it is now printed only when the compiled closure contains more than one user module. The JSON `run_finished.test_candidates` field is unchanged and no event field was added: the closure size reaches the human renderer out of band through a renderer context the driver fills from a new `published_user_module_count` accessor on the session, which counts the same published modules the orphan report defines closure membership against, excluding the standard library.

The reporter is now constructed after the test image exists, since the closure is only published then; `--list` keeps a default context because a listing emits no summary. No directory scan and no new flag.

Unit tests: the existing note test becomes the multi-module case and gains a single-module inverse. CLI cases pin presence for a multi-module root, absence for a single-file root, and the JSON field's presence in both. `docs/process/test-events.md` states the condition.

Verification: `//crates/rue:rue-test test_mode` (87), `scripts/rue cli rue_test` (52), `scripts/rue quick`, fmt clean.