### PR TITLE
RUE-1966: centralize unqualified nominal resolution

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -12,6 +12,7 @@ use crate::Type;
 use crate::intern_pool::TypeInternPool;
 use crate::scope::ScopedContext;
 use crate::sema::{ComptimeSelection, ConstValue, select_module_nominal};
+use crate::semantic_type_resolution::{UnqualifiedNominalTier, select_unqualified_nominal};
 #[cfg(test)]
 use crate::types::ArrayLen;
 use crate::types::{ModuleId, StructId, TypeKind};
@@ -1201,18 +1202,6 @@ impl<'a> ConstraintGenerator<'a> {
             ConstValue::Integer(n) => Some(*n),
             _ => None,
         }
-    }
-
-    /// Resolve a bare type-alias name in alias-head position against the
-    /// referencing file's scope, with the same by-file discipline as
-    /// [`Self::scoped_const_value`]: a `const T = SomeType(...)` in the current
-    /// module resolves; a same-named alias elsewhere is qualified, not bare.
-    fn scoped_const_type_alias(&self, sym: Spur, file_id: FileId) -> Option<Type> {
-        if let Some(lazy) = self.lazy {
-            return lazy.const_type_alias((file_id, sym));
-        }
-        self.const_type_aliases
-            .and_then(|aliases| aliases.get(&(file_id, sym)).copied())
     }
 
     /// Get the type variables allocated for integer literals.
@@ -3349,10 +3338,9 @@ impl<'a> ConstraintGenerator<'a> {
                 // could not reduce falls through to the error path below and
                 // sema diagnoses it. Module-qualified literals
                 // (`m.Point { ... }`) resolve in the module's defining file,
-                // matching sema. Unqualified literals check type_subst first
-                // (for Self/type parameters), then comptime type aliases
-                // (`let P = F(); P { ... }`, RUE-170), then the current
-                // file's module-local type table, then builtins.
+                // matching sema. Unqualified literals delegate their
+                // substitution/alias/declaration/builtin precedence to the
+                // shared nominal selector below.
                 let struct_ty = if let Some(head) = ctor_head {
                     self.inline_ctor_head_types
                         .and_then(|heads| heads.get(head).copied())
@@ -3368,13 +3356,7 @@ impl<'a> ConstraintGenerator<'a> {
                         .and_then(|module_id| self.module_file_id(module_id))
                         .and_then(|file_id| self.struct_type_by_file((file_id, *type_name)))
                 } else {
-                    self.type_subst
-                        .and_then(|subst| subst.get(type_name).copied())
-                        .or_else(|| self.comptime_alias_types.get(type_name).copied())
-                        .or_else(|| {
-                            self.struct_type_by_file((span.file_id, *type_name))
-                                .or_else(|| self.builtin_struct_type(*type_name))
-                        })
+                    self.struct_type_for(type_name, span.file_id)
                 };
 
                 let fields = self.rir.field_inits(fields);
@@ -4619,61 +4601,60 @@ impl<'a> ConstraintGenerator<'a> {
         Some(method_sig.return_type.clone())
     }
 
-    /// Resolve an enum type name that may be a comptime type-variable binding
-    /// (`let O = Option(i32); O.Some(..)`), falling back to the named-enum
-    /// table. Mirrors sema's `resolve_enum_type_name`; without the
-    /// comptime-alias lookup, generic-enum construction/matching inferred
-    /// `<error>` and poisoned the surrounding constraints (RUE-6 phase 2).
-    /// Struct type for an unqualified name. Present precedence is substitutions,
-    /// lexical aliases, file-level aliases, a declaration in the reference
-    /// file, then builtins (RUE-525).
+    /// Resolve one unqualified nominal spelling through the shared inference /
+    /// aggregate-sema authority. Keeping the kind filter at each consumer is
+    /// important: a higher-precedence enum binding in struct position (or vice
+    /// versa) must not fall through to a lower-precedence declaration.
+    fn unqualified_nominal_type(&self, type_name: Spur, file_id: FileId) -> Option<Type> {
+        self.unqualified_nominal_type_with_substitution(type_name, file_id, self.type_subst, false)
+    }
+
+    fn unqualified_nominal_type_with_substitution(
+        &self,
+        type_name: Spur,
+        file_id: FileId,
+        substitution: Option<&AHashMap<Spur, Type>>,
+        lexical_shadowed: bool,
+    ) -> Option<Type> {
+        select_unqualified_nominal(|tier| {
+            Ok::<_, std::convert::Infallible>(match tier {
+                UnqualifiedNominalTier::Substitution => {
+                    substitution.and_then(|subst| subst.get(&type_name).copied())
+                }
+                UnqualifiedNominalTier::LexicalAlias => {
+                    if let Some(ty) = self.comptime_alias_types.get(&type_name).copied() {
+                        Some(ty)
+                    } else if lexical_shadowed {
+                        Some(Type::ERROR)
+                    } else {
+                        None
+                    }
+                }
+                UnqualifiedNominalTier::FileAlias => self.const_type_alias((file_id, type_name)),
+                UnqualifiedNominalTier::Primitive => {
+                    Type::from_primitive_name(self.interner.resolve(&type_name))
+                }
+                UnqualifiedNominalTier::Declaration => self
+                    .struct_type_by_file((file_id, type_name))
+                    .or_else(|| self.enum_type_by_file((file_id, type_name))),
+                UnqualifiedNominalTier::Builtin => self
+                    .builtin_struct_type(type_name)
+                    .or_else(|| self.builtin_enum_type(type_name)),
+            })
+        })
+        .expect("infallible inference nominal selection")
+        .map(|selected| selected.value)
+    }
+
+    /// Struct type for an unqualified name.
     fn struct_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
-        // `Self` (and comptime type parameters) resolve through the enclosing
-        // substitution first, so `Self.assoc_fn(args)` constrains its
-        // arguments like `StructName.assoc_fn(args)` (RUE-639).
-        self.type_subst
-            .and_then(|subst| subst.get(type_name).copied())
+        self.unqualified_nominal_type(*type_name, file_id)
             .filter(|ty| ty.as_struct().is_some())
-            .or_else(|| {
-                self.comptime_alias_types
-                    .get(type_name)
-                    .copied()
-                    .filter(|ty| ty.as_struct().is_some())
-            })
-            .or_else(|| {
-                // File-level `const Ints = ArrayBuf(i64);` aliases: without
-                // this, a method chain rooted at the alias (`Ints.new()`)
-                // missed the type-qualified path, the receiver degraded to a
-                // fresh variable, and every later method argument was left
-                // unconstrained — an integer-literal expression argument then
-                // defaulted to i32 and was zero-extended into the declared
-                // 64-bit slot (miscompile, RUE-633).
-                self.const_type_alias((file_id, *type_name))
-                    .filter(|ty| ty.as_struct().is_some())
-            })
-            .or_else(|| self.struct_type_by_file((file_id, *type_name)))
-            .or_else(|| self.builtin_struct_type(*type_name))
     }
 
     fn enum_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
-        self.type_subst
-            .and_then(|subst| subst.get(type_name).copied())
-            .filter(|ty| ty.is_enum())
-            .or_else(|| {
-                self.comptime_alias_types
-                    .get(type_name)
-                    .copied()
-                    .filter(|ty| ty.is_enum())
-            })
-            .or_else(|| {
-                // File-level const enum aliases, for the same reason as
-                // `struct_type_for` (RUE-633): a construction rooted at the
-                // alias must constrain its payload arguments.
-                self.const_type_alias((file_id, *type_name))
-                    .filter(|ty| ty.is_enum())
-            })
-            .or_else(|| self.enum_type_by_file((file_id, *type_name)))
-            .or_else(|| self.builtin_enum_type(*type_name))
+        self.unqualified_nominal_type(*type_name, file_id)
+            .filter(Type::is_enum)
     }
 
     /// The type `module.Name` names, over the one source order semantic
@@ -4869,29 +4850,6 @@ impl<'a> ConstraintGenerator<'a> {
     /// type) - those are type-checked in sema instead.
     fn extract_type_argument(&self, arg: InstRef, ctx: &ConstraintContext) -> Option<Type> {
         let file_id = self.rir.get(arg).span.file_id;
-        let resolve_sym = |sym: &Spur| -> Option<Type> {
-            // A forwarded type parameter substitutes to whatever the enclosing
-            // specialization bound it to, of any kind (a primitive, an array,
-            // a nominal type), so this lookup is unfiltered and comes first.
-            if let Some(subst) = self.type_subst {
-                if let Some(&ty) = subst.get(sym) {
-                    return Some(ty);
-                }
-            }
-            // A directly named struct/enum — `identity(Foo, ..)` — is a type
-            // value exactly like `identity(i32, ..)`. `struct_type_for` /
-            // `enum_type_for` are the same by-file lookups the type-qualified
-            // call path uses (lexical aliases, file-level aliases, the
-            // referencing file's declarations, then builtins), so a nominal
-            // spelling resolves wherever its alias spelling already did.
-            // Consulting only the builtin tables left the argument out of
-            // `type_subst`, so a `-> T` return type could not be substituted
-            // and stayed the literal `type` placeholder — reported as a bogus
-            // "expected Foo, found type" mismatch at the binding (RUE-1680).
-            self.struct_type_for(sym, file_id)
-                .or_else(|| self.enum_type_for(sym, file_id))
-        };
-
         match &self.rir.get(arg).data {
             InstData::TypeConst { type_name } => {
                 match self.infer_rir_type_hint(*type_name, self.rir.get(arg).span.file_id) {
@@ -4912,9 +4870,6 @@ impl<'a> ConstraintGenerator<'a> {
                 // RUE-281). The literal form (`identity(i32, 42)`) already
                 // worked via the `TypeConst` arm; this makes an aliased type
                 // behave identically.
-                if let Some(ty) = self.comptime_alias_types.get(name).copied() {
-                    return Some(ty);
-                }
                 // A local or parameter shadows any same-named struct/enum. A
                 // local *not* bound to a comptime type value (a runtime value)
                 // has no concrete type here. Preserve that error through
@@ -4924,10 +4879,13 @@ impl<'a> ConstraintGenerator<'a> {
                 // Forwarded type parameters (`T` inside a specialized generic
                 // body) are not in scope as runtime params/locals and resolve
                 // via `self.type_subst` above.
-                if ctx.locals.contains_key(name) || ctx.contains_param(*name) {
-                    return Some(Type::ERROR);
-                }
-                resolve_sym(name)
+                let lexical_shadowed = ctx.locals.contains_key(name) || ctx.contains_param(*name);
+                self.unqualified_nominal_type_with_substitution(
+                    *name,
+                    file_id,
+                    self.type_subst,
+                    lexical_shadowed,
+                )
             }
             _ => None,
         }
@@ -4993,16 +4951,8 @@ impl<'a> ConstraintGenerator<'a> {
         match arena.node(syntax)? {
             RirTypeSyntaxNode::Named(symbol) => {
                 let name = *arena.symbol(*symbol)?;
-                if let Some(ty) = subst.and_then(|subst| subst.get(&name)).copied() {
-                    return Some(self.type_to_infer(ty));
-                }
-                if let Some(ty) = self.comptime_alias_types.get(&name).copied() {
-                    return Some(self.type_to_infer(ty));
-                }
-                if let Some(ty) = self.const_type_alias((file_id, name)) {
-                    return Some(self.type_to_infer(ty));
-                }
-                self.infer_named_type_hint(self.interner.resolve(&name), file_id)
+                self.unqualified_nominal_type_with_substitution(name, file_id, subst, false)
+                    .map(|ty| self.type_to_infer(ty))
             }
             RirTypeSyntaxNode::Unit => Some(InferType::Concrete(Type::UNIT)),
             RirTypeSyntaxNode::Never => Some(InferType::Concrete(Type::NEVER)),
@@ -5050,31 +5000,12 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
+    #[cfg(test)]
     fn infer_named_type_hint(&self, name: &str, file_id: FileId) -> Option<InferType> {
-        // Check primitives (single shared table, RUE-155)
-        if let Some(ty) = Type::from_primitive_name(name) {
-            return Some(InferType::Concrete(ty));
-        }
-
-        // Check for struct types (including builtin String)
-        if let Some(name_spur) = self.interner.get(name) {
-            if let Some(ty) = self.struct_type_by_file((file_id, name_spur)) {
-                return Some(InferType::Concrete(ty));
-            }
-            if let Some(ty) = self.enum_type_by_file((file_id, name_spur)) {
-                return Some(InferType::Concrete(ty));
-            }
-            if let Some(struct_ty) = self.builtin_struct_type(name_spur) {
-                return Some(InferType::Concrete(struct_ty));
-            }
-            if let Some(enum_ty) = self.builtin_enum_type(name_spur) {
-                return Some(InferType::Concrete(enum_ty));
-            }
-            if let Some(alias_ty) = self.scoped_const_type_alias(name_spur, file_id) {
-                return Some(InferType::Concrete(alias_ty));
-            }
-        }
-        None
+        self.interner
+            .get(name)
+            .and_then(|name| self.unqualified_nominal_type(name, file_id))
+            .map(InferType::Concrete)
     }
 }
 

--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -5,6 +5,7 @@
 
 use ahash::AHashMap;
 use std::cell::RefCell;
+use std::convert::Infallible;
 use std::hash::Hash;
 
 use lasso::Spur;
@@ -15,6 +16,9 @@ use super::ConstInfo;
 use super::body_identity::{DurableNominalSource, ProviderIdentityContext};
 use super::context::{ConstValue, LocalVar};
 use crate::intern_pool::TypeInternPool;
+use crate::semantic_type_resolution::{
+    UnqualifiedNominal, UnqualifiedNominalTier, select_unqualified_nominal,
+};
 use crate::types::{EnumId, ModuleId, StructId, Type};
 use crate::{SemanticImportNominalKind, SemanticImportType};
 
@@ -23,6 +27,7 @@ pub(crate) trait AggregateFacts {
     fn aggregate_module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
     fn aggregate_struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId>;
     fn aggregate_enum_in_file(&self, file: FileId, name: Spur) -> Option<EnumId>;
+    fn aggregate_primitive_type(&self, name: Spur) -> Option<Type>;
     fn aggregate_builtin_struct(&self, name: Spur) -> Option<StructId>;
     fn aggregate_builtin_enum(&self, name: Spur) -> Option<EnumId>;
     fn aggregate_module(&self, module: ModuleId) -> AggregateModuleFact;
@@ -63,6 +68,38 @@ pub(crate) enum ModuleTypeMember {
     Enum(EnumId),
     Const(ConstInfo),
     Absent,
+}
+
+fn select_unqualified_aggregate_type<P: AggregateFacts>(
+    facts: &P,
+    local_type: Option<Type>,
+    file: FileId,
+    name: Spur,
+) -> Option<UnqualifiedNominal<Type>> {
+    select_unqualified_nominal(|tier| {
+        Ok::<_, Infallible>(match tier {
+            UnqualifiedNominalTier::Substitution => None,
+            UnqualifiedNominalTier::LexicalAlias => local_type,
+            UnqualifiedNominalTier::FileAlias => {
+                facts
+                    .aggregate_value_const(file, name)
+                    .and_then(|info| match info.value {
+                        ConstValue::Type(ty) => Some(ty),
+                        _ => None,
+                    })
+            }
+            UnqualifiedNominalTier::Primitive => facts.aggregate_primitive_type(name),
+            UnqualifiedNominalTier::Declaration => facts
+                .aggregate_struct_in_file(file, name)
+                .map(Type::new_struct)
+                .or_else(|| facts.aggregate_enum_in_file(file, name).map(Type::new_enum)),
+            UnqualifiedNominalTier::Builtin => facts
+                .aggregate_builtin_struct(name)
+                .map(Type::new_struct)
+                .or_else(|| facts.aggregate_builtin_enum(name).map(Type::new_enum)),
+        })
+    })
+    .expect("infallible aggregate nominal selection")
 }
 
 /// A nominal type named through a module (`m.Name`), plus the `const` binding
@@ -134,18 +171,12 @@ pub(crate) fn resolve_enum_type_name<P: AggregateFacts>(
     file: FileId,
     name: Spur,
 ) -> Option<(EnumId, bool)> {
-    if let Some(ty) = local_type {
-        return ty.as_enum().map(|id| (id, true));
-    }
-    if let Some(info) = facts.aggregate_value_const(file, name)
-        && let ConstValue::Type(ty) = info.value
-    {
-        return ty.as_enum().map(|id| (id, true));
-    }
-    facts
-        .aggregate_enum_in_file(file, name)
-        .or_else(|| facts.aggregate_builtin_enum(name))
-        .map(|id| (id, false))
+    select_unqualified_aggregate_type(facts, local_type, file, name).and_then(|selected| {
+        selected
+            .value
+            .as_enum()
+            .map(|id| (id, selected.tier.via_binding()))
+    })
 }
 
 pub(crate) fn resolve_struct_type_name<P: AggregateFacts>(
@@ -154,18 +185,12 @@ pub(crate) fn resolve_struct_type_name<P: AggregateFacts>(
     file: FileId,
     name: Spur,
 ) -> Option<(StructId, bool)> {
-    if let Some(ty) = local_type {
-        return ty.as_struct().map(|id| (id, true));
-    }
-    if let Some(info) = facts.aggregate_value_const(file, name)
-        && let ConstValue::Type(ty) = info.value
-    {
-        return ty.as_struct().map(|id| (id, true));
-    }
-    facts
-        .aggregate_struct_in_file(file, name)
-        .or_else(|| facts.aggregate_builtin_struct(name))
-        .map(|id| (id, false))
+    select_unqualified_aggregate_type(facts, local_type, file, name).and_then(|selected| {
+        selected
+            .value
+            .as_struct()
+            .map(|id| (id, selected.tier.via_binding()))
+    })
 }
 
 pub(crate) fn select_struct_literal_head<P: AggregateFacts>(
@@ -174,18 +199,15 @@ pub(crate) fn select_struct_literal_head<P: AggregateFacts>(
     file: FileId,
     name: Spur,
 ) -> StructLiteralHead {
-    if let Some(ty) = local_type {
-        return StructLiteralHead::Bound(ty);
+    let selected = select_unqualified_aggregate_type(facts, local_type, file, name);
+    match selected {
+        Some(selected) if selected.tier.via_binding() => StructLiteralHead::Bound(selected.value),
+        Some(selected) => selected
+            .value
+            .as_struct()
+            .map_or(StructLiteralHead::Absent, StructLiteralHead::Named),
+        None => StructLiteralHead::Absent,
     }
-    if let Some(info) = facts.aggregate_value_const(file, name)
-        && let ConstValue::Type(ty) = info.value
-    {
-        return StructLiteralHead::Bound(ty);
-    }
-    facts
-        .aggregate_struct_in_file(file, name)
-        .or_else(|| facts.aggregate_builtin_struct(name))
-        .map_or(StructLiteralHead::Absent, StructLiteralHead::Named)
 }
 
 /// The one source order for a type named through a module (`m.Name`): a struct
@@ -563,8 +585,8 @@ where
     }
 
     /// Run the provider-generic [`select_struct_literal_head`] over this driver
-    /// for an unqualified head (`local_type = None`): the const→struct→builtin
-    /// order, including an installed const arm.
+    /// for an unqualified head (`local_type = None`), including an installed
+    /// const arm and the canonical declaration/builtin fallback order.
     pub fn select_struct_literal_head(&self, file: FileId, name: &str) -> ProviderStructHead {
         let Ok(symbol) = self.identity.pool().intern_name(name) else {
             return ProviderStructHead::Absent;
@@ -629,6 +651,10 @@ where
             .resolve(&SemanticImportType::Nominal(key))
             .ok()?
             .as_enum()
+    }
+
+    fn aggregate_primitive_type(&self, name: Spur) -> Option<Type> {
+        Type::from_primitive_name(self.identity.pool().resolve_symbol(name))
     }
 
     fn aggregate_builtin_struct(&self, name: Spur) -> Option<StructId> {

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -133,6 +133,26 @@ mod tests {
     const TYPES_SOURCE: &str = include_str!("../types.rs");
     const AIR_LIB_SOURCE: &str = include_str!("../lib.rs");
     const VISIBILITY_SOURCE: &str = include_str!("visibility.rs");
+
+    fn source_item<'source>(source: &'source str, header: &str) -> &'source str {
+        let start = source.find(header).expect("item header is present");
+        let rest = &source[start..];
+        let open = rest.find('{').expect("item body opens");
+        let mut depth = 0;
+        for (offset, ch) in rest[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &rest[..open + offset + 1];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("item body closes");
+    }
     const BINDING_MANIFEST_SOURCE: &str = include_str!("binding_manifest.rs");
     const CALL_INTRINSIC_PEER_SOURCE: &str = concat!(
         include_str!("mod.rs"),
@@ -1390,6 +1410,261 @@ mod tests {
         assert!(FACT_MODE_SOURCE.contains(
             "BodyEndpointProvider + CallResolutionFacts + AggregateFacts + InferenceFactSource"
         ));
+    }
+
+    #[test]
+    fn unqualified_nominal_resolution_has_one_ordered_authority() {
+        assert_eq!(
+            [
+                SEMANTIC_TYPE_RESOLUTION_SOURCE,
+                AGGREGATE_RESOLUTION_SOURCE,
+                GENERATE_SOURCE,
+            ]
+            .iter()
+            .map(|source| {
+                source
+                    .matches("pub(crate) fn select_unqualified_nominal<")
+                    .count()
+            })
+            .sum::<usize>(),
+            1,
+            "unqualified nominal selection must have one policy authority"
+        );
+
+        let authority = source_item(
+            SEMANTIC_TYPE_RESOLUTION_SOURCE,
+            "pub(crate) fn select_unqualified_nominal<",
+        );
+        let mut previous = 0;
+        for tier in [
+            "UnqualifiedNominalTier::Substitution",
+            "UnqualifiedNominalTier::LexicalAlias",
+            "UnqualifiedNominalTier::FileAlias",
+            "UnqualifiedNominalTier::Primitive",
+            "UnqualifiedNominalTier::Declaration",
+            "UnqualifiedNominalTier::Builtin",
+        ] {
+            let position = authority[previous..]
+                .find(tier)
+                .map(|offset| previous + offset)
+                .unwrap_or_else(|| panic!("canonical unqualified nominal precedence lost {tier}"));
+            assert!(position >= previous, "{tier} moved out of canonical order");
+            previous = position + tier.len();
+        }
+
+        for (source, marker) in [
+            (
+                GENERATE_SOURCE,
+                "fn unqualified_nominal_type_with_substitution(",
+            ),
+            (GENERATE_SOURCE, "fn extract_type_argument("),
+            (GENERATE_SOURCE, "fn infer_type_hint("),
+            (GENERATE_SOURCE, "fn infer_named_type_hint("),
+            (
+                AGGREGATE_RESOLUTION_SOURCE,
+                "fn select_unqualified_aggregate_type<",
+            ),
+            (
+                SEMANTIC_TYPE_RESOLUTION_SOURCE,
+                "fn resolve_unqualified_semantic_type<",
+            ),
+        ] {
+            assert!(
+                source_item(source, marker).contains("select_unqualified_nominal(")
+                    || source_item(source, marker).contains("unqualified_nominal_type(")
+                    || source_item(source, marker)
+                        .contains("unqualified_nominal_type_with_substitution("),
+                "{marker} regained a peer unqualified nominal arm chain"
+            );
+        }
+
+        let adapter = source_item(
+            GENERATE_SOURCE,
+            "fn unqualified_nominal_type_with_substitution(",
+        );
+        assert_eq!(adapter.matches("select_unqualified_nominal(").count(), 1);
+        for probe in [
+            "substitution.and_then(",
+            "self.comptime_alias_types.get(",
+            "self.const_type_alias(",
+            "Type::from_primitive_name(",
+            ".struct_type_by_file(",
+            ".enum_type_by_file(",
+            ".builtin_struct_type(",
+            ".builtin_enum_type(",
+        ] {
+            assert_eq!(
+                adapter.matches(probe).count(),
+                1,
+                "the inference adapter must contain exactly its one tier probe {probe}"
+            );
+        }
+        assert_eq!(
+            adapter.matches(".or_else(").count(),
+            2,
+            "only the declaration and builtin tiers may join their two nominal kinds"
+        );
+        assert!(!adapter.contains("return Some("));
+
+        let direct_nominal_probes = [
+            "self.comptime_alias_types.get(",
+            "self.const_type_alias(",
+            "Type::from_primitive_name(",
+            ".struct_type_by_file(",
+            ".enum_type_by_file(",
+            ".builtin_struct_type(",
+            ".builtin_enum_type(",
+        ];
+        let extract = source_item(GENERATE_SOURCE, "fn extract_type_argument(");
+        assert_eq!(
+            extract
+                .matches("self.unqualified_nominal_type_with_substitution(")
+                .count(),
+            1
+        );
+        assert_eq!(extract.matches(".or_else(").count(), 0);
+        assert_eq!(extract.matches("return Some(").count(), 0);
+        for probe in direct_nominal_probes {
+            assert!(
+                !extract.contains(probe),
+                "extract_type_argument regained {probe}"
+            );
+        }
+
+        let hint = source_item(GENERATE_SOURCE, "fn infer_type_hint(");
+        let named_start = hint
+            .find("RirTypeSyntaxNode::Named(symbol) => {")
+            .expect("named type-hint arm is present");
+        let named_end = hint[named_start..]
+            .find("RirTypeSyntaxNode::Unit")
+            .map(|offset| named_start + offset)
+            .expect("unit arm follows the named arm");
+        let named_hint = &hint[named_start..named_end];
+        assert_eq!(
+            named_hint
+                .matches("self.unqualified_nominal_type_with_substitution(")
+                .count(),
+            1
+        );
+        assert!(!named_hint.contains(".or_else("));
+        assert!(!named_hint.contains("return "));
+        for probe in direct_nominal_probes {
+            assert!(
+                !named_hint.contains(probe),
+                "infer_type_hint regained {probe}"
+            );
+        }
+        assert_eq!(
+            hint.matches(".or_else(").count(),
+            1,
+            "infer_type_hint's sole non-nominal fallback is named array-length lookup"
+        );
+        assert_eq!(hint.matches("self.scoped_const_value(").count(), 1);
+
+        let named_helper = source_item(GENERATE_SOURCE, "fn infer_named_type_hint(");
+        assert_eq!(
+            named_helper
+                .matches("self.unqualified_nominal_type(")
+                .count(),
+            1
+        );
+        assert!(!named_helper.contains(".or_else("));
+        assert!(!named_helper.contains("return "));
+        for probe in direct_nominal_probes {
+            assert!(
+                !named_helper.contains(probe),
+                "infer_named_type_hint regained {probe}"
+            );
+        }
+
+        let aggregate_adapter = source_item(
+            AGGREGATE_RESOLUTION_SOURCE,
+            "fn select_unqualified_aggregate_type<",
+        );
+        assert!(
+            aggregate_adapter.contains(
+                "UnqualifiedNominalTier::Primitive => facts.aggregate_primitive_type(name)"
+            )
+        );
+        for marker in ["fn struct_type_for(", "fn enum_type_for("] {
+            let consumer = source_item(GENERATE_SOURCE, marker);
+            assert!(consumer.contains("self.unqualified_nominal_type("));
+            for forbidden in [
+                "type_subst",
+                "comptime_alias_types",
+                "const_type_alias",
+                "struct_type_by_file",
+                "enum_type_by_file",
+                "builtin_struct_type",
+                "builtin_enum_type",
+                ".or_else",
+            ] {
+                assert!(
+                    !consumer.contains(forbidden),
+                    "{marker} regained peer arm {forbidden}"
+                );
+            }
+        }
+        for marker in [
+            "pub(crate) fn resolve_enum_type_name<",
+            "pub(crate) fn resolve_struct_type_name<",
+            "pub(crate) fn select_struct_literal_head<",
+        ] {
+            let consumer = source_item(AGGREGATE_RESOLUTION_SOURCE, marker);
+            assert!(consumer.contains("select_unqualified_aggregate_type("));
+            assert!(
+                !consumer.contains("aggregate_builtin_")
+                    && !consumer.contains("aggregate_value_const")
+                    && !consumer.contains(".or_else"),
+                "{marker} regained a peer aggregate resolution chain"
+            );
+        }
+        let structured = source_item(
+            SEMANTIC_TYPE_RESOLUTION_SOURCE,
+            "fn resolve_unqualified_semantic_type<",
+        );
+        assert_eq!(structured.matches("select_unqualified_nominal(").count(), 1);
+        assert!(
+            !structured.contains("return Ok(Some"),
+            "structured semantic resolver regained an early-return arm chain"
+        );
+        let provider_nominal =
+            source_item(PROVIDER_BODY_HOST_SOURCE, "fn nominal_type_for_symbol(");
+        assert!(provider_nominal.contains("self.declared_nominal_type_for_symbol(file, symbol)"));
+        let declared = provider_nominal
+            .find("self.declared_nominal_type_for_symbol(file, symbol)")
+            .expect("provider nominal lookup includes its unified declaration tier");
+        for builtin in [
+            "endpoint_builtin_or_generated_struct(symbol)",
+            "endpoint_builtin_enum(symbol)",
+        ] {
+            assert!(
+                declared
+                    < provider_nominal
+                        .find(builtin)
+                        .expect("builtin tier is present"),
+                "provider nominal lookup must try unified user declarations before {builtin}"
+            );
+        }
+        let declared_nominal = source_item(
+            PROVIDER_BODY_HOST_SOURCE,
+            "fn declared_nominal_type_for_symbol(",
+        );
+        assert!(
+            !declared_nominal.contains("endpoint_builtin"),
+            "the declaration tier must not preselect a kind-specific builtin"
+        );
+        let struct_init = GENERATE_SOURCE
+            .split_once("// Struct initialization")
+            .expect("StructInit section starts")
+            .1
+            .split_once("// Field access")
+            .expect("StructInit section ends")
+            .0;
+        assert!(
+            struct_init.contains("self.struct_type_for(type_name, span.file_id)"),
+            "StructInit regained a peer unqualified nominal arm chain"
+        );
     }
 
     #[test]

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -2397,44 +2397,58 @@ where
         Some(info)
     }
 
-    fn nominal_type_for_symbol(&self, file: FileId, symbol: Spur) -> Option<Type> {
+    fn declared_nominal_type_for_symbol(&self, file: FileId, symbol: Spur) -> Option<Type> {
         if let Some(id) = self.generated_structs.get(&symbol) {
             return Some(Type::new_struct(*id));
         }
         if let Some(id) = self.generated_enums.get(&symbol) {
             return Some(Type::new_enum(*id));
         }
-        if let Some(id) = self.endpoint.endpoint_builtin_or_generated_struct(symbol) {
-            return Some(Type::new_struct(id));
-        }
-        if let Some(id) = self.endpoint.endpoint_builtin_enum(symbol) {
-            return Some(Type::new_enum(id));
-        }
         let name = self.interner.resolve(&symbol);
-        let (key, kind) = if file == self.owner_file {
-            DurableBodyLookupSource::nominal(&self.source, &self.key, name)?
+        let declared = if file == self.owner_file {
+            DurableBodyLookupSource::nominal(&self.source, &self.key, name)
         } else {
-            let module = self.modules_by_file.borrow().get(&file)?.clone();
-            self.source.qualified_nominal(&module, name)?
+            self.modules_by_file
+                .borrow()
+                .get(&file)
+                .cloned()
+                .and_then(|module| self.source.qualified_nominal(&module, name))
         };
-        let token = self
-            .endpoint
-            .register_named_nominal(key.clone(), file.index(), name, kind)?;
-        let imported = crate::SemanticImportType::Nominal(key.clone());
-        self.register_import_nominal_identities(&imported).ok()?;
-        let ty = self
-            .state
-            .identity_context()
-            .pool_mut()?
-            .resolve_provider_type(&imported)
-            .ok()?;
-        match kind {
-            crate::StableDefinitionKind::Struct if ty.as_struct().is_some() => {}
-            crate::StableDefinitionKind::Enum if ty.as_enum().is_some() => {}
-            _ => return None,
+        if let Some((key, kind)) = declared {
+            let token =
+                self.endpoint
+                    .register_named_nominal(key.clone(), file.index(), name, kind)?;
+            let imported = crate::SemanticImportType::Nominal(key.clone());
+            self.register_import_nominal_identities(&imported).ok()?;
+            let ty = self
+                .state
+                .identity_context()
+                .pool_mut()?
+                .resolve_provider_type(&imported)
+                .ok()?;
+            match kind {
+                crate::StableDefinitionKind::Struct if ty.as_struct().is_some() => {}
+                crate::StableDefinitionKind::Enum if ty.as_enum().is_some() => {}
+                _ => return None,
+            }
+            self.nominal_tokens.borrow_mut().insert(ty, (token, key));
+            return Some(ty);
         }
-        self.nominal_tokens.borrow_mut().insert(ty, (token, key));
-        Some(ty)
+        None
+    }
+
+    fn nominal_type_for_symbol(&self, file: FileId, symbol: Spur) -> Option<Type> {
+        self.declared_nominal_type_for_symbol(file, symbol)
+            .or_else(|| {
+                self.endpoint
+                    .endpoint_builtin_or_generated_struct(symbol)
+                    .map(Type::new_struct)
+            })
+            .or_else(|| {
+                self.endpoint
+                    .endpoint_builtin_enum(symbol)
+                    .map(Type::new_enum)
+            })
     }
 
     fn ensure_named_nominal_identity(
@@ -3494,10 +3508,11 @@ where
         self.endpoint.endpoint_module_endpoint(token)
     }
     fn endpoint_struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
-        self.nominal_type_for_symbol(file, name)?.as_struct()
+        self.declared_nominal_type_for_symbol(file, name)?
+            .as_struct()
     }
     fn endpoint_enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
-        self.nominal_type_for_symbol(file, name)?.as_enum()
+        self.declared_nominal_type_for_symbol(file, name)?.as_enum()
     }
     fn endpoint_builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
         self.endpoint.endpoint_builtin_or_generated_struct(name)
@@ -3611,10 +3626,14 @@ where
         self.module_binding_for_symbol(file, name)
     }
     fn aggregate_struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
-        self.nominal_type_for_symbol(file, name)?.as_struct()
+        self.declared_nominal_type_for_symbol(file, name)?
+            .as_struct()
     }
     fn aggregate_enum_in_file(&self, file: FileId, name: Spur) -> Option<EnumId> {
-        self.nominal_type_for_symbol(file, name)?.as_enum()
+        self.declared_nominal_type_for_symbol(file, name)?.as_enum()
+    }
+    fn aggregate_primitive_type(&self, name: Spur) -> Option<Type> {
+        Type::from_primitive_name(self.interner.resolve(&name))
     }
     fn aggregate_builtin_struct(&self, name: Spur) -> Option<StructId> {
         AggregateFactsTrait::aggregate_builtin_struct(&self.aggregate, name)
@@ -3743,7 +3762,7 @@ where
             .map(Type::new_struct)
     }
     fn inference_struct_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
-        self.nominal_type_for_symbol(key.0, key.1)
+        self.declared_nominal_type_for_symbol(key.0, key.1)
             .filter(|ty| ty.as_struct().is_some())
     }
     fn inference_builtin_enum_type(&self, name: Spur) -> Option<Type> {
@@ -3752,7 +3771,7 @@ where
             .map(Type::new_enum)
     }
     fn inference_enum_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
-        self.nominal_type_for_symbol(key.0, key.1)
+        self.declared_nominal_type_for_symbol(key.0, key.1)
             .filter(|ty| ty.as_enum().is_some())
     }
     fn inference_nominal_type_accessible(&self, accessing_file: FileId, ty: Type) -> bool {
@@ -3890,7 +3909,7 @@ where
             .unwrap_or_else(|| authority.file());
         let selected = match kind {
             TypeSyntaxNamedKind::Struct => self
-                .nominal_type_for_symbol(file, name)
+                .declared_nominal_type_for_symbol(file, name)
                 .filter(|ty| ty.as_struct().is_some())
                 .map(|ty| {
                     let metadata = self
@@ -3900,7 +3919,7 @@ where
                     (ty, metadata.file_id, metadata.is_pub)
                 }),
             TypeSyntaxNamedKind::Enum => self
-                .nominal_type_for_symbol(file, name)
+                .declared_nominal_type_for_symbol(file, name)
                 .filter(|ty| ty.as_enum().is_some())
                 .map(|ty| {
                     let metadata = self
@@ -4940,7 +4959,8 @@ where
     }
 
     fn struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
-        self.nominal_type_for_symbol(file, name)?.as_struct()
+        self.declared_nominal_type_for_symbol(file, name)?
+            .as_struct()
     }
 
     fn builtin_struct(&self, name: Spur) -> Option<StructId> {

--- a/crates/rue-air/src/semantic_type_resolution.rs
+++ b/crates/rue-air/src/semantic_type_resolution.rs
@@ -12,6 +12,58 @@ use std::sync::Arc;
 use ahash::AHashMap;
 use lasso::{Key, Spur};
 
+/// One precedence tier in unqualified type-name resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnqualifiedNominalTier {
+    Substitution,
+    LexicalAlias,
+    FileAlias,
+    Primitive,
+    Declaration,
+    Builtin,
+}
+
+impl UnqualifiedNominalTier {
+    pub(crate) fn via_binding(self) -> bool {
+        matches!(
+            self,
+            Self::Substitution | Self::LexicalAlias | Self::FileAlias
+        )
+    }
+}
+
+/// The winner selected by [`select_unqualified_nominal`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct UnqualifiedNominal<T> {
+    pub(crate) value: T,
+    pub(crate) tier: UnqualifiedNominalTier,
+}
+
+/// Canonical precedence authority for one unqualified type spelling.
+///
+/// The probe owns all provider-specific work and is invoked lazily, once per
+/// tier, until a winner or provider failure is observed. Declaration and
+/// builtin probes must each expose their unified nominal namespace before a
+/// consumer applies a struct/enum kind filter; otherwise an opposite-kind user
+/// declaration can be skipped and a same-named builtin can counterfeit it.
+pub(crate) fn select_unqualified_nominal<T, E>(
+    mut probe: impl FnMut(UnqualifiedNominalTier) -> Result<Option<T>, E>,
+) -> Result<Option<UnqualifiedNominal<T>>, E> {
+    for tier in [
+        UnqualifiedNominalTier::Substitution,
+        UnqualifiedNominalTier::LexicalAlias,
+        UnqualifiedNominalTier::FileAlias,
+        UnqualifiedNominalTier::Primitive,
+        UnqualifiedNominalTier::Declaration,
+        UnqualifiedNominalTier::Builtin,
+    ] {
+        if let Some(value) = probe(tier)? {
+            return Ok(Some(UnqualifiedNominal { value, tier }));
+        }
+    }
+    Ok(None)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SemanticVisibilityDomain(Option<Arc<str>>);
 
@@ -622,51 +674,57 @@ fn resolve_unqualified_semantic_type<S, M, A, K, N, T, V, P>(
 where
     P: SemanticTypeSyntaxProvider<S, M, A, K, N, T, V>,
 {
-    // Computed lazily, next to the only readers below: the substituted,
-    // primitive and builtin fast paths resolve most names and all return before
-    // any visibility check, so eagerly deriving the domain here made every `i32`
-    // pay a path parse and an Arc<str> allocation it discarded (RUE-1840).
-    if let Some(ty) = lift_provider(provider.substituted_type(root_scope, name))? {
-        lift_provider(provider.observe_materialized_type(&ty))?;
-        return Ok(Some(ty));
+    enum Candidate<T, A> {
+        Materialized(T),
+        Direct(T),
+        Named(SemanticTypeFactKind, SemanticTypeFact<T, A>),
     }
-    if let Some(ty) = lift_provider(provider.primitive_type(name))? {
-        return Ok(Some(ty));
-    }
-    if let Some(ty) = lift_provider(provider.builtin_type(root_scope, name))? {
-        return Ok(Some(ty));
-    }
-    if let Some(fact) = lift_provider(provider.root_struct_type(root_scope, name))? {
-        return select_named_type(
+
+    let selected = select_unqualified_nominal(|tier| match tier {
+        UnqualifiedNominalTier::Substitution => {
+            lift_provider(provider.substituted_type(root_scope, name))
+                .map(|value| value.map(Candidate::Materialized))
+        }
+        // The structured semantic provider's substitution hook owns all
+        // lexical comptime bindings for its current continuation.
+        UnqualifiedNominalTier::LexicalAlias => Ok(None),
+        UnqualifiedNominalTier::FileAlias => {
+            lift_provider(provider.root_type_alias(root_scope, name)).map(|value| {
+                value.map(|fact| Candidate::Named(SemanticTypeFactKind::Constant, fact))
+            })
+        }
+        UnqualifiedNominalTier::Primitive => {
+            lift_provider(provider.primitive_type(name)).map(|value| value.map(Candidate::Direct))
+        }
+        UnqualifiedNominalTier::Declaration => {
+            if let Some(fact) = lift_provider(provider.root_struct_type(root_scope, name))? {
+                Ok(Some(Candidate::Named(SemanticTypeFactKind::Struct, fact)))
+            } else {
+                lift_provider(provider.root_enum_type(root_scope, name)).map(|value| {
+                    value.map(|fact| Candidate::Named(SemanticTypeFactKind::Enum, fact))
+                })
+            }
+        }
+        UnqualifiedNominalTier::Builtin => lift_provider(provider.builtin_type(root_scope, name))
+            .map(|value| value.map(Candidate::Direct)),
+    })?;
+
+    match selected.map(|selected| selected.value) {
+        Some(Candidate::Materialized(ty)) => {
+            lift_provider(provider.observe_materialized_type(&ty))?;
+            Ok(Some(ty))
+        }
+        Some(Candidate::Direct(ty)) => Ok(Some(ty)),
+        Some(Candidate::Named(kind, fact)) => select_named_type(
             provider,
             fact,
-            SemanticTypeFactKind::Struct,
+            kind,
             name,
             &provider.accessing_domain(root_scope),
         )
-        .map(Some);
+        .map(Some),
+        None => Ok(None),
     }
-    if let Some(fact) = lift_provider(provider.root_enum_type(root_scope, name))? {
-        return select_named_type(
-            provider,
-            fact,
-            SemanticTypeFactKind::Enum,
-            name,
-            &provider.accessing_domain(root_scope),
-        )
-        .map(Some);
-    }
-    if let Some(fact) = lift_provider(provider.root_type_alias(root_scope, name))? {
-        return select_named_type(
-            provider,
-            fact,
-            SemanticTypeFactKind::Constant,
-            name,
-            &provider.accessing_domain(root_scope),
-        )
-        .map(Some);
-    }
-    Ok(None)
 }
 
 fn resolve_qualified_semantic_type<S, M, A, K, N, T, V, P>(
@@ -2493,6 +2551,62 @@ mod tests {
     }
 
     #[test]
+    fn unqualified_nominal_selector_is_ordered_lazy_and_kind_neutral() {
+        let tiers = [
+            UnqualifiedNominalTier::Substitution,
+            UnqualifiedNominalTier::LexicalAlias,
+            UnqualifiedNominalTier::FileAlias,
+            UnqualifiedNominalTier::Primitive,
+            UnqualifiedNominalTier::Declaration,
+            UnqualifiedNominalTier::Builtin,
+        ];
+        for (winner_index, winner) in tiers.into_iter().enumerate() {
+            let mut probes = Vec::new();
+            let selected = select_unqualified_nominal(|tier| {
+                probes.push(tier);
+                Ok::<_, ()>((tier == winner).then_some(winner_index))
+            })
+            .unwrap()
+            .expect("configured winner is selected");
+            assert_eq!(selected.tier, winner);
+            assert_eq!(selected.value, winner_index);
+            assert_eq!(probes, &tiers[..=winner_index]);
+        }
+
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        enum Kind {
+            Struct,
+            Enum,
+        }
+        let selected = select_unqualified_nominal(|tier| {
+            Ok::<_, ()>(match tier {
+                UnqualifiedNominalTier::Declaration => Some(Kind::Struct),
+                UnqualifiedNominalTier::Builtin => Some(Kind::Enum),
+                _ => None,
+            })
+        })
+        .unwrap()
+        .expect("declaration wins");
+        assert_eq!(selected.value, Kind::Struct);
+        assert!(
+            (selected.value == Kind::Enum).then_some(()).is_none(),
+            "a consumer kind filter must not fall through to the builtin"
+        );
+
+        let mut probes = Vec::new();
+        let failed = select_unqualified_nominal(|tier| {
+            probes.push(tier);
+            if tier == UnqualifiedNominalTier::FileAlias {
+                Err("ambiguous")
+            } else {
+                Ok(None::<()>)
+            }
+        });
+        assert_eq!(failed, Err("ambiguous"));
+        assert_eq!(probes, &tiers[..=2]);
+    }
+
+    #[test]
     fn structured_poll_suspends_each_call_once_without_replaying_traversal() {
         let mut fixture = Fixture::default();
         configure_nested_calls(&mut fixture);
@@ -2571,6 +2685,7 @@ mod tests {
                 "builtin_call:app/main.rue:Inner",
                 "root_constructor:app/main.rue:Inner",
                 "substitution:app/main.rue:i32",
+                "root_alias:app/main.rue:i32",
                 "primitive:-:i32",
                 "reduce:ctor-key",
                 "root_constructor:app/main.rue:InnerValue",
@@ -2797,7 +2912,7 @@ mod tests {
     }
 
     #[test]
-    fn unqualified_nominal_precedes_alias_and_stops_discovery_exactly() {
+    fn unqualified_alias_precedes_declaration_and_stops_discovery_exactly() {
         let mut fixture = Fixture::default();
         fixture.root_structs.insert(
             ("app/main.rue", "Thing"),
@@ -2808,14 +2923,12 @@ mod tests {
             fact("alias", "alias-site", true, "app/aliases.rue"),
         );
 
-        assert_eq!(resolve_type(&mut fixture, "Thing"), Ok("struct"));
+        assert_eq!(resolve_type(&mut fixture, "Thing"), Ok("alias"));
         assert_eq!(
             fixture.calls,
             [
                 "substitution:app/main.rue:Thing",
-                "primitive:-:Thing",
-                "builtin:app/main.rue:Thing",
-                "root_struct:app/main.rue:Thing",
+                "root_alias:app/main.rue:Thing",
             ]
         );
     }
@@ -2888,6 +3001,7 @@ mod tests {
                 "[i32; 2]",
                 &[
                     "substitution:app/main.rue:i32",
+                    "root_alias:app/main.rue:i32",
                     "primitive:-:i32",
                     "array_length:app/main.rue:Integer(2)",
                     "array_type",
@@ -2897,6 +3011,7 @@ mod tests {
                 "ptr const i32",
                 &[
                     "substitution:app/main.rue:i32",
+                    "root_alias:app/main.rue:i32",
                     "primitive:-:i32",
                     "ptr_const",
                 ],
@@ -2907,6 +3022,7 @@ mod tests {
                     "builtin_call:app/main.rue:Make",
                     "root_constructor:app/main.rue:Make",
                     "substitution:app/main.rue:i32",
+                    "root_alias:app/main.rue:i32",
                     "primitive:-:i32",
                     "reduce:ctor-key",
                 ],
@@ -2915,6 +3031,7 @@ mod tests {
                 "[i32]",
                 &[
                     "substitution:app/main.rue:i32",
+                    "root_alias:app/main.rue:i32",
                     "primitive:-:i32",
                     "slice:app/main.rue:[i32]",
                 ],
@@ -3317,6 +3434,7 @@ mod tests {
             fixture.calls,
             [
                 "substitution:app/main.rue:i32",
+                "root_alias:app/main.rue:i32",
                 "primitive:-:i32",
                 "root_constructor:app/main.rue:Width",
                 "value:app/main.rue:Width",
@@ -3812,7 +3930,11 @@ mod tests {
             assert_eq!(resolve_type(&mut fixture, "i32"), Err(expected));
             assert_eq!(
                 fixture.calls,
-                ["substitution:app/main.rue:i32", "primitive:-:i32"]
+                [
+                    "substitution:app/main.rue:i32",
+                    "root_alias:app/main.rue:i32",
+                    "primitive:-:i32"
+                ]
             );
         }
     }

--- a/crates/rue-cli-tests/cases/module_const_type_namespace.toml
+++ b/crates/rue-cli-tests/cases/module_const_type_namespace.toml
@@ -112,6 +112,114 @@ fn main() -> i32 {
 """ }]
 stdout = "42\n"
 
+# --- RUE-1966: the alias must reach inference, not only sema ---
+
+[[case]]
+name = "module_const_u8_struct_literal_constrains_fields"
+description = "RUE-1966: a file const alias constrains a struct literal's fields before AIR emission; 200 fits u8 and must not reach the mixed-width ICE path."
+files = [{ path = "main.rue", source = """
+fn Point(comptime T: type) -> type { struct { x: T } }
+const P = Point(u8);
+
+fn identity(comptime T: type, value: T) -> T { value }
+fn get(p: P) -> u8 { p.x }
+
+fn main() -> i32 {
+    let p: P = P { x: 200 };
+    let q = identity(P, p);
+    if get(q) == 200 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "module_const_u8_struct_literal_out_of_range"
+description = "RUE-1966 control: the same alias gives an out-of-range field a stable user diagnostic rather than an ICE."
+files = [{ path = "main.rue", source = """
+fn Point(comptime T: type) -> type { struct { x: T } }
+const P = Point(u8);
+fn main() -> i32 { let _ = P { x: 300 }; 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0800", "300", "out of range", "u8"]
+
+[[case]]
+name = "module_const_u8_struct_literal_type_mismatch"
+description = "RUE-1966 control: the alias-constrained field keeps the ordinary E0206 mismatch class."
+files = [{ path = "main.rue", source = """
+fn Point(comptime T: type) -> type { struct { x: T } }
+const P = Point(u8);
+fn main() -> i32 { let _ = P { x: true }; 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0206", "expected u8", "found bool"]
+
+[[case]]
+name = "user_struct_shadows_opposite_kind_builtin_enum"
+description = "RUE-1966 precedence control: a user struct named Arch wins before the builtin Arch enum for annotations, generic arguments, and literals."
+files = [{ path = "main.rue", source = """
+struct Arch { x: i32 }
+fn identity(comptime T: type, value: T) -> T { value }
+fn get(value: Arch) -> i32 { value.x }
+fn main() -> i32 { get(identity(Arch, Arch { x: 42 })) }
+""" }]
+exit_code = 42
+
+[[case]]
+name = "local_comptime_alias_shadows_file_alias"
+description = "RUE-1966 precedence control: a lexical comptime alias wins over a same-named file alias for a struct-literal head."
+files = [{ path = "main.rue", source = """
+fn Point(comptime T: type) -> type { struct { x: T } }
+const P = Point(i32);
+fn main() -> i32 {
+    let P = Point(u8);
+    let p = P { x: 200 };
+    if p.x == 200 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "user_struct_blocks_opposite_kind_builtin_enum_variant"
+description = "RUE-1966 wrong-kind control: a same-named user struct blocks fallback to the builtin Arch enum."
+files = [{ path = "main.rue", source = """
+struct Arch { x: i32 }
+fn main() -> i32 { let _ = Arch.X86_64; 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0423", "field access on non-struct type 'type'"]
+
+[[case]]
+name = "user_enum_blocks_opposite_kind_builtin_struct_literal"
+description = "RUE-1966 symmetric wrong-kind control: a same-named user enum blocks fallback to builtin str as a struct-literal head."
+files = [{ path = "main.rue", source = """
+enum str { Value }
+fn main() -> i32 { let _ = str { x: 1 }; 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0204", "unknown type 'str'"]
+
+[[case]]
+name = "primitive_spelling_blocks_same_named_user_struct_literal"
+description = "RUE-1966 primitive control: the legal declaration spelling `f32` cannot make struct-literal resolution disagree with annotation resolution, where the primitive wins."
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct f32 { x: i32 }
+fn main() -> i32 { let _: f32 = f32 { x: 42 }; 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0204", "unknown type 'f32'"]
+
+[[case]]
+name = "non_type_const_is_not_a_struct_literal_alias"
+description = "RUE-1966 counterfeit control: a value const cannot satisfy the nominal alias slot."
+files = [{ path = "main.rue", source = """
+const P: i32 = 0;
+fn main() -> i32 { let _ = P { x: 200 }; 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0204", "unknown type 'P'"]
+
 # --- Guard: enum consts (which always worked) still resolve, so the struct
 #     fix keeps struct and enum namespaces uniform ---
 

--- a/crates/rue-compiler/src/revisioned_query_database/tests/body_provider/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/body_provider/provider.rs
@@ -147,8 +147,8 @@ fn provider_type_facts_resolve_primitive_and_structural_shapes() {
 
     // Enumerate the `SemanticImportType` (durable) arms r2 covers structurally.
     // Each is resolved through the shared logic driven by ProviderTypeFacts;
-    // primitives and structural wrappers consult no declaration fact, so they
-    // record no dependency edge (proven below).
+    // Primitive spellings first consult the higher-precedence file-alias
+    // namespace, including the canonical spellings for unit and never.
     let primitive_cases: &[(&str, T)] = &[
         ("i8", T::I8),
         ("i16", T::I16),
@@ -169,9 +169,15 @@ fn provider_type_facts_resolve_primitive_and_structural_shapes() {
         let (resolved, _materialized, deps) =
             resolve_type_via_provider(&database, revision, &scope, syntax, None);
         assert_eq!(resolved.as_ref(), Some(expected), "primitive `{syntax}`");
+        assert_eq!(
+            deps.len(),
+            1,
+            "primitives record exactly their canonical file-alias probe: `{syntax}` -> {deps:?}"
+        );
         assert!(
-            deps.is_empty(),
-            "a primitive consults no declaration fact and records no edge: `{syntax}` -> {deps:?}"
+            deps.iter()
+                .all(|dependency| dependency.family() == "compiler.lookup-name"),
+            "primitive resolution recorded a non-name dependency: `{syntax}` -> {deps:?}"
         );
     }
 
@@ -204,10 +210,12 @@ fn provider_type_facts_resolve_primitive_and_structural_shapes() {
         let (resolved, _materialized, deps) =
             resolve_type_via_provider(&database, revision, &scope, syntax, None);
         assert_eq!(resolved.as_ref(), Some(expected), "structural `{syntax}`");
-        assert!(
-            deps.is_empty(),
-            "structural `{syntax}` records no edge: {deps:?}"
+        assert_eq!(
+            deps.len(),
+            1,
+            "each structural case contains one named primitive and records its canonical file-alias probe: `{syntax}` -> {deps:?}"
         );
+        assert_eq!(deps[0].family(), "compiler.lookup-name");
     }
 }
 
@@ -260,12 +268,14 @@ fn provider_type_facts_builtin_str_and_slice_names_match_epoch() {
         }),
         "`str` resolves to the builtin-nominal durable identity"
     );
-    // A pool/overlay-answered name fact records no provider query edge (edge
-    // honesty — the builtin identity is not a boundary lookup).
-    assert!(
-        deps.is_empty(),
-        "resolving `str` records no provider edge: {deps:?}"
+    // The builtin identity itself is pool answered, but the higher-precedence
+    // file declaration/alias namespace must first be disproved.
+    assert_eq!(
+        deps.len(),
+        1,
+        "resolving `str` probes its file name: {deps:?}"
     );
+    assert_eq!(deps[0].family(), "compiler.lookup-name");
 
     // `[i32]` resolves to the durable slice identity whose name IS the slice
     // syntax and whose element is the resolved element type.
@@ -279,10 +289,12 @@ fn provider_type_facts_builtin_str_and_slice_names_match_epoch() {
         }),
         "`[i32]` resolves to the slice durable identity keyed by the slice syntax"
     );
-    assert!(
-        deps.is_empty(),
-        "resolving `[i32]` records no provider edge: {deps:?}"
+    assert_eq!(
+        deps.len(),
+        1,
+        "resolving `[i32]` probes the element's file alias: {deps:?}"
     );
+    assert_eq!(deps[0].family(), "compiler.lookup-name");
 }
 
 // Explicit enumeration of the `SemanticImportType` arms this family does NOT

--- a/crates/rue-compiler/src/revisioned_query_database/tests/semantic_declaration.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/semantic_declaration.rs
@@ -556,9 +556,10 @@ fn direct_identity_and_signature_families_are_complete_per_declaration() {
                 &[
                     "compiler.declaration-occurrence-index",
                     "compiler.declaration-shell",
+                    "compiler.lookup-name",
                     "compiler.parse-module",
                 ],
-                4,
+                5,
             ),
         }
         let V::Signature(signature) = signature else {

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -1110,7 +1110,10 @@ fn provider_observation_counters_record_exact_production_work() {
         .rooted_cfg(&CompileOptions::default())
         .expect("the program analyzes");
     let metrics = crate::unstable::provider_observation_metrics(&session);
-    assert_eq!(metrics.name_lookups, 3);
+    assert_eq!(
+        metrics.name_lookups, 5,
+        "the two distinct named primitive signatures each perform their canonical file-alias probe: {metrics:?}"
+    );
     assert_eq!(metrics.import_lookups, 0);
     assert_eq!(metrics.method_candidates, 0);
     assert_eq!(metrics.operator_candidates, 0);
@@ -1172,8 +1175,8 @@ fn repeated_named_imports_register_their_identity_closure_once_per_body() {
 
     let metrics = crate::unstable::provider_observation_metrics(&session);
     assert_eq!(
-        metrics.name_lookups, 11,
-        "the first Item payload must serve type minting and endpoint installation without repeating candidate/destructor lookups: {metrics:?}"
+        metrics.name_lookups, 14,
+        "the first Item payload must serve type minting and endpoint installation without repeating candidate/destructor lookups; signature and struct-literal names also perform their canonical file-const alias probes: {metrics:?}"
     );
     assert_eq!(metrics.declaration_facts, 10, "{metrics:?}");
     assert_eq!(metrics.identity_facts, 5, "{metrics:?}");

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -392,6 +392,48 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "file_const_type_alias_struct_literal_head"
+spec = ["4.14:22"]
+description = "A top-level const binding of a type-constructor result is an unqualified struct-literal head, and constrains its fields before AIR emission (RUE-1966)"
+source = """
+fn Point(comptime T: type) -> type { struct { x: T } }
+const P = Point(u8);
+fn main() -> i32 {
+    let p = P { x: 200 };
+    if p.x == 200 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "file_const_type_alias_generic_argument"
+spec = ["4.14:22"]
+description = "A top-level const type alias is an unqualified comptime type argument (RUE-1966)"
+source = """
+fn Point(comptime T: type) -> type { struct { x: T } }
+const P = Point(u8);
+fn identity(comptime T: type, value: T) -> T { value }
+fn main() -> i32 {
+    let p = identity(P, P { x: 42 });
+    if p.x == 42 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "file_const_type_alias_annotation"
+spec = ["4.14:22"]
+description = "A top-level const type alias is an unqualified parameter, return, and local annotation (RUE-1966)"
+source = """
+fn Point(comptime T: type) -> type { struct { x: T } }
+const P = Point(i32);
+fn make() -> P { P { x: 42 } }
+fn get(p: P) -> i32 { p.x }
+fn main() -> i32 { let p: P = make(); get(p) }
+"""
+exit_code = 42
+
+[[case]]
 name = "generic_function_type_arg_is_user_struct_name"
 spec = ["4.14:5"]
 description = "A user-declared struct name is a comptime type argument in its own right (`identity(Foo, ..)`), resolving T:=Foo exactly as the primitive and alias spellings do (RUE-1680)"

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -470,7 +470,9 @@ compile-time known (rule 4.14:6), and each `type`-typed argument must be
 supplied by a `comptime` parameter or another type value.
 
 In *value position*, the reduced type is an ordinary compile-time type value:
-it may be bound with `let` and then used as the path of a struct-literal
+it may be bound with `let`, or by a top-level `const` as the type alias described
+by rule 10.4:21. Either binding may then be used unqualified as a type
+annotation, as a comptime `type` argument, or as the path of a struct-literal
 expression (`P { … }`), a method call, or an associated-function call
 (`P.origin()`), exactly as in rules 4.14:7 through 4.14:13.
 


### PR DESCRIPTION
## Summary

- add one ordered, lazy authority for unqualified type-name selection across inference, aggregate semantics, and structured type annotations
- preserve substitution, lexical alias, file alias, primitive, declaration, and builtin precedence while preventing opposite-kind builtin fallback
- cover const aliases in struct literals, generic type arguments, and annotations, with stable negative diagnostics and a source guard against peer lookup chains
- specify top-level const type aliases in rule 4.14:22

## Testing

- `scripts/rue quick`
- `scripts/rue premerge`
- `scripts/rue unit air`
- `scripts/rue cli module_const_type_namespace`
- `scripts/rue spec 4.14`
- generated oracle smoke and focused changed-corpus audit
- `scripts/rue test`: 243 targets passed with zero test failures; six oracle corpus actions were host-aborted by worker-thread `EAGAIN` resource exhaustion

Fixes RUE-1966