### PR TITLE
RUE-1992: compare string components of aggregates by content

### DIFF
--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -19,7 +19,9 @@ use super::aggregate_resolution::{
 };
 use super::analysis::FirstClassStrSite;
 use super::context::{AnalysisContext, AnalysisResult, ConstValue};
-use crate::inst::{Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirRef};
+use crate::inst::{
+    Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirPattern, AirProjection, AirRef,
+};
 use crate::types::{Type, TypeKind};
 
 impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
@@ -214,8 +216,25 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(AnalysisResult::new(air_ref, Type::BOOL))
     }
 
-    /// Prepare source-defined aggregate equality when the aggregate provides
-    /// the canonical borrowed equality method.
+    /// Prepare structural equality for an operand type that carries a string.
+    ///
+    /// Equality on an aggregate is structural, its components "determined
+    /// recursively by this rule down to scalar leaves" (4.3:3b, with 4.3:3c for
+    /// arrays and 4.3:3d for enum payloads). Naive recursion through a string
+    /// does not stop at a scalar leaf: every string type is a synthetic struct,
+    /// so the walk reaches the `ptr` field of a `StrBuf`, or the `{ptr, len}`
+    /// header of a `str`/`Str(N)` view, and 4.3:3e turns the comparison into an
+    /// address compare. A string *is* a leaf, so the recursion stops at one and
+    /// compares content under 4.3:3 wherever it is reached — an owned `StrBuf`
+    /// through the same borrowed `equals_borrowed` a top-level
+    /// `StrBuf == StrBuf` already uses, a view through the same single `Eq`
+    /// node a top-level `str == str` already uses (RUE-1992).
+    ///
+    /// A top-level view operand is left to that node: code generation already
+    /// answers it by content, and routing it through here would only wrap it.
+    /// Everything with no string inside likewise keeps the single `Eq` node
+    /// that CFG and code generation compare slot-wise, so this adds no second
+    /// lowering for the comparisons that were already right.
     pub(super) fn try_prepare_aggregate_equality(
         &mut self,
         air: &mut Air,
@@ -225,39 +244,37 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Option<AnalysisResult>> {
-        let Some(struct_id) = lhs.ty.as_struct().filter(|struct_id| {
-            self.body_type_pool().struct_lang_item(*struct_id) == Some(crate::LangItem::StrBuf)
-        }) else {
-            return Ok(None);
+        let component_wise = if self.is_strbuf(lhs.ty) {
+            true
+        } else if self.is_string_equality_leaf(lhs.ty) {
+            false
+        } else {
+            self.type_carries_string(lhs.ty)
         };
-        let method = self.intern_body_symbol("equals_borrowed")?;
-        if self.method_info((struct_id, method)).is_none() {
+        if !component_wise {
             return Ok(None);
         }
-        ctx.referenced_methods.insert((struct_id, method));
+        // Only an owned-string leaf calls `equals_borrowed`; a comparison whose
+        // strings are all views never needs it, and its program may not link
+        // `StrBuf` at all.
+        if self.type_carries_owned_string(lhs.ty) && !self.strbuf_equality_is_available()? {
+            return Ok(None);
+        }
+        // Both operands are read as borrowed places: equality borrows (4.3:3f),
+        // so an operand that already names storage is projected in place and an
+        // owning temporary gets the same home a borrow argument gets.
         let (lhs_arg, mut temp_scope) =
             self.materialize_borrow_argument(air, lhs.air_ref, lhs.ty, span, ctx)?;
         let (rhs_arg, rhs_scope) =
             self.materialize_borrow_argument(air, rhs.air_ref, rhs.ty, span, ctx)?;
         temp_scope.extend(rhs_scope);
-        let call_name =
-            self.intern_body_symbol(&self.method_symbol(struct_id, "equals_borrowed", false))?;
-        let equal = air.add_call(
-            None,
-            call_name,
-            &[
-                AirCallArg {
-                    value: lhs_arg,
-                    mode: AirArgMode::Borrow,
-                },
-                AirCallArg {
-                    value: rhs_arg,
-                    mode: AirArgMode::Borrow,
-                },
-            ],
-            Type::BOOL,
-            span,
-        )?;
+        let (lhs_arg, lhs_root_scope) =
+            self.root_comparison_operand(air, lhs_arg, lhs.ty, span, ctx)?;
+        let (rhs_arg, rhs_root_scope) =
+            self.root_comparison_operand(air, rhs_arg, rhs.ty, span, ctx)?;
+        temp_scope.extend(lhs_root_scope);
+        temp_scope.extend(rhs_root_scope);
+        let equal = self.build_structural_equality(air, lhs_arg, rhs_arg, lhs.ty, span, ctx)?;
         let equal = self.wrap_value_with_temp_scope(air, equal, Type::BOOL, span, temp_scope)?;
         let value = if matches!(comparison, AirInstData::Ne(..)) {
             air.add_inst(AirInst {
@@ -269,6 +286,604 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             equal
         };
         Ok(Some(AnalysisResult::new(value, Type::BOOL)))
+    }
+
+    /// Whether the trusted `StrBuf` this program links against still provides
+    /// the canonical borrowed equality method the owned-string leaves call.
+    ///
+    /// Without it there is no content comparison to lower to, so the whole
+    /// route declines and the ordinary `Eq` node stands.
+    fn strbuf_equality_is_available(&mut self) -> CompileResult<bool> {
+        let Some(struct_id) = self
+            .body_type_pool()
+            .lang_item_type(crate::LangItem::StrBuf)
+            .and_then(|ty| ty.as_struct())
+        else {
+            return Ok(false);
+        };
+        let method = self.intern_body_symbol("equals_borrowed")?;
+        Ok(self.method_info((struct_id, method)).is_some())
+    }
+
+    /// Whether `ty` is a string as far as equality is concerned: an owned
+    /// `StrBuf` or a `str`/`Str(N)` view.
+    ///
+    /// This is the semantic side of one notion, mirrored by code generation's
+    /// `is_string_like_for_equality`; both spell the view names through
+    /// [`crate::types::is_string_view_struct_name`]. The two must agree, or a
+    /// component would compare by content on one walk and by header on the
+    /// other, which is exactly the disagreement 4.3:3 forbids.
+    pub(super) fn is_string_equality_leaf(&self, ty: Type) -> bool {
+        self.is_strbuf(ty) || self.is_str_like(ty)
+    }
+
+    /// Whether `ty` transitively holds a string by value — including when it
+    /// *is* one.
+    ///
+    /// This is the predicate that decides whether a comparison needs the
+    /// component-wise lowering at all. The by-value containment graph is
+    /// acyclic (a type cannot hold itself by value), but the walk carries a
+    /// visited set so a malformed pool cannot turn a containment cycle into
+    /// unbounded recursion.
+    pub(super) fn type_carries_string(&self, ty: Type) -> bool {
+        self.type_carries_string_leaf(ty, false)
+    }
+
+    /// Whether `ty` transitively holds an *owned* string. Only those leaves
+    /// lower to `equals_borrowed`, so only they need it to exist; a program
+    /// whose strings are all views never mentions `StrBuf` at all.
+    fn type_carries_owned_string(&self, ty: Type) -> bool {
+        self.type_carries_string_leaf(ty, true)
+    }
+
+    fn type_carries_string_leaf(&self, ty: Type, owned_only: bool) -> bool {
+        let mut visited = AHashSet::new();
+        self.type_carries_string_within(ty, owned_only, &mut visited)
+    }
+
+    fn type_carries_string_within(
+        &self,
+        ty: Type,
+        owned_only: bool,
+        visited: &mut AHashSet<Type>,
+    ) -> bool {
+        if if owned_only {
+            self.is_strbuf(ty)
+        } else {
+            self.is_string_equality_leaf(ty)
+        } {
+            return true;
+        }
+        if !visited.insert(ty) {
+            return false;
+        }
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
+                let def = self.body_type_pool().struct_def(struct_id);
+                def.fields
+                    .iter()
+                    .any(|field| self.type_carries_string_within(field.ty, owned_only, visited))
+            }
+            TypeKind::Array(array_id) => {
+                let (element, length) = self.body_type_pool().array_def(array_id);
+                length > 0 && self.type_carries_string_within(element, owned_only, visited)
+            }
+            TypeKind::Enum(enum_id) => {
+                let def = self.body_type_pool().enum_def(enum_id);
+                (0..def.variant_count()).any(|variant| {
+                    def.variant_payload(variant).iter().any(|payload| {
+                        self.type_carries_string_within(*payload, owned_only, visited)
+                    })
+                })
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether a component of this type is read through a borrow or projected
+    /// further, and so needs an addressable home of its own.
+    ///
+    /// A component compared by the single `Eq` node — a scalar, a view, a
+    /// string-free aggregate — is used as a value and needs none.
+    fn equality_component_needs_home(&self, ty: Type) -> bool {
+        self.is_strbuf(ty) || (!self.is_string_equality_leaf(ty) && self.type_carries_string(ty))
+    }
+
+    /// Build the 4.3:3b conjunction comparing two operands of type `ty`.
+    ///
+    /// Both operands must already name storage; every component is reached by
+    /// extending their place paths, so nothing is copied and nothing is
+    /// dropped. The recursion has three stopping points: an owned string
+    /// compares its bytes through `equals_borrowed`, a string view compares
+    /// its bytes through the single `Eq` node code generation already routes
+    /// to the runtime text helper (both are 4.3:3), and any component with no
+    /// string inside compares with that same `Eq` node, slot-wise.
+    fn build_structural_equality(
+        &mut self,
+        air: &mut Air,
+        lhs: AirRef,
+        rhs: AirRef,
+        ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AirRef> {
+        if self.is_strbuf(ty) {
+            return self.build_strbuf_content_equality(air, lhs, rhs, ty, span, ctx);
+        }
+        if self.is_string_equality_leaf(ty) || !self.type_carries_string(ty) {
+            return Ok(air.add_inst(AirInst {
+                data: AirInstData::Eq(lhs, rhs),
+                ty: Type::BOOL,
+                span,
+            }));
+        }
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
+                let fields = self
+                    .body_type_pool()
+                    .struct_def(struct_id)
+                    .fields
+                    .iter()
+                    .map(|field| field.ty)
+                    .collect::<Vec<_>>();
+                let mut components = Vec::with_capacity(fields.len());
+                for (index, field_ty) in fields.into_iter().enumerate() {
+                    let projection = AirProjection::Field {
+                        struct_id,
+                        field_index: index as u32,
+                    };
+                    let lhs_field = self
+                        .project_addressable_component(air, lhs, ty, projection, field_ty, span)?;
+                    let rhs_field = self
+                        .project_addressable_component(air, rhs, ty, projection, field_ty, span)?;
+                    components.push(self.build_structural_equality(
+                        air, lhs_field, rhs_field, field_ty, span, ctx,
+                    )?);
+                }
+                Ok(Self::conjoin_equality(air, components, span))
+            }
+            TypeKind::Array(array_id) => {
+                self.build_array_structural_equality(air, lhs, rhs, ty, array_id, span, ctx)
+            }
+            TypeKind::Enum(enum_id) => {
+                self.build_enum_structural_equality(air, lhs, rhs, enum_id, span, ctx)
+            }
+            _ => Err(CompileError::new(
+                ErrorKind::InternalError(
+                    "a string-carrying comparison operand is not an aggregate".to_string(),
+                ),
+                span,
+            )),
+        }
+    }
+
+    /// Compare two `StrBuf` components by content, through the source-defined
+    /// borrowed equality method (4.3:3).
+    fn build_strbuf_content_equality(
+        &mut self,
+        air: &mut Air,
+        lhs: AirRef,
+        rhs: AirRef,
+        ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AirRef> {
+        let struct_id = ty.as_struct().expect("StrBuf is a struct");
+        let method = self.intern_body_symbol("equals_borrowed")?;
+        ctx.referenced_methods.insert((struct_id, method));
+        let call_name =
+            self.intern_body_symbol(&self.method_symbol(struct_id, "equals_borrowed", false))?;
+        Ok(air.add_call(
+            None,
+            call_name,
+            &[
+                AirCallArg {
+                    value: lhs,
+                    mode: AirArgMode::Borrow,
+                },
+                AirCallArg {
+                    value: rhs,
+                    mode: AirArgMode::Borrow,
+                },
+            ],
+            Type::BOOL,
+            span,
+        )?)
+    }
+
+    /// Compare two arrays element by element (4.3:3c), as a counted loop.
+    ///
+    /// Unrolling the elements would make the emitted program grow with the
+    /// array's length — and, because a conjunction is lowered by recursive
+    /// descent, would make the *compiler's* stack grow with it too. One loop
+    /// body keeps both bounded: the comparison advances while the index is in
+    /// range and the elements so far are equal, so it stops at the first
+    /// difference exactly as a conjunction would, and the answer is whether
+    /// the index reached the end.
+    #[allow(clippy::too_many_arguments)]
+    fn build_array_structural_equality(
+        &mut self,
+        air: &mut Air,
+        lhs: AirRef,
+        rhs: AirRef,
+        array_ty: Type,
+        array_id: crate::types::ArrayTypeId,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AirRef> {
+        let (element_ty, length) = self.body_type_pool().array_def(array_id);
+        if length == 0 {
+            return Ok(Self::equality_constant(air, true, span));
+        }
+        let (index_slot, mut statements) = self.open_counter_slot(air, span, ctx)?;
+        let length_constant = |air: &mut Air| {
+            air.add_inst(AirInst {
+                data: AirInstData::Const(length),
+                ty: Type::U64,
+                span,
+            })
+        };
+        let index_read = |air: &mut Air| {
+            air.add_inst(AirInst {
+                data: AirInstData::Load { slot: index_slot },
+                ty: Type::U64,
+                span,
+            })
+        };
+
+        // Condition: still in range, and this element is equal. `And` is
+        // short-circuiting, so the element read never runs at the end index.
+        let in_range = {
+            let index = index_read(air);
+            let length = length_constant(air);
+            air.add_inst(AirInst {
+                data: AirInstData::Lt(index, length),
+                ty: Type::BOOL,
+                span,
+            })
+        };
+        let lhs_element = {
+            let index = index_read(air);
+            self.project_addressable_component(
+                air,
+                lhs,
+                array_ty,
+                AirProjection::Index {
+                    array_type: array_ty,
+                    index,
+                },
+                element_ty,
+                span,
+            )?
+        };
+        let rhs_element = {
+            let index = index_read(air);
+            self.project_addressable_component(
+                air,
+                rhs,
+                array_ty,
+                AirProjection::Index {
+                    array_type: array_ty,
+                    index,
+                },
+                element_ty,
+                span,
+            )?
+        };
+        let element_equal =
+            self.build_structural_equality(air, lhs_element, rhs_element, element_ty, span, ctx)?;
+        let condition = air.add_inst(AirInst {
+            data: AirInstData::And(in_range, element_equal),
+            ty: Type::BOOL,
+            span,
+        });
+
+        // Body: advance the index.
+        let advance = {
+            let index = index_read(air);
+            let one = air.add_inst(AirInst {
+                data: AirInstData::Const(1),
+                ty: Type::U64,
+                span,
+            });
+            let next = air.add_inst(AirInst {
+                data: AirInstData::Add(index, one),
+                ty: Type::U64,
+                span,
+            });
+            air.add_inst(AirInst {
+                data: AirInstData::Store {
+                    slot: index_slot,
+                    value: next,
+                },
+                ty: Type::UNIT,
+                span,
+            })
+        };
+        let unit = air.add_inst(AirInst {
+            data: AirInstData::UnitConst,
+            ty: Type::UNIT,
+            span,
+        });
+        let body = air.add_block(&[advance], unit, Type::UNIT, span)?;
+        let counted_loop = air.add_inst(AirInst {
+            data: AirInstData::Loop {
+                cond: condition,
+                body,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+        statements.push(counted_loop);
+
+        // The loop stops either at the end or at the first unequal element.
+        let equal = {
+            let index = index_read(air);
+            let length = length_constant(air);
+            air.add_inst(AirInst {
+                data: AirInstData::Eq(index, length),
+                ty: Type::BOOL,
+                span,
+            })
+        };
+        Ok(air.add_block(&statements, equal, Type::BOOL, span)?)
+    }
+
+    /// Compare two enum operands by tag and then, for the shared variant,
+    /// payload field by payload field (4.3:3d).
+    ///
+    /// The tags are compared first, as ordinary scalars. That is what keeps
+    /// the emitted program linear in the variant count: once the tags are
+    /// known equal, the payload dispatch reads the *rhs* payload of the lhs's
+    /// own variant, so a variant needs one payload comparison rather than one
+    /// per pair of variants. Variants whose payload types match share that
+    /// comparison — their payload fields sit at the same offsets — so a
+    /// uniform enum emits one payload comparison in total, and a chain of
+    /// nested enums costs the sum of their variant counts rather than the
+    /// product.
+    fn build_enum_structural_equality(
+        &mut self,
+        air: &mut Air,
+        lhs: AirRef,
+        rhs: AirRef,
+        enum_id: crate::types::EnumId,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AirRef> {
+        let def = self.body_type_pool().enum_def(enum_id);
+        let payloads = (0..def.variant_count())
+            .map(|variant| def.variant_payload(variant).to_vec())
+            .collect::<Vec<_>>();
+        drop(def);
+        if payloads.is_empty() {
+            // An uninhabited enum has no value to compare; the point is
+            // unreachable, and `true` keeps the conjunction well-typed.
+            return Ok(Self::equality_constant(air, true, span));
+        }
+        let enum_ty = Type::new_enum(enum_id);
+
+        // Group the variants by payload signature, keeping one representative
+        // of each. Two variants carrying the same types lay their payload
+        // fields out identically, so the representative's field indices read
+        // the same storage for every variant in its group.
+        let mut groups: Vec<(Vec<Type>, u32)> = Vec::new();
+        let mut group_of = Vec::with_capacity(payloads.len());
+        for (variant, payload) in payloads.iter().enumerate() {
+            let index = match groups.iter().position(|(types, _)| types == payload) {
+                Some(index) => index,
+                None => {
+                    groups.push((payload.clone(), variant as u32));
+                    groups.len() - 1
+                }
+            };
+            group_of.push(index as i64);
+        }
+
+        let variant_tags = (0..payloads.len() as i64).collect::<Vec<_>>();
+        let lhs_tag = self.build_enum_selector(air, lhs, enum_id, enum_ty, &variant_tags, span)?;
+        let rhs_tag = self.build_enum_selector(air, rhs, enum_id, enum_ty, &variant_tags, span)?;
+        let tags_equal = air.add_inst(AirInst {
+            data: AirInstData::Eq(lhs_tag, rhs_tag),
+            ty: Type::BOOL,
+            span,
+        });
+
+        let payload_equal = if groups.len() == 1 {
+            let (payload, representative) = &groups[0];
+            self.build_enum_payload_equality(
+                air,
+                lhs,
+                rhs,
+                enum_id,
+                enum_ty,
+                *representative,
+                payload,
+                span,
+                ctx,
+            )?
+        } else {
+            let selector = self.build_enum_selector(air, lhs, enum_id, enum_ty, &group_of, span)?;
+            let mut arms = Vec::with_capacity(groups.len());
+            for (index, (payload, representative)) in groups.iter().enumerate() {
+                let body = self.build_enum_payload_equality(
+                    air,
+                    lhs,
+                    rhs,
+                    enum_id,
+                    enum_ty,
+                    *representative,
+                    payload,
+                    span,
+                    ctx,
+                )?;
+                arms.push((AirPattern::Int(index as i64), body));
+            }
+            air.add_match(selector, &arms, Type::BOOL, span)?
+        };
+
+        // The payload dispatch runs only once the tags agree, so reading the
+        // rhs payload as the lhs's variant is sound.
+        Ok(air.add_inst(AirInst {
+            data: AirInstData::And(tags_equal, payload_equal),
+            ty: Type::BOOL,
+            span,
+        }))
+    }
+
+    /// Read one integer per variant out of an enum operand: its tag, or the
+    /// index of the payload group its tag belongs to.
+    fn build_enum_selector(
+        &mut self,
+        air: &mut Air,
+        operand: AirRef,
+        enum_id: crate::types::EnumId,
+        enum_ty: Type,
+        values: &[i64],
+        span: Span,
+    ) -> CompileResult<AirRef> {
+        let scrutinee = self.reread_rooted_operand(air, operand, enum_ty, span)?;
+        let mut arms = Vec::with_capacity(values.len());
+        for (variant, value) in values.iter().enumerate() {
+            let selected = air.add_inst(AirInst {
+                data: AirInstData::Const(*value as u64),
+                ty: Type::U32,
+                span,
+            });
+            arms.push((
+                AirPattern::EnumVariant {
+                    enum_id,
+                    variant_index: variant as u32,
+                },
+                selected,
+            ));
+        }
+        Ok(air.add_match(scrutinee, &arms, Type::U32, span)?)
+    }
+
+    /// Compare the payload fields both operands carry under one variant.
+    #[allow(clippy::too_many_arguments)]
+    fn build_enum_payload_equality(
+        &mut self,
+        air: &mut Air,
+        lhs: AirRef,
+        rhs: AirRef,
+        enum_id: crate::types::EnumId,
+        enum_ty: Type,
+        variant_index: u32,
+        payload_types: &[Type],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AirRef> {
+        let mut statements = Vec::new();
+        let mut components = Vec::with_capacity(payload_types.len());
+        for (field_index, payload_ty) in payload_types.iter().enumerate() {
+            let lhs_payload = self.project_enum_payload(
+                air,
+                lhs,
+                enum_id,
+                enum_ty,
+                variant_index,
+                field_index as u32,
+                *payload_ty,
+                span,
+                ctx,
+                &mut statements,
+            )?;
+            let rhs_payload = self.project_enum_payload(
+                air,
+                rhs,
+                enum_id,
+                enum_ty,
+                variant_index,
+                field_index as u32,
+                *payload_ty,
+                span,
+                ctx,
+                &mut statements,
+            )?;
+            components.push(self.build_structural_equality(
+                air,
+                lhs_payload,
+                rhs_payload,
+                *payload_ty,
+                span,
+                ctx,
+            )?);
+        }
+        let equal = Self::conjoin_equality(air, components, span);
+        self.wrap_value_with_temp_scope(air, equal, Type::BOOL, span, statements)
+    }
+
+    /// Read one payload field of a known variant, giving it a non-owning home
+    /// only when the recursion below will borrow or project it.
+    #[allow(clippy::too_many_arguments)]
+    fn project_enum_payload(
+        &mut self,
+        air: &mut Air,
+        base: AirRef,
+        enum_id: crate::types::EnumId,
+        enum_ty: Type,
+        variant_index: u32,
+        field_index: u32,
+        payload_ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+        statements: &mut Vec<AirRef>,
+    ) -> CompileResult<AirRef> {
+        let base = self.reread_rooted_operand(air, base, enum_ty, span)?;
+        let payload = air.add_inst(AirInst {
+            data: AirInstData::EnumPayloadGet {
+                base,
+                enum_id,
+                variant_index,
+                field_index,
+            },
+            ty: payload_ty,
+            span,
+        });
+        if !self.equality_component_needs_home(payload_ty) {
+            return Ok(payload);
+        }
+        let (home, prefix) =
+            self.materialize_borrowed_component(air, payload, payload_ty, span, ctx)?;
+        statements.extend(prefix);
+        Ok(home)
+    }
+
+    /// Conjoin the component comparisons of one aggregate.
+    ///
+    /// The conjunction is balanced rather than left-deep. `And` short-circuits
+    /// and re-associating it preserves both the order and the stopping point,
+    /// while CFG construction lowers each operand by recursive descent — so a
+    /// left-deep chain over an aggregate's components would put the compiler's
+    /// stack depth in the hands of the program's field count.
+    fn conjoin_equality(air: &mut Air, components: Vec<AirRef>, span: Span) -> AirRef {
+        if components.is_empty() {
+            return Self::equality_constant(air, true, span);
+        }
+        let mut level = components;
+        while level.len() > 1 {
+            let mut next = Vec::with_capacity(level.len().div_ceil(2));
+            let mut pairs = level.chunks_exact(2);
+            for pair in &mut pairs {
+                next.push(air.add_inst(AirInst {
+                    data: AirInstData::And(pair[0], pair[1]),
+                    ty: Type::BOOL,
+                    span,
+                }));
+            }
+            next.extend(pairs.remainder());
+            level = next;
+        }
+        level[0]
+    }
+
+    fn equality_constant(air: &mut Air, value: bool, span: Span) -> AirRef {
+        air.add_inst(AirInst {
+            data: AirInstData::BoolConst(value),
+            ty: Type::BOOL,
+            span,
+        })
     }
 
     // ========================================================================

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -71,6 +71,31 @@ pub(crate) enum BorrowOperandElaboration {
     Temporary,
 }
 
+/// Whether a compiler-synthesized temporary owns what its slot holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TemporaryOwnership {
+    /// The slot owns its value and is dropped when its scope closes.
+    Owning,
+    /// The slot holds a view of storage something else owns, so drop
+    /// elaboration schedules nothing for it (see [`Air::add_borrow_slot`]).
+    NonOwning,
+}
+
+/// One frame slot holding a compiler-synthesized temporary, and the AIR pieces
+/// that establish it. Kept separate so each lands in the position its
+/// obligation requires.
+pub(crate) struct MaterializedTemporary {
+    /// The reserved frame slot.
+    pub(crate) slot: u32,
+    /// Addressable read of the temporary.
+    pub(crate) load: AirRef,
+    /// Initializer. Its position fixes when the value is evaluated.
+    pub(crate) alloc: AirRef,
+    /// Storage annotation. Its position fixes the scope whose exit ends the
+    /// temporary's lifetime.
+    pub(crate) storage_live: AirRef,
+}
+
 /// The AIR pieces of an elaborated `borrow` operand, kept separate so each
 /// lands in the position its obligation requires.
 pub(crate) struct ElaboratedBorrowOperand {
@@ -570,31 +595,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         } else {
             BorrowOperandElaboration::Temporary
         };
-        let slots = self.require_layout_slots(ty, span)?;
-        let slot = self.reserve_frame_slots(&mut ctx.next_slot, slots, span)?;
-        if kind == BorrowOperandElaboration::Promoted {
-            // The promoted image is immortal and owns nothing — a literal's
-            // bytes live in `.rodata`, and a `StrBuf` promoted at a `borrow
-            // StrBuf` position is the non-owning `cap == 0` header over them.
-            // Registering the slot as non-owning is what makes "no drop glue"
-            // structural rather than incidental.
-            air.add_borrow_slot(slot);
-        }
-        let live = air.add_inst(AirInst {
-            data: AirInstData::StorageLive { slot },
-            ty,
-            span,
-        });
-        let alloc = air.add_inst(AirInst {
-            data: AirInstData::Alloc { slot, init: value },
-            ty: Type::UNIT,
-            span,
-        });
-        let load = air.add_inst(AirInst {
-            data: AirInstData::Load { slot },
-            ty,
-            span,
-        });
+        // The promoted image is immortal and owns nothing — a literal's bytes
+        // live in `.rodata`, and a `StrBuf` promoted at a `borrow StrBuf`
+        // position is the non-owning `cap == 0` header over them. Registering
+        // its slot as non-owning is what makes "no drop glue" structural
+        // rather than incidental.
+        let ownership = if kind == BorrowOperandElaboration::Promoted {
+            TemporaryOwnership::NonOwning
+        } else {
+            TemporaryOwnership::Owning
+        };
+        let temporary = self.materialize_in_temporary(air, value, ty, ownership, span, ctx)?;
+        let (load, alloc, live) = (temporary.load, temporary.alloc, temporary.storage_live);
         Ok(ElaboratedBorrowOperand {
             load,
             alloc,
@@ -615,9 +627,41 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if self.is_addressable_read(air, value) {
             return Ok((value, prefix));
         }
+        let temporary =
+            self.materialize_in_temporary(air, value, ty, TemporaryOwnership::Owning, span, ctx)?;
+        prefix.extend([temporary.storage_live, temporary.alloc]);
+        Ok((temporary.load, prefix))
+    }
+
+    /// Store one value in a fresh frame slot and read it back.
+    ///
+    /// This is the single place a compiler-synthesized temporary is created.
+    /// The only choice a caller makes is whether the slot *owns* what it
+    /// holds: an owning slot is dropped when its scope closes, while a
+    /// non-owning one (registered through [`Air::add_borrow_slot`]) holds a
+    /// view of storage something else owns and drop elaboration schedules
+    /// nothing for it. Getting that choice wrong is a leak on one side and a
+    /// double free on the other, so it is the parameter rather than a
+    /// per-caller convention.
+    ///
+    /// The `StorageLive` and `Alloc` are returned rather than emitted into a
+    /// block: each caller decides which scope they open, which is what lets a
+    /// borrow operand's drop land after the call it is passed to.
+    fn materialize_in_temporary(
+        &mut self,
+        air: &mut Air,
+        value: AirRef,
+        ty: Type,
+        ownership: TemporaryOwnership,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<MaterializedTemporary> {
         let slots = self.require_layout_slots(ty, span)?;
         let slot = self.reserve_frame_slots(&mut ctx.next_slot, slots, span)?;
-        let live = air.add_inst(AirInst {
+        if ownership == TemporaryOwnership::NonOwning {
+            air.add_borrow_slot(slot);
+        }
+        let storage_live = air.add_inst(AirInst {
             data: AirInstData::StorageLive { slot },
             ty,
             span,
@@ -632,8 +676,273 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty,
             span,
         });
-        prefix.extend([live, alloc]);
-        Ok((load, prefix))
+        Ok(MaterializedTemporary {
+            slot,
+            load,
+            alloc,
+            storage_live,
+        })
+    }
+
+    /// Decompose a read that already names storage into its place path.
+    ///
+    /// This is the one AIR-level place decomposition: `Load`/`Param` name a
+    /// bare slot, a `PlaceRead` carries a base and a projection chain, and a
+    /// move marker is transparent. `None` for anything else — a computed
+    /// value names no storage to extend.
+    pub(super) fn read_place_path(
+        &self,
+        air: &Air,
+        value: AirRef,
+        base_ty: Type,
+    ) -> Option<(AirPlaceBase, Type, Vec<AirProjection>)> {
+        let mut value = value;
+        while let AirInstData::MarkMoved { value: inner, .. } = air.get(value).data {
+            value = inner;
+        }
+        match air.get(value).data {
+            AirInstData::Load { slot } => Some((AirPlaceBase::Local(slot), base_ty, Vec::new())),
+            AirInstData::Param { index } => Some((AirPlaceBase::Param(index), base_ty, Vec::new())),
+            AirInstData::PlaceRead { place } => {
+                let stored = air.get_place(place);
+                let projections = air.get_place_projections(stored).to_vec();
+                Some((stored.base, stored.base_type, projections))
+            }
+            _ => None,
+        }
+    }
+
+    /// Decompose a comparison operand, re-emitting every index the path names.
+    ///
+    /// An index is an operand of the place, so a single index instruction
+    /// shared by two derived reads is lowered in whichever short-circuit
+    /// conjunct, loop header, or dispatch arm demanded it first and dominates
+    /// neither. Every derived place therefore reads its own index. Constants
+    /// and slot reads are the only indices that reach here — a path naming any
+    /// other computed index is copied to a slot first
+    /// ([`Self::root_comparison_operand`]) — and re-reading either is free and
+    /// yields the same value at every point of the comparison.
+    fn comparison_operand_path(
+        &self,
+        air: &mut Air,
+        value: AirRef,
+        base_ty: Type,
+        span: Span,
+    ) -> CompileResult<(AirPlaceBase, Type, Vec<AirProjection>)> {
+        let Some((place_base, place_base_type, mut projections)) =
+            self.read_place_path(air, value, base_ty)
+        else {
+            return Err(CompileError::new(
+                ErrorKind::InternalError(
+                    "a structural comparison operand names no storage".to_string(),
+                ),
+                span,
+            ));
+        };
+        for projection in &mut projections {
+            if let AirProjection::Index { array_type, index } = *projection {
+                let data = match air.get(index).data {
+                    AirInstData::Const(constant) => Some(AirInstData::Const(constant)),
+                    AirInstData::Load { slot } => Some(AirInstData::Load { slot }),
+                    _ => None,
+                };
+                if let Some(data) = data {
+                    let index_ty = air.get(index).ty;
+                    *projection = AirProjection::Index {
+                        array_type,
+                        index: air.add_inst(AirInst {
+                            data,
+                            ty: index_ty,
+                            span,
+                        }),
+                    };
+                }
+            }
+        }
+        Ok((place_base, place_base_type, projections))
+    }
+
+    /// Read one component out of an operand that already names storage,
+    /// without copying the aggregate the component belongs to.
+    ///
+    /// [`Self::emit_projected_rvalue_read`] is the counterpart for a computed
+    /// base: it gives the rvalue an *owning* temporary home before projecting
+    /// it. A structural comparison never owns its operands — equality borrows
+    /// them (4.3:3f) — so it needs the other half: extend the path of a place
+    /// the caller already named and read through it. The result is itself an
+    /// addressable read, so a nested component composes by calling this again.
+    pub(crate) fn project_addressable_component(
+        &mut self,
+        air: &mut Air,
+        base: AirRef,
+        base_ty: Type,
+        projection: AirProjection,
+        result_ty: Type,
+        span: Span,
+    ) -> CompileResult<AirRef> {
+        let (place_base, place_base_type, mut projections) =
+            self.comparison_operand_path(air, base, base_ty, span)?;
+        projections.push(projection);
+        let place = air.make_place(place_base, place_base_type, projections)?;
+        Ok(air.add_inst(AirInst {
+            data: AirInstData::PlaceRead { place },
+            ty: result_ty,
+            span,
+        }))
+    }
+
+    /// Root a comparison operand at a frame slot or a parameter, so every
+    /// component read below it stands on its own.
+    ///
+    /// A component is read by extending its operand's place path, so every
+    /// *value* that path names — an accessor or `@place` base, a computed
+    /// array index — is carried into every extension. CFG construction lowers
+    /// a value once and caches it at the block that first demanded it, so such
+    /// a value shared by the arms of a short-circuit conjunction, a loop
+    /// header, or a variant dispatch would be defined in a block that
+    /// dominates neither. An operand whose path names one is copied into a
+    /// non-owning slot first, leaving a bare slot every component read can
+    /// stand on.
+    pub(crate) fn root_comparison_operand(
+        &mut self,
+        air: &mut Air,
+        value: AirRef,
+        ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<(AirRef, Vec<AirRef>)> {
+        let mut read = value;
+        while let AirInstData::MarkMoved { value: inner, .. } = air.get(read).data {
+            read = inner;
+        }
+        let rooted = self
+            .read_place_path(air, read, ty)
+            .is_some_and(|(base, _, projections)| {
+                matches!(base, AirPlaceBase::Local(_) | AirPlaceBase::Param(_))
+                    && projections.iter().all(|projection| match projection {
+                        AirProjection::Field { .. } => true,
+                        AirProjection::Index { index, .. } => matches!(
+                            air.get(*index).data,
+                            AirInstData::Const(_) | AirInstData::Load { .. }
+                        ),
+                    })
+            });
+        if rooted {
+            return Ok((read, Vec::new()));
+        }
+        self.stage_borrowed_component(air, read, ty, span, ctx)
+    }
+
+    /// Re-emit a read of the storage an operand already names.
+    ///
+    /// A dispatch arm, a loop header, and each conjunct of a short-circuit
+    /// conjunction are separate blocks, and a single shared read instruction
+    /// would be lowered and cached in whichever of them demanded it first.
+    /// Reading the same place again through a fresh instruction costs nothing
+    /// at run time and leaves each of them self-contained. The operand must
+    /// already be rooted at storage ([`Self::root_comparison_operand`]).
+    pub(crate) fn reread_rooted_operand(
+        &self,
+        air: &mut Air,
+        value: AirRef,
+        ty: Type,
+        span: Span,
+    ) -> CompileResult<AirRef> {
+        let (place_base, place_base_type, projections) =
+            self.comparison_operand_path(air, value, ty, span)?;
+        if projections.is_empty() {
+            let data = match place_base {
+                AirPlaceBase::Local(slot) => Some(AirInstData::Load { slot }),
+                AirPlaceBase::Param(index) => Some(AirInstData::Param { index }),
+                AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => None,
+            };
+            if let Some(data) = data {
+                return Ok(air.add_inst(AirInst { data, ty, span }));
+            }
+        }
+        let place = air.make_place(place_base, place_base_type, projections)?;
+        Ok(air.add_inst(AirInst {
+            data: AirInstData::PlaceRead { place },
+            ty,
+            span,
+        }))
+    }
+
+    /// Open a compiler-synthesized loop counter: one `u64` slot initialized to
+    /// zero, plus the statements that establish it.
+    ///
+    /// The counter carries no drop glue, so its slot is an ordinary owning one
+    /// and the enclosing block's scope exit ends its storage.
+    pub(crate) fn open_counter_slot(
+        &mut self,
+        air: &mut Air,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<(u32, Vec<AirRef>)> {
+        let zero = air.add_inst(AirInst {
+            data: AirInstData::Const(0),
+            ty: Type::U64,
+            span,
+        });
+        let temporary = self.materialize_in_temporary(
+            air,
+            zero,
+            Type::U64,
+            TemporaryOwnership::Owning,
+            span,
+            ctx,
+        )?;
+        Ok((
+            temporary.slot,
+            vec![temporary.storage_live, temporary.alloc],
+        ))
+    }
+
+    /// Give a component the body does not own an addressable home.
+    ///
+    /// An enum payload is reached by decoding the active variant rather than by
+    /// a place projection, so a payload a comparison only borrows still has to
+    /// be staged in a frame slot before it can be borrowed again. The slot is
+    /// registered as non-owning, because the bits it holds belong to the enum
+    /// being compared: dropping them when the staging scope closes would free
+    /// storage the operand still owns. The returned statements must precede
+    /// every read of the home.
+    pub(crate) fn materialize_borrowed_component(
+        &mut self,
+        air: &mut Air,
+        value: AirRef,
+        ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<(AirRef, Vec<AirRef>)> {
+        if self.is_addressable_read(air, value) {
+            return Ok((value, Vec::new()));
+        }
+        self.stage_borrowed_component(air, value, ty, span, ctx)
+    }
+
+    /// The staging half of [`Self::materialize_borrowed_component`], for a
+    /// caller that needs the slot even though the value already names storage.
+    fn stage_borrowed_component(
+        &mut self,
+        air: &mut Air,
+        value: AirRef,
+        ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<(AirRef, Vec<AirRef>)> {
+        let temporary = self.materialize_in_temporary(
+            air,
+            value,
+            ty,
+            TemporaryOwnership::NonOwning,
+            span,
+            ctx,
+        )?;
+        Ok((
+            temporary.load,
+            vec![temporary.storage_live, temporary.alloc],
+        ))
     }
 
     pub(crate) fn wrap_value_with_temp_scope(
@@ -837,12 +1146,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // twice.
         let (base, mut stmts) = self.peel_projected_rvalue_scope(air, base);
         if !stmts.is_empty()
-            && let AirInstData::PlaceRead { place } = air.get(base).data
+            && matches!(air.get(base).data, AirInstData::PlaceRead { .. })
+            && let Some((base, base_type, mut projections)) =
+                self.read_place_path(air, base, base_type)
         {
-            let place = air.get_place(place);
-            let base = place.base;
-            let base_type = place.base_type;
-            let mut projections = air.get_place_projections(place).to_vec();
             projections.push(projection);
             let place = air.make_place(base, base_type, projections)?;
             let value = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -1829,6 +1829,11 @@ mod tests {
             "allocate_local_storage",
             "try_read_traced_place",
             "materialize_borrow_argument",
+            "materialize_borrowed_component",
+            "materialize_in_temporary",
+            "open_counter_slot",
+            "project_addressable_component",
+            "read_place_path",
             "project_strbuf_text_fields",
             "peel_projected_rvalue_scope",
             "emit_projected_rvalue_read",
@@ -1972,6 +1977,12 @@ mod tests {
             "analyze_enum_ops",
             "validate_equality_operand_type",
             "try_prepare_aggregate_equality",
+            "type_carries_string",
+            "is_string_equality_leaf",
+            "build_structural_equality",
+            "build_strbuf_content_equality",
+            "build_array_structural_equality",
+            "build_enum_structural_equality",
         ] {
             let definition = format!("fn {method}(");
             assert!(

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -454,14 +454,17 @@ impl<'a> CfgLowerContext<'a> {
     /// Check if a type has string byte-content equality semantics.
     ///
     /// `StrBuf`, `str`, and `Str(N)` use byte-content equality rather than
-    /// structural pointer/length equality.
+    /// structural pointer/length equality. Semantic analysis asks the same
+    /// question of a *component* of an aggregate — a string leaf compares by
+    /// content at any depth (spec 4.3:3, RUE-1992) — so the view spelling is
+    /// read through the one shared classifier rather than open-coded here:
+    /// two walks with two answers would compare the same field by content on
+    /// one and by address on the other.
     pub fn is_string_like_for_equality(&self, ty: Type) -> bool {
         match ty.kind() {
             TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
-                self.is_strbuf(ty)
-                    || &*struct_def.name == "str"
-                    || (struct_def.name.starts_with("Str(") && struct_def.name.ends_with(')'))
+                self.is_strbuf(ty) || rue_air::is_string_view_struct_name(&struct_def.name)
             }
             _ => false,
         }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -2186,14 +2186,22 @@ pub fn integer_width(ty: Type) -> Option<IntegerWidth> {
 
 /// Select the width used by a scalar comparison. Booleans and discriminant-only
 /// enums are represented in the ordinary 32-bit unsigned scalar register form;
-/// every other valid scalar comparison operand must be an integer. Do not
-/// silently assign an integer width to malformed or unsupported types: doing so
-/// would let the backends choose a target-specific interpretation of the same
-/// invalid CFG.
+/// a raw pointer compares as its address at full width (spec 4.3:3e), the same
+/// width [`crate::types::slot_needs_wide_compare`] gives a pointer leaf of a
+/// slot-wise aggregate comparison — a component-wise aggregate equality
+/// (RUE-1992) reaches such a leaf as a comparison of its own; every other
+/// valid scalar comparison operand must be an integer. Do not silently assign
+/// an integer width to malformed or unsupported types: doing so would let the
+/// backends choose a target-specific interpretation of the same invalid CFG.
 pub fn comparison_integer_width(ty: Type) -> IntegerWidth {
     if ty == Type::BOOL || ty.is_enum() {
         IntegerWidth {
             bits: 32,
+            signed: false,
+        }
+    } else if crate::types::slot_needs_wide_compare(ty) && integer_width(ty).is_none() {
+        IntegerWidth {
+            bits: 64,
             signed: false,
         }
     } else {

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -100,6 +100,12 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "expressions.intrinsics",
+        "assert_eq_on_a_string_carrying_struct_aborts_on_different_bytes",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "expressions.intrinsics",
         "assert_ne_failing_names_the_other_comparison",
         intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -995,10 +995,13 @@ impl Value {
             Value::Int(n) => *n,
             Value::AddressInt { value, .. } => *value,
             Value::Bool(b) => *b as i128,
-            // Unreachable for a well-typed program (aggregates/pointers never
-            // reach a bare scalar context; a pointer becomes an integer only
-            // through `@ptr_to_int`, which computes its address explicitly);
-            // defined so callers need not thread an error.
+            // Zero is a placeholder, not an address: a pointer becomes an
+            // integer only through `@ptr_to_int`, which computes its address
+            // explicitly and yields an `AddressInt`. Nothing that observes a
+            // pointer's identity may route it here — comparison in particular
+            // sends a pointer to `values_equal_typed` instead, because reading
+            // every address as zero would call two distinct pointers equal
+            // (spec 4.3:3e). Defined so callers need not thread an error.
             Value::Unit | Value::Aggregate(_) | Value::Ptr(_) => 0,
         }
     }
@@ -4450,11 +4453,15 @@ impl<'a> Interp<'a> {
         // aggregates (structs, arrays, payload enums) compare STRUCTURALLY,
         // field-by-field / element-by-element / same-variant-and-equal-payload,
         // via `Value`'s derived `PartialEq` which recurses into nested
-        // aggregates (RUE-285). Only `==` / `!=` reach a non-text aggregate here
-        // (ordering `< > <= >=` is a type error on those), so we report `Equal`
-        // iff structurally equal and an arbitrary non-`Equal` ordering
+        // aggregates (RUE-285). A raw pointer compares by ADDRESS — allocation
+        // identity, lifetime generation, and byte offset — which is the same
+        // identity `values_equal_typed` gives a pointer leaf nested in an
+        // aggregate (spec 4.3:3e). Only `==` / `!=` reach a non-text aggregate
+        // or a pointer here (ordering `< > <= >=` is a type error on those), so
+        // we report `Equal` iff equal and an arbitrary non-`Equal` ordering
         // otherwise — enough for `pick` to decide `==`/`!=`. Everything else
-        // compares by integer value.
+        // compares by integer value, which is what an *address integer* from
+        // `@ptr_to_int` must do: its provenance is invisible to arithmetic.
         let ty = cfg.get_inst(a).ty;
         let ord = if self.is_text_type(ty) {
             let bx = self.text_bytes(&x)?;
@@ -4462,11 +4469,19 @@ impl<'a> Interp<'a> {
             bx.cmp(&by)
         } else {
             match (&x, &y) {
-                (Value::Aggregate(_), _) | (_, Value::Aggregate(_)) => {
-                    // Only `==`/`!=` reach an aggregate; compare with text
-                    // awareness so a text field/element/payload is judged by its
-                    // byte content, not by the identity of its heap buffer
-                    // pointer (RUE-1010 §6.13).
+                // A pointer belongs here rather than below: `as_int` reads
+                // every pointer as zero, so the numeric path would call two
+                // distinct addresses equal. Component-wise aggregate equality
+                // (RUE-1992) compares a string-carrying aggregate one
+                // component at a time, so a pointer field reaches this
+                // comparison directly and not only through the aggregate arm.
+                (Value::Aggregate(_), _)
+                | (_, Value::Aggregate(_))
+                | (Value::Ptr(_), _)
+                | (_, Value::Ptr(_)) => {
+                    // Compare with text awareness so a text field/element/
+                    // payload is judged by its byte content, not by the
+                    // identity of its heap buffer pointer (RUE-1010 §6.13).
                     if self.values_equal_typed(&x, &y, ty)? {
                         std::cmp::Ordering::Equal
                     } else {

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -1800,6 +1800,36 @@ fn raw_pointer_read_roundtrip() {
     assert_eq!(run(src).stdout, "123\n");
 }
 
+/// A raw-pointer leaf compares by ADDRESS, not by pointee, when equality
+/// reaches it as an operand of its own (spec 4.3:3e).
+///
+/// A bare `p == q` is a type error, so a pointer used to reach the comparison
+/// only inside an aggregate, where `values_equal_typed` judged it by identity.
+/// Component-wise aggregate equality (RUE-1992) compares a string-carrying
+/// aggregate one component at a time, so a pointer field now reaches the
+/// scalar comparison path directly — which used to read every pointer as the
+/// integer zero and call two distinct addresses equal.
+#[test]
+fn raw_pointer_component_compares_by_address() {
+    let src = r#"struct Marked { s: str, at: ptr const i32 }
+        fn main() -> i32 {
+            let x: i32 = 42;
+            let y: i32 = 42;
+            let a = checked { Marked { s: "q", at: @raw(x) } };
+            let b = checked { Marked { s: "q", at: @raw(x) } };
+            let c = checked { Marked { s: "q", at: @raw(y) } };
+            let d = checked { Marked { s: "r", at: @raw(x) } };
+            let mut r: i32 = 0;
+            if a == b { r = r + 1; }
+            if a != c { r = r + 2; }
+            if a != d { r = r + 4; }
+            r
+        }"#;
+    // Same address and same bytes: equal. Same bytes, different address:
+    // unequal. Same address, different bytes: unequal.
+    assert_eq!(exit(src), 7);
+}
+
 /// A write through a `ptr mut` from `@raw_mut` mutates the source local.
 #[test]
 fn raw_mut_write_mutates_local() {

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -484,3 +484,184 @@ params = [
   { variant = "different_variant", a = "Circle(5)", b = "Square(5)", op = "==", exit_code = 0 },
   { variant = "inequality", a = "Circle(5)", b = "Square(5)", op = "!=", exit_code = 1 },
 ]
+
+# =============================================================================
+# Aggregates carrying a string (RUE-1992)
+#
+# A `StrBuf` is a synthetic struct, so a naive structural walk reaches its `ptr`
+# field and 4.3:3e answers with an address compare. A `StrBuf` is a string, so
+# the recursion stops there instead and 4.3:3 compares its bytes — wherever the
+# walk reaches one: a struct field, an array element, an enum payload field, at
+# any depth. The other leaves keep their own rules, so a raw pointer beside a
+# string still compares by address.
+# =============================================================================
+
+[[case]]
+name = "struct_strbuf_field_equality_{variant}"
+spec = ["4.3:2", "4.3:3", "4.3:3b"]
+real_std = true
+description = "A StrBuf field compares by byte content, not by its header."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Pair { name: StrBuf }
+
+fn mk(s: str) -> StrBuf { StrBuf.from_str(borrow s) }
+
+fn main() -> i32 {
+    let a = Pair { name: mk("{left}") };
+    let b = Pair { name: mk("{right}") };
+    if a {op} b { 1 } else { 0 }
+}
+"""
+params = [
+  { variant = "equal_bytes", left = "abc", right = "abc", op = "==", exit_code = 1 },
+  { variant = "different_bytes", left = "abc", right = "abd", op = "==", exit_code = 0 },
+  { variant = "different_lengths", left = "abc", right = "abcd", op = "==", exit_code = 0 },
+  { variant = "inequality", left = "abc", right = "abd", op = "!=", exit_code = 1 },
+]
+
+[[case]]
+name = "array_of_strbuf_equality_is_element_content"
+spec = ["4.3:2", "4.3:3", "4.3:3c"]
+real_std = true
+description = "Array elements that are strings compare index-by-index on content."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn mk(s: str) -> StrBuf { StrBuf.from_str(borrow s) }
+
+fn main() -> i32 {
+    let a = [mk("ab"), mk("cd")];
+    let b = [mk("ab"), mk("cd")];
+    let c = [mk("ab"), mk("ce")];
+    if a == b && a != c { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "enum_strbuf_payload_equality_is_content"
+spec = ["4.3:2", "4.3:3", "4.3:3d"]
+real_std = true
+description = "A string payload field compares on content; a different variant is never equal."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+enum Tagged { Empty, Named(StrBuf) }
+
+fn mk(s: str) -> StrBuf { StrBuf.from_str(borrow s) }
+
+fn main() -> i32 {
+    let a = Tagged.Named(mk("hi"));
+    let b = Tagged.Named(mk("hi"));
+    let c = Tagged.Named(mk("ho"));
+    let d = Tagged.Empty;
+    if a == b && a != c && a != d { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "nested_struct_strbuf_equality_reaches_every_depth"
+spec = ["4.3:2", "4.3:3", "4.3:3b"]
+real_std = true
+description = "A string two aggregates deep still compares on content, beside a scalar leaf."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Inner { name: StrBuf }
+struct Outer { inner: Inner, n: i32 }
+
+fn mk(s: str) -> StrBuf { StrBuf.from_str(borrow s) }
+
+fn main() -> i32 {
+    let a = Outer { inner: Inner { name: mk("zz") }, n: 7 };
+    let b = Outer { inner: Inner { name: mk("zz") }, n: 7 };
+    let c = Outer { inner: Inner { name: mk("zz") }, n: 8 };
+    let d = Outer { inner: Inner { name: mk("zy") }, n: 7 };
+    if a == b && a != c && a != d { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "struct_strbuf_and_raw_pointer_fields_keep_their_own_rules"
+spec = ["4.3:2", "4.3:3", "4.3:3b", "4.3:3e"]
+real_std = true
+description = "Beside a string field, a raw-pointer leaf still compares by address."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Marked { name: StrBuf, at: ptr const i32 }
+
+fn mk(s: str) -> StrBuf { StrBuf.from_str(borrow s) }
+
+fn main() -> i32 {
+    let x: i32 = 42;
+    let y: i32 = 42;
+    let a = checked { Marked { name: mk("q"), at: @raw(x) } };
+    let b = checked { Marked { name: mk("q"), at: @raw(x) } };
+    let c = checked { Marked { name: mk("q"), at: @raw(y) } };
+    let d = checked { Marked { name: mk("r"), at: @raw(x) } };
+    if a == b && a != c && a != d { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+# A string *view* is a string too. These cases put the two literals in
+# different modules on purpose: identical spellings compiled into one module
+# can share a single run, so a same-file test cannot tell a content comparison
+# from an address comparison, while separate runs make the difference visible.
+
+[[case]]
+name = "struct_str_view_field_equality_is_content"
+spec = ["4.3:2", "4.3:3", "4.3:3b"]
+description = "A `str` field compares by byte content, not by the run its view points at."
+source = """
+const view = @import("view.rue");
+
+fn main() -> i32 {
+    let mine = view.W { s: "hello" };
+    let theirs = view.make();
+    let mut r: i32 = 0;
+    if mine.s == theirs.s { r = r + 1; }
+    if mine == theirs { r = r + 2; }
+    if mine != theirs { r = r + 4; }
+    r
+}
+"""
+aux_files = { "view.rue" = """
+pub struct W { s: str }
+pub fn make() -> W { W { s: "hello" } }
+""" }
+exit_code = 3
+
+[[case]]
+name = "struct_str_fixed_field_equality_is_content"
+spec = ["4.3:2", "4.3:3", "4.3:3b"]
+description = "A `Str(N)` field compares by byte content on the same terms as a `str` one."
+source = """
+const fixed = @import("fixed.rue");
+
+fn main() -> i32 {
+    let mine = fixed.F { s: "hello" };
+    let theirs = fixed.make();
+    let other = fixed.F { s: "world" };
+    let mut r: i32 = 0;
+    if mine == theirs { r = r + 1; }
+    if mine == other { r = r + 2; }
+    if mine != other { r = r + 4; }
+    r
+}
+"""
+aux_files = { "fixed.rue" = """
+pub struct F { s: Str(8) }
+pub fn make() -> F { F { s: "hello" } }
+""" }
+exit_code = 5

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -3081,3 +3081,49 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "takes a type in this argument position"
+
+# The comparison the intrinsic performs is the one `==` performs: it reaches
+# `build_comparison`, so a struct carrying a string is compared on content
+# (4.3:3b) rather than on the string's header (RUE-1992).
+[[case]]
+name = "assert_eq_on_a_string_carrying_struct_holds_on_equal_bytes"
+spec = ["4.13:5f", "4.3:3b"]
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Pair { name: StrBuf }
+
+fn mk(s: str) -> StrBuf { StrBuf.from_str(borrow s) }
+
+fn main() -> i32 {
+    let a = Pair { name: mk("abc") };
+    let b = Pair { name: mk("abc") };
+    @assert_eq(a, b);
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "assert_eq_on_a_string_carrying_struct_aborts_on_different_bytes"
+spec = ["4.13:5f", "4.3:3b"]
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Pair { name: StrBuf }
+
+fn mk(s: str) -> StrBuf { StrBuf.from_str(borrow s) }
+
+fn main() -> i32 {
+    let a = Pair { name: mk("abc") };
+    let b = Pair { name: mk("abd") };
+    @assert_eq(a, b);
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "panic: assertion failed: left == right"

--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -29,6 +29,11 @@ aggregate types: structs, arrays, and enums.
 {{ rule(id="4.3:3", cat="normative") }}
 
 Two strings are equal if they have the same length and identical byte content.
+This holds wherever a string is reached, not only as a whole operand: a string
+that is a struct field, an array element, or an enum payload field, at any
+depth, is compared by this rule and not by the representation of its header
+(a string is a leaf of the structural recursion in rule 4.3:3b, so rule 4.3:3e
+never applies to the pointer inside one).
 
 {{ rule(id="4.3:3a", cat="normative") }}
 


### PR DESCRIPTION
Fixes RUE-1992. Fixes RUE-1998.

`==` on a struct that owned a `StrBuf` compared the field's `{ptr, len, cap}` header rather than its bytes, so two content-equal structs compared unequal while the same two `StrBuf`s compared equal at top level. Spec 4.3:3 says strings compare by content and 4.3:3b makes aggregate equality structural down to scalar leaves; a `StrBuf` is a synthetic struct, so naive recursion reached its `ptr` field and 4.3:3e made it an address compare. The same held for a `str` or `Str(N)` field, sibling-dependently.

The fix is one recursive "structural equality with string leaves" builder at the single comparison lowering in sema, taken only when an operand type transitively carries a string; every other aggregate keeps the existing slot-wise `Eq` lowering byte for byte. Sema and codegen now share one notion of a string leaf (`is_string_view_struct_name`): a `StrBuf` leaf routes to `equals_borrowed`, a `str`/`Str(N)` leaf to the `Eq` node codegen already answers with `StrEq`. Components are reached by extending the operands' place paths (borrowed projections, no copies, no drops, per 4.3:3f), arrays lower to a counted short-circuiting loop so compile cost is O(1) in the element count, struct fields conjoin as a balanced tree, and enums compare both tags as scalars first and then dispatch once on the shared payload layout, so block count is linear in variant count and additive in nesting depth. A raw pointer reached as a leaf compares by address at full width (4.3:3e). Materialization and place-path decomposition are collapsed to one helper each.

An adversarial review drove the array, enum, and `str`-leaf shapes: `[StrBuf; 600]` no longer overflows the compiler stack, a four-deep nest of 8-variant enums compiles in 0.3 s instead of 118 s followed by a backend ICE, and a cross-module `str`-only struct now compares by content. Confirmed clean under that review: memory safety across call temporaries, borrow and inout parameters and loops, exact-once evaluation with short-circuit, tag-before-payload guarding, dominance under -O0 and -O2, and `!=`, `@assert_eq`, `@assert_ne` on every shape.

Spec: 4.3:3 states explicitly that it governs a string reached as a component. Ten spec cases across 4.3:3b/3c/3d/3e and the assert intrinsics, two of them cross-module; one oracle model-gap entry for the failing-assert renderer. Verification: `scripts/rue spec 4.3` (82), `4.13` (217), `3.7`, `scripts/rue cli rue_test` and `assert`, unit suites for rue-air, rue-cfg, rue-codegen (both backends), `scripts/rue quick`, fmt clean. Two pre-existing defects found along the way are filed separately: RUE-1997 (whole-element operand double free) and RUE-2001 (float field equality ICE).