### PR TITLE
RUE-1948: explain the bit reinterpretation diagnostic

### DIFF
--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -732,6 +732,18 @@ compile_stdout_contains = ["E0802: Chained comparison", "Chain two comparisons:"
 compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
+# The bit-reinterpretation tranche covers the sole active code in E0950-E0959:
+# the same-width requirement of `@bitCast`. Invalid source pins the invocation
+# as a non-compiling metadata path.
+[[case]]
+name = "bit_cast_width_mismatch_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0950"]
+compile_only = true
+compile_stdout_contains = ["E0950: Bit cast width mismatch", "Reinterpret across a width change:", "Reinterpret at the same width:", "docs/spec/src/04-expressions/13-intrinsics.md (spec rule 4.13:120)", "docs/spec/src/04-expressions/13-intrinsics.md (spec rule 4.13:121)", "docs/spec/src/04-expressions/13-intrinsics.md (spec rule 4.13:26)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
 [[case]]
 name = "malformed_code_is_rejected"
 files = [{ path = "main.rue", source = "fn main() {}\n" }]

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -112,9 +112,9 @@ rue_rust_test(
 # consumer verifies the bounded documented lexer, parser, semantic-foundation,
 # struct-foundation, method/item, enum/place, place/borrow, and
 # const/item/ownership, single-file destructor/const, slice/string/container,
-# match, single-file intrinsic/inference/ownership/alignment, and
-# literal/operator tranches through the real one-shot compiler path without
-# copying the examples into a second fixture. Multi-file E0460 and
+# match, single-file intrinsic/inference/ownership/alignment, literal/operator,
+# and bit-reinterpretation tranches through the real one-shot compiler path
+# without copying the examples into a second fixture. Multi-file E0460 and
 # import/module examples are validated by compiler unit tests.
 rue_rust_test(
     name = "error-explanation-examples-test",

--- a/crates/rue-compiler/tests/error_explanation_examples.rs
+++ b/crates/rue-compiler/tests/error_explanation_examples.rs
@@ -25,6 +25,7 @@ fn compiler_owned_explanation_examples_have_the_declared_outcome() {
                     | 700..=702
                     | 709..=712
                     | 800..=802
+                    | 950
             )
     }) {
         let explanation = error_code_explanation(metadata.code)

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1929,7 +1929,19 @@ define_error_codes! {
     /// (RUE-952, spec 4.13:120). A bit reinterpretation renames the bits it is
     /// given; it neither invents nor discards any, so the source and target
     /// **must** share a width. The value-changing conversion is `@intCast`.
-    BIT_CAST_WIDTH_MISMATCH = 950;
+    BIT_CAST_WIDTH_MISMATCH = 950 => {
+        explanation: "`@bitCast` reinterprets an integer value's bits at another integer type of the same width. It is the bit-preserving counterpart to `@intCast`: `@bitCast` keeps the representation and lets the number change, while `@intCast` keeps the number and rejects the values the target cannot represent. A reinterpretation neither invents nor discards bits, so it is defined only between the same-width pairs — `i8`/`u8`, `i16`/`u16`, `i32`/`u32`, and `i64`/`u64` — in either direction, and between an integer type and itself. E0950 reports a width disagreement specifically: a target type that cannot be inferred reports E0709 instead, and a non-integer argument or target reports E0702.",
+        likely_cause: "The target type — taken from the surrounding annotation, parameter, or return position exactly as `@intCast`'s is — is narrower or wider than the argument's type, as in `let narrow: u32 = @bitCast(wide);` for a `u64` source. Reinterpret at the same-width partner of the argument's type when only a signedness change was intended, or use `@intCast` when the width change was intended.",
+        examples: [
+            ErrorCodeExample { title: "Reinterpret across a width change", source: "fn main() -> i32 {\n    let wide: u64 = 1;\n    let narrow: u32 = @bitCast(wide);\n    0\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Reinterpret at the same width", source: "fn main() -> i32 {\n    let bits: u32 = 1;\n    let signed: i32 = @bitCast(bits);\n    signed\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [
+            ErrorCodeReference { title: "Bit reinterpretation legality", path: "docs/spec/src/04-expressions/13-intrinsics.md", rule: Some("4.13:120") },
+            ErrorCodeReference { title: "Bit reinterpretation semantics", path: "docs/spec/src/04-expressions/13-intrinsics.md", rule: Some("4.13:121") },
+            ErrorCodeReference { title: "Context-inferred cast targets", path: "docs/spec/src/04-expressions/13-intrinsics.md", rule: Some("4.13:26") },
+        ],
+    };
 
     // ========================================================================
     // Linker/target errors (E1000-E1099)
@@ -4565,6 +4577,34 @@ mod tests {
             .iter()
             .filter_map(|declaration| {
                 (800..=802)
+                    .contains(&declaration.code.0)
+                    .then_some(declaration.code)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(explained, expected);
+        assert!(
+            expected
+                .into_iter()
+                .all(|code| error_code_explanation(code).is_some())
+        );
+    }
+
+    #[test]
+    fn active_bit_reinterpretation_explanation_band_is_complete_and_bounded() {
+        let expected = [ErrorCode::BIT_CAST_WIDTH_MISMATCH];
+        let active = error_code_metadata()
+            .iter()
+            .filter(|metadata| (950..=959).contains(&metadata.code.0))
+            .map(|metadata| {
+                assert_eq!(metadata.source_path, "crates/rue-error/src/lib.rs");
+                metadata.code
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(active, expected);
+        let explained = ERROR_CODE_EXPLANATION_DECLARATIONS
+            .iter()
+            .filter_map(|declaration| {
+                (950..=959)
                     .contains(&declaration.code.0)
                     .then_some(declaration.code)
             })


### PR DESCRIPTION
Fixes RUE-1948

## Summary

Adds the canonical compiler-owned explanation for E0950 `BIT_CAST_WIDTH_MISMATCH`, the only active code in the E0950–E0959 band. The prose states what the compiler actually does today: a width disagreement is E0950, an uninferable target is E0709, and a non-integer operand is E0702. (The spec paragraph 4.13:120 attributes all three to E0950; that drift is filed separately as RUE-2041 and is not changed here.)

- `crates/rue-error/src/lib.rs`: the explanation plus an exact active-set guard test for the whole 950..=959 band.
- `crates/rue-compiler/tests/error_explanation_examples.rs`: the examples run through the real one-shot compiler and must emit exactly E0950 or compile cleanly.
- `crates/rue-cli-tests/cases/cli_explain.toml`: a `rue explain E0950` case.
- `crates/rue-compiler/BUCK`: comment refresh only.

No language or conversion semantics, code numbers, names, summaries, spans, ordering, or JSON output change.

## Verification

- `scripts/rue fmt`
- `//crates/rue-error:rue-error-test`, `rue-error-clippy`, `rue-error-fmt-check`
- `//crates/rue-compiler:error-explanation-examples-test`
- `scripts/rue cli explain` (77 passed)
- `scripts/rue spec 4.13` (223 passed)
- `//crates/rue-spec:error-pages` generator ran clean, validating every reference path and rule id.
- `scripts/rue quick` (35 targets, 0 failures)