### PR TITLE
RUE-1997: read a whole array element through its place

### DIFF
--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -1584,9 +1584,33 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // indexing without checking if the element type is Copy. This enables
         // accessing Copy fields of non-Copy array elements.
         if let InstData::IndexGet { base, index } = &inst.data {
+            let base_root = self.extract_root_variable(*base);
+
+            // A *whole element* of an array place is read through that array's
+            // own place, exactly as the field arm above reads a whole field
+            // through its struct's place. The spill below is for a computed
+            // base; applying it to a place copies the entire array into an
+            // owning temporary and projects that, so every non-Copy element's
+            // heap buffer is freed when the temporary drops at the end of the
+            // expression while the array still owns it (RUE-1997).
+            //
+            // Projection mode exists because its consumers borrow what they
+            // read — the operands of `==` (4.3:3f), `@dbg`, `@assert`, string
+            // concatenation. Marking the array's root as a by-reference use is
+            // what says so: `analyze_index_get` then reads the element in
+            // place, with its bounds and use-after-move checks intact, instead
+            // of taking the by-value path that moves a non-Copy element out of
+            // the array.
+            if let Some(root) = base_root
+                && self
+                    .peek_place_type(*base, ctx)
+                    .is_some_and(|ty| ty.as_array().is_some())
+            {
+                return self.analyze_with_borrow_root(air, inst_ref, Some(root), ctx);
+            }
+
             // Snapshot the base root's move state before analysis, in case this
             // is a String/str/slice byte index in projection mode (RUE-700).
-            let base_root = self.extract_root_variable(*base);
             let base_move_state_before = self.snapshot_move_state_value(base_root, ctx);
 
             // Recursively analyze the base in projection mode

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -407,6 +407,32 @@ fn main() -> i32 {
 """
 exit_code = 4
 
+# A whole array ELEMENT operand is borrowed on the same terms as the array
+# itself: the element is read through the array's place, not copied out of it
+# (RUE-1997). A copy would give a non-Copy element's owned resources a second
+# owner that destroys them at the end of the comparison, while the array still
+# holds them -- so each element must still be dropped exactly once, after both
+# arrays are read again.
+[[case]]
+name = "array_element_equality_borrows_operands"
+spec = ["4.3:3f", "3.8:76"]
+description = "Comparing whole non-Copy array elements borrows them; both arrays stay usable and every element is dropped exactly once"
+source = """
+struct D { v: i32 }
+
+drop fn D(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let a = [D { v: 1 }, D { v: 2 }];
+    let b = [D { v: 1 }, D { v: 2 }];
+    let equal = a[0] == b[0] && a[1] == b[1];
+    @dbg(a[0].v + b[1].v);
+    if equal { 0 } else { 9 }
+}
+"""
+expected_stdout = "3\n1\n2\n1\n2\n"
+exit_code = 0
+
 # A raw-pointer leaf compares by ADDRESS (identity): two structs holding the
 # address of the same local are equal; one holding a different local is not.
 [[case]]

--- a/crates/rue-spec/cases/expressions/index.toml
+++ b/crates/rue-spec/cases/expressions/index.toml
@@ -178,3 +178,74 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Whole-Element Reads in a Place Context (RUE-1997)
+# =============================================================================
+#
+# In a place context (3.8:76) -- an equality operand, a `borrow`/`inout`
+# argument, the base of a further projection -- `a[i]` names the element in the
+# array rather than producing a copy of it. Copying the array into a temporary
+# and projecting that temporary would give every non-Copy element a second
+# owner whose scope ends with the expression, destroying resources the array
+# still holds.
+
+[[case]]
+name = "whole_element_place_read_leaves_the_array_live"
+spec = ["4.11:14", "3.8:76"]
+description = "A whole non-Copy element read as an equality operand reads through the array; the same element is still live afterwards and drops exactly once"
+source = """
+struct D { v: i32 }
+
+drop fn D(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let a = [D { v: 7 }, D { v: 8 }];
+    let b = [D { v: 7 }, D { v: 8 }];
+    let equal = a[1] == b[1];
+    @dbg(a[1].v);
+    if equal { 0 } else { 9 }
+}
+"""
+expected_stdout = "8\n7\n8\n7\n8\n"
+exit_code = 0
+
+[[case]]
+name = "whole_element_place_read_with_runtime_index"
+spec = ["4.11:8", "4.11:14", "3.8:76"]
+description = "A runtime-indexed whole-element read in a place context keeps its bounds check and does not consume the array"
+source = """
+struct D { v: i32 }
+
+drop fn D(self) { @dbg(self.v); }
+
+fn pick() -> u64 { 1 }
+
+fn main() -> i32 {
+    let a = [D { v: 4 }, D { v: 5 }];
+    let i = pick();
+    let j = pick();
+    let same = a[i] == a[j];
+    @dbg(a[1].v);
+    if same { 0 } else { 9 }
+}
+"""
+expected_stdout = "5\n4\n5\n"
+exit_code = 0
+
+[[case]]
+name = "whole_element_place_read_out_of_bounds_traps"
+spec = ["4.11:8", "4.11:9", "4.11:14"]
+description = "The bounds check on a whole-element place read still traps for an out-of-range runtime index"
+source = """
+struct D { v: i32 }
+
+fn pick() -> u64 { 5 }
+
+fn main() -> i32 {
+    let a = [D { v: 4 }, D { v: 5 }];
+    let i = pick();
+    if a[i] == a[0] { 0 } else { 9 }
+}
+"""
+exit_code = 101


### PR DESCRIPTION
Fixes RUE-1997.

Reading a whole non-Copy array element in projection (borrowing) mode, as a comparison operand, a `borrow` argument, or a `@dbg` operand, went to the computed-base path: the entire array was copied into an owning temporary and the element projected from the copy, so the temporary's drop at the end of the expression freed every element's heap buffer while the array still owned it. `a[0] == b[0] && a[1] == b[1]` answered false for equal contents, a later read of `a[1]` saw freed memory, and with a computed index it was an -O2 ICE (a drop consuming a value already dropped on a reaching path).

The index arm of `analyze_inst_for_projection` now does what the field arm already did: when the base is an array place with a root binding, it marks the root as a by-reference use and reads the element in place through `analyze_index_get`, keeping the constant and runtime bounds checks and the use-after-move checks. A by-value element read is a value context and never enters projection mode, so `let c = xs[0]` and `consume(xs[0])` still move (3.8:68, pinned by existing cases).

Evidence: each element's destructor runs exactly once (drop-counter programs went from 8 to 4 and 12 to 4 drops), the -O2 ICE is gone, and every control program is unchanged. Four spec cases under 4.3:3f and 4.11 pin the whole-element comparison, a runtime index, and a later read of the same element; the oracle-diff binary over those cases reports agreement with no gap. Verification: full `scripts/rue spec` (2690), full `scripts/rue ui` (328), full `scripts/rue cli` (2530), `scripts/rue unit rue-air` and `rue-cfg`, `scripts/rue quick`, fmt clean. Two further legality holes found in projection-mode reads are filed as RUE-2006.