### PR TITLE
RUE-1946: explain literal and operator diagnostics

### DIFF
--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -701,6 +701,37 @@ compile_stdout_contains = ["E0715: Import spellings same file", "Import hard-lin
 compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
+# The literal/operator tranche covers integer-literal range validation, the
+# signed/floating-point operand requirement of unary `-`, and the syntactic
+# ban on chained comparisons. Invalid source pins each invocation as a
+# non-compiling metadata path.
+[[case]]
+name = "literal_out_of_range_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0800"]
+compile_only = true
+compile_stdout_contains = ["E0800: Literal out of range", "Assign a literal too large for its type:", "Widen the annotated type:", "docs/spec/src/03-types/01-integer-types.md (spec rule 3.1:17)", "docs/spec/src/03-types/01-integer-types.md (spec rule 3.1:18)", "docs/spec/src/06-items/05-constants.md (spec rule 6.5:5)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "cannot_negate_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0801"]
+compile_only = true
+compile_stdout_contains = ["E0801: Cannot negate", "Negate an unsigned value:", "Negate a signed value:", "docs/spec/src/04-expressions/02-arithmetic-operators.md (spec rule 4.2:14)", "docs/spec/src/04-expressions/02-arithmetic-operators.md (spec rule 4.2:6)", "docs/spec/src/04-expressions/07-match-expressions.md (spec rule 4.7:24)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "chained_comparison_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0802"]
+compile_only = true
+compile_stdout_contains = ["E0802: Chained comparison", "Chain two comparisons:", "Combine comparisons with a logical operator:", "docs/spec/src/04-expressions/03-comparison-operators.md (spec rule 4.3:12)", "docs/spec/src/04-expressions/03-comparison-operators.md (spec rule 4.3:13)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
 [[case]]
 name = "malformed_code_is_rejected"
 files = [{ path = "main.rue", source = "fn main() {}\n" }]

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -112,10 +112,10 @@ rue_rust_test(
 # consumer verifies the bounded documented lexer, parser, semantic-foundation,
 # struct-foundation, method/item, enum/place, place/borrow, and
 # const/item/ownership, single-file destructor/const, slice/string/container,
-# match, and single-file intrinsic/inference/ownership/alignment tranches
-# through the real one-shot compiler path without copying the examples into a
-# second fixture. Multi-file E0460 and import/module examples are validated by
-# compiler unit tests.
+# match, single-file intrinsic/inference/ownership/alignment, and
+# literal/operator tranches through the real one-shot compiler path without
+# copying the examples into a second fixture. Multi-file E0460 and
+# import/module examples are validated by compiler unit tests.
 rue_rust_test(
     name = "error-explanation-examples-test",
     srcs = ["tests/error_explanation_examples.rs"],

--- a/crates/rue-compiler/tests/error_explanation_examples.rs
+++ b/crates/rue-compiler/tests/error_explanation_examples.rs
@@ -24,6 +24,7 @@ fn compiler_owned_explanation_examples_have_the_declared_outcome() {
                     | 600..=602
                     | 700..=702
                     | 709..=712
+                    | 800..=802
             )
     }) {
         let explanation = error_code_explanation(metadata.code)

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1867,9 +1867,44 @@ define_error_codes! {
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
     // ========================================================================
-    LITERAL_OUT_OF_RANGE = 800;
-    CANNOT_NEGATE = 801;
-    CHAINED_COMPARISON = 802;
+    LITERAL_OUT_OF_RANGE = 800 => {
+        explanation: "An integer literal must denote a value representable in the type it is given. Rue takes that type from the surrounding annotation, parameter, return position, struct field, `match` scrutinee, or constant declaration and range-checks the literal against it, so an out-of-range value is rejected rather than silently truncated or wrapped. The deliberate exception is a negated literal that denotes a signed type's minimum, such as `-128` for `i8`. Comptime evaluation applies the same check to a non-negative computed result that does not fit its target type. Float literals are governed by their own finite-value rule and do not report this code.",
+        likely_cause: "An annotation, field type, parameter, scrutinee, or constant is narrower than the literal written for it, as in `let small: u8 = 300;` or `const BAD: u8 = 300;`. Widen the target type, or write a value inside its range. An unannotated literal takes its type from its uses, so a wrong or missing annotation is the usual source.",
+        examples: [
+            ErrorCodeExample { title: "Assign a literal too large for its type", source: "fn main() -> i32 {\n    let small: u8 = 300;\n    0\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Widen the annotated type", source: "fn main() -> i32 {\n    let small: u16 = 300;\n    @intCast(small)\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Integer literal range validation", path: "docs/spec/src/03-types/01-integer-types.md", rule: Some("3.1:17") },
+            ErrorCodeReference { title: "Negated literals at a signed type's minimum", path: "docs/spec/src/03-types/01-integer-types.md", rule: Some("3.1:18") },
+            ErrorCodeReference { title: "Constant values must fit their annotation", path: "docs/spec/src/06-items/05-constants.md", rule: Some("6.5:5") },
+        ],
+    };
+    CANNOT_NEGATE = 801 => {
+        explanation: "Unary `-` requires a signed integer or floating-point operand. Unsigned integer types have no negative range, and non-numeric types such as `bool` or `()` are not negatable at all, so applying `-` to either is a compile-time error. The same rule rejects a negative integer literal pattern whose `match` scrutinee has an unsigned type, because such an arm could never match.",
+        likely_cause: "The operand's annotated or inferred type is an unsigned integer (`u8` through `u64`, `usize`) or a non-numeric type. Give the value a signed integer or floating-point type, or compute the quantity you meant with subtraction on the unsigned type instead of negating it.",
+        examples: [
+            ErrorCodeExample { title: "Negate an unsigned value", source: "fn main() -> i32 {\n    let count: u32 = 5;\n    let negated = -count;\n    0\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Negate a signed value", source: "fn main() -> i32 {\n    let count: i32 = 5;\n    -count\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Unary negation operand types", path: "docs/spec/src/04-expressions/02-arithmetic-operators.md", rule: Some("4.2:14") },
+            ErrorCodeReference { title: "Unary negation semantics", path: "docs/spec/src/04-expressions/02-arithmetic-operators.md", rule: Some("4.2:6") },
+            ErrorCodeReference { title: "Negative patterns on unsigned scrutinees", path: "docs/spec/src/04-expressions/07-match-expressions.md", rule: Some("4.7:24") },
+        ],
+    };
+    CHAINED_COMPARISON = 802 => {
+        explanation: "Comparison operators cannot be chained. They share one precedence level and associate to the left, so `a < b < c` would parse as `(a < b) < c` and compare a boolean against `c` rather than testing an ordering. The parser rejects the chain syntactically whenever a comparison expression is directly the left operand of another comparison; explicit parentheses break the chain, so `(a < b) == c` stays an ordinary boolean equality and is typed like any other.",
+        likely_cause: "A range test was written in mathematical notation, such as `low < value < high`. Combine two complete comparisons with `&&`, or parenthesize the boolean operand when a comparison against a boolean is what was actually meant.",
+        examples: [
+            ErrorCodeExample { title: "Chain two comparisons", source: "fn main() -> i32 {\n    let a = 1;\n    let b = 2;\n    let c = 3;\n    if a < b < c { 1 } else { 0 }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Combine comparisons with a logical operator", source: "fn main() -> i32 {\n    let a = 1;\n    let b = 2;\n    let c = 3;\n    if a < b && b < c { 1 } else { 0 }\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Comparison operators cannot be chained", path: "docs/spec/src/04-expressions/03-comparison-operators.md", rule: Some("4.3:12") },
+            ErrorCodeReference { title: "Combining comparisons with logical operators", path: "docs/spec/src/04-expressions/03-comparison-operators.md", rule: Some("4.3:13") },
+        ],
+    };
 
     // ========================================================================
     // Array errors (E0900-E0999)
@@ -4507,6 +4542,38 @@ mod tests {
         assert_eq!(
             retired.to_string().parse::<ErrorCode>(),
             Err(ParseErrorCodeError::Unknown(retired))
+        );
+    }
+
+    #[test]
+    fn active_literal_and_operator_explanation_band_is_complete_and_bounded() {
+        let expected = [
+            ErrorCode::LITERAL_OUT_OF_RANGE,
+            ErrorCode::CANNOT_NEGATE,
+            ErrorCode::CHAINED_COMPARISON,
+        ];
+        let active = error_code_metadata()
+            .iter()
+            .filter(|metadata| (800..=802).contains(&metadata.code.0))
+            .map(|metadata| {
+                assert_eq!(metadata.source_path, "crates/rue-error/src/lib.rs");
+                metadata.code
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(active, expected);
+        let explained = ERROR_CODE_EXPLANATION_DECLARATIONS
+            .iter()
+            .filter_map(|declaration| {
+                (800..=802)
+                    .contains(&declaration.code.0)
+                    .then_some(declaration.code)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(explained, expected);
+        assert!(
+            expected
+                .into_iter()
+                .all(|code| error_code_explanation(code).is_some())
         );
     }
 


### PR DESCRIPTION
Fixes RUE-1946

## Summary

Adds canonical compiler-owned explanations for the active E0800–E0802 literal/operator band: `LITERAL_OUT_OF_RANGE`, `CANNOT_NEGATE`, and `CHAINED_COMPARISON`. Each entry has a likely cause, one failing and one corrected example, and spec references whose rule ids exist in the cited files.

- `crates/rue-error/src/lib.rs`: the three explanations plus a bounded active-set guard test for 800..=802.
- `crates/rue-compiler/tests/error_explanation_examples.rs`: the tranche's examples now run through the real one-shot compiler and must emit exactly their owning code or compile cleanly.
- `crates/rue-cli-tests/cases/cli_explain.toml`: `rue explain` cases for each code.
- `crates/rue-compiler/BUCK`: comment refresh only.

No language semantics, code numbers, names, summaries, spans, ordering, or JSON output change.

## Verification

- `scripts/rue fmt`
- `//crates/rue-error:rue-error-test`, `rue-error-clippy`, `rue-error-fmt-check`
- `//crates/rue-compiler:error-explanation-examples-test`
- `scripts/rue cli explain` (76 passed)
- `scripts/rue spec 3.1`, `scripts/rue spec 4.3`, `scripts/rue ui negation`
- `scripts/rue quick` (35 targets, 0 failures)
- `//crates/rue-spec:error-pages` generator ran clean, validating every reference path and rule id.