### PR TITLE
RUE-1955: stabilize test declarations

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -5874,10 +5874,8 @@ where
             // A test declaration is an ordinary `()`-returning, parameterless
             // body (ADR-0083 §1), so it reuses the free-function mechanics
             // above rather than forking a second analysis path. The only
-            // differences are where the declaration is found — its own RIR
-            // index, since a test's name is not a callable name — and the
-            // preview gate, which is repeated here so a test-rooted request is
-            // gated even when the request-level check is bypassed.
+            // difference is where the declaration is found — its own RIR
+            // index, since a test's name is not a callable name.
             crate::StableDefinitionKind::Test => {
                 let declaration = host.endpoint.first_test(name, owner_file).ok_or_else(|| {
                     CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(format!(
@@ -5886,11 +5884,6 @@ where
                 })?;
                 let instruction = host.rir.rir().get(declaration);
                 let declaration_span = instruction.span;
-                host.require_preview(
-                    rue_error::PreviewFeature::TestDeclarations,
-                    "a test declaration",
-                    declaration_span,
-                )?;
                 let InstData::FnDecl {
                     return_type,
                     body,

--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -42,7 +42,7 @@ test "so does comparison" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 0
 compile_stdout_contains = ["2 passed ("]
 compile_stdout_not_contains = ["FAIL", "PASS "]
@@ -71,7 +71,7 @@ test "two plus two is five" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"failure":{"exit_code":101,"kind":"assert","location":{"column":5,"file":"tests.rue","line":2}',
@@ -105,7 +105,7 @@ test "checks the port" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"failure":{"exit_code":101,"kind":"assert","location":{"column":5,"file":"tests.rue","line":3}',
@@ -138,7 +138,7 @@ test "several checks" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"failure":{"exit_code":101,"kind":"assert","location":{"column":5,"file":"tests.rue","line":3}',
@@ -172,7 +172,7 @@ test "formats its message" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"failure":{"exit_code":101,"kind":"assert","location":{"column":5,"file":"tests.rue","line":4}',
@@ -205,7 +205,7 @@ test "with a message" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 1
 compile_stdout_contains = [
     "assert: assertion failed  (tests.rue:2:5)",
@@ -276,7 +276,7 @@ test "gives up" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = ['"kind":"trap:panic"', '"message":"panic: boom"']
 
@@ -303,7 +303,7 @@ test "divides by zero" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = ['"kind":"trap:div_by_zero"', '"message":"error: division by zero"']
 
@@ -332,7 +332,7 @@ test "leaves before it checks anything" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"incomplete"',
@@ -366,7 +366,7 @@ test "never finishes" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--timeout-ms", "500", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--timeout-ms", "500", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"verdict":"timeout"',
@@ -402,7 +402,7 @@ test "floods its own stdout" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = ['"kind":"output_overflow"', '"verdict":"fail"']
 # RUE-1958 bounds the *human* rendering only. The event stream carries the
@@ -436,7 +436,7 @@ test "floods its own stdout" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "human"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "human"]
 driver_exit_code = 1
 compile_stdout_contains = [
     "FAIL tests.rue::floods its own stdout",
@@ -470,7 +470,7 @@ test "alpha" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--list"]
+args = ["test", "main.rue", "--list"]
 driver_exit_code = 0
 compile_stdout_contains = ["tests.rue::alpha\ntests.rue::beta\n"]
 
@@ -494,7 +494,7 @@ test "alpha" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--list", "--format", "json"]
+args = ["test", "main.rue", "--list", "--format", "json"]
 driver_exit_code = 0
 compile_stdout_contains = [
     '{"column":1,"event":"test","file":"tests.rue","id":"tests.rue::alpha","line":1,"module":"tests.rue","name":"alpha","schema":"1.0"}',
@@ -525,7 +525,7 @@ test "lexer eats spaces" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--list", "--filter", "parse_port"]
+args = ["test", "main.rue", "--list", "--filter", "parse_port"]
 driver_exit_code = 0
 compile_stdout_contains = ["tests.rue::parse_port accepts\ntests.rue::parse_port rejects\n"]
 compile_stdout_not_contains = ["lexer"]
@@ -555,7 +555,7 @@ test "unrelated" {
 """ },
 ]
 args = [
-    "test", "main.rue", "--preview", "test_declarations", "--list",
+    "test", "main.rue", "--list",
     "--filter", "parse_port", "--filter", "lexer",
 ]
 driver_exit_code = 0
@@ -582,7 +582,7 @@ test "alpha" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--filter", "no_such_test", "-j1"]
+args = ["test", "main.rue", "--filter", "no_such_test", "-j1"]
 driver_exit_code = 3
 compile_stderr_contains = ["no tests matched the selection"]
 
@@ -620,7 +620,7 @@ test "delta" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--list", "--shard", "1/2"]
+args = ["test", "main.rue", "--list", "--shard", "1/2"]
 driver_exit_code = 0
 compile_stdout_contains = ["tests.rue::alpha\ntests.rue::beta\ntests.rue::delta\n"]
 compile_stdout_not_contains = ["gamma"]
@@ -653,7 +653,7 @@ test "delta" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--list", "--shard", "2/2"]
+args = ["test", "main.rue", "--list", "--shard", "2/2"]
 driver_exit_code = 0
 compile_stdout_contains = ["tests.rue::gamma\n"]
 compile_stdout_not_contains = ["alpha", "beta", "delta"]
@@ -683,7 +683,7 @@ test "alpha" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "424242", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "424242", "-j1", "--format", "json"]
 driver_exit_code = 0
 compile_stdout_contains = [
     '{"event":"run_started","jobs":1,"opt_level":"0",',
@@ -721,13 +721,13 @@ test "fails on purpose" {
 """ },
 ]
 args = [
-    "test", "main.rue", "--preview", "test_declarations", "--seed", "9",
+    "test", "main.rue", "--seed", "9",
     "-j1", "--timeout-ms", "9000", "--format", "json",
 ]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"repro":["rue","test","main.rue","--filter","tests.rue::fails on purpose","--seed","9",',
-    '"-O0","--preview","test_declarations","--timeout-ms","9000"]',
+    '"-O0","--timeout-ms","9000"]',
     '"stderr":{"bytes_total":17,"data":"assertion failed\n","encoding":"utf8"}',
     '"scratch_dir":"',
 ]
@@ -760,7 +760,7 @@ test "fails on purpose" {
 ]
 args = [
     "test", "main.rue", "--filter", "tests.rue::fails on purpose", "--seed", "9",
-    "-O0", "--preview", "test_declarations", "--timeout-ms", "9000",
+    "-O0", "--timeout-ms", "9000",
     "-j1", "--format", "json",
 ]
 driver_exit_code = 1
@@ -796,7 +796,7 @@ test "beta" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "7", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "7", "-j1", "--format", "json"]
 driver_exit_code = 0
 compile_stdout_contains = ['"seed":7,', '"--seed","7"']
 
@@ -829,40 +829,13 @@ test "delta" {
 """ },
 ]
 args = [
-    "test", "main.rue", "--preview", "test_declarations", "--seed", "1",
+    "test", "main.rue", "--seed", "1",
     "-j1", "--shard", "2/2", "--format", "json",
 ]
 driver_exit_code = 0
 compile_stdout_contains = ['"shard":"2/2"', '"plan":{"selected":1,"total":4}']
 
-# ========================= the preview gate and the candidate inventory =========================
-
-[[case]]
-name = "test_mode_does_not_enable_the_preview_gate_for_you"
-description = """
-ADR-0083 §1, ruled: `--preview test_declarations` is required exactly as for a
-build. Auto-enabling it in test mode would make `rue test` the first flag to
-bypass ADR-0005's explicit opt-in while leaving the same files failing ordinary
-builds. A program that will not compile is the runner-error status.
-"""
-files = [
-    { path = "main.rue", source = """
-const tests = @import("tests.rue");
-
-fn main() -> i32 {
-    0
-}
-""" },
-    { path = "tests.rue", source = """
-test "alpha" {
-    @assert(1 == 1);
-}
-""" },
-]
-args = ["test", "main.rue"]
-driver_exit_code = 2
-compile_stderr_contains = ["E1100", "test_declarations"]
-compile_stdout_not_contains = ["run_started"]
+# ========================= the candidate inventory =========================
 
 [[case]]
 name = "an_orphaned_test_file_is_warned_about_and_reported_in_run_finished"
@@ -900,7 +873,7 @@ test "nor this one" {
 """ },
 ]
 args = [
-    "test", "main.rue", "--preview", "test_declarations",
+    "test", "main.rue",
     "--test-candidates", "test-candidates.list", "--seed", "1", "-j1", "--format", "json",
 ]
 driver_exit_code = 0
@@ -952,7 +925,7 @@ test "nor this one" {
 """ },
 ]
 args = [
-    "test", "main.rue", "--preview", "test_declarations",
+    "test", "main.rue",
     "--test-candidates", "test-candidates.list", "--seed", "1", "-j1", "--format", "human",
 ]
 driver_exit_code = 0
@@ -983,7 +956,7 @@ test "alpha" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 0
 compile_stdout_contains = [
     "note: no --test-candidates inventory; unimported test files are not detected",
@@ -1008,7 +981,7 @@ fn main() -> i32 {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 0
 compile_stdout_contains = ["1 passed"]
 compile_stdout_not_contains = ["note: no --test-candidates inventory"]
@@ -1031,7 +1004,7 @@ fn main() -> i32 {
 """ },
 ]
 args = [
-    "test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1",
+    "test", "main.rue", "--seed", "1", "-j1",
     "--format", "json",
 ]
 driver_exit_code = 0
@@ -1075,7 +1048,7 @@ test "alpha" {
 }
 """ },
 ]
-args = ["test", "./test", "--preview", "test_declarations", "--list"]
+args = ["test", "./test", "--list"]
 driver_exit_code = 0
 compile_stdout_contains = ["tests.rue::alpha"]
 
@@ -1182,7 +1155,7 @@ test "trivial" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "-O2"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "-O2"]
 driver_exit_code = 0
 compile_stdout_contains = ["2 passed ("]
 compile_stdout_not_contains = ["FAIL"]
@@ -1204,7 +1177,7 @@ test "trivial" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "-O3"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "-O3"]
 driver_exit_code = 0
 compile_stdout_contains = ["2 passed ("]
 compile_stdout_not_contains = ["FAIL"]
@@ -1227,7 +1200,7 @@ test "two plus two is five" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "-O2", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "-O2", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"failure":{"exit_code":101,"kind":"assert"',

--- a/crates/rue-cli-tests/cases/rue_test_assert.toml
+++ b/crates/rue-cli-tests/cases/rue_test_assert.toml
@@ -51,7 +51,7 @@ test "parses a port" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"assert_eq"',
@@ -92,7 +92,7 @@ test "compares two owned strings" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"assert_eq"',
@@ -129,7 +129,7 @@ test "compares two points" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"left":"{ x: 41, y: true }"',
@@ -163,7 +163,7 @@ test "compares two shapes" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"left":"Line(3)"',
@@ -196,7 +196,7 @@ test "rejects a duplicate port" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"assert_ne"',
@@ -227,7 +227,7 @@ test "accepts a port" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 0
 compile_stdout_contains = [
     '"verdict":"pass"',
@@ -280,7 +280,7 @@ test "compares a borrowed field" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"assert_eq"',
@@ -338,7 +338,7 @@ test "borrowed operands are read, not taken" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 0
 compile_stdout_contains = [
     '"verdict":"pass"',
@@ -388,7 +388,7 @@ test "compares a returned string on the left" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"diff":[{"op":"equal","text":"alp"},{"op":"delete","text":"ha"},{"op":"insert","text":"ine"}],"exit_code":101,"kind":"assert_eq","left":"alpha"',
@@ -423,7 +423,7 @@ test "compares a returned string on the right" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"diff":[{"op":"equal","text":"alp"},{"op":"delete","text":"ine"},{"op":"insert","text":"ha"}],"exit_code":101,"kind":"assert_eq","left":"alpine"',
@@ -463,7 +463,7 @@ test "compares a returned struct" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"assert_eq"',
@@ -508,7 +508,7 @@ test "owning temporaries are dropped exactly once" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 0
 compile_stdout_contains = [
     '"verdict":"pass"',
@@ -545,7 +545,7 @@ test "parses a port" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 1
 compile_stdout_contains = [
     "assert_eq: assertion failed: left == right",
@@ -576,7 +576,7 @@ test "compares two documents" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 1
 compile_stdout_contains = [
     "  left:\n    alpha\n    beta\n    gamma\n",

--- a/crates/rue-cli-tests/cases/rue_test_question.toml
+++ b/crates/rue-cli-tests/cases/rue_test_question.toml
@@ -56,7 +56,7 @@ test "unwraps a missing option" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"exit_code":101,"kind":"unhandled_error"',
@@ -103,7 +103,7 @@ test "unwraps a failed result" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"kind":"unhandled_error"',
@@ -157,7 +157,7 @@ test "a payload variant" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1", "--format", "json"]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
 compile_stdout_contains = [
     '"payload":"Missing"',
@@ -195,7 +195,7 @@ test "unwraps a present option" {
 }
 """ },
 ]
-args = ["test", "main.rue", "--preview", "test_declarations", "--seed", "1", "-j1"]
+args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 0
 compile_stdout_contains = ["1 passed ("]
 compile_stdout_not_contains = ["FAIL", "unhandled_error"]

--- a/crates/rue-cli-tests/cases/test_declarations.toml
+++ b/crates/rue-cli-tests/cases/test_declarations.toml
@@ -1,21 +1,21 @@
-# Test declarations end to end through the real driver (ADR-0083 Phase 1,
-# RUE-1618).
+# Test declarations end to end through the real driver (ADR-0083, RUE-1618;
+# stabilized by RUE-1955).
 #
 # The shape here is the MVP idiom the ADR names: a root `main.rue` whose only
 # wiring to the test file is one aggregator `const tests = @import(...)`, and a
 # `parser_tests.rue` holding the tests plus the private helper they exercise.
-# The three things a driver user can observe in Phase 1 are pinned: the program
-# still builds and runs, the test bodies are absent from the executable's AIR,
-# and the declarations are present in the pre-semantic AST.
+# The three things a driver user can observe are pinned: the program still
+# builds and runs, the test bodies are absent from the executable's AIR, and
+# the declarations are present in the pre-semantic AST. No flag is required.
 
 [section]
 id = "cli.test_declarations"
 name = "Test declarations"
-description = "`test \"name\" { ... }` behind --preview test_declarations: an executable build ignores test bodies, the pre-semantic AST shows them, and the gate is required."
+description = "`test \"name\" { ... }` needs no flag: an executable build ignores test bodies and the pre-semantic AST shows them."
 
 [[case]]
 name = "aggregator_import_builds_and_runs"
-description = "The aggregator-import idiom compiles and runs: the test file is in the closure, its tests are parsed, and nothing about the program changes."
+description = "The aggregator-import idiom compiles and runs with no preview flag (RUE-1955): the test file is in the closure, its tests are parsed, and nothing about the program changes."
 files = [
     { path = "main.rue", source = """
 const tests = @import("parser_tests.rue");
@@ -36,7 +36,7 @@ test "double handles zero" {
 }
 """ },
 ]
-args = ["main.rue", "--preview", "test_declarations", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 [[case]]
@@ -58,7 +58,7 @@ test "calls the helper" {
 }
 """ },
 ]
-args = ["main.rue", "--preview", "test_declarations", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 0
 compile_stderr_not_contains = ["warning", "unused"]
 
@@ -81,7 +81,7 @@ test "double doubles" {
 }
 """ },
 ]
-args = ["--emit", "air", "main.rue", "--preview", "test_declarations"]
+args = ["--emit", "air", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== AIR ===", "function main:"]
 compile_stdout_not_contains = ["__rue_test_", "double doubles", "double"]
@@ -103,31 +103,6 @@ test "double doubles" {
 }
 """ },
 ]
-args = ["--emit", "ast", "main.rue", "--preview", "test_declarations"]
+args = ["--emit", "ast", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== AST (parser_tests.rue) ===", "Test sym:"]
-
-[[case]]
-name = "without_the_preview_flag_the_build_is_gated"
-description = "ADR-0083 §1: a test item anywhere in the closure gates the request, executable builds included."
-files = [
-    { path = "main.rue", source = """
-const tests = @import("parser_tests.rue");
-
-fn main() -> i32 {
-    42
-}
-""" },
-    { path = "parser_tests.rue", source = """
-test "double doubles" {
-    let y = 1;
-}
-""" },
-]
-args = ["main.rue", "-o", "prog"]
-compile_fail = true
-error_contains = [
-    "E1100",
-    "a test declaration requires preview feature `test_declarations`",
-    "use --preview test_declarations to enable this feature (ADR-0083)",
-]

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -2061,7 +2061,6 @@ impl TestRootCorpus {
 
 fn test_root_options(root_selection: RootSelection) -> CompileOptions {
     CompileOptions {
-        preview_features: PreviewFeatures::from([PreviewFeature::TestDeclarations]),
         root_selection,
         ..CompileOptions::default()
     }

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -69,43 +69,6 @@ impl CompilerSession {
                 ));
             }
         };
-        // ADR-0083 §1: the `test_declarations` gate covers a parser change, so
-        // ANY request whose closure contains a test item needs the flag —
-        // executable builds included, since they parse test items for the
-        // unused-item scan. This is the request-level half of the gate; the
-        // body-analysis half (`analyze_provider_ordinary_body`'s `Test` arm)
-        // catches a test-rooted request that reached analysis another way.
-        if !options
-            .preview_features
-            .contains(&rue_error::PreviewFeature::TestDeclarations)
-            && projection
-                .declarations
-                .iter()
-                .any(|declaration| declaration.key.kind() == crate::StableDefinitionKind::Test)
-        {
-            let kind = ErrorKind::PreviewFeatureRequired {
-                feature: rue_error::PreviewFeature::TestDeclarations,
-                what: "a test declaration".to_owned(),
-            };
-            // The first test item in module order, so the diagnostic points at
-            // the declaration a reader would fix first.
-            let span = program.modules().iter().find_map(|module| {
-                module.ast().items.iter().find_map(|item| match item {
-                    rue_parser::ast::Item::Test(test) => Some(test.header_span),
-                    _ => None,
-                })
-            });
-            let error = match span {
-                Some(span) => CompileError::new(kind, span),
-                None => CompileError::without_span(kind),
-            };
-            return Err(SemanticRequestControl::Compile(
-                error
-                    .with_help(rue_error::PreviewFeature::TestDeclarations.enable_help())
-                    .into(),
-            ));
-        }
-
         // This is the single root-set authority. `RootSelection::Tests` roots
         // every test declaration in the module closure and neither needs nor
         // roots `main`; `RootSelection::Executable` roots `main` plus the

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -5559,7 +5559,6 @@ fn unreachable_body_is_not_requested_by_production_reachability() {
 
 fn test_declaration_options(root_selection: crate::RootSelection) -> CompileOptions {
     CompileOptions {
-        preview_features: PreviewFeatures::from([PreviewFeature::TestDeclarations]),
         root_selection,
         ..CompileOptions::default()
     }
@@ -5928,10 +5927,7 @@ fn a_test_request_roots_no_c_export() {
     )
     .unwrap();
     let options = |root_selection| CompileOptions {
-        preview_features: PreviewFeatures::from([
-            PreviewFeature::TestDeclarations,
-            PreviewFeature::CFfi,
-        ]),
+        preview_features: PreviewFeatures::from([PreviewFeature::CFfi]),
         root_selection,
         ..CompileOptions::default()
     };
@@ -6004,32 +6000,25 @@ fn test_body_calls_count_as_warning_references_in_an_executable_build() {
     );
 }
 
-/// The request-level preview gate of ADR-0083 §1 fires for an executable
-/// build, not only for a test request.
+/// Test declarations are stable (RUE-1955): no flag is needed, in either
+/// request shape. The executable half is the one that used to be surprising —
+/// an ordinary build parses test items for the unused-item scan.
 #[test]
-fn test_declarations_require_their_preview_feature_in_every_request() {
+fn test_declarations_need_no_preview_feature_in_any_request() {
     let source =
-        SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }\ntest \"gated\" { }").unwrap();
+        SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }\ntest \"stable\" { }").unwrap();
     let mut session = CompilerSession::new();
     session.update(&source).into_result().unwrap();
     for selection in [
         crate::RootSelection::Executable,
         crate::RootSelection::Tests,
     ] {
-        let errors = session
+        session
             .rooted_cfg(&CompileOptions {
                 root_selection: selection,
                 ..CompileOptions::default()
             })
-            .expect_err("a test declaration is gated in every request");
-        assert!(
-            errors.iter().any(|error| matches!(
-                &error.kind,
-                ErrorKind::PreviewFeatureRequired { feature, .. }
-                    if *feature == PreviewFeature::TestDeclarations
-            )),
-            "{selection:?}: unexpected diagnostics: {errors:?}"
-        );
+            .unwrap_or_else(|errors| panic!("{selection:?}: unexpected diagnostics: {errors:?}"));
     }
 }
 

--- a/crates/rue-compiler/src/test_body_try_tests.rs
+++ b/crates/rue-compiler/src/test_body_try_tests.rs
@@ -16,7 +16,6 @@ use crate::*;
 use std::sync::Arc;
 
 use ahash::{AHashMap, AHashSet};
-use rue_error::{PreviewFeature, PreviewFeatures};
 
 /// The trusted standard-library `Option`, verbatim from `std/option.rue`.
 const TRUSTED_OPTION_SOURCE: &str = r#"
@@ -127,7 +126,6 @@ pub(crate) fn trusted_snapshot(root_source: &str) -> SourceSnapshot {
 
 pub(crate) fn test_options() -> CompileOptions {
     CompileOptions {
-        preview_features: PreviewFeatures::from([PreviewFeature::TestDeclarations]),
         root_selection: RootSelection::Tests,
         ..CompileOptions::default()
     }

--- a/crates/rue-compiler/src/test_image_tests.rs
+++ b/crates/rue-compiler/src/test_image_tests.rs
@@ -14,7 +14,6 @@
 #![cfg(all(test, unix))]
 
 use crate::{CompileOptions, CompilerSession, RootSelection};
-use rue_error::{PreviewFeature, PreviewFeatures};
 
 /// The exact completion frame the dispatcher's epilogue writes.
 const COMPLETE_FRAME: &str = "{\"record\":\"complete\",\"schema\":\"1.0\"}\n";
@@ -45,7 +44,6 @@ struct DispatchedRun {
 
 fn test_options() -> CompileOptions {
     CompileOptions {
-        preview_features: PreviewFeatures::from([PreviewFeature::TestDeclarations]),
         root_selection: RootSelection::Tests,
         ..CompileOptions::default()
     }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -2230,12 +2230,6 @@ pub enum PreviewFeature {
     Floats,
     /// Public enums may promise that importing matches include a wildcard.
     NonExhaustiveEnums,
-    /// Test declarations: the `test "name" { .. }` language item (ADR-0083
-    /// §1, RUE-1618). The gate covers a parser change, so any request whose
-    /// closure contains a test item — an executable build included, which
-    /// parses test items for the unused-item scan — needs the flag to compile
-    /// at all. `rue test` will not enable it implicitly.
-    TestDeclarations,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -2259,7 +2253,6 @@ impl PreviewFeature {
             PreviewFeature::CFfi => "c_ffi",
             PreviewFeature::Floats => "floats",
             PreviewFeature::NonExhaustiveEnums => "non_exhaustive_enums",
-            PreviewFeature::TestDeclarations => "test_declarations",
         }
     }
 
@@ -2271,7 +2264,6 @@ impl PreviewFeature {
             PreviewFeature::CFfi => "ADR-0064",
             PreviewFeature::Floats => "ADR-0065",
             PreviewFeature::NonExhaustiveEnums => "ADR-0005",
-            PreviewFeature::TestDeclarations => "ADR-0083",
         }
     }
 
@@ -2282,7 +2274,6 @@ impl PreviewFeature {
             PreviewFeature::CFfi,
             PreviewFeature::Floats,
             PreviewFeature::NonExhaustiveEnums,
-            PreviewFeature::TestDeclarations,
         ]
     }
 
@@ -2326,7 +2317,6 @@ impl std::str::FromStr for PreviewFeature {
             "c_ffi" => Ok(PreviewFeature::CFfi),
             "floats" => Ok(PreviewFeature::Floats),
             "non_exhaustive_enums" => Ok(PreviewFeature::NonExhaustiveEnums),
-            "test_declarations" => Ok(PreviewFeature::TestDeclarations),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -5496,10 +5486,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(
-            names,
-            "test_infra, c_ffi, floats, non_exhaustive_enums, test_declarations"
-        );
+        assert_eq!(names, "test_infra, c_ffi, floats, non_exhaustive_enums");
     }
 
     #[test]
@@ -5604,8 +5591,9 @@ mod tests {
     fn test_preview_feature_stabilized_are_unknown() {
         // for_loops, method_receivers, enum_payloads, array_repeat,
         // field_init_shorthand, inline_type_ctor_paths, raw_bytes,
-        // aggregate_layout, slices, and borrow_accessors were stabilized (no
-        // longer gated) — their names must now be rejected.
+        // aggregate_layout, slices, borrow_accessors, and test_declarations
+        // were stabilized (no longer gated) — their names must now be
+        // rejected.
         for name in [
             "for_loops",
             "method_receivers",
@@ -5617,6 +5605,7 @@ mod tests {
             "aggregate_layout",
             "slices",
             "borrow_accessors",
+            "test_declarations",
         ] {
             assert!(
                 name.parse::<PreviewFeature>().is_err(),

--- a/crates/rue-spec/cases/items/tests.toml
+++ b/crates/rue-spec/cases/items/tests.toml
@@ -1,8 +1,8 @@
 # Test declarations (ADR-0083 Phase 1, RUE-1618).
 #
-# `test "name" { ... }` is an item behind the `test_declarations` preview
-# feature. It is analyzed as an ordinary parameterless `()`-returning body and
-# is a root only for a test request, so an executable request never sees it.
+# `test "name" { ... }` is a stable item (stabilized by RUE-1955). It is
+# analyzed as an ordinary parameterless `()`-returning body and is a root only
+# for a test request, so an executable request never sees it.
 
 [section]
 id = "items.tests"
@@ -11,30 +11,23 @@ name = "Tests"
 description = "Test declarations: the contextual `test` keyword, per-module name uniqueness, ordinary `()` body analysis, and invisibility to executable requests."
 
 # =============================================================================
-# The preview gate (8.4:1). Both sides of the gate are pinned.
+# The declaration itself (6.7:11: no preview flag).
 # =============================================================================
 
 [[case]]
-name = "test_declaration_requires_its_preview_feature"
-spec = ["6.7:2", "8.4:1"]
-description = "Without --preview test_declarations, a test declaration is the standard preview-gate diagnostic — in an ordinary executable build."
+name = "test_declaration_needs_no_preview_feature"
+spec = ["6.7:2", "6.7:11"]
+description = "Test declarations are stable: an ordinary executable build carrying one compiles with no flag."
 source = """
 fn main() -> i32 { 0 }
-test "needs the flag" { }
+test "needs no flag" { }
 """
-compile_fail = true
-error_contains = [
-    "E1100",
-    "a test declaration requires preview feature `test_declarations`",
-    "use --preview test_declarations",
-]
+exit_code = 0
 
 [[case]]
-name = "test_declaration_compiles_with_its_preview_feature"
+name = "test_declaration_compiles_in_an_executable_build"
 spec = ["6.7:2", "6.7:7"]
-description = "With the flag, a program carrying test declarations builds and runs exactly as it would without them."
-preview = "test_declarations"
-preview_should_pass = true
+description = "A program carrying test declarations builds and runs exactly as it would without them."
 source = """
 fn double(x: i32) -> i32 { x * 2 }
 
@@ -54,8 +47,6 @@ exit_code = 42
 name = "test_declaration_accepts_function_directives"
 spec = ["6.7:5"]
 description = "A test declaration carries the same directives a function carries."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 @allow(unused_variable)
 test "tolerates an unused binding" {
@@ -69,8 +60,6 @@ exit_code = 0
 name = "public_test_declaration_is_rejected"
 spec = ["6.7:5"]
 description = "`test` takes no visibility modifier: a test is not callable, so `pub` has no meaning for it."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 pub test "not public" { }
 fn main() -> i32 { 0 }
@@ -82,8 +71,6 @@ error_contains = ["E0100"]
 name = "unchecked_test_declaration_is_rejected"
 spec = ["6.7:5"]
 description = "`test` takes no `unchecked` modifier either."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 unchecked test "not unchecked" { }
 fn main() -> i32 { 0 }
@@ -99,8 +86,6 @@ error_contains = ["E0100"]
 name = "test_remains_an_ordinary_identifier"
 spec = ["6.7:3"]
 description = "`test` is a keyword only at item position followed by a string; a function, a constant, and a local binding named `test` keep their meaning."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 fn test(x: i32) -> i32 { x }
 const test_limit: i32 = 1;
@@ -124,8 +109,6 @@ exit_code = 42
 name = "duplicate_test_names_in_one_module_are_rejected"
 spec = ["6.7:6"]
 description = "Two test declarations in one module may not share a name."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 test "same name" { }
 test "same name" { }
@@ -141,8 +124,6 @@ error_contains = [
 name = "a_test_may_share_its_spelling_with_a_function"
 spec = ["6.7:6"]
 description = "Test names live in their own namespace, so `test \"parse\"` and `fn parse` coexist."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 fn parse() -> i32 { 42 }
 
@@ -162,8 +143,6 @@ exit_code = 42
 name = "test_body_is_an_ordinary_unit_block"
 spec = ["6.7:7"]
 description = "A test body is an ordinary `()`-typed block: statements, control flow, and calls all behave as they do in a `()`-returning function."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 fn classify(x: i32) -> i32 {
     if x > 0 { 1 } else { 0 }
@@ -190,8 +169,6 @@ exit_code = 1
 name = "a_test_sees_its_modules_private_items"
 spec = ["6.7:8"]
 description = "A test resolves names exactly as its module's other items do, so it uses private siblings with no visibility loosening."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 fn private_helper(x: i32) -> i32 { x + 1 }
 
@@ -211,8 +188,6 @@ exit_code = 42
 name = "a_test_body_is_invisible_to_an_executable_request"
 spec = ["6.7:9"]
 description = "An executable request never analyzes a test body, so a type error inside one does not reject the program."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 test "carries a type error an executable never sees" {
     let x: i32 = true;
@@ -226,8 +201,6 @@ exit_code = 42
 name = "a_test_only_helper_does_not_warn_as_unused"
 spec = ["6.7:10"]
 description = "A private helper referenced only from a test body is not reported as unused in an executable build."
-preview = "test_declarations"
-preview_should_pass = true
 source = """
 fn only_a_test_calls_me(x: i32) -> i32 { x + 1 }
 
@@ -248,8 +221,6 @@ no_warnings = true
 name = "test_declaration_ast_shape"
 spec = ["6.7:2"]
 description = "A test declaration is its own AST item kind, named by its string literal."
-preview = "test_declarations"
-preview_should_pass = true
 source = "test \"names the block\" { let x = 1; }"
 expected_ast = """
 Test sym:1

--- a/crates/rue-ui-tests/cases/diagnostics/test-declarations.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/test-declarations.toml
@@ -2,35 +2,20 @@
 id = "diagnostics.test-declarations"
 name = "Test declaration diagnostics"
 description = """
-ADR-0083 Phase 1 (RUE-1618). The two-sided `test_declarations` preview gate —
-E1100 without `--preview test_declarations`, and an ordinary compile with it,
-since Phase 1 ships the declaration whole — plus the duplicate-name diagnostic
-and the modifiers the grammar does not accept.
+ADR-0083 (RUE-1618), stabilized by RUE-1955: a test declaration compiles with
+no flag, in an ordinary executable build included — plus the duplicate-name
+diagnostic and the modifiers the grammar does not accept.
 """
 
 [[case]]
-name = "gated_without_the_preview_flag"
-description = "Spec 8.4:1 — a gated feature errors without its flag, and the help names the flag and the ADR. The request is an ordinary executable build: a test item in the closure gates it too."
+name = "no_preview_gate_for_a_test_item"
+description = "Spec 6.7:11 — test declarations are stable, so no E1100 is emitted for one. The request is an ordinary executable build, which is the case that used to be gated: a test item is in its parsed closure."
 source = """
 fn main() -> i32 { 0 }
-test "needs the flag" { }
+test "needs no flag" { }
 """
-compile_fail = true
-error_contains = [
-    "E1100",
-    "a test declaration requires preview feature `test_declarations`",
-    "use --preview test_declarations to enable this feature (ADR-0083)",
-]
-
-[[case]]
-name = "enabled_by_the_preview_flag"
-description = "With the flag the declaration compiles: unlike the float gate, Phase 1 ships the whole declaration, so nothing stops at a phase marker."
-source = """
-fn main() -> i32 { 0 }
-test "needs the flag" { }
-"""
-preview = "test_declarations"
 exit_code = 0
+no_warnings = true
 
 [[case]]
 name = "duplicate_test_names_name_the_test_and_its_first_declaration"
@@ -40,7 +25,6 @@ test "same name" { }
 test "same name" { }
 fn main() -> i32 { 0 }
 """
-preview = "test_declarations"
 compile_fail = true
 error_contains = [
     "E0262",
@@ -55,7 +39,6 @@ source = """
 pub test "not public" { }
 fn main() -> i32 { 0 }
 """
-preview = "test_declarations"
 compile_fail = true
 error_contains = [
     "E0100",
@@ -69,6 +52,5 @@ source = """
 test { }
 fn main() -> i32 { 0 }
 """
-preview = "test_declarations"
 compile_fail = true
 error_contains = ["E0100", "'test'"]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -3362,12 +3362,12 @@ mod tests {
     #[test]
     fn flags_before_the_subcommand_do_not_hide_it() {
         assert_eq!(
-            test_subcommand_index(&["--preview", "test_declarations", "test", "main.rue"]),
+            test_subcommand_index(&["--preview", "test_infra", "test", "main.rue"]),
             Some(2)
         );
         let options = unwrap_options(parse_args_from(&[
             "--preview",
-            "test_declarations",
+            "test_infra",
             "-O2",
             "--jobs",
             "3",
@@ -3540,7 +3540,7 @@ mod tests {
             "test",
             "main.rue",
             "--preview",
-            "test_declarations",
+            "test_infra",
             "--target",
             "x86-64-linux",
             "-O1",
@@ -3588,7 +3588,7 @@ mod tests {
             "x86-64-linux",
             "-O2",
             "--preview",
-            "test_declarations",
+            "test_infra",
             "--timeout-ms",
             "500",
             "--source-manifest",
@@ -3602,7 +3602,7 @@ mod tests {
                 "x86-64-linux",
                 "-O2",
                 "--preview",
-                "test_declarations",
+                "test_infra",
                 "--timeout-ms",
                 "500",
                 "--source-manifest",

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -796,7 +796,7 @@ mod tests {
                 "x86-64-linux".to_owned(),
                 "-O1".to_owned(),
                 "--preview".to_owned(),
-                "test_declarations".to_owned(),
+                "test_infra".to_owned(),
                 "--timeout-ms".to_owned(),
                 "500".to_owned(),
             ],
@@ -815,7 +815,7 @@ mod tests {
                 "x86-64-linux",
                 "-O1",
                 "--preview",
-                "test_declarations",
+                "test_infra",
                 "--timeout-ms",
                 "500",
             ]

--- a/docs/designs/0005-preview-features.md
+++ b/docs/designs/0005-preview-features.md
@@ -180,6 +180,7 @@ The following preview features completed this process and are now stable (their
 - `string_trio` — see ADR-0043; stabilized by RUE-876 on 2026-07-14.
 - `slices` — see ADR-0043; stabilized by RUE-936 on 2026-08-20.
 - `borrow_accessors` — see ADR-0062; stabilized by RUE-1018 on 2026-08-21.
+- `test_declarations` — see ADR-0083; stabilized by RUE-1955 on 2026-09-04.
 
 `test_infra` remains permanently unstable (it exists only to exercise the gating
 mechanism), so the `PreviewFeature` enum is not empty.
@@ -192,13 +193,6 @@ mechanism), so the `PreviewFeature` enum is not empty.
   module remain exhaustively checked against the variants known there. Adding
   variants can still change layout, ABI, or runtime behavior, so the promise
   does not provide a binary compatibility guarantee.
-- `test_declarations` — the `test "name" { ... }` language item (RUE-1618). See
-  ADR-0083, which owns the feature. The gate covers a grammar change, so any
-  request whose module closure contains a test declaration needs the flag,
-  executable builds included; `rue test` will not enable it implicitly. It
-  gates semantic analysis and rooting only — pre-semantic requests
-  (`--emit tokens|ast|rir|deps`) present test items without the flag, exactly
-  as float literals do.
 
 ## Implementation Phases
 

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -3,10 +3,10 @@ id: 0083
 title: "rue test MVP: test declarations, runner, and event protocol"
 status: accepted
 tags: [tooling, testing, syntax, semantics, incremental, cli, language-shape]
-feature-flag: test_declarations
+feature-flag: (none - feature stabilized)
 created: 2026-08-22
 accepted: 2026-09-02
-implemented:
+implemented: 2026-09-04
 spec-sections: []
 superseded-by:
 relates: ["RUE-506", "RUE-505", "RUE-504", "RUE-438", "ADR-0063", "ADR-0061", "ADR-0058", "ADR-0055", "ADR-0064", "ADR-0038", "ADR-0027", "ADR-0025", "ADR-0069", "ADR-0005"]
@@ -31,6 +31,10 @@ unimported-test-file warning (§1); `--filter` narrows the run set and never
 the analysis root set (§2); and the structured failure channel is a
 dedicated inherited pipe (§5.1). Phases 1 through 2.5 (RUE-1618, RUE-1619,
 RUE-1620) are authorized to proceed on that basis, and are complete.
+
+Test declarations were stabilized by RUE-1955 on 2026-09-04: the
+`test_declarations` preview gate is removed, and a test item compiles with no
+flag in every request shape. ADR-0005 records the stabilization.
 
 Acceptance does not settle the lower-impact calls that Open Questions marks
 decidable within their phase — exit codes, `@assert` stabilization, the
@@ -266,14 +270,14 @@ design-capture rounds on rue-language/rue#2239 and is not revisited here.
   honestly: test items in the closure cost executable requests parse plus
   that syntactic scan — nothing more.
 - **Preview gate**: `test_declarations`, required explicitly like every
-  other preview feature — `rue test` does **not** enable it implicitly.
-  The gate covers a parser change, so any request whose closure contains
+  other preview feature — `rue test` did **not** enable it implicitly.
+  The gate covered a parser change, so any request whose closure contained
   test items — executable builds included, which parse test items for the
-  warnings scan — needs the flag to compile at all. Auto-enabling it in
-  test mode alone would leave those same files failing ordinary builds
+  warnings scan — needed the flag to compile at all. Auto-enabling it in
+  test mode alone would have left those same files failing ordinary builds
   while making `rue test` the first flag to bypass ADR-0005's explicit
-  opt-in, for no net convenience. Declaring a test without the preview
-  enabled is the standard preview-gate diagnostic.
+  opt-in, for no net convenience. *Historical: the gate was removed by
+  RUE-1955 on 2026-09-04 and a test declaration now needs no flag.*
 
 ### 2. `rue test` is a driver mode emitting a versioned event stream
 
@@ -694,6 +698,13 @@ companion project "rue test follow-ups" (§6).
       unchanged (spec 4.13:5d). The dedicated message-carrying `@assert`
       lowering retires with it: the conditional `assert` intrinsic now has
       exactly one producer, a comptime-decidable comparison.
+- [x] **Phase 3: stabilization** - RUE-1955. The `test_declarations` preview
+      gate is removed from the enum, both gate sites, the cases, the spec, and
+      the repro argv, so a test item compiles with no flag in every request
+      shape. Dogfooding a maintained example on the runner is deferred to a
+      follow-up: `examples/ruelex`, the Rue-written stage-1 parser, has no
+      `test` item production, and `//:frontend-diff-test` runs it over all of
+      `examples/`, so a test item cannot land there until ruelex parses one.
 
 ## Consequences
 

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -11,16 +11,13 @@ surface: `--error-format json` compiler diagnostics on stderr. The two are
 orthogonal and stay on their own streams.
 
 ```bash
-rue test app/main.rue --preview test_declarations
-rue test app/main.rue --preview test_declarations --format json
-rue test app/main.rue --preview test_declarations --list --format json
+rue test app/main.rue
+rue test app/main.rue --format json
+rue test app/main.rue --list --format json
 ```
 
-`--preview test_declarations` is required exactly as it is for a build. `rue
-test` does not enable it implicitly: any request whose closure contains test
-items — ordinary executable builds included — needs the flag to compile at all,
-so auto-enabling it here would leave those same files failing ordinary builds
-while making `rue test` the first flag to bypass ADR-0005's explicit opt-in.
+Test declarations are stable (RUE-1955), so no preview flag is needed here or
+for an ordinary build of the same closure.
 
 ## Streams
 
@@ -474,13 +471,13 @@ Every `test_finished` carries the exact argv that reproduces that one test:
 
 ```json
 ["rue","test","app/main.rue","--filter","app/t.rue::parses a port","--seed","417",
- "--target","x86-64-linux","-O0","--preview","test_declarations","--timeout-ms","10000"]
+ "--target","x86-64-linux","-O0","--timeout-ms","10000"]
 ```
 
 It selects by the **full stable ID, never the bare name** — two modules may
 declare tests with the same name, and a repro that re-runs both is not a repro.
-The seed, target, optimization level, preview set, and per-test budget travel
-with it so the same image is rebuilt, and `--source-manifest` and
+The seed, target, optimization level, any enabled preview features, and the
+per-test budget travel with it so the same image is rebuilt, and `--source-manifest` and
 `--link-archive` are repeated when they were given. The target and optimization
 level are emitted even when they were defaulted: a repro is run later, possibly
 elsewhere, and "whatever the host was" is not a reproduction.

--- a/docs/spec/src/06-items/07-tests.md
+++ b/docs/spec/src/06-items/07-tests.md
@@ -102,15 +102,15 @@ A test body nevertheless participates in the whole-program reference scan that
 filters unused-item warnings, so an item used only by a test is not reported as
 unused in an executable build.
 
-## Preview gate
+## Stability
 
 {{ rule(id="6.7:11", cat="informative") }}
 
-Test declarations require the `test_declarations` preview feature (8.4:1). The
-gate covers a grammar change, so *any* request whose module closure contains a
-test declaration needs the flag — an executable build included, since it parses
-test declarations for the reference scan of 6.7:10. Declaring a test without
-the feature enabled is the standard preview-gate diagnostic (E1100).
+Test declarations are part of the stable language surface. No preview flag is
+required to declare one, in any request — an executable build included, since
+it parses test declarations for the reference scan of 6.7:10. (The feature was
+introduced behind the `test_declarations` preview gate and stabilized by
+RUE-1955.)
 
 {{ rule(id="6.7:12", cat="informative") }}
 

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -93,7 +93,7 @@ const_decl     = directives [ "pub" ] "const" IDENT [ ":" type ] "=" expression 
 
 (* Tests. `test` is a contextual keyword: it introduces a test only at item
    position and only when followed by a STRING. Name uniqueness within a
-   module and the `test_declarations` preview gate are legality rules. *)
+   module is a legality rule. *)
 test_item      = directives "test" STRING "{" block "}" ;
 
 (* Statements *)


### PR DESCRIPTION
Fixes RUE-1955.

The `test_declarations` preview gate covered a parser change, so any request whose closure contained a `test` item needed `--preview test_declarations`, executable builds included. That kept every example and corpus program from carrying a test during the very period the runner most needed dogfooding. With the assertion-report fixes and the schema rename landed, the gate comes off per ADR-0005's stabilization steps: the `PreviewFeature` variant and both gate sites (the request-level check in the session and the body-analysis `require_preview` on the test arm) are removed, spec, UI, and CLI cases drop the flag with exact-JSON repro assertions re-derived, and the repro argv no longer carries a preview set unless another preview is enabled.

Spec 6.7:11 keeps its rule ID as an informative note that the feature is stable; ADR-0005 lists it under stabilized features; ADR-0083 clears its feature flag, takes an `implemented:` date, and records the stabilization phase; test-events.md drops the flag from its commands and repro example.

The Gazette dogfood originally planned for this change is deferred: `examples/ruelex`, the Rue-written stage-1 parser that `//:frontend-diff-test` differentials over all of `examples/`, has no `test` item, so no file under `examples/` can carry one yet. RUE-1999 adds the item to ruelex and RUE-2000 lands the suite after it.

Verification: `scripts/rue spec 6.7` and `8.4`, `scripts/rue ui test-declarations`, `scripts/rue cli rue_test`, `test_declarations`, `examples_gazette`, `//crates/rue:rue-test test_mode`, rue-compiler and rue-parser unit suites, `//:frontend-diff-test`, doc-link, spec-traceability, ADR-registry and CLI-shard-weight validation, `//:ui-tests`, `//:spec-tests`, `scripts/rue quick`, fmt clean. The tree-wide sweep leaves `test_declarations` only in ADR-0005's stabilized list, ADR-0083's history, and the spec's history note.