### PR TITLE
RUE-2008: apply the constant-index bounds check to traced writes

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1577,6 +1577,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ctx.ownership.byref_arg_root = prev_byref_root;
             trace?.ok_or_else(|| CompileError::new(ErrorKind::BorrowNonLvalue, receiver_span))?
         };
+        // The receiver is a place that is read here and, for an `inout`
+        // accessor, written through: `xs[5].cell_mut().value = 7` reaches the
+        // same element `xs[5]` names. Its chain must be bounds-checked now,
+        // because the receiver's projections are replaced below by the
+        // accessor result's own base and no later check can see them
+        // (4.11:7, RUE-2008).
+        self.check_traced_const_index_bounds(&receiver_trace, ctx)?;
         let root = receiver_trace.root_var;
         let accessor_loan_kind = if info.returns_inout {
             CallLoanKind::Inout
@@ -5006,6 +5013,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 }
             }
 
+            // The base chain reached here is read in place context
+            // (3.8:76), so a constant index in it must still name an element
+            // of its array: `xs[5].a = 7` is as out of range as `xs[5] = p`
+            // is, which `analyze_index_set` already rejects. The check runs
+            // over the base alone, since the field projection appended below
+            // carries no index (4.11:7, RUE-2008).
+            self.check_traced_const_index_bounds(&trace, ctx)?;
+
             // Add the final field projection
             let base_type = trace.result_type();
             let struct_id = match base_type.as_struct() {
@@ -5204,12 +5219,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 }
             }
 
-            // Get array type info from the trace
+            // Get array type info from the trace. The array's length is not
+            // read here: `check_traced_const_index_bounds` re-derives it per
+            // projection when it checks the whole chain below.
             let base_type = trace.result_type();
-            let (_array_type_id, elem_type, array_len) = match base_type.as_array() {
+            let elem_type = match base_type.as_array() {
                 Some(id) => {
-                    let (elem, len) = self.body_type_pool().array_def(id);
-                    (id, elem, len)
+                    let (elem, _len) = self.body_type_pool().array_def(id);
+                    elem
                 }
                 None => {
                     return Err(CompileError::new(
@@ -5241,21 +5258,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ));
             }
 
-            // Compile-time bounds check for constant indices, evaluated at the
-            // index's resolved operand types so an overflowing index expression
-            // is a compile-time error, not a folded runtime panic (RUE-234).
-            if let Some(const_index) = self.try_get_const_index_checked(index, ctx)? {
-                if const_index < 0 || const_index >= array_len as i128 {
-                    return Err(CompileError::new(
-                        ErrorKind::IndexOutOfBounds {
-                            index: const_index,
-                            length: array_len,
-                        },
-                        self.body_rir_ref().get(index).span,
-                    ));
-                }
-            }
-
             // Add the index projection. A non-negative constant index carries
             // its element path segment so field_path nests through it (RUE-279).
             let const_index = self.try_get_const_index(index);
@@ -5274,6 +5276,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 index_segment,
                 index_inst: Some(index),
             });
+
+            // Constant out-of-bounds indices anywhere in the traced chain,
+            // this write's own index included (4.11:7, RUE-234). Checking the
+            // whole chain after the projection is pushed is what catches the
+            // nested form `xs[5].arr[0] = 1`, whose out-of-range index is in
+            // the base rather than in the assigned index (RUE-2008).
+            self.check_traced_const_index_bounds(&trace, ctx)?;
 
             // Writing into an array with moved-out elements is rejected
             // (RUE-186, E0480): the write can't re-arm per-element ownership.
@@ -6371,6 +6380,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// index expression that overflows its integer type is a compile-time
     /// error rather than a folded runtime panic (RUE-234), and the diagnostic
     /// is labelled on the index expression, matching a direct element read.
+    ///
+    /// Naming an element is not reading it, so this is the one check of the
+    /// read set that a **write** through a traced place makes as well: an
+    /// assignment target is a place context and its base chain is not a use
+    /// (3.8:76), but the element it names must exist either way. Every traced
+    /// write path calls it — `analyze_field_set` on the base chain,
+    /// `analyze_index_set` on the chain including its own index, and
+    /// `expand_accessor_call` on the receiver chain before that chain is
+    /// replaced by the accessor result (RUE-2008). The rest of the read set
+    /// does not carry over: a write to a moved path reinitializes it (3.8:55),
+    /// and the write paths reject a partially moved array with their own
+    /// E0480 rule (3.8:72) instead.
     fn check_traced_const_index_bounds(
         &mut self,
         trace: &PlaceTrace,

--- a/crates/rue-spec/cases/expressions/index.toml
+++ b/crates/rue-spec/cases/expressions/index.toml
@@ -212,6 +212,160 @@ fn main() -> i32 {
 """
 exit_code = 4
 
+# A write names an element the same way a read does. An assignment target is a
+# place context and its base chain is not a use (3.8:76), but the element it
+# names must still exist, so every traced write path applies the same
+# constant-index check the reads above do: a field assignment through the
+# element, a nested field or element assignment under it, an `inout` argument,
+# a compound assignment, and an accessor receiver. Each reports E0902 at the
+# index, with the span `xs[5].a` reports as a read (RUE-2008).
+
+[[case]]
+name = "constant_index_out_of_bounds_in_field_assignment"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7"]
+description = "Assigning a field through an out-of-range constant element is rejected"
+source = """
+struct P { a: i32, b: i32 }
+
+fn main() -> i32 {
+    let mut xs: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    xs[5].a = 7;
+    xs[0].a
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_out_of_bounds_in_nested_field_assignment"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7"]
+description = "The out-of-range element is found however deep the assigned field chain is"
+source = """
+struct Inner { b: i32 }
+struct P { a: i32, inner: Inner }
+
+fn main() -> i32 {
+    let mut xs: [P; 2] = [
+        P { a: 1, inner: Inner { b: 2 } },
+        P { a: 3, inner: Inner { b: 4 } },
+    ];
+    xs[5].inner.b = 1;
+    xs[0].a
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_out_of_bounds_in_nested_element_assignment"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7"]
+description = "An element assignment reports the out-of-range index in its base, not only its own"
+source = """
+struct P { a: i32, arr: [i32; 2] }
+
+fn main() -> i32 {
+    let mut xs: [P; 2] = [P { a: 1, arr: [1, 2] }, P { a: 3, arr: [3, 4] }];
+    xs[5].arr[0] = 1;
+    xs[0].a
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_out_of_bounds_in_inout_argument"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7"]
+description = "An `inout` argument naming a field of an out-of-range element is rejected"
+source = """
+struct P { a: i32, b: i32 }
+
+fn bump(inout v: i32) { v = v + 1; }
+
+fn main() -> i32 {
+    let mut xs: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    bump(inout xs[5].a);
+    xs[0].a
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_out_of_bounds_in_compound_assignment"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7", "5.2:16"]
+description = "A compound assignment through an out-of-range element is rejected"
+source = """
+struct P { a: i32, b: i32 }
+
+fn main() -> i32 {
+    let mut xs: [P; 2] = [P { a: 1, b: 2 }, P { a: 3, b: 4 }];
+    xs[5].a += 1;
+    xs[0].a
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_out_of_bounds_in_accessor_receiver"
+error_contains = "[E0902]"
+expected_error_code = "E0902"
+spec = ["4.11:7", "6.6:15"]
+description = "An accessor receiver written through an out-of-range element is rejected"
+source = """
+struct Cell { value: i64 }
+struct P {
+    cell: Cell,
+    fn cell_mut(inout self) -> inout Cell { yield self.cell; }
+}
+
+fn main() -> i32 {
+    let mut xs: [P; 2] = [P { cell: Cell { value: 1 } }, P { cell: Cell { value: 2 } }];
+    xs[5].cell_mut().value = 7;
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_index_in_bounds_in_write_chain_runs"
+spec = ["4.11:7", "4.11:12", "5.2:16", "6.6:15"]
+description = "The in-bounds forms of those same writes compile and run"
+source = """
+struct Inner { b: i32 }
+struct Cell { value: i32 }
+struct P {
+    a: i32,
+    inner: Inner,
+    arr: [i32; 2],
+    cell: Cell,
+
+    fn cell_mut(inout self) -> inout Cell { yield self.cell; }
+}
+
+fn bump(inout v: i32) { v = v + 1; }
+
+fn main() -> i32 {
+    let mut xs: [P; 2] = [
+        P { a: 1, inner: Inner { b: 2 }, arr: [3, 4], cell: Cell { value: 5 } },
+        P { a: 6, inner: Inner { b: 7 }, arr: [8, 9], cell: Cell { value: 10 } },
+    ];
+    xs[1].a = 7;
+    xs[0].inner.b = 1;
+    xs[1].arr[0] = 1;
+    bump(inout xs[0].a);
+    xs[1].inner.b += 1;
+    xs[0].cell_mut().value = 3;
+    xs[1].a + xs[0].inner.b + xs[1].arr[0] + xs[0].a + xs[1].inner.b + xs[0].cell.value
+}
+"""
+exit_code = 22
+
 # =============================================================================
 # Runtime Bounds Checking
 # =============================================================================


### PR DESCRIPTION
Fixes RUE-2008.

RUE-2006 made every projection-mode read apply the constant-index bounds check (spec 4.11:7) across the whole traced place chain; the write paths did not. `xs[5].a = 7`, `xs[5].inner.b = 1`, and `xs[5].arr[0] = 1` compiled and trapped at runtime while `xs[5] = t` was E0902 at compile time: `analyze_field_set` checked no index in its chain, and `analyze_index_set`'s inline check covered only the index being assigned, not the base chain. A third hole surfaced on the way: `expand_accessor_call` cleared the receiver trace's projections before any check could see them, so `xs[5].xr() = 7` and `xs[5].cell_mut().value = 7` slipped through, for reads as well as writes.

All of them now call the one existing `check_traced_const_index_bounds`; the inline copy in the index-set path is deleted rather than kept beside it. The moved-root and moved-path read checks are deliberately not applied to writes: an assignment target is a place context (3.8:76), assigning to a moved field reinitializes it (3.8:55), and partially moved arrays already have their own write rule (3.8:72, E0480), so the write paths keep their existing full-move check and gain only bounds.

Seven spec cases under 4.11:7 (field, nested field, nested element, `inout`, compound assignment, accessor receiver, and an in-bounds positive exercising all six), mirroring the RUE-2006 read block. Verification: `scripts/rue spec 4.11` (27), full `scripts/rue spec` (2727), full `scripts/rue ui` (339), `scripts/rue unit rue-air` (854), traceability unchanged, `scripts/rue quick`, fmt clean; the oracle-diff binary over the new cases reports agreement with no gap.