### PR TITLE
RUE-1961: report a statically failing comparison assertion

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -1512,13 +1512,24 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // types are comparable.
         self.validate_equality_operand_type(left.ty, left_span)?;
 
-        if let Some(fails) = Self::comptime_comparison(air, &failed) {
-            // Both operands are compile-time constants, so the comparison has
-            // an answer now and the intrinsic is exactly the `@assert` it could
-            // have been written as — no branch, no rendering, and no printer
-            // synthesized for a type nothing will render at run time.
+        // Only a comparison that *holds* folds. Both operands are compile-time
+        // constants, the assertion passes, and nothing downstream can observe
+        // the difference — so the intrinsic is exactly the `@assert` it could
+        // have been written as: no branch, no rendering, and no printer
+        // synthesized for a type nothing will render at run time.
+        //
+        // A statically failing one keeps the ordinary lowering (RUE-1961).
+        // Folding it too traded the report for the condition's answer: the arm
+        // that renders both operands and stages the intrinsic's own site is the
+        // only thing that makes the verdict `assert_eq` with `left` and `right`
+        // rather than a bare `assert` carrying the enclosing declaration's line,
+        // and a failing assertion is the one case where that report is what the
+        // program is for. The condition the branch tests is still a constant,
+        // and the optimizer folds it like any other, so nothing but the report
+        // survives to code generation.
+        if Self::comptime_comparison(air, &failed) == Some(false) {
             let condition = air.add_inst(AirInst {
-                data: AirInstData::BoolConst(!fails),
+                data: AirInstData::BoolConst(true),
                 ty: Type::BOOL,
                 span,
             });

--- a/crates/rue-cli-tests/cases/rue_test_assert.toml
+++ b/crates/rue-cli-tests/cases/rue_test_assert.toml
@@ -236,6 +236,121 @@ compile_stdout_contains = [
 compile_stdout_not_contains = ['"failure"', '"left":', '"diff"']
 
 # =============================================================================
+# Operands the compiler can compare for itself (RUE-1961).
+#
+# When both operands fold to a compile-time scalar the comparison has an answer
+# before the program runs, and the two directions are not symmetric. A holding
+# one is the `@assert` it could have been written as and lowers to nothing. A
+# failing one is exactly the case the report exists for, so it keeps the
+# ordinary lowering: the verdict is still `assert_eq`/`assert_ne` with `left`,
+# `right`, a `diff`, and the intrinsic's own line — not a bare `assert` at the
+# enclosing declaration's header. This is a compile-time fact and not a warning:
+# `@allow` has no always-true/always-false lint family to join.
+# =============================================================================
+
+[[case]]
+name = "a_statically_failing_comparison_reports_like_any_other"
+description = """
+Both operands of `@assert_eq(41, 42)` are constants, so the condition is decided
+at compile time — and the report is unchanged by that. The site is the
+intrinsic's own line 2, not the declaration's line 1, and `left`/`right` are the
+two constants as the structural printer rendered them.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "rejects a mismatched constant pair" {
+    @assert_eq(41, 42);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"diff":[{"op":"equal","text":"4"},{"op":"delete","text":"1"},{"op":"insert","text":"2"}],"exit_code":101,"kind":"assert_eq","left":"41","location":{"column":5,"file":"tests.rue","line":2},"message":"assertion failed: left == right","right":"42"',
+    '"verdict":"fail"',
+    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+]
+compile_stdout_not_contains = ['"kind":"assert"', '"message":"assertion failed"']
+
+[[case]]
+name = "a_statically_equal_pair_reports_the_inequality_it_demanded"
+description = """
+The `@assert_ne` direction of the same fact. Two identical constants make one
+`equal` diff hunk, and the site is the intrinsic's line 2.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "rejects an equal constant pair" {
+    @assert_ne(1, 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"diff":[{"op":"equal","text":"1"}],"exit_code":101,"kind":"assert_ne","left":"1","location":{"column":5,"file":"tests.rue","line":2},"message":"assertion failed: left != right","right":"1"',
+    '"verdict":"fail"',
+    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+]
+compile_stdout_not_contains = ['"kind":"assert"', '"message":"assertion failed"']
+
+[[case]]
+name = "a_statically_holding_comparison_synthesizes_no_printer"
+description = """
+The other direction, read off the AIR: a comparison that holds keeps folding to
+the plain `@assert` intrinsic on a constant, so no structural printer is
+synthesized for a type nothing will render at run time.
+"""
+files = [{ path = "main.rue", source = """
+fn check() {
+    @assert_eq(1, 1);
+}
+
+fn main() -> i32 {
+    check();
+    0
+}
+""" }]
+args = ["--emit", "air", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== AIR ===", "AssertFailed intrinsic @assert"]
+compile_stdout_not_contains = ["__rue_error_printer__"]
+
+[[case]]
+name = "a_statically_failing_comparison_synthesizes_its_printer"
+description = """
+The same program with the constants changed does synthesize one, which is what
+the report arm renders both operands with.
+"""
+files = [{ path = "main.rue", source = """
+fn check() {
+    @assert_eq(41, 42);
+}
+
+fn main() -> i32 {
+    check();
+    0
+}
+""" }]
+args = ["--emit", "air", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== AIR ===", "__rue_error_printer__"]
+
+# =============================================================================
 # Borrowed operands (spec 4.13:5f, 4.3:3f).
 #
 # The report arm renders each operand with a printer whose parameter is by

--- a/crates/rue-compiler/src/assert_comparison_tests.rs
+++ b/crates/rue-compiler/src/assert_comparison_tests.rs
@@ -256,17 +256,17 @@ fn main() -> i32 {
     );
 }
 
-/// A comparison both of whose operands are compile-time constants has its
-/// answer now, so it lowers to exactly the `@assert` it could have been written
-/// as: no branch to report from, no rendering, and no printer synthesized for a
-/// type nothing will render at run time.
+/// A comparison both of whose operands are compile-time constants *and which
+/// holds* has its answer now, so it lowers to exactly the `@assert` it could
+/// have been written as: no branch to report from, no rendering, and no printer
+/// synthesized for a type nothing will render at run time.
 #[test]
-fn a_comptime_known_comparison_folds_to_a_plain_assert() {
+fn a_comptime_known_passing_comparison_folds_to_a_plain_assert() {
     let output = rooted_cfg(
         r#"
 fn check() {
-    @assert_eq(1, 2);
-    @assert_ne(true, true);
+    @assert_eq(1, 1);
+    @assert_ne(true, false);
 }
 fn main() -> i32 {
     check();
@@ -304,6 +304,46 @@ fn main() -> i32 {
             rue_air::IntrinsicOperation::AssertFailed
         ],
         "the fold is the ordinary `@assert` lowering"
+    );
+}
+
+/// A comparison that is statically *false* keeps the report (RUE-1961).
+///
+/// Its answer is known too, but the answer is not what the program wants from
+/// it: a failing assertion exists to say which two values disagreed and where.
+/// Folding it away left a bare `assert` carrying the enclosing declaration's
+/// line, so the failing case takes the ordinary lowering — one printer for the
+/// operand type, both renderings, the intrinsic's own site, and the terminal
+/// comparison report — with a condition the optimizer folds like any other.
+#[test]
+fn a_comptime_known_failing_comparison_still_reports() {
+    let output = rooted_cfg(
+        r#"
+fn check() {
+    @assert_eq(41, 42);
+}
+fn main() -> i32 {
+    check();
+    0
+}
+"#,
+    )
+    .expect("a constant comparison is legal");
+    assert_eq!(
+        call_sequence(unit(&output, "check")),
+        [
+            "printer#0",
+            "printer#0",
+            "TestFailureSite",
+            "TestFailComparison",
+        ],
+        "a statically failing comparison reports like any other"
+    );
+    assert_eq!(
+        printers(&output).len(),
+        1,
+        "the report renders both operands with one printer: {:?}",
+        printers(&output)
     );
 }
 


### PR DESCRIPTION
Fixes RUE-1961.

`@assert_eq(41, 42)` folded both constant operands into a plain `AssertFailed` on a constant condition, so a statically failing comparison reported as kind `assert` with `assertion failed` at the test declaration's header, with no operands and no site. The fold now applies only to a comparison that holds (no branch, no rendering, no printer, unchanged); a failing one takes the ordinary lowering with a constant condition the optimizer folds anyway, so it reports `assert_eq`/`assert_ne` with `left`, `right`, `diff`, and the intrinsic's location. Literal strings never folded and are byte-identical before and after. `AssertFailed` keeps its producer through the holding fold, so no intrinsic removal was needed. No lint is added: there is no constant-condition warning family to join.

Tests: the compiler's assert-comparison unit tests split into the holding fold (still `[AssertFailed, AssertFailed]`) and the failing fold (printer, site, comparison helper, one synthesized printer); four CLI cases pin the two folded failing forms with exact JSON and the presence or absence of a printer in `--emit air`. Verification: `scripts/rue cli rue_test` (68), `scripts/rue spec 4.13` (217), `expressions.intrinsics`, `expressions.try`, `scripts/rue ui assert_comparison`, `scripts/rue unit rue-air` and `rue-oracle`, `scripts/rue quick`, fmt clean; the oracle-diff binary run over the modified case file reports no new gap.