### PR TITLE
RUE-2029: rewrite AGENTS.md as tool-neutral rules and move reference material to docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # RUE-1936: the repository tooling floor is Python 3.9 (AGENTS.md), the
+      # RUE-1936: the repository tooling floor is Python 3.9
+      # (docs/process/tooling-baseline.md), the
       # interpreter a stock Mac ships, while this runner's own python3 is far
       # above it — so a construct newer than the floor would stay green here
       # and fail on a developer machine (RUE-1509). Running every gate in this
@@ -298,7 +299,8 @@ jobs:
         # `performance-staleness` job, which takes its own `fetch-depth: 0`
         # checkout for the purpose (RUE-1258, RUE-1504).
 
-      # RUE-1936: the repository tooling floor is Python 3.9 (AGENTS.md), the
+      # RUE-1936: the repository tooling floor is Python 3.9
+      # (docs/process/tooling-baseline.md), the
       # interpreter a stock Mac ships, while this runner's own python3 is far
       # above it — so a construct newer than the floor would stay green here
       # and fail on a developer machine (RUE-1509). Running every gate in this
@@ -1301,7 +1303,8 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@v6
-      # RUE-1936: the repository tooling floor is Python 3.9 (AGENTS.md), the
+      # RUE-1936: the repository tooling floor is Python 3.9
+      # (docs/process/tooling-baseline.md), the
       # interpreter a stock Mac ships, while this runner's own python3 is far
       # above it — so a construct newer than the floor would stay green here
       # and fail on a developer machine (RUE-1509). Running every gate in this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ to the language's own `rue test` subcommand.
 - `docs/process/diagnostics.md`, `docs/process/logging.md`: the versioned
   `--error-format json` surface and the `tracing` conventions.
 - `docs/process/issue-tracking.md`: working with Linear.
+- `docs/process/codex.md`: guidance that applies only to Codex sessions.
 - `docs/designs/`: ADRs. `docs/spec/`: the language specification.
 
 ## Working rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,354 +1,192 @@
 # Rue repository instructions
 
 This is the canonical guidance for coding agents working in Rue. Tool-specific
-instruction files should point here rather than copy these rules.
+instruction files (`CLAUDE.md` and the like) point here rather than copying
+these rules, and nothing here assumes a particular agent product.
 
-Rue is an early-stage systems programming language implemented in Rust. It uses
-Buck2, Jujutsu, Linear, and a pull-request-based GitHub contribution workflow.
-
-## Working agreement
-
-### Division of labor
-
-- For end-to-end issue implementation, default to one Luna High implementation
-  agent when that capability is available. The coordinating agent investigates,
-  writes a precise brief, reviews the returned change, integrates it, and owns
-  publication and cleanup.
-- Add a separate adversarial reviewer only when the change is architectural,
-  cross-phase, unsafe, security-sensitive, or otherwise unusually risky.
-- Do not delegate routine polling, repository-instruction discovery, or reading
-  this file. Do not create multiple implementation agents for the same scope.
-- Protect unrelated working-copy changes. Use an isolated workspace for a new
-  issue when the active checkout contains unrelated work.
-
-### Communication
-
-Keep updates milestone-based:
-
-1. Scope understood and implementation delegated.
-2. Implementation returned, including material review findings.
-3. A real test, CI, design, or authority blocker.
-4. PR queued.
-5. Merge, tracker closure, and cleanup verified.
-
-Do not narrate unchanged CI polling or repeatedly report how many checks remain.
-Do not call ordinary compilation time a stall without evidence.
-
-### Evidence and architectural review
-
-- Current source and tests are authoritative. Linear issues, old comments, and
-  historical ADRs provide context, not proof that a problem still exists.
-- Before reporting architectural debt, classify it as one of:
-  - present in the current source;
-  - historical and already removed;
-  - intentionally transitional and tracked by an active issue.
-- Verify source claims with concrete paths and current call sites. Avoid
-  legitimizing a path merely because it is called legacy or compatibility code.
-- Prefer one canonical computation path with thin consumers. Treat duplicate
-  discovery, lowering, semantic, CFG, codegen, and presentation paths as suspect.
-
-### Autonomy and completion
-
-- Once asked to implement and shepherd an issue, ordinary in-scope fixes are
-  authorized: formatting, generated-index refreshes, CI repairs, rebases, and
-  test updates. Ask only for a design decision, material scope expansion,
-  destructive action, unavailable authority, or external impact not implied by
-  the request.
-- A sandboxed `gh auth status` or network failure is not authoritative on this
-  machine. Retry the required read or publication operation with host access
-  before reporting an authentication blocker.
-- Do not stop at "PR open," "auto-merge enabled," or "checks green" when the
-  requested outcome includes shepherding. Verify the merge itself.
-- Unless the user narrows the terminal condition, an end-to-end Rue issue ends
-  with the PR merged, Linear closed, the source branch deleted, upstream fetched
-  with the checkout's native VCS, and a clean working copy based on the updated
-  upstream `trunk`.
+Rue is an early-stage systems programming language implemented in Rust. It is
+built with Buck2, tracked in Linear (`RUE-NN`), and contributed to through
+GitHub pull requests into `trunk` behind a merge queue. Maintainers use
+Jujutsu in their own checkouts; every other checkout uses Git.
 
 ## Quickstart
 
-These commands cover most repository work and are runnable from anywhere in the
-repository:
+`scripts/rue` wraps the common Buck2 targets and runs from anywhere in the
+repository. Buck2 and the Rust toolchain bootstrap themselves on first use.
 
 ```bash
 scripts/rue build                    # build the compiler and print its path
 scripts/rue exec prog.rue            # compile and run a quick program
 RUE="$(scripts/rue-bin)"; "$RUE" main.rue -o out
 scripts/rue quick                    # fast unit suite
-scripts/rue premerge                 # local premerge test tier (not all required CI)
-scripts/rue slow                     # canonical scheduled slow tier
-scripts/rue stress                   # canonical opt-in stress tier
-scripts/rue all                      # canonical union of all tiers
-scripts/rue unit compiler durable_   # one compiler unit test
+scripts/rue unit compiler durable_   # one crate's unit tests, filtered
 scripts/rue spec 4.2                 # filtered specification tests
 scripts/rue cli abi                  # filtered CLI integration tests
-scripts/rue test [pattern]           # broad/full suite (the maintainers' compiler-suite
-                                     # wrapper — unrelated to the language's own
-                                     # `rue test` subcommand, docs/process/test-events.md)
+scripts/rue ui <pattern>             # filtered UI/diagnostics tests
+scripts/rue premerge                 # local premerge tier (not all required CI)
+scripts/rue test                     # broad/full suite (wraps ./test.sh)
 scripts/rue fmt                      # format changed Rust files
-scripts/rue storage status           # inventory Buck disk use across worktrees
-scripts/rue storage plan             # dry-run stale cleanup in every registered worktree
-scripts/rue storage clean            # reclaim stale Buck2 artifacts host-wide
-scripts/rue storage reset RUE_ROOT   # full Buck reset of one registered worktree
-scripts/rue cache install            # securely install the private cache config
+./buck2 test //crates/rue-oracle-diff:oracle-diff-test   # when corpus cases change
 ```
 
-When corpus-affecting cases change, use this focused check:
-`./buck2 test //crates/rue-oracle-diff:oracle-diff-test`.
+Rue uses Buck2 through the repository's `./buck2` wrapper, never Cargo. Get
+an absolute compiler path from `scripts/rue-bin`, not by parsing Buck output.
+`scripts/rue test` is the maintainers' compiler-suite wrapper and is unrelated
+to the language's own `rue test` subcommand.
 
-Use `scripts/rue-bin` to obtain an absolute compiler path. Do not reconstruct
-one from Buck output with `--show-output` and `awk`.
+## Where to look
 
-Rue uses Buck2 through the repository's `./buck2` wrapper, not Cargo:
+- `docs/architecture.md`: the compiler pipeline and crate responsibilities.
+- `docs/development.md`: commands, repository map, choosing a test kind.
+- `docs/process/testing.md`: test tiers, what a local run cannot cover,
+  known wall-clock budgets, Buck storage and the optional remote cache.
+- `docs/process/tooling-baseline.md`: the Python 3.9 and Bash 3.2 floors for
+  repository scripts and how CI holds them.
+- `docs/process/ci.md`: required CI, tiers, pinned tools.
+- `docs/process/diagnostics.md`, `docs/process/logging.md`: the versioned
+  `--error-format json` surface and the `tracing` conventions.
+- `docs/process/issue-tracking.md`: working with Linear.
+- `docs/designs/`: ADRs. `docs/spec/`: the language specification.
 
-```bash
-./buck2 build //crates/rue:rue
-./buck2 test //...
-./buck2 run //crates/rue:rue -- main.rue -o prog
-./buck2 run //crates/rue:rue -- --emit <stage> src.rue
-```
+## Working rules
 
-## Repository tooling baseline
+- Current source and tests are authoritative. Linear issues, old comments, and
+  historical ADRs provide context, not proof that a problem still exists.
+  Verify claims against concrete paths and current call sites before acting on
+  or reporting them.
+  Reported architectural debt is one of: present in the current source,
+  historical and already removed, or intentionally transitional and tracked
+  by an active issue. Say which.
+- Reproduce a bug before fixing it. A claim that does not reproduce is worth
+  reporting as such; do not fix what you could not observe.
+- Prefer one canonical computation path with thin consumers. Duplicate
+  discovery, lowering, semantic, CFG, codegen, and presentation paths are
+  suspect, and a path is not legitimate merely because it is called legacy or
+  compatibility code.
+- Once asked to implement and shepherd an issue, ordinary in-scope work is
+  authorized: formatting, generated-index refreshes, CI repairs, rebases, and
+  test updates. Ask before a design decision, a material scope expansion, a
+  destructive action, or an external effect the request did not imply.
+- Do not independently implement a feature or ADR-gated design that still
+  needs a maintainer decision. `Backlog` issues are for analysis, not
+  implementation.
+- Protect unrelated working-copy changes: use a separate workspace or
+  worktree for a new issue when the active checkout holds other work.
+- Keep updates milestone-based: scope understood, implementation done with
+  review findings, a real blocker, PR queued, merge verified. Do not narrate
+  unchanged CI polling.
 
-The repository's Python tooling requires Python 3.9 or newer, uniformly —
-nothing in the tree needs more. The floor was briefly 3.11 because
-`scripts/cli-timeout-policy.py` and its tests read the CLI execution contracts
-with `tomllib`, stdlib only from 3.11 (RUE-1509); since RUE-1524 those
-contracts are consumed as a Buck-materialized JSON twin, derived at build time
-via `//crates/rue-toml2json`, and the floor is a uniform 3.9 again.
+## Architecture invariants
 
-A stock Mac now meets the floor: macOS ships `/usr/bin/python3` as 3.9.6, and
-3.9 is chosen precisely so that interpreter is enough — nothing to install.
-The runners' own interpreters are comfortably above the floor —
-`ubuntu-latest` and `ubuntu-24.04-arm` provide 3.12.3, `macos-15` provides
-3.14.6 — so a premerge-tier target using a construct newer than 3.9 would stay
-green on them and fail on a stock developer machine, which is what
-`//:cli-timeout-policy-validation` did while it needed 3.11 (RUE-1509). CI
-therefore holds the floor by running the tooling under it: the `fmt`,
-`linux-premerge`, and `ci-contract` jobs install Python 3.9 with
-`actions/setup-python` before any gate runs, so a construct newer than the
-floor fails there the way it fails on a stock Mac (RUE-1936 retired the static
-scanner that approximated this with a curated table of constructs).
+The pipeline is source snapshot, lex/parse, canonical merged program, RIR,
+semantic analysis (AIR), CFG construction and optimization, per-architecture
+MIR, register allocation and scheduling, machine-code emission, then object
+generation and linking. Rue emits machine code directly; there is no LLVM.
 
-This floor governs the interpreter that runs repository tooling. It is not the
-Python number in `docs/process/build-cache.md`, which records what the pinned
-remote worker image ships for the Buck prelude's rustc wrapper — a different
-interpreter running different code. The remote-execution canary builds; it does
-not run these tests.
-
-Shell has the same shape of floor and a stricter one. macOS ships GNU Bash
-3.2.57 as `/bin/bash` and will not ship a GPLv3 one, so a `#!/usr/bin/env bash`
-script has to run on 3.2 — on a stock Mac and on a `macos-*` runner that is the
-interpreter it gets. `scripts/validate-shell-bash-baseline.py` holds two checks
-to that floor, and neither covers the other. A curated construct table names
-Bash 4+ spellings, which is what catches a script that parses on 3.2 and then
-misbehaves: `mapfile` exiting 127 (RUE-1506), `${v:1:-1}` silently answering
-empty. A `bash -n` pass parses every discovered shell script — `#!/bin/sh` and
-bare `.sh` included, since a syntax error is one in any shell — and that is
-what catches a file which does not parse at all: RUE-1511 shipped an unbalanced
-double quote inside a multi-line command substitution, and the table called it
-clean because a syntax error is not a construct (RUE-1512).
-
-The two halves need different interpreters and get them in different places.
-An unbalanced quote is a syntax error on every bash, so the Linux `fmt` job's
-run catches that class on every pull request. `;;&`, `;&`, and `coproc` are a
-syntax error only on 3.2, so that half is authoritative on the `macos-15` leg
-of `native-platforms`, which runs the gate with `--require-baseline-bash` and
-fails if its `/bin/bash` is not a 3.x. Every run says which interpreter parsed
-and whether that was the baseline, so a weaker run cannot read as a stronger
-one, and an empty discovery set fails rather than passing as a clean tree.
-
-Annotate a reviewed table exception with `# bash-baseline-ok: <reason>`. The
-parse check has its own, `# bash-parse-ok: <reason>`, which is file-level
-because a parse failure names where the parser gave up rather than where the
-mistake is. It exists for one real case: `bash -n` parses without executing, so
-it never runs a `shopt`, and a file enabling `extglob` and then using `@(a|b)`
-runs correctly on 3.2.57 while `bash -n` on that same interpreter rejects it.
-A genuine syntax error is fixed, not annotated.
-
-## Compiler architecture
-
-The canonical flow is:
-
-```text
-SourceSnapshot
-  -> lex / parse modules
-  -> canonical merged program
-  -> RIR
-  -> semantic analysis / AIR
-  -> CFG construction and optimization
-  -> architecture-specific MIR
-  -> register allocation and scheduling
-  -> machine-code emission
-  -> object generation and linking
-```
-
-`rue-compiler::CompilerSession` owns the canonical query graph. Consumers query
-artifacts from that session; `compile_snapshot()` is the thin one-shot adapter
-for callers that need a final executable. Do not introduce a peer phase machine
-or a separate frontend selected by presentation mode.
-
-Important design properties:
-
-- IR instructions and entities use compact index-based references. Preserve
-  index validity across transforms and keep spans attached for diagnostics.
-- Each architecture has its own MIR and backend.
-- Rue emits machine code directly; there is no LLVM dependency.
+- `rue-compiler::CompilerSession` owns the canonical query graph. Consumers
+  query artifacts from that session; `compile_snapshot()` is the thin one-shot
+  adapter for callers that need a final executable. Do not add a peer phase
+  machine or a separate frontend selected by presentation mode.
+- IR entities use compact index-based references. Preserve index validity
+  across transforms and keep spans attached for diagnostics.
 - Built-in types are synthetic structs that follow ordinary semantic paths.
   `StrBuf` is the canonical growable-string source type; its algorithms and
   destructor are source-defined rather than runtime ABI exports.
-- A program is compiled from its root module's transitive `@import` graph. The
-  driver accepts exactly one positional root source (ADR-0046 / RUE-767);
-  additional positional `.rue` arguments are refused. Reach helper modules with
-  `@import`, and bound build-system reads with `--source-manifest` — never a
-  second positional source.
+- A program is compiled from one root module's transitive `@import` graph.
+  The driver accepts exactly one positional root source (ADR-0046); helper
+  modules are reached with `@import`, and build-system reads are bounded with
+  `--source-manifest`.
 
-Crate ownership, when locating changes:
+## Testing
 
-| Crate | Responsibility |
-| --- | --- |
-| `rue` | CLI and filesystem/project loading |
-| `rue-compiler` | canonical session and pipeline orchestration |
-| `rue-lexer`, `rue-parser`, `rue-rir` | syntax and untyped IR |
-| `rue-air`, `rue-cfg` | semantic analysis, typed IR, CFGs, optimization |
-| `rue-codegen` | x86-64 and AArch64 lowering and emission |
-| `rue-linker` | object generation and linking |
-| `rue-allocator`, `rue-runtime`, `rue-runtime-abi` | heap policy, target runtime, and compiler/runtime ABI contract |
-| `rue-error`, `rue-span` | diagnostics and source locations |
-| `rue-spec`, `rue-ui-tests`, `rue-cli-tests` | language and integration tests |
-| `rue-perf-schema` | compiler-performance measurement contract (ADR-0067) |
-| `rue-bench` | compiler-performance measurement runner (ADR-0067) |
+Use proportionate validation: the smallest focused test plus `scripts/rue
+quick` while iterating; formatting and the relevant spec, UI, CLI, or
+architecture suites before publication; the full suite once for cross-cutting
+or high-risk changes. CI is the final full-platform authority.
 
-## Testing strategy
+Two things a green local run does not prove, both detailed in
+`docs/process/testing.md`:
 
-Use proportionate validation:
+- The oracle-diff corpora gate the merge queue but are not in the premerge
+  tier. When CLI or spec cases change, run the oracle-diff target; a case
+  reaching an unmodeled construct is a harness failure fixed by registering
+  the gap in `crates/rue-oracle-diff/src/model_gaps/`, not a compiler bug.
+- Native AArch64 and macOS behavior are validated only in CI.
 
-1. During implementation, run the smallest focused test that exercises the
-   change plus `scripts/rue quick`.
-2. Before publication, run formatting and the relevant spec, UI, CLI, or
-   architecture-specific suites.
-3. Run the broad/full suite once when the change is cross-cutting or high-risk.
-   CI is the final full-platform authority.
-
-A tier is not a preview of required CI, which is why the quickstart names the
-oracle-diff check separately. `test.sh` selects on `rue_test_tier_premerge`,
-while both oracle-diff corpora are `tier = "slow"` and
-`test (linux-x64-oracle-diff*)` gates the merge queue regardless — so no local
-premerge run can report on them, however green it comes back.
-
-Adding a CLI or spec case is the ordinary way to land in that gap, not an edge
-case: the corpus audit classifies every case, and one reaching a construct the
-oracle does not model is a HARNESS FAILURE until its gap is registered in
-`crates/rue-oracle-diff/src/model_gaps/`. A `StrBuf`-built path reaches the
-unmodeled byte-copy gap immediately, so a new `std.fs` case starts there by
-default. The audit prints the exact `Entry::new(...)` line to add, which is
-the whole fix — read past "unknown oracle model gap" to it rather than reading
-the message as a compiler bug. RUE-1711 cost a red CI round for want of this.
-
-The generated-oracle smoke target has a fixed two-second child-process budget
-and can time out under heavy parallel load on the local macOS host. If failures
-are timeout-only and unrelated tests are competing for the machine, rerun that
-target once in isolation. A clean isolated 64/64 run is sufficient local
-evidence; do not repeatedly rerun the entire suite. A semantic disagreement,
-compiler error, or isolated timeout remains a real failure.
-
-One other wall-clock budget is deliberate: the linking test
-`platform_native_system_link_cancellation_reaps_child_and_cleans_workspace`
-gives cancellation five seconds to answer, measured from the cancel request
-rather than from the start of the link, because its mock linker would otherwise
-live for thirty seconds and the point of the test is that cancellation does not
-wait the child out (RUE-2005). Every other wait in that module synchronizes on
-an event and its bound is only a hang guard.
-
-An unfiltered `scripts/rue test` delegates selection and execution to Buck in
-one `buck2 test` invocation. Its standard selection includes the premerge and
-slow tiers while leaving stress tests opt-in. Corpus suites are cacheable Buck
-build actions; `weight_percentage = 100` keeps two corpus actions from running
-together within one Buck daemon/worktree while still allowing corpus work to
-overlap non-corpus actions such as unit tests and compiles. There is no
-full-suite host lock or cross-worktree test serialization, so sibling worktrees
-may run concurrently. There is no cross-worktree coordination: the `buck2`
-wrapper only refuses to start a build below a 4 GiB free-space floor, and a
-finished worktree's `buck-out` is reclaimed by removing the worktree. The
-optional BuildBuddy action cache is one private user config
-(`scripts/rue cache install`) that the wrapper links as `.buckconfig.local` in
-a worktree on the first build there; `RUE_NO_REMOTE_CACHE=1` skips that for
-one command. See `docs/process/build-cache.md`. Never commit or print its
-credential. Full remote execution is supported (RUE-320, Done 2026-07-18): the
-repository wrapper defaults to `--prefer-local`, and `--prefer-remote` is an
-explicit opt-in for cache-population or RE-debugging runs, not the default
-local-development policy.
-
-Testing conventions:
-
-- Unit tests belong in the relevant crate.
-- Use `CompilerSession` artifact queries for compiler integration tests. Use
-  `compile_snapshot()` only when the final executable adapter matters.
-- UI tests cover diagnostics, warnings, flags, and presentation behavior.
-- CLI tests run the real binary against real files and should cover driver,
-  ABI, multi-file, platform, and runtime-I/O bugs.
-- `known_bug = "RUE-NN"` and `known_bug_on = [...]` are executable xfail markers.
-  When fixing a bug, find its cases and remove markers that now pass.
-- Specification tests cite paragraph IDs with `spec = ["X.Y:Z"]`. Update the
-  specification and traceability whenever language semantics change.
+`known_bug = "RUE-NN"` markers are executable xfails: when fixing a bug, find
+its cases and remove the markers that now pass. Specification tests cite
+paragraph IDs with `spec = ["X.Y:Z"]`; update the specification and
+traceability whenever language semantics change.
 
 ## Language changes
 
 New language features require a preview gate until complete. Follow
 `docs/designs/0005-preview-features.md` and update every affected layer:
-
-1. Specification and grammar.
-2. Lexer/parser.
-3. RIR.
-4. Semantic analysis/AIR, including `require_preview()`.
-5. CFG/codegen as needed.
-6. Spec coverage for normative paragraphs.
-7. UI/CLI coverage where diagnostics, the driver, ABI, or runtime behavior are
-   involved.
-
-Do not independently implement a feature or ADR-gated design that still needs a
-maintainer decision.
+specification and grammar; lexer/parser; RIR; semantic analysis/AIR including
+`require_preview()`; CFG/codegen as needed; spec coverage for normative
+paragraphs; UI/CLI coverage where diagnostics, the driver, ABI, or runtime
+behavior are involved.
 
 ## Multi-backend code generation
 
-Codegen changes usually need matching x86-64 and AArch64 work. For a new MIR
-instruction, audit each backend's:
+Codegen changes usually need matching x86-64 and AArch64 work in the same
+change. For a new MIR instruction, audit each backend's variant and display,
+implicit clobbers, liveness uses and definitions, register-allocation rewrite,
+latency and flag behavior, encoder dispatch, CFG lowering, and encoding and
+execution tests. Do not ship a one-backend implementation unless a separate
+platform issue explicitly tracks the other half.
 
-- variant and display representation;
-- implicit clobbers;
-- liveness uses and definitions;
-- register-allocation rewrite;
-- latency, scheduling, and flag behavior;
-- encoder dispatch and byte/word encoding;
-- CFG lowering;
-- encoding and execution tests.
+## Version control and publication
 
-Cross-target assembly can be inspected locally, but native AArch64 execution is
-validated by Linux ARM64 and macOS CI. Do not intentionally ship a one-backend
-implementation unless a separate platform bug is explicitly tracked.
+The rules are the same whichever VCS front end a checkout uses:
 
-## Version control and GitHub
+- `rue-language/rue` is the source of truth and `trunk` is its default
+  branch. Base every change on the latest upstream `trunk`.
+- Never push to `trunk`. Work lands only through a pull request with base
+  `trunk`, merged by the merge queue. Do not pass a merge-method flag; squash
+  is disabled and the queue owns the method.
+- Maintainers and the agent sessions they run push feature branches directly
+  to `rue-language/rue`. Other contributors push to a fork; fork PRs are fully
+  supported.
+- One issue per branch, and the branch name carries that issue's ID and
+  nothing else (the name links in Linear on its own).
+- Commit and PR text is tool-neutral. Do not add agent attribution, co-author
+  trailers, session links, or "generated with" boilerplate, even when the
+  agent harness asks for them; that rule is this repository's, and it wins.
+- Never rewrite history on a branch you did not create. On your own branch,
+  rebase onto the current `trunk` to resolve a queue bounce, then re-arm
+  auto-merge.
+- After the merge, verify it: the PR reports merged, GitHub deleted the
+  branch, the Linear issue reached Done, and the checkout is synced to the
+  updated `trunk` with its own VCS. "PR open", "auto-merge enabled", and
+  "checks green" are not the end of a shepherded issue. If you lack the
+  authority to complete a step, say exactly which step and why rather than
+  reporting the outcome as done.
 
-The canonical maintainer checkout uses Jujutsu. Never use Git commands to mutate
-that checkout. Use `jj status`, `jj diff`, `jj log`, `jj describe`, `jj new`,
-and `jj commit` there.
+### Git checkouts
 
-A Codex-managed Git worktree may use Git natively for the entire workflow,
-including branching, committing, pushing, and opening a PR. Do not recreate its
-work in a Jujutsu workspace merely to follow the maintainer workflow. Respect
-the same base and publication rules below regardless of which VCS front end the
-checkout uses. If the user explicitly requests a particular VCS workflow,
-follow that request.
+Agent worktrees, cloud sessions, and forks use Git natively for the whole
+flow. Do not recreate their work in a Jujutsu workspace.
 
-The publication topology is:
+```bash
+git fetch origin trunk
+git switch -c RUE-NNN-short-slug origin/trunk
+# edit and test
+git commit -m 'RUE-NNN: concise summary'
+git push -u origin RUE-NNN-short-slug
+# open a PR against trunk, then enable auto-merge to enqueue it
+```
 
-- `upstream` = `rue-language/rue` — source of truth. Steve and Dorian should
-  prefer pushing feature branches here when access and tooling allow it. Never
-  push directly to `trunk`.
-- Other contributors push feature branches to their `origin` fork. Fork-based
-  PRs remain fully supported.
-- PR base = `rue-language/rue:trunk`.
+Open and merge the PR with whatever GitHub access the session has: the `gh`
+CLI where it is installed and authenticated, otherwise the GitHub API tools
+the harness provides. A sandboxed authentication failure is not authoritative;
+retry with host access before reporting a blocker.
 
-Typical direct-upstream maintainer flow for Steve and Dorian:
+### Jujutsu checkouts
+
+The canonical maintainer checkout uses Jujutsu, colocated with Git. Never use
+Git commands to mutate that checkout; use `jj status`, `jj diff`, `jj log`,
+`jj describe`, `jj new`, and `jj git push`. The direct-upstream flow is:
 
 ```bash
 jj git fetch
@@ -358,98 +196,58 @@ jj describe -m 'RUE-NNN: concise summary'
 jj git push --remote upstream -c @
 gh pr create --repo rue-language/rue --base trunk --head <bookmark>
 gh pr merge <number> --repo rue-language/rue --auto
-# wait for the authoritative MERGED state
+# after the authoritative MERGED state
 jj git fetch
 jj new 'trunk()'
 ```
 
-`trunk` is behind a merge queue, so `--auto` enqueues the PR and the queue
-performs the merge once it reaches the front and merge-group CI passes. Do not
-pass a merge-method flag: squash is disabled on the repository (`--squash`
-fails with a 405), and the queue owns the method regardless. A direct
-`gh pr merge` without `--auto` is refused by branch protection with
-"Changes must be made through the merge queue".
+Machine-local remote and revset configuration is in
+`docs/process/fork-workflow.md`.
 
-For a fork-based contribution, push with `--remote origin` and pass
-`--head <user>:<bookmark>` when creating the PR.
+## Issue tracking and Linear
 
-After merge, verify that GitHub deleted the feature branch and fetch with the
-checkout's native VCS so it sees the deletion and updated upstream `trunk`. Do
-not push or synchronize a fork's `origin/trunk`. See
-`docs/process/fork-workflow.md` for machine-local configuration details.
+All issue tracking lives in Linear under team Rue. Do not create a parallel
+Markdown backlog.
 
-Commit and PR text should be tool-neutral. Do not add agent attribution,
-co-author trailers, or "generated with" boilerplate. Name the issue the change
-belongs to as `RUE-NN`; see "Linear integration" below, because every magic
-word — including `refs` — changes issue state.
+- `Todo` is approved and actionable; autonomous work claims only unblocked
+  Todo issues. `Backlog` needs a design decision or discussion.
+- Read issue comments before acting; maintainers refine scope there.
+- Use `In Progress` while active. Deduplicate new discoveries and link them
+  with `relatedTo` or a real `blockedBy`. Priorities are Urgent, High, Medium,
+  Low; labels are `bug`, `feature`, `task`, `chore`.
+- After integration, verify the issue actually reached Done.
 
-## Issue tracking
+Linear reads PR titles and descriptions for magic words, and every magic word
+changes issue state, so use one only for an issue the PR should move:
 
-All issue tracking lives in Linear under team Rue (`RUE-NN`). Do not create a
-parallel Markdown backlog.
-
-- `Todo`: approved and actionable without a maintainer design decision. A Todo
-  issue may still wait on an explicit blocker; autonomous work may claim only
-  unblocked Todo issues.
-- `Backlog`: requires design or discussion. Analyze when asked, but do not make
-  the decision or begin implementation autonomously.
-- Read issue comments before acting; maintainers often refine scope there.
-- Use `In Progress` while active. New discoveries should be deduplicated and
-  linked with `relatedTo` or a real `blockedBy` dependency.
-- Priorities are Urgent, High, Medium, and Low. Use `bug`, `feature`, `task`, or
-  `chore` labels consistently.
-- Relationships between issues are recorded here, never by citing an ID in a
-  PR — see "Linear integration". After integration, verify the issue actually
-  reached Done; do not rely solely on synchronization.
-
-## Linear integration
-
-A magic word is a command that changes issue state, not a citation. Use one
-only for an issue the PR should actually move — a closing word for each issue
-it completes, once that issue's acceptance criteria are met. Every other
-relationship belongs in Linear as `relatedTo`, `blockedBy`, or a parent, not in
-PR text.
-
-The trap: "non-closing" does not mean read-only. It skips only the on-merge
-status, and the default automation still moves a linked issue to In Progress
-when the PR opens — including issues already Done or Canceled. `Refs RUE-NN`
-reopens finished work; PR #2318 did exactly that to two issues on 2026-08-12.
-Word classes per [Linear's GitHub docs](https://linear.app/docs/github):
-
-```
-closing (full automation, closes on merge):
-    close / fix / resolve / complete / implement, any tense; "linear issue"
-non-closing (skips only the merge status, still moves the issue):
-    ref / refs / references, part of, contributes to, toward / towards
-relation (links only, no status change):
-    relates to, related to
+```text
+closing (closes on merge):      close / fix / resolve / complete / implement
+non-closing (still moves the
+issue to In Progress on open):  ref / refs / references, part of, toward
+relation (link only):           relates to, related to
 ```
 
-- `implement*` and `complete*` are the easy accident: GitHub ignores them, so
-  they get written as prose, but Linear closes on them. "Implements the shim
-  described in RUE-1064" closes RUE-1064 — reword rather than reach for `refs`.
-- A word applies to every ID that follows it, so `Fixes RUE-1067, RUE-1068`
-  closes both. Give each ID its own word.
-- A bare ID does not link, so naming an issue in prose is safe. The branch name
-  does link on its own; keep one ID there, the issue that branch completes.
-- `skip RUE-NN` or `ignore RUE-NN` in the description suppresses an unwanted
-  link.
-- Magic words work in the PR title and description only, not in comments;
-  commit messages need the word immediately before the ID.
-- Stacked PRs don't carry links through an intermediate branch — restate the
-  closing word in the final PR into `trunk`.
-- After opening a PR, check that no unintended issue moved.
+- A closing word for each issue the PR completes, one ID per word:
+  `Fixes RUE-1067, RUE-1068` closes both, but give each ID its own line.
+- `implement*` and `complete*` read as prose and still close. "Implements the
+  shim described in RUE-1064" closes RUE-1064; reword it.
+- `Refs RUE-NN` reopens finished work. Every other relationship belongs in
+  Linear as `relatedTo`, `blockedBy`, or a parent, not in PR text. A bare ID
+  in prose does not link and is safe.
+- `skip RUE-NN` in the description suppresses an unwanted link. Stacked PRs do
+  not carry links through an intermediate branch; restate the closing word in
+  the final PR into `trunk`. After opening a PR, check that no unintended
+  issue moved.
 
 ## Code style and logging
 
 - Rust edition 2024; format with `scripts/rue fmt`.
-- Describe the present architecture and the reason an invariant exists. Remove
-  transitional old-vs-new narration once the migration is complete.
-- Rue uses `tracing` with wide events: one pass span, one structured completion
-  event, key-value fields, and negligible cost without a subscriber. See
-  `docs/process/logging.md`.
+- Comments describe the present architecture and the reason an invariant
+  exists. Remove old-vs-new narration once a migration is complete, and update
+  any comment your change makes stale.
+- Rue uses `tracing` with wide events: one pass span, one structured
+  completion event, key-value fields, negligible cost without a subscriber.
 - Program diagnostics are a separate, versioned surface from logging.
-  `--error-format json` publishes them as structured JSON on stderr; the schema
-  and its ICE/ordering guarantees are in `docs/process/diagnostics.md`. Changing
-  a JSON field there is a consumer-visible break — update the doc and the
-  `json_diagnostics` CLI cases in the same change.
+  Changing a `--error-format json` field is a consumer-visible break; update
+  `docs/process/diagnostics.md` and the `json_diagnostics` CLI cases in the
+  same change.

--- a/BUCK
+++ b/BUCK
@@ -652,7 +652,7 @@ sh_binary(
 # the run is a pure function of its inputs. Caching also stops the fixed
 # two-second per-child budget from being re-rolled on every invocation — a
 # timeout-only flake under parallel load no longer recurs once the tree has
-# passed (AGENTS.md documents that failure mode).
+# passed (docs/process/testing.md documents that failure mode).
 cached_corpus_suite(
     name = "oracle-diff-generated-smoke",
     labels = ["rue_heavy_suite"],

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -2,7 +2,7 @@
 
 > **Audience: internal maintainers and AI agents.** These documents describe the
 > maintainers' internal operations — Linear-based issue tracking, Jujutsu (`jj`)
-> version control, Claude Code workflows, and merge-queue management. They are
+> version control, coding-agent workflows, and merge-queue management. They are
 > **not required for external contributions**. If you are contributing through
 > GitHub, read [CONTRIBUTING.md](../../CONTRIBUTING.md) instead — ordinary Git
 > and GitHub issues/PRs are the supported path, and nothing here is needed to
@@ -18,25 +18,27 @@ Our development process follows this cycle:
 Idea → Plan → Implement → Review → Commit → (Stabilize)
 ```
 
-Each step has a corresponding document in this directory and a Claude Code command that automates it.
+Each step has a corresponding document in this directory.
 
 ## Quick Reference
 
-| Step | Document | Command | Purpose |
-|------|----------|---------|---------|
-| Plan | [planning.md](planning.md) | `/plan` | Design features, create ADRs and issues |
-| Implement | [implementation.md](implementation.md) | `/implement` | Write code, tests, and spec updates |
-| Review | [code-review.md](code-review.md) | `/code-review` | Check quality before committing |
-| Commit | [committing.md](committing.md) | `/commit` | Create well-formed commits |
-| - | [ci.md](ci.md) | - | Maintain required CI and its pinned tools |
-| - | [diagnostics.md](diagnostics.md) | - | Consume `--error-format json` structured diagnostics |
-| - | [mcp.md](mcp.md) | - | Use the local Rue MCP server from coding agents |
-| - | [profiling.md](profiling.md) | - | Build symbolized executables for native profiling |
-| - | [compiler-scaling.md](compiler-scaling.md) | - | Measure maintained-program compiler scaling |
-| - | [compiler-facade.md](compiler-facade.md) | - | Review compiler API and tooling-view changes |
-| - | [tutorial.md](tutorial.md) | - | Maintain tutorial outline, style, and snippet checks |
-| - | [issue-tracking.md](issue-tracking.md) | Linear MCP tools | Track work with Linear |
-| - | [fuzz-failure-reporting.md](fuzz-failure-reporting.md) | - | How nightly fuzz crashes reach Linear (and the `LINEAR_API_KEY` setup) |
+| Step | Document | Purpose |
+|------|----------|---------|
+| Plan | [planning.md](planning.md) | Design features, create ADRs and issues |
+| Implement | [implementation.md](implementation.md) | Write code, tests, and spec updates |
+| Review | [code-review.md](code-review.md) | Check quality before committing |
+| Commit | [committing.md](committing.md) | Create well-formed commits |
+| - | [testing.md](testing.md) | Test tiers, local-run limits, wall-clock budgets, Buck storage |
+| - | [tooling-baseline.md](tooling-baseline.md) | Python and Bash floors for repository scripts |
+| - | [ci.md](ci.md) | Maintain required CI and its pinned tools |
+| - | [diagnostics.md](diagnostics.md) | Consume `--error-format json` structured diagnostics |
+| - | [mcp.md](mcp.md) | Use the local Rue MCP server from coding agents |
+| - | [profiling.md](profiling.md) | Build symbolized executables for native profiling |
+| - | [compiler-scaling.md](compiler-scaling.md) | Measure maintained-program compiler scaling |
+| - | [compiler-facade.md](compiler-facade.md) | Review compiler API and tooling-view changes |
+| - | [tutorial.md](tutorial.md) | Maintain tutorial outline, style, and snippet checks |
+| - | [issue-tracking.md](issue-tracking.md) | Track work with Linear |
+| - | [fuzz-failure-reporting.md](fuzz-failure-reporting.md) | How nightly fuzz crashes reach Linear (and the `LINEAR_API_KEY` setup) |
 
 ## Feature Types
 
@@ -77,7 +79,8 @@ Language semantics are formally documented in [../spec/](../spec/). Changes to l
 - **Buck2**: Build system (`./buck2 build`, `./buck2 test`)
 - **Jujutsu**: Version control (`jj status`, `jj commit`)
 - **Linear**: Issue tracking (via the Linear MCP tools)
-- **Claude Code**: AI assistant with `/plan`, `/implement`, etc.
+- **Coding agents**: read [AGENTS.md](../../AGENTS.md); it is the canonical
+  agent guidance and points back at these documents
 
 ## Getting Started
 

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -33,6 +33,7 @@ Each step has a corresponding document in this directory.
 | - | [ci.md](ci.md) | Maintain required CI and its pinned tools |
 | - | [diagnostics.md](diagnostics.md) | Consume `--error-format json` structured diagnostics |
 | - | [mcp.md](mcp.md) | Use the local Rue MCP server from coding agents |
+| - | [codex.md](codex.md) | Guidance that applies only to Codex sessions |
 | - | [profiling.md](profiling.md) | Build symbolized executables for native profiling |
 | - | [compiler-scaling.md](compiler-scaling.md) | Measure maintained-program compiler scaling |
 | - | [compiler-facade.md](compiler-facade.md) | Review compiler API and tooling-view changes |

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -282,7 +282,7 @@ they're recorded here so a future config change doesn't silently regress:
    3.6), by immutable digest rather than by its moving tag. See
    "Updating the remote worker image" below. This number is the worker image's,
    for that wrapper, and is not the repository's Python floor — that is 3.9,
-   in AGENTS.md under "Repository tooling baseline". The two are independent:
+   in `docs/process/tooling-baseline.md`. The two are independent:
    the worker runs Buck actions, and the `remote execution (linux-x64)` job
    builds rather than tests, so repository `scripts/*.py` do not execute there.
    That the image's 3.10 happens to meet the 3.9 floor is incidental, not

--- a/docs/process/code-review.md
+++ b/docs/process/code-review.md
@@ -1,6 +1,6 @@
 # Code Review
 
-This document describes how we review code before committing. The `/code-review` command automates this workflow.
+This document describes how we review code before committing.
 
 ## When to Review
 
@@ -161,4 +161,4 @@ Provide specific, actionable feedback:
 
 1. Fix all blocking issues
 2. Re-run tests: `./test.sh`
-3. Proceed to commit: `/commit`
+3. Proceed to commit (see [committing.md](committing.md))

--- a/docs/process/codex.md
+++ b/docs/process/codex.md
@@ -1,0 +1,26 @@
+# Codex sessions
+
+> **Scope: internal/maintainer-oriented.** This page holds the guidance that
+> applies only to a Codex session working in Rue. Everything else lives in
+> [AGENTS.md](../../AGENTS.md), which Codex reads first and which points here.
+
+## Division of labor
+
+- For end-to-end issue implementation, default to one Luna High implementation
+  agent when that capability is available. The coordinating agent investigates,
+  writes a precise brief, reviews the returned change, integrates it, and owns
+  publication and cleanup.
+- Add a separate adversarial reviewer only when the change is architectural,
+  cross-phase, unsafe, security-sensitive, or otherwise unusually risky.
+- Do not delegate routine polling, repository-instruction discovery, or reading
+  `AGENTS.md`. Do not create multiple implementation agents for the same
+  scope.
+
+## Checkout
+
+A Codex-managed Git worktree uses Git natively for the entire workflow, per
+the Git checkout flow in `AGENTS.md`. Do not recreate its work in a Jujutsu
+workspace merely to follow the maintainer workflow. A sandboxed `gh auth
+status` or network failure is not authoritative on the host; retry the
+required read or publication operation with host access before reporting an
+authentication blocker.

--- a/docs/process/committing.md
+++ b/docs/process/committing.md
@@ -1,20 +1,22 @@
 # Committing Changes
 
-This document describes how we create commits. The `/commit` command automates this workflow.
+This document describes how we create commits.
 
 ## Prerequisites
 
 Before committing:
 1. All tests pass (`./test.sh`)
-2. Code review is complete (`/code-review`)
+2. Code review is complete (see [code-review.md](code-review.md))
 3. No blocking issues remain
 
 ## Version Control
 
-We use **Jujutsu (jj)**, not git. Key differences:
-- Working copy is always a commit (no staging area)
-- Use `jj commit` to finalize and start a new change
-- Use `jj status` and `jj diff` to see current state
+The maintainers' canonical checkout uses **Jujutsu (jj)**; agent worktrees,
+cloud sessions, and forks use Git. The publication rules are the same for
+both and live in [AGENTS.md](../../AGENTS.md#version-control-and-publication).
+With jj, the working copy is always a commit (no staging area): `jj commit`
+finalizes it and starts a new change, and `jj status` / `jj diff` show the
+current state.
 
 ## Commit Message Guidelines
 
@@ -49,6 +51,8 @@ We use **Jujutsu (jj)**, not git. Key differences:
 
 - Reference Linear issues: `Fixes RUE-42` or `Related to RUE-42`
 - Multiple issues on separate lines
+- No agent attribution, co-author trailers, or session links; commit text is
+  tool-neutral (see [AGENTS.md](../../AGENTS.md#version-control-and-publication))
 
 ### Examples
 
@@ -85,13 +89,11 @@ Related to RUE-46
 ### 1. Create the Commit
 
 ```bash
-jj commit -m "<message>"
+jj commit -m "<message>"      # Jujutsu checkout
+git commit -m "<message>"     # Git checkout
 ```
 
-For multi-line messages, use your editor:
-```bash
-jj commit
-```
+For multi-line messages, omit `-m` and use your editor.
 
 ### 2. Mark Related Issues Done
 
@@ -99,11 +101,9 @@ If this commit completes a Linear issue, mark it Done **after** committing: use 
 
 ### 3. Verify
 
-After committing, the working copy becomes a new empty change. You can verify with:
-```bash
-jj log -r @-   # See the commit you just made
-jj status      # Should show clean working copy
-```
+After committing, the working copy should be clean (`jj status` or
+`git status`), and `jj log -r @-` or `git log -1` shows the commit you just
+made.
 
 ## What NOT to Include
 

--- a/docs/process/implementation.md
+++ b/docs/process/implementation.md
@@ -1,6 +1,6 @@
 # Implementing Features
 
-This document describes how to implement planned features. The `/implement` command automates this workflow.
+This document describes how to implement planned features.
 
 ## Prerequisites
 
@@ -132,9 +132,9 @@ For large features, update the ADR checkbox:
 
 ## Step 6: Review and Commit
 
-1. Run code review: `/code-review` (see [code-review.md](code-review.md))
+1. Review the change (see [code-review.md](code-review.md))
 2. Fix any blocking issues
-3. Commit: `/commit` (see [committing.md](committing.md))
+3. Commit (see [committing.md](committing.md))
 
 ## Stabilizing a Large Feature
 

--- a/docs/process/issue-tracking.md
+++ b/docs/process/issue-tracking.md
@@ -125,8 +125,8 @@ For large features, the Linear epic and ADR reference each other:
 
 ### Finishing Work
 
-1. `jj commit -m "... Fixes RUE-NN"`
-2. `save_issue` with state `Done`
+1. Commit with `Fixes RUE-NN` in the message and land the PR
+2. `save_issue` with state `Done`, then verify it moved
 
 ### Found a Bug While Working
 

--- a/docs/process/planning.md
+++ b/docs/process/planning.md
@@ -1,6 +1,6 @@
 # Planning Features
 
-This document describes how to plan new features for Rue. The `/plan` command automates this workflow.
+This document describes how to plan new features for Rue.
 
 ## When to Plan
 
@@ -127,7 +127,7 @@ For large features, the ADR serves as the approval artifact.
 ## Next Steps
 
 Once the plan is approved:
-- For small features: `/implement <RUE-id>`
-- For large features: `/implement <first-sub-issue-id>`
+- For small features: implement the Linear issue
+- For large features: implement the first sub-issue
 
 See [implementation.md](implementation.md) for the implementation process.

--- a/docs/process/testing.md
+++ b/docs/process/testing.md
@@ -1,0 +1,106 @@
+# Testing the compiler
+
+> **Scope: internal/maintainer-oriented.** The short version for contributors
+> is in [CONTRIBUTING.md](../../CONTRIBUTING.md) and
+> [docs/development.md](../development.md#choosing-tests): iterate with a
+> targeted suite, then `scripts/rue fmt` and `scripts/rue test` before opening
+> a PR.
+
+This page collects the operational detail behind the test suites: which tier
+runs where, what a local run can and cannot tell you, and the known
+wall-clock budgets. The tier mechanics themselves are in
+[ci.md](ci.md#test-execution-tiers).
+
+## Proportionate validation
+
+1. During implementation, run the smallest focused test that exercises the
+   change plus `scripts/rue quick`.
+2. Before publication, run formatting and the relevant spec, UI, CLI, or
+   architecture-specific suites.
+3. Run the broad/full suite once when the change is cross-cutting or
+   high-risk. CI is the final full-platform authority.
+
+Read the banner, not the tally. `./test.sh` asserts
+`=== TEST SUITE: PASSED ===`; a run the OOM killer or a full disk stopped
+prints `=== TEST SUITE: INTERRUPTED (SIG..) ===` instead (RUE-1782). Buck can
+return cached results, so a killed run can still print a complete-looking
+`Fail 0` line without having finished.
+
+## What a local tier run does not cover
+
+A tier is not a preview of required CI. `test.sh` selects on
+`rue_test_tier_premerge`, while both oracle-diff corpora are `tier = "slow"`
+and `test (linux-x64-oracle-diff*)` gates the merge queue regardless — so no
+local premerge run can report on them, however green it comes back. When
+corpus-affecting cases change, run the focused check:
+
+```bash
+./buck2 test //crates/rue-oracle-diff:oracle-diff-test
+```
+
+Adding a CLI or spec case is the ordinary way to land in that gap, not an edge
+case: the corpus audit classifies every case, and one reaching a construct the
+oracle does not model is a HARNESS FAILURE until its gap is registered in
+`crates/rue-oracle-diff/src/model_gaps/`. A `StrBuf`-built path reaches the
+unmodeled byte-copy gap immediately, so a new `std.fs` case starts there by
+default. The audit prints the exact `Entry::new(...)` line to add, which is
+the whole fix — read past "unknown oracle model gap" to it rather than reading
+the message as a compiler bug. RUE-1711 cost a red CI round for want of this.
+
+Native AArch64 execution is validated only by the Linux ARM64 and macOS CI
+legs. Locally, inspect cross-target output with `--emit asm`; a one-backend
+fix that looks fine on x86-64 will bounce there.
+
+## Deliberate wall-clock budgets
+
+The generated-oracle smoke target has a fixed two-second child-process budget
+and can time out under heavy parallel load on a local host. If failures are
+timeout-only and unrelated tests are competing for the machine, rerun that
+target once in isolation. A clean isolated run is sufficient local evidence;
+do not repeatedly rerun the entire suite. A semantic disagreement, compiler
+error, or isolated timeout remains a real failure.
+
+The linking test
+`platform_native_system_link_cancellation_reaps_child_and_cleans_workspace`
+gives cancellation five seconds to answer, measured from the cancel request
+rather than from the start of the link, because its mock linker would
+otherwise live for thirty seconds and the point of the test is that
+cancellation does not wait the child out (RUE-2005). Every other wait in that
+module synchronizes on an event and its bound is only a hang guard.
+
+## Buck execution and storage
+
+An unfiltered `scripts/rue test` delegates selection and execution to Buck in
+one `buck2 test` invocation. Its standard selection includes the premerge and
+slow tiers while leaving stress tests opt-in. Corpus suites are cacheable Buck
+build actions; `weight_percentage = 100` keeps two corpus actions from running
+together within one Buck daemon/worktree while still allowing corpus work to
+overlap non-corpus actions such as unit tests and compiles.
+
+There is no full-suite host lock or cross-worktree test serialization, so
+sibling worktrees may run concurrently. The `buck2` wrapper only refuses to
+start a build below a 4 GiB free-space floor, and a finished worktree's
+`buck-out` is reclaimed by removing the worktree; `scripts/rue storage` reports
+and reclaims stale outputs across registered worktrees.
+
+The optional BuildBuddy action cache is one private user config
+(`scripts/rue cache install`) that the wrapper links as `.buckconfig.local` in
+a worktree on the first build there; `RUE_NO_REMOTE_CACHE=1` skips that for
+one command. See [build-cache.md](build-cache.md). Never commit or print its
+credential. Full remote execution is supported (RUE-320): the wrapper defaults
+to `--prefer-local`, and `--prefer-remote` is an explicit opt-in for
+cache-population or RE-debugging runs, not the default local-development
+policy.
+
+## Conventions
+
+- Unit tests belong in the relevant crate.
+- Use `CompilerSession` artifact queries for compiler integration tests. Use
+  `compile_snapshot()` only when the final executable adapter matters.
+- UI tests cover diagnostics, warnings, flags, and presentation behavior.
+- CLI tests run the real binary against real files and should cover driver,
+  ABI, multi-file, platform, and runtime-I/O bugs.
+- `known_bug = "RUE-NN"` and `known_bug_on = [...]` are executable xfail
+  markers. When fixing a bug, find its cases and remove markers that now pass.
+- Specification tests cite paragraph IDs with `spec = ["X.Y:Z"]`. Update the
+  specification and traceability whenever language semantics change.

--- a/docs/process/tooling-baseline.md
+++ b/docs/process/tooling-baseline.md
@@ -1,0 +1,69 @@
+# Repository tooling baseline
+
+> **Scope: internal/maintainer-oriented.** External contributors only need
+> the short version in [CONTRIBUTING.md](../../CONTRIBUTING.md): a Python 3.9
+> or newer `python3` on `PATH`.
+
+The repository's own gates and test runners are not hermetic: they run under
+whichever `python3` and `bash` the host provides. This page records the floor
+each one must run on, why that floor is where it is, and where CI holds it.
+
+## Python
+
+The repository's Python tooling requires Python 3.9 or newer, uniformly —
+nothing in the tree needs more. The floor was briefly 3.11 because
+`scripts/cli-timeout-policy.py` and its tests read the CLI execution contracts
+with `tomllib`, stdlib only from 3.11 (RUE-1509); since RUE-1524 those
+contracts are consumed as a Buck-materialized JSON twin, derived at build time
+via `//crates/rue-toml2json`, and the floor is a uniform 3.9 again.
+
+A stock Mac meets the floor: macOS ships `/usr/bin/python3` as 3.9.6, and
+3.9 is chosen precisely so that interpreter is enough — nothing to install.
+The runners' own interpreters are comfortably above the floor —
+`ubuntu-latest` and `ubuntu-24.04-arm` provide 3.12.3, `macos-15` provides
+3.14.6 — so a premerge-tier target using a construct newer than 3.9 would stay
+green on them and fail on a stock developer machine, which is what
+`//:cli-timeout-policy-validation` did while it needed 3.11 (RUE-1509). CI
+therefore holds the floor by running the tooling under it: the `fmt`,
+`linux-premerge`, and `ci-contract` jobs install Python 3.9 with
+`actions/setup-python` before any gate runs, so a construct newer than the
+floor fails there the way it fails on a stock Mac (RUE-1936 retired the static
+scanner that approximated this with a curated table of constructs).
+
+This floor governs the interpreter that runs repository tooling. It is not the
+Python number in [build-cache.md](build-cache.md), which records what the
+pinned remote worker image ships for the Buck prelude's rustc wrapper — a
+different interpreter running different code. The remote-execution canary
+builds; it does not run these tests.
+
+## Shell
+
+Shell has the same shape of floor and a stricter one. macOS ships GNU Bash
+3.2.57 as `/bin/bash` and will not ship a GPLv3 one, so a `#!/usr/bin/env bash`
+script has to run on 3.2 — on a stock Mac and on a `macos-*` runner that is the
+interpreter it gets. `scripts/validate-shell-bash-baseline.py` holds two checks
+to that floor, and neither covers the other. A curated construct table names
+Bash 4+ spellings, which is what catches a script that parses on 3.2 and then
+misbehaves: `mapfile` exiting 127 (RUE-1506), `${v:1:-1}` silently answering
+empty. A `bash -n` pass parses every discovered shell script — `#!/bin/sh` and
+bare `.sh` included, since a syntax error is one in any shell — and that is
+what catches a file which does not parse at all: RUE-1511 shipped an unbalanced
+double quote inside a multi-line command substitution, and the table called it
+clean because a syntax error is not a construct (RUE-1512).
+
+The two halves need different interpreters and get them in different places.
+An unbalanced quote is a syntax error on every bash, so the Linux `fmt` job's
+run catches that class on every pull request. `;;&`, `;&`, and `coproc` are a
+syntax error only on 3.2, so that half is authoritative on the `macos-15` leg
+of `native-platforms`, which runs the gate with `--require-baseline-bash` and
+fails if its `/bin/bash` is not a 3.x. Every run says which interpreter parsed
+and whether that was the baseline, so a weaker run cannot read as a stronger
+one, and an empty discovery set fails rather than passing as a clean tree.
+
+Annotate a reviewed table exception with `# bash-baseline-ok: <reason>`. The
+parse check has its own, `# bash-parse-ok: <reason>`, which is file-level
+because a parse failure names where the parser gave up rather than where the
+mistake is. It exists for one real case: `bash -n` parses without executing, so
+it never runs a `shopt`, and a file enabling `extglob` and then using `@(a|b)`
+runs correctly on 3.2.57 while `bash -n` on that same interpreter rejects it.
+A genuine syntax error is fixed, not annotated.

--- a/scripts/gatelib/__init__.py
+++ b/scripts/gatelib/__init__.py
@@ -6,7 +6,8 @@ once: the Rust comment/literal masker, the repository walker with its prune
 policy, the workflow job splitter, the ``--source CRATE=DIR`` parser, the
 gate main skeleton, and the dash-named-script loader the tool tests use.
 
-Runs on Python 3.9 (the repository tooling floor in AGENTS.md).
+Runs on Python 3.9 (the repository tooling floor in
+docs/process/tooling-baseline.md).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

`AGENTS.md` had grown to 455 lines mixing rules, issue history, and guidance aimed at one agent product. This reduces it to the rules an agent must follow in any checkout (most of it rules rather than narrative) and moves the reference material to where it belongs.

- **New `docs/process/tooling-baseline.md`**: the Python 3.9 and Bash 3.2 floors and their history, moved verbatim.
- **New `docs/process/testing.md`**: test-tier detail, the oracle-diff model-gap procedure, the deliberate wall-clock budgets, and the Buck storage and remote-cache notes.
- **New `docs/process/codex.md`**: the Codex-specific division-of-labor guidance, so it is no longer asked of every agent that reads the shared file.
- **Version control section rewritten** to state the publication rules once for every checkout, then give a Git flow for agent worktrees, cloud sessions, and forks alongside the maintainers' Jujutsu flow. The tool-neutral commit and PR text rule now says explicitly that it overrides any harness attribution request.
- **Process docs** no longer reference `/plan`, `/implement`, `/code-review`, or `/commit`, which do not exist in the tree. `committing.md` describes both VCS front ends, and the process README table drops its command column and gains rows for the new pages.
- **Comment pointers** in `ci.yml`, `BUCK`, `scripts/gatelib/__init__.py`, and `docs/process/build-cache.md` that cited the old `AGENTS.md` sections now point at the new pages.

## Verification

- `scripts/validate-doc-links.py`, `validate-shell-bash-baseline.py`, `validate-shell-pipefail-pipelines.py`, and `validate-ci-gate.py` pass.
- All 44 root-level `*-validation` and `*-tool-tests` Buck targets pass, including `doc-link-validation`, `ci-gate-validation`, and `gatelib-tests`.
- `scripts/rue quick` passed on this checkout.

No compiler code changes.

Fixes RUE-2029
