### PR TITLE
RUE-2042: treat a by-ref call argument as a write to a parameter slot in CSE

### DIFF
--- a/crates/rue-cfg/src/opt/cse.rs
+++ b/crates/rue-cfg/src/opt/cse.rs
@@ -44,19 +44,14 @@
 //! parameter to their first occurrence, which in turn lets the adds dedupe.
 //!
 //! This is sound ONLY for a parameter that is never written, so its every read
-//! yields the identical value. A `Param { index }`'s `index` is the parameter's
-//! ABI slot (the same numbering as [`Cfg::is_param_writable`] and a
-//! `ParamStore`'s `param_slot`; both flow from sema's `abi_slot`). A slot is
-//! treated as never-written when it is (a) not logically writable
-//! (`is_param_writable(slot) == false`, i.e. `borrow` or plain by-value —
-//! never `inout`, and never a `mut self` receiver slot) and (b) receives no
-//! `ParamStore` anywhere among the block-attached instructions. Plain
-//! by-value (`Normal`) parameters are immutable in the callee (assignment is
-//! rejected, E0203) and `borrow` parameters cannot be written, so only
-//! writable slots — excluded by (a) — and any slot a `ParamStore` targets —
-//! excluded by (b) — are left out. (As defense in depth, a projected
-//! `PlaceWrite` whose base is a parameter slot also excludes it, though such a
-//! write only ever targets an already-excluded `inout` slot.)
+//! yields the identical value. Which slots those are is not decided here:
+//! [`super::slot_facts::classify_never_written_params`] owns the write/escape
+//! discipline for parameter slots exactly as it owns it for local slots, so
+//! the two cannot drift apart. Its answer covers direct writes, address
+//! escapes, and — the channel that makes a parameter mutable without its own
+//! function ever writing it — a by-ref (`inout`/`borrow`) call argument
+//! rooted at the slot, which hands the callee the slot's address for the
+//! duration of the call.
 //!
 //! Constants MUST be keyed: two separately materialized `Const(1)` instructions
 //! would otherwise give `x + 1` and `x + 1` different operand ids, defeating the
@@ -93,6 +88,8 @@
 
 use crate::{BlockId, Cfg, CfgInstData, CfgValue, Type};
 use ahash::AHashMap;
+
+use super::slot_facts;
 
 /// Work counters for one run (RUE-794 convention): a single forward scan of
 /// every block, then one batched use-rewrite. There is no fixpoint loop.
@@ -209,47 +206,6 @@ fn key_of(
     })
 }
 
-/// Compute, per parameter ABI slot, whether the parameter is never written and
-/// so its reads are all the identical pure value (RUE-914). A slot is
-/// never-written when it is not logically writable by-ref (`inout`) and receives
-/// no `ParamStore` (nor, defensively, a projected `PlaceWrite`) among the
-/// block-attached instructions. Indexed by ABI slot; `Param { index }`'s `index`
-/// is exactly that slot.
-fn never_written_params(cfg: &Cfg) -> Vec<bool> {
-    let num_params = cfg.num_params() as usize;
-    let mut never_written = vec![false; num_params];
-    for (slot, flag) in never_written.iter_mut().enumerate() {
-        // A parameter whose ADDRESS escapes through @raw/@raw_mut/@field_ptr
-        // is mutable through the raw pointer (@ptr_write), so its reads are
-        // NOT interchangeable even though nothing writes it directly — keying
-        // such reads merged a post-write read into the stale pre-write value
-        // (found by the 2026-07-16 optimizer hunt).
-        *flag = !cfg.is_param_writable(slot as u32) && !cfg.is_param_address_taken(slot as u32);
-    }
-
-    for block in cfg.blocks() {
-        for &value in &block.insts {
-            match &cfg.get_inst(value).data {
-                CfgInstData::ParamStore { param_slot, .. } => {
-                    if let Some(flag) = never_written.get_mut(*param_slot as usize) {
-                        *flag = false;
-                    }
-                }
-                CfgInstData::PlaceWrite { place, .. } => {
-                    if let crate::PlaceBase::Param(slot) = place.base {
-                        if let Some(flag) = never_written.get_mut(slot as usize) {
-                            *flag = false;
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    never_written
-}
-
 /// Scan one block in program order. Returns the keys introduced by this block,
 /// which the dominator-tree walk removes when it exits the block's subtree.
 fn scan_block(
@@ -294,7 +250,7 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
     // `subst[dup] = first` for every replaced duplicate. Each entry points to a
     // definition that dominates it, so global chain resolution stays valid.
     let mut subst: Vec<Option<CfgValue>> = vec![None; cfg.value_count()];
-    let never_written_param = never_written_params(cfg);
+    let never_written_param = slot_facts::classify_never_written_params(cfg);
 
     stats.dominator_computations += 1;
     let dominators = crate::dominators::DominatorTree::compute(cfg);
@@ -383,7 +339,8 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CfgInst, Terminator, Type};
+    use crate::{CfgArgMode, CfgCallArg, CfgInst, Terminator, Type};
+    use lasso::{Key, Spur};
     use rue_span::Span;
 
     fn make_cfg() -> Cfg {
@@ -873,6 +830,91 @@ mod tests {
         // The add now reads the first parameter value twice.
         assert!(matches!(cfg.get_inst(sum).data, CfgInstData::Add(x, y) if x == a1 && y == a1));
         assert!(matches!(cfg.get_inst(a2).data, CfgInstData::Const(0)));
+    }
+
+    #[test]
+    fn test_byref_call_argument_ends_param_read_dedupe() {
+        // `fn f(v) { g(inout v); v }`: the by-value parameter is not writable
+        // in `f`'s own body, but passing it `inout` hands `g` the slot's
+        // address, so the read after the call is a different value from the
+        // read before it (RUE-2042).
+        for mode in [CfgArgMode::Inout, CfgArgMode::Borrow] {
+            let mut cfg = Cfg::new(Type::I32, 0, 1, "f".to_string(), vec![false]);
+            let entry = cfg.new_block();
+            cfg.entry = entry;
+            let before = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+            let args = cfg
+                .push_call_args([CfgCallArg {
+                    value: before,
+                    mode,
+                }])
+                .unwrap();
+            push(
+                &mut cfg,
+                CfgInstData::Call {
+                    runtime: None,
+                    name: Spur::try_from_usize(0).unwrap(),
+                    args,
+                },
+                Type::UNIT,
+            );
+            let after = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+            cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(after) });
+
+            let stats = run(&mut cfg).unwrap();
+            assert_eq!(stats.duplicates_replaced, 0, "mode {mode:?}");
+            assert!(
+                matches!(cfg.get_inst(after).data, CfgInstData::Param { index: 0 }),
+                "the post-call read must survive as a read ({mode:?})"
+            );
+            assert!(
+                matches!(
+                    cfg.get_block(cfg.entry).terminator,
+                    Terminator::Return { value: Some(v) } if v == after
+                ),
+                "the return must still read the post-call value ({mode:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_byref_call_argument_on_other_root_keeps_param_read_dedupe() {
+        // The over-correction control: a by-ref argument rooted at a LOCAL
+        // slot cannot alias a parameter slot, so parameter reads still dedupe.
+        let mut cfg = Cfg::new(Type::I32, 1, 1, "f".to_string(), vec![false]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let before = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: before,
+            },
+            Type::UNIT,
+        );
+        let arg = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        let args = cfg
+            .push_call_args([CfgCallArg {
+                value: arg,
+                mode: CfgArgMode::Inout,
+            }])
+            .unwrap();
+        push(
+            &mut cfg,
+            CfgInstData::Call {
+                runtime: None,
+                name: Spur::try_from_usize(0).unwrap(),
+                args,
+            },
+            Type::UNIT,
+        );
+        let after = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(after) });
+
+        let stats = run(&mut cfg).unwrap();
+        assert_eq!(stats.duplicates_replaced, 1);
+        assert!(matches!(cfg.get_inst(after).data, CfgInstData::Const(0)));
     }
 
     #[test]

--- a/crates/rue-cfg/src/opt/licm.rs
+++ b/crates/rue-cfg/src/opt/licm.rs
@@ -1114,7 +1114,7 @@ mod tests {
         // parameter that the loop body mutates (a `ParamStore`) varies per
         // iteration: hoisting the read would freeze the parameter at its entry
         // value and miscompile the loop (the same hazard the Load gate guards,
-        // and CSE's `never_written_params`). It must stay in the body.
+        // and CSE through `slot_facts::classify_never_written_params`). It must stay in the body.
         let mut cfg = Cfg::new(
             Type::UNIT,
             1,

--- a/crates/rue-cfg/src/opt/slot_facts.rs
+++ b/crates/rue-cfg/src/opt/slot_facts.rs
@@ -7,8 +7,18 @@
 //! that nothing else can write. Each pass used to restate the scan that
 //! decides this; a rule learned in one (a new escape channel, a new write
 //! form) could silently miss the other. Following the [`super::classify`]
-//! precedent (ADR-0054 §2), this module names the discipline once and both
-//! passes consume it.
+//! precedent (ADR-0054 §2), this module names the discipline once and every
+//! consumer reads it from here.
+//!
+//! The same discipline covers both slot kinds, and deliberately in one place:
+//! [`classify_slot_writes`] classifies *local* slots for constopt and
+//! forwarding, [`classify_never_written_params`] classifies *parameter* ABI
+//! slots for CSE's parameter-read keying, and
+//! [`LoopSlotFactsWorkspace::classify_loop_slot_invariance`] classifies both
+//! per loop for LICM. A local and a parameter have the same write channels —
+//! a direct write, a projected write, an address escape, and a by-ref call
+//! argument that hands the callee the slot's address — so the parameter side
+//! must never be the weaker analysis.
 //!
 //! ## What qualifies a slot
 //!
@@ -357,6 +367,117 @@ pub(super) fn classify_slot_writes(cfg: &Cfg, reachable: Option<&BitSet>) -> Vec
     }
 
     slot_writes
+}
+
+/// Classify every parameter ABI slot as *never written*: `true` means every
+/// `Param { index }` read of that slot observes the identical value for the
+/// whole function body, so the reads are interchangeable.
+///
+/// [`super::cse`] keys such reads by slot so that expressions built over
+/// parameters deduplicate (RUE-914). The classification lives here, beside
+/// [`classify_slot_writes`], because a parameter slot has exactly the same
+/// write channels as a local one and the two must not drift apart: a channel
+/// learned for locals is a channel for parameters.
+///
+/// Indexing is by ABI slot — the numbering shared by `Param { index }`,
+/// `ParamStore`'s `param_slot`, [`Cfg::is_param_writable`], and
+/// `PlaceBase::Param`, all of which flow from sema's `abi_slot`.
+///
+/// A slot is disqualified by any of these channels:
+///
+/// - **Logically writable slots** (`inout`, or a `mut self` receiver): the
+///   callee body assigns them. A plain by-value (`Normal`) parameter cannot be
+///   assigned in its own body (E0203), and neither can a `borrow` one.
+/// - **Address-taken slots** (`@raw`/`@raw_mut`/`@field_ptr`, recorded by
+///   CfgBuilder): a raw pointer may store into the slot between two reads.
+/// - **A `ParamStore` targeting the slot, or a projected `PlaceWrite` rooted at
+///   it**: a direct whole or partial write.
+/// - **A by-ref (`inout`/`borrow`) call argument rooted at the slot**, on
+///   either call form. This is the channel that makes a *caller's* own
+///   parameter mutable without the caller ever writing it: passing the slot
+///   by reference hands its ADDRESS to the callee for the duration of the
+///   call, and the callee writes through that address (an `inout` assignment,
+///   or `@raw_mut` plus `@ptr_write` — which the frontend also allows on a
+///   `borrow` parameter, so a `borrow` argument counts as a write here until
+///   RUE-2047 rules on that). A read after such a call is therefore not
+///   interchangeable with a read before it. This is the same rule
+///   [`classify_slot_writes`] applies to a local passed by reference, and the
+///   same one [`LoopSlotFactsWorkspace::classify_loop_slot_invariance`]
+///   applies per loop.
+///
+/// A by-ref argument whose root this scan cannot resolve to a specific slot
+/// (an accessor-yielded or indirect place) disqualifies every parameter for
+/// the whole function. That is deliberately stricter than
+/// [`classify_slot_writes`], which ignores such roots for locals, and than
+/// [`super::forward`]'s block-local clear: an indirect place can only alias a
+/// parameter slot whose address was taken, which is already recorded, so the
+/// clear is redundant in principle, and it is kept because a parameter read
+/// is re-materialized at every use and the cost of being wrong is a wrong
+/// value, not a missed dedupe.
+///
+/// All blocks are scanned, reachable or not: an unreachable write can only
+/// narrow the result (disqualify a slot that would otherwise key), never
+/// unsoundly widen it.
+pub(super) fn classify_never_written_params(cfg: &Cfg) -> Vec<bool> {
+    let num_params = cfg.num_params() as usize;
+    let mut never_written: Vec<bool> = (0..num_params as u32)
+        .map(|slot| !cfg.is_param_writable(slot) && !cfg.is_param_address_taken(slot))
+        .collect();
+
+    // Out-of-range slots are skipped rather than panicking, matching
+    // `record_write` above.
+    fn mark_written(never_written: &mut [bool], slot: u32) {
+        if let Some(flag) = never_written.get_mut(slot as usize) {
+            *flag = false;
+        }
+    }
+
+    for block in cfg.blocks() {
+        for &value in &block.insts {
+            match &cfg.get_inst(value).data {
+                CfgInstData::ParamStore { param_slot, .. } => {
+                    mark_written(&mut never_written, *param_slot);
+                }
+                CfgInstData::PlaceWrite { place, .. } => {
+                    if let PlaceBase::Param(slot) = place.base {
+                        mark_written(&mut never_written, slot);
+                    }
+                }
+                CfgInstData::Call { args, .. } | CfgInstData::AccessorCall { args, .. } => {
+                    for arg in cfg.call_args(args) {
+                        if !arg.is_by_ref() {
+                            continue;
+                        }
+                        match &cfg.get_inst(arg.value).data {
+                            // The two shapes that root a by-ref argument at a
+                            // parameter slot: a materialized read of the whole
+                            // slot, and a projection out of it.
+                            CfgInstData::Param { index } => {
+                                mark_written(&mut never_written, *index);
+                            }
+                            CfgInstData::PlaceRead { place } => match place.base {
+                                PlaceBase::Param(slot) => {
+                                    mark_written(&mut never_written, slot);
+                                }
+                                // A local root hands the callee a local slot's
+                                // address, which cannot alias a parameter slot.
+                                PlaceBase::Local(_) => {}
+                                PlaceBase::Accessor(_) | PlaceBase::Indirect(_) => {
+                                    never_written.fill(false);
+                                }
+                            },
+                            // A `Load` roots the argument at a local slot.
+                            CfgInstData::Load { .. } => {}
+                            _ => never_written.fill(false),
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    never_written
 }
 
 #[cfg(test)]

--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -29,11 +29,16 @@
 # (`g(inout v)` inside `fn f(inout v: T)`, and since RUE-143 also
 # `g(borrow v)` inside `fn f(borrow v: T)`) is a re-borrow, not a move, and
 # must keep working.
+#
+# The caller's side of the same boundary closes the file (RUE-2042): once a
+# place is passed by reference, every later read of its root observes what the
+# callee wrote — including when that root is the caller's own by-value
+# parameter.
 
 [section]
 id = "cli.byref_params"
 name = "By-ref parameter soundness"
-description = "Field/element by-ref arguments and moves out of inout parameters (RUE-127, RUE-143)."
+description = "Field/element by-ref arguments, moves out of inout parameters, and re-reading a by-ref argument's root after the call (RUE-127, RUE-143, RUE-2042)."
 
 # ---------------------------------------------------------------------------
 # By-ref arguments accept place projections (RUE-143): the callee must see
@@ -642,3 +647,154 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 42
+
+# ---------------------------------------------------------------------------
+# The CALLER's own parameter passed by reference (RUE-2042).
+#
+# Passing a place by reference hands the callee that place's ADDRESS, so every
+# read of the same root after the call must observe what the callee wrote.
+# That holds whatever the root is, and a caller's own by-value parameter is a
+# root like any other: `fn f(v: i64) { bump(inout v); v }` returns 6, not 5.
+#
+# A parameter read is materialized as a `Param { index }` instruction rather
+# than a `Load`, and the optimizer keys repeated reads of a never-written
+# parameter slot to one value so expressions over parameters deduplicate. The
+# by-ref call argument is one of the channels that writes such a slot, so the
+# post-call read is a distinct value; the classification lives with the local
+# one in rue-cfg's `opt::slot_facts`. Every case here is `differential_opt`:
+# -O2/-O3 must agree with the -O0 baseline, which is where the divergence was.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "inout_param_arg_reread_after_call"
+differential_opt = true
+description = "RUE-2042 repro: a scalar by-value parameter passed `inout` reads the callee's write afterwards, not its entry value."
+files = [{ path = "main.rue", source = """
+fn bump(inout x: i64) { x = x + 1; }
+fn f(v: i64) -> i64 { bump(inout v); v }
+fn main() -> i32 { @intCast(f(5)) }
+""" }]
+stdout = ""
+exit_code = 6
+
+[[case]]
+name = "inout_param_arg_raw_pointer_write_reread"
+differential_opt = true
+description = "The callee writes through a raw pointer into the `inout` parameter instead of assigning it; the caller's post-call read still observes the write."
+files = [{ path = "main.rue", source = """
+fn poke(inout x: i64) {
+    let p: ptr mut i64 = checked { @raw_mut(x) };
+    checked { @ptr_write(p, 42); };
+}
+fn f(v: i64) -> i64 { poke(inout v); v }
+fn main() -> i32 { @intCast(f(5)) }
+""" }]
+stdout = ""
+exit_code = 42
+
+[[case]]
+name = "inout_param_arg_in_loop_reread"
+differential_opt = true
+description = "The call sits in a loop body: each iteration's read must observe the previous iteration's write, so three iterations add three."
+files = [{ path = "main.rue", source = """
+fn bump(inout x: i64) { x = x + 1; }
+fn f(v: i64) -> i64 {
+    let mut i: i64 = 0;
+    while i < 3 {
+        bump(inout v);
+        i = i + 1;
+    }
+    v
+}
+fn main() -> i32 { @intCast(f(5)) }
+""" }]
+stdout = ""
+exit_code = 8
+
+[[case]]
+name = "inout_param_arg_in_branch_reread"
+differential_opt = true
+description = "The call sits in one arm of an `if` and the read is after the join, so the taken arm reports 6 and the untaken one reports 5."
+files = [{ path = "main.rue", source = """
+fn bump(inout x: i64) { x = x + 1; }
+fn f(v: i64, c: bool) -> i64 {
+    if c { bump(inout v); }
+    v
+}
+fn main() -> i32 {
+    @dbg(f(5, true));
+    @dbg(f(5, false));
+    0
+}
+""" }]
+stdout = """
+6
+5
+"""
+exit_code = 0
+
+[[case]]
+name = "inout_param_arg_passed_twice_reread"
+differential_opt = true
+description = "Two by-ref passes of the same parameter: the second call's argument reads the first call's write, and so does the final read."
+files = [{ path = "main.rue", source = """
+fn bump(inout x: i64) { x = x + 1; }
+fn f(v: i64) -> i64 { bump(inout v); bump(inout v); v }
+fn main() -> i32 { @intCast(f(5)) }
+""" }]
+stdout = ""
+exit_code = 7
+
+[[case]]
+name = "inout_param_arg_subword_and_float_scalars"
+differential_opt = true
+description = "The rule is per ABI slot, not per width: `u8`, `bool`, and `f64` parameters passed `inout` all re-read the callee's write."
+files = [{ path = "main.rue", source = """
+fn bump8(inout x: u8) { x = x + 1; }
+fn flip(inout b: bool) { b = !b; }
+fn bumpf(inout x: f64) { x = x + 1.0; }
+fn u8_case(v: u8) -> u8 { bump8(inout v); v }
+fn bool_case(v: bool) -> bool { flip(inout v); v }
+fn f64_case(v: f64) -> f64 { bumpf(inout v); v }
+fn main() -> i32 {
+    @dbg(u8_case(5));
+    @dbg(bool_case(false));
+    @dbg(f64_case(5.0));
+    0
+}
+""" }]
+stdout = """
+6
+true
+6.0
+"""
+exit_code = 0
+
+[[case]]
+name = "inout_local_arg_reread_control"
+differential_opt = true
+description = "Control: the same callee on a LOCAL root, which reads through a `Load` rather than a parameter read and was always correct."
+files = [{ path = "main.rue", source = """
+fn bump(inout x: i64) { x = x + 1; }
+fn f(v: i64) -> i64 {
+    let mut l = v;
+    bump(inout l);
+    l
+}
+fn main() -> i32 { @intCast(f(5)) }
+""" }]
+stdout = ""
+exit_code = 6
+
+[[case]]
+name = "inout_aggregate_param_arg_reread_control"
+differential_opt = true
+description = "Control: a multi-slot aggregate parameter passed `inout` reads through a projection rather than a whole-slot parameter read, and was always correct."
+files = [{ path = "main.rue", source = """
+struct P { a: i64, b: i64 }
+fn poke(inout p: P) { p.a = 9; }
+fn f(v: P) -> i64 { poke(inout v); v.a }
+fn main() -> i32 { @intCast(f(P { a: 1, b: 2 })) }
+""" }]
+stdout = ""
+exit_code = 9

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -5143,18 +5143,19 @@ impl<'a> Interp<'a> {
             CfgInstData::PlaceRead { place } if self.is_inout_writeback_place(cfg, v, place) => {
                 Ok(WritebackPlace::Stored(place))
             }
-            // Forwarding a writable `inout` parameter as a nested call's `inout`
-            // argument (the container `self`-chain: `push` -> `self.reserve()`).
-            // The caller place is the parameter slot itself; the post-call
-            // copy-out writes the callee's final value back into it, and this
-            // frame in turn copies its own parameter back to *its* caller on
-            // return, so the mutation threads all the way up the chain.
-            // `place_write` routes a `Param` base through the promoted heap
-            // allocation when the slot's address was taken, matching the `Param`
-            // read path, so an address-taken forwarded parameter stays coherent.
-            CfgInstData::Param { index }
-                if *index < cfg.num_params() && cfg.is_param_writable(*index) =>
-            {
+            // A parameter passed as a nested call's `inout` argument. The caller
+            // place is the parameter slot itself, whatever the parameter's own
+            // mode: a by-value parameter is this frame's own mutable storage,
+            // and a forwarded writable `inout` parameter (the container
+            // `self`-chain: `push` -> `self.reserve()`) additionally copies
+            // back to *its* caller on return, so the mutation threads all the
+            // way up the chain. The post-call copy-out writes the callee's
+            // final value into the slot either way, and every later `Param`
+            // read of that slot observes it (RUE-2042). `place_write` routes a
+            // `Param` base through the promoted heap allocation when the
+            // slot's address was taken, matching the `Param` read path, so an
+            // address-taken parameter stays coherent.
+            CfgInstData::Param { index } if *index < cfg.num_params() => {
                 Ok(WritebackPlace::Simple {
                     base: PlaceBase::Param(*index),
                     base_type: cfg.get_inst(v).ty,

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -187,10 +187,21 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
         small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
-    let inout = expect_flow_unsupported(ordinary_interp.lvalue_of(ordinary_cfg, ordinary_param));
-    assert_eq!(
-        inout.kind(),
-        UnsupportedKind::ContractViolation(ContractViolationKind::InoutArgumentNotLvalue)
+    // A by-value parameter is the frame's own mutable storage, so passing it
+    // `inout` to a nested call is an ordinary write-back to its slot
+    // (RUE-2042); only a projection of one, above, is not caller-writable.
+    let Ok(inout) = ordinary_interp.lvalue_of(ordinary_cfg, ordinary_param) else {
+        panic!("a by-value parameter slot is an inout lvalue");
+    };
+    assert!(
+        matches!(
+            inout,
+            WritebackPlace::Simple {
+                base: PlaceBase::Param(0),
+                ..
+            }
+        ),
+        "the write-back place is the parameter slot itself"
     );
 }
 

--- a/crates/rue-planted-miscompiles/patches/RUE-914.patch
+++ b/crates/rue-planted-miscompiles/patches/RUE-914.patch
@@ -1,18 +1,12 @@
-diff --git a/crates/rue-cfg/src/opt/cse.rs b/crates/rue-cfg/src/opt/cse.rs
---- a/crates/rue-cfg/src/opt/cse.rs
-+++ b/crates/rue-cfg/src/opt/cse.rs
-@@ -207,13 +207,13 @@ fn never_written_params(cfg: &Cfg) -> Vec<bool> {
+diff --git a/crates/rue-cfg/src/opt/slot_facts.rs b/crates/rue-cfg/src/opt/slot_facts.rs
+--- a/crates/rue-cfg/src/opt/slot_facts.rs
++++ b/crates/rue-cfg/src/opt/slot_facts.rs
+@@ -421,7 +421,7 @@ pub(super) fn classify_slot_writes(cfg: &Cfg, reachable: Option<&BitSet>) -> Vec
+ pub(super) fn classify_never_written_params(cfg: &Cfg) -> Vec<bool> {
      let num_params = cfg.num_params() as usize;
-     let mut never_written = vec![false; num_params];
-     for (slot, flag) in never_written.iter_mut().enumerate() {
-         // A parameter whose ADDRESS escapes through @raw/@raw_mut/@field_ptr
-         // is mutable through the raw pointer (@ptr_write), so its reads are
-         // NOT interchangeable even though nothing writes it directly — keying
-         // such reads merged a post-write read into the stale pre-write value
-         // (found by the 2026-07-16 optimizer hunt).
--        *flag = !cfg.is_param_writable(slot as u32) && !cfg.is_param_address_taken(slot as u32);
-+        *flag = !cfg.is_param_writable(slot as u32);
-     }
-
-     for block in cfg.blocks() {
-         for &value in &block.insts {
+     let mut never_written: Vec<bool> = (0..num_params as u32)
+-        .map(|slot| !cfg.is_param_writable(slot) && !cfg.is_param_address_taken(slot))
++        .map(|slot| !cfg.is_param_writable(slot))
+         .collect();
+ 
+     // Out-of-range slots are skipped rather than panicking, matching

--- a/scripts/planted-miscompile-study.py
+++ b/scripts/planted-miscompile-study.py
@@ -24,12 +24,12 @@ from typing import Dict, List, Optional, Tuple
 DEFECTS = ("RUE-348", "RUE-914", "RUE-1758")
 PATCH_TARGETS = {
     "RUE-348": "crates/rue-cfg/src/opt/constfold.rs",
-    "RUE-914": "crates/rue-cfg/src/opt/cse.rs",
+    "RUE-914": "crates/rue-cfg/src/opt/slot_facts.rs",
     "RUE-1758": "crates/rue-codegen/src/terminator_plan.rs",
 }
 PATCH_PREIMAGE_SHA256 = {
     "RUE-348": "1d5d9990b397c5ff39c95178dbb8f24a7e82fd303aa934d466d331b98c1e6b26",
-    "RUE-914": "cc00b46e5840e02b80095ae9e121a39ab66bcf6b25d17e9bc37d7fe996b72fb1",
+    "RUE-914": "4d93001c85ae13ef69ae9b008097737dde497310d0c5a7a4895df1c932350efc",
     "RUE-1758": "a093afb95a27540ca01a3aabd20b721b1b8bdb4e60a464942a4c717b7f0a03d5",
 }
 FOCUSED_CLI = {


### PR DESCRIPTION
Fixes RUE-2042

At -O2 and above, a scalar by-value parameter passed `inout` (or `borrow`, since the frontend allows `@raw_mut` on a borrow parameter) read its pre-call value afterwards: `fn f(v: i64) -> i64 { bump(inout v); v }` returned 5 instead of 6. `std.mem.replace` written as `swap(T, inout v, inout dst); v` returned the new value and double-freed, which is how this was found.

## Root cause

CFG construction materializes every parameter use as a fresh `Param` re-read, and RUE-914 taught CSE to dedupe those by slot behind a private `never_written_params` scan. That scan knew about writable and address-taken parameters, `ParamStore`, and rooted `PlaceWrite`, but not about a `Call`/`AccessorCall` argument passed by reference, so the post-call read was numbered equal to the pre-call one and folded away. The local-slot classifier in `slot_facts` has always treated a by-ref call argument as a write; the parameter side was the weaker analysis.

## Fix

The private scan is deleted. `slot_facts::classify_never_written_params` sits beside `classify_slot_writes` and applies the same channels to parameter slots: a by-ref argument rooted at `Param` or `PlaceRead { base: Param }` marks the slot written; an unresolvable by-ref root disqualifies every parameter (deliberately stricter than the local classifier, documented). Both CSE run sites are covered: pre-inlining sees the call; post-inlining sees the callee's write as a `ParamStore` in the caller. Target-independent; both backends now reload the parameter's home slot after the call (verified in emitted asm for x86-64-linux and aarch64-linux).

Treating `borrow` as a write costs some dedupe across read-only `borrow` calls when the callee is not inlined; that is forced by sema accepting `@raw_mut` on a `borrow` parameter and is tracked as RUE-2047 (needs a maintainer call).

## Coverage

Nine `differential_opt = true` cases in `byref_params.toml` (plain inout, raw-pointer write, borrow, loop, branch, passed twice, sub-word and float scalars) plus two controls; six fail on trunk. Two CSE unit tests pin the pass-level rule in both directions.

## Verified

rue-cfg unit tests 422/422, `scripts/rue cli byref_params` 45/45, full `scripts/rue cli` 2604/2604, `scripts/rue quick` green, `//examples:cli-staged-programs` builds, rustfmt clean. Adversarially reviewed: the reviewer enumerated every CFG write channel and both pass orderings, ran fourteen probes against the pre-fix and fixed binaries, and found no divergence; the one should-fix (a stale comment) is applied.

Local oracle-diff is host-blocked (RUE-2043); CI's corpus gate is the authority for the new cases.
