### PR TITLE
RUE-2014: gate Grid2D on a trivially-droppable cell type at construction

### DIFF
--- a/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
@@ -12,8 +12,9 @@ for an in-place read or `pop`
 body, demand-driven analysis (ADR-0045) fires it only when a by-copy read is
 actually called — storing/pushing/popping/dropping a drop-glue element stays legal
 (RUE-646). Mirrors Swift's rule that a non-copyable element cannot use a by-value
-`get` subscript. These cases use a self-contained minimal container so the gate is
-tested independent of the std `ArrayBuf` source.
+`get` subscript. Most cases here use a self-contained minimal container so the gate
+is tested independent of the std `ArrayBuf` source; the `real_std` cases at the end
+pin the same gate where `std/grid.rue` states it for a whole element type.
 """
 
 [[case]]
@@ -290,3 +291,110 @@ fn main() {}
 """
 compile_fail = true
 error_contains = ["E0711", "Outer"]
+
+# `std/grid.rue` states the gate for the whole element type rather than for one
+# by-copy read. `Grid2D.new(rows, cols, fill)` pushes `fill` once per cell, so
+# each use of `fill` has to duplicate it and the element type must be Copy
+# (3.8:1, RUE-2014). Rue has no Copy gate, so `new` checks the drop-glue half
+# with `@require_trivially_droppable(T)`, ahead of the fill loop: an owning
+# element type gets one E0711 naming it, instead of the moved-value error the
+# loop would otherwise raise. The two sets are not the same, and the last pair
+# of cases pins the gap — a struct that is not `@copy` has no drop glue, passes
+# the gate, and is rejected at the loop with E0205.
+[[case]]
+name = "e0711_grid2d_owning_element_rejected_at_new"
+description = "Constructing `Grid2D(StrBuf)` is rejected with E0711 naming `StrBuf`, not a moved-value error against `fill` inside std."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let G = std.grid.Grid2D(StrBuf);
+    let mut g = G.new(1, 1, "fill");
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "element of type `StrBuf`",
+]
+
+[[case]]
+name = "grid2d_copy_element_compiles"
+description = "The same constructor compiles and runs for a trivially-droppable (Copy) element type."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let OI = std.option.Option(i64);
+    let G = std.grid.Grid2D(i64);
+    let mut g = G.new(3, 3, 0);
+    g.set(1, 2, 42);
+    match g.get(1, 2) { OI.Some(v) => @intCast(v), OI.None => 0 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 42
+
+[[case]]
+name = "grid2d_owning_element_unconstructed_compiles"
+description = "Naming `Grid2D(StrBuf)` without constructing one is legal; the constructor's gate is demand-driven (ADR-0045)."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let G = std.grid.Grid2D(StrBuf);
+    5
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 5
+
+# The gate is drop-glue, not Copy, and these two pin the difference. A struct
+# with no `drop fn` and no `@copy` is a move type (3.8:3) with no drop glue: it
+# passes the gate and is then rejected at the fill loop. Marking it `@copy`
+# (legal because its fields are Copy, 3.8:18) is the remedy the header names.
+[[case]]
+name = "grid2d_move_only_element_without_drop_glue_hits_fill_loop"
+description = "A struct that is neither `@copy` nor drop-glue passes the E0711 gate and is rejected at the fill loop with E0205 — the residual gap while Rue has no Copy gate."
+source = """
+const std = @import("std");
+
+struct Cell { a: i64, b: i64 }
+
+fn main() -> i32 {
+    let G = std.grid.Grid2D(Cell);
+    let mut g = G.new(2, 2, Cell { a: 1, b: 2 });
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0205"
+error_contains = ["E0205", "fill"]
+
+[[case]]
+name = "grid2d_copy_marked_struct_element_compiles"
+description = "Marking the same struct `@copy` makes it a Copy type, and the grid builds and reads back."
+source = """
+const std = @import("std");
+
+@copy
+struct Cell { a: i64, b: i64 }
+
+fn main() -> i32 {
+    let OC = std.option.Option(Cell);
+    let G = std.grid.Grid2D(Cell);
+    let mut g = G.new(2, 2, Cell { a: 1, b: 2 });
+    match g.get(1, 1) { OC.Some(c) => @intCast(c.a + c.b), OC.None => 0 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 3

--- a/std/grid.rue
+++ b/std/grid.rue
@@ -1,6 +1,33 @@
-// std.collections — Grid2D(T): a row-major dynamic 2D grid over a single
-// ArrayBuf(T). Reads return elements BY COPY, so `get` is usable for
-// trivially-droppable (`Copy`) `T` only (RUE-651); `set` works for any `T`.
+// std.collections — Grid2D(T): a row-major dynamic 2D grid laid out in a
+// single ArrayBuf(T), for a Copy element type.
+//
+// COPY-`T` ONLY. `new(rows, cols, fill)` is the only constructor and it
+// initialises every cell from one `fill` value, so a use of `fill` must
+// duplicate it rather than consume it — that is what a Copy type does (3.8:1).
+// The Copy types are the primitives, `str` and `Str(N)`, discriminant-only
+// (C-like) enums, Copy arrays, structs marked `@copy`, and anonymous structs
+// whose fields are all Copy — `std.tuple.Pair(i64, i64)` among them (3.8:2,
+// 3.8:16). A payload-carrying enum is Copy when every payload is
+// (`Option(i64)` qualifies). `Deque` and `IntMap` take a filler value and
+// restrict their element type the same way (RUE-651).
+//
+// Rue has no intrinsic that gates on Copy, so `new` states the half it can:
+// `@require_trivially_droppable(T)` (E0711) rejects a `T` with drop glue — an
+// owning element such as `StrBuf`, or a struct with a `drop fn` — and names
+// that type. The remaining Copy requirement is unstated and surfaces later. A
+// move-only `T` with no drop glue is exactly a struct not marked `@copy`
+// (3.8:3, 3.8:19): it passes the gate and is then rejected at the fill loop
+// with E0205 against `fill`, inside this module. Mark such a struct `@copy` —
+// legal whenever its fields are all Copy (3.8:18) — and the grid works.
+//
+// A `T` that is neither Copy nor markable `@copy` has no constructor here, and
+// giving it one needs a language feature Rue does not have. Duplicating an
+// owning `fill` per cell needs a generic clone, which needs traits (RUE-246);
+// a `new_with(rows, cols, f)` that computes each cell instead needs function
+// values (RUE-643).
+//
+// `get` reads a cell by copy and `set` overwrites one; `get_ref` borrows a
+// cell in place.
 //
 //     const std = @import("std");
 //     let G = std.grid.Grid2D(i64);
@@ -19,7 +46,19 @@ pub fn Grid2D(comptime T: type) -> type {
         cols: u64,
 
         // A `rows`x`cols` grid with every cell initialised to `fill`.
+        //
+        // COPY-`T` ONLY: the loop below pushes `fill` once per cell, so each
+        // use of `fill` has to duplicate it (3.8:1). The gate here checks the
+        // drop-glue half of that — there is no Copy gate to call — and it is
+        // stated ahead of the loop so an owning `T` gets E0711 naming its
+        // element type rather than a moved-value error against `fill`
+        // (RUE-2014). A move-only `T` with no drop glue, i.e. a struct not
+        // marked `@copy`, still reaches the loop and fails there with E0205;
+        // marking the struct `@copy` is the fix. The gate lives in the method
+        // body, so demand-driven analysis (ADR-0045) applies it only when a
+        // program actually constructs a grid.
         fn new(rows: u64, cols: u64, fill: T) -> Self {
+            @require_trivially_droppable(T);
             let b = arraybuf.ArrayBuf(T);
             let mut cells = b.new();
             if cols > 0 && rows > 18446744073709551615 / cols {
@@ -45,7 +84,7 @@ pub fn Grid2D(comptime T: type) -> type {
             r < self.rows && c < self.cols
         }
 
-        // Cell `(r, c)` by copy, or `None` when out of bounds. COPY-`T` ONLY.
+        // Cell `(r, c)` by copy, or `None` when out of bounds.
         fn get(borrow self, r: u64, c: u64) -> option.Option(T) {
             let O = option.Option(T);
             if r < self.rows && c < self.cols {


### PR DESCRIPTION
Fixes RUE-2014

`Grid2D(T).new(rows, cols, fill)` fills every cell from one `fill`, so a `T` with drop glue failed inside std with `E0205: use of moved value 'fill'` while the header claimed `set` works for any `T`.

- `new` now gates with `@require_trivially_droppable(T)` first, so `Grid2D(StrBuf)` is a single E0711 at the demand site and never reaches the fill loop. The gate is demand-driven: naming the instantiation without calling `new` still compiles.
- The header states the real contract: `T` must be a Copy type, like `Deque` and `IntMap`. It also says what the gate does not cover: the language has no Copy gate, so a struct not marked `@copy` (no drop glue, but move-only) still hits E0205 at the fill loop, and the remedy is `@copy`. That gap is filed as RUE-2028 (needs a maintainer call); the read-shaped wording and std-internal span of E0711 are RUE-2026.
- Five UI cases in `trivially_droppable_gate.toml` pin both halves, including `expected_error_code = "E0711"` so the case proves E0711 is the only diagnostic.

Verified: `scripts/rue ui trivially-droppable-gate` 20/20 and the full UI suite 347/347; `scripts/rue cli std_collections`, `borrow_accessors`, `string_alloc` pass; `scripts/rue quick` green. Every in-tree `Grid2D` instantiation is `i64` or `u8` and is unaffected. Adversarially reviewed; both should-fix findings applied.
