### PR TITLE
RUE-1953: report bare @assert failures with their site on the test channel

### DIFF
--- a/crates/rue-air/src/intrinsic.rs
+++ b/crates/rue-air/src/intrinsic.rs
@@ -333,7 +333,6 @@ pub enum IntrinsicOperation {
     PanicNoMessage,
     Panic,
     AssertFailed,
-    AssertWithMessage,
     BoundsCheck,
     DebugI64,
     DebugU64,
@@ -381,11 +380,10 @@ pub enum IntrinsicOperation {
 impl IntrinsicOperation {
     /// Every semantic identity, kept in one place so consumers and tests can
     /// prove that dispatch remains exhaustive when a new intrinsic is added.
-    pub const ALL: [Self; 46] = [
+    pub const ALL: [Self; 45] = [
         Self::PanicNoMessage,
         Self::Panic,
         Self::AssertFailed,
-        Self::AssertWithMessage,
         Self::BoundsCheck,
         Self::DebugI64,
         Self::DebugU64,
@@ -436,8 +434,7 @@ impl IntrinsicOperation {
     pub const fn expected_spelling(self) -> &'static str {
         match self {
             Self::PanicNoMessage | Self::Panic => "panic",
-            Self::AssertFailed | Self::AssertWithMessage => "assert",
-            Self::BoundsCheck => "assert",
+            Self::AssertFailed | Self::BoundsCheck => "assert",
             Self::DebugI64 | Self::DebugU64 | Self::DebugBool | Self::DebugStr => "dbg",
             Self::ReadLine => "read_line",
             Self::ParseI32 => "parse_i32",
@@ -484,7 +481,6 @@ impl IntrinsicOperation {
             RuntimeCallKind::PanicNoMessage => Self::PanicNoMessage,
             RuntimeCallKind::Panic => Self::Panic,
             RuntimeCallKind::AssertFailed => Self::AssertFailed,
-            RuntimeCallKind::AssertWithMessage => Self::AssertWithMessage,
             RuntimeCallKind::BoundsCheck => Self::BoundsCheck,
             RuntimeCallKind::DebugI64 => Self::DebugI64,
             RuntimeCallKind::DebugU64 => Self::DebugU64,
@@ -525,14 +521,15 @@ impl IntrinsicOperation {
             // The ADR-0083 test channel has no intrinsic identity. The
             // dispatcher's own helpers are runner plumbing no source spelling
             // selects; the reporting helpers are reached by a test body's `?`
-            // and by `@assert_eq`/`@assert_ne`, which emit the calls directly
-            // rather than through an `IntrinsicOperation` — a comparison is a
-            // branch around a pair of calls, not one conditional runtime call.
+            // and by the assertion family, which emit the calls directly rather
+            // than through an `IntrinsicOperation` — an assertion is a branch
+            // around a pair of calls, not one conditional runtime call.
             | RuntimeCallKind::TestNormalizeProcess
             | RuntimeCallKind::TestComplete
             | RuntimeCallKind::TestFailureSite
             | RuntimeCallKind::TestFail
             | RuntimeCallKind::TestFailComparison
+            | RuntimeCallKind::TestFailAssert
             | RuntimeCallKind::TestUsageError => return None,
         })
     }
@@ -549,7 +546,6 @@ impl IntrinsicOperation {
             Self::PanicNoMessage => RuntimeCallKind::PanicNoMessage,
             Self::Panic => RuntimeCallKind::Panic,
             Self::AssertFailed => RuntimeCallKind::AssertFailed,
-            Self::AssertWithMessage => RuntimeCallKind::AssertWithMessage,
             Self::BoundsCheck => RuntimeCallKind::BoundsCheck,
             Self::ReadLine => RuntimeCallKind::ReadLine,
             Self::ParseI32 => RuntimeCallKind::ParseI32,
@@ -749,7 +745,6 @@ impl IntrinsicOperation {
             Self::PanicNoMessage
             | Self::Panic
             | Self::AssertFailed
-            | Self::AssertWithMessage
             | Self::BoundsCheck
             | Self::DebugI64
             | Self::DebugU64
@@ -789,11 +784,10 @@ mod tests {
     use std::collections::BTreeSet;
     use std::sync::Arc;
 
-    const EXACT_OPERATIONS: [(IntrinsicOperation, &str); 46] = [
+    const EXACT_OPERATIONS: [(IntrinsicOperation, &str); 45] = [
         (IntrinsicOperation::PanicNoMessage, "panic"),
         (IntrinsicOperation::Panic, "panic"),
         (IntrinsicOperation::AssertFailed, "assert"),
-        (IntrinsicOperation::AssertWithMessage, "assert"),
         (IntrinsicOperation::BoundsCheck, "assert"),
         (IntrinsicOperation::DebugI64, "dbg"),
         (IntrinsicOperation::DebugU64, "dbg"),
@@ -838,7 +832,7 @@ mod tests {
         (IntrinsicOperation::TotalCmp, "total_cmp"),
     ];
 
-    const EXACT_RUNTIME_MAPPINGS: [(IntrinsicOperation, RuntimeCallKind); 30] = [
+    const EXACT_RUNTIME_MAPPINGS: [(IntrinsicOperation, RuntimeCallKind); 29] = [
         (
             IntrinsicOperation::PanicNoMessage,
             RuntimeCallKind::PanicNoMessage,
@@ -847,10 +841,6 @@ mod tests {
         (
             IntrinsicOperation::AssertFailed,
             RuntimeCallKind::AssertFailed,
-        ),
-        (
-            IntrinsicOperation::AssertWithMessage,
-            RuntimeCallKind::AssertWithMessage,
         ),
         (
             IntrinsicOperation::BoundsCheck,
@@ -890,7 +880,7 @@ mod tests {
     // family, which sema selects from ordinary method calls, and the ADR-0083
     // test channel, which the synthesized dispatcher and the assertion sugar
     // emit as direct calls rather than through an `IntrinsicOperation`.
-    const ORDINARY_CALL_ONLY: [RuntimeCallKind; 17] = [
+    const ORDINARY_CALL_ONLY: [RuntimeCallKind; 18] = [
         RuntimeCallKind::StrByteAt,
         RuntimeCallKind::StrCharScalar,
         RuntimeCallKind::StrCharNext,
@@ -907,12 +897,13 @@ mod tests {
         RuntimeCallKind::TestFailureSite,
         RuntimeCallKind::TestFail,
         RuntimeCallKind::TestFailComparison,
+        RuntimeCallKind::TestFailAssert,
         RuntimeCallKind::TestUsageError,
     ];
 
     #[test]
     fn all_operations_are_unique_and_runtime_mapping_is_symmetric() {
-        assert_eq!(IntrinsicOperation::ALL.len(), 46);
+        assert_eq!(IntrinsicOperation::ALL.len(), 45);
         assert_eq!(
             IntrinsicOperation::ALL,
             EXACT_OPERATIONS.map(|(operation, _)| operation)
@@ -995,7 +986,7 @@ mod tests {
             .iter()
             .filter_map(|operation| operation.runtime_call_kind())
             .collect::<Vec<_>>();
-        assert_eq!(runtime.len(), 30);
+        assert_eq!(runtime.len(), 29);
         assert_eq!(
             IntrinsicOperation::ALL
                 .iter()
@@ -1009,7 +1000,7 @@ mod tests {
                 .enumerate()
                 .filter(|(index, kind)| !runtime[..*index].contains(kind))
                 .count(),
-            30
+            29
         );
         assert_eq!(
             runtime,
@@ -1690,11 +1681,6 @@ mod tests {
             (
                 IntrinsicOperation::AssertFailed,
                 vec![(Type::BOOL, n)],
-                Type::UNIT,
-            ),
-            (
-                IntrinsicOperation::AssertWithMessage,
-                vec![(Type::BOOL, n), (text, n)],
                 Type::UNIT,
             ),
             (

--- a/crates/rue-air/src/runtime_call.rs
+++ b/crates/rue-air/src/runtime_call.rs
@@ -123,7 +123,6 @@ pub enum RuntimeCallKind {
     Panic,
     PanicNoMessage,
     AssertFailed,
-    AssertWithMessage,
     /// Typed identity for compiler-inserted slice bounds traps. This shares
     /// the `assert` intrinsic's conditional shape while selecting the
     /// dedicated `__rue_bounds_check` runtime helper in codegen.
@@ -161,6 +160,9 @@ pub enum RuntimeCallKind {
     /// `expected` and `actual` — on the §5.1 channel, then abort. What
     /// `@assert_eq` and `@assert_ne` lower to (ADR-0083 Phase 2.5).
     TestFailComparison,
+    /// Report a failed `@assert` — the pinned or user-supplied message — on
+    /// the §5.1 channel, then abort. What `@assert` lowers to (spec 4.13:5d).
+    TestFailAssert,
     /// Write the pinned malformed-selector diagnostic and return.
     TestUsageError,
 }
@@ -320,6 +322,18 @@ const TEST_FAILURE_SITE: &[RuntimeOperandOrigin] = &[
         ty: AbiType::U32,
     },
 ];
+// `__rue_test_fail_assert(message, with_message)`. The site is staged by the
+// same first call the other reporting helpers use; what differs is the second
+// operand, which states which of `@assert`'s two pinned stderr forms this is
+// rather than leaving the helper to infer it from an empty message.
+const TEST_FAIL_ASSERT: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::TextPointer(0),
+    RuntimeOperandOrigin::TextLength(0),
+    RuntimeOperandOrigin::ValueArgument {
+        index: 1,
+        ty: AbiType::U32,
+    },
+];
 const TEST_FAIL: &[RuntimeOperandOrigin] = &[
     RuntimeOperandOrigin::TextPointer(0),
     RuntimeOperandOrigin::TextLength(0),
@@ -349,7 +363,6 @@ impl RuntimeCallKind {
         Self::Panic,
         Self::PanicNoMessage,
         Self::AssertFailed,
-        Self::AssertWithMessage,
         Self::BoundsCheck,
         Self::ReadLine,
         Self::ParseI32,
@@ -377,6 +390,7 @@ impl RuntimeCallKind {
         Self::TestFailureSite,
         Self::TestFail,
         Self::TestFailComparison,
+        Self::TestFailAssert,
         Self::TestUsageError,
     ];
 
@@ -398,7 +412,6 @@ impl RuntimeCallKind {
             Self::Panic => RuntimeHelperId::Panic,
             Self::PanicNoMessage => RuntimeHelperId::PanicNoMessage,
             Self::AssertFailed => RuntimeHelperId::AssertFailed,
-            Self::AssertWithMessage => RuntimeHelperId::Panic,
             Self::BoundsCheck => RuntimeHelperId::BoundsCheck,
             Self::ReadLine => RuntimeHelperId::ReadLine,
             Self::ParseI32 => RuntimeHelperId::ParseI32,
@@ -426,6 +439,7 @@ impl RuntimeCallKind {
             Self::TestFailureSite => RuntimeHelperId::TestFailureSite,
             Self::TestFail => RuntimeHelperId::TestFail,
             Self::TestFailComparison => RuntimeHelperId::TestFailComparison,
+            Self::TestFailAssert => RuntimeHelperId::TestFailAssert,
             Self::TestUsageError => RuntimeHelperId::TestUsageError,
         }
     }
@@ -443,10 +457,6 @@ impl RuntimeCallKind {
                 TEXT
             }
             Self::StrPrintProjected | Self::StrPrintlnProjected => PROJECTED_TEXT,
-            Self::AssertWithMessage => &[
-                RuntimeOperandOrigin::TextPointer(1),
-                RuntimeOperandOrigin::TextLength(1),
-            ],
             Self::DebugI64 => SIGNED_SCALAR,
             Self::DebugU64 => UNSIGNED_SCALAR,
             Self::DebugBool => BOOL_SCALAR,
@@ -473,14 +483,13 @@ impl RuntimeCallKind {
             // open form carries `kind`, `message`, and `payload`: three byte
             // views either way, so one operand plan serves both.
             Self::TestFail | Self::TestFailComparison => TEST_FAIL,
+            Self::TestFailAssert => TEST_FAIL_ASSERT,
         }
     }
 
     pub const fn activation(self) -> RuntimeCallActivation {
         match self {
-            Self::AssertFailed | Self::AssertWithMessage | Self::BoundsCheck => {
-                RuntimeCallActivation::WhenArgumentIsFalse(0)
-            }
+            Self::AssertFailed | Self::BoundsCheck => RuntimeCallActivation::WhenArgumentIsFalse(0),
             _ => RuntimeCallActivation::Always,
         }
     }
@@ -721,10 +730,6 @@ mod tests {
         for kind in RuntimeCallKind::ALL {
             assert!(kind.validate(), "{kind:?}");
         }
-        assert_eq!(
-            RuntimeCallKind::AssertWithMessage.activation(),
-            RuntimeCallActivation::WhenArgumentIsFalse(0)
-        );
         assert_eq!(
             RuntimeCallKind::Panic.activation(),
             RuntimeCallActivation::Always

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -1261,8 +1261,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
 
-        // Build args for AIR
-        let mut extra_data = vec![cond_result.air_ref];
+        // The two operands the assertion evaluates, in source order, before it
+        // tests anything.
+        let mut message = None;
         let mut temp_scope = Vec::new();
         if args.len() > 1 {
             let reachable_edges_before_message = ctx.ownership.loop_break_stack.clone();
@@ -1277,45 +1278,126 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 msg_result.ty,
                 self.body_rir_ref().get(args[1].value).span,
             )?;
-            let source_strbuf = msg_result.ty.as_struct().is_some_and(|struct_id| {
-                self.body_type_pool().struct_lang_item(struct_id) == Some(crate::LangItem::StrBuf)
-            });
+            let source_strbuf = self.is_strbuf(msg_result.ty);
+            // Narrow a StrBuf message to a layout-stable `{ptr, len}` str view,
+            // exactly as `@panic` does (RUE-1066): the report helper reads a
+            // `str`, not the StrBuf header, and the view is a borrow the arm can
+            // carry without owning anything the enclosing block would drop.
             let msg_ref = if source_strbuf {
-                let (msg_ref, scope) = self.materialize_borrow_argument(
-                    air,
-                    msg_result.air_ref,
-                    msg_result.ty,
-                    span,
-                    ctx,
-                )?;
+                let (msg_ref, scope) =
+                    self.strbuf_text_view(air, msg_result.air_ref, msg_result.ty, span, ctx)?;
                 temp_scope = scope;
                 msg_ref
             } else {
                 msg_result.air_ref
             };
-            extra_data.push(msg_ref);
+            message = Some(msg_ref);
             if !temp_scope.is_empty() {
                 // The message's hoisted owner scope must not jump ahead of the
-                // condition. Lower it first; the intrinsic reuses the cached
+                // condition. Lower it first; the branch below reuses the cached
                 // value after the message has been evaluated.
                 temp_scope.insert(0, cond_result.air_ref);
             }
         }
 
-        let intrinsic_ref = air.add_intrinsic(
-            if args.len() > 1 {
-                crate::IntrinsicOperation::AssertWithMessage
-            } else {
-                crate::IntrinsicOperation::AssertFailed
+        // The failing arm is the then-arm of a branch with no else, the same
+        // shape `@assert_eq` reports through: the arm ends in a `-> !` call, so
+        // nothing after the report is reachable from it.
+        //
+        // `@assert(cond, msg)` evaluates its message whether or not the
+        // condition holds, and that stays true of the lowering: both operands
+        // are statements of the enclosing block, so both are evaluated before
+        // the condition is tested rather than inside the arm. Neither owns
+        // anything — the message is a text view by this point — so listing them
+        // schedules no drop.
+        let mut statements = vec![cond_result.air_ref];
+        statements.extend(message);
+        let report = self.build_assert_report(air, message, span, ctx)?;
+        let failed = air.add_inst(AirInst {
+            data: AirInstData::Not(cond_result.air_ref),
+            ty: Type::BOOL,
+            span,
+        });
+        let branch = air.add_inst(AirInst {
+            data: AirInstData::Branch {
+                cond: failed,
+                then_value: report,
+                else_value: None,
             },
-            self.known_symbols().assert,
-            &extra_data,
+            ty: Type::UNIT,
+            span,
+        });
+        let assertion = air.add_block(&statements, branch, Type::UNIT, span)?;
+        let air_ref =
+            self.wrap_value_with_temp_scope(air, assertion, Type::UNIT, span, temp_scope)?;
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
+    /// The failing arm of an `@assert`: stage the site, report, abort.
+    ///
+    /// The two channel calls are a pair by ABI — a failure record is more
+    /// arguments than a register-only helper can take — and the second adopts
+    /// whatever site the first staged, so nothing may run between them. The
+    /// message is not one of them: it was materialized before the branch, and
+    /// the arm only hands the terminal call the view it already has.
+    ///
+    /// The lowering is the same in a test image and in an ordinary executable
+    /// (ADR-0083's rule for the assertion family). Only the outcome differs,
+    /// and only because the channel is a descriptor an ordinary process does
+    /// not have: the frame write fails with `EBADF` and the pinned stderr
+    /// message spec 4.13:5d fixes is the whole report.
+    fn build_assert_report(
+        &mut self,
+        air: &mut Air,
+        message: Option<AirRef>,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AirRef> {
+        let str_ty = self.get_or_create_str_struct(span)?;
+        // A site the host cannot resolve is reported as the empty file at 0:0
+        // rather than as a compile error: the ABI accepts an absent location,
+        // and a report that cannot name its line is still a better failure than
+        // no report.
+        let (path, line, column) = self
+            .body_source_coordinate(span)
+            .unwrap_or_else(|| (std::sync::Arc::from(""), 0, 0));
+        let file = self.synthesized_string(air, ctx, &path, str_ty, span);
+        let line = air.add_inst(AirInst {
+            data: AirInstData::Const(u64::from(line)),
+            ty: Type::U32,
+            span,
+        });
+        let column = air.add_inst(AirInst {
+            data: AirInstData::Const(u64::from(column)),
+            ty: Type::U32,
+            span,
+        });
+        let site = self.runtime_channel_call(
+            air,
+            crate::RuntimeCallKind::TestFailureSite,
+            &[file, line, column],
             Type::UNIT,
             span,
         )?;
-        let air_ref =
-            self.wrap_value_with_temp_scope(air, intrinsic_ref, Type::UNIT, span, temp_scope)?;
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+
+        // Which of the two pinned stderr forms this is, stated rather than
+        // inferred from the message's length: `@assert(cond, "")` is the
+        // message form and keeps printing `panic: `.
+        let with_message = air.add_inst(AirInst {
+            data: AirInstData::Const(u64::from(message.is_some())),
+            ty: Type::U32,
+            span,
+        });
+        let message =
+            message.unwrap_or_else(|| self.synthesized_string(air, ctx, "", str_ty, span));
+        let report = self.runtime_channel_call(
+            air,
+            crate::RuntimeCallKind::TestFailAssert,
+            &[message, with_message],
+            Type::NEVER,
+            span,
+        )?;
+        Ok(air.add_block(&[with_message, site], report, Type::NEVER, span)?)
     }
 
     /// Analyze `@assert_eq(left, right)` and `@assert_ne(left, right)`

--- a/crates/rue-air/src/sema/provider_semantics_tests.rs
+++ b/crates/rue-air/src/sema/provider_semantics_tests.rs
@@ -113,8 +113,13 @@ fn provider_body_keeps_reserved_looking_source_intrinsics_unknown() {
 
 // Migrated from `tests::panic_is_never_and_assert_is_unit_in_air`: `@panic`
 // diverges (`!` result), `@assert` stays unit; the message operand's type
-// never changes the intrinsic result, and only unit trailing intrinsics
-// synthesize a return. The `diverge` callee crosses as a durable fact.
+// never changes that result, and only unit trailing assertions synthesize a
+// return. The `diverge` callee crosses as a durable fact.
+//
+// The two are different AIR shapes. `@panic` is one intrinsic. `@assert` is a
+// branch with no else whose then-arm reports the failure on the ADR-0083 §5.1
+// channel and aborts, so its result type is the branch's — and its failing arm
+// is a pair of runtime calls, not an intrinsic.
 #[test]
 fn provider_body_panic_is_never_and_assert_is_unit() {
     for (name, body_source, expected) in [
@@ -133,6 +138,7 @@ fn provider_body_panic_is_never_and_assert_is_unit() {
         ),
         ("never panic message", "@panic(diverge())", Type::NEVER),
     ] {
+        let asserts = expected == Type::UNIT;
         let mut fixture = ProviderFixture::new();
         fixture.declare_function("diverge", Vec::new(), SemanticImportType::Never);
         fixture.declare_function("probe", Vec::new(), SemanticImportType::Unit);
@@ -141,18 +147,23 @@ fn provider_body_panic_is_never_and_assert_is_unit() {
             .analyze(&source, "probe")
             .unwrap_or_else(|error| panic!("{name} must analyze: {error:?}"));
 
-        let intrinsic_types: Vec<_> = body
+        let result_types: Vec<_> = body
             .function
             .air
             .iter()
             .filter_map(|(_, inst)| {
-                matches!(inst.data, AirInstData::Intrinsic { .. }).then_some(inst.ty)
+                let selected = if asserts {
+                    matches!(inst.data, AirInstData::Branch { .. })
+                } else {
+                    matches!(inst.data, AirInstData::Intrinsic { .. })
+                };
+                selected.then_some(inst.ty)
             })
             .collect();
         assert_eq!(
-            intrinsic_types,
+            result_types,
             vec![expected],
-            "{name} intrinsic result must agree with HM"
+            "{name} result must agree with HM"
         );
         // A unit-valued trailing `@assert` still needs an implicit return; a
         // never-valued trailing `@panic` diverges, so no return is synthesized.
@@ -161,7 +172,7 @@ fn provider_body_panic_is_never_and_assert_is_unit() {
             .air
             .iter()
             .any(|(_, inst)| matches!(inst.data, AirInstData::Ret(_)));
-        if expected == Type::UNIT {
+        if asserts {
             assert!(has_ret, "{name}: a unit trailing intrinsic needs a return");
         } else {
             assert!(

--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -50,8 +50,12 @@ compile_stdout_not_contains = ["FAIL", "PASS "]
 [[case]]
 name = "a_failed_assert_is_kind_assert_and_exits_one"
 description = """
-The pinned `assertion failed` message from `__rue_assert_failed` is what the
-`assert` kind is classified from; this case runs the real runtime path.
+`@assert` writes its own `failure` frame on the §5.1 channel (RUE-1953), so the
+`assert` kind comes from the frame rather than from the pinned `assertion
+failed` stderr line, and the location is the intrinsic's own — line 2, column 5
+— rather than the declaration header on line 1. This case runs the real runtime
+path; the stderr byte count pins that the message itself did not change. Object
+keys are alphabetical, so `location` follows `kind`.
 """
 files = [
     { path = "main.rue", source = """
@@ -70,11 +74,190 @@ test "two plus two is five" {
 args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
-    '"failure":{"exit_code":101,"kind":"assert"',
-    '"message":"assertion failed"',
+    '"failure":{"exit_code":101,"kind":"assert","location":{"column":5,"file":"tests.rue","line":2}',
+    '"message":"assertion failed"}',
+    '"stderr":{"bytes_total":17,"data":"assertion failed\n","encoding":"utf8"}',
     '"verdict":"fail"',
     '"crash":0,"event":"run_finished","failed":1,"passed":0',
 ]
+
+[[case]]
+name = "an_assert_message_is_the_frames_message_under_the_same_kind"
+description = """
+`@assert(cond, "msg")` publishes the programmer's text as the frame's message
+under the same `assert` kind, so a consumer never has to know which spelling
+failed. Its stderr is unchanged and is `@panic`'s: `panic: <msg>` — which the
+sibling case above shows would classify as `trap:panic` on stderr alone. The
+frame is what makes it an assertion, and it carries the intrinsic's site.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "checks the port" {
+    let port: i32 = 0;
+    @assert(port != 0, "port must be assigned");
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"assert","location":{"column":5,"file":"tests.rue","line":3}',
+    '"message":"port must be assigned"}',
+    '"stderr":{"bytes_total":29,"data":"panic: port must be assigned\n","encoding":"utf8"}',
+    '"verdict":"fail"',
+]
+
+[[case]]
+name = "each_bare_assert_in_one_body_names_its_own_line"
+description = """
+The gap RUE-1953 closed: several bare assertions in one body used to report the
+declaration header, because the kind was classified from stderr and stderr
+carries no site. The second assertion is the one that fails, and the record says
+so.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "several checks" {
+    @assert(1 + 1 == 2);
+    @assert(2 + 2 == 5);
+    @assert(3 + 3 == 6);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"assert","location":{"column":5,"file":"tests.rue","line":3}',
+    '"message":"assertion failed"}',
+]
+
+[[case]]
+name = "an_owned_assert_message_reports_its_own_length"
+description = """
+A `StrBuf` message is narrowed to a `{ptr, len}` view before it reaches the
+report, the same narrowing `@panic` performs (RUE-1066). The assertion used to
+hand the runtime the StrBuf header's first two slots — `buf` and `cap` — so
+`@assert(false, @to_string(8))` wrote `panic: 8` followed by the uninitialized
+remainder of a 16-byte buffer, while `@panic` on the same value was always
+correct. The captured stderr's byte count is what pins that the two now agree.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+test "formats its message" {
+    @assert(1 + 1 == 3, @to_string(8));
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"assert","location":{"column":5,"file":"tests.rue","line":4}',
+    '"message":"8"}',
+    '"stderr":{"bytes_total":9,"data":"panic: 8\n","encoding":"utf8"}',
+]
+
+[[case]]
+name = "the_human_rendering_of_an_assert_names_its_message_and_site"
+description = """
+The default renderer reads the same record the event stream does, so a bare
+assertion prints `assert: assertion failed  (file:line:col)` and a message one
+prints its own text in the same shape.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "bare" {
+    @assert(2 + 2 == 5);
+}
+
+test "with a message" {
+    @assert(2 + 2 == 5, "arithmetic is broken");
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    "assert: assertion failed  (tests.rue:2:5)",
+    "assert: arithmetic is broken  (tests.rue:6:5)",
+]
+
+[[case]]
+name = "an_ordinary_build_keeps_both_pinned_assert_messages"
+description = """
+`@assert` lowers the same way outside a test image (spec 4.13:5d): there is no
+descriptor 3, the frame write fails with `EBADF` as designed, and the pinned
+stderr message plus status 101 is the whole report. Adding the report changed
+neither message.
+"""
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @assert(1 + 1 == 3);
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["assertion failed"]
+
+[[case]]
+name = "an_ordinary_build_prints_an_assert_message_as_a_panic"
+description = "The message form's stderr is `@panic`'s, unchanged (spec 4.13:5d)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @assert(1 + 1 == 3, "why");
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: why"]
+
+[[case]]
+name = "an_empty_assert_message_stays_the_message_form"
+description = """
+`@assert(cond, "")` is the message form with nothing in it, and still writes
+`@panic`'s bare `panic: ` line rather than collapsing into `assertion failed`.
+The runtime is told which form it is rather than inferring it from the message's
+length, and this is the case that would notice if that changed: the substring
+here is not one the bare form can produce.
+"""
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @assert(1 + 1 == 3, "");
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: "]
 
 [[case]]
 name = "a_panicking_test_is_kind_trap_panic"

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2470,7 +2470,6 @@ impl<'a> CfgLower<'a> {
             rue_air::IntrinsicOperation::PanicNoMessage
             | rue_air::IntrinsicOperation::Panic
             | rue_air::IntrinsicOperation::AssertFailed
-            | rue_air::IntrinsicOperation::AssertWithMessage
             | rue_air::IntrinsicOperation::BoundsCheck => {
                 unreachable!("trap handled above")
             }

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -836,10 +836,6 @@ mod tests {
             IntrinsicOperation::AssertFailed | IntrinsicOperation::BoundsCheck => {
                 vec![append(CfgInstData::BoolConst(false), Type::BOOL)]
             }
-            IntrinsicOperation::AssertWithMessage => vec![
-                append(CfgInstData::BoolConst(false), Type::BOOL),
-                append(CfgInstData::StringConst(0), str_ty),
-            ],
             IntrinsicOperation::DebugI64 => vec![append(CfgInstData::Const(7), Type::I64)],
             IntrinsicOperation::DebugU64 => vec![append(CfgInstData::Const(7), Type::U64)],
             IntrinsicOperation::DebugBool => {
@@ -1153,7 +1149,6 @@ mod tests {
             IntrinsicOperation::PanicNoMessage,
             IntrinsicOperation::Panic,
             IntrinsicOperation::AssertFailed,
-            IntrinsicOperation::AssertWithMessage,
             IntrinsicOperation::BoundsCheck,
             IntrinsicOperation::DebugI64,
             IntrinsicOperation::DebugU64,

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1771,37 +1771,16 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                 Some(ValueKind::Intrinsic)
             } else if matches!(
                 operation,
-                IntrinsicOperation::AssertFailed
-                    | IntrinsicOperation::AssertWithMessage
-                    | IntrinsicOperation::BoundsCheck
+                IntrinsicOperation::AssertFailed | IntrinsicOperation::BoundsCheck
             ) {
+                // Both take no runtime arguments: the condition is tested here
+                // and the helper it guards is a bare abort. `@assert`'s own
+                // failure is not one of these — it is a branch around the
+                // ADR-0083 §5.1 report, planned as ordinary runtime calls.
                 let runtime = operation
                     .runtime_call_kind()
                     .expect("assert operation must be runtime-backed");
-                let call = match operation {
-                    IntrinsicOperation::AssertFailed | IntrinsicOperation::BoundsCheck => {
-                        crate::runtime_call_plan::RuntimeCallPlan::no_args(runtime.helper())
-                    }
-                    IntrinsicOperation::AssertWithMessage => {
-                        let message = values
-                            .get(1)
-                            .expect("validated message assertion must carry text");
-                        crate::runtime_call_plan::RuntimeCallPlan::expect_manifest(
-                            runtime.helper(),
-                            [
-                                crate::runtime_call_plan::RuntimeCallArg::const_pointer(
-                                    message.slots[0],
-                                    rue_runtime_abi::AbiType::Byte,
-                                ),
-                                crate::runtime_call_plan::RuntimeCallArg::value(
-                                    message.slots[1],
-                                    rue_runtime_abi::AbiType::U64,
-                                ),
-                            ],
-                        )
-                    }
-                    _ => unreachable!("non-assert operation in assert dispatch"),
-                };
+                let call = crate::runtime_call_plan::RuntimeCallPlan::no_args(runtime.helper());
                 let result = adapter.emit_trap(TrapPlan::Assert {
                     condition: values[0].primary,
                     call,
@@ -2147,7 +2126,6 @@ fn intrinsic_runtime_call(
         IntrinsicOperation::Panic
         | IntrinsicOperation::PanicNoMessage
         | IntrinsicOperation::AssertFailed
-        | IntrinsicOperation::AssertWithMessage
         | IntrinsicOperation::BoundsCheck => {
             unreachable!("trap runtime calls are planned by exact operation above")
         }
@@ -3421,10 +3399,6 @@ mod tests {
             (
                 IntrinsicOperation::AssertFailed,
                 RuntimeHelperId::AssertFailed,
-            ),
-            (
-                IntrinsicOperation::AssertWithMessage,
-                RuntimeHelperId::Panic,
             ),
             (
                 IntrinsicOperation::BoundsCheck,

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2767,7 +2767,6 @@ impl<'a> CfgLower<'a> {
             rue_air::IntrinsicOperation::PanicNoMessage
             | rue_air::IntrinsicOperation::Panic
             | rue_air::IntrinsicOperation::AssertFailed
-            | rue_air::IntrinsicOperation::AssertWithMessage
             | rue_air::IntrinsicOperation::BoundsCheck => {
                 unreachable!("trap handled above")
             }

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -1364,6 +1364,13 @@ drop fn StrBuf(self) { }
         fn assert_uses_the_unit_contract_through_cfg() {
             // `@assert` is unit-typed: it returns on the success path, so the CFG
             // reuses the `UnitConst`-style dummy value for the trailing return.
+            //
+            // Its failure is a branch around the ADR-0083 §5.1 report rather
+            // than one conditional runtime helper (RUE-1953), so what the CFG
+            // must retain is the ordered pair of channel calls — the site the
+            // record adopts, then the terminal report — and nothing between
+            // them. Both spellings emit the same pair; only the `with_message`
+            // operand differs.
             for (name, body) in [
                 ("assertion", "@assert(true)"),
                 ("assertion_with_message", "@assert(true, \"ok\")"),
@@ -1378,40 +1385,32 @@ drop fn StrBuf(self) { }
                     .unwrap_or_else(|| panic!("missing CFG for {name}"))
                     .record
                     .cfg;
-                let intrinsic_types: Vec<_> = cfg
-                    .blocks()
-                    .iter()
-                    .flat_map(|block| block.insts.iter())
-                    .filter_map(|value| {
-                        let inst = cfg.get_inst(*value);
-                        matches!(inst.data, rue_cfg::CfgInstData::Intrinsic { .. })
-                            .then_some(inst.ty)
-                    })
-                    .collect();
-                assert_eq!(
-                    intrinsic_types,
-                    vec![Type::UNIT],
-                    "{name} must carry the unit result into CFG"
+                assert!(
+                    !cfg.blocks()
+                        .iter()
+                        .flat_map(|block| block.insts.iter())
+                        .any(|value| matches!(
+                            cfg.get_inst(*value).data,
+                            rue_cfg::CfgInstData::Intrinsic { .. }
+                        )),
+                    "{name} must no longer lower to a conditional assert intrinsic"
                 );
                 let runtime_kinds: Vec<_> = cfg
                     .blocks()
                     .iter()
                     .flat_map(|block| block.insts.iter())
                     .filter_map(|value| match cfg.get_inst(*value).data {
-                        rue_cfg::CfgInstData::Intrinsic { operation, .. } => {
-                            operation.runtime_call()
-                        }
+                        rue_cfg::CfgInstData::Call { runtime, .. } => runtime,
                         _ => None,
                     })
                     .collect();
                 assert_eq!(
                     runtime_kinds,
-                    vec![if name == "assertion_with_message" {
-                        rue_air::RuntimeCallKind::AssertWithMessage
-                    } else {
-                        rue_air::RuntimeCallKind::AssertFailed
-                    }],
-                    "CompilerSession CFG artifacts must retain typed assert identity"
+                    vec![
+                        rue_air::RuntimeCallKind::TestFailureSite,
+                        rue_air::RuntimeCallKind::TestFailAssert,
+                    ],
+                    "CompilerSession CFG artifacts must retain the reporting pair"
                 );
 
                 let return_values: Vec<_> = cfg

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -2465,7 +2465,7 @@ mod runtime_archive_validation_tests {
         inventory.symbols.push(marker("__rue_runtime_abi_v0", 1));
         let stale = error(&inventory, RuntimeTarget::Aarch64Linux);
         assert!(stale.contains(
-            "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v4`"
+            "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v5`"
         ));
 
         inventory
@@ -2619,7 +2619,7 @@ mod runtime_archive_validation_tests {
         let err = validation_error(&bytes);
         assert!(
             err.contains(
-                "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v4`"
+                "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v5`"
             ),
             "{err}"
         );

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1205,7 +1205,6 @@ fn unsupported_intrinsic_kind_for_operation(
         rue_air::IntrinsicOperation::PanicNoMessage
         | rue_air::IntrinsicOperation::Panic
         | rue_air::IntrinsicOperation::AssertFailed
-        | rue_air::IntrinsicOperation::AssertWithMessage
         | rue_air::IntrinsicOperation::BoundsCheck
         | rue_air::IntrinsicOperation::DebugI64
         | rue_air::IntrinsicOperation::DebugU64
@@ -1240,7 +1239,6 @@ fn unsupported_runtime_call_kind(kind: RuntimeCallKind) -> Option<UnsupportedRun
         | RuntimeCallKind::Panic
         | RuntimeCallKind::PanicNoMessage
         | RuntimeCallKind::AssertFailed
-        | RuntimeCallKind::AssertWithMessage
         | RuntimeCallKind::BoundsCheck
         | RuntimeCallKind::ReadLine
         | RuntimeCallKind::ParseI32
@@ -1264,17 +1262,19 @@ fn unsupported_runtime_call_kind(kind: RuntimeCallKind) -> Option<UnsupportedRun
         | RuntimeCallKind::ByteMove
         | RuntimeCallKind::ByteSet
         // The ADR-0083 test channel. The dispatcher's own helpers belong to a
-        // test image, which the oracle never compiles. The reporting helpers
-        // are reachable in an ordinary program — `@assert_eq` lowers to them —
-        // but only after the rendering that precedes them, and that rendering
-        // opens with the allocation helper below, so the interpreter has
-        // already stopped at a registered gap by the time a channel call is
-        // evaluated.
+        // test image, which the oracle never compiles. Of the reporting helpers
+        // reachable in an ordinary program, the two `@assert` lowers to are
+        // modeled outright (`preflight_test_channel_call`), because nothing
+        // precedes them to stop at. `__rue_test_fail` and its comparison form
+        // are reached only after a rendering that opens with the allocation
+        // helper above, so the interpreter has already stopped at a registered
+        // gap by the time either is evaluated.
         | RuntimeCallKind::TestNormalizeProcess
         | RuntimeCallKind::TestComplete
         | RuntimeCallKind::TestFailureSite
         | RuntimeCallKind::TestFail
         | RuntimeCallKind::TestFailComparison
+        | RuntimeCallKind::TestFailAssert
         | RuntimeCallKind::TestUsageError => None,
     }
 }
@@ -1584,6 +1584,88 @@ impl<'a> Interp<'a> {
             generation: self.heap[alloc].generation,
             byte_offset: 0,
         }))
+    }
+
+    /// Whether `kind` is a §5.1 failure-channel call the interpreter models,
+    /// validating its whole static shape before an operand is evaluated.
+    ///
+    /// `@assert` lowers to the staging call and the terminal report in every
+    /// build, not only in a test image (spec 4.13:5d, ADR-0083), so an ordinary
+    /// corpus program reaches both — and, unlike the comparison family, with no
+    /// rendering in front of them to stop at. The channel itself is invisible
+    /// here: an ordinary process has no descriptor 3, so the frame write fails
+    /// with `EBADF` by design and what is left to model is the staging call's
+    /// absence of effect and the terminal call's pinned abort.
+    fn preflight_test_channel_call(
+        &self,
+        kind: RuntimeCallKind,
+        arg_types: &[Type],
+        arg_modes: &[CfgArgMode],
+        result_ty: Type,
+    ) -> Step<bool> {
+        let expected = match kind {
+            RuntimeCallKind::TestFailureSite => 3,
+            RuntimeCallKind::TestFailAssert => 2,
+            _ => return Ok(false),
+        };
+        let name = kind.helper().symbol();
+        if arg_types.len() != expected || arg_modes.len() != expected {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallArity),
+                format!("runtime call '{name}' arity"),
+            ));
+        }
+        if !arg_modes.iter().all(|mode| *mode == CfgArgMode::Normal) {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature),
+                format!("runtime call '{name}' argument mode"),
+            ));
+        }
+        let signature_matches = match kind {
+            RuntimeCallKind::TestFailureSite => {
+                self.is_str_like_type(arg_types[0])
+                    && arg_types[1] == Type::U32
+                    && arg_types[2] == Type::U32
+                    && result_ty == Type::UNIT
+            }
+            _ => {
+                self.is_str_like_type(arg_types[0])
+                    && arg_types[1] == Type::U32
+                    && result_ty == PANIC_CFG_RESULT_TYPE
+            }
+        };
+        if !signature_matches {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature),
+                format!("runtime call '{name}' signature"),
+            ));
+        }
+        Ok(true)
+    }
+
+    /// Execute one modeled failure-channel call.
+    ///
+    /// The staging call has no observable effect in an ordinary program, and
+    /// the terminal one writes exactly what spec 4.13:5d pins — the same two
+    /// messages, and the same two trap categories, the conditional `@assert`
+    /// intrinsic wrote before the report was added.
+    fn eval_test_channel_call(&mut self, kind: RuntimeCallKind, args: &[Value]) -> Step<Value> {
+        if kind == RuntimeCallKind::TestFailureSite {
+            return Ok(Value::Unit);
+        }
+        match args {
+            [_, Value::Int(0)] => {
+                self.abort_with_stderr(TrapKind::AssertionFailure, &[b"assertion failed\n"])
+            }
+            [message, Value::Int(_)] if Self::text_ptr_len(message).is_some() => {
+                let bytes = self.text_bytes(message)?;
+                self.abort_with_stderr(TrapKind::UserPanic, &[b"panic: ", &bytes, b"\n"])
+            }
+            _ => Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature),
+                "runtime call '__rue_test_fail_assert' runtime value shape",
+            )),
+        }
     }
 
     fn classify_unsupported_runtime_call_static(
@@ -2146,7 +2228,6 @@ impl<'a> Interp<'a> {
             | rue_air::IntrinsicOperation::BitCast => args.len() == 1,
             rue_air::IntrinsicOperation::TotalCmp => args.len() == 2,
             rue_air::IntrinsicOperation::PanicNoMessage => args.is_empty(),
-            rue_air::IntrinsicOperation::AssertWithMessage => args.len() == 2,
         };
         if !arity_matches {
             return UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicArity);
@@ -2288,7 +2369,6 @@ impl<'a> Interp<'a> {
             rue_air::IntrinsicOperation::PanicNoMessage
             | rue_air::IntrinsicOperation::Panic
             | rue_air::IntrinsicOperation::AssertFailed
-            | rue_air::IntrinsicOperation::AssertWithMessage
             | rue_air::IntrinsicOperation::BoundsCheck
             | rue_air::IntrinsicOperation::DebugI64
             | rue_air::IntrinsicOperation::DebugU64
@@ -2319,8 +2399,7 @@ impl<'a> Interp<'a> {
             rue_air::IntrinsicOperation::PanicNoMessage | rue_air::IntrinsicOperation::Panic => {
                 AbortIntrinsic::Panic
             }
-            rue_air::IntrinsicOperation::AssertFailed
-            | rue_air::IntrinsicOperation::AssertWithMessage => AbortIntrinsic::Assert,
+            rue_air::IntrinsicOperation::AssertFailed => AbortIntrinsic::Assert,
             rue_air::IntrinsicOperation::BoundsCheck
             | rue_air::IntrinsicOperation::DebugI64
             | rue_air::IntrinsicOperation::DebugU64
@@ -2368,7 +2447,6 @@ impl<'a> Interp<'a> {
             rue_air::IntrinsicOperation::PanicNoMessage => args.is_empty(),
             rue_air::IntrinsicOperation::Panic => args.len() == 1,
             rue_air::IntrinsicOperation::AssertFailed => args.len() == 1,
-            rue_air::IntrinsicOperation::AssertWithMessage => args.len() == 2,
             rue_air::IntrinsicOperation::BoundsCheck
             | rue_air::IntrinsicOperation::DebugI64
             | rue_air::IntrinsicOperation::DebugU64
@@ -2427,13 +2505,11 @@ impl<'a> Interp<'a> {
                         || self.is_str_like_type(ty(0))
                         || self.is_owned_string_type(ty(0)))
             }
-            AbortIntrinsic::Assert => {
-                result_ty == Type::UNIT
-                    && ty(0) == Type::BOOL
-                    && (args.len() == 1
-                        || self.is_str_like_type(ty(1))
-                        || self.is_owned_string_type(ty(1)))
-            }
+            // The conditional `assert` intrinsic carries its condition and
+            // nothing else since `@assert` moved to the §5.1 report
+            // (RUE-1953); a comptime-decidable `@assert_eq` is what still
+            // produces it.
+            AbortIntrinsic::Assert => result_ty == Type::UNIT && ty(0) == Type::BOOL,
         };
         if !signature_matches {
             return Err(unsupported(
@@ -2508,26 +2584,16 @@ impl<'a> Interp<'a> {
                 _ => unreachable!("@panic arity was preflighted"),
             },
             AbortIntrinsic::Assert => {
-                let (condition, message) = match values.as_slice() {
-                    [Value::Bool(condition)] => (*condition, None),
-                    [Value::Bool(condition), message] if Self::text_ptr_len(message).is_some() => {
-                        (*condition, Some(self.text_bytes(message)?))
-                    }
-                    _ => {
-                        return Err(unsupported(
-                            UnsupportedKind::ContractViolation(
-                                ContractViolationKind::IntrinsicSignature,
-                            ),
-                            "intrinsic @assert runtime value shape",
-                        ));
-                    }
+                let [Value::Bool(condition)] = values.as_slice() else {
+                    return Err(unsupported(
+                        UnsupportedKind::ContractViolation(
+                            ContractViolationKind::IntrinsicSignature,
+                        ),
+                        "intrinsic @assert runtime value shape",
+                    ));
                 };
-                if condition {
+                if *condition {
                     Ok(Value::Unit)
-                } else if let Some(message) = message {
-                    // The message-carrying assertion uses the same runtime path
-                    // and trap category as `@panic(message)`.
-                    self.abort_with_stderr(TrapKind::UserPanic, &[b"panic: ", &message, b"\n"])
                 } else {
                     self.abort_with_stderr(TrapKind::AssertionFailure, &[b"assertion failed\n"])
                 }
@@ -2619,7 +2685,6 @@ impl<'a> Interp<'a> {
             rue_air::IntrinsicOperation::PanicNoMessage
             | rue_air::IntrinsicOperation::Panic
             | rue_air::IntrinsicOperation::AssertFailed
-            | rue_air::IntrinsicOperation::AssertWithMessage
             | rue_air::IntrinsicOperation::BoundsCheck
             | rue_air::IntrinsicOperation::ReadLine
             | rue_air::IntrinsicOperation::ParseI32
@@ -3892,45 +3957,56 @@ impl<'a> Interp<'a> {
                 } else {
                     false
                 };
-                let missing_call_kind = if !is_string_builtin && runtime.is_some() {
-                    let runtime = runtime.expect("checked above");
-                    // A compiler-synthesized body reaches the memory helpers as
-                    // runtime calls rather than through the `@alloc` /
-                    // `@byte_copy` intrinsics that name them: drop glue and the
-                    // ADR-0083 §1 structural printer are written directly in
-                    // semantic-body form, and the printer is what a failing
-                    // `@assert_eq` calls before it reports. The interpreter's
-                    // gap is the same one either way, so it is reported as that
-                    // intrinsic's gap — which a corpus case can register —
-                    // rather than as a missing function body, which is a
-                    // harness failure. It stops here rather than joining the
-                    // output calls below, which are unmodeled *and* executable;
-                    // there is nothing to execute for an unmodeled allocation.
-                    if let Some(operation) = rue_air::IntrinsicOperation::from_runtime_call(runtime)
-                    {
-                        let borrowed = unsupported_intrinsic_kind_for_operation(operation);
-                        if borrowed.model_gap().is_some() {
-                            return Err(unsupported(borrowed, format!("call to '{fname}'")));
-                        }
-                    }
-                    let kind = self.classify_unsupported_runtime_call_static(
-                        runtime, &arg_types, &arg_modes, ty,
-                    );
-                    if kind.model_gap().is_none() {
-                        return Err(unsupported(kind, format!("call to '{fname}'")));
-                    }
-                    Some(kind)
-                } else if !is_string_builtin && self.find_function(&fname).is_none() {
-                    return Err(unsupported(
-                        UnsupportedKind::ContractViolation(
-                            ContractViolationKind::MissingFunctionBody,
-                        ),
-                        format!("call to '{fname}'"),
-                    ));
+                let is_channel_call = if let Some(runtime) = runtime {
+                    !is_string_builtin
+                        && self.preflight_test_channel_call(*runtime, &arg_types, &arg_modes, ty)?
                 } else {
-                    None
+                    false
                 };
-                if !is_string_builtin && missing_call_kind.is_none() {
+                let missing_call_kind =
+                    if !is_string_builtin && !is_channel_call && runtime.is_some() {
+                        let runtime = runtime.expect("checked above");
+                        // A compiler-synthesized body reaches the memory helpers as
+                        // runtime calls rather than through the `@alloc` /
+                        // `@byte_copy` intrinsics that name them: drop glue and the
+                        // ADR-0083 §1 structural printer are written directly in
+                        // semantic-body form, and the printer is what a failing
+                        // `@assert_eq` calls before it reports. The interpreter's
+                        // gap is the same one either way, so it is reported as that
+                        // intrinsic's gap — which a corpus case can register —
+                        // rather than as a missing function body, which is a
+                        // harness failure. It stops here rather than joining the
+                        // output calls below, which are unmodeled *and* executable;
+                        // there is nothing to execute for an unmodeled allocation.
+                        if let Some(operation) =
+                            rue_air::IntrinsicOperation::from_runtime_call(runtime)
+                        {
+                            let borrowed = unsupported_intrinsic_kind_for_operation(operation);
+                            if borrowed.model_gap().is_some() {
+                                return Err(unsupported(borrowed, format!("call to '{fname}'")));
+                            }
+                        }
+                        let kind = self.classify_unsupported_runtime_call_static(
+                            runtime, &arg_types, &arg_modes, ty,
+                        );
+                        if kind.model_gap().is_none() {
+                            return Err(unsupported(kind, format!("call to '{fname}'")));
+                        }
+                        Some(kind)
+                    } else if !is_string_builtin
+                        && !is_channel_call
+                        && self.find_function(&fname).is_none()
+                    {
+                        return Err(unsupported(
+                            UnsupportedKind::ContractViolation(
+                                ContractViolationKind::MissingFunctionBody,
+                            ),
+                            format!("call to '{fname}'"),
+                        ));
+                    } else {
+                        None
+                    };
+                if !is_string_builtin && !is_channel_call && missing_call_kind.is_none() {
                     let callee = &*self.state.functions[self
                         .find_function(&fname)
                         .expect("a present user call has a CFG body")]
@@ -3977,6 +4053,11 @@ impl<'a> Interp<'a> {
                         ty,
                     )?
                     .expect("preflight recognized this String builtin")
+                } else if is_channel_call {
+                    self.eval_test_channel_call(
+                        runtime.expect("typed runtime channel call"),
+                        &argvals,
+                    )?
                 } else if missing_call_kind.is_some() {
                     let runtime = runtime.expect("typed runtime output call");
                     // Static validation above establishes the compiler/runtime
@@ -4043,8 +4124,7 @@ impl<'a> Interp<'a> {
                     }
                     rue_air::IntrinsicOperation::PanicNoMessage
                     | rue_air::IntrinsicOperation::Panic
-                    | rue_air::IntrinsicOperation::AssertFailed
-                    | rue_air::IntrinsicOperation::AssertWithMessage => {
+                    | rue_air::IntrinsicOperation::AssertFailed => {
                         let Some(intrinsic) =
                             self.preflight_abort_intrinsic(cfg, *operation, &args, ty)?
                         else {
@@ -6515,7 +6595,6 @@ impl<'a> Interp<'a> {
             rue_air::IntrinsicOperation::PanicNoMessage
             | rue_air::IntrinsicOperation::Panic
             | rue_air::IntrinsicOperation::AssertFailed
-            | rue_air::IntrinsicOperation::AssertWithMessage
             | rue_air::IntrinsicOperation::BoundsCheck
             | rue_air::IntrinsicOperation::DebugI64
             | rue_air::IntrinsicOperation::DebugU64

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -945,7 +945,6 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
         Operation::PanicNoMessage,
         Operation::Panic,
         Operation::AssertFailed,
-        Operation::AssertWithMessage,
         Operation::BoundsCheck,
         Operation::DebugI64,
         Operation::DebugU64,
@@ -961,7 +960,7 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
         );
     }
 
-    assert_eq!(Operation::ALL.len(), 46);
+    assert_eq!(Operation::ALL.len(), 45);
 }
 
 #[test]
@@ -1410,6 +1409,39 @@ fn slice_bounds_check_uses_index_trap_category_without_changing_assertions() {
     let assertion = run("fn main() -> i32 { @assert(false); 0 }");
     assert_eq!(assertion.stderr, "assertion failed\n");
     assert_eq!(assertion.panic, Some(TrapKind::AssertionFailure));
+}
+
+/// `@assert` reports on the ADR-0083 §5.1 channel in every build (RUE-1953),
+/// so a failing assertion in an ordinary program is a branch around two channel
+/// calls rather than one conditional intrinsic. The interpreter models both —
+/// the staged site has no observable effect where there is no descriptor 3, and
+/// the terminal call aborts — and what it must agree with the native runtime
+/// about is exactly what spec 4.13:5d pins: the two messages and the trap
+/// category each takes.
+#[test]
+fn assert_reports_through_the_channel_and_keeps_its_pinned_messages() {
+    let bare = run("fn main() -> i32 { @assert(1 + 1 == 3); 0 }");
+    assert_eq!(bare.exit_code, 101);
+    assert_eq!(bare.stderr, "assertion failed\n");
+    assert_eq!(bare.panic, Some(TrapKind::AssertionFailure));
+
+    let message = run(r#"fn main() -> i32 { @assert(1 + 1 == 3, "why"); 0 }"#);
+    assert_eq!(message.exit_code, 101);
+    assert_eq!(message.stderr, "panic: why\n");
+    assert_eq!(message.panic, Some(TrapKind::UserPanic));
+
+    // An empty message is still the message form: the runtime is told which
+    // form it is rather than inferring it from the message's length.
+    let empty = run(r#"fn main() -> i32 { @assert(1 + 1 == 3, ""); 0 }"#);
+    assert_eq!(empty.exit_code, 101);
+    assert_eq!(empty.stderr, "panic: \n");
+    assert_eq!(empty.panic, Some(TrapKind::UserPanic));
+
+    // A holding assertion never enters the arm, so no channel call is reached
+    // and the message it would have carried is still evaluated for its effects.
+    let holds = run(r#"fn main() -> i32 { @assert(1 + 1 == 2, "unused"); 7 }"#);
+    assert_eq!(holds.exit_code, 7);
+    assert_eq!(holds.panic, None);
 }
 
 #[test]

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -772,9 +772,14 @@ fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
 
 #[test]
 fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
+    // A comptime-decidable `@assert_eq` is what still lowers to the conditional
+    // `assert` intrinsic: source `@assert` reports on the ADR-0083 §5.1 channel
+    // instead (RUE-1953), so it is a branch around two runtime calls and no
+    // longer an abort intrinsic to preflight. The intrinsic that remains takes
+    // its condition and nothing else.
     let source = r#"fn main() -> i32 {
         let entropy: u32 = @random_u32();
-        @assert(true, "ok");
+        @assert_eq(1, 1);
         @panic("stop");
         if entropy == 0 { 0 } else { 1 }
     }"#;
@@ -815,13 +820,13 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
             ),
             2 => (
                 assertion,
-                vec![assert_args[0], assert_args[1], random],
+                vec![assert_args[0], random],
                 Type::UNIT,
                 ContractViolationKind::IntrinsicArity,
             ),
             3 => (
                 assertion,
-                vec![random, assert_args[1]],
+                vec![random],
                 Type::UNIT,
                 ContractViolationKind::IntrinsicSignature,
             ),
@@ -872,15 +877,18 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
 
 #[test]
 fn abort_intrinsics_require_exact_runtime_value_shapes() {
+    // As above: the surviving `assert` intrinsic is the comptime-decidable
+    // comparison's, whose only operand is the condition. `@panic` is the one
+    // abort intrinsic that still carries text.
     let source = r#"fn main() -> i32 {
-        @assert(true, "ok");
+        @assert_eq(1, 1);
         @panic("stop");
         0
     }"#;
 
-    for name in ["panic", "assert"] {
+    {
         let state = query_cfg_state(source).expect("abort value-shape probe must compile");
-        let (cfg, intrinsic, args, _) = find_intrinsic_in_function(&state, "main", name);
+        let (cfg, intrinsic, args, _) = find_intrinsic_in_function(&state, "main", "panic");
         let mut interp = Interp {
             state: &state,
             stdout_trace: Vec::new(),
@@ -901,14 +909,13 @@ fn abort_intrinsics_require_exact_runtime_value_shapes() {
             param_places: HashMap::new(),
             place_return: false,
         };
-        let corrupted = if name == "panic" { args[0] } else { args[1] };
-        frame.cache.insert(corrupted.as_u32(), Value::Int(7));
+        frame.cache.insert(args[0].as_u32(), Value::Int(7));
 
         let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, intrinsic));
         assert_eq!(
             unsupported.kind(),
             UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
-            "@{name} must reject a non-text runtime value"
+            "@panic must reject a non-text runtime value"
         );
     }
 
@@ -1369,8 +1376,7 @@ fn every_source_intrinsic_operation_survives_semantic_export_import_and_cfg_buil
             let unsigned: u32 = 1;
             let wide_signed: i64 = -2;
             let wide_unsigned: u64 = 2;
-            @assert(true);
-            @assert(true, "ok");
+            @assert_eq(1, 1);
             @dbg(wide_signed);
             @dbg(wide_unsigned);
             @dbg(true);
@@ -1439,7 +1445,7 @@ fn every_source_intrinsic_operation_survives_semantic_export_import_and_cfg_buil
             }
         }
     }
-    assert_eq!(rue_air::IntrinsicOperation::ALL.len(), 46);
+    assert_eq!(rue_air::IntrinsicOperation::ALL.len(), 45);
     for operation in rue_air::IntrinsicOperation::ALL {
         if matches!(
             operation,

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -16,7 +16,7 @@ use core::fmt;
 #[macro_export]
 macro_rules! runtime_abi_version {
     ($callback:ident) => {
-        $callback!(4, __rue_runtime_abi_v4);
+        $callback!(5, __rue_runtime_abi_v5);
     };
 }
 
@@ -1012,6 +1012,24 @@ macro_rules! for_each_runtime_helper {
             safety: READABLE.union(TERMINATES),
             returns: NEVER
         },
+        // The `@assert` form of the same terminal call (spec 4.13:5d). Its
+        // two stderr messages are two different pinned strings rather than one
+        // string built from the kind, so the form travels as a parameter:
+        // `with_message` selects the user's text and `@panic`'s `panic: `
+        // prefix over the bare `assertion failed` that is both the frame's
+        // message and the whole stderr line. Neither form carries a `payload`;
+        // a bare assertion has nothing structured to put in one.
+        TestFailAssert => unsafe __rue_test_fail_assert(
+            message_ptr: *const u8,
+            message_len: u64,
+            with_message: u32,
+        ) -> ! {
+            symbol: "__rue_test_fail_assert",
+            parameters: params![BYTE_VIEW, U64_VALUE, U32_VALUE],
+            result: VOID,
+            safety: READABLE.union(TERMINATES),
+            returns: NEVER
+        },
         TestUsageError => safe __rue_test_usage_error() {
             symbol: "__rue_test_usage_error",
             parameters: params![],
@@ -1377,10 +1395,11 @@ const fn starts_with(value: &str, prefix: &str) -> bool {
 
 const fn ends_with_decimal_version(symbol: &str, version: u32) -> bool {
     // Version 3 added the ADR-0083 §5.1 comparison failure channel; version 4
-    // added width-explicit float formatting. This explicit check makes an ABI
-    // bump update both metadata values rather than silently retaining a stale
-    // symbol.
-    version == 4 && string_eq(symbol, "__rue_runtime_abi_v4")
+    // added width-explicit float formatting; version 5 added the channel's
+    // `@assert` form, `__rue_test_fail_assert`. This explicit check makes an
+    // ABI bump update both metadata values rather than silently retaining a
+    // stale symbol.
+    version == 5 && string_eq(symbol, "__rue_runtime_abi_v5")
 }
 
 /// Validate all table ordering, uniqueness, classification, and layout invariants.
@@ -1466,7 +1485,7 @@ mod tests {
     #[test]
     fn manifest_is_const_valid_and_exhaustive() {
         assert_eq!(validate_manifest(), Ok(()));
-        assert_eq!(RuntimeHelperId::ALL.len(), 53);
+        assert_eq!(RuntimeHelperId::ALL.len(), 54);
         assert_eq!(RuntimeHelperId::ALL.len(), RUNTIME_HELPERS.len());
         for (index, id) in RuntimeHelperId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, index);
@@ -1540,6 +1559,7 @@ mod tests {
             "__rue_test_failure_site",
             "__rue_test_fail",
             "__rue_test_fail_comparison",
+            "__rue_test_fail_assert",
             "__rue_test_usage_error",
         ];
         assert_eq!(
@@ -1552,7 +1572,7 @@ mod tests {
     #[test]
     fn every_helper_has_the_exact_accepted_signature_and_contract() {
         fn check(
-            visited: &mut [bool; 53],
+            visited: &mut [bool; 54],
             ids: &[RuntimeHelperId],
             parameters: &[AbiParameter],
             result: AbiResult,
@@ -1573,7 +1593,7 @@ mod tests {
             }
         }
 
-        let mut visited = [false; 53];
+        let mut visited = [false; 54];
         check(
             &mut visited,
             &[RuntimeHelperId::Exit],
@@ -1842,6 +1862,14 @@ mod tests {
             READABLE.union(TERMINATES),
             NEVER,
         );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::TestFailAssert],
+            &[BYTE_VIEW, U64_VALUE, U32_VALUE],
+            VOID,
+            READABLE.union(TERMINATES),
+            NEVER,
+        );
         assert!(visited.into_iter().all(|was_visited| was_visited));
     }
 
@@ -2031,7 +2059,7 @@ mod tests {
 
     #[test]
     fn abi_version_metadata_is_a_one_byte_data_export() {
-        assert_eq!(RUNTIME_ABI_VERSION, 4);
+        assert_eq!(RUNTIME_ABI_VERSION, 5);
         assert_eq!(
             RUNTIME_ABI_VERSION_SYMBOL,
             format!("__rue_runtime_abi_v{RUNTIME_ABI_VERSION}")

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -219,6 +219,9 @@ macro_rules! call_runtime_helper_implementation {
     (__rue_test_fail_comparison($($argument:expr),*)) => {
         crate::test_channel::__rue_test_fail_comparison($($argument),*)
     };
+    (__rue_test_fail_assert($($argument:expr),*)) => {
+        crate::test_channel::__rue_test_fail_assert($($argument),*)
+    };
     (__rue_test_usage_error($($argument:expr),*)) => {
         crate::test_channel::__rue_test_usage_error($($argument),*)
     };

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -66,6 +66,14 @@ const PAYLOAD_FIELD: [u8; 13] = *b"},\"payload\":\"";
 const LEFT_FIELD: [u8; 10] = *b"},\"left\":\"";
 const RIGHT_FIELD: [u8; 11] = *b"\",\"right\":\"";
 const FRAME_TAIL: [u8; 3] = *b"\"}\n";
+/// Closes the location object and the record with no field after it: the shape
+/// a bare assertion writes, which has neither an open `payload` nor a pair of
+/// operands to report.
+const LOCATION_TAIL: [u8; 3] = *b"}}\n";
+
+/// The kind `@assert` reports under, both spellings alike, so a consumer never
+/// has to know which one failed.
+const ASSERT_KIND: [u8; 6] = *b"assert";
 
 /// The pinned message each comparison kind reports.
 ///
@@ -285,6 +293,18 @@ fn comparison_message(kind: &[u8]) -> &'static [u8] {
     }
 }
 
+/// Write one `@assert` failure frame (spec 4.13:5d).
+///
+/// The kind is pinned rather than passed — `@assert` is the only producer — and
+/// the record ends at the location object: a bare assertion has no operands to
+/// report and nothing structured to put in the open `payload`, and an empty
+/// `payload` would claim otherwise.
+fn assert_frame(emit: &mut dyn FnMut(&[u8]), message: &[u8], file: &[u8], line: u32, column: u32) {
+    let mut writer = FrameWriter::new(emit);
+    failure_head(&mut writer, &ASSERT_KIND, message, file, line, column);
+    writer.raw(&LOCATION_TAIL);
+}
+
 /// Best-effort write of already-framed bytes to the inherited channel.
 fn emit_to_channel(bytes: &[u8]) {
     // Discarded deliberately: `EBADF` when the program was run by hand without
@@ -494,6 +514,79 @@ crate::define_runtime_implementation! {
 }
 
 crate::define_runtime_implementation! {
+    /// Report a failed `@assert`, then abort like any other trap.
+    ///
+    /// The `@assert` form of [`__rue_test_fail`] (spec 4.13:5d). It writes a
+    /// `failure` frame of kind `assert` carrying whatever location
+    /// [`__rue_test_failure_site`] staged, and then writes the pinned stderr
+    /// line the assertion has always written and exits 101.
+    ///
+    /// `@assert` has two pinned stderr forms rather than one, which is why the
+    /// form is a parameter instead of a second symbol. With `with_message`
+    /// zero, the message is not read at all: the frame carries the pinned
+    /// `assertion failed`, and so does stderr, through the same
+    /// [`crate::error::__rue_assert_failed`] the assertion used before it
+    /// reported anything. Otherwise the caller's text is both the frame's
+    /// message and `@panic`'s: `panic: {message}`. An empty message is
+    /// therefore still the message form — `@assert(c, "")` keeps printing
+    /// `panic: ` — because the form is stated, not inferred from the length.
+    ///
+    /// Both halves matter in different builds. Inside a test image the frame is
+    /// what the runner reads; in an ordinary executable there is no descriptor
+    /// 3, the frame write fails with `EBADF` as designed, and the pinned stderr
+    /// message is the whole report. `@assert` therefore lowers the same way
+    /// wherever it is written.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_test_fail_assert(
+    ///     message_ptr: *const u8, message_len: u64, with_message: u32,
+    /// ) -> !
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// `message_ptr`/`message_len` must describe initialized bytes valid for
+    /// the call, or be null with a zero length.
+    pub unsafe extern "C" fn __rue_test_fail_assert(
+        message_ptr: *const u8,
+        message_len: u64,
+        with_message: u32,
+    ) -> ! {
+        // SAFETY: the caller guarantees the pair describes readable bytes.
+        let message = unsafe { view(message_ptr, message_len) };
+        let position = SITE_POSITION.load(Ordering::Relaxed);
+        // SAFETY: a staged site's bytes stay readable across the pair, and an
+        // unstaged one is the null-with-zero-length form `view` accepts.
+        let file = unsafe {
+            view(
+                SITE_FILE.load(Ordering::Relaxed) as *const u8,
+                SITE_FILE_LEN.load(Ordering::Relaxed),
+            )
+        };
+        let framed = if with_message == 0 {
+            &ASSERT_MESSAGE[..]
+        } else {
+            message
+        };
+        assert_frame(
+            &mut emit_to_channel,
+            framed,
+            file,
+            (position >> 32) as u32,
+            position as u32,
+        );
+        if with_message == 0 {
+            crate::error::__rue_assert_failed()
+        } else {
+            // SAFETY: `message` is a live borrow of the caller's bytes.
+            unsafe { crate::error::__rue_panic(message.as_ptr(), message.len() as u64) }
+        }
+    }
+}
+
+crate::define_runtime_implementation! {
     /// Write the pinned malformed-selector diagnostic to stderr and return.
     ///
     /// The dispatcher, not the runtime, owns the exit status for this case, so
@@ -643,6 +736,49 @@ mod tests {
              \"message\":\"assertion failed: left == right\",\
              \"location\":{\"file\":\"\",\"line\":0,\"column\":0},\
              \"left\":\"\",\"right\":\"\"}\n"
+        );
+    }
+
+    /// The `@assert` frame's field order, and the field it does not have: the
+    /// record ends at the location object, so a consumer reading `payload`
+    /// sees an absent field rather than an empty one that would claim the
+    /// assertion had something structured to say.
+    #[test]
+    fn assert_frame_ends_at_the_location_and_carries_no_payload() {
+        let bytes =
+            frame_bytes(|emit| assert_frame(emit, &ASSERT_MESSAGE, b"app/parser_tests.rue", 7, 3));
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert\",\
+             \"message\":\"assertion failed\",\
+             \"location\":{\"file\":\"app/parser_tests.rue\",\"line\":7,\"column\":3}}\n"
+        );
+    }
+
+    /// `@assert(cond, msg)` reports the user's text as the frame's message and
+    /// keeps the same shape: one kind for both forms, so a consumer never has
+    /// to know which spelling failed.
+    #[test]
+    fn an_assert_message_replaces_the_pinned_one_in_the_same_shape() {
+        let bytes = frame_bytes(|emit| assert_frame(emit, b"port must be free", b"a.rue", 12, 5));
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert\",\
+             \"message\":\"port must be free\",\
+             \"location\":{\"file\":\"a.rue\",\"line\":12,\"column\":5}}\n"
+        );
+    }
+
+    /// An assertion message is escaped by the same rule every other string is,
+    /// so user text containing a quote or a newline cannot break its frame.
+    #[test]
+    fn an_assert_message_is_escaped_like_every_other_string() {
+        let bytes = frame_bytes(|emit| assert_frame(emit, b"say \"hi\"\n", b"a.rue", 1, 1));
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"assert\",\
+             \"message\":\"say \\\"hi\\\"\\u000a\",\
+             \"location\":{\"file\":\"a.rue\",\"line\":1,\"column\":1}}\n"
         );
     }
 

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -684,6 +684,16 @@ companion project "rue test follow-ups" (§6).
       Pulled ahead of all deferred work deliberately: unstructured failure
       output is the primary agent token sink, and a runner that is
       agent-first in transport but prose in content has not met the bar.
+- [x] **Phase 2.6: `@assert` reports its own site** - RUE-1953. `@assert`
+      joins the family on the §5.1 channel through one further helper,
+      `__rue_test_fail_assert` (ABI version 5), so a test with several bare
+      assertions names the one that failed instead of the declaration
+      header. It lowers to a branch around the staging and terminal calls,
+      the same shape the comparison family uses and identically inside and
+      outside a test image; both pinned stderr forms and exit 101 are
+      unchanged (spec 4.13:5d). The dedicated message-carrying `@assert`
+      lowering retires with it: the conditional `assert` intrinsic now has
+      exactly one producer, a comptime-decidable comparison.
 
 ## Consequences
 

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -89,6 +89,7 @@ budget. Two record kinds exist in this version, and `failure` has two shapes:
 {"record":"complete","schema":"1.0"}
 {"record":"failure","schema":"1.0","kind":"...","message":"...","location":{"file":"...","line":0,"column":0},"payload":"..."}
 {"record":"failure","schema":"1.0","kind":"...","message":"...","location":{"file":"...","line":0,"column":0},"left":"...","right":"..."}
+{"record":"failure","schema":"1.0","kind":"assert","message":"...","location":{"file":"...","line":0,"column":0}}
 ```
 
 The `complete` record is written by the dispatcher's epilogue alone, after the
@@ -97,8 +98,11 @@ sugar and by the test-body `?` failure arm before aborting; `kind` is an open
 field, so a user assertion library's own kind is published verbatim rather than
 flattened (ADR-0083 §5.1).
 
-A `failure` record carries **either** `payload` or the pair `left`/`right`,
-never both. `payload` is the open, versioned extension point §5.1 reserves for
+A `failure` record carries **at most one of** `payload` and the pair
+`left`/`right`, and a bare `@assert` carries neither: its record ends at the
+location object, because it has no operands to report and nothing structured to
+put in the open field. `payload` is the open, versioned extension point §5.1
+reserves for
 an assertion library with something structured to say in one string.
 `left`/`right` is the shape a **comparison** assertion writes: they are the two
 operands in the order the source spelled them, so `@assert_eq(want, got)` reads
@@ -107,12 +111,20 @@ printer under the same rules and the same 4 KiB bound the test-body `?` payload
 uses. An empty rendering is a value and stays present as an empty string; a
 comparison is recognized by the fields' presence, not by parsing `kind`.
 
-`@assert_eq` and `@assert_ne` are the producers in this version, through the
-`__rue_test_fail_comparison` helper ([runtime-abi.md](../runtime-abi.md)). They
-are ordinary intrinsics, usable anywhere `@assert` is, and they lower the same
-way in a test image and in an ordinary executable — the only difference is that
-an ordinary process has no descriptor 3, so the frame write fails with `EBADF`
-as designed and the pinned stderr message is the whole report.
+`@assert_eq` and `@assert_ne` are the producers of that pair in this version,
+through the `__rue_test_fail_comparison` helper
+([runtime-abi.md](../runtime-abi.md)). They are ordinary intrinsics, usable
+anywhere `@assert` is, and they lower the same way in a test image and in an
+ordinary executable — the only difference is that an ordinary process has no
+descriptor 3, so the frame write fails with `EBADF` as designed and the pinned
+stderr message is the whole report.
+
+`@assert` reports through the same channel, with `__rue_test_fail_assert`, and
+under the same build-independent rule. Its record's `message` is the pinned
+`assertion failed` for `@assert(cond)` and the programmer's text for
+`@assert(cond, msg)`, so both spellings publish one kind and a consumer never
+has to know which was written. Both stderr forms are unchanged: `assertion
+failed` and `panic: {msg}` respectively, with status 101 (spec 4.13:5d).
 
 Writes are best-effort by design: an image run by hand has no descriptor 3, and
 `EBADF` there is expected rather than exceptional. The channel is **not a
@@ -203,7 +215,7 @@ consumers already handle instead of adding one.
 | `exit_code` | integer | The process's exit status. **Absent** when it did not exit normally. |
 | `signal` | integer | The signal that killed it. **Absent** otherwise. |
 | `location` | object | `{"file","line","column"}` — the test declaration's header, unless a failure frame carried its own site. |
-| `payload` | string | The channel's open payload. **Absent** when empty. |
+| `payload` | string | The channel's open payload. **Absent** when empty, and a bare `@assert` writes none. |
 | `left` | string | A comparison assertion's left operand, rendered. **Absent** on every other failure. |
 | `right` | string | Its right operand, rendered. Present exactly when `left` is. |
 | `diff` | array | The runner's diff from `left` to `right`. Present exactly when `left` is. |
@@ -340,7 +352,7 @@ of stderr, and the frames read from the failure channel.
 |---------|--------------|---------------|
 | `pass` | — | Exit `0` **and** a `complete` frame was read. |
 | `fail` | `incomplete` | Exit `0` with no `complete` frame. |
-| `fail` | `assert` | The last stderr line is exactly `assertion failed`. |
+| `fail` | `assert` | A `failure` frame from a failed `@assert`, carrying the intrinsic's own site and its message. Falls back to the last stderr line being exactly `assertion failed` — which is what a comptime-decidable `@assert_eq` still reports as, and what an older image writes. |
 | `fail` | `assert_eq` | A `failure` frame from a failed `@assert_eq`, carrying `left` and `right`. |
 | `fail` | `assert_ne` | The same, from a failed `@assert_ne`. |
 | `fail` | `trap:<class>` | The last stderr line is another pinned runtime message. |

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -129,10 +129,10 @@ diagnostic and terminate the process with the runtime-error status.
 
 ## The test failure channel
 
-Six helpers implement the ADR-0083 §3 and §5.1 channel. Three are dispatcher
+Seven helpers implement the ADR-0083 §3 and §5.1 channel. Three are dispatcher
 plumbing no source spelling selects; the reporting helpers are what a test
-body's `?` and the comparison assertions lower to, in an ordinary executable as
-well as in a test image.
+body's `?` and the assertion family lower to, in an ordinary executable as well
+as in a test image.
 
 - `__rue_test_normalize_process` narrows the captured argument count to one, so
   a test observes the pinned inventory rather than the selector it was
@@ -152,15 +152,30 @@ well as in a test image.
   `assertion failed: left != right` for `assert_ne` — which is what keeps a
   six-register call able to carry both operands. It pairs with
   `__rue_test_failure_site` under the same adjacency rule.
+- `__rue_test_fail_assert` is the same terminal call for `@assert`
+  (spec 4.13:5d, ABI version 5). It writes a record of kind `assert` that ends
+  at the location — no `payload`, and no operands — and then writes the one
+  stderr line the assertion has always written. `@assert` has two pinned stderr
+  forms rather than one, so the form is a parameter instead of a second symbol:
+  with `with_message` zero the message is not read at all and both the record
+  and stderr carry the pinned `assertion failed`; otherwise the caller's text is
+  the record's message and `panic: {message}` is the stderr line. An empty
+  message is still the message form, so `@assert(c, "")` keeps printing
+  `panic: `. It pairs with `__rue_test_failure_site` under the same adjacency
+  rule.
 - `__rue_test_usage_error` writes one pinned diagnostic for a malformed
   selector and *returns*, unlike every other stderr-writing runtime path,
   because the dispatcher owns that case's exit status.
 
 `@assert_eq(l, r)` and `@assert_ne(l, r)` compile to the ordinary equality
-lowering plus, on the failing branch, the two rendering calls and this pair. The
-lowering does not depend on whether the request is a test one: an ordinary
-process simply has no descriptor 3, so the frame write fails with `EBADF` as
-designed and the pinned stderr message plus exit 101 is the whole report.
+lowering plus, on the failing branch, the two rendering calls and this pair.
+`@assert(cond)` and `@assert(cond, msg)` compile to a branch on the negated
+condition whose only arm is `__rue_test_failure_site` and
+`__rue_test_fail_assert`; the message is materialized before the branch, so it
+is still evaluated when the condition holds. The lowering does not depend on
+whether the request is a test one: an ordinary process simply has no descriptor
+3, so the frame write fails with `EBADF` as designed and the pinned stderr
+message plus exit 101 is the whole report.
 
 The completion and failure records go to a dedicated inherited descriptor,
 number 3, one JSON object per line. Writes are best-effort: a test image run by

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -171,9 +171,12 @@ and terminates with status 101, exactly as `@assert` does.
 
 Inside a test image the same failure is additionally reported as structured
 data: a record naming the failing kind, the intrinsic's source location, and
-both operands rendered as `left` and `right`. Ordinary builds are
-unaffected — the report goes to a descriptor a test runner supplies, and its
-absence is not an error. See
+both operands rendered as `left` and `right`. A failed `@assert` (4.13:5d) is
+reported the same way, naming the kind `assert`, the intrinsic's source
+location, and the message it wrote to standard error — the pinned
+`assertion failed`, or the supplied one. Ordinary builds are unaffected — the
+report goes to a descriptor a test runner supplies, and its absence is not an
+error. See
 [docs/process/test-events.md](https://github.com/rue-language/rue/blob/trunk/docs/process/test-events.md)
 for that surface, which is a tooling contract rather than a language rule.
 

--- a/reproducibility/fixture/source-order/main.rue
+++ b/reproducibility/fixture/source-order/main.rue
@@ -18,6 +18,14 @@ fn identity(comptime T: type, value: T) -> T {
 
 fn main() -> i32 {
     let result = finish(rotate(identity(i32, 10)));
-    @assert(result == 11);
+    // `@bitCast` is the intrinsic witness for the stable-IR assertion in
+    // scripts/test-reproducible-output.sh: an intrinsic resolves to its own
+    // name where an ordinary call resolves to a module-qualified one. `@assert`
+    // used to serve that role and no longer belongs to the class — since
+    // RUE-1953 it resolves to the two ADR-0083 §5.1 channel helpers, which the
+    // same assertion pins as their own resolved class.
+    let bits: u32 = @bitCast(result);
+    let round_trip: i32 = @bitCast(bits);
+    @assert(round_trip == 11);
     result
 }

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -202,16 +202,28 @@ assert_source_order_independent_ir() {
     assert_identical "source-order root-only AIR/CFG/lowering" "$ir_a" "$ir_b"
 
     # Make the comparison non-vacuous: each adapter must have resolved the
-    # symbols exercised by ordinary, generic, and intrinsic calls. A source
-    # call resolves to the callee's internal symbol, which an ordinary function
-    # qualifies by its own module (RUE-1125) and a specialization extends with
-    # its argument mangling; an intrinsic keeps its own name.
+    # symbols exercised by ordinary, generic, intrinsic, and runtime calls. A
+    # source call resolves to the callee's internal symbol, which an ordinary
+    # function qualifies by its own module (RUE-1125) and a specialization
+    # extends with its argument mangling; an intrinsic keeps its own name; a
+    # runtime call keeps the ABI symbol from the manifest. None of the four is
+    # derived from the physical root, which is what this assertion exists to
+    # pin, and each resolves by a different rule, which is why all four are
+    # listed rather than one representative.
+    #
+    # `@assert` witnesses the runtime-call rule rather than the intrinsic one:
+    # since RUE-1953 it lowers to a branch around the ADR-0083 §5.1 staging and
+    # terminal calls instead of to a conditional `assert` intrinsic, so its
+    # resolved names are those two helpers. `@bitCast` carries the intrinsic
+    # rule in its place.
     local expected_symbol
     for expected_symbol in \
         '@__rue_fn_main_2erue__rotate(' \
         '@__rue_fn_main_2erue__finish(' \
         '@__rue_fn_main_2erue__identity.i32(' \
-        '@assert('; do
+        '@bitCast(' \
+        '@__rue_test_failure_site(' \
+        '@__rue_test_fail_assert('; do
         if ! grep -Fq "$expected_symbol" "$ir_a"; then
             printf 'FAIL: stable IR omitted resolved symbol %s\n' "$expected_symbol" >&2
             return 1


### PR DESCRIPTION
Fixes RUE-1953.

In a test image only `@assert_eq`, `@assert_ne`, and the test-body `?` arm wrote a failure frame on the channel. `@assert(cond)` was classified from the stderr line alone, so its location fell back to the `test` header, and `@assert(cond, "message")` printed `panic: message` and was classified as `trap:panic`, losing the `assert` kind entirely.

`@assert` now lowers the way the comparison family does: a branch on the negated condition whose failing arm stages the site (`__rue_test_failure_site`) and calls one new terminal helper, `__rue_test_fail_assert(message, len, with_message)`, ABI version 5. The form travels as a parameter because `@assert` has two pinned stderr strings rather than one built from the kind: the bare form writes the frame and then takes the unchanged `__rue_assert_failed` path (`assertion failed`), the message form writes the frame and takes `__rue_panic` (`panic: <msg>`). stderr is byte-identical to before at -O0, -O1, and -O2, exit 101 throughout; spec 4.13:5d is unchanged and 4.13:5g's informative note now covers `@assert`. Outside a test image the frame write fails with `EBADF` as designed. No backend change: both operands stay statements of the enclosing block and the report is a sema branch.

Two consequences worth reading. `IntrinsicOperation::AssertWithMessage` and its `RuntimeCallKind` had no producer left, and the oracle asserts every operation has one, so the variant is removed across rue-air, both codegen backends, and the oracle rather than exempted; `AssertFailed` and `__rue_assert_failed` stay (the folded `@assert_eq` still produces the former). The oracle models `TestFailureSite` and `TestFailAssert` instead of registering gaps: a failing `@assert` in a corpus program would otherwise reach a `MissingFunctionBody` contract violation, which is a harness failure and not a registrable gap. One stderr change is a bug fix: a `StrBuf` message was passed to the runtime as the header's first two slots (`buf`, `cap`, not `len`, since RUE-1066 reordered the header), so `@assert(false, @to_string(8))` printed `panic: 8` followed by fifteen NUL bytes; the message now narrows through the same text view `@panic` uses, and a CLI case pins the byte count.

The runner needs no classifier change: a `failure` frame with kind `assert` already wins over the exit status, so the human renderer prints `assert: why  (file:line:col)`. The `assert` row of the taxonomy in `docs/process/test-events.md`, `docs/runtime-abi.md`, and ADR-0083 are updated.

Verification: full `scripts/rue cli` (2509), full `scripts/rue spec` (2664), full `scripts/rue ui` (329), `scripts/rue quick`, unit suites for rue-air, rue-oracle, rue-runtime, rue-runtime-abi, rue-codegen, rue-cfg, rue-compiler, `//crates/rue-runtime:runtime-archives-test` (v5 marker), doc-link, spec-traceability and ADR-registry validation, clippy and fmt clean. Eight new or updated CLI cases in `rue_test.toml`, three runtime frame-text tests, an oracle test pinning all four outcomes. Rebased over RUE-1073's ABI bump (4 to 5) and RUE-1951/1957/1958.