### PR TITLE
RUE-2025: rue test review follow-ups: Ctrl-C forwarding, exit codes, channel overflow, --jobs scope, doc drift

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -1208,3 +1208,71 @@ compile_stdout_contains = [
     '"verdict":"fail"',
     '"crash":0,"event":"run_finished","failed":1,"passed":0',
 ]
+
+# ==================== the stopped-run exit-code contract ====================
+#
+# ADR-0083 §2 gives `rue test` one status for every reason the run did not
+# happen, so an agent branching on the exit code never has to also parse stderr
+# to tell a bad flag from an unreadable input. These cases pin the inputs the
+# driver reads before the image exists — the root and the declared candidate
+# inventory — which reported compile mode's `1` until RUE-2025.
+
+[[case]]
+name = "a_missing_root_stops_the_run_with_the_runner_error_status"
+description = "ADR-0083 §2: an unreadable root is a run that did not happen, not a compile-mode argument error."
+files = []
+args = ["test", "missing.rue"]
+driver_exit_code = 2
+compile_stderr_contains = ["Error reading ", "missing.rue:"]
+
+[[case]]
+name = "an_unreadable_candidate_inventory_stops_the_run_with_the_runner_error_status"
+description = "ADR-0083 §2: the declared inventory is read before the image exists, so a missing list stops the run."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+
+test "the run never reaches this" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--test-candidates", "absent-candidates.list"]
+driver_exit_code = 2
+compile_stderr_contains = ["Error reading test candidates", "absent-candidates.list"]
+
+[[case]]
+name = "a_candidate_escaping_the_project_root_stops_the_run_with_the_runner_error_status"
+description = """
+ADR-0083 §2: acquisition rejects a declared path that escapes the project root.
+The list is readable and the root compiles, so this refusal comes later than the
+missing-list case above and must still report the same stopped-run status.
+"""
+files = [
+    { path = "test-candidates.list", source = """
+main.rue
+../outside.rue
+""" },
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+
+test "the run never reaches this" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--test-candidates", "test-candidates.list"]
+driver_exit_code = 2
+compile_stderr_contains = ["escapes the project root", "../outside.rue"]
+
+[[case]]
+name = "compile_mode_keeps_its_own_status_for_the_same_unreadable_root"
+description = "Control: the mapping is per mode. An ordinary build's source-load failure stays `1`."
+files = []
+args = ["missing.rue", "-o", "prog"]
+driver_exit_code = 1
+compile_stderr_contains = ["Error reading ", "missing.rue:"]

--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -1276,3 +1276,55 @@ files = []
 args = ["missing.rue", "-o", "prog"]
 driver_exit_code = 1
 compile_stderr_contains = ["Error reading ", "missing.rue:"]
+
+[[case]]
+name = "a_flooded_failure_channel_is_killed_with_kind_output_overflow"
+description = """
+RUE-2025: the channel's 256 KiB budget is enforced the way a stream's is. It was
+checked nowhere before, so a test that wrote past it had its last frame cut in
+half and reported as a bare `exit` with a runner note about an unreadable
+channel — the symptom, not the cause. The message names the capture that
+overflowed and the budget it exceeded, which for the channel is a quarter of a
+stream's.
+
+Descriptor 3 is written raw, because the built-in producers write one frame per
+failure and no Rue-level program reaches a quarter of a megabyte through them.
+Linux only: the write syscall's number is per-platform, and what this pins is
+the runner's supervision rather than any portable language behavior.
+"""
+only_on = ["x86-64-linux", "aarch64-linux"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+
+test "floods its own failure channel" {
+    let write_nr: u64 = match @target_arch() {
+        Arch.X86_64 => 1,
+        Arch.Aarch64 => 64,
+    };
+    let buf: ptr mut u8 = checked { @alloc(4096, 1) };
+    let mut i: u64 = 0;
+    while i < 4096 {
+        checked { @ptr_write(@ptr_offset(buf, i), 120); };
+        i = i + 1;
+    }
+    let addr: u64 = checked { @ptr_to_int(buf) };
+    let mut writes: u64 = 0;
+    while writes < 160 {
+        checked { @syscall(write_nr, 3, addr, 4096); };
+        writes = writes + 1;
+    }
+    checked { @free(buf, 4096, 1); };
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"output_overflow"',
+    '"message":"the failure channel exceeded its 262144-byte retention budget; the process group was killed"',
+    '"verdict":"fail"',
+    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -291,8 +291,10 @@ Commands:
   --test-candidates <path>
                        Report declared test files nothing imports
   Test mode reuses --target, -O<n>, --preview, --jobs, --source-manifest,
-  --link-archive, --error-format, and the logging options. It cannot be
-  combined with --emit, --watch, --benchmark-json, --time-passes, or -o.
+  --link-archive, --error-format, and the logging options. There --jobs bounds
+  concurrent test processes only; compilation uses auto-detected parallelism.
+  It cannot be combined with --emit, --watch, --benchmark-json, --time-passes,
+  or -o.
   Exit codes: 0 all passed, 1 failures, 2 compilation or runner error,
   3 empty selection.
   A root module actually named `test` is spelled `./test`.
@@ -500,6 +502,23 @@ enum DriverMode {
     Compile,
     /// `rue test`: build the test image and run its tests (ADR-0083 §2).
     Test,
+}
+
+/// The exit status a driver failure reports when it stops the run before it
+/// began.
+///
+/// `rue test` gives every "the run did not happen" reason one status — a bad
+/// flag combination, an unreadable root or candidate inventory, a program that
+/// will not compile — so an agent branching on the exit code never has to also
+/// parse stderr to tell them apart (ADR-0083 §2). Compile mode's own failure
+/// status is `1` and stays that way. Every such site maps through here rather
+/// than repeating the match, so the two modes cannot drift apart one site at a
+/// time.
+fn driver_failure_exit_code(mode: &DriverMode) -> i32 {
+    match mode {
+        DriverMode::Test => test_mode::TestExitCode::RunnerError.code(),
+        DriverMode::Compile => 1,
+    }
 }
 
 /// Parse arguments from a slice of strings (for testing).
@@ -1020,6 +1039,21 @@ fn test_mode_jobs(jobs: usize) -> usize {
     std::thread::available_parallelism()
         .map(std::num::NonZeroUsize::get)
         .unwrap_or(1)
+}
+
+/// The worker count the compiler's shared query pool is configured with.
+///
+/// Compile mode reads `--jobs` as that pool's budget. Test mode does not:
+/// ADR-0083 §3 defines `--jobs` there as a bound on concurrent test processes
+/// alone, so the compilation that builds the image keeps the pool's own
+/// auto-detection. Without this, `rue test --jobs 1` — the way to isolate a
+/// test that interferes with its neighbors — would also single-thread a
+/// compilation the isolation question says nothing about.
+fn compile_pool_jobs(mode: &DriverMode, jobs: usize) -> usize {
+    match mode {
+        DriverMode::Test => 0,
+        DriverMode::Compile => jobs,
+    }
 }
 
 /// The compile-mode flags a repro argv repeats (ADR-0083 §3).
@@ -2142,9 +2176,13 @@ fn render_internal_error(format: ErrorFormat, message: impl Into<String>) -> Str
 /// a hermetic build-configuration denial (distinct from a broken toolchain — the
 /// remedy is the source manifest, not the installation); and program diagnostics
 /// rendered against the failing snapshot's source views.
-fn report_source_load_error(error: SourceLoadError, error_format: ErrorFormat) -> ! {
+fn report_source_load_error(
+    error: SourceLoadError,
+    error_format: ErrorFormat,
+    mode: &DriverMode,
+) -> ! {
     eprintln!("{}", render_source_load_error(error, error_format));
-    std::process::exit(1);
+    std::process::exit(driver_failure_exit_code(mode));
 }
 
 /// Diagnostic format the ICE panic hook renders with.
@@ -2306,10 +2344,7 @@ fn main() {
     // (ADR-0083 §2). Compile mode's own argument errors keep exiting `1`.
     if let Err(message) = validate_mode_combinations(&options) {
         eprintln!("{message}");
-        std::process::exit(match options.mode {
-            DriverMode::Test => test_mode::TestExitCode::RunnerError.code(),
-            DriverMode::Compile => 1,
-        });
+        std::process::exit(driver_failure_exit_code(&options.mode));
     }
 
     // Initialize tracing based on CLI options
@@ -2338,7 +2373,7 @@ fn main() {
             }
             Err(message) => {
                 eprintln!("{message}");
-                std::process::exit(1);
+                std::process::exit(driver_failure_exit_code(&options.mode));
             }
         },
         None => None,
@@ -2346,8 +2381,9 @@ fn main() {
 
     // Configure the compiler's shared structured-query budget before
     // dispatching to either the `--emit` path or the normal compile path, so
-    // every driver path honors `-j`/`--jobs` (RUE-352).
-    let resolved_workers = configure_thread_pool(options.jobs);
+    // every compile-mode driver path honors `-j`/`--jobs` (RUE-352). In test
+    // mode `--jobs` bounds test processes instead, so the pool auto-detects.
+    let resolved_workers = configure_thread_pool(compile_pool_jobs(&options.mode, options.jobs));
 
     // Discover and load @import-ed modules from disk, transitively. Sema
     // resolves imports only against already-loaded files, so without this
@@ -2375,7 +2411,7 @@ fn main() {
             std_root: captured_std_root.as_deref(),
         }) {
             Ok(result) => result,
-            Err(error) => report_source_load_error(error, options.error_format),
+            Err(error) => report_source_load_error(error, options.error_format, &options.mode),
         }
     };
 
@@ -2415,7 +2451,7 @@ fn main() {
     if options.emit_stages.is_empty() || emit::emit_requires_semantic(&options.emit_stages) {
         let _compile = compile_span.enter();
         if let Err(error) = compiler_host.acquire_reached_toolchain_modules(&compile_options) {
-            report_source_load_error(error, options.error_format);
+            report_source_load_error(error, options.error_format, &options.mode);
         }
     }
 
@@ -2467,7 +2503,7 @@ fn main() {
             }
             Err(errors) => {
                 diagnostics.print_errors(&errors);
-                std::process::exit(1);
+                std::process::exit(driver_failure_exit_code(&options.mode));
             }
         },
         None => None,
@@ -2513,10 +2549,7 @@ fn main() {
         // a link failure or a runner error — the run could not be performed —
         // and ADR-0083 §2 gives that one code, so an agent branching on the
         // exit status never has to also parse stderr to tell them apart.
-        std::process::exit(match options.mode {
-            DriverMode::Test => test_mode::TestExitCode::RunnerError.code(),
-            DriverMode::Compile => 1,
-        });
+        std::process::exit(driver_failure_exit_code(&options.mode));
     }
 
     // `rue test` owns the rest of this process: it links the test image, runs
@@ -3623,6 +3656,30 @@ mod tests {
     fn test_mode_jobs_resolves_auto_to_available_parallelism() {
         assert_eq!(test_mode_jobs(4), 4);
         assert!(test_mode_jobs(0) >= 1);
+    }
+
+    /// ADR-0083 §3 scopes test mode's `--jobs` to concurrent test processes, so
+    /// it must not also shrink the compile that builds the image: `rue test
+    /// --jobs 1` is how a suite isolates an interfering test, not a request to
+    /// compile single-threaded. Compile mode still passes the value through.
+    #[test]
+    fn test_mode_leaves_the_compile_pool_on_auto_detection() {
+        assert_eq!(compile_pool_jobs(&DriverMode::Test, 1), 0);
+        assert_eq!(compile_pool_jobs(&DriverMode::Test, 0), 0);
+        assert_eq!(compile_pool_jobs(&DriverMode::Compile, 1), 1);
+        assert_eq!(compile_pool_jobs(&DriverMode::Compile, 0), 0);
+    }
+
+    /// Every reason a run never happened reports one status per mode, and the
+    /// two modes disagree: compile mode's argument/IO failure is `1`, and
+    /// `rue test` reports the runner-error code (ADR-0083 §2).
+    #[test]
+    fn a_stopped_run_reports_the_mode_s_failure_status() {
+        assert_eq!(driver_failure_exit_code(&DriverMode::Compile), 1);
+        assert_eq!(
+            driver_failure_exit_code(&DriverMode::Test),
+            test_mode::TestExitCode::RunnerError.code()
+        );
     }
 
     // ========== Positional source acceptance tests ==========

--- a/crates/rue/src/test_mode/exec.rs
+++ b/crates/rue/src/test_mode/exec.rs
@@ -21,12 +21,15 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::time::{Duration, Instant};
 
 use rue_test_runner::pipe_drain::{PIPE_DRAIN_FINISH_TIMEOUT, PipeDrain, spawn_pipe_drain};
 use rue_test_runner::{configure_process_group, kill_process_group};
 
-use super::verdict::{ChannelFrames, Classification, Observation, Supervision, classify};
+use super::verdict::{
+    CaptureStream, ChannelFrames, Classification, Observation, Overflow, Supervision, classify,
+};
 
 /// The failure channel's descriptor, pinned by the ADR-0083 §3 exec contract
 /// and by `crates/rue-runtime/src/test_channel.rs`, which writes to it.
@@ -167,6 +170,131 @@ pub(crate) fn reserve_channel_descriptor() {
     });
 }
 
+/// Slots in the live-group registry.
+///
+/// One slot per concurrently running test, with room to spare: `--jobs` is
+/// capped at `MAX_EXPLICIT_JOBS` (256) in `main.rs`, so a run cannot have more
+/// children alive than that. The registry is a fixed array because the signal
+/// handler walks it, and a handler may neither allocate nor take a lock.
+const MAX_LIVE_GROUPS: usize = 1024;
+
+/// The process-group ids of the tests running right now; 0 marks a free slot.
+///
+/// Async-signal-safe storage on purpose. Every child leads its own process
+/// group, so the terminal's SIGINT reaches the runner and nothing else; without
+/// this registry a Ctrl-C would leave the images running with nobody left to
+/// enforce their timeout.
+static LIVE_GROUPS: [AtomicI32; MAX_LIVE_GROUPS] = [const { AtomicI32::new(0) }; MAX_LIVE_GROUPS];
+
+/// Publish a live process group to the signal handler.
+///
+/// `None` means the registry was full, which is not a failure: the test still
+/// runs, and only the handler's best-effort teardown is missed. The slot index
+/// comes back so the entry can be withdrawn by exactly its owner.
+fn register_group(pgid: i32) -> Option<usize> {
+    register_in(&LIVE_GROUPS, pgid)
+}
+
+/// Withdraw a group once its child is reaped.
+///
+/// Prompt withdrawal is what keeps the handler honest: a pid is reusable the
+/// moment its group is empty, and a stale entry would aim a SIGKILL at whatever
+/// unrelated process inherited the number.
+fn unregister_group(slot: usize, pgid: i32) {
+    unregister_in(&LIVE_GROUPS, slot, pgid);
+}
+
+/// SIGKILL every registered process group.
+///
+/// This is what the handler runs, and the tests exercise the same body over a
+/// registry of their own — the only way to observe it without signalling the
+/// test binary itself.
+fn kill_registered_groups() {
+    kill_groups_in(&LIVE_GROUPS);
+}
+
+/// The registry operations, over the array rather than the static, so a test
+/// can drive them without publishing pids into the process-wide registry the
+/// signal handler reads.
+fn register_in(groups: &[AtomicI32], pgid: i32) -> Option<usize> {
+    groups.iter().position(|slot| {
+        slot.compare_exchange(0, pgid, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+    })
+}
+
+fn unregister_in(groups: &[AtomicI32], slot: usize, pgid: i32) {
+    if let Some(entry) = groups.get(slot) {
+        let _ = entry.compare_exchange(pgid, 0, Ordering::AcqRel, Ordering::Relaxed);
+    }
+}
+
+fn kill_groups_in(groups: &[AtomicI32]) {
+    for slot in groups {
+        let pgid = slot.load(Ordering::Acquire);
+        if pgid > 0 {
+            // SAFETY: async-signal-safe. A negative pid names the group led by
+            // `pgid`; an already-empty group fails harmlessly.
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+/// The handler installed for SIGINT, SIGTERM, and SIGHUP.
+///
+/// Kill the tests, then die of the same signal with the default disposition, so
+/// the runner's wait status is the conventional one and an interactive shell
+/// sees an interrupt rather than an ordinary exit.
+extern "C" fn forward_termination(signal: i32) {
+    kill_registered_groups();
+    // SAFETY: every call here is async-signal-safe and nothing allocates.
+    // `sigaction` with SIG_DFL cannot fail for a catchable signal, and the
+    // `raise` that follows does not return.
+    unsafe {
+        let mut action: libc::sigaction = std::mem::zeroed();
+        action.sa_sigaction = libc::SIG_DFL;
+        libc::sigemptyset(&mut action.sa_mask);
+        libc::sigaction(signal, &action, std::ptr::null_mut());
+        libc::raise(signal);
+    }
+}
+
+static SIGNAL_FORWARDING: OnceLock<()> = OnceLock::new();
+
+/// Take responsibility for the tests when the runner is asked to stop.
+///
+/// Each test leads its own process group so a timeout can kill its whole tree,
+/// which also means the terminal's Ctrl-C is delivered to the runner alone.
+/// Without a handler the runner would die and leave every live test running
+/// with no supervisor and no timeout.
+///
+/// Idempotent, and called once per invocation next to
+/// [`reserve_channel_descriptor`]. A signal already ignored when we started —
+/// `nohup`, or a shell that detached the job — stays ignored: overriding that
+/// would make the runner catchable where its parent deliberately made it not.
+pub(crate) fn install_signal_forwarding() {
+    SIGNAL_FORWARDING.get_or_init(|| {
+        for signal in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
+            // SAFETY: `sigaction` on a catchable signal with a valid handler.
+            unsafe {
+                let mut previous: libc::sigaction = std::mem::zeroed();
+                if libc::sigaction(signal, std::ptr::null(), &mut previous) == 0
+                    && previous.sa_sigaction == libc::SIG_IGN
+                {
+                    continue;
+                }
+                let mut action: libc::sigaction = std::mem::zeroed();
+                action.sa_sigaction = forward_termination as libc::sighandler_t;
+                libc::sigemptyset(&mut action.sa_mask);
+                action.sa_flags = libc::SA_RESTART;
+                libc::sigaction(signal, &action, std::ptr::null_mut());
+            }
+        }
+    });
+}
+
 /// Run one test to a verdict.
 ///
 /// Errors are runner errors — the image could not be executed at all — and are
@@ -209,6 +337,10 @@ pub(crate) fn run_one(dispatch: Dispatch<'_>) -> io::Result<Execution> {
     // reader below can never see end of stream.
     drop(channel_write);
     let pid = child.id() as i32;
+    // The child leads its own group, so its pid is its pgid. Registered before
+    // anything can block, so a signal arriving during the drain below still
+    // finds this test.
+    let group_slot = register_group(pid);
 
     let mut stdout_drain = spawn_pipe_drain(child.stdout.take(), Some(dispatch.stream_budget));
     let mut stderr_drain = spawn_pipe_drain(child.stderr.take(), Some(dispatch.stream_budget));
@@ -226,8 +358,13 @@ pub(crate) fn run_one(dispatch: Dispatch<'_>) -> io::Result<Execution> {
         stderr_drain.poll();
         channel_drain.poll();
 
-        if stdout_drain.overflowed() || stderr_drain.overflowed() {
-            supervision = Supervision::OutputOverflow;
+        if let Some(overflow) = overflowed(
+            &stdout_drain,
+            &stderr_drain,
+            &channel_drain,
+            dispatch.stream_budget,
+        ) {
+            supervision = Supervision::OutputOverflow(overflow);
             kill_process_group(&mut child);
             break None;
         }
@@ -250,6 +387,9 @@ pub(crate) fn run_one(dispatch: Dispatch<'_>) -> io::Result<Execution> {
     // (ADR-0083 §3). A descendant that outlived its parent would otherwise keep
     // a pipe open and stall the bounded finish below for no useful reason.
     reap_process_group(pid);
+    if let Some(slot) = group_slot {
+        unregister_group(slot, pid);
+    }
 
     finish(&mut stdout_drain);
     finish(&mut stderr_drain);
@@ -261,9 +401,14 @@ pub(crate) fn run_one(dispatch: Dispatch<'_>) -> io::Result<Execution> {
     // the flag again after the bounded finish is what keeps such a test from
     // reporting as a pass whose digest silently covers a truncated prefix.
     if supervision == Supervision::Exited
-        && (stdout_drain.overflowed() || stderr_drain.overflowed())
+        && let Some(overflow) = overflowed(
+            &stdout_drain,
+            &stderr_drain,
+            &channel_drain,
+            dispatch.stream_budget,
+        )
     {
-        supervision = Supervision::OutputOverflow;
+        supervision = Supervision::OutputOverflow(overflow);
     }
 
     let (exit_code, signal) = match &status {
@@ -306,22 +451,59 @@ fn finish(drain: &mut PipeDrain) {
     drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
 }
 
+/// The first capture to outgrow its budget, if any.
+///
+/// The channel is checked with the streams rather than left to the frame parser
+/// (RUE-2025): a channel truncated mid-line surfaces as a malformed frame, which
+/// reports the test as a bare `exit` with a runner note about an unreadable
+/// channel — a description of the symptom, not of the test writing a quarter of
+/// a megabyte of failure records.
+fn overflowed(
+    stdout: &PipeDrain,
+    stderr: &PipeDrain,
+    channel: &PipeDrain,
+    stream_budget: usize,
+) -> Option<Overflow> {
+    let candidates = [
+        (stdout, CaptureStream::Stdout, stream_budget),
+        (stderr, CaptureStream::Stderr, stream_budget),
+        (channel, CaptureStream::Channel, CHANNEL_BUDGET),
+    ];
+    candidates
+        .into_iter()
+        .find(|(drain, _, _)| drain.overflowed())
+        .map(|(_, stream, budget)| Overflow { stream, budget })
+}
+
 /// A fresh pipe for one test's failure channel.
 ///
-/// Both ends are marked close-on-exec immediately: this runner spawns from
-/// several threads at once, and a descriptor without the flag would be
-/// inherited by whichever unrelated test happened to fork next, keeping that
-/// test's channel from ever reaching end of stream. The child's own descriptor
-/// 3 has the flag cleared inside `pre_exec`, where it is the one descriptor
-/// meant to survive.
+/// Both ends are close-on-exec: this runner spawns from several threads at
+/// once, and a descriptor without the flag would be inherited by whichever
+/// unrelated test happened to fork next, keeping that test's channel from ever
+/// reaching end of stream and making it pay the bounded finish timeout. The
+/// child's own descriptor 3 has the flag cleared inside `pre_exec`, where it is
+/// the one descriptor meant to survive.
+///
+/// On Linux the flag is set by `pipe2(O_CLOEXEC)`, atomically with the pipe's
+/// creation. A `pipe` followed by two `fcntl` calls leaves exactly the window
+/// this flag exists to close: a fork on another worker thread in between
+/// inherits an unflagged end (RUE-2025). Other targets keep that spelling
+/// because they have no `pipe2` — macOS in particular — so the window is
+/// narrowed there rather than closed.
 fn channel_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     let mut fds = [0 as libc::c_int; 2];
+    #[cfg(target_os = "linux")]
+    // SAFETY: `fds` is a valid two-element array for `pipe2` to fill.
+    let created = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+    #[cfg(not(target_os = "linux"))]
     // SAFETY: `fds` is a valid two-element array for `pipe` to fill.
-    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+    let created = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if created != 0 {
         return Err(io::Error::last_os_error());
     }
-    // SAFETY: `pipe` succeeded, so both descriptors are open and unowned.
+    // SAFETY: the pipe was created, so both descriptors are open and unowned.
     let ends = unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) };
+    #[cfg(not(target_os = "linux"))]
     for end in [&ends.0, &ends.1] {
         // SAFETY: the descriptor is owned and open.
         if unsafe { libc::fcntl(end.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC) } < 0 {
@@ -344,6 +526,22 @@ fn channel_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 /// `dup2` onto itself, which is a no-op that leaves close-on-exec set and would
 /// hand the image a channel that closes at `exec`.
 fn install_channel(write_fd: i32, read_fd: i32) -> io::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        // A runner killed by SIGKILL runs no handler, so nothing forwards the
+        // kill to the tests; this asks the kernel to do it instead. Best effort
+        // — a kernel that refuses it costs nothing that was promised.
+        //
+        // PDEATHSIG fires when the forking *thread* dies, not the process. That
+        // is the behaviour we want here: a worker thread outlives every child
+        // it spawns, waiting for each before claiming the next and exiting only
+        // when the scope ends, so the signal cannot arrive while the test is
+        // still legitimately supervised.
+        // SAFETY: async-signal-safe, and `prctl` here touches only this child.
+        unsafe {
+            libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
+        }
+    }
     if write_fd == CHANNEL_FD {
         // SAFETY: async-signal-safe, on a descriptor this child owns.
         if unsafe { libc::fcntl(CHANNEL_FD, libc::F_SETFD, 0) } < 0 {
@@ -441,6 +639,40 @@ mod tests {
         assert_ne!(DEFAULT_STREAM_BUDGET, CHANNEL_BUDGET);
     }
 
+    fn drained(bytes: usize, budget: usize) -> PipeDrain {
+        let mut drain =
+            spawn_pipe_drain(Some(std::io::Cursor::new(vec![b'x'; bytes])), Some(budget));
+        drain.finish(Duration::from_secs(5));
+        drain
+    }
+
+    /// A channel past its budget is the same supervision outcome as a flooded
+    /// stream, and names its own budget: before RUE-2025 it was not checked at
+    /// all, so it surfaced as a truncated frame and a bare `exit`.
+    #[test]
+    fn a_channel_past_its_budget_overflows_naming_the_channel() {
+        let quiet = drained(16, DEFAULT_STREAM_BUDGET);
+        let flooded = drained(CHANNEL_BUDGET + 1, CHANNEL_BUDGET);
+        let overflow = overflowed(&quiet, &quiet, &flooded, DEFAULT_STREAM_BUDGET)
+            .expect("a channel past its budget is an overflow");
+        assert_eq!(overflow.stream, CaptureStream::Channel);
+        assert_eq!(overflow.budget, CHANNEL_BUDGET);
+    }
+
+    /// Each capture reports its own budget, which is the whole reason the
+    /// overflow carries one: the channel's is a quarter of a stream's.
+    #[test]
+    fn an_overflowing_stream_reports_the_budget_it_exceeded() {
+        let quiet = drained(16, 64);
+        let flooded = drained(128, 64);
+        let stdout = overflowed(&flooded, &quiet, &quiet, 64).expect("stdout overflowed");
+        assert_eq!(stdout.stream, CaptureStream::Stdout);
+        assert_eq!(stdout.budget, 64);
+        let stderr = overflowed(&quiet, &flooded, &quiet, 64).expect("stderr overflowed");
+        assert_eq!(stderr.stream, CaptureStream::Stderr);
+        assert!(overflowed(&quiet, &quiet, &quiet, 64).is_none());
+    }
+
     /// A pipe both of whose ends leaked into an unrelated concurrent spawn
     /// would keep that test's channel from ever reaching end of stream.
     #[test]
@@ -484,6 +716,120 @@ mod tests {
         // An ordinary file open is allocated from the same descriptor space.
         let file = std::fs::File::open("/dev/null").expect("/dev/null");
         assert_ne!(file.as_raw_fd(), CHANNEL_FD);
+    }
+
+    /// A registry of the tests' own. The process-wide one is what the signal
+    /// handler kills, so a test must never publish a pid into it that it is not
+    /// about to reap: an unrelated process could hold that number by then.
+    fn registry(slots: usize) -> Vec<AtomicI32> {
+        (0..slots).map(|_| AtomicI32::new(0)).collect()
+    }
+
+    /// A registration is visible until it is withdrawn, and withdrawal is by
+    /// owner: a slot recycled between the two must not be cleared by the
+    /// previous tenant.
+    #[test]
+    fn a_group_registration_is_withdrawn_by_its_owner() {
+        let groups = registry(4);
+        let slot = register_in(&groups, 4_242).expect("a free slot");
+        assert_eq!(groups[slot].load(Ordering::Acquire), 4_242);
+        unregister_in(&groups, slot, 9_999);
+        assert_eq!(
+            groups[slot].load(Ordering::Acquire),
+            4_242,
+            "a withdrawal naming another group leaves the slot alone"
+        );
+        unregister_in(&groups, slot, 4_242);
+        assert_eq!(groups[slot].load(Ordering::Acquire), 0);
+        // An out-of-range slot is a lost teardown, never a crashed runner.
+        unregister_in(&groups, groups.len(), 1);
+    }
+
+    /// A full registry refuses rather than failing a run: registration is best
+    /// effort, and all that is lost is the handler's teardown of that group.
+    #[test]
+    fn a_full_registry_refuses_rather_than_failing_a_run() {
+        let groups = registry(3);
+        let held: Vec<usize> = (0..3)
+            .map(|index| register_in(&groups, 100 + index).expect("a free slot"))
+            .collect();
+        assert_eq!(held.len(), 3);
+        assert!(register_in(&groups, 200).is_none());
+        unregister_in(&groups, held[1], 101);
+        assert_eq!(
+            register_in(&groups, 200),
+            Some(held[1]),
+            "a freed slot is reused"
+        );
+    }
+
+    /// What a Ctrl-C must do, exercised without signalling this process: the
+    /// registered group dies even though the child leads a process group of its
+    /// own, which is exactly the group the terminal's SIGINT never reaches.
+    #[test]
+    fn killing_the_registered_groups_kills_a_live_child() {
+        use std::os::unix::process::{CommandExt as _, ExitStatusExt as _};
+
+        let mut command = Command::new("sleep");
+        command
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut child = command.spawn().expect("sleep(1) is a POSIX utility");
+        let pid = child.id() as i32;
+        let groups = registry(2);
+        register_in(&groups, pid).expect("a free slot");
+
+        kill_groups_in(&groups);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let status = loop {
+            if let Some(status) = child.try_wait().expect("waiting on our own child") {
+                break status;
+            }
+            assert!(Instant::now() < deadline, "the child outlived the kill");
+            std::thread::sleep(POLL_INTERVAL);
+        };
+        assert_eq!(status.signal(), Some(libc::SIGKILL));
+    }
+
+    /// A withdrawn group is not signalled again: the pid is reusable the moment
+    /// its group empties, and a stale entry would aim a kill at a stranger.
+    #[test]
+    fn a_withdrawn_group_is_no_longer_reachable_from_the_handler() {
+        let groups = registry(2);
+        let slot = register_in(&groups, 1_234).expect("a free slot");
+        unregister_in(&groups, slot, 1_234);
+        assert!(
+            groups.iter().all(|slot| slot.load(Ordering::Acquire) == 0),
+            "a withdrawn group leaves nothing for the handler to kill"
+        );
+    }
+
+    /// The registry is sized against the driver's own cap on `--jobs`, so the
+    /// full case is unreachable in a real run rather than merely handled.
+    #[test]
+    fn the_registry_holds_more_groups_than_a_run_can_have_children() {
+        assert!(MAX_LIVE_GROUPS > crate::MAX_EXPLICIT_JOBS);
+        assert_eq!(LIVE_GROUPS.len(), MAX_LIVE_GROUPS);
+    }
+
+    /// Installing the handlers twice must be harmless: the runner calls it once
+    /// per invocation, and these tests call it alongside.
+    #[test]
+    fn installing_signal_forwarding_is_idempotent() {
+        install_signal_forwarding();
+        install_signal_forwarding();
+        for signal in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
+            // SAFETY: a bare query of a signal's current disposition.
+            let mut installed: libc::sigaction = unsafe { std::mem::zeroed() };
+            // SAFETY: `installed` is a valid destination for the query.
+            let queried = unsafe { libc::sigaction(signal, std::ptr::null(), &mut installed) };
+            assert_eq!(queried, 0);
+            assert_ne!(installed.sa_sigaction, libc::SIG_DFL, "signal {signal}");
+        }
     }
 
     /// Reserving twice is not an error and does not change what is held: the

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -210,6 +210,10 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
     // can be allocated there and then be destroyed by a child's `dup2` onto
     // the channel. See `exec::reserve_channel_descriptor`.
     exec::reserve_channel_descriptor();
+    // And take responsibility for the children: each test leads its own process
+    // group, so a terminal's Ctrl-C reaches this process alone and would
+    // otherwise leave every live test running unsupervised.
+    exec::install_signal_forwarding();
 
     let seed = options.seed.unwrap_or_else(fresh_seed);
 
@@ -360,6 +364,10 @@ fn candidate_source(candidates: Option<&TestCandidateInventory>) -> CandidateSou
 /// Filtering and sharding apply — a listing answers "what would this
 /// invocation run" — but the shuffle does not. A listing is an inventory, and
 /// stable-ID order is the property that makes two listings comparable.
+///
+/// Membership therefore comes from `selection::select`, the same computation
+/// `plan` runs, rather than from a second copy of the predicate here: a listing
+/// that could disagree with the run it previews is worse than no listing.
 fn list(
     host: &mut FilesystemCompilerHost,
     compile_options: &CompileOptions,
@@ -374,16 +382,7 @@ fn list(
             return TestExitCode::RunnerError;
         }
     };
-    let selected: Vec<&TestInventoryEntry> = inventory
-        .entries
-        .iter()
-        .filter(|entry| selection::matches_filters(&entry.id, &options.filters))
-        .filter(|entry| {
-            options.shard.is_none_or(|shard| {
-                selection::shard_hash(&entry.id) % shard.count == shard.index - 1
-            })
-        })
-        .collect();
+    let selected = selection::select(&inventory.entries, &options.filters, options.shard);
     if selected.is_empty() {
         eprintln!("{}", empty_selection_reason(inventory.entries.len()));
         return TestExitCode::EmptySelection;
@@ -656,9 +655,10 @@ fn failure_message(
         FailureKind::Incomplete => {
             "the test exited 0 without the dispatcher's completion record".to_owned()
         }
-        FailureKind::OutputOverflow => format!(
-            "a captured stream exceeded its {DEFAULT_STREAM_BUDGET}-byte retention budget; \
-             the process group was killed"
+        FailureKind::OutputOverflow(overflow) => format!(
+            "{} exceeded its {}-byte retention budget; the process group was killed",
+            overflow.stream.name(),
+            overflow.budget
         ),
         FailureKind::Assert
         | FailureKind::AssertEq

--- a/crates/rue/src/test_mode/selection.rs
+++ b/crates/rue/src/test_mode/selection.rs
@@ -122,6 +122,24 @@ pub(crate) fn matches_filters(id: &str, filters: &[String]) -> bool {
     filters.is_empty() || filters.iter().any(|filter| id.contains(filter.as_str()))
 }
 
+/// Which tests an invocation acts on: filter, then shard, in inventory order.
+///
+/// The membership half of the pipeline, shared by `plan` and `--list` so the
+/// listing cannot answer a different question from the run it previews. Order
+/// is left alone here because the two consumers want different orders — a run
+/// shuffles, a listing must not — and order is not membership.
+pub(crate) fn select<'a>(
+    entries: &'a [TestInventoryEntry],
+    filters: &[String],
+    shard: Option<Shard>,
+) -> Vec<&'a TestInventoryEntry> {
+    entries
+        .iter()
+        .filter(|entry| matches_filters(&entry.id, filters))
+        .filter(|entry| shard.is_none_or(|shard| shard.owns(&entry.id)))
+        .collect()
+}
+
 /// Filter, shard, and shuffle one inventory into the order tests will run in.
 pub(crate) fn plan(
     entries: &[TestInventoryEntry],
@@ -129,10 +147,8 @@ pub(crate) fn plan(
     shard: Option<Shard>,
     seed: u64,
 ) -> Vec<TestInventoryEntry> {
-    let mut selected: Vec<TestInventoryEntry> = entries
-        .iter()
-        .filter(|entry| matches_filters(&entry.id, filters))
-        .filter(|entry| shard.is_none_or(|shard| shard.owns(&entry.id)))
+    let mut selected: Vec<TestInventoryEntry> = select(entries, filters, shard)
+        .into_iter()
         .cloned()
         .collect();
     shuffle(&mut selected, seed);
@@ -279,6 +295,42 @@ mod tests {
                 .unwrap_err()
                 .contains("positive integer")
         );
+    }
+
+    /// What `--list` publishes: the same membership a run would have, in
+    /// inventory order. A listing is compared against another listing, so the
+    /// shuffle belongs to `plan` alone.
+    #[test]
+    fn a_selection_keeps_inventory_order_while_a_plan_shuffles_it() {
+        let entries = inventory(24);
+        let selected: Vec<String> = select(&entries, &[], None)
+            .into_iter()
+            .map(|entry| entry.id.clone())
+            .collect();
+        assert_eq!(selected, ids(&entries));
+        assert_ne!(
+            selected,
+            ids(&plan(&entries, &[], None, 417)),
+            "a run's order is shuffled; a listing's is not"
+        );
+    }
+
+    /// The listing and the run answer the same membership question, filters and
+    /// shard included — one computation, two consumers.
+    #[test]
+    fn a_selection_and_a_plan_agree_on_membership() {
+        let entries = inventory(40);
+        let filters = vec!["test 1".to_owned()];
+        let shard = Some(Shard { index: 2, count: 3 });
+        let mut selected: Vec<String> = select(&entries, &filters, shard)
+            .into_iter()
+            .map(|entry| entry.id.clone())
+            .collect();
+        let mut planned = ids(&plan(&entries, &filters, shard, 417));
+        assert!(!selected.is_empty(), "the fixture must select something");
+        selected.sort();
+        planned.sort();
+        assert_eq!(selected, planned);
     }
 
     #[test]

--- a/crates/rue/src/test_mode/verdict.rs
+++ b/crates/rue/src/test_mode/verdict.rs
@@ -73,8 +73,11 @@ pub(crate) enum FailureKind {
     UnhandledError,
     /// Any other nonzero exit.
     Exit,
-    /// A capture budget was exhausted and the process group was killed.
-    OutputOverflow,
+    /// A capture budget was exhausted and the process group was killed. It
+    /// carries which capture overflowed and the budget that was exceeded,
+    /// because the three budgets differ and a message naming the wrong one
+    /// sends a reader to the wrong flag.
+    OutputOverflow(Overflow),
     /// A kind a failure frame supplied verbatim (ADR-0083 §5.1).
     Reported(String),
 }
@@ -102,7 +105,10 @@ impl fmt::Display for FailureKind {
             Self::Trap(class) => write!(f, "trap:{class}"),
             Self::UnhandledError => f.write_str("unhandled_error"),
             Self::Exit => f.write_str("exit"),
-            Self::OutputOverflow => f.write_str("output_overflow"),
+            // The published kind names the class, not which capture produced
+            // it: the stream is presentation, and a consumer branching on
+            // `kind` must not have to enumerate three spellings.
+            Self::OutputOverflow(_) => f.write_str("output_overflow"),
             Self::Reported(kind) => f.write_str(kind),
         }
     }
@@ -259,6 +265,37 @@ fn location_number(value: &serde_json::Value, key: &str) -> u32 {
         .unwrap_or(0)
 }
 
+/// One of the three captures a test process feeds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CaptureStream {
+    Stdout,
+    Stderr,
+    /// The §5.1 failure channel on descriptor 3.
+    Channel,
+}
+
+impl CaptureStream {
+    /// How a failure message names this capture to a person.
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+            Self::Channel => "the failure channel",
+        }
+    }
+}
+
+/// A capture that outgrew its retention budget.
+///
+/// The budget travels with the stream because the channel's is a quarter of a
+/// stream's (ADR-0083 §2): a message that always quoted the stream budget would
+/// misreport the channel by a factor of four.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Overflow {
+    pub(crate) stream: CaptureStream,
+    pub(crate) budget: usize,
+}
+
 /// How the runner's own supervision ended a test, before its exit status is
 /// consulted at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -268,7 +305,7 @@ pub(crate) enum Supervision {
     /// The wall-clock budget expired; the group was killed.
     TimedOut,
     /// A capture budget was exhausted; the group was killed.
-    OutputOverflow,
+    OutputOverflow(Overflow),
 }
 
 /// Everything the classifier reads about one finished test process.
@@ -308,9 +345,9 @@ pub(crate) fn classify(observation: Observation<'_>) -> Classification {
                 runner_note: None,
             };
         }
-        Supervision::OutputOverflow => {
+        Supervision::OutputOverflow(overflow) => {
             return Classification {
-                verdict: Verdict::Fail(FailureKind::OutputOverflow),
+                verdict: Verdict::Fail(FailureKind::OutputOverflow(overflow)),
                 runner_note: None,
             };
         }
@@ -562,16 +599,45 @@ mod tests {
         });
         assert_eq!(timed_out.verdict, Verdict::Timeout);
 
+        let overflow = Overflow {
+            stream: CaptureStream::Stdout,
+            budget: 1024,
+        };
         let overflowed = classify(Observation {
-            supervision: Supervision::OutputOverflow,
+            supervision: Supervision::OutputOverflow(overflow),
             status: Err(9),
             stderr: b"",
             frames: &ChannelFrames::default(),
         });
         assert_eq!(
             overflowed.verdict,
-            Verdict::Fail(FailureKind::OutputOverflow)
+            Verdict::Fail(FailureKind::OutputOverflow(overflow))
         );
+    }
+
+    /// A channel that outgrew its budget is the same supervision outcome as a
+    /// flooded stream — the group is killed and the verdict is a failure —
+    /// but it carries its own, smaller budget so the message names that one.
+    #[test]
+    fn an_overflow_carries_the_capture_that_produced_it() {
+        let overflow = Overflow {
+            stream: CaptureStream::Channel,
+            budget: 256 * 1024,
+        };
+        let classified = classify(Observation {
+            supervision: Supervision::OutputOverflow(overflow),
+            status: Err(9),
+            stderr: b"",
+            frames: &ChannelFrames::default(),
+        });
+        let Verdict::Fail(FailureKind::OutputOverflow(reported)) = classified.verdict else {
+            panic!("a channel overflow is an output_overflow failure");
+        };
+        assert_eq!(reported.stream, CaptureStream::Channel);
+        assert_eq!(reported.budget, 256 * 1024);
+        assert_eq!(CaptureStream::Stdout.name(), "stdout");
+        assert_eq!(CaptureStream::Stderr.name(), "stderr");
+        assert_eq!(CaptureStream::Channel.name(), "the failure channel");
     }
 
     /// A channel the runner could not read is never silently ignored — least
@@ -704,7 +770,15 @@ mod tests {
         assert_eq!(FailureKind::Trap("panic").to_string(), "trap:panic");
         assert_eq!(FailureKind::UnhandledError.to_string(), "unhandled_error");
         assert_eq!(FailureKind::Exit.to_string(), "exit");
-        assert_eq!(FailureKind::OutputOverflow.to_string(), "output_overflow");
+        // The kind is one published spelling whichever capture overflowed.
+        for stream in [
+            CaptureStream::Stdout,
+            CaptureStream::Stderr,
+            CaptureStream::Channel,
+        ] {
+            let kind = FailureKind::OutputOverflow(Overflow { stream, budget: 7 });
+            assert_eq!(kind.to_string(), "output_overflow");
+        }
     }
 
     #[test]

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -358,9 +358,10 @@ $ rue test app/main.rue --filter parse_port      # run a subset
   `rue-test-runner` limited-drain mechanics); exceeding a stream's limit
   kills the process group and yields `fail` with kind `output_overflow`,
   retained prefix attached. Failing tests carry retained capture inline;
-  passing tests carry digests and byte counts, with a flag to opt passes
-  into inline capture. The §5.1 failure channel is budgeted separately, so
-  a test that floods its streams cannot truncate its own failure record.
+  passing tests carry digests and byte counts. A flag to opt passes into
+  inline capture is deferred and not part of the MVP. The §5.1 failure
+  channel is budgeted separately, so a test that floods its streams cannot
+  truncate its own failure record.
 - **Asymmetric verbosity**: the human renderer prints failures in full —
   structure, captured output, repro line — and passes as a count. No wall
   of green.
@@ -457,11 +458,14 @@ The MVP mechanism:
   determinism boundary. These exact values participate in the deferred
   verdict-cache key (§6); their stability is what will keep routine runs
   cache-hittable.
-- **Parallelism**: up to `--jobs` concurrent test processes. In the MVP
-  every test runs in parallel by default — a pragmatic default, not a
-  guarantee: unverified tests *can* interfere through the OS, and a suite
-  that observes it reaches for `--jobs 1` today, declared serial groups in
-  the deferred scheduling work (§6), and a platform sandbox eventually.
+- **Parallelism**: up to `--jobs` concurrent test processes, and only
+  those — the compilation that builds the image keeps auto-detected
+  parallelism, so isolating a test with `--jobs 1` does not also serialize
+  the build. In the MVP every test runs in parallel by default — a
+  pragmatic default, not a guarantee: unverified tests *can* interfere
+  through the OS, and a suite that observes it reaches for `--jobs 1`
+  today, declared serial groups in the deferred scheduling work (§6), and a
+  platform sandbox eventually.
   When capability inference lands, verified-hermetic parallelism becomes
   unconditional. The runner never silently serializes; scheduling changes
   are always visible policy.
@@ -516,6 +520,9 @@ runtime protocol. `@assert`, the comparison family `@assert_eq`/`@assert_ne`
 (Phase 2.5), and the test-body `?` failure arm (§1) are sugar over the same
 channel any Rue function can invoke before aborting; user libraries emit the
 same records, and the stream carries them without knowing who produced them.
+As of Phase 3 those compiler-synthesized producers are the only ones — no
+user-callable way to write a record has shipped — and the classification and
+reserved shapes below stand for when one does.
 
 The mechanism — **ruled 2026-08-23** — is a **dedicated inherited pipe**:
 its own file descriptor, pinned in the §3 exec contract, written through a

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -40,7 +40,7 @@ for an ordinary build of the same closure.
 |------|---------|
 | `0` | Every selected test passed. |
 | `1` | At least one selected test failed, timed out, or crashed. |
-| `2` | The run could not be performed: a compile failure, a failing image link, an ICE, a bad flag combination, or a runner error. |
+| `2` | The run could not be performed: a compile failure, a failing image link, an ICE, a bad flag combination, an unreadable root or candidate inventory, or a runner error. |
 | `3` | The selection was empty. |
 
 `3` is a distinct outcome rather than a vacuous success because an empty
@@ -131,6 +131,15 @@ Writes are best-effort by design: an image run by hand has no descriptor 3, and
 security boundary** — it prevents accidental collision with a test's own stdout,
 which is all its consumers are promised.
 
+**Producers in this version.** Every record on this channel is
+compiler-synthesized: `@assert`, `@assert_eq`, `@assert_ne`, the test-body `?`
+failure arm, and the dispatcher's `complete` epilogue. Nothing in the language
+can call `__rue_test_failure_site` or `__rue_test_fail`, so the user assertion
+library of ADR-0083 §5.1 is what the open `kind` and the reserved payload shapes
+are *for* rather than something that exists yet — a line naming an unknown
+`record` is recorded as malformed, which fails the test. A user-callable
+intrinsic is tracked as RUE-2027.
+
 Reserved by ADR-0083 §5.1 and §5.2, and produced by nothing in this version:
 `promotion` payloads (a machine-applicable suggested fix, for a future
 `rue test --accept`) and `sub_result` records (named child results attributed as
@@ -175,7 +184,7 @@ The head event, and the only one carrying the schema version for a run.
 | `target` | string | The Rue target the image was built for. |
 | `opt_level` | string | The optimization level's digit: `"0"`–`"3"`. |
 | `seed` | integer | The run's shuffle seed (see `--seed`). |
-| `jobs` | integer | Concurrent test processes. |
+| `jobs` | integer | Concurrent test processes, which is all `--jobs` bounds in test mode; compilation uses auto-detected parallelism. |
 | `shard` | string | `"K/N"`. **Absent** when `--shard` was not given. |
 | `plan` | object | `{"selected": integer, "total": integer}` — tests selected, and tests in the closure. |
 
@@ -286,7 +295,8 @@ otherwise.
 The asymmetry is deliberate (ADR-0083 §2): a failing test's output is what a
 reader needs, and inlining every passing test's output is the wall of green the
 design rejects. A pass can never have overflowed its budget — an overflow is a
-failure verdict — so a pass's digest always covers the whole stream.
+failure verdict — so a pass's digest always covers the whole stream. This
+version has no flag to inline a passing test's output; the opt-in is deferred.
 
 **Budgets.** 1 MiB retained per stream for stdout and stderr; 256 KiB for the
 failure channel, deliberately separate so a test that floods its streams cannot

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -300,9 +300,14 @@ version has no flag to inline a passing test's output; the opt-in is deferred.
 
 **Budgets.** 1 MiB retained per stream for stdout and stderr; 256 KiB for the
 failure channel, deliberately separate so a test that floods its streams cannot
-truncate its own failure record. Exceeding a *stream* budget kills the process
-group and yields `fail` with kind `output_overflow`, retained prefix attached.
-Reading continues past the budget so `bytes_total` is the true count.
+truncate its own failure record. Exceeding any of the three kills the process
+group and yields `fail` with kind `output_overflow`, retained prefix attached;
+the failure message names the capture that overflowed and the budget it
+exceeded, because the channel's is a quarter of a stream's. A channel past its
+budget is a supervision outcome for the same reason a stream is: truncating it
+mid-line would otherwise surface as an unreadable frame and a bare `exit`,
+describing the symptom rather than the flood. Reading continues past the budget
+so `bytes_total` is the true count.
 
 That window is sized for a machine, so the human renderer bounds what it prints
 of it: at most 64 lines or 8 KiB per stream, as a 48-line head and a 16-line
@@ -515,6 +520,20 @@ process id, and are themselves named `rue-test-<seed>-<ordinal>`. The run
 directory is what keeps two runs that share an explicit `--seed` — a repro next
 to the run that produced it, or two suites in parallel — from deleting each
 other's live working directories.
+
+**Retention is the user's to undo.** The run directory and every scratch
+directory it holds sit under the OS temp directory. A retained one is evidence,
+so no later run sweeps it: a run removes only paths inside its own run
+directory — the scratch of each of its passing tests, its image, and the run
+directory itself once that is empty — and its process id is what makes that
+directory its own. The runner has no expiry, so deleting what is left is the
+user's call, and the OS temp directory's own policy is the only other thing that
+will do it. A run interrupted by SIGINT, SIGTERM, or SIGHUP kills its
+live tests before it dies, so nothing is left running, but it dies of that
+signal without a chance to clean up: its run directory and its image stay behind
+under the temp directory. A runner killed by SIGKILL runs nothing at all; on
+Linux its children still die, because each is asked at exec time for a SIGKILL
+when its parent goes.
 
 **What isolation does and does not promise.** Each test observes fresh process
 state, has an independent lifecycle the runner enforces, gets its output


### PR DESCRIPTION
Follow-ups from a code review of the ADR-0083 `rue test` runner as merged. Seven findings, all verified against the tree before the change.

Fixes RUE-2025

## Runner mechanics

- **Ctrl-C and SIGTERM no longer orphan test processes.** Children run in their own process groups, so the terminal's SIGINT never reached them and the runner installed no handler. Verified by experiment: killing the runner mid-run left the test image running with nobody enforcing its timeout. The runner now keeps live process groups in an async-signal-safe registry; SIGINT, SIGTERM, and SIGHUP handlers kill every registered group and then re-raise so the shell sees the conventional status. On Linux each child also sets `PR_SET_PDEATHSIG` for the SIGKILL case no handler can catch. Re-verified by hand on the merged build: after SIGINT or SIGTERM the image is gone.
- **Channel budget overflow** is now a supervision outcome like a stream overflow. The overflow carries which capture and which budget, so the message no longer quotes the 1 MiB stream budget for the 256 KiB channel. A CLI case floods descriptor 3 through raw write syscalls to pin it.
- **`pipe2(O_CLOEXEC)`** on Linux for the channel pipe, closing the non-atomic `pipe` then `fcntl` window in which a concurrent fork could inherit an end.
- `--list` and the run planner share one selection computation instead of two copies of the shard predicate.
- The schema doc states the scratch-directory retention policy and the channel overflow behavior.

## Driver and docs

- **Exit-code contract.** `docs/process/test-events.md` promises exit `2` for everything that stops a run. An unreadable root, an unreadable `--test-candidates` list, and a rejected candidate path exited `1` through compile mode's paths. One helper now maps the driver mode to the stopped-run status and every such site goes through it. Three CLI cases pin test mode's `2`; a control pins compile mode's `1`.
- **`--jobs` in test mode** bounds concurrent test processes only, as ADR-0083 §3 defines it. The compile that builds the image keeps the query pool's auto-detection, so `--jobs 1` no longer single-threads compilation to isolate one test. Help text, the schema doc's `jobs` row, and the ADR's Parallelism bullet say so. This is the one judgment call in the PR; the alternative was to leave `--jobs` governing both and only document it.
- **Channel producers stated.** The schema doc now says every channel record is compiler-synthesized, that nothing in the language can write one yet, and that an unknown `record` fails the test. The user-callable intrinsic is tracked as RUE-2027.
- **ADR drift.** The ADR no longer promises an inline-capture flag for passing tests that was never shipped.

## Verification

- `scripts/rue fmt`, `scripts/rue quick`, `scripts/rue cli rue_test` (73 passed, five new cases), the `rue` crate's `test_mode` unit tests (99 passed), clippy, the oracle-diff check, and `scripts/rue premerge` on the merged branch.
- By hand on the merged build: SIGINT and SIGTERM to a running `rue test` kill the spinning test image; `rue test` exits 2 for a missing root and a missing candidates list while compile mode keeps 1.

Noticed in passing, not changed here: `scripts/rue unit rue <pattern>` cannot reach the driver crate's unit tests because the wrapper maps a bare name to `crates/rue-<name>`; the equivalent is `./buck2 run //crates/rue:rue-test -- <pattern>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHjkC1rnp8YxaehX4JZwtq