### PR TITLE
RUE-2003: keep hermetic toolchain distributions out of the remote CAS

### DIFF
--- a/.buckconfig.local.example
+++ b/.buckconfig.local.example
@@ -33,12 +33,18 @@
 #     when remote is enabled — even for cache-only use)
 #   - default_allow_cache_upload=true (the upload-enabled executor is one gate;
 #     ordinary Rust actions defer to this separate OSS-default-off gate)
+#
+# max_total_batch_size is not one of those four: it affects no hit rate, only
+# how much one BatchReadBlobs response may carry. See "Toolchain distributions
+# do not travel through the CAS" in docs/process/build-cache.md (RUE-2003).
 
 [buck2_re_client]
 engine_address = grpc://remote.buildbuddy.io
 action_cache_address = grpc://remote.buildbuddy.io
 cas_address = grpc://remote.buildbuddy.io
 tls = true
+max_total_batch_size = 1000000
+max_decoding_message_size = 16000000
 http_headers = x-buildbuddy-api-key:<YOUR_BUILDBUDDY_API_KEY>
 
 [buck2]

--- a/buck2
+++ b/buck2
@@ -100,31 +100,44 @@ if [[ "$uses_remote_cache" -eq 1 ]] && [[ "$execution_command" -eq 1 ]] && [[ "$
     [[ "$inserted" -eq 1 ]] || args+=(--prefer-local)
 fi
 
-# BuildBuddy occasionally terminates a large BatchReadBlobs response while
-# Buck is materializing the Zig executable. The failure happens before the
-# requested action runs, and immediately replaying the same command has proved
-# sufficient. Keep the exception deliberately narrower than a general remote
-# cache retry: every observed invariant must be present in the first attempt's
-# stderr, and the replay calls DotSlash directly so there can only be one retry.
-is_truncated_zig_materialization() {
-    local line previous_is_zig_failure=0
-    local zig_failure_re='Internal error \(stage: materialize_inputs_failed\): Error materializing artifact at path `buck-out/[^[:space:]`]+/toolchains/[^[:space:]`]+/zig/[^[:space:]`]+/zig`'
+# BuildBuddy sometimes terminates a BatchReadBlobs response mid-stream while
+# Buck is materializing an artifact it declared from a cache hit. The failure
+# happens before the requested action runs, so replaying the command can only
+# repeat work that was going to be attempted anyway.
+#
+# RUE-2003 removed the reason this fires at all: the hermetic toolchain
+# distributions, the only artifacts big enough to need a batch of thousands of
+# blobs, no longer travel through the remote CAS. This stays as the
+# belt-and-braces path for a merge-group run, which has no operator to press
+# rerun, and it is no longer scoped to the Zig tree: of the twenty-three
+# failing jobs surveyed for RUE-2003, three named the rustc or rust-std tree
+# instead and RUE-1949's zig-only classifier never fired for them. Note the
+# ceiling this buys: the replay rescued five of the twenty it did fire on,
+# because the failure is deterministic for a given batch. It is a mitigation,
+# not a fix.
+#
+# Keep the exception deliberately narrower than a general remote-cache retry:
+# every invariant must be present in the first attempt's stderr, and the replay
+# calls DotSlash directly so there can only be one retry.
+is_truncated_cas_materialization() {
+    local line previous_is_materialization_failure=0
+    local materialization_failure_re='Internal error \(stage: materialize_inputs_failed\): Error materializing artifact at path `buck-out/[^[:space:]`]+`'
 
     # Buck emits the materialization failure and its transport cause as two
     # adjacent stderr diagnostics. Requiring that structure prevents ordinary
     # action/program output from assembling the classifier out of unrelated
     # lines after the requested action has already run.
     while IFS= read -r line; do
-        if [[ "$previous_is_zig_failure" -eq 1 ]] &&
+        if [[ "$previous_is_materialization_failure" -eq 1 ]] &&
            [[ "$line" == *'Error: (Failed to make BatchReadBlobs request:'* ]] &&
            { [[ "$line" == *'missing grpc-status trailer, stream was terminated without a final status (possible truncation by a proxy or load balancer)'* ]] ||
              [[ "$line" == *'Unexpected EOF decoding stream'* ]]; }; then
             return 0
         fi
-        if [[ "$line" =~ $zig_failure_re ]]; then
-            previous_is_zig_failure=1
+        if [[ "$line" =~ $materialization_failure_re ]]; then
+            previous_is_materialization_failure=1
         else
-            previous_is_zig_failure=0
+            previous_is_materialization_failure=0
         fi
     done <"$1"
     return 1
@@ -164,8 +177,8 @@ if [[ "${#args[@]}" -gt 0 ]]; then
 
         if [[ "$first_status" -ne 0 ]] && [[ "$stdout_tee_status" -eq 0 ]] &&
            [[ "$stderr_tee_status" -eq 0 ]] &&
-           is_truncated_zig_materialization "$retry_stderr"; then
-            echo "note: retrying Buck once after a truncated BuildBuddy Zig materialization" >&2
+           is_truncated_cas_materialization "$retry_stderr"; then
+            echo "note: retrying Buck once after a truncated BuildBuddy CAS materialization" >&2
             cleanup_retry_capture
             trap - EXIT
             set +e

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -97,43 +97,134 @@ intended experiment. The checked-in `.buckconfig.local.example` documents the
 same knobs for a hand-written per-checkout config; the installed user config
 is the recommended setup.
 
-### Bounded Zig materialization retry
+### Toolchain distributions do not travel through the CAS (RUE-2003)
 
-On 2026-09-03 and 2026-09-04 UTC, first attempts of CI runs
-33814662565 and 33824226528 intermittently failed before their requested tests
-ran. Buck reported `materialize_inputs_failed` for the Zig executable under
-`buck-out/.../toolchains/.../zig/.../zig`; BuildBuddy's `BatchReadBlobs`
-response ended without its final `grpc-status` trailer and the diagnostic
-called out possible proxy/load-balancer truncation. The same incident record
-also includes one `BatchReadBlobs` `Unexpected EOF decoding stream` failure for
-that stage and artifact. Plain failed-job reruns passed.
+Between 2026-09-03 16:34 UTC and 2026-09-04, CI jobs began dying in their first
+minute, and the merge queue ejected the pull requests they were validating.
+Buck reported `materialize_inputs_failed` for a toolchain path and named a
+transport cause:
 
-The repository `./buck2` wrapper therefore makes one bounded replay of the
-exact same DotSlash/Buck argv only in GitHub Actions, when those facts occur as
-an adjacent pair of Buck stderr diagnostics on a failed execution command using
-the configured remote-cache platform. The first attempt remains in the log and
-the replay streams normally. A successful replay returns success; a failed
-replay preserves the first failure's status and both attempts' output. A
-matching second failure is not retried again. Successful
-commands, compiler/test/semantic failures, other remote errors, non-Zig
-materialization failures, ordinary local configurations, and
-`RUE_NO_REMOTE_CACHE=1`, `--no-remote-cache`, and `--local-only` retain
-fail-fast behavior. Other explicit local/remote preferences are replayed
-unchanged, so this applies equally to cache-only and intentionally remote
-execution without changing either mode's semantics.
+```
+Error: (Failed to make BatchReadBlobs request: code: 'Unknown error', message:
+"protocol error: missing grpc-status trailer, stream was terminated without a
+final status (possible truncation by a proxy or load balancer)")
+```
 
-This policy is centralized in the wrapper used by CI rather than duplicated in
-workflow jobs. Interactive and other local commands still directly `exec`
-DotSlash without capture. Fork jobs without the secret never acquire the
-installed config and remain ineligible. The wrapper does not read config
-contents into the capture or print argv, configuration, or credentials; the
-temporary captures hold only the first attempt's output that was already
-streamed to the caller.
-Hermetic synthetic tests pin the exact classifier, argv replay, one-retry
-ceiling, and exit propagation. Those tests prove the repository policy, not
-that the intermittent service-side truncation has disappeared; that conclusion
-requires continued operational evidence from ordinary pull-request and
-merge-group runs.
+with `Unexpected EOF decoding stream` as the other ending. Both mean the same
+thing: BuildBuddy's response body stopped part-way.
+
+Across the failing pull-request and merge-group runs of those two days, the
+failing artifact was one of **exactly four action digests**, and all four are
+hermetic toolchain distributions — the Zig `x86_64-linux` and `aarch64-linux`
+trees, the `rustc` component, and the `rust-std` component. Nothing else in the
+graph ever failed this way, and no run before 2026-09-03 16:34 UTC contains the
+signature at all. Those four are also the only artifacts Rue has that are made
+of tens of thousands of tiny files: the Zig 0.16.0 `x86_64-linux` distribution
+is 19,546 files and 341 MiB, of which 19,544 files and 170 MiB are under the
+batch threshold. Materializing one is therefore the only thing Rue ever asks
+BuildBuddy to answer with a batch of thousands of blobs. The failures land
+within seconds of a build starting, after a few hundred kilobytes of traffic:
+this is a property of one response, not of load or of a lane's total volume.
+
+The same operation demonstrably worked three days earlier. The 2026-08-31 cache
+probe rebuilds from an emptied `buck-out`, which is the same condition, and its
+warm phase pulled `Network: Down: 483MiB` from the CAS with all four trees
+included. Nothing in the client configuration changed in between — RUE-1934
+rewrote how that config is delivered but generates it byte for byte — and
+per-lane traffic did not grow either side of the onset, so the change is on
+BuildBuddy's side rather than in this repository. What varies is *exposure*,
+because these action-cache entries come and go: a lane that finds one
+materializes the tree from the CAS and can be truncated, while a lane that
+misses extracts locally and cannot. That is why plain reruns sometimes passed,
+why merge-group runs stayed green through the evening of 2026-09-03 and began
+failing on 2026-09-04, and why the wrapper replay described below rescued only
+a quarter of the failures it caught.
+
+Two changes remove it, in that order of importance.
+
+**The distributions are no longer cache artifacts.** `http_archive`'s
+extraction is an ordinary Buck action, so `[buck2] default_allow_cache_upload =
+true` — which ordinary Rust actions need — also uploaded each unpacked
+toolchain tree and served it back from the CAS. `toolchain_distribution`
+(`toolchains/distribution.bzl`) replaces `http_archive` for all of them: the
+archive is fetched with `download_file`, which buck2's materializer serves from
+the origin URL and never through the CAS, and the extraction sets
+`allow_cache_upload = False`, an explicit opt-out that buck2 honours over the
+config default. No action-cache entry exists for these trees, so no machine can
+be served one, and the four poisoned digests are permanently orphaned. The
+archives are SHA-pinned, so the extracted bytes are what the cache would have
+returned: converting them re-ran the twelve extraction actions and invalidated
+nothing downstream.
+
+**This is not free, and the cost is not where you would guess.** An action's
+output digest is what keys its consumers, and with no action-cache entry buck2
+can only learn that digest by running the action. Every lane with a fresh
+`buck-out` therefore fetches and extracts every toolchain distribution its
+graph reaches, including a lane that would otherwise have been served entirely
+from cache and materialized nothing. Measured on the same tree, `CI` run
+33820449895 (before) against 33889388662 (after):
+
+| Lane | Before | After |
+| --- | --- | --- |
+| `clippy` (38 local actions) | 273 MiB down | 296 MiB down |
+| `release (linux-x64)` (1 local action) | 2.3 MiB down, 20s | 237 MiB down, 34s |
+| `test (linux-x64-cli-shard-2)` (0 local actions) | 2.4 MiB down, 21s | 237 MiB down, 28s |
+
+A lane that already needed a toolchain pays roughly what it paid before — the
+bytes move from BuildBuddy's CAS to the origin CDNs — and a lane that did not
+pays about 237 MiB and ten to twenty seconds it did not pay before. Across the
+whole run that was +134 seconds of job time and roughly 2.8 GiB of additional
+origin traffic. That is the price of the failing operation being impossible
+rather than merely less likely, and it is the line to reconsider first if
+BuildBuddy confirms a fix: dropping `allow_cache_upload = False` restores
+cache-served trees while leaving the bound below in place.
+
+**One BatchReadBlobs response is bounded.** The provisioned config now sets
+`max_total_batch_size = 1000000` and `max_decoding_message_size = 16000000`.
+buck2 packs blobs up to `max_total_batch_size` content bytes per request and
+uses `min(this, the server's advertised max_batch_total_size_bytes)`, so
+lowering it can only cost extra round trips. This covers every remaining CAS
+read rather than just the toolchains, and it matters because buck2's own CAS
+retry cannot help here: `remote_execution/oss/re_grpc/src/client.rs` retries
+`BatchReadBlobs` five times, but only for `Unavailable`, `ResourceExhausted`,
+`Aborted`, or an `io::Error`. The truncation arrives as `Unknown` or
+`Internal`, so buck2 treats it as fatal on the first attempt.
+
+Whether the response BuildBuddy could not send exceeded its own limit, its
+proxy's, or something else is **not settled from this side**; the bound is
+chosen with an order of magnitude of headroom under the 4 MiB message size gRPC
+servers and proxies commonly enforce, and it is the knob to revisit if the
+signature returns.
+
+The `./buck2` wrapper keeps one bounded replay of the same DotSlash/Buck argv
+in GitHub Actions when the materialization failure and the transport cause
+occur as an adjacent pair of Buck stderr diagnostics on a failed execution
+command using the configured remote-cache platform. RUE-1949 introduced it
+scoped to the Zig path; it is now scoped to any artifact, because three of the
+twenty-three failing jobs surveyed named the rustc or rust-std tree and never
+qualified for a retry at all. **Read the ceiling honestly**: of the twenty jobs
+where it did fire, the replay rescued five. The failure is deterministic for a
+given batch, so replaying the same command usually reproduces it. The retry is
+there because a merge-group run has no operator to press rerun, not because it
+works.
+
+A successful replay returns success; a failed replay preserves the first
+failure's status and both attempts' output, and is not retried again.
+Successful commands, compiler/test/semantic failures, other remote errors,
+ordinary local configurations, and `RUE_NO_REMOTE_CACHE=1`,
+`--no-remote-cache`, and `--local-only` retain fail-fast behavior. Fork jobs
+without the secret never acquire the installed config and remain ineligible.
+The wrapper does not read config contents into the capture or print argv,
+configuration, or credentials. Hermetic synthetic tests in
+`scripts/test-build-sharing.sh` pin the classifier, the argv replay, the
+one-retry ceiling, and exit propagation; they prove the repository policy, not
+that the service-side truncation has disappeared.
+
+Each required-CI step's job summary now records Buck's own `Network` byte
+counters next to the action counters (`scripts/ci-timed`), so "did this lane
+materialize a toolchain" is answerable from the summary rather than by
+reconstructing it from raw job logs, which is what RUE-2003 had to do.
+
 
 ## Full-suite host coordination
 

--- a/scripts/ci-timed
+++ b/scripts/ci-timed
@@ -80,6 +80,42 @@ if [[ "$commands" -gt 0 ]]; then
     hit_rate="$((cached * 100 / commands))%"
 fi
 
+# Buck ends every invocation with `Network: Up: <n>  Down: <n>`, counting both
+# remote-cache traffic and the toolchain archives it fetches over HTTP. Nothing
+# recorded that, so the cost of a lane's cold materialization was invisible
+# after the fact and RUE-2003's before/after had to be reconstructed from raw
+# job logs. Sum it per step instead, alongside the action counters it explains:
+# a lane whose Commands line says everything was cached and whose Down is
+# hundreds of megabytes is a lane that materialized a toolchain.
+network_up="—"
+network_down="—"
+network="$(grep -oE 'Network: Up: [0-9.]+[A-Za-z]+ +Down: [0-9.]+[A-Za-z]+' "$log" | awk '
+    function bytes(v,   n, u, m) {
+        n = v + 0
+        u = v
+        sub(/^[0-9.]+/, "", u)
+        m = 1
+        if (u == "KiB") m = 1024
+        else if (u == "MiB") m = 1048576
+        else if (u == "GiB") m = 1073741824
+        else if (u == "TiB") m = 1099511627776
+        return n * m
+    }
+    function human(b,   unit, i) {
+        split("B KiB MiB GiB TiB", unit, " ")
+        i = 1
+        while (b >= 1024 && i < 5) { b /= 1024; i++ }
+        if (i == 1) return sprintf("%dB", b)
+        return sprintf("%.1f%s", b, unit[i])
+    }
+    { up += bytes($3); down += bytes($5) }
+    END { if (NR > 0) printf "%s %s", human(up), human(down) }
+')"
+if [[ -n "$network" ]]; then
+    network_up="${network%% *}"
+    network_down="${network##* }"
+fi
+
 if [[ "$status" -eq 0 && "${RUE_CI_REQUIRE_REMOTE_ACTIONS:-0}" == "1" && "$remote" -eq 0 ]]; then
     echo "::error::remote-execution canary completed without any remotely executed Buck actions" >&2
     status=1
@@ -96,14 +132,16 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     {
         echo "### CI timing: $safe_label"
         echo
-        echo "| Result | Wall time | Test time | Cache hits | CLI cases | Buck invocations | Commands | Cached | Remote | Local |"
-        echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
-        echo "| $result | ${elapsed}s | $test_time | $hit_rate | $cli_cases | $invocations | $commands | $cached | $remote | $local_actions |"
+        echo "| Result | Wall time | Test time | Cache hits | CLI cases | Buck invocations | Commands | Cached | Remote | Local | Net down | Net up |"
+        echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+        echo "| $result | ${elapsed}s | $test_time | $hit_rate | $cli_cases | $invocations | $commands | $cached | $remote | $local_actions | $network_down | $network_up |"
         echo
         echo "<sup>Cached/Remote/Local count Buck actions by how each was obtained."
         echo "Test time is the summed duration Buck reports for the test processes"
         echo "themselves — opaque to those counters, and where a corpus lane's wall"
-        echo "time actually goes.</sup>"
+        echo "time actually goes. Net down/up is Buck's own byte count for the"
+        echo "invocations in this step: remote-cache traffic plus the toolchain"
+        echo "archives fetched from their origin.</sup>"
         echo
     } >>"$GITHUB_STEP_SUMMARY"
 fi

--- a/scripts/provision-build-cache
+++ b/scripts/provision-build-cache
@@ -43,6 +43,20 @@ engine_address = grpc://remote.buildbuddy.io
 action_cache_address = grpc://remote.buildbuddy.io
 cas_address = grpc://remote.buildbuddy.io
 tls = true
+# Bound one BatchReadBlobs response (RUE-2003). buck2 packs blobs up to this
+# many content bytes per request and takes min(this, the server's advertised
+# max_batch_total_size_bytes), so lowering it can only cost extra round trips.
+# During 2026-09-03/04 every response carrying thousands of small blobs came
+# back cut off mid-stream -- `missing grpc-status trailer` or `Unexpected EOF
+# decoding stream` -- and buck2's own CAS retry does not cover either, because
+# neither maps to Unavailable, ResourceExhausted, or Aborted. One megabyte
+# leaves an order of magnitude of headroom under the 4 MiB message size gRPC
+# servers and proxies commonly enforce.
+max_total_batch_size = 1000000
+# The client must never be the side that truncates: keep the decode ceiling
+# far above any response the bound above can produce. buck2 defaults this to
+# twice max_total_batch_size and refuses a value below it.
+max_decoding_message_size = 16000000
 CONFIG
         printf 'http_headers = x-buildbuddy-api-key:%s\n' "$key"
         cat <<'CONFIG'

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -87,6 +87,16 @@ Error: (Failed to make BatchReadBlobs request: Unexpected EOF decoding stream)
 EOF
 }
 
+# RUE-1949's classifier matched only the Zig tree. The same transport failure
+# lands on the rustc and rust-std distributions too, and those merge-group
+# ejections were never retried (RUE-2003).
+rust_tree_failure() {
+    cat <<'EOF'
+Internal error (stage: materialize_inputs_failed): Error materializing artifact at path `buck-out/v2/art/toolchains/01d1977e3655e393/rust/__rustc-linux-x86_64__/rustc-linux-x86_64/rustc/bin/rustc`
+Error: (Failed to make BatchReadBlobs request: code: 'Internal error', message: "Unexpected EOF decoding stream.")
+EOF
+}
+
 disjoint_grpc_failure() {
     cat <<'EOF'
 Internal error (stage: materialize_inputs_failed): Error materializing artifact at path `buck-out/v2/art/toolchains/01d1977e3655e393/zig/__dist-linux-x86_64__/dist-linux-x86_64/zig`
@@ -153,6 +163,9 @@ test_cache_install() {
         "$(grep -Eq '^default_allow_cache_upload = true$' "$config" && echo 0 || echo 1)"
     check "cache: the remote-cache execution platform is selected" \
         "$(grep -Eq '^execution_platforms = root//platforms:remote_cache$' "$config" && echo 0 || echo 1)"
+    check "cache: one BatchReadBlobs response is bounded" \
+        "$(grep -Eq '^max_total_batch_size = 1000000$' "$config" &&
+           grep -Eq '^max_decoding_message_size = 16000000$' "$config" && echo 0 || echo 1)"
     check "cache: install writes nothing into the checkout" \
         "$([ ! -e "$sb/checkout/.buckconfig.local" ] && echo 0 || echo 1)"
 
@@ -276,7 +289,7 @@ test_buck_wrapper_links_installed_config() {
     rm -rf "$sb"
 }
 
-test_buck_wrapper_retries_only_truncated_zig_materialization() {
+test_buck_wrapper_retries_only_truncated_cas_materialization() {
     local sb out rc fixture variant missing preference_ok status_ok expected_output
     sb="$(mktemp -d)"
     make_wrapper_sandbox "$sb"
@@ -287,9 +300,13 @@ EOF
 
     # Both transport endings observed for this incident classify, and a clean
     # replay returns success while retaining both attempts' output.
-    for variant in grpc eof; do
+    for variant in grpc eof rust; do
         rm -f "$sb"/attempt.* "$sb"/retry.args.*
-        if [[ "$variant" == grpc ]]; then fixture="$(grpc_failure)"; else fixture="$(eof_failure)"; fi
+        case "$variant" in
+            grpc) fixture="$(grpc_failure)" ;;
+            eof) fixture="$(eof_failure)" ;;
+            rust) fixture="$(rust_tree_failure)" ;;
+        esac
         write_retry_attempt "$sb" 1 41 "first attempt stdout ($variant)"
         write_retry_stderr_attempt "$sb" 1 "$fixture"
         write_retry_attempt "$sb" 2 0 "second attempt succeeded ($variant)"
@@ -387,12 +404,12 @@ EOF
     done
 
     # Removing any one invariant from the conjunction fails closed.
-    for missing in stage zig batch transport; do
+    for missing in stage path batch transport; do
         rm -f "$sb"/attempt.* "$sb"/retry.args.*
         fixture="$(grpc_failure)"
         case "$missing" in
             stage) fixture="${fixture/materialize_inputs_failed/materialize_failed}" ;;
-            zig) fixture="${fixture/toolchains\/01d1977e3655e393\/zig/toolchains\/01d1977e3655e393\/rust}" ;;
+            path) fixture="${fixture/Error materializing artifact at path/Error preparing artifact}" ;;
             batch) fixture="${fixture/BatchReadBlobs/ReadBlob}" ;;
             transport) fixture="${fixture/missing grpc-status trailer, stream was terminated without a final status (possible truncation by a proxy or load balancer)/connection reset by peer}" ;;
         esac
@@ -491,7 +508,7 @@ EOF
 test_cache_install
 test_buck_wrapper_prefers_local_cache_misses
 test_buck_wrapper_links_installed_config
-test_buck_wrapper_retries_only_truncated_zig_materialization
+test_buck_wrapper_retries_only_truncated_cas_materialization
 test_full_suite_orchestration
 
 echo "--------------------------------------------------"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -929,6 +929,8 @@ echo '✓ Pass: root//:ui-tests (7.5s)'
 echo '✗ Fail: root//:cli-tests (2s)'
 echo 'Skip: root//:stress-tests'
 echo 'cli-tests: measured 37 cases in /tmp/timings.jsonl'
+echo 'Network: Up: 214KiB  Down: 274MiB  (GRPC-SESSION-ID)'
+echo 'Network: Up: 1.0MiB  Down: 2.0GiB'
 exit "${FAKE_EXIT:-0}"
 EOF
   chmod +x "$sb/fake-command"
@@ -949,6 +951,10 @@ EOF
     "$(grep -Fq '| 81.750s |' "$sb/summary" && echo 0 || echo 1)"
   check "ci-timed: action-cache hit rate is reported" \
     "$(grep -Fq '| 66% |' "$sb/summary" && echo 0 || echo 1)"
+  # 274MiB + 2.0GiB down, 214KiB + 1.0MiB up, summed across invocations and
+  # both unit spellings.
+  check "ci-timed: network bytes are aggregated across invocations" \
+    "$(grep -Fq '| 2.3GiB | 1.2MiB |' "$sb/summary" && echo 0 || echo 1)"
 
   rc=0
   RUE_CI_REQUIRE_REMOTE_ACTIONS=1 "$sb/ci-timed" "remote wrapper" -- "$sb/fake-command" >/dev/null 2>&1 || rc=$?

--- a/toolchains/distribution.bzl
+++ b/toolchains/distribution.bzl
@@ -1,0 +1,107 @@
+"""Hermetic toolchain distributions, fetched from their origin instead of the cache.
+
+Every pinned toolchain payload Rue downloads — the Rust `rustc`, `rust-std`,
+Clippy, and rustfmt components, and the Zig distribution — used to be a
+`prelude//:http_archive`. That rule's extraction step is an ordinary Buck
+action, so with `[buck2] default_allow_cache_upload = true` (which the shared
+BuildBuddy configuration sets, because ordinary Rust actions need it) the
+*extracted tree* was uploaded to the remote CAS and later served back from it.
+
+Those trees are the only artifacts in Rue's graph made of tens of thousands of
+tiny files: the Zig 0.16.0 `x86_64-linux` distribution alone is 19,546 files
+and 341 MiB, of which 19,544 files and 170 MiB are small enough to travel in
+`BatchReadBlobs` rather than the ByteStream API. Materializing one is therefore
+the only thing Rue ever asks BuildBuddy to answer with a batch of thousands of
+blobs, and from 2026-09-03 16:34 UTC those answers started coming back cut off
+mid-stream — `missing grpc-status trailer, stream was terminated without a
+final status`, or `Unexpected EOF decoding stream` — which buck2 reports as
+`materialize_inputs_failed` and does not retry, because neither maps to a
+retryable gRPC code. Across the merge-group failures of 2026-09-03/04 the
+failing artifact was one of exactly four action digests, and all four are these
+distributions (RUE-2003).
+
+`toolchain_distribution` keeps them out of that path entirely:
+
+- the archive is fetched with `download_file`, which buck2's materializer
+  serves from the origin URL and never through the CAS;
+- the extraction declares `allow_cache_upload = False`, so no action-cache
+  entry is ever written for the tree and no machine can be served one. That
+  flag is an explicit opt-out of `default_allow_cache_upload`, which buck2
+  documents as "default for per-action `allow_cache_upload`, to make it
+  opt-out instead of opt-in".
+
+The archives are SHA-pinned, so extracting locally produces the same bytes the
+cache would have returned; nothing about reproducibility or hermeticity
+changes. What is given up is sharing the *unpacked* tree between machines.
+
+The cost is real and lands in a place worth naming, because an action's output
+digest is what keys its consumers: with no action-cache entry, buck2 can only
+learn that digest by running the action, so every lane with a fresh `buck-out`
+now fetches and extracts every distribution its graph reaches — including a
+lane that would otherwise have been served entirely from cache and materialized
+nothing. Measured across one CI run that is about 237 MiB and ten to twenty
+seconds per such lane. docs/process/build-cache.md has the before/after table
+and the argument for paying it.
+
+Execution placement is deliberately left at buck2's default, matching what
+`http_archive` did for a SHA256-pinned archive: ordinary commands carry
+`--prefer-local` from the `./buck2` wrapper and extract on the runner, while
+`--prefer-remote` still extracts on the worker, so the remote-execution canary
+is unchanged.
+"""
+
+def _strip_components(strip_prefix: str) -> int:
+    return len([c for c in strip_prefix.split("/") if c != ""])
+
+def _toolchain_distribution_impl(ctx: AnalysisContext) -> list[Provider]:
+    archive = ctx.actions.declare_output("archive.tar.xz")
+    ctx.actions.download_file(
+        archive.as_output(),
+        ctx.attrs.url,
+        sha256 = ctx.attrs.sha256,
+    )
+
+    # The output directory keeps the target's own name, so a buck-out path
+    # names the distribution it came from exactly as `http_archive` did.
+    output = ctx.actions.declare_output(ctx.label.name, dir = True)
+
+    # `sh -c SCRIPT NAME ARG...` binds $0 to NAME and $1.. to the arguments, so
+    # every path reaches tar as a positional word and needs no quoting in the
+    # command string. Actions run from the project root and buck2 substitutes
+    # project-relative paths, which is what `-C` and `-f` want.
+    #
+    # `--strip-components=N PREFIX` mirrors the prelude: the prefix is also a
+    # member selector, so a distribution that ever grew a sibling top-level
+    # directory would be extracted the same way it is today rather than
+    # silently gaining files.
+    ctx.actions.run(
+        cmd_args(
+            "/bin/sh",
+            "-c",
+            'set -eu; mkdir -p "$1"; exec tar -J -x -f "$2" -C "$1" --strip-components="$3" "$4"',
+            "toolchain_distribution",
+            output.as_output(),
+            archive,
+            str(_strip_components(ctx.attrs.strip_prefix)),
+            ctx.attrs.strip_prefix,
+        ),
+        category = "toolchain_distribution",
+        identifier = ctx.label.name,
+        # The point of this rule. See the module docstring.
+        allow_cache_upload = False,
+    )
+
+    return [DefaultInfo(default_output = output)]
+
+toolchain_distribution = rule(
+    impl = _toolchain_distribution_impl,
+    attrs = {
+        "sha256": attrs.string(
+            doc = "SHA256 of the archive. Pins the payload; buck2 verifies it.",
+        ),
+        "strip_prefix": attrs.string(
+            doc = "Top-level directory inside the archive, removed on extraction.",
+        ),
+        "url": attrs.string(doc = "Origin URL of the `.tar.xz` archive."),
+    },
+)

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -5,6 +5,7 @@
 # archive also contains Cargo, rust-analyzer, LLVM tools, and large documentation
 # trees; materializing those unused payloads in every worktree is wasteful.
 
+load("@toolchains//:distribution.bzl", "toolchain_distribution")
 load(":defs.bzl", "RUST_VERSION", "RUST_STD_RELEASES", "hermetic_rust_toolchain", "rust_host_archives", "rustfmt", "host_rustfmt")
 load("@root//:test_defs.bzl", "rue_sh_test")
 
@@ -39,39 +40,39 @@ rust_host_archives("macos-x86_64", "x86_64-apple-darwin")
 # Standard-library components used by the host toolchains and fixed-target Rue
 # runtime rules. They are compiler-host agnostic: whichever hermetic rustc runs
 # consumes the same pinned target sysroot.
-http_archive(
+#
+# `toolchain_distribution` rather than `http_archive` for the reason in
+# toolchains/distribution.bzl: the unpacked tree never travels through the
+# remote CAS (RUE-2003).
+toolchain_distribution(
     name = "rust-std-x86_64-unknown-linux-gnu",
-    urls = [RUST_STD_RELEASES["x86_64-unknown-linux-gnu"].url],
+    url = RUST_STD_RELEASES["x86_64-unknown-linux-gnu"].url,
     sha256 = RUST_STD_RELEASES["x86_64-unknown-linux-gnu"].sha256,
     strip_prefix = "rust-std-{}-x86_64-unknown-linux-gnu".format(RUST_VERSION),
-    type = "tar.xz",
     visibility = ["PUBLIC"],
 )
 
-http_archive(
+toolchain_distribution(
     name = "rust-std-aarch64-unknown-linux-gnu",
-    urls = [RUST_STD_RELEASES["aarch64-unknown-linux-gnu"].url],
+    url = RUST_STD_RELEASES["aarch64-unknown-linux-gnu"].url,
     sha256 = RUST_STD_RELEASES["aarch64-unknown-linux-gnu"].sha256,
     strip_prefix = "rust-std-{}-aarch64-unknown-linux-gnu".format(RUST_VERSION),
-    type = "tar.xz",
     visibility = ["PUBLIC"],
 )
 
-http_archive(
+toolchain_distribution(
     name = "rust-std-aarch64-apple-darwin",
-    urls = [RUST_STD_RELEASES["aarch64-apple-darwin"].url],
+    url = RUST_STD_RELEASES["aarch64-apple-darwin"].url,
     sha256 = RUST_STD_RELEASES["aarch64-apple-darwin"].sha256,
     strip_prefix = "rust-std-{}-aarch64-apple-darwin".format(RUST_VERSION),
-    type = "tar.xz",
     visibility = ["PUBLIC"],
 )
 
-http_archive(
+toolchain_distribution(
     name = "rust-std-x86_64-apple-darwin",
-    urls = [RUST_STD_RELEASES["x86_64-apple-darwin"].url],
+    url = RUST_STD_RELEASES["x86_64-apple-darwin"].url,
     sha256 = RUST_STD_RELEASES["x86_64-apple-darwin"].sha256,
     strip_prefix = "rust-std-{}-x86_64-apple-darwin".format(RUST_VERSION),
-    type = "tar.xz",
     visibility = ["PUBLIC"],
 )
 

--- a/toolchains/rust/defs.bzl
+++ b/toolchains/rust/defs.bzl
@@ -4,6 +4,7 @@
 # for use with Buck2's Rust rules.
 
 load("@prelude//rust:rust_toolchain.bzl", "PanicRuntime", "RustToolchainInfo")
+load("@toolchains//:distribution.bzl", "toolchain_distribution")
 
 # Rust 1.92.0 release info
 RUST_VERSION = "1.92.0"
@@ -70,34 +71,37 @@ RUST_STD_RELEASES = {
 }
 
 def rust_host_archives(name: str, triple: str):
-    """Declare the minimal official host components for one Rust platform."""
+    """Declare the minimal official host components for one Rust platform.
+
+    `toolchain_distribution` rather than `http_archive`: an unpacked component
+    tree is tens of thousands of small files, and serving one from the remote
+    CAS is what RUE-2003 traced the merge queue's `materialize_inputs_failed`
+    ejections to. See toolchains/distribution.bzl.
+    """
     release = RUST_RELEASES[triple]
-    native.http_archive(
+    toolchain_distribution(
         name = "rustc-{}".format(name),
-        urls = [release.rustc_url],
+        url = release.rustc_url,
         sha256 = release.rustc_sha256,
         strip_prefix = "rustc-{}-{}".format(RUST_VERSION, triple),
-        type = "tar.xz",
         visibility = [],
     )
-    native.http_archive(
+    toolchain_distribution(
         name = "clippy-{}".format(name),
-        urls = [release.clippy_url],
+        url = release.clippy_url,
         sha256 = release.clippy_sha256,
         strip_prefix = "clippy-{}-{}".format(RUST_VERSION, triple),
-        type = "tar.xz",
         visibility = [],
     )
-    native.http_archive(
+    toolchain_distribution(
         name = "rustfmt-dist-{}".format(name),
-        urls = [release.rustfmt_url],
+        url = release.rustfmt_url,
         sha256 = release.rustfmt_sha256,
         strip_prefix = "rustfmt-{}-{}".format(RUST_VERSION, triple),
-        type = "tar.xz",
         visibility = [],
     )
 
-# Paths within the extracted Rust component archives. After http_archive strips
+# Paths within the extracted Rust component archives. After extraction strips
 # each outer prefix, we have:
 #   rustc/bin/rustc, rustc/bin/rustdoc
 #   rustc/lib/rustlib/{triple}/bin/rust-lld (linker tools)
@@ -229,13 +233,13 @@ hermetic_rust_toolchain = rule(
         # for the execution platform. A target-configured dep would materialize
         # the same archive again for every debug/release target configuration.
         "rustc_distribution": attrs.exec_dep(
-            doc = "The downloaded rustc component (from http_archive)",
+            doc = "The downloaded rustc component (from toolchain_distribution)",
         ),
         "standard_library_distribution": attrs.exec_dep(
-            doc = "The downloaded rust-std component (from http_archive)",
+            doc = "The downloaded rust-std component (from toolchain_distribution)",
         ),
         "clippy_distribution": attrs.exec_dep(
-            doc = "The downloaded Clippy component (from http_archive)",
+            doc = "The downloaded Clippy component (from toolchain_distribution)",
         ),
         "merge_script": attrs.source(
             doc = "Portable script that assembles a relocatable Rust sysroot",
@@ -300,10 +304,10 @@ rustfmt = rule(
         # rustfmt runs on the execution host; keep its component archives out
         # of each target configuration for the same reason as the toolchain.
         "rustc_distribution": attrs.exec_dep(
-            doc = "The downloaded rustc component (from http_archive)",
+            doc = "The downloaded rustc component (from toolchain_distribution)",
         ),
         "rustfmt_distribution": attrs.exec_dep(
-            doc = "The downloaded rustfmt component (from http_archive)",
+            doc = "The downloaded rustfmt component (from toolchain_distribution)",
         ),
     },
 )

--- a/toolchains/zig/defs.bzl
+++ b/toolchains/zig/defs.bzl
@@ -5,6 +5,8 @@ tree as a hidden input so the compiler executable, bundled libc descriptions,
 and archive implementation all participate in action keys and remote inputs.
 """
 
+load("@toolchains//:distribution.bzl", "toolchain_distribution")
+
 ZIG_VERSION = "0.16.0"
 
 ZIG_RELEASES = {
@@ -35,14 +37,19 @@ ZigToolchainInfo = provider(fields = [
 ])
 
 def zig_host_archive(name: str, platform: str):
-    """Declare one official, SHA-pinned Zig host distribution."""
+    """Declare one official, SHA-pinned Zig host distribution.
+
+    `toolchain_distribution` rather than `http_archive`: the unpacked tree is
+    19,546 files, and serving one from the remote CAS is what RUE-2003 traced
+    the merge queue's `materialize_inputs_failed` ejections to. See
+    toolchains/distribution.bzl.
+    """
     release = ZIG_RELEASES[platform]
-    native.http_archive(
+    toolchain_distribution(
         name = "dist-{}".format(name),
-        urls = [release.url],
+        url = release.url,
         sha256 = release.sha256,
         strip_prefix = "zig-{}-{}".format(platform, ZIG_VERSION),
-        type = "tar.xz",
         visibility = [],
     )
 


### PR DESCRIPTION
Fixes RUE-2003.

CI jobs have been dying in their first minute since 2026-09-03 16:34 UTC with `materialize_inputs_failed` and a truncated BuildBuddy `BatchReadBlobs` response, and the merge queue has been ejecting approved PRs. In every failing job the artifact is one of exactly four action digests, and all four are hermetic toolchain distributions: the Zig x86_64 and aarch64 trees, `rustc`, and `rust-std`. They are the only artifacts we make of tens of thousands of tiny files (Zig alone is 19,546 files and 341 MiB, all but two under the batch threshold), so materializing one is the only time we ask BuildBuddy for a batch of thousands of blobs. The failures land seconds into a build after a few hundred KiB, per-lane traffic is unchanged across the onset, RUE-1934 generates the client config byte for byte identically, and the same warm-from-CAS operation succeeded on 2026-08-31 at 483 MiB down. This is the service's handling of one large response, not our volume and not our config. RUE-1937 only exposed it by re-keying every Linux link so cached links became local misses that need a toolchain on disk; the intermittency is whether a lane gets an action-cache hit for the tree (materialize from CAS, can be truncated) or a miss (extract the tarball locally, cannot).

`toolchain_distribution` replaces `http_archive` for all twelve distributions: the archive comes from its origin URL through `download_file`, and the extraction sets `allow_cache_upload = False`, so the trees never enter the CAS and the failing operation cannot occur. The provisioned config also bounds one `BatchReadBlobs` response, since buck2's own CAS retry ignores the `Unknown`/`Internal` codes this arrives as. RUE-1949's replay is generalized from the Zig path to any artifact (3 of the 23 surveyed failures never qualified for it) with its measured 5-of-20 rescue rate recorded rather than implied, kept because a merge-group run has no operator. `scripts/ci-timed` reports buck2's `Network` counters per step so this is measurable next time.

The cost is measured and deliberate: a lane that already needed a toolchain is unchanged (clippy 273 to 296 MiB); a lane that did not now pays about 237 MiB and 10 to 20 s, about 134 s and 2.8 GiB across a run, because an action's output digest keys its consumers and buck2 can only learn it by running the extraction. Dropping the one `allow_cache_upload = False` line restores cache-served trees if BuildBuddy confirms a fix on their side.

Evidence: two independent CI runs on this branch, 33889388662 and 33890275789, both green with zero `materialize_inputs_failed`, and per-lane `Network: Down` identical across the two runs (a deterministic fetch of the pinned tarballs). The remote-execution canary only runs in the merge group and is exercised for the first time there; it already passed `--no-remote-cache`, which executes the same extraction on the worker. Local: the twelve converted extractions invalidated nothing downstream, and the build-sharing and wrapper-script suites (230 checks) pass, including a new rustc-tree retry fixture. Follow-ups filed: RUE-2009 (silent no-cache daemons).