### PR TITLE
Name every calling convention with one target-keyed type

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -13,10 +13,12 @@
 //! contract consult *one* place instead of each rediscovering
 //! `slot_count > budget`.
 //!
-//! [`CallAbi`] is the extensibility seam ADR-0052 requires. The preserved native
-//! Rue convention is the first and only implementation; the guaranteed target C
-//! ABI (RUE-742 / RUE-745, SysV / AAPCS) will add further variants to this
-//! authority rather than embedding a peer FFI calculator inside a backend.
+//! Which convention governs a boundary is named by exactly one value type,
+//! [`rue_target::CallingConvention`], whose rows are the native Rue convention
+//! and the concrete platform psABIs. This module is the classifier that reads
+//! those rows: [`NativeAbiTypeFacts`] answers the native decision tree, and
+//! [`TargetCCallAbi`] answers the psABI thresholds and extensions for whichever
+//! C row a target's `"C"` alias resolves to.
 //!
 //! ## Two planes, one policy kernel
 //!
@@ -28,8 +30,8 @@
 //! kernel — [`NativeAbiTypeFacts`] for the native decision tree,
 //! [`TargetCCallAbi`] plus [`CAbiScalarKind`] for the target-C thresholds and
 //! extensions, [`native_return_register_budget`] and
-//! [`TargetCAbiFlavor::for_arch`] for the per-target numbers — so the
-//! classification policy itself has exactly one production home.
+//! [`rue_target::CallingConvention::c_for_target`] for the per-target numbers —
+//! so the classification policy itself has exactly one production home.
 //!
 //! ## Memory-first transitional rule (ADR-0052 ratified ruling 9)
 //!
@@ -45,7 +47,7 @@
 //! historical register classification byte-for-byte.
 
 use crate::{FrozenTypeInternPool, Type, TypeKind};
-use rue_target::Arch;
+use rue_target::{Arch, CallingConvention, StackedArgumentPacking};
 
 /// The native return-register budget for a target architecture: how many
 /// flattened eight-byte slots an aggregate return may occupy before it must
@@ -155,27 +157,6 @@ impl NativeAbiTypeFacts {
     }
 }
 
-/// Which calling convention governs a boundary.
-///
-/// The seam ADR-0052 requires so the guaranteed target-C classifier extends this
-/// authority instead of adding a peer path. ADR-0064 P2 (RUE-1056) fills the
-/// second variant with [`TargetCCallAbi`] for scalars and pointers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CallAbi {
-    /// The preserved native Rue convention (RUE-106): a by-value aggregate is
-    /// returned one flattened ABI slot per return register, or via sret when it
-    /// does not fit; canonical `StrBuf` always returns via sret; a by-reference
-    /// `inout` / `borrow` argument is one pointer slot; a by-value argument
-    /// occupies one slot per leaf.
-    Native,
-    /// The guaranteed target-C convention (ADR-0064): SysV AMD64 or AAPCS64 per
-    /// the target flavor. In P2 it governs scalar and pointer crossings at an
-    /// `extern "C"` boundary — one integer register per scalar, with the psABI's
-    /// narrow-integer extension and the 1-byte `_Bool` 0/1 contract. See
-    /// [`TargetCCallAbi`].
-    TargetC(TargetCAbiFlavor),
-}
-
 /// How a by-value return value crosses the call boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReturnClass {
@@ -260,7 +241,7 @@ impl ArgClass {
     }
 }
 
-/// The native call-ABI classifier: the [`CallAbi::Native`] implementation.
+/// The native call-ABI classifier: the [`CallingConvention::Rue`] implementation.
 ///
 /// Consumes the canonical slot decomposition and the target's return-register
 /// budget. Argument register partitioning is a downstream concern of the
@@ -300,8 +281,8 @@ impl<'a> NativeCallAbi<'a> {
     }
 
     /// The convention this classifier implements.
-    pub const fn abi(&self) -> CallAbi {
-        CallAbi::Native
+    pub const fn abi(&self) -> CallingConvention {
+        CallingConvention::Rue
     }
 
     /// Project the kernel facts for `ty` from the live type pool. This is the
@@ -432,32 +413,6 @@ pub fn is_slot_identical_layout<P: crate::FfiTypePool + ?Sized>(type_pool: &P, t
 // The guaranteed target-C classifier (ADR-0064 P2, RUE-1056)
 // ============================================================================
 
-/// Which platform psABI a [`CallAbi::TargetC`] boundary follows. The flavor is
-/// selected from the compilation target's architecture: x86-64 uses SysV AMD64,
-/// AArch64 uses AAPCS64. The two agree on the scalar operations P2 needs (one
-/// integer register per scalar, narrow values extended to their canonical form),
-/// and differ only in the details documented on the flavor's methods — details
-/// P3/P4 will exercise (byval stack area, sret register + echo).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TargetCAbiFlavor {
-    /// System V AMD64 psABI (x86-64 Linux/BSD/macOS).
-    SysVAmd64,
-    /// The ARM 64-bit Procedure Call Standard (AArch64 Linux/macOS).
-    Aapcs64,
-}
-
-impl TargetCAbiFlavor {
-    /// The psABI flavor a target architecture's C boundary follows. The single
-    /// home of the architecture-to-flavor mapping, consulted by the export
-    /// thunk, the import call lowering, and the stable query plane.
-    pub const fn for_arch(arch: Arch) -> Self {
-        match arch {
-            Arch::X86_64 => Self::SysVAmd64,
-            Arch::Aarch64 => Self::Aapcs64,
-        }
-    }
-}
-
 /// Width-and-signedness class of a target-C-passable scalar: the one fact the
 /// extension policy needs. Each plane projects its own type representation
 /// onto this class, so the sign/zero/`_Bool` extension table itself
@@ -533,6 +488,18 @@ impl ScalarAbiExtension {
     pub const fn is_noop(self) -> bool {
         matches!(self, Self::None)
     }
+
+    /// The scalar's natural C width in bytes: the declared width a narrow value
+    /// is extended *from*, or the full 8-byte register for a register-width
+    /// value. This is the size a stacked argument occupies under a psABI that
+    /// packs the outgoing argument area at natural size
+    /// ([`StackedArgumentPacking::NaturalSize`]).
+    pub const fn natural_bytes(self) -> u32 {
+        match self {
+            Self::None => 8,
+            Self::Signed { from_bits } | Self::Unsigned { from_bits } => from_bits / 8,
+        }
+    }
 }
 
 /// How a C-classifiable aggregate crosses a target-C boundary as an *argument*
@@ -602,21 +569,28 @@ pub enum AggregateReturnClass {
     },
 }
 
-/// The guaranteed target-C call-ABI classifier: the [`CallAbi::TargetC`]
-/// implementation for scalars and pointers (ADR-0064 P2, RUE-1056).
+/// The guaranteed target-C call-ABI classifier: the classifier for one C row of
+/// [`CallingConvention`] (ADR-0064).
 ///
 /// This is the single authority both backends' `extern "C"` call lowering and
-/// the oracle consult, so no backend makes a local target-C ABI decision. In P2
-/// its scope is register-only scalar crossings; P3 extends the same authority
-/// with eightbyte aggregate classification and byval stack arguments, and P5
-/// with the SSE/FP register class once RUE-714 lands floats.
+/// the oracle consult, so no backend makes a local target-C ABI decision. It is
+/// constructed from a convention, and a target reaches it through the one
+/// `"C"` alias table ([`Self::for_target`]) — so the two AArch64 targets, which
+/// share an architecture, get their own rows. The SSE/FP register class joins
+/// this authority once RUE-714 lands floats.
+///
+/// The rows agree on every scalar operation and on aggregate classification;
+/// they differ in the argument-register budget, the sret register and echo, and
+/// — the Apple arm64 amendment — how the outgoing argument area is packed
+/// ([`Self::stacked_argument_packing`]).
 ///
 /// ## What P2 fixes, and why scalars need only the return re-extension
 ///
 /// Every supported scalar (`c_passable_by_value`: the full integer set, `bool`,
 /// pointers) occupies exactly one general-purpose integer register — the first
 /// six on SysV (`rdi, rsi, rdx, rcx, r8, r9`), the first eight on AAPCS64
-/// (`x0..x7`) — and P2 stays within that budget (no stack arguments). Rue's
+/// (`x0..x7`) — and spills to the outgoing argument area only once that budget
+/// is exhausted. Rue's
 /// internal scalar invariant already keeps a narrow value canonically extended
 /// in its 64-bit vreg (signed values sign-extended, unsigned/`bool`
 /// zero-extended), which is a *stronger* guarantee than either psABI asks of an
@@ -639,6 +613,10 @@ pub enum AggregateReturnClass {
 ///   bits, but bits 32..63 stay unspecified, so re-extending from the value's
 ///   *own* declared width is still correct (bits already agree up to 32). The
 ///   caller therefore applies the same [`ScalarAbiExtension`].
+/// - **Apple arm64.** The *caller* must extend an argument narrower than 32
+///   bits. Rue's canonical 64-bit form already satisfies that, so the import
+///   side needs no extra instruction, and the export thunk re-extends on every
+///   row because the native body needs the stronger 64-bit form regardless.
 ///
 /// ## `_Bool`
 ///
@@ -648,42 +626,64 @@ pub enum AggregateReturnClass {
 /// ([`ScalarAbiExtension::Unsigned`] `{ from_bits: 8 }`).
 #[derive(Debug, Clone, Copy)]
 pub struct TargetCCallAbi {
-    flavor: TargetCAbiFlavor,
+    convention: CallingConvention,
 }
 
 impl TargetCCallAbi {
-    /// Build the classifier for a given psABI flavor.
-    pub const fn new(flavor: TargetCAbiFlavor) -> Self {
-        Self { flavor }
+    /// Build the classifier for one platform C convention.
+    ///
+    /// `convention` must be a C row; [`CallingConvention::Rue`] is the native
+    /// convention and is classified by [`NativeCallAbi`] instead.
+    pub const fn new(convention: CallingConvention) -> Self {
+        assert!(
+            convention.is_c(),
+            "TargetCCallAbi classifies a C boundary; the native Rue convention \
+             is NativeCallAbi's authority"
+        );
+        Self { convention }
     }
 
-    /// The SysV AMD64 classifier (x86-64).
+    /// The classifier for the convention `target`'s `"C"` boundary follows.
+    pub const fn for_target(target: rue_target::Target) -> Self {
+        Self::new(CallingConvention::c_for_target(target))
+    }
+
+    /// The SysV AMD64 classifier (x86-64 Linux).
     pub const fn sysv_amd64() -> Self {
-        Self::new(TargetCAbiFlavor::SysVAmd64)
+        Self::new(CallingConvention::X86_64SysV)
     }
 
-    /// The AAPCS64 classifier (AArch64).
+    /// The AAPCS64 classifier (AArch64 Linux).
     pub const fn aapcs64() -> Self {
-        Self::new(TargetCAbiFlavor::Aapcs64)
+        Self::new(CallingConvention::Aarch64Aapcs)
+    }
+
+    /// The Apple arm64 classifier (AArch64 macOS): AAPCS64 with Apple's
+    /// amendments.
+    pub const fn aapcs64_darwin() -> Self {
+        Self::new(CallingConvention::Aarch64AapcsDarwin)
     }
 
     /// The convention this classifier implements.
-    pub const fn abi(&self) -> CallAbi {
-        CallAbi::TargetC(self.flavor)
+    pub const fn convention(&self) -> CallingConvention {
+        self.convention
     }
 
-    /// The psABI flavor this classifier follows.
-    pub const fn flavor(&self) -> TargetCAbiFlavor {
-        self.flavor
+    /// How this psABI lays a stacked (byval / register-overflow) argument out in
+    /// the outgoing argument area. Every C row answers; the packing rule is the
+    /// convention's, so no backend needs an operating-system test.
+    pub const fn stacked_argument_packing(&self) -> StackedArgumentPacking {
+        self.convention.stacked_argument_packing()
     }
 
     /// The number of general-purpose integer registers used for arguments
     /// before the byval stack area (P3) begins: 6 on SysV (`rdi..r9`), 8 on
     /// AAPCS64 (`x0..x7`). P2 stays within this budget.
     pub const fn int_arg_register_budget(&self) -> u32 {
-        match self.flavor {
-            TargetCAbiFlavor::SysVAmd64 => 6,
-            TargetCAbiFlavor::Aapcs64 => 8,
+        match self.convention {
+            CallingConvention::X86_64SysV => 6,
+            CallingConvention::Aarch64Aapcs | CallingConvention::Aarch64AapcsDarwin => 8,
+            CallingConvention::Rue => unreachable!(),
         }
     }
 
@@ -693,9 +693,10 @@ impl TargetCCallAbi {
     /// echoed. Reachable from P3: an aggregate return >16 bytes takes the sret
     /// path; scalars in P2 never do.
     pub const fn sret_pointer_echoed_in_result_register(&self) -> bool {
-        match self.flavor {
-            TargetCAbiFlavor::SysVAmd64 => true,
-            TargetCAbiFlavor::Aapcs64 => false,
+        match self.convention {
+            CallingConvention::X86_64SysV => true,
+            CallingConvention::Aarch64Aapcs | CallingConvention::Aarch64AapcsDarwin => false,
+            CallingConvention::Rue => unreachable!(),
         }
     }
 
@@ -706,9 +707,10 @@ impl TargetCCallAbi {
     /// passes the sret pointer as the hidden first argument in `rdi`, consuming
     /// the first integer argument register. P3 aggregate returns exercise both.
     pub const fn sret_pointer_in_dedicated_register(&self) -> bool {
-        match self.flavor {
-            TargetCAbiFlavor::SysVAmd64 => false,
-            TargetCAbiFlavor::Aapcs64 => true,
+        match self.convention {
+            CallingConvention::X86_64SysV => false,
+            CallingConvention::Aarch64Aapcs | CallingConvention::Aarch64AapcsDarwin => true,
+            CallingConvention::Rue => unreachable!(),
         }
     }
 
@@ -760,9 +762,12 @@ impl TargetCCallAbi {
         }
         let size = Self::saturate_u32(size);
         let align = Self::saturate_u32(align);
-        match self.flavor {
-            TargetCAbiFlavor::SysVAmd64 => AggregateArgClass::ByValueStack { size, align },
-            TargetCAbiFlavor::Aapcs64 => AggregateArgClass::ByReferenceCopy { size, align },
+        match self.convention {
+            CallingConvention::X86_64SysV => AggregateArgClass::ByValueStack { size, align },
+            CallingConvention::Aarch64Aapcs | CallingConvention::Aarch64AapcsDarwin => {
+                AggregateArgClass::ByReferenceCopy { size, align }
+            }
+            CallingConvention::Rue => unreachable!(),
         }
     }
 
@@ -927,8 +932,8 @@ mod tests {
         // 16-byte call alignment on both.
         assert_eq!(sysv.call_stack_alignment(), 16);
         assert_eq!(aapcs.call_stack_alignment(), 16);
-        assert_eq!(sysv.abi(), CallAbi::TargetC(TargetCAbiFlavor::SysVAmd64));
-        assert_eq!(aapcs.abi(), CallAbi::TargetC(TargetCAbiFlavor::Aapcs64));
+        assert_eq!(sysv.convention(), CallingConvention::X86_64SysV);
+        assert_eq!(aapcs.convention(), CallingConvention::Aarch64Aapcs);
     }
 
     #[test]
@@ -1019,17 +1024,99 @@ mod tests {
     }
 
     #[test]
-    fn per_arch_budget_and_flavor_have_one_home() {
+    fn per_arch_native_budget_has_one_home() {
         assert_eq!(native_return_register_budget(Arch::X86_64), 6);
         assert_eq!(native_return_register_budget(Arch::Aarch64), 8);
+    }
+
+    #[test]
+    fn the_classifier_follows_the_target_c_alias_not_the_architecture() {
+        use rue_target::Target;
         assert_eq!(
-            TargetCAbiFlavor::for_arch(Arch::X86_64),
-            TargetCAbiFlavor::SysVAmd64
+            TargetCCallAbi::for_target(Target::X86_64Linux).convention(),
+            CallingConvention::X86_64SysV
         );
         assert_eq!(
-            TargetCAbiFlavor::for_arch(Arch::Aarch64),
-            TargetCAbiFlavor::Aapcs64
+            TargetCCallAbi::for_target(Target::Aarch64Linux).convention(),
+            CallingConvention::Aarch64Aapcs
         );
+        assert_eq!(
+            TargetCCallAbi::for_target(Target::Aarch64Macos).convention(),
+            CallingConvention::Aarch64AapcsDarwin
+        );
+    }
+
+    #[test]
+    fn the_two_aapcs_rows_agree_except_on_stacked_argument_packing() {
+        let aapcs = TargetCCallAbi::aapcs64();
+        let darwin = TargetCCallAbi::aapcs64_darwin();
+        assert_eq!(
+            aapcs.int_arg_register_budget(),
+            darwin.int_arg_register_budget()
+        );
+        assert_eq!(
+            aapcs.sret_pointer_in_dedicated_register(),
+            darwin.sret_pointer_in_dedicated_register()
+        );
+        assert_eq!(
+            aapcs.sret_pointer_echoed_in_result_register(),
+            darwin.sret_pointer_echoed_in_result_register()
+        );
+        assert_eq!(aapcs.call_stack_alignment(), darwin.call_stack_alignment());
+        assert_eq!(
+            aapcs.classify_aggregate_arg(24, 8),
+            darwin.classify_aggregate_arg(24, 8)
+        );
+        assert_eq!(
+            aapcs.classify_aggregate_return(24, 8),
+            darwin.classify_aggregate_return(24, 8)
+        );
+        // Apple's amendment: a stacked argument occupies its natural size at
+        // its natural alignment rather than a whole 8-byte slot.
+        assert_eq!(
+            aapcs.stacked_argument_packing(),
+            StackedArgumentPacking::EightByteSlots
+        );
+        assert_eq!(
+            darwin.stacked_argument_packing(),
+            StackedArgumentPacking::NaturalSize
+        );
+        assert_eq!(
+            TargetCCallAbi::sysv_amd64().stacked_argument_packing(),
+            StackedArgumentPacking::EightByteSlots,
+            "x86-64 is unaffected by the Apple amendment"
+        );
+    }
+
+    #[test]
+    fn every_c_row_agrees_on_the_caller_side_narrow_extension() {
+        // Apple requires the caller to extend an argument narrower than 32 bits;
+        // Rue's canonical 64-bit-extension invariant already produces that, and
+        // every C row asks for the same operation, so the import side needs no
+        // Darwin-specific work.
+        for convention in [
+            CallingConvention::X86_64SysV,
+            CallingConvention::Aarch64Aapcs,
+            CallingConvention::Aarch64AapcsDarwin,
+        ] {
+            let abi = TargetCCallAbi::new(convention);
+            assert_eq!(
+                abi.scalar_arg_extension(Type::I8),
+                ScalarAbiExtension::Signed { from_bits: 8 },
+                "{convention} must sign-extend a narrow signed argument"
+            );
+            assert_eq!(
+                abi.scalar_arg_extension(Type::U16),
+                ScalarAbiExtension::Unsigned { from_bits: 16 },
+                "{convention} must zero-extend a narrow unsigned argument"
+            );
+            assert_eq!(
+                abi.scalar_arg_extension(Type::BOOL),
+                ScalarAbiExtension::Unsigned { from_bits: 8 },
+                "{convention} must materialize the 1-byte `_Bool` 0/1 contract"
+            );
+            assert!(abi.scalar_arg_extension(Type::I64).is_noop());
+        }
     }
 
     #[test]

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -43,9 +43,9 @@ mod type_properties;
 mod types;
 
 pub use call_abi::{
-    AggregateArgClass, AggregateReturnClass, ArgClass, ArgConvention, CAbiScalarKind, CallAbi,
-    NativeAbiTypeFacts, NativeCallAbi, ReturnClass, ScalarAbiExtension, TargetCAbiFlavor,
-    TargetCCallAbi, is_slot_identical_layout, native_return_register_budget,
+    AggregateArgClass, AggregateReturnClass, ArgClass, ArgConvention, CAbiScalarKind,
+    NativeAbiTypeFacts, NativeCallAbi, ReturnClass, ScalarAbiExtension, TargetCCallAbi,
+    is_slot_identical_layout, native_return_register_budget,
 };
 pub use exact_decimal::canonical_decimal_literal;
 pub use exact_decimal::finite_float_literal_bits;

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -348,6 +348,38 @@ execute_if_native = true
 stdout = "true\ntrue\ntrue\n"
 exit_code = 0
 
+# The Apple arm64 row (`CallingConvention::Aarch64AapcsDarwin`) end to end: a
+# `pub extern "C"` export is compiled for aarch64-macos, so its C entry thunk is
+# generated from the Darwin convention, encoded, and linked into a Mach-O image.
+# Narrow parameters are what the Apple amendments govern, so the signatures name
+# them. No C toolchain and no archive are involved; the macOS CI host executes
+# the image and every other host structurally validates it.
+[[case]]
+name = "aarch64_macos_narrow_exports_build_under_the_apple_row"
+description = "`pub extern \"C\"` exports with narrow scalar parameters compile and link for aarch64-macos, exercising the Apple arm64 convention row's export thunks."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn rue_id_i8(x: i8) -> i8 {
+    x
+}
+
+pub extern "C" fn rue_id_u16(x: u16) -> u16 {
+    x
+}
+
+pub extern "C" fn rue_id_bool(x: bool) -> bool {
+    x
+}
+
+fn main() -> i32 {
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--target", "aarch64-macos", "-o", "prog"]
+executable_target = "aarch64-macos"
+execute_if_native = true
+stdout = ""
+exit_code = 0
+
 [[case]]
 name = "repr_c_requires_preview"
 description = "The `@repr(c)` marker is inert without `--preview c_ffi` (it is meaningless without FFI)."

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -137,6 +137,10 @@ pub struct CfgLower<'a> {
 }
 
 impl crate::call_plan::CallMaterializer for CfgLower<'_> {
+    fn target_c_convention(&self) -> rue_target::CallingConvention {
+        self.target.c_calling_convention()
+    }
+
     fn materialize_scalar(&mut self, value: CfgValue) -> VReg {
         self.get_vreg(value)
     }
@@ -335,10 +339,18 @@ impl<'a> CfgLower<'a> {
         &mut self,
         plan: crate::runtime_call_plan::RuntimeCallPlan,
     ) -> crate::value_plan::MaterializedValue {
-        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallResult};
-        use rue_runtime_abi::CallingConvention;
+        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallPlan, RuntimeCallResult};
 
-        assert_eq!(plan.calling_convention(), CallingConvention::TargetC);
+        assert!(
+            matches!(
+                RuntimeCallPlan::calling_convention(self.target),
+                rue_target::CallingConvention::Aarch64Aapcs
+                    | rue_target::CallingConvention::Aarch64AapcsDarwin
+            ),
+            "this lowering implements the AAPCS64 rows; the runtime-helper boundary on \
+             {} must resolve to one of them",
+            self.target
+        );
         assert!(
             plan.args().len() <= ARG_REGS.len(),
             "runtime manifest exceeds the AArch64 target-C register budget"
@@ -590,6 +602,7 @@ impl<'a> CfgLower<'a> {
                 gp: ARG_REGS.len(),
                 fp: FP_ARG_REGS.len(),
             },
+            self.target.c_calling_convention(),
         );
         let _ = self.lower_call_plan(plan);
     }
@@ -3867,9 +3880,6 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn is_foreign_symbol(&self, machine_symbol: &str) -> bool {
         self.symbols.is_foreign(machine_symbol)
     }
-    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
-        rue_air::TargetCAbiFlavor::Aapcs64
-    }
     fn call_arg_register_banks(&self) -> crate::call_plan::AbiRegisterBanks {
         crate::call_plan::AbiRegisterBanks {
             gp: ARG_REGS.len(),
@@ -4002,8 +4012,8 @@ fn emit_marshal_tag_ne(mir: &mut Aarch64Mir, tag: VReg, discriminant: u32, label
 }
 
 impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
-    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
-        rue_air::TargetCAbiFlavor::Aapcs64
+    fn target_c_convention(&self) -> rue_target::CallingConvention {
+        self.target.c_calling_convention()
     }
 
     fn foreign_int_arg_register_count(&self) -> usize {
@@ -4064,26 +4074,40 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         ptr
     }
 
-    fn foreign_emit_stack_args(&mut self, stack_ops: &[VReg]) {
-        let stack_bytes = checked_aligned_cell_region_bytes(
-            u64::try_from(stack_ops.len()).expect("foreign stack slot count must fit u64"),
-        )
-        .expect("foreign stack area must pass frame-budget preflight");
-        if stack_bytes > 0 {
+    fn foreign_emit_stack_args(&mut self, stack: &crate::foreign_call::ForeignStackArea) {
+        if stack.bytes > 0 {
             self.mir.push(Aarch64Inst::SubImm {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
-                imm: checked_displacement_bytes(u64::from(stack_bytes))
+                imm: checked_displacement_bytes(u64::from(stack.bytes))
                     .expect("foreign stack area must fit displacement"),
             });
         }
-        for (index, v) in stack_ops.iter().enumerate() {
-            self.mir.push(Aarch64Inst::Str {
-                src: Operand::Virtual(*v),
-                base: Reg::Sp,
-                offset: checked_cell_byte_offset(index as u64)
-                    .expect("foreign stack slot offset must fit displacement"),
-            });
+        // Each store commits exactly the width the convention's packing rule
+        // assigned it: a whole eightbyte under AAPCS64, and the scalar's own C
+        // width under Apple's amendment, so a stacked `i8` writes one byte.
+        // The planner keeps every offset a multiple of its width, which is what
+        // the scaled `imm12` addressing mode requires.
+        for store in &stack.stores {
+            let offset = checked_displacement_bytes(u64::from(store.offset))
+                .expect("foreign stack slot offset must fit displacement");
+            let src = Operand::Virtual(store.value);
+            match store.bytes {
+                8 => self.mir.push(Aarch64Inst::Str {
+                    src,
+                    base: Reg::Sp,
+                    offset,
+                }),
+                width @ (1 | 2 | 4) => self.mir.push(Aarch64Inst::NarrowStore {
+                    src,
+                    base: Reg::Sp,
+                    offset,
+                    width: width as u8,
+                }),
+                other => {
+                    panic!("a stacked target-C argument commits 1, 2, 4, or 8 bytes; got {other}")
+                }
+            }
         }
     }
 
@@ -4108,16 +4132,12 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         self.mir.push(Aarch64Inst::call(symbol_id));
     }
 
-    fn foreign_cleanup_stack(&mut self, stack_count: usize) {
-        if stack_count > 0 {
-            let stack_bytes = checked_aligned_cell_region_bytes(
-                u64::try_from(stack_count).expect("foreign stack slot count must fit u64"),
-            )
-            .expect("foreign stack area must pass frame-budget preflight");
+    fn foreign_cleanup_stack(&mut self, stack: &crate::foreign_call::ForeignStackArea) {
+        if stack.bytes > 0 {
             self.mir.push(Aarch64Inst::AddImm {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
-                imm: checked_displacement_bytes(u64::from(stack_bytes))
+                imm: checked_displacement_bytes(u64::from(stack.bytes))
                     .expect("foreign stack area must fit displacement"),
             });
         }
@@ -5117,17 +5137,20 @@ mod tests {
             CfgLower::new(&cfg, self.pool, self.interner, Target::Aarch64Linux).lower()
         }
 
-        /// Lower for the host target, as the whole-pipeline tests do.
+        /// Lower for the host target, as the whole-pipeline tests do — but
+        /// only when the host is one this backend serves. This lowerer answers
+        /// target-keyed questions (the `"C"` convention row, and through it the
+        /// outgoing argument packing), so handing it an x86-64 host target on a
+        /// cross host would ask AArch64 code generation an x86-64 question.
         fn lower_host(self) -> Aarch64Mir {
+            let target = match Target::host() {
+                Some(host) if host.arch() == rue_target::Arch::Aarch64 => host,
+                _ => Target::Aarch64Linux,
+            };
             let cfg = self.cfg.finish(self.pool).expect("test CFG must verify");
-            CfgLower::new(
-                &cfg,
-                self.pool,
-                self.interner,
-                Target::host().expect("test lowering requires a supported Rue host target"),
-            )
-            .lower()
-            .expect("test lowering should succeed")
+            CfgLower::new(&cfg, self.pool, self.interner, target)
+                .lower()
+                .expect("test lowering should succeed")
         }
 
         /// Lower with the pipeline's real parameter storage plan applied
@@ -6357,14 +6380,21 @@ mod tests {
 
     #[test]
     fn runtime_manifest_fits_register_only_target_c_subset() {
+        for target in [
+            rue_target::Target::Aarch64Linux,
+            rue_target::Target::Aarch64Macos,
+        ] {
+            assert!(
+                matches!(
+                    crate::runtime_call_plan::RuntimeCallPlan::calling_convention(target),
+                    rue_target::CallingConvention::Aarch64Aapcs
+                        | rue_target::CallingConvention::Aarch64AapcsDarwin
+                ),
+                "the {target} runtime-helper boundary is an AAPCS64 row"
+            );
+        }
         for id in rue_runtime_abi::RuntimeHelperId::ALL {
             let helper = id.helper();
-            assert_eq!(
-                helper.calling_convention,
-                rue_runtime_abi::CallingConvention::TargetC,
-                "{} must use the target C convention",
-                helper.symbol
-            );
             assert!(
                 helper.parameters.len() <= ARG_REGS.len(),
                 "{} has {} parameters, exceeding the AArch64 register-only runtime-call budget of {}",
@@ -6884,5 +6914,143 @@ mod tests {
             )),
             "a `u8` @ptr_read must use the one-byte zero-extended narrow load"
         );
+    }
+
+    fn empty_cfg(pool: &FrozenTypeInternPool, interner: &ThreadedRodeo) -> ValidatedCfg {
+        let mut fixture = FixtureCfg::new(
+            Type::UNIT,
+            0,
+            "f",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            pool,
+            interner,
+        );
+        fixture.ret(None);
+        fixture.cfg.finish(pool).expect("test CFG must verify")
+    }
+
+    /// The stacked `i8`/`i16`/`i32`/`i64` tail of an `extern "C"` call whose
+    /// earlier arguments have exhausted `x0`-`x7`, laid out by the shared
+    /// planner for `convention`.
+    fn narrow_tail_area(
+        convention: rue_target::CallingConvention,
+    ) -> crate::foreign_call::ForeignStackArea {
+        use crate::foreign_call::{AggregateImage, ForeignArg, ForeignCallInputs, ForeignReturn};
+        let mut args = vec![ForeignArg::AggregateRegisters {
+            value: CfgValue::from_raw(0),
+            image: AggregateImage {
+                map: Vec::new(),
+                padding: Vec::new(),
+                slot_count: 0,
+                size: 8,
+                align: 8,
+                storage_bytes: 16,
+            },
+        }];
+        args.extend((1..8).map(|index| ForeignArg::Scalar {
+            value: CfgValue::from_raw(index),
+            natural_bytes: 8,
+        }));
+        for (index, natural_bytes) in [(8, 1), (9, 2), (10, 4), (11, 8)] {
+            args.push(ForeignArg::Scalar {
+                value: CfgValue::from_raw(index),
+                natural_bytes,
+            });
+        }
+        crate::foreign_call::ForeignCallPlan::new(
+            ForeignCallInputs {
+                symbol: "narrow_tail".into(),
+                convention,
+                args,
+                ret: ForeignReturn::ZeroSized,
+            },
+            ARG_REGS.len(),
+        )
+        .stack_area_for_test(&[VReg::new(80), VReg::new(81), VReg::new(82), VReg::new(83)])
+    }
+
+    #[test]
+    fn darwin_packs_a_narrow_stacked_tail_where_aapcs64_uses_whole_slots() {
+        use crate::foreign_call::ForeignCallLoweringBackend;
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let cfg = empty_cfg(&pool, &interner);
+
+        let emitted = |target: Target| {
+            let area = narrow_tail_area(target.c_calling_convention());
+            let mut lower = CfgLower::new(&cfg, &pool, &interner, target);
+            lower.foreign_emit_stack_args(&area);
+            lower.foreign_cleanup_stack(&area);
+            let stores = lower
+                .mir
+                .instructions()
+                .iter()
+                .filter_map(|inst| match inst {
+                    Aarch64Inst::Str {
+                        base: Reg::Sp,
+                        offset,
+                        ..
+                    } => Some((*offset, 8_u8)),
+                    Aarch64Inst::NarrowStore {
+                        base: Reg::Sp,
+                        offset,
+                        width,
+                        ..
+                    } => Some((*offset, *width)),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            (area.bytes, stores)
+        };
+
+        // AAPCS64 on Linux: one whole 8-byte slot per stacked argument.
+        assert_eq!(
+            emitted(Target::Aarch64Linux),
+            (32, vec![(0, 8), (8, 8), (16, 8), (24, 8)])
+        );
+        // Apple's arm64 amendment: each stacked scalar takes its natural size at
+        // its natural alignment, so the tail packs into 16 bytes and each store
+        // commits exactly the C width.
+        assert_eq!(
+            emitted(Target::Aarch64Macos),
+            (16, vec![(0, 1), (2, 2), (4, 4), (8, 8)])
+        );
+    }
+
+    #[test]
+    fn the_outgoing_argument_area_reservation_follows_the_packing_rule() {
+        use crate::foreign_call::ForeignCallLoweringBackend;
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let cfg = empty_cfg(&pool, &interner);
+
+        let reservation = |target: Target| {
+            let area = narrow_tail_area(target.c_calling_convention());
+            let mut lower = CfgLower::new(&cfg, &pool, &interner, target);
+            lower.foreign_emit_stack_args(&area);
+            lower.foreign_cleanup_stack(&area);
+            lower
+                .mir
+                .instructions()
+                .iter()
+                .filter_map(|inst| match inst {
+                    Aarch64Inst::SubImm {
+                        dst: Operand::Physical(Reg::Sp),
+                        imm,
+                        ..
+                    } => Some(-*imm),
+                    Aarch64Inst::AddImm {
+                        dst: Operand::Physical(Reg::Sp),
+                        imm,
+                        ..
+                    } => Some(*imm),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(reservation(Target::Aarch64Linux), vec![-32, 32]);
+        assert_eq!(reservation(Target::Aarch64Macos), vec![-16, 16]);
     }
 }

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -70,7 +70,6 @@ impl Backend for Aarch64CodegenBackend {
     const RETURN_REG_COUNT: u32 = cfg_lower::RET_REGS.len() as u32;
     const SAVED_REG_SCHEME: crate::frame_layout::SavedRegScheme =
         crate::frame_layout::SavedRegScheme::Aarch64;
-    const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor = rue_air::TargetCAbiFlavor::Aapcs64;
 
     fn lower(
         cfg: &ValidatedCfg,

--- a/crates/rue-codegen/src/backend.rs
+++ b/crates/rue-codegen/src/backend.rs
@@ -36,7 +36,6 @@ pub(crate) trait Backend {
     const FP_ARG_REG_COUNT: u32;
     const RETURN_REG_COUNT: u32;
     const SAVED_REG_SCHEME: SavedRegScheme;
-    const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor;
 
     fn lower(
         cfg: &ValidatedCfg,

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -10,28 +10,27 @@ use rue_air::{ArgClass, ArgConvention, FrozenTypeInternPool, NativeCallAbi, Retu
 // stays visible to readers of the field; no direct import is needed.
 use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, Type};
 use rue_runtime_abi::{ReservedExportClass, ReservedExportId};
+use rue_target::CallingConvention;
 
 use crate::types;
 use crate::vreg::VReg;
 
 use crate::frame_layout::checked_aligned_cell_region_bytes;
 
-/// The source ABI expected by a call target.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CalleeAbi {
-    /// A Rue-compiled function, whose aggregate arguments use reversed ABI
-    /// slot order to preserve the ascending logical frame layout.
-    Rue,
-    /// A compiler-built C routine using natural C-compatible slot order.
-    Runtime,
-}
-
-impl CalleeAbi {
-    const fn for_target(target: &CallTarget) -> Self {
-        match target {
-            CallTarget::Rue(_) => Self::Rue,
-            CallTarget::MemoryBuiltin(_) => Self::Runtime,
-        }
+/// The convention a call target's callee follows.
+///
+/// A Rue-compiled function uses the native convention, whose aggregate
+/// arguments are in reversed ABI slot order so the callee reconstructs the
+/// ascending logical frame layout. A compiler-built C memory routine crosses
+/// the platform C boundary, in natural C slot order; which C row that is comes
+/// from the compilation target, so the caller supplies it.
+const fn callee_convention(
+    target: &CallTarget,
+    c_convention: CallingConvention,
+) -> CallingConvention {
+    match target {
+        CallTarget::Rue(_) => CallingConvention::Rue,
+        CallTarget::MemoryBuiltin(_) => c_convention,
     }
 }
 
@@ -333,7 +332,7 @@ impl ReturnPlan {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallPlan {
     pub target: CallTarget,
-    pub callee_abi: CalleeAbi,
+    pub callee_convention: CallingConvention,
     pub hidden_sret: Option<HiddenSretPlan>,
     pub user_args: Vec<UserArgPlan>,
     /// Complete logical ABI slots, including the hidden sret pointer when
@@ -571,6 +570,12 @@ fn normalize_call_arg(
 /// Keeping these as one adapter prevents competing mutable callbacks from
 /// creating a second aggregate or by-ref discovery path.
 pub trait CallMaterializer {
+    /// The convention this backend's compilation target resolves `"C"` to.
+    /// Names the classifier that governs every C boundary the backend lowers —
+    /// a foreign call, a compiler-built memory routine, or a runtime helper. It
+    /// comes from the target rather than the architecture, so AArch64 Linux and
+    /// AArch64 macOS answer differently.
+    fn target_c_convention(&self) -> CallingConvention;
     fn materialize_scalar(&mut self, value: rue_cfg::CfgValue) -> VReg;
     fn materialize_aggregate(&mut self, value: rue_cfg::CfgValue) -> Vec<VReg>;
     fn materialize_by_ref(&mut self, plan: &crate::value_plan::ByRefAddressPlan) -> VReg;
@@ -633,7 +638,7 @@ impl CallPlan {
         materializer: &mut M,
         result: Option<VReg>,
     ) -> Self {
-        let callee_abi = CalleeAbi::for_target(&target);
+        let callee_convention = callee_convention(&target, materializer.target_c_convention());
         let mut hidden_sret = None;
         let mut abi_slots = Vec::new();
         let mut abi_classes = Vec::new();
@@ -718,10 +723,10 @@ impl CallPlan {
                             *slot_count as usize,
                             "aggregate materialization must produce every logical ABI slot"
                         );
-                        if callee_abi == CalleeAbi::Runtime {
-                            slots
-                        } else {
+                        if callee_convention.is_rue() {
                             slots.into_iter().rev().collect()
+                        } else {
+                            slots
                         }
                     } else {
                         vec![materializer.materialize_scalar(*value)]
@@ -738,7 +743,7 @@ impl CallPlan {
                             .map(AbiSlotClass::for_leaf)
                             .collect::<Vec<_>>()
                     };
-                    if *is_multislot_aggregate && callee_abi == CalleeAbi::Rue {
+                    if *is_multislot_aggregate && callee_convention.is_rue() {
                         classes.reverse();
                     }
                     assert_eq!(
@@ -778,7 +783,7 @@ impl CallPlan {
 
         Self {
             target,
-            callee_abi,
+            callee_convention,
             hidden_sret,
             user_args,
             abi_slots,
@@ -807,6 +812,7 @@ impl CallPlan {
         target: CallTarget,
         slots: &[VReg],
         arg_register_banks: impl Into<AbiRegisterBanks>,
+        c_convention: CallingConvention,
     ) -> Self {
         let abi_classes = vec![AbiSlotClass::Gp; slots.len()];
         let abi_locations =
@@ -816,7 +822,7 @@ impl CallPlan {
             .filter(|location| matches!(location, AbiSlotLocation::Stack(_)))
             .count();
         Self {
-            callee_abi: CalleeAbi::for_target(&target),
+            callee_convention: callee_convention(&target, c_convention),
             target,
             hidden_sret: None,
             user_args: vec![UserArgPlan {
@@ -869,6 +875,10 @@ mod tests {
     struct TestMaterializer;
 
     impl CallMaterializer for TestMaterializer {
+        fn target_c_convention(&self) -> CallingConvention {
+            CallingConvention::X86_64SysV
+        }
+
         fn materialize_scalar(&mut self, value: rue_cfg::CfgValue) -> VReg {
             VReg::new(100 + value.as_u32())
         }
@@ -966,7 +976,12 @@ mod tests {
     #[test]
     fn slot_call_plan_counts_aligned_stack_slots() {
         let slots: Vec<_> = (0..9).map(VReg::new).collect();
-        let plan = CallPlan::from_slot_values(CallTarget::rue("drop"), &slots, 6);
+        let plan = CallPlan::from_slot_values(
+            CallTarget::rue("drop"),
+            &slots,
+            6,
+            CallingConvention::X86_64SysV,
+        );
 
         assert_eq!(plan.abi_slots, slots);
         assert_eq!(plan.stack_slot_count, 3);
@@ -1002,7 +1017,7 @@ mod tests {
         let slots = vec![VReg::new(7)];
         let plan = CallPlan {
             target: CallTarget::rue("test"),
-            callee_abi: CalleeAbi::Rue,
+            callee_convention: CallingConvention::Rue,
             hidden_sret: None,
             user_args: vec![
                 UserArgPlan {
@@ -1166,7 +1181,7 @@ mod tests {
             8,
             &mut materializer,
         );
-        assert_eq!(generated_rue.callee_abi, CalleeAbi::Rue);
+        assert_eq!(generated_rue.callee_convention, CallingConvention::Rue);
         assert_eq!(generated_rue.abi_slots, vec![VReg::new(11), VReg::new(10)]);
     }
 
@@ -1174,7 +1189,16 @@ mod tests {
     fn memory_builtins_are_distinct_from_helpers_and_rue_symbols() {
         let target = CallTarget::memory_builtin(ReservedExportId::Memcpy);
         assert_eq!(target.symbol(), "memcpy");
-        assert_eq!(CalleeAbi::for_target(&target), CalleeAbi::Runtime);
+        // A memory builtin crosses the caller's `"C"` boundary, so it takes
+        // whichever row the compilation target resolves the alias to.
+        assert_eq!(
+            callee_convention(&target, CallingConvention::Aarch64AapcsDarwin),
+            CallingConvention::Aarch64AapcsDarwin
+        );
+        assert_eq!(
+            callee_convention(&CallTarget::rue("f"), CallingConvention::Aarch64AapcsDarwin),
+            CallingConvention::Rue
+        );
         assert!(matches!(
             target,
             CallTarget::MemoryBuiltin(id) if id.export_id() == ReservedExportId::Memcpy

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -112,7 +112,7 @@ pub(crate) fn validate_pre_lowering_budget(
         arg_reg_count,
         return_reg_count,
         scheme,
-        rue_air::TargetCAbiFlavor::SysVAmd64,
+        rue_target::CallingConvention::X86_64SysV,
         &|_| false,
     )
 }
@@ -123,7 +123,7 @@ pub(crate) fn validate_pre_lowering_budget_for_target(
     arg_reg_count: u32,
     return_reg_count: u32,
     scheme: SavedRegScheme,
-    target_c_flavor: rue_air::TargetCAbiFlavor,
+    target_c_convention: rue_target::CallingConvention,
     is_foreign_symbol: &dyn Fn(lasso::Spur) -> bool,
 ) -> CompileResult<bool> {
     let return_class =
@@ -151,7 +151,7 @@ pub(crate) fn validate_pre_lowering_budget_for_target(
                 type_pool,
                 inst.ty,
                 call_args,
-                target_c_flavor,
+                target_c_convention,
             )
             .map_err(|_| frame_budget_error(cfg, Some(value)))?;
             continue;
@@ -219,7 +219,7 @@ pub(crate) fn prepare_mir_with_backend<B: crate::backend::Backend>(
         B::ARG_REG_COUNT,
         B::RETURN_REG_COUNT,
         B::SAVED_REG_SCHEME,
-        B::TARGET_C_FLAVOR,
+        target.c_calling_convention(),
         &|name| symbols.is_foreign(&symbols.resolve(interner.resolve(&name))),
     )?;
     let param_storage = crate::param_storage::ParamStoragePlan::plan(
@@ -390,7 +390,6 @@ mod tests {
         const FP_ARG_REG_COUNT: u32 = 8;
         const RETURN_REG_COUNT: u32 = 6;
         const SAVED_REG_SCHEME: SavedRegScheme = SavedRegScheme::X86_64;
-        const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor = rue_air::TargetCAbiFlavor::SysVAmd64;
 
         fn lower(
             _cfg: &ValidatedCfg,
@@ -617,18 +616,24 @@ mod tests {
         cfg.append_call(entry, None, Spur::default(), args, huge, Span::default())
             .unwrap();
 
-        for (arg_regs, ret_regs, scheme, flavor) in [
+        for (arg_regs, ret_regs, scheme, convention) in [
             (
                 6,
                 6,
                 SavedRegScheme::X86_64,
-                rue_air::TargetCAbiFlavor::SysVAmd64,
+                rue_target::CallingConvention::X86_64SysV,
             ),
             (
                 8,
                 8,
                 SavedRegScheme::Aarch64,
-                rue_air::TargetCAbiFlavor::Aapcs64,
+                rue_target::CallingConvention::Aarch64Aapcs,
+            ),
+            (
+                8,
+                8,
+                SavedRegScheme::Aarch64,
+                rue_target::CallingConvention::Aarch64AapcsDarwin,
             ),
         ] {
             let error = super::validate_pre_lowering_budget_for_target(
@@ -637,7 +642,7 @@ mod tests {
                 arg_regs,
                 ret_regs,
                 scheme,
-                flavor,
+                convention,
                 &|_| true,
             )
             .unwrap_err();
@@ -694,18 +699,24 @@ mod tests {
         // aggregate argument's 16-byte image scratch is live alongside it
         // during lowering. Both target-C lowerers must reject that peak before
         // their stack adjustments are emitted.
-        for (arg_regs, ret_regs, scheme, flavor) in [
+        for (arg_regs, ret_regs, scheme, convention) in [
             (
                 6,
                 6,
                 SavedRegScheme::X86_64,
-                rue_air::TargetCAbiFlavor::SysVAmd64,
+                rue_target::CallingConvention::X86_64SysV,
             ),
             (
                 8,
                 8,
                 SavedRegScheme::Aarch64,
-                rue_air::TargetCAbiFlavor::Aapcs64,
+                rue_target::CallingConvention::Aarch64Aapcs,
+            ),
+            (
+                8,
+                8,
+                SavedRegScheme::Aarch64,
+                rue_target::CallingConvention::Aarch64AapcsDarwin,
             ),
         ] {
             assert!(
@@ -715,11 +726,11 @@ mod tests {
                     arg_regs,
                     ret_regs,
                     scheme,
-                    flavor,
+                    convention,
                     &|_| true,
                 )
                 .is_err(),
-                "foreign scratch must count against the {flavor:?} live sret area"
+                "foreign scratch must count against the {convention:?} live sret area"
             );
         }
     }

--- a/crates/rue-codegen/src/export_thunk.rs
+++ b/crates/rue-codegen/src/export_thunk.rs
@@ -12,14 +12,15 @@
 //! ## Why scalars/pointers are a prologue, not a repack
 //!
 //! For the integer/pointer scalars this phase supports, the native Rue argument
-//! convention and both target-C conventions already agree on *where* each
+//! convention and every target-C convention already agree on *where* each
 //! argument lives: the first arguments occupy the same integer registers (`rdi,
-//! rsi, rdx, rcx, r8, r9` on SysV; `x0..x7` on AAPCS64), a scalar return comes
-//! back in the same primary result register, and Rue's internal invariant keeps
-//! a scalar canonically extended — which is *stronger* than what a C caller
-//! guarantees. The one place the conventions disagree is the **narrow-integer
-//! extension**: a C caller may leave the bits above a narrow argument's declared
-//! width unspecified (SysV) or extended only to 32 bits (AAPCS64), whereas the
+//! rsi, rdx, rcx, r8, r9` on SysV; `x0..x7` on the AAPCS64 rows), a scalar
+//! return comes back in the same primary result register, and Rue's internal
+//! invariant keeps a scalar canonically extended — which is *stronger* than what
+//! a C caller guarantees. The one place the conventions disagree is the
+//! **narrow-integer extension**: a C caller may leave the bits above a narrow
+//! argument's declared width unspecified (SysV), extended only to 32 bits
+//! (AAPCS64), or extended to 32 bits by requirement (Apple arm64), whereas the
 //! native body assumes the program-wide canonical 64-bit form. So the thunk
 //! re-extends each narrow argument register in place — reusing the shared
 //! [`TargetCCallAbi`] authority so it cannot disagree with the import side about
@@ -45,7 +46,7 @@
 //! analysis (`ExportSignatureUnsupported`, E1106); this module only ever sees
 //! register-resident scalar/pointer signatures.
 
-use rue_air::{ScalarAbiExtension, TargetCAbiFlavor, TargetCCallAbi, Type};
+use rue_air::{ScalarAbiExtension, TargetCCallAbi, Type};
 use rue_target::{Arch, Target};
 
 use crate::{EmittedRelocation, MachineCode};
@@ -62,22 +63,28 @@ pub fn generate_export_thunk(
     param_types: &[Type],
 ) -> MachineCode {
     match target.arch() {
-        Arch::X86_64 => generate_x86_64(native_symbol, param_types),
-        Arch::Aarch64 => generate_aarch64(native_symbol, param_types),
+        Arch::X86_64 => generate_x86_64(target, native_symbol, param_types),
+        Arch::Aarch64 => generate_aarch64(target, native_symbol, param_types),
     }
 }
 
-/// The classifier flavor for a target's architecture. Both directions of the C
-/// boundary consult the same authority (`TargetCCallAbi`), so the export thunk
-/// and the import call agree on every scalar extension.
-fn flavor_for(target: Target) -> TargetCAbiFlavor {
-    TargetCAbiFlavor::for_arch(target.arch())
-}
-
-/// The extension each argument register needs, in register order. Shared by both
-/// backends and by the import side.
+/// The extension each argument register needs, in register order.
+///
+/// The convention comes from the target's `"C"` alias, not from its
+/// architecture, so an AArch64 macOS export consults the Apple row. Both
+/// directions of the C boundary consult the same authority
+/// ([`TargetCCallAbi`]), so the export thunk and the import call agree on every
+/// scalar extension.
+///
+/// Apple's arm64 ABI *requires* the caller to extend an argument narrower than
+/// 32 bits, so a Darwin thunk could in principle trust the incoming register.
+/// It re-extends anyway: SysV and generic AAPCS64 callers make no such promise,
+/// the native body needs Rue's canonical 64-bit form (which is stronger than
+/// Apple's 32-bit guarantee), and re-extending an already-extended value is a
+/// no-op. One rule for every row is both correct and cheaper than a per-row
+/// prologue.
 fn arg_extensions(target: Target, param_types: &[Type]) -> Vec<ScalarAbiExtension> {
-    let abi = TargetCCallAbi::new(flavor_for(target));
+    let abi = TargetCCallAbi::for_target(target);
     param_types
         .iter()
         .map(|ty| abi.scalar_arg_extension(*ty))
@@ -99,8 +106,8 @@ const X86_ARG_REGS: [(u8, bool); 6] = [
     (1, true),  // r9
 ];
 
-fn generate_x86_64(native_symbol: &str, param_types: &[Type]) -> MachineCode {
-    let extensions = arg_extensions(Target::X86_64Linux, param_types);
+fn generate_x86_64(target: Target, native_symbol: &str, param_types: &[Type]) -> MachineCode {
+    let extensions = arg_extensions(target, param_types);
     let mut code = Vec::new();
 
     // Re-extend each narrow argument register in place before forwarding.
@@ -163,8 +170,8 @@ fn x86_extend_reg(code: &mut Vec<u8>, reg: u8, ext_bit: bool, ext: ScalarAbiExte
 // AArch64 / AAPCS64
 // ============================================================================
 
-fn generate_aarch64(native_symbol: &str, param_types: &[Type]) -> MachineCode {
-    let extensions = arg_extensions(Target::Aarch64Linux, param_types);
+fn generate_aarch64(target: Target, native_symbol: &str, param_types: &[Type]) -> MachineCode {
+    let extensions = arg_extensions(target, param_types);
     let mut words: Vec<u32> = Vec::new();
 
     for (index, ext) in extensions.iter().enumerate() {
@@ -271,5 +278,19 @@ mod tests {
         let code = generate_export_thunk(Target::Aarch64Linux, "native", &[Type::I16, Type::U8]);
         assert_eq!(&code.code[..4], &(0x9340_3C00u32).to_le_bytes()); // sxth x0, w0
         assert_eq!(&code.code[4..8], &(0x5300_1C21u32).to_le_bytes()); // uxtb w1, w1
+    }
+
+    #[test]
+    fn every_target_row_re_extends_narrow_export_arguments() {
+        // The thunk asks the convention, not the architecture, which extension
+        // each argument needs. Apple's row requires the caller to extend below
+        // 32 bits, but the native body needs the canonical 64-bit form, so the
+        // Darwin thunk re-extends exactly as the Linux one does.
+        let params = [Type::I8, Type::U16, Type::I32, Type::BOOL, Type::I64];
+        let linux = generate_export_thunk(Target::Aarch64Linux, "native", &params);
+        let darwin = generate_export_thunk(Target::Aarch64Macos, "native", &params);
+        assert_eq!(linux.code, darwin.code);
+        // Four narrow arguments plus the five-word frame; `i64` needs nothing.
+        assert_eq!(darwin.code.len(), 9 * 4);
     }
 }

--- a/crates/rue-codegen/src/foreign_call.rs
+++ b/crates/rue-codegen/src/foreign_call.rs
@@ -20,11 +20,14 @@
 use rue_air::layout::PaddingRange;
 use rue_air::{
     AggregateArgClass, AggregateReturnClass, FrozenTypeInternPool, ScalarAbiExtension,
-    TargetCAbiFlavor, TargetCCallAbi, Type,
+    TargetCCallAbi, Type,
 };
 use rue_cfg::{Cfg, CfgCallArg, CfgValue};
+use rue_target::{CallingConvention, StackedArgumentPacking};
 
-use crate::frame_layout::{checked_aligned_region_bytes, checked_call_area_bytes};
+use crate::frame_layout::{
+    FrameBudgetExceeded, checked_aligned_region_bytes, checked_call_area_from_stack_bytes,
+};
 use crate::types::{self, PhysicalEnumSlot};
 use crate::vreg::VReg;
 
@@ -85,7 +88,12 @@ pub enum ForeignArg {
     /// A scalar or pointer, already canonically extended in its vreg by Rue's
     /// internal invariant — occupies one integer register (or spills to the
     /// stack once the integer registers are exhausted).
-    Scalar { value: CfgValue },
+    ///
+    /// `natural_bytes` is the scalar's declared C width (1, 2, 4, or 8). It is
+    /// the footprint a stacked copy occupies under a psABI that packs its
+    /// outgoing argument area at natural size (Apple's arm64 amendment); under
+    /// the 8-byte-slot rule the whole slot is written and the width is unused.
+    Scalar { value: CfgValue, natural_bytes: u32 },
     /// A ≤16-byte aggregate packed into one or two integer registers in C field
     /// order ([`AggregateArgClass::IntegerRegisters`]).
     AggregateRegisters {
@@ -124,12 +132,14 @@ pub enum ForeignReturn {
 }
 
 /// A classified foreign call: the C symbol, every argument and the return, plus
-/// the psABI flavor whose classifier produced them.
+/// the convention whose classifier produced them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForeignCallInputs {
     /// The resolved (unmangled) C symbol the undefined reference targets.
     pub symbol: String,
-    pub flavor: TargetCAbiFlavor,
+    /// The convention the compilation target's `"C"` alias resolves to. Always
+    /// a C row; the native Rue convention never reaches this path.
+    pub convention: CallingConvention,
     pub args: Vec<ForeignArg>,
     pub ret: ForeignReturn,
 }
@@ -153,8 +163,40 @@ impl ForeignCallInputs {
 /// target-specific MIR.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ForeignArgPlacement {
-    Register { arg_index: usize },
-    Stack { arg_index: usize },
+    Register {
+        arg_index: usize,
+    },
+    Stack {
+        arg_index: usize,
+        /// Byte offset of this argument from the base of the outgoing argument
+        /// area.
+        offset: u64,
+    },
+}
+
+/// One store into the outgoing argument area, in ascending-offset order.
+///
+/// `bytes` is the number of low bytes of `value` the store must commit: 1, 2, 4,
+/// or 8. Under [`StackedArgumentPacking::EightByteSlots`] it is always 8. Under
+/// [`StackedArgumentPacking::NaturalSize`] a stacked *scalar* names its own C
+/// width, so an `i8` writes one byte at the next free byte and an `i16` starts
+/// at the next even offset.
+///
+/// `offset` is always a multiple of `bytes`, which is what makes every store
+/// encodable in AArch64's scaled `imm12` addressing mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ForeignStackStore {
+    pub(crate) value: VReg,
+    pub(crate) offset: u32,
+    pub(crate) bytes: u32,
+}
+
+/// The complete outgoing argument area: what to store where, and how many bytes
+/// the caller reserves (already rounded to the psABI's call alignment).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ForeignStackArea {
+    pub(crate) stores: Vec<ForeignStackStore>,
+    pub(crate) bytes: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -165,50 +207,115 @@ struct ForeignArgShape {
     byref_bytes: u64,
     /// Whether this argument may use integer argument registers.
     can_register: bool,
+    /// Whether the argument is a scalar or pointer rather than a composite.
+    /// Only the natural-size packing rule reads it.
+    scalar: bool,
+    /// A scalar's declared C width in bytes (1, 2, 4, or 8). Only the
+    /// natural-size packing rule reads it, and only for a scalar.
+    natural_bytes: u64,
+}
+
+impl ForeignArgShape {
+    /// The footprint and alignment this argument claims in the outgoing
+    /// argument area under `packing`.
+    ///
+    /// Apple's amendment is applied to stacked *scalars*, which is where Rue's
+    /// supported C surface differs from the generic 8-byte-slot rule: a stacked
+    /// `i8` occupies one byte, an `i16` starts at the next even offset. A
+    /// composite keeps whole eightbytes at 8-byte alignment under every row,
+    /// because it crosses through its eightbyte image and a byte-exact copy
+    /// would need marshaling this path does not have — the one Apple stack
+    /// amendment still open, recorded in
+    /// `docs/notes/ffi-abi-conformance-audit.md`. Keeping composites on whole
+    /// eightbytes is also what keeps every store's offset a multiple of its
+    /// width, so each one encodes in AArch64's scaled addressing mode.
+    fn stack_extent(self, packing: StackedArgumentPacking) -> (u64, u64) {
+        match packing {
+            StackedArgumentPacking::NaturalSize if self.scalar => {
+                let bytes = self.natural_bytes.clamp(1, 8);
+                (bytes, bytes)
+            }
+            StackedArgumentPacking::EightByteSlots | StackedArgumentPacking::NaturalSize => {
+                (self.pieces.saturating_mul(8), 8)
+            }
+        }
+    }
+
+    /// The width of each store this argument makes into the outgoing area: its
+    /// packed footprint for a scalar, one whole eightbyte per piece otherwise.
+    fn store_widths(self, packing: StackedArgumentPacking) -> impl Iterator<Item = u64> {
+        let (size, _) = self.stack_extent(packing);
+        let width = if self.scalar { size } else { 8 };
+        (0..self.pieces).map(move |_| width)
+    }
+}
+
+/// Round `value` up to a multiple of `align`, refusing rather than wrapping.
+///
+/// `align` is always one of the psABI's argument alignments (1, 2, 4, or 8), so
+/// the power-of-two mask below is exact; [`ForeignArgShape::stack_extent`] is
+/// the only producer.
+fn align_up(value: u64, align: u64) -> Result<u64, FrameBudgetExceeded> {
+    value
+        .checked_add(align - 1)
+        .map(|sum| sum & !(align - 1))
+        .ok_or(FrameBudgetExceeded)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ForeignPlacementPlan {
     placements: Vec<ForeignArgPlacement>,
     byref_bytes: u64,
-    stack_cells: u64,
+    /// Bytes the outgoing argument area occupies before call alignment.
+    stack_bytes: u64,
     sret_in_argument_register: bool,
+}
+
+impl ForeignPlacementPlan {
+    /// Reserved size of the outgoing argument area: the packed footprint
+    /// rounded to the call-boundary alignment.
+    fn stack_area_bytes(&self) -> Result<u32, FrameBudgetExceeded> {
+        checked_aligned_region_bytes(self.stack_bytes)
+    }
 }
 
 fn place_foreign_args(
     shapes: &[ForeignArgShape],
     int_register_budget: u64,
     sret_in_argument_register: bool,
-) -> Result<ForeignPlacementPlan, crate::frame_layout::FrameBudgetExceeded> {
+    packing: StackedArgumentPacking,
+) -> Result<ForeignPlacementPlan, FrameBudgetExceeded> {
     let mut used_registers = u64::from(sret_in_argument_register);
     let mut placements = Vec::with_capacity(shapes.len());
     let mut byref_bytes = 0_u64;
-    let mut stack_cells = 0_u64;
+    let mut stack_bytes = 0_u64;
+
+    let stack = |shape: &ForeignArgShape,
+                 arg_index: usize,
+                 stack_bytes: &mut u64|
+     -> Result<ForeignArgPlacement, FrameBudgetExceeded> {
+        let (size, align) = shape.stack_extent(packing);
+        let offset = align_up(*stack_bytes, align)?;
+        *stack_bytes = offset.checked_add(size).ok_or(FrameBudgetExceeded)?;
+        Ok(ForeignArgPlacement::Stack { arg_index, offset })
+    };
 
     for (arg_index, shape) in shapes.iter().enumerate() {
         byref_bytes = byref_bytes
             .checked_add(shape.byref_bytes)
-            .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+            .ok_or(FrameBudgetExceeded)?;
         let placement = if shape.can_register {
             let register_end = used_registers
                 .checked_add(shape.pieces)
-                .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+                .ok_or(FrameBudgetExceeded)?;
             if register_end <= int_register_budget {
                 used_registers = register_end;
                 ForeignArgPlacement::Register { arg_index }
             } else {
-                let stack_end = stack_cells
-                    .checked_add(shape.pieces)
-                    .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
-                stack_cells = stack_end;
-                ForeignArgPlacement::Stack { arg_index }
+                stack(shape, arg_index, &mut stack_bytes)?
             }
         } else {
-            let stack_end = stack_cells
-                .checked_add(shape.pieces)
-                .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
-            stack_cells = stack_end;
-            ForeignArgPlacement::Stack { arg_index }
+            stack(shape, arg_index, &mut stack_bytes)?
         };
         placements.push(placement);
     }
@@ -216,32 +323,42 @@ fn place_foreign_args(
     Ok(ForeignPlacementPlan {
         placements,
         byref_bytes,
-        stack_cells,
+        stack_bytes,
         sret_in_argument_register,
     })
 }
 
 fn shape_from_foreign_arg(arg: &ForeignArg) -> ForeignArgShape {
     match arg {
-        ForeignArg::Scalar { .. } => ForeignArgShape {
+        ForeignArg::Scalar { natural_bytes, .. } => ForeignArgShape {
             pieces: 1,
             byref_bytes: 0,
             can_register: true,
+            scalar: true,
+            natural_bytes: u64::from(*natural_bytes),
         },
         ForeignArg::AggregateRegisters { image, .. } => ForeignArgShape {
             pieces: u64::from(image.eightbytes()),
             byref_bytes: 0,
             can_register: true,
+            scalar: false,
+            natural_bytes: u64::from(image.size),
         },
         ForeignArg::AggregateByvalStack { image, .. } => ForeignArgShape {
             pieces: u64::from(image.eightbytes()),
             byref_bytes: 0,
             can_register: false,
+            scalar: false,
+            natural_bytes: u64::from(image.size),
         },
+        // A by-reference copy crosses as one pointer, which is a
+        // register-width scalar wherever it lands.
         ForeignArg::AggregateByRefCopy { image, .. } => ForeignArgShape {
             pieces: 1,
             byref_bytes: u64::from(image.storage_bytes),
             can_register: true,
+            scalar: true,
+            natural_bytes: 8,
         },
     }
 }
@@ -251,13 +368,15 @@ fn shape_from_cfg_arg(
     type_pool: &FrozenTypeInternPool,
     abi: TargetCCallAbi,
     arg: &CfgCallArg,
-) -> Result<ForeignArgShape, crate::frame_layout::FrameBudgetExceeded> {
+) -> Result<ForeignArgShape, FrameBudgetExceeded> {
     let ty = cfg.get_inst(arg.value).ty;
     if !is_aggregate(ty) {
         return Ok(ForeignArgShape {
             pieces: 1,
             byref_bytes: 0,
             can_register: true,
+            scalar: true,
+            natural_bytes: u64::from(abi.scalar_arg_extension(ty).natural_bytes()),
         });
     }
 
@@ -269,16 +388,22 @@ fn shape_from_cfg_arg(
                 pieces: u64::from(eightbytes),
                 byref_bytes: 0,
                 can_register: true,
+                scalar: false,
+                natural_bytes: layout.size,
             },
             AggregateArgClass::ByValueStack { .. } => ForeignArgShape {
                 pieces: layout.size.div_ceil(8),
                 byref_bytes: 0,
                 can_register: false,
+                scalar: false,
+                natural_bytes: layout.size,
             },
             AggregateArgClass::ByReferenceCopy { .. } => ForeignArgShape {
                 pieces: 1,
                 byref_bytes: copy_bytes()?,
                 can_register: true,
+                scalar: true,
+                natural_bytes: 8,
             },
         },
     )
@@ -288,7 +413,7 @@ impl ForeignArgPlacement {
     #[inline]
     pub const fn arg_index(self) -> usize {
         match self {
-            Self::Register { arg_index } | Self::Stack { arg_index } => arg_index,
+            Self::Register { arg_index } | Self::Stack { arg_index, .. } => arg_index,
         }
     }
 }
@@ -300,6 +425,13 @@ pub(crate) struct ForeignCallPlan {
     /// Every user argument's placement, retaining source order for lowering
     /// side effects and deterministic virtual-register numbering.
     placements: Vec<ForeignArgPlacement>,
+    /// Per-argument shapes, retained so the driver can ask each stacked
+    /// argument how wide each of its stores is.
+    shapes: Vec<ForeignArgShape>,
+    /// How the convention lays out the outgoing argument area.
+    packing: StackedArgumentPacking,
+    /// Reserved size of the outgoing argument area, call-aligned.
+    stack_area_bytes: u32,
     /// Total storage reserved for AAPCS64 by-reference argument copies.
     byref_bytes: u32,
     /// SysV consumes the hidden sret pointer from the integer argument budget;
@@ -311,7 +443,8 @@ impl ForeignCallPlan {
     /// Plan argument placement after classification, preserving aggregate
     /// all-or-nothing register allocation and source ordering.
     pub fn new(inputs: ForeignCallInputs, int_register_budget: usize) -> Self {
-        let abi = TargetCCallAbi::new(inputs.flavor);
+        let abi = TargetCCallAbi::new(inputs.convention);
+        let packing = abi.stacked_argument_packing();
         let sret_in_argument_register = matches!(&inputs.ret, ForeignReturn::AggregateSret { .. })
             && !abi.sret_pointer_in_dedicated_register();
         let shapes = inputs
@@ -323,15 +456,73 @@ impl ForeignCallPlan {
             &shapes,
             u64::try_from(int_register_budget).expect("foreign register budget must fit u64"),
             sret_in_argument_register,
+            packing,
         )
         .expect("foreign argument placement must pass frame-budget preflight");
+        let stack_area_bytes = placement
+            .stack_area_bytes()
+            .expect("foreign stack area must pass frame-budget preflight");
 
         Self {
             inputs,
             placements: placement.placements,
+            shapes,
+            packing,
+            stack_area_bytes,
             byref_bytes: u32::try_from(placement.byref_bytes)
                 .expect("foreign argument storage must fit u32"),
             sret_in_argument_register,
+        }
+    }
+
+    /// The stores one stacked argument makes: its eightbyte (or narrower)
+    /// pieces at ascending offsets from the argument's own packed offset.
+    fn stack_stores(
+        &self,
+        arg_index: usize,
+        offset: u64,
+        values: &[VReg],
+    ) -> Vec<ForeignStackStore> {
+        let widths = self.shapes[arg_index].store_widths(self.packing);
+        values
+            .iter()
+            .zip(widths)
+            .enumerate()
+            .map(|(piece, (value, bytes))| ForeignStackStore {
+                value: *value,
+                offset: u32::try_from(offset + piece as u64 * 8)
+                    .expect("foreign stack offset must fit u32"),
+                bytes: u32::try_from(bytes).expect("foreign stack store width must fit u32"),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+impl ForeignCallPlan {
+    /// The outgoing argument area this plan produces, taking one vreg per
+    /// stacked piece in placement order. Backend encoding tests drive
+    /// [`ForeignCallLoweringBackend::foreign_emit_stack_args`] with it instead
+    /// of standing up a whole lowering fixture.
+    pub(crate) fn stack_area_for_test(&self, values: &[VReg]) -> ForeignStackArea {
+        let mut values = values.iter().copied();
+        let mut stores = Vec::new();
+        for placement in &self.placements {
+            let ForeignArgPlacement::Stack { arg_index, offset } = placement else {
+                continue;
+            };
+            let pieces = self.shapes[*arg_index].pieces as usize;
+            let taken = (&mut values).take(pieces).collect::<Vec<_>>();
+            assert_eq!(taken.len(), pieces, "one vreg per stacked piece");
+            stores.extend(self.stack_stores(*arg_index, *offset, &taken));
+        }
+        assert!(
+            values.next().is_none(),
+            "every vreg must name a stacked piece"
+        );
+        ForeignStackArea {
+            stores,
+            bytes: self.stack_area_bytes,
         }
     }
 }
@@ -342,7 +533,8 @@ impl ForeignCallPlan {
 /// decisions. Implementations only select concrete registers/instructions and
 /// perform the target's stack and image operations.
 pub(crate) trait ForeignCallLoweringBackend {
-    fn target_c_flavor(&self) -> TargetCAbiFlavor;
+    /// The convention this backend's compilation target resolves `"C"` to.
+    fn target_c_convention(&self) -> CallingConvention;
     fn foreign_int_arg_register_count(&self) -> usize;
     fn foreign_reserve_sret(&mut self, image: &AggregateImage) -> VReg;
     fn foreign_get_vreg(&mut self, value: CfgValue) -> VReg;
@@ -352,11 +544,17 @@ pub(crate) trait ForeignCallLoweringBackend {
         image: &AggregateImage,
     ) -> Vec<VReg>;
     fn foreign_byref_copy(&mut self, value: CfgValue, image: &AggregateImage) -> VReg;
-    fn foreign_emit_stack_args(&mut self, stack_ops: &[VReg]);
+    /// Reserve the outgoing argument area and commit every store in it. The
+    /// area's size and each store's offset and width are the convention's
+    /// decision, made once in [`ForeignCallPlan`]; the backend chooses only the
+    /// instructions.
+    fn foreign_emit_stack_args(&mut self, stack: &ForeignStackArea);
     fn foreign_emit_register_args(&mut self, int_ops: &[VReg]);
     fn foreign_assign_sret(&mut self, sret_ptr: VReg);
     fn foreign_issue_call(&mut self, symbol: &str);
-    fn foreign_cleanup_stack(&mut self, stack_count: usize);
+    /// Release the outgoing argument area reserved by
+    /// [`foreign_emit_stack_args`](Self::foreign_emit_stack_args).
+    fn foreign_cleanup_stack(&mut self, stack: &ForeignStackArea);
     fn foreign_cleanup_byref(&mut self, byref_bytes: u32);
     fn foreign_zero_result(&mut self, primary: VReg);
     fn foreign_scalar_result(&mut self, primary: VReg, ext: ScalarAbiExtension);
@@ -379,11 +577,11 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
     primary: VReg,
 ) -> crate::value_plan::MaterializedValue {
     assert_eq!(
-        inputs.flavor,
-        backend.target_c_flavor(),
-        "foreign call ABI flavor disagrees with the selected backend"
+        inputs.convention,
+        backend.target_c_convention(),
+        "foreign call convention disagrees with the selected backend"
     );
-    let abi = TargetCCallAbi::new(backend.target_c_flavor());
+    let abi = TargetCCallAbi::new(backend.target_c_convention());
     let budget = usize::try_from(abi.int_arg_register_budget())
         .expect("target-C integer argument budget must fit usize");
     assert_eq!(
@@ -402,47 +600,53 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
     };
 
     let mut int_ops = Vec::new();
-    let mut stack_ops = Vec::new();
+    let mut stack = ForeignStackArea {
+        stores: Vec::new(),
+        bytes: plan.stack_area_bytes,
+    };
     if plan.sret_in_argument_register {
         int_ops.push(sret_ptr.expect("SysV sret placement requires storage"));
     }
     for placement in &plan.placements {
-        let to_register = matches!(placement, ForeignArgPlacement::Register { .. });
-        let arg = &inputs.args[placement.arg_index()];
-        let mut placed = |values: Vec<VReg>| {
-            if to_register {
-                int_ops.extend(values);
-            } else {
-                stack_ops.extend(values);
-            }
-        };
-        match arg {
-            ForeignArg::Scalar { value } => placed(vec![backend.foreign_get_vreg(*value)]),
+        let arg_index = placement.arg_index();
+        let arg = &inputs.args[arg_index];
+        let values = match arg {
+            ForeignArg::Scalar { value, .. } => vec![backend.foreign_get_vreg(*value)],
             ForeignArg::AggregateRegisters { value, image }
             | ForeignArg::AggregateByvalStack { value, image } => {
                 if matches!(arg, ForeignArg::AggregateByvalStack { .. })
-                    && inputs.flavor != TargetCAbiFlavor::SysVAmd64
+                    && inputs.convention != CallingConvention::X86_64SysV
                 {
                     panic!(
                         "AAPCS64 passes a >16-byte aggregate by reference to a caller copy, not \
                          byval-on-stack; ByValueStack is a SysV-only class"
                     );
                 }
-                placed(backend.foreign_image_arg_eightbytes(*value, image));
+                backend.foreign_image_arg_eightbytes(*value, image)
             }
             ForeignArg::AggregateByRefCopy { value, image } => {
-                if inputs.flavor != TargetCAbiFlavor::Aapcs64 {
-                    panic!("SysV AMD64 does not pass foreign aggregates by reference");
-                }
-                placed(vec![backend.foreign_byref_copy(*value, image)]);
+                assert!(
+                    matches!(
+                        inputs.convention,
+                        CallingConvention::Aarch64Aapcs | CallingConvention::Aarch64AapcsDarwin
+                    ),
+                    "SysV AMD64 does not pass foreign aggregates by reference"
+                );
+                vec![backend.foreign_byref_copy(*value, image)]
             }
+        };
+        match placement {
+            ForeignArgPlacement::Register { .. } => int_ops.extend(values),
+            ForeignArgPlacement::Stack { offset, .. } => stack
+                .stores
+                .extend(plan.stack_stores(arg_index, *offset, &values)),
         }
     }
 
     // The adapters own concrete stack layout and register moves, but the
     // driver fixes the shared boundary order: outgoing stack, integer args,
     // hidden sret assignment, call, then stack/byref cleanup.
-    backend.foreign_emit_stack_args(&stack_ops);
+    backend.foreign_emit_stack_args(&stack);
     backend.foreign_emit_register_args(&int_ops);
     if let Some(sret_ptr) = sret_ptr {
         if !plan.sret_in_argument_register {
@@ -450,7 +654,7 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
         }
     }
     backend.foreign_issue_call(inputs.symbol_ref());
-    backend.foreign_cleanup_stack(stack_ops.len());
+    backend.foreign_cleanup_stack(&stack);
     backend.foreign_cleanup_byref(plan.byref_bytes);
 
     let slots = match &inputs.ret {
@@ -499,9 +703,9 @@ impl ForeignCallInputs {
         type_pool: &FrozenTypeInternPool,
         return_ty: Type,
         args: &[CfgCallArg],
-        flavor: TargetCAbiFlavor,
-    ) -> Result<u32, crate::frame_layout::FrameBudgetExceeded> {
-        let abi = TargetCCallAbi::new(flavor);
+        convention: CallingConvention,
+    ) -> Result<u32, FrameBudgetExceeded> {
+        let abi = TargetCCallAbi::new(convention);
         let register_budget = u64::from(abi.int_arg_register_budget());
         let sret_storage_bytes = if is_aggregate(return_ty) {
             let layout = type_pool.layout(return_ty);
@@ -520,7 +724,12 @@ impl ForeignCallInputs {
             .iter()
             .map(|arg| shape_from_cfg_arg(cfg, type_pool, abi, arg))
             .collect::<Result<Vec<_>, _>>()?;
-        let placement = place_foreign_args(&shapes, register_budget, sret_in_argument_register)?;
+        let placement = place_foreign_args(
+            &shapes,
+            register_budget,
+            sret_in_argument_register,
+            abi.stacked_argument_packing(),
+        )?;
         let mut indirect_bytes = 0_u64;
 
         for (arg, shape) in args.iter().zip(&shapes) {
@@ -537,7 +746,7 @@ impl ForeignCallInputs {
                     // can overlap the hidden sret area and any earlier AAPCS64
                     // caller-owned copies.
                     let scratch = checked_aligned_region_bytes(layout.size)?;
-                    checked_call_area_bytes(
+                    checked_call_area_from_stack_bytes(
                         0,
                         sret_storage_bytes,
                         indirect_bytes
@@ -549,7 +758,7 @@ impl ForeignCallInputs {
                     // SysV still needs a temporary C image before its
                     // eightbytes are copied into the outgoing stack area.
                     let scratch = checked_aligned_region_bytes(layout.size)?;
-                    checked_call_area_bytes(
+                    checked_call_area_from_stack_bytes(
                         0,
                         sret_storage_bytes,
                         indirect_bytes
@@ -578,12 +787,16 @@ impl ForeignCallInputs {
                     // and AAPCS64 by-reference areas are released, so it is a
                     // separate peak from the call-boundary reservation.
                     let scratch = checked_aligned_region_bytes(layout.size)?;
-                    checked_call_area_bytes(0, 0, u64::from(scratch))?;
+                    checked_call_area_from_stack_bytes(0, 0, u64::from(scratch))?;
                 }
                 AggregateReturnClass::Indirect { .. } => {}
             }
         }
-        checked_call_area_bytes(placement.stack_cells, sret_storage_bytes, indirect_bytes)
+        checked_call_area_from_stack_bytes(
+            u64::from(placement.stack_area_bytes()?),
+            sret_storage_bytes,
+            indirect_bytes,
+        )
     }
 
     /// Classify a foreign call through the shared [`TargetCCallAbi`] authority.
@@ -593,9 +806,9 @@ impl ForeignCallInputs {
         type_pool: &FrozenTypeInternPool,
         return_ty: Type,
         args: &[CfgCallArg],
-        flavor: TargetCAbiFlavor,
+        convention: CallingConvention,
     ) -> Self {
-        let abi = TargetCCallAbi::new(flavor);
+        let abi = TargetCCallAbi::new(convention);
         let planned_args = args
             .iter()
             .map(|arg| {
@@ -607,7 +820,10 @@ impl ForeignCallInputs {
                      C boundary"
                 );
                 if !is_aggregate(ty) {
-                    return ForeignArg::Scalar { value };
+                    return ForeignArg::Scalar {
+                        value,
+                        natural_bytes: abi.scalar_arg_extension(ty).natural_bytes(),
+                    };
                 }
                 let image = AggregateImage::for_type(type_pool, ty);
                 match abi.classify_aggregate_arg(image.size as u64, image.align as u64) {
@@ -643,7 +859,7 @@ impl ForeignCallInputs {
 
         Self {
             symbol,
-            flavor,
+            convention,
             args: planned_args,
             ret,
         }
@@ -665,27 +881,56 @@ mod tests {
     use rue_cfg::CfgValue;
 
     fn image(size: u32) -> AggregateImage {
+        image_aligned(size, 8)
+    }
+
+    fn image_aligned(size: u32, align: u32) -> AggregateImage {
         AggregateImage {
             map: Vec::new(),
             padding: Vec::new(),
             slot_count: 0,
             size,
-            align: 8,
+            align,
             storage_bytes: size.div_ceil(16) * 16,
         }
     }
 
     fn scalar(index: u32) -> ForeignArg {
+        narrow_scalar(index, 8)
+    }
+
+    fn narrow_scalar(index: u32, natural_bytes: u32) -> ForeignArg {
         ForeignArg::Scalar {
             value: CfgValue::from_raw(index),
+            natural_bytes,
         }
+    }
+
+    fn shape(pieces: u64, byref_bytes: u64, can_register: bool) -> ForeignArgShape {
+        ForeignArgShape {
+            pieces,
+            byref_bytes,
+            can_register,
+            scalar: false,
+            natural_bytes: pieces.saturating_mul(8),
+        }
+    }
+
+    fn stack_offsets(plan: &ForeignCallPlan) -> Vec<u64> {
+        plan.placements
+            .iter()
+            .filter_map(|placement| match placement {
+                ForeignArgPlacement::Stack { offset, .. } => Some(*offset),
+                ForeignArgPlacement::Register { .. } => None,
+            })
+            .collect()
     }
 
     #[test]
     fn sysv_hidden_sret_and_aggregate_placement_are_shared_decisions() {
         let inputs = ForeignCallInputs {
             symbol: "f".into(),
-            flavor: TargetCAbiFlavor::SysVAmd64,
+            convention: CallingConvention::X86_64SysV,
             args: vec![
                 scalar(0),
                 ForeignArg::AggregateRegisters {
@@ -720,7 +965,7 @@ mod tests {
         ));
         assert!(matches!(
             plan.placements[4],
-            ForeignArgPlacement::Stack { .. }
+            ForeignArgPlacement::Stack { offset: 0, .. }
         ));
     }
 
@@ -728,7 +973,7 @@ mod tests {
     fn aapcs_byref_storage_does_not_consume_a_register_per_byte() {
         let inputs = ForeignCallInputs {
             symbol: "f".into(),
-            flavor: TargetCAbiFlavor::Aapcs64,
+            convention: CallingConvention::Aarch64Aapcs,
             args: vec![ForeignArg::AggregateByRefCopy {
                 value: CfgValue::from_raw(0),
                 image: image(24),
@@ -745,75 +990,189 @@ mod tests {
         ));
     }
 
+    /// The byval tail of a call whose arguments overflow the eight AAPCS64
+    /// integer registers. Every argument after the eighth is stacked, so the two
+    /// AAPCS rows can be compared on identical inputs.
+    fn narrow_tail_inputs(convention: CallingConvention) -> ForeignCallInputs {
+        let mut args = vec![ForeignArg::AggregateRegisters {
+            value: CfgValue::from_raw(0),
+            image: image(8),
+        }];
+        // Seven register-width scalars fill x1..x7 behind the aggregate in x0.
+        args.extend((1..8).map(scalar));
+        // The stacked tail: i8, i16, i32, i64.
+        args.push(narrow_scalar(8, 1));
+        args.push(narrow_scalar(9, 2));
+        args.push(narrow_scalar(10, 4));
+        args.push(narrow_scalar(11, 8));
+        ForeignCallInputs {
+            symbol: "narrow_tail".into(),
+            convention,
+            args,
+            ret: ForeignReturn::ZeroSized,
+        }
+    }
+
+    #[test]
+    fn a_narrow_scalar_tail_takes_whole_slots_under_aapcs_and_packs_under_darwin() {
+        let aapcs = ForeignCallPlan::new(narrow_tail_inputs(CallingConvention::Aarch64Aapcs), 8);
+        // AAPCS64 gives every stacked argument its own 8-byte slot.
+        assert_eq!(stack_offsets(&aapcs), vec![0, 8, 16, 24]);
+        assert_eq!(aapcs.stack_area_bytes, 32);
+
+        let darwin =
+            ForeignCallPlan::new(narrow_tail_inputs(CallingConvention::Aarch64AapcsDarwin), 8);
+        // Apple's amendment packs each argument at its natural size and
+        // alignment: i8 at 0, i16 at 2 (aligned), i32 at 4, i64 at 8.
+        assert_eq!(stack_offsets(&darwin), vec![0, 2, 4, 8]);
+        // 16 packed bytes, already call-aligned.
+        assert_eq!(darwin.stack_area_bytes, 16);
+    }
+
+    #[test]
+    fn only_the_darwin_row_narrows_a_stacked_scalar_store() {
+        let plan = ForeignCallPlan::new(narrow_tail_inputs(CallingConvention::Aarch64Aapcs), 8);
+        let stores = plan.stack_stores(8, 0, &[VReg::new(1)]);
+        assert_eq!(stores[0].bytes, 8, "AAPCS64 writes the whole 8-byte slot");
+
+        let plan =
+            ForeignCallPlan::new(narrow_tail_inputs(CallingConvention::Aarch64AapcsDarwin), 8);
+        assert_eq!(plan.stack_stores(8, 0, &[VReg::new(1)])[0].bytes, 1);
+        assert_eq!(plan.stack_stores(9, 2, &[VReg::new(1)])[0].bytes, 2);
+        assert_eq!(plan.stack_stores(10, 4, &[VReg::new(1)])[0].bytes, 4);
+        assert_eq!(plan.stack_stores(11, 8, &[VReg::new(1)])[0].bytes, 8);
+    }
+
+    #[test]
+    fn x86_64_is_unaffected_by_the_apple_amendment() {
+        // The same narrow tail on SysV: six integer registers, then whole
+        // 8-byte slots for every stacked argument regardless of its C width.
+        let mut args = vec![ForeignArg::AggregateRegisters {
+            value: CfgValue::from_raw(0),
+            image: image(8),
+        }];
+        args.extend((1..6).map(scalar));
+        args.push(narrow_scalar(6, 1));
+        args.push(narrow_scalar(7, 2));
+        args.push(narrow_scalar(8, 4));
+        let plan = ForeignCallPlan::new(
+            ForeignCallInputs {
+                symbol: "narrow_tail".into(),
+                convention: CallingConvention::X86_64SysV,
+                args,
+                ret: ForeignReturn::ZeroSized,
+            },
+            6,
+        );
+        assert_eq!(stack_offsets(&plan), vec![0, 8, 16]);
+        assert_eq!(plan.stack_area_bytes, 32);
+        for arg_index in 6..9 {
+            assert_eq!(plan.stack_stores(arg_index, 0, &[VReg::new(1)])[0].bytes, 8);
+        }
+    }
+
+    #[test]
+    fn a_stacked_composite_keeps_whole_eightbytes_under_every_row() {
+        // A stacked byte followed by a 12-byte, 4-aligned composite: the byte
+        // packs to one byte under Apple's rule, and the composite still takes
+        // whole eightbytes at 8-byte alignment, so it starts at 8 and the
+        // following scalar at 24. Every store offset stays a multiple of its
+        // width, which is what keeps the AArch64 encodings in range.
+        let args = (0..8)
+            .map(scalar)
+            .chain([
+                narrow_scalar(8, 1),
+                ForeignArg::AggregateRegisters {
+                    value: CfgValue::from_raw(9),
+                    image: image_aligned(12, 4),
+                },
+                narrow_scalar(10, 4),
+            ])
+            .collect();
+        let plan = ForeignCallPlan::new(
+            ForeignCallInputs {
+                symbol: "composite_tail".into(),
+                convention: CallingConvention::Aarch64AapcsDarwin,
+                args,
+                ret: ForeignReturn::ZeroSized,
+            },
+            8,
+        );
+        assert_eq!(stack_offsets(&plan), vec![0, 8, 24]);
+        assert_eq!(plan.stack_area_bytes, 32);
+        let stores = plan.stack_stores(9, 8, &[VReg::new(1), VReg::new(2)]);
+        assert_eq!(stores.len(), 2);
+        assert_eq!((stores[0].offset, stores[0].bytes), (8, 8));
+        assert_eq!((stores[1].offset, stores[1].bytes), (16, 8));
+    }
+
+    #[test]
+    fn every_stacked_store_offset_is_a_multiple_of_its_width() {
+        // AArch64 addresses a stacked store through the scaled `imm12` form, so
+        // an unaligned offset would be unencodable. The packing rule keeps the
+        // invariant for both AAPCS rows.
+        for convention in [
+            CallingConvention::Aarch64Aapcs,
+            CallingConvention::Aarch64AapcsDarwin,
+        ] {
+            let plan = ForeignCallPlan::new(narrow_tail_inputs(convention), 8);
+            for (arg_index, placement) in plan.placements.iter().enumerate() {
+                let ForeignArgPlacement::Stack { offset, .. } = placement else {
+                    continue;
+                };
+                for store in plan.stack_stores(arg_index, *offset, &[VReg::new(1)]) {
+                    assert_eq!(
+                        store.offset % store.bytes,
+                        0,
+                        "{convention}: store at {} is not {}-aligned",
+                        store.offset,
+                        store.bytes
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn placement_arithmetic_reports_budget_overflow_without_panicking() {
+        let packing = StackedArgumentPacking::EightByteSlots;
         let byref_overflow = place_foreign_args(
-            &[
-                ForeignArgShape {
-                    pieces: 0,
-                    byref_bytes: u64::MAX,
-                    can_register: false,
-                },
-                ForeignArgShape {
-                    pieces: 0,
-                    byref_bytes: 1,
-                    can_register: false,
-                },
-            ],
+            &[shape(0, u64::MAX, false), shape(0, 1, false)],
             0,
             false,
+            packing,
         );
         assert!(byref_overflow.is_err());
 
         let stack_overflow = place_foreign_args(
-            &[
-                ForeignArgShape {
-                    pieces: u64::MAX,
-                    byref_bytes: 0,
-                    can_register: false,
-                },
-                ForeignArgShape {
-                    pieces: 1,
-                    byref_bytes: 0,
-                    can_register: false,
-                },
-            ],
+            &[shape(u64::MAX, 0, false), shape(1, 0, false)],
             0,
             false,
+            packing,
         );
         assert!(stack_overflow.is_err());
 
         let register_overflow = place_foreign_args(
-            &[
-                ForeignArgShape {
-                    pieces: u64::MAX,
-                    byref_bytes: 0,
-                    can_register: true,
-                },
-                ForeignArgShape {
-                    pieces: 1,
-                    byref_bytes: 0,
-                    can_register: true,
-                },
-            ],
+            &[shape(u64::MAX, 0, true), shape(1, 0, true)],
             u64::MAX,
             false,
+            packing,
         );
         assert!(register_overflow.is_err());
     }
 
     #[derive(Debug)]
     struct TraceBackend {
-        flavor: TargetCAbiFlavor,
+        convention: CallingConvention,
         register_count: usize,
         next_vreg: u32,
         events: Vec<String>,
     }
 
     impl TraceBackend {
-        fn new(flavor: TargetCAbiFlavor, register_count: usize) -> Self {
+        fn new(convention: CallingConvention, register_count: usize) -> Self {
             Self {
-                flavor,
+                convention,
                 register_count,
                 next_vreg: 100,
                 events: Vec::new(),
@@ -832,8 +1191,8 @@ mod tests {
     }
 
     impl ForeignCallLoweringBackend for TraceBackend {
-        fn target_c_flavor(&self) -> TargetCAbiFlavor {
-            self.flavor
+        fn target_c_convention(&self) -> CallingConvention {
+            self.convention
         }
 
         fn foreign_int_arg_register_count(&self) -> usize {
@@ -864,8 +1223,13 @@ mod tests {
             self.vreg()
         }
 
-        fn foreign_emit_stack_args(&mut self, stack_ops: &[VReg]) {
-            self.record(format!("stack:{stack_ops:?}"));
+        fn foreign_emit_stack_args(&mut self, stack: &ForeignStackArea) {
+            let stores = stack
+                .stores
+                .iter()
+                .map(|store| format!("{}@{}+{}", store.value, store.offset, store.bytes))
+                .collect::<Vec<_>>();
+            self.record(format!("stack[{}]:{}", stack.bytes, stores.join(",")));
         }
 
         fn foreign_emit_register_args(&mut self, int_ops: &[VReg]) {
@@ -880,8 +1244,8 @@ mod tests {
             self.record(format!("call:{symbol}"));
         }
 
-        fn foreign_cleanup_stack(&mut self, stack_count: usize) {
-            self.record(format!("cleanup_stack:{stack_count}"));
+        fn foreign_cleanup_stack(&mut self, stack: &ForeignStackArea) {
+            self.record(format!("cleanup_stack:{}", stack.bytes));
         }
 
         fn foreign_cleanup_byref(&mut self, byref_bytes: u32) {
@@ -920,7 +1284,7 @@ mod tests {
     fn shared_driver_preserves_sysv_and_aapcs_event_order() {
         let sysv_inputs = ForeignCallInputs {
             symbol: "sysv_fn".into(),
-            flavor: TargetCAbiFlavor::SysVAmd64,
+            convention: CallingConvention::X86_64SysV,
             args: vec![
                 scalar(0),
                 ForeignArg::AggregateRegisters {
@@ -933,7 +1297,7 @@ mod tests {
             ],
             ret: ForeignReturn::AggregateSret { image: image(24) },
         };
-        let mut sysv = TraceBackend::new(TargetCAbiFlavor::SysVAmd64, 6);
+        let mut sysv = TraceBackend::new(CallingConvention::X86_64SysV, 6);
         let sysv_result = lower_foreign_call(&mut sysv, sysv_inputs, VReg::new(0));
         assert_eq!(sysv_result.slots.len(), 1);
         assert_eq!(
@@ -945,10 +1309,10 @@ mod tests {
                 "get:CfgValue(2)",
                 "get:CfgValue(3)",
                 "get:CfgValue(4)",
-                "stack:[VReg(106)]",
+                "stack[16]:v106@0+8",
                 "registers:[VReg(100), VReg(101), VReg(102), VReg(103), VReg(104), VReg(105)]",
                 "call:sysv_fn",
-                "cleanup_stack:1",
+                "cleanup_stack:16",
                 "cleanup_byref:0",
                 "sret_result:3",
                 "move_primary",
@@ -957,7 +1321,7 @@ mod tests {
 
         let aapcs_inputs = ForeignCallInputs {
             symbol: "aapcs_fn".into(),
-            flavor: TargetCAbiFlavor::Aapcs64,
+            convention: CallingConvention::Aarch64Aapcs,
             args: vec![
                 scalar(0),
                 ForeignArg::AggregateByRefCopy {
@@ -975,7 +1339,7 @@ mod tests {
             ],
             ret: ForeignReturn::AggregateSret { image: image(24) },
         };
-        let mut aapcs = TraceBackend::new(TargetCAbiFlavor::Aapcs64, 8);
+        let mut aapcs = TraceBackend::new(CallingConvention::Aarch64Aapcs, 8);
         let aapcs_result = lower_foreign_call(&mut aapcs, aapcs_inputs, VReg::new(0));
         assert_eq!(aapcs_result.slots.len(), 1);
         assert_eq!(
@@ -992,11 +1356,11 @@ mod tests {
                 "get:CfgValue(7)",
                 "get:CfgValue(8)",
                 "get:CfgValue(9)",
-                "stack:[VReg(109), VReg(110)]",
+                "stack[16]:v109@0+8,v110@8+8",
                 "registers:[VReg(101), VReg(102), VReg(103), VReg(104), VReg(105), VReg(106), VReg(107), VReg(108)]",
                 "assign_sret",
                 "call:aapcs_fn",
-                "cleanup_stack:2",
+                "cleanup_stack:16",
                 "cleanup_byref:32",
                 "sret_result:3",
                 "move_primary",
@@ -1005,18 +1369,18 @@ mod tests {
 
         let register_return_inputs = ForeignCallInputs {
             symbol: "aapcs_register_fn".into(),
-            flavor: TargetCAbiFlavor::Aapcs64,
+            convention: CallingConvention::Aarch64Aapcs,
             args: Vec::new(),
             ret: ForeignReturn::AggregateRegisters { image: image(16) },
         };
-        let mut register_return = TraceBackend::new(TargetCAbiFlavor::Aapcs64, 8);
+        let mut register_return = TraceBackend::new(CallingConvention::Aarch64Aapcs, 8);
         let register_result =
             lower_foreign_call(&mut register_return, register_return_inputs, VReg::new(0));
         assert_eq!(register_result.slots.len(), 1);
         assert_eq!(
             register_return.events,
             vec![
-                "stack:[]",
+                "stack[0]:",
                 "registers:[]",
                 "call:aapcs_register_fn",
                 "cleanup_stack:0",
@@ -1024,6 +1388,37 @@ mod tests {
                 "register_result:2",
                 "move_primary",
             ]
+        );
+    }
+
+    #[test]
+    fn the_darwin_row_reaches_the_backend_as_packed_stores() {
+        let mut darwin = TraceBackend::new(CallingConvention::Aarch64AapcsDarwin, 8);
+        lower_foreign_call(
+            &mut darwin,
+            narrow_tail_inputs(CallingConvention::Aarch64AapcsDarwin),
+            VReg::new(0),
+        );
+        assert!(
+            darwin
+                .events
+                .contains(&"stack[16]:v108@0+1,v109@2+2,v110@4+4,v111@8+8".to_string()),
+            "packed Darwin stores must reach the backend leaf: {:?}",
+            darwin.events
+        );
+
+        let mut linux = TraceBackend::new(CallingConvention::Aarch64Aapcs, 8);
+        lower_foreign_call(
+            &mut linux,
+            narrow_tail_inputs(CallingConvention::Aarch64Aapcs),
+            VReg::new(0),
+        );
+        assert!(
+            linux
+                .events
+                .contains(&"stack[32]:v108@0+8,v109@8+8,v110@16+8,v111@24+8".to_string()),
+            "AAPCS64 keeps whole 8-byte slots: {:?}",
+            linux.events
         );
     }
 }

--- a/crates/rue-codegen/src/frame_layout.rs
+++ b/crates/rue-codegen/src/frame_layout.rs
@@ -131,6 +131,22 @@ pub fn checked_call_area_bytes(
     indirect_argument_bytes: u64,
 ) -> Result<u32, FrameBudgetExceeded> {
     let stack_bytes = u64::from(checked_aligned_cell_region_bytes(stack_slots)?);
+    checked_call_area_from_stack_bytes(stack_bytes, sret_storage_bytes, indirect_argument_bytes)
+}
+
+/// The same validation for a caller that has already sized its outgoing
+/// argument area in bytes rather than in whole cells.
+///
+/// A target-C argument area is not a whole number of cells under every psABI:
+/// Apple's arm64 amendment packs stacked scalars at their natural size, so the
+/// area's size is computed by the foreign-call planner and passed through here
+/// as bytes.
+#[inline]
+pub fn checked_call_area_from_stack_bytes(
+    stack_bytes: u64,
+    sret_storage_bytes: u64,
+    indirect_argument_bytes: u64,
+) -> Result<u32, FrameBudgetExceeded> {
     let total = sret_storage_bytes
         .checked_add(indirect_argument_bytes)
         .and_then(|bytes| bytes.checked_add(stack_bytes))

--- a/crates/rue-codegen/src/runtime_call_plan.rs
+++ b/crates/rue-codegen/src/runtime_call_plan.rs
@@ -6,13 +6,40 @@
 //! argument materialization until a target adapter assigns physical registers.
 
 use rue_runtime_abi::{
-    AbiParameter, AbiResult, AbiType, AggregateShapeId, CallingConvention, ParameterMode,
-    ReturnBehavior, RuntimeHelperId,
+    AbiParameter, AbiResult, AbiType, AggregateShapeId, ParameterMode, ReturnBehavior,
+    RuntimeHelperId, RuntimeTarget,
 };
+use rue_target::{CallingConvention, Target};
 
 use crate::allocation::ScalePlan;
 use crate::call_plan::{CallArgInput, CallMaterializer, ReturnPlan};
 use crate::vreg::VReg;
+
+/// The one correspondence between the compiler's [`Target`] and the runtime
+/// manifest's dependency-light [`RuntimeTarget`] mirror.
+///
+/// `rue-runtime-abi` is a `no_std` leaf that cannot depend on `rue-target`
+/// (ADR-0055), so it names targets in its own enum. This pair of renamings is
+/// the bridge, and it carries no ABI policy of its own: a manifest-side target
+/// reaches the single `"C"` alias table by becoming a [`Target`] first. Both
+/// directions are total, and the crate's tests pin them as mutual inverses.
+pub const fn runtime_target(target: Target) -> RuntimeTarget {
+    match target {
+        Target::X86_64Linux => RuntimeTarget::X86_64Linux,
+        Target::Aarch64Linux => RuntimeTarget::Aarch64Linux,
+        Target::Aarch64Macos => RuntimeTarget::Aarch64Macos,
+    }
+}
+
+/// The [`Target`] a manifest-side [`RuntimeTarget`] names; the inverse of
+/// [`runtime_target`].
+pub const fn compiler_target(target: RuntimeTarget) -> Target {
+    match target {
+        RuntimeTarget::X86_64Linux => Target::X86_64Linux,
+        RuntimeTarget::Aarch64Linux => Target::Aarch64Linux,
+        RuntimeTarget::Aarch64Macos => Target::Aarch64Macos,
+    }
+}
 
 /// One canonical logical runtime argument.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,7 +150,6 @@ pub struct RuntimeCallPlan {
     args: Vec<RuntimeCallArg>,
     result: RuntimeCallResult,
     return_behavior: ReturnBehavior,
-    calling_convention: CallingConvention,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,7 +220,6 @@ impl RuntimeCallPlan {
             args,
             result,
             return_behavior: manifest.return_behavior,
-            calling_convention: manifest.calling_convention,
         })
     }
 
@@ -322,8 +347,16 @@ impl RuntimeCallPlan {
         self.return_behavior
     }
 
-    pub const fn calling_convention(&self) -> CallingConvention {
-        self.calling_convention
+    /// The convention a runtime-helper call crosses under on `target`.
+    ///
+    /// The helper boundary is a `"C"` call like any other, so it resolves
+    /// through the one alias table rather than carrying a convention of its
+    /// own: every compiler-callable helper in the manifest is a C call, and
+    /// which C row that is depends only on the compilation target. This is an
+    /// associated function, not a method, because the plan itself holds nothing
+    /// target-specific.
+    pub const fn calling_convention(target: Target) -> CallingConvention {
+        CallingConvention::c_for_target(target)
     }
 
     pub const fn symbol(&self) -> &'static str {
@@ -341,6 +374,62 @@ impl RuntimeCallPlan {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every `RuntimeTarget` the manifest can name. `RuntimeTarget` has no
+    /// `ALL`, so this list is exhaustive by construction: adding a variant makes
+    /// [`compiler_target`] fail to compile and this list fail its round trip.
+    const RUNTIME_TARGETS: [RuntimeTarget; 3] = [
+        RuntimeTarget::X86_64Linux,
+        RuntimeTarget::Aarch64Linux,
+        RuntimeTarget::Aarch64Macos,
+    ];
+
+    #[test]
+    fn the_target_correspondence_is_a_total_bijection() {
+        for target in Target::all() {
+            assert_eq!(compiler_target(runtime_target(*target)), *target);
+        }
+        for target in RUNTIME_TARGETS {
+            assert_eq!(runtime_target(compiler_target(target)), target);
+        }
+        assert_eq!(Target::all().len(), RUNTIME_TARGETS.len());
+    }
+
+    #[test]
+    fn the_helper_boundary_resolves_through_the_one_c_alias_table() {
+        // Total over every `Target`, total over every `RuntimeTarget`, and the
+        // two agree: a manifest-side target resolves the alias by becoming a
+        // compiler target first, so there is one mapping table and not two.
+        for target in Target::all() {
+            let convention = RuntimeCallPlan::calling_convention(*target);
+            assert_eq!(
+                convention,
+                CallingConvention::c_for_target(*target),
+                "the runtime-helper boundary is the target's `\"C\"` convention"
+            );
+            assert!(convention.is_c());
+            assert_eq!(
+                convention,
+                CallingConvention::c_for_target(compiler_target(runtime_target(*target))),
+                "the `RuntimeTarget` route must reach the same row"
+            );
+        }
+        for target in RUNTIME_TARGETS {
+            assert!(CallingConvention::c_for_target(compiler_target(target)).is_c());
+        }
+        assert_eq!(
+            RuntimeCallPlan::calling_convention(Target::Aarch64Macos),
+            CallingConvention::Aarch64AapcsDarwin
+        );
+        assert_eq!(
+            RuntimeCallPlan::calling_convention(Target::Aarch64Linux),
+            CallingConvention::Aarch64Aapcs
+        );
+        assert_eq!(
+            RuntimeCallPlan::calling_convention(Target::X86_64Linux),
+            CallingConvention::X86_64SysV
+        );
+    }
 
     #[test]
     fn panic_rejects_arbitrary_arguments_and_sret() {
@@ -368,7 +457,6 @@ mod tests {
         let random = RuntimeCallPlan::no_args(RuntimeHelperId::RandomU64);
         assert_eq!(random.result, RuntimeCallResult::Scalar(AbiType::U64));
         assert_eq!(random.return_behavior, ReturnBehavior::Returns);
-        assert_eq!(random.calling_convention, CallingConvention::TargetC);
 
         let read = RuntimeCallPlan::expect_manifest(
             RuntimeHelperId::ReadLine,

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -448,9 +448,6 @@ pub trait ValueLowerAdapter:
     /// [`resolve_symbol`](Self::resolve_symbol)) names an `extern "C"` foreign
     /// function, so its call crosses under the target-C ABI (ADR-0064 P2).
     fn is_foreign_symbol(&self, machine_symbol: &str) -> bool;
-    /// The target-C psABI flavor for this backend: SysV AMD64 on x86-64, AAPCS64
-    /// on AArch64. Names the classifier that governs a foreign-call boundary.
-    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor;
     fn resolve_named_symbol(&self, symbol: &str) -> String;
     fn call_arg_register_banks(&self) -> crate::call_plan::AbiRegisterBanks;
     /// The target's RETURN register file, one bank per register class. Its
@@ -1786,7 +1783,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         ctx.type_pool,
                         inst.ty,
                         call_args,
-                        adapter.target_c_flavor(),
+                        adapter.target_c_convention(),
                     );
                     let result_vreg = adapter.reserve_typed_value_result(float_width(inst.ty));
                     adapter.emit_foreign_call(foreign_inputs, result_vreg)
@@ -1799,7 +1796,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     let foreign_return_extension = if is_foreign
                         && matches!(inputs.return_plan, crate::call_plan::ReturnPlan::Scalar)
                     {
-                        let ext = rue_air::TargetCCallAbi::new(adapter.target_c_flavor())
+                        let ext = rue_air::TargetCCallAbi::new(adapter.target_c_convention())
                             .scalar_return_extension(inst.ty);
                         (!ext.is_noop()).then_some(ext)
                     } else {
@@ -3985,10 +3982,6 @@ mod tests {
                 .map(|arg| arg.parameter())
                 .collect::<Vec<_>>(),
             RuntimeHelperId::Realloc.helper().parameters
-        );
-        assert_eq!(
-            realloc.calling_convention(),
-            RuntimeHelperId::Realloc.helper().calling_convention
         );
         assert_eq!(
             realloc.return_behavior(),

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -45,6 +45,17 @@ use crate::vreg::BLOCK_LABEL_BASE;
 /// these are passed on the caller's stack (slot `k >= 6` at `[rbp+16+(k-6)*8]`
 /// in the callee); the callee prologue copies them into its frame param area
 /// so the body addresses every param slot uniformly (see `emit_prologue`).
+/// The one x86-64 target Rue supports. This backend serves exactly that target,
+/// so it names it rather than threading it through lowering; every convention
+/// question still resolves through the single `"C"` alias table keyed by it,
+/// never by architecture.
+pub(super) const X86_64_TARGET: rue_target::Target = rue_target::Target::X86_64Linux;
+
+/// The convention an `extern "C"` boundary follows on this backend's target.
+pub(super) const fn x86_64_target_c_convention() -> rue_target::CallingConvention {
+    X86_64_TARGET.c_calling_convention()
+}
+
 pub(super) const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9];
 pub(super) const FP_ARG_REGS: [Reg; 8] = [
     Reg::Xmm0,
@@ -145,6 +156,10 @@ pub struct CfgLower<'a> {
 }
 
 impl crate::call_plan::CallMaterializer for CfgLower<'_> {
+    fn target_c_convention(&self) -> rue_target::CallingConvention {
+        x86_64_target_c_convention()
+    }
+
     fn materialize_scalar(&mut self, value: CfgValue) -> VReg {
         self.get_vreg(value)
     }
@@ -334,10 +349,14 @@ impl<'a> CfgLower<'a> {
         &mut self,
         plan: crate::runtime_call_plan::RuntimeCallPlan,
     ) -> crate::value_plan::MaterializedValue {
-        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallResult};
-        use rue_runtime_abi::CallingConvention;
+        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallPlan, RuntimeCallResult};
 
-        assert_eq!(plan.calling_convention(), CallingConvention::TargetC);
+        assert_eq!(
+            RuntimeCallPlan::calling_convention(X86_64_TARGET),
+            rue_target::CallingConvention::X86_64SysV,
+            "this lowering implements SysV AMD64, the convention the runtime-helper \
+             boundary resolves to on x86-64"
+        );
         assert!(
             plan.args().len() <= ARG_REGS.len(),
             "runtime manifest exceeds the x86-64 target-C register budget"
@@ -598,6 +617,7 @@ impl<'a> CfgLower<'a> {
                 gp: ARG_REGS.len(),
                 fp: FP_ARG_REGS.len(),
             },
+            x86_64_target_c_convention(),
         );
         let _ = self.lower_call_plan(plan);
     }
@@ -3994,9 +4014,6 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn is_foreign_symbol(&self, machine_symbol: &str) -> bool {
         self.symbols.is_foreign(machine_symbol)
     }
-    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
-        rue_air::TargetCAbiFlavor::SysVAmd64
-    }
     fn call_arg_register_banks(&self) -> crate::call_plan::AbiRegisterBanks {
         crate::call_plan::AbiRegisterBanks {
             gp: ARG_REGS.len(),
@@ -4095,8 +4112,8 @@ fn emit_marshal_tag_ne(mir: &mut X86Mir, tag: VReg, discriminant: u32, label: La
 }
 
 impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
-    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
-        rue_air::TargetCAbiFlavor::SysVAmd64
+    fn target_c_convention(&self) -> rue_target::CallingConvention {
+        x86_64_target_c_convention()
     }
 
     fn foreign_int_arg_register_count(&self) -> usize {
@@ -4137,26 +4154,38 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         panic!("SysV AMD64 does not pass foreign aggregates by reference")
     }
 
-    fn foreign_emit_stack_args(&mut self, stack_ops: &[VReg]) {
-        let count = u64::try_from(stack_ops.len()).expect("foreign stack slot count must fit u64");
+    fn foreign_emit_stack_args(&mut self, stack: &crate::foreign_call::ForeignStackArea) {
+        // SysV packs its outgoing argument area in whole 8-byte slots, so the
+        // planner's stores are always one full slot at an ascending cell offset
+        // and this adapter keeps its push-based sequence: pushing in reverse
+        // order leaves store 0 nearest `rsp`, which is the offset the planner
+        // assigned it.
+        let count =
+            u64::try_from(stack.stores.len()).expect("foreign stack slot count must fit u64");
+        for (index, store) in stack.stores.iter().enumerate() {
+            let cell_offset = checked_cell_byte_offset(index as u64)
+                .ok()
+                .and_then(|offset| u32::try_from(offset).ok())
+                .expect("foreign stack slot offset must fit an unsigned displacement");
+            assert_eq!(
+                (store.bytes, store.offset),
+                (8, cell_offset),
+                "SysV AMD64 stacks every argument in one whole 8-byte slot"
+            );
+        }
         let cell_bytes =
             checked_cell_region_bytes(count).expect("foreign stack area must fit displacement");
-        let stack_bytes = checked_aligned_cell_region_bytes(count)
-            .expect("foreign stack area must pass frame-budget preflight");
-        if stack_bytes > cell_bytes {
+        if stack.bytes > cell_bytes {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
-                imm: -i32::try_from(
-                    checked_cell_region_padding_bytes(count)
-                        .expect("foreign stack alignment padding must fit displacement"),
-                )
-                .expect("foreign stack alignment padding must fit i32"),
+                imm: -i32::try_from(stack.bytes - cell_bytes)
+                    .expect("foreign stack alignment padding must fit i32"),
             });
         }
-        for v in stack_ops.iter().rev() {
+        for store in stack.stores.iter().rev() {
             self.mir.push(X86Inst::MovRR {
                 dst: Operand::Physical(Reg::Rax),
-                src: Operand::Virtual(*v),
+                src: Operand::Virtual(store.value),
             });
             self.mir.push(X86Inst::Push {
                 src: Operand::Physical(Reg::Rax),
@@ -4190,15 +4219,11 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         self.mir.push(X86Inst::call(symbol_id));
     }
 
-    fn foreign_cleanup_stack(&mut self, stack_count: usize) {
-        if stack_count > 0 {
-            let stack_bytes = checked_aligned_cell_region_bytes(
-                u64::try_from(stack_count).expect("foreign stack slot count must fit u64"),
-            )
-            .expect("foreign stack area must pass frame-budget preflight");
+    fn foreign_cleanup_stack(&mut self, stack: &crate::foreign_call::ForeignStackArea) {
+        if stack.bytes > 0 {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
-                imm: checked_displacement_bytes(u64::from(stack_bytes))
+                imm: checked_displacement_bytes(u64::from(stack.bytes))
                     .expect("foreign stack area must fit displacement"),
             });
         }
@@ -6537,14 +6562,13 @@ mod tests {
 
     #[test]
     fn runtime_manifest_fits_register_only_target_c_subset() {
+        assert_eq!(
+            crate::runtime_call_plan::RuntimeCallPlan::calling_convention(X86_64_TARGET),
+            rue_target::CallingConvention::X86_64SysV,
+            "the x86-64 runtime-helper boundary is SysV AMD64"
+        );
         for id in rue_runtime_abi::RuntimeHelperId::ALL {
             let helper = id.helper();
-            assert_eq!(
-                helper.calling_convention,
-                rue_runtime_abi::CallingConvention::TargetC,
-                "{} must use the target C convention",
-                helper.symbol
-            );
             assert!(
                 helper.parameters.len() <= ARG_REGS.len(),
                 "{} has {} parameters, exceeding the x86-64 register-only runtime-call budget of {}",
@@ -7189,5 +7213,89 @@ mod tests {
             )),
             "a `u8` @ptr_read must use the one-byte zero-extended narrow load"
         );
+    }
+
+    #[test]
+    fn sysv_stacks_a_narrow_tail_in_whole_slots_unaffected_by_the_apple_amendment() {
+        use crate::foreign_call::{
+            AggregateImage, ForeignArg, ForeignCallInputs, ForeignCallLoweringBackend,
+            ForeignCallPlan, ForeignReturn,
+        };
+        // The same narrow `i8`/`i16`/`i32` tail Apple packs on AArch64: SysV has
+        // no natural-size amendment, so each stacked argument keeps a whole
+        // 8-byte slot whatever its C width, and the push-based sequence stands.
+        let mut args = vec![ForeignArg::AggregateRegisters {
+            value: CfgValue::from_raw(0),
+            image: AggregateImage {
+                map: Vec::new(),
+                padding: Vec::new(),
+                slot_count: 0,
+                size: 8,
+                align: 8,
+                storage_bytes: 16,
+            },
+        }];
+        args.extend((1..6).map(|index| ForeignArg::Scalar {
+            value: CfgValue::from_raw(index),
+            natural_bytes: 8,
+        }));
+        for (index, natural_bytes) in [(6, 1), (7, 2), (8, 4)] {
+            args.push(ForeignArg::Scalar {
+                value: CfgValue::from_raw(index),
+                natural_bytes,
+            });
+        }
+        let plan = ForeignCallPlan::new(
+            ForeignCallInputs {
+                symbol: "narrow_tail".into(),
+                convention: x86_64_target_c_convention(),
+                args,
+                ret: ForeignReturn::ZeroSized,
+            },
+            ARG_REGS.len(),
+        );
+        let area = plan.stack_area_for_test(&[VReg::new(80), VReg::new(81), VReg::new(82)]);
+        assert_eq!(area.bytes, 32);
+        assert_eq!(
+            area.stores
+                .iter()
+                .map(|store| (store.offset, store.bytes))
+                .collect::<Vec<_>>(),
+            vec![(0, 8), (8, 8), (16, 8)]
+        );
+
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let mut fixture = FixtureCfg::new(
+            Type::UNIT,
+            0,
+            "f",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        fixture.ret(None);
+        let cfg = fixture.cfg.finish(&pool).expect("test CFG must verify");
+        let mut lower = CfgLower::new(&cfg, &pool, &interner);
+        lower.foreign_emit_stack_args(&area);
+        // Three whole slots plus one cell of call-alignment padding, pushed in
+        // reverse so the first store lands nearest `rsp`.
+        assert_eq!(
+            lower
+                .mir
+                .instructions()
+                .iter()
+                .filter(|inst| matches!(inst, X86Inst::Push { .. }))
+                .count(),
+            3
+        );
+        assert!(lower.mir.instructions().iter().any(|inst| matches!(
+            inst,
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: -8
+            }
+        )));
     }
 }

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -67,7 +67,6 @@ impl Backend for X86CodegenBackend {
     const RETURN_REG_COUNT: u32 = cfg_lower::RET_REGS.len() as u32;
     const SAVED_REG_SCHEME: crate::frame_layout::SavedRegScheme =
         crate::frame_layout::SavedRegScheme::X86_64;
-    const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor = rue_air::TargetCAbiFlavor::SysVAmd64;
 
     fn lower(
         cfg: &ValidatedCfg,

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -949,12 +949,7 @@ impl CfgDomainProjection {
                     // native symbol come from the same facts, and this map is
                     // keyed by a recursive callable identity.
                     let abi = call_abis.get(callable);
-                    let foreign = abi.is_some_and(|facts| {
-                        matches!(
-                            facts.convention,
-                            crate::type_queries::CallAbiConvention::TargetC(_)
-                        )
-                    });
+                    let foreign = abi.is_some_and(|facts| facts.convention.is_c());
                     let machine = if foreign {
                         foreign_callable_symbol(callable).ok_or(CfgDomainFailure::Shape)?
                     } else if source == "main" {
@@ -977,12 +972,7 @@ impl CfgDomainProjection {
                         crate::semantic_identity::function_instance_from_specialization(identity)
                             .ok_or(CfgDomainFailure::Shape)?;
                     let abi = call_abis.get(&callable);
-                    let foreign = abi.is_some_and(|facts| {
-                        matches!(
-                            facts.convention,
-                            crate::type_queries::CallAbiConvention::TargetC(_)
-                        )
-                    });
+                    let foreign = abi.is_some_and(|facts| facts.convention.is_c());
                     let machine = if foreign {
                         foreign_callable_symbol(&callable).ok_or(CfgDomainFailure::Shape)?
                     } else if source == "main" {

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -757,13 +757,9 @@ fn check_runtime_archive_work(
     }
 }
 
-fn runtime_target(target: Target) -> rue_runtime_abi::RuntimeTarget {
-    match target {
-        Target::X86_64Linux => rue_runtime_abi::RuntimeTarget::X86_64Linux,
-        Target::Aarch64Linux => rue_runtime_abi::RuntimeTarget::Aarch64Linux,
-        Target::Aarch64Macos => rue_runtime_abi::RuntimeTarget::Aarch64Macos,
-    }
-}
+// The compiler-target to runtime-manifest-target correspondence has one home;
+// linking names the same renaming the runtime-helper boundary resolves through.
+use rue_codegen::runtime_call_plan::runtime_target;
 
 fn parsed_object_target(
     object: &ObjectFile,

--- a/crates/rue-compiler/src/revisioned_query_database/semantic.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/semantic.rs
@@ -1886,9 +1886,10 @@ pub(super) fn evaluate_call_abi(
 ) -> Result<QueryOutput<crate::type_queries::CallAbiValue>, QueryAbort> {
     use crate::durable_semantics::DurableParameterMode;
     use crate::type_queries::{
-        CallAbiArgument, CallAbiArgumentClass as A, CallAbiConvention, CallAbiFacts,
-        CallAbiReturnClass as R, CallAbiValue,
+        CallAbiArgument, CallAbiArgumentClass as A, CallAbiFacts, CallAbiReturnClass as R,
+        CallAbiValue,
     };
+    use rue_target::CallingConvention;
     let signature = match query_callable_signature(
         context,
         semantic_nucleus,
@@ -1903,12 +1904,13 @@ pub(super) fn evaluate_call_abi(
                 .with_terminal_kind(QueryTerminalKind::Failure));
         }
     };
+    // `"C"` is an alias resolved by the whole target, not by its architecture:
+    // AArch64 Linux and AArch64 macOS share an architecture and follow different
+    // conventions. The stable plane consults the same table code generation does.
     let convention = if signature.target_c {
-        CallAbiConvention::TargetC(rue_air::TargetCAbiFlavor::for_arch(
-            key.configuration.target.arch(),
-        ))
+        CallingConvention::c_for_target(key.configuration.target)
     } else {
-        CallAbiConvention::Native
+        CallingConvention::Rue
     };
     // Every layout this ABI needs, in one batch: each by-value parameter in
     // signature order, then the result. A reference parameter is passed as a
@@ -1967,44 +1969,34 @@ pub(super) fn evaluate_call_abi(
                     .with_terminal_kind(QueryTerminalKind::Failure));
             }
         };
-        let class = match convention {
-            CallAbiConvention::Native => {
-                match stable_native_abi_facts(layout, ty)
-                    .classify_arg(rue_air::ArgConvention::ByValue)
-                {
-                    rue_air::ArgClass::Omitted => A::Omitted,
-                    rue_air::ArgClass::Direct { slot_count } => {
-                        A::NativeDirect { slots: slot_count }
-                    }
-                    rue_air::ArgClass::Indirect => A::NativeIndirect,
-                }
+        let class = if convention.is_rue() {
+            match stable_native_abi_facts(layout, ty).classify_arg(rue_air::ArgConvention::ByValue)
+            {
+                rue_air::ArgClass::Omitted => A::Omitted,
+                rue_air::ArgClass::Direct { slot_count } => A::NativeDirect { slots: slot_count },
+                rue_air::ArgClass::Indirect => A::NativeIndirect,
             }
-            CallAbiConvention::TargetC(flavor) => {
-                if layout.size == 0 {
-                    A::Omitted
-                } else if !stable_type_is_aggregate(ty) {
-                    A::CScalar {
-                        extension: c_scalar_extension(ty),
-                    }
-                } else {
-                    match rue_air::TargetCCallAbi::new(flavor)
-                        .classify_aggregate_arg(layout.size, layout.alignment)
-                    {
-                        rue_air::AggregateArgClass::IntegerRegisters { eightbytes } => {
-                            A::CIntegerRegisters { eightbytes }
-                        }
-                        rue_air::AggregateArgClass::ByValueStack { size, align } => {
-                            A::CByValueStack {
-                                size,
-                                alignment: align,
-                            }
-                        }
-                        rue_air::AggregateArgClass::ByReferenceCopy { size, align } => {
-                            A::CByReferenceCopy {
-                                size,
-                                alignment: align,
-                            }
-                        }
+        } else if layout.size == 0 {
+            A::Omitted
+        } else if !stable_type_is_aggregate(ty) {
+            A::CScalar {
+                extension: c_scalar_extension(ty),
+            }
+        } else {
+            match rue_air::TargetCCallAbi::new(convention)
+                .classify_aggregate_arg(layout.size, layout.alignment)
+            {
+                rue_air::AggregateArgClass::IntegerRegisters { eightbytes } => {
+                    A::CIntegerRegisters { eightbytes }
+                }
+                rue_air::AggregateArgClass::ByValueStack { size, align } => A::CByValueStack {
+                    size,
+                    alignment: align,
+                },
+                rue_air::AggregateArgClass::ByReferenceCopy { size, align } => {
+                    A::CByReferenceCopy {
+                        size,
+                        alignment: align,
                     }
                 }
             }
@@ -2022,43 +2014,37 @@ pub(super) fn evaluate_call_abi(
                 .with_terminal_kind(QueryTerminalKind::Failure));
         }
     };
-    let return_class = match convention {
-        CallAbiConvention::Native => {
-            let budget = rue_air::native_return_register_budget(key.configuration.target.arch());
-            match stable_native_abi_facts(return_layout, &signature.result).classify_return(budget)
-            {
-                rue_air::ReturnClass::ZeroSized => R::ZeroSized,
-                rue_air::ReturnClass::Scalar => R::Scalar {
-                    extension: rue_air::ScalarAbiExtension::None,
-                },
-                rue_air::ReturnClass::Registers { slot_count } => {
-                    R::NativeRegisters { slots: slot_count }
-                }
-                rue_air::ReturnClass::Indirect { slot_count } => {
-                    R::NativeIndirect { slots: slot_count }
-                }
+    let return_class = if convention.is_rue() {
+        let budget = rue_air::native_return_register_budget(key.configuration.target.arch());
+        match stable_native_abi_facts(return_layout, &signature.result).classify_return(budget) {
+            rue_air::ReturnClass::ZeroSized => R::ZeroSized,
+            rue_air::ReturnClass::Scalar => R::Scalar {
+                extension: rue_air::ScalarAbiExtension::None,
+            },
+            rue_air::ReturnClass::Registers { slot_count } => {
+                R::NativeRegisters { slots: slot_count }
+            }
+            rue_air::ReturnClass::Indirect { slot_count } => {
+                R::NativeIndirect { slots: slot_count }
             }
         }
-        CallAbiConvention::TargetC(flavor) => {
-            if return_layout.abi_slots == 0 {
-                R::ZeroSized
-            } else if !stable_type_is_aggregate(&signature.result) {
-                R::Scalar {
-                    extension: c_scalar_extension(&signature.result),
-                }
-            } else {
-                match rue_air::TargetCCallAbi::new(flavor)
-                    .classify_aggregate_return(return_layout.size, return_layout.alignment)
-                {
-                    rue_air::AggregateReturnClass::IntegerRegisters { eightbytes } => {
-                        R::CIntegerRegisters { eightbytes }
-                    }
-                    rue_air::AggregateReturnClass::Indirect { size, align } => R::CIndirect {
-                        size,
-                        alignment: align,
-                    },
-                }
+    } else if return_layout.abi_slots == 0 {
+        R::ZeroSized
+    } else if !stable_type_is_aggregate(&signature.result) {
+        R::Scalar {
+            extension: c_scalar_extension(&signature.result),
+        }
+    } else {
+        match rue_air::TargetCCallAbi::new(convention)
+            .classify_aggregate_return(return_layout.size, return_layout.alignment)
+        {
+            rue_air::AggregateReturnClass::IntegerRegisters { eightbytes } => {
+                R::CIntegerRegisters { eightbytes }
             }
+            rue_air::AggregateReturnClass::Indirect { size, align } => R::CIndirect {
+                size,
+                alignment: align,
+            },
         }
     };
     Ok(QueryOutput::success(CallAbiValue::Available(
@@ -2066,7 +2052,7 @@ pub(super) fn evaluate_call_abi(
             convention,
             return_class,
             arguments: arguments.into(),
-            native_symbol: matches!(convention, CallAbiConvention::Native).then(|| {
+            native_symbol: convention.is_rue().then(|| {
                 Arc::from(crate::StableSymbolEncoder::encode(
                     &crate::StableSymbolId::Callable(crate::StableCallableId::Function(
                         key.callable.clone(),

--- a/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
@@ -548,9 +548,8 @@ fn request_call_abi(
 
 #[test]
 fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_targets() {
-    use crate::type_queries::{
-        CallAbiArgumentClass as A, CallAbiConvention as C, CallAbiReturnClass as R,
-    };
+    use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
+    use rue_target::CallingConvention as C;
     let source = source_snapshot(
         &[(
             1,
@@ -581,7 +580,7 @@ fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_ta
         ));
     for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
         let native = request_call_abi(&database, revision, native.clone(), target);
-        assert_eq!(native.convention, C::Native);
+        assert_eq!(native.convention, C::Rue);
         assert!(native.native_symbol.is_some());
         assert_eq!(
             native.return_class,
@@ -593,14 +592,7 @@ fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_ta
         );
 
         let foreign = request_call_abi(&database, revision, foreign.clone(), target);
-        assert_eq!(
-            foreign.convention,
-            C::TargetC(if target == crate::Target::X86_64Linux {
-                rue_air::TargetCAbiFlavor::SysVAmd64
-            } else {
-                rue_air::TargetCAbiFlavor::Aapcs64
-            })
-        );
+        assert_eq!(foreign.convention, C::c_for_target(target));
         assert!(foreign.native_symbol.is_none());
         assert_eq!(
             foreign.return_class,
@@ -616,7 +608,7 @@ fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_ta
         ));
 
         let exported = request_call_abi(&database, revision, exported.clone(), target);
-        assert_eq!(exported.convention, C::Native);
+        assert_eq!(exported.convention, C::Rue);
         assert_eq!(
             exported.return_class,
             R::Scalar {
@@ -625,7 +617,7 @@ fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_ta
         );
 
         let destructor = request_call_abi(&database, revision, destructor.clone(), target);
-        assert_eq!(destructor.convention, C::Native);
+        assert_eq!(destructor.convention, C::Rue);
         assert_eq!(destructor.arguments.len(), 1);
         assert!(matches!(
             destructor.arguments[0].class,
@@ -638,7 +630,7 @@ fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_ta
             crate::FunctionInstanceKey::DropGlue(Node::new(owner.clone())),
             target,
         );
-        assert_eq!(glue.convention, C::Native);
+        assert_eq!(glue.convention, C::Rue);
         assert_eq!(glue.return_class, R::ZeroSized);
         assert!(matches!(
             glue.arguments[0].class,
@@ -649,9 +641,8 @@ fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_ta
 
 #[test]
 fn call_abi_batches_layouts_across_mixed_modes_and_duplicate_parameter_types() {
-    use crate::type_queries::{
-        CallAbiArgumentClass as A, CallAbiConvention as C, CallAbiReturnClass as R,
-    };
+    use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
+    use rue_target::CallingConvention as C;
     // `mixed` interleaves reference and by-value parameters and repeats
     // `[u64; 7]`, so the batch is sparser than the parameter list and
     // carries a duplicate key. `scalars` repeats `u32` under Target-C.
@@ -675,7 +666,7 @@ fn call_abi_batches_layouts_across_mixed_modes_and_duplicate_parameter_types() {
 
     for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
         let mixed = request_call_abi(&database, revision, mixed.clone(), target);
-        assert_eq!(mixed.convention, C::Native);
+        assert_eq!(mixed.convention, C::Rue);
         assert_eq!(mixed.arguments.len(), 5);
 
         // Reference parameters stay layout-free and keep one value slot,
@@ -706,14 +697,7 @@ fn call_abi_batches_layouts_across_mixed_modes_and_duplicate_parameter_types() {
         );
 
         let scalars = request_call_abi(&database, revision, scalars.clone(), target);
-        assert_eq!(
-            scalars.convention,
-            C::TargetC(if target == crate::Target::X86_64Linux {
-                rue_air::TargetCAbiFlavor::SysVAmd64
-            } else {
-                rue_air::TargetCAbiFlavor::Aapcs64
-            })
-        );
+        assert_eq!(scalars.convention, C::c_for_target(target));
         assert_eq!(scalars.arguments.len(), 3);
         assert_eq!(scalars.arguments[0].class, scalars.arguments[1].class);
         assert_eq!(
@@ -739,9 +723,8 @@ fn call_abi_batches_layouts_across_mixed_modes_and_duplicate_parameter_types() {
 
 #[test]
 fn call_abi_resolves_value_specialized_array_layout_on_both_targets() {
-    use crate::type_queries::{
-        CallAbiArgumentClass as A, CallAbiConvention as C, CallAbiReturnClass as R,
-    };
+    use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
+    use rue_target::CallingConvention as C;
     let source = source_snapshot(
         &[(
             1,
@@ -765,7 +748,7 @@ fn call_abi_resolves_value_specialized_array_layout_on_both_targets() {
     let revision = revision_for(&mut database, &source);
     for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
         let named = request_call_abi(&database, revision, named.clone(), target);
-        assert_eq!(named.convention, C::Native);
+        assert_eq!(named.convention, C::Rue);
         assert_eq!(
             named.return_class,
             R::Scalar {
@@ -781,7 +764,7 @@ fn call_abi_resolves_value_specialized_array_layout_on_both_targets() {
         );
 
         let facts = request_call_abi(&database, revision, callable.clone(), target);
-        assert_eq!(facts.convention, C::Native);
+        assert_eq!(facts.convention, C::Rue);
         assert_eq!(
             facts.return_class,
             if target == crate::Target::X86_64Linux {
@@ -806,9 +789,8 @@ fn call_abi_resolves_value_specialized_array_layout_on_both_targets() {
 
 #[test]
 fn call_abi_derives_anonymous_destructor_signature_from_its_exact_producer() {
-    use crate::type_queries::{
-        CallAbiArgumentClass as A, CallAbiConvention as C, CallAbiReturnClass as R,
-    };
+    use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
+    use rue_target::CallingConvention as C;
     let source = source_snapshot(
         &[(
             1,
@@ -850,7 +832,7 @@ fn call_abi_derives_anonymous_destructor_signature_from_its_exact_producer() {
     };
     for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
         let facts = request_call_abi(&database, revision, callable.clone(), target);
-        assert_eq!(facts.convention, C::Native);
+        assert_eq!(facts.convention, C::Rue);
         assert_eq!(facts.return_class, R::ZeroSized);
         assert_eq!(facts.arguments.len(), 1);
         assert!(matches!(
@@ -1075,7 +1057,7 @@ fn call_abi_native_classification_matches_the_live_classifier_on_both_targets() 
             );
             assert_eq!(
                 facts.convention,
-                crate::type_queries::CallAbiConvention::Native,
+                rue_target::CallingConvention::Rue,
                 "{name} is a native callable"
             );
             assert_eq!(facts.arguments.len(), params.len(), "arity of {name}");
@@ -1361,12 +1343,8 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
     let mut database = RevisionedQueryDatabase::default();
     let revision = revision_for(&mut database, &source);
     for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
-        let flavor = if target == crate::Target::X86_64Linux {
-            rue_air::TargetCAbiFlavor::SysVAmd64
-        } else {
-            rue_air::TargetCAbiFlavor::Aapcs64
-        };
-        let abi = TargetCCallAbi::new(flavor);
+        let convention = rue_target::CallingConvention::c_for_target(target);
+        let abi = TargetCCallAbi::new(convention);
         let request = |name: &str| {
             request_call_abi(
                 &database,
@@ -1377,10 +1355,7 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
         };
 
         let signed = request("c_signed");
-        assert_eq!(
-            signed.convention,
-            crate::type_queries::CallAbiConvention::TargetC(flavor)
-        );
+        assert_eq!(signed.convention, convention);
         assert_scalar_args(
             &signed,
             &abi,
@@ -1490,10 +1465,7 @@ fn call_abi_strbuf_return_uses_sret_on_both_planes() {
             free_function_instance(&strbuf_module, "echo"),
             target,
         );
-        assert_eq!(
-            facts.convention,
-            crate::type_queries::CallAbiConvention::Native
-        );
+        assert_eq!(facts.convention, rue_target::CallingConvention::Rue);
         assert_eq!(
             facts.return_class,
             crate::type_queries::CallAbiReturnClass::NativeIndirect { slots: 3 }

--- a/crates/rue-compiler/src/type_queries.rs
+++ b/crates/rue-compiler/src/type_queries.rs
@@ -140,7 +140,7 @@ impl QueryKey for CallAbiQueryKey {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CallAbiFacts {
-    pub(crate) convention: CallAbiConvention,
+    pub(crate) convention: rue_target::CallingConvention,
     pub(crate) return_class: CallAbiReturnClass,
     pub(crate) arguments: Arc<[CallAbiArgument]>,
     /// The stable native machine symbol is derived once by the ABI terminal.
@@ -157,12 +157,6 @@ impl PartialEq for CallAbiFacts {
 }
 
 impl Eq for CallAbiFacts {}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CallAbiConvention {
-    Native,
-    TargetC(rue_air::TargetCAbiFlavor),
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CallAbiReturnClass {
@@ -589,7 +583,7 @@ mod tests {
 
     fn native_facts(symbol: &str) -> CallAbiFacts {
         CallAbiFacts {
-            convention: CallAbiConvention::Native,
+            convention: rue_target::CallingConvention::Rue,
             return_class: CallAbiReturnClass::ZeroSized,
             arguments: Arc::from([]),
             native_symbol: Some(Arc::from(symbol)),

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -119,12 +119,6 @@ pub enum ReturnBehavior {
     Never,
 }
 
-/// Calling-convention family. Physical register assignment remains target-owned.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum CallingConvention {
-    TargetC,
-}
-
 /// Supported runtime targets, represented without depending on `rue-target`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RuntimeTarget {
@@ -385,7 +379,6 @@ const MUT_POINTER_RESULT: AbiResult = AbiResult::Scalar(AbiType::MutBytePointer)
 /// A `bool`-valued helper result: the C-ABI word carrying 0 or 1, the same
 /// representation `AbiType::BoolWordI64` gives a `bool` argument.
 const BOOL_WORD_RESULT: AbiResult = AbiResult::Scalar(AbiType::BoolWordI64);
-const TARGET_C: CallingConvention = CallingConvention::TargetC;
 const ALL_TARGETS: TargetSet = TargetSet::ALL;
 
 const READABLE: SafetyContract = SafetyContract::READABLE_BYTES;
@@ -462,7 +455,6 @@ macro_rules! runtime_helpers {
                     safety: $safety,
                     return_behavior: $returns,
                     availability: ALL_TARGETS,
-                    calling_convention: TARGET_C,
                 }
             ),+
         ];
@@ -492,6 +484,16 @@ macro_rules! runtime_helpers {
 }
 
 /// Complete logical signature and contract for one runtime helper.
+///
+/// There is no calling-convention field. Every compiler-callable helper crosses
+/// the platform C boundary, and that boundary's *concrete* convention — SysV
+/// AMD64, AAPCS64, or AAPCS64 with Apple's arm64 amendments — is a fact about
+/// the compilation target, not about the helper. This crate is the `no_std`,
+/// dependency-free manifest (ADR-0055), so it cannot name `rue_target::Target`
+/// and must not carry a second, target-free spelling of "which convention".
+/// The caller resolves the row through the one `"C"` alias table,
+/// `rue_target::CallingConvention::c_for_target`; `rue-codegen`'s
+/// `runtime_call_plan` is where that happens for helper calls.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RuntimeHelper {
     pub id: RuntimeHelperId,
@@ -501,7 +503,6 @@ pub struct RuntimeHelper {
     pub safety: SafetyContract,
     pub return_behavior: ReturnBehavior,
     pub availability: TargetSet,
-    pub calling_convention: CallingConvention,
 }
 
 /// Invoke a callback with the canonical Rust declaration and logical contract
@@ -1054,12 +1055,15 @@ macro_rules! for_each_runtime_helper {
 for_each_runtime_helper!(runtime_helpers);
 
 /// Logical function signature for separately classified non-helper exports.
+///
+/// Like [`RuntimeHelper`], a signature carries no convention field: see that
+/// type's documentation for why the boundary is named here and the concrete
+/// convention row is resolved by the caller from its target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AbiSignature {
     pub parameters: &'static [AbiParameter],
     pub result: AbiResult,
     pub return_behavior: ReturnBehavior,
-    pub calling_convention: CallingConvention,
 }
 
 /// Why a reserved runtime symbol is externally visible.
@@ -1221,13 +1225,11 @@ const VOID_FUNCTION: AbiSignature = AbiSignature {
     parameters: &[],
     result: VOID,
     return_behavior: RETURNS,
-    calling_convention: TARGET_C,
 };
 const NEVER_FUNCTION: AbiSignature = AbiSignature {
     parameters: &[],
     result: VOID,
     return_behavior: NEVER,
-    calling_convention: TARGET_C,
 };
 const COPY_FUNCTION: AbiSignature = AbiSignature {
     parameters: &[
@@ -1237,7 +1239,6 @@ const COPY_FUNCTION: AbiSignature = AbiSignature {
     ],
     result: MUT_POINTER_RESULT,
     return_behavior: RETURNS,
-    calling_convention: TARGET_C,
 };
 const MEMSET_FUNCTION: AbiSignature = AbiSignature {
     parameters: &[
@@ -1247,7 +1248,6 @@ const MEMSET_FUNCTION: AbiSignature = AbiSignature {
     ],
     result: MUT_POINTER_RESULT,
     return_behavior: RETURNS,
-    calling_convention: TARGET_C,
 };
 const COMPARE_FUNCTION: AbiSignature = AbiSignature {
     parameters: &[
@@ -1257,7 +1257,6 @@ const COMPARE_FUNCTION: AbiSignature = AbiSignature {
     ],
     result: AbiResult::Scalar(AbiType::I32),
     return_behavior: RETURNS,
-    calling_convention: TARGET_C,
 };
 
 macro_rules! define_reserved_exports {
@@ -2012,7 +2011,7 @@ mod tests {
     }
 
     #[test]
-    fn all_helpers_are_available_on_every_runtime_target_and_use_target_c() {
+    fn all_helpers_are_available_on_every_runtime_target() {
         for helper in RUNTIME_HELPERS {
             for target in [
                 RuntimeTarget::X86_64Linux,
@@ -2021,7 +2020,6 @@ mod tests {
             ] {
                 assert!(helper.availability.contains(target));
             }
-            assert_eq!(helper.calling_convention, CallingConvention::TargetC);
         }
     }
 

--- a/crates/rue-target/src/calling_convention.rs
+++ b/crates/rue-target/src/calling_convention.rs
@@ -1,0 +1,218 @@
+//! The one calling-convention value type and the one `"C"` alias table.
+//!
+//! [`CallingConvention`] names a *concrete* convention: the compiler-chosen
+//! native Rue convention, or one of the platform psABIs Rue targets. It is the
+//! only spelling of "which calling convention governs this boundary" in the
+//! tree — semantic analysis, the stable query plane, both code-generation
+//! backends, and the runtime-helper boundary all name these rows.
+//!
+//! ## Why this crate is the home
+//!
+//! A convention row is a *target* fact, so the type belongs wherever every
+//! consumer can already see a target. `rue-target` is that place: it is a leaf
+//! with no dependencies, and `rue-air`, `rue-cfg`, `rue-codegen`, and
+//! `rue-compiler` all depend on it already. Putting the type here also puts the
+//! `"C"` alias table next to the [`Target`] rows it is keyed by, so a new
+//! target cannot compile without answering which psABI it follows.
+//!
+//! The one crate that cannot see a [`Target`] is `rue-runtime-abi`, the
+//! `no_std`, dependency-free compiler/runtime ABI manifest (ADR-0055). It is
+//! not given a peer convention enum and it does not gain a dependency: its
+//! manifest rows are target-independent, so they record only that a helper
+//! crosses the platform C boundary, and the concrete row is resolved by the
+//! caller — which always has a `Target` — through
+//! [`CallingConvention::c_for_target`]. `RuntimeTarget` reaches the same table
+//! through the `Target` correspondence in `rue-codegen`, so the alias has
+//! exactly one mapping table.
+//!
+//! ## Apple's arm64 amendments
+//!
+//! `Aarch64Aapcs` and `Aarch64AapcsDarwin` are separate rows because Apple's
+//! platform ABI amends AAPCS64 ("Writing ARM64 code for Apple platforms"). The
+//! amendments Rue's supported surface reaches are the caller-side extension of
+//! arguments narrower than 32 bits and, the one that changes placement,
+//! [`stacked_argument_packing`](CallingConvention::stacked_argument_packing):
+//! a stacked argument occupies its natural size at its natural alignment
+//! instead of a whole 8-byte slot. This type states the convention; how far the
+//! foreign-call lowering implements it (scalars today, composites still on
+//! whole eightbytes) is recorded in
+//! `docs/notes/ffi-abi-conformance-audit.md`.
+
+use crate::Target;
+
+/// Which calling convention governs a call boundary.
+///
+/// The variants are concrete conventions, not families: there is no "target C"
+/// row to be resolved later. `"C"` is an alias that a [`Target`] resolves to one
+/// of these rows through [`CallingConvention::c_for_target`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CallingConvention {
+    /// The native, unstable, compiler-chosen Rue convention (RUE-106): a
+    /// by-value aggregate is returned one flattened ABI slot per return
+    /// register, or via sret when it does not fit; canonical `StrBuf` always
+    /// returns via sret; a by-reference `inout` / `borrow` argument is one
+    /// pointer slot; a by-value argument occupies one slot per leaf, reversed
+    /// within each multi-slot value.
+    Rue,
+    /// The System V AMD64 psABI, as used on x86-64 Linux.
+    X86_64SysV,
+    /// The ARM 64-bit Procedure Call Standard (AAPCS64), as used on AArch64
+    /// Linux.
+    Aarch64Aapcs,
+    /// AAPCS64 with Apple's arm64 amendments, as used on AArch64 macOS.
+    Aarch64AapcsDarwin,
+}
+
+/// How a psABI lays a stacked (byval / register-overflow) argument out in the
+/// outgoing argument area.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StackedArgumentPacking {
+    /// Every stacked argument starts at the next 8-byte boundary and occupies a
+    /// whole multiple of 8 bytes (SysV AMD64 §3.2.3, AAPCS64 §6.4.2 with its
+    /// 8-byte stack-slot granule).
+    EightByteSlots,
+    /// Every stacked argument occupies its natural size at its natural
+    /// alignment, packed against its predecessor: Apple's arm64 amendment, so a
+    /// stacked `i8` occupies one byte and a stacked `i16` starts at the next
+    /// even offset.
+    NaturalSize,
+}
+
+impl CallingConvention {
+    /// The convention a `"C"` boundary follows on `target`.
+    ///
+    /// This is the single `"C"` alias table. It is keyed by the whole target,
+    /// not by its architecture: AArch64 Linux and AArch64 macOS share an
+    /// architecture and do not share a convention.
+    pub const fn c_for_target(target: Target) -> Self {
+        match target {
+            Target::X86_64Linux => Self::X86_64SysV,
+            Target::Aarch64Linux => Self::Aarch64Aapcs,
+            Target::Aarch64Macos => Self::Aarch64AapcsDarwin,
+        }
+    }
+
+    /// Whether this is the native Rue convention.
+    pub const fn is_rue(self) -> bool {
+        matches!(self, Self::Rue)
+    }
+
+    /// Whether this is a platform C convention — the complement of
+    /// [`is_rue`](Self::is_rue), spelled for call sites that read better as a
+    /// positive.
+    pub const fn is_c(self) -> bool {
+        !self.is_rue()
+    }
+
+    /// How a stacked argument is laid out in the outgoing argument area under
+    /// this convention. Panics on [`CallingConvention::Rue`], whose stack
+    /// arguments are the native uniform 8-byte slot model rather than a psABI
+    /// argument area.
+    pub const fn stacked_argument_packing(self) -> StackedArgumentPacking {
+        match self {
+            Self::X86_64SysV | Self::Aarch64Aapcs => StackedArgumentPacking::EightByteSlots,
+            Self::Aarch64AapcsDarwin => StackedArgumentPacking::NaturalSize,
+            Self::Rue => panic!(
+                "the native Rue convention has no psABI outgoing argument area; \
+                 stacked_argument_packing is a target-C question"
+            ),
+        }
+    }
+
+    /// The canonical name of this convention, for diagnostics and dumps.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Rue => "rue",
+            Self::X86_64SysV => "x86-64-sysv",
+            Self::Aarch64Aapcs => "aarch64-aapcs",
+            Self::Aarch64AapcsDarwin => "aarch64-aapcs-darwin",
+        }
+    }
+}
+
+impl core::fmt::Display for CallingConvention {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl Target {
+    /// The convention this target's `"C"` boundary follows; the method spelling
+    /// of [`CallingConvention::c_for_target`].
+    pub const fn c_calling_convention(self) -> CallingConvention {
+        CallingConvention::c_for_target(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_c_alias_is_total_and_distinct_over_every_target() {
+        let mut seen = Vec::new();
+        for target in Target::all() {
+            let convention = target.c_calling_convention();
+            assert_eq!(
+                convention,
+                CallingConvention::c_for_target(*target),
+                "the method and the free function must name one table"
+            );
+            assert!(convention.is_c(), "a C boundary is never the Rue row");
+            assert!(
+                !seen.contains(&convention),
+                "each target names its own psABI row: {convention} repeated"
+            );
+            seen.push(convention);
+        }
+        assert_eq!(seen.len(), Target::all().len());
+    }
+
+    #[test]
+    fn aarch64_targets_share_an_architecture_and_not_a_convention() {
+        assert_eq!(
+            Target::Aarch64Linux.arch(),
+            Target::Aarch64Macos.arch(),
+            "the two AArch64 targets share an architecture"
+        );
+        assert_ne!(
+            Target::Aarch64Linux.c_calling_convention(),
+            Target::Aarch64Macos.c_calling_convention(),
+            "the `\"C\"` alias is keyed by target, not architecture"
+        );
+        assert_eq!(
+            Target::Aarch64Macos.c_calling_convention(),
+            CallingConvention::Aarch64AapcsDarwin
+        );
+    }
+
+    #[test]
+    fn only_darwin_packs_stacked_arguments_at_their_natural_size() {
+        assert_eq!(
+            CallingConvention::X86_64SysV.stacked_argument_packing(),
+            StackedArgumentPacking::EightByteSlots
+        );
+        assert_eq!(
+            CallingConvention::Aarch64Aapcs.stacked_argument_packing(),
+            StackedArgumentPacking::EightByteSlots
+        );
+        assert_eq!(
+            CallingConvention::Aarch64AapcsDarwin.stacked_argument_packing(),
+            StackedArgumentPacking::NaturalSize
+        );
+    }
+
+    #[test]
+    fn the_rue_row_is_the_only_native_convention() {
+        assert!(CallingConvention::Rue.is_rue());
+        assert!(!CallingConvention::Rue.is_c());
+        for convention in [
+            CallingConvention::X86_64SysV,
+            CallingConvention::Aarch64Aapcs,
+            CallingConvention::Aarch64AapcsDarwin,
+        ] {
+            assert!(!convention.is_rue());
+            assert!(convention.is_c());
+        }
+    }
+}

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -1,8 +1,15 @@
 //! Target architecture and OS definitions for the Rue compiler.
 //!
 //! This crate provides the `Target` enum and related types that define
-//! compilation targets. It is a leaf crate with no dependencies, designed
-//! to be used by the CLI, compiler, codegen, and linker crates.
+//! compilation targets, including [`CallingConvention`] — the one value type
+//! for "which calling convention governs this boundary" — and the `"C"` alias
+//! table that resolves it from a target. It is a leaf crate with no
+//! dependencies, designed to be used by the CLI, compiler, codegen, and linker
+//! crates.
+
+mod calling_convention;
+
+pub use calling_convention::{CallingConvention, StackedArgumentPacking};
 
 use std::fmt;
 use std::str::FromStr;

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -2,13 +2,27 @@
 
 Status: verified against the compiler and runtime source for RUE-738.
 
-Rue currently has two distinct calling conventions:
+One value type names every calling convention in the tree,
+`rue_target::CallingConvention`, and its members are concrete conventions:
 
-1. A private native convention for calls between Rue functions. It borrows
-   target register and stack rules but deliberately is not a C ABI.
-2. A typed `CallingConvention::TargetC` subset for calls from generated code to
-   the bundled runtime. The compiler and runtime share this contract through
-   `rue-runtime-abi`.
+| Member | Convention |
+| --- | --- |
+| `Rue` | the private native convention for calls between Rue functions |
+| `X86_64SysV` | System V AMD64 psABI |
+| `Aarch64Aapcs` | AAPCS64 as on Linux |
+| `Aarch64AapcsDarwin` | AAPCS64 with Apple's arm64 amendments |
+
+`"C"` is an alias, not a member. One table, `CallingConvention::c_for_target`,
+resolves it from the whole compilation target — `x86-64-linux` to `X86_64SysV`,
+`aarch64-linux` to `Aarch64Aapcs`, `aarch64-macos` to `Aarch64AapcsDarwin` —
+and every C boundary consults it: `extern "C"` imports and exports, the
+compiler-built memory routines, and the typed runtime-helper subset the compiler
+and runtime share through `rue-runtime-abi`. The alias is keyed by target rather
+than by architecture because the two AArch64 targets share an architecture and
+do not share a convention.
+
+The native `Rue` convention borrows target register and stack rules but
+deliberately is not a C ABI.
 
 Rue does not yet support general foreign imports or exports. In particular,
 the runtime's zero-argument process entry into Rue `main` is not evidence that
@@ -34,6 +48,7 @@ supported representation.
 | --- | --- | --- | --- |
 | Integer/pointer argument registers | `rdi`, `rsi`, `rdx`, `rcx`, `r8`, `r9` | `x0`-`x7` | Same target registers |
 | Stack arguments | 8-byte slots, first overflow slot nearest return address | 8-byte slots beginning at incoming `sp` | Not implemented; every current helper fits registers |
+| Stacked target-C arguments (`extern "C"`) | 8-byte slots | 8-byte slots on Linux; scalars at natural size and alignment, packed, on macOS | Not reached |
 | Scalar result | `rax` | `x0` | `rax` or `x0`/`w0` |
 | Multi-slot result | Up to six slots in `rax`, `rdx`, `rcx`, `r8`, `r9`, `r10` | Up to eight slots in `x0`-`x7` | No direct aggregate results |
 | Aggregate result storage | Hidden first ordinary slot (`rdi`) | Hidden first ordinary slot (`x0`) | Explicit first out-pointer parameter where required |
@@ -109,21 +124,45 @@ veneer scratch registers `x16`/`x17`. Vector registers are currently
 unused. The stack pointer remains 16-byte aligned, and generated code does not
 access memory below `sp`. Condition flags are caller-clobbered.
 
-Apple arm64 permits a 128-byte red zone, but Rue does not use it. Apple's ABI
-also requires callers to extend arguments narrower than 32 bits, gives stacked
-arguments their natural sizes, and places variadic arguments on the stack. The
-current target-C subset has no sub-32-bit parameters, stack parameters, or
-variadic calls, so these amendments are outside its present surface. Native Rue
+Apple arm64 permits a 128-byte red zone, but Rue does not use it. Apple's other
+amendments are answered by the `Aarch64AapcsDarwin` convention row rather than
+by an operating-system test inside a backend:
+
+- **Stacked scalars take their natural size and alignment.** The foreign-call
+  planner packs the outgoing argument area per
+  `CallingConvention::stacked_argument_packing`, so on macOS a stacked `i8`,
+  `i16`, `i32`, `i64` tail lies at offsets 0, 2, 4, 8 where AAPCS64 and SysV put
+  it at 0, 8, 16, 24, and the AArch64 lowerer commits each store at the C width
+  (`strb`/`strh`/`str w`/`str`). A stacked composite keeps whole eightbytes at
+  8-byte alignment under every row: it crosses through its eightbyte image, and a
+  byte-exact copy needs marshaling this path does not have. Apple's byte-exact
+  placement of a stacked composite whose size or alignment is not a multiple of
+  eight is therefore still open, and is listed below.
+- **The caller extends arguments narrower than 32 bits.** Rue's canonical
+  64-bit-extension invariant already produces a value satisfying it, so the
+  import side needs nothing Darwin-specific; a unit assertion pins that every C
+  row asks for the same extension. The export thunk re-extends narrow arguments
+  in place on every row, because the native body needs the canonical 64-bit
+  form, which is stronger than Apple's 32-bit guarantee.
+- **Variadic arguments go on the stack.** Out of scope: variadic `extern "C"`
+  declarations are rejected.
+
+The typed runtime-helper subset still has no sub-32-bit or stack parameters, so
+these amendments do not change it today; they govern the `extern "C"` import and
+export paths, which do reach stacked arguments and narrow scalars. Native Rue
 continues to use its uniform 8-byte slot model on macOS.
 
 ## Typed target-C runtime subset
 
 Every compiler-callable helper is identified by `RuntimeHelperId` and declares
-`CallingConvention::TargetC`, ordered physical parameter types, pointer modes,
-result behavior, and target availability in `rue-runtime-abi`. Shared runtime
-call planning validates the logical signature before either backend assigns
-registers. The runtime exports matching `extern "C"` wrappers generated from the
-same manifest.
+ordered physical parameter types, pointer modes, result behavior, and target
+availability in `rue-runtime-abi`. A manifest row carries no convention field:
+`rue-runtime-abi` is the `no_std`, dependency-free manifest crate (ADR-0055) and
+cannot name a `Target`, so it records only that a helper crosses the platform C
+boundary and the caller resolves the concrete row through the one `"C"` alias
+table. Shared runtime call planning validates the logical signature before
+either backend assigns registers. The runtime exports matching `extern "C"`
+wrappers generated from the same manifest.
 
 The current physical surface is intentionally smaller than either complete C
 ABI:
@@ -167,12 +206,19 @@ The probe covers:
 - a five-parameter parse helper with explicit aggregate-result storage; and
 - allocation and mutation through the `StrBuf` runtime boundary.
 
-Backend tests additionally enforce that the typed runtime manifest remains
-target-C and within each backend's implemented register-only subset. This is
-not a complete bidirectional C harness because no general foreign-call syntax or
-export mode exists yet. Those features should extend the matrix with separately
-compiled C caller and callee probes when they introduce their respective
-boundaries.
+`cli.c_ffi` covers the `extern "C"` import and export paths. Its executing
+cases pair a Rue program with a C archive on x86-64 Linux and AArch64 Linux;
+`aarch64_macos_narrow_exports_build_under_the_apple_row` compiles and links a
+narrow-parameter export for AArch64 macOS, so the Apple row's export thunks are
+generated, encoded, and placed in a Mach-O image on every host and executed on
+the macOS CI host. There is no macOS C-caller archive, so the Apple row's
+stacked-argument packing is proved by backend unit tests over the shared
+foreign-call planner rather than by execution.
+
+Backend tests additionally enforce that the typed runtime manifest stays within
+each backend's implemented register-only subset and that its boundary resolves
+to that backend's C convention row. The C-caller/C-callee matrix is still
+one-sided on macOS; a macOS C toolchain probe would close it.
 
 ## Finding
 
@@ -196,7 +242,9 @@ Before general FFI can claim conformance, its target-C path must independently
 cover at least:
 
 - C layout and classification for supported by-value aggregates;
-- target-C stack arguments, including Apple's packed stack-area amendment;
+- Apple's byte-exact placement of a stacked composite argument, which needs
+  byte-granular marshaling rather than the whole-eightbyte image stores the
+  current path emits;
 - direct and indirect C aggregate returns, including AAPCS64 `x8`;
 - floating-point/vector arguments and results if exposed;
 - variadic calls, or an explicit diagnostic rejecting them;

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -12,8 +12,7 @@ target rules without duplicating that contract's helper table.
 - every compiler-callable runtime helper and its exported symbol;
 - ordered C-boundary parameters, pointer modes, scalar results, and explicit
   result-storage aggregates;
-- safety requirements, return behavior, target availability, and calling
-  convention;
+- safety requirements, return behavior, and target availability;
 - separately classified entry points, compiler-built memory routines,
   platform shims, and the retained ABI-version marker; and
 - the current lockstep ABI version.
@@ -41,20 +40,49 @@ export table.
 
 ## Runtime ABI versus native Rue ABI
 
-This document describes only the typed target-C boundary from generated Rue
-code to `rue-runtime`. Calls between Rue functions use a separate native Rue
-convention that is intentionally not C-compatible or stable across compiler
-revisions. Rue does not yet expose general foreign imports or exports.
+This document describes only the typed C boundary from generated Rue code to
+`rue-runtime`. Calls between Rue functions use a separate native Rue convention
+that is intentionally not C-compatible or stable across compiler revisions.
+
+Both boundaries name their convention with one value type,
+`rue_target::CallingConvention`, whose members are concrete conventions:
+
+| Member | Convention |
+| --- | --- |
+| `Rue` | the native, unstable, compiler-chosen convention |
+| `X86_64SysV` | System V AMD64 psABI |
+| `Aarch64Aapcs` | AAPCS64 as on Linux |
+| `Aarch64AapcsDarwin` | AAPCS64 with Apple's arm64 amendments |
+
+There is no "target C" member. `"C"` is an **alias**, resolved from the whole
+compilation target by the single table `CallingConvention::c_for_target`
+(spelled `Target::c_calling_convention` as a method):
+
+| Target | `"C"` resolves to |
+| --- | --- |
+| `x86-64-linux` | `X86_64SysV` |
+| `aarch64-linux` | `Aarch64Aapcs` |
+| `aarch64-macos` | `Aarch64AapcsDarwin` |
+
+The alias is keyed by target rather than by architecture because the two
+AArch64 targets share an architecture and do not share a convention.
+
+`rue-runtime-abi` is the `no_std`, dependency-free manifest crate (ADR-0055), so
+it cannot name a `Target` and does not carry a convention field: every
+compiler-callable helper crosses the platform C boundary, and the caller — which
+always knows the target — resolves the row through the same alias table. That
+keeps one mapping table for foreign calls, compiler-built memory routines, and
+runtime helpers alike.
 
 The [FFI ABI conformance audit](notes/ffi-abi-conformance-audit.md) records the
-current native convention, compares both boundaries with System V AMD64,
-AAPCS64, and Apple's arm64 amendments, and defines the executable evidence
-required before the target-C subset is expanded.
+native convention, compares both boundaries with System V AMD64, AAPCS64, and
+Apple's arm64 amendments, and defines the executable evidence required before
+the C subset is expanded.
 
 ## Target C calling conventions
 
-All callable runtime helpers use the target C convention declared by the
-manifest.
+All callable runtime helpers cross the C boundary, so their convention is
+whichever row the compilation target's `"C"` alias names.
 
 ### x86-64 Linux
 
@@ -68,12 +96,36 @@ Linux syscalls are a separate runtime-internal boundary: their number is in
 `rax`, arguments use `rdi`, `rsi`, `rdx`, `r10`, `r8`, and `r9`, and the
 instruction clobbers `rcx` and `r11`.
 
-### AArch64 Linux and macOS
+### AArch64 Linux (`Aarch64Aapcs`)
 
 The AArch64 procedure-call standard supplies the first eight integer and
 pointer arguments in `x0`-`x7` (or the corresponding `w` register for a
-32-bit scalar), then on the stack. Scalar results use `x0`/`w0`. The stack is
+32-bit scalar), then on the stack in 8-byte slots. Scalar results use `x0`/`w0`.
+An aggregate larger than sixteen bytes is passed as a pointer to a caller-owned
+copy, and an indirect result address uses the dedicated `x8`. The stack is
 16-byte aligned. `x19`-`x28` are callee-saved.
+
+### AArch64 macOS (`Aarch64AapcsDarwin`)
+
+Apple's platform ABI amends AAPCS64. Register placement, the by-reference rule
+for large aggregates, `x8`, the callee-saved set, and stack alignment are all as
+above; two amendments differ, and both are driven by the convention value rather
+than by an operating-system test in a backend:
+
+- **Stacked scalars are packed at natural size and alignment.** A stacked scalar
+  occupies exactly its C size at its own alignment instead of a whole 8-byte
+  slot, so a stacked `i8`, `i16`, `i32`, `i64` tail lies at offsets 0, 2, 4, 8
+  rather than 0, 8, 16, 24. A stacked composite keeps whole eightbytes at 8-byte
+  alignment under every row, because it crosses through its eightbyte image; the
+  audit note records Apple's byte-exact composite placement as still open.
+- **The caller extends arguments narrower than 32 bits.** Rue's canonical
+  64-bit-extension invariant already satisfies this on the import side. On the
+  export side the thunk re-extends narrow arguments in place for every row: the
+  native body needs the canonical 64-bit form, which is stronger than what any C
+  caller promises, and re-extending an already-extended value is a no-op.
+
+Apple's variadic amendment is out of scope: variadic `extern "C"` declarations
+are rejected.
 
 Linux and macOS use different syscall conventions and numbers. Those details
 belong to the target-specific runtime modules and do not alter the compiler


### PR DESCRIPTION
Slice 1 of the calling-convention infrastructure epic (RUE-2030).

## What

"Which calling convention governs this boundary" was spelled five ways: `rue_air::CallAbi` and `TargetCAbiFlavor`, `rue_codegen::CalleeAbi`, `rue_runtime_abi::CallingConvention`, and `rue_compiler`'s `CallAbiConvention`. Only the flavor knew anything about a target, and it was keyed on architecture, so AArch64 macOS silently got plain AAPCS64 and Apple's arm64 amendments had no row and no test.

This introduces `rue_target::CallingConvention` with the concrete rows Rue targets (`Rue`, `X86_64SysV`, `Aarch64Aapcs`, `Aarch64AapcsDarwin`) and makes `"C"` an alias resolved from the whole target by one table, `CallingConvention::c_for_target`. `rue-target` is the home because a convention row is a target fact and every consumer already depends on that crate. `rue-runtime-abi` keeps its `no_std` leaf shape and gains no dependency: a manifest row is target-independent, so it drops its convention field and the caller resolves the row; the `RuntimeTarget` correspondence now has one home in `rue-codegen`.

## The Darwin row

The shared foreign-call planner packs the outgoing argument area per the convention, so a stacked `i8`/`i16`/`i32`/`i64` tail lies at offsets 0, 2, 4, 8 on macOS where AAPCS64 and SysV use 0, 8, 16, 24, and the AArch64 lowerer commits each store at the C width. A stacked composite still crosses as whole eightbytes at 8-byte alignment; Apple's byte-exact composite placement needs byte-granular marshaling the image path does not have and is recorded in the conformance audit as open. The export thunk consults the target's row rather than its architecture.

Also repairs a latent test defect: the AArch64 fixture's `lower_host` handed the AArch64 lowerer whatever `Target::host()` returned.

## Verification

- `scripts/rue fmt`, `scripts/rue quick`, `scripts/rue cli c_ffi` (47, one new macOS structural case), `scripts/rue cli abi` (65)
- `./buck2 test //crates/rue-oracle-diff:oracle-diff-test`
- per-crate clippy, fmt, and debug-assert gates for the five touched crates
- `scripts/rue premerge`: 213/213 non-CLI targets; the CLI corpus's two failures (`remove_dir_all_permission_denied_is_not_partial_success`, `tcp_ipv6_loopback_round_trip`) reproduce on the untouched baseline and are sandbox-environmental (root user, no IPv6 loopback)

New unit tests pin the `"C"` alias as total and distinct over every `Target` and every `RuntimeTarget`, the Darwin versus Linux stack offsets and store widths at the planner and at both backends' encoding leaves, x86-64 unaffected, and the export thunk identical across the two AArch64 rows.

Closes RUE-2031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_