### PR TITLE
RUE-2022: add the standard-library contract suite under tests/std

### DIFF
--- a/tests/std/BUCK
+++ b/tests/std/BUCK
@@ -1,0 +1,13 @@
+# The standard library's own `rue test` suite (ADR-0083). The root lives
+# outside `std/` because a test root may not sit inside the configured
+# standard-library tree, so these tests exercise std's PUBLIC surface only —
+# the contract a user program sees. `srcs` doubles as the candidate inventory:
+# a `*_tests.rue` added here without an `@import` from main.rue fails this
+# target as unimported instead of silently not running.
+load("//:rue_rules.bzl", "rue_test")
+
+rue_test(
+    name = "std-tests",
+    root = "tests/std/main.rue",
+    srcs = glob(["**/*.rue"]),
+)

--- a/tests/std/ascii_tests.rue
+++ b/tests/std/ascii_tests.rue
@@ -1,0 +1,58 @@
+const std = @import("std");
+const ascii = std.ascii;
+const OptU8 = std.option.Option(u8);
+
+test "digit and letter classes are disjoint and exact at their edges" {
+    @assert(ascii.is_digit(48));
+    @assert(ascii.is_digit(57));
+    @assert(!ascii.is_digit(47));
+    @assert(!ascii.is_digit(58));
+    @assert(ascii.is_upper(65));
+    @assert(ascii.is_upper(90));
+    @assert(!ascii.is_upper(91));
+    @assert(ascii.is_lower(97));
+    @assert(ascii.is_lower(122));
+    @assert(!ascii.is_lower(96));
+    @assert(ascii.is_alpha(65));
+    @assert(ascii.is_alpha(122));
+    @assert(!ascii.is_alpha(48));
+    @assert(ascii.is_alnum(48));
+    @assert(ascii.is_alnum(65));
+    @assert(!ascii.is_alnum(32));
+}
+
+test "whitespace is exactly space, tab, newline, carriage return" {
+    @assert(ascii.is_whitespace(32));
+    @assert(ascii.is_whitespace(9));
+    @assert(ascii.is_whitespace(10));
+    @assert(ascii.is_whitespace(13));
+    @assert(!ascii.is_whitespace(11));
+    @assert(!ascii.is_whitespace(12));
+    @assert(!ascii.is_whitespace(0));
+}
+
+test "is_ascii cuts at 127" {
+    @assert(ascii.is_ascii(0));
+    @assert(ascii.is_ascii(127));
+    @assert(!ascii.is_ascii(128));
+    @assert(!ascii.is_ascii(255));
+}
+
+test "case mapping touches only letters" {
+    @assert_eq(ascii.to_upper(97), 65);
+    @assert_eq(ascii.to_upper(122), 90);
+    @assert_eq(ascii.to_upper(65), 65);
+    @assert_eq(ascii.to_upper(48), 48);
+    @assert_eq(ascii.to_lower(65), 97);
+    @assert_eq(ascii.to_lower(90), 122);
+    @assert_eq(ascii.to_lower(97), 97);
+    @assert_eq(ascii.to_lower(200), 200);
+}
+
+test "digit_value is Some only for a digit" {
+    @assert_eq(ascii.digit_value(48), OptU8.Some(0));
+    @assert_eq(ascii.digit_value(55), OptU8.Some(7));
+    @assert_eq(ascii.digit_value(57), OptU8.Some(9));
+    @assert_eq(ascii.digit_value(97), OptU8.None);
+    @assert_eq(ascii.digit_value(47), OptU8.None);
+}

--- a/tests/std/binary_tests.rue
+++ b/tests/std/binary_tests.rue
@@ -1,0 +1,56 @@
+const std = @import("std");
+const binary = std.binary;
+
+test "u16 big-endian puts the high byte first" {
+    let b = binary.u16_to_be_bytes(8080);
+    @assert_eq(b[0], 0x1f);
+    @assert_eq(b[1], 0x90);
+    @assert_eq(binary.u16_from_be_bytes(b), 8080);
+}
+
+test "u16 little-endian puts the low byte first" {
+    let b = binary.u16_to_le_bytes(8080);
+    @assert_eq(b[0], 0x90);
+    @assert_eq(b[1], 0x1f);
+    @assert_eq(binary.u16_from_le_bytes(b), 8080);
+}
+
+test "u16 endian forms are byte reversals of each other" {
+    let be = binary.u16_to_be_bytes(0xabcd);
+    let le = binary.u16_to_le_bytes(0xabcd);
+    @assert_eq(be[0], le[1]);
+    @assert_eq(be[1], le[0]);
+    @assert_eq(binary.u16_from_le_bytes(be), 0xcdab);
+}
+
+test "u32 round trips and byte order" {
+    let v: u32 = 0x01020304;
+    let be = binary.u32_to_be_bytes(v);
+    @assert_eq(be[0], 1);
+    @assert_eq(be[3], 4);
+    @assert_eq(binary.u32_from_be_bytes(be), v);
+    let le = binary.u32_to_le_bytes(v);
+    @assert_eq(le[0], 4);
+    @assert_eq(le[3], 1);
+    @assert_eq(binary.u32_from_le_bytes(le), v);
+    @assert_eq(binary.u32_from_be_bytes(le), 0x04030201);
+}
+
+test "u64 round trips at the extremes" {
+    let be = binary.u64_to_be_bytes(@int_max(u64));
+    @assert_eq(be[0], 255);
+    @assert_eq(be[7], 255);
+    @assert_eq(binary.u64_from_be_bytes(be), @int_max(u64));
+    let one = binary.u64_to_le_bytes(1);
+    @assert_eq(one[0], 1);
+    @assert_eq(one[7], 0);
+    @assert_eq(binary.u64_from_le_bytes(one), 1);
+    let top = binary.u64_to_be_bytes(0x8000000000000000);
+    @assert_eq(top[0], 0x80);
+    @assert_eq(binary.u64_from_le_bytes(top), 0x80);
+}
+
+test "array equality compares whole encodings" {
+    @assert_eq(binary.u32_to_be_bytes(0xdeadbeef), [0xde, 0xad, 0xbe, 0xef]);
+    @assert_ne(binary.u32_to_be_bytes(1), binary.u32_to_le_bytes(1));
+}

--- a/tests/std/buffers_tests.rue
+++ b/tests/std/buffers_tests.rue
@@ -1,0 +1,231 @@
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const Buf = std.arraybuf.ArrayBuf(i64);
+const Bytes = std.arraybuf.ArrayBuf(u8);
+const Strs = std.arraybuf.ArrayBuf(StrBuf);
+const OptI = std.option.Option(i64);
+const OptU8 = std.option.Option(u8);
+const OptU64 = std.option.Option(u64);
+
+test "ArrayBuf push, len, get, get_or, set, pop" {
+    let mut v = Buf.new();
+    @assert(v.is_empty());
+    @assert_eq(v.get(0), OptI.None);
+    @assert_eq(v.get_or(0, -1), -1);
+    @assert_eq(v.pop(), OptI.None);
+    v.push(10);
+    v.push(20);
+    @assert_eq(v.len(), 2);
+    @assert_eq(v.get(0), OptI.Some(10));
+    @assert_eq(v.get(2), OptI.None);
+    v.set(0, 99);
+    @assert_eq(v.get(0), OptI.Some(99));
+    @assert_eq(v.pop(), OptI.Some(20));
+    @assert_eq(v.pop_or(-5), 99);
+    @assert_eq(v.pop_or(-5), -5);
+}
+
+test "ArrayBuf first, last, index_of, contains" {
+    let mut v = Buf.new();
+    @assert_eq(v.first(), OptI.None);
+    @assert_eq(v.last(), OptI.None);
+    v.push(3); v.push(1); v.push(4); v.push(1);
+    @assert_eq(v.first(), OptI.Some(3));
+    @assert_eq(v.last(), OptI.Some(1));
+    @assert_eq(v.index_of(1), OptU64.Some(1));
+    @assert_eq(v.index_of(5), OptU64.None);
+    @assert(v.contains(4));
+    @assert(!v.contains(2));
+}
+
+test "ArrayBuf swap and reverse" {
+    let mut v = Buf.new();
+    v.push(1); v.push(2); v.push(3); v.push(4);
+    v.swap(0, 3);
+    @assert_eq(v.get(0), OptI.Some(4));
+    @assert_eq(v.get(3), OptI.Some(1));
+    v.reverse();
+    @assert_eq(v.get(0), OptI.Some(1));
+    @assert_eq(v.get(1), OptI.Some(3));
+    @assert_eq(v.get(2), OptI.Some(2));
+    @assert_eq(v.get(3), OptI.Some(4));
+    let mut one = Buf.new();
+    one.push(7);
+    one.reverse();
+    @assert_eq(one.get(0), OptI.Some(7));
+    let mut none = Buf.new();
+    none.reverse();
+    @assert_eq(none.len(), 0);
+}
+
+test "ArrayBuf grows well past its initial capacity" {
+    let mut v = Buf.new();
+    let mut i: i64 = 0;
+    while i < 10000 {
+        v.push(i * i);
+        i += 1;
+    }
+    @assert_eq(v.len(), 10000);
+    @assert_eq(v.get(9999), OptI.Some(99980001));
+    @assert(v.capacity() >= 10000);
+}
+
+test "ArrayBuf with_capacity and reserve do not change len" {
+    let mut v = Buf.with_capacity(32);
+    @assert_eq(v.len(), 0);
+    @assert(v.capacity() >= 32);
+    v.reserve(100);
+    @assert(v.capacity() >= 100);
+    @assert_eq(v.len(), 0);
+}
+
+test "ArrayBuf clear keeps capacity and free resets it" {
+    let mut v = Buf.new();
+    v.push(1); v.push(2);
+    v.clear();
+    @assert_eq(v.len(), 0);
+    @assert(v.capacity() >= 2);
+    v.push(3);
+    @assert_eq(v.get(0), OptI.Some(3));
+    v.free();
+    @assert_eq(v.len(), 0);
+    v.push(4);
+    @assert_eq(v.get(0), OptI.Some(4));
+}
+
+test "ArrayBuf extend_from copies another buffer" {
+    let mut a = Buf.new();
+    a.push(1);
+    let mut b = Buf.new();
+    b.push(2); b.push(3);
+    a.extend_from(borrow b);
+    @assert_eq(a.len(), 3);
+    @assert_eq(a.get(2), OptI.Some(3));
+    @assert_eq(b.len(), 2);
+}
+
+test "ArrayBuf(u8) bridges from str" {
+    let mut b = Bytes.from_str(borrow "Rue");
+    @assert_eq(b.len(), 3);
+    @assert_eq(b.get(0), OptU8.Some(82));
+    b.extend_str(borrow "!");
+    @assert_eq(b.len(), 4);
+    @assert_eq(b.get(3), OptU8.Some(33));
+    let s = StrBuf.from_bytes(borrow b);
+    @assert_eq(s, "Rue!");
+}
+
+test "ArrayBuf of StrBuf reads in place and moves out with pop" {
+    let mut v = Strs.new();
+    let a: StrBuf = "one";
+    let b: StrBuf = "two";
+    v.push(a);
+    v.push(b);
+    @assert_eq(v.get_ref(0), "one");
+    @assert_eq(v.get_ref(1), "two");
+    let OS = std.option.Option(StrBuf);
+    match v.pop() {
+        OS.Some(s) => @assert_eq(s, "two"),
+        OS.None => @assert(false, "expected an element"),
+    }
+    @assert_eq(v.len(), 1);
+}
+
+test "StrBuf construction, length, and push" {
+    let mut s = StrBuf.new();
+    @assert(s.is_empty());
+    @assert_eq(s.len(), 0);
+    s.push(104);
+    s.push(105);
+    @assert_eq(s, "hi");
+    @assert_eq(s.len(), 2);
+    s.append_str(borrow " there");
+    @assert_eq(s, "hi there");
+    let tail: StrBuf = "!";
+    s.push_str(tail);
+    @assert_eq(s, "hi there!");
+}
+
+test "StrBuf from_str and clone are independent copies" {
+    let a = StrBuf.from_str(borrow "abc");
+    let mut b = a.clone();
+    b.push(100);
+    @assert_eq(a, "abc");
+    @assert_eq(b, "abcd");
+    @assert_ne(a, b);
+}
+
+test "StrBuf byte access and indexing" {
+    let s: StrBuf = "abc";
+    @assert_eq(s.byte_at(0), OptU8.Some(97));
+    @assert_eq(s.byte_at(2), OptU8.Some(99));
+    @assert_eq(s.byte_at(3), OptU8.None);
+    @assert_eq(s[1], 98);
+}
+
+test "StrBuf prefix, suffix, containment, and search" {
+    let s: StrBuf = "hello world";
+    @assert(s.starts_with(borrow "hello"));
+    @assert(!s.starts_with(borrow "world"));
+    @assert(s.ends_with(borrow "world"));
+    @assert(!s.ends_with(borrow "hello"));
+    @assert(s.starts_with(borrow ""));
+    @assert(s.ends_with(borrow ""));
+    @assert(s.contains(borrow "o w"));
+    @assert(!s.contains(borrow "ow"));
+    @assert_eq(s.find_str(borrow "o"), OptU64.Some(4));
+    @assert_eq(s.rfind_str(borrow "o"), OptU64.Some(7));
+    @assert_eq(s.find_str_from(borrow "o", 5), OptU64.Some(7));
+    @assert_eq(s.find_str_from(borrow "o", 8), OptU64.None);
+    @assert(s.matches_at(6, borrow "world"));
+    @assert(!s.matches_at(7, borrow "world"));
+}
+
+test "StrBuf substring, byte_range, and concat" {
+    let s: StrBuf = "hello world";
+    @assert_eq(s.substring(6, 5), "world");
+    @assert_eq(s.byte_range(0, 5), "hello");
+    @assert_eq(s.byte_range(11, 0), "");
+    let other: StrBuf = "!";
+    @assert_eq(s.concat(borrow other), "hello world!");
+    @assert_eq(s, "hello world");
+}
+
+test "StrBuf to_bytes and back" {
+    let s: StrBuf = "bytes";
+    let b = s.to_bytes();
+    @assert_eq(b.len(), 5);
+    @assert_eq(b.get(0), OptU8.Some(98));
+    @assert_eq(StrBuf.from_bytes(borrow b), "bytes");
+    @assert_eq(StrBuf.from_byte_range(borrow b, 1, 3), "yte");
+}
+
+test "StrBuf clear empties but stays usable" {
+    let mut s: StrBuf = "data";
+    s.clear();
+    @assert_eq(s.len(), 0);
+    @assert_eq(s, "");
+    s.append_str(borrow "again");
+    @assert_eq(s, "again");
+}
+
+test "StrBuf equality is by content" {
+    let a: StrBuf = "same";
+    let b = StrBuf.from_str(borrow "same");
+    let c: StrBuf = "Same";
+    @assert_eq(a, b);
+    @assert_ne(a, c);
+    @assert(StrBuf.equals_borrowed(borrow a, borrow b));
+}
+
+test "StrBuf chars iterates scalars" {
+    let s: StrBuf = "aé😀";
+    let mut n: u64 = 0;
+    let mut last: u32 = 0;
+    for c in s.chars() {
+        n += 1;
+        last = c;
+    }
+    @assert_eq(n, 3);
+    @assert_eq(last, 0x1F600);
+}

--- a/tests/std/cmp_tests.rue
+++ b/tests/std/cmp_tests.rue
@@ -1,0 +1,33 @@
+const std = @import("std");
+const cmp = std.cmp;
+const Ordering = std.cmp.Ordering;
+
+test "cmp orders two integers three ways" {
+    @assert_eq(cmp.cmp(i64, 3, 7), Ordering.Less);
+    @assert_eq(cmp.cmp(i64, 7, 3), Ordering.Greater);
+    @assert_eq(cmp.cmp(i64, 5, 5), Ordering.Equal);
+}
+
+test "cmp works on unsigned and narrow types" {
+    @assert_eq(cmp.cmp(u8, 0, 255), Ordering.Less);
+    @assert_eq(cmp.cmp(u64, 18446744073709551615, 0), Ordering.Greater);
+}
+
+test "min and max return the first argument on a tie" {
+    @assert_eq(cmp.min(i64, 3, 7), 3);
+    @assert_eq(cmp.max(i64, 3, 7), 7);
+    @assert_eq(cmp.min(i64, -4, -4), -4);
+    @assert_eq(cmp.max(i32, -1, -9), -1);
+}
+
+test "clamp pins to either bound and passes an in-range value" {
+    @assert_eq(cmp.clamp(i64, 12, 0, 9), 9);
+    @assert_eq(cmp.clamp(i64, -3, 0, 9), 0);
+    @assert_eq(cmp.clamp(i64, 4, 0, 9), 4);
+    @assert_eq(cmp.clamp(i64, 0, 0, 0), 0);
+}
+
+test "eq is structural equality" {
+    @assert(cmp.eq(i64, 42, 42));
+    @assert(!cmp.eq(u8, 1, 2));
+}

--- a/tests/std/collections_tests.rue
+++ b/tests/std/collections_tests.rue
@@ -1,0 +1,249 @@
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const OptI = std.option.Option(i64);
+const OptS = std.option.Option(StrBuf);
+const Stack = std.stack.Stack(i64);
+const StackS = std.stack.Stack(StrBuf);
+const Queue = std.queue.Queue(i64);
+const Deque = std.deque.Deque(i64);
+const Heap = std.binary_heap.BinaryHeap(i64);
+const PQ = std.binary_heap.PriorityQueue(u64, i64);
+const Grid = std.grid.Grid2D(i64);
+const BitSet = std.bitset.BitSet();
+
+test "Stack is LIFO with peek, pop, and clear" {
+    let mut s = Stack.new();
+    @assert(s.is_empty());
+    @assert_eq(s.pop(), OptI.None);
+    @assert_eq(s.peek(), OptI.None);
+    s.push(10);
+    s.push(20);
+    @assert_eq(s.len(), 2);
+    @assert_eq(s.peek(), OptI.Some(20));
+    @assert_eq(s.pop(), OptI.Some(20));
+    @assert_eq(s.pop(), OptI.Some(10));
+    @assert_eq(s.pop(), OptI.None);
+    s.push(1);
+    s.clear();
+    @assert(s.is_empty());
+}
+
+test "Stack of owned StrBuf moves elements out with pop" {
+    let mut s = StackS.new();
+    let a: StrBuf = "first";
+    let b: StrBuf = "second";
+    s.push(a);
+    s.push(b);
+    // RUE-2012: `@assert_eq(s.peek_ref(), "second")` on Stack(StrBuf) is
+    // E9000 "mandatory accessor CFG splice failed"; restore it when that lands.
+    @assert_eq(s.len(), 2);
+    match s.pop() {
+        OptS.Some(v) => @assert_eq(v, "second"),
+        OptS.None => @assert(false, "expected an element"),
+    }
+    @assert_eq(s.len(), 1);
+}
+
+test "Queue is FIFO and reclaims its buffer after a full drain" {
+    let mut q = Queue.new();
+    @assert_eq(q.dequeue(), OptI.None);
+    q.enqueue(1);
+    q.enqueue(2);
+    q.enqueue(3);
+    @assert_eq(q.len(), 3);
+    @assert_eq(q.peek(), OptI.Some(1));
+    @assert_eq(q.dequeue(), OptI.Some(1));
+    @assert_eq(q.len(), 2);
+    @assert_eq(q.dequeue(), OptI.Some(2));
+    @assert_eq(q.dequeue(), OptI.Some(3));
+    @assert(q.is_empty());
+    q.enqueue(4);
+    @assert_eq(q.peek_ref(), 4);
+    @assert_eq(q.dequeue(), OptI.Some(4));
+    @assert_eq(q.dequeue(), OptI.None);
+}
+
+test "Queue interleaves enqueue and dequeue in order" {
+    let mut q = Queue.new();
+    let mut next_in: i64 = 0;
+    let mut next_out: i64 = 0;
+    let mut round: u64 = 0;
+    while round < 50 {
+        q.enqueue(next_in); next_in += 1;
+        q.enqueue(next_in); next_in += 1;
+        @assert_eq(q.dequeue(), OptI.Some(next_out));
+        next_out += 1;
+        round += 1;
+    }
+    @assert_eq(q.len(), 50);
+}
+
+test "Deque pushes and pops at both ends" {
+    let mut d = Deque.new(0);
+    @assert(d.is_empty());
+    @assert_eq(d.pop_front(), OptI.None);
+    @assert_eq(d.pop_back(), OptI.None);
+    d.push_back(2);
+    d.push_front(1);
+    d.push_back(3);
+    @assert_eq(d.len(), 3);
+    @assert_eq(d.front(), OptI.Some(1));
+    @assert_eq(d.back(), OptI.Some(3));
+    @assert_eq(d.pop_front(), OptI.Some(1));
+    @assert_eq(d.pop_back(), OptI.Some(3));
+    @assert_eq(d.pop_back(), OptI.Some(2));
+    @assert_eq(d.front(), OptI.None);
+}
+
+test "Deque wraps around and grows past its initial ring" {
+    let mut d = Deque.new(-1);
+    // Rotate the head away from zero so growth must re-lay a wrapped ring.
+    let mut i: i64 = 0;
+    while i < 5 { d.push_back(i); i += 1; }
+    let mut k: u64 = 0;
+    while k < 5 { let _ = d.pop_front(); k += 1; }
+    let mut j: i64 = 0;
+    while j < 100 {
+        d.push_back(j);
+        d.push_front(-j - 1);
+        j += 1;
+    }
+    @assert_eq(d.len(), 200);
+    @assert_eq(d.front(), OptI.Some(-100));
+    @assert_eq(d.back(), OptI.Some(99));
+    let mut expect: i64 = -100;
+    while expect < 100 {
+        @assert_eq(d.pop_front(), OptI.Some(expect));
+        expect += 1;
+    }
+    @assert(d.is_empty());
+}
+
+test "BinaryHeap pops in ascending order with duplicates" {
+    let mut h = Heap.new();
+    @assert_eq(h.pop(), OptI.None);
+    @assert_eq(h.peek(), OptI.None);
+    h.push(5); h.push(1); h.push(3); h.push(1); h.push(-7); h.push(3);
+    @assert_eq(h.len(), 6);
+    @assert_eq(h.peek(), OptI.Some(-7));
+    @assert_eq(h.pop(), OptI.Some(-7));
+    @assert_eq(h.pop(), OptI.Some(1));
+    @assert_eq(h.pop(), OptI.Some(1));
+    @assert_eq(h.pop(), OptI.Some(3));
+    @assert_eq(h.pop(), OptI.Some(3));
+    @assert_eq(h.pop(), OptI.Some(5));
+    @assert_eq(h.pop(), OptI.None);
+}
+
+test "BinaryHeap of a pseudo-random sequence pops sorted" {
+    let mut rng = std.rand.Lcg.new(42);
+    let mut h = Heap.new();
+    let mut i: u64 = 0;
+    while i < 200 {
+        let v: i64 = @intCast(rng.next_below(1000));
+        h.push(v);
+        i += 1;
+    }
+    let mut prev: i64 = -1;
+    let mut popped: u64 = 0;
+    while !h.is_empty() {
+        match h.pop() {
+            OptI.Some(v) => {
+                @assert(v >= prev);
+                prev = v;
+                popped += 1;
+            },
+            OptI.None => @assert(false, "non-empty heap popped None"),
+        }
+    }
+    @assert_eq(popped, 200);
+}
+
+test "PriorityQueue pops the lowest priority first and keeps its payload" {
+    let OptItem = std.option.Option(std.tuple.Pair(u64, i64));
+    let mut pq = PQ.new();
+    pq.push(30, 300);
+    pq.push(10, 100);
+    pq.push(20, 200);
+    @assert_eq(pq.len(), 3);
+    match pq.pop() {
+        OptItem.Some(it) => {
+            @assert_eq(it.first, 10);
+            @assert_eq(it.second, 100);
+        },
+        OptItem.None => @assert(false, "expected an item"),
+    }
+    match pq.pop() {
+        OptItem.Some(it) => @assert_eq(it.second, 200),
+        OptItem.None => @assert(false, "expected an item"),
+    }
+    match pq.pop() {
+        OptItem.Some(it) => @assert_eq(it.second, 300),
+        OptItem.None => @assert(false, "expected an item"),
+    }
+    @assert(pq.is_empty());
+}
+
+test "Grid2D get and set are bounds-aware" {
+    let mut g = Grid.new(2, 3, 0);
+    @assert_eq(g.rows(), 2);
+    @assert_eq(g.cols(), 3);
+    @assert(g.in_bounds(1, 2));
+    @assert(!g.in_bounds(2, 0));
+    @assert(!g.in_bounds(0, 3));
+    g.set(1, 2, 42);
+    g.set(5, 5, 99);
+    @assert_eq(g.get(1, 2), OptI.Some(42));
+    @assert_eq(g.get(0, 0), OptI.Some(0));
+    @assert_eq(g.get(2, 0), OptI.None);
+    @assert_eq(g.get(0, 3), OptI.None);
+    @assert_eq(g.get_ref(1, 2), 42);
+}
+
+test "Grid2D row-major layout keeps rows apart" {
+    let mut g = Grid.new(3, 3, 0);
+    g.set(0, 2, 1);
+    g.set(1, 0, 2);
+    @assert_eq(g.get(0, 2), OptI.Some(1));
+    @assert_eq(g.get(1, 0), OptI.Some(2));
+    @assert_eq(g.get(0, 1), OptI.Some(0));
+    @assert_eq(g.get(1, 1), OptI.Some(0));
+}
+
+test "a zero-sized Grid2D has no cells" {
+    let g = Grid.new(0, 5, 7);
+    @assert_eq(g.rows(), 0);
+    @assert(!g.in_bounds(0, 0));
+    @assert_eq(g.get(0, 0), OptI.None);
+    let h = Grid.new(4, 0, 7);
+    @assert_eq(h.get(0, 0), OptI.None);
+}
+
+test "BitSet set, test, clear, toggle, count across word boundaries" {
+    let mut bs = BitSet.new();
+    @assert_eq(bs.count(), 0);
+    @assert(!bs.test(0));
+    bs.set(0);
+    bs.set(63);
+    bs.set(64);
+    bs.set(200);
+    @assert(bs.test(0));
+    @assert(bs.test(63));
+    @assert(bs.test(64));
+    @assert(bs.test(200));
+    @assert(!bs.test(1));
+    @assert(!bs.test(65));
+    @assert(!bs.test(10000));
+    @assert_eq(bs.count(), 4);
+    bs.clear(63);
+    @assert(!bs.test(63));
+    @assert_eq(bs.count(), 3);
+    bs.clear(5000);
+    @assert_eq(bs.count(), 3);
+    bs.toggle(1);
+    @assert(bs.test(1));
+    bs.toggle(1);
+    @assert(!bs.test(1));
+    bs.set(0);
+    @assert_eq(bs.count(), 3);
+}

--- a/tests/std/env_tests.rue
+++ b/tests/std/env_tests.rue
@@ -1,0 +1,37 @@
+// The runner pins the test-visible inventory (docs/process/test-events.md):
+// argv is exactly ["rue-test"], the environment is exactly ["RUE_TEST=1"],
+// stdin is EOF, and the working directory is a private scratch directory.
+// These tests are the contract's executable form.
+const std = @import("std");
+const env = std.env;
+const StrBuf = std.strbuf.StrBuf;
+const OptS = std.option.Option(StrBuf);
+
+test "a test process sees exactly one argument, the logical argv[0]" {
+    @assert_eq(env.arg_count(), 1);
+    @assert_eq(env.arg(0), OptS.Some("rue-test"));
+    @assert_eq(env.arg(1), OptS.None);
+    let all = env.args();
+    @assert_eq(all.len(), 1);
+    @assert_eq(all.get_ref(0), "rue-test");
+}
+
+test "a test process sees exactly RUE_TEST=1 in its environment" {
+    @assert_eq(env.env_count(), 1);
+    let name: StrBuf = "RUE_TEST";
+    @assert_eq(env.var(borrow name), OptS.Some("1"));
+    let home: StrBuf = "HOME";
+    @assert_eq(env.var(borrow home), OptS.None);
+    let path: StrBuf = "PATH";
+    @assert_eq(env.var(borrow path), OptS.None);
+}
+
+test "the scratch directory starts empty and is writable" {
+    let dot: StrBuf = ".";
+    let entries = std.fs.read_dir(borrow dot);
+    let R = std.result.Result(std.fs.DirEntries, std.fs.FileError);
+    match entries {
+        R.Ok(d) => @assert_eq(d.len(), 0),
+        R.Err(e) => @assert(false, "read_dir of the scratch directory failed"),
+    }
+}

--- a/tests/std/fmt_tests.rue
+++ b/tests/std/fmt_tests.rue
@@ -1,0 +1,34 @@
+const std = @import("std");
+const fmt = std.fmt;
+
+test "int_to_string renders signed and unsigned widths" {
+    @assert_eq(fmt.int_to_string(i64, 0), "0");
+    @assert_eq(fmt.int_to_string(i64, -42), "-42");
+    @assert_eq(fmt.int_to_string(u8, 255), "255");
+    @assert_eq(fmt.int_to_string(i64, @int_min(i64)), "-9223372036854775808");
+    @assert_eq(fmt.int_to_string(u64, @int_max(u64)), "18446744073709551615");
+}
+
+test "bool_to_string" {
+    @assert_eq(fmt.bool_to_string(true), "true");
+    @assert_eq(fmt.bool_to_string(false), "false");
+}
+
+test "to_hex and to_binary have no prefix and are lowercase" {
+    @assert_eq(fmt.to_hex(0), "0");
+    @assert_eq(fmt.to_hex(255), "ff");
+    @assert_eq(fmt.to_hex(3735928559), "deadbeef");
+    @assert_eq(fmt.to_hex(@int_max(u64)), "ffffffffffffffff");
+    @assert_eq(fmt.to_binary(0), "0");
+    @assert_eq(fmt.to_binary(5), "101");
+    @assert_eq(fmt.to_binary(256), "100000000");
+}
+
+test "to_radix covers the whole 2..=16 range" {
+    @assert_eq(fmt.to_radix(255, 2), "11111111");
+    @assert_eq(fmt.to_radix(255, 3), "100110");
+    @assert_eq(fmt.to_radix(255, 8), "377");
+    @assert_eq(fmt.to_radix(255, 10), "255");
+    @assert_eq(fmt.to_radix(255, 16), "ff");
+    @assert_eq(fmt.to_radix(35, 6), "55");
+}

--- a/tests/std/fs_tests.rue
+++ b/tests/std/fs_tests.rue
@@ -1,0 +1,230 @@
+// std.fs against the runner's private scratch directory: every test starts in
+// a fresh empty directory (`.`), so relative paths are isolated per test.
+const std = @import("std");
+const fs = std.fs;
+const StrBuf = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+const CountR = std.result.Result(u64, fs.FileError);
+const MetaR = std.result.Result(fs.Metadata, fs.FileError);
+const UnitR = std.result.Result((), fs.FileError);
+
+fn read_all(inout f: fs.File) -> StrBuf {
+    let mut buf = Bytes.new();
+    let mut reading = true;
+    while reading {
+        buf.reserve(64);
+        match f.read(inout buf) {
+            CountR.Ok(n) => { if n == 0 { reading = false; } },
+            CountR.Err(e) => @panic("read failed"),
+        }
+    }
+    StrBuf.from_bytes(borrow buf)
+}
+
+test "create, write_all, close, open, read round-trips bytes" {
+    let path: StrBuf = "hello.txt";
+    let mut f = fs.File.create(borrow path)?;
+    let bytes = Bytes.from_str(borrow "hello, scratch\n");
+    f.write_all(borrow bytes)?;
+    f.close()?;
+    let mut g = fs.File.open(borrow path)?;
+    @assert_eq(read_all(inout g), "hello, scratch\n");
+    g.close()?;
+}
+
+test "write returns the count and an empty write is Ok(0)" {
+    let path: StrBuf = "count.txt";
+    let mut f = fs.File.create(borrow path)?;
+    let bytes = Bytes.from_str(borrow "12345");
+    let n: u64 = f.write(borrow bytes)?;
+    @assert_eq(n, 5);
+    let none = Bytes.new();
+    let zero: u64 = f.write(borrow none)?;
+    @assert_eq(zero, 0);
+    f.close()?;
+}
+
+test "read into a buffer with no spare capacity is InvalidInput, not Ok(0)" {
+    let path: StrBuf = "full.txt";
+    let mut f = fs.File.create(borrow path)?;
+    f.write_all(borrow Bytes.from_str(borrow "abc"))?;
+    f.close()?;
+    let mut g = fs.File.open(borrow path)?;
+    let mut buf = Bytes.new();
+    match g.read(inout buf) {
+        CountR.Ok(n) => @assert(false, "expected an error for a full buffer"),
+        CountR.Err(e) => @assert_eq(e, fs.FileError.InvalidInput),
+    }
+    g.close()?;
+}
+
+test "append adds to the end of an existing file" {
+    let path: StrBuf = "log.txt";
+    let mut f = fs.File.create(borrow path)?;
+    f.write_all(borrow Bytes.from_str(borrow "one\n"))?;
+    f.close()?;
+    let mut a = fs.File.append(borrow path)?;
+    a.write_all(borrow Bytes.from_str(borrow "two\n"))?;
+    a.close()?;
+    let mut g = fs.File.open(borrow path)?;
+    @assert_eq(read_all(inout g), "one\ntwo\n");
+    g.close()?;
+}
+
+test "create truncates an existing file" {
+    let path: StrBuf = "trunc.txt";
+    let mut f = fs.File.create(borrow path)?;
+    f.write_all(borrow Bytes.from_str(borrow "a much longer first version"))?;
+    f.close()?;
+    let mut g = fs.File.create(borrow path)?;
+    g.write_all(borrow Bytes.from_str(borrow "short"))?;
+    g.close()?;
+    let mut h = fs.File.open(borrow path)?;
+    @assert_eq(read_all(inout h), "short");
+    h.close()?;
+}
+
+test "seek and tell move the cursor" {
+    let path: StrBuf = "seek.txt";
+    let mut f = fs.File.create(borrow path)?;
+    f.write_all(borrow Bytes.from_str(borrow "0123456789"))?;
+    f.close()?;
+    let mut g = fs.File.open(borrow path)?;
+    let start: u64 = g.tell()?;
+    @assert_eq(start, 0);
+    let at: u64 = g.seek(7, fs.Whence.Set)?;
+    @assert_eq(at, 7);
+    @assert_eq(read_all(inout g), "789");
+    let back: u64 = g.seek(-4, fs.Whence.End)?;
+    @assert_eq(back, 6);
+    let now: u64 = g.tell()?;
+    @assert_eq(now, 6);
+    g.close()?;
+}
+
+test "metadata reports size and kind" {
+    let path: StrBuf = "meta.txt";
+    let mut f = fs.File.create(borrow path)?;
+    f.write_all(borrow Bytes.from_str(borrow "sized"))?;
+    f.close()?;
+    let m = fs.metadata(borrow path)?;
+    @assert_eq(m.size(), 5);
+    @assert(m.is_file());
+    @assert(!m.is_dir());
+    let dot: StrBuf = ".";
+    let d = fs.metadata(borrow dot)?;
+    @assert(d.is_dir());
+    @assert(!d.is_file());
+}
+
+test "metadata of a missing path is NotFound" {
+    let missing: StrBuf = "does-not-exist";
+    match fs.metadata(borrow missing) {
+        MetaR.Ok(m) => @assert(false, "expected NotFound"),
+        MetaR.Err(e) => @assert_eq(e, fs.FileError.NotFound),
+    }
+}
+
+test "rename moves a file and remove deletes it" {
+    let from: StrBuf = "from.txt";
+    let to: StrBuf = "to.txt";
+    let mut f = fs.File.create(borrow from)?;
+    f.write_all(borrow Bytes.from_str(borrow "moved"))?;
+    f.close()?;
+    fs.rename(borrow from, borrow to)?;
+    match fs.metadata(borrow from) {
+        MetaR.Ok(m) => @assert(false, "source should be gone"),
+        MetaR.Err(e) => @assert_eq(e, fs.FileError.NotFound),
+    }
+    let mut g = fs.File.open(borrow to)?;
+    @assert_eq(read_all(inout g), "moved");
+    g.close()?;
+    fs.remove(borrow to)?;
+    match fs.remove(borrow to) {
+        UnitR.Ok(u) => @assert(false, "second remove should fail"),
+        UnitR.Err(e) => @assert_eq(e, fs.FileError.NotFound),
+    }
+}
+
+test "create_dir, create_dir_all, remove_dir, remove_dir_all" {
+    let d: StrBuf = "d";
+    fs.create_dir(borrow d)?;
+    let m = fs.metadata(borrow d)?;
+    @assert(m.is_dir());
+    match fs.create_dir(borrow d) {
+        UnitR.Ok(u) => @assert(false, "creating an existing dir should fail"),
+        UnitR.Err(e) => @assert_eq(e, fs.FileError.AlreadyExists),
+    }
+    let deep: StrBuf = "x/y/z";
+    fs.create_dir_all(borrow deep)?;
+    fs.create_dir_all(borrow deep)?;
+    let leaf: StrBuf = "x/y/z/leaf.txt";
+    let mut f = fs.File.create(borrow leaf)?;
+    f.close()?;
+    fs.remove_dir(borrow d)?;
+    let x: StrBuf = "x";
+    match fs.remove_dir(borrow x) {
+        UnitR.Ok(u) => @assert(false, "non-empty dir should not remove"),
+        UnitR.Err(e) => @assert_ne(e, fs.FileError.NotFound),
+    }
+    fs.remove_dir_all(borrow x)?;
+    match fs.metadata(borrow x) {
+        MetaR.Ok(m) => @assert(false, "tree should be gone"),
+        MetaR.Err(e) => @assert_eq(e, fs.FileError.NotFound),
+    }
+}
+
+test "read_dir lists entries in a deterministic name order with kinds" {
+    let b: StrBuf = "b.txt";
+    let a: StrBuf = "a.txt";
+    let sub: StrBuf = "sub";
+    let mut fb = fs.File.create(borrow b)?;
+    fb.close()?;
+    let mut fa = fs.File.create(borrow a)?;
+    fa.close()?;
+    fs.create_dir(borrow sub)?;
+    let dot: StrBuf = ".";
+    let entries = fs.read_dir(borrow dot)?;
+    @assert_eq(entries.len(), 3);
+    @assert_eq(entries.name(0), "a.txt");
+    @assert_eq(entries.name(1), "b.txt");
+    @assert_eq(entries.name(2), "sub");
+    @assert(entries.is_file(0));
+    @assert(!entries.is_dir(0));
+    @assert(entries.is_dir(2));
+    @assert_eq(entries.kind(2), fs.FileKind.Dir);
+    @assert(entries.path(0).ends_with(borrow "a.txt"));
+}
+
+test "walk descends into subdirectories" {
+    let sub: StrBuf = "sub";
+    fs.create_dir(borrow sub)?;
+    let inner: StrBuf = "sub/inner.txt";
+    let mut f = fs.File.create(borrow inner)?;
+    f.close()?;
+    let top: StrBuf = "top.txt";
+    let mut t = fs.File.create(borrow top)?;
+    t.close()?;
+    let dot: StrBuf = ".";
+    let entries = fs.walk(borrow dot)?;
+    @assert_eq(entries.len(), 3);
+    let mut saw_inner = false;
+    let mut i: u64 = 0;
+    while i < entries.len() {
+        if entries.name(i) == "inner.txt" {
+            saw_inner = true;
+            @assert(entries.path(i).ends_with(borrow "sub/inner.txt"));
+        }
+        i += 1;
+    }
+    @assert(saw_inner);
+}
+
+test "opening a missing file fails with NotFound" {
+    let FileR = std.result.Result(fs.File, fs.FileError);
+    let missing: StrBuf = "nope.txt";
+    match fs.File.open(borrow missing) {
+        FileR.Ok(f) => @assert(false, "expected NotFound"),
+        FileR.Err(e) => @assert_eq(e, fs.FileError.NotFound),
+    }
+}

--- a/tests/std/hash_rand_tests.rue
+++ b/tests/std/hash_rand_tests.rue
@@ -1,0 +1,102 @@
+const std = @import("std");
+const hash = std.hash;
+const StrBuf = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+
+test "fnv1a matches the published 64-bit vectors" {
+    @assert_eq(hash.fnv1a_str(borrow ""), 0xcbf29ce484222325);
+    @assert_eq(hash.fnv1a_str(borrow "a"), 0xaf63dc4c8601ec8c);
+    @assert_eq(hash.fnv1a_str(borrow "foobar"), 0x85944171f73967e8);
+}
+
+test "djb2 (64-bit state) known answers" {
+    @assert_eq(hash.djb2_str(borrow ""), 0x1505);
+    @assert_eq(hash.djb2_str(borrow "a"), 0x2b606);
+    @assert_eq(hash.djb2_str(borrow "foobar"), 0x652fde460be);
+}
+
+test "the three byte-shaped one-shot entry points agree" {
+    let s: StrBuf = "foobar";
+    let b = Bytes.from_str(borrow "foobar");
+    @assert_eq(hash.fnv1a_strbuf(borrow s), hash.fnv1a_str(borrow "foobar"));
+    @assert_eq(hash.fnv1a_bytes(borrow b), hash.fnv1a_str(borrow "foobar"));
+    @assert_eq(hash.djb2_strbuf(borrow s), hash.djb2_str(borrow "foobar"));
+    @assert_eq(hash.djb2_bytes(borrow b), hash.djb2_str(borrow "foobar"));
+}
+
+test "Hasher depends only on the concatenated bytes, not the chunking" {
+    let mut h = hash.Hasher.fnv1a();
+    h.write_str(borrow "foo");
+    h.write_str(borrow "bar");
+    @assert_eq(h.finish(), hash.fnv1a_str(borrow "foobar"));
+    let mut d = hash.Hasher.djb2();
+    d.write_byte(102);
+    let oobar: StrBuf = "oobar";
+    d.write_strbuf(borrow oobar);
+    @assert_eq(d.finish(), hash.djb2_str(borrow "foobar"));
+}
+
+test "finish does not consume; reset returns to the seed" {
+    let mut h = hash.Hasher.fnv1a();
+    @assert_eq(h.finish(), 0xcbf29ce484222325);
+    h.write_str(borrow "a");
+    @assert_eq(h.finish(), 0xaf63dc4c8601ec8c);
+    h.write_str(borrow "");
+    @assert_eq(h.finish(), 0xaf63dc4c8601ec8c);
+    h.reset();
+    @assert_eq(h.finish(), 0xcbf29ce484222325);
+    h.write_str(borrow "foobar");
+    @assert_eq(h.finish(), 0x85944171f73967e8);
+}
+
+test "Hasher.new with an explicit Algorithm equals the named constructors" {
+    let mut a = hash.Hasher.new(hash.Algorithm.Djb2);
+    let mut b = hash.Hasher.djb2();
+    a.write_bytes(borrow Bytes.from_str(borrow "xyz"));
+    b.write_str(borrow "xyz");
+    @assert_eq(a.finish(), b.finish());
+    @assert_ne(a.finish(), hash.fnv1a_str(borrow "xyz"));
+}
+
+test "Lcg is deterministic per seed and follows the Numerical Recipes step" {
+    let mut a = std.rand.Lcg.new(0);
+    @assert_eq(a.next_u64(), 1013904223);
+    @assert_eq(a.next_u64(), (1013904223 * 1664525 + 1013904223) % 4294967296);
+    let mut b = std.rand.Lcg.new(12345);
+    let mut c = std.rand.Lcg.new(12345);
+    let mut i: u64 = 0;
+    while i < 20 {
+        @assert_eq(b.next_u64(), c.next_u64());
+        i += 1;
+    }
+}
+
+test "Lcg reduces its seed modulo 2^32" {
+    let mut a = std.rand.Lcg.new(5);
+    let mut b = std.rand.Lcg.new(4294967296 + 5);
+    @assert_eq(a.next_u64(), b.next_u64());
+}
+
+test "next_u64 stays below 2^32 and next_below respects its bound" {
+    let mut r = std.rand.Lcg.new(99);
+    let mut i: u64 = 0;
+    while i < 1000 {
+        @assert(r.next_u64() < 4294967296);
+        @assert(r.next_below(6) < 6);
+        @assert_eq(r.next_below(1), 0);
+        i += 1;
+    }
+    @assert_eq(r.next_below(0), 0);
+}
+
+test "next_bool produces both values over a short run" {
+    let mut r = std.rand.Lcg.new(3);
+    let mut trues: u64 = 0;
+    let mut i: u64 = 0;
+    while i < 64 {
+        if r.next_bool() { trues += 1; }
+        i += 1;
+    }
+    @assert(trues > 0);
+    @assert(trues < 64);
+}

--- a/tests/std/json_tests.rue
+++ b/tests/std/json_tests.rue
@@ -1,0 +1,120 @@
+const std = @import("std");
+const json = std.json;
+const Json = std.json.Json;
+const ParseError = std.json.ParseError;
+const StrBuf = std.strbuf.StrBuf;
+const R = std.result.Result(Json, ParseError);
+
+fn roundtrip(text: StrBuf) -> StrBuf {
+    match json.parse(text) {
+        R.Ok(v) => json.to_string(v),
+        R.Err(e) => @panic("parse failed"),
+    }
+}
+
+fn error_of(text: StrBuf) -> ParseError {
+    match json.parse(text) {
+        R.Ok(v) => @panic("expected a parse error"),
+        R.Err(e) => e,
+    }
+}
+
+test "scalars round-trip through parse and to_string" {
+    @assert_eq(roundtrip("null"), "null");
+    @assert_eq(roundtrip("true"), "true");
+    @assert_eq(roundtrip("false"), "false");
+    @assert_eq(roundtrip("0"), "0");
+    @assert_eq(roundtrip("-12"), "-12");
+    @assert_eq(roundtrip("1.5e+10"), "1.5e+10");
+    @assert_eq(roundtrip("123456789012345678901234567890"), "123456789012345678901234567890");
+    @assert_eq(roundtrip("\"hi\""), "\"hi\"");
+}
+
+test "surrounding whitespace is accepted and dropped" {
+    @assert_eq(roundtrip(" \n\t[ 1 , 2 ] \r\n"), "[1,2]");
+    @assert_eq(roundtrip("  {  \"a\" : null }  "), "{\"a\":null}");
+}
+
+test "nested arrays and objects serialize compactly in source order" {
+    @assert_eq(roundtrip("[]"), "[]");
+    @assert_eq(roundtrip("{}"), "{}");
+    @assert_eq(roundtrip("[[1],[2,[3]]]"), "[[1],[2,[3]]]");
+    @assert_eq(roundtrip("{\"b\":1,\"a\":{\"c\":[true,false]}}"), "{\"b\":1,\"a\":{\"c\":[true,false]}}");
+}
+
+test "string escapes decode and re-encode canonically" {
+    @assert_eq(roundtrip("\"a\\nb\""), "\"a\\nb\"");
+    @assert_eq(roundtrip("\"tab\\there\""), "\"tab\\there\"");
+    @assert_eq(roundtrip("\"q\\\"q\""), "\"q\\\"q\"");
+    @assert_eq(roundtrip("\"back\\\\slash\""), "\"back\\\\slash\"");
+    @assert_eq(roundtrip("\"sl\\/ash\""), "\"sl/ash\"");
+    @assert_eq(roundtrip("\"\\u0041\""), "\"A\"");
+    @assert_eq(roundtrip("\"\\u00e9\""), "\"é\"");
+    @assert_eq(roundtrip("\"\\u0001\""), "\"\\u0001\"");
+}
+
+test "surrogate pairs decode to one scalar" {
+    @assert_eq(roundtrip("\"\\ud83d\\ude00\""), "\"😀\"");
+}
+
+test "raw UTF-8 in strings passes through" {
+    @assert_eq(roundtrip("\"日本語\""), "\"日本語\"");
+}
+
+// RUE-2015: the offset each variant names follows no single convention yet;
+// these pin the observed values and change with that issue.
+test "parse errors name the byte offset" {
+    @assert_eq(error_of(""), ParseError.UnexpectedEnd(0));
+    @assert_eq(error_of("[1,"), ParseError.UnexpectedEnd(3));
+    @assert_eq(error_of("[1 2]"), ParseError.UnexpectedByte(3));
+    @assert_eq(error_of("nul"), ParseError.UnexpectedEnd(3));
+    @assert_eq(error_of("01"), ParseError.InvalidNumber(1));
+    @assert_eq(error_of("1."), ParseError.InvalidNumber(2));
+    @assert_eq(error_of("-"), ParseError.InvalidNumber(0));
+    @assert_eq(error_of("1e"), ParseError.InvalidNumber(2));
+    @assert_eq(error_of("\"\\x\""), ParseError.InvalidEscape(1));
+    @assert_eq(error_of("\"\\u12\""), ParseError.InvalidUnicode(3));
+    @assert_eq(error_of("\"\\ud800\""), ParseError.InvalidUnicode(1));
+    @assert_eq(error_of("1 2"), ParseError.TrailingCharacters(2));
+    @assert_eq(error_of("{\"a\" 1}"), ParseError.UnexpectedByte(5));
+    @assert_eq(error_of("{1:2}"), ParseError.UnexpectedByte(1));
+    @assert_eq(error_of("\"unterminated"), ParseError.UnexpectedEnd(0));
+}
+
+test "a control byte inside a string is rejected" {
+    let mut s = StrBuf.new();
+    s.push(34);
+    s.push(10);
+    s.push(34);
+    @assert_eq(error_of(s), ParseError.UnexpectedByte(1));
+}
+
+test "deep nesting is bounded" {
+    let deep = std.strings.repeat("[", 10000);
+    match json.parse(deep) {
+        R.Ok(v) => @assert(false, "expected an error"),
+        R.Err(e) => {
+            match e {
+                ParseError.NestingTooDeep(at) => @assert(at > 0),
+                ParseError.UnexpectedEnd(at) => @assert(false, "ran off the end before the depth limit"),
+                ParseError.UnexpectedByte(at) => @assert(false, "unexpected byte"),
+                ParseError.InvalidNumber(at) => @assert(false, "invalid number"),
+                ParseError.InvalidEscape(at) => @assert(false, "invalid escape"),
+                ParseError.InvalidUnicode(at) => @assert(false, "invalid unicode"),
+                ParseError.TrailingCharacters(at) => @assert(false, "trailing"),
+            }
+        },
+    }
+}
+
+test "values built by hand serialize" {
+    let Items = std.arraybuf.ArrayBuf(Json);
+    let mut items = Items.new();
+    items.push(Json.Null);
+    items.push(Json.Bool(true));
+    let n: StrBuf = "42";
+    items.push(Json.Number(n));
+    let s: StrBuf = "x\"y";
+    items.push(Json.String(s));
+    @assert_eq(json.to_string(Json.Array(items)), "[null,true,42,\"x\\\"y\"]");
+}

--- a/tests/std/main.rue
+++ b/tests/std/main.rue
@@ -1,0 +1,24 @@
+// Test root for the Rue standard library. Not a program: `rue test
+// tests/std/main.rue` roots every `test` item in this import closure.
+//
+// The tree lives beside std/, not inside it, because a test root may not sit
+// inside the configured standard-library tree. So these tests see exactly the
+// public API a user program sees and prove its sufficiency (ADR-0083 §1,
+// "placement is the visibility model").
+const cmp_tests = @import("cmp_tests.rue");
+const math_tests = @import("math_tests.rue");
+const ascii_tests = @import("ascii_tests.rue");
+const tuple_mem_tests = @import("tuple_mem_tests.rue");
+const fmt_tests = @import("fmt_tests.rue");
+const binary_tests = @import("binary_tests.rue");
+const option_result_tests = @import("option_result_tests.rue");
+const strings_tests = @import("strings_tests.rue");
+const sort_tests = @import("sort_tests.rue");
+const hash_rand_tests = @import("hash_rand_tests.rue");
+const collections_tests = @import("collections_tests.rue");
+const maps_tests = @import("maps_tests.rue");
+const json_tests = @import("json_tests.rue");
+const buffers_tests = @import("buffers_tests.rue");
+const env_tests = @import("env_tests.rue");
+const fs_tests = @import("fs_tests.rue");
+const net_c_tests = @import("net_c_tests.rue");

--- a/tests/std/maps_tests.rue
+++ b/tests/std/maps_tests.rue
@@ -1,0 +1,143 @@
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const OptI = std.option.Option(i64);
+const IntMap = std.intmap.IntMap(i64);
+const StrMap = std.strmap.StrMap(i64);
+
+test "IntMap insert, get, contains, overwrite, remove" {
+    let mut m = IntMap.new(0);
+    @assert(m.is_empty());
+    @assert_eq(m.get(1), OptI.None);
+    m.insert(42, 100);
+    @assert_eq(m.len(), 1);
+    @assert_eq(m.get(42), OptI.Some(100));
+    @assert(m.contains(42));
+    @assert(!m.contains(43));
+    m.insert(42, 101);
+    @assert_eq(m.len(), 1);
+    @assert_eq(m.get(42), OptI.Some(101));
+    @assert(m.remove(42));
+    @assert(!m.remove(42));
+    @assert_eq(m.get(42), OptI.None);
+    @assert(m.is_empty());
+}
+
+test "IntMap accepts negative keys, zero, and i64::MIN" {
+    let mut m = IntMap.new(0);
+    m.insert(-1, 1);
+    m.insert(0, 2);
+    m.insert(@int_min(i64), 3);
+    m.insert(@int_max(i64), 4);
+    @assert_eq(m.get(-1), OptI.Some(1));
+    @assert_eq(m.get(0), OptI.Some(2));
+    @assert_eq(m.get(@int_min(i64)), OptI.Some(3));
+    @assert_eq(m.get(@int_max(i64)), OptI.Some(4));
+    @assert_eq(m.len(), 4);
+}
+
+test "IntMap grows and keeps every entry" {
+    let mut m = IntMap.new(0);
+    let mut k: i64 = 0;
+    while k < 2000 {
+        m.insert(k * 7, k);
+        k += 1;
+    }
+    @assert_eq(m.len(), 2000);
+    let mut j: i64 = 0;
+    while j < 2000 {
+        @assert_eq(m.get(j * 7), OptI.Some(j));
+        j += 1;
+    }
+    @assert_eq(m.get(1), OptI.None);
+}
+
+test "IntMap survives insert/remove churn that fills the table with tombstones" {
+    let mut m = IntMap.new(0);
+    let mut k: i64 = 0;
+    while k < 5000 {
+        m.insert(k, k);
+        @assert(m.remove(k));
+        k += 1;
+    }
+    @assert(m.is_empty());
+    m.insert(7, 7);
+    @assert_eq(m.get(7), OptI.Some(7));
+    @assert_eq(m.get(8), OptI.None);
+    @assert_eq(m.len(), 1);
+}
+
+test "IntMap remove then reinsert of the same key" {
+    let mut m = IntMap.new(0);
+    m.insert(5, 1);
+    @assert(m.remove(5));
+    m.insert(5, 2);
+    @assert_eq(m.get(5), OptI.Some(2));
+    @assert_eq(m.len(), 1);
+}
+
+test "StrMap insert, get, contains, overwrite, remove" {
+    let mut m = StrMap.new(0);
+    let k: StrBuf = "alpha";
+    let other: StrBuf = "beta";
+    @assert_eq(m.get(borrow k), OptI.None);
+    m.insert(borrow k, 1);
+    @assert_eq(m.get(borrow k), OptI.Some(1));
+    @assert(m.contains(borrow k));
+    @assert(!m.contains(borrow other));
+    m.insert(borrow k, 2);
+    @assert_eq(m.len(), 1);
+    @assert_eq(m.get(borrow k), OptI.Some(2));
+    @assert(m.remove(borrow k));
+    @assert(!m.remove(borrow k));
+    @assert(m.is_empty());
+}
+
+test "StrMap distinguishes prefixes, the empty key, and byte-identical copies" {
+    let mut m = StrMap.new(0);
+    let a: StrBuf = "ab";
+    let ab: StrBuf = "abc";
+    let empty: StrBuf = "";
+    m.insert(borrow a, 1);
+    m.insert(borrow ab, 2);
+    m.insert(borrow empty, 3);
+    @assert_eq(m.len(), 3);
+    @assert_eq(m.get(borrow a), OptI.Some(1));
+    @assert_eq(m.get(borrow ab), OptI.Some(2));
+    @assert_eq(m.get(borrow empty), OptI.Some(3));
+    let copy: StrBuf = "abc";
+    @assert_eq(m.get(borrow copy), OptI.Some(2));
+    let built = std.fmt.int_to_string(i64, 0);
+    @assert_eq(m.get(borrow built), OptI.None);
+}
+
+test "StrMap grows, compacting its key pool, and keeps every entry" {
+    let mut m = StrMap.new(0);
+    let mut i: i64 = 0;
+    while i < 1000 {
+        let key = std.fmt.int_to_string(i64, i);
+        m.insert(borrow key, i);
+        i += 1;
+    }
+    @assert_eq(m.len(), 1000);
+    let mut j: i64 = 0;
+    while j < 1000 {
+        let key = std.fmt.int_to_string(i64, j);
+        @assert_eq(m.get(borrow key), OptI.Some(j));
+        j += 1;
+    }
+}
+
+test "StrMap survives tombstone churn" {
+    let mut m = StrMap.new(0);
+    let mut i: i64 = 0;
+    while i < 3000 {
+        let key = std.fmt.int_to_string(i64, i);
+        m.insert(borrow key, i);
+        @assert(m.remove(borrow key));
+        i += 1;
+    }
+    @assert(m.is_empty());
+    let k: StrBuf = "survivor";
+    m.insert(borrow k, 9);
+    @assert_eq(m.get(borrow k), OptI.Some(9));
+}

--- a/tests/std/math_tests.rue
+++ b/tests/std/math_tests.rue
@@ -1,0 +1,115 @@
+const std = @import("std");
+const math = std.math;
+const OptI64 = std.option.Option(i64);
+const OptU8 = std.option.Option(u8);
+const OptU64 = std.option.Option(u64);
+
+test "legacy i32 helpers: abs, min, max, clamp" {
+    @assert_eq(math.abs(-5), 5);
+    @assert_eq(math.abs(5), 5);
+    @assert_eq(math.abs(0), 0);
+    @assert_eq(math.min(2, 9), 2);
+    @assert_eq(math.max(2, 9), 9);
+    @assert_eq(math.clamp(15, 0, 10), 10);
+    @assert_eq(math.clamp(-15, 0, 10), 0);
+}
+
+test "sign of negative, zero, positive" {
+    @assert_eq(math.sign(i64, -99), -1);
+    @assert_eq(math.sign(i64, 0), 0);
+    @assert_eq(math.sign(i64, 17), 1);
+}
+
+test "gcd handles zero, commutes, and normalises sign" {
+    @assert_eq(math.gcd(i64, 12, 18), 6);
+    @assert_eq(math.gcd(i64, 18, 12), 6);
+    @assert_eq(math.gcd(i64, 0, 0), 0);
+    @assert_eq(math.gcd(i64, 0, 7), 7);
+    @assert_eq(math.gcd(i64, -12, 18), 6);
+    @assert_eq(math.gcd(i64, -12, -18), 6);
+    @assert_eq(math.gcd(u64, 100, 75), 25);
+}
+
+test "gcd survives an i64::MIN operand when the answer is representable" {
+    // RUE-1708: the old |a|/|b| prelude trapped here.
+    @assert_eq(math.gcd(i64, @int_min(i64), 2), 2);
+    @assert_eq(math.gcd(i64, @int_min(i64), 1), 1);
+    @assert_eq(math.gcd(i64, -1, @int_min(i64)), 1);
+}
+
+test "lcm is zero on a zero operand and positive otherwise" {
+    @assert_eq(math.lcm(i64, 4, 6), 12);
+    @assert_eq(math.lcm(i64, -4, 6), 12);
+    @assert_eq(math.lcm(i64, 0, 6), 0);
+    @assert_eq(math.lcm(i64, 6, 0), 0);
+    @assert_eq(math.lcm(i64, 7, 7), 7);
+}
+
+test "pow by squaring" {
+    @assert_eq(math.pow(i64, 2, 10), 1024);
+    @assert_eq(math.pow(i64, 3, 0), 1);
+    @assert_eq(math.pow(i64, 0, 0), 1);
+    @assert_eq(math.pow(i64, -2, 3), -8);
+    @assert_eq(math.pow(u64, 10, 19), 10000000000000000000);
+}
+
+test "isqrt is the floor square root" {
+    @assert_eq(math.isqrt(u64, 0), 0);
+    @assert_eq(math.isqrt(u64, 1), 1);
+    @assert_eq(math.isqrt(u64, 15), 3);
+    @assert_eq(math.isqrt(u64, 16), 4);
+    @assert_eq(math.isqrt(u64, 17), 4);
+    @assert_eq(math.isqrt(u64, @int_max(u64)), 4294967295);
+    @assert_eq(math.isqrt(i32, @int_max(i32)), 46340);
+}
+
+test "is_pow_of_two rejects zero and non-powers" {
+    @assert(!math.is_pow_of_two(u64, 0));
+    @assert(math.is_pow_of_two(u64, 1));
+    @assert(math.is_pow_of_two(u64, 1024));
+    @assert(!math.is_pow_of_two(u64, 1023));
+    @assert(!math.is_pow_of_two(i64, -8));
+}
+
+test "is_prime at the small cases and at the i32 maximum" {
+    @assert(!math.is_prime(i64, 0));
+    @assert(!math.is_prime(i64, 1));
+    @assert(math.is_prime(i64, 2));
+    @assert(math.is_prime(i64, 3));
+    @assert(!math.is_prime(i64, 4));
+    @assert(math.is_prime(i64, 97));
+    @assert(!math.is_prime(i64, 91));
+    // RUE-1708: `i * i <= n` overflowed here.
+    @assert(math.is_prime(i32, @int_max(i32)));
+}
+
+test "checked_add reports overflow at both ends" {
+    @assert_eq(math.checked_add(i64, 1, 2), OptI64.Some(3));
+    @assert_eq(math.checked_add(i64, @int_max(i64), 1), OptI64.None);
+    @assert_eq(math.checked_add(i64, @int_min(i64), -1), OptI64.None);
+    @assert_eq(math.checked_add(i64, @int_max(i64), 0), OptI64.Some(@int_max(i64)));
+    @assert_eq(math.checked_add(u8, 200, 55), OptU8.Some(255));
+    @assert_eq(math.checked_add(u8, 200, 56), OptU8.None);
+}
+
+test "checked_sub reports overflow at both ends" {
+    @assert_eq(math.checked_sub(i64, 1, 2), OptI64.Some(-1));
+    @assert_eq(math.checked_sub(i64, @int_min(i64), 1), OptI64.None);
+    @assert_eq(math.checked_sub(i64, @int_max(i64), -1), OptI64.None);
+    @assert_eq(math.checked_sub(u8, 0, 1), OptU8.None);
+    @assert_eq(math.checked_sub(u8, 1, 1), OptU8.Some(0));
+}
+
+test "checked_mul covers the signed corners" {
+    @assert_eq(math.checked_mul(i64, 6, 7), OptI64.Some(42));
+    @assert_eq(math.checked_mul(i64, 0, @int_min(i64)), OptI64.Some(0));
+    @assert_eq(math.checked_mul(i64, -1, @int_min(i64)), OptI64.None);
+    @assert_eq(math.checked_mul(i64, @int_min(i64), -1), OptI64.None);
+    @assert_eq(math.checked_mul(i64, -1, @int_max(i64)), OptI64.Some(-@int_max(i64)));
+    @assert_eq(math.checked_mul(i64, 4611686018427387904, 2), OptI64.None);
+    @assert_eq(math.checked_mul(i64, -4611686018427387904, 2), OptI64.Some(@int_min(i64)));
+    @assert_eq(math.checked_mul(i64, -3, -4), OptI64.Some(12));
+    @assert_eq(math.checked_mul(i64, 3, -4), OptI64.Some(-12));
+    @assert_eq(math.checked_mul(u64, 4294967296, 4294967296), OptU64.None);
+    @assert_eq(math.checked_mul(u64, 4294967295, 4294967297), OptU64.Some(18446744073709551615));
+}

--- a/tests/std/net_c_tests.rue
+++ b/tests/std/net_c_tests.rue
@@ -1,0 +1,98 @@
+const std = @import("std");
+const net = std.net;
+const c = std.c;
+const StrBuf = std.strbuf.StrBuf;
+const OptSock = std.option.Option(net.SockAddr);
+
+test "Ipv4Addr octets are in dotted-quad order" {
+    let ip = net.Ipv4Addr.new(192, 168, 1, 20);
+    @assert_eq(ip.octets(), [192, 168, 1, 20]);
+    let lo = net.Ipv4Addr.localhost();
+    let any = net.Ipv4Addr.unspecified();
+    @assert_eq(lo.octets(), [127, 0, 0, 1]);
+    @assert_eq(any.octets(), [0, 0, 0, 0]);
+}
+
+test "Ipv6Addr well-known addresses" {
+    let lo_addr = net.Ipv6Addr.localhost();
+    @assert_eq(lo_addr.octets(), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    let any_addr = net.Ipv6Addr.unspecified();
+    @assert_eq(any_addr.octets(), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+}
+
+test "sockaddr_in marshals the port big-endian after the family and round-trips" {
+    @assert_eq(net.sockaddr_in_len(), 16);
+    let addr = net.SockAddr.v4(net.Ipv4Addr.new(10, 0, 0, 7), 8080);
+    let raw = addr.to_sockaddr_in();
+    @assert_eq(raw[2], 0x1f);
+    @assert_eq(raw[3], 0x90);
+    @assert_eq(raw[4], 10);
+    @assert_eq(raw[7], 7);
+    match net.SockAddr.from_sockaddr_in(raw) {
+        OptSock.Some(back) => {
+            @assert_eq(back.port, 8080);
+            match back.ip {
+                net.IpAddr.V4(v4) => @assert_eq(v4.octets(), [10, 0, 0, 7]),
+                net.IpAddr.V6(v6) => @assert(false, "expected a V4 address"),
+            }
+        },
+        OptSock.None => @assert(false, "expected a decodable sockaddr_in"),
+    }
+}
+
+test "sockaddr_in6 marshals and round-trips" {
+    @assert_eq(net.sockaddr_in6_len(), 28);
+    let addr = net.SockAddr.v6(net.Ipv6Addr.localhost(), 443);
+    let raw = addr.to_sockaddr_in6();
+    @assert_eq(raw[2], 1);
+    @assert_eq(raw[3], 0xbb);
+    match net.SockAddr.from_sockaddr_in6(raw) {
+        OptSock.Some(back) => {
+            @assert_eq(back.port, 443);
+            match back.ip {
+                net.IpAddr.V4(v4) => @assert(false, "expected a V6 address"),
+                net.IpAddr.V6(v6) => {
+                    let o = v6.octets();
+                    @assert_eq(o[15], 1);
+                },
+            }
+        },
+        OptSock.None => @assert(false, "expected a decodable sockaddr_in6"),
+    }
+}
+
+test "a sockaddr with the wrong family does not decode" {
+    let mut raw = net.SockAddr.v4(net.Ipv4Addr.localhost(), 1).to_sockaddr_in();
+    raw[0] = 0xff;
+    raw[1] = 0xff;
+    @assert_eq(net.SockAddr.from_sockaddr_in(raw), OptSock.None);
+}
+
+test "C scalar aliases have the psABI widths on every supported target" {
+    @assert_eq(@size_of(c.c_schar), 1);
+    @assert_eq(@size_of(c.c_uchar), 1);
+    @assert_eq(@size_of(c.c_short), 2);
+    @assert_eq(@size_of(c.c_int), 4);
+    @assert_eq(@size_of(c.c_uint), 4);
+    @assert_eq(@size_of(c.c_long), 8);
+    @assert_eq(@size_of(c.c_longlong), 8);
+    @assert_eq(@size_of(c.c_size_t), 8);
+    @assert_eq(@size_of(c.c_ssize_t), 8);
+    @assert_eq(@size_of(c.c_ptrdiff_t), 8);
+    @assert_eq(@size_of(c.wchar_t), 4);
+    @assert_eq(@size_of(c.c_bool), 1);
+}
+
+test "owned C strings round-trip and report their length" {
+    let s: StrBuf = "hello, C";
+    @assert(!c.has_interior_nul(borrow s));
+    let p = c.owned_c_string(borrow s);
+    @assert_eq(c.c_strlen(p), 8);
+    @assert_eq(c.strbuf_from_c_string(p), "hello, C");
+    c.free_c_string(p);
+    let mut with_nul = StrBuf.new();
+    with_nul.push(97);
+    with_nul.push(0);
+    with_nul.push(98);
+    @assert(c.has_interior_nul(borrow with_nul));
+}

--- a/tests/std/option_result_tests.rue
+++ b/tests/std/option_result_tests.rue
@@ -1,0 +1,53 @@
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const OptI = std.option.Option(i32);
+const OptS = std.option.Option(StrBuf);
+const Res = std.result.Result(i64, StrBuf);
+const Unit = std.result.Result((), u8);
+
+fn halve(n: i64) -> Res {
+    if n % 2 == 0 { Res.Ok(n / 2) } else { Res.Err("odd") }
+}
+
+fn lookup(present: bool) -> OptI {
+    if present { OptI.Some(42) } else { OptI.None }
+}
+
+test "Option variants compare structurally" {
+    @assert_eq(lookup(true), OptI.Some(42));
+    @assert_eq(lookup(false), OptI.None);
+    @assert_ne(OptI.Some(1), OptI.Some(2));
+    @assert_ne(OptI.Some(0), OptI.None);
+}
+
+test "Option can carry an owned StrBuf" {
+    let s: OptS = OptS.Some("hello");
+    match s {
+        OptS.Some(v) => @assert_eq(v, "hello"),
+        OptS.None => @assert(false, "expected Some"),
+    }
+}
+
+test "? on Some unwraps in a test body" {
+    let v = lookup(true)?;
+    @assert_eq(v, 42);
+}
+
+test "Result variants compare structurally" {
+    @assert_eq(halve(10), Res.Ok(5));
+    @assert_eq(halve(7), Res.Err("odd"));
+    @assert_ne(halve(10), halve(12));
+}
+
+test "? on Ok unwraps in a test body" {
+    let half = halve(84)?;
+    @assert_eq(half, 42);
+    @assert_eq(half + 1, 43);
+}
+
+test "a unit Result is expressible" {
+    let ok: Unit = Unit.Ok(());
+    let err: Unit = Unit.Err(7);
+    @assert_eq(ok, Unit.Ok(()));
+    @assert_ne(ok, err);
+}

--- a/tests/std/sort_tests.rue
+++ b/tests/std/sort_tests.rue
@@ -1,0 +1,110 @@
+const std = @import("std");
+const sort = std.sort;
+const Buf = std.arraybuf.ArrayBuf(i64);
+const OptU64 = std.option.Option(u64);
+
+fn of(a: i64, b: i64, c: i64, d: i64, e: i64) -> Buf {
+    let mut xs = Buf.new();
+    xs.push(a); xs.push(b); xs.push(c); xs.push(d); xs.push(e);
+    xs
+}
+
+fn ramp(n: u64, down: bool) -> Buf {
+    let mut xs = Buf.new();
+    let mut i: u64 = 0;
+    while i < n {
+        let v: i64 = @intCast(i);
+        if down { xs.push(@intCast(n - 1 - i)); } else { xs.push(v); }
+        i += 1;
+    }
+    xs
+}
+
+test "quicksort sorts a small shuffled buffer" {
+    let mut xs = of(5, -1, 3, 3, 0);
+    sort.quicksort(i64, inout xs);
+    @assert(sort.is_sorted(i64, borrow xs));
+    let first: i64 = xs.get_or(0, 99);
+    let last: i64 = xs.get_or(4, 99);
+    @assert_eq(first, -1);
+    @assert_eq(last, 5);
+}
+
+test "quicksort handles empty, single, sorted, reversed, and all-equal inputs" {
+    let mut empty = Buf.new();
+    sort.quicksort(i64, inout empty);
+    @assert_eq(empty.len(), 0);
+    let mut one = Buf.new();
+    one.push(7);
+    sort.quicksort(i64, inout one);
+    @assert(sort.is_sorted(i64, borrow one));
+    let mut up = ramp(500, false);
+    sort.quicksort(i64, inout up);
+    @assert(sort.is_sorted(i64, borrow up));
+    let mut down = ramp(500, true);
+    sort.quicksort(i64, inout down);
+    @assert(sort.is_sorted(i64, borrow down));
+    @assert_eq(down.get_or(0, -1), 0);
+    @assert_eq(down.get_or(499, -1), 499);
+    let mut same = of(4, 4, 4, 4, 4);
+    sort.quicksort(i64, inout same);
+    @assert(sort.is_sorted(i64, borrow same));
+}
+
+test "quicksort of a pseudo-random buffer agrees with insertion_sort" {
+    let mut rng = std.rand.Lcg.new(7);
+    let mut a = Buf.new();
+    let mut b = Buf.new();
+    let mut i: u64 = 0;
+    while i < 300 {
+        let v: i64 = @intCast(rng.next_below(50));
+        a.push(v - 25);
+        b.push(v - 25);
+        i += 1;
+    }
+    sort.quicksort(i64, inout a);
+    sort.insertion_sort(i64, inout b);
+    @assert(sort.is_sorted(i64, borrow a));
+    @assert(sort.is_sorted(i64, borrow b));
+    let mut j: u64 = 0;
+    while j < 300 {
+        @assert_eq(a.get_or(j, 0), b.get_or(j, 0));
+        j += 1;
+    }
+}
+
+test "insertion_sort sorts and is_sorted detects a single inversion" {
+    let mut xs = of(2, 1, 4, 3, 5);
+    @assert(!sort.is_sorted(i64, borrow xs));
+    sort.insertion_sort(i64, inout xs);
+    @assert(sort.is_sorted(i64, borrow xs));
+    xs.set(2, -100);
+    @assert(!sort.is_sorted(i64, borrow xs));
+}
+
+test "is_sorted is true for short buffers and allows duplicates" {
+    let empty = Buf.new();
+    @assert(sort.is_sorted(i64, borrow empty));
+    let dup = of(1, 1, 2, 2, 2);
+    @assert(sort.is_sorted(i64, borrow dup));
+}
+
+test "binary_search finds present values and reports absent ones" {
+    let xs = of(-3, 0, 4, 9, 20);
+    @assert_eq(sort.binary_search(i64, borrow xs, -3), OptU64.Some(0));
+    @assert_eq(sort.binary_search(i64, borrow xs, 20), OptU64.Some(4));
+    @assert_eq(sort.binary_search(i64, borrow xs, 4), OptU64.Some(2));
+    @assert_eq(sort.binary_search(i64, borrow xs, 5), OptU64.None);
+    @assert_eq(sort.binary_search(i64, borrow xs, -10), OptU64.None);
+    @assert_eq(sort.binary_search(i64, borrow xs, 100), OptU64.None);
+    let empty = Buf.new();
+    @assert_eq(sort.binary_search(i64, borrow empty, 1), OptU64.None);
+}
+
+test "binary_search over a u8 buffer" {
+    let B8 = std.arraybuf.ArrayBuf(u8);
+    let mut xs = B8.new();
+    xs.push(1); xs.push(2); xs.push(200);
+    @assert_eq(sort.binary_search(u8, borrow xs, 200), OptU64.Some(2));
+    @assert_eq(sort.binary_search(u8, borrow xs, 3), OptU64.None);
+}

--- a/tests/std/strings_tests.rue
+++ b/tests/std/strings_tests.rue
@@ -1,0 +1,175 @@
+const std = @import("std");
+const strings = std.strings;
+const StrBuf = std.strbuf.StrBuf;
+const OptI64 = std.option.Option(i64);
+const OptU64 = std.option.Option(u64);
+const Parts = std.arraybuf.ArrayBuf(StrBuf);
+
+test "parse_int accepts decimal with an optional leading minus" {
+    @assert_eq(strings.parse_int("0"), OptI64.Some(0));
+    @assert_eq(strings.parse_int("42"), OptI64.Some(42));
+    @assert_eq(strings.parse_int("-42"), OptI64.Some(-42));
+    @assert_eq(strings.parse_int("007"), OptI64.Some(7));
+    @assert_eq(strings.parse_int("9223372036854775807"), OptI64.Some(@int_max(i64)));
+}
+
+test "parse_int rejects empty, lone minus, plus sign, junk, and spaces" {
+    @assert_eq(strings.parse_int(""), OptI64.None);
+    @assert_eq(strings.parse_int("-"), OptI64.None);
+    @assert_eq(strings.parse_int("+5"), OptI64.None);
+    @assert_eq(strings.parse_int("12a"), OptI64.None);
+    @assert_eq(strings.parse_int(" 12"), OptI64.None);
+    @assert_eq(strings.parse_int("1 2"), OptI64.None);
+    @assert_eq(strings.parse_int("--1"), OptI64.None);
+}
+
+test "parse_int reports overflow as None, including i64::MIN by documented limitation" {
+    @assert_eq(strings.parse_int("9223372036854775808"), OptI64.None);
+    @assert_eq(strings.parse_int("99999999999999999999"), OptI64.None);
+    // Documented: the magnitude is accumulated positively, so MIN is None.
+    @assert_eq(strings.parse_int("-9223372036854775808"), OptI64.None);
+    @assert_eq(strings.parse_int("-9223372036854775807"), OptI64.Some(-@int_max(i64)));
+}
+
+test "find and rfind locate the first and last byte" {
+    @assert_eq(strings.find("hello", 108), OptU64.Some(2));
+    @assert_eq(strings.rfind("hello", 108), OptU64.Some(3));
+    @assert_eq(strings.find("hello", 122), OptU64.None);
+    @assert_eq(strings.rfind("", 104), OptU64.None);
+    @assert_eq(strings.find("h", 104), OptU64.Some(0));
+}
+
+test "find_str and rfind_str with empty, missing, and repeated needles" {
+    let s: StrBuf = "hello world";
+    @assert_eq(strings.find_str(borrow s, borrow "o w"), OptU64.Some(4));
+    @assert_eq(strings.find_str(borrow s, borrow "o"), OptU64.Some(4));
+    @assert_eq(strings.rfind_str(borrow s, borrow "o"), OptU64.Some(7));
+    @assert_eq(strings.find_str(borrow s, borrow ""), OptU64.Some(0));
+    @assert_eq(strings.rfind_str(borrow s, borrow ""), OptU64.Some(11));
+    @assert_eq(strings.find_str(borrow s, borrow "hello world!"), OptU64.None);
+    @assert_eq(strings.find_str(borrow s, borrow "xyz"), OptU64.None);
+}
+
+test "count and starts_with_byte" {
+    @assert_eq(strings.count("banana", 97), 3);
+    @assert_eq(strings.count("banana", 122), 0);
+    @assert_eq(strings.count("", 97), 0);
+    @assert(strings.starts_with_byte("banana", 98));
+    @assert(!strings.starts_with_byte("banana", 97));
+    @assert(!strings.starts_with_byte("", 97));
+}
+
+test "trim family strips only ASCII whitespace at the ends" {
+    @assert_eq(strings.trim("  hi  "), "hi");
+    @assert_eq(strings.trim_start("  hi  "), "hi  ");
+    @assert_eq(strings.trim_end("  hi  "), "  hi");
+    @assert_eq(strings.trim("\t\r\n x y \n"), "x y");
+    @assert_eq(strings.trim("     "), "");
+    @assert_eq(strings.trim(""), "");
+    @assert_eq(strings.trim("nospace"), "nospace");
+}
+
+test "repeat" {
+    @assert_eq(strings.repeat("ab", 3), "ababab");
+    @assert_eq(strings.repeat("ab", 0), "");
+    @assert_eq(strings.repeat("", 5), "");
+    @assert_eq(strings.repeat("x", 1), "x");
+}
+
+test "split on a byte keeps empty pieces at both ends" {
+    let s: StrBuf = ",a,,b,";
+    let mut parts = strings.split(borrow s, 44);
+    @assert_eq(parts.len(), 5);
+    @assert_eq(parts.get_ref(0), "");
+    @assert_eq(parts.get_ref(1), "a");
+    @assert_eq(parts.get_ref(2), "");
+    @assert_eq(parts.get_ref(3), "b");
+    @assert_eq(parts.get_ref(4), "");
+}
+
+test "split of the empty string is one empty piece" {
+    let s: StrBuf = "";
+    let parts = strings.split(borrow s, 44);
+    @assert_eq(parts.len(), 1);
+    @assert_eq(parts.get_ref(0), "");
+}
+
+test "split_str with a multi-byte separator and an empty separator" {
+    let s: StrBuf = "a::b::::c";
+    let parts = strings.split_str(borrow s, borrow "::");
+    @assert_eq(parts.len(), 4);
+    @assert_eq(parts.get_ref(0), "a");
+    @assert_eq(parts.get_ref(1), "b");
+    @assert_eq(parts.get_ref(2), "");
+    @assert_eq(parts.get_ref(3), "c");
+    let abc: StrBuf = "abc";
+    let bytes = strings.split_str(borrow abc, borrow "");
+    @assert_eq(bytes.len(), 5);
+    @assert_eq(bytes.get_ref(0), "");
+    @assert_eq(bytes.get_ref(1), "a");
+    @assert_eq(bytes.get_ref(3), "c");
+    @assert_eq(bytes.get_ref(4), "");
+}
+
+test "replace is non-overlapping, left to right, and never rescans its output" {
+    let aaa: StrBuf = "aaa";
+    @assert_eq(strings.replace(borrow aaa, borrow "aa", borrow "b"), "ba");
+    let aa: StrBuf = "aa";
+    @assert_eq(strings.replace(borrow aa, borrow "a", borrow "aa"), "aaaa");
+    let ab: StrBuf = "ab";
+    @assert_eq(strings.replace(borrow ab, borrow "", borrow "-"), "-a-b-");
+    let none: StrBuf = "hello";
+    @assert_eq(strings.replace(borrow none, borrow "z", borrow "y"), "hello");
+    @assert_eq(strings.replace(borrow none, borrow "l", borrow ""), "heo");
+}
+
+test "join is the inverse of split_str for a non-empty separator" {
+    let s: StrBuf = "a, b, c";
+    let parts = strings.split_str(borrow s, borrow ", ");
+    @assert_eq(parts.len(), 3);
+    @assert_eq(strings.join(parts, borrow ", "), "a, b, c");
+}
+
+test "join of zero and one parts" {
+    let empty = Parts.new();
+    @assert_eq(strings.join(empty, borrow "-"), "");
+    let mut one = Parts.new();
+    let only: StrBuf = "solo";
+    one.push(only);
+    @assert_eq(strings.join(one, borrow "-"), "solo");
+}
+
+test "lines terminates rather than separates and strips a CR before LF" {
+    let s: StrBuf = "a\r\nb\n\nc";
+    let ls = strings.lines(borrow s);
+    @assert_eq(ls.len(), 4);
+    @assert_eq(ls.get_ref(0), "a");
+    @assert_eq(ls.get_ref(1), "b");
+    @assert_eq(ls.get_ref(2), "");
+    @assert_eq(ls.get_ref(3), "c");
+    let trailing: StrBuf = "a\nb\n";
+    let t = strings.lines(borrow trailing);
+    @assert_eq(t.len(), 2);
+    let empty: StrBuf = "";
+    let e = strings.lines(borrow empty);
+    @assert_eq(e.len(), 0);
+    let lone_cr: StrBuf = "a\r";
+    let l2 = strings.lines(borrow lone_cr);
+    @assert_eq(l2.len(), 1);
+    @assert_eq(l2.get_ref(0), "a\r");
+}
+
+test "count_chars counts scalars, not bytes" {
+    @assert_eq(strings.count_chars("café"), 4);
+    @assert_eq(strings.count_chars(""), 0);
+    @assert_eq(strings.count_chars("日本語"), 3);
+    @assert_eq(strings.count_chars_lossy("café"), 4);
+}
+
+test "count_chars_lossy folds a malformed sequence into one replacement" {
+    let mut s = StrBuf.new();
+    s.push(97);
+    s.push(255);
+    s.push(98);
+    @assert_eq(strings.count_chars_lossy(s), 3);
+}

--- a/tests/std/tuple_mem_tests.rue
+++ b/tests/std/tuple_mem_tests.rue
@@ -1,0 +1,72 @@
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const Pair = std.tuple.Pair(i64, i64);
+const Triple = std.tuple.Triple(u8, bool, i64);
+const Named = std.tuple.Pair(StrBuf, u64);
+
+test "Pair.new stores its fields in order" {
+    let p = Pair.new(40, 2);
+    @assert_eq(p.first, 40);
+    @assert_eq(p.second, 2);
+    @assert_eq(p.first + p.second, 42);
+}
+
+test "Pair compares structurally" {
+    @assert_eq(Pair.new(1, 2), Pair.new(1, 2));
+    @assert_ne(Pair.new(1, 2), Pair.new(2, 1));
+}
+
+test "Triple mixes element types" {
+    let t = Triple.new(7, true, -1);
+    @assert_eq(t.first, 7);
+    @assert(t.second);
+    @assert_eq(t.third, -1);
+}
+
+test "a Pair may own a StrBuf" {
+    let p = Named.new("answer", 42);
+    @assert_eq(p.first, "answer");
+    @assert_eq(p.second, 42);
+}
+
+test "mem.swap exchanges two integers" {
+    let mut a: i64 = 1;
+    let mut b: i64 = 2;
+    std.mem.swap(i64, inout a, inout b);
+    @assert_eq(a, 2);
+    @assert_eq(b, 1);
+}
+
+test "mem.swap exchanges two owned StrBufs without a double free" {
+    let mut a: StrBuf = "left";
+    let mut b: StrBuf = "right side";
+    std.mem.swap(StrBuf, inout a, inout b);
+    @assert_eq(a, "right side");
+    @assert_eq(b, "left");
+}
+
+test "mem.swap a value with itself is a no-op" {
+    let mut a: i64 = 9;
+    let mut b: i64 = 9;
+    std.mem.swap(i64, inout a, inout b);
+    @assert_eq(a, 9);
+    @assert_eq(b, 9);
+}
+
+test "mem.replace stores the new value and returns the old" {
+    let mut x: i64 = 5;
+    let old = std.mem.replace(i64, inout x, 6);
+    @assert_eq(old, 5);
+    @assert_eq(x, 6);
+}
+
+// RUE-2013: `std.mem.replace(StrBuf, ...)` does not compile — `let old = dst;`
+// in std/mem.rue is E0437 (move out of an inout parameter) for any drop-glue
+// `T`, so `replace` only works for Copy types despite its doc. There is no
+// per-test xfail yet (RUE-2018), and a compile error fails the whole run, so
+// the case is recorded here until RUE-2013 lands:
+//
+//     let mut s: StrBuf = "before";
+//     let old = std.mem.replace(StrBuf, inout s, "after");
+//     @assert_eq(old, "before");
+//     @assert_eq(s, "after");


### PR DESCRIPTION
Fixes RUE-2022

A `rue test` contract suite for the standard library: 153 tests across 16 files under `tests/std/`, rooted at `tests/std/main.rue`, run by the premerge `rue_test` target `//tests/std:std-tests`.

## Shape

- The tree lives beside `std/`, not inside it, because a test root may not sit inside the configured standard-library tree. So the suite sees exactly what a user program sees and covers the public surface only.
- `srcs = glob(["**/*.rue"])` is the candidate inventory, so a test file added without an `@import` from `main.rue` fails the target as unimported instead of silently not running (verified by adding an orphan and watching the target fail).
- The env tests pin the runner's visible inventory from `docs/process/test-events.md` (argv `["rue-test"]`, environment `["RUE_TEST=1"]`, empty scratch directory). A change to that contract updates them in the same PR.

## Recorded, not tested

Two cases are commented at their sites naming the issue that restores them: `Stack(StrBuf).peek_ref` (RUE-2012, ICE) and `mem.replace` over a drop-glue `T` (RUE-2013). The json error-offset test pins the observed offsets and names RUE-2015. The typed-local workarounds originally written for RUE-2016 were folded back to one-line assertions after confirming that bug no longer reproduces on trunk.

## Verified

- Green under seeds 1–9, `-O2`, `-j1`, `-j16`, `-j64`.
- `./buck2 test //tests/std:std-tests` passes; the target is in the premerge selection (`test_tiers.bxl:premerge`).
- Adversarially reviewed; all should-fix findings applied (stale RUE-2016 workarounds, issue citations in comments, header comment, tightened assertions).
