### PR TITLE
RUE-1995: keep the test dispatcher reachable through general inlining

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -923,3 +923,83 @@ fn other() -> i32 {
 args = ["test", "main.rue", "other.rue"]
 compile_fail = true
 error_contains = ["unexpected extra source file 'other.rue'"]
+
+# ========================= optimization levels =========================
+
+[[case]]
+name = "trivial_test_bodies_link_at_o2"
+description = """
+RUE-1995: whole-program reachability runs only at -O2/-O3, and the synthesized
+dispatcher is the test image's entry point that nothing calls. When no test body
+makes a call, dependency discovery is complete and the pruner is free to act, so
+a dispatcher missing from the root set was dropped and the image failed to link.
+Call-free bodies are the shape that reproduces it; a body that calls anything
+unresolved leaves the graph incomplete and nothing is pruned at all.
+"""
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+
+test "empty" {
+}
+
+test "trivial" {
+    let _x = 1;
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "-O2"]
+driver_exit_code = 0
+compile_stdout_contains = ["2 passed ("]
+compile_stdout_not_contains = ["FAIL"]
+
+[[case]]
+name = "trivial_test_bodies_link_at_o3"
+description = "RUE-1995: the same reachability pass runs at -O3."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+
+test "empty" {
+}
+
+test "trivial" {
+    let _x = 1;
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "-O3"]
+driver_exit_code = 0
+compile_stdout_contains = ["2 passed ("]
+compile_stdout_not_contains = ["FAIL"]
+
+[[case]]
+name = "a_failed_assert_is_classified_at_o2"
+description = """
+RUE-1995: an optimized test image must reach the same verdict as an unoptimized
+one, so the failing path is pinned at -O2 too — the runtime trap still classifies
+as `assert` rather than disappearing into a link error.
+"""
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+
+test "two plus two is five" {
+    @assert(2 + 2 == 5);
+}
+""" },
+]
+args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "-O2", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"assert"',
+    '"message":"assertion failed"',
+    '"verdict":"fail"',
+    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+]

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -657,9 +657,25 @@ impl CompilerSession {
             .map(|test| test.identity.clone())
             .collect::<Vec<_>>()
             .into();
+        // Whole-program CFG reachability at O2/O3 publishes only what the
+        // request's roots reach, so the dispatcher has to be one of them.
+        // `graph.roots` is the semantic root set, and it can only name
+        // declarations the body closure was analyzed from; the dispatcher has
+        // no declaration and is synthesized here. Nothing calls it, so a test
+        // image built from the semantic roots alone classified the entry point
+        // itself as unreachable and general inlining dropped its unit, leaving
+        // the image with an undefined `main` (RUE-1995). It is a root of the
+        // request exactly as `main` and the `extern "C"` exports are for an
+        // executable one; this is where it becomes nameable, so this is where
+        // it joins the root set.
+        let mut cfg_roots = graph.roots.to_vec();
         if dispatches_tests {
             identities.insert(crate::FunctionInstanceKey::TestDispatcher);
+            cfg_roots.push(crate::FunctionInstanceKey::TestDispatcher);
+            cfg_roots.sort();
+            cfg_roots.dedup();
         }
+        let cfg_roots: Arc<[crate::FunctionInstanceKey]> = cfg_roots.into();
         // Only an executable request has a `main`, and only its symbol is
         // spelled unmangled (ADR-0083 §1: a test request has no entry point).
         let main_identity = graph
@@ -1216,7 +1232,7 @@ impl CompilerSession {
         let (cfg_batch_key, attempt) = self.queries.revisioned.optimized_cfg_batch(
             graph.revision,
             optimized_keys,
-            Arc::clone(&graph.roots),
+            Arc::clone(&cfg_roots),
             cancellation,
         );
         let batch_execution = attempt.execution();

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -5869,6 +5869,53 @@ fn the_test_dispatcher_is_the_test_image_entry_point() {
     assert_eq!(defined_symbols(&executable_again), executable_symbols);
 }
 
+/// The dispatcher is a root of a test request, so whole-program reachability
+/// keeps it (RUE-1995).
+///
+/// General inlining runs only at -O2/-O3, and it publishes only what the
+/// request's roots reach. Nothing calls the dispatcher — it is the entry point
+/// the loader calls — so a root set holding only the test declarations left it
+/// unreachable and dropped the test image's `main`.
+///
+/// The bodies are deliberately call-free. A test body that calls anything the
+/// batch cannot resolve makes dependency discovery incomplete, and an
+/// incomplete graph removes nothing at all, so a call-heavy image hid this.
+#[test]
+fn the_test_dispatcher_survives_general_inlining() {
+    let source = SourceSnapshot::single(
+        "main.rue",
+        "fn main() -> i32 { 0 }\ntest \"empty\" { }\ntest \"trivial\" { let _x = 1; }",
+    )
+    .unwrap();
+    let mut session = CompilerSession::new();
+
+    for opt_level in [OptLevel::O0, OptLevel::O1, OptLevel::O2, OptLevel::O3] {
+        session.update(&source).into_result().unwrap();
+        let tests = session
+            .rooted_cfg(&CompileOptions {
+                opt_level,
+                ..test_declaration_options(crate::RootSelection::Tests)
+            })
+            .unwrap_or_else(|errors| {
+                panic!("the test image compiles at {opt_level:?}: {errors:?}")
+            });
+        assert!(
+            tests
+                .functions()
+                .iter()
+                .any(|unit| unit.function == crate::FunctionInstanceKey::TestDispatcher),
+            "the dispatcher must reach the backend at {opt_level:?}"
+        );
+        assert!(
+            defined_symbols(&tests)
+                .iter()
+                .any(|symbol| symbol == "main"),
+            "the image keeps its entry symbol at {opt_level:?}"
+        );
+        assert_eq!(test_units(&tests), ["empty", "trivial"], "at {opt_level:?}");
+    }
+}
+
 /// `extern "C"` exports are executable-only (ADR-0083 §1). A test image links
 /// no export thunk, because a test request roots no c-export.
 #[test]


### PR DESCRIPTION
Fixes RUE-1995.

`rue test` at -O2 or -O3 failed to link the test image for programs with call-free test bodies (`undefined symbol __main`, or `main (… rel_type=Call26)` when the runtime entry member had been pulled transitively). The test image's entry point is the synthesized dispatcher, which has no declaration and is added only to the codegen identity set, never to the semantic root set. General inlining, which runs only at -O2 and above, computes whole-program reachability from that root set and publishes the complement as unreachable; nothing calls the dispatcher, so the entry point itself was classified unreachable and its unit dropped. Call-heavy images survived only because any incomplete reachability edge (an opaque call, or a callee outside the batch) makes the sweep fail closed and prune nothing, so the shape that reached the pruner was exactly the trivial one.

The dispatcher now joins the CFG root set at the one place it becomes nameable, for a test request only, alongside `main` and the `extern "C"` exports of an executable one. No by-name special case in the inliner.

A session unit test asserts the dispatcher survives general inlining (fails without the fix); CLI cases pin trivial-body tests at -O2 and -O3 and a failing assert at -O2. Verification: `scripts/rue unit rue-compiler test_image` and `pipeline` (114), `scripts/rue cli rue_test` (55), `scripts/rue cli abi` (65), `scripts/rue quick`, fmt clean. A separate latent linker defect found along the way (the required-symbol pull for the Mach-O entry looks up the unnormalized spelling and never fires) is filed as RUE-1996.