### PR TITLE
RUE-1999: parse test items in ruelex

### DIFF
--- a/crates/rue-cli-tests/cases/examples_rueparse.toml
+++ b/crates/rue-cli-tests/cases/examples_rueparse.toml
@@ -75,3 +75,53 @@ env = { RUE_STD_PATH = "${REAL_STD}" }
 program_args = ["--ast", "missing.rue"]
 exit_code = 1
 stdout = "ruelex: cannot read missing.rue\n"
+
+[[case]]
+name = "rueparse_parses_test_items"
+description = "6.7:2/6.7:3: `test` followed by a string literal at item position is a test item whose children are its directives then its body block, in that order; an empty body is still a test item."
+contract = "heavyweight"
+source_path = "examples/ruelex/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "tests.rue", source = """
+@allow(unused_variable)
+test "a test item may carry directives" {
+    let ignored = 1;
+}
+
+test "an empty body is still a test item" {}
+
+fn main() -> i32 {
+    0
+}
+""" }]
+program_args = ["--ast", "tests.rue"]
+exit_code = 0
+stdout_contains = [
+    "(test v=3 @24..88 (list v=0 @0..23 (directive",
+    "(test v=5 @90..134 (block v=0 @132..134))",
+]
+
+[[case]]
+name = "rueparse_keeps_test_an_ordinary_identifier"
+description = "6.7:4: `test` is a contextual keyword only at item position with a string literal next. As a function name, a field name, a method name, a let binder, and a callee it stays IDENT, so the shape holds no test node at all."
+contract = "heavyweight"
+source_path = "examples/ruelex/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "ident.rue", source = """
+fn test(x: i32) -> i32 { x }
+
+struct Fixture {
+    test: i64,
+
+    fn test(borrow self) -> i64 { self.test }
+}
+
+fn main() -> i32 {
+    let test = test(0);
+    test
+}
+""" }]
+program_args = ["--ast-shape", "ident.rue"]
+exit_code = 0
+stdout = """(program (list (list (list _ (function flags=0 _ (list _ (param mode=0 (type form=named _ _ _ _) _ _ _) _ _) (type form=named _ _ _ _) (block _ (ident _ _ _ _) _ _)) _ _) (struct flags=0 _ (list (list _ (field-def (type form=named _ _ _ _) _ _ _) _ _) (method _ (list _ (param mode=10 _ _ _ _) _ _) (type form=named _ _ _ _) (block _ (field (ident _ _ _ _) _ _ _) _ _)) _ _) _ _) _ _) (function flags=0 _ _ (type form=named _ _ _ _) (block (list _ (let flags=512 _ _ (call (ident _ _ _ _) (list _ (arg mode=0 (int _ _ _ _) _ _ _) _ _) _ _) _) _ _) (ident _ _ _ _) _ _)) _ _) _ _ _)
+"""

--- a/crates/rue-frontend-diff/src/corpus_manifest.rs
+++ b/crates/rue-frontend-diff/src/corpus_manifest.rs
@@ -1395,6 +1395,7 @@ pub(crate) const ROOTS: &[(&str, &[&str])] = &[
             "structs.rue",
             "sudoku/board.rue",
             "sudoku/main.rue",
+            "test_items.rue",
             "tinydb/db/_db.rue",
             "tinydb/db/query.rue",
             "tinydb/db/record.rue",

--- a/examples/ruelex/ast.rue
+++ b/examples/ruelex/ast.rue
@@ -64,6 +64,7 @@ pub const CONST_DECL: u64 = 52;
 pub const ANON_ENUM_TYPE: u64 = 53;
 pub const SLICE_TYPE: u64 = 54;
 pub const YIELD: u64 = 55;
+pub const TEST_DECL: u64 = 56;
 
 pub struct Node {
     kind: u64,
@@ -167,6 +168,7 @@ pub struct Arena {
         else if kind == ENUM_DEF { "enum" }
         else if kind == VARIANT { "variant" }
         else if kind == DROP_FN { "drop-fn" }
+        else if kind == TEST_DECL { "test" }
         else { "const" }
     }
 

--- a/examples/ruelex/lex.rue
+++ b/examples/ruelex/lex.rue
@@ -87,6 +87,7 @@ pub struct Lexer {
     last_kind: u64,
     last_value: u64,
     last_aux: u64,
+    last_ctx: u64,
 
     fn new(src: Bytes, pretty: bool) -> Self {
         let mut lx = Self {
@@ -100,6 +101,7 @@ pub struct Lexer {
             last_kind: token.UNKNOWN,
             last_value: 0,
             last_aux: 0,
+            last_ctx: token.CTX_NONE,
         };
         lx.n = lx.src.len();
         lx
@@ -227,6 +229,14 @@ pub struct Lexer {
         } else if word_eq(borrow key, "offset_of") {
             self.last_aux = 2;
         }
+
+        // `test` is not a keyword (2.4:2): it stays an IDENT here and only the
+        // parser's item-position lookahead can turn it into a test item
+        // (6.7:4). Recording the lexeme is all the parser needs to decide.
+        if word_eq(borrow key, "test") {
+            self.last_ctx = token.CTX_TEST;
+        }
+
         let sym = self.interner.intern(borrow key);
         self.last_kind = token.IDENT;
         self.last_value = sym;
@@ -447,6 +457,7 @@ pub struct Lexer {
             self.last_kind = token.UNKNOWN;
             self.last_value = 0;
             self.last_aux = 0;
+            self.last_ctx = token.CTX_NONE;
             let kind = if is_ident_start(c) {
                 self.lex_ident(start)
             } else if is_digit(c) {
@@ -468,6 +479,7 @@ pub struct Lexer {
                 end: end,
                 value: self.last_value,
                 aux: self.last_aux,
+                ctx: self.last_ctx,
             });
             self.emit(inout out, start, end, sl, sc, kind);
         }
@@ -477,6 +489,7 @@ pub struct Lexer {
             end: self.n,
             value: 0,
             aux: 0,
+            ctx: token.CTX_NONE,
         });
         self.emit(inout out, self.n, self.n, self.line, self.col, "EOF");
     }

--- a/examples/ruelex/parse.rue
+++ b/examples/ruelex/parse.rue
@@ -34,7 +34,7 @@ pub struct Parser {
     }
 
     fn fallback() -> token.Token {
-        token.Token { kind: token.EOF, start: 0, end: 0, value: 0, aux: 0 }
+        token.Token { kind: token.EOF, start: 0, end: 0, value: 0, aux: 0, ctx: token.CTX_NONE }
     }
 
     fn current(borrow self) -> token.Token {
@@ -844,6 +844,27 @@ pub struct Parser {
         self.add(ast.DROP_FN, name.value, start, self.arena.at(body).end, body, 0, 0)
     }
 
+    // Whether the cursor is at the contextual `test` keyword introducing a
+    // test item: an IDENT spelled `test` whose very next token is a STRING
+    // (6.7:2, 6.7:3). Everywhere else `test` is an ordinary identifier
+    // (6.7:4), so this lookahead is the whole of the contextual split.
+    fn at_test_item(borrow self) -> bool {
+        self.at(token.IDENT) && self.current().ctx == token.CTX_TEST &&
+            self.kind_at(self.pos + 1) == token.STRING
+    }
+
+    // `test_item = directives "test" STRING block ;` (6.7:2). A test item
+    // takes no visibility or `unchecked`/`linear` modifier (6.7:5), so the
+    // caller only reaches this with no modifier eaten. The name string is a
+    // value, not a child: like `parse_function`, the node records its
+    // directives and body and nothing else.
+    fn parse_test(inout self, directives: u64) -> u64 {
+        let start = self.bump().start;
+        let name = self.expect(token.STRING);
+        let body = self.parse_block();
+        self.add(ast.TEST_DECL, name.value, start, self.arena.at(body).end, directives, body, 0)
+    }
+
     fn parse_item(inout self) -> u64 {
         let directives = self.parse_directives();
         let mut flags: u64 = 0;
@@ -855,6 +876,7 @@ pub struct Parser {
         else if self.at(token.ENUM) { self.parse_enum(directives, flags) }
         else if self.at(token.DROP) { self.parse_drop(false) }
         else if self.at(token.CONST) { self.parse_const(directives, flags) }
+        else if flags == 0 && self.at_test_item() { self.parse_test(directives) }
         else {
             self.report(token.FN);
             let bad = self.bump();

--- a/examples/ruelex/token.rue
+++ b/examples/ruelex/token.rue
@@ -107,6 +107,13 @@ pub const GTGTEQ: u64 = 105;
 
 pub const UNKNOWN: u64 = 255;
 
+// Contextual keywords (6.7:4). A contextual keyword lexes as an ordinary
+// IDENT — the token dump is unchanged — so the parser needs the lexeme to
+// decide whether it introduces an item. The parser has no interner, so the
+// lexer tags the word here instead.
+pub const CTX_NONE: u64 = 0;
+pub const CTX_TEST: u64 = 1;
+
 pub struct Token {
     kind: u64,
     start: u64,
@@ -115,6 +122,10 @@ pub struct Token {
     // Parser-only lexical policy (0 ordinary, 1 all intrinsic args are types,
     // 2 only the first intrinsic arg is a type). Never affects token dumps.
     aux: u64,
+    // Contextual-keyword identity of an IDENT lexeme (CTX_* above), kept apart
+    // from `aux` so an intrinsic spelled with a contextual keyword's name
+    // cannot be read as a type-argument policy. Never affects token dumps.
+    ctx: u64,
 }
 
 pub const Tokens = std.arraybuf.ArrayBuf(Token);

--- a/examples/test_items.rue
+++ b/examples/test_items.rue
@@ -1,0 +1,55 @@
+// Test items (6.7), and the contextual keyword that introduces them.
+//
+// `test` is not a keyword (2.4:2): it introduces a test item only at item
+// position and only when the very next token is a string literal (6.7:2,
+// 6.7:3). Everywhere else it is an ordinary identifier (6.7:4). Both halves
+// live here so the stage-1 frontend differential compares them against the
+// production parser on every run.
+//
+// A test item takes no visibility or `unchecked`/`linear` modifier (6.7:5),
+// but it may carry the directives a function carries. An executable build
+// ignores the bodies (RUE-1955), so `main` below is the whole program.
+
+const std = @import("std");
+const OptI64 = std.option.Option(i64);
+
+// 6.7:4: `test` as an ordinary function name.
+fn test(x: i32) -> i32 { x }
+
+// 6.7:4: `test` as a struct field name.
+struct Fixture {
+    test: i64,
+}
+
+// 6.7:4: `test` as a method name.
+struct Runner {
+    count: i64,
+
+    fn test(borrow self) -> i64 { self.count }
+}
+
+fn present() -> OptI64 {
+    OptI64.Some(7)
+}
+
+// 6.7:2: directives precede the contextual keyword.
+@allow(unused_variable)
+test "a test item may carry directives" {
+    let ignored = test(1);
+}
+
+// 6.7:2: the block is a block, so an empty one is a whole test item.
+test "an empty body is still a test item" {}
+
+test "a body is an ordinary block" {
+    let value = present()?;
+    @assert_eq(value, 7);
+}
+
+fn main() -> i32 {
+    // 6.7:4: `test` as a local binder, and as the callee initializing it.
+    let test = test(0);
+    let fixture = Fixture { test: 2 };
+    let runner = Runner { count: 3 };
+    if test == 0 && fixture.test == 2 && runner.test() == 3 { 0 } else { 1 }
+}


### PR DESCRIPTION
Fixes RUE-1999.

The stage-1 Rue front end in `examples/ruelex` had no `test` item, and `//:frontend-diff-test` differentials it against the Rust parser over every file under `examples/`, so no example could carry a test declaration now that they are stable. ruelex parses `test_item = directives "test" STRING block` (spec 6.7:2) with `test` as a contextual keyword: the lexer tags the identifier out of band (a `ctx` field on the token, not a new kind, so the token dump is unchanged), and one parser predicate, an `IDENT` tagged `test` followed by a `STRING` at item position with no modifier eaten (6.7:3, 6.7:5), is the whole of the split. `fn test(…)`, a field named `test`, and a method named `test` keep parsing as identifiers (6.7:4). The node mirrors the Rust projection exactly: kind `test`, directives then body, the name kept as the node value and erased from the shape.

A new corpus fixture, `examples/test_items.rue`, pins both halves in the differential (directives on a test item, an empty body, `?` and `@assert_eq` in a body, and the three identifier cases); the corpus manifest gains that one line. Two `examples_rueparse` CLI cases cover the shape dump.

Verification: `//:frontend-diff-test` (1443 files), `scripts/rue cli rueparse`, `ruelex`, `examples` (119), `scripts/rue quick`, fmt clean. `examples/` is not an oracle-diff corpus input, so no model-gap entry is involved.