### PR TITLE
RUE-1964: resolve every module spine through the one canonical walker

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -11,7 +11,7 @@ use super::types::{InferType, TypeVarAllocator, TypeVarId};
 use crate::Type;
 use crate::intern_pool::TypeInternPool;
 use crate::scope::ScopedContext;
-use crate::sema::{ComptimeSelection, ConstValue, select_module_nominal};
+use crate::sema::{ComptimeSelection, ConstValue, decode_module_spine, select_module_nominal};
 use crate::semantic_type_resolution::{UnqualifiedNominalTier, select_unqualified_nominal};
 #[cfg(test)]
 use crate::types::ArrayLen;
@@ -3288,7 +3288,7 @@ impl<'a> ConstraintGenerator<'a> {
                         break;
                     }
                     // Patterns constrain the scrutinee type
-                    let pattern_ty = self.pattern_type(&pattern);
+                    let pattern_ty = self.pattern_type(&pattern, ctx);
                     self.add_constraint(Constraint::equal(
                         scrutinee_info.ty.clone(),
                         pattern_ty,
@@ -3467,7 +3467,7 @@ impl<'a> ConstraintGenerator<'a> {
                     base: module_ref,
                     field: type_name,
                 } = self.rir.get(*base).data
-                    && let Some(enum_ty) = self.enum_type_for_module(module_ref, &type_name)
+                    && let Some(enum_ty) = self.enum_type_for_module(module_ref, &type_name, ctx)
                     && let Some(enum_id) = enum_ty.as_enum()
                     && self
                         .type_pool
@@ -3590,7 +3590,7 @@ impl<'a> ConstraintGenerator<'a> {
                 module, type_name, ..
             } => {
                 let enum_ty = module
-                    .and_then(|module_ref| self.enum_type_for_module(module_ref, type_name))
+                    .and_then(|module_ref| self.enum_type_for_module(module_ref, type_name, ctx))
                     .or_else(|| self.enum_type_for(type_name, span.file_id));
                 if let Some(enum_ty) = enum_ty {
                     InferType::Concrete(enum_ty)
@@ -3808,12 +3808,9 @@ impl<'a> ConstraintGenerator<'a> {
                     base: module_ref,
                     field: type_name,
                 } = self.rir.get(*receiver).data
-                    && !matches!(self.rir.get(module_ref).data,
-                        InstData::VarRef { name, .. }
-                            if ctx.locals.contains_key(&name) || ctx.contains_param(name))
                     && let Some(member_ty) = self
-                        .struct_type_for_module(module_ref, &type_name)
-                        .or_else(|| self.enum_type_for_module(module_ref, &type_name))
+                        .struct_type_for_module(module_ref, &type_name, ctx)
+                        .or_else(|| self.enum_type_for_module(module_ref, &type_name, ctx))
                     && let Some(result) =
                         self.generate_call_on_reduced_type(member_ty, *method, args, span, ctx)
                 {
@@ -4126,8 +4123,8 @@ impl<'a> ConstraintGenerator<'a> {
                                 base: module_ref,
                                 field: type_name,
                             } => self
-                                .struct_type_for_module(module_ref, &type_name)
-                                .or_else(|| self.enum_type_for_module(module_ref, &type_name)),
+                                .struct_type_for_module(module_ref, &type_name, ctx)
+                                .or_else(|| self.enum_type_for_module(module_ref, &type_name, ctx)),
                             _ => None,
                         };
                         if let Some(reduced) = self
@@ -4718,8 +4715,13 @@ impl<'a> ConstraintGenerator<'a> {
     /// selector hands back the alias's whole `ConstInfo` so the semantic pass
     /// can apply E0706, and this fact source exposes types only — so the two
     /// share the order and not the selector (RUE-1956).
-    fn nominal_type_for_module(&self, module: InstRef, type_name: &Spur) -> Option<Type> {
-        let file_id = self.module_member_file(module)?;
+    fn nominal_type_for_module(
+        &self,
+        module: InstRef,
+        type_name: &Spur,
+        ctx: &ConstraintContext,
+    ) -> Option<Type> {
+        let file_id = self.module_member_file(module, ctx)?;
         select_module_nominal(
             || self.struct_type_by_file((file_id, *type_name)),
             || self.enum_type_by_file((file_id, *type_name)),
@@ -4727,8 +4729,13 @@ impl<'a> ConstraintGenerator<'a> {
         )
     }
 
-    fn enum_type_for_module(&self, module: InstRef, type_name: &Spur) -> Option<Type> {
-        self.nominal_type_for_module(module, type_name)
+    fn enum_type_for_module(
+        &self,
+        module: InstRef,
+        type_name: &Spur,
+        ctx: &ConstraintContext,
+    ) -> Option<Type> {
+        self.nominal_type_for_module(module, type_name, ctx)
             .filter(|ty| ty.is_enum())
     }
 
@@ -4738,8 +4745,13 @@ impl<'a> ConstraintGenerator<'a> {
     /// and an integer-literal operand later compared against the result
     /// defaulted to i32 — zero-extended against the callee's real 64-bit
     /// value at run time (the RUE-633 miscompile family).
-    fn struct_type_for_module(&self, module: InstRef, type_name: &Spur) -> Option<Type> {
-        self.nominal_type_for_module(module, type_name)
+    fn struct_type_for_module(
+        &self,
+        module: InstRef,
+        type_name: &Spur,
+        ctx: &ConstraintContext,
+    ) -> Option<Type> {
+        self.nominal_type_for_module(module, type_name, ctx)
             .filter(|ty| ty.as_struct().is_some())
     }
 
@@ -4750,20 +4762,37 @@ impl<'a> ConstraintGenerator<'a> {
     /// on) — without the recursion a nested-facade payload construction left
     /// its arguments unconstrained (RUE-633 family, reject-valid this time:
     /// sema's E0206 caught the defaulted literal).
-    fn module_member_file(&self, module: InstRef) -> Option<FileId> {
-        let inst = self.rir.get(module);
-        match &inst.data {
-            InstData::VarRef { name, .. } => {
-                let module_ty = self.module_binding_type((inst.span.file_id, *name))?;
-                self.module_file(module_ty)
+    ///
+    /// The spine is decoded by the one shared syntactic decoder and its root
+    /// obeys the one shadowing rule, so `let lib = 5; lib.Color.Green` is an
+    /// ordinary field access here exactly as it is in semantic analysis
+    /// (RUE-1964). The hops themselves are still walked with this pass's own
+    /// `module_binding_type` lookups rather than sema's canonical walker:
+    /// that walker resolves privacy, and this fact source exposes types only.
+    /// Resolving a private hop here is harmless — semantic analysis rejects
+    /// the same path with E0706 — while a *shadowed* root must not resolve,
+    /// since inference would otherwise constrain a value expression with an
+    /// unrelated module member's type.
+    fn module_member_file(&self, module: InstRef, ctx: &ConstraintContext) -> Option<FileId> {
+        let spine = decode_module_spine(self.rir, module)?;
+        let mut file_id = match ctx
+            .locals
+            .get(&spine.root)
+            .map(|local| &local.ty)
+            .or_else(|| ctx.lookup_param(spine.root).map(|param| &param.ty))
+        {
+            // A binding that *is* a module names it; any other binding
+            // shadows the import and this is not a module path.
+            Some(InferType::Concrete(ty)) => self.module_file(*ty)?,
+            Some(_) => return None,
+            None => {
+                self.module_file(self.module_binding_type((spine.root_span.file_id, spine.root))?)?
             }
-            InstData::FieldGet { base, field } => {
-                let base_file = self.module_member_file(*base)?;
-                let module_ty = self.module_binding_type((base_file, *field))?;
-                self.module_file(module_ty)
-            }
-            _ => None,
+        };
+        for field in spine.fields {
+            file_id = self.module_file(self.module_binding_type((file_id, field))?)?;
         }
+        Some(file_id)
     }
 
     fn module_file(&self, module_ty: Type) -> Option<FileId> {
@@ -4800,7 +4829,7 @@ impl<'a> ConstraintGenerator<'a> {
                     .and_then(|heads| heads.get(&head).copied())
             })
             .or_else(|| {
-                module.and_then(|module_ref| self.enum_type_for_module(module_ref, type_name))
+                module.and_then(|module_ref| self.enum_type_for_module(module_ref, type_name, ctx))
             })
             .or_else(|| self.enum_type_for(type_name, pat_span.file_id));
         let Some(payload) = enum_ty
@@ -4831,7 +4860,11 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     /// Get the inferred type for a pattern.
-    fn pattern_type(&mut self, pattern: &rue_rir::RirPatternView<'_>) -> InferType {
+    fn pattern_type(
+        &mut self,
+        pattern: &rue_rir::RirPatternView<'_>,
+        ctx: &ConstraintContext,
+    ) -> InferType {
         match pattern {
             rue_rir::RirPatternView::Wildcard(_) => {
                 // Wildcard matches anything - use a fresh type variable
@@ -4875,8 +4908,9 @@ impl<'a> ConstraintGenerator<'a> {
                             .and_then(|heads| heads.get(&head).copied())
                     })
                     .or_else(|| {
-                        module
-                            .and_then(|module_ref| self.enum_type_for_module(module_ref, type_name))
+                        module.and_then(|module_ref| {
+                            self.enum_type_for_module(module_ref, type_name, ctx)
+                        })
                     })
                     .or_else(|| self.enum_type_for(type_name, pattern.span().file_id));
                 if let Some(enum_ty) = enum_ty {

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -175,7 +175,7 @@ pub use semantic_type_resolution::{
     SemanticTypeConstructorHead, SemanticTypeConstructorParameter, SemanticTypeFact,
     SemanticTypeFactKind, SemanticTypeSyntaxError, SemanticTypeSyntaxFailure,
     SemanticTypeSyntaxProvider, SemanticValueSyntax, SemanticVisibilityDomain,
-    SemanticVisibilityDomainCache, resolve_semantic_module_path,
+    SemanticVisibilityDomainCache, resolve_semantic_module_path, resolve_semantic_module_path_from,
     resolve_structured_semantic_type_syntax, resolve_structured_semantic_type_syntax_with,
 };
 pub use types::{

--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -14,7 +14,7 @@ use rue_span::FileId;
 
 use super::ConstInfo;
 use super::body_identity::{DurableNominalSource, ProviderIdentityContext};
-use super::context::{ConstValue, LocalVar};
+use super::context::ConstValue;
 use crate::intern_pool::TypeInternPool;
 use crate::semantic_type_resolution::{
     UnqualifiedNominal, UnqualifiedNominalTier, select_unqualified_nominal,
@@ -259,58 +259,61 @@ pub(crate) fn select_module_type_member<P: AggregateFacts>(
     .unwrap_or(ModuleTypeMember::Absent)
 }
 
-pub(crate) fn resolve_aggregate_module_ref<P: AggregateFacts>(
-    facts: &P,
-    rir: &Rir,
-    inst_ref: InstRef,
-    root_file: FileId,
-    locals: &AHashMap<Spur, LocalVar>,
-) -> Option<ModuleId> {
-    match rir.get(inst_ref).data {
-        InstData::VarRef { name, .. } => {
-            if let Some(local) = locals.get(&name) {
-                if let Some(module_id) = local.ty.as_module() {
-                    return Some(module_id);
-                }
-            }
-            facts
-                .aggregate_module_binding(root_file, name)
-                .and_then(|binding| binding.ty.as_module())
-        }
-        InstData::FieldGet { base, field } => {
-            let parent = resolve_aggregate_module_ref(facts, rir, base, root_file, locals)?;
-            let parent_file = facts.aggregate_module(parent).file;
-            facts
-                .aggregate_module_binding(parent_file, field)
-                .and_then(|binding| binding.ty.as_module())
-        }
-        _ => None,
-    }
+/// The dotted spine of a candidate module path (`lib.inner.deep`), decoded
+/// from RIR syntax alone.
+pub(crate) struct ModuleSpine {
+    /// The name at the root of the `FieldGet` chain.
+    pub(crate) root: Spur,
+    /// The span of the root `VarRef`, whose file owns the root binding.
+    pub(crate) root_span: rue_span::Span,
+    /// The field names hanging off the root, in source order.
+    pub(crate) fields: Vec<Spur>,
 }
 
-pub(crate) fn resolve_visibility_module_ref<P: AggregateFacts>(
-    facts: &P,
-    rir: &Rir,
-    inst_ref: InstRef,
-    locals: &AHashMap<Spur, LocalVar>,
-) -> Option<ModuleId> {
-    let inst = rir.get(inst_ref);
-    let module_ty = match inst.data {
-        InstData::VarRef { name, .. } => locals.get(&name).map(|local| local.ty).or_else(|| {
-            facts
-                .aggregate_module_binding(inst.span.file_id, name)
-                .map(|binding| binding.ty)
-        }),
-        InstData::FieldGet { base, field } => {
-            let parent = resolve_visibility_module_ref(facts, rir, base, locals)?;
-            let parent_file = facts.aggregate_module(parent).file;
-            facts
-                .aggregate_module_binding(parent_file, field)
-                .map(|binding| binding.ty)
+/// The one syntactic decoder for a dotted module spine (RUE-1964).
+///
+/// Pure syntax: it walks the `FieldGet` chain down to its `VarRef` root and
+/// reports the root name plus the field names in source order. No fact source,
+/// scope, or visibility rule is consulted here, so every consumer — semantic
+/// analysis, the comptime engine, and the inference prepass — decodes the same
+/// spine and then applies the one shadowing rule and (where privacy is its
+/// job) the one per-hop visibility walk to it. Returns `None` for a spine that
+/// bottoms out in anything other than a name, which can never be a module path.
+pub(crate) fn decode_module_spine(rir: &Rir, inst_ref: InstRef) -> Option<ModuleSpine> {
+    let mut fields = Vec::new();
+    let mut cursor = inst_ref;
+    let (root, root_span) = loop {
+        let inst = rir.get(cursor);
+        match inst.data {
+            InstData::VarRef { name, .. } => break (name, inst.span),
+            InstData::FieldGet { base, field } => {
+                fields.push(field);
+                cursor = base;
+            }
+            _ => return None,
         }
-        _ => None,
-    }?;
-    module_ty.as_module()
+    };
+    fields.reverse();
+    Some(ModuleSpine {
+        root,
+        root_span,
+        fields,
+    })
+}
+
+/// Where a decoded [`ModuleSpine`]'s root binds, after the one shadowing rule
+/// (spec 5.1:11) is applied to it.
+pub(crate) enum ModuleSpineRoot {
+    /// A runtime local or parameter of non-module type carries the name, so it
+    /// shadows any import of the same name and this is not a module path at
+    /// all — the consumer falls through to ordinary value field/method access.
+    Shadowed,
+    /// A local or parameter that *is* a module (`let m = lib.geo;`): the
+    /// binding is the module, and any remaining segments are its members.
+    LocalModule(ModuleId),
+    /// Nothing shadows the name: the root is a module binding of the file the
+    /// spine is written in, resolved by the canonical module-path walker.
+    FileBinding,
 }
 
 pub(crate) fn is_accessible<P: AggregateFacts>(

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -14,8 +14,9 @@ use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::Span;
 
 use super::aggregate_resolution::{
-    ModuleTypeMember, StructLiteralHead, resolve_aggregate_module_ref, resolve_enum_type_name,
-    resolve_struct_type_name, select_module_type_member, select_struct_literal_head,
+    ModuleSpine, ModuleSpineRoot, ModuleTypeMember, StructLiteralHead, decode_module_spine,
+    resolve_enum_type_name, resolve_struct_type_name, select_module_type_member,
+    select_struct_literal_head,
 };
 use super::analysis::FirstClassStrSite;
 use super::context::{AnalysisContext, AnalysisResult, ConstValue};
@@ -1568,6 +1569,79 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx.locals.contains_key(&name) || ctx.has_param(name)
     }
 
+    /// Classify a decoded module spine's root against this body's bindings —
+    /// the one shadowing rule (spec 5.1:11) every position shares (RUE-1964).
+    ///
+    /// A `let` binding shadows an outer name for the rest of its scope, so a
+    /// runtime local or parameter named `lib` makes `lib.Color.Green` ordinary
+    /// value field access even when the file also imports a module called
+    /// `lib`. A binding that *is* a module (`let m = lib.geo;`) is not a
+    /// runtime value at all: it names the module, and the walk continues
+    /// through its members.
+    pub(crate) fn classify_module_spine_root(
+        &self,
+        root: Spur,
+        ctx: &AnalysisContext,
+    ) -> ModuleSpineRoot {
+        let bound = ctx
+            .locals
+            .get(&root)
+            .map(|local| local.ty)
+            .or_else(|| ctx.param(root).map(|param| param.ty));
+        match bound {
+            Some(ty) => match ty.as_module() {
+                Some(module) => ModuleSpineRoot::LocalModule(module),
+                None => ModuleSpineRoot::Shadowed,
+            },
+            None => ModuleSpineRoot::FileBinding,
+        }
+    }
+
+    /// Resolve the module a decoded spine denotes, applying the one shadowing
+    /// rule and then the one per-hop visibility walk.
+    ///
+    /// `Ok(None)` means "not a module path here" — a shadowed root, an unknown
+    /// root or member, or a segment that is not a module — and every consumer
+    /// falls through to its own not-a-module-path behavior and diagnostic. A
+    /// private hop is a hard error (E0706) rather than a fall-through: the path
+    /// names a real module binding, it is simply not visible (RUE-1964).
+    fn resolve_module_spine(
+        &mut self,
+        spine: &ModuleSpine,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<Option<crate::types::ModuleId>> {
+        let start = match self.classify_module_spine_root(spine.root, ctx) {
+            ModuleSpineRoot::Shadowed => return Ok(None),
+            ModuleSpineRoot::LocalModule(module) if spine.fields.is_empty() => {
+                return Ok(Some(module));
+            }
+            ModuleSpineRoot::LocalModule(module) => Some(module),
+            ModuleSpineRoot::FileBinding => None,
+        };
+        let names: Vec<String> = start
+            .is_none()
+            .then_some(spine.root)
+            .into_iter()
+            .chain(spine.fields.iter().copied())
+            .map(|name| self.body_interner().resolve(&name).to_owned())
+            .collect();
+        let segments: Vec<&str> = names.iter().map(String::as_str).collect();
+        match self.resolve_type_module_prefix_from(spine.root_span.file_id, start, &segments, span)
+        {
+            Ok((module, _, _)) => Ok(Some(module)),
+            Err(error)
+                if matches!(
+                    error.kind,
+                    ErrorKind::UnknownType(_) | ErrorKind::UnknownModuleMember { .. }
+                ) =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// Resolve the module a reference denotes, if any, without emitting AIR.
     ///
     /// Used to recognize module-qualified dotted member access
@@ -1576,20 +1650,21 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// type or a per-file module binding) — and a nested submodule chain
     /// (`std.geo.Sign.Pos`), resolving `std.geo` by looking `geo` up as a module
     /// binding re-exported from `std`'s file.
+    ///
+    /// This is a thin consumer of [`decode_module_spine`] and
+    /// [`Self::resolve_module_spine`]: the shadowing rule and the per-hop
+    /// privacy check live there, shared with the match-pattern path, so a
+    /// private intermediate hop is E0706 in every position (RUE-1964).
     pub(crate) fn try_module_id_of(
-        &self,
+        &mut self,
         inst_ref: rue_rir::InstRef,
         span: Span,
         ctx: &AnalysisContext,
-    ) -> Option<crate::types::ModuleId> {
-        let facts = self.aggregate_facts();
-        resolve_aggregate_module_ref(
-            facts,
-            self.body_rir_ref(),
-            inst_ref,
-            span.file_id,
-            &ctx.locals,
-        )
+    ) -> CompileResult<Option<crate::types::ModuleId>> {
+        let Some(spine) = decode_module_spine(self.body_rir_ref(), inst_ref) else {
+            return Ok(None);
+        };
+        self.resolve_module_spine(&spine, span, ctx)
     }
 
     /// Try to analyze a module-qualified type-member call:
@@ -1612,7 +1687,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Option<AnalysisResult>> {
-        let Some(module_id) = self.try_module_id_of(module_ref, span, ctx) else {
+        let Some(module_id) = self.try_module_id_of(module_ref, span, ctx)? else {
             return Ok(None);
         };
         let module_file = self.aggregate_facts().aggregate_module(module_id).file;
@@ -1708,7 +1783,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &AnalysisContext,
     ) -> CompileResult<Option<AnalysisResult>> {
-        let Some(module_id) = self.try_module_id_of(module_ref, span, ctx) else {
+        let Some(module_id) = self.try_module_id_of(module_ref, span, ctx)? else {
             return Ok(None);
         };
         let module_file = self.aggregate_facts().aggregate_module(module_id).file;

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -13,6 +13,7 @@ use rue_span::Span;
 use std::hash::Hash;
 use std::sync::Arc;
 
+use super::aggregate_resolution::decode_module_spine;
 use crate::integer_semantics::{CheckedIntegerResult, IntegerType};
 
 // Source-level partitions of this one evaluator (RUE-1831), following the
@@ -1648,64 +1649,27 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         }
     }
 
-    /// Decode only the syntactic module path for a method call. Resolution of
-    /// the path's declarations and visibility stays in the semantic host; the
-    /// engine owns this RIR edge so hosts never need to inspect child
-    /// instructions to discover a callable.
+    /// Decode a dotted module path before crossing the host boundary, applying
+    /// the one lexical-shadowing rule to its root.
+    ///
+    /// The RIR spine itself is decoded by the shared syntactic decoder
+    /// [`decode_module_spine`], the same one semantic analysis and the
+    /// inference prepass use, so every position agrees on what a module path
+    /// even looks like (RUE-1964). Resolution of the path's declarations and
+    /// visibility stays in the semantic host; the engine owns this RIR edge so
+    /// hosts never need to inspect child instructions to discover a callable,
+    /// nor an evaluation environment to decide whether a name is shadowed.
+    ///
+    /// One decoder serves both consumers — a method call's receiver
+    /// (`lib.nums.max(..)`) and a dotted type path (`std.strbuf.StrBuf`) — as
+    /// they ask exactly the same question of exactly the same spine.
     fn decode_module_path(
-        &self,
-        receiver: InstRef,
-        env: &ComptimeEnv<'_, H::Value, H::Type, H::Name, H::File, H::CanonicalIdentity>,
-    ) -> Option<(H::File, Vec<H::Name>)> {
-        let mut chain_rev = Vec::new();
-        let mut cursor = receiver;
-        let root = loop {
-            match self.program_rir().get(cursor).data {
-                InstData::VarRef { name, .. } => break self.name_from_rir(name.into()),
-                InstData::FieldGet { base, field } => {
-                    chain_rev.push(self.name_from_rir(field.into()));
-                    cursor = base;
-                }
-                _ => return None,
-            }
-        };
-        if env.locals.contains_key(&root)
-            || env.is_runtime_local_name(&root)
-            || env.runtime_binding_names.contains(&root)
-            || env.type_subst.contains_key(&root)
-            || env.value_subst.contains_key(&root)
-        {
-            return None;
-        }
-        let file_id = env.defining_file.clone()?;
-        chain_rev.reverse();
-        let mut segments = Vec::with_capacity(chain_rev.len() + 1);
-        segments.push(root);
-        segments.extend(chain_rev);
-        Some((file_id, segments))
-    }
-
-    /// Decode a dotted type path before crossing the host boundary. The host
-    /// receives only copied semantic path facts; it never needs to inspect the
-    /// RIR spine or an evaluation environment to decide whether this is a
-    /// module/type path.
-    fn decode_type_path(
         &self,
         inst_ref: InstRef,
         env: &ComptimeEnv<'_, H::Value, H::Type, H::Name, H::File, H::CanonicalIdentity>,
     ) -> Option<(H::File, Vec<H::Name>)> {
-        let mut chain_rev = Vec::new();
-        let mut cursor = inst_ref;
-        let root = loop {
-            match self.program_rir().get(cursor).data {
-                InstData::VarRef { name, .. } => break self.name_from_rir(name.into()),
-                InstData::FieldGet { base, field } => {
-                    chain_rev.push(self.name_from_rir(field.into()));
-                    cursor = base;
-                }
-                _ => return None,
-            }
-        };
+        let spine = decode_module_spine(self.program_rir(), inst_ref)?;
+        let root = self.name_from_rir(spine.root.into());
         if env.locals.contains_key(&root)
             || env.is_runtime_local_name(&root)
             || env.runtime_binding_names.contains(&root)
@@ -1715,10 +1679,14 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             return None;
         }
         let file_id = env.defining_file.clone()?;
-        chain_rev.reverse();
-        let mut segments = Vec::with_capacity(chain_rev.len() + 1);
+        let mut segments = Vec::with_capacity(spine.fields.len() + 1);
         segments.push(root);
-        segments.extend(chain_rev);
+        segments.extend(
+            spine
+                .fields
+                .into_iter()
+                .map(|field| self.name_from_rir(field.into())),
+        );
         Some((file_id, segments))
     }
 
@@ -3218,7 +3186,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 if let Some(value) = env.const_module_members.get(&inst_ref) {
                     return ComptimeOutcome::Known(value.clone());
                 }
-                if let Some((file, segments)) = self.decode_type_path(inst_ref, env) {
+                if let Some((file, segments)) = self.decode_module_path(inst_ref, env) {
                     if let Some(value) =
                         host_value!(self.host.resolve_comptime_type_path(file, &segments, span))
                     {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -54,6 +54,7 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_rir::{InstData, InstRef};
 use rue_span::{FileId, Span};
 
+use super::aggregate_resolution::decode_module_spine;
 use super::comptime::{
     ComptimeAnonymousKind, ComptimeArgMode, ComptimeArrayLengthBinding, ComptimeCallAdmission,
     ComptimeCallArgument, ComptimeCallKey, ComptimeCallPreparation, ComptimeCallProtocol,
@@ -1162,40 +1163,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         arg: InstRef,
         ctx: &AnalysisContext,
     ) -> Option<String> {
-        // Walk the FieldGet chain to its root, collecting the dotted spine.
-        let mut fields_rev: Vec<Spur> = Vec::new();
-        let mut cursor = arg;
-        let root_name = loop {
-            match self.body_rir_ref().get(cursor).data {
-                InstData::VarRef { name, .. } => break name,
-                InstData::FieldGet { base, field } => {
-                    fields_rev.push(field);
-                    cursor = base;
-                }
-                _ => return None,
-            }
-        };
+        // Decode the dotted spine with the one shared syntactic decoder
+        // (RUE-1964), then apply the same shadowing rule every other position
+        // applies to its root.
+        let spine = decode_module_spine(self.body_rir_ref(), arg)?;
         // A bare `VarRef` (no field) is a plain runtime binding, not a path.
-        if fields_rev.is_empty() {
+        if spine.fields.is_empty() {
             return None;
         }
         // A runtime local or parameter of the same name shadows the import, so
         // this is an ordinary field access on a value — the generic help is
         // correct there.
-        if ctx.locals.contains_key(&root_name) || ctx.has_param(root_name) {
+        if self.is_runtime_value_binding(spine.root, ctx) {
             return None;
         }
         // The root must name a module import of the current file for this to be
         // a module-qualified member-access path at all.
-        let binding = self.module_binding(&(ctx.current_file_id, root_name))?;
+        let binding = self.module_binding(&(ctx.current_file_id, spine.root))?;
         binding.ty.as_module()?;
-        let mut segments: Vec<&str> = vec![self.body_interner().resolve(&root_name)];
-        segments.extend(
-            fields_rev
-                .iter()
-                .rev()
-                .map(|s| self.body_interner().resolve(s)),
-        );
+        let mut segments: Vec<&str> = vec![self.body_interner().resolve(&spine.root)];
+        segments.extend(spine.fields.iter().map(|s| self.body_interner().resolve(s)));
         let path = segments.join(".");
         Some(format!(
             "the module-qualified path `{path}` names a compile-time value that \

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -803,12 +803,21 @@ mod tests {
 
         let mut engine_methods = method_names(engine);
         engine_methods.sort_unstable();
-        assert_eq!(
-            engine_methods,
-            ["module_file_for_ref", "resolve_enum_through_module"]
+        // `resolve_enum_through_module` is the whole of visibility.rs: the
+        // module spine it needs is decoded and walked by the one canonical
+        // owner (`aggregates.rs`'s `try_module_id_of`), so the file holds no
+        // private module-reference walker of its own (RUE-1964).
+        assert_eq!(engine_methods, ["resolve_enum_through_module"]);
+        assert!(
+            !VISIBILITY_SOURCE.contains("InstData::"),
+            "visibility must not regrow its own RIR module-spine walker"
+        );
+        assert!(
+            VISIBILITY_SOURCE.contains("self.try_module_id_of("),
+            "visibility resolves its module spine through the canonical walker"
         );
 
-        for method in ["resolve_enum_through_module", "module_file_for_ref"] {
+        for method in ["resolve_enum_through_module"] {
             let needle = format!("fn {method}(");
             assert_eq!(
                 VISIBILITY_SOURCE.matches(&needle).count(),

--- a/crates/rue-air/src/sema/fact_mode.rs
+++ b/crates/rue-air/src/sema/fact_mode.rs
@@ -36,7 +36,13 @@ pub(crate) struct StructuredTypeSyntaxRequest<'a> {
 
 /// Exact input for resolving a module-qualified type prefix.
 pub(crate) struct ModulePrefixRequest<'a> {
+    /// The file the path is written in: the scope its root binding is looked
+    /// up in, and the domain its visibility is judged from.
     pub(crate) root_file: FileId,
+    /// A module the walk already starts from, for a spine whose root is a
+    /// binding that *is* a module. `None` resolves `segments[0]` as a module
+    /// binding of `root_file` instead (RUE-1964).
+    pub(crate) start_module: Option<crate::types::ModuleId>,
     pub(crate) segments: &'a [&'a str],
     pub(crate) span: Span,
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -63,7 +63,7 @@ pub use binding_manifest::{
 // RUE-1831: the comptime module tree as one string, for the structural
 // guards in `api_inventory` and `consistency_tests`. `comptime` itself
 // stays private; only the guard source crosses this boundary.
-pub(crate) use aggregate_resolution::select_module_nominal;
+pub(crate) use aggregate_resolution::{decode_module_spine, select_module_nominal};
 pub use comptime::ComptimeMethodReceiverPolicy;
 #[cfg(test)]
 pub(crate) use comptime::{COMPTIME_PRODUCTION_SOURCE, COMPTIME_SOURCE};

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1215,10 +1215,31 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         segments: &[&str],
         span: Span,
     ) -> CompileResult<(ModuleId, Option<FileId>, String)> {
+        self.resolve_type_module_prefix_from(root_file, None, segments, span)
+    }
+
+    /// Resolve a dotted module prefix, optionally continuing from a module the
+    /// caller already holds.
+    ///
+    /// `start_module` is `Some` only for a spine whose root is a binding that
+    /// *is* a module (`let m = lib.geo; m.deep.E.A`). The remaining segments
+    /// are then walked as members of that module by the same canonical per-hop
+    /// visibility loop the root-from-file entry uses, so there is exactly one
+    /// place where a private module hop is rejected (RUE-1964). `root_file`
+    /// stays the accessing file either way — privacy is judged from where the
+    /// path is written, not from where the module was bound.
+    pub(crate) fn resolve_type_module_prefix_from(
+        &mut self,
+        root_file: FileId,
+        start_module: Option<ModuleId>,
+        segments: &[&str],
+        span: Span,
+    ) -> CompileResult<(ModuleId, Option<FileId>, String)> {
         TypeResolutionHost::resolve_type_module_prefix(
             self.storage,
             super::fact_mode::ModulePrefixRequest {
                 root_file,
+                start_module,
                 segments,
                 span,
             },

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -4524,9 +4524,32 @@ where
             None,
             None,
         );
+        // A spine rooted at a binding that already *is* a module enters the
+        // canonical walk at that module; every other spine resolves its root as
+        // a module binding of the accessing file first. Both then share the one
+        // per-hop visibility loop (RUE-1964).
+        let start = request.start_module.map(|module| {
+            let site = self
+                .calls
+                .module_def(module)
+                .map_or(request.root_file, |definition| definition.file_id);
+            crate::SemanticResolvedModule { module, site }
+        });
         let resolved = {
             let mut provider = TypeSyntaxProvider::new(self, &mut state);
-            crate::resolve_semantic_module_path(&mut provider, &request.root_file, request.segments)
+            match start {
+                Some(start) => crate::resolve_semantic_module_path_from(
+                    &mut provider,
+                    &request.root_file,
+                    start,
+                    request.segments,
+                ),
+                None => crate::resolve_semantic_module_path(
+                    &mut provider,
+                    &request.root_file,
+                    request.segments,
+                ),
+            }
         }
         .map_err(|failure| {
             super::typeck::module_path_resolution_compile_error(failure, request.span)

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -796,11 +796,20 @@ fn module_path_compile_error(
                 span,
             )
         }
-        crate::SemanticModulePathFailure::PrivateMember {
-            member,
-            defining_file,
-            ..
-        } => private_qualified_item_error("constant", &member, &defining_file, span),
+        // A module binding is a `const` (spec 10.4:1), so crossing a private
+        // one is the ordinary module-member privacy violation E0706 — the same
+        // code the identical hop reports when it is read as a value, named in a
+        // struct literal, or used as an associated-function receiver (spec
+        // 10.3:7, 10.4:18). E0460 stays reserved for its one carve-out,
+        // applying a private comptime type constructor in type position
+        // (10.4:16), which arrives through `PrivateItem`, not here (RUE-1964).
+        crate::SemanticModulePathFailure::PrivateMember { member, .. } => CompileError::new(
+            ErrorKind::PrivateMemberAccess {
+                item_kind: "const".to_string(),
+                name: member.to_string(),
+            },
+            span,
+        ),
     }
 }
 

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -6,7 +6,7 @@
 
 use rue_error::{CompileError, CompileResult, ErrorKind};
 
-use super::aggregate_resolution::{resolve_visibility_module_ref, select_module_type_member};
+use super::aggregate_resolution::select_module_type_member;
 use super::context::AnalysisContext;
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use crate::types::EnumId;
@@ -21,27 +21,28 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// declaration does (RUE-1956). Visibility is E0706, checked against the
     /// alias binding when the name arrived through one.
     pub(crate) fn resolve_enum_through_module(
-        &self,
+        &mut self,
         module_ref: rue_rir::InstRef,
         type_name: lasso::Spur,
         span: rue_span::Span,
         ctx: &AnalysisContext,
     ) -> CompileResult<EnumId> {
-        let type_name_str = self.body_interner().resolve(&type_name);
+        let type_name_str = self.body_interner().resolve(&type_name).to_string();
 
-        // Resolve the receiver's full module spine.  The root binding belongs
-        // to the source file containing the expression; every subsequent
-        // field is a module binding in the preceding module's defining file.
-        // This mirrors inference's module-member walk for paths such as
-        // `std.geo.Sign.Pos`, while keeping every lookup file-qualified.
-        let module_file_id = self.module_file_for_ref(module_ref, ctx);
+        // Resolve the receiver's full module spine through the one canonical
+        // walker, shared with expression position (`Self::try_module_id_of`):
+        // the root binding belongs to the source file containing the pattern,
+        // a runtime binding of the same name shadows it, and every subsequent
+        // field is a module binding in the preceding module's defining file
+        // whose own visibility is checked as it is crossed (RUE-1964).
+        let module_id = self.try_module_id_of(module_ref, span, ctx)?;
 
         // A qualified member is resolved only in the referenced module's
         // defining file. If the receiver has no module identity, it is not a
         // valid qualified type path.
         let unknown_enum =
             || CompileError::new(ErrorKind::UnknownEnumType(type_name_str.to_string()), span);
-        let module_file = module_file_id
+        let module_file = module_id
             .map(|module_id| self.aggregate_facts().aggregate_module(module_id).file)
             .ok_or_else(&unknown_enum)?;
         let member = {
@@ -56,19 +57,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             module_file,
             (enum_def.file_id, enum_def.is_pub),
             "enum",
-            type_name_str,
+            &type_name_str,
             span,
         )?;
 
         Ok(nominal.id)
-    }
-
-    fn module_file_for_ref(
-        &self,
-        module_ref: rue_rir::InstRef,
-        ctx: &AnalysisContext,
-    ) -> Option<crate::types::ModuleId> {
-        let facts = self.aggregate_facts();
-        resolve_visibility_module_ref(facts, self.body_rir_ref(), module_ref, &ctx.locals)
     }
 }

--- a/crates/rue-air/src/semantic_type_resolution.rs
+++ b/crates/rue-air/src/semantic_type_resolution.rs
@@ -270,6 +270,12 @@ fn lift_provider<T, E, P, F>(
     })
 }
 
+/// Resolve a dotted module path whose root is a module binding of `root_scope`.
+///
+/// The root's own visibility is checked here; every subsequent hop is checked
+/// by the one shared member walk [`resolve_semantic_module_path_from`], so a
+/// private module binding is rejected the same way wherever it appears in a
+/// path (RUE-1964).
 pub fn resolve_semantic_module_path<S, M, A, P>(
     provider: &mut P,
     root_scope: &S,
@@ -307,11 +313,41 @@ where
         }));
     }
 
-    let mut resolved = SemanticResolvedModule {
+    let resolved = SemanticResolvedModule {
         module: first.target,
         site: first.site,
     };
-    for segment in rest {
+    resolve_semantic_module_path_from(provider, root_scope, resolved, rest)
+}
+
+/// Resolve the remaining `segments` as module members of an already-known
+/// `start` module, judged from `root_scope`'s accessing domain.
+///
+/// This is the one per-hop module walk. The root-from-scope entry
+/// [`resolve_semantic_module_path`] delegates its tail here, and callers that
+/// already hold a module — a `let`-bound `@import`, whose local binding *is*
+/// the module — enter here directly rather than writing a second hop loop with
+/// its own visibility rule (RUE-1964).
+pub fn resolve_semantic_module_path_from<S, M, A, P>(
+    provider: &mut P,
+    root_scope: &S,
+    start: SemanticResolvedModule<M, A>,
+    segments: &[&str],
+) -> Result<
+    SemanticResolvedModule<M, A>,
+    SemanticResolutionError<P::Abort, P::Failure, SemanticModulePathFailure<A>>,
+>
+where
+    M: Clone,
+    A: Clone,
+    P: SemanticModulePathProvider<S, M, A>,
+{
+    use SemanticModulePathFailure as F;
+    use SemanticResolutionError as E;
+
+    let accessing = provider.accessing_domain(root_scope);
+    let mut resolved = start;
+    for segment in segments {
         let display = provider.module_display_name(&resolved.module);
         let binding = lift_provider(provider.module_binding(&resolved.module, segment))?
             .ok_or_else(|| {

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -753,3 +753,233 @@ pub const H = Hidden;
 """ }
 compile_fail = true
 error_contains = ["E0706", "enum", "is private"]
+
+# =============================================================================
+# A private module binding crossed as an INTERMEDIATE path segment (RUE-1964).
+#
+# `lib.inner.E` names the private `const inner` of `sub/facade.rue` on its way
+# to the public enum behind it. A module binding is a `const` (10.4:1), so that
+# hop is the ordinary uniform module-member privacy violation E0706 (10.3:7,
+# 10.4:18) — in every position, not only the ones that happened to route
+# through the type-annotation walker. Before the fix the expression, pattern,
+# and associated-function spellings accepted the private hop outright and the
+# type-annotation spelling reported E0460, the code 10.4:18 reserves for
+# applying a private comptime type constructor.
+
+[[case]]
+name = "private_module_hop_variant_expression_rejected"
+spec = ["10.4:18", "10.3:7"]
+description = "A private intermediate module binding crossed in a variant expression is E0706 naming the binding (RUE-1964)"
+source = """
+const lib = @import("sub/facade.rue");
+
+fn main() -> i32 {
+    let e = lib.inner.E.B;
+    0
+}
+"""
+aux_files = { "sub/facade.rue" = """
+const inner = @import("deep/inner.rue");
+pub fn touch() -> i32 { match inner.E.A { inner.E.A => 1, inner.E.B => 2, } }
+""", "sub/deep/inner.rue" = """
+pub enum E { A, B, }
+pub struct Point {
+    x: i32,
+    fn origin() -> Point { Point { x: 1 } }
+}
+""" }
+compile_fail = true
+error_contains = ["E0706", "inner", "is private"]
+
+[[case]]
+name = "private_module_hop_match_pattern_rejected"
+spec = ["10.4:18", "10.3:7"]
+description = "A private intermediate module binding crossed in a match-pattern head is E0706 (RUE-1964)"
+source = """
+const lib = @import("sub/facade.rue");
+
+fn main() -> i32 {
+    let e = lib.make();
+    match e {
+        lib.inner.E.A => 1,
+        lib.inner.E.B => 2,
+    }
+}
+"""
+aux_files = { "sub/facade.rue" = """
+const inner = @import("deep/inner.rue");
+pub fn make() -> inner.E { inner.E.A }
+""", "sub/deep/inner.rue" = """
+pub enum E { A, B, }
+""" }
+compile_fail = true
+error_contains = ["E0706", "inner", "is private"]
+
+[[case]]
+name = "private_module_hop_assoc_fn_call_rejected"
+spec = ["10.4:18", "10.4:19"]
+description = "A private intermediate module binding crossed in a module-qualified associated-function call is E0706 (RUE-1964)"
+source = """
+const lib = @import("sub/facade.rue");
+
+fn main() -> i32 {
+    let p = lib.inner.Point.origin();
+    p.x
+}
+"""
+aux_files = { "sub/facade.rue" = """
+const inner = @import("deep/inner.rue");
+pub fn touch() -> i32 { inner.Point.origin().x }
+""", "sub/deep/inner.rue" = """
+pub struct Point {
+    x: i32,
+    fn origin() -> Point { Point { x: 1 } }
+}
+""" }
+compile_fail = true
+error_contains = ["E0706", "inner", "is private"]
+
+[[case]]
+name = "private_module_hop_struct_literal_rejected"
+spec = ["10.4:18"]
+description = "A private intermediate module binding crossed in a module-qualified struct literal is E0706 (RUE-1964)"
+source = """
+const lib = @import("sub/facade.rue");
+
+fn main() -> i32 {
+    let p = lib.inner.Point { x: 7 };
+    p.x
+}
+"""
+aux_files = { "sub/facade.rue" = """
+const inner = @import("deep/inner.rue");
+pub fn touch() -> i32 { let p = inner.Point { x: 1 }; p.x }
+""", "sub/deep/inner.rue" = """
+pub struct Point { x: i32, }
+""" }
+compile_fail = true
+error_contains = ["E0706", "inner", "is private"]
+
+[[case]]
+name = "private_module_hop_type_annotation_rejected"
+spec = ["10.4:18", "10.4:16"]
+description = "A private intermediate module binding crossed in a type annotation is E0706, not the type-constructor carve-out E0460 (RUE-1964)"
+source = """
+const lib = @import("sub/facade.rue");
+
+fn main() -> i32 {
+    let e: lib.inner.E = lib.make();
+    0
+}
+"""
+aux_files = { "sub/facade.rue" = """
+const inner = @import("deep/inner.rue");
+pub fn make() -> inner.E { inner.E.A }
+""", "sub/deep/inner.rue" = """
+pub enum E { A, B, }
+""" }
+compile_fail = true
+error_contains = ["E0706", "inner", "is private"]
+
+[[case]]
+name = "pub_module_hop_all_positions_allowed"
+spec = ["10.4:18", "10.4:15", "10.4:16"]
+description = "The positive twin: with `pub const inner = @import(..)` every position that crosses the hop compiles and runs (RUE-1964)"
+source = """
+const lib = @import("sub/facade.rue");
+
+fn classify(e: lib.inner.E) -> i32 {
+    match e {
+        lib.inner.E.A => 1,
+        lib.inner.E.B => 2,
+    }
+}
+
+fn main() -> i32 {
+    let e = lib.inner.E.B;
+    let p = lib.inner.Point.origin();
+    let q = lib.inner.Point { x: 39 };
+    classify(e) + p.x + q.x
+}
+"""
+aux_files = { "sub/facade.rue" = """
+pub const inner = @import("deep/inner.rue");
+""", "sub/deep/inner.rue" = """
+pub enum E { A, B, }
+pub struct Point {
+    x: i32,
+    fn origin() -> Point { Point { x: 1 } }
+}
+""" }
+exit_code = 42
+
+# =============================================================================
+# A local binding shadows a file's module binding (5.1:10-5.1:12, 10.4:8).
+#
+# After `let lib = 5;` the name is a runtime i32, so `lib.Color.Green` is field
+# access on that value in every position and never the import's module path.
+# Before RUE-1964 the expression and associated-function spellings silently used
+# the import anyway, so a shadowed name resolved differently in three positions.
+
+[[case]]
+name = "runtime_binding_shadows_module_in_expression"
+spec = ["10.4:8", "5.1:10"]
+description = "A runtime local shadows the file's module binding: `lib.Color.Green` is field access on the local, not a module path (RUE-1964)"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let lib = 5;
+    let c = lib.Color.Green;
+    0
+}
+"""
+aux_files = { "sub/lib.rue" = """
+pub enum Color { Red, Green, }
+""" }
+compile_fail = true
+error_contains = ["E0423"]
+
+[[case]]
+name = "runtime_binding_shadows_module_in_pattern"
+spec = ["10.4:8", "5.1:10"]
+description = "The same shadowing rule applies to a match-pattern head (RUE-1964)"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let c = lib.Color.Green;
+    let lib = 5;
+    match c {
+        lib.Color.Red => 1,
+        lib.Color.Green => 2,
+    }
+}
+"""
+aux_files = { "sub/lib.rue" = """
+pub enum Color { Red, Green, }
+""" }
+compile_fail = true
+error_contains = ["E0421"]
+
+[[case]]
+name = "runtime_binding_shadows_module_in_assoc_fn_call"
+spec = ["10.4:8", "5.1:10"]
+description = "The same shadowing rule applies to a module-qualified associated-function call (RUE-1964)"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let lib = 5;
+    let p = lib.Point.origin();
+    p.x
+}
+"""
+aux_files = { "sub/lib.rue" = """
+pub struct Point {
+    x: i32,
+    fn origin() -> Point { Point { x: 1 } }
+}
+""" }
+compile_fail = true
+error_contains = ["E0423"]

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -38,6 +38,12 @@ A top-level `const` module binding is scoped to the file that declares it,
 like every other top-level name (10.5:2). Two files **MAY** bind the same
 name — whether to the same module or to different modules — without
 conflict; references in each file resolve to that file's own binding.
+A local binding of the same name shadows the file's module binding by the
+ordinary shadowing rules (5.1:10–5.1:12): after `let lib = 5;`, the path
+`lib.Color.Green` is field access on that local and not a module-qualified
+path, in every position. A local binding whose value *is* a module
+(`let m = lib.geo;`) names that module and member access continues through
+it, since a module is not a runtime value (10.4:6).
 Declaring two module bindings with the same name in one file remains a
 compile-time error (E0418).
 
@@ -181,9 +187,14 @@ and reports one member-access diagnostic: accessing a private member
 through a module binding from a source file in another directory is a
 compile-time error E0706 — for a struct named in a qualified struct
 literal or type annotation, for an enum's variant, for an associated
-function's enclosing type, and for functions and constants alike. The one
-exception is the comptime type-constructor application form in a type
-position (10.4:16), which reports E0460 (10.3:7).
+function's enclosing type, and for functions and constants alike. A module
+binding named as an intermediate segment of a longer path
+(`lib.inner.E.B`, `lib.inner.Point.origin()`, `let e: lib.inner.E`) is
+itself a `const` member of the preceding module (10.4:1), so crossing a
+private one is this same E0706 in every position — expression, pattern,
+associated-function receiver, struct literal, and type annotation alike.
+The one exception is the comptime type-constructor application form in a
+type position (10.4:16), which reports E0460 (10.3:7).
 
 {{ rule(id="10.4:19", cat="legality-rule") }}
 


### PR DESCRIPTION
Fixes RUE-1964.

A private module binding crossed as an intermediate path segment (`lib.inner.E.B`, where `sub/facade.rue` has a private `const inner = @import("deep/inner.rue")`) was accepted in expression, match-pattern, and associated-function position, rejected with E0460 in type-annotation position, and rejected with E0706 when read as a value or named in a struct literal. Spec 10.3:7 and 10.4:18 make module-member privacy uniformly E0706, with E0460 reserved for applying a private comptime type constructor in type position. Shadowing was likewise position-dependent: after `let lib = 5;` the expression and associated-function spellings still used the import while the pattern spelling honored the local.

The cause was four module-spine walkers with three different rules. `resolve_semantic_module_path` checked visibility on every hop; the two RIR walkers in `aggregate_resolution.rs` checked none and disagreed on whether a non-module local shadows the import; inference's `module_member_file` ignored locals entirely.

This makes `resolve_semantic_module_path` the only walker. Its per-hop loop is factored into `resolve_semantic_module_path_from`, so a spine rooted at a local that is itself a module (`let m = lib.geo; m.deep.E.A`) enters the same loop instead of a second one. One syntactic decoder, `decode_module_spine`, turns a `FieldGet` chain into its root and segments; `try_module_id_of` and `resolve_enum_through_module` decode, apply one shadowing rule (spec 5.1:10–5.1:12: a runtime local or parameter shadows the import; a local of module type is the module), and resolve through the host's `resolve_type_module_prefix`. Both RIR walkers are deleted. The comptime engine's two identical spine decoders collapse onto the shared one, as does the hand-rolled walk in `comptime_arg_member_access_help`. Inference decodes with the same decoder and applies the same shadowing rule; its hop lookups stay local because its fact source exposes types only and privacy is sema's to decide.

`module_path_compile_error` now reports a private hop as E0706 (``const `inner` is private``) instead of E0460, so all six spellings agree:

| spelling | before | after |
| -- | -- | -- |
| `let e = lib.inner.E.B;` | compiled | E0706 |
| `match e { lib.inner.E.A => .. }` | compiled | E0706 |
| `lib.inner.Point.origin()` | compiled | E0706 |
| `let e: lib.inner.E = ..` | E0460 | E0706 |
| `let m = lib.inner;` | E0706 | E0706 |
| `lib.inner.Point { .. }` | E0706 | E0706 |

One behavioral side effect worth a reviewer's eye: expression- and pattern-position module resolution now goes through the host method that records observed type dependencies, so those positions record incremental invalidation edges the old walkers did not. That is strictly more correct, and the incremental and query suites are green.

Spec: 10.4:8 states the shadowing rule for a module binding; 10.4:18 states that an intermediate module binding is a `const` member for the uniform-privacy rule in every position. Nine spec cases in `modules/bindings.toml` cover the five rejected positions, the `pub const inner` positive twin (runs, exit 42), and shadowing in expression, pattern, and associated-function position. The `consistency_tests` guard on `visibility.rs` now asserts it holds no spine walker of its own.

Verification: `scripts/rue fmt`, `scripts/rue quick` (1214 passed), full `scripts/rue spec` (2820 passed), `scripts/rue cli modules` / `assoc_fn_privacy` / `module_consts`, rue-air consistency unit tests, UI suite, oracle-diff, `//:spec-traceability`, `//:compiler-spec-machine-index`. `scripts/rue premerge` was green except two runtime cases that cannot pass in this sandbox (`remove_dir_all_permission_denied_is_not_partial_success` runs as uid 0, `tcp_ipv6_loopback_round_trip` has no IPv6); neither touches module resolution. The new spec cases are multi-file and ineligible for the oracle, so no model-gap entry is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLdye39ijo7zuAP9YLNgy7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLdye39ijo7zuAP9YLNgy7)_