### PR TITLE
RUE-2012: keep an accessor's yielded place intact through CFG construction

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -733,6 +733,50 @@ pub struct CfgBuilder<'a> {
     implicit_destructor_types: AHashSet<Type>,
     anonymous_destructor_dependency_incomplete: bool,
     callable_kind: AnalyzedCallableKind,
+    /// For an accessor body, the AIR values on the spine from `Ret` down to
+    /// the `PlaceRead` that lowered the trailing `yield`.
+    ///
+    /// The mandatory accessor splice consumes that `PlaceRead` as a place
+    /// descriptor, so it must reach `Return` as itself — never materialized
+    /// into a value. Every scope-cleanup shaping that would rewrite the
+    /// operand consults this set (RUE-2012).
+    accessor_yield_spine: AHashSet<AirRef>,
+}
+
+/// The AIR values on an accessor's yield spine: every `Ret` operand, and every
+/// block value beneath it, down to the `PlaceRead` that lowered the trailing
+/// `yield`.
+///
+/// An accessor's `Return` operand is a place descriptor, not a value: the
+/// mandatory splice (ADR-0062, RUE-1208) reads the place off that `PlaceRead`
+/// and substitutes it into the caller, so nothing may rewrite the operand into
+/// a load of a materialized copy on the way to `Return`. Scope cleanup would
+/// otherwise spill a multi-slot block result to frame storage (RUE-875), which
+/// both breaks the splice and copies a borrowed aggregate the accessor does not
+/// own (RUE-2012).
+///
+/// The set is empty for every other callable kind.
+fn accessor_yield_spine(
+    air: &ValidatedAir,
+    callable_kind: AnalyzedCallableKind,
+) -> AHashSet<AirRef> {
+    let mut spine = AHashSet::new();
+    if callable_kind != AnalyzedCallableKind::Accessor {
+        return spine;
+    }
+    for index in 0..air.len() {
+        let AirInstData::Ret(Some(value)) = air.get(AirRef::from_raw(index as u32)).data else {
+            continue;
+        };
+        let mut current = value;
+        while spine.insert(current) {
+            let AirInstData::Block { value, .. } = air.get(current).data else {
+                break;
+            };
+            current = value;
+        }
+    }
+    spine
 }
 
 /// Derive the grouped per-source-parameter ABI descriptors (ADR-0052 phase 5.8,
@@ -1004,11 +1048,13 @@ impl<'a> CfgBuilder<'a> {
             implicit_destructor_types: AHashSet::new(),
             anonymous_destructor_dependency_incomplete: false,
             callable_kind,
+            accessor_yield_spine: AHashSet::new(),
         };
 
         // Create entry block
         builder.current_block = builder.cfg.new_block();
         builder.cfg.entry = builder.current_block;
+        builder.accessor_yield_spine = accessor_yield_spine(air, callable_kind);
         builder.has_droppable_params = builder
             .air
             .param_drops()
@@ -1892,6 +1938,7 @@ impl<'a> CfgBuilder<'a> {
             AirInstData::Block { statements, value } => {
                 // Collect statements into a Vec for iteration (needed for checking remaining)
                 let statements: Vec<AirRef> = self.air.get_block_statements(statements).collect();
+                let value_ref = *value;
 
                 // A binding's storage wrapper — `Block { [StorageLive s], Alloc s }`,
                 // emitted by `let` lowering to pair a slot's storage annotation with
@@ -2013,11 +2060,19 @@ impl<'a> CfgBuilder<'a> {
                             // boundary, so it deliberately is not added to the
                             // drop scope. The post-cleanup Load continues the
                             // same value and the eventual consumer owns it.
+                            //
+                            // An accessor's yielded place is the exception:
+                            // it is a place descriptor the mandatory splice
+                            // reads and deletes, never a value that reaches a
+                            // register. Spilling it would both break the
+                            // splice's `PlaceRead` operand and copy a borrowed
+                            // aggregate the accessor does not own (RUE-2012).
                             let preserved = if !scope_slots.is_empty()
                                 && let Some(value) = result.value
                                 && ty != Type::UNIT
                                 && ty != Type::NEVER
                                 && self.type_pool.abi_slot_count(ty) > 1
+                                && !self.accessor_yield_spine.contains(&value_ref)
                             {
                                 let width = self.type_pool.abi_slot_count(ty).max(1);
                                 let slot = self.cfg.alloc_temp_local_slots(width);
@@ -3488,6 +3543,24 @@ impl<'a> CfgBuilder<'a> {
             return;
         }
 
+        // An accessor returns a place descriptor, not a value: the mandatory
+        // splice reads the yielded `PlaceRead` straight off the `Return`
+        // operand (ADR-0062, RUE-1208). The shared cleanup suffix re-lands
+        // every return value as a block parameter of one common exit, which
+        // erases that operand. An accessor has exactly one non-diverging exit,
+        // so there is nothing to share: emit its cleanup inline and return the
+        // place read itself (RUE-2012).
+        if self.callable_kind == AnalyzedCallableKind::Accessor
+            && value.is_some_and(|value| {
+                matches!(self.cfg.get_inst(value).data, CfgInstData::PlaceRead { .. })
+            })
+        {
+            self.emit_return_cleanup_inline(span);
+            self.cfg
+                .set_terminator(self.current_block, Terminator::Return { value });
+            return;
+        }
+
         #[cfg(test)]
         RETURN_CLEANUP_STATS.with(|stats| {
             let mut next = stats.get();
@@ -3581,6 +3654,43 @@ impl<'a> CfgBuilder<'a> {
                 successor,
             );
         self.goto_return_cleanup(self.current_block, successor.entry, value, span);
+    }
+
+    /// Emit an accessor's return cleanup into the current block rather than
+    /// into the interned, shared cleanup suffix.
+    ///
+    /// The actions and their order are the ones
+    /// [`Self::branch_through_return_cleanup`] schedules — every live lexical
+    /// slot innermost-first, then every unmoved droppable parameter in reverse
+    /// declaration order. Emitting them here needs no `MoveState` swap dance:
+    /// an interned region is shared across move states and must therefore
+    /// impersonate the one it was keyed on, while this path runs under the
+    /// live state it belongs to.
+    fn emit_return_cleanup_inline(&mut self, span: rue_span::Span) {
+        let live_slots: Vec<LiveSlot> = self
+            .scope_stack
+            .iter()
+            .rev()
+            .flat_map(|scope| scope.iter().rev().cloned())
+            .collect();
+        for live_slot in live_slots {
+            let slot_span = live_slot.span;
+            self.emit_drop_for_slot(&live_slot, slot_span);
+        }
+
+        for index in (0..self.air.param_drops().len()).rev() {
+            let (abi_slot, ty) = self.air.param_drops()[index];
+            let key = MovedSlot::Param(abi_slot);
+            if self.moved.is_slot_moved(key) || !self.type_needs_drop(ty) {
+                continue;
+            }
+            self.emit_guarded(key, span, |b| {
+                if !b.emit_partial_drop(key, ty, span) {
+                    let param_val = b.emit(CfgInstData::Param { index: abi_slot }, ty, span);
+                    b.emit(CfgInstData::Drop { value: param_val }, Type::UNIT, span);
+                }
+            });
+        }
     }
 
     fn return_cleanup_paths(&self, key: MovedSlot) -> (Vec<FieldPath>, Vec<FieldPath>) {

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -111,6 +111,18 @@ pub enum CfgInlineError {
         call_type: Type,
         callee_return_type: Type,
     },
+    /// An accessor callee has no `Return` terminator carrying a value, so the
+    /// mandatory splice has no yielded place to substitute (ADR-0062 §1).
+    AccessorHasNoReturn,
+    /// An accessor callee returns a value that is not a place read. Every
+    /// non-diverging accessor exit yields a projection of the receiver
+    /// (ADR-0062 §1), so the returned value is a `PlaceRead` by construction;
+    /// anything else means the accessor body was lowered through a shape the
+    /// mandatory splice cannot substitute.
+    AccessorReturnNotAPlaceRead {
+        returned: CfgValue,
+        returned_kind: String,
+    },
     /// A physically by-reference argument is not a place read at all — a
     /// violated sema/CFG invariant at the call site (RUE-760).
     NonPlaceByRefArgument { arg_index: usize },
@@ -159,8 +171,23 @@ impl std::fmt::Display for CfgInlineError {
             } => write!(
                 f,
                 "call result type {} does not match callee return type {}",
-                call_type.name(),
-                callee_return_type.name()
+                // No pool is threaded through `Display`; the id-bearing
+                // fallback still distinguishes two structs, which the bare
+                // `<struct>` placeholder did not (RUE-2012). Use
+                // `describe` where a pool is available.
+                call_type.safe_name_with_frozen_pool(None),
+                callee_return_type.safe_name_with_frozen_pool(None)
+            ),
+            Self::AccessorHasNoReturn => write!(
+                f,
+                "accessor callee has no return terminator carrying a yielded place"
+            ),
+            Self::AccessorReturnNotAPlaceRead {
+                returned,
+                returned_kind,
+            } => write!(
+                f,
+                "accessor callee returns {returned} ({returned_kind}), which is not a place read"
             ),
             Self::NonPlaceByRefArgument { arg_index } => {
                 write!(f, "by-ref argument {arg_index} is not a place read")
@@ -187,6 +214,44 @@ impl std::fmt::Display for CfgInlineError {
 }
 
 impl std::error::Error for CfgInlineError {}
+
+/// The variant name of a CFG instruction, for diagnostics.
+///
+/// `CfgInstData` derives `Debug`, which prints the variant name first, so the
+/// leading identifier is the kind. Naming the kind rather than the whole
+/// payload keeps an internal-compiler-error message bounded while still
+/// saying what shape was found (RUE-2012).
+fn inst_kind_name(data: &CfgInstData) -> String {
+    let rendered = format!("{data:?}");
+    rendered
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .next()
+        .unwrap_or_default()
+        .to_owned()
+}
+
+impl CfgInlineError {
+    /// Render this failure with type names resolved through `type_pool`.
+    ///
+    /// [`Display`](std::fmt::Display) has no pool to consult and falls back to
+    /// `<struct#7>`-style identity names. Diagnostics that reach a user — the
+    /// mandatory accessor splice reports its failures as an internal compiler
+    /// error — go through here so the message names the actual types
+    /// (RUE-2012).
+    pub fn describe(&self, type_pool: &FrozenTypeInternPool) -> String {
+        match self {
+            Self::ReturnTypeMismatch {
+                call_type,
+                callee_return_type,
+            } => format!(
+                "call result type {} does not match callee return type {}",
+                call_type.safe_name_with_frozen_pool(Some(type_pool)),
+                callee_return_type.safe_name_with_frozen_pool(Some(type_pool))
+            ),
+            other => other.to_string(),
+        }
+    }
+}
 
 impl From<CfgEditError> for CfgInlineError {
     fn from(error: CfgEditError) -> Self {
@@ -656,14 +721,11 @@ pub fn splice_call_in_block_in_place(
                 Terminator::Return { value: Some(value) } => Some(value),
                 _ => None,
             })
-            .ok_or(CfgInlineError::ReturnTypeMismatch {
-                call_type: call_ty,
-                callee_return_type: callee.return_type(),
-            })?;
+            .ok_or(CfgInlineError::AccessorHasNoReturn)?;
         let CfgInstData::PlaceRead { place } = &callee.get_inst(returned).data else {
-            return Err(CfgInlineError::ReturnTypeMismatch {
-                call_type: call_ty,
-                callee_return_type: callee.return_type(),
+            return Err(CfgInlineError::AccessorReturnNotAPlaceRead {
+                returned,
+                returned_kind: inst_kind_name(&callee.get_inst(returned).data),
             });
         };
         Some((

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -760,3 +760,162 @@ args = ["--emit", "asm", "--target", "aarch64-linux", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:"]
 compile_stdout_not_contains = ["xr:", "yr:"]
+
+[[case]]
+name = "nested_accessor_yield_over_aggregate_element_runs"
+differential_opt = true
+description = "An accessor whose body holds a local and yields a nested accessor over a multi-slot element splices and runs (RUE-2012)."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const Buf = std.arraybuf.ArrayBuf(StrBuf);
+struct Holder {
+    buf: Buf,
+    fn last(borrow self) -> borrow StrBuf {
+        let n = self.buf.len();
+        yield self.buf.get_ref(n - 1);
+    }
+}
+fn main() -> i32 {
+    let mut h = Holder { buf: Buf.new() };
+    let a: StrBuf = "first";
+    let b: StrBuf = "second";
+    h.buf.push(a);
+    h.buf.push(b);
+    println(h.last());
+    @dbg(h.last().len());
+    if h.last().len() == 6 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "second\n6\n"
+exit_code = 0
+
+[[case]]
+name = "std_stack_of_strbuf_peek_ref_runs"
+differential_opt = true
+description = "Stack(StrBuf).peek_ref — a local, a computed index, and a drop-glue element — borrows the top in place."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const Stack = std.stack.Stack(StrBuf);
+fn main() -> i32 {
+    let mut s = Stack.new();
+    let a: StrBuf = "first";
+    let b: StrBuf = "second";
+    s.push(a);
+    s.push(b);
+    println(s.peek_ref());
+    @dbg(s.len());
+    if s.peek_ref().len() == 6 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "second\n2\n"
+exit_code = 0
+
+[[case]]
+name = "accessor_yield_over_aggregate_element_constant_index_runs"
+description = "Control: the same aggregate element yielded at a constant index, with no local in the accessor body."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const Buf = std.arraybuf.ArrayBuf(StrBuf);
+struct Holder {
+    buf: Buf,
+    fn first(borrow self) -> borrow StrBuf {
+        yield self.buf.get_ref(0);
+    }
+}
+fn main() -> i32 {
+    let mut h = Holder { buf: Buf.new() };
+    let a: StrBuf = "first";
+    h.buf.push(a);
+    println(h.first());
+    if h.first().len() == 5 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "first\n"
+exit_code = 0
+
+[[case]]
+name = "accessor_yield_over_scalar_element_with_local_runs"
+description = "Control: the same body over a single-slot element, which never took the aggregate-preserve spill."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const Buf = std.arraybuf.ArrayBuf(i64);
+struct Holder {
+    buf: Buf,
+    fn last(borrow self) -> borrow i64 {
+        let n = self.buf.len();
+        yield self.buf.get_ref(n - 1);
+    }
+}
+fn main() -> i32 {
+    let mut h = Holder { buf: Buf.new() };
+    h.buf.push(41);
+    h.buf.push(42);
+    @dbg(h.last());
+    if h.last() == 42 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "42\n"
+exit_code = 0
+
+[[case]]
+name = "accessor_with_owned_parameter_drops_it_once"
+differential_opt = true
+description = "An accessor taking an owned droppable parameter drops it exactly once and still returns its yielded place (RUE-2012)."
+files = [{ path = "main.rue", source = """
+struct Noisy { id: i64 }
+drop fn Noisy(self) { @dbg(self.id); }
+struct Holder {
+    cells: [i64; 4],
+    fn at(borrow self, tag: Noisy, i: u64) -> borrow i64 {
+        let n = i;
+        yield self.cells[n];
+    }
+}
+fn main() -> i32 {
+    let h = Holder { cells: [1, 2, 3, 4] };
+    let t = Noisy { id: 9 };
+    @dbg(h.at(t, 2));
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "9\n3\n"
+exit_code = 0
+
+[[case]]
+name = "nested_accessor_yield_over_aggregate_element_lowers_on_aarch64"
+description = "The spliced nested-accessor place lowers on AArch64 without publishing an accessor symbol."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const Buf = std.arraybuf.ArrayBuf(StrBuf);
+struct Holder {
+    buf: Buf,
+    fn last(borrow self) -> borrow StrBuf {
+        let n = self.buf.len();
+        yield self.buf.get_ref(n - 1);
+    }
+}
+fn main() -> i32 {
+    let mut h = Holder { buf: Buf.new() };
+    let a: StrBuf = "first";
+    h.buf.push(a);
+    if h.last().len() == 5 { 0 } else { 1 }
+}
+""" }]
+args = ["--emit", "asm", "--target", "aarch64-linux", "main.rue"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:"]
+compile_stdout_not_contains = [".last:", "get_ref:"]

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -2112,7 +2112,10 @@ fn plan_codegen_symbol_mappings(
     Ok(additions)
 }
 
-fn accessor_splice_failure_message(error: SpliceCalleeFailure) -> String {
+fn accessor_splice_failure_message(
+    error: SpliceCalleeFailure,
+    type_pool: &rue_air::FrozenTypeInternPool,
+) -> String {
     match error {
         SpliceCalleeFailure::Domain(error) => {
             format!("accessor CFG domain import failed: {error:?}")
@@ -2124,13 +2127,19 @@ fn accessor_splice_failure_message(error: SpliceCalleeFailure) -> String {
             "accessor local atom has no imported string id".to_owned()
         }
         SpliceCalleeFailure::Splice(error) => {
-            format!("mandatory accessor CFG splice failed: {error}")
+            format!(
+                "mandatory accessor CFG splice failed: {}",
+                error.describe(type_pool)
+            )
         }
         error => format!("accessor CFG splice merge failed: {error}"),
     }
 }
 
-fn general_splice_failure_message(error: SpliceCalleeFailure) -> String {
+fn general_splice_failure_message(
+    error: SpliceCalleeFailure,
+    type_pool: &rue_air::FrozenTypeInternPool,
+) -> String {
     match error {
         SpliceCalleeFailure::Domain(error) => {
             format!("general inline CFG domain import failed: {error:?}")
@@ -2141,7 +2150,12 @@ fn general_splice_failure_message(error: SpliceCalleeFailure) -> String {
         SpliceCalleeFailure::MissingAtomString => {
             "general inline local atom has no imported string id".to_owned()
         }
-        SpliceCalleeFailure::Splice(error) => format!("general inline splice failed: {error}"),
+        SpliceCalleeFailure::Splice(error) => {
+            format!(
+                "general inline splice failed: {}",
+                error.describe(type_pool)
+            )
+        }
         error => format!("general inline splice merge failed: {error}"),
     }
 }
@@ -2500,7 +2514,7 @@ pub(crate) fn evaluate_optimized_cfg(
             Err(SpliceCalleeFailure::Canceled(abort)) => return Err(abort),
             Err(error) => {
                 return Ok(QueryOutput::success(internal_failure(
-                    accessor_splice_failure_message(error),
+                    accessor_splice_failure_message(error, &record.type_pool),
                     record.body_span,
                 ))
                 .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
@@ -3035,7 +3049,7 @@ pub(crate) fn apply_general_inlining(
                     continue;
                 }
                 Err(error) => {
-                    failed = Some(general_splice_failure_message(error));
+                    failed = Some(general_splice_failure_message(error, &record.type_pool));
                     break;
                 }
             }
@@ -4476,14 +4490,18 @@ mod accessor_graph_tests {
             "accessor CFG domain import failed: {error:?}",
             "imported accessor CFG failed verification: {error}",
             "accessor local atom has no imported string id",
-            "mandatory accessor CFG splice failed: {error}",
+            "mandatory accessor CFG splice failed: {}",
             "general inline CFG domain import failed: {error:?}",
             "imported general inline CFG failed verification: {error}",
             "general inline local atom has no imported string id",
-            "general inline splice failed: {error}",
+            "general inline splice failed: {}",
         ] {
             assert!(production.contains(legacy_message));
         }
+        // Both splice ICE messages name their types through the frozen pool.
+        // `Display` alone renders every struct as `<struct#7>`, which is what
+        // made RUE-2012's report undiagnosable.
+        assert_eq!(production.matches("error.describe(type_pool)").count(), 2);
 
         let domains = include_str!("durable_cfg.rs");
         let lookup = domains

--- a/tests/std/collections_tests.rue
+++ b/tests/std/collections_tests.rue
@@ -34,8 +34,7 @@ test "Stack of owned StrBuf moves elements out with pop" {
     let b: StrBuf = "second";
     s.push(a);
     s.push(b);
-    // RUE-2012: `@assert_eq(s.peek_ref(), "second")` on Stack(StrBuf) is
-    // E9000 "mandatory accessor CFG splice failed"; restore it when that lands.
+    @assert_eq(s.peek_ref(), "second");
     @assert_eq(s.len(), 2);
     match s.pop() {
         OptS.Some(v) => @assert_eq(v, "second"),


### PR DESCRIPTION
Fixes RUE-2012

A method that yields a nested borrow accessor with a computed index over a drop-glue element (`yield self.buf.get_ref(n - 1)` over `ArrayBuf(StrBuf)`) was an ICE in the mandatory accessor splice: "call result type <struct> does not match callee return type <struct>". `Stack(StrBuf).peek_ref` hit it on every use.

## Root cause and fix

The splice reads the yielded place off the `PlaceRead` in the accessor's `Return` operand (ADR-0062 / RUE-1208), so that operand has to survive CFG construction as a place descriptor. Two shapings rewrote it into a value:

1. **Scope-cleanup spill** (RUE-875): a multi-slot block result is spilled to frame storage when a scope with live slots ends. For an accessor with a `let` in its body, the yielded place became a `Load` of a copy, which broke the splice and copied a borrowed aggregate the accessor does not own. Values on the accessor's yield spine are now exempt. This is sound because the splice substitutes the place at every caller use site, so no aggregate value ever lives across the accessor's local drops.
2. **Shared return-cleanup suffix**: the interned suffix re-lands every return value as a block parameter of one exit, erasing the `PlaceRead` whenever the accessor had droppable locals or parameters. An accessor has exactly one non-diverging exit (sema enforces the single trailing `yield`), so its cleanup is emitted inline in the same order the suffix schedules, and the place read itself is returned.

Also: the splice no longer reuses `ReturnTypeMismatch` for "no return" / "return is not a place read" (two accessor-specific errors), and the ICE message names real types through the frozen pool instead of `<struct>`.

## Coverage

`borrow_accessors.toml` runs the repro, `Stack(StrBuf).peek_ref`, and an accessor with an owned parameter under `differential_opt = true` (so -O0 through -O3 must agree), with constant-index and `i64` controls; the first two fail on trunk via path 1 and the third via path 2. The std contract suite's `peek_ref` assertion is restored.

## Verified

Every repro shape compiles and runs correctly at -O0 and -O2, including a three-deep accessor chain, yields whose index expressions create droppable temporaries, owned parameters with drop-flag and partial-move cleanup, and 2000-iteration push/pop loops with counted destructors. `scripts/rue cli borrow_accessors` 43/43, std suite green, `//examples:cli-staged-programs` builds, `scripts/rue quick` green, rustfmt clean. Adversarially reviewed: the reviewer independently traced both cleanup paths line by line and executed fifteen probe programs; both should-fix items (fmt, `differential_opt`) applied.

The review also surfaced an unrelated pre-existing -O2 ICE (CSE merging two identical `StrBuf` literals in sibling scopes), filed separately.

Local oracle-diff is host-blocked (RUE-2043); CI's corpus gate is the authority for the new cases.
