### PR TITLE
RUE-1985: own the --benchmark-json envelope in rue-perf-schema

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -22,7 +22,7 @@ use rue_perf_schema::{
     OutcomeKind, PhaseWork, QuerySchedulingMeasurements, RetainedGauges, RetentionSequence,
     RetentionStep, RetentionStepOutcome, SourceShape, StructuralWork, TransformationIdentity,
     ValidationWork as ReportValidationWork, WorkerMode, canonical_json, derive_edit_report,
-    is_commit, render_edit_report_markdown, validate_edit_report,
+    is_commit, render_edit_report_markdown, utc_timestamp, validate_edit_report,
 };
 use serde::Deserialize;
 
@@ -395,7 +395,7 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
         },
         ..CompileOptions::default()
     };
-    let started_at = crate::utc_timestamp();
+    let started_at = utc_timestamp();
 
     let mut rows = Vec::new();
     for workload in &manifest.workloads {
@@ -574,7 +574,7 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
             fixture_revision: manifest.fixture_revision,
             commit: options.commit,
             started_at,
-            finished_at: crate::utc_timestamp(),
+            finished_at: utc_timestamp(),
             target: manifest.target.clone(),
             environment: crate::environment::fingerprint(),
         },

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -35,12 +35,12 @@ mod staleness_inputs;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use rue_perf_schema::{
     Completeness, FULL_EVIDENCE_SCHEMA_VERSION, FailureRecord, Invocation, Manifest,
     ProcessElapsedRegression, ResolvedPins, RunIdentity, RunObject, Sample, ValidationOutcome,
-    WorkloadObservation, encode_stored_v3, process_elapsed_regressions, validate_run,
+    WorkloadObservation, encode_stored_v3, process_elapsed_regressions, utc_timestamp,
+    validate_run,
 };
 
 use crate::measure::{SampleOutcome, SampleRequest, measure_sample};
@@ -796,42 +796,6 @@ fn report(
     }
 }
 
-/// The current instant as `YYYY-MM-DDTHH:MM:SSZ`.
-///
-/// One spelling, because two identical measurements formatting the same instant
-/// differently would produce two content addresses. Computed from the Unix
-/// epoch rather than pulling in a date library for two fields.
-pub(crate) fn utc_timestamp() -> String {
-    let seconds = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_secs())
-        .unwrap_or(0);
-    let (days, rest) = (seconds / 86_400, seconds % 86_400);
-    let (hour, minute, second) = (rest / 3600, (rest % 3600) / 60, rest % 60);
-    let (year, month, day) = civil_from_days(days as i64);
-    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
-}
-
-/// Howard Hinnant's `civil_from_days`, shifting the era to start in March so
-/// the leap day lands at the end of a cycle.
-fn civil_from_days(days: i64) -> (i64, u32, u32) {
-    let z = days + 719_468;
-    let era = z.div_euclid(146_097);
-    let day_of_era = z.rem_euclid(146_097);
-    let year_of_era =
-        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
-    let year = year_of_era + era * 400;
-    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
-    let shifted_month = (5 * day_of_year + 2) / 153;
-    let day = (day_of_year - (153 * shifted_month + 2) / 5 + 1) as u32;
-    let month = if shifted_month < 10 {
-        shifted_month + 3
-    } else {
-        shifted_month - 9
-    } as u32;
-    (if month <= 2 { year + 1 } else { year }, month, day)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -937,26 +901,6 @@ window = 10
             }],
             failures: Vec::new(),
         }
-    }
-
-    #[test]
-    fn timestamps_use_the_one_spelling_validation_accepts() {
-        let stamp = utc_timestamp();
-        assert_eq!(stamp.len(), 20, "{stamp}");
-        assert!(stamp.ends_with('Z'), "{stamp}");
-        assert_eq!(stamp.as_bytes()[10], b'T', "{stamp}");
-        // Sub-second precision would make two runs of the same instant hash
-        // differently, so it must not appear.
-        assert!(!stamp.contains('.'), "{stamp}");
-    }
-
-    #[test]
-    fn civil_dates_match_known_values() {
-        assert_eq!(civil_from_days(0), (1970, 1, 1));
-        assert_eq!(civil_from_days(19_723), (2024, 1, 1));
-        // A leap day, which the March-shifted era exists to get right.
-        assert_eq!(civil_from_days(19_782), (2024, 2, 29));
-        assert_eq!(civil_from_days(19_783), (2024, 3, 1));
     }
 
     #[test]

--- a/crates/rue-bench/src/measure.rs
+++ b/crates/rue-bench/src/measure.rs
@@ -20,9 +20,9 @@ use std::time::Instant;
 
 use crate::digest::{sha256_bytes, sha256_file};
 use rue_perf_schema::{
-    BuildBoundaryEvidence, BuildBoundaryPolicy, CompilerBoundaryEvidence,
-    CompilerCriticalPathEvidence, CompilerInputClass, CompilerWork, FailureRecord, PhaseAccounting,
-    RunnerBoundaryEvidence, RunnerClockBoundary, Sample, WorkloadShape,
+    BenchmarkReport, BuildBoundaryEvidence, BuildBoundaryPolicy, CompilerBoundaryEvidence,
+    CompilerInputClass, CompilerWork, FailureRecord, PhaseAccounting, RunnerBoundaryEvidence,
+    RunnerClockBoundary, Sample, WorkloadShape,
 };
 
 static PROCESS_DIRECTORY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -63,66 +63,6 @@ pub enum SampleOutcome {
     Measured(Box<Sample>),
     /// The sample could not be produced, with structured evidence of why.
     Failed(Box<FailureRecord>),
-}
-
-/// The compiler's `--benchmark-json` output.
-#[derive(serde::Deserialize)]
-struct BenchmarkJson {
-    #[serde(
-        rename = "schema_version",
-        deserialize_with = "deserialize_benchmark_schema_version"
-    )]
-    // The custom deserializer validates this wire field; the benchmark
-    // consumer otherwise has no need to retain the already-checked value.
-    _schema_version: u32,
-    phase_accounting: PhaseAccounting,
-    metadata: BenchmarkMetadata,
-    source_metrics: SourceMetrics,
-    compiler_work: CompilerWork,
-    emitted_output: EmittedOutput,
-    #[serde(default)]
-    compiler_boundary: Option<CompilerBoundaryEvidence>,
-    #[serde(default)]
-    critical_path: Option<CompilerCriticalPathEvidence>,
-}
-
-const BENCHMARK_JSON_SCHEMA_VERSION: u32 = 19;
-
-fn deserialize_benchmark_schema_version<'de, D>(deserializer: D) -> Result<u32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::Error;
-
-    let version = <u32 as serde::Deserialize>::deserialize(deserializer)?;
-    if version != BENCHMARK_JSON_SCHEMA_VERSION {
-        return Err(D::Error::custom(format!(
-            "unsupported benchmark JSON schema version {version}; expected {BENCHMARK_JSON_SCHEMA_VERSION}"
-        )));
-    }
-    Ok(version)
-}
-
-#[derive(serde::Deserialize)]
-struct BenchmarkMetadata {
-    target: String,
-    compiler_build_profile: String,
-}
-
-#[derive(serde::Deserialize)]
-struct SourceMetrics {
-    files: u64,
-    modules: u64,
-    bytes: u64,
-    lines: u64,
-    tokens: u64,
-    functions: u64,
-}
-
-#[derive(serde::Deserialize)]
-struct EmittedOutput {
-    size_bytes: u64,
-    sha256: String,
 }
 
 struct CompletedCompile {
@@ -332,10 +272,22 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
         ));
     }
 
-    let parsed: BenchmarkJson = serde_json::from_str(stdout.trim()).map_err(|error| {
+    let parsed: BenchmarkReport = serde_json::from_str(stdout.trim()).map_err(|error| {
         let tail: String = stderr.lines().rev().take(5).collect::<Vec<_>>().join("\n");
         format!("no benchmark JSON on stdout ({error}); stderr tail:\n{tail}")
     })?;
+    // Every section below is optional on the wire, because a driver path that
+    // measured less still publishes a valid report. A sample is not a sample
+    // without them, so the runner is where their absence is refused.
+    let emitted_output = parsed
+        .emitted_output
+        .ok_or_else(|| "compiler omitted the emitted-output digest".to_string())?;
+    let source_metrics = parsed
+        .source_metrics
+        .ok_or_else(|| "compiler omitted source metrics".to_string())?;
+    let compiler_work = parsed
+        .compiler_work
+        .ok_or_else(|| "compiler omitted compiler-work counters".to_string())?;
     let output_bytes = fs::read(&output_path)
         .map_err(|error| format!("could not read compiler output for verification: {error}"))?;
     if output_bytes.is_empty()
@@ -348,9 +300,7 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
     }
     let output_sha256 = sha256_bytes(&output_bytes);
     let output_binary_bytes = u64::try_from(output_bytes.len()).unwrap_or(u64::MAX);
-    if parsed.emitted_output.sha256 != output_sha256
-        || parsed.emitted_output.size_bytes != output_binary_bytes
-    {
+    if emitted_output.sha256 != output_sha256 || emitted_output.size_bytes != output_binary_bytes {
         return Err("compiler and runner disagree about emitted output bytes".to_string());
     }
     if !directory_contains_only(&output_directory, &output_path)? {
@@ -391,7 +341,7 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
                 },
                 compiler,
                 critical_path,
-                compiler_work: parsed.compiler_work.clone(),
+                compiler_work: compiler_work.clone(),
             };
             let expected_target = request.target.ok_or_else(|| {
                 "boundary policy has no independently declared target".to_string()
@@ -407,17 +357,10 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
         accounting: parsed.phase_accounting,
         peak_memory_bytes: peak,
         output_binary_bytes,
-        shape: WorkloadShape {
-            files: parsed.source_metrics.files,
-            modules: parsed.source_metrics.modules,
-            bytes: parsed.source_metrics.bytes,
-            lines: parsed.source_metrics.lines,
-            tokens: parsed.source_metrics.tokens,
-            functions: parsed.source_metrics.functions,
-        },
+        shape: source_metrics,
         target: parsed.metadata.target,
         compiler_build_profile: parsed.metadata.compiler_build_profile,
-        compiler_work: parsed.compiler_work,
+        compiler_work,
         process_elapsed_ns,
         output_sha256,
         boundary_evidence,
@@ -608,36 +551,78 @@ fn max_rss_bytes(ru_maxrss: libc::c_long) -> u64 {
 mod tests {
     use std::collections::BTreeMap;
 
-    use rue_perf_schema::Phase;
+    use rue_perf_schema::{
+        BENCHMARK_JSON_SCHEMA_VERSION, BENCHMARK_TIMING_MODEL, BenchmarkMetadata, EmittedOutput,
+        Phase,
+    };
 
     use super::*;
 
-    #[test]
-    fn benchmark_json_schema_16_is_rejected() {
-        let error = serde_json::from_str::<BenchmarkJson>(r#"{"schema_version":16}"#)
-            .err()
-            .expect("retired benchmark JSON schema must be rejected");
-        assert!(error.to_string().contains("expected 19"));
+    /// A report shaped like the compiler's, built through the shared producer
+    /// type rather than by hand: the fixture this replaced could keep spelling
+    /// a field the compiler had renamed, and still pass.
+    fn published_report() -> String {
+        BenchmarkReport {
+            schema_version: BENCHMARK_JSON_SCHEMA_VERSION,
+            timing_model: BENCHMARK_TIMING_MODEL.to_string(),
+            phase_accounting: PhaseAccounting {
+                phase_ns: BTreeMap::new(),
+                mixed_parallel_ns: 0,
+                unattributed_ns: 0,
+                compiler_root_ns: 0,
+            },
+            metadata: BenchmarkMetadata {
+                timestamp: "2026-01-02T03:04:05Z".to_string(),
+                version: "0.1.0".to_string(),
+                target: "x86_64-linux".to_string(),
+                compiler_build_profile: "test".to_string(),
+            },
+            passes: Vec::new(),
+            driver_phases: Vec::new(),
+            total_ms: 0.0,
+            source_metrics: Some(WorkloadShape {
+                files: 1,
+                modules: 1,
+                bytes: 24,
+                lines: 1,
+                tokens: 9,
+                functions: 1,
+            }),
+            compiler_work: Some(CompilerWork::default()),
+            peak_memory_bytes: None,
+            emitted_output: Some(EmittedOutput::of(b"artifact")),
+            compiler_boundary: None,
+            critical_path: None,
+            compiler_allocations: None,
+        }
+        .to_wire_json()
+        .expect("a benchmark report renders")
     }
 
     #[test]
-    fn benchmark_json_schema_19_is_accepted_by_the_parser() {
-        let phase_accounting = PhaseAccounting {
-            phase_ns: BTreeMap::new(),
-            mixed_parallel_ns: 0,
-            unattributed_ns: 0,
-            compiler_root_ns: 0,
-        };
-        let value = serde_json::json!({
-            "schema_version": 19,
-            "phase_accounting": phase_accounting,
-            "metadata": {"target": "x86_64-linux", "compiler_build_profile": "test"},
-            "source_metrics": {"files": 0, "modules": 0, "bytes": 0, "lines": 0, "tokens": 0, "functions": 0},
-            "compiler_work": CompilerWork::default(),
-            "emitted_output": {"size_bytes": 0, "sha256": ""}
-        });
-        let parsed: BenchmarkJson = serde_json::from_value(value).expect("schema 19 parses");
-        assert_eq!(parsed._schema_version, BENCHMARK_JSON_SCHEMA_VERSION);
+    fn a_retired_benchmark_json_schema_is_rejected() {
+        let error = serde_json::from_str::<BenchmarkReport>(r#"{"schema_version":16}"#)
+            .err()
+            .expect("retired benchmark JSON schema must be rejected");
+        assert!(error.to_string().contains("expected 19"), "{error}");
+    }
+
+    #[test]
+    fn the_current_schema_is_accepted_by_the_parser() {
+        let parsed: BenchmarkReport =
+            serde_json::from_str(&published_report()).expect("the current schema parses");
+        assert_eq!(parsed.schema_version, BENCHMARK_JSON_SCHEMA_VERSION);
+        assert_eq!(
+            parsed.source_metrics.expect("source metrics survive").bytes,
+            24
+        );
+        assert_eq!(
+            parsed
+                .emitted_output
+                .expect("an emitted-output digest survives")
+                .size_bytes,
+            8
+        );
     }
 
     fn accounting(root_ns: u64, semantic_ns: u64, unattributed_ns: u64) -> PhaseAccounting {

--- a/crates/rue-bench/src/runtime.rs
+++ b/crates/rue-bench/src/runtime.rs
@@ -37,7 +37,8 @@ use rue_perf_schema::{
     PeerObservation, PeerPolicy, PeerRole, PeerThreadPolicy, ProgramIdentity, RUNTIME_RECORD_KIND,
     RUNTIME_REPORT_SCHEMA_VERSION, RecordedInput, RuntimeCompleteness, RuntimeEpoch,
     RuntimeFailure, RuntimeIdentity, RuntimeManifest, RuntimeObservation, RuntimeRegime,
-    RuntimeReport, RuntimeSample, RuntimeSuiteRevision, RuntimeWorkload, validate_runtime_report,
+    RuntimeReport, RuntimeSample, RuntimeSuiteRevision, RuntimeWorkload, utc_timestamp,
+    validate_runtime_report,
 };
 
 use crate::digest::sha256_bytes as sha256;
@@ -202,7 +203,7 @@ pub fn run() -> Result<u8, String> {
         }
     };
 
-    let started_at = crate::utc_timestamp();
+    let started_at = utc_timestamp();
     let compiler_version = compiler_version(&options.compiler)?;
     let toolchain_hash =
         pins::toolchain_hash(&options.repo_root).map_err(|error| error.to_string())?;
@@ -255,7 +256,7 @@ pub fn run() -> Result<u8, String> {
             commit: options.commit.clone(),
             compiler_version,
             started_at,
-            finished_at: crate::utc_timestamp(),
+            finished_at: utc_timestamp(),
             toolchain_hash,
             stdlib_hash,
             workload_source_hashes,

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -10,7 +10,7 @@ use rue_perf_schema::{
     Band, BuildBoundaryPolicy, CompilerCriticalPathEvidence, DurationDistribution,
     SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity, ScalingManifest, ScalingObservation,
     ScalingRegime, ScalingReport, Summary, WorkerSetting, WorkloadShape, canonical_json,
-    content_address,
+    content_address, utc_timestamp,
 };
 
 use crate::measure::{SampleRequest, measure_fresh_compile};
@@ -45,7 +45,7 @@ pub fn run() -> Result<(), String> {
         }
     };
 
-    let started_at = crate::utc_timestamp();
+    let started_at = utc_timestamp();
     let mut target: Option<String> = None;
     let mut observations = Vec::with_capacity(manifest.workloads.len() * manifest.workers.len());
     for workload in &manifest.workloads {
@@ -191,7 +191,7 @@ pub fn run() -> Result<(), String> {
             manifest_revision: manifest.revision,
             commit: options.commit,
             started_at,
-            finished_at: crate::utc_timestamp(),
+            finished_at: utc_timestamp(),
             target: target.unwrap_or_else(|| manifest.target.clone()),
             environment: crate::environment::fingerprint(),
         },

--- a/crates/rue-perf-schema/src/benchmark.rs
+++ b/crates/rue-perf-schema/src/benchmark.rs
@@ -1,0 +1,333 @@
+//! The `--benchmark-json` envelope: what the compiler publishes about one
+//! compilation, and what the runner reads back.
+//!
+//! This is the outermost object of the measurement contract. The sections
+//! inside it are owned elsewhere in this crate — [`PhaseAccounting`] partitions
+//! compiler-root wall time, [`CompilerWork`] counts host-independent work,
+//! [`CompilerBoundaryEvidence`] and [`CompilerCriticalPathEvidence`] carry the
+//! protocol-v2 evidence — and the envelope's own job is to say which of them
+//! are present and under which schema version.
+//!
+//! One declaration, two directions. The compiler builds a [`BenchmarkReport`]
+//! and serializes it; the runner deserializes the same type. Renaming a field
+//! therefore renames it for both, which is the property the separate producer
+//! and consumer declarations this replaced could not offer.
+//!
+//! The wire form is key-sorted JSON ([`sorted_json`]), so the bytes depend on
+//! the value rather than on a producer's field declaration order and two
+//! reports can be diffed line for line.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::boundary::{CompilerBoundaryEvidence, CompilerCriticalPathEvidence};
+use crate::canonical::{CanonicalError, sorted_json};
+use crate::run::PhaseAccounting;
+use crate::scaling::{CompilerWork, WorkloadShape};
+
+/// Version of the machine-readable timing contract the compiler publishes.
+///
+/// Producer and consumer read this one constant, so a schema change is a
+/// single edit and a runner cannot silently accept a report it was not built
+/// for. Bumping it is a consumer-visible break: every reader of
+/// `--benchmark-json` refuses the previous shape from that moment on.
+pub const BENCHMARK_JSON_SCHEMA_VERSION: u32 = 19;
+
+/// The pass table's timing model: inclusive spans that nest and overlap.
+pub const BENCHMARK_TIMING_MODEL: &str = "inclusive_spans";
+
+/// The interval whole-compiler allocation counting covers.
+pub const COMPILER_ALLOCATION_BOUNDARY: &str =
+    "canonical compile root including discovery and backend";
+
+/// One compilation, as the compiler reports it on stdout.
+///
+/// Every section a driver path may not have is an `Option` that is omitted
+/// from the wire rather than written as null, so a report from a path that
+/// measured less is still a valid report rather than a parse failure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkReport {
+    /// Always [`BENCHMARK_JSON_SCHEMA_VERSION`]; a reader refuses anything else.
+    #[serde(deserialize_with = "deserialize_schema_version")]
+    pub schema_version: u32,
+    /// Always [`BENCHMARK_TIMING_MODEL`]: pass durations are inclusive and may
+    /// overlap their parents.
+    pub timing_model: String,
+    /// The additive wall-clock partition of compiler-root time.
+    ///
+    /// This is the only model that may be stacked. Its integer nanoseconds
+    /// satisfy `sum(phase_ns) + mixed_parallel_ns + unattributed_ns ==
+    /// compiler_root_ns` exactly. The `passes` table is the *other* model —
+    /// inclusive spans that nest and overlap — and the two must never be mixed
+    /// in one visualization.
+    pub phase_accounting: PhaseAccounting,
+    /// Who produced this report, where, and when.
+    pub metadata: BenchmarkMetadata,
+    /// Individual pass timings in milliseconds.
+    pub passes: Vec<BenchmarkPass>,
+    /// Driver-side phases measured outside the compiler's timing root.
+    ///
+    /// These break down `process - total_ms`, never `total_ms` itself, so they
+    /// must not be added to the pass table. The field is omitted entirely when
+    /// the run measured no driver phase.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub driver_phases: Vec<BenchmarkDriverPhase>,
+    /// Total compilation time in milliseconds.
+    pub total_ms: f64,
+    /// Source and program-shape metrics for throughput calculations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_metrics: Option<WorkloadShape>,
+    /// Deterministic compiler work independent of host timing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compiler_work: Option<CompilerWork>,
+    /// Peak memory usage in bytes, where the platform reports it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peak_memory_bytes: Option<u64>,
+    /// The artifact this compilation published, identified by digest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emitted_output: Option<EmittedOutput>,
+    /// Protocol-v2 evidence that this was a fresh source-to-native build.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compiler_boundary: Option<CompilerBoundaryEvidence>,
+    /// Protocol-v2 evidence about what the schedule was waiting on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub critical_path: Option<CompilerCriticalPathEvidence>,
+    /// Whole-compiler allocation accounting, when the binary was built with it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compiler_allocations: Option<CompilerAllocations>,
+}
+
+impl BenchmarkReport {
+    /// Render the report as the bytes `--benchmark-json` writes to stdout.
+    ///
+    /// Keys are sorted at every depth, so the shape is a function of the value
+    /// and not of the order this struct happens to declare its fields in.
+    pub fn to_wire_json(&self) -> Result<String, CanonicalError> {
+        sorted_json(self)
+    }
+}
+
+/// Who produced a report, where, and when.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkMetadata {
+    /// UTC timestamp of when the benchmark was run, from
+    /// [`utc_timestamp`](crate::utc_timestamp).
+    pub timestamp: String,
+    /// Compiler version.
+    pub version: String,
+    /// Target platform (for example `x86_64-linux`, `aarch64-macos`).
+    pub target: String,
+    /// Build profile of the Rust compiler binary being measured.
+    pub compiler_build_profile: String,
+}
+
+/// Timing for a single compiler pass, from the inclusive-span model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkPass {
+    /// Name of the pass (for example `lexer`, `parser`).
+    pub name: String,
+    /// Time spent in this pass in milliseconds.
+    pub duration_ms: f64,
+    /// Percentage of total compilation time.
+    pub percent: f64,
+    /// Number of spans aggregated into this row.
+    pub invocations: u64,
+    /// Number of invocations without a parent span.
+    pub root_invocations: u64,
+    /// Number of invocations without a child span.
+    pub leaf_invocations: u64,
+}
+
+/// Timing for one driver-side phase outside the compiler's timing root.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkDriverPhase {
+    /// Name of the driver phase (for example `output_write`).
+    pub name: String,
+    /// Time spent in this phase in milliseconds.
+    pub duration_ms: f64,
+    /// Number of spans aggregated into this row.
+    pub invocations: u64,
+}
+
+/// The artifact a compilation published, identified by digest.
+///
+/// The runner hashes the file it finds on disk and compares; a mismatch means
+/// the compiler and the runner are not talking about the same bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmittedOutput {
+    /// Lowercase hexadecimal SHA-256 of the published bytes.
+    pub sha256: String,
+    /// Size of the published bytes.
+    pub size_bytes: u64,
+}
+
+impl EmittedOutput {
+    /// Identify published bytes, digesting them once for every consumer that
+    /// needs the digest.
+    pub fn of(bytes: &[u8]) -> Self {
+        Self {
+            sha256: format!("{:x}", Sha256::digest(bytes)),
+            size_bytes: u64::try_from(bytes.len()).unwrap_or(u64::MAX),
+        }
+    }
+}
+
+/// Whole-compiler allocation accounting over the compile root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompilerAllocations {
+    /// Allocations performed inside the boundary.
+    pub count: u64,
+    /// Bytes requested by those allocations.
+    pub requested_bytes: u64,
+    /// Prose statement of what the counters cover.
+    pub boundary: String,
+}
+
+impl CompilerAllocations {
+    /// Record counts taken over [`COMPILER_ALLOCATION_BOUNDARY`].
+    pub fn over_compile_root(count: u64, requested_bytes: u64) -> Self {
+        Self {
+            count,
+            requested_bytes,
+            boundary: COMPILER_ALLOCATION_BOUNDARY.to_string(),
+        }
+    }
+}
+
+fn deserialize_schema_version<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    let version = <u32 as Deserialize>::deserialize(deserializer)?;
+    if version != BENCHMARK_JSON_SCHEMA_VERSION {
+        return Err(D::Error::custom(format!(
+            "unsupported benchmark JSON schema version {version}; expected {BENCHMARK_JSON_SCHEMA_VERSION}"
+        )));
+    }
+    Ok(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn report() -> BenchmarkReport {
+        BenchmarkReport {
+            schema_version: BENCHMARK_JSON_SCHEMA_VERSION,
+            timing_model: BENCHMARK_TIMING_MODEL.to_string(),
+            phase_accounting: PhaseAccounting {
+                phase_ns: BTreeMap::new(),
+                mixed_parallel_ns: 0,
+                unattributed_ns: 0,
+                compiler_root_ns: 0,
+            },
+            metadata: BenchmarkMetadata {
+                timestamp: "2026-01-02T03:04:05Z".to_string(),
+                version: "0.1.0".to_string(),
+                target: "x86_64-linux".to_string(),
+                compiler_build_profile: "release_thin_lto".to_string(),
+            },
+            passes: vec![BenchmarkPass {
+                name: "lexer".to_string(),
+                duration_ms: 1.5,
+                percent: 50.0,
+                invocations: 1,
+                root_invocations: 1,
+                leaf_invocations: 1,
+            }],
+            driver_phases: Vec::new(),
+            total_ms: 3.0,
+            source_metrics: Some(WorkloadShape {
+                files: 1,
+                modules: 1,
+                bytes: 24,
+                lines: 1,
+                tokens: 9,
+                functions: 1,
+            }),
+            compiler_work: Some(CompilerWork::default()),
+            peak_memory_bytes: Some(4096),
+            emitted_output: Some(EmittedOutput::of(b"artifact")),
+            compiler_boundary: None,
+            critical_path: None,
+            compiler_allocations: None,
+        }
+    }
+
+    #[test]
+    fn the_wire_form_round_trips_through_the_consumer() {
+        // Producer and consumer are the same declaration, so this fails at
+        // compile time on a rename and at test time on a serde attribute that
+        // stops agreeing with itself.
+        let published = report().to_wire_json().expect("a report renders");
+        let parsed: BenchmarkReport =
+            serde_json::from_str(&published).expect("the runner parses what the compiler writes");
+        assert_eq!(parsed.schema_version, BENCHMARK_JSON_SCHEMA_VERSION);
+        assert_eq!(parsed.timing_model, BENCHMARK_TIMING_MODEL);
+        assert_eq!(parsed.emitted_output, report().emitted_output);
+        assert_eq!(
+            parsed
+                .source_metrics
+                .as_ref()
+                .expect("source metrics survive")
+                .bytes,
+            24
+        );
+        assert_eq!(
+            parsed.to_wire_json().expect("a parsed report renders"),
+            published
+        );
+    }
+
+    #[test]
+    fn the_wire_form_sorts_keys_at_every_depth() {
+        let published = report().to_wire_json().expect("a report renders");
+        assert!(published.starts_with(r#"{"compiler_work":"#), "{published}");
+        assert!(published.contains(r#""emitted_output":{"sha256":"#));
+        assert!(published.contains(r#""metadata":{"compiler_build_profile":"#));
+    }
+
+    #[test]
+    fn absent_sections_are_omitted_rather_than_written_as_null() {
+        let published = report().to_wire_json().expect("a report renders");
+        assert!(!published.contains("null"), "{published}");
+        assert!(!published.contains("critical_path"), "{published}");
+        assert!(!published.contains("driver_phases"), "{published}");
+    }
+
+    #[test]
+    fn a_report_without_the_optional_sections_still_parses() {
+        // The runner requires more than this, and says so itself. Parsing is
+        // not where a path that measured less is refused.
+        let mut lean = report();
+        lean.source_metrics = None;
+        lean.compiler_work = None;
+        lean.peak_memory_bytes = None;
+        lean.emitted_output = None;
+        let published = lean.to_wire_json().expect("a lean report renders");
+        let parsed: BenchmarkReport =
+            serde_json::from_str(&published).expect("a lean report parses");
+        assert!(parsed.emitted_output.is_none());
+    }
+
+    #[test]
+    fn a_retired_schema_version_is_refused() {
+        let error = serde_json::from_str::<BenchmarkReport>(r#"{"schema_version":16}"#)
+            .expect_err("a retired schema version must be refused");
+        assert!(error.to_string().contains("expected 19"), "{error}");
+    }
+
+    #[test]
+    fn the_emitted_output_digest_is_the_sha256_of_the_bytes() {
+        let emitted = EmittedOutput::of(b"");
+        assert_eq!(
+            emitted.sha256,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(emitted.size_bytes, 0);
+    }
+}

--- a/crates/rue-perf-schema/src/canonical.rs
+++ b/crates/rue-perf-schema/src/canonical.rs
@@ -1,11 +1,13 @@
-//! Canonical serialization and content addressing.
+//! Key-sorted serialization, content addressing, and the reporting form.
 //!
 //! A run object's name is the SHA-256 digest of its canonical form. For that
 //! name to be stable, serialization must be a function of the value alone:
 //! object keys sorted, no insignificant whitespace, and no floating-point
 //! numbers anywhere. The float rule is the reason raw records hold integer
 //! nanoseconds and integer bytes — hashing must never depend on how some
-//! writer chose to format `0.1`.
+//! writer chose to format `0.1`. Reports that are read rather than hashed —
+//! the `--benchmark-json` envelope above all — keep the sorted-key shape but
+//! may carry floats, and take [`sorted_json`] instead.
 
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -53,7 +55,25 @@ pub fn canonical_json<T: Serialize + ?Sized>(value: &T) -> Result<String, Canoni
         detail: error.to_string(),
     })?;
     let mut out = String::new();
-    write_canonical(&value, "", &mut out)?;
+    write_sorted(&value, "", &mut out, Floats::Rejected)?;
+    Ok(out)
+}
+
+/// Serialize a value to key-sorted compact JSON, floating-point numbers
+/// included.
+///
+/// This is the shape a published report takes on the wire: the same object
+/// keys in the same order whatever a producer's field declaration order
+/// happens to be, so a consumer diffing two reports sees only real changes.
+/// Unlike [`canonical_json`] it is not a content-addressing form — a float's
+/// text is a formatting decision, so a digest over these bytes would not be a
+/// function of the value alone.
+pub fn sorted_json<T: Serialize + ?Sized>(value: &T) -> Result<String, CanonicalError> {
+    let value = serde_json::to_value(value).map_err(|error| CanonicalError::NotSerializable {
+        detail: error.to_string(),
+    })?;
+    let mut out = String::new();
+    write_sorted(&value, "", &mut out, Floats::Permitted)?;
     Ok(out)
 }
 
@@ -69,10 +89,20 @@ pub fn content_address<T: Serialize + ?Sized>(value: &T) -> Result<String, Canon
     Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
 }
 
-fn write_canonical(
+/// Whether a writer may emit a floating-point number or must refuse one.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Floats {
+    /// Content addressing: a float is an error, located by JSON pointer.
+    Rejected,
+    /// Reporting: a float is written exactly as `serde_json` would write it.
+    Permitted,
+}
+
+fn write_sorted(
     value: &serde_json::Value,
     path: &str,
     out: &mut String,
+    floats: Floats,
 ) -> Result<(), CanonicalError> {
     match value {
         serde_json::Value::Null => out.push_str("null"),
@@ -83,6 +113,11 @@ fn write_canonical(
                 out.push_str(&unsigned.to_string());
             } else if let Some(signed) = number.as_i64() {
                 out.push_str(&signed.to_string());
+            } else if floats == Floats::Permitted {
+                // `Number`'s `Display` is the serializer's own float
+                // formatting, so a permitted float reads exactly as
+                // `serde_json` would have written it.
+                out.push_str(&number.to_string());
             } else {
                 return Err(CanonicalError::FloatingPoint {
                     path: if path.is_empty() {
@@ -108,7 +143,7 @@ fn write_canonical(
                 if index > 0 {
                     out.push(',');
                 }
-                write_canonical(item, &format!("{path}/{index}"), out)?;
+                write_sorted(item, &format!("{path}/{index}"), out, floats)?;
             }
             out.push(']');
         }
@@ -131,7 +166,7 @@ fn write_canonical(
                 out.push_str(&encoded);
                 out.push(':');
                 let child = entries.get(key).expect("key came from this map");
-                write_canonical(child, &format!("{path}/{key}"), out)?;
+                write_sorted(child, &format!("{path}/{key}"), out, floats)?;
             }
             out.push('}');
         }
@@ -185,6 +220,22 @@ mod tests {
     fn non_ascii_keys_sort_by_scalar_sequence() {
         let canonical = canonical_json(&json!({"é": 1, "e": 2, "z": 3})).unwrap();
         assert_eq!(canonical, "{\"e\":2,\"z\":3,\"\u{e9}\":1}");
+    }
+
+    #[test]
+    fn the_reporting_form_sorts_keys_and_keeps_floats() {
+        let report = sorted_json(&json!({"b": 0.5, "a": {"d": 1, "c": [2.25]}})).unwrap();
+        assert_eq!(report, r#"{"a":{"c":[2.25],"d":1},"b":0.5}"#);
+    }
+
+    #[test]
+    fn the_reporting_form_writes_floats_as_serde_json_does() {
+        // The wire bytes must not depend on which writer produced them.
+        let value = json!({"a": 0.1, "b": 1.0, "c": 1e300, "d": -0.0});
+        assert_eq!(
+            sorted_json(&value).unwrap(),
+            serde_json::to_string(&value).unwrap()
+        );
     }
 
     #[test]

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -34,6 +34,12 @@
 //! disk. [`ValidationOutcome`] reports both, plus the run's
 //! [`Completeness`].
 //!
+//! **The wire envelope is declared once.** [`BenchmarkReport`] is what the
+//! compiler's `--benchmark-json` writes and what the runner reads back: one
+//! declaration serialized in one direction and deserialized in the other, so a
+//! renamed field is renamed for both and [`BENCHMARK_JSON_SCHEMA_VERSION`] is
+//! a single edit rather than two literals that can drift apart.
+//!
 //! ADR-0072 adds a second record kind on the same three ideas. A
 //! [`RuntimeReport`] measures how fast a *compiled Rue program* runs rather
 //! than how fast the compiler produced it, and introduces one category the
@@ -42,6 +48,7 @@
 //! observation instead of failing validation when it moves. Nothing about
 //! ADR-0067's rules for the compile-time suites changes.
 
+mod benchmark;
 mod boundary;
 mod canonical;
 mod encoding;
@@ -54,8 +61,14 @@ mod scaling;
 mod series;
 mod stats;
 mod stored;
+mod timestamp;
 mod validate;
 
+pub use benchmark::{
+    BENCHMARK_JSON_SCHEMA_VERSION, BENCHMARK_TIMING_MODEL, BenchmarkDriverPhase, BenchmarkMetadata,
+    BenchmarkPass, BenchmarkReport, COMPILER_ALLOCATION_BOUNDARY, CompilerAllocations,
+    EmittedOutput,
+};
 pub use boundary::{
     ArtifactHitEvidence, BuildBoundary, BuildBoundaryEvidence, BuildBoundaryPolicy,
     CompilerBoundaryEvidence, CompilerBuildProfile, CompilerConfigurationEvidence,
@@ -63,7 +76,7 @@ pub use boundary::{
     CompilerStage, DurationDistribution, EmbeddedAssetClass, EmbeddedAssetEvidence, LinkPolicy,
     OptimizationLevel, OutputKind, RunnerBoundaryEvidence, RunnerClockBoundary, WorkerSetting,
 };
-pub use canonical::{CanonicalError, canonical_json, content_address};
+pub use canonical::{CanonicalError, canonical_json, content_address, sorted_json};
 pub use encoding::{
     CompilerRunInvariant, CompilerWorkloadInvariant, EncodeError, EvidenceSource,
     FULL_EVIDENCE_SCHEMA_VERSION, IDENTITY_DIGEST_TAG, LEGACY_FULL_EVIDENCE_SCHEMA_VERSION,
@@ -117,6 +130,7 @@ pub use stats::{
     ratio, sample_value,
 };
 pub use stored::{Stored, StoredRecordError, StoredRun, StoredRuntimeReport};
+pub use timestamp::utc_timestamp;
 pub use validate::{
     Completeness, InvalidSample, InvalidSampleReason, ProcessElapsedRegression,
     SUPPORTED_SCHEMA_VERSIONS, ValidationError, ValidationOutcome, process_elapsed_regressions,

--- a/crates/rue-perf-schema/src/timestamp.rs
+++ b/crates/rue-perf-schema/src/timestamp.rs
@@ -1,0 +1,71 @@
+//! The one spelling of an instant in the measurement contract.
+//!
+//! Two identical measurements formatting the same instant differently would
+//! produce two content addresses, so every producer — the compiler's benchmark
+//! report, the runner's run identities — formats through here. Computed from
+//! the Unix epoch rather than pulling in a date library for six fields.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// The current instant as `YYYY-MM-DDTHH:MM:SSZ`.
+pub fn utc_timestamp() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0);
+    let (days, rest) = (seconds / 86_400, seconds % 86_400);
+    let (hour, minute, second) = (rest / 3600, (rest % 3600) / 60, rest % 60);
+    let (year, month, day) = civil_from_days(days as i64);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+/// Howard Hinnant's `civil_from_days`, shifting the era to start in March so
+/// the leap day lands at the end of a cycle.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let day_of_era = z.rem_euclid(146_097);
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let shifted_month = (5 * day_of_year + 2) / 153;
+    let day = (day_of_year - (153 * shifted_month + 2) / 5 + 1) as u32;
+    let month = if shifted_month < 10 {
+        shifted_month + 3
+    } else {
+        shifted_month - 9
+    } as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_epoch_is_the_first_of_january_1970() {
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+    }
+
+    #[test]
+    fn a_leap_day_is_placed_correctly() {
+        // 2000-02-29 is 11,016 days after the epoch; 1900 was not a leap year
+        // and 2000 was, which is the case a naive rule gets wrong.
+        assert_eq!(civil_from_days(11_016), (2000, 2, 29));
+        assert_eq!(civil_from_days(11_017), (2000, 3, 1));
+        assert_eq!(civil_from_days(19_723), (2024, 1, 1));
+        assert_eq!(civil_from_days(19_782), (2024, 2, 29));
+    }
+
+    #[test]
+    fn the_timestamp_has_the_published_shape() {
+        let stamp = utc_timestamp();
+        assert_eq!(stamp.len(), 20, "{stamp}");
+        assert_eq!(stamp.as_bytes()[10], b'T', "{stamp}");
+        assert!(stamp.ends_with('Z'), "{stamp}");
+        // Sub-second precision would make two runs of the same instant hash
+        // differently, so it must not appear.
+        assert!(!stamp.contains('.'), "{stamp}");
+    }
+}

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -45,10 +45,11 @@ use rue_error::{
     CompileError, DiagnosticWrapper, ErrorCode, ErrorCodeExplanation, error_code_explanation,
 };
 use rue_perf_schema::{
-    ArtifactHitEvidence, BuildBoundary, CompilerBoundaryEvidence, CompilerBuildProfile,
-    CompilerConfigurationEvidence, CompilerCriticalPathEvidence, CompilerInputClass,
-    CompilerInputEvidence, CompilerPipeline, CompilerStage, EmbeddedAssetClass,
-    EmbeddedAssetEvidence, LinkPolicy, OptimizationLevel, OutputKind, WorkerSetting,
+    ArtifactHitEvidence, BenchmarkReport, BuildBoundary, CompilerBoundaryEvidence,
+    CompilerBuildProfile, CompilerConfigurationEvidence, CompilerCriticalPathEvidence,
+    CompilerInputClass, CompilerInputEvidence, CompilerPipeline, CompilerStage, EmbeddedAssetClass,
+    EmbeddedAssetEvidence, EmittedOutput, LinkPolicy, OptimizationLevel, OutputKind, WorkerSetting,
+    WorkloadShape,
 };
 use rue_target::Target;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1474,58 +1475,88 @@ fn init_tracing(
 }
 
 /// Print timing output based on CLI flags.
+///
+/// The two surfaces are exclusive: `--benchmark-json` owns stdout and prints
+/// the assembled envelope, `--time-passes` prints the human report on stderr.
+/// A caller with no benchmark report to publish passes `None` and gets the
+/// human report if it asked for one.
 fn print_timing_output(
     timing_data: &Option<timing::TimingData>,
     time_passes: bool,
-    benchmark_json: bool,
-    target: &Target,
-    source_metrics: Option<timing::SourceMetrics>,
-    compiler_work: Option<rue_perf_schema::CompilerWork>,
-    emitted_output: Option<&[u8]>,
-    compiler_boundary: Option<&CompilerBoundaryEvidence>,
-    critical_path: Option<&CompilerCriticalPathEvidence>,
+    benchmark_report: Option<&BenchmarkReport>,
 ) {
-    if let Some(timing) = timing_data {
-        if benchmark_json {
-            // JSON output goes to stdout for easy capture
-            // Include metadata and source metrics for historical analysis
-            let mut payload: serde_json::Value =
-                serde_json::from_str(&timing.to_json_with_metrics(
-                    &target.to_string(),
-                    VERSION,
-                    source_metrics,
-                    compiler_work,
-                    get_peak_memory_bytes(),
-                ))
-                .unwrap();
-            if let Some(bytes) = emitted_output {
-                use sha2::{Digest, Sha256};
-                payload["emitted_output"] = serde_json::json!({
-                    "sha256": format!("{:x}", Sha256::digest(bytes)),
-                    "size_bytes": bytes.len(),
-                });
+    if let Some(report) = benchmark_report {
+        match report.to_wire_json() {
+            Ok(json) => println!("{json}"),
+            Err(error) => {
+                eprintln!("Error: benchmark timing could not be rendered as JSON: {error}");
+                std::process::exit(1);
             }
-            if let Some(boundary) = compiler_boundary {
-                payload["compiler_boundary"] = serde_json::to_value(boundary).unwrap();
-            }
-            if let Some(critical_path) = critical_path {
-                payload["critical_path"] = serde_json::to_value(critical_path).unwrap();
-            }
-            #[cfg(rue_benchmark_allocations)]
-            {
-                let metrics = allocation::snapshot();
-                payload["compiler_allocations"] = serde_json::json!({
-                    "count": metrics.allocations,
-                    "requested_bytes": metrics.allocated_bytes,
-                    "boundary": "canonical compile root including discovery and backend",
-                });
-            }
-            println!("{payload}");
-        } else if time_passes {
-            // Human-readable output goes to stderr
+        }
+    } else if time_passes {
+        if let Some(timing) = timing_data {
+            // Human-readable output goes to stderr.
             eprintln!("{}", timing.report());
         }
     }
+}
+
+/// Assemble the `--benchmark-json` envelope for a completed compilation.
+///
+/// Everything the report can carry is filled in here, once: the timing module
+/// contributes the two timing models and the metadata, and this function adds
+/// the evidence only the driver knows. `emitted_output` identifies the
+/// published artifact and is digested by its caller, so the boundary evidence
+/// and the envelope's own section report the same digest without hashing the
+/// bytes twice.
+fn benchmark_report(
+    timing: &timing::TimingData,
+    options: &Options,
+    resolved_workers: usize,
+    source_snapshot: &rue_compiler::SourceSnapshot,
+    metrics: rue_compiler::unstable::OneShotMetrics,
+    emitted_output: EmittedOutput,
+) -> BenchmarkReport {
+    let source_metrics = WorkloadShape {
+        files: metrics.files as u64,
+        // Every accepted source file is one module in the canonical import
+        // graph. Query-work counters do not include the root module, so
+        // `files` is the exact one-shot module count rather than a work
+        // estimate.
+        modules: metrics.files as u64,
+        bytes: metrics.bytes as u64,
+        lines: metrics.lines as u64,
+        tokens: metrics.tokens as u64,
+        functions: metrics.semantic.cfg.functions_considered as u64,
+    };
+    let mut compiler_work = benchmark_compiler_work(metrics);
+    compiler_work.semantic_analysis_structure = benchmark_semantic_analysis_structure(timing);
+
+    let mut report = timing.to_benchmark_report(
+        &options.target.to_string(),
+        VERSION,
+        Some(source_metrics),
+        Some(compiler_work),
+        get_peak_memory_bytes(),
+    );
+    report.compiler_boundary = compiler_boundary_evidence(
+        options,
+        resolved_workers,
+        source_snapshot,
+        emitted_output.clone(),
+    );
+    report.critical_path = Some(compiler_critical_path_evidence(timing, metrics));
+    report.emitted_output = Some(emitted_output);
+    #[cfg(rue_benchmark_allocations)]
+    {
+        let allocations = allocation::snapshot();
+        report.compiler_allocations =
+            Some(rue_perf_schema::CompilerAllocations::over_compile_root(
+                allocations.allocations,
+                allocations.allocated_bytes,
+            ));
+    }
+    report
 }
 
 /// Finish a successful one-shot native compile after every observable
@@ -1555,7 +1586,7 @@ fn compiler_boundary_evidence(
     options: &Options,
     resolved_workers: usize,
     snapshot: &rue_compiler::SourceSnapshot,
-    emitted_output: &[u8],
+    emitted_output: EmittedOutput,
 ) -> Option<CompilerBoundaryEvidence> {
     let requested_workers = WorkerSetting::from_jobs(options.jobs)?;
     let mut accepted_inputs = snapshot
@@ -1621,11 +1652,8 @@ fn compiler_boundary_evidence(
             target: options.target.to_string(),
         }],
         artifact_hits: ArtifactHitEvidence::default(),
-        emitted_output_sha256: {
-            use sha2::{Digest, Sha256};
-            format!("{:x}", Sha256::digest(emitted_output))
-        },
-        emitted_output_size_bytes: u64::try_from(emitted_output.len()).unwrap_or(u64::MAX),
+        emitted_output_sha256: emitted_output.sha256,
+        emitted_output_size_bytes: emitted_output.size_bytes,
     })
 }
 
@@ -2531,17 +2559,10 @@ fn main() {
             }
         }
         drop(compile_span);
-        print_timing_output(
-            &timing_data,
-            options.time_passes,
-            options.benchmark_json,
-            &options.target,
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
+        // `--emit` and `--benchmark-json` both want stdout, so
+        // `validate_output_modes` already refused the combination: this path
+        // has no benchmark envelope to publish, only the human report.
+        print_timing_output(&timing_data, options.time_passes, None);
         return;
     }
 
@@ -2670,7 +2691,7 @@ fn main() {
             // file rather than the pre-publication linker buffer.
             let benchmark_emitted_output = if options.benchmark_json {
                 match std::fs::read(&options.output_path) {
-                    Ok(bytes) => Some(bytes),
+                    Ok(bytes) => Some(EmittedOutput::of(&bytes)),
                     Err(error) => {
                         eprintln!(
                             "Error: could not verify published benchmark output '{}': {error}",
@@ -2683,56 +2704,18 @@ fn main() {
                 None
             };
 
-            let benchmark_metrics = options.benchmark_json.then(|| output.unstable_metrics());
-            let compiler_boundary = options
-                .benchmark_json
-                .then(|| {
-                    compiler_boundary_evidence(
-                        &options,
-                        resolved_workers,
-                        &source_snapshot,
-                        benchmark_emitted_output
-                            .as_deref()
-                            .expect("benchmark output was read after publication"),
-                    )
-                })
-                .flatten();
-            let critical_path = benchmark_metrics.and_then(|metrics| {
-                timing_data
-                    .as_ref()
-                    .map(|timing| compiler_critical_path_evidence(timing, metrics))
-            });
-            print_timing_output(
-                &timing_data,
-                options.time_passes,
-                options.benchmark_json,
-                &options.target,
-                benchmark_metrics.map(|source_stats| {
-                    timing::SourceMetrics {
-                        files: source_stats.files,
-                        // Every accepted source file is one module in the
-                        // canonical import graph. Query-work counters do not
-                        // include the root module, so `files` is the exact
-                        // one-shot module count rather than a work estimate.
-                        modules: source_stats.files,
-                        bytes: source_stats.bytes,
-                        lines: source_stats.lines,
-                        tokens: source_stats.tokens,
-                        functions: source_stats.semantic.cfg.functions_considered,
-                    }
-                }),
-                benchmark_metrics.map(|metrics| {
-                    let mut work = benchmark_compiler_work(metrics);
-                    if let Some(timing) = timing_data.as_ref() {
-                        work.semantic_analysis_structure =
-                            benchmark_semantic_analysis_structure(timing);
-                    }
-                    work
-                }),
-                benchmark_emitted_output.as_deref(),
-                compiler_boundary.as_ref(),
-                critical_path.as_ref(),
-            );
+            let report = match (timing_data.as_ref(), benchmark_emitted_output) {
+                (Some(timing), Some(emitted_output)) => Some(benchmark_report(
+                    timing,
+                    &options,
+                    resolved_workers,
+                    &source_snapshot,
+                    output.unstable_metrics(),
+                    emitted_output,
+                )),
+                _ => None,
+            };
+            print_timing_output(&timing_data, options.time_passes, report.as_ref());
             exit_successful_native_compile();
         }
         Err(errors) => {
@@ -3187,7 +3170,7 @@ mod tests {
             edges.contains(&("compile".to_owned(), "compile_pipeline".to_owned())),
             "post-discovery pipeline escaped the compile root: {edges:?}"
         );
-        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
+        let timing = data.to_benchmark_report("test", "test", None, None, None);
         for pass in &timing.passes {
             if pass.name == "compile" {
                 assert_eq!(pass.invocations, 1);

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -17,8 +17,9 @@
 //!    buffers.
 //!
 //! 3. **Reporting**: After compilation, `TimingData::report()` formats the collected
-//!    timing as a human-readable table. For machine-readable output, use
-//!    `TimingData::to_json()`.
+//!    timing as a human-readable table. For machine-readable output,
+//!    `TimingData::to_benchmark_report()` fills in the `rue-perf-schema`
+//!    envelope that `--benchmark-json` publishes.
 //!
 //! # Two timing models, kept distinct
 //!
@@ -30,7 +31,7 @@
 //! concurrently across query workers. Summing them double-counts, which is why
 //! the root total is a union of active intervals rather than a sum.
 //!
-//! **Wall-clock phase accounting** is [`BenchmarkTiming::phase_accounting`]. A
+//! **Wall-clock phase accounting** is `BenchmarkReport::phase_accounting`. A
 //! small set of explicitly instrumented, mutually exclusive phases partitions
 //! compiler-root wall time so that, in exact integer nanoseconds:
 //!
@@ -87,8 +88,9 @@
 //! // Print the timing report
 //! eprintln!("{}", timing_data.report());
 //!
-//! // Or get JSON for benchmarking
-//! println!("{}", timing_data.to_json());
+//! // Or fill in the machine-readable envelope for benchmarking
+//! let report = timing_data.to_benchmark_report(target, version, None, None, None);
+//! println!("{}", report.to_wire_json().unwrap());
 //! ```
 
 use std::cell::RefCell;
@@ -96,7 +98,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError, Weak};
 #[cfg(test)]
 use std::thread::ThreadId;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 #[cfg(rue_release_build)]
 const COMPILER_BUILD_PROFILE: &str = "release_thin_lto";
@@ -104,8 +106,11 @@ const COMPILER_BUILD_PROFILE: &str = "release_thin_lto";
 const COMPILER_BUILD_PROFILE: &str = "debug";
 
 use ahash::AHashMap;
-use rue_perf_schema::{CompilerWork, DurationDistribution, Phase, PhaseAccounting};
-use serde::Serialize;
+use rue_perf_schema::{
+    BENCHMARK_JSON_SCHEMA_VERSION, BENCHMARK_TIMING_MODEL, BenchmarkDriverPhase, BenchmarkMetadata,
+    BenchmarkPass, BenchmarkReport, CompilerWork, DurationDistribution, Phase, PhaseAccounting,
+    WorkloadShape, utc_timestamp,
+};
 
 use tracing::span::{Attributes, Id};
 use tracing::{Event, Subscriber};
@@ -297,107 +302,6 @@ fn merge_driver_phase(
     let aggregate = target.entry(name).or_default();
     aggregate.duration += local.duration;
     aggregate.invocations += local.invocations;
-}
-
-/// JSON output structure for benchmark timing data.
-///
-/// This structure is designed for machine-readable output that can be
-/// consumed by the benchmark runner and visualization tools. It includes
-/// metadata for historical analysis and comparison across runs.
-#[derive(Debug, Clone, Serialize)]
-pub struct BenchmarkTiming {
-    /// Version of this machine-readable timing contract.
-    pub schema_version: u32,
-    /// Pass durations are inclusive and may overlap their parents.
-    pub timing_model: &'static str,
-    /// The additive wall-clock partition of compiler-root time.
-    ///
-    /// This is the only model that may be stacked. Its integer nanoseconds
-    /// satisfy `sum(phase_ns) + mixed_parallel_ns + unattributed_ns ==
-    /// compiler_root_ns` exactly. The `passes` table below is the *other*
-    /// model — inclusive spans that nest and overlap — and the two must never
-    /// be mixed in one visualization.
-    pub phase_accounting: PhaseAccounting,
-    /// Metadata about this benchmark run.
-    pub metadata: BenchmarkMetadata,
-    /// Individual pass timings in milliseconds.
-    pub passes: Vec<PassTiming>,
-    /// Driver-side phases measured outside the compiler's timing root.
-    ///
-    /// These break down `process - total_ms`, never `total_ms` itself, so they
-    /// must not be added to the pass table. The field is omitted entirely when
-    /// the run measured no driver phase.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub driver_phases: Vec<DriverPhaseTiming>,
-    /// Total compilation time in milliseconds.
-    pub total_ms: f64,
-    /// Source and program-shape metrics for throughput calculations.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_metrics: Option<SourceMetrics>,
-    /// Deterministic compiler work independent of host timing.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub compiler_work: Option<CompilerWork>,
-    /// Peak memory usage in bytes (if available).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub peak_memory_bytes: Option<u64>,
-}
-
-/// Source and program-shape metrics for throughput calculations.
-#[derive(Debug, Clone, Serialize)]
-pub struct SourceMetrics {
-    /// Number of source files compiled.
-    pub files: usize,
-    /// Number of modules consumed by parsing.
-    pub modules: usize,
-    /// Total bytes across source files.
-    pub bytes: usize,
-    /// Total lines across source files.
-    pub lines: usize,
-    /// Total tokens produced by the lexer invocations consumed by parsing.
-    pub tokens: usize,
-    /// Number of source and synthesized functions considered for CFG construction.
-    pub functions: usize,
-}
-
-/// Metadata about a benchmark run for historical analysis.
-#[derive(Debug, Clone, Serialize)]
-pub struct BenchmarkMetadata {
-    /// ISO 8601 timestamp of when the benchmark was run.
-    pub timestamp: String,
-    /// Compiler version.
-    pub version: String,
-    /// Target platform (e.g., "x86_64-linux", "aarch64-macos").
-    pub target: String,
-    /// Build profile of the Rust compiler binary being measured.
-    pub compiler_build_profile: &'static str,
-}
-
-/// Timing data for a single compiler pass.
-#[derive(Debug, Clone, Serialize)]
-pub struct PassTiming {
-    /// Name of the pass (e.g., "lexer", "parser").
-    pub name: String,
-    /// Time spent in this pass in milliseconds.
-    pub duration_ms: f64,
-    /// Percentage of total compilation time.
-    pub percent: f64,
-    /// Number of spans aggregated into this row.
-    pub invocations: u64,
-    /// Number of invocations without a parent span.
-    pub root_invocations: u64,
-    /// Number of invocations without a child span.
-    pub leaf_invocations: u64,
-}
-
-/// Timing for one driver-side phase outside the compiler's timing root.
-#[derive(Debug, Clone, Serialize)]
-pub struct DriverPhaseTiming {
-    /// Name of the driver phase (e.g., "output_write").
-    pub name: String,
-    /// Time spent in this phase in milliseconds.
-    pub duration_ms: f64,
-    /// Number of spans aggregated into this row.
-    pub invocations: u64,
 }
 
 impl TimingData {
@@ -720,7 +624,11 @@ impl TimingData {
         output
     }
 
-    /// Generate structured timing data with optional source metrics and memory usage.
+    /// Fill in the `--benchmark-json` envelope for this compilation.
+    ///
+    /// The report's optional evidence sections are left empty: only the driver
+    /// knows what it published, so it sets them on the value returned here and
+    /// then renders the whole envelope once.
     ///
     /// # Arguments
     /// * `target` - The target platform string (e.g., "x86_64-linux")
@@ -728,14 +636,14 @@ impl TimingData {
     /// * `source_metrics` - Optional source and program-shape metrics
     /// * `compiler_work` - Optional deterministic compiler-work counters
     /// * `peak_memory_bytes` - Optional peak memory usage in bytes
-    pub fn to_benchmark_timing_with_metrics(
+    pub fn to_benchmark_report(
         &self,
         target: &str,
         version: &str,
-        source_metrics: Option<SourceMetrics>,
+        source_metrics: Option<WorkloadShape>,
         compiler_work: Option<CompilerWork>,
         peak_memory_bytes: Option<u64>,
-    ) -> BenchmarkTiming {
+    ) -> BenchmarkReport {
         self.flush_local();
         let inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
 
@@ -757,7 +665,7 @@ impl TimingData {
                     } else {
                         0.0
                     };
-                    PassTiming {
+                    BenchmarkPass {
                         name: pass,
                         duration_ms,
                         percent,
@@ -775,7 +683,7 @@ impl TimingData {
                 inner
                     .driver_phases
                     .get(&phase)
-                    .map(|measurement| DriverPhaseTiming {
+                    .map(|measurement| BenchmarkDriverPhase {
                         name: phase,
                         duration_ms: duration_ns(measurement.duration) as f64 / 1_000_000.0,
                         invocations: measurement.invocations,
@@ -784,15 +692,15 @@ impl TimingData {
             .collect();
 
         let metadata = BenchmarkMetadata {
-            timestamp: iso8601_now(),
+            timestamp: utc_timestamp(),
             version: version.to_string(),
             target: target.to_string(),
-            compiler_build_profile: COMPILER_BUILD_PROFILE,
+            compiler_build_profile: COMPILER_BUILD_PROFILE.to_string(),
         };
 
-        BenchmarkTiming {
-            schema_version: 19,
-            timing_model: "inclusive_spans",
+        BenchmarkReport {
+            schema_version: BENCHMARK_JSON_SCHEMA_VERSION,
+            timing_model: BENCHMARK_TIMING_MODEL.to_string(),
             phase_accounting,
             metadata,
             passes,
@@ -801,33 +709,11 @@ impl TimingData {
             source_metrics,
             compiler_work,
             peak_memory_bytes,
+            emitted_output: None,
+            compiler_boundary: None,
+            critical_path: None,
+            compiler_allocations: None,
         }
-    }
-
-    /// Generate JSON output with additional source metrics.
-    ///
-    /// # Arguments
-    /// * `target` - The target platform string
-    /// * `version` - The compiler version string
-    /// * `source_metrics` - Source and program-shape metrics
-    /// * `compiler_work` - Deterministic compiler-work counters
-    /// * `peak_memory_bytes` - Optional peak memory usage
-    pub fn to_json_with_metrics(
-        &self,
-        target: &str,
-        version: &str,
-        source_metrics: Option<SourceMetrics>,
-        compiler_work: Option<CompilerWork>,
-        peak_memory_bytes: Option<u64>,
-    ) -> String {
-        let timing = self.to_benchmark_timing_with_metrics(
-            target,
-            version,
-            source_metrics,
-            compiler_work,
-            peak_memory_bytes,
-        );
-        serde_json::to_string(&timing).unwrap_or_else(|_| "{}".to_string())
     }
 }
 
@@ -1029,79 +915,6 @@ fn capitalize(s: &str) -> String {
         None => String::new(),
         Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
     }
-}
-
-/// Generate an ISO 8601 timestamp for the current time.
-///
-/// Format: "2025-12-27T21:30:00Z"
-fn iso8601_now() -> String {
-    let now = SystemTime::now();
-    let duration = now.duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO);
-    let secs = duration.as_secs();
-
-    // Convert to date/time components (simplified, assumes UTC)
-    // This is a basic implementation without external dependencies
-    const SECS_PER_MIN: u64 = 60;
-    const SECS_PER_HOUR: u64 = 3600;
-    const SECS_PER_DAY: u64 = 86400;
-
-    let days = secs / SECS_PER_DAY;
-    let remaining = secs % SECS_PER_DAY;
-    let hours = remaining / SECS_PER_HOUR;
-    let remaining = remaining % SECS_PER_HOUR;
-    let minutes = remaining / SECS_PER_MIN;
-    let seconds = remaining % SECS_PER_MIN;
-
-    // Calculate year, month, day from days since epoch (1970-01-01)
-    let (year, month, day) = days_to_ymd(days);
-
-    format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
-        year, month, day, hours, minutes, seconds
-    )
-}
-
-/// Convert days since Unix epoch to (year, month, day).
-fn days_to_ymd(days: u64) -> (u64, u64, u64) {
-    // Simplified algorithm for date calculation
-    let mut remaining_days = days as i64;
-    let mut year: i64 = 1970;
-
-    // Find the year
-    loop {
-        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
-        if remaining_days < days_in_year {
-            break;
-        }
-        remaining_days -= days_in_year;
-        year += 1;
-    }
-
-    // Find the month and day
-    let leap = is_leap_year(year);
-    let days_in_months: [i64; 12] = if leap {
-        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    } else {
-        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    };
-
-    let mut month = 1;
-    for &days_in_month in &days_in_months {
-        if remaining_days < days_in_month {
-            break;
-        }
-        remaining_days -= days_in_month;
-        month += 1;
-    }
-
-    let day = remaining_days + 1; // Days are 1-indexed
-
-    (year as u64, month, day as u64)
-}
-
-/// Check if a year is a leap year.
-fn is_leap_year(year: i64) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
 }
 
 /// A tracing layer that collects timing information from spans.
@@ -1906,8 +1719,7 @@ mod tests {
             );
         }
 
-        let direct_timing =
-            direct_data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
+        let direct_timing = direct_data.to_benchmark_report("test", "test", None, None, None);
         let direct_parse = direct_timing
             .passes
             .iter()
@@ -1951,8 +1763,7 @@ mod tests {
             );
         }
 
-        let session_timing =
-            session_data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
+        let session_timing = session_data.to_benchmark_report("test", "test", None, None, None);
         let session_parse_file = session_timing
             .passes
             .iter()
@@ -2096,8 +1907,7 @@ mod tests {
             "normal compilation must not enter whole-program semantic spans: {compile_edges:?}"
         );
 
-        let compile_timing =
-            compile_data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
+        let compile_timing = compile_data.to_benchmark_report("test", "test", None, None, None);
         let compile = compile_timing
             .passes
             .iter()
@@ -2191,7 +2001,7 @@ mod tests {
         // coordinator span. The semantic phase has one work span for the
         // prerequisite fan-out and one for body analysis; the retired session
         // worklist and body-local epoch pipeline must not reappear.
-        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
+        let timing = data.to_benchmark_report("test", "test", None, None, None);
         for retired in [
             "body_queries",
             "body_transaction",
@@ -2302,7 +2112,7 @@ mod tests {
             std::thread::sleep(Duration::from_millis(5));
         });
 
-        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
+        let timing = data.to_benchmark_report("test", "test", None, None, None);
         let pass_names: Vec<_> = timing
             .passes
             .iter()
@@ -2338,7 +2148,10 @@ mod tests {
             .unwrap();
         assert!(write.duration_ms > 0.0);
 
-        let json = data.to_json_with_metrics("test", "test", None, None, None);
+        let json = data
+            .to_benchmark_report("test", "test", None, None, None)
+            .to_wire_json()
+            .expect("a benchmark report renders");
         assert!(json.contains("\"driver_phases\""), "{json}");
         assert!(data.report().contains("Driver phases"));
     }
@@ -2347,7 +2160,10 @@ mod tests {
     fn a_run_without_driver_phases_omits_the_field_entirely() {
         let data = TimingData::new();
         data.record("lexer", Duration::from_millis(1));
-        let json = data.to_json_with_metrics("test", "test", None, None, None);
+        let json = data
+            .to_benchmark_report("test", "test", None, None, None)
+            .to_wire_json()
+            .expect("a benchmark report renders");
         assert!(!json.contains("driver_phases"), "{json}");
         assert!(!data.report().contains("Driver phases"));
     }
@@ -2411,8 +2227,7 @@ mod tests {
     #[test]
     fn test_to_benchmark_timing_empty() {
         let data = TimingData::new();
-        let timing =
-            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
+        let timing = data.to_benchmark_report("x86_64-linux", "0.1.0", None, None, None);
         assert!(timing.passes.is_empty());
         assert_eq!(timing.total_ms, 0.0);
     }
@@ -2423,8 +2238,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
         data.record("parser", Duration::from_millis(200));
 
-        let timing =
-            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
+        let timing = data.to_benchmark_report("x86_64-linux", "0.1.0", None, None, None);
         assert_eq!(timing.passes.len(), 2);
         assert_eq!(timing.passes[0].name, "lexer");
         assert_eq!(timing.passes[1].name, "parser");
@@ -2438,8 +2252,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
         data.record("parser", Duration::from_millis(300));
 
-        let timing =
-            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
+        let timing = data.to_benchmark_report("x86_64-linux", "0.1.0", None, None, None);
         // lexer should be 25%, parser should be 75%
         assert!((timing.passes[0].percent - 25.0).abs() < 0.1);
         assert!((timing.passes[1].percent - 75.0).abs() < 0.1);
@@ -2454,8 +2267,7 @@ mod tests {
         data.record_test_span("parser", Duration::from_millis(2), false, true);
         data.record_test_span("codegen", Duration::from_millis(4), false, true);
 
-        let timing =
-            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
+        let timing = data.to_benchmark_report("x86_64-linux", "0.1.0", None, None, None);
         assert!((timing.total_ms - 10.0).abs() < f64::EPSILON);
 
         let compile = timing
@@ -2552,8 +2364,7 @@ mod tests {
         let data = TimingData::new();
         data.record("lexer", Duration::from_millis(100));
 
-        let timing =
-            data.to_benchmark_timing_with_metrics("aarch64-macos", "0.2.0", None, None, None);
+        let timing = data.to_benchmark_report("aarch64-macos", "0.2.0", None, None, None);
         assert_eq!(timing.metadata.target, "aarch64-macos");
         assert_eq!(timing.metadata.version, "0.2.0");
         // Timestamp should be an ISO 8601 format
@@ -2562,11 +2373,14 @@ mod tests {
     }
 
     #[test]
-    fn test_to_json_structure() {
+    fn test_wire_json_structure() {
         let data = TimingData::new();
         data.record("lexer", Duration::from_millis(100));
 
-        let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
+        let json = data
+            .to_benchmark_report("x86_64-linux", "0.1.0", None, None, None)
+            .to_wire_json()
+            .expect("a benchmark report renders");
         assert!(json.contains("\"schema_version\":19"));
         assert!(json.contains(&format!(
             "\"compiler_build_profile\":\"{COMPILER_BUILD_PROFILE}\""
@@ -2589,12 +2403,51 @@ mod tests {
     }
 
     #[test]
-    fn test_to_json_empty() {
+    fn test_wire_json_empty() {
         let data = TimingData::new();
-        let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
+        let json = data
+            .to_benchmark_report("x86_64-linux", "0.1.0", None, None, None)
+            .to_wire_json()
+            .expect("a benchmark report renders");
         // Should produce valid JSON even with empty data
         assert!(json.contains("\"passes\":[]"));
         assert!(json.contains("\"total_ms\":0"));
+    }
+
+    #[test]
+    fn the_published_report_parses_back_through_the_shared_consumer() {
+        // Producer and consumer share one declaration in `rue-perf-schema`, and
+        // this is where the driver's real serializer meets the runner's real
+        // parser: a field renamed on one side cannot compile on the other.
+        let data = TimingData::new();
+        data.record("lexer", Duration::from_millis(100));
+        let published = data
+            .to_benchmark_report(
+                "x86_64-linux",
+                "0.1.0",
+                Some(WorkloadShape {
+                    files: 1,
+                    modules: 1,
+                    bytes: 24,
+                    lines: 1,
+                    tokens: 9,
+                    functions: 1,
+                }),
+                Some(CompilerWork::default()),
+                Some(4096),
+            )
+            .to_wire_json()
+            .expect("a benchmark report renders");
+        let parsed: BenchmarkReport =
+            serde_json::from_str(&published).expect("the runner parses the driver's report");
+        assert_eq!(parsed.schema_version, BENCHMARK_JSON_SCHEMA_VERSION);
+        assert_eq!(parsed.timing_model, BENCHMARK_TIMING_MODEL);
+        assert_eq!(parsed.passes[0].name, "lexer");
+        assert_eq!(
+            parsed.source_metrics.expect("source metrics survive").bytes,
+            24
+        );
+        assert_eq!(parsed.peak_memory_bytes, Some(4096));
     }
 
     #[test]
@@ -2604,48 +2457,10 @@ mod tests {
         data.record("zzz", Duration::from_millis(100));
         data.record("mmm", Duration::from_millis(100));
 
-        let timing =
-            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
+        let timing = data.to_benchmark_report("x86_64-linux", "0.1.0", None, None, None);
         assert_eq!(timing.passes[0].name, "aaa");
         assert_eq!(timing.passes[1].name, "mmm");
         assert_eq!(timing.passes[2].name, "zzz");
-    }
-
-    #[test]
-    fn test_iso8601_now() {
-        let timestamp = iso8601_now();
-        // Should be in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
-        assert!(timestamp.contains('T'));
-        assert!(timestamp.ends_with('Z'));
-        assert_eq!(timestamp.len(), 20); // "2025-12-27T21:30:00Z"
-    }
-
-    #[test]
-    fn test_days_to_ymd_epoch() {
-        // Day 0 should be 1970-01-01
-        let (year, month, day) = days_to_ymd(0);
-        assert_eq!(year, 1970);
-        assert_eq!(month, 1);
-        assert_eq!(day, 1);
-    }
-
-    #[test]
-    fn test_days_to_ymd_known_date() {
-        // Test a known date: 2000-01-01 is 10957 days since epoch
-        // (calculated as: 30 years, with 7 leap years: 1972,76,80,84,88,92,96)
-        // 30 * 365 + 7 = 10957
-        let (year, month, day) = days_to_ymd(10957);
-        assert_eq!(year, 2000);
-        assert_eq!(month, 1);
-        assert_eq!(day, 1);
-    }
-
-    #[test]
-    fn test_is_leap_year() {
-        assert!(!is_leap_year(1900)); // divisible by 100 but not 400
-        assert!(is_leap_year(2000)); // divisible by 400
-        assert!(is_leap_year(2024)); // divisible by 4, not by 100
-        assert!(!is_leap_year(2025)); // not divisible by 4
     }
 }
 
@@ -3410,8 +3225,7 @@ mod phase_accounting_tests {
             thread::sleep(TICK);
         });
 
-        let timing =
-            data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None, None);
+        let timing = data.to_benchmark_report("probe-target", "probe", None, None, None);
         assert_eq!(timing.schema_version, 19);
         assert_eq!(
             timing.metadata.compiler_build_profile,
@@ -3464,7 +3278,10 @@ mod phase_accounting_tests {
             },
             ..CompilerWork::default()
         };
-        let json = data.to_json_with_metrics("test-target", "test", None, Some(work), None);
+        let json = data
+            .to_benchmark_report("test-target", "test", None, Some(work), None)
+            .to_wire_json()
+            .expect("a benchmark report renders");
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
         let structure = &value["compiler_work"]["semantic_analysis_structure"];
         assert_eq!(structure["staged_resolved_instructions"], 23);

--- a/docs/designs/0067-compiler-performance-measurement.md
+++ b/docs/designs/0067-compiler-performance-measurement.md
@@ -843,8 +843,11 @@ refused by validation.
 - ADR-0019 (performance dashboard) and ADR-0031 (robust performance testing)
   — superseded; their system was removed by the benchmarking reset.
 - ADR-0018 (tracing infrastructure) — the inclusive spans retained here.
-- `crates/rue/src/timing.rs` — root active-interval union, inclusive span
-  semantics, schema versioning.
+- `crates/rue/src/timing.rs` — root active-interval union and inclusive span
+  semantics.
+- `crates/rue-perf-schema/src/benchmark.rs` — the `--benchmark-json` envelope
+  the compiler publishes and the runner reads, and the one constant its schema
+  version is written down in.
 - GitHub hosted-runner documentation and `actions/runner-images` — source of
   runner image version identity.
 - [Boundary evidence and the size of performance-data-v1](../notes/performance-boundary-evidence-size.md)


### PR DESCRIPTION
The `--benchmark-json` envelope was declared three times: a Serialize-only `BenchmarkTiming` in the driver's `timing.rs`, `serde_json::Value` patching in `main.rs` that bolted on `emitted_output` / `compiler_boundary` / `critical_path` / `compiler_allocations` (and hashed the emitted output a second time), and a Deserialize-only `BenchmarkJson` in rue-bench with its own copy of the schema version. Nothing tied the two sides together at build time; the pin tests used a hand-written fixture.

Now `rue-perf-schema` owns the envelope, as ADR-0067 intends:

- `crates/rue-perf-schema/src/benchmark.rs`: `BenchmarkReport` (Serialize + Deserialize), every optional section typed and omitted when absent, one `BENCHMARK_JSON_SCHEMA_VERSION` (still 19), `EmittedOutput::of(bytes)` computing the SHA-256 once, and `to_wire_json()` for the bytes.
- `canonical.rs`: `sorted_json` alongside `canonical_json`. The old output went through a `serde_json::Value`, whose maps are `BTreeMap`s, so the published envelope has always been key-sorted at every depth; the sorted writer keeps that without a `Value` round trip.
- `timestamp.rs`: the one `utc_timestamp()`; the driver and rue-bench each had their own with identical output.
- Driver: builds the report directly and serializes once. rue-bench: parses the shared type and refuses a report missing the sections it needs with explicit messages. rue-bench's private `SourceMetrics` was a third spelling of `WorkloadShape` and is gone.
- Tests: a producer → consumer round trip in rue-perf-schema, the driver's real serializer parsed by the real consumer in `timing.rs`, and rue-bench's pin tests now parse a `BenchmarkReport` rendered through `to_wire_json` instead of a `json!` fixture.

One issue claim did not hold: the `--emit` path could never publish an envelope because `--emit` combined with `--benchmark-json` is rejected before any I/O; that path now passes `None` explicitly.

Wire format is byte-identical: `--benchmark-json` captured before and after on the ordinary and allocation-accounting binaries, with all numeric literals and the timestamp masked, diffs empty; every deterministic value (schema version, timing model, source metrics, compiler work, emitted-output digest, the whole boundary block, pass names and invocation counts) is unchanged. No schema bump.

Verified: fmt; `//crates/rue:rue-test`; rue-bench and rue-perf-schema unit suites; `cli benchmark`, `cli timing`, `cli time_passes`; the performance tool tests; clippy on all three crates; the allocation-accounting build; quick. All re-run after rebasing onto current trunk.

Fixes RUE-1985

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRFiTXZ1kLd7DspSvraq53)_