### PR TITLE
RUE-2004: add the rue_test rule and declare the Gazette suite

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -139,8 +139,9 @@ sh_binary(
 
 # The rue_program tool surface (ADR-0070 / RUE-1404): the scan wrapper, the
 # manifest derivation script that owns the declared-boundary check, the two
-# advisory precision reports, and the scenario runner. rue_rules.bzl reaches
-# them by default attr, so they are PUBLIC.
+# advisory precision reports, the scenario runner, and `rue_test`'s `rue test`
+# supervisor (ADR-0083 / RUE-2004). rue_rules.bzl reaches them by default attr,
+# so they are PUBLIC.
 sh_binary(
     name = "rue-program-scan",
     main = "scripts/rue-program-scan",
@@ -162,6 +163,7 @@ sh_binary(
         ("rue-program-srcs-precision", "rue-program-srcs-precision.py"),
         ("rue-program-family-report", "rue-program-family-report.py"),
         ("rue-program-test-runner", "rue-program-test-runner.py"),
+        ("rue-test-supervisor", "rue-test-supervisor.py"),
     ]
 ]
 

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -145,10 +145,13 @@ Build integration adds exactly one optional input in the MVP: a declared
 candidate inventory (`--test-candidates`, which the `rue_program` build rule
 feeds from its `srcs`) powering the unimported-test-file warning of §1.
 Without it, that warning degrades to a one-line notice — nothing else
-changes. No discovery, scheduling, or execution behavior lives in the build
-system, and the deferred layers (§6) keep the same boundary. (The
-maintainers' `scripts/rue test` compiler-suite wrapper is an unrelated
-homonym; see Open Questions.)
+changes. The build-side producer is the `rue_test` rule (`rue_rules.bzl`,
+RUE-2004): it runs `rue test` over a declared closure, writes that inventory
+from the same `srcs`, and is what makes an unimported test file fail a build —
+the compiler warns and still exits `0`. No discovery, scheduling, or execution
+behavior lives in the build system, and the deferred layers (§6) keep the same
+boundary. (The maintainers' `scripts/rue test` compiler-suite wrapper is an
+unrelated homonym; see Open Questions.)
 
 ## Decision
 

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -324,6 +324,12 @@ filtered rerun pasted from a `repro:` line. The condition is presentation only:
 `test_candidates` still answers `"none"` for such a run, and no event carries the
 closure size.
 
+The inventory file is one path per line, each relative to the ROOT MODULE'S
+DIRECTORY — the compiler's project root — and its build-side producer is the
+`rue_test` rule (`rue_rules.bzl`, ADR-0083's boundary), which writes it from
+the target's declared `srcs` and fails the target when this array is non-empty,
+since `rue test` itself reports the orphan and still exits `0`.
+
 ### `test` (listing records)
 
 `--list --format json` emits one of these per inventory entry **and nothing

--- a/examples/BUCK
+++ b/examples/BUCK
@@ -6,7 +6,7 @@
 # A root-package `glob()` cannot reach into this package, so anything at the
 # root that needs example files depends on a target declared here.
 
-load("//:rue_rules.bzl", "rue_program", "rue_program_family", "rue_program_staging", "rue_program_test")
+load("//:rue_rules.bzl", "rue_program", "rue_program_family", "rue_program_staging", "rue_program_test", "rue_test")
 load("//:test_defs.bzl", "rue_test_suite")
 
 # The example programs are runtime inputs to the CLI integration tests: the
@@ -89,6 +89,20 @@ filegroup(
         ("second-calculator", "second/calculator", glob(["second/**/*.rue"])),
     ]
 ]
+
+# ADR-0083 (RUE-2004): Gazette's own `test` declarations, run by `rue test`
+# under the declared candidate inventory. The glob is deliberately the same one
+# `:gazette` compiles from, because the inventory IS that srcs list: a fourth
+# `*_tests.rue` dropped into the directory without an aggregator import lands
+# in the glob, is reported as unimported, and fails this target instead of
+# being silently invisible. The CLI case over the same suite
+# (`cli.examples_gazette`) asserts the count through the human summary; this
+# target is what makes the inventory a build-declared fact.
+rue_test(
+    name = "gazette-tests",
+    root = "examples/gazette/main.rue",
+    srcs = glob(["gazette/**/*.rue"]),
+)
 
 # The ten artifacts as one directory keyed by root path, so a corpus action
 # declares a single `$(location ...)` and the harness's lookup key is the

--- a/fixtures/rue-program/BUCK
+++ b/fixtures/rue-program/BUCK
@@ -12,8 +12,13 @@
 #                       assertion; the sh_test only gives it a test surface).
 #   :family-*           two sibling roots sharing a glob, plus the aggregate
 #                       srcs report that judges unread files family-wide.
+#   :runner-*           the `rue_test` rule (ADR-0083 / RUE-2004) from both
+#                       sides: an allowed orphan and the negative control that
+#                       the same orphan otherwise FAILS the target. `rue test`
+#                       itself exits 0 either way, so nothing else in the tree
+#                       can tell the two apart.
 
-load("//:rue_rules.bzl", "rue_program", "rue_program_boundary_control", "rue_program_family", "rue_program_test")
+load("//:rue_rules.bzl", "rue_program", "rue_program_boundary_control", "rue_program_family", "rue_program_test", "rue_test")
 load("//:test_defs.bzl", "rue_sh_test")
 
 rue_program(
@@ -68,4 +73,28 @@ rue_program_test(
     name = "family-alpha-test",
     program = ":family-alpha",
     exit_code = 10,
+)
+
+# The rue_test proving ground. `runner/main.rue` imports `lib_tests.rue` and
+# nothing imports `orphan_tests.rue`; both files are in srcs, so both are in
+# the declared candidate inventory.
+#
+# The pair is what pins the rule's one non-obvious behavior. `rue test` reports
+# the orphan as a warning and still exits 0, so a rule that only forwarded the
+# exit code would pass here — and a target that merely passes proves nothing
+# about a check that never fired.
+rue_test(
+    name = "runner-allowed-orphan-test",
+    root = "fixtures/rue-program/runner/main.rue",
+    srcs = glob(["runner/**/*.rue"]),
+    allow_unimported = True,
+)
+
+rue_test(
+    name = "runner-orphan-control-test",
+    root = "fixtures/rue-program/runner/main.rue",
+    srcs = glob(["runner/**/*.rue"]),
+    # Negative control: passes if and only if the run WOULD have failed the
+    # target, for exactly this path and for no other reason.
+    expect_unimported = ["orphan_tests.rue"],
 )

--- a/fixtures/rue-program/runner/lib_tests.rue
+++ b/fixtures/rue-program/runner/lib_tests.rue
@@ -1,0 +1,8 @@
+// Imported by main.rue, so its tests are in the compiled closure.
+test "the runner reaches an imported test module" {
+    @assert(1 == 1);
+}
+
+test "and runs every test it declares" {
+    @assert_eq(2 + 2, 4);
+}

--- a/fixtures/rue-program/runner/main.rue
+++ b/fixtures/rue-program/runner/main.rue
@@ -1,0 +1,9 @@
+// ADR-0083 fixture root (RUE-2004): the aggregator import is the whole point.
+// `lib_tests.rue` is reachable only because this file imports it, and
+// `orphan_tests.rue` is deliberately reachable from nothing — which is what
+// the two rue_test targets over this directory pin from both sides.
+const tests = @import("lib_tests.rue");
+
+fn main() -> i32 {
+    0
+}

--- a/fixtures/rue-program/runner/orphan_tests.rue
+++ b/fixtures/rue-program/runner/orphan_tests.rue
@@ -1,0 +1,6 @@
+// Declared in srcs, imported by nothing. A `rue test` run exits 0 with only a
+// warning about this file, so the rue_test rule — not the compiler — is what
+// turns it into a failure.
+test "nothing imports this file" {
+    @assert(1 == 1);
+}

--- a/rue_rules.bzl
+++ b/rue_rules.bzl
@@ -32,6 +32,14 @@ corpus.bzl's action does: this repository's genrule upload gating is driven by
 a Meta-internal label allowlist, and the whole point of the rule is that a PR
 run's compile is served to the merge-group run.
 
+`rue_test` is the third rule and the odd one out: it produces no executable and
+runs no scenario, it runs the compiler's OWN `rue test` subcommand over a
+declared closure (ADR-0083 / RUE-2004). It reuses the scan and derive actions
+for the same boundary reason `rue_program` does — with the manifest widened by
+`--include-srcs`, since a run reads its candidate inventory under that policy —
+and it is the build-side producer of that `--test-candidates` inventory, the
+one input ADR-0083's boundary gives the build system.
+
 `rue_program_test` is not the only consumer. `rue_program_staging` collects
 programs into one directory keyed by root path, which the CLI corpus actions
 declare as an ordinary input so their harness runs prebuilt executables
@@ -105,8 +113,14 @@ def _resolve(ctx: AnalysisContext):
     return toolchain, resolved_target, opt_level, std_dir
 
 
-def _scan_and_derive(ctx: AnalysisContext, toolchain, std_dir, expect_violation = None):
-    """The scan and derive actions, shared by rue_program and the boundary control."""
+def _scan_and_derive(
+        ctx: AnalysisContext,
+        toolchain,
+        std_dir,
+        expect_violation = None,
+        include_srcs = False):
+    """The scan and derive actions, shared by rue_program, rue_test, and the
+    boundary control."""
     envelope = ctx.actions.declare_output("deps-envelope.json")
     scan_cmd = cmd_args(
         ctx.attrs._scan[RunInfo],
@@ -146,6 +160,8 @@ def _scan_and_derive(ctx: AnalysisContext, toolchain, std_dir, expect_violation 
         # directly (the unconditional union walks it).
         hidden = [toolchain.std],
     )
+    if include_srcs:
+        derive_cmd.add("--include-srcs")
     if expect_violation:
         derive_cmd.add("--expect-violation", expect_violation)
     ctx.actions.run(
@@ -156,6 +172,44 @@ def _scan_and_derive(ctx: AnalysisContext, toolchain, std_dir, expect_violation 
         allow_cache_upload = True,
     )
     return envelope, manifest
+
+
+def _test_candidate_list(ctx: AnalysisContext):
+    """The declared candidate inventory, spelled the way `rue test` reads it.
+
+    TWO DIFFERENT PROJECT ROOTS MEET HERE, which is the whole reason this is a
+    function rather than one `ctx.actions.write` of `srcs`. Buck's project root
+    is the repository root, and that is what `root` and every `srcs` path are
+    spelled against everywhere else in this file. The compiler's is the ROOT
+    MODULE'S DIRECTORY — `source_loader.rs` builds the discovery context from
+    the root file's parent — so `rue test examples/gazette/main.rue` resolves
+    each `--test-candidates` entry under `examples/gazette/`.
+
+    Handing it repository-relative paths instead is not a loud error: every
+    candidate resolves to a file that does not exist, an absent candidate is
+    not an orphan, and the warning the inventory exists to power silently
+    reports nothing. So entries are re-anchored on the root's directory here,
+    once, for both rules.
+
+    A source artifact's `short_path` is package-relative, so its repository
+    path is the package plus that — which assumes `srcs` are this package's own
+    files. A src from elsewhere fails below rather than being re-anchored on a
+    prefix that was never its own.
+    """
+    root_dir = ctx.attrs.root.rsplit("/", 1)[0] if "/" in ctx.attrs.root else ""
+    prefix = root_dir + "/" if root_dir else ""
+    package = ctx.label.package
+    candidates = []
+    for src in ctx.attrs.srcs:
+        project_path = package + "/" + src.short_path if package else src.short_path
+        if not project_path.startswith(prefix):
+            fail("{}: src '{}' lies outside the root's directory '{}', so it has no spelling in the test-candidate inventory; declare srcs from the package that owns the root".format(
+                ctx.label.name,
+                project_path,
+                root_dir,
+            ))
+        candidates.append(project_path[len(prefix):])
+    return ctx.actions.write("test-candidates.list", candidates)
 
 
 def _rue_program_impl(ctx: AnalysisContext) -> list[Provider]:
@@ -224,9 +278,10 @@ def _rue_program_impl(ctx: AnalysisContext) -> list[Provider]:
     # derive step exists to close. Consumers that want the inventory — the
     # `rue test` driver mode — take it from the provider and pass it themselves.
     #
-    # The content shape matches `srcs.list`: project-root-relative paths, one
-    # per line, which is exactly what `--test-candidates` parses.
-    test_candidates = ctx.actions.write("test-candidates.list", ctx.attrs.srcs)
+    # One path per line, anchored on the ROOT'S DIRECTORY rather than on Buck's
+    # project root, which is what `--test-candidates` parses; see
+    # `_test_candidate_list`. `rue_test` writes the identical file.
+    test_candidates = _test_candidate_list(ctx)
 
     runs_natively = resolved_target == toolchain.native_target
     return [
@@ -373,6 +428,130 @@ def rue_program_test(name, tier = "premerge", platform = None, labels = [], **kw
     and reads the labels attr — both conditions are load-bearing (ADR-0070).
     """
     _rue_program_test(
+        name = name,
+        labels = rue_test_labels(tier, platform, labels),
+        **kwargs
+    )
+
+
+def _rue_test_impl(ctx: AnalysisContext) -> list[Provider]:
+    """The `rue test` driver over one declared closure (ADR-0083 / RUE-2004).
+
+    This is the build side of ADR-0083's boundary, and it is exactly one input
+    wide: the declared candidate inventory, written from `srcs` in the same
+    shape `rue_program` writes it. Everything else — discovery, the test image,
+    execution, the event stream — is the compiler's.
+
+    The closure is bounded the way a `rue_program` compile is, by the SAME
+    scan and derive actions: a test image free to read outside `srcs` would be
+    a hermeticity hole the program build does not have, and the derive step
+    fails the build on exactly that.
+
+    The two files the run receives are not interchangeable, which is why they
+    are written separately. `sources.manifest` is a READ POLICY — what may be
+    imported — and `test-candidates.list` is an INVENTORY: what this target
+    owns, orphans included, spelled relative to the root's directory. The
+    manifest is a superset by construction here, because a candidate is
+    observed under the policy; it is still the policy that decides what the
+    image may read.
+    """
+    toolchain = ctx.attrs._rue_toolchain[RueToolchainInfo]
+    std_dir = toolchain.std
+
+    # `--include-srcs` because a candidate is observed UNDER the read policy:
+    # an orphan test file is by definition not an accepted read, so a manifest
+    # of accepted reads alone would make every orphan "could not be parsed"
+    # with no test count — one warning for an unimported file and a corrupt
+    # one. The declared boundary is unchanged: the derive step still fails the
+    # build on a read outside srcs ∪ std, and srcs are this target's declared,
+    # keyed inputs either way.
+    _envelope, manifest = _scan_and_derive(ctx, toolchain, std_dir, include_srcs = True)
+
+    # The inventory, byte-identical to what `rue_program` puts on
+    # RueProgramInternalInfo for the same root and srcs.
+    candidates = _test_candidate_list(ctx)
+
+    command = cmd_args(
+        ctx.attrs._runner[RunInfo],
+        # The compiler reads the roots and their imports from their real
+        # project paths, so srcs and std must be materialized even though the
+        # command line names only the root, the manifest, and the inventory.
+        hidden = [ctx.attrs.srcs, toolchain.std],
+    )
+    if ctx.attrs.allow_unimported:
+        command.add("--allow-unimported")
+    for path in ctx.attrs.expect_unimported:
+        command.add("--expect-unimported", path)
+
+    # Everything after `--` is the compiler argv the supervisor runs, assembled
+    # here so the whole command is a fact of the rule rather than of a script.
+    # `--seed 1` because a suite that shuffles differently every run reports a
+    # different failure order for the same tree; rerunning under another seed
+    # is a deliberate act, not the default.
+    command.add("--")
+    command.add(toolchain.compiler)
+    command.add("test", ctx.attrs.root)
+    command.add("--source-manifest", manifest)
+    command.add("--test-candidates", candidates)
+    command.add("--seed", "1")
+    command.add("--format", "json")
+    for feature in ctx.attrs.preview_features:
+        command.add("--preview", feature)
+
+    return inject_test_run_info(
+        ctx,
+        ExternalRunnerTestInfo(
+            type = "custom",
+            command = [command],
+            env = {"RUE_STD_PATH": cmd_args(std_dir)},
+            labels = ctx.attrs.labels,
+            contacts = [],
+        ),
+    ) + [DefaultInfo(default_output = candidates, other_outputs = [manifest])]
+
+
+_rue_test = rule(
+    impl = _rue_test_impl,
+    attrs = {
+        # `root` and `srcs` carry the same meaning as on rue_program: a
+        # project-relative path string for the root the compiler resolves, and
+        # the declared file set. Here srcs is also the candidate inventory.
+        "root": attrs.string(),
+        "srcs": attrs.list(attrs.source()),
+        "preview_features": attrs.list(attrs.string(), default = []),
+        # `rue test` exits 0 with the orphan warning on stderr, so a rule that
+        # only forwarded the exit code would let an unimported `*_tests.rue`
+        # stay invisible — the whole reason to declare the inventory. The
+        # target fails on a non-empty report unless this says it is intended.
+        "allow_unimported": attrs.bool(default = False),
+        # Negative control, the way `--expect-violation` inverts the derive
+        # step's boundary check (fixtures/rue-program/BUCK): the target passes
+        # if and only if the run WOULD have been failed, for exactly these
+        # paths. Not for production targets.
+        "expect_unimported": attrs.list(attrs.string(), default = []),
+        "labels": attrs.list(attrs.string(), default = []),
+        "_derive": attrs.dep(providers = [RunInfo], default = "root//:rue-program-derive-manifest"),
+        "_runner": attrs.dep(providers = [RunInfo], default = "root//:rue-test-supervisor"),
+        "_scan": attrs.dep(providers = [RunInfo], default = "root//:rue-program-scan"),
+        "_rue_toolchain": attrs.toolchain_dep(default = "toolchains//:rue"),
+        "_inject_test_env": attrs.default_only(
+            attrs.dep(default = "prelude//test/tools:inject_test_env"),
+        ),
+    },
+)
+
+
+def rue_test(name, tier = "premerge", platform = None, labels = [], **kwargs):
+    """One `rue test` run over a declared closure, with tier ownership.
+
+    Like rue_program_test, the rule name keeps the `_test` suffix and exposes
+    `labels` so test_tiers.bxl's `^(.*_test|test_suite)$` kind regex and its
+    label read both find it (ADR-0070). The name is the language subcommand's,
+    not the ecosystem's `rue_binary`/`rue_test` pair ADR-0070 declined: this
+    rule runs `rue test`, and a runtime scenario over one prebuilt executable
+    is still `rue_program_test`.
+    """
+    _rue_test(
         name = name,
         labels = rue_test_labels(tier, platform, labels),
         **kwargs

--- a/scripts/rue-program-derive-manifest.py
+++ b/scripts/rue-program-derive-manifest.py
@@ -34,6 +34,11 @@ declared std tree:
     it, and manifest membership means "available to import", not "read"
     (ADR-0047).
 
+`--include-srcs` adds the declared srcs to that union for `rue_test`
+(ADR-0083 / RUE-2004), whose run observes its `--test-candidates` inventory
+under this manifest; see the comment at the call site. The boundary check is
+unaffected either way.
+
 `--expect-violation PATH` inverts the boundary check for negative control 1:
 the script succeeds (writing a marker as the output) if and only if the
 boundary check rejects exactly PATH. The control materializes its
@@ -96,6 +101,11 @@ def main() -> None:
     parser.add_argument("--srcs-list", required=True, help="file of project-relative srcs")
     parser.add_argument("--std-dir", required=True, help="project-relative std root directory")
     parser.add_argument("--out", required=True, help="project-relative manifest output path")
+    parser.add_argument(
+        "--include-srcs",
+        action="store_true",
+        help="union the declared srcs into the manifest (rue_test)",
+    )
     parser.add_argument("--expect-violation", default=None)
     args = parser.parse_args()
 
@@ -165,6 +175,18 @@ def main() -> None:
             f"(outside srcs and std):\n{details}\n"
             "Declare them in srcs, or remove the import."
         )
+
+    # `rue_test` additionally declares every src (ADR-0083 / RUE-2004). The
+    # boundary check above is unchanged — an accepted read outside srcs ∪ std
+    # still fails the build — so this widens the read policy only to files the
+    # target already declares and Buck already materializes and keys. It is
+    # what a candidate inventory needs to mean anything: `--test-candidates`
+    # entries are observed UNDER the manifest, so an orphan test file, which by
+    # definition is not an accepted read, would otherwise be unreadable and
+    # reported as "could not be parsed" with no test count — the same warning
+    # for an unimported file as for a corrupt one.
+    if args.include_srcs:
+        entries.update(srcs)
 
     # Every file of the declared std tree, unconditionally (trusted-std reads
     # are invisible to the scan).

--- a/scripts/rue-test-supervisor.py
+++ b/scripts/rue-test-supervisor.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Supervise one `rue test` run for the `rue_test` build rule (RUE-2004).
+
+Named a supervisor rather than a runner because the runner is the compiler:
+`crates/rue-test-runner` is the compiler suite's own harness, and `rue test`
+owns the run this script watches.
+
+ADR-0083's boundary gives the build system exactly one input to the runner: the
+declared candidate inventory. `rue_test` writes that inventory from its `srcs`
+and assembles the whole compiler command line at analysis time, so everything
+this script receives after `--` is already the argv to run. What is left here is
+policy, and it is deliberately the only thing here:
+
+  * the run's verdict is read from the NDJSON EVENT STREAM, never from the human
+    rendering, which is not a contract (test-events.md, "Streams");
+  * a nonzero exit (1 failures, 2 compile or runner error, 3 empty selection)
+    fails the target;
+  * a non-empty `run_finished.unimported_test_files` fails the target too,
+    unless the rule set `allow_unimported`. `rue test` itself exits 0 with that
+    warning on stderr, which is why a build rule that only forwarded the exit
+    code would let a `*_tests.rue` nobody imports stay invisible — the gap this
+    rule closes.
+
+On any failure the script prints a reader-facing summary — the runner's own
+stderr verbatim, then each non-passing test with its failure record and repro
+argv, then the offending unimported paths. The machine surface decides; the
+human surface is printed so the log explains itself.
+
+`--expect-unimported` inverts the last check for the fixture negative control
+(fixtures/rue-program/BUCK), the way `--expect-violation` inverts the derive
+step's boundary check: the script succeeds if and only if the run would have
+been failed for exactly those paths.
+"""
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+
+# Exit codes of `rue test` (docs/process/test-events.md, "Exit codes").
+_EXIT_REASONS = {
+    1: "a selected test failed, timed out, or crashed",
+    2: "the run could not be performed (compile failure, ICE, or runner error)",
+    3: "the selection was empty",
+}
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument("--allow-unimported", action="store_true")
+    parser.add_argument("--expect-unimported", action="append", default=[])
+    parser.add_argument("command", nargs="+")
+    return parser.parse_args(argv)
+
+
+def read_events(stdout):
+    """The NDJSON stream as objects, plus any line that was not one.
+
+    A line that is not an object is reported rather than skipped: under
+    `--format json` stdout is the stream, so anything else on it means the
+    surface this rule reads is not the surface the runner wrote.
+    """
+    events = []
+    malformed = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            malformed.append(line)
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+        else:
+            malformed.append(line)
+    return events, malformed
+
+
+def describe_failure(test):
+    """One non-passing `test_finished` event, rendered for a reader."""
+    lines = ["  {} [{}]".format(test.get("id", "<no id>"), test.get("verdict"))]
+    failure = test.get("failure") or {}
+    if failure:
+        lines.append(
+            "    {}: {}".format(
+                failure.get("kind", "<no kind>"),
+                failure.get("message", ""),
+            )
+        )
+        location = failure.get("location") or {}
+        if location:
+            lines.append(
+                "    at {}:{}:{}".format(
+                    location.get("file", "?"),
+                    location.get("line", 0),
+                    location.get("column", 0),
+                )
+            )
+        if "left" in failure and "right" in failure:
+            lines.append("    left:  {}".format(failure["left"]))
+            lines.append("    right: {}".format(failure["right"]))
+    for stream in ("stdout", "stderr"):
+        capture = test.get(stream) or {}
+        data = capture.get("data")
+        if data:
+            lines.append("    {}: {}".format(stream, data.rstrip("\n")))
+    repro = test.get("repro")
+    if repro:
+        lines.append("    repro: {}".format(shlex.join(repro)))
+    return lines
+
+
+def describe_unimported(files):
+    lines = []
+    for entry in files:
+        if entry.get("parse_failed"):
+            lines.append(
+                "  {} (could not be read or parsed)".format(entry.get("path"))
+            )
+        else:
+            tests = entry.get("tests")
+            lines.append(
+                "  {} declares {} {} that no module in the compiled closure "
+                "imports".format(
+                    entry.get("path"),
+                    tests,
+                    "test" if tests == 1 else "tests",
+                )
+            )
+    return lines
+
+
+def report(command, result, reasons, run_finished, events):
+    """The human-readable summary, printed only when the target fails."""
+    print("rue_test: {}".format("; ".join(reasons)), file=sys.stderr)
+    print("command: {}".format(shlex.join(command)), file=sys.stderr)
+    if result.stderr:
+        print("--- rue test stderr ---", file=sys.stderr)
+        sys.stderr.write(result.stderr)
+        if not result.stderr.endswith("\n"):
+            sys.stderr.write("\n")
+    failed = [
+        event
+        for event in events
+        if event.get("event") == "test_finished" and event.get("verdict") != "pass"
+    ]
+    if failed:
+        print("--- non-passing tests ---", file=sys.stderr)
+        for test in failed:
+            for line in describe_failure(test):
+                print(line, file=sys.stderr)
+    unimported = (run_finished or {}).get("unimported_test_files") or []
+    if unimported:
+        print("--- test files nothing imports ---", file=sys.stderr)
+        for line in describe_unimported(unimported):
+            print(line, file=sys.stderr)
+        print(
+            "add an @import for each file above to the root's closure, or set "
+            "allow_unimported = True on the rue_test target",
+            file=sys.stderr,
+        )
+    if run_finished:
+        print(
+            "summary: {} passed, {} failed, {} timed out, {} crashed in {} ms".format(
+                run_finished.get("passed", 0),
+                run_finished.get("failed", 0),
+                run_finished.get("timeout", 0),
+                run_finished.get("crash", 0),
+                run_finished.get("wall_ms", 0),
+            ),
+            file=sys.stderr,
+        )
+
+
+def main(argv):
+    args = parse_args(argv)
+    command = args.command
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    events, malformed = read_events(result.stdout)
+    run_finished = next(
+        (event for event in events if event.get("event") == "run_finished"),
+        None,
+    )
+
+    reasons = []
+    if result.returncode != 0:
+        reasons.append(
+            "rue test exited {} — {}".format(
+                result.returncode,
+                _EXIT_REASONS.get(result.returncode, "unknown status"),
+            )
+        )
+    for line in malformed:
+        reasons.append("stdout carried a line that is not one event: {!r}".format(line))
+    if result.returncode == 0 and run_finished is None:
+        reasons.append("the event stream carried no run_finished event")
+
+    unimported = (run_finished or {}).get("unimported_test_files")
+    if unimported is None and run_finished is not None:
+        # The rule always passes --test-candidates, so the field is always
+        # present; its absence means the inventory never reached the compiler.
+        reasons.append(
+            "run_finished carried no unimported_test_files: the declared "
+            "inventory did not reach the compiler"
+        )
+        unimported = []
+    unimported = unimported or []
+    orphan_paths = sorted(entry.get("path") for entry in unimported)
+
+    if args.expect_unimported:
+        # Negative control: the run must be the one this rule fails, for
+        # exactly these paths and for no other reason.
+        expected = sorted(args.expect_unimported)
+        problems = []
+        if reasons:
+            problems.append("the run failed for another reason: {}".format(reasons))
+        if orphan_paths != expected:
+            problems.append(
+                "expected unimported {} but the run reported {}".format(
+                    expected, orphan_paths
+                )
+            )
+        for path in expected:
+            if path not in result.stderr:
+                problems.append("stderr never named {}".format(path))
+        if problems:
+            print(
+                "rue_test negative control: {}".format("; ".join(problems)),
+                file=sys.stderr,
+            )
+            report(command, result, ["negative control did not hold"], run_finished, events)
+            return 1
+        print(
+            "rue_test negative control held: {} would fail the target".format(
+                ", ".join(expected)
+            )
+        )
+        return 0
+
+    if orphan_paths and not args.allow_unimported:
+        reasons.append(
+            "declared test files nothing imports: {}".format(", ".join(orphan_paths))
+        )
+
+    if reasons:
+        report(command, result, reasons, run_finished, events)
+        return 1
+
+    if orphan_paths:
+        # allow_unimported: the warning still belongs in the log, since the
+        # attribute suppresses the failure, not the finding.
+        print("rue_test: test files nothing imports (allowed by this target):")
+        for line in describe_unimported(unimported):
+            print(line)
+    print(
+        "rue_test: {} passed in {} ms".format(
+            run_finished.get("passed", 0),
+            run_finished.get("wall_ms", 0),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test-rue-program-derive-manifest.py
+++ b/scripts/test-rue-program-derive-manifest.py
@@ -165,6 +165,38 @@ class DeriveManifestTest(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("incomplete", result.stderr)
 
+    def test_include_srcs_declares_unread_srcs_without_widening_the_boundary(self):
+        # ADR-0083 / RUE-2004: rue_test observes its candidate inventory under
+        # this manifest, so a test file nothing imports — never an accepted
+        # read — has to be declared or it reads back as unparsable.
+        env = envelope(
+            "/checkout/prog",
+            "/checkout/stdroot",
+            accepted=["/checkout/prog/main.rue"],
+            absent=[],
+        )
+        srcs = ["prog/main.rue", "prog/orphan_tests.rue"]
+        without = self.run_derive(env, srcs)
+        self.assertEqual(without.returncode, 0, without.stderr)
+        self.assertNotIn("orphan_tests.rue", self.read_out())
+
+        result = self.run_derive(
+            env, srcs, out="out/with-srcs.manifest", extra=["--include-srcs"]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("../prog/orphan_tests.rue", self.read_out("out/with-srcs.manifest"))
+
+    def test_include_srcs_still_fails_an_out_of_srcs_read(self):
+        env = envelope(
+            "/checkout/prog",
+            "/checkout/stdroot",
+            accepted=["/checkout/prog/main.rue", "/checkout/prog/extra.rue"],
+            absent=[],
+        )
+        result = self.run_derive(env, ["prog/main.rue"], extra=["--include-srcs"])
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("prog/extra.rue", result.stderr)
+
     def test_expect_violation_succeeds_only_on_exact_match(self):
         env = envelope(
             "/checkout/prog",


### PR DESCRIPTION
Fixes RUE-2004.

ADR-0083 gives the build system exactly one input to the test runner, the declared candidate inventory behind `--test-candidates`, and until now nothing in `rue_rules.bzl` produced it or ran `rue test` at all. `rue_test` is the rule: it takes `root` and `srcs` like `rue_program`, reuses the same scan and derive actions so the test image is bounded exactly as a program build is, writes the candidate list from `srcs`, and runs `rue test <root> --source-manifest … --test-candidates … --seed 1 --format json` under a small supervisor that reads the NDJSON stream. Exit 1/2/3 fails the target, and a non-empty `run_finished.unimported_test_files` fails it too unless `allow_unimported` is set; `expect_unimported` inverts that for a negative control. The rule keeps the `_test` suffix and `labels` so tier discovery finds it.

Two things the runner's contract made necessary. The compiler's project root is the root module's directory, not the repository, so candidate paths are re-anchored there once, shared with `rue_program`'s existing list (which had been written repository-relative and would have matched nothing). And a candidate is observed under the source manifest, so an orphan outside the declared manifest read as `parse_failed` rather than as unimported; the derive step gains `--include-srcs` for this rule only, widening the manifest to the declared sources while the boundary check stays as it was, with unit tests for both halves.

`examples/BUCK` declares `gazette-tests` (35 tests, premerge tier). `fixtures/rue-program/runner/` pins the behaviour permanently: a root importing one test file plus an unimported `orphan_tests.rue`, with an allowed target and a negative-control target that passes only if the run would otherwise have failed for exactly that path. Docs: one sentence each in test-events.md and ADR-0083's boundary section.

Verification: `//examples:gazette-tests`, both fixture targets, `//:rue-program-derive-manifest-tests` (9), `//:cli-timeout-policy-validation`, `//:tier-ci-selector-validation`, the test-duplication and CI-gate validators, `bxl //test_tiers.bxl:validate` (all three targets in the premerge selection), `./buck2 build //examples:gazette //fixtures/rue-program:hello`, `scripts/rue quick`, fmt clean; both scripts parse under Python 3.9.