### PR TITLE
RUE-1980: collapse three duplicate rue-compiler helpers

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -389,11 +389,11 @@ fn accessor_postorder<K: Clone + Ord>(
 }
 
 pub(crate) fn accessor_source_name(identity: &crate::FunctionInstanceKey) -> String {
-    match identity {
+    match crate::semantic_identity::function_specialization_base(identity) {
         crate::FunctionInstanceKey::Definition(definition) => definition.name().to_owned(),
-        crate::FunctionInstanceKey::Specialization { base, .. } => accessor_source_name(base),
         crate::FunctionInstanceKey::AnonymousMember { member, .. } => member.name.to_string(),
-        crate::FunctionInstanceKey::DropGlue(_)
+        crate::FunctionInstanceKey::Specialization { .. }
+        | crate::FunctionInstanceKey::DropGlue(_)
         | crate::FunctionInstanceKey::ErrorPrinter(_)
         | crate::FunctionInstanceKey::TestDispatcher => "<accessor>".to_owned(),
     }
@@ -3395,20 +3395,8 @@ fn phase3_size_eligible(value_count: usize) -> bool {
 }
 
 fn is_true_free_function(function: &crate::FunctionInstanceKey) -> bool {
-    let definition = match function {
-        crate::FunctionInstanceKey::Definition(definition) => definition,
-        crate::FunctionInstanceKey::Specialization { base, .. } => {
-            let crate::FunctionInstanceKey::Definition(definition) = base.as_ref() else {
-                return false;
-            };
-            definition
-        }
-        crate::FunctionInstanceKey::AnonymousMember { .. }
-        | crate::FunctionInstanceKey::DropGlue(_)
-        | crate::FunctionInstanceKey::ErrorPrinter(_)
-        | crate::FunctionInstanceKey::TestDispatcher => return false,
-    };
-    definition.kind() == crate::StableDefinitionKind::Function
+    crate::semantic_identity::function_base_definition(function)
+        .is_some_and(|definition| definition.kind() == crate::StableDefinitionKind::Function)
 }
 
 /// Return every node in a cyclic strongly-connected component. Duplicate

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -309,14 +309,8 @@ fn live_primitive(ty: &CanonicalType) -> Option<Type> {
 }
 
 fn foreign_callable_symbol(callable: &crate::FunctionInstanceKey) -> Option<String> {
-    match callable {
-        crate::FunctionInstanceKey::Definition(definition) => Some(definition.name().to_owned()),
-        crate::FunctionInstanceKey::Specialization { base, .. } => foreign_callable_symbol(base),
-        crate::FunctionInstanceKey::AnonymousMember { .. }
-        | crate::FunctionInstanceKey::DropGlue(_)
-        | crate::FunctionInstanceKey::ErrorPrinter(_)
-        | crate::FunctionInstanceKey::TestDispatcher => None,
-    }
+    crate::semantic_identity::function_base_definition(callable)
+        .map(|definition| definition.name().to_owned())
 }
 
 fn canonical_type_instance(ty: &CanonicalType) -> Option<crate::TypeInstanceKey> {

--- a/crates/rue-compiler/src/durable_comptime/projection.rs
+++ b/crates/rue-compiler/src/durable_comptime/projection.rs
@@ -205,14 +205,7 @@ fn durable_type_diagnostic_name_kernel(ty: &DurableType) -> String {
     use crate::durable_semantics::DurableType as T;
 
     fn function_name(function: &crate::FunctionInstanceKey) -> Option<&str> {
-        match function {
-            crate::FunctionInstanceKey::Definition(key) => Some(key.name()),
-            crate::FunctionInstanceKey::Specialization { base, .. } => function_name(base),
-            crate::FunctionInstanceKey::AnonymousMember { .. }
-            | crate::FunctionInstanceKey::DropGlue(_)
-            | crate::FunctionInstanceKey::ErrorPrinter(_)
-            | crate::FunctionInstanceKey::TestDispatcher => None,
-        }
+        crate::semantic_identity::function_base_definition(function).map(|key| key.name())
     }
 
     match ty {
@@ -305,31 +298,7 @@ pub(crate) fn durable_type_diagnostic_name_with_parameters(
     let crate::StableProducerId::Function(function) = &identity.producer else {
         return durable_type_diagnostic_name(ty);
     };
-    let definition = match function.as_ref() {
-        crate::FunctionInstanceKey::Definition(definition) => Some(definition),
-        crate::FunctionInstanceKey::Specialization { base, .. } => {
-            fn base_definition(
-                function: &crate::FunctionInstanceKey,
-            ) -> Option<&crate::StableDefinitionKey> {
-                match function {
-                    crate::FunctionInstanceKey::Definition(definition) => Some(definition),
-                    crate::FunctionInstanceKey::Specialization { base, .. } => {
-                        base_definition(base)
-                    }
-                    crate::FunctionInstanceKey::AnonymousMember { .. }
-                    | crate::FunctionInstanceKey::DropGlue(_)
-                    | crate::FunctionInstanceKey::ErrorPrinter(_)
-                    | crate::FunctionInstanceKey::TestDispatcher => None,
-                }
-            }
-            base_definition(base)
-        }
-        crate::FunctionInstanceKey::AnonymousMember { .. }
-        | crate::FunctionInstanceKey::DropGlue(_)
-        | crate::FunctionInstanceKey::ErrorPrinter(_)
-        | crate::FunctionInstanceKey::TestDispatcher => None,
-    };
-    let Some(definition) = definition else {
+    let Some(definition) = crate::semantic_identity::function_base_definition(function) else {
         return durable_type_diagnostic_name(ty);
     };
     let parameters = parameters

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -78,15 +78,7 @@ fn map_linker_control(err: rue_linker::LinkError) -> crate::session::PipelineReq
 }
 
 fn uncancellable<T>(result: CancellableLinkResult<T>, context: &str) -> MultiErrorResult<T> {
-    result.map_err(|control| match control {
-        crate::session::PipelineRequestControl::Compile(errors) => errors,
-        crate::session::PipelineRequestControl::Abort(abort) => {
-            crate::session::pipeline_abort_errors(context, abort)
-        }
-        crate::session::PipelineRequestControl::Parked(park) => {
-            crate::session::unresolved_toolchain_park_errors(&park)
-        }
-    })
+    result.map_err(|control| crate::session::pipeline_control_errors(context, control))
 }
 
 fn clone_warnings_with_cancellation(
@@ -1289,7 +1281,13 @@ fn validate_parsed_runtime_archive(
     Ok(archive)
 }
 
-#[allow(dead_code)] // retained for byte-container linker callers and focused tests
+/// Link an already-materialized set of object byte containers.
+///
+/// Production linking runs from retained codegen units through
+/// `link_internal_structured_units_with_warnings_and_cancellation`; this entry
+/// exists for the focused image test that asserts a byte-container link and a
+/// structured link agree, so it is compiled only for tests.
+#[cfg(test)]
 pub(crate) fn link_internal_with_warnings(
     options: &CompileOptions,
     object_files: &[Vec<u8>],
@@ -1316,6 +1314,7 @@ pub(crate) fn link_internal_with_warnings(
     finish_internal_link(linker, options, object_files.len(), warnings)
 }
 
+#[cfg(test)]
 fn finish_internal_link(
     linker: Linker,
     options: &CompileOptions,

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -754,11 +754,10 @@ pub(crate) type LocalSemanticMaterialization =
     rue_air::SemanticLocalMaterialization<StableDefinitionKey, ModuleId>;
 
 fn callable_kind_for_identity(identity: &FunctionInstanceKey) -> rue_air::AnalyzedCallableKind {
-    match identity {
+    match crate::semantic_identity::function_specialization_base(identity) {
         FunctionInstanceKey::Definition(key) if key.kind() == StableDefinitionKind::Destructor => {
             rue_air::AnalyzedCallableKind::Destructor
         }
-        FunctionInstanceKey::Specialization { base, .. } => callable_kind_for_identity(base),
         FunctionInstanceKey::AnonymousMember { member, .. }
             if member.kind == crate::AnonymousMemberKind::Destructor =>
         {

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -103,15 +103,7 @@ fn cancellable_sort_by<T>(
 
 #[cfg_attr(not(test), allow(dead_code))]
 fn uncancellable<T>(result: CancellableImageResult<T>, context: &str) -> MultiErrorResult<T> {
-    result.map_err(|control| match control {
-        crate::session::PipelineRequestControl::Compile(errors) => errors,
-        crate::session::PipelineRequestControl::Abort(abort) => {
-            crate::session::pipeline_abort_errors(context, abort)
-        }
-        crate::session::PipelineRequestControl::Parked(park) => {
-            crate::session::unresolved_toolchain_park_errors(&park)
-        }
-    })
+    result.map_err(|control| crate::session::pipeline_control_errors(context, control))
 }
 
 /// Stable, link-relevant identity for one reached codegen terminal.

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -294,33 +294,25 @@ fn require_published_snapshot_membership(
         })
 }
 
+/// Run the canonical pipeline for a caller that cannot cancel it.
+///
+/// The cancellable entry point below owns the whole sequence — membership
+/// preflight, linker-mode dispatch, and finalization — so this hands it a
+/// never-canceled token and renders the control answer as errors. A preflight
+/// or ordering rule therefore exists once, in the one place both entry points
+/// run through.
 pub(crate) fn compile_with_session(
     session: &mut CompilerSession,
     snapshot: &SourceSnapshot,
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
-    let _span = info_span!("compile_pipeline").entered();
-    require_published_snapshot_membership(session, snapshot)?;
-    let rooted = if matches!(options.linker, LinkerMode::Internal) {
-        session
-            .rooted_codegen_internal_with_cancellation(
-                options,
-                rue_codegen::BackendArtifactRequest::default(),
-                rue_query::CancellationToken::new(),
-            )
-            .map_err(|control| match control {
-                crate::session::PipelineRequestControl::Compile(errors) => errors,
-                crate::session::PipelineRequestControl::Abort(abort) => {
-                    crate::session::pipeline_abort_errors("internal codegen", abort)
-                }
-                crate::session::PipelineRequestControl::Parked(park) => {
-                    crate::session::unresolved_toolchain_park_errors(&park)
-                }
-            })?
-    } else {
-        session.rooted_codegen(options, rue_codegen::BackendArtifactRequest::default())?
-    };
-    compile_rooted_with_session(session, snapshot, options, rooted)
+    compile_with_session_with_cancellation(
+        session,
+        snapshot,
+        options,
+        rue_query::CancellationToken::new(),
+    )
+    .map_err(|control| crate::session::pipeline_control_errors("compile pipeline", control))
 }
 
 pub(crate) fn compile_with_session_with_cancellation(
@@ -389,15 +381,7 @@ pub(crate) fn compile_rooted_with_session(
         rooted,
         &rue_query::CancellationToken::new(),
     )
-    .map_err(|control| match control {
-        crate::session::PipelineRequestControl::Compile(errors) => errors,
-        crate::session::PipelineRequestControl::Abort(abort) => {
-            crate::session::pipeline_abort_errors("compile finalization", abort)
-        }
-        crate::session::PipelineRequestControl::Parked(park) => {
-            crate::session::unresolved_toolchain_park_errors(&park)
-        }
-    })
+    .map_err(|control| crate::session::pipeline_control_errors("compile finalization", control))
 }
 
 pub(crate) fn compile_rooted_with_session_with_cancellation(

--- a/crates/rue-compiler/src/revisioned_query_database/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/provider.rs
@@ -780,23 +780,12 @@ impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
         &self,
         identity: &rue_air::AnonymousNominalKey<crate::StableDefinitionKey, ModuleId>,
     ) -> Option<ModuleId> {
-        fn function_module(
-            function: &rue_air::FunctionInstanceKey<crate::StableDefinitionKey, ModuleId>,
-        ) -> Option<ModuleId> {
-            match function {
-                rue_air::FunctionInstanceKey::Definition(definition) => {
-                    Some(definition.module().clone())
-                }
-                rue_air::FunctionInstanceKey::Specialization { base, .. } => function_module(base),
-                rue_air::FunctionInstanceKey::AnonymousMember { .. }
-                | rue_air::FunctionInstanceKey::DropGlue(_)
-                | rue_air::FunctionInstanceKey::ErrorPrinter(_)
-                | rue_air::FunctionInstanceKey::TestDispatcher => None,
-            }
-        }
         match &identity.producer {
             rue_air::StableProducerId::Definition(definition) => Some(definition.module().clone()),
-            rue_air::StableProducerId::Function(function) => function_module(function),
+            rue_air::StableProducerId::Function(function) => {
+                crate::semantic_identity::function_base_definition(function)
+                    .map(|definition| definition.module().clone())
+            }
         }
     }
 

--- a/crates/rue-compiler/src/revisioned_query_database/semantic.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/semantic.rs
@@ -315,14 +315,7 @@ pub(super) fn semantic_nucleus_cycle_names(nodes: &[rue_query::NodeIdentity]) ->
 pub(crate) fn function_definition_key(
     function: &crate::FunctionInstanceKey,
 ) -> Option<&StableDefinitionKey> {
-    match function {
-        crate::FunctionInstanceKey::Definition(key) => Some(key),
-        crate::FunctionInstanceKey::Specialization { base, .. } => function_definition_key(base),
-        crate::FunctionInstanceKey::AnonymousMember { .. }
-        | crate::FunctionInstanceKey::DropGlue(_)
-        | crate::FunctionInstanceKey::ErrorPrinter(_)
-        | crate::FunctionInstanceKey::TestDispatcher => None,
-    }
+    crate::semantic_identity::function_base_definition(function)
 }
 
 pub(super) fn producer_body_source_definition_key(
@@ -339,11 +332,8 @@ pub(super) fn producer_body_source_definition_key(
 pub(super) fn function_body_source_definition_key(
     function: &crate::FunctionInstanceKey,
 ) -> Option<&StableDefinitionKey> {
-    match function {
+    match crate::semantic_identity::function_specialization_base(function) {
         crate::FunctionInstanceKey::Definition(key) => Some(key),
-        crate::FunctionInstanceKey::Specialization { base, .. } => {
-            function_body_source_definition_key(base)
-        }
         crate::FunctionInstanceKey::AnonymousMember { owner, .. } => {
             let crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(owner)) =
                 owner.as_ref()
@@ -352,7 +342,8 @@ pub(super) fn function_body_source_definition_key(
             };
             producer_body_source_definition_key(&owner.producer)
         }
-        crate::FunctionInstanceKey::DropGlue(_)
+        crate::FunctionInstanceKey::Specialization { .. }
+        | crate::FunctionInstanceKey::DropGlue(_)
         | crate::FunctionInstanceKey::ErrorPrinter(_)
         | crate::FunctionInstanceKey::TestDispatcher => None,
     }

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -31,6 +31,43 @@ pub type StableCallableId = rue_air::StableCallableId<StableDefinitionKey, Modul
 pub type LocalAtomId = rue_air::LocalAtomId<StableDefinitionKey, ModuleId>;
 pub type StableSymbolId = rue_air::StableSymbolId<StableDefinitionKey, ModuleId>;
 
+/// The identity a chain of specializations is applied to.
+///
+/// A specialization wraps the callable it specializes, so the innermost
+/// non-specialization variant is the callable an instance is an instance of.
+/// Answering that separately from what a caller does with the answer is what
+/// lets the arm lists below stay in one place.
+pub(crate) fn function_specialization_base(function: &FunctionInstanceKey) -> &FunctionInstanceKey {
+    let mut current = function;
+    while let FunctionInstanceKey::Specialization { base, .. } = current {
+        current = base.as_ref();
+    }
+    current
+}
+
+/// The source definition a callable identity is rooted at, or `None` when it
+/// is synthesized and has no definition of its own.
+///
+/// This walk is a property of the variant list, not of any one caller, and it
+/// is spelled once because every independent copy has to be revisited whenever
+/// a variant is added. `ErrorPrinter` and `TestDispatcher`, the two most
+/// recent, each had to be threaded through every copy, and a copy that misses
+/// one does not fail to compile: it answers with a wrong diagnostic name, or
+/// silently drops an unused-function warning or a foreign symbol.
+pub(crate) fn function_base_definition(
+    function: &FunctionInstanceKey,
+) -> Option<&StableDefinitionKey> {
+    match function_specialization_base(function) {
+        FunctionInstanceKey::Definition(definition) => Some(definition),
+        // The walk above never ends on a specialization.
+        FunctionInstanceKey::Specialization { .. }
+        | FunctionInstanceKey::AnonymousMember { .. }
+        | FunctionInstanceKey::DropGlue(_)
+        | FunctionInstanceKey::ErrorPrinter(_)
+        | FunctionInstanceKey::TestDispatcher => None,
+    }
+}
+
 /// The sole machine-symbol encoder for stable semantic identities.
 ///
 /// Fields are encoded with explicit tags and byte lengths. Text bytes are hex

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -356,6 +356,24 @@ impl From<CompileError> for PipelineRequestControl {
     }
 }
 
+/// Render one pipeline control answer on the uncancellable error surface.
+///
+/// Every entry point that cannot be canceled still runs the cancellable
+/// pipeline underneath and has to answer in `CompileErrors` alone. `context`
+/// names the stage the control came from and reaches the reader only through
+/// an internal-error diagnostic; a park and a compile failure carry their own
+/// diagnostics already.
+pub(crate) fn pipeline_control_errors(
+    context: &str,
+    control: PipelineRequestControl,
+) -> CompileErrors {
+    match control {
+        PipelineRequestControl::Compile(errors) => errors,
+        PipelineRequestControl::Abort(abort) => pipeline_abort_errors(context, abort),
+        PipelineRequestControl::Parked(park) => unresolved_toolchain_park_errors(&park),
+    }
+}
+
 pub(crate) fn pipeline_abort_errors(context: &str, abort: rue_query::QueryAbort) -> CompileErrors {
     CompileError::without_span(ErrorKind::InternalError(abort_internal_message(
         context, &abort,

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -2261,13 +2261,12 @@ pub(super) fn stable_function_definition_root(
     value: &crate::FunctionInstanceKey,
 ) -> Option<&crate::StableDefinitionKey> {
     use crate::FunctionInstanceKey as F;
-    match value {
+    match crate::semantic_identity::function_specialization_base(value) {
         F::Definition(value) => Some(value),
-        F::Specialization { base, .. } => stable_function_definition_root(base),
         F::AnonymousMember { owner, .. } | F::DropGlue(owner) | F::ErrorPrinter(owner) => {
             stable_type_definition_root(owner)
         }
-        F::TestDispatcher => None,
+        F::Specialization { .. } | F::TestDispatcher => None,
     }
 }
 
@@ -2324,19 +2323,6 @@ fn rooted_unused_function_warnings(
     graph: &RootedBodyGraph,
     warning_references: &BTreeSet<crate::StableDefinitionKey>,
 ) -> Vec<CompileWarning> {
-    fn source_definition(
-        instance: &crate::FunctionInstanceKey,
-    ) -> Option<&crate::StableDefinitionKey> {
-        match instance {
-            crate::FunctionInstanceKey::Definition(definition) => Some(definition),
-            crate::FunctionInstanceKey::Specialization { base, .. } => source_definition(base),
-            crate::FunctionInstanceKey::AnonymousMember { .. }
-            | crate::FunctionInstanceKey::DropGlue(_)
-            | crate::FunctionInstanceKey::ErrorPrinter(_)
-            | crate::FunctionInstanceKey::TestDispatcher => None,
-        }
-    }
-
     let mut referenced = graph
         .declaration_dependencies
         .iter()
@@ -2360,7 +2346,7 @@ fn rooted_unused_function_warnings(
             .closure
             .reached
             .iter()
-            .filter_map(source_definition)
+            .filter_map(crate::semantic_identity::function_base_definition)
             .cloned(),
     );
     referenced.extend(warning_references.iter().cloned());

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -10,7 +10,6 @@ use rue_air::normalize_module_path;
 use rue_cfg::OptLevel;
 use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeatures};
 use rue_target::Target;
-use sha2::{Digest, Sha256};
 
 use crate::{SourceMetadata, SourceSnapshot};
 
@@ -23,12 +22,11 @@ trait SourceDigester {
 struct Sha256Digester;
 
 impl SourceDigester for Sha256Digester {
+    /// Source identity is one instance of the compiler's domain-separated
+    /// content framing, under its own domain: the shared kernel is the single
+    /// authority on how a domain, a length, and the bytes are laid out.
     fn digest(&self, text: &[u8]) -> [u8; 32] {
-        let mut hasher = Sha256::new();
-        hasher.update(SOURCE_DOMAIN_V1);
-        hasher.update((text.len() as u64).to_le_bytes());
-        hasher.update(text);
-        hasher.finalize().into()
+        crate::content_digest::bytes_digest(SOURCE_DOMAIN_V1, text)
     }
 }
 
@@ -747,6 +745,34 @@ mod tests {
         value.hash(&mut h);
         h.finish()
     }
+
+    /// Pin the persisted source-identity framing to concrete digests.
+    ///
+    /// A `SourceId` is domain-separated SHA-256 over `SOURCE_DOMAIN_V1`, the
+    /// byte length as a little-endian `u64`, and the exact bytes. Every stored
+    /// identity and every module revision derived from one moves if any of
+    /// those three parts changes, and nothing else in the suite would fail, so
+    /// the framing is asserted here as a value rather than as a shape.
+    #[test]
+    fn source_digest_framing_is_pinned() {
+        fn hex(digest: [u8; 32]) -> String {
+            digest.iter().fold(String::new(), |mut text, byte| {
+                use std::fmt::Write as _;
+                write!(text, "{byte:02x}").expect("writing to a String cannot fail");
+                text
+            })
+        }
+
+        assert_eq!(
+            hex(Sha256Digester.digest(b"")),
+            "723317c691cf08d6625541302ba1ef39227c5345aa77ee207cd4bbf546fd8da8"
+        );
+        assert_eq!(
+            hex(Sha256Digester.digest(b"fn main() -> i64 { 0 }\n")),
+            "1fd809626528b30070eecf80925c0b37d85ead959c024e6a731aa8ba89ac3892"
+        );
+    }
+
     #[test]
     fn collisions_do_not_equal_or_replace_text() {
         let a = SourceId::from_shared_text_with(Arc::new("a".into()), &Constant);


### PR DESCRIPTION
Fixes RUE-1980

## Summary

Three low-severity duplicates in `crates/rue-compiler`, collapsed to one owner each. No behavior change.

**Base definition of a `FunctionInstanceKey`.** The "walk through `Specialization` to the innermost variant" match was spelled nine times. It now lives once in `semantic_identity.rs` as `function_specialization_base` and `function_base_definition` (free functions, since the key type is a `rue-air` alias). Sites that also handle `AnonymousMember`, `DropGlue`, or `ErrorPrinter` keep their own arm on top of the shared walk, so each rewrite is arm-for-arm equivalent. Sites that consume specialization arguments as well as the base keep their own match and are listed in the commit message. `function_definition_key` survives as a one-line delegate because the public-API inventory fingerprints that module's crate-visible signatures.

**`compile_with_session` vs its cancellable twin.** The uncancellable entry is now a wrapper over `compile_with_session_with_cancellation` with a fresh token, so the membership preflight, linker-mode dispatch, and finalization exist in one place for batch and watch alike. The `PipelineRequestControl → CompileErrors` match that was copied in four places is one `session::pipeline_control_errors` adapter. The only text consequence is that an internal-error abort on the uncancellable path is now labelled with one stage name instead of three; nothing asserts those strings.

**SHA-256 framing.** `source_identity`'s digester calls `content_digest::bytes_digest` under its own domain. A new test pins the framing to concrete digests that were computed against the previous hand-rolled code (and cross-checked with `hashlib`), so persisted source identities are provably unchanged.

**Dead code.** `link_internal_with_warnings` and its finisher are `#[cfg(test)]`; production links structured units.

## Verification

- `scripts/rue fmt`
- `//crates/rue-compiler:rue-compiler-test` (1215 passed), `rue-compiler-clippy`, `rue-compiler-fmt-check`, `rue-compiler-public-api-test`, `rue-compiler-debug-assert-check`, `rue-compiler-differential-oracle-test`
- `//crates/rue:rue-test`, `rue-clippy`
- `scripts/rue cli watch`, `scripts/rue cli abi`
- `scripts/rue quick` (35 targets, 0 failures)