### PR TITLE
RUE-1974: answer named-method declarations from the declaration index

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -2141,7 +2141,7 @@ where
         // Request-local RIR remains authoritative when the owner declaration
         // is present, preserving parity for bodies materialized from a slice.
         let mut info = self.calls.method_signature_info(&key)?;
-        if let Some(method_ref) = self.rir_struct_method_decl(struct_id, symbol)
+        if let Some(method_ref) = self.named_method_declaration(struct_id, symbol)
             && let InstData::FnDecl {
                 returns_borrow,
                 returns_inout,
@@ -2172,20 +2172,23 @@ where
         Some(info)
     }
 
-    /// Locate a named method's `FnDecl` by walking the request-local RIR's
-    /// struct declarations. The provider's request RIR carries the owning
-    /// `StructDecl` (types are part of every consumer's inputs) even when the
-    /// method's own body query is a different request, so this is the one
-    /// resolution path that can recover declaration-level facts — like the
-    /// `-> borrow T` accessor flag (ADR-0062) — that the durable signature
-    /// subset does not carry.
-    fn rir_struct_method_decl(&self, struct_id: StructId, method: Spur) -> Option<InstRef> {
+    /// The declaration index's key preimage for a named struct owner: the
+    /// `(owner_file, owner_type_name)` half of the key
+    /// `BodyRirIndex::named_method_declaration` takes.
+    ///
+    /// The index owns the fact "which `FnDecl` is `S.m`". Reaching that
+    /// `FnDecl` is what recovers declaration-level facts the durable signature
+    /// subset does not carry — like the `-> borrow T` accessor flag (ADR-0062)
+    /// — from the request RIR, which holds the owning `StructDecl` (types are
+    /// part of every consumer's inputs) even when the method's own body query
+    /// is a different request.
+    ///
+    /// The RIR names structs by their source name, so the declaring file
+    /// qualifies the key and same-named structs in sibling files cannot
+    /// collide. The lookup goes through strings because a distinct semantic
+    /// interner cannot be allowed to skew the Spurs.
+    fn named_method_owner_key(&self, struct_id: StructId) -> Option<(FileId, Spur)> {
         let struct_def = self.type_pool.struct_def(struct_id);
-        // The RIR names structs by their source name; qualify by declaring
-        // file below so same-named structs in sibling files cannot collide.
-        // Translate lookups through strings so a distinct semantic interner
-        // cannot skew the Spurs.
-        let owner_file = struct_def.file_id;
         // A cross-file-unique pool name is `Source$escaped_file`; the RIR
         // declaration carries the bare source name ('$' cannot appear in a
         // source identifier).
@@ -2195,27 +2198,23 @@ where
             .next()
             .expect("split yields at least one segment");
         let owner_sym = self.rir.rir_interner().get(source_name)?;
+        Some((struct_def.file_id, owner_sym))
+    }
+
+    /// The request RIR's `FnDecl` for the named method `S.m`, answered by the
+    /// declaration index so the cost is one map probe regardless of RIR size.
+    /// `None` when the owner or method name is not interned in the RIR or the
+    /// index holds no such method, which is also the answer for anonymous and
+    /// comptime-produced owners that have no `StructDecl`.
+    fn named_method_declaration(&self, struct_id: StructId, method: Spur) -> Option<InstRef> {
+        let (owner_file, owner_sym) = self.named_method_owner_key(struct_id)?;
         let method_sym = self
             .rir
             .rir_interner()
             .get(self.interner.resolve(&method))?;
-        let rir = self.rir.rir();
-        for index in 0..rir.len() {
-            let inst_ref = InstRef::from_raw(index as u32);
-            if let InstData::StructDecl { name, methods, .. } = &rir.get(inst_ref).data
-                && *name == owner_sym
-                && rir.get(inst_ref).span.file_id == owner_file
-            {
-                for method_ref in rir.struct_methods(methods) {
-                    if let InstData::FnDecl { name, .. } = &rir.get(method_ref).data
-                        && *name == method_sym
-                    {
-                        return Some(method_ref);
-                    }
-                }
-            }
-        }
-        None
+        self.rir
+            .rir_index()
+            .named_method_declaration(owner_file, owner_sym, method_sym)
     }
 
     fn named_method_definition(&self, struct_id: StructId, symbol: Spur) -> Option<K> {
@@ -2309,8 +2308,7 @@ where
                 return info;
             }
         }
-        let definition = self.rir_struct_method_decl(struct_id, name);
-        let Some(definition) = definition else {
+        let Some(definition) = self.named_method_declaration(struct_id, name) else {
             return info;
         };
         let trusted = self.endpoint_file_is_trusted_standard_library(


### PR DESCRIPTION
Fixes RUE-1974

## Summary

`ProviderBodyHost` located a named method's `FnDecl` by scanning the whole request RIR for the owning `StructDecl` on every call, beside the indexed `BodyRirIndex::named_method_declaration` that already answers the same fact. The scan was O(RIR) per call and uncached on the trusted-accessor recovery path.

One host method now derives the index's key preimage from the struct's declaring file and bare source name, interned through the RIR interner exactly as before, and probes the index. Both call sites use it and the `StructDecl` walk is gone. Only `crates/rue-air/src/sema/provider_body_host.rs` changes.

Keying equivalence: the index keys by the method `FnDecl`'s `span.file_id`, which is its enclosing struct's file because a named method is lexically inline, so it matches the scan's `StructDecl.span.file_id` predicate; the owner edge exists only for methods listed by a `StructDecl`; and duplicate struct or method names in one file are rejected (E0418) before either path is consulted. `None` cases are preserved: uninterned owner or method name, no such entry, and anonymous or comptime-produced owners with no `StructDecl`.

## Verification

- `scripts/rue fmt`
- `//crates/rue-air:rue-air-test` (855 passed), `rue-air-clippy`, `rue-air-fmt-check`, `rue-air-debug-assert-check`
- `scripts/rue quick` (35 targets, 0 failures)
- `scripts/rue spec 6.4`, `scripts/rue spec 6.6`
- `scripts/rue ui accessor`, `scripts/rue cli multi`
- `//examples:cli-staged-programs` builds