### PR TITLE
RUE-2040: let scripts/rue unit reach the crates/rue package

### DIFF
--- a/scripts/rue
+++ b/scripts/rue
@@ -15,7 +15,8 @@
 #   scripts/rue all                Canonical union of every tier
 #   scripts/rue unit <crate> [args] One crate's Rust unit tests, case-filtered
 #                                  (crate name with or without the rue- prefix,
-#                                  or an explicit <crate>:<target>; forwards
+#                                  `rue` for the driver, or an explicit
+#                                  <crate>:<target>; forwards
 #                                  <pattern>/--exact/--nocapture to libtest)
 #   scripts/rue spec [pattern]     Spec tests, optional filter
 #   scripts/rue cli [pattern]      CLI integration tests, optional filter
@@ -124,16 +125,41 @@ case "$cmd" in
             crate="$sel"
             unit_target=""
         fi
-        # Map the friendly crate name to its package, accepting it with or
-        # without the rue- prefix (`compiler` -> `rue-compiler`).
+        # Map the friendly crate name to its package against the source tree.
+        # A package spelled exactly like the token wins, so `rue` reaches
+        # crates/rue — where the driver and the `rue test` runner live — and
+        # only then is the rue- prefix supplied, so `compiler` still reaches
+        # crates/rue-compiler (RUE-2040). A token that already carries the
+        # prefix has just the one spelling; nothing is named `rue-rue-*`.
+        # A token is a bare package name: a path separator or a dot-relative
+        # spelling would probe outside crates/ and then hand buck2 a malformed
+        # label, so it is refused up front.
         case "$crate" in
-            rue-*) pkg="$crate" ;;
-            *)     pkg="rue-$crate" ;;
+            */*|.|..|"")
+                echo "scripts/rue unit: crate '$crate' must be a bare package name" >&2
+                exit 2
+                ;;
         esac
-        # Validate against the source tree so an unknown crate produces a clear
-        # message instead of a raw buck2 target-not-found dump.
-        if [[ ! -f "crates/$pkg/BUCK" ]]; then
-            echo "scripts/rue unit: unknown crate '$crate' (no crates/$pkg)" >&2
+        candidates=("$crate")
+        case "$crate" in
+            rue-*) ;;
+            *) candidates+=("rue-$crate") ;;
+        esac
+        pkg=""
+        for candidate in "${candidates[@]}"; do
+            if [[ -f "crates/$candidate/BUCK" ]]; then
+                pkg="$candidate"
+                break
+            fi
+        done
+        # An unknown crate produces a clear message naming every package that
+        # was probed, instead of a raw buck2 target-not-found dump.
+        if [[ -z "$pkg" ]]; then
+            tried=""
+            for candidate in "${candidates[@]}"; do
+                tried="${tried:+$tried or }crates/$candidate"
+            done
+            echo "scripts/rue unit: unknown crate '$crate' (no $tried)" >&2
             exit 2
         fi
         [[ -n "$unit_target" ]] || unit_target="$pkg-test"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -820,8 +820,12 @@ test_sanitizer_status_contracts() {
 # passes); the real run exits with $FAKE_RUN_EXIT. Echoes the sandbox path.
 make_rue_unit_sandbox() {
   local sb; sb="$(mktemp -d)"
-  mkdir -p "$sb/scripts" "$sb/crates/rue-parser" "$sb/crates/rue-compiler"
+  mkdir -p "$sb/scripts" "$sb/crates/rue" "$sb/crates/rue-parser" \
+    "$sb/crates/rue-compiler"
   cp "$SRC_ROOT/scripts/rue" "$sb/scripts/rue"; chmod +x "$sb/scripts/rue"
+  # crates/rue is the package whose own name needs no prefix; keeping it in the
+  # sandbox pins that the exact spelling wins over crates/rue-rue (RUE-2040).
+  printf '# stub\n' >"$sb/crates/rue/BUCK"
   printf '# stub\n' >"$sb/crates/rue-parser/BUCK"
   printf '# stub\n' >"$sb/crates/rue-compiler/BUCK"
   cat >"$sb/buck2" <<'EOF'
@@ -864,6 +868,25 @@ test_rue_unit_maps_crate_and_forwards_args() {
       ./scripts/rue unit compiler:rue-compiler-public-api-test ) >/dev/null 2>&1 || rc=$?
   check "scripts/rue unit: explicit crate:target form reaches the alternate target" \
     "$([ "$rc" -eq 0 ] && grep -Fxq 'run //crates/rue-compiler:rue-compiler-public-api-test --' "$sb/buck.log" && echo 0 || echo 1)"
+
+  # RUE-2040: the package named `rue` — the driver and the `rue test` runner —
+  # is reached by its own name. Prefixing unconditionally sent this to a
+  # crates/rue-rue that has never existed, leaving those unit tests with no
+  # spelling at all through this wrapper.
+  : >"$sb/buck.log"; rc=0
+  ( cd "$sb" && BUCK_LOG="$sb/buck.log" \
+      FAKE_LIST_OUT='rue::test_mode::tests::renders: test' \
+      ./scripts/rue unit rue test_mode ) >/dev/null 2>&1 || rc=$?
+  check "scripts/rue unit: a package needing no prefix resolves to itself" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'run //crates/rue:rue-test -- test_mode' "$sb/buck.log" && echo 0 || echo 1)"
+
+  # ...and its second test target stays reachable through the explicit form.
+  : >"$sb/buck.log"; rc=0
+  ( cd "$sb" && BUCK_LOG="$sb/buck.log" \
+      FAKE_LIST_OUT='rue_driver::tests::case: test' \
+      ./scripts/rue unit rue:rue-driver-test ) >/dev/null 2>&1 || rc=$?
+  check "scripts/rue unit: crate:target form reaches a second target in that package" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'run //crates/rue:rue-driver-test --' "$sb/buck.log" && echo 0 || echo 1)"
   rm -rf "$sb"
 }
 
@@ -908,6 +931,10 @@ test_rue_unit_unknown_crate_errors_cleanly() {
     "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
   check "scripts/rue unit: unknown crate names the missing crate" \
     "$(grep -q "unknown crate 'nosuchcrate'" <<< "$out" && echo 0 || echo 1)"
+  # Both spellings were probed, so both are named: a reader can tell whether
+  # they meant the prefixed package or the bare one (RUE-2040).
+  check "scripts/rue unit: unknown crate names every package it probed" \
+    "$(grep -Fq 'crates/nosuchcrate or crates/rue-nosuchcrate' <<< "$out" && echo 0 || echo 1)"
   check "scripts/rue unit: unknown crate never invokes buck2" \
     "$([ ! -s "$sb/buck.log" ] && echo 0 || echo 1)"
   rm -rf "$sb"


### PR DESCRIPTION
Fixes RUE-2040

`scripts/rue unit <crate>` derived the Buck package as `rue-<crate>` for any token not already prefixed, so `crates/rue` (the driver, and every `rue test` runner unit test) was unreachable: `scripts/rue unit rue` reported "no crates/rue-rue".

- Resolution probes the exact spelling first and supplies the `rue-` prefix only as a fallback: `rue` reaches `crates/rue`, `compiler` still reaches `crates/rue-compiler`. No existing name has both spellings, so no previously working invocation changes destination.
- `<crate>:<target>` is unchanged and reaches a package's second target (`rue:rue-driver-test`).
- An unknown crate names every package it probed; a token with a path separator, `.`, `..`, or empty is refused before any label is built.
- `scripts/test-wrapper-scripts.sh` gains a `crates/rue` stub and three checks that fail on the old resolution (verified against trunk's script).

Bash 3.2.57 parse and the baseline validator are clean. `scripts/rue unit rue test_mode` 100 passed, `rue:rue-driver-test` 71 passed, `compiler durable_` 131 passed, `//:wrapper-script-tests` all checks pass. Adversarially reviewed: merge as-is, with the two optional nits (path-token guard, usage text) applied.

Follow-up filed as RUE-2045: a bare second-target name such as `rue-driver` still needs the `package:target` spelling.