### PR TITLE
RUE-1960: fix the ADR example, E0705 help, test-mode usage, and the ? site wording

### DIFF
--- a/crates/rue-cli-tests/cases/cli_help_streams.toml
+++ b/crates/rue-cli-tests/cases/cli_help_streams.toml
@@ -35,3 +35,31 @@ args = ["--nonsense-flag", "main.rue"]
 compile_fail = true
 error_contains = ["Unknown option", "Usage: rue [options]"]
 compile_stdout_not_contains = ["Usage: rue"]
+
+# RUE-1960: `rue test` with no root used to report the compile-mode wording
+# ("No source file specified"), so the error named a form the user had not
+# typed. The subcommand was already recognized at that point, so the message
+# names it, and the usage block that follows carries the test-mode form.
+[[case]]
+name = "test_subcommand_without_a_root_names_the_test_form"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+args = ["test"]
+compile_fail = true
+error_contains = [
+    "Error: rue test needs a root source file",
+    "rue test [options] <root.rue>",
+]
+compile_stdout_not_contains = ["Usage: rue"]
+
+# The compile-mode wording is unchanged: a flag with no positional source is
+# still the generic message, and it is still the one the compile forms explain.
+[[case]]
+name = "compile_mode_without_a_root_keeps_the_generic_message"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+args = ["-O2"]
+compile_fail = true
+error_contains = [
+    "Error: No source file specified",
+    "Usage: rue [options] <root.rue> [output]",
+]
+compile_stderr_not_contains = ["rue test needs a root source file"]

--- a/crates/rue-cli-tests/cases/rue_test_question.toml
+++ b/crates/rue-cli-tests/cases/rue_test_question.toml
@@ -6,8 +6,8 @@ RUE-1921 (ADR-0083 §1, spec 6.7:13 - 6.7:17): `?` in a test body reports and
 traps instead of propagating. These run the whole path through the real binary —
 compiler, linked test image, dispatched process, failure channel, runner — so
 what is pinned here is the verdict a consumer of the event stream actually sees:
-kind `unhandled_error`, the `?` site's own line and column rather than the test
-declaration's header, and the error rendered by the synthesized structural
+kind `unhandled_error`, the `?` operand's own line and column rather than the
+test declaration's header, and the error rendered by the synthesized structural
 printer.
 
 They use the real standard library because `?` accepts only the trusted
@@ -18,8 +18,8 @@ is by design under parallel workers, and the event schema is a consumer contract
 (docs/process/test-events.md).
 
 Each `?` site is pinned by line and column, which is how these cases show the
-report names the operator's own position rather than the test declaration's
-header: `    let value = <call>()?;` puts the operand at column 17.
+report names the operand's own start rather than the test declaration's header
+or the `?` token: `    let value = <call>()?;` puts the operand at column 17.
 """
 
 # =============================================================================
@@ -199,3 +199,52 @@ args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 0
 compile_stdout_contains = ["1 passed ("]
 compile_stdout_not_contains = ["FAIL", "unhandled_error"]
+
+# =============================================================================
+# Which position 6.7:14 means (RUE-1960).
+# =============================================================================
+
+[[case]]
+name = "the_reported_site_is_the_operand_start_not_the_operator"
+description = """
+Spec 6.7:14: the report names where the `?` operator's OPERAND begins, not the
+`?` token. The two coordinates are one column apart in the sibling cases above,
+which is enough to show the header is not used but not enough to show which end
+of the expression is. Here the `?` site is indented inside an `if` and the
+operand is eight characters wide, so the operand starts at column 21 and the
+operator sits at column 29 — an implementation that staged the operator's own
+position would report 29, and this case would fail.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+fn absent() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
+    O.None
+}
+
+test "reports where the failing expression begins" {
+    if true {
+        let value = absent()?;
+        @assert(value == 0);
+    }
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"unhandled_error"',
+    '"column":21,"file":',
+    '"line":10}',
+]
+compile_stdout_not_contains = ['"column":29,', '"column":9,']

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1899,7 +1899,16 @@ pub(crate) fn exact_import_diagnostics(
             Some([_, _, ..]) => unreachable!("candidate groups hold one candidate"),
             Some([]) => unreachable!(),
             None if site.specifier() == "std" => {
-                errors.push(CompileError::new(ErrorKind::StdLibNotFound, span));
+                // The message names what failed; the help names the one knob
+                // that fixes it. Without this line the driver prints the span
+                // and nothing else, which tells a user running the binary
+                // outside a build system nothing about how to supply a std.
+                // `rue explain E0705` already names the same variable, so this
+                // is the short form of an explanation that already exists.
+                errors.push(
+                    CompileError::new(ErrorKind::StdLibNotFound, span)
+                        .with_help(rue_error::ErrorKind::STD_LIB_NOT_FOUND_HELP),
+                );
             }
             None => errors.push(CompileError::new(
                 ErrorKind::ModuleNotFound {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -3656,6 +3656,19 @@ pub enum ErrorKind {
 }
 
 impl ErrorKind {
+    /// The `help:` line E0705 carries: the one setting that supplies a
+    /// standard library.
+    ///
+    /// The message itself says only that std was not found, which is the whole
+    /// diagnostic a user sees when running the compiler directly outside a
+    /// build system — the case where nothing else has configured a std root.
+    /// `rue explain E0705` already names this variable in its likely-cause
+    /// text; this is the same fact in the one-line form the diagnostic can
+    /// carry, kept here so the two spellings sit next to each other rather
+    /// than drifting apart in the compiler crate that raises the error.
+    pub const STD_LIB_NOT_FOUND_HELP: &'static str =
+        "set RUE_STD_PATH to the toolchain's standard-library directory";
+
     /// Get the error code for this error kind.
     ///
     /// Every error kind has a unique, stable error code that can be used

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -345,7 +345,7 @@ pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[
          Covered end to end by \
          `crates/rue-compiler/src/test_image_tests.rs::platform_native_a_failing_test_body_question_reports_and_traps` \
          (exit 101, `panic: unhandled error` on stderr, one `unhandled_error` frame \
-         naming the `?` site) and \
+         naming the start of the `?` operand) and \
          `..._a_succeeding_test_body_question_completes_normally`.",
     ),
     (

--- a/crates/rue-ui-tests/cases/diagnostics/std-path-missing.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/std-path-missing.toml
@@ -1,0 +1,38 @@
+[section]
+id = "diagnostics.std-path-missing"
+name = "A missing standard library says how to supply one"
+description = """
+RUE-1960: E0705's message says only that std was not found. Run directly —
+no build system, no toolchain wrapper — that was the whole diagnostic: a span
+on the `@import("std")` and nothing about what to do. The diagnostic now
+carries the `help:` line naming `RUE_STD_PATH`, the same variable
+`rue explain E0705` already names in its likely-cause text.
+
+The harness removes `RUE_STD_PATH` from every case environment that does not
+ask for the real standard library, so these cases reach the missing-std path
+without arranging anything.
+"""
+
+[[case]]
+name = "missing_std_import_helps_with_the_std_path_variable"
+description = "The E0705 diagnostic carries an actionable help line, not just the failing span."
+source = """
+const std = @import("std");
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E0705",
+    "standard library not found",
+    "help: set RUE_STD_PATH to the toolchain's standard-library directory",
+]
+
+[[case]]
+name = "a_resolvable_std_import_carries_no_std_path_help"
+description = "The help line belongs to the failure, not to every std import: with a real standard library the program compiles and nothing mentions the variable."
+real_std = true
+source = """
+const std = @import("std");
+fn main() -> i32 { std.math.abs(-7) }
+"""
+exit_code = 7

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -840,7 +840,13 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     }
 
     if positional.is_empty() {
-        eprintln!("Error: No source file specified");
+        // Name the form the user actually invoked. `rue test` with no root
+        // reached the compile-mode wording, so the error and the usage text
+        // that follows it both described a command the user had not typed.
+        match mode {
+            DriverMode::Test => eprintln!("Error: rue test needs a root source file"),
+            DriverMode::Compile => eprintln!("Error: No source file specified"),
+        }
         print_usage();
         return ParseResult::Error;
     }

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -158,15 +158,17 @@ A test is a declaration, not a convention:
 
 ```rue
 const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const Port = std.option.Option(u16);
 
-fn parse_port(s: StrBuf) -> Option(u16) { ... }
+fn parse_port(s: StrBuf) -> Port { ... }
 
 test "parse_port accepts the loopback default" {
-    @assert(parse_port(StrBuf.from("8080")).is_some());
+    @assert(parse_port(StrBuf.from_str(borrow "8080")) == Port.Some(8080));
 }
 
 test "parse_port rejects out-of-range values" {
-    @assert(parse_port(StrBuf.from("70000")).is_none());
+    @assert(parse_port(StrBuf.from_str(borrow "70000")) == Port.None);
 }
 ```
 

--- a/docs/spec/src/06-items/07-tests.md
+++ b/docs/spec/src/06-items/07-tests.md
@@ -145,10 +145,17 @@ the expression evaluates to `v` and execution continues normally, exactly as
 
 When the operand is `None` or `Err(e)`, the enclosing function does **not**
 return. The implementation reports a structured failure naming the kind
-`unhandled_error`, the source position of the `?` operator itself, and the
-rendered error value (6.7:15); it then terminates the process the way every
-other trap does — exit status 101, with `panic: unhandled error` on the standard
-error stream (8.5). No further code in the test body is executed.
+`unhandled_error`, the source position at which the `?` operator's operand
+begins, and the rendered error value (6.7:15); it then terminates the process
+the way every other trap does — exit status 101, with `panic: unhandled error`
+on the standard error stream (8.5). No further code in the test body is
+executed.
+
+The reported position is the operand's first character rather than the `?`
+token, so the report names the expression that failed: in
+`let mut f = std.fs.File.open(borrow path)?;` it is the column of
+`std.fs.File.open`, which is what a reader needs in order to see which call
+produced the error.
 
 {{ rule(id="6.7:15", cat="normative") }}
 


### PR DESCRIPTION
Fixes RUE-1960.

Four small papercuts from the first hands-on run of the test runner, one commit:

- ADR-0083 §1's example did not compile: `StrBuf.from` does not exist, `StrBuf` and `Option` are not unqualified names, and `Option` has no `is_some`. The example is now a program that builds and passes under `--preview test_declarations`, keeping the two-test shape.
- E0705 (`standard library not found`) carries a help line naming `RUE_STD_PATH`, attached at its single raise site; a UI case pins it (the UI harness already runs without `RUE_STD_PATH`), and a `real_std` sibling pins that a normal build never mentions the variable. `rue explain E0705` already named the variable and is unchanged.
- `rue test` with no root said `No source file specified` before a usage block that already listed the test form; the error now names the form invoked (`rue test needs a root source file`), pinned by CLI cases for both modes.
- Spec 6.7:14 said the `?` report names the operator's own position while test-events.md and the runner report the operand's start. The spec now says the operand's start and explains why, rule IDs unchanged; because a spec case is an executable request that never runs a test body, the column is pinned in the CLI corpus with a case where operand and operator columns differ, and the traceability note is reworded to match.

Verification: `scripts/rue spec 6.7` and `10.2`, `scripts/rue ui std-path-missing` and `import-error-masking`, `scripts/rue cli rue_test` (56), `help_streams`, `modules`, `explain`, doc-link, spec-traceability and ADR-registry validation, `scripts/rue quick`, `//crates/rue:rue-test` (329), fmt clean.