### PR TITLE
RUE-1994: report query worker spawn failure as a diagnostic, not a panic

### DIFF
--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -212,7 +212,10 @@ pub(crate) fn project_backend_structured_object(
         }
         Err(crate::session::PipelineRequestControl::Abort(abort)) => {
             Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-                format!("uncancellable structured object projection aborted: {abort:?}"),
+                crate::session::abort_internal_message(
+                    "uncancellable structured object projection",
+                    &abort,
+                ),
             )))
         }
         Err(crate::session::PipelineRequestControl::Parked(_)) => {

--- a/crates/rue-compiler/src/revisioned_query_database/body/transactions.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/transactions.rs
@@ -34,9 +34,13 @@ pub(in crate::revisioned_query_database) fn classify_well_known_dependency_abort
         QueryAbort::Canceled | QueryAbort::MissingInput(_) => {
             WellKnownDependencyAbortClass::Incomplete
         }
-        QueryAbort::Cycle(_) | QueryAbort::ForeignRuntime | QueryAbort::UnpublishedRevision(_) => {
-            WellKnownDependencyAbortClass::Propagate
-        }
+        QueryAbort::Cycle(_)
+        | QueryAbort::ForeignRuntime
+        | QueryAbort::UnpublishedRevision(_)
+        // A refused worker thread is a host condition, not missing input. It
+        // propagates so the requesting boundary can publish it as an internal
+        // error rather than reporting the dependency as merely incomplete.
+        | QueryAbort::WorkerSpawn(_) => WellKnownDependencyAbortClass::Propagate,
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database/shared.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/shared.rs
@@ -447,7 +447,8 @@ where
             Some(
                 QueryAbort::ForeignRuntime
                 | QueryAbort::MissingInput(_)
-                | QueryAbort::UnpublishedRevision(_),
+                | QueryAbort::UnpublishedRevision(_)
+                | QueryAbort::WorkerSpawn(_),
             )
             | None => AbortedQueryReason::Canceled,
         };

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -357,10 +357,25 @@ impl From<CompileError> for PipelineRequestControl {
 }
 
 pub(crate) fn pipeline_abort_errors(context: &str, abort: rue_query::QueryAbort) -> CompileErrors {
-    CompileError::without_span(ErrorKind::InternalError(format!(
-        "{context} query aborted: {abort:?}"
+    CompileError::without_span(ErrorKind::InternalError(abort_internal_message(
+        context, &abort,
     )))
     .into()
+}
+
+/// Renders one query abort as the message of an internal-error diagnostic.
+///
+/// A refused physical worker thread is a condition of the host the compiler is
+/// running on rather than a defect in the compiler or the program, so it keeps
+/// its own contracted sentence: it names the operating system's refusal and the
+/// worker budget that was live, and a driver or harness can recognize it
+/// without parsing a structural dump. Every other abort keeps the structural
+/// rendering, which is a compiler-internal condition worth reading as one.
+pub(crate) fn abort_internal_message(context: &str, abort: &rue_query::QueryAbort) -> String {
+    match abort {
+        rue_query::QueryAbort::WorkerSpawn(failure) => failure.to_string(),
+        abort => format!("{context} query aborted: {abort:?}"),
+    }
 }
 
 impl From<CompileErrors> for SemanticRequestControl {

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -2028,8 +2028,8 @@ impl CompilerSession {
                 )
                 .map_err(|abort| {
                     crate::CompileErrors::from(crate::CompileError::without_span(
-                        crate::ErrorKind::InternalError(format!(
-                            "codegen query aborted: {abort:?}"
+                        crate::ErrorKind::InternalError(crate::session::abort_internal_message(
+                            "codegen", &abort,
                         )),
                     ))
                 })?;
@@ -2042,7 +2042,9 @@ impl CompilerSession {
             }
             let terminal = attempt.into_result().map_err(|abort| {
                 crate::CompileErrors::from(crate::CompileError::without_span(
-                    crate::ErrorKind::InternalError(format!("codegen query aborted: {abort:?}")),
+                    crate::ErrorKind::InternalError(crate::session::abort_internal_message(
+                        "codegen", &abort,
+                    )),
                 ))
             })?;
             let rue_query::QueryOutcome::Success(unit) = terminal.outcome() else {

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -6340,3 +6340,39 @@ fn editing_one_candidate_rescans_only_that_candidate() {
         ]
     );
 }
+
+#[test]
+fn a_refused_query_worker_becomes_an_internal_error_diagnostic() {
+    let abort = rue_query::QueryAbort::WorkerSpawn(rue_query::WorkerSpawnFailure::new(
+        &std::io::Error::from_raw_os_error(35),
+        7,
+        8 * 1024 * 1024,
+    ));
+    let errors = pipeline_abort_errors("rooted CFG", abort);
+
+    let error = errors
+        .first()
+        .expect("a refusal must publish one diagnostic");
+    assert_eq!(error.kind.code(), crate::ErrorCode::INTERNAL_ERROR);
+    let crate::ErrorKind::InternalError(message) = &error.kind else {
+        panic!(
+            "a refused worker thread must be an internal error: {:?}",
+            error.kind
+        )
+    };
+    assert!(
+        message.starts_with(rue_query::WORKER_SPAWN_MESSAGE_PREFIX),
+        "the diagnostic must open with the contracted sentence: {message}"
+    );
+    assert!(
+        message.ends_with("; 7 workers of 8 MiB stack were live"),
+        "the diagnostic must name the live worker budget: {message}"
+    );
+    assert!(
+        message.contains("os error 35"),
+        "the diagnostic must name the host's own refusal: {message}"
+    );
+    // A resource condition is not a cancellation: it must not be rendered as
+    // the structural dump every other abort gets.
+    assert!(!message.contains("query aborted"), "{message}");
+}

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -850,9 +850,9 @@ pub fn cancellable_executable_in_compile_scope(
         }
         Err(crate::session::PipelineRequestControl::Abort(abort)) => {
             CancellableCompileOutcome::Errors(crate::CompileErrors::from(
-                crate::CompileError::without_span(crate::ErrorKind::InternalError(format!(
-                    "cancellable compile query aborted: {abort:?}"
-                ))),
+                crate::CompileError::without_span(crate::ErrorKind::InternalError(
+                    crate::session::abort_internal_message("cancellable compile", &abort),
+                )),
             ))
         }
         Err(crate::session::PipelineRequestControl::Parked(park)) => {

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -27,6 +27,10 @@ rue_binary(
         # as the spec suite does, so the `spec` mode's templating can't drift.
         "//crates/rue-test-runner:rue-test-runner",
         "//crates/rue-error:rue-error",
+        # The harness classifies a refused query-runtime worker thread as a host
+        # resource condition rather than a corpus failure, and matches on the
+        # runtime's own contracted message prefix to do it (RUE-1994).
+        "//crates/rue-query:rue-query",
         "//third-party:serde",
         # Generated native runs use a unique RAII work directory so every
         # normal exit path removes sources and binaries (RUE-589).

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -242,6 +242,10 @@ enum CaseOutcome {
     Ineligible(IneligibleReason),
     /// An eligible case was rejected by the shared compiler front end.
     FrontendFailure(String),
+    /// The host, not the compiler, stopped the case: the query runtime could
+    /// not obtain a worker thread. Nothing was judged, so this is neither an
+    /// agreement nor evidence of a defect — but it is not a green run either.
+    HarnessResource(String),
     /// Interpretation hit a resource limit or compiler/oracle contract breach.
     OracleFailure(String),
     /// The oracle ran but disagreed with the expected behavior.
@@ -387,6 +391,10 @@ struct Report {
     disagreements: Vec<String>,
     /// corpus discovery/read/parse failures — the harness did not check all inputs
     harness_failures: Vec<String>,
+    /// host resource conditions — the machine, not the corpus or the compiler,
+    /// stopped these cases. Reported apart from harness failures so a loaded
+    /// host cannot read as a broken harness or a real disagreement.
+    harness_resource: Vec<String>,
 }
 
 impl Report {
@@ -401,6 +409,7 @@ impl Report {
                 *self.ineligible_reasons.entry(reason).or_default() += 1;
             }
             CaseOutcome::FrontendFailure(failure) => self.frontend_failures.push(failure),
+            CaseOutcome::HarnessResource(condition) => self.harness_resource.push(condition),
             CaseOutcome::OracleFailure(failure) => self.oracle_failures.push(failure),
             CaseOutcome::Disagreement(disagreement) => self.disagreements.push(disagreement),
         }
@@ -428,6 +437,7 @@ impl Report {
             + self.frontend_failures.len() as u32
             + self.oracle_failures.len() as u32
             + self.disagreements.len() as u32
+            + self.harness_resource.len() as u32
     }
 
     fn ineligible_breakdown_lines(&self) -> Vec<String> {
@@ -443,6 +453,61 @@ impl Report {
             .map(|(reason, count)| format!("    {reason}: {count}"))
             .collect()
     }
+}
+
+/// Classify one already-rendered compiler failure.
+///
+/// A refused query-runtime worker thread is a condition of the machine this
+/// harness is running on — too many live threads or too little address space
+/// for another 8 MiB stack — and it reaches here looking exactly like a
+/// front-end rejection. Separating the two is the whole point: a resource
+/// condition judged nothing, so calling it a front-end failure would report the
+/// host as a compiler defect (RUE-1994).
+fn classify_frontend_failure(message: String) -> CaseOutcome {
+    if message.contains(rue_query::WORKER_SPAWN_MESSAGE_PREFIX) {
+        CaseOutcome::HarnessResource(message)
+    } else {
+        CaseOutcome::FrontendFailure(message)
+    }
+}
+
+/// Environment variable bounding this harness's in-process query concurrency.
+const ORACLE_JOBS_VAR: &str = "RUE_ORACLE_JOBS";
+
+/// Read `RUE_ORACLE_JOBS`, which bounds the compiler's shared structured-query
+/// concurrency for every case this process compiles.
+///
+/// `None` keeps the compiler's own default (host parallelism), which is the
+/// behavior every existing invocation gets. A loaded host — several worktrees
+/// building, corpora running side by side — sets a smaller number and trades
+/// wall time for worker threads it can actually obtain.
+fn parse_oracle_jobs(raw: Option<&str>) -> Result<Option<usize>, String> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    match trimmed.parse::<usize>() {
+        Ok(0) => Err(format!(
+            "{ORACLE_JOBS_VAR} must be a positive worker count, got {trimmed:?}: \
+             zero would leave no thread to run a case on"
+        )),
+        Ok(jobs) => Ok(Some(jobs)),
+        Err(_) => Err(format!(
+            "{ORACLE_JOBS_VAR} must be a positive whole number of workers, got {trimmed:?}"
+        )),
+    }
+}
+
+/// Apply the `RUE_ORACLE_JOBS` bound to the shared compiler query concurrency.
+fn apply_oracle_jobs() -> Result<(), String> {
+    let raw = std::env::var(ORACLE_JOBS_VAR).ok();
+    if let Some(jobs) = parse_oracle_jobs(raw.as_deref())? {
+        rue_compiler::configure_thread_pool(jobs);
+    }
+    Ok(())
 }
 
 fn main() -> ExitCode {
@@ -461,6 +526,10 @@ fn main() -> ExitCode {
 }
 
 fn run() -> ExitCode {
+    if let Err(message) = apply_oracle_jobs() {
+        eprintln!("rue-oracle-diff: {message}");
+        return ExitCode::FAILURE;
+    }
     // Subcommand dispatch: `rue-oracle-diff fuzz [...]` runs the differential
     // *fuzzer* (generate valid programs, cross-check oracle vs compiled binary);
     // with no subcommand it runs the corpus differential (below).
@@ -645,7 +714,11 @@ fn model_gap_observation(case: &Case, outcome: &CaseOutcome) -> model_gaps::Obse
         CaseOutcome::Ineligible(_) => model_gaps::Observation::OtherIneligible,
         CaseOutcome::FrontendFailure(_)
         | CaseOutcome::OracleFailure(_)
-        | CaseOutcome::Disagreement(_) => model_gaps::Observation::HardFailure,
+        | CaseOutcome::Disagreement(_)
+        // A host that refused a worker thread already fails the run, and the
+        // case never reached the oracle. Diagnosing stale registry debt on top
+        // of that would be reading a loaded machine as coverage evidence.
+        | CaseOutcome::HarnessResource(_) => model_gaps::Observation::HardFailure,
     }
 }
 
@@ -670,6 +743,10 @@ fn finish_report(report: &Report, corpus: &str) -> ExitCode {
     for failure in &report.harness_failures {
         println!("\n  ✗ {failure}");
     }
+    println!("  HARNESS RESOURCE: {}", report.harness_resource.len());
+    for condition in &report.harness_resource {
+        println!("\n  ⚠ {condition}");
+    }
     println!("  FRONTEND FAILURES: {}", report.frontend_failures.len());
     for failure in &report.frontend_failures {
         println!("\n  ✗ {failure}");
@@ -681,6 +758,22 @@ fn finish_report(report: &Report, corpus: &str) -> ExitCode {
     println!("  DISAGREEMENTS:    {}", report.disagreements.len());
     for d in &report.disagreements {
         println!("\n  ✗ {d}");
+    }
+
+    // A host resource condition judged nothing, so it is reported before the
+    // coverage checks below: the run is not green, but the cause is the machine
+    // rather than the corpus, the compiler, or the oracle. Say so explicitly and
+    // name the lever, because the alternative — reading a loaded host as a
+    // corpus failure — is exactly what RUE-1994 fixed.
+    if !report.harness_resource.is_empty() {
+        println!(
+            "\n{} case(s) stopped on a host resource condition, not a disagreement — \
+             each ⚠ above carries the operating system's own refusal and the worker \
+             budget that was live. Lower in-process concurrency with {ORACLE_JOBS_VAR}=N \
+             (or run fewer corpora and worktrees at once) and rerun.",
+            report.harness_resource.len(),
+        );
+        return ExitCode::FAILURE;
     }
 
     // Ineligible and unmodeled cases do not judge compiler semantics. A corpus
@@ -831,7 +924,11 @@ fn spec_model_gap_observation(
         CaseOutcome::Ineligible(_) => model_gaps::Observation::OtherIneligible,
         CaseOutcome::FrontendFailure(_)
         | CaseOutcome::OracleFailure(_)
-        | CaseOutcome::Disagreement(_) => model_gaps::Observation::HardFailure,
+        | CaseOutcome::Disagreement(_)
+        // A host that refused a worker thread already fails the run, and the
+        // case never reached the oracle. Diagnosing stale registry debt on top
+        // of that would be reading a loaded machine as coverage evidence.
+        | CaseOutcome::HarnessResource(_) => model_gaps::Observation::HardFailure,
     }
 }
 
@@ -1051,7 +1148,7 @@ fn check_spec_case_with_known_gap(
         match run_source_with_real_std(&case.source, &preview_features) {
             Ok(result) => result,
             Err(error) => {
-                return CaseOutcome::FrontendFailure(format!(
+                return classify_frontend_failure(format!(
                     "{ident} :: {}\n      {error}",
                     case.name
                 ));
@@ -1335,7 +1432,7 @@ fn check_case_with_native(
         match run_source_with_real_std(source, &preview_features) {
             Ok(result) => result,
             Err(error) => {
-                return CaseOutcome::FrontendFailure(format!(
+                return classify_frontend_failure(format!(
                     "{} :: {}\n      {error}",
                     rel(path),
                     case.name
@@ -1495,7 +1592,7 @@ fn check_case_with_native(
 fn record_oracle_error(context: &str, error: RunSourceError) -> CaseOutcome {
     match error {
         RunSourceError::Compile(errors) => {
-            CaseOutcome::FrontendFailure(format!("{context}\n      {errors:#?}"))
+            classify_frontend_failure(format!("{context}\n      {errors:#?}"))
         }
         RunSourceError::Unsupported(unsupported) => {
             if let Some(kind) = unsupported.model_gap() {
@@ -2618,6 +2715,67 @@ files = [{ path = "probe.rue", source = "not Rue" }]
             check_case(Path::new("trap.toml"), &case),
             CaseOutcome::Disagreement(_)
         ));
+    }
+
+    #[test]
+    fn a_refused_query_worker_is_a_resource_condition_not_a_frontend_failure() {
+        let refused = rue_query::WorkerSpawnFailure::new(
+            &std::io::Error::from_raw_os_error(35),
+            9,
+            8 * 1024 * 1024,
+        )
+        .to_string();
+        let outcome = classify_frontend_failure(format!("case :: probe\n      {refused}"));
+        let CaseOutcome::HarnessResource(condition) = &outcome else {
+            panic!("a refused worker thread must not be reported as a corpus failure: {outcome:?}")
+        };
+        assert!(
+            condition.contains("os error 35"),
+            "the reported condition must carry the operating system's refusal: {condition}"
+        );
+        assert!(
+            condition.contains("9 workers of 8 MiB stack were live"),
+            "the reported condition must carry the worker budget: {condition}"
+        );
+
+        // A resource condition is counted and reported apart from a real
+        // corpus failure, and judges no case.
+        let mut report = Report::default();
+        report.record(outcome);
+        report.record(CaseOutcome::FrontendFailure("frontend".to_string()));
+        assert_eq!(report.harness_resource.len(), 1);
+        assert_eq!(report.frontend_failures.len(), 1);
+        assert!(report.harness_failures.is_empty());
+        assert_eq!(report.modeled_eligible_count(), 1);
+        assert_eq!(report.classified_case_count(), 2);
+
+        // An ordinary front-end rejection keeps its own class.
+        assert!(matches!(
+            classify_frontend_failure("case :: probe\n      unresolved name".to_string()),
+            CaseOutcome::FrontendFailure(_)
+        ));
+    }
+
+    #[test]
+    fn oracle_jobs_bounds_in_process_concurrency_and_rejects_nonsense() {
+        // Unset and empty keep the compiler's own host-parallelism default.
+        assert_eq!(parse_oracle_jobs(None), Ok(None));
+        assert_eq!(parse_oracle_jobs(Some("")), Ok(None));
+        assert_eq!(parse_oracle_jobs(Some("  ")), Ok(None));
+
+        assert_eq!(parse_oracle_jobs(Some("1")), Ok(Some(1)));
+        assert_eq!(parse_oracle_jobs(Some(" 4 ")), Ok(Some(4)));
+
+        let zero = parse_oracle_jobs(Some("0")).expect_err("zero leaves nothing to run on");
+        assert!(zero.contains(ORACLE_JOBS_VAR), "{zero}");
+        assert!(zero.contains("positive"), "{zero}");
+
+        for rejected in ["two", "-1", "2.5", "4 workers"] {
+            let message = parse_oracle_jobs(Some(rejected))
+                .expect_err("a non-numeric worker count must be rejected, not ignored");
+            assert!(message.contains(ORACLE_JOBS_VAR), "{message}");
+            assert!(message.contains(rejected), "{message}");
+        }
     }
 
     #[test]

--- a/crates/rue-query/src/context.rs
+++ b/crates/rue-query/src/context.rs
@@ -710,6 +710,12 @@ impl QueryContext {
         }
         let mut workers = Vec::with_capacity(worker_claim.count);
         let mut coordinator_measurement = BatchCoordinatorMeasurement::new(&self.task.core.metrics);
+        // A host that refuses a worker thread stops dispatch but not the batch.
+        // The inline worker below drains the whole queue regardless of how many
+        // physical workers exist, so every already-dispatched child still joins
+        // and absorbs through the ordinary path; the refusal is reported after
+        // that scope closes.
+        let mut worker_spawn_failure = None;
         for _ in 0..worker_claim.count {
             let queue = queue.clone();
             let items = items.clone();
@@ -719,7 +725,7 @@ impl QueryContext {
             let tracing_dispatch = tracing_dispatch.clone();
             let tracing_parent = tracing_parent.clone();
             let dispatch_started = Instant::now();
-            let (worker, born) = self.task.core.batch_executor.submit(move || {
+            let dispatched = self.task.core.batch_executor.submit(move || {
                 run_registered_batch_worker(
                     queue,
                     items,
@@ -730,6 +736,13 @@ impl QueryContext {
                     tracing_parent,
                 )
             });
+            let (worker, born) = match dispatched {
+                Ok(dispatched) => dispatched,
+                Err(failure) => {
+                    worker_spawn_failure = Some(failure);
+                    break;
+                }
+            };
             coordinator_measurement
                 .record_submission(born, duration_ns(dispatch_started.elapsed()));
             workers.push(worker);
@@ -804,7 +817,10 @@ impl QueryContext {
             );
             terminals.push(result.into_result()?);
         }
-        Ok(terminals)
+        match worker_spawn_failure {
+            Some(failure) => Err(QueryAbort::WorkerSpawn(failure)),
+            None => Ok(terminals),
+        }
     }
 
     /// Duplicates every terminal lease currently observed by this rooted task.

--- a/crates/rue-query/src/executor.rs
+++ b/crates/rue-query/src/executor.rs
@@ -1,6 +1,7 @@
 //! Runtime-owned physical workers for registered query batches.
 
 use std::fmt;
+use std::io;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
@@ -10,6 +11,98 @@ use std::time::Instant;
 use crate::{REGISTERED_BATCH_WORKER_STACK_BYTES, lock};
 
 type Job = Box<dyn FnOnce() + Send + 'static>;
+
+/// Stable opening of every rendering of [`WorkerSpawnFailure`].
+///
+/// Drivers publish the rendering as an internal-error diagnostic and harnesses
+/// match this prefix to separate a loaded host from a compiler defect, so the
+/// text is a contract rather than an incidental message.
+pub const WORKER_SPAWN_MESSAGE_PREFIX: &str = "query runtime could not spawn a worker thread";
+
+/// The host refused a query-runtime physical worker thread.
+///
+/// Thread creation is the one step of registered-batch dispatch that depends on
+/// a resource the compiler does not own. `EAGAIN` under host thread or
+/// address-space pressure is a condition of the machine, not a compiler defect,
+/// so it is reported as a typed value the caller can turn into a diagnostic
+/// rather than an abort of the process.
+///
+/// The payload is a value type rather than an `io::Error` because
+/// [`QueryAbort`](crate::QueryAbort) is `Clone + Eq`: the refusal is captured
+/// as its rendering, its raw OS code, and the worker budget that was live when
+/// the host said no.
+#[derive(Clone, PartialEq, Eq)]
+pub struct WorkerSpawnFailure {
+    os_error: String,
+    raw_os_error: Option<i32>,
+    live_workers: usize,
+    worker_stack_bytes: usize,
+}
+
+impl fmt::Display for WorkerSpawnFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{WORKER_SPAWN_MESSAGE_PREFIX}: {}; {} workers of {} MiB stack were live",
+            self.os_error,
+            self.live_workers,
+            self.worker_stack_mib()
+        )
+    }
+}
+
+/// The structural rendering is the diagnostic sentence.
+///
+/// Compiler abort-reporting sites render a [`QueryAbort`](crate::QueryAbort)
+/// with `{:?}`, and this refusal must name the OS error and the worker budget
+/// wherever it is reported — not only on the one path that formats it
+/// deliberately.
+impl fmt::Debug for WorkerSpawnFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl WorkerSpawnFailure {
+    /// Captures one host refusal.
+    ///
+    /// `live_workers` is how many physical workers the runtime already owned,
+    /// and `worker_stack_bytes` the reservation each of them asks for; together
+    /// they are the budget a report needs in order to be actionable.
+    pub fn new(error: &io::Error, live_workers: usize, worker_stack_bytes: usize) -> Self {
+        Self {
+            os_error: error.to_string(),
+            raw_os_error: error.raw_os_error(),
+            live_workers,
+            worker_stack_bytes,
+        }
+    }
+
+    /// The operating system's own account of the refusal.
+    pub fn os_error(&self) -> &str {
+        &self.os_error
+    }
+
+    /// The raw `errno` when the host reported one.
+    pub const fn raw_os_error(&self) -> Option<i32> {
+        self.raw_os_error
+    }
+
+    /// Physical workers this runtime already owned when the spawn was refused.
+    pub const fn live_workers(&self) -> usize {
+        self.live_workers
+    }
+
+    /// Stack reservation each physical worker requests.
+    pub const fn worker_stack_bytes(&self) -> usize {
+        self.worker_stack_bytes
+    }
+
+    /// Per-worker stack reservation in whole MiB, for diagnostics.
+    pub const fn worker_stack_mib(&self) -> usize {
+        self.worker_stack_bytes / (1024 * 1024)
+    }
+}
 
 /// A query-runtime-owned set of reusable physical workers.
 ///
@@ -21,6 +114,8 @@ pub(crate) struct ReusableBatchExecutor {
     receiver: Arc<Mutex<mpsc::Receiver<Job>>>,
     workers: Mutex<Vec<JoinHandle<()>>>,
     worker_capacity: usize,
+    #[cfg(test)]
+    forced_spawn_failure: Mutex<Option<io::Error>>,
 }
 
 impl fmt::Debug for ReusableBatchExecutor {
@@ -41,13 +136,20 @@ impl ReusableBatchExecutor {
             receiver: Arc::new(Mutex::new(receiver)),
             workers: Mutex::new(Vec::with_capacity(worker_capacity)),
             worker_capacity,
+            #[cfg(test)]
+            forced_spawn_failure: Mutex::new(None),
         }
     }
 
+    /// Dispatches one job onto this runtime's physical workers.
+    ///
+    /// Returns the refusal when the host declines a new worker thread. Nothing
+    /// is queued in that case, so the caller owes no join for this job and may
+    /// surface the condition without leaving batch state behind.
     pub(crate) fn submit<R>(
         &self,
         job: impl FnOnce() -> R + Send + 'static,
-    ) -> (BatchJobHandle<R>, u64)
+    ) -> Result<(BatchJobHandle<R>, u64), WorkerSpawnFailure>
     where
         R: Send + 'static,
     {
@@ -55,27 +157,10 @@ impl ReusableBatchExecutor {
         {
             let mut workers = lock(&self.workers);
             if workers.len() < self.worker_capacity {
-                let receiver = self.receiver.clone();
                 let index = workers.len();
-                let worker = thread::Builder::new()
-                    .name(format!("rue-query-worker-{index}"))
-                    .stack_size(REGISTERED_BATCH_WORKER_STACK_BYTES)
-                    .spawn(move || {
-                        loop {
-                            let job = {
-                                // Exactly one idle worker waits on the receiver;
-                                // after it takes a job, the next idle worker takes
-                                // its place. Executing jobs never holds this lock.
-                                let receiver = lock(&receiver);
-                                receiver.recv()
-                            };
-                            let Ok(job) = job else {
-                                return;
-                            };
-                            job();
-                        }
-                    })
-                    .expect("query runtime worker thread must spawn");
+                let worker = self.spawn_worker(index).map_err(|error| {
+                    WorkerSpawnFailure::new(&error, index, REGISTERED_BATCH_WORKER_STACK_BYTES)
+                })?;
                 workers.push(worker);
                 thread_births = 1;
             }
@@ -90,14 +175,53 @@ impl ReusableBatchExecutor {
                 let _ = completed.send((result, finished_at));
             }))
             .expect("query runtime executor workers remain live with the runtime");
-        (
+        Ok((
             BatchJobHandle {
                 receiver: Some(receiver),
                 #[cfg(test)]
                 drop_wait_started: None,
             },
             thread_births,
-        )
+        ))
+    }
+
+    /// Creates one physical worker, or reports the host's refusal.
+    ///
+    /// Tests arm [`force_next_worker_spawn_failure`] here rather than shrinking
+    /// a process-wide thread limit, so the refusal path is exercised without a
+    /// resource the test would have to restore.
+    ///
+    /// [`force_next_worker_spawn_failure`]: Self::force_next_worker_spawn_failure
+    fn spawn_worker(&self, index: usize) -> io::Result<JoinHandle<()>> {
+        #[cfg(test)]
+        if let Some(error) = lock(&self.forced_spawn_failure).take() {
+            return Err(error);
+        }
+        let receiver = self.receiver.clone();
+        thread::Builder::new()
+            .name(format!("rue-query-worker-{index}"))
+            .stack_size(REGISTERED_BATCH_WORKER_STACK_BYTES)
+            .spawn(move || {
+                loop {
+                    let job = {
+                        // Exactly one idle worker waits on the receiver;
+                        // after it takes a job, the next idle worker takes
+                        // its place. Executing jobs never holds this lock.
+                        let receiver = lock(&receiver);
+                        receiver.recv()
+                    };
+                    let Ok(job) = job else {
+                        return;
+                    };
+                    job();
+                }
+            })
+    }
+
+    /// Makes the next physical worker creation fail with `error`.
+    #[cfg(test)]
+    pub(crate) fn force_next_worker_spawn_failure(&self, error: io::Error) {
+        *lock(&self.forced_spawn_failure) = Some(error);
     }
 }
 
@@ -155,11 +279,54 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
+    fn a_refused_worker_thread_is_a_typed_submission_error() {
+        let executor = ReusableBatchExecutor::new(2);
+        // One worker exists before the host starts refusing, so the reported
+        // budget is the live count rather than the configured capacity.
+        let (first, births) = executor.submit(|| 1).unwrap();
+        assert_eq!(births, 1);
+        assert_eq!(first.join().0.unwrap(), 1);
+
+        executor.force_next_worker_spawn_failure(io::Error::from_raw_os_error(
+            EAGAIN_LIKE_RAW_OS_ERROR,
+        ));
+        let Err(refused) = executor.submit(|| 2) else {
+            panic!("a refused worker thread must not be reported as a dispatched job")
+        };
+        assert_eq!(refused.raw_os_error(), Some(EAGAIN_LIKE_RAW_OS_ERROR));
+        assert_eq!(refused.live_workers(), 1);
+        assert_eq!(
+            refused.worker_stack_bytes(),
+            REGISTERED_BATCH_WORKER_STACK_BYTES
+        );
+        assert!(!refused.os_error().is_empty());
+        let rendered = refused.to_string();
+        assert!(
+            rendered.starts_with(WORKER_SPAWN_MESSAGE_PREFIX),
+            "a refusal must render with the contracted prefix: {rendered}"
+        );
+        assert!(
+            rendered.ends_with("; 1 workers of 8 MiB stack were live"),
+            "a refusal must name the live worker budget: {rendered}"
+        );
+        assert_eq!(format!("{refused:?}"), rendered);
+
+        // The refusal queued nothing, so the executor still dispatches onto the
+        // workers it already owns and drops without a job to join.
+        let (next, next_births) = executor.submit(|| 3).unwrap();
+        assert_eq!(next_births, 1);
+        assert_eq!(next.join().0.unwrap(), 3);
+    }
+
+    /// macOS `EAGAIN`, the code a thread-exhausted host returns in the field.
+    const EAGAIN_LIKE_RAW_OS_ERROR: i32 = 35;
+
+    #[test]
     fn submitted_jobs_reuse_one_physical_worker() {
         let executor = ReusableBatchExecutor::new(1);
 
-        let (first, first_births) = executor.submit(|| 41);
-        let (second, second_births) = executor.submit(|| 42);
+        let (first, first_births) = executor.submit(|| 41).unwrap();
+        let (second, second_births) = executor.submit(|| 42).unwrap();
         assert_eq!(first_births, 1);
         assert_eq!(second_births, 0);
         let (first, _) = first.join();
@@ -175,11 +342,13 @@ mod tests {
         let (release_sender, release) = mpsc::sync_channel(1);
         let completed = Arc::new(AtomicBool::new(false));
         let completed_by_job = completed.clone();
-        let (mut handle, births) = executor.submit(move || {
-            job_started_sender.send(()).unwrap();
-            release.recv().unwrap();
-            completed_by_job.store(true, Ordering::Release);
-        });
+        let (mut handle, births) = executor
+            .submit(move || {
+                job_started_sender.send(()).unwrap();
+                release.recv().unwrap();
+                completed_by_job.store(true, Ordering::Release);
+            })
+            .unwrap();
         assert_eq!(births, 1);
         job_started.recv().unwrap();
 

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -17,6 +17,7 @@ mod task;
 mod validation;
 
 pub use context::*;
+pub use executor::{WORKER_SPAWN_MESSAGE_PREFIX, WorkerSpawnFailure};
 pub use hash::*;
 pub use metrics::*;
 pub use node::*;

--- a/crates/rue-query/src/outcome.rs
+++ b/crates/rue-query/src/outcome.rs
@@ -329,6 +329,13 @@ pub enum QueryAbort {
     UnpublishedRevision(Revision),
     /// A query requested a leaf absent from its pinned immutable revision.
     MissingInput(InputIdentity),
+    /// The host refused a physical worker thread for a registered batch.
+    ///
+    /// This is a condition of the machine the compiler is running on, not of
+    /// the program being compiled. It is reported rather than panicked so a
+    /// driver can publish it as an internal-error diagnostic and a harness can
+    /// tell a loaded host apart from a real compiler defect.
+    WorkerSpawn(WorkerSpawnFailure),
 }
 
 /// How one immutable request attempt reached its result.

--- a/crates/rue-query/src/registered_batch_tests.rs
+++ b/crates/rue-query/src/registered_batch_tests.rs
@@ -164,6 +164,50 @@ fn run_registered_batch(worker_count: usize) -> QueryRequestAttempt<Arc<[u64]>> 
 }
 
 #[test]
+fn a_refused_worker_thread_aborts_the_batch_without_panicking() {
+    let runtime = QueryRuntime::new(2);
+    publish_empty(&runtime, [revision(1)]);
+    let child = runtime
+        .family_with_evaluator::<Slot, u64, _>("refused-worker-child", 8, |_, _, key| {
+            Ok(QueryOutput::success(key.0))
+        })
+        .unwrap();
+    let child_for_root = child.clone();
+    let root = runtime
+        .family_with_evaluator::<Key, u64, _>("refused-worker-root", 8, move |context, _, _| {
+            let mut sum = 0;
+            for terminal in context.query_registered_batch(&child_for_root, [Slot(1), Slot(2)])? {
+                let QueryOutcome::Success(value) = terminal.outcome() else {
+                    unreachable!()
+                };
+                sum += *value;
+            }
+            Ok(QueryOutput::success(sum))
+        })
+        .unwrap();
+
+    runtime.force_next_batch_worker_spawn_failure(std::io::Error::from_raw_os_error(35));
+    let abort = runtime
+        .request_registered(&root, revision(1), Key("root"), CancellationToken::new())
+        .into_result()
+        .expect_err("a refused worker thread must reach the caller as a typed abort");
+    let QueryAbort::WorkerSpawn(failure) = abort else {
+        panic!("a refused worker thread must not be reported as another abort: {abort:?}")
+    };
+    assert_eq!(failure.raw_os_error(), Some(35));
+    assert_eq!(failure.live_workers(), 0);
+    assert!(failure.to_string().starts_with(WORKER_SPAWN_MESSAGE_PREFIX));
+
+    // The runtime is not poisoned by the refusal: with the host willing again,
+    // the same request completes on a freshly created worker.
+    let recovered = runtime
+        .request_registered(&root, revision(1), Key("root"), CancellationToken::new())
+        .into_result()
+        .expect("a runtime that reported a refusal must still be usable");
+    assert_eq!(recovered.outcome(), &QueryOutcome::Success(3));
+}
+
+#[test]
 fn reusable_worker_births_do_not_repeat_across_registered_batches() {
     let runtime = QueryRuntime::new(2);
     let startup = runtime.metrics();

--- a/crates/rue-query/src/revision.rs
+++ b/crates/rue-query/src/revision.rs
@@ -1271,6 +1271,17 @@ impl QueryRuntime {
         }
     }
 
+    /// Makes the next physical batch-worker creation fail with `error`.
+    ///
+    /// Tests reach the host-refusal path this way instead of shrinking a
+    /// process-wide thread limit, which no test could restore for its peers.
+    #[cfg(test)]
+    pub(crate) fn force_next_batch_worker_spawn_failure(&self, error: std::io::Error) {
+        self.core
+            .batch_executor
+            .force_next_worker_spawn_failure(error);
+    }
+
     /// Returns a point-in-time structural metrics snapshot.
     pub fn metrics(&self) -> RuntimeMetrics {
         let retention = self.core.retention_snapshot();


### PR DESCRIPTION
Fixes RUE-1994.

The query runtime spawned worker threads with an `.expect()`, so under host thread or address-space pressure (`EAGAIN` from `Builder::spawn`, seen on a loaded macOS host with several worktrees building) a resource condition became a panic, and the oracle-diff harness reported it as a corpus failure indistinguishable from a real disagreement.

The executor now returns a typed `WorkerSpawnFailure` (OS rendering, errno, live worker count, per-worker stack bytes) from submission; nothing is queued when a spawn is refused, the batch drains its already-dispatched children through the ordinary path, and the runtime is not poisoned, so a later request spawns again. The compiler renders it through one helper as an ordinary E9000 `CompileError` on the normal diagnostic path (`--error-format json` included): `query runtime could not spawn a worker thread: <os error>; N workers of M MiB stack were live`. The oracle-diff harness classifies that message as a new `HARNESS RESOURCE` outcome, distinct from `HARNESS FAILURES`, still exits non-zero, and names the lever; `RUE_ORACLE_JOBS=N` bounds the compiler's query-runtime parallelism per case, rejecting `0` and non-numbers.

One design choice for the maintainer: on a refusal the inline worker has in fact completed the batch, so the compiler could silently degrade to fewer workers instead. It reports, because silent degradation hides exactly the condition the harness is meant to surface; the degradation variant is a small local change in `context.rs` if preferred.

Tests: a `rue-query` injection hook forces a refusal (no `ulimit`), with two unit tests, two harness tests for the classification and the jobs parsing, and a compiler test for the rendering. Verification: `scripts/rue unit rue-query` (206), `rue-compiler query` (283), `rue-oracle-diff` (106), the oracle-diff binary over a two-case directory (green path unchanged, also under `RUE_ORACLE_JOBS=1` and `2`), `scripts/rue quick`, clippy and fmt clean. `docs/process/diagnostics.md` needs no change: a graceful ICE is already specified as an ordinary E9000 on the normal path.