### PR TITLE
RUE-2001: load single-slot float aggregates in the float register class

### DIFF
--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -517,6 +517,29 @@ pub fn float_width(ty: Type) -> Option<FloatWidth> {
     }
 }
 
+/// The float width of a value whose whole representation is one storage slot,
+/// given that value's [`crate::types::aggregate_leaf_types`].
+///
+/// A slot-addressed plan (`Alloc`, `Load`, `Store`, `ParamStore`) reaches a
+/// single-slot value through its primary vreg rather than through the typed
+/// slot walk, so that vreg's register class has to come from the leaf the slot
+/// actually holds. A bare `f64` and a `struct Q { f: f64 }` hold the same thing
+/// in the same one slot; reading the width off the value's own type answers
+/// `None` for the wrapper and loads the float into a general-purpose register,
+/// which every float-typed consumer of that slot then rejects — the
+/// aggregate-equality walk's float compare most visibly (RUE-2001). Reading it
+/// off the leaf instead gives the wrapper the float register class its content
+/// already had, so `Q == Q` compares the same way `f64 == f64` does.
+///
+/// Multi-slot values answer `None`: their per-slot classes are not one width,
+/// and the typed slot walk selects each slot's own from `leaf_types`.
+fn single_slot_float_width(leaf_types: &[Type]) -> Option<FloatWidth> {
+    match leaf_types {
+        [leaf] => float_width(*leaf),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FloatToIntGuardRelation {
     OrderedGreaterEqual,
@@ -1169,44 +1192,48 @@ fn residual_plan<A: ValueLowerAdapter>(
         // Slot-addressed plans carry emitted-frame slot numbers: the CFG's
         // slot numbering assumes every parameter is homed, while the emitted
         // frame compacts register-only parameters away (RUE-1170).
-        ResidualInput::Alloc { slot, init } => ResidualValuePlan::Alloc {
-            slot: ctx.frame_slot(slot),
-            init: operand(ctx, adapter, init),
-            init_shape: ValuePlan::for_value(ctx, init).shape,
-            float_width: float_width(ctx.cfg.get_inst(init).ty),
-            leaf_types: crate::types::aggregate_leaf_types(
-                ctx.type_pool,
-                ctx.cfg.get_inst(init).ty,
-            ),
-        },
-        ResidualInput::Load { slot } => ResidualValuePlan::Load {
-            slot: ctx.frame_slot(slot),
-            float_width: float_width(ctx.cfg.get_inst(value).ty),
-            leaf_types: crate::types::aggregate_leaf_types(
-                ctx.type_pool,
-                ctx.cfg.get_inst(value).ty,
-            ),
-        },
-        ResidualInput::Store { slot, value } => ResidualValuePlan::Store {
-            destination: store_destination(ctx, slot),
-            value: operand(ctx, adapter, value),
-            value_shape: ValuePlan::for_value(ctx, value).shape,
-            float_width: float_width(ctx.cfg.get_inst(value).ty),
-            leaf_types: crate::types::aggregate_leaf_types(
-                ctx.type_pool,
-                ctx.cfg.get_inst(value).ty,
-            ),
-        },
-        ResidualInput::ParamStore { param_slot, value } => ResidualValuePlan::ParamStore {
-            param_slot,
-            value: operand(ctx, adapter, value),
-            value_shape: ValuePlan::for_value(ctx, value).shape,
-            float_width: float_width(ctx.cfg.get_inst(value).ty),
-            leaf_types: crate::types::aggregate_leaf_types(
-                ctx.type_pool,
-                ctx.cfg.get_inst(value).ty,
-            ),
-        },
+        ResidualInput::Alloc { slot, init } => {
+            let leaf_types =
+                crate::types::aggregate_leaf_types(ctx.type_pool, ctx.cfg.get_inst(init).ty);
+            ResidualValuePlan::Alloc {
+                slot: ctx.frame_slot(slot),
+                init: operand(ctx, adapter, init),
+                init_shape: ValuePlan::for_value(ctx, init).shape,
+                float_width: single_slot_float_width(&leaf_types),
+                leaf_types,
+            }
+        }
+        ResidualInput::Load { slot } => {
+            let leaf_types =
+                crate::types::aggregate_leaf_types(ctx.type_pool, ctx.cfg.get_inst(value).ty);
+            ResidualValuePlan::Load {
+                slot: ctx.frame_slot(slot),
+                float_width: single_slot_float_width(&leaf_types),
+                leaf_types,
+            }
+        }
+        ResidualInput::Store { slot, value } => {
+            let leaf_types =
+                crate::types::aggregate_leaf_types(ctx.type_pool, ctx.cfg.get_inst(value).ty);
+            ResidualValuePlan::Store {
+                destination: store_destination(ctx, slot),
+                value: operand(ctx, adapter, value),
+                value_shape: ValuePlan::for_value(ctx, value).shape,
+                float_width: single_slot_float_width(&leaf_types),
+                leaf_types,
+            }
+        }
+        ResidualInput::ParamStore { param_slot, value } => {
+            let leaf_types =
+                crate::types::aggregate_leaf_types(ctx.type_pool, ctx.cfg.get_inst(value).ty);
+            ResidualValuePlan::ParamStore {
+                param_slot,
+                value: operand(ctx, adapter, value),
+                value_shape: ValuePlan::for_value(ctx, value).shape,
+                float_width: single_slot_float_width(&leaf_types),
+                leaf_types,
+            }
+        }
         ResidualInput::StructInit { struct_id } => ResidualValuePlan::StructInit {
             struct_id,
             fields: ctx
@@ -2373,10 +2400,10 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        ComparisonPreparation, DebugValuePlan, IntegerExtension, IntegerWidth, IntrinsicArgPlan,
-        MaterializationRequirement, PointerAccessPlan, StoragePolicy, StoreDestination, ValuePlan,
-        ValueShape, assert_slot_policy, comparison_integer_width, integer_range,
-        pointer_access_plan, type_bits, type_range,
+        ComparisonPreparation, DebugValuePlan, FloatWidth, IntegerExtension, IntegerWidth,
+        IntrinsicArgPlan, MaterializationRequirement, PointerAccessPlan, StoragePolicy,
+        StoreDestination, ValuePlan, ValueShape, assert_slot_policy, comparison_integer_width,
+        integer_range, pointer_access_plan, type_bits, type_range,
     };
     use lasso::ThreadedRodeo;
     use rue_air::{
@@ -3357,6 +3384,155 @@ mod tests {
         assert_eq!(arm_actions.len(), 1);
         assert_eq!(arm_actions[0].symbol, "DropAggregate::__drop");
         assert_eq!(arm_actions[0].slots, arm_value.slots);
+    }
+
+    /// A float leaf reached through an aggregate is compared the way a
+    /// top-level `f64 == f64` is: in the floating-point register class
+    /// (RUE-2001).
+    ///
+    /// A single-slot aggregate travels through its primary vreg rather than the
+    /// typed slot walk, so the wrapper's own type — not a float — used to pick
+    /// that vreg's class. The slot then held float bits in a general-purpose
+    /// register, and the aggregate-equality walk handed it to the float
+    /// compare; both backends assert their float operand classes while
+    /// encoding, so the mismatch was an internal compiler error rather than a
+    /// wrong answer.
+    #[test]
+    fn a_single_slot_float_aggregate_is_loaded_and_compared_in_the_float_class() {
+        for (leaf, width, bits) in [
+            (Type::F64, FloatWidth::F64, 0x3ff8_0000_0000_0000u64),
+            (Type::F32, FloatWidth::F32, 0x3fc0_0000u64),
+        ] {
+            let pool = TypeInternPool::new();
+            let interner = ThreadedRodeo::new();
+            let name = interner.get_or_intern("Wrapper");
+            let (struct_id, _) = pool.register_struct(
+                name,
+                StructDef {
+                    name: "Wrapper".into(),
+                    fields: vec![StructField {
+                        name: "value".to_string(),
+                        ty: leaf,
+                    }],
+                    is_copy: true,
+                    is_linear: false,
+                    declared_linear: false,
+                    destructor: None,
+                    is_builtin: false,
+                    is_pub: false,
+                    file_id: FileId::DEFAULT,
+                },
+            );
+            let pool = pool.freeze();
+            let wrapper_ty = Type::new_struct(struct_id);
+
+            let mut cfg = Cfg::new(
+                Type::BOOL,
+                2,
+                0,
+                "single_slot_float_aggregate_equality".to_string(),
+                vec![],
+            );
+            let entry = cfg.new_block();
+            cfg.entry = entry;
+            for slot in 0..2 {
+                let field = cfg.append_inst(entry, inst(CfgInstData::Const(bits), leaf));
+                let value = cfg
+                    .append_struct_init(entry, struct_id, [field], wrapper_ty, Span::new(0, 0))
+                    .expect("wrapper initializer");
+                cfg.append_inst(
+                    entry,
+                    inst(CfgInstData::Alloc { slot, init: value }, Type::UNIT),
+                );
+            }
+            let lhs = cfg.append_inst(entry, inst(CfgInstData::Load { slot: 0 }, wrapper_ty));
+            let rhs = cfg.append_inst(entry, inst(CfgInstData::Load { slot: 1 }, wrapper_ty));
+            let equal = cfg.append_inst(entry, inst(CfgInstData::Eq(lhs, rhs), Type::BOOL));
+            cfg.set_return(entry, Some(equal));
+
+            let x86 = X86CfgLower::new_unchecked(&cfg, &pool, &interner)
+                .lower()
+                .expect("x86 single-slot float aggregate equality should lower");
+            let x86_compares: Vec<_> = x86
+                .instructions()
+                .iter()
+                .filter_map(|inst| match inst {
+                    X86Inst::FloatCmp {
+                        lhs: crate::x86_64::Operand::Virtual(lhs),
+                        rhs: crate::x86_64::Operand::Virtual(rhs),
+                        width: compare_width,
+                    } => Some((*lhs, *rhs, *compare_width)),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                x86_compares.len(),
+                1,
+                "the float leaf is compared exactly once ({leaf:?})"
+            );
+            let (x86_lhs, x86_rhs, x86_width) = x86_compares[0];
+            assert_eq!(x86_width, width);
+            assert_eq!(x86.vreg_class(x86_lhs), crate::reg_class::RegClass::Fp);
+            assert_eq!(x86.vreg_class(x86_rhs), crate::reg_class::RegClass::Fp);
+            assert!(
+                x86.instructions()
+                    .iter()
+                    .any(|inst| matches!(inst, X86Inst::FloatLoad { .. })),
+                "the wrapper's one slot is loaded as a float ({leaf:?})"
+            );
+
+            let arm = Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux)
+                .lower()
+                .expect("AArch64 single-slot float aggregate equality should lower");
+            let arm_compares: Vec<_> = arm
+                .instructions()
+                .iter()
+                .filter_map(|inst| match inst {
+                    Aarch64Inst::FloatCmp {
+                        lhs: crate::aarch64::Operand::Virtual(lhs),
+                        rhs: crate::aarch64::Operand::Virtual(rhs),
+                        width: compare_width,
+                    } => Some((*lhs, *rhs, *compare_width)),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                arm_compares.len(),
+                1,
+                "the float leaf is compared exactly once ({leaf:?})"
+            );
+            let (arm_lhs, arm_rhs, arm_width) = arm_compares[0];
+            assert_eq!(arm_width, width);
+            assert_eq!(arm.vreg_class(arm_lhs), crate::reg_class::RegClass::Fp);
+            assert_eq!(arm.vreg_class(arm_rhs), crate::reg_class::RegClass::Fp);
+            assert!(
+                arm.instructions()
+                    .iter()
+                    .any(|inst| matches!(inst, Aarch64Inst::FloatLoad { .. })),
+                "the wrapper's one slot is loaded as a float ({leaf:?})"
+            );
+        }
+    }
+
+    /// The width a slot-addressed plan gives one storage slot comes from the
+    /// leaf that slot holds, so a wrapper around a float is a float slot and a
+    /// multi-slot aggregate has no single width (RUE-2001).
+    #[test]
+    fn a_single_slot_float_leaf_selects_the_float_class_for_its_wrapper() {
+        assert_eq!(
+            super::single_slot_float_width(&[Type::F64]),
+            Some(FloatWidth::F64)
+        );
+        assert_eq!(
+            super::single_slot_float_width(&[Type::F32]),
+            Some(FloatWidth::F32)
+        );
+        assert_eq!(super::single_slot_float_width(&[Type::I64]), None);
+        assert_eq!(super::single_slot_float_width(&[]), None);
+        assert_eq!(
+            super::single_slot_float_width(&[Type::F64, Type::F64]),
+            None
+        );
     }
 
     #[test]

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -87,6 +87,126 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::EmptySlicePointer),
         &[],
     ),
+    // Float-carrying aggregate equality (RUE-2001). The oracle has no
+    // floating-point value domain, so a case reaches the same
+    // `FloatArithmetic` boundary the `floats` CLI cases reach as soon as a
+    // float literal is evaluated — before any of the aggregate equality these
+    // cases are about. The equality itself is checked natively by the spec
+    // suite and by the codegen lowering tests.
+    Entry::new(
+        "expressions.comparison",
+        "aggregate_holding_nan_is_not_equal_to_itself",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "array_of_floats_equality_different_element",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "array_of_floats_equality_equal",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "array_of_floats_equality_inequality",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "array_of_floats_equality_signed_zero_elements_are_equal",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "enum_float_payload_equality_different_payload",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "enum_float_payload_equality_different_variant",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "enum_float_payload_equality_inequality",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "enum_float_payload_equality_same_payload",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "enum_float_payload_equality_signed_zero_payload_is_equal",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "single_element_float_array_equality_f32",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "single_element_float_array_equality_f64",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "struct_float_field_equality_different_f32_field",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "struct_float_field_equality_different_f64_field",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "struct_float_field_equality_equal",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "struct_float_field_equality_inequality",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "struct_float_field_negative_zero_equals_positive_zero",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "struct_single_float_field_equality_f32",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
+    Entry::new(
+        "expressions.comparison",
+        "struct_single_float_field_equality_f64",
+        semantic(SemanticGapKind::FloatArithmetic),
+        &[],
+    ),
     // A *failing* comparison assertion renders both operands first (spec
     // 4.13:5f), and the compiler-synthesized structural printer opens by taking
     // a bounded buffer from the allocation helper. The interpreter stops there;
@@ -431,6 +551,10 @@ const fn intrinsic(kind: UnsupportedIntrinsicKind) -> ModelGapKind {
 
 const fn external(kind: ExternalDependencyKind) -> ModelGapKind {
     ModelGapKind::ExternalDependency(kind)
+}
+
+const fn semantic(kind: SemanticGapKind) -> ModelGapKind {
+    ModelGapKind::Semantic(kind)
 }
 
 #[cfg(test)]

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -665,3 +665,172 @@ pub struct F { s: Str(8) }
 pub fn make() -> F { F { s: "hello" } }
 """ }
 exit_code = 5
+
+# =============================================================================
+# Aggregates carrying a float (`floats` preview, RUE-2001)
+#
+# A float is an ordinary scalar leaf of the structural recursion, so a float
+# field, element, or payload compares exactly the way a top-level `f64 == f64`
+# compares: the IEEE-754 equality predicate, not a comparison of the stored
+# bits. The two places that distinguishes are signed zero, where `-0.0 == 0.0`
+# holds although the bit patterns differ, and `NaN`, where a value is not equal
+# to itself although the bit patterns agree.
+# =============================================================================
+
+[[case]]
+name = "struct_float_field_equality_{variant}"
+spec = ["4.3:2", "4.3:3b"]
+preview = "floats"
+preview_should_pass = true
+description = "Float fields compare field-by-field under IEEE equality, at both widths."
+source = """
+struct Sample { wide: f64, small: f32 }
+
+fn main() -> i32 {
+    let a = Sample { wide: {aw}, small: {as} };
+    let b = Sample { wide: {bw}, small: {bs} };
+    if a {op} b { 1 } else { 0 }
+}
+"""
+params = [
+  { variant = "equal", aw = "1.5", as = "2.5", bw = "1.5", bs = "2.5", op = "==", exit_code = 1 },
+  { variant = "different_f64_field", aw = "1.5", as = "2.5", bw = "1.25", bs = "2.5", op = "==", exit_code = 0 },
+  { variant = "different_f32_field", aw = "1.5", as = "2.5", bw = "1.5", bs = "2.25", op = "==", exit_code = 0 },
+  { variant = "inequality", aw = "1.5", as = "2.5", bw = "1.25", bs = "2.5", op = "!=", exit_code = 1 },
+]
+
+# The wrapper is one storage slot, so it travels through the primary register
+# rather than the per-slot walk. That is the shape that used to lose the float
+# register class and reach the float compare with a general-purpose operand
+# (RUE-2001).
+[[case]]
+name = "struct_single_float_field_equality_{width}"
+spec = ["4.3:2", "4.3:3b"]
+preview = "floats"
+preview_should_pass = true
+description = "A struct whose only field is a float compares on that field's value."
+source = """
+struct Wrapper { value: {width} }
+
+fn main() -> i32 {
+    let a = Wrapper { value: 1.5 };
+    let b = Wrapper { value: 1.5 };
+    let c = Wrapper { value: 2.5 };
+    if a == b && a != c { 1 } else { 0 }
+}
+"""
+params = [
+  { width = "f64", exit_code = 1 },
+  { width = "f32", exit_code = 1 },
+]
+
+[[case]]
+name = "struct_float_field_negative_zero_equals_positive_zero"
+spec = ["4.3:2", "4.3:3b"]
+preview = "floats"
+preview_should_pass = true
+description = "`-0.0 == 0.0` inside an aggregate, as it is for a bare float: IEEE equality, not a bit comparison."
+source = """
+struct Sample { wide: f64, small: f32 }
+
+fn main() -> i32 {
+    let positive = Sample { wide: 0.0, small: 0.0 };
+    let negative = Sample { wide: -0.0, small: -0.0 };
+    if positive == negative && !(positive != negative) { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "array_of_floats_equality_{variant}"
+spec = ["4.3:2", "4.3:3c"]
+preview = "floats"
+preview_should_pass = true
+description = "Float array elements compare index-by-index under IEEE equality."
+source = """
+fn main() -> i32 {
+    let a: [f64; 3] = [{a0}, {a1}, {a2}];
+    let b: [f64; 3] = [{b0}, {b1}, {b2}];
+    if a {op} b { 1 } else { 0 }
+}
+"""
+params = [
+  { variant = "equal", a0 = "1.5", a1 = "2.5", a2 = "3.5", b0 = "1.5", b1 = "2.5", b2 = "3.5", op = "==", exit_code = 1 },
+  { variant = "different_element", a0 = "1.5", a1 = "2.5", a2 = "3.5", b0 = "1.5", b1 = "2.5", b2 = "9.5", op = "==", exit_code = 0 },
+  { variant = "signed_zero_elements_are_equal", a0 = "1.5", a1 = "-0.0", a2 = "3.5", b0 = "1.5", b1 = "0.0", b2 = "3.5", op = "==", exit_code = 1 },
+  { variant = "inequality", a0 = "1.5", a1 = "2.5", a2 = "3.5", b0 = "1.5", b1 = "2.5", b2 = "9.5", op = "!=", exit_code = 1 },
+]
+
+[[case]]
+name = "single_element_float_array_equality_{width}"
+spec = ["4.3:2", "4.3:3c"]
+preview = "floats"
+preview_should_pass = true
+description = "A one-element float array is one storage slot and still compares on its element's value."
+source = """
+fn main() -> i32 {
+    let a: [{width}; 1] = [1.5];
+    let b: [{width}; 1] = [1.5];
+    let c: [{width}; 1] = [2.5];
+    if a == b && a != c { 1 } else { 0 }
+}
+"""
+params = [
+  { width = "f64", exit_code = 1 },
+  { width = "f32", exit_code = 1 },
+]
+
+[[case]]
+name = "enum_float_payload_equality_{variant}"
+spec = ["4.3:2", "4.3:3d"]
+preview = "floats"
+preview_should_pass = true
+description = "A float enum payload compares under IEEE equality once the variants agree."
+source = """
+enum Reading { Value(f64), Missing }
+
+fn main() -> i32 {
+    let a = Reading.{a};
+    let b = Reading.{b};
+    if a {op} b { 1 } else { 0 }
+}
+"""
+params = [
+  { variant = "same_payload", a = "Value(1.5)", b = "Value(1.5)", op = "==", exit_code = 1 },
+  { variant = "different_payload", a = "Value(1.5)", b = "Value(2.5)", op = "==", exit_code = 0 },
+  { variant = "signed_zero_payload_is_equal", a = "Value(-0.0)", b = "Value(0.0)", op = "==", exit_code = 1 },
+  { variant = "different_variant", a = "Value(1.5)", b = "Missing", op = "==", exit_code = 0 },
+  { variant = "inequality", a = "Value(1.5)", b = "Missing", op = "!=", exit_code = 1 },
+]
+
+# RUE-2007 baseline. Structural equality is documented as a total equivalence
+# (4.3:3g), which `NaN` breaks: a float leaf compares under IEEE equality, so an
+# aggregate holding a `NaN` is not equal to itself even though both operands are
+# the same value with the same bits. This case records what the implementation
+# does today, at each depth the recursion reaches; deciding what the language
+# should say about it is RUE-2007's, not this case's.
+[[case]]
+name = "aggregate_holding_nan_is_not_equal_to_itself"
+spec = ["4.3:2", "4.3:3b", "4.3:3c", "4.3:3d"]
+preview = "floats"
+preview_should_pass = true
+description = "Observed NaN behaviour inside an aggregate, the measured baseline for RUE-2007's partial-equality decision."
+source = """
+struct Sample { wide: f64 }
+enum Reading { Value(f64), Missing }
+
+fn main() -> i32 {
+    let zero: f64 = 0.0;
+    let nan = zero / zero;
+    let field = Sample { wide: nan };
+    let element: [f64; 2] = [1.5, nan];
+    let payload = Reading.Value(nan);
+    let mut r: i32 = 0;
+    if field != field { r = r + 1; }
+    if !(field == field) { r = r + 2; }
+    if element != element { r = r + 4; }
+    if payload != payload { r = r + 8; }
+    r
+}
+"""
+exit_code = 15


### PR DESCRIPTION
Fixes RUE-2001.

Under `--preview floats`, `struct Q { f: f64 }` compared with `==` ICEd in the AArch64 emitter with a register-class assertion on `FloatCmp`, and x86-64 ICEd identically rather than silently emitting an integer compare. The equality walk was not at fault: both backends already select the float compare for a float leaf, and multi-slot values already load each slot in its leaf's class. The defect was where a single-slot value gets its register class: the slot-addressed value plans (`Alloc`, `Load`, `Store`, `ParamStore`) took their float width from the value's own type, so a one-field struct, a `[f64; 1]`, or any nesting of those, which is one slot holding a float but is not itself a float type, was loaded with an integer frame load into a general-purpose register, and every float consumer of that slot (`FloatCmp`, `FloatStore` for `let b = a`, `FloatMov` when passed as an argument) then had the wrong class.

The width now comes from the leaf the single slot actually holds; multi-slot values keep the typed slot walk unchanged. A dual-backend lowering test asserts the leaf compare's operands are in the float class and the slot is loaded with a float load at both widths, and fails with the fix reverted. Nineteen preview-gated spec cases under 4.3:3b/3c/3d cover struct, array, and enum-payload float leaves at both widths, signed zero, and NaN; the NaN case records the IEEE result that falls out (an aggregate holding NaN is not equal to itself) as the baseline for the RUE-2007 decision, with no spec prose changed. The cases are oracle-eligible and hit the oracle's `FloatArithmetic` gap at their first literal, so nineteen gap entries are registered.

Verification: `scripts/rue spec 4.3` (101) and full `scripts/rue spec` (2705), `scripts/rue spec float`, `scripts/rue cli float`, `scripts/rue unit rue-codegen` (832) and `rue-cfg`, `scripts/rue quick`, spec traceability and the machine index, clippy and fmt clean; cross-builds clean for both Linux targets, with native execution left to the Linux CI lanes. Returning such an aggregate by value still ICEs for an ABI reason (argument and return slot classes disagree) and is filed as RUE-2010 for a decision.