### PR TITLE
RUE-2041: attribute each @bitCast legality failure to the code the compiler emits

### DIFF
--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -1381,7 +1381,7 @@ error_contains = ["[E0950]", "same width"]
 
 [[case]]
 name = "bitcast_target_not_inferred"
-spec = ["4.13:120"]
+spec = ["4.13:27", "4.13:120"]
 source = """
 fn main() -> i32 {
     let x: u32 = 100;
@@ -1390,7 +1390,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "cannot infer the target type of '@bitCast'"
+error_contains = ["[E0709]", "cannot infer the target type of '@bitCast'"]
 
 [[case]]
 name = "bitcast_non_integer_target_rejected"
@@ -1403,11 +1403,11 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "integer"
+error_contains = ["[E0702]", "'@bitCast' expects integer"]
 
 [[case]]
 name = "bitcast_non_integer_argument_rejected"
-spec = ["4.13:119"]
+spec = ["4.13:119", "4.13:120"]
 source = """
 fn main() -> i32 {
     let x: bool = true;
@@ -1416,7 +1416,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "integer"
+error_contains = ["[E0702]", "'@bitCast' expects integer"]
 
 [[case]]
 name = "bitcast_wrong_arg_count"

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -520,12 +520,16 @@ target type is (4.13:26).
 
 {{ rule(id="4.13:120", cat="legality-rule") }}
 
-It is a compile-time error if the target type cannot be inferred, is not an
-integer type, or is an integer type whose width differs from the argument's
-width (E0950). A reinterpretation neither invents nor discards bits, so it is
-defined only between the same-width pairs — `i8`/`u8`, `i16`/`u16`,
-`i32`/`u32`, and `i64`/`u64` — in either direction, and between an integer type
-and itself. Converting between widths is `@intCast`'s job.
+It is a compile-time error if the target type cannot be inferred, if the
+argument's type or the target type is not an integer type, or if the two are
+integer types of differing widths. A reinterpretation neither invents nor
+discards bits, so it is defined only between the same-width pairs —
+`i8`/`u8`, `i16`/`u16`, `i32`/`u32`, and `i64`/`u64` — in either direction, and
+between an integer type and itself. Converting between widths is `@intCast`'s
+job. Each of those failures is reported under its own code: an uninferable
+target is the uninferred cast target of 4.13:27 (E0709), a non-integer argument
+or target is an ordinary type mismatch (E0702), and a width disagreement
+between two integer types is E0950.
 
 {{ rule(id="4.13:121", cat="dynamic-semantics") }}
 


### PR DESCRIPTION
Spec rule `4.13:120` attributed all three `@bitCast` legality failures to E0950. The compiler answers each differently, verified by running the built compiler:

- width disagreement between two integer types → E0950 `BIT_CAST_WIDTH_MISMATCH`
- uninferable target → E0709 `CANNOT_INFER_CAST_TARGET` (rule 4.13:27)
- non-integer argument or target → E0702 type mismatch

The E0950 canonical explanation already states the compiler's behavior; the spec paragraph was the inaccurate side. This rewords `4.13:120` (ID unchanged) so each failure names its own code, and tightens the three non-width spec cases in `crates/rue-spec/cases/expressions/intrinsics.toml` to assert the code the text now names, with `bitcast_target_not_inferred` also citing 4.13:27. No compiler change.

Verified: `scripts/rue spec 4.13` (223 passed), `scripts/rue cli explain` (77 passed), `//:spec-traceability`, `//:compiler-spec-machine-index`, `scripts/validate-doc-links.py`, `//crates/rue-oracle-diff:oracle-diff-test`.

Fixes RUE-2041

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRFiTXZ1kLd7DspSvraq53)_