### PR TITLE
RUE-2006: apply move and bounds checks to projection-mode reads

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -153,6 +153,14 @@ struct ProjectionInfo {
     /// instead of stripping the index (RUE-279). None for field projections,
     /// dynamic indices, and negative constants.
     index_segment: Option<Spur>,
+    /// For index projections: the RIR instruction of the index expression, in
+    /// the body being analyzed. `check_traced_const_index_bounds` needs it to
+    /// evaluate the index at its own operand types and to place the E0902
+    /// label on the index rather than on the whole access (RUE-2006). None for
+    /// field projections and for projections copied from an accessor-inline
+    /// alias, whose index instructions belong to the caller's body and were
+    /// bounds-checked when the caller traced the receiver.
+    index_inst: Option<InstRef>,
 }
 
 /// Result of tracing a place expression in RIR.
@@ -415,6 +423,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let Some(mut trace) = self.try_trace_place(value, air, ctx)? else {
             return Ok(None);
         };
+        // A borrowing read is still a read: it may not go through a moved
+        // root, a moved ancestor path, or a moved-out element, and a constant
+        // index in the chain must be in bounds. These are the checks a
+        // value-context read makes for the same expression (RUE-2006).
+        self.check_traced_place_read(&trace, ctx, span)?;
         let ty = trace.result_type();
         let place = Self::build_place_ref(air, &trace)?;
         let value = air.add_inst(AirInst {
@@ -1262,6 +1275,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                 field_name: p.field_name,
                                 const_index: p.const_index,
                                 index_segment: p.index_segment,
+                                index_inst: None,
                             })
                             .collect(),
                         root_var: alias.root_var,
@@ -1352,6 +1366,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             field_name: Some(*field),
                             const_index: None,
                             index_segment: None,
+                            index_inst: None,
                         });
 
                         Ok(Some(trace))
@@ -1431,6 +1446,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             field_name: None,
                             const_index,
                             index_segment,
+                            index_inst: Some(*index),
                         });
 
                         Ok(Some(trace))
@@ -3424,22 +3440,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
             let field_type = trace.result_type();
 
-            // Check if the root variable was fully moved (applies regardless of field type)
-            if let Some(state) = ctx.ownership.moved_vars.get(&trace.root_var) {
-                if let Some(moved_span) = state.full_move {
-                    let root_name = self.body_interner().resolve(&trace.root_var);
-                    return Err(CompileError::new(
-                        ErrorKind::UseAfterMove(root_name.to_string()),
-                        span,
-                    )
-                    .with_label("value moved here", moved_span)
-                    .with_help(super::borrow_instead_of_move_help(root_name)));
-                }
-            }
-
-            // A field read through an array element (`xs[0].f`) must not go
-            // through a moved-out element (RUE-186).
+            // The first three of the four read checks
+            // `check_traced_place_read` names: a fully moved root invalidates
+            // every place under it whatever the field type is (3.8:5), a field
+            // read through an array element must not go through a moved-out
+            // element (RUE-186, 3.8:70), and no constant index in the chain may
+            // leave its array (4.11:7). The fourth — the moved-ancestor path
+            // check — is per-branch below, because a move-out of a non-Copy
+            // field checks descendants too and is ordered after the rejections
+            // that come between.
+            self.reject_read_through_moved_root(&trace, ctx, span)?;
             self.check_read_through_moved_element(&trace, ctx, span)?;
+            self.check_traced_const_index_bounds(&trace, ctx)?;
 
             // Whole-value destructuring consumption (3.8:33) is the model for
             // a struct DECLARED `linear` only: its obligation belongs to the
@@ -3542,18 +3554,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // nested declared-`linear` access consumes (RUE-1632).
             let mut marker_depth = trace.projections.len();
             if is_byref_arg_use {
-                let field_path = trace.field_path();
-                if let Some(state) = ctx.ownership.moved_vars.get(&trace.root_var) {
-                    if let Some(moved_span) = state.is_path_moved(&field_path) {
-                        return Err(super::use_after_move_path_error(
-                            self.body_interner(),
-                            trace.root_var,
-                            &field_path,
-                            span,
-                            moved_span,
-                        ));
-                    }
-                }
+                self.reject_read_through_moved_path(&trace, ctx, span)?;
             } else if is_declared_linear {
                 // For a declared-linear struct, field access destructures and
                 // so consumes that struct's whole value (3.8:33).
@@ -3696,21 +3697,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // Copy fields are read, not moved — but reading one THROUGH
                 // a moved ancestor (`o.f.x` after `o.f` was moved out) reads
                 // memory whose owner is gone: drops are move-aware, so the
-                // moved part is logically dead. `is_path_moved` checks the
-                // exact path and every ancestor prefix (the full-move case
-                // was already rejected above).
-                let field_path = trace.field_path();
-                if let Some(state) = ctx.ownership.moved_vars.get(&trace.root_var) {
-                    if let Some(moved_span) = state.is_path_moved(&field_path) {
-                        return Err(super::use_after_move_path_error(
-                            self.body_interner(),
-                            trace.root_var,
-                            &field_path,
-                            span,
-                            moved_span,
-                        ));
-                    }
-                }
+                // moved part is logically dead (3.8:53). The full-move case
+                // was already rejected above.
+                self.reject_read_through_moved_path(&trace, ctx, span)?;
             }
 
             // Emit PlaceRead instruction
@@ -3894,6 +3883,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     field_name: Some(field),
                     const_index: None,
                     index_segment: None,
+                    index_inst: None,
                 }],
                 root_var: field,
                 is_root_mutable: false,
@@ -3962,10 +3952,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Check for constant out-of-bounds index early (before tracing)
-        // We need the array type for bounds checking, so peek at the base first
-        let _base_inst = self.body_rir_ref().get(base);
-
         // Try to trace this expression to a place (lvalue)
         if let Some(mut trace) = self.try_trace_place(inst_ref, air, ctx)? {
             if !trace.via_accessor && ctx.ownership.byref_arg_root != Some(trace.root_var) {
@@ -3993,20 +3979,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // moved field/element prefix, or this exact constant element,
             // without flagging a *sibling* element (`arr[1]` after `arr[0]`
             // moved has a disjoint path).
-            {
-                let field_path = trace.field_path();
-                if let Some(state) = ctx.ownership.moved_vars.get(&trace.root_var) {
-                    if let Some(moved_span) = state.is_path_moved(&field_path) {
-                        return Err(super::use_after_move_path_error(
-                            self.body_interner(),
-                            trace.root_var,
-                            &field_path,
-                            span,
-                            moved_span,
-                        ));
-                    }
-                }
-            }
+            self.reject_read_through_moved_path(&trace, ctx, span)?;
 
             // Get array info from the parent type (before the last projection)
             let parent_type = if trace.projections.len() > 1 {
@@ -4015,37 +3988,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 trace.base_type
             };
 
-            let array_len = match parent_type.as_array() {
-                Some(type_id) => {
-                    let (_elem, len) = self.body_type_pool().array_def(type_id);
-                    len
-                }
-                None => {
-                    // This shouldn't happen if try_trace_place worked correctly
-                    return Err(CompileError::new(
-                        ErrorKind::IndexOnNonArray {
-                            found: self.format_type_name(parent_type),
-                        },
-                        span,
-                    ));
-                }
-            };
-
-            // Check for constant out-of-bounds index. Evaluate at the index's
-            // resolved operand types so an expression that overflows its own
-            // integer type (`arr[X + 1]`, X: i8 = 127) is a compile-time error
-            // rather than a folded-then-bounds-checked value (RUE-234).
-            if let Some(const_idx) = self.try_get_const_index_checked(index, ctx)? {
-                if const_idx < 0 || const_idx >= array_len as i128 {
-                    return Err(CompileError::new(
-                        ErrorKind::IndexOutOfBounds {
-                            index: const_idx,
-                            length: array_len,
-                        },
-                        self.body_rir_ref().get(index).span,
-                    ));
-                }
+            if parent_type.as_array().is_none() {
+                // This shouldn't happen if try_trace_place worked correctly
+                return Err(CompileError::new(
+                    ErrorKind::IndexOnNonArray {
+                        found: self.format_type_name(parent_type),
+                    },
+                    span,
+                ));
             }
+
+            // Constant out-of-bounds indices anywhere in the traced chain,
+            // this one included (4.11:7, RUE-234).
+            self.check_traced_const_index_bounds(&trace, ctx)?;
 
             // A use as a by-ref call argument (`f(borrow a[i])`, `f(inout
             // a[i])`) borrows the element in place rather than moving it out
@@ -4116,18 +4071,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 self.reject_field_move_out_of_destructor_type(&trace, span)?;
             }
             if is_byref_arg_use {
-                let field_path = trace.field_path();
-                if let Some(state) = ctx.ownership.moved_vars.get(&trace.root_var) {
-                    if let Some(moved_span) = state.is_path_moved(&field_path) {
-                        return Err(super::use_after_move_path_error(
-                            self.body_interner(),
-                            trace.root_var,
-                            &field_path,
-                            span,
-                            moved_span,
-                        ));
-                    }
-                }
+                self.reject_read_through_moved_path(&trace, ctx, span)?;
                 self.check_read_through_moved_element(&trace, ctx, span)?;
             } else if let Some(declared_depth) = trackable_declared_depth {
                 self.reject_accessor_place_move(&trace, elem_type, span)?;
@@ -5100,6 +5044,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 field_name: Some(field),
                 const_index: None,
                 index_segment: None,
+                index_inst: None,
             });
 
             // A write through an element of a partially moved array
@@ -5327,6 +5272,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 field_name: None,
                 const_index,
                 index_segment,
+                index_inst: Some(index),
             });
 
             // Writing into an array with moved-out elements is rejected
@@ -6335,6 +6281,128 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: elem_type,
             span,
         }))
+    }
+
+    /// Every legality check a **read** through a traced place performs, in the
+    /// order a value-context read reports them (spec 3.8:5, 3.8:53, 3.8:70,
+    /// 4.11:7).
+    ///
+    /// Reading a place is reading a place: the checks cannot depend on which
+    /// mode asked for the value. A projection-mode read — a comparison operand
+    /// (4.3:3f), a `borrow` argument, `@dbg`, an `@assert*` operand, string
+    /// concatenation — borrows what it reads instead of moving it, so it has
+    /// none of the move-out rejections `analyze_field_get` and
+    /// `analyze_index_get` interleave with these, and it calls the set as a
+    /// whole here. Those two call the same four functions individually, at the
+    /// points where their own move-out rejections order around them.
+    ///
+    /// Before RUE-2006 the traced reader ran none of them: `x.a == y.a` read
+    /// through a moved `x` (a read of memory a destructor may already have
+    /// freed, not merely a missing diagnostic), and `xs[5].a == ys[0].a`
+    /// reached codegen for a constant index outside its array.
+    fn check_traced_place_read(
+        &mut self,
+        trace: &PlaceTrace,
+        ctx: &mut AnalysisContext,
+        span: Span,
+    ) -> CompileResult<()> {
+        self.reject_read_through_moved_root(trace, ctx, span)?;
+        self.check_read_through_moved_element(trace, ctx, span)?;
+        self.check_traced_const_index_bounds(trace, ctx)?;
+        self.reject_read_through_moved_path(trace, ctx, span)
+    }
+
+    /// Reject any use of a place whose root binding has been moved as a whole
+    /// (spec 3.8:5). The root's full move invalidates every place under it,
+    /// whatever the read's own type is, and the diagnostic names the root.
+    fn reject_read_through_moved_root(
+        &self,
+        trace: &PlaceTrace,
+        ctx: &AnalysisContext,
+        span: Span,
+    ) -> CompileResult<()> {
+        let Some(state) = ctx.ownership.moved_vars.get(&trace.root_var) else {
+            return Ok(());
+        };
+        let Some(moved_span) = state.full_move else {
+            return Ok(());
+        };
+        let root_name = self.body_interner().resolve(&trace.root_var);
+        Err(
+            CompileError::new(ErrorKind::UseAfterMove(root_name.to_string()), span)
+                .with_label("value moved here", moved_span)
+                .with_help(super::borrow_instead_of_move_help(root_name)),
+        )
+    }
+
+    /// Reject a read through a moved ancestor path (spec 3.8:53): `o.f.x`
+    /// after `o.f` moved reads storage the binding no longer owns, even though
+    /// `x` is itself Copy. `is_path_moved` matches the exact path and every
+    /// ancestor prefix; a sibling's move (`o.g`) leaves a disjoint path and is
+    /// not affected.
+    fn reject_read_through_moved_path(
+        &self,
+        trace: &PlaceTrace,
+        ctx: &AnalysisContext,
+        span: Span,
+    ) -> CompileResult<()> {
+        let field_path = trace.field_path();
+        let Some(state) = ctx.ownership.moved_vars.get(&trace.root_var) else {
+            return Ok(());
+        };
+        let Some(moved_span) = state.is_path_moved(&field_path) else {
+            return Ok(());
+        };
+        Err(super::use_after_move_path_error(
+            self.body_interner(),
+            trace.root_var,
+            &field_path,
+            span,
+            moved_span,
+        ))
+    }
+
+    /// Reject a constant index that leaves its array anywhere in a traced
+    /// chain (spec 4.11:7).
+    ///
+    /// The whole chain is checked, not just its last index: `xs[5].a` is as
+    /// out of bounds as `xs[5]` is, and its projection is built from the same
+    /// trace. Each index is evaluated at its own resolved operand types, so an
+    /// index expression that overflows its integer type is a compile-time
+    /// error rather than a folded runtime panic (RUE-234), and the diagnostic
+    /// is labelled on the index expression, matching a direct element read.
+    fn check_traced_const_index_bounds(
+        &mut self,
+        trace: &PlaceTrace,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<()> {
+        for (position, projection) in trace.projections.iter().enumerate() {
+            let Some(index_inst) = projection.index_inst else {
+                continue;
+            };
+            let array_type = if position == 0 {
+                trace.base_type
+            } else {
+                trace.projections[position - 1].result_type
+            };
+            let Some(array_type_id) = array_type.as_array() else {
+                continue;
+            };
+            let (_element_type, length) = self.body_type_pool().array_def(array_type_id);
+            let Some(const_index) = self.try_get_const_index_checked(index_inst, ctx)? else {
+                continue;
+            };
+            if const_index < 0 || const_index >= length as i128 {
+                return Err(CompileError::new(
+                    ErrorKind::IndexOutOfBounds {
+                        index: const_index,
+                        length,
+                    },
+                    self.body_rir_ref().get(index_inst).span,
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Reject a read through an array element that is (or may be) moved out

--- a/crates/rue-spec/cases/expressions/index.toml
+++ b/crates/rue-spec/cases/expressions/index.toml
@@ -117,6 +117,101 @@ fn main() -> i32 {
 """
 compile_fail = true
 
+# A constant index is bounds-checked wherever it appears in a place chain, not
+# only as the whole expression: `xs[5].a` names the same out-of-range element
+# `xs[5]` does. Reading the field in a place context — a comparison operand
+# (4.3:3f), a `borrow` argument, an `@dbg` operand — traces the chain through
+# the same projection machinery as a value-context read, so all four spellings
+# report E0902 at the index (RUE-2006).
+
+[[case]]
+name = "constant_index_out_of_bounds_in_field_chain"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7"]
+description = "A constant out-of-bounds index is rejected when a field is read through it"
+source = """
+struct P { a: i32, b: i32 }
+
+fn main() -> i32 {
+    let xs: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    xs[5].a
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_out_of_bounds_in_field_chain_comparison_operand"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7", "4.3:3f"]
+description = "The comparison operand's borrowing read of a field chain is bounds-checked too"
+source = """
+struct P { a: i32, b: i32 }
+
+fn main() -> i32 {
+    let xs: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    let ys: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    if xs[5].a == ys[0].a { 1 } else { 0 }
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_out_of_bounds_in_field_chain_borrow_argument"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7"]
+description = "A `borrow` argument reading a field through an out-of-range element is rejected"
+source = """
+struct P { a: i32, b: i32 }
+
+fn peek(borrow v: i32) -> i32 { v }
+
+fn main() -> i32 {
+    let xs: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    peek(borrow xs[5].a)
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_out_of_bounds_in_field_chain_dbg_operand"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7"]
+description = "An `@dbg` operand reading a field through an out-of-range element is rejected"
+source = """
+struct P { a: i32, b: i32 }
+
+fn main() -> i32 {
+    let xs: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    @dbg(xs[5].a);
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_in_bounds_in_field_chain_runs"
+spec = ["4.11:7", "4.3:3f"]
+description = "The in-bounds forms of those same reads compile and run"
+source = """
+struct P { a: i32, b: i32 }
+
+fn peek(borrow v: i32) -> i32 { v }
+
+fn main() -> i32 {
+    let xs: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    let ys: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    let equal = xs[1].a == ys[1].a;
+    let borrowed = peek(borrow xs[0].a);
+    @dbg(xs[1].b);
+    if equal { borrowed + xs[1].a } else { 0 }
+}
+"""
+exit_code = 4
+
 # =============================================================================
 # Runtime Bounds Checking
 # =============================================================================

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -965,6 +965,137 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "use of moved value"
 
+# A read in a PLACE context (3.8:76) — the operand of `==`/`!=` (4.3:3f), a
+# `borrow` argument, an `@dbg` operand — borrows what it reads instead of
+# consuming it, but it is still a read: it may not go through a moved binding
+# or a moved ancestor path. Before RUE-2006 the comparison operand's read
+# skipped both checks, so `x.a == y.a` after `let z = x` compiled and read
+# storage the new owner's destructor may already have freed.
+
+[[case]]
+name = "moved_struct_field_as_comparison_operand_error"
+spec = ["3.8:5", "3.8:76"]
+description = "A comparison operand may not read a field of a moved struct (RUE-2006)"
+source = """
+struct P { a: i32, b: i32 }
+
+fn main() -> i32 {
+    let x = P { a: 1, b: 2 };
+    let y = P { a: 1, b: 3 };
+    let z = x;
+    if x.a == y.a { z.b } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = ["[E0205]", "use of moved value 'x'"]
+expected_error_code = "E0205"
+
+[[case]]
+name = "moved_struct_field_as_borrow_argument_error"
+spec = ["3.8:5", "3.8:76"]
+description = "A `borrow` argument may not read a field of a moved struct"
+source = """
+struct P { a: i32, b: i32 }
+
+fn peek(borrow v: i32) -> i32 { v }
+
+fn main() -> i32 {
+    let x = P { a: 1, b: 2 };
+    let z = x;
+    peek(borrow x.a) + z.b
+}
+"""
+compile_fail = true
+error_contains = ["[E0205]", "use of moved value 'x'"]
+expected_error_code = "E0205"
+
+[[case]]
+name = "moved_struct_field_as_dbg_operand_error"
+spec = ["3.8:5", "3.8:76"]
+description = "An `@dbg` operand may not read a field of a moved struct"
+source = """
+struct P { a: i32, b: i32 }
+
+fn main() -> i32 {
+    let x = P { a: 1, b: 2 };
+    let z = x;
+    @dbg(x.a);
+    z.b
+}
+"""
+compile_fail = true
+error_contains = ["[E0205]", "use of moved value 'x'"]
+expected_error_code = "E0205"
+
+[[case]]
+name = "moved_ancestor_field_as_comparison_operand_error"
+spec = ["3.8:53", "3.8:76"]
+description = "A comparison operand may not read a Copy field through a moved ancestor path"
+source = """
+struct Inner { x: i32 }
+struct Outer { f: Inner, tag: i32 }
+
+fn consume(i: Inner) -> i32 { i.x }
+
+fn main() -> i32 {
+    let o = Outer { f: Inner { x: 1 }, tag: 2 };
+    let p = Outer { f: Inner { x: 1 }, tag: 3 };
+    let a = consume(o.f);
+    if o.f.x == p.f.x { a } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = ["[E0205]", "use of moved value 'o.f.x'"]
+expected_error_code = "E0205"
+
+[[case]]
+name = "moved_strbuf_field_as_comparison_operand_error"
+spec = ["3.8:5", "3.8:76"]
+real_std = true
+description = "The freed-storage shape: the moved value's owner has already been dropped when the comparison operand reads its StrBuf field (RUE-2006)"
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Holder { s: StrBuf, tag: i32 }
+
+fn main() -> i32 {
+    let mut owned = StrBuf.new();
+    owned.push_str("AAAA");
+    let h = Holder { s: owned, tag: 1 };
+    {
+        let taken = h;
+        @dbg(taken.tag);
+    }
+    let mut probe = StrBuf.new();
+    probe.push_str("AAAA");
+    if h.s == probe { 1 } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = ["[E0205]", "use of moved value 'h'"]
+expected_error_code = "E0205"
+
+[[case]]
+name = "unmoved_struct_field_in_place_contexts_runs"
+spec = ["3.8:5", "3.8:76"]
+description = "The not-moved forms of those same place-context reads compile and run"
+source = """
+struct P { a: i32, b: i32 }
+
+fn peek(borrow v: i32) -> i32 { v }
+
+fn main() -> i32 {
+    let x = P { a: 1, b: 2 };
+    let y = P { a: 1, b: 3 };
+    let equal = x.a == y.a;
+    let borrowed = peek(borrow x.a);
+    @dbg(x.b);
+    if equal { borrowed + x.b } else { 0 }
+}
+"""
+exit_code = 3
+
 [[case]]
 name = "moved_field_reassign_then_read"
 spec = ["3.8:55", "3.8:56"]


### PR DESCRIPTION
Fixes RUE-2006.

Reads in projection mode, the borrowing reads a comparison operand, a `borrow` argument, `@dbg`, `@assert*`, and string concatenation perform, reach their place through `try_read_traced_place`, which traced the place and emitted the read with no legality check at all. Two consequences: a field of a moved struct could be read (`let z = x; x.a == y.a` compiled, and with a `StrBuf` field the comparison observed whatever the recycled heap block held, demonstrated before the fix), and a constant out-of-range index inside a field chain was accepted in every read mode and trapped at runtime, where the bare `xs[5]` is E0902 at compile time.

The four checks value-mode reads already performed inline (moved root, moved element, constant-index bounds over the whole traced chain, moved ancestor path) are now four named functions, applied as one set by the traced reader and called individually by `analyze_field_get` and `analyze_index_get` at the points their move-out ordering requires, so both modes report the same code at the same span. `ProjectionInfo` carries the index instruction so the bounds label lands on the index.

Spec cases under 3.8 (a moved struct's field as comparison operand, `borrow` argument, and `@dbg` operand; a moved ancestor path; the freed-storage shape) and 4.11 (a constant out-of-range index in a field chain in each position), each with a positive counterpart. Verification: full `scripts/rue spec` (2697), full `scripts/rue ui` (330), `scripts/rue unit rue-air`, `scripts/rue quick`, clippy and fmt clean; the tree also passes the full spec suite (2701) with RUE-1997 merged in. The write-side counterpart (`xs[5].a = 7`) is filed as RUE-2008.