### PR TITLE
RUE-2021: keep the missing-inventory notice off stdout and fix the assert_eq operand-order prose

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -936,11 +936,13 @@ compile_stdout_contains = ["1 passed"]
 compile_stdout_not_contains = ["warning:", "orphan_tests.rue"]
 
 [[case]]
-name = "without_an_inventory_a_multi_module_summary_says_orphans_are_not_detected"
+name = "without_an_inventory_a_multi_module_run_says_on_stderr_orphans_are_not_detected"
 description = """
 Silence would be read as "no orphans found". This root imports a second module,
 so an orphan is a thing that could exist here, and the run says instead that it
-did not look.
+did not look. RUE-2021: it says so on stderr, where the runner's own warnings
+and notices live, so stdout ends at the summary line and a terminal joining the
+streams shows the note once.
 """
 files = [
     { path = "main.rue", source = """
@@ -958,9 +960,11 @@ test "alpha" {
 ]
 args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 0
-compile_stdout_contains = [
+compile_stderr_contains = [
     "note: no --test-candidates inventory; unimported test files are not detected",
 ]
+compile_stdout_contains = ["1 passed"]
+compile_stdout_not_contains = ["note: no --test-candidates inventory"]
 
 [[case]]
 name = "a_single_module_run_is_owed_no_note_about_candidates"
@@ -968,7 +972,8 @@ description = """
 RUE-1959: a closure of one user module has no second module that could have
 failed to import a test file, so there is nothing for the note to be about. It
 was noise under every filtered rerun pasted from a `repro:` line. The JSON
-`test_candidates` field is unaffected — this is the human summary only.
+`test_candidates` field is unaffected — this is presentation only, and neither
+stream carries the note.
 """
 files = [
     { path = "main.rue", source = """
@@ -985,11 +990,12 @@ args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 0
 compile_stdout_contains = ["1 passed"]
 compile_stdout_not_contains = ["note: no --test-candidates inventory"]
+compile_stderr_not_contains = ["note: no --test-candidates inventory"]
 
 [[case]]
 name = "a_single_module_run_still_reports_test_candidates_none_in_json"
 description = """
-RUE-1959 changed the human summary only. `run_finished.test_candidates` is a
+RUE-1959 changed the presentation only. `run_finished.test_candidates` is a
 published field and answers `"none"` for the same run.
 """
 files = [
@@ -1009,6 +1015,36 @@ args = [
 ]
 driver_exit_code = 0
 compile_stdout_contains = ['"test_candidates":"none"']
+
+[[case]]
+name = "a_json_run_without_an_inventory_keeps_stdout_to_events"
+description = """
+RUE-2021: the missing-inventory note is a human-format notice on stderr. Under
+`--format json` stdout is the event stream and nothing else, and the same fact
+reaches a machine consumer as `run_finished.test_candidates`.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "alpha" {
+    @assert(1 == 1);
+}
+""" },
+]
+args = [
+    "test", "main.rue", "--seed", "1", "-j1",
+    "--format", "json",
+]
+driver_exit_code = 0
+compile_stdout_contains = ['"test_candidates":"none"']
+compile_stdout_not_contains = ["note: no --test-candidates inventory"]
+compile_stderr_not_contains = ["note: no --test-candidates inventory"]
 
 # ========================= dispatch and flag combinations =========================
 

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -246,8 +246,9 @@ fn failure_frame(
 /// It carries `left` and `right` where [`failure_frame`] carries the open
 /// `payload`, and no `payload` at all: two rendered operands are not one string
 /// a consumer has to split, and the runner computes the diff between them.
-/// `left` and `right` are the operands in the order the source wrote them, so
-/// `@assert_eq(want, got)` reads the way it is spelled.
+/// `left` and `right` are the operands in the order the source wrote them and
+/// carry no role, so `@assert_eq(got, want)` — the conventional spelling, with
+/// the observed value first — reads the way it is spelled.
 ///
 /// The message is not a parameter: it is pinned by the kind, which is what
 /// keeps this call to the six registers a runtime helper is limited to while

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -155,7 +155,7 @@ fn fresh_seed() -> u64 {
 /// and routes each event to the surface the invocation asked for.
 struct Reporter {
     format: OutputFormat,
-    /// Presentation policy the human renderer needs and the event schema does
+    /// Presentation policy the runner's notices need and the event schema does
     /// not carry. See `render::Context`.
     context: render::Context,
     stdout: Mutex<()>,
@@ -181,12 +181,21 @@ impl Reporter {
                 let _ = writeln!(out, "{}", event.to_ndjson());
             }
             OutputFormat::Human => {
-                if let Some(text) = render::render(event, self.context) {
+                if let Some(text) = render::render(event) {
                     let _ = writeln!(out, "{text}");
                 }
             }
         }
         let _ = out.flush();
+        // A notice is the runner's own voice, not run data, so it follows the
+        // warnings onto stderr rather than joining the events on stdout. Said
+        // under the same lock, after the line it annotates, so a terminal
+        // joining the streams reads them in order.
+        if self.format == OutputFormat::Human
+            && let Some(notice) = render::notice(event, self.context)
+        {
+            eprintln!("{notice}");
+        }
     }
 }
 

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -35,7 +35,10 @@ pub(crate) struct Context {
 
 /// Render one event for a person, or `None` when a person is owed nothing by
 /// it.
-pub(crate) fn render(event: &Event, context: Context) -> Option<String> {
+///
+/// Every line it produces is run data. Presentation policy that is not — the
+/// missing-inventory notice — is [`notice`]'s, and goes to stderr.
+pub(crate) fn render(event: &Event) -> Option<String> {
     match event {
         Event::RunStarted { .. } | Event::TestStarted { .. } => None,
         Event::Test { id, .. } => Some(id.clone()),
@@ -53,17 +56,32 @@ pub(crate) fn render(event: &Event, context: Context) -> Option<String> {
             // "Streams"). Rendering them here too would print a second copy
             // on stdout whenever a terminal joins the streams.
             unimported_test_files: _,
-            test_candidates,
-        } => {
-            let mut out = summary(*passed, *failed, *timeout, *crash, *wall_ms);
-            if *test_candidates == CandidateSource::None && context.multi_module_closure {
-                out.push('\n');
-                out.push_str(
-                    "note: no --test-candidates inventory; unimported test files are not detected",
-                );
-            }
-            Some(out)
+            // The missing-inventory notice is the runner's own too, and goes
+            // to stderr with them. See `notice`.
+            test_candidates: _,
+        } => Some(summary(*passed, *failed, *timeout, *crash, *wall_ms)),
+    }
+}
+
+/// The runner's own notice for this event, or `None` when a run is owed none.
+///
+/// A notice is not run data, so it goes where the runner's warnings go: stderr,
+/// once, and never repeated on stdout, where a terminal joining the streams
+/// would show two copies of one line (test-events.md, "Streams"). Only the
+/// human format is owed one at all — `--format json` publishes the same fact as
+/// `run_finished.test_candidates`.
+pub(crate) fn notice(event: &Event, context: Context) -> Option<&'static str> {
+    match event {
+        // RUE-1959: a closure of one user module has no second module that
+        // could have failed to import a test file, so the note would answer a
+        // question this run cannot raise. `test_candidates` is unaffected.
+        Event::RunFinished {
+            test_candidates: CandidateSource::None,
+            ..
+        } if context.multi_module_closure => {
+            Some("note: no --test-candidates inventory; unimported test files are not detected")
         }
+        _ => None,
     }
 }
 
@@ -322,11 +340,10 @@ mod tests {
     use crate::test_mode::events::{Comparison, FailureRecord, Location, UnimportedFile};
     use crate::test_mode::verdict::FailureKind;
 
-    /// Render as an ordinary multi-module program, which is what every case
-    /// that is not about the closure size wants: the closure-size policy only
-    /// governs the missing-inventory note.
-    fn render_multi(event: &Event) -> Option<String> {
-        super::render(
+    /// The notice an ordinary multi-module program is owed: the closure-size
+    /// policy governs the missing-inventory note and nothing else.
+    fn notice_multi(event: &Event) -> Option<&'static str> {
+        super::notice(
             event,
             Context {
                 multi_module_closure: true,
@@ -368,7 +385,7 @@ mod tests {
     /// No wall of green: a pass prints nothing.
     #[test]
     fn a_pass_prints_nothing() {
-        assert!(render_multi(&finished(Verdict::Pass, None)).is_none());
+        assert!(super::render(&finished(Verdict::Pass, None)).is_none());
     }
 
     /// The head events are machine bookkeeping; a person is shown failures and
@@ -376,13 +393,13 @@ mod tests {
     #[test]
     fn run_and_test_start_print_nothing() {
         assert!(
-            render_multi(&Event::TestStarted {
+            super::render(&Event::TestStarted {
                 id: "app/t.rue::ok".to_owned()
             })
             .is_none()
         );
         assert!(
-            render_multi(&Event::RunStarted {
+            super::render(&Event::RunStarted {
                 root: "m.rue".to_owned(),
                 target: "x86-64-linux".to_owned(),
                 opt_level: "0".to_owned(),
@@ -398,7 +415,7 @@ mod tests {
 
     #[test]
     fn a_failure_prints_structure_output_scratch_and_repro() {
-        let rendered = render_multi(&finished(
+        let rendered = super::render(&finished(
             Verdict::Fail(FailureKind::Assert),
             Some(FailureRecord {
                 kind: "assert".to_owned(),
@@ -439,7 +456,7 @@ mod tests {
     /// disagree about where the difference is.
     #[test]
     fn a_single_line_comparison_prints_both_values_and_a_caret() {
-        let rendered = render_multi(&finished(
+        let rendered = super::render(&finished(
             Verdict::Fail(FailureKind::AssertEq),
             Some(FailureRecord {
                 kind: "assert_eq".to_owned(),
@@ -460,7 +477,7 @@ mod tests {
     /// difference and no caret is drawn — the two values *are* the report.
     #[test]
     fn identical_values_print_no_caret() {
-        let rendered = render_multi(&finished(
+        let rendered = super::render(&finished(
             Verdict::Fail(FailureKind::AssertNe),
             Some(FailureRecord {
                 kind: "assert_ne".to_owned(),
@@ -480,7 +497,7 @@ mod tests {
     /// of text locates nothing.
     #[test]
     fn a_multi_line_comparison_prints_a_hunk_listing() {
-        let rendered = render_multi(&finished(
+        let rendered = super::render(&finished(
             Verdict::Fail(FailureKind::AssertEq),
             Some(FailureRecord {
                 kind: "assert_eq".to_owned(),
@@ -508,7 +525,7 @@ mod tests {
     /// is the only account of a failure report the runner could not read.
     #[test]
     fn a_runner_note_is_printed_with_its_failure() {
-        let rendered = render_multi(&finished(
+        let rendered = super::render(&finished(
             Verdict::Fail(FailureKind::Exit),
             Some(FailureRecord {
                 kind: "exit".to_owned(),
@@ -526,9 +543,9 @@ mod tests {
 
     #[test]
     fn timeouts_and_crashes_carry_their_own_banners() {
-        let timeout = render_multi(&finished(Verdict::Timeout, None)).expect("a timeout renders");
+        let timeout = super::render(&finished(Verdict::Timeout, None)).expect("a timeout renders");
         assert!(timeout.starts_with("TIMEOUT "), "{timeout}");
-        let crash = render_multi(&finished(Verdict::Crash(11), None)).expect("a crash renders");
+        let crash = super::render(&finished(Verdict::Crash(11), None)).expect("a crash renders");
         assert!(crash.starts_with("CRASH "), "{crash}");
     }
 
@@ -537,17 +554,17 @@ mod tests {
     #[test]
     fn the_summary_names_only_the_classes_that_occurred() {
         assert!(
-            render_multi(&run_finished(2, 0, 0, 0))
+            super::render(&run_finished(2, 0, 0, 0))
                 .unwrap()
                 .starts_with("2 passed (0.9s)")
         );
         assert!(
-            render_multi(&run_finished(2, 1, 0, 0))
+            super::render(&run_finished(2, 1, 0, 0))
                 .unwrap()
                 .starts_with("2 passed, 1 failed (0.9s)")
         );
         assert!(
-            render_multi(&run_finished(2, 1, 1, 1))
+            super::render(&run_finished(2, 1, 1, 1))
                 .unwrap()
                 .starts_with("2 passed, 1 failed, 1 timed out, 1 crashed (0.9s)")
         );
@@ -567,16 +584,14 @@ mod tests {
 
     /// Where an orphan is possible, the runner cannot detect one without an
     /// inventory and says so, rather than leaving silence to be read as "none
-    /// found".
+    /// found". It says so as a notice, so stdout carries the summary alone.
     #[test]
     fn a_multi_module_run_without_a_candidate_inventory_says_so() {
-        let rendered = render_multi(&no_inventory()).expect("a summary renders");
-        assert!(rendered.contains("0 passed (0.1s)"), "{rendered}");
-        assert!(
-            rendered.contains(
-                "note: no --test-candidates inventory; unimported test files are not detected"
-            ),
-            "{rendered}"
+        let rendered = super::render(&no_inventory()).expect("a summary renders");
+        assert_eq!(rendered, "0 passed (0.1s)");
+        assert_eq!(
+            notice_multi(&no_inventory()),
+            Some("note: no --test-candidates inventory; unimported test files are not detected")
         );
     }
 
@@ -586,22 +601,34 @@ mod tests {
     /// line. The event's `test_candidates` is unchanged.
     #[test]
     fn a_single_module_run_is_owed_no_note_about_candidates() {
-        let rendered = super::render(
-            &no_inventory(),
-            Context {
-                multi_module_closure: false,
-            },
-        )
-        .expect("a summary renders");
+        let context = Context {
+            multi_module_closure: false,
+        };
+        let rendered = super::render(&no_inventory()).expect("a summary renders");
         assert_eq!(rendered, "0 passed (0.1s)");
+        assert_eq!(super::notice(&no_inventory(), context), None);
+    }
+
+    /// Only a run's terminal event can be owed a notice, so nothing repeats it
+    /// per test.
+    #[test]
+    fn no_event_but_the_run_summary_carries_a_notice() {
+        assert_eq!(notice_multi(&finished(Verdict::Pass, None)), None);
+        assert_eq!(
+            notice_multi(&Event::TestStarted {
+                id: "app/t.rue::parses a port".to_owned(),
+            }),
+            None
+        );
     }
 
     /// The runner already warns about these on stderr, in both formats. The
     /// human renderer writes to stdout, so repeating them here would show a
     /// person two copies of one warning on a terminal that joins the streams.
+    /// A run that supplied an inventory is owed no notice either: it did look.
     #[test]
     fn orphaned_test_files_are_left_to_the_stderr_warning() {
-        let rendered = render_multi(&Event::RunFinished {
+        let event = Event::RunFinished {
             passed: 1,
             failed: 0,
             timeout: 0,
@@ -620,22 +647,19 @@ mod tests {
                 },
             ]),
             test_candidates: CandidateSource::Declared,
-        })
-        .expect("a summary renders");
+        };
+        let rendered = super::render(&event).expect("a summary renders");
         assert_eq!(rendered, "1 passed (0.0s)");
         assert!(!rendered.contains("warning:"), "{rendered}");
         assert!(!rendered.contains("app/orphan.rue"), "{rendered}");
         assert!(!rendered.contains("could not be parsed"), "{rendered}");
-        assert!(
-            !rendered.contains("note: no --test-candidates"),
-            "{rendered}"
-        );
+        assert_eq!(notice_multi(&event), None);
     }
 
     #[test]
     fn a_listing_entry_renders_as_its_bare_identity() {
         assert_eq!(
-            render_multi(&Event::Test {
+            super::render(&Event::Test {
                 id: "app/t.rue::ok".to_owned(),
                 module: "app/t.rue".to_owned(),
                 name: "ok".to_owned(),

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -26,10 +26,13 @@ for an ordinary build of the same closure.
   events are rendered as text on stdout instead.
 - **stderr is the compiler's surface**, byte-for-byte as
   [diagnostics.md](diagnostics.md) pins it, plus the runner's own warnings
-  (unimported test files) and its one-line reason for a nonzero exit. Those
-  warnings are stderr's alone, once, in both formats: the human renderer does
-  not repeat them on stdout, where a terminal joining the streams would show
-  two copies of one warning.
+  (unimported test files) and notices (the missing-inventory note), and its
+  one-line reason for a nonzero exit. Those are stderr's alone, once: the human
+  renderer does not repeat them on stdout, where a terminal joining the streams
+  would show two copies of one line. The warnings are written in both formats;
+  the missing-inventory note is presentation and so is written in the human
+  format only, because `--format json` publishes the same fact as
+  `run_finished.test_candidates`.
 - **No event is emitted before the test image exists.** A compile failure is
   diagnostics on stderr, an empty event stream, and exit `2` — never a
   `run_started` for a run that never began.
@@ -105,11 +108,17 @@ put in the open field. `payload` is the open, versioned extension point §5.1
 reserves for
 an assertion library with something structured to say in one string.
 `left`/`right` is the shape a **comparison** assertion writes: they are the two
-operands in the order the source spelled them, so `@assert_eq(want, got)` reads
-the way it is written — each rendered by the compiler-synthesized structural
-printer under the same rules and the same 4 KiB bound the test-body `?` payload
-uses. An empty rendering is a value and stays present as an empty string; a
-comparison is recognized by the fields' presence, not by parsing `kind`.
+operands in the order the source spelled them and are never reordered or
+labelled by role, so `@assert_eq(got, want)` reads the way it is written — each
+rendered by the compiler-synthesized structural printer under the same rules and
+the same 4 KiB bound the test-body `?` payload uses. The runner has no notion of
+which operand is expected and which observed. The conventional spelling puts the
+observed value first, as Go's `got, want` idiom and this repository's own tests
+do; the human rendering prints `left:` above `right:` with the caret under
+`right`, so that spelling shows the wanted value beneath the observed one at the
+first differing column. An empty rendering is a value and stays present as an
+empty string; a comparison is recognized by the fields' presence, not by parsing
+`kind`.
 
 `@assert_eq` and `@assert_ne` are the producers of that pair in this version,
 through the `__rue_test_fail_comparison` helper
@@ -265,9 +274,10 @@ kind `exit` and a `runner_note` (see Precedence below). There is no second
 encoding tag on these fields, unlike a capture record's.
 
 Under `--format human` the same values are printed as `left:` and `right:`
-lines. A single-line pair gets a caret under the first differing character; a
-multi-line pair gets a `-`/`+` hunk listing instead, because a caret into a wall
-of text locates nothing.
+lines, in source order — the labels name the operand positions, not roles. A
+single-line pair gets a caret under the first differing character; a multi-line
+pair gets a `-`/`+` hunk listing instead, because a caret into a wall of text
+locates nothing.
 
 #### Capture records
 
@@ -314,15 +324,16 @@ second retention limit.
 Each `unimported_test_files` entry is `{"path": string, "tests": integer,
 "parse_failed": boolean}`. `parse_failed` means the candidate could not be read
 or parsed, so `tests` counts nothing and the honest answer is that the count is
-unknown. Without `--test-candidates`, the human summary appends
-`note: no --test-candidates inventory; unimported test files are not detected` —
-silence would be read as "none found" — but only when the compiled closure holds
-more than one user module (the standard library does not count). A closure of
-one has no second module that could have failed to import a test file, so the
-note would answer a question that run cannot raise; it was noise under every
-filtered rerun pasted from a `repro:` line. The condition is presentation only:
-`test_candidates` still answers `"none"` for such a run, and no event carries the
-closure size.
+unknown. Without `--test-candidates`, a human-format run writes
+`note: no --test-candidates inventory; unimported test files are not detected`
+to stderr after the summary line — silence would be read as "none found" — but
+only when the compiled closure holds more than one user module (the standard
+library does not count). A closure of one has no second module that could have
+failed to import a test file, so the note would answer a question that run
+cannot raise; it was noise under every filtered rerun pasted from a `repro:`
+line. Both conditions are presentation only: `test_candidates` still answers
+`"none"` for such a run, no event carries the closure size, and stdout carries
+the summary alone (RUE-2021).
 
 The inventory file is one path per line, each relative to the ROOT MODULE'S
 DIRECTORY — the compiler's project root — and its build-side producer is the


### PR DESCRIPTION
Fixes RUE-2021

Two papercuts from the std-suite run (items 1 and 4 of the issue).

**The missing-inventory notice moves to stderr.** The human renderer appended `note: no --test-candidates inventory; unimported test files are not detected` to stdout after the summary, contradicting `docs/process/test-events.md` and making `rue test ... 2>/dev/null | tail -1` print the note instead of the summary. `render()` now produces run data only; a new `render::notice` decides whether a `run_finished` owes the note (RUE-1959's single-module suppression unchanged), and `Reporter::emit` writes it to stderr after flushing the summary, human format only. JSON stdout stays pure events and its stderr stays empty. CLI cases in `rue_test.toml` pin both streams in both formats, and the multi-module case would fail on trunk on both assertions.

**Operand-order prose.** The doc's example was `@assert_eq(want, got)`. Operands are reported in source order with no role; the conventional spelling is observed-first, as Go's `got, want` idiom and this repository's own tests do (565 `@assert_eq` calls in `tests/` and `std/`, none with a literal first), and the caret under `right` then shows the wanted value beneath the observed one. Spec §4.13:5f's neutral `left`/`right` naming is untouched.

Not touched: item 2 (exit code for a root inside the std tree) is covered by RUE-2025; item 3 was split out as RUE-2024.

Verified: `test_mode` unit tests 88/88, `scripts/rue cli rue_test` 69/69, `scripts/rue quick` green, clippy and rustfmt clean. Adversarially reviewed; all findings applied.
