### PR TITLE
RUE-2005: make the system-link capture tests event-driven

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,14 @@ target once in isolation. A clean isolated 64/64 run is sufficient local
 evidence; do not repeatedly rerun the entire suite. A semantic disagreement,
 compiler error, or isolated timeout remains a real failure.
 
+One other wall-clock budget is deliberate: the linking test
+`platform_native_system_link_cancellation_reaps_child_and_cleans_workspace`
+gives cancellation five seconds to answer, measured from the cancel request
+rather than from the start of the link, because its mock linker would otherwise
+live for thirty seconds and the point of the test is that cancellation does not
+wait the child out (RUE-2005). Every other wait in that module synchronizes on
+an event and its bound is only a hang guard.
+
 An unfiltered `scripts/rue test` delegates selection and execution to Buck in
 one `buck2 test` invocation. Its standard selection includes the premerge and
 slow tiers while leaving stress tests opt-in. Corpus suites are cacheable Buck

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -1716,6 +1716,47 @@ mod temp_link_dir_tests {
         "out=''\nprev=''\nfor arg in \"$@\"; do\n  if [ \"$prev\" = '-o' ]; then out=$arg; break; fi\n  prev=$arg\ndone\n"
     }
 
+    /// Upper bound for every wait in this module.
+    ///
+    /// Each of those waits synchronizes on an event — a marker file the mock
+    /// linker writes, the child leaving the process table, the link call
+    /// returning — so this bound is a hang guard and never the assertion: it
+    /// exists only so a wedged test fails by name instead of running to the
+    /// suite timeout. It is deliberately far above any latency a loaded host
+    /// can produce, because exceeding it must mean "blocked", not "slow".
+    const EVENT_WAIT_LIMIT: Duration = Duration::from_secs(60);
+
+    /// How often the marker-file and process-liveness waits re-check.
+    const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+    /// How long the cancellation mock linker stays alive when nobody kills it.
+    /// Cancellation has to beat this, not merely finish quickly.
+    const MOCK_LINKER_LIFETIME: Duration = Duration::from_secs(30);
+
+    /// Bound on the interval between the cancel request and the link call
+    /// returning.
+    ///
+    /// This one is a real budget, derived from the mechanism: `wait_for_linker`
+    /// polls the child every 10 ms and then kills and reaps the process group,
+    /// so a working cancellation answers within about one poll interval. The
+    /// limit allows five hundred of them for a loaded host while staying six
+    /// times below `MOCK_LINKER_LIFETIME`, so failing it means the link waited
+    /// the child out rather than cancelling it. It is measured from the cancel
+    /// request rather than from the start of the link, because the runtime
+    /// validation and the 3 MB archive write that precede the spawn are not
+    /// part of the property under test and are exactly what host load inflates.
+    const CANCELLATION_RESPONSE_LIMIT: Duration = Duration::from_secs(5);
+
+    /// Poll `ready` until it observes the event, failing with `message` only if
+    /// the event never arrives at all.
+    fn wait_for_event(message: &str, mut ready: impl FnMut() -> bool) {
+        let deadline = std::time::Instant::now() + EVENT_WAIT_LIMIT;
+        while !ready() {
+            assert!(std::time::Instant::now() < deadline, "{message}");
+            std::thread::sleep(EVENT_POLL_INTERVAL);
+        }
+    }
+
     #[test]
     #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
     fn platform_native_system_link_cancellation_reaps_child_and_cleans_workspace() {
@@ -1725,9 +1766,10 @@ mod temp_link_dir_tests {
         let descendant_pid_path = directory.path().join("descendant-pid");
         let workspace_path = directory.path().join("workspace");
         let body = format!(
-            "{}printf '%s\\n' \"$$\" > '{}'\nsleep 30 &\nprintf '%s\\n' \"$!\" > '{}'\nprintf '%s\\n' \"$(dirname \"$out\")\" > '{}'\n: > '{}'\nwait",
+            "{}printf '%s\\n' \"$$\" > '{}'\nsleep {} &\nprintf '%s\\n' \"$!\" > '{}'\nprintf '%s\\n' \"$(dirname \"$out\")\" > '{}'\n: > '{}'\nwait",
             mock_output_argument(),
             pid_path.display(),
+            MOCK_LINKER_LIFETIME.as_secs(),
             descendant_pid_path.display(),
             workspace_path.display(),
             ready.display(),
@@ -1737,19 +1779,15 @@ mod temp_link_dir_tests {
         let canceler = cancellation.clone();
         let ready_for_thread = ready.clone();
         let cancel_thread = std::thread::spawn(move || {
-            let deadline = std::time::Instant::now() + Duration::from_secs(10);
-            while !ready_for_thread.exists() {
-                assert!(
-                    std::time::Instant::now() < deadline,
-                    "mock linker never started"
-                );
-                std::thread::sleep(Duration::from_millis(1));
-            }
+            wait_for_event("mock linker never started", || ready_for_thread.exists());
+            // Time the cancellation from the request, so the answer does not
+            // include the setup the link performs before the child exists.
+            let requested = std::time::Instant::now();
             canceler.cancel();
+            requested
         });
         let mut options = CompileOptions::default();
         options.target = Target::host().unwrap();
-        let started = std::time::Instant::now();
         let result = link_system_with_warnings_and_cancellation(
             &options,
             &[],
@@ -1757,7 +1795,8 @@ mod temp_link_dir_tests {
             &[],
             &cancellation,
         );
-        cancel_thread.join().unwrap();
+        let returned = std::time::Instant::now();
+        let requested = cancel_thread.join().unwrap();
 
         assert!(matches!(
             result,
@@ -1765,7 +1804,12 @@ mod temp_link_dir_tests {
                 rue_query::QueryAbort::Canceled
             ))
         ));
-        assert!(started.elapsed() < Duration::from_secs(2));
+        let response = returned.saturating_duration_since(requested);
+        assert!(
+            response < CANCELLATION_RESPONSE_LIMIT,
+            "cancellation answered in {response:?}; the mock linker's own \
+             lifetime is {MOCK_LINKER_LIFETIME:?}"
+        );
         let workspace = std::fs::read_to_string(&workspace_path).unwrap();
         assert!(!Path::new(workspace.trim()).exists());
         for pid_path in [&pid_path, &descendant_pid_path] {
@@ -1774,19 +1818,16 @@ mod temp_link_dir_tests {
                 .trim()
                 .parse()
                 .unwrap();
-            let deadline = std::time::Instant::now() + Duration::from_secs(2);
-            loop {
-                if unsafe { libc::kill(pid, 0) } == -1
-                    && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
-                {
-                    break;
-                }
-                assert!(
-                    std::time::Instant::now() < deadline,
-                    "linker process {pid} survived process-group termination"
-                );
-                std::thread::sleep(Duration::from_millis(1));
-            }
+            // The property is that the process group is gone, not how quickly
+            // the kernel reaped it, so this waits on the event.
+            wait_for_event(
+                &format!("linker process {pid} survived process-group termination"),
+                || {
+                    let probe = unsafe { libc::kill(pid, 0) };
+                    probe == -1
+                        && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+                },
+            );
         }
     }
 
@@ -1831,16 +1872,25 @@ mod temp_link_dir_tests {
                     replacement_command,
                 ),
             );
-            let mut options = CompileOptions::default();
-            options.target = Target::host().unwrap();
-            let started = std::time::Instant::now();
-            let error = link_system_with_warnings(&options, &[], linker.to_str().unwrap(), &[])
+            // The capture is read through the descriptor the link created, so
+            // unlinking `linker.stderr` and putting a symlink or a fifo in its
+            // place cannot redirect the read or stall it. The failure mode a
+            // regression would produce is not slowness: reopening the pathname
+            // would block in `open(2)` forever on a fifo nobody writes to. So
+            // the link runs on a worker and the bound below is a hang guard on
+            // that block, never a latency budget the healthy path must fit in.
+            let (finished, link_result) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                let mut options = CompileOptions::default();
+                options.target = Target::host().unwrap();
+                let result =
+                    link_system_with_warnings(&options, &[], linker.to_str().unwrap(), &[]);
+                let _ = finished.send(result.map(|_| ()).map_err(|error| error.to_string()));
+            });
+            let diagnostic = link_result
+                .recv_timeout(EVENT_WAIT_LIMIT)
+                .unwrap_or_else(|_| panic!("{replacement} replacement blocked stderr capture"))
                 .unwrap_err();
-            assert!(
-                started.elapsed() < Duration::from_secs(2),
-                "{replacement} replacement blocked stderr capture"
-            );
-            let diagnostic = error.to_string();
             assert!(diagnostic.contains("retained diagnostic"));
             assert!(!diagnostic.contains("pathname replacement must not be read"));
         }
@@ -1852,9 +1902,9 @@ mod temp_link_dir_tests {
         let mut command = Command::new("/bin/sh");
         command.args(["-c", "exit 0"]);
         let mut job = LinkerJob::spawn(&mut command).unwrap();
-        while job.try_wait().unwrap().is_none() {
-            std::thread::yield_now();
-        }
+        wait_for_event("linker child never exited", || {
+            job.try_wait().unwrap().is_some()
+        });
         let cancellation = rue_query::CancellationToken::new();
         cancellation.cancel();
 


### PR DESCRIPTION
Fixes RUE-2005.

`//crates/rue-compiler:rue-compiler-platform-native-test` flaked under host load on the system-link temp-dir tests. Every timing assumption in that module was a wall-clock budget charged to the wrong thing: the stderr-capture test timed the entire link call against 2 s and blamed the fifo replacement, when what fills that window is the runtime-archive validation (memoized per process, paid by the first test to arrive) and writing the 3.2 MB archive into the workspace; under one competing suite the call took 1.47 s, and the reported failures had two. There was no production race: the capture leaf is created once with `create_new` and `O_NOFOLLOW`, the child gets a dup, and the read seeks the retained descriptor, so a replaced pathname cannot redirect or stall it.

The tests now synchronize on events. The link runs on a worker thread and its result is taken with a 60 s hang guard; the marker-file and process-death waits use the same guard instead of 10 s and 2 s deadlines; an unbounded busy-spin becomes the same helper with 1 ms sleeps. The one wall-clock budget that is genuinely the property under test, that cancellation answers without waiting the child out, is measured from the cancel request (observed 3 to 9 ms) against 5 s, derived in a comment from the poll interval and the mock linker's 30 s lifetime, now a shared constant. Regressing the production read to `File::open` makes the symlink case fail in 0.16 s and the fifo case trip the hang guard, and disabling the cancel branch fails the budget at 30 s, so the tests keep their teeth. AGENTS.md documents the one remaining budget next to the oracle-smoke note.

Verification: `scripts/rue unit rue-compiler linking` (17), the platform-native target 10 times under a concurrent CLI-suite load plus standalone (46 passed each time), `scripts/rue quick`, clippy and fmt clean.