### PR TITLE
RUE-1963: unify Copy type policy

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -4070,3 +4070,31 @@ fn intrinsic_semantics_have_one_typed_authority_across_sema_and_durable_air() {
         }
     }
 }
+
+#[test]
+fn copy_semantics_have_one_air_policy_owner() {
+    let types = include_str!("types.rs");
+    let pool = include_str!("intern_pool.rs");
+    let import = include_str!("semantic_import.rs");
+    let ordinary = include_str!("sema/ordinary_engine.rs");
+    let identity = include_str!("sema/body_identity.rs");
+
+    assert!(pool.contains("fn is_copy_type_inner("));
+    assert!(
+        !types.contains("pub fn is_copy(&self)"),
+        "a pool-free Type::is_copy would be an incomplete composite policy"
+    );
+    assert!(ordinary.contains("ty.is_copy_in_pool(self.body_type_pool())"));
+    assert!(identity.contains("ty.is_copy_in_pool(pool)"));
+    assert!(import.contains("matches!(key, NominalInstanceKey::Anonymous(_))"));
+    assert!(import.contains("field.ty.is_copy_in_pool(type_pool)"));
+    assert!(
+        !import.contains("NominalInstanceKey::Anonymous(_) => false"),
+        "anonymous import completion must not restore a hardcoded non-Copy policy"
+    );
+    assert_eq!(
+        ordinary.matches("fn is_type_copy(&self, ty: Type)").count(),
+        1,
+        "ordinary ownership must retain only its thin pool delegate"
+    );
+}

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -2481,14 +2481,76 @@ impl TypeInternPoolInner {
         }
     }
 
+    /// Canonical Copy decision for an AIR type in this pool.
+    ///
+    /// Composite Copy behavior must be decided here because only the pool can
+    /// resolve every compact child handle. Cycles are provisionally Copy: the
+    /// equations for enum payloads and arrays are conjunctions, so a cycle is
+    /// Copy exactly when no reachable leaf disproves it. Struct declarations
+    /// are leaves because `StructDef::is_copy` records the already-validated
+    /// nominal `@copy` contract (and the derived contract for anonymous
+    /// structs).
     fn is_copy_type(&self, ty: Type) -> bool {
-        ty.as_struct()
-            .map(|id| {
-                self.struct_metadata(id)
-                    .map(|metadata| metadata.is_copy)
-                    .expect("struct type must have declaration metadata")
-            })
-            .unwrap_or_else(|| ty.is_copy())
+        self.is_copy_type_inner(ty, &mut AHashSet::new())
+    }
+
+    fn is_copy_type_inner(&self, ty: Type, visiting: &mut AHashSet<Type>) -> bool {
+        match ty.kind() {
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Unit
+            | TypeKind::Never
+            | TypeKind::Error
+            | TypeKind::Module(_)
+            | TypeKind::ComptimeType
+            | TypeKind::F32
+            | TypeKind::F64
+            | TypeKind::ComptimeFloat
+            | TypeKind::PtrConst(_)
+            | TypeKind::PtrMut(_) => true,
+            TypeKind::Struct(id) => self
+                .struct_metadata(id)
+                .map(|metadata| metadata.is_copy)
+                .expect("struct type must have declaration metadata"),
+            TypeKind::Enum(id) => {
+                if !visiting.insert(ty) {
+                    return true;
+                }
+                let is_copy = match self.try_enum_def(id) {
+                    Some(def) => def
+                        .variant_payloads
+                        .iter()
+                        .flatten()
+                        .all(|&payload| self.is_copy_type_inner(payload, visiting)),
+                    // Declaration shells exist only while the graph is being
+                    // assembled. Reaching one from a completed child's Copy
+                    // derivation is the cycle back-edge; use the same
+                    // provisional-true answer as an explicit visiting hit.
+                    None if self.enum_metadata(id).is_some() => true,
+                    None => panic!("enum type must have declaration metadata"),
+                };
+                visiting.remove(&ty);
+                is_copy
+            }
+            TypeKind::Array(id) => {
+                if !visiting.insert(ty) {
+                    return true;
+                }
+                let is_copy = self
+                    .try_array_def(id)
+                    .map(|(element, _)| self.is_copy_type_inner(element, visiting))
+                    .expect("array type must have a definition");
+                visiting.remove(&ty);
+                is_copy
+            }
+        }
     }
 
     fn stats(&self) -> TypeInternPoolStats {
@@ -4255,6 +4317,85 @@ mod tests {
             is_non_exhaustive: false,
             file_id: FileId::DEFAULT,
         }
+    }
+
+    #[test]
+    fn copy_policy_recurses_through_composites_and_terminates_on_cycles() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+
+        let mut copy_leaf = struct_def("CopyLeaf", vec![]);
+        copy_leaf.is_copy = true;
+        let (copy_leaf, _) =
+            pool.register_struct(declarations.get_or_intern("CopyLeaf"), copy_leaf);
+        let (move_leaf, _) = pool.register_struct(
+            declarations.get_or_intern("MoveLeaf"),
+            struct_def("MoveLeaf", vec![]),
+        );
+        let copy_array = pool
+            .try_intern_array(Type::new_struct(copy_leaf), 2)
+            .unwrap();
+        let move_array = pool
+            .try_intern_array(Type::new_struct(move_leaf), 2)
+            .unwrap();
+        let move_pointer = pool
+            .try_intern_ptr_const(Type::new_struct(move_leaf))
+            .unwrap();
+
+        let copy_choice = EnumDef {
+            name: "CopyChoice".into(),
+            variants: Arc::from(["Array".into(), "Pointer".into()]),
+            variant_payloads: vec![vec![copy_array], vec![move_pointer]],
+            is_pub: false,
+            is_non_exhaustive: false,
+            file_id: FileId::DEFAULT,
+        };
+        let (copy_choice, _) =
+            pool.register_enum(declarations.get_or_intern("CopyChoice"), copy_choice);
+        let move_choice = EnumDef {
+            name: "MoveChoice".into(),
+            variants: Arc::from(["Array".into()]),
+            variant_payloads: vec![vec![move_array]],
+            is_pub: false,
+            is_non_exhaustive: false,
+            file_id: FileId::DEFAULT,
+        };
+        let (move_choice, _) =
+            pool.register_enum(declarations.get_or_intern("MoveChoice"), move_choice);
+
+        assert!(Type::I32.is_copy_in_pool(&pool));
+        assert!(Type::new_struct(copy_leaf).is_copy_in_pool(&pool));
+        assert!(!Type::new_struct(move_leaf).is_copy_in_pool(&pool));
+        assert!(copy_array.is_copy_in_pool(&pool));
+        assert!(!move_array.is_copy_in_pool(&pool));
+        assert!(move_pointer.is_copy_in_pool(&pool));
+        assert!(Type::new_enum(copy_choice).is_copy_in_pool(&pool));
+        assert!(!Type::new_enum(move_choice).is_copy_in_pool(&pool));
+        let frozen = pool.freeze();
+        assert!(Type::new_enum(copy_choice).is_copy_in_frozen_pool(&frozen));
+        assert!(!Type::new_enum(move_choice).is_copy_in_frozen_pool(&frozen));
+
+        // Invalid recursive-by-value graphs are rejected before freezing, but
+        // the query can run while declarations are being assembled and must
+        // still terminate deterministically rather than overflowing.
+        let cycle_pool = TypeInternPool::new();
+        let (recursive, _) = cycle_pool.declare_enum(
+            declarations.get_or_intern("Recursive"),
+            enum_def("Recursive"),
+        );
+        cycle_pool.complete_declared_enum(
+            recursive,
+            EnumDef {
+                name: "Recursive".into(),
+                variants: Arc::from(["Next".into(), "End".into()]),
+                variant_payloads: vec![vec![Type::new_enum(recursive)], vec![]],
+                is_pub: false,
+                is_non_exhaustive: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        assert!(Type::new_enum(recursive).is_copy_in_pool(&cycle_pool));
+        assert!(Type::new_enum(recursive).is_copy_in_pool(&cycle_pool));
     }
 
     #[test]

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -3940,38 +3940,8 @@ mod tests {
         }
     }
 
-    /// A local mirror of the host's `is_type_copy`, likewise index-independent.
     fn is_copy(pool: &TypeInternPool, ty: Type) -> bool {
-        use crate::types::TypeKind;
-        match ty.kind() {
-            TypeKind::I8
-            | TypeKind::I16
-            | TypeKind::I32
-            | TypeKind::I64
-            | TypeKind::U8
-            | TypeKind::U16
-            | TypeKind::U32
-            | TypeKind::U64
-            | TypeKind::Bool
-            | TypeKind::Unit
-            | TypeKind::Never
-            | TypeKind::Error
-            | TypeKind::Module(_)
-            | TypeKind::ComptimeType
-            | TypeKind::F32
-            | TypeKind::F64
-            | TypeKind::ComptimeFloat
-            | TypeKind::PtrConst(_)
-            | TypeKind::PtrMut(_) => true,
-            TypeKind::Enum(id) => pool
-                .enum_def(id)
-                .variant_payloads
-                .iter()
-                .flatten()
-                .all(|&ty| is_copy(pool, ty)),
-            TypeKind::Struct(id) => pool.struct_def(id).is_copy,
-            TypeKind::Array(id) => is_copy(pool, pool.array_def(id).0),
-        }
+        ty.is_copy_in_pool(pool)
     }
 
     // ----- Epoch-registration twin -------------------------------------------

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1621,39 +1621,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         }
     }
     pub(crate) fn is_type_copy(&self, ty: Type) -> bool {
-        match ty.kind() {
-            crate::types::TypeKind::I8
-            | crate::types::TypeKind::I16
-            | crate::types::TypeKind::I32
-            | crate::types::TypeKind::I64
-            | crate::types::TypeKind::U8
-            | crate::types::TypeKind::U16
-            | crate::types::TypeKind::U32
-            | crate::types::TypeKind::U64
-            | crate::types::TypeKind::Bool
-            | crate::types::TypeKind::Unit
-            | crate::types::TypeKind::Never
-            | crate::types::TypeKind::Error
-            | crate::types::TypeKind::Module(_)
-            | crate::types::TypeKind::ComptimeType
-            | crate::types::TypeKind::ComptimeFloat
-            | crate::types::TypeKind::F32
-            | crate::types::TypeKind::F64
-            | crate::types::TypeKind::PtrConst(_)
-            | crate::types::TypeKind::PtrMut(_) => true,
-            crate::types::TypeKind::Enum(id) => self
-                .body_type_pool()
-                .enum_def(id)
-                .variant_payloads
-                .iter()
-                .flatten()
-                .all(|&ty| self.is_type_copy(ty)),
-            crate::types::TypeKind::Struct(id) => self.body_type_pool().struct_def(id).is_copy,
-            crate::types::TypeKind::Array(id) => {
-                let (element, _) = self.body_type_pool().array_def(id);
-                self.is_type_copy(element)
-            }
-        }
+        ty.is_copy_in_pool(self.body_type_pool())
     }
     pub(crate) fn types_compatible(&self, found: Type, expected: Type) -> bool {
         found.is_never() || found.is_error() || self.types_equivalent(found, expected)

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -2245,7 +2245,7 @@ where
                 SemanticImportFailure::NominalKindMismatch
             }
         })?;
-        let fields = fields
+        let fields: Vec<StructField> = fields
             .iter()
             .map(|(name, ty)| {
                 Ok(StructField {
@@ -2254,6 +2254,14 @@ where
                 })
             })
             .collect::<Result<_, _>>()?;
+        let is_copy = if matches!(key, NominalInstanceKey::Anonymous(_)) {
+            is_copy
+                && fields
+                    .iter()
+                    .all(|field| field.ty.is_copy_in_pool(type_pool))
+        } else {
+            is_copy
+        };
         type_pool.complete_declared_struct(
             id,
             StructDef {

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -931,37 +931,7 @@ impl Type {
         )
     }
 
-    /// Check if this is a Copy type (can be implicitly duplicated).
-    ///
-    /// Copy types are:
-    /// - All integer types (i8-i64, u8-u64)
-    /// - Boolean
-    /// - Unit
-    /// - Enum types
-    /// - Never type and Error type (for convenience in error recovery)
-    ///
-    /// Non-Copy types (move types) are:
-    /// - Struct types (unless marked @copy, checked via StructDef.is_copy)
-    /// - Array types (unless element type is Copy, checked by the body host)
-    ///
-    /// Note: This method can't check struct's is_copy attribute or array element
-    /// types since it doesn't have access to StructDefs or array type information.
-    /// Use the body host's `is_type_copy` for full checking.
-    pub fn is_copy(&self) -> bool {
-        match type_encoding::decode(self.0) {
-            Some(Decoded::Primitive(_)) => true,
-            Some(Decoded::Composite {
-                kind: Composite::Enum | Composite::Module,
-                ..
-            }) => true,
-            Some(Decoded::Composite { .. }) | None => false,
-        }
-    }
-
-    /// Check if this type is Copy, with access to TypeInternPool for struct checking.
-    ///
-    /// This is used during anonymous struct creation to determine if the new struct
-    /// should be Copy based on its field types.
+    /// Check whether this type is Copy using the canonical pool-level policy.
     pub fn is_copy_in_pool(&self, type_pool: &crate::intern_pool::TypeInternPool) -> bool {
         type_pool.is_copy_type(*self)
     }
@@ -1380,42 +1350,6 @@ mod tests {
         assert_eq!(Type::new_struct(StructId(0)).as_array(), None);
     }
 
-    // ========== Type::is_copy() tests ==========
-
-    #[test]
-    fn test_is_copy_primitives() {
-        // All integer types are Copy
-        assert!(Type::I8.is_copy());
-        assert!(Type::I16.is_copy());
-        assert!(Type::I32.is_copy());
-        assert!(Type::I64.is_copy());
-        assert!(Type::U8.is_copy());
-        assert!(Type::U16.is_copy());
-        assert!(Type::U32.is_copy());
-        assert!(Type::U64.is_copy());
-
-        // Bool and Unit are Copy
-        assert!(Type::BOOL.is_copy());
-        assert!(Type::UNIT.is_copy());
-    }
-
-    #[test]
-    fn test_is_copy_special() {
-        // Enum types are Copy
-        assert!(Type::new_enum(EnumId(0)).is_copy());
-
-        // Never and Error are Copy for convenience
-        assert!(Type::NEVER.is_copy());
-        assert!(Type::ERROR.is_copy());
-    }
-
-    #[test]
-    fn test_is_copy_move_types() {
-        // Struct and Array are move types (String is a builtin struct now)
-        assert!(!Type::new_struct(StructId(0)).is_copy());
-        assert!(!Type::new_array(ArrayTypeId(0)).is_copy());
-    }
-
     // ========== Type::from_primitive_name() tests ==========
 
     #[test]
@@ -1786,7 +1720,7 @@ mod tests {
 
     #[test]
     fn test_comptime_type_is_copy() {
-        assert!(Type::COMPTIME_TYPE.is_copy());
+        assert!(Type::COMPTIME_TYPE.is_copy_in_pool(&crate::TypeInternPool::new()));
     }
 
     #[test]

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4285,7 +4285,7 @@ pub(super) use register_parse_import_parse;"#;
             (
                 "revisioned_database::tests::body_provider::provider".to_owned(),
                 "RevisionedQueryDatabase:call".to_owned(),
-                32
+                35
             ),
             (
                 "revisioned_database::tests::parse_import".to_owned(),
@@ -9153,4 +9153,47 @@ fn candidate_plan_metrics_have_one_query_terminal_authority() {
     assert!(database.contains("candidate_body_plan.construction"));
     assert!(database.contains("candidate_body_plan.materialization"));
     assert!(session.contains("accrue_candidate_body_plan_work"));
+}
+
+#[test]
+fn durable_copy_policy_projections_have_an_exact_inventory() {
+    const OWNER_MARKER: &str = "COPY_POLICY_DURABLE_PROJECTION_OWNER:";
+    let owners = REVISIONED_DATABASE_PHASES
+        .iter()
+        .filter_map(|(name, source)| source.contains(OWNER_MARKER).then_some(*name))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        owners,
+        ["semantic", "body_provider_body"],
+        "the only permitted pre-materialization Copy projections are TypeFacts and the body provider"
+    );
+    assert_eq!(
+        REVISIONED_DATABASE_PHASES
+            .iter()
+            .map(|(_, source)| source.matches(OWNER_MARKER).count())
+            .sum::<usize>(),
+        2,
+        "every durable Copy projection must be explicitly inventoried"
+    );
+
+    let semantic = REVISIONED_DATABASE_PHASES
+        .iter()
+        .find(|(name, _)| *name == "semantic")
+        .map(|(_, source)| *source)
+        .unwrap();
+    let provider = REVISIONED_DATABASE_PHASES
+        .iter()
+        .find(|(name, _)| *name == "body_provider_body")
+        .map(|(_, source)| *source)
+        .unwrap();
+    assert_eq!(provider.matches("fn type_is_copy_walk(").count(), 1);
+    assert!(
+        provider.contains("T::Array { element, .. } => self.type_is_copy_inner(element, walk)")
+    );
+    assert!(provider.contains("P::Enum { variants, .. }"));
+    assert!(provider.contains("method.name.as_ref() == \"__drop\""));
+    assert_eq!(semantic.matches("is_copy &= child.is_copy;").count(), 2);
+    assert!(semantic.contains("T::Array { element, .. }"));
+    assert!(semantic.contains("S::Enum { .. } => (true, true, false)"));
+    assert!(semantic.contains("let mut is_copy = destructor.is_none();"));
 }

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -1235,10 +1235,11 @@ pub(crate) fn materialize_semantic_body_with_indexes_in_space(
                     rue_air::SemanticImportNominalKind::Struct,
                     rue_air::SemanticLocalNominalShape::Struct {
                         fields: fields.clone(),
-                        // Anonymous structs have no `copy` or `linear`
-                        // declaration modifiers. Transitive ownership facts are
-                        // derived by the completed local type pool.
-                        is_copy: false,
+                        // Anonymous structs have no `copy` modifier. Carry
+                        // only destructor eligibility here; the AIR import
+                        // pool recursively derives the field portion after it
+                        // has resolved the durable children.
+                        is_copy: destructor.is_none(),
                         is_linear: false,
                         declared_linear: false,
                         destructor,

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -890,6 +890,12 @@ impl SemanticNucleusTypeProvider<'_> {
             crate::semantic_query_nucleus::SemanticNucleusFailure,
         >,
     > {
+        // COPY_POLICY_DURABLE_PROJECTION_OWNER: provider-body
+        // This walk runs before AIR pool materialization, so it is the durable
+        // representation of `TypeInternPool::is_copy_type`: scalar and pointer
+        // leaves are Copy, arrays and enums recursively conjoin their children,
+        // structs use their validated declaration bit, and cycles provisionally
+        // answer true until a reachable non-Copy leaf disproves them.
         use crate::durable_semantics::{DurableAnonymousNominalShape as S, DurableType as T};
         use crate::semantic_query_nucleus::DeclarationSignatureProjection as P;
 
@@ -974,7 +980,13 @@ impl SemanticNucleusTypeProvider<'_> {
                     )
                 })?;
                 match nominal.shape {
-                    S::Struct { fields, .. } => {
+                    S::Struct { fields, methods } => {
+                        if methods
+                            .iter()
+                            .any(|method| method.has_self && method.name.as_ref() == "__drop")
+                        {
+                            return Ok(false);
+                        }
                         for (_, field) in fields.iter() {
                             if !self.type_is_copy_inner(field, walk)? {
                                 return Ok(false);

--- a/crates/rue-compiler/src/revisioned_query_database/semantic.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/semantic.rs
@@ -794,6 +794,7 @@ pub(super) fn evaluate_type_facts(
     use crate::type_queries::{TypeFacts, TypeFactsValue, TypeShape};
     use crate::{NominalInstanceKey as N, TypeInstanceKey as T};
 
+    // COPY_POLICY_DURABLE_PROJECTION_OWNER: type-facts
     let shape_terminal = context.query_registered(type_shapes, key.clone())?;
     let canonical_shape = match type_shape_from_terminal(&shape_terminal) {
         Ok(shape) => shape.clone(),
@@ -839,18 +840,7 @@ pub(super) fn evaluate_type_facts(
             direct(rue_builtins::get_builtin_enum(name).is_some())
         }
         T::BuiltinNominal { .. } | T::Nominal(N::Builtin { .. }) => direct(false),
-        T::Array { element, len } => {
-            if *len == 0 {
-                return Ok(QueryOutput::success(TypeFactsValue::Available(Box::new(
-                    TypeFacts {
-                        is_copy: true,
-                        carries_linear: false,
-                        needs_drop: false,
-                        destructor: None,
-                        shape: canonical_shape.clone(),
-                    },
-                ))));
-            }
+        T::Array { element, .. } => {
             let child = context.query_registered(
                 family,
                 crate::type_queries::TypeQueryKey {
@@ -888,14 +878,14 @@ pub(super) fn evaluate_type_facts(
             let rue_query::QueryOutcome::Success(signature) = signature.outcome() else {
                 unreachable!("SemanticNucleus publishes typed values")
             };
-            let (is_copy, is_linear) = match signature {
+            let (mut is_copy, copy_from_children, is_linear) = match signature {
                 crate::semantic_query_nucleus::SemanticNucleusValue::Signature(signature) => {
                     use crate::semantic_query_nucleus::DeclarationSignatureProjection as S;
                     match &signature.signature {
                         S::Struct {
                             is_copy, is_linear, ..
-                        } => (*is_copy, *is_linear),
-                        S::Enum { .. } => (false, false),
+                        } => (*is_copy, false, *is_linear),
+                        S::Enum { .. } => (true, true, false),
                         _ => {
                             return Ok(QueryOutput::success(type_query_failure(
                                 "named type resolved to a non-type signature",
@@ -942,6 +932,9 @@ pub(super) fn evaluate_type_facts(
             for child in &child_terminals {
                 match type_facts_from_terminal(child) {
                     Ok(child) => {
+                        if copy_from_children {
+                            is_copy &= child.is_copy;
+                        }
                         carries_linear |= child.carries_linear;
                         needs_drop |= child.needs_drop;
                     }
@@ -1033,11 +1026,18 @@ pub(super) fn evaluate_type_facts(
                         configuration: key.configuration.clone(),
                     }),
             )?;
+            // Durable types cannot delegate directly to the AIR pool because
+            // they are evaluated before pool materialization. This is the
+            // representation-boundary projection of TypeInternPool's policy:
+            // anonymous composites are Copy iff they have no destructor and
+            // every by-value child is Copy.
+            let mut is_copy = destructor.is_none();
             let mut carries_linear = false;
             let mut needs_drop = destructor.is_some();
             for child in &child_terminals {
                 match type_facts_from_terminal(child) {
                     Ok(child) => {
+                        is_copy &= child.is_copy;
                         carries_linear |= child.carries_linear;
                         needs_drop |= child.needs_drop;
                     }
@@ -1048,7 +1048,7 @@ pub(super) fn evaluate_type_facts(
                 }
             }
             TypeFactsValue::Available(Box::new(TypeFacts {
-                is_copy: false,
+                is_copy,
                 carries_linear,
                 needs_drop,
                 destructor,

--- a/crates/rue-compiler/src/revisioned_query_database/test_support.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/test_support.rs
@@ -374,18 +374,7 @@ pub(crate) fn endpoint_display(pool: &rue_air::TypeInternPool, ty: rue_air::Type
 
 /// Index-independent copyability over the pool's own definitions.
 pub(crate) fn endpoint_is_copy(pool: &rue_air::TypeInternPool, ty: rue_air::Type) -> bool {
-    use rue_air::TypeKind;
-    match ty.kind() {
-        TypeKind::Struct(id) => pool.struct_def(id).is_copy,
-        TypeKind::Enum(id) => pool
-            .enum_def(id)
-            .variant_payloads
-            .iter()
-            .flatten()
-            .all(|&ty| endpoint_is_copy(pool, ty)),
-        TypeKind::Array(id) => endpoint_is_copy(pool, pool.array_def(id).0),
-        _ => true,
-    }
+    ty.is_copy_in_pool(pool)
 }
 
 /// Render a nominal (struct or enum) pool [`rue_air::Type`] to its

--- a/crates/rue-compiler/src/revisioned_query_database/tests.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests.rs
@@ -98,6 +98,7 @@ const EXPECTED_REVISIONED_QUERY_TESTS: &[&str] = &[
     "drop_glue_reads_the_shape_carried_by_type_facts_instead_of_requesting_it",
     "duplicate_occurrences_share_one_host_operation_and_fan_out_typed_results",
     "durable_callable_admission_pipeline_preserves_policy_table",
+    "durable_copy_facts_match_the_air_composite_policy",
     "durable_function_materialization_shares_the_canonical_parameter_payload",
     "durable_module_member_projection_preserves_order_types_and_dependencies",
     "durable_named_member_rejects_every_multi_candidate_shape",

--- a/crates/rue-compiler/src/revisioned_query_database/tests/body_provider/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/body_provider/provider.rs
@@ -212,6 +212,272 @@ fn provider_type_facts_resolve_primitive_and_structural_shapes() {
 }
 
 #[test]
+fn durable_copy_facts_match_the_air_composite_policy() {
+    use crate::DurableType as T;
+    use crate::StableDefinitionKind as K;
+
+    let source = "struct Owner { value: i32 }\n\
+                  @copy struct CopyLeaf { value: i32 }\n\
+                  enum MoveChoice { Some(Owner), None }\n\
+                  enum CopyChoice { Some(CopyLeaf), None }\n\
+                  fn CopyAnonStruct() -> type { struct { value: i32 } }\n\
+                  fn MoveAnonStruct() -> type { struct { value: Owner } }\n\
+                  fn DropAnonStruct() -> type { struct { value: i32, drop fn(self) {} } }\n\
+                  fn CopyAnonEnum() -> type { enum { Some(i32), None } }\n\
+                  fn MoveAnonEnum() -> type { enum { Some(Owner), None } }\n\
+                  struct Holder {\n\
+                      owner: Owner, copy_leaf: CopyLeaf,\n\
+                      move_choice: MoveChoice, copy_choice: CopyChoice,\n\
+                      copy_anon_struct: CopyAnonStruct(),\n\
+                      move_anon_struct: MoveAnonStruct(),\n\
+                      drop_anon_struct: DropAnonStruct(),\n\
+                      copy_anon_enum: CopyAnonEnum(),\n\
+                      move_anon_enum: MoveAnonEnum(),\n\
+                      zero_owner_array: [Owner; 0],\n\
+                      copy_array: [CopyLeaf; 2],\n\
+                      owner_pointer: ptr mut Owner,\n\
+                  }\n\
+                  fn make() -> Holder {\n\
+                      let CopyStruct = CopyAnonStruct();\n\
+                      let MoveStruct = MoveAnonStruct();\n\
+                      let DropStruct = DropAnonStruct();\n\
+                      let CopyEnum = CopyAnonEnum();\n\
+                      let MoveEnum = MoveAnonEnum();\n\
+                      let zero: u64 = 0;\n\
+                      Holder {\n\
+                          owner: Owner { value: 1 },\n\
+                          copy_leaf: CopyLeaf { value: 2 },\n\
+                          move_choice: MoveChoice.None, copy_choice: CopyChoice.None,\n\
+                          copy_anon_struct: CopyStruct { value: 3 },\n\
+                          move_anon_struct: MoveStruct { value: Owner { value: 4 } },\n\
+                          drop_anon_struct: DropStruct { value: 5 },\n\
+                          copy_anon_enum: CopyEnum.None, move_anon_enum: MoveEnum.None,\n\
+                          zero_owner_array: [],\n\
+                          copy_array: [CopyLeaf { value: 6 }, CopyLeaf { value: 7 }],\n\
+                          owner_pointer: checked { @int_to_ptr(zero) },\n\
+                      }\n\
+                  }\n\
+                  fn consume(value: Holder) -> i32 { value.copy_leaf.value }\n\
+                  fn main() -> i32 { consume(make()) }\n";
+    let snapshot = source_snapshot(&[(1, "/m.rue", "m.rue", source)], 1);
+    let declarations = production_declarations(&snapshot);
+    let holder = durable_decl(&declarations, K::Struct, "Holder");
+    let crate::durable_semantics::DurableDeclarationPayload::Struct {
+        fields: durable_fields,
+        ..
+    } = &holder.payload
+    else {
+        panic!("Holder has a durable struct projection")
+    };
+
+    // This is the independent ordinary semantic result. Its frozen AIR pool
+    // has already materialized the same named and producer-anonymous types;
+    // comparing its field handles with durable TypeFacts makes this a real
+    // cross-representation differential rather than two expected-value lists.
+    let (_, ordinary, _) =
+        crate::test_support::test_frontend_snapshot(&snapshot, &crate::CompileOptions::default())
+            .expect("ordinary frontend compiles the Copy matrix");
+    let pool = ordinary
+        .functions()
+        .iter()
+        .find(|unit| unit.source_name() == "main")
+        .expect("main has a rooted CFG")
+        .type_pool();
+    let holder_id = pool
+        .all_struct_ids()
+        .find(|&id| pool.struct_def(id).name.as_ref() == "Holder")
+        .unwrap_or_else(|| {
+            panic!(
+                "ordinary AIR materialized Holder; structs: {:?}",
+                pool.all_struct_ids()
+                    .map(|id| pool.struct_def(id).name.clone())
+                    .collect::<Vec<_>>()
+            )
+        });
+    let air_holder = pool.struct_def(holder_id);
+    assert_eq!(air_holder.fields.len(), durable_fields.len());
+
+    let mut database = RevisionedQueryDatabase::default();
+    let revision = revision_for(&mut database, &snapshot);
+
+    let durable_is_copy = |ty: &T| {
+        let attempt = database.runtime.request_registered(
+            &database.type_facts,
+            revision,
+            crate::type_queries::TypeQueryKey {
+                ty: crate::drop_glue::type_instance_from_semantic(ty),
+                configuration: semantic_configuration(),
+            },
+            CancellationToken::new(),
+        );
+        let rue_query::QueryOutcome::Success(crate::type_queries::TypeFactsValue::Available(facts)) =
+            attempt
+                .terminal()
+                .expect("type-facts query completes")
+                .outcome()
+        else {
+            panic!("type-facts query did not produce available facts")
+        };
+        facts.is_copy
+    };
+
+    let expected = AHashMap::from([
+        ("owner", false),
+        ("copy_leaf", true),
+        ("move_choice", false),
+        ("copy_choice", true),
+        ("copy_anon_struct", true),
+        ("move_anon_struct", false),
+        ("drop_anon_struct", false),
+        ("copy_anon_enum", true),
+        ("move_anon_enum", false),
+        ("zero_owner_array", false),
+        ("copy_array", true),
+        ("owner_pointer", true),
+    ]);
+    for ((durable_name, durable_ty), air_field) in
+        durable_fields.iter().zip(air_holder.fields.iter())
+    {
+        assert_eq!(durable_name.as_ref(), air_field.name);
+        let durable_copy = durable_is_copy(durable_ty);
+        let air_copy = air_field.ty.is_copy_in_frozen_pool(pool);
+        assert_eq!(
+            durable_copy,
+            air_copy,
+            "durable TypeFacts and ordinary AIR disagree for `{durable_name}`: AIR type {:?} ({:?})",
+            air_field.ty,
+            air_field
+                .ty
+                .as_struct()
+                .map(|id| pool.struct_def(id).clone())
+        );
+        assert_eq!(
+            durable_copy,
+            expected[durable_name.as_ref()],
+            "unexpected Copy classification for `{durable_name}`"
+        );
+        if durable_name.contains("anon") {
+            assert!(
+                matches!(durable_ty, T::AnonymousNominal(_)),
+                "`{durable_name}` must exercise anonymous TypeFacts"
+            );
+            let air_is_anonymous = air_field
+                .ty
+                .as_struct()
+                .is_some_and(|id| pool.is_anonymous_struct(id))
+                || air_field
+                    .ty
+                    .as_enum()
+                    .is_some_and(|id| pool.enum_def(id).name.starts_with("__anon_enum_"));
+            assert!(
+                air_is_anonymous,
+                "`{durable_name}` must exercise an AIR anonymous nominal"
+            );
+        }
+    }
+
+    // Exercise the other permitted durable projection directly: resolving a
+    // named `@copy` signature asks `SemanticNucleusTypeProvider` to validate
+    // every field through `type_is_copy_walk` before any AIR pool exists.
+    use crate::declaration_candidate::DeclarationCandidateCategory as Cat;
+    use crate::semantic_query_nucleus::{SemanticNucleusFailure as F, SemanticNucleusKey as Key};
+    let module = ModuleId::from_logical_path("m.rue").unwrap();
+    let accepted_source = "struct Owner { value: i32 }\n\
+                           @copy struct CopyLeaf { value: i32 }\n\
+                           fn CopyStruct() -> type { struct { value: CopyLeaf } }\n\
+                           fn CopyEnum() -> type { enum { Some(CopyLeaf), None } }\n\
+                           @copy struct Good {\n\
+                               s: CopyStruct(), e: CopyEnum(), a: [CopyLeaf; 2],\n\
+                               p: ptr const Owner, named: CopyLeaf,\n\
+                           }\n\
+                           fn main() -> i32 { 0 }\n";
+    let accepted = source_snapshot(&[(1, "/m.rue", "m.rue", accepted_source)], 1);
+    let mut accepted_db = RevisionedQueryDatabase::default();
+    let accepted_revision = revision_for(&mut accepted_db, &accepted);
+    let good = declaration_candidate(
+        &accepted_db,
+        accepted_revision,
+        &module,
+        Cat::Struct,
+        "Good",
+    );
+    let good = request_semantic_nucleus(
+        &accepted_db,
+        accepted_revision,
+        Key::Signature(crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+            declaration: good,
+            configuration: semantic_configuration(),
+        }),
+    );
+    assert!(matches!(
+        good,
+        crate::semantic_query_nucleus::SemanticNucleusValue::Signature(ref signature)
+            if matches!(
+                signature.signature,
+                crate::semantic_query_nucleus::DeclarationSignatureProjection::Struct {
+                    is_copy: true,
+                    ..
+                }
+            )
+    ));
+
+    let rejected = [
+        (
+            "anonymous struct with move field",
+            "struct Owner { value: i32 }\n\
+             fn MoveStruct() -> type { struct { value: Owner } }\n\
+             @copy struct Bad { value: MoveStruct() }\n\
+             fn main() -> i32 { 0 }\n",
+        ),
+        (
+            "anonymous enum with move payload",
+            "struct Owner { value: i32 }\n\
+             fn MoveEnum() -> type { enum { Some(Owner), None } }\n\
+             @copy struct Bad { value: MoveEnum() }\n\
+             fn main() -> i32 { 0 }\n",
+        ),
+        (
+            "owning anonymous wrapper",
+            "struct Owner { value: i32 }\n\
+             fn MoveEnum() -> type { enum { Some(Owner), None } }\n\
+             fn Wrapper() -> type { struct { value: MoveEnum() } }\n\
+             @copy struct Bad { value: Wrapper() }\n\
+             fn main() -> i32 { 0 }\n",
+        ),
+        (
+            "destructor-bearing anonymous struct",
+            "fn Resource() -> type { struct { value: i32, drop fn(self) {} } }\n\
+             @copy struct Bad { value: Resource() }\n\
+             fn main() -> i32 { 0 }\n",
+        ),
+    ];
+    for (label, rejected_source) in rejected {
+        let rejected = source_snapshot(&[(1, "/m.rue", "m.rue", rejected_source)], 1);
+        let mut rejected_db = RevisionedQueryDatabase::default();
+        let rejected_revision = revision_for(&mut rejected_db, &rejected);
+        let bad =
+            declaration_candidate(&rejected_db, rejected_revision, &module, Cat::Struct, "Bad");
+        let failure = request_semantic_nucleus(
+            &rejected_db,
+            rejected_revision,
+            Key::Signature(crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                declaration: bad,
+                configuration: semantic_configuration(),
+            }),
+        );
+        assert!(
+            matches!(
+                failure,
+                crate::semantic_query_nucleus::SemanticNucleusValue::Failure(F::Diagnostic(
+                    rue_error::ErrorKind::CopyStructNonCopyField(_)
+                ))
+            ),
+            "provider Copy validation accepted {label}: {failure:?}"
+        );
+    }
+}
+
+#[test]
 fn provider_type_facts_absent_and_kind_mismatch_do_not_resolve() {
     let source = "pub struct Point { x: i32 }\n\
                       pub enum Shape { A, B }\n\

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2561,6 +2561,85 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "anonymous_struct_option_strbuf_is_move_type"
+spec = ["3.7:39", "3.8:2", "3.8:3", "4.14:22"]
+real_std = true
+description = "An anonymous struct containing Option(StrBuf) is a move type, so a second use after assignment is E0205 (RUE-1963)"
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn Wrapper(comptime T: type) -> type { struct { value: T } }
+fn main() -> i32 {
+    let O = Option(StrBuf);
+    let W = Wrapper(O);
+    let value: W = W { value: O.Some("owned") };
+    let moved = value;
+    @dbg(value);
+    @dbg(moved);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0205", "use of moved value 'value'"]
+
+[[case]]
+name = "anonymous_struct_user_enum_with_move_payload_is_move_type"
+spec = ["3.8:2", "3.8:3", "4.14:22"]
+description = "An anonymous struct containing a user enum with a non-Copy named payload is a move type, so a second use is E0205 (RUE-1963)"
+source = """
+struct Owner { value: i32 }
+enum Choice { Some(Owner), None }
+fn Wrapper(comptime T: type) -> type { struct { value: T } }
+fn main() -> i32 {
+    let W = Wrapper(Choice);
+    let value: W = W { value: Choice.Some(Owner { value: 42 }) };
+    let moved = value;
+    @dbg(value);
+    @dbg(moved);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0205", "use of moved value 'value'"]
+
+[[case]]
+name = "anonymous_struct_copy_array_is_copy"
+spec = ["3.8:2", "4.14:22"]
+description = "An anonymous struct containing an array of Copy elements can be used after assignment (RUE-1963)"
+source = """
+fn Wrapper(comptime T: type) -> type { struct { value: T } }
+fn main() -> i32 {
+    let W = Wrapper([i32; 2]);
+    let value: W = W { value: [20, 1] };
+    let duplicate = value;
+    value.value[0] + duplicate.value[1] + 21
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "anonymous_struct_pointer_to_move_type_is_copy"
+spec = ["3.8:2", "4.14:22", "9.1:12"]
+description = "An anonymous struct containing a pointer remains Copy regardless of its pointee's ownership (RUE-1963)"
+source = """
+struct Owner { value: i32 }
+fn PointerWrapper(comptime T: type) -> type { struct { value: ptr mut T } }
+fn main() -> i32 {
+    let W = PointerWrapper(Owner);
+    let zero: u64 = 0;
+    let value: W = checked { W { value: @int_to_ptr(zero) } };
+    let duplicate = value;
+    let first = value.value;
+    let second = duplicate.value;
+    let _ = first;
+    let _ = second;
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "type_constructor_accepts_unit_type_argument"
 spec = ["4.14:22"]
 description = "The unit type () is a valid comptime type argument; the parameter's declared `type` kind disambiguates it from the unit value (RUE-565)"


### PR DESCRIPTION
## Summary

- make the AIR type intern pool the canonical recursive Copy authority
- route ordinary ownership and anonymous materialization through that authority
- align durable type facts and named `@copy` validation across composites, destructors, and cycles
- add ownership regressions plus AIR/durable/provider parity and policy-owner guards

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue premerge` (211 passed)
- focused anonymous struct spec matrix (4 passed)
- focused AIR/durable/provider Copy parity and inventory tests

The broad standard suite was also exercised; its non-corpus coverage passed, while multiple optimized oracle corpus lanes hit the host process limit (`EAGAIN` spawning query workers), including an isolated O2 rerun. CI remains the full-platform corpus authority.

Fixes RUE-1963