### PR TITLE
RUE-2020: make the repro line runnable as printed

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -443,7 +443,9 @@ compile_stdout_contains = [
     "output_overflow",
     "omitted here; --format json carries the whole capture",
     "further bytes were not retained",
-    "repro: rue test main.rue --filter",
+    "repro: /",
+    "/rue test /",
+    "/main.rue --filter",
     "0 passed, 1 failed",
 ]
 
@@ -705,6 +707,11 @@ ADR-0083 §3: every non-pass carries the exact argv that reproduces that one
 test — selected by the full stable id, never the bare name, and carrying the
 seed and the compile flags so the same image is rebuilt. Running that argv is
 the round trip the repro promises.
+
+RUE-2020: the compiler and the root are named by absolute path, because a
+reproduction is pasted into another shell from another directory, where `rue`
+is not on PATH and a relative root resolves to nothing. Those paths are
+per-machine, so the case pins the structure rather than the bytes.
 """
 files = [
     { path = "main.rue", source = """
@@ -726,18 +733,151 @@ args = [
 ]
 driver_exit_code = 1
 compile_stdout_contains = [
-    '"repro":["rue","test","main.rue","--filter","tests.rue::fails on purpose","--seed","9",',
+    # Absolute paths are per-machine, so the case pins the structure around
+    # them: argv[0] and the root are absolute (they start at the root
+    # directory), and everything after the root is the fixed repro tail.
+    '"repro":["/',
+    '"--filter","tests.rue::fails on purpose","--seed","9",',
     '"-O0","--timeout-ms","9000"]',
+    '/main.rue","--filter"',
     '"stderr":{"bytes_total":17,"data":"assertion failed\n","encoding":"utf8"}',
     '"scratch_dir":"',
+]
+# Nothing in this run's environment decided it -- the harness clears
+# RUE_STD_PATH unless a case sets it -- so `repro_env` is absent, not empty.
+compile_stdout_not_contains = ['"repro_env"']
+
+[[case]]
+name = "a_symlinked_root_keeps_its_own_spelling_in_the_repro"
+description = """
+RUE-2020: the root is absolutized lexically, never canonicalized. The
+compiler's project root and module identities are lexical — `source_loader`
+takes the root's parent from `normalize_lexical_path` and retains the lexical
+project spelling — so resolving a symlinked root FILE to its target hands the
+repro a different `@import` closure. Here `link/main.rue` points at
+`real/main.rue` and each directory holds its own `tests.rue`: the run selects
+`link/tests.rue`, and a canonicalizing repro named `real/main.rue` and selected
+nothing at all (exit 3).
+"""
+files = [
+    { path = "real/main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "real/tests.rue", source = """
+test "real passes" {
+    @assert(1 == 1);
+}
+""" },
+    { path = "link/tests.rue", source = """
+test "link fails" {
+    @assert(1 == 2);
+}
+""" },
+]
+symlinks = [{ link = "link/main.rue", target = "../real/main.rue" }]
+args = ["test", "link/main.rue", "--seed", "3", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    # The failing test is the LINK directory's, and the repro root is the link
+    # spelling that reaches it.
+    '"id":"tests.rue::link fails"',
+    '/link/main.rue","--filter","tests.rue::link fails"',
+]
+# The target's spelling would name a project whose closure holds `real passes`
+# instead, so the repro would select nothing.
+compile_stdout_not_contains = ['/real/main.rue"']
+
+[[case]]
+name = "the_repro_absolutizes_the_build_system_inputs_it_repeats"
+description = """
+RUE-2020: `--source-manifest` used to be repeated verbatim, and the `rue_test`
+rule spells its manifest as a project-relative buck-out path — so every
+Buck-produced repro died with "Error reading source manifest" anywhere but the
+directory that produced it. The manifest is absolutized the same lexical way
+the root is. `--link-archive` travels the same path; no case here links one.
+"""
+files = [
+    { path = "sources.manifest", source = """
+main.rue
+tests.rue
+""" },
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "fails on purpose" {
+    @assert(1 == 2);
+}
+""" },
+]
+args = [
+    "test", "main.rue", "--source-manifest", "sources.manifest",
+    "--seed", "9", "-j1", "--format", "json",
+]
+driver_exit_code = 1
+compile_stdout_contains = [
+    # Absolute (it starts at the root directory) and still naming the file the
+    # command line named.
+    '"--source-manifest","/',
+    '/sources.manifest"]',
+]
+# The relative spelling the command line used must not survive into the repro.
+compile_stdout_not_contains = ['"--source-manifest","sources.manifest"']
+
+[[case]]
+name = "a_run_that_found_its_std_through_the_environment_publishes_repro_env"
+description = """
+RUE-2020: `RUE_STD_PATH` is not argv, so a repro that carried only the argv
+died with E0705 in any shell that did not happen to have the variable set. The
+environment that decided the run travels with it, absolute, in an object that
+is present only when it has something to say — the same convention `shard`
+follows.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+test "fails on purpose" {
+    @assert(1 == 2, @to_string(9));
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "9", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    # The value is the repo's own std/, absolute; the key order is the
+    # alphabetical one every object in this stream uses, so `repro_env`
+    # follows `repro`.
+    '"repro_env":{"RUE_STD_PATH":"/',
+    '/std"}',
+    '"kind":"assert"',
 ]
 
 [[case]]
 name = "the_repro_argv_reproduces_the_same_verdict_alone"
 description = """
-The repro from the previous case, run as its own invocation: the same one test,
+The repro from the earlier case, run as its own invocation: the same one test,
 the same `assert` verdict, and no other test in the run. A repro that selected
-by the bare name would also re-run the passing homonym below it.
+by the bare name would also re-run the passing homonym below it. The published
+repro spells the root absolutely; a case's argv has to be machine-independent,
+so this one spells it relative to the fixture directory the harness runs in —
+the selection is what the case is about.
 """
 files = [
     { path = "main.rue", source = """

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -71,6 +71,9 @@ rue_binary(
     ],
     test_deps = [
         "//crates/rue-query:rue-query",
+        # The repro-path unit tests build a real symlinked project root: the
+        # lexical-vs-canonical distinction only exists on a filesystem.
+        "//third-party:tempfile",
     ],
     rustc_flags = [
         "--check-cfg=cfg(rue_benchmark_allocations)",

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1042,15 +1042,45 @@ fn test_repro_flags(options: &Options) -> Vec<String> {
     }
     flags.push("--timeout-ms".to_string());
     flags.push(options.test.timeout_ms.to_string());
+    // The build-system inputs are absolutized like the root, and for the same
+    // reason: the `rue_test` rule spells its manifest as a project-relative
+    // buck-out path, so a repro that repeated it verbatim died with "Error
+    // reading source manifest" anywhere but the directory it was produced in
+    // (RUE-2020).
     if let Some(manifest) = &options.source_manifest_path {
         flags.push("--source-manifest".to_string());
-        flags.push(manifest.clone());
+        flags.push(test_mode::absolute_spelling(Path::new(manifest)));
     }
     for archive in &options.link_archives {
         flags.push("--link-archive".to_string());
-        flags.push(archive.display().to_string());
+        flags.push(test_mode::absolute_spelling(archive));
     }
     flags
+}
+
+/// The environment a repro must be run under (ADR-0083 §3).
+///
+/// Environment is not argv, so a run whose standard library was found through
+/// `RUE_STD_PATH` would otherwise publish a reproduction that dies with E0705
+/// in any shell that does not happen to have the variable set (RUE-2020). It
+/// travels absolute for the same reason the root does: a repro is run later,
+/// possibly from somewhere else.
+///
+/// The CLI's empty spelling means "no toolchain std is configured" and is
+/// carried verbatim — absolutizing it would silently turn that into the
+/// current directory, which is a different run.
+fn test_repro_env(std_root: Option<&Path>) -> Vec<(String, String)> {
+    let Some(std_root) = std_root else {
+        return Vec::new();
+    };
+    let value = if std_root.as_os_str().is_empty() {
+        String::new()
+    } else {
+        // Canonical, not lexical: this is a toolchain location, and
+        // `source_loader::capture_std_root` resolves it the same way.
+        test_mode::std_root_spelling(std_root)
+    };
+    vec![("RUE_STD_PATH".to_string(), value)]
 }
 
 fn parse_args() -> ParseResult {
@@ -2535,6 +2565,7 @@ fn main() {
                 diagnostics: &diagnostics,
                 root: options.source_path.clone(),
                 repro_flags: test_repro_flags(&options),
+                repro_env: test_repro_env(captured_std_root.as_deref()),
                 jobs: test_mode_jobs(options.jobs),
                 target: options.target,
                 opt_level: options.opt_level,
@@ -3601,6 +3632,12 @@ mod tests {
             "sources.manifest",
         ]));
         let flags = test_repro_flags(&options);
+        // The manifest is absolutized rather than repeated: the `rue_test`
+        // rule spells it as a project-relative buck-out path, and a repro is
+        // run from somewhere else (RUE-2020).
+        let manifest = test_mode::absolute_spelling(Path::new("sources.manifest"));
+        assert!(Path::new(&manifest).is_absolute(), "{manifest}");
+        assert!(manifest.ends_with("/sources.manifest"), "{manifest}");
         assert_eq!(
             flags,
             vec![
@@ -3612,8 +3649,54 @@ mod tests {
                 "--timeout-ms",
                 "500",
                 "--source-manifest",
-                "sources.manifest",
+                manifest.as_str(),
             ]
+        );
+    }
+
+    /// The standard library reached a run through the environment, so it
+    /// travels with the repro — absolute, since a repro is run from somewhere
+    /// else (RUE-2020).
+    #[test]
+    fn the_repro_environment_carries_an_absolute_std_path() {
+        assert_eq!(test_repro_env(None), Vec::new());
+
+        // The std root is a toolchain location, so it is canonicalized the way
+        // `source_loader::capture_std_root` canonicalizes it: a real symlinked
+        // prefix resolves to its target, which is the spelling that compares
+        // against the paths discovery actually reads.
+        let temporary = tempfile::tempdir().expect("a temp directory");
+        let real = temporary.path().join("real-std");
+        let linked = temporary.path().join("linked-std");
+        std::fs::create_dir_all(&real).expect("create real-std/");
+        std::os::unix::fs::symlink(&real, &linked).expect("symlink the std root");
+        assert_eq!(
+            test_repro_env(Some(&linked)),
+            vec![(
+                "RUE_STD_PATH".to_string(),
+                std::fs::canonicalize(&real)
+                    .expect("the std root canonicalizes")
+                    .display()
+                    .to_string()
+            )]
+        );
+
+        // A root the filesystem cannot answer for keeps the lexical absolute
+        // spelling rather than becoming relative again.
+        let directory = std::env::current_dir().expect("a test process has a working directory");
+        assert_eq!(
+            test_repro_env(Some(Path::new("no-such-std-root"))),
+            vec![(
+                "RUE_STD_PATH".to_string(),
+                directory.join("no-such-std-root").display().to_string()
+            )]
+        );
+
+        // The empty spelling means "no toolchain std is configured";
+        // absolutizing it would silently name the current directory instead.
+        assert_eq!(
+            test_repro_env(Some(Path::new(""))),
+            vec![("RUE_STD_PATH".to_string(), String::new())]
         );
     }
 

--- a/crates/rue/src/test_mode/events.rs
+++ b/crates/rue/src/test_mode/events.rs
@@ -314,6 +314,9 @@ pub(crate) struct TestFinished {
     pub(crate) stderr: Capture,
     pub(crate) scratch_dir: Option<String>,
     pub(crate) repro: Vec<String>,
+    /// The environment assignments the repro argv must be run under, sorted by
+    /// name. Empty when nothing in the environment decided the run.
+    pub(crate) repro_env: Vec<(String, String)>,
 }
 
 impl Event {
@@ -367,6 +370,7 @@ impl Event {
                     stderr,
                     scratch_dir,
                     repro,
+                    repro_env,
                 } = finished.as_ref();
                 object.insert(
                     "event".to_owned(),
@@ -396,6 +400,19 @@ impl Event {
                     "repro".to_owned(),
                     Value::Array(repro.iter().cloned().map(Value::String).collect()),
                 );
+                // Absent rather than empty, the way `shard` is: a consumer that
+                // finds the key knows the run depended on what it names.
+                if !repro_env.is_empty() {
+                    object.insert(
+                        "repro_env".to_owned(),
+                        Value::Object(
+                            repro_env
+                                .iter()
+                                .map(|(key, value)| (key.clone(), Value::String(value.clone())))
+                                .collect(),
+                        ),
+                    );
+                }
             }
             Self::RunFinished {
                 passed,
@@ -519,7 +536,8 @@ mod tests {
             stdout: Capture::new(b"hi\n".to_vec(), 3, true),
             stderr: Capture::new(Vec::new(), 0, true),
             scratch_dir: None,
-            repro: vec!["rue".to_owned(), "test".to_owned()],
+            repro: vec!["/opt/rue/bin/rue".to_owned(), "test".to_owned()],
+            repro_env: Vec::new(),
         }))
         .to_ndjson();
         assert!(line.contains("\"verdict\":\"pass\""), "{line}");
@@ -553,10 +571,11 @@ mod tests {
             stderr: Capture::new(b"assertion failed\n".to_vec(), 17, false),
             scratch_dir: Some("/tmp/rue-test-1-0".to_owned()),
             repro: vec![
-                "rue".to_owned(),
+                "/opt/rue/bin/rue".to_owned(),
                 "test".to_owned(),
-                "app/main.rue".to_owned(),
+                "/work/app/main.rue".to_owned(),
             ],
+            repro_env: vec![("RUE_STD_PATH".to_owned(), "/opt/rue/std".to_owned())],
         }))
         .to_ndjson();
         assert!(line.contains("\"verdict\":\"fail\""), "{line}");
@@ -570,6 +589,34 @@ mod tests {
             line.contains("\"scratch_dir\":\"/tmp/rue-test-1-0\""),
             "{line}"
         );
+        // The repro names the compiler and the root absolutely, and the
+        // environment that decided the run travels beside it (RUE-2020).
+        assert!(
+            line.contains(
+                "\"repro\":[\"/opt/rue/bin/rue\",\"test\",\"/work/app/main.rue\"],\
+                 \"repro_env\":{\"RUE_STD_PATH\":\"/opt/rue/std\"}"
+            ),
+            "{line}"
+        );
+    }
+
+    /// `repro_env` is absent rather than empty when nothing in the environment
+    /// decided the run, the way `shard` is absent without `--shard`.
+    #[test]
+    fn a_run_that_owed_nothing_to_the_environment_publishes_no_repro_env() {
+        let line = Event::TestFinished(Box::new(TestFinished {
+            id: "app/t.rue::bad".to_owned(),
+            verdict: Verdict::Fail(FailureKind::Assert),
+            duration_ms: 1,
+            failure: None,
+            stdout: Capture::new(Vec::new(), 0, false),
+            stderr: Capture::new(Vec::new(), 0, false),
+            scratch_dir: None,
+            repro: vec!["/opt/rue/bin/rue".to_owned(), "test".to_owned()],
+            repro_env: Vec::new(),
+        }))
+        .to_ndjson();
+        assert!(!line.contains("repro_env"), "{line}");
     }
 
     /// A comparison failure publishes `left`, `right`, and the runner's
@@ -592,6 +639,7 @@ mod tests {
             stderr: Capture::new(Vec::new(), 0, false),
             scratch_dir: None,
             repro: Vec::new(),
+            repro_env: Vec::new(),
         }))
         .to_ndjson();
         assert!(
@@ -624,6 +672,7 @@ mod tests {
             stderr: Capture::new(Vec::new(), 0, false),
             scratch_dir: None,
             repro: Vec::new(),
+            repro_env: Vec::new(),
         }))
         .to_ndjson();
         assert!(!line.contains("\"left\""), "{line}");

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -25,7 +25,7 @@ pub(crate) mod selection;
 pub(crate) mod verdict;
 
 use std::io::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
@@ -127,11 +127,17 @@ pub(crate) struct TestRequest<'a, 'diagnostics> {
     pub(crate) compile_options: CompileOptions,
     pub(crate) options: TestOptions,
     pub(crate) diagnostics: &'a crate::DiagnosticOutput<'diagnostics>,
-    /// The root source exactly as the command line spelled it, which is what a
-    /// repro argv must repeat.
+    /// The root source exactly as the command line spelled it, which is what
+    /// `run_started` publishes.
     pub(crate) root: String,
     /// The compile-mode flags a repro argv repeats after the filter and seed.
     pub(crate) repro_flags: Vec<String>,
+    /// The environment assignments a repro must be run under, sorted by name.
+    ///
+    /// Environment is not argv, so a variable that decided the run — the
+    /// standard library `RUE_STD_PATH` names — would otherwise be silently
+    /// missing from a pasted reproduction (RUE-2020).
+    pub(crate) repro_env: Vec<(String, String)>,
     pub(crate) jobs: usize,
     pub(crate) target: Target,
     pub(crate) opt_level: OptLevel,
@@ -208,6 +214,7 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
         diagnostics,
         root,
         repro_flags,
+        repro_env,
         jobs,
         target,
         opt_level,
@@ -292,6 +299,12 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
         }
     };
 
+    // A repro is pasted into some other shell, from some other directory, so it
+    // names the compiler and the root by absolute path rather than by whatever
+    // spelling this invocation happened to use (RUE-2020).
+    let repro_program = repro_program();
+    let repro_root = absolute_spelling(Path::new(&root));
+
     let outcome = execute_plan(ExecutionRequest {
         plan: &plan,
         image: &image_path,
@@ -299,8 +312,10 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
         seed,
         timeout: Duration::from_millis(options.timeout_ms),
         jobs,
-        root: &root,
+        repro_program: &repro_program,
+        repro_root: &repro_root,
         repro_flags: &repro_flags,
+        repro_env: &repro_env,
         reporter: &reporter,
     });
     // The image is the runner's own artifact and is never retained; the run
@@ -451,8 +466,10 @@ struct ExecutionRequest<'a> {
     seed: u64,
     timeout: Duration,
     jobs: usize,
-    root: &'a str,
+    repro_program: &'a str,
+    repro_root: &'a str,
     repro_flags: &'a [String],
+    repro_env: &'a [(String, String)],
     reporter: &'a Reporter,
 }
 
@@ -533,8 +550,12 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
                     let event = finish_event(
                         entry,
                         execution,
-                        request.root,
-                        request.repro_flags,
+                        &Repro {
+                            program: request.repro_program,
+                            root: request.repro_root,
+                            flags: request.repro_flags,
+                            env: request.repro_env,
+                        },
                         request.seed,
                         request.timeout,
                     );
@@ -564,8 +585,7 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
 fn finish_event(
     entry: &TestInventoryEntry,
     execution: exec::Execution,
-    root: &str,
-    repro_flags: &[String],
+    repro: &Repro<'_>,
     seed: u64,
     timeout: Duration,
 ) -> Event {
@@ -583,7 +603,8 @@ fn finish_event(
         stdout: Capture::new(execution.stdout, execution.stdout_total, passed),
         stderr: Capture::new(execution.stderr, execution.stderr_total, passed),
         scratch_dir: (!passed).then(|| execution.scratch_dir.display().to_string()),
-        repro: repro_argv(root, &entry.id, seed, repro_flags),
+        repro: repro.argv(&entry.id, seed),
+        repro_env: repro.env.to_vec(),
     }))
 }
 
@@ -695,23 +716,100 @@ fn last_message_line(stderr: &[u8]) -> String {
         .to_owned()
 }
 
-/// The argv that reproduces exactly this one test (ADR-0083 §3).
+/// Everything a reproduction of one test is assembled from (ADR-0083 §3).
 ///
-/// It selects by the full stable ID, never the bare name: two modules may
-/// declare tests with the same name, and a repro that re-runs both is not a
-/// repro. The seed travels with it so a shuffle-dependent failure comes back.
-fn repro_argv(root: &str, id: &str, seed: u64, flags: &[String]) -> Vec<String> {
-    let mut argv = vec![
-        "rue".to_owned(),
-        "test".to_owned(),
-        root.to_owned(),
-        "--filter".to_owned(),
-        id.to_owned(),
-        "--seed".to_owned(),
-        seed.to_string(),
-    ];
-    argv.extend(flags.iter().cloned());
-    argv
+/// The whole point of the promise is a line that runs without thought, so the
+/// program and the root are already absolute here and the environment that
+/// decided the run travels alongside the argv (RUE-2020).
+struct Repro<'a> {
+    program: &'a str,
+    root: &'a str,
+    flags: &'a [String],
+    env: &'a [(String, String)],
+}
+
+impl Repro<'_> {
+    /// The argv that reproduces exactly this one test.
+    ///
+    /// It selects by the full stable ID, never the bare name: two modules may
+    /// declare tests with the same name, and a repro that re-runs both is not
+    /// a repro. The seed travels with it so a shuffle-dependent failure comes
+    /// back.
+    fn argv(&self, id: &str, seed: u64) -> Vec<String> {
+        let mut argv = vec![
+            self.program.to_owned(),
+            "test".to_owned(),
+            self.root.to_owned(),
+            "--filter".to_owned(),
+            id.to_owned(),
+            "--seed".to_owned(),
+            seed.to_string(),
+        ];
+        argv.extend(self.flags.iter().cloned());
+        argv
+    }
+}
+
+/// The running compiler, as a path another shell can execute.
+///
+/// `rue` is rarely on `PATH` while a compiler is being worked on, and the
+/// binary a repro must re-run is *this* one, not whichever the reader's
+/// installation would resolve. This one is an installed artifact rather than a
+/// project input, so it is canonicalized: the identity that matters is the file
+/// on disk, and a launcher symlink may be replaced under it. The literal `rue`
+/// remains the fallback for a platform that cannot answer `current_exe` at all
+/// — a bare name is a worse repro than an absolute path, but a better one than
+/// nothing.
+fn repro_program() -> String {
+    match std::env::current_exe() {
+        Ok(exe) => canonical_spelling(&exe),
+        Err(_) => "rue".to_owned(),
+    }
+}
+
+/// A project input spelled so it resolves from any working directory, and
+/// names the same project it named here.
+///
+/// Lexical and cwd-joined, never canonicalized. The compiler's project root
+/// and module identities are lexical — `source_loader` takes the root's parent
+/// from `normalize_lexical_path` and "retains the lexical project spelling for
+/// durable caller identities" — so resolving a symlinked root file to its
+/// target hands the repro a *different* `@import` closure. A run rooted at
+/// `link/main.rue -> real/main.rue` selects `link/tests.rue`, and a repro
+/// naming `real/main.rue` selects nothing at all (RUE-2020).
+///
+/// `std::path::absolute` is exactly that operation: absolute, symlink- and
+/// `..`-preserving, resolving only against the current directory.
+pub(crate) fn absolute_spelling(path: &Path) -> String {
+    match std::path::absolute(path) {
+        Ok(absolute) => absolute.display().to_string(),
+        Err(_) => path.display().to_string(),
+    }
+}
+
+/// An installed artifact spelled by the identity the filesystem gives it.
+///
+/// The counterpart to [`absolute_spelling`], for paths that are toolchain
+/// locations rather than project inputs: the compiler binary, and the
+/// standard-library root, which `source_loader::capture_std_root`
+/// canonicalizes for the same reason — on macOS a `/var/folders` prefix is a
+/// symlink to `/private/var/folders`, and only the resolved spelling compares
+/// against the paths discovery actually reads. Falls back to the lexical
+/// absolute spelling when the filesystem cannot answer, which is the
+/// missing-or-unreadable-toolchain case.
+fn canonical_spelling(path: &Path) -> String {
+    match std::fs::canonicalize(path) {
+        Ok(canonical) => canonical.display().to_string(),
+        Err(_) => absolute_spelling(path),
+    }
+}
+
+/// The standard-library root as a repro must name it.
+///
+/// Exposed for the driver, which captures `RUE_STD_PATH` and owns the empty
+/// spelling's meaning.
+pub(crate) fn std_root_spelling(path: &Path) -> String {
+    canonical_spelling(path)
 }
 
 /// Render the unimported-test-file warnings and collect them for the event.
@@ -793,29 +891,32 @@ mod tests {
     }
 
     /// The repro selects by the full stable ID and repeats the run's seed and
-    /// compile flags, so re-running it lands on the same one test.
+    /// compile flags, so re-running it lands on the same one test. The program
+    /// and the root are the absolute spellings the run resolved, so the line
+    /// runs from any directory (RUE-2020).
     #[test]
-    fn a_repro_argv_names_the_stable_id_the_seed_and_the_flags() {
-        let argv = repro_argv(
-            "app/main.rue",
-            "app/t.rue::parses a port",
-            417,
-            &[
-                "--target".to_owned(),
-                "x86-64-linux".to_owned(),
-                "-O1".to_owned(),
-                "--preview".to_owned(),
-                "test_infra".to_owned(),
-                "--timeout-ms".to_owned(),
-                "500".to_owned(),
-            ],
-        );
+    fn a_repro_argv_names_the_program_the_root_the_stable_id_and_the_flags() {
+        let flags = [
+            "--target".to_owned(),
+            "x86-64-linux".to_owned(),
+            "-O1".to_owned(),
+            "--preview".to_owned(),
+            "test_infra".to_owned(),
+            "--timeout-ms".to_owned(),
+            "500".to_owned(),
+        ];
+        let repro = Repro {
+            program: "/opt/rue/bin/rue",
+            root: "/work/app/main.rue",
+            flags: &flags,
+            env: &[],
+        };
         assert_eq!(
-            argv,
+            repro.argv("app/t.rue::parses a port", 417),
             vec![
-                "rue",
+                "/opt/rue/bin/rue",
                 "test",
-                "app/main.rue",
+                "/work/app/main.rue",
                 "--filter",
                 "app/t.rue::parses a port",
                 "--seed",
@@ -828,6 +929,84 @@ mod tests {
                 "--timeout-ms",
                 "500",
             ]
+        );
+    }
+
+    /// A relative spelling is resolved against the current directory rather
+    /// than repeated, because a repro is pasted somewhere else.
+    #[test]
+    fn an_absolute_spelling_resolves_from_any_directory() {
+        let directory = std::env::current_dir().expect("a test process has a working directory");
+        let resolved = absolute_spelling(Path::new("no/such/file.rue"));
+        assert_eq!(
+            resolved,
+            directory.join("no/such/file.rue").display().to_string()
+        );
+        assert!(Path::new(&resolved).is_absolute());
+
+        // An absolute path that does not exist is already its own answer.
+        assert_eq!(
+            absolute_spelling(Path::new("/no/such/root.rue")),
+            "/no/such/root.rue"
+        );
+
+        // `..` is preserved rather than resolved: this is a lexical operation,
+        // and the compiler's own project identity is lexical too.
+        assert_eq!(
+            absolute_spelling(Path::new("/a/b/../c/root.rue")),
+            "/a/b/../c/root.rue"
+        );
+    }
+
+    /// The root keeps the spelling the run resolved it by, symlink and all.
+    ///
+    /// Canonicalizing it would resolve a symlinked root FILE to its target,
+    /// whose directory is a different project root with a different `@import`
+    /// closure — the run selects `link/tests.rue` and the repro would select
+    /// `real/tests.rue`, which is to say nothing at all (RUE-2020).
+    #[test]
+    fn a_symlinked_root_keeps_its_own_spelling() {
+        let temporary = tempfile::tempdir().expect("a temp directory");
+        let real = temporary.path().join("real");
+        let link = temporary.path().join("link");
+        std::fs::create_dir_all(&real).expect("create real/");
+        std::fs::create_dir_all(&link).expect("create link/");
+        std::fs::write(real.join("main.rue"), "fn main() -> i32 { 0 }\n").expect("write root");
+        let linked_root = link.join("main.rue");
+        std::os::unix::fs::symlink(real.join("main.rue"), &linked_root).expect("symlink the root");
+
+        // The link is a real, resolvable file, so a canonicalizing spelling
+        // would silently answer with the target's directory.
+        assert_eq!(
+            absolute_spelling(&linked_root),
+            linked_root.display().to_string()
+        );
+        assert_ne!(
+            absolute_spelling(&linked_root),
+            canonical_spelling(&linked_root)
+        );
+        assert_eq!(
+            canonical_spelling(&linked_root),
+            std::fs::canonicalize(real.join("main.rue"))
+                .expect("the target canonicalizes")
+                .display()
+                .to_string()
+        );
+    }
+
+    /// `argv[0]` is this compiler, by absolute path: `rue` is rarely on `PATH`
+    /// while one is being worked on. The binary is an installed artifact
+    /// rather than a project input, so it is canonicalized.
+    #[test]
+    fn the_repro_program_is_an_absolute_path_to_the_running_binary() {
+        let program = repro_program();
+        assert!(
+            Path::new(&program).is_absolute(),
+            "expected an absolute program path, got {program}"
+        );
+        assert_eq!(
+            program,
+            canonical_spelling(&std::env::current_exe().expect("this platform has a current_exe"))
         );
     }
 

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -119,6 +119,7 @@ fn render_failure(finished: &TestFinished) -> String {
         stderr,
         scratch_dir,
         repro,
+        repro_env,
         ..
     } = finished;
     let banner = match verdict {
@@ -158,7 +159,7 @@ fn render_failure(finished: &TestFinished) -> String {
     if let Some(scratch) = scratch_dir {
         let _ = write!(out, "\n  scratch: {scratch}");
     }
-    let _ = write!(out, "\n  repro: {}", shell_command(repro));
+    let _ = write!(out, "\n  repro: {}", shell_command(repro_env, repro));
     out
 }
 
@@ -313,25 +314,35 @@ fn whole_lines_within<'a>(
     taken
 }
 
-/// The repro argv as a line a person can paste.
+/// The repro as a line a person can paste: the environment the run depended
+/// on, then the argv.
 ///
-/// Quoting is presentation only: the argv the event stream publishes is the
-/// authoritative form, because a test name may contain any byte a shell would
-/// argue about and a consumer should never have to unquote to re-execute.
-fn shell_command(argv: &[String]) -> String {
-    argv.iter()
-        .map(|argument| {
-            let safe = argument.bytes().all(|byte| {
-                matches!(byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'/' | b'=' | b':')
-            });
-            if argument.is_empty() || !safe {
-                format!("'{}'", argument.replace('\'', "'\\''"))
-            } else {
-                argument.clone()
-            }
-        })
+/// The assignments lead because that is where a shell accepts them, and each
+/// one quotes only its value — quoting the name half would stop the shell from
+/// reading the word as an assignment at all.
+///
+/// Quoting is presentation only: the argv and the `repro_env` object the event
+/// stream publishes are the authoritative forms, because a test name may
+/// contain any byte a shell would argue about and a consumer should never have
+/// to unquote to re-execute.
+fn shell_command(env: &[(String, String)], argv: &[String]) -> String {
+    env.iter()
+        .map(|(name, value)| format!("{name}={}", shell_word(value)))
+        .chain(argv.iter().map(|argument| shell_word(argument)))
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// One argument, quoted only when a shell would read it as more than itself.
+fn shell_word(argument: &str) -> String {
+    let safe = argument.bytes().all(|byte| {
+        matches!(byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'/' | b'=' | b':')
+    });
+    if argument.is_empty() || !safe {
+        format!("'{}'", argument.replace('\'', "'\\''"))
+    } else {
+        argument.to_owned()
+    }
 }
 
 #[cfg(test)]
@@ -361,12 +372,13 @@ mod tests {
             stderr: Capture::new(b"assertion failed\n".to_vec(), 17, false),
             scratch_dir: Some("/tmp/rue-test-417-2".to_owned()),
             repro: vec![
-                "rue".to_owned(),
+                "/opt/rue/bin/rue".to_owned(),
                 "test".to_owned(),
-                "app/main.rue".to_owned(),
+                "/work/app/main.rue".to_owned(),
                 "--filter".to_owned(),
                 "app/t.rue::parses a port".to_owned(),
             ],
+            repro_env: vec![("RUE_STD_PATH".to_owned(), "/opt/rue/std".to_owned())],
         }))
     }
 
@@ -444,8 +456,13 @@ mod tests {
             rendered.contains("scratch: /tmp/rue-test-417-2"),
             "{rendered}"
         );
+        // The environment leads and every path is absolute, so the line runs
+        // in a clean shell from any directory (RUE-2020).
         assert!(
-            rendered.contains("repro: rue test app/main.rue --filter 'app/t.rue::parses a port'"),
+            rendered.contains(
+                "repro: RUE_STD_PATH=/opt/rue/std /opt/rue/bin/rue test /work/app/main.rue \
+                 --filter 'app/t.rue::parses a port'"
+            ),
             "{rendered}"
         );
     }
@@ -674,12 +691,33 @@ mod tests {
     #[test]
     fn repro_quoting_survives_a_name_with_a_quote_in_it() {
         assert_eq!(
-            shell_command(&["rue".to_owned(), "it's fine".to_owned()]),
+            shell_command(&[], &["rue".to_owned(), "it's fine".to_owned()]),
             "rue 'it'\\''s fine'"
         );
         assert_eq!(
-            shell_command(&["--seed".to_owned(), "417".to_owned()]),
+            shell_command(&[], &["--seed".to_owned(), "417".to_owned()]),
             "--seed 417"
+        );
+    }
+
+    /// An assignment quotes only its value: quoting the name half would stop
+    /// the shell from reading the word as an assignment at all.
+    #[test]
+    fn an_environment_assignment_leads_and_quotes_only_its_value() {
+        assert_eq!(
+            shell_command(
+                &[("RUE_STD_PATH".to_owned(), "/a std/lib".to_owned())],
+                &["/opt/rue/bin/rue".to_owned(), "test".to_owned()]
+            ),
+            "RUE_STD_PATH='/a std/lib' /opt/rue/bin/rue test"
+        );
+        // The empty spelling means "no toolchain std", and survives as such.
+        assert_eq!(
+            shell_command(
+                &[("RUE_STD_PATH".to_owned(), String::new())],
+                &["rue".to_owned()]
+            ),
+            "RUE_STD_PATH='' rue"
         );
     }
 

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -168,6 +168,13 @@ alphabetical order**; consumers must not depend on key order, but the ordering
 is fixed so two runs over the same inputs produce byte-identical output — the
 same determinism stance [diagnostics.md](diagnostics.md) takes.
 
+That promise is scoped to one invocation repeated from one working directory on
+one installation. `repro`, `repro_env`, and `scratch_dir` carry absolute paths,
+so the same source run from a different directory, or against a compiler
+installed elsewhere, prints different bytes on those fields. That is deliberate
+rather than a lapse: a reproduction is consumed somewhere else, and a spelling
+that only resolves where it was produced is not one (RUE-2020).
+
 Under `--jobs N` with `N > 1`, whole lines from concurrent tests interleave. The
 schema promises the content of each line, not an order across concurrent tests;
 `test_started` always precedes its own `test_finished`.
@@ -208,7 +215,8 @@ The head event, and the only one carrying the schema version for a run.
 | `stdout` | object | Capture record. |
 | `stderr` | object | Capture record. |
 | `scratch_dir` | string | The retained scratch directory. **Absent** on a pass, whose directory is deleted. |
-| `repro` | array of strings | The argv that reproduces this one test. Always present. |
+| `repro` | array of strings | The argv that reproduces this one test, naming the compiler and the root by absolute path. Always present. |
+| `repro_env` | object | The environment assignments that argv must be run under, as `name` → `value`. **Absent** when the run owed the environment nothing. |
 
 `capability_summary` is present from v1.0 with an explicit `unavailable` status
 rather than omitted. The MVP verifies no hermeticity claim for any test and says
@@ -484,11 +492,14 @@ an inventory, and stable-ID order is what makes two listings comparable.
 
 ## Reproduction as data
 
-Every `test_finished` carries the exact argv that reproduces that one test:
+Every `test_finished` carries the exact argv that reproduces that one test, and
+the environment it has to be run under:
 
 ```json
-["rue","test","app/main.rue","--filter","app/t.rue::parses a port","--seed","417",
- "--target","x86-64-linux","-O0","--timeout-ms","10000"]
+"repro":["/opt/rue/bin/rue","test","/work/app/main.rue",
+ "--filter","app/t.rue::parses a port","--seed","417",
+ "--target","x86-64-linux","-O0","--timeout-ms","10000"],
+"repro_env":{"RUE_STD_PATH":"/opt/rue/std"}
 ```
 
 It selects by the **full stable ID, never the bare name** — two modules may
@@ -499,9 +510,59 @@ per-test budget travel with it so the same image is rebuilt, and `--source-manif
 level are emitted even when they were defaulted: a repro is run later, possibly
 elsewhere, and "whatever the host was" is not a reproduction.
 
-The argv array is the authoritative form. The human renderer's `repro:` line is
-the same argv shell-quoted for pasting; a consumer should re-execute the array
-rather than parse the line.
+For the same reason nothing in it is spelled relative to the run that produced
+it (RUE-2020) — not the root, and not the build-system inputs
+(`--source-manifest`, `--link-archive`) it repeats, which the `rue_test` rule
+spells as project-relative buck-out paths.
+
+`argv[0]` is the **absolute path of the running compiler** — `rue` is rarely on
+`PATH` while one is being worked on, and the binary to re-run is that one
+rather than whichever an installation would resolve; the literal `rue` survives
+only as the fallback for a platform that cannot answer `current_exe` at all.
+
+Two spellings of "absolute" are in play here, and which one a path gets follows
+what the path *is*.
+
+- **Project inputs — the root and the build-system inputs — are absolutized
+  lexically**: joined onto the working directory, with symlinks and `..` left
+  alone. This is the operation the loader itself performs, which is why the
+  repro has to match it: the compiler's project root and module identities are
+  lexical, so canonicalizing a symlinked root **file** would resolve it to a
+  target in a different directory with a different `@import` closure. A run
+  rooted at `link/main.rue -> real/main.rue` selects `link/tests.rue`; a repro
+  naming `real/main.rue` selects nothing at all and exits `3`.
+- **Toolchain locations — the compiler binary and the standard-library root —
+  are canonicalized**, the way the loader canonicalizes a configured std root.
+  These are installed artifacts rather than project inputs: the identity that
+  matters is the file on disk, and on macOS a `/var/folders` prefix is a
+  symlink whose unresolved spelling would not compare against the paths
+  discovery reads.
+
+`repro_env` closes the last gap: environment is not argv, so a run that found
+its standard library through `RUE_STD_PATH` published a reproduction that died
+with `E0705: standard library not found` in any shell that did not happen to
+have the variable set. The object carries that variable, absolute, and is
+**absent rather than empty** when the run owed the environment nothing — the
+same convention `run_started.shard` follows. The empty spelling, which means
+"no toolchain standard library is configured", travels verbatim: absolutizing
+it would silently name the current directory instead.
+
+A repro is a snapshot, not a permanent address. One produced by the `rue_test`
+rule names buck-out artifacts — the compiler, the standard library, the source
+manifest — that the next build may replace or remove; it reproduces the run it
+came from, on the tree it came from, for as long as those artifacts are there.
+
+The argv array and the `repro_env` object are the authoritative forms. The
+human renderer's `repro:` line is the assignments followed by the argv, all
+shell-quoted for pasting —
+
+```text
+repro: RUE_STD_PATH=/opt/rue/std /opt/rue/bin/rue test /work/app/main.rue --filter 'app/t.rue::parses a port' --seed 417 --target x86-64-linux -O0 --timeout-ms 10000
+```
+
+— and a consumer should re-execute the array under the object rather than parse
+the line. Each assignment quotes only its value: a shell stops reading a word as
+an assignment once the name half is quoted.
 
 ## Scratch directories and isolation
 
@@ -537,6 +598,11 @@ event of a run and in each `--list --format json` record.
   failure record's `left`, `right`, and `diff` and the `assert_eq` /
   `assert_ne` kinds arrived this way (ADR-0083 Phase 2.5): the version stays
   `1.0` because nothing a `1.0` consumer already read changed.
+- `repro_env` arrived the same way (RUE-2020), alongside a `repro` whose
+  `argv[0]` and root became absolute. The version stays `1.0`: the field is new
+  and optional, and `repro` still holds what it always did — the argv that
+  reproduces this one test — in a spelling that resolves from more places than
+  the old one, not a different kind of value.
 - The comparison operands were briefly named `expected`/`actual` and were
   renamed to `left`/`right` in place, still at `1.0` (RUE-1954): the rename
   landed before any consumer outside this repository existed, so it is the one

--- a/scripts/rue-test-supervisor.py
+++ b/scripts/rue-test-supervisor.py
@@ -108,7 +108,17 @@ def describe_failure(test):
             lines.append("    {}: {}".format(stream, data.rstrip("\n")))
     repro = test.get("repro")
     if repro:
-        lines.append("    repro: {}".format(shlex.join(repro)))
+        # The environment leads, the way a shell wants it: `repro` is argv
+        # alone, and `repro_env` carries what the run owed to the environment
+        # (RUE-2020). Only the value is quoted -- quoting the name half would
+        # stop the shell reading the word as an assignment.
+        assignments = [
+            "{}={}".format(name, shlex.quote(value))
+            for name, value in sorted((test.get("repro_env") or {}).items())
+        ]
+        lines.append(
+            "    repro: {}".format(" ".join(assignments + [shlex.join(repro)]))
+        )
     return lines
 
 


### PR DESCRIPTION
Fixes RUE-2020

A failure's `repro:` line and the `repro` argv in `test_finished` were not runnable outside the shell that produced them: `argv[0]` was the bare word `rue`, the root and build-system inputs were spelled as typed, and `RUE_STD_PATH` was not part of argv, so a paste from a clean shell died with E0705.

## What changes

- **argv**: the compiler by its canonical executable path; the root, `--source-manifest`, and `--link-archive` by lexical absolute paths (`std::path::absolute`). Lexical, not canonical, for project inputs because the compiler's project root and module identity are lexical: canonicalizing a symlinked root file re-rooted the repro in the target's directory and the printed line then selected no tests (exit 3). Toolchain locations (the binary, the std root) are canonicalized, matching `capture_std_root`.
- **`repro_env`**: a new `test_finished` object, present only when non-empty like `shard`, carrying `RUE_STD_PATH` when the run's std came from it. An empty spelling travels verbatim because the loader reads it as "no toolchain std".
- **Human line**: `repro: RUE_STD_PATH=/abs/std /abs/rue test /abs/root.rue --filter '...' ...`, assignments first with only their values quoted so a POSIX shell still reads them as assignments. The Buck `rue_test` supervisor renders the same shape.
- **Docs**: `test_finished` table, the reproduction section, the determinism note (byte-identical for one invocation from one cwd on one install; absolute paths are deliberate), and a note that a Buck-produced repro names buck-out artifacts the next build may replace. Schema stays 1.0; additive.

## Verified

The printed line, pasted verbatim under `env -i` from `/`, reproduces the single failure for a plain root, a relative root, a symlinked root, and hostile bytes (quotes, spaces, `$`, backticks) in every component; the JSON pair reconstructs the same command. `test_mode` unit tests 93/93 after rebase, whole driver crate 335/335, `scripts/rue cli rue_test` 72/72 and `repro` 10/10, `scripts/rue quick` green, clippy and rustfmt clean, the `rue_test` Buck rule under the supervisor passes on Gazette and the orphan fixtures. Adversarially reviewed; both should-fix findings (lexical root, absolute build inputs) applied.

Note on the local oracle-diff corpus: this host currently stops 282 cases on a thread-spawn `EAGAIN` for every run including unmodified trunk (0 disagreements, 0 failures in what runs), so CI's corpus gate is the authority for this PR. The three added cases are `driver_exit_code` cases in `cli.rue_test`, which produce no program for the oracle to model.
