### PR TITLE
RUE-2013: make std.mem.replace work for any T

### DIFF
--- a/crates/rue-cli-tests/cases/std_core.toml
+++ b/crates/rue-cli-tests/cases/std_core.toml
@@ -421,3 +421,85 @@ fn main() -> i32 {
     0
 }
 """ }]
+
+# ── std.mem.replace at a drop-glue T (RUE-2013) ──────────────────────────────
+#
+# `let old = dst;` moves out of the `inout` borrow (E0437), so a `replace`
+# written that way compiles only at a `Copy` `T`. This case pins the drop-glue
+# instantiations: a StrBuf, repeated replacement of a heap value, and a struct
+# with an observable destructor whose drop lines prove each replaced value's
+# destructor runs exactly once — the allocator has no double-free detection, so
+# only a counted destructor can observe that property.
+[[case]]
+name = "mem_replace_copy_and_drop_glue"
+description = "std.mem.replace returns the old value and stores the new one for a Copy T, a StrBuf T, and a drop fn T whose destructor runs exactly once (RUE-2013)."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """i64 old=5 new=6
+strbuf old=before new=after
+loop old=seed
+loop old=payload-0
+loop old=payload-1
+loop old=payload-2
+loop final=payload-3
+got old 0
+drop 0
+got old 1
+drop 1
+got old 2
+drop 2
+end d=3
+drop 3
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct D {
+    v: i64,
+}
+
+drop fn D(self) {
+    println("drop " + @to_string(self.v));
+}
+
+fn main() -> i32 {
+    // Copy T: the instantiation that already compiled.
+    let mut x: i64 = 5;
+    let six: i64 = 6;
+    let oldx: i64 = std.mem.replace(i64, inout x, six);
+    println("i64 old=" + @to_string(oldx) + " new=" + @to_string(x));
+
+    // Drop-glue T: E0437 before RUE-2013.
+    let mut s: StrBuf = "before";
+    let olds = std.mem.replace(StrBuf, inout s, "after");
+    println("strbuf old=" + olds + " new=" + s);
+
+    // Repeated replacement of a heap value: a lost write or an aliased block
+    // prints the wrong line.
+    let mut cur: StrBuf = "seed";
+    let mut i: i64 = 0;
+    while i < 4 {
+        let next: StrBuf = "payload-" + @to_string(i);
+        let old = std.mem.replace(StrBuf, inout cur, next);
+        println("loop old=" + old);
+        i += 1;
+    }
+    println("loop final=" + cur);
+
+    // A destructor that reports: each replaced value drops exactly once, at
+    // the end of the iteration that received it, and the last value drops at
+    // the end of main after "end d=3".
+    let mut d = D { v: 0 };
+    let mut j: i64 = 1;
+    while j < 4 {
+        let old = std.mem.replace(D, inout d, D { v: j });
+        println("got old " + @to_string(old.v));
+        j += 1;
+    }
+    println("end d=" + @to_string(d.v));
+    0
+}
+""" }]

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -491,6 +491,14 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::PointerRead),
         &[],
     ),
+    // `std.mem.replace` delegates to `swap`, whose bytewise exchange is spelled
+    // in raw-pointer intrinsics, so this case reaches the same unmodeled read.
+    Entry::new(
+        "cli.std_core",
+        "mem_replace_copy_and_drop_glue",
+        intrinsic(UnsupportedIntrinsicKind::PointerRead),
+        &[],
+    ),
     // Output observation is modeled now; this case still reaches its genuine
     // text parsing boundary while formatting the StrBuf consumers.
     Entry::new(

--- a/std/mem.rue
+++ b/std/mem.rue
@@ -35,8 +35,21 @@ pub fn swap(comptime T: type, inout a: T, inout b: T) {
 }
 
 // Store `v` into `dst` and return the value that was there before.
+//
+// Works for any `T`, linear values included. Reading the old value out with
+// `let old = dst;` would move out of the `inout` borrow and leave the caller's
+// binding uninitialized (E0437), so `replace` instead moves `v` into a local
+// and swaps that local with `dst`: `swap` exchanges the two storages bytewise
+// (see its comment), so both bindings stay initialized throughout, `dst` ends
+// up owning `v`'s resources, the local owns what `dst` held on entry, and each
+// is dropped exactly once.
+//
+// The local is load-bearing, not style: swapping the by-value parameter `v`
+// itself (`swap(T, inout v, inout dst); v`) returns the pre-call `v` at -O2
+// and above, because the optimizer forwards a parameter's incoming value across
+// the `inout` call that overwrote it (RUE-2042).
 pub fn replace(comptime T: type, inout dst: T, v: T) -> T {
-    let old = dst;
-    dst = v;
+    let mut old = v;
+    swap(T, inout old, inout dst);
     old
 }

--- a/tests/std/tuple_mem_tests.rue
+++ b/tests/std/tuple_mem_tests.rue
@@ -60,13 +60,9 @@ test "mem.replace stores the new value and returns the old" {
     @assert_eq(x, 6);
 }
 
-// RUE-2013: `std.mem.replace(StrBuf, ...)` does not compile — `let old = dst;`
-// in std/mem.rue is E0437 (move out of an inout parameter) for any drop-glue
-// `T`, so `replace` only works for Copy types despite its doc. There is no
-// per-test xfail yet (RUE-2018), and a compile error fails the whole run, so
-// the case is recorded here until RUE-2013 lands:
-//
-//     let mut s: StrBuf = "before";
-//     let old = std.mem.replace(StrBuf, inout s, "after");
-//     @assert_eq(old, "before");
-//     @assert_eq(s, "after");
+test "mem.replace works on an owned StrBuf" {
+    let mut s: StrBuf = "before";
+    let old = std.mem.replace(StrBuf, inout s, "after");
+    @assert_eq(old, "before");
+    @assert_eq(s, "after");
+}


### PR DESCRIPTION
Fixes RUE-2013

`std.mem.replace` read the old value with `let old = dst;`, a move out of the `inout` borrow that the checker rejects (E0437) for any `T` with drop glue, so it compiled only at Copy types while its doc claimed any `T`.

It now moves `v` into a local and swaps that local with `dst` through `swap`'s bytewise exchange: both bindings stay initialized, `dst` ends up owning `v`'s resources, the local owns what `dst` held, and each is dropped exactly once. Linear values are accepted, as `swap` accepts them.

The local is load-bearing. Swapping the by-value parameter itself (`swap(T, inout v, inout dst); v`) returns the pre-call `v` at -O2 and above, a scalar-parameter miscompile found during this PR's review and filed as RUE-2042 (Urgent, in progress); the code comment names it.

## Coverage

- `std_core` CLI case with `differential_opt = true` (so -O0 through -O3 must agree): a Copy `T`, a `StrBuf` `T`, repeated replacement of a heap value, and a `drop fn` struct whose printed drops prove each replaced value's destructor runs exactly once. The allocator has no double-free detection, so the counted destructor is what actually observes that property.
- The case reaches `swap`'s unmodeled pointer read; the model-gap entry for the oracle audit is registered.
- The std contract suite's `tuple_mem` case for `replace` over `StrBuf` is restored (154 tests, green at -O0 and -O2).

## Verified

Repro passes at -O0 and -O2; `scripts/rue cli std_core` 10/10; `scripts/rue quick` green; adversarially reviewed with the one should-fix (destructor-counting case) applied.

Note on the local oracle-diff corpus: this host currently stops 282 cases on a thread-spawn `EAGAIN` for every run including unmodified trunk (filed separately), so CI's corpus gate is the authority for the new case's model-gap registration.
