### PR TITLE
RUE-2033: report signature placements with --emit abi

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -134,7 +134,7 @@ pub use sema::{
     SemanticProducedAnonymousMethodType, SemanticProducedAnonymousNominal,
     SemanticProducedAnonymousNominalShape, SourceParamAbi, analyze_provider_anonymous_body,
     analyze_provider_ordinary_body, analyze_provider_specialized_body, body_parameter_types,
-    comptime_depth_over_limit, next_comptime_depth,
+    by_reference_parameter_pointee_types, comptime_depth_over_limit, next_comptime_depth,
 };
 pub use sema::{
     ComptimeDiagnosticSite, ComptimeIntegerOperation, ComptimeMatchPattern,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -105,7 +105,7 @@ pub use output::{
     DeclarationTypeDependencyTargetKind, ImplicitDropDependencySourceEvent,
     ImplicitNamedDestructorDependencyEvent, NamedConstDependencyEvent,
     NamedConstDependencyTargetEvent, NativeArgClass, ParamSlotModes, SourceParamAbi,
-    body_parameter_types,
+    body_parameter_types, by_reference_parameter_pointee_types,
 };
 pub use provider::{
     BodyFactProvider, DropCopyMetadata, ImportResolution, MemberCandidate, MemberKind,

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -302,6 +302,30 @@ pub fn body_parameter_types(air: &crate::Air) -> ahash::AHashMap<u32, crate::Typ
     types
 }
 
+/// The pointee type of every `borrow` / `inout` parameter the body reaches,
+/// keyed by the parameter's ABI slot.
+///
+/// A by-reference parameter has no `Param` instruction and no drop entry — its
+/// slot carries the caller's pointer, and every use goes through a place whose
+/// base is that slot — so [`body_parameter_types`] deliberately does not see
+/// it. The place's own [`AirPlace::base_type`](crate::AirPlace) is the pointee
+/// type, recorded because a physical slot index does not identify it.
+///
+/// This is a *presentation* recovery, not an ABI input: a by-reference
+/// parameter crosses as one pointer whatever it points at, so nothing in
+/// classification, layout, or code generation consults this. `--emit abi` reads
+/// it to name the type beside a placement. A parameter the body never reads
+/// through a place has no entry, and the report says so.
+pub fn by_reference_parameter_pointee_types(air: &crate::Air) -> ahash::AHashMap<u32, crate::Type> {
+    let mut types: ahash::AHashMap<u32, crate::Type> = ahash::AHashMap::new();
+    for place in air.places() {
+        if let crate::AirPlaceBase::Param(slot) = place.base {
+            types.entry(slot).or_insert(place.base_type);
+        }
+    }
+    types
+}
+
 impl SourceParamAbi {
     /// Whether this parameter is a by-value aggregate the classifier forced
     /// indirect: it reserves `slot_count` frame slots but arrives as one pointer

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -365,3 +365,92 @@ fn main() -> i32 {
 args = ["--target", "aarch64-macos", "--emit", "air", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["enum_variant #", "::1"]
+
+# RUE-2033: `--emit abi` reports where every value of every reachable signature
+# travels. An FFI-safety failure is the one thing it cannot report *beside* a
+# function: the predicate rejects the `extern` signature while that signature is
+# resolved, before any body is analyzed, so there is no function to describe and
+# the driver's ordinary error path runs instead. The diagnostic still carries
+# the FfiPredicateFailure data — the failing field path and the reject reason —
+# which is what makes the question answerable without the stage.
+[[case]]
+name = "emit_abi_ffi_predicate_failure_takes_the_error_path"
+description = "RUE-2033: an extern signature naming an FFI-ineligible type fails before signatures exist, so --emit abi reports the predicate failure and prints no report."
+files = [{ path = "main.rue", source = """
+struct Plain {
+    a: i64,
+}
+
+@repr(c)
+struct Holder {
+    inner: Plain,
+}
+
+extern "C" {
+    fn take(h: Holder) -> i64;
+}
+
+fn main() -> i32 {
+    let h = Holder { inner: Plain { a: 1 } };
+    let r = checked { take(h) };
+    let code: i32 = @intCast(r);
+    code
+}
+""" }]
+args = ["--emit", "abi", "--preview", "c_ffi", "main.rue"]
+compile_fail = true
+error_contains = [
+    "E1104",
+    "`Holder` is not FFI-eligible",
+    "field `inner` of type `Plain`",
+    "a nested aggregate must itself be marked `@repr(c)`",
+]
+compile_stdout_not_contains = ["=== ABI", "import take"]
+
+# RUE-2033: the stage is target-driven like the other backend emits, so the
+# Darwin row's placements are readable on any host. The `i8` behind eight
+# register-width arguments is that row's visible amendment: one byte at its
+# natural alignment rather than a whole eightbyte.
+[[case]]
+name = "emit_abi_honors_the_requested_target"
+description = "RUE-2033: --emit abi --target aarch64-macos prints the Darwin row's placements on any host."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn wide(
+        a: i64,
+        b: i64,
+        c: i64,
+        d: i64,
+        e: i64,
+        f: i64,
+        g: i64,
+        h: i64,
+        tail: i8,
+    ) -> i64;
+}
+
+fn main() -> i32 {
+    let total = checked { wide(1, 2, 3, 4, 5, 6, 7, 8, 9) };
+    let code: i32 = @intCast(total);
+    code
+}
+""" }]
+args = ["--emit", "abi", "--preview", "c_ffi", "--target", "aarch64-macos", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "=== ABI (aarch64-macos) ===",
+    "import wide",
+    "convention aarch64-aapcs-darwin, symbol wide",
+    "parameter 7: i64, by value, gp register 7 (x7)",
+    "parameter 8: i8, by value, stack +0 (1 byte, align 1), sign-extended from 8 bits",
+]
+
+# The `--emit` help text renders the stage table, so this is what makes a stage
+# that exists but is undocumented impossible.
+[[case]]
+name = "emit_abi_is_listed_in_the_help_text"
+description = "RUE-2033: `abi` appears in the --emit stage list the help text renders."
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+args = ["--help"]
+compile_only = true
+compile_stdout_contains = ["--emit <stage>", "regalloc, asm, stackframe, abi, deps"]

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -39,6 +39,33 @@ use crate::MachineCode;
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation};
 
+/// Physical names of the general-purpose argument roster, in roster order.
+///
+/// The ABI report (`--emit abi`) asks the backend for the name of a roster
+/// index instead of restating a roster of its own, so renaming or reordering
+/// [`cfg_lower::ARG_REGS`] moves the report with it. AAPCS64's own argument
+/// registers are these eight.
+pub(crate) const GP_ARGUMENT_REGISTER_NAMES: [&str; 8] =
+    crate::roster_names!(cfg_lower::ARG_REGS; 0 1 2 3 4 5 6 7);
+
+/// Physical names of the floating-point argument roster, in roster order.
+pub(crate) const FP_ARGUMENT_REGISTER_NAMES: [&str; 8] =
+    crate::roster_names!(cfg_lower::FP_ARG_REGS; 0 1 2 3 4 5 6 7);
+
+/// Physical names of the general-purpose return roster, in roster order.
+/// AAPCS64's own result registers are its first two, `x0:x1`.
+pub(crate) const GP_RETURN_REGISTER_NAMES: [&str; 8] =
+    crate::roster_names!(cfg_lower::RET_REGS; 0 1 2 3 4 5 6 7);
+
+/// Physical names of the floating-point return roster, in roster order.
+pub(crate) const FP_RETURN_REGISTER_NAMES: [&str; 8] =
+    crate::roster_names!(cfg_lower::FP_RET_REGS; 0 1 2 3 4 5 6 7);
+
+/// AAPCS64 section 6.9 carries the hidden indirect-result pointer in `x8`, a
+/// register outside the ordinary argument roster, so user arguments still start
+/// at roster index 0. The export thunk names the same register physically.
+pub(crate) const DEDICATED_SRET_REGISTER_NAME: &str = "x8";
+
 struct Aarch64CodegenBackend;
 
 pub(crate) fn prepare_backend(

--- a/crates/rue-codegen/src/abi_report.rs
+++ b/crates/rue-codegen/src/abi_report.rs
@@ -1,0 +1,1289 @@
+//! The `--emit abi` report: where every value of every reachable function's
+//! signature actually travels (RUE-2033).
+//!
+//! ## One source of truth
+//!
+//! This module classifies nothing. It projects the artifacts code generation
+//! already consumes onto text:
+//!
+//! * a C boundary — a reached `extern "C"` import call and the C entry of a
+//!   `pub extern "C" fn` export — reads [`rue_air::lower_c_signature`]'s
+//!   [`LoweredSignature`], the one placement function every C crossing site
+//!   consumes, through the very same projections the import lowering
+//!   ([`crate::foreign_call::ForeignCallInputs`]) and the export thunk
+//!   ([`crate::export_thunk::ExportSignature`]) build;
+//! * the native Rue convention reads [`rue_air::NativeCallAbi`] through
+//!   [`return_plan`] for the classification and [`assign_abi_slots`] /
+//!   [`crate::call_plan::return_slot_regs`] for the physical slot plan, over the
+//!   same class vector the callee's parameter storage plan builds.
+//!
+//! Physical register *names* stay in the two backends: this module asks
+//! [`TargetRegisters`] for the name of a roster index and never restates a
+//! roster, so a backend that renames or reorders a roster changes the report
+//! with it.
+//!
+//! ## What the report cannot show
+//!
+//! An `extern` or export signature naming a type that fails an FFI predicate
+//! ([`rue_air::FfiPredicateFailure`]) is rejected while its *signature* is
+//! resolved — before any body is analyzed, and therefore before this report has
+//! a function to describe. Such a program produces no ABI report at all:
+//! `--emit abi` takes the driver's ordinary error path and prints the
+//! diagnostic, which the `emit_abi_ffi_predicate_failure_takes_the_error_path`
+//! CLI case pins.
+//!
+//! ## Structure
+//!
+//! [`AbiFunctionReport`] and the placement types are data; [`std::fmt::Display`]
+//! is one projection of that data. A machine-readable projection would be
+//! another projection of the same values, not a second walk of the artifacts.
+
+use lasso::ThreadedRodeo;
+use rue_air::{
+    ArgLocation, FrozenTypeInternPool, LoweredReturn, LoweredSignature, PointerLocation,
+    ScalarAbiExtension, SourceParamAbi, Type, ValidatedAir, native_return_register_budget,
+};
+use rue_cfg::{CfgInstData, CfgValue, ValidatedCfg};
+use rue_target::{Arch, CRegisterClass, CallingConvention, SretRegisterKind, Target};
+
+use crate::call_plan::{
+    AbiRegisterBanks, AbiSlotClass, AbiSlotLocation, ReturnPlan, ReturnSlotReg, assign_abi_slots,
+    return_plan, return_slot_regs,
+};
+
+// ============================================================================
+// Register naming
+// ============================================================================
+
+/// The physical register rosters of one target, as the backend that owns them
+/// names them.
+///
+/// Both rosters are the *native* Rue convention's, and both C rows reuse them:
+/// a platform argument register is this argument roster's entry (`rdi..r9`,
+/// `x0..x7`) and a platform result register is this return roster's (`rax, rdx`
+/// on SysV; `x0, x1` on AAPCS64). How many of each a convention may use comes
+/// from [`rue_target::CConventionSpec`], never from these lengths, so this type
+/// answers only "what is register `n` of bank `c` called".
+#[derive(Debug, Clone, Copy)]
+pub struct TargetRegisters {
+    arch: Arch,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RegisterRole {
+    Argument,
+    Result,
+}
+
+impl TargetRegisters {
+    /// The rosters of `target`'s architecture.
+    pub fn new(target: Target) -> Self {
+        Self {
+            arch: target.arch(),
+        }
+    }
+
+    fn roster(self, role: RegisterRole, class: CRegisterClass) -> &'static [&'static str] {
+        match (self.arch, role, class) {
+            (Arch::X86_64, RegisterRole::Argument, CRegisterClass::Gp) => {
+                &crate::x86_64::GP_ARGUMENT_REGISTER_NAMES
+            }
+            (Arch::X86_64, RegisterRole::Argument, CRegisterClass::Fp) => {
+                &crate::x86_64::FP_ARGUMENT_REGISTER_NAMES
+            }
+            (Arch::X86_64, RegisterRole::Result, CRegisterClass::Gp) => {
+                &crate::x86_64::GP_RETURN_REGISTER_NAMES
+            }
+            (Arch::X86_64, RegisterRole::Result, CRegisterClass::Fp) => {
+                &crate::x86_64::FP_RETURN_REGISTER_NAMES
+            }
+            (Arch::Aarch64, RegisterRole::Argument, CRegisterClass::Gp) => {
+                &crate::aarch64::GP_ARGUMENT_REGISTER_NAMES
+            }
+            (Arch::Aarch64, RegisterRole::Argument, CRegisterClass::Fp) => {
+                &crate::aarch64::FP_ARGUMENT_REGISTER_NAMES
+            }
+            (Arch::Aarch64, RegisterRole::Result, CRegisterClass::Gp) => {
+                &crate::aarch64::GP_RETURN_REGISTER_NAMES
+            }
+            (Arch::Aarch64, RegisterRole::Result, CRegisterClass::Fp) => {
+                &crate::aarch64::FP_RETURN_REGISTER_NAMES
+            }
+        }
+    }
+
+    /// The name of argument register `index` of `class`. `?` when the index is
+    /// past the roster, which no placement produces.
+    pub fn argument(self, class: CRegisterClass, index: u32) -> &'static str {
+        self.roster(RegisterRole::Argument, class)
+            .get(index as usize)
+            .copied()
+            .unwrap_or("?")
+    }
+
+    /// The name of result register `index` of `class`.
+    pub fn result(self, class: CRegisterClass, index: u32) -> &'static str {
+        self.roster(RegisterRole::Result, class)
+            .get(index as usize)
+            .copied()
+            .unwrap_or("?")
+    }
+
+    /// The register carrying the hidden indirect-result pointer under a
+    /// convention that dedicates one outside the argument roster (AAPCS64's
+    /// `x8`, section 6.9).
+    pub fn dedicated_sret(self) -> &'static str {
+        match self.arch {
+            Arch::X86_64 => crate::x86_64::DEDICATED_SRET_REGISTER_NAME,
+            Arch::Aarch64 => crate::aarch64::DEDICATED_SRET_REGISTER_NAME,
+        }
+    }
+
+    fn argument_banks(self) -> AbiRegisterBanks {
+        AbiRegisterBanks {
+            gp: self
+                .roster(RegisterRole::Argument, CRegisterClass::Gp)
+                .len(),
+            fp: self
+                .roster(RegisterRole::Argument, CRegisterClass::Fp)
+                .len(),
+        }
+    }
+
+    fn return_banks(self) -> AbiRegisterBanks {
+        AbiRegisterBanks {
+            gp: self.roster(RegisterRole::Result, CRegisterClass::Gp).len(),
+            fp: self.roster(RegisterRole::Result, CRegisterClass::Fp).len(),
+        }
+    }
+}
+
+// ============================================================================
+// Report data
+// ============================================================================
+
+/// How a source parameter is presented before ABI classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbiParameterMode {
+    /// A normal by-value parameter.
+    ByValue,
+    /// A `borrow` parameter: one read-only caller pointer.
+    Borrow,
+    /// An `inout` parameter: one writable caller pointer.
+    Inout,
+}
+
+impl AbiParameterMode {
+    /// The source spelling of this mode.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::ByValue => "by value",
+            Self::Borrow => "borrow",
+            Self::Inout => "inout",
+        }
+    }
+}
+
+/// Where one value of a C signature travels, as
+/// [`rue_air::lower_c_signature`] placed it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CPlacement {
+    /// No register, no stack byte, no pointer.
+    Omitted,
+    /// `count` consecutive registers of `class` from roster index `first`.
+    Registers {
+        class: CRegisterClass,
+        first: u32,
+        count: u32,
+    },
+    /// By value in the outgoing argument area.
+    Stack { offset: u32, size: u32, align: u32 },
+    /// By pointer to a caller-owned copy.
+    Indirect {
+        pointer: PointerLocation,
+        size: u32,
+        align: u32,
+    },
+    /// In result registers.
+    Result { class: CRegisterClass, count: u32 },
+    /// Through caller storage whose address crosses as a hidden argument.
+    Sret {
+        register: SretRegisterKind,
+        echoed: bool,
+        size: u32,
+        align: u32,
+    },
+    /// No value crosses back.
+    Void,
+}
+
+impl From<ArgLocation> for CPlacement {
+    fn from(location: ArgLocation) -> Self {
+        match location {
+            ArgLocation::Omitted => Self::Omitted,
+            ArgLocation::Registers {
+                class,
+                first_index,
+                count,
+            } => Self::Registers {
+                class,
+                first: first_index,
+                count,
+            },
+            ArgLocation::Stack {
+                offset,
+                size,
+                align,
+            } => Self::Stack {
+                offset,
+                size,
+                align,
+            },
+            ArgLocation::Indirect {
+                pointer,
+                size,
+                align,
+            } => Self::Indirect {
+                pointer,
+                size,
+                align,
+            },
+        }
+    }
+}
+
+impl From<LoweredReturn> for CPlacement {
+    fn from(ret: LoweredReturn) -> Self {
+        match ret {
+            LoweredReturn::Void => Self::Void,
+            LoweredReturn::Registers { class, count, .. } => Self::Result { class, count },
+            LoweredReturn::Sret {
+                register,
+                echoed,
+                size,
+                align,
+            } => Self::Sret {
+                register,
+                echoed,
+                size,
+                align,
+            },
+        }
+    }
+}
+
+/// One flattened native ABI slot's physical position, and which logical slot of
+/// its value rides there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NativeSlot {
+    /// The value's own logical slot index. The native convention reverses a
+    /// multi-slot by-value aggregate, so this descends across such a
+    /// parameter's positions.
+    pub logical: u32,
+    /// The position the shared slot assignment gave it.
+    pub location: AbiSlotLocation,
+}
+
+/// Where one value of the native Rue convention travels.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativePlacement {
+    /// No slot at all (a zero-sized result).
+    None,
+    /// The value's flattened slots, in ABI order.
+    Slots {
+        slots: Vec<NativeSlot>,
+        /// Whether the slots cross in reverse logical order, which the native
+        /// convention does for every multi-slot by-value aggregate.
+        reversed: bool,
+    },
+    /// One pointer slot standing for caller storage: a `borrow` / `inout`
+    /// parameter, or a by-value aggregate the compact layout forces indirect.
+    Pointer {
+        location: AbiSlotLocation,
+        /// How many of the callee's parameter slots the pointed-at value
+        /// occupies, for the by-value indirect case where the classifier
+        /// collapsed a wider value onto one incoming register. `None` for a
+        /// by-reference parameter, whose single slot holds only the pointer and
+        /// says nothing about the pointee.
+        pointee_slots: Option<u32>,
+    },
+    /// The result is written to caller storage whose address is the hidden
+    /// first ABI slot.
+    Sret {
+        location: AbiSlotLocation,
+        slot_count: u32,
+        storage_bytes: u32,
+    },
+    /// The result comes back one logical slot per return register.
+    ReturnRegisters {
+        /// One `(bank, roster index)` per logical slot, in logical order.
+        slots: Vec<(CRegisterClass, u32)>,
+    },
+}
+
+/// A placement under whichever convention the enclosing side follows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AbiPlacement {
+    C(CPlacement),
+    Native(NativePlacement),
+}
+
+/// One parameter of one side of one function's signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbiParameter {
+    /// Source position, counting from zero.
+    pub index: u32,
+    /// Structural spelling of the parameter's type
+    /// ([`rue_air::drop_glue_names::type_name`]), or `?` when the analyzed body
+    /// recovered no type for it.
+    pub ty: String,
+    pub mode: AbiParameterMode,
+    pub placement: AbiPlacement,
+    /// The extension a narrow integer carries at a C boundary.
+    pub extension: ScalarAbiExtension,
+}
+
+/// One signature's result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbiReturn {
+    pub ty: String,
+    pub placement: AbiPlacement,
+    pub extension: ScalarAbiExtension,
+}
+
+/// One side of one function's ABI: a convention and the placements it fixes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbiSide {
+    pub convention: CallingConvention,
+    /// The machine symbol this side is entered through, when it has one.
+    pub symbol: Option<String>,
+    pub parameters: Vec<AbiParameter>,
+    pub ret: AbiReturn,
+    /// Bytes the caller reserves for the outgoing argument area. Present for a
+    /// C side, whose convention measures the area in bytes.
+    pub stack_bytes: Option<u32>,
+}
+
+/// What kind of boundary a report block describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbiFunctionKind {
+    /// An ordinary Rue function, method, or reached generic instance.
+    Function,
+    /// A reached `extern "C"` import: a C side only, since Rue compiles no body
+    /// for it.
+    Import,
+    /// A `pub extern "C" fn` export: the C entry thunk and the native body it
+    /// forwards to.
+    Export,
+}
+
+impl AbiFunctionKind {
+    const fn keyword(self) -> &'static str {
+        match self {
+            Self::Function => "function",
+            Self::Import => "import",
+            Self::Export => "export",
+        }
+    }
+}
+
+/// One function's block of the report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbiFunctionReport {
+    /// The name the block is headed by: the source name of a native function,
+    /// the unmangled C symbol of an import or export.
+    pub name: String,
+    pub kind: AbiFunctionKind,
+    /// The C side, present for an import and an export.
+    pub c: Option<AbiSide>,
+    /// The native side, present for a function and an export.
+    pub native: Option<AbiSide>,
+    /// The target whose rosters name the registers.
+    pub target: Target,
+}
+
+// ============================================================================
+// Projection: the native Rue convention
+// ============================================================================
+
+fn type_text(type_pool: &FrozenTypeInternPool, ty: Option<Type>) -> String {
+    match ty {
+        Some(ty) => rue_air::drop_glue_names::type_name(ty, type_pool),
+        None => "?".to_owned(),
+    }
+}
+
+/// The parameter grouping this report walks.
+///
+/// Real compilation always carries the classifier's own [`SourceParamAbi`]
+/// descriptors. A directly constructed CFG (synthetic backend tests) carries
+/// none, and code generation then homes one incoming register per parameter
+/// slot. The report takes the same fallback under the same condition
+/// `crate::param_storage::ParamStoragePlan::plan` does — no descriptors, or
+/// descriptors that do not tile the parameter area exactly — so it describes
+/// the prologue that will actually be emitted rather than metadata code
+/// generation is about to ignore.
+fn parameter_descriptors(cfg: &ValidatedCfg) -> Vec<SourceParamAbi> {
+    let descriptors = cfg.source_param_abi();
+    let tiles = !descriptors.is_empty()
+        && descriptors.iter().map(|d| d.slot_count).sum::<u32>() == cfg.num_params()
+        && descriptors.first().is_some_and(|d| d.start_slot == 0)
+        && descriptors
+            .iter()
+            .zip(descriptors.iter().skip(1))
+            .all(|(a, b)| a.start_slot + a.slot_count == b.start_slot);
+    if tiles {
+        return descriptors.to_vec();
+    }
+    (0..cfg.num_params())
+        .map(|slot| SourceParamAbi {
+            start_slot: slot,
+            slot_count: 1,
+            crossing_regs: 1,
+            crossing_classes: vec![rue_air::NativeArgClass::Gp],
+            ty: None,
+        })
+        .collect()
+}
+
+fn parameter_mode(cfg: &ValidatedCfg, descriptor: &SourceParamAbi) -> AbiParameterMode {
+    let slot = descriptor.start_slot;
+    if !cfg
+        .param_modes()
+        .get(slot as usize)
+        .copied()
+        .unwrap_or(false)
+    {
+        return AbiParameterMode::ByValue;
+    }
+    if cfg.is_param_writable(slot) {
+        AbiParameterMode::Inout
+    } else {
+        AbiParameterMode::Borrow
+    }
+}
+
+/// Project one function's native ABI from its CFG.
+///
+/// The parameter grouping is the CFG's own [`SourceParamAbi`] descriptors — the
+/// classification semantic analysis recorded — and the physical positions come
+/// from [`assign_abi_slots`] over the same class vector
+/// `crate::param_storage::ParamStoragePlan` builds, so the report and the
+/// prologue read one assignment rather than two.
+fn native_side(
+    cfg: &ValidatedCfg,
+    air: &ValidatedAir,
+    symbol: Option<&str>,
+    type_pool: &FrozenTypeInternPool,
+    target: Target,
+) -> AbiSide {
+    let registers = TargetRegisters::new(target);
+    let return_type = cfg.return_type();
+    let plan = return_plan(
+        type_pool,
+        return_type,
+        native_return_register_budget(target.arch()),
+    );
+
+    let descriptors = parameter_descriptors(cfg);
+    let mut classes = Vec::new();
+    if plan.uses_sret() {
+        classes.push(AbiSlotClass::Gp);
+    }
+    for descriptor in &descriptors {
+        classes.extend(
+            descriptor
+                .crossing_classes
+                .iter()
+                .copied()
+                .map(AbiSlotClass::from),
+        );
+    }
+    let locations = assign_abi_slots(classes.iter().copied(), registers.argument_banks());
+
+    // Two recoveries, because a body records the two parameter kinds
+    // differently: a by-value parameter through its drop entry or `Param`
+    // instruction, a by-reference one only through the pointee type on the
+    // places that read it.
+    let value_types = rue_air::body_parameter_types(air);
+    let pointee_types = rue_air::by_reference_parameter_pointee_types(air);
+    let mut cursor = usize::from(plan.uses_sret());
+    let mut parameters = Vec::with_capacity(descriptors.len());
+    for (index, descriptor) in descriptors.iter().enumerate() {
+        let crossing = descriptor.crossing_regs as usize;
+        let positions = &locations[cursor..cursor + crossing];
+        cursor += crossing;
+        let mode = parameter_mode(cfg, descriptor);
+        let ty = descriptor.ty.or_else(|| {
+            let recovered = if mode == AbiParameterMode::ByValue {
+                &value_types
+            } else {
+                &pointee_types
+            };
+            recovered.get(&descriptor.start_slot).copied()
+        });
+        parameters.push(AbiParameter {
+            index: index as u32,
+            ty: type_text(type_pool, ty),
+            mode,
+            placement: AbiPlacement::Native(native_parameter_placement(
+                descriptor, mode, ty, type_pool, positions,
+            )),
+            extension: ScalarAbiExtension::None,
+        });
+    }
+
+    AbiSide {
+        convention: CallingConvention::Rue,
+        symbol: symbol.map(str::to_owned),
+        parameters,
+        ret: AbiReturn {
+            ty: type_text(type_pool, Some(return_type)),
+            placement: AbiPlacement::Native(native_return_placement(
+                plan,
+                type_pool,
+                return_type,
+                registers,
+                locations.first().copied(),
+            )),
+            extension: ScalarAbiExtension::None,
+        },
+        stack_bytes: None,
+    }
+}
+
+fn native_parameter_placement(
+    descriptor: &SourceParamAbi,
+    mode: AbiParameterMode,
+    ty: Option<Type>,
+    type_pool: &FrozenTypeInternPool,
+    positions: &[AbiSlotLocation],
+) -> NativePlacement {
+    // One incoming pointer standing for a wider value: a by-reference
+    // parameter, or a by-value aggregate the compact layout forced indirect
+    // (`crossing_regs < slot_count`).
+    if mode != AbiParameterMode::ByValue || descriptor.is_by_value_indirect() {
+        return match positions.first() {
+            Some(&location) => NativePlacement::Pointer {
+                location,
+                pointee_slots: descriptor
+                    .is_by_value_indirect()
+                    .then_some(descriptor.slot_count),
+            },
+            None => NativePlacement::None,
+        };
+    }
+    // The native convention reverses a multi-slot by-value aggregate's slots so
+    // the callee reconstructs the ascending frame layout (`CallPlan` reverses
+    // the materialized slots before assigning them), so ABI position `k` of
+    // such a parameter carries logical slot `count - 1 - k`.
+    let reversed = positions.len() > 1
+        && ty.is_some_and(|ty| crate::types::is_multislot_aggregate(type_pool, ty));
+    let slots = positions
+        .iter()
+        .enumerate()
+        .map(|(position, &location)| NativeSlot {
+            logical: if reversed {
+                positions.len() as u32 - 1 - position as u32
+            } else {
+                position as u32
+            },
+            location,
+        })
+        .collect();
+    NativePlacement::Slots { slots, reversed }
+}
+
+fn native_return_placement(
+    plan: ReturnPlan,
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+    registers: TargetRegisters,
+    hidden_slot: Option<AbiSlotLocation>,
+) -> NativePlacement {
+    match plan {
+        ReturnPlan::ZeroSized => NativePlacement::None,
+        ReturnPlan::Scalar => NativePlacement::ReturnRegisters {
+            slots: vec![(primary_return_class(type_pool, ty), 0)],
+        },
+        ReturnPlan::Registers { .. } => NativePlacement::ReturnRegisters {
+            slots: return_slot_regs(type_pool, ty, registers.return_banks())
+                .into_iter()
+                .map(|register| match register {
+                    ReturnSlotReg::Gp(index) => (CRegisterClass::Gp, index as u32),
+                    ReturnSlotReg::Fp { index, .. } => (CRegisterClass::Fp, index as u32),
+                })
+                .collect(),
+        },
+        ReturnPlan::Sret {
+            slot_count,
+            storage_bytes,
+        } => NativePlacement::Sret {
+            // The hidden pointer is ABI slot 0 by construction, so the first
+            // assigned location is its own.
+            location: hidden_slot.unwrap_or(AbiSlotLocation::GpReg(0)),
+            slot_count,
+            storage_bytes,
+        },
+    }
+}
+
+/// The bank the primary return register of a one-slot result belongs to: a
+/// float leaf comes back in the floating-point file, everything else in the
+/// general-purpose one — the same leaf rule [`AbiSlotClass::for_leaf`] applies
+/// to arguments.
+fn primary_return_class(type_pool: &FrozenTypeInternPool, ty: Type) -> CRegisterClass {
+    match crate::types::aggregate_leaf_types(type_pool, ty)
+        .first()
+        .copied()
+        .map(AbiSlotClass::for_leaf)
+    {
+        Some(AbiSlotClass::Fp(_)) => CRegisterClass::Fp,
+        _ => CRegisterClass::Gp,
+    }
+}
+
+// ============================================================================
+// Projection: a C boundary
+// ============================================================================
+
+/// Project one lowered C signature. `parameter_types` and `return_type` are the
+/// source spellings the block prints beside each placement; the placements
+/// themselves are `signature`'s alone.
+fn c_side(
+    signature: &LoweredSignature,
+    symbol: Option<&str>,
+    parameter_types: &[String],
+    return_type: String,
+) -> AbiSide {
+    let parameters = signature
+        .arguments()
+        .iter()
+        .enumerate()
+        .map(|(index, argument)| AbiParameter {
+            index: index as u32,
+            ty: parameter_types
+                .get(index)
+                .cloned()
+                .unwrap_or_else(|| "?".to_owned()),
+            // Semantic analysis rejects `borrow` / `inout` in an `extern "C"`
+            // signature, so every C parameter is by value.
+            mode: AbiParameterMode::ByValue,
+            placement: AbiPlacement::C(argument.location.into()),
+            extension: argument.extension,
+        })
+        .collect();
+    AbiSide {
+        convention: signature.convention(),
+        symbol: symbol.map(str::to_owned),
+        parameters,
+        ret: AbiReturn {
+            ty: return_type,
+            placement: AbiPlacement::C(signature.ret().into()),
+            extension: match signature.ret() {
+                LoweredReturn::Registers { extension, .. } => extension,
+                _ => ScalarAbiExtension::None,
+            },
+        },
+        stack_bytes: Some(signature.stack_bytes()),
+    }
+}
+
+// ============================================================================
+// Entry points
+// ============================================================================
+
+/// One reached Rue function, method, or generic instance.
+pub fn function_abi_report(
+    cfg: &ValidatedCfg,
+    air: &ValidatedAir,
+    source_name: &str,
+    symbol: &str,
+    type_pool: &FrozenTypeInternPool,
+    target: Target,
+) -> AbiFunctionReport {
+    AbiFunctionReport {
+        name: source_name.to_owned(),
+        kind: AbiFunctionKind::Function,
+        c: None,
+        native: Some(native_side(cfg, air, Some(symbol), type_pool, target)),
+        target,
+    }
+}
+
+/// One `pub extern "C" fn` export: the C entry the thunk implements, and the
+/// native body it forwards to.
+///
+/// `signature` is the very [`crate::export_thunk::ExportSignature`] the thunk
+/// generator consumes, so the C side printed here is the C side emitted.
+pub fn export_abi_report(
+    exported_symbol: &str,
+    native_symbol: &str,
+    signature: &crate::export_thunk::ExportSignature,
+    cfg: &ValidatedCfg,
+    air: &ValidatedAir,
+    type_pool: &FrozenTypeInternPool,
+    target: Target,
+) -> AbiFunctionReport {
+    let native = native_side(cfg, air, Some(native_symbol), type_pool, target);
+    let parameter_types = native
+        .parameters
+        .iter()
+        .map(|parameter| parameter.ty.clone())
+        .collect::<Vec<_>>();
+    let return_type = native.ret.ty.clone();
+    AbiFunctionReport {
+        name: exported_symbol.to_owned(),
+        kind: AbiFunctionKind::Export,
+        c: Some(c_side(
+            &signature.lowered(target),
+            Some(exported_symbol),
+            &parameter_types,
+            return_type,
+        )),
+        native: Some(native),
+        target,
+    }
+}
+
+/// Every `extern "C"` import one function reaches, in call order.
+///
+/// The signature comes from [`crate::foreign_call::ForeignCallInputs::from_cfg`]
+/// against the call site's own argument and result types — the same
+/// construction the import lowering performs — so an import's report is the
+/// placement its call sequence writes.
+pub fn import_abi_reports(
+    cfg: &ValidatedCfg,
+    interner: &ThreadedRodeo,
+    symbols: &crate::MachineSymbolResolver<'_>,
+    type_pool: &FrozenTypeInternPool,
+    target: Target,
+) -> Vec<AbiFunctionReport> {
+    let convention = target.c_calling_convention();
+    let mut reports = Vec::new();
+    for raw in 0..cfg.value_count() {
+        let value = CfgValue::from_raw(raw as u32);
+        let inst = cfg.get_inst(value);
+        let CfgInstData::Call { name, runtime, .. } = &inst.data else {
+            continue;
+        };
+        if runtime.is_some() {
+            continue;
+        }
+        let symbol = symbols.resolve(interner.resolve(name));
+        if !symbols.is_foreign(&symbol) {
+            continue;
+        }
+        let args = cfg.get_call_args(&inst.data);
+        let inputs = crate::foreign_call::ForeignCallInputs::from_cfg(
+            symbol.clone(),
+            cfg,
+            type_pool,
+            inst.ty,
+            args,
+            convention,
+        );
+        let parameter_types = args
+            .iter()
+            .map(|arg| type_text(type_pool, Some(cfg.get_inst(arg.value).ty)))
+            .collect::<Vec<_>>();
+        reports.push(AbiFunctionReport {
+            name: symbol.clone(),
+            kind: AbiFunctionKind::Import,
+            c: Some(c_side(
+                inputs.signature(),
+                Some(&symbol),
+                &parameter_types,
+                type_text(type_pool, Some(inst.ty)),
+            )),
+            native: None,
+            target,
+        });
+    }
+    reports
+}
+
+// ============================================================================
+// Text
+// ============================================================================
+
+fn extension_text(extension: ScalarAbiExtension) -> String {
+    match extension {
+        ScalarAbiExtension::None => String::new(),
+        ScalarAbiExtension::Signed { from_bits } => {
+            format!(", sign-extended from {from_bits} bits")
+        }
+        ScalarAbiExtension::Unsigned { from_bits } => {
+            format!(", zero-extended from {from_bits} bits")
+        }
+    }
+}
+
+const fn bank(class: CRegisterClass) -> &'static str {
+    match class {
+        CRegisterClass::Gp => "gp",
+        CRegisterClass::Fp => "fp",
+    }
+}
+
+fn register_run(
+    registers: TargetRegisters,
+    role: RegisterRole,
+    class: CRegisterClass,
+    first: u32,
+    count: u32,
+    noun: &str,
+) -> String {
+    let name = |index: u32| match role {
+        RegisterRole::Argument => registers.argument(class, index),
+        RegisterRole::Result => registers.result(class, index),
+    };
+    if count <= 1 {
+        return format!("{} {noun} {first} ({})", bank(class), name(first));
+    }
+    let names = (first..first + count)
+        .map(name)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "{} {noun}s {first}-{} ({names})",
+        bank(class),
+        first + count - 1
+    )
+}
+
+fn native_slot_text(registers: TargetRegisters, location: AbiSlotLocation) -> String {
+    match location {
+        AbiSlotLocation::GpReg(index) => register_run(
+            registers,
+            RegisterRole::Argument,
+            CRegisterClass::Gp,
+            index as u32,
+            1,
+            "register",
+        ),
+        AbiSlotLocation::FpReg(index) => register_run(
+            registers,
+            RegisterRole::Argument,
+            CRegisterClass::Fp,
+            index as u32,
+            1,
+            "register",
+        ),
+        AbiSlotLocation::Stack(index) => format!("stack slot {index}"),
+    }
+}
+
+/// Where an indirectly-passed argument's own pointer lives, with the
+/// preposition its position wants: a pointer travels *in* a register and sits
+/// *at* an offset in the outgoing argument area.
+fn c_pointer_text(registers: TargetRegisters, pointer: PointerLocation) -> String {
+    match pointer {
+        PointerLocation::Register { index } => format!(
+            "in {}",
+            register_run(
+                registers,
+                RegisterRole::Argument,
+                CRegisterClass::Gp,
+                index,
+                1,
+                "register",
+            )
+        ),
+        PointerLocation::Stack { offset } => format!("at stack +{offset}"),
+    }
+}
+
+/// `1 byte` / `N bytes`, so a one-byte Darwin stack slot does not read as
+/// `1 bytes`.
+fn bytes(count: u32) -> String {
+    counted(count, "byte")
+}
+
+/// `1 slot` / `N slots`.
+fn slots(count: u32) -> String {
+    counted(count, "slot")
+}
+
+fn counted(count: u32, noun: &str) -> String {
+    if count == 1 {
+        format!("1 {noun}")
+    } else {
+        format!("{count} {noun}s")
+    }
+}
+
+/// The one-line rendering of a placement, plus any continuation lines it needs.
+fn placement_text(registers: TargetRegisters, placement: &AbiPlacement) -> (String, Vec<String>) {
+    match placement {
+        AbiPlacement::C(placement) => (c_placement_text(registers, *placement), Vec::new()),
+        AbiPlacement::Native(placement) => native_placement_text(registers, placement),
+    }
+}
+
+fn c_placement_text(registers: TargetRegisters, placement: CPlacement) -> String {
+    match placement {
+        CPlacement::Omitted => "omitted (zero-sized)".to_owned(),
+        CPlacement::Registers {
+            class,
+            first,
+            count,
+        } => register_run(
+            registers,
+            RegisterRole::Argument,
+            class,
+            first,
+            count,
+            "register",
+        ),
+        CPlacement::Stack {
+            offset,
+            size,
+            align,
+        } => format!("stack +{offset} ({}, align {align})", bytes(size)),
+        CPlacement::Indirect {
+            pointer,
+            size,
+            align,
+        } => format!(
+            "indirect: pointer {} to {} (align {align})",
+            c_pointer_text(registers, pointer),
+            bytes(size)
+        ),
+        CPlacement::Result { class, count } => register_run(
+            registers,
+            RegisterRole::Result,
+            class,
+            0,
+            count,
+            "result register",
+        ),
+        CPlacement::Sret {
+            register,
+            echoed,
+            size,
+            align,
+        } => {
+            let pointer = match register {
+                SretRegisterKind::ArgumentRegister => {
+                    registers.argument(CRegisterClass::Gp, 0).to_owned()
+                }
+                SretRegisterKind::DedicatedRegister => registers.dedicated_sret().to_owned(),
+            };
+            let echo = if echoed {
+                format!(", echoed in {}", registers.result(CRegisterClass::Gp, 0))
+            } else {
+                String::new()
+            };
+            format!(
+                "sret: pointer in {pointer}{echo} ({}, align {align})",
+                bytes(size)
+            )
+        }
+        CPlacement::Void => "no value".to_owned(),
+    }
+}
+
+fn native_placement_text(
+    registers: TargetRegisters,
+    placement: &NativePlacement,
+) -> (String, Vec<String>) {
+    match placement {
+        NativePlacement::None => ("no value".to_owned(), Vec::new()),
+        NativePlacement::Slots {
+            slots: value_slots,
+            reversed,
+        } => match value_slots.as_slice() {
+            [] => ("omitted (no ABI slot)".to_owned(), Vec::new()),
+            [only] => (native_slot_text(registers, only.location), Vec::new()),
+            many => (
+                // Whether a multi-slot value crosses reversed is the native
+                // convention's least guessable rule, so it is stated either
+                // way rather than implied by its absence.
+                format!(
+                    "{}, {}",
+                    slots(many.len() as u32),
+                    if *reversed {
+                        "reversed"
+                    } else {
+                        "in logical order"
+                    }
+                ),
+                many.iter()
+                    .map(|slot| {
+                        format!(
+                            "slot {}: {}",
+                            slot.logical,
+                            native_slot_text(registers, slot.location)
+                        )
+                    })
+                    .collect(),
+            ),
+        },
+        NativePlacement::Pointer {
+            location,
+            pointee_slots,
+        } => (
+            match pointee_slots {
+                Some(count) => format!(
+                    "indirect: pointer in {} to {}",
+                    native_slot_text(registers, *location),
+                    slots(*count)
+                ),
+                None => format!(
+                    "indirect: pointer in {}",
+                    native_slot_text(registers, *location)
+                ),
+            },
+            Vec::new(),
+        ),
+        NativePlacement::Sret {
+            location,
+            slot_count,
+            storage_bytes,
+        } => (
+            format!(
+                "sret: pointer in {} to {} ({} of caller storage)",
+                native_slot_text(registers, *location),
+                slots(*slot_count),
+                bytes(*storage_bytes)
+            ),
+            Vec::new(),
+        ),
+        NativePlacement::ReturnRegisters {
+            slots: return_slots,
+        } => match return_slots.as_slice() {
+            [] => ("no value".to_owned(), Vec::new()),
+            [(class, index)] => (
+                register_run(
+                    registers,
+                    RegisterRole::Result,
+                    *class,
+                    *index,
+                    1,
+                    "return register",
+                ),
+                Vec::new(),
+            ),
+            many => (
+                slots(many.len() as u32),
+                many.iter()
+                    .enumerate()
+                    .map(|(logical, (class, index))| {
+                        format!(
+                            "slot {logical}: {}",
+                            register_run(
+                                registers,
+                                RegisterRole::Result,
+                                *class,
+                                *index,
+                                1,
+                                "return register",
+                            )
+                        )
+                    })
+                    .collect(),
+            ),
+        },
+    }
+}
+
+fn write_side(
+    f: &mut std::fmt::Formatter<'_>,
+    side: &AbiSide,
+    registers: TargetRegisters,
+    indent: &str,
+) -> std::fmt::Result {
+    match &side.symbol {
+        Some(symbol) => writeln!(f, "{indent}convention {}, symbol {symbol}", side.convention)?,
+        None => writeln!(f, "{indent}convention {}", side.convention)?,
+    }
+    for parameter in &side.parameters {
+        let (line, continuation) = placement_text(registers, &parameter.placement);
+        writeln!(
+            f,
+            "{indent}parameter {}: {}, {}, {line}{}",
+            parameter.index,
+            parameter.ty,
+            parameter.mode.name(),
+            extension_text(parameter.extension)
+        )?;
+        for extra in continuation {
+            writeln!(f, "{indent}  {extra}")?;
+        }
+    }
+    let (line, continuation) = placement_text(registers, &side.ret.placement);
+    writeln!(
+        f,
+        "{indent}return: {}, {line}{}",
+        side.ret.ty,
+        extension_text(side.ret.extension)
+    )?;
+    for extra in continuation {
+        writeln!(f, "{indent}  {extra}")?;
+    }
+    if let Some(bytes) = side.stack_bytes {
+        writeln!(f, "{indent}outgoing argument area: {bytes} bytes")?;
+    }
+    Ok(())
+}
+
+impl std::fmt::Display for AbiFunctionReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let registers = TargetRegisters::new(self.target);
+        writeln!(f, "{} {}", self.kind.keyword(), self.name)?;
+        // An export prints both halves of the crossing it owns: the C entry
+        // callers see, then the native body the thunk forwards to.
+        if self.kind == AbiFunctionKind::Export {
+            if let Some(side) = &self.c {
+                writeln!(f, "  c side")?;
+                write_side(f, side, registers, "    ")?;
+            }
+            if let Some(side) = &self.native {
+                writeln!(f, "  native side")?;
+                write_side(f, side, registers, "    ")?;
+            }
+            return Ok(());
+        }
+        if let Some(side) = self.c.as_ref().or(self.native.as_ref()) {
+            write_side(f, side, registers, "  ")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_target::Target;
+
+    /// The C rows name registers out of the backend rosters this module asks,
+    /// so a C placement can only be rendered correctly while each row's budget
+    /// fits inside the roster it indexes.
+    #[test]
+    fn every_c_row_indexes_inside_the_backend_rosters_it_names() {
+        for target in Target::all() {
+            let registers = TargetRegisters::new(*target);
+            let spec = target.c_calling_convention().c_spec();
+            for class in [CRegisterClass::Gp, CRegisterClass::Fp] {
+                let arguments = registers.roster(RegisterRole::Argument, class);
+                let results = registers.roster(RegisterRole::Result, class);
+                assert!(
+                    spec.argument_registers(class) as usize <= arguments.len(),
+                    "{target:?} {class:?} argument roster is smaller than its psABI budget"
+                );
+                assert!(
+                    spec.return_registers(class) as usize <= results.len(),
+                    "{target:?} {class:?} result roster is smaller than its psABI budget"
+                );
+                assert!(arguments.iter().all(|name| !name.is_empty()));
+                assert!(results.iter().all(|name| !name.is_empty()));
+            }
+        }
+    }
+
+    #[test]
+    fn the_sysv_row_names_its_own_registers() {
+        let registers = TargetRegisters::new(Target::X86_64Linux);
+        assert_eq!(registers.argument(CRegisterClass::Gp, 0), "rdi");
+        assert_eq!(registers.argument(CRegisterClass::Gp, 2), "rdx");
+        assert_eq!(registers.result(CRegisterClass::Gp, 0), "rax");
+        assert_eq!(registers.result(CRegisterClass::Gp, 1), "rdx");
+        assert_eq!(
+            c_placement_text(
+                registers,
+                CPlacement::Sret {
+                    register: SretRegisterKind::ArgumentRegister,
+                    echoed: true,
+                    size: 24,
+                    align: 8,
+                }
+            ),
+            "sret: pointer in rdi, echoed in rax (24 bytes, align 8)"
+        );
+    }
+
+    #[test]
+    fn the_aapcs64_row_names_its_dedicated_indirect_result_register() {
+        let registers = TargetRegisters::new(Target::Aarch64Macos);
+        assert_eq!(registers.argument(CRegisterClass::Gp, 7), "x7");
+        assert_eq!(registers.dedicated_sret(), "x8");
+        assert_eq!(
+            c_placement_text(
+                registers,
+                CPlacement::Sret {
+                    register: SretRegisterKind::DedicatedRegister,
+                    echoed: false,
+                    size: 24,
+                    align: 8,
+                }
+            ),
+            "sret: pointer in x8 (24 bytes, align 8)"
+        );
+    }
+
+    #[test]
+    fn a_stacked_and_an_indirect_placement_state_their_physical_detail() {
+        let registers = TargetRegisters::new(Target::X86_64Linux);
+        assert_eq!(
+            c_placement_text(
+                registers,
+                CPlacement::Stack {
+                    offset: 16,
+                    size: 8,
+                    align: 8,
+                }
+            ),
+            "stack +16 (8 bytes, align 8)"
+        );
+        assert_eq!(
+            c_placement_text(
+                registers,
+                CPlacement::Indirect {
+                    pointer: PointerLocation::Register { index: 2 },
+                    size: 24,
+                    align: 8,
+                }
+            ),
+            "indirect: pointer in gp register 2 (rdx) to 24 bytes (align 8)"
+        );
+        assert_eq!(
+            c_placement_text(registers, CPlacement::Omitted),
+            "omitted (zero-sized)"
+        );
+    }
+
+    #[test]
+    fn a_reversed_multislot_parameter_names_the_logical_slot_each_register_carries() {
+        let registers = TargetRegisters::new(Target::X86_64Linux);
+        let (line, continuation) = native_placement_text(
+            registers,
+            &NativePlacement::Slots {
+                slots: vec![
+                    NativeSlot {
+                        logical: 2,
+                        location: AbiSlotLocation::GpReg(0),
+                    },
+                    NativeSlot {
+                        logical: 1,
+                        location: AbiSlotLocation::GpReg(1),
+                    },
+                    NativeSlot {
+                        logical: 0,
+                        location: AbiSlotLocation::Stack(0),
+                    },
+                ],
+                reversed: true,
+            },
+        );
+        assert_eq!(line, "3 slots, reversed");
+        assert_eq!(
+            continuation,
+            [
+                "slot 2: gp register 0 (rdi)",
+                "slot 1: gp register 1 (rsi)",
+                "slot 0: stack slot 0",
+            ]
+        );
+    }
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -41,6 +41,22 @@ macro_rules! end_inst {
     };
 }
 
+/// Project a backend's physical register roster onto its names, in roster
+/// order.
+///
+/// The ABI report names registers by asking the backend that owns them, so a
+/// roster must be spelled exactly once. This macro is how each backend hands
+/// over `[Reg; N]` as `[&str; N]` in a const item: `Reg::name64` is a `const
+/// fn`, but a `const fn` cannot build a fixed-size array from a slice, so the
+/// indices are written out and the compiler checks the length.
+macro_rules! roster_names {
+    ($roster:expr; $($index:literal)+) => {
+        [$($roster[$index].name64()),+]
+    };
+}
+pub(crate) use roster_names;
+
+pub mod abi_report;
 mod allocation;
 mod backend;
 pub mod call_plan;

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -36,6 +36,34 @@ use rue_target::Target;
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation, MachineCode};
 
+/// Physical names of the general-purpose argument roster, in roster order.
+///
+/// The ABI report (`--emit abi`) asks the backend for the name of a roster
+/// index instead of restating a roster of its own, so renaming or reordering
+/// [`cfg_lower::ARG_REGS`] moves the report with it. SysV's own argument
+/// registers are these six.
+pub(crate) const GP_ARGUMENT_REGISTER_NAMES: [&str; 6] =
+    crate::roster_names!(cfg_lower::ARG_REGS; 0 1 2 3 4 5);
+
+/// Physical names of the floating-point argument roster, in roster order.
+pub(crate) const FP_ARGUMENT_REGISTER_NAMES: [&str; 8] =
+    crate::roster_names!(cfg_lower::FP_ARG_REGS; 0 1 2 3 4 5 6 7);
+
+/// Physical names of the general-purpose return roster, in roster order. SysV's
+/// own result registers are its first two, `rax:rdx`.
+pub(crate) const GP_RETURN_REGISTER_NAMES: [&str; 6] =
+    crate::roster_names!(cfg_lower::RET_REGS; 0 1 2 3 4 5);
+
+/// Physical names of the floating-point return roster, in roster order.
+pub(crate) const FP_RETURN_REGISTER_NAMES: [&str; 8] =
+    crate::roster_names!(cfg_lower::FP_RET_REGS; 0 1 2 3 4 5 6 7);
+
+/// SysV AMD64 passes the hidden indirect-result pointer in the first ordinary
+/// argument register rather than a dedicated one, so no register outside the
+/// roster carries it. The name exists so the report's per-target lookup is
+/// total.
+pub(crate) const DEDICATED_SRET_REGISTER_NAME: &str = "rdi";
+
 struct X86CodegenBackend;
 
 pub(crate) fn prepare_backend(

--- a/crates/rue-compiler/src/session/rooted_artifacts.rs
+++ b/crates/rue-compiler/src/session/rooted_artifacts.rs
@@ -154,6 +154,16 @@ impl RootedCfgOutput {
         &self.graph.declarations
     }
 
+    /// The `pub extern "C" fn` exports this rooted set carries, each with the
+    /// signature the entry thunk is generated from.
+    ///
+    /// This is the same [`collect_rooted_exports`] intersection the codegen
+    /// projection publishes, so an ABI presentation and a real link describe one
+    /// export set.
+    pub(crate) fn c_export_thunks(&self) -> Vec<crate::program_image_plan::RootedExportThunk> {
+        collect_rooted_exports(&self.graph, &self.cfgs)
+    }
+
     pub(crate) fn anonymous_nominals(
         &self,
     ) -> &[crate::durable_semantics::DurableAnonymousNominal] {

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -587,6 +587,7 @@ pub enum PresentationStage {
     RegAlloc,
     Asm,
     StackFrame,
+    Abi,
 }
 
 /// One explicitly unstable textual presentation request.
@@ -1034,6 +1035,67 @@ impl PresentationOutput {
     }
 }
 
+/// Render the `--emit abi` report for one rooted reached set.
+///
+/// Order is part of the presentation's contract, so it is fixed here rather
+/// than left to iteration incident:
+///
+/// 1. Every reached function — ordinary functions, methods, and the generic
+///    instances that were reached — in the rooted CFG order, which is the order
+///    `--emit air` and `--emit cfg` already present. A `pub extern "C" fn`
+///    export takes an export block there instead of a function block, so its C
+///    entry and the native body it forwards to appear together.
+/// 2. Then every reached `extern "C"` import, deduplicated by C symbol and
+///    ordered by it. An import has no body and therefore no place in the
+///    function order; a signature disagreement between two call sites of one
+///    symbol is already a semantic error, so one block per symbol is complete.
+fn write_abi_presentation(text: &mut String, rooted: &RootedCfgOutput, target: crate::Target) {
+    let exports = rooted.c_export_thunks();
+    let mut imports = std::collections::BTreeMap::new();
+    for function in rooted.functions() {
+        let record = &function.record;
+        let symbols = rue_codegen::MachineSymbolResolver::new_with_foreign(
+            &record.codegen.symbol_mappings,
+            &record.codegen.foreign_symbols,
+        );
+        for report in rue_codegen::abi_report::import_abi_reports(
+            &record.cfg,
+            &record.interner,
+            &symbols,
+            &record.type_pool,
+            target,
+        ) {
+            imports.entry(report.name.clone()).or_insert(report);
+        }
+        let report = match exports
+            .iter()
+            .find(|export| export.function == function.function)
+        {
+            Some(export) => rue_codegen::abi_report::export_abi_report(
+                &export.exported_symbol,
+                &export.native_symbol,
+                &export.signature,
+                &record.cfg,
+                &record.air,
+                &record.type_pool,
+                target,
+            ),
+            None => rue_codegen::abi_report::function_abi_report(
+                &record.cfg,
+                &record.air,
+                &record.source_name,
+                &record.codegen.defined_symbol,
+                &record.type_pool,
+                target,
+            ),
+        };
+        writeln!(text, "{report}").expect("write to String");
+    }
+    for report in imports.into_values() {
+        writeln!(text, "{report}").expect("write to String");
+    }
+}
+
 /// Query the canonical reached-body/CFG artifact used by codegen.
 pub fn rooted_cfg(
     session: &mut crate::CompilerSession,
@@ -1272,6 +1334,10 @@ impl crate::CompilerSession {
                             _ => unreachable!("backend request has a backend presentation stage"),
                         }
                     }
+                } else if matches!(stage, PresentationStage::Abi) {
+                    let rooted = self.rooted_cfg(request.options)?;
+                    write_abi_presentation(&mut text, &rooted, request.options.target);
+                    warnings = rooted.warnings;
                 } else {
                     let rooted = self.rooted_cfg(request.options)?;
                     warnings = rooted.warnings;
@@ -1317,7 +1383,8 @@ impl crate::CompilerSession {
                             | PresentationStage::Mir
                             | PresentationStage::Liveness
                             | PresentationStage::RegAlloc
-                            | PresentationStage::Asm => unreachable!(),
+                            | PresentationStage::Asm
+                            | PresentationStage::Abi => unreachable!(),
                         }
                     }
                 }
@@ -1464,6 +1531,7 @@ mod codegen_unit_tests {
                 PresentationStage::Air,
                 PresentationStage::Cfg,
                 PresentationStage::StackFrame,
+                PresentationStage::Abi,
             ] {
                 frontend
                     .unstable_present(PresentationRequest {

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -251,8 +251,8 @@ impl<'de> Deserialize<'de> for ErrorContains {
 ///
 /// Golden-IR assertions (`expected_tokens`, `expected_ast`, `expected_rir`,
 /// `expected_air`, `expected_cfg`, `expected_mir`, `expected_lowering`,
-/// `expected_liveness`, `expected_regalloc`, `expected_asm`, and
-/// `expected_stackframe`) are checked by running
+/// `expected_liveness`, `expected_regalloc`, `expected_asm`,
+/// `expected_stackframe`, and `expected_abi`) are checked by running
 /// `rue --emit <stage>` and comparing the dump. Execution assertions
 /// (`exit_code`, `expected_stdout`, `runtime_error`, warning checks, ...)
 /// are checked by compiling and running the program.
@@ -322,6 +322,9 @@ pub struct Case {
     /// Expected stack frame dump (golden test)
     #[serde(default)]
     pub expected_stackframe: Option<String>,
+    /// Expected calling-convention/placement report (golden test)
+    #[serde(default)]
+    pub expected_abi: Option<String>,
     /// Expected CFG dump (golden test)
     #[serde(default)]
     pub expected_cfg: Option<String>,
@@ -423,6 +426,7 @@ impl Case {
             || self.expected_regalloc.is_some()
             || self.expected_asm.is_some()
             || self.expected_stackframe.is_some()
+            || self.expected_abi.is_some()
     }
 
     /// Whether this case carries any golden-IR assertion whose output depends
@@ -434,6 +438,7 @@ impl Case {
             || self.expected_regalloc.is_some()
             || self.expected_asm.is_some()
             || self.expected_stackframe.is_some()
+            || self.expected_abi.is_some()
     }
 
     /// Whether verifying this case requires *running* the produced binary, as
@@ -464,6 +469,7 @@ impl Case {
             ("expected_regalloc", self.expected_regalloc.is_some()),
             ("expected_asm", self.expected_asm.is_some()),
             ("expected_stackframe", self.expected_stackframe.is_some()),
+            ("expected_abi", self.expected_abi.is_some()),
         ]
         .into_iter()
         .filter_map(|(field, present)| present.then_some(field))
@@ -1128,6 +1134,7 @@ const PARAM_OVERRIDE_KEYS: &[&str] = &[
     "expected_regalloc",
     "expected_asm",
     "expected_stackframe",
+    "expected_abi",
     "warning_contains",
     "expected_warning_count",
     "spec_extra",
@@ -1180,7 +1187,8 @@ fn invalid_param_override_expectation(key: &str, value: &toml::Value) -> Option<
         | "expected_liveness"
         | "expected_regalloc"
         | "expected_asm"
-        | "expected_stackframe" => value.is_str(),
+        | "expected_stackframe"
+        | "expected_abi" => value.is_str(),
         "timeout_ms" => value
             .as_integer()
             .is_some_and(|value| u64::try_from(value).is_ok()),
@@ -1216,7 +1224,8 @@ fn invalid_param_override_expectation(key: &str, value: &toml::Value) -> Option<
         | "expected_liveness"
         | "expected_regalloc"
         | "expected_asm"
-        | "expected_stackframe" => "a string",
+        | "expected_stackframe"
+        | "expected_abi" => "a string",
         "timeout_ms" | "expected_warning_count" => "a non-negative integer",
         "error_contains" | "warning_contains" => "a string or an array of strings",
         "spec_extra" => "an array of strings",
@@ -1319,6 +1328,10 @@ fn case_contains_placeholder(case: &Case, key: &str) -> bool {
             .is_some_and(|value| contains_placeholder(value, key))
         || case
             .expected_stackframe
+            .as_ref()
+            .is_some_and(|value| contains_placeholder(value, key))
+        || case
+            .expected_abi
             .as_ref()
             .is_some_and(|value| contains_placeholder(value, key))
         || case
@@ -1473,6 +1486,7 @@ pub fn expand_case(case: Case) -> Vec<Case> {
                 expected_regalloc: substitute_optional_string(&case.expected_regalloc, &params),
                 expected_asm: substitute_optional_string(&case.expected_asm, &params),
                 expected_stackframe: substitute_optional_string(&case.expected_stackframe, &params),
+                expected_abi: substitute_optional_string(&case.expected_abi, &params),
                 expected_cfg: substitute_optional_string(&case.expected_cfg, &params),
                 runtime_error: substitute_optional_string(&case.runtime_error, &params),
                 warning_contains: substitute_optional_string_vec(&case.warning_contains, &params),
@@ -1639,6 +1653,11 @@ pub fn expand_case(case: Case) -> Vec<Case> {
             if let Some(value) = params.get("expected_asm") {
                 if let Some(s) = value.as_str() {
                     expanded.expected_asm = Some(substitute_placeholders(s, &params));
+                }
+            }
+            if let Some(value) = params.get("expected_abi") {
+                if let Some(s) = value.as_str() {
+                    expanded.expected_abi = Some(substitute_placeholders(s, &params));
                 }
             }
             if let Some(value) = params.get("expected_stackframe") {
@@ -2577,6 +2596,7 @@ fn stage_to_header_name(stage: &str) -> &'static str {
         "regalloc" => "Register Allocation",
         "asm" => "Assembly",
         "stackframe" => "Stack Frame",
+        "abi" => "ABI",
         _ => panic!("Unknown stage: {}", stage),
     }
 }
@@ -3118,6 +3138,17 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
                 rue_binary,
                 &source_path,
                 "stackframe",
+                expected,
+                &build_command,
+                compile_timeout,
+            )?;
+        }
+
+        if let Some(ref expected) = case.expected_abi {
+            run_golden_ir_test(
+                rue_binary,
+                &source_path,
+                "abi",
                 expected,
                 &build_command,
                 compile_timeout,
@@ -3763,6 +3794,7 @@ params = [
             expected_regalloc: None,
             expected_asm: None,
             expected_stackframe: None,
+            expected_abi: None,
             expected_cfg: None,
             runtime_error: None,
             runtime_exit_code: None,
@@ -3820,6 +3852,7 @@ params = [
             expected_regalloc: None,
             expected_asm: None,
             expected_stackframe: None,
+            expected_abi: None,
             expected_cfg: None,
             runtime_error: None,
             runtime_exit_code: None,
@@ -3885,6 +3918,7 @@ params = [
             expected_regalloc: None,
             expected_asm: None,
             expected_stackframe: None,
+            expected_abi: None,
             expected_cfg: None,
             runtime_error: None,
             runtime_exit_code: None,
@@ -3942,6 +3976,7 @@ params = [
             expected_regalloc: None,
             expected_asm: None,
             expected_stackframe: None,
+            expected_abi: None,
             expected_cfg: None,
             runtime_error: None,
             runtime_exit_code: None,
@@ -4761,6 +4796,7 @@ chmod +x "$output"
             expected_regalloc: None,
             expected_asm: None,
             expected_stackframe: None,
+            expected_abi: None,
             expected_cfg: None,
             runtime_error: None,
             runtime_exit_code: None,

--- a/crates/rue-ui-tests/cases/emit/abi.toml
+++ b/crates/rue-ui-tests/cases/emit/abi.toml
@@ -1,0 +1,365 @@
+# `--emit abi` is the evidence surface for "where does this value actually
+# travel" (RUE-2033). These cases pin the full report text, because the whole
+# point of the stage is that a placement can be read off it without reading
+# assembly — a wording or a register that drifts is a regression, not a detail.
+#
+# The blocks are ordered by the stage's documented contract: reached functions
+# in the `--emit air` order (a `pub extern "C" fn` export taking an export block
+# there), then every reached `extern "C"` import by C symbol.
+
+[section]
+id = "emit.abi"
+name = "--emit abi calling-convention report"
+description = "Per-function convention and per-value placement for native functions, C imports, and C exports."
+
+[[case]]
+name = "native_multislot_aggregate_argument_and_sret_return"
+description = "A 7-slot by-value aggregate crosses the native convention reversed, spilling past the six SysV argument registers; the same aggregate returns through sret, whose hidden pointer takes argument register 0."
+target = "x86-64-linux"
+source = """
+struct Wide {
+    a: i64,
+    b: i64,
+    c: i64,
+    d: i64,
+    e: i64,
+    f: i64,
+    g: i64,
+}
+
+fn through(w: Wide) -> Wide {
+    w
+}
+
+fn main() -> i32 {
+    let w = Wide { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7 };
+    let t = through(w);
+    let last: i32 = @intCast(t.g);
+    last
+}
+"""
+expected_abi = """
+function __rue_fn_test_2erue__through
+  convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s7_7468726f756768t0_
+  parameter 0: Wide$test_2erue, by value, 7 slots, reversed
+    slot 6: gp register 1 (rsi)
+    slot 5: gp register 2 (rdx)
+    slot 4: gp register 3 (rcx)
+    slot 3: gp register 4 (r8)
+    slot 2: gp register 5 (r9)
+    slot 1: stack slot 0
+    slot 0: stack slot 1
+  return: Wide$test_2erue, sret: pointer in gp register 0 (rdi) to 7 slots (64 bytes of caller storage)
+
+function main
+  convention rue, symbol main
+  return: i32, gp return register 0 (rax)
+"""
+
+# The same `extern "C"` signature on all three rows. Eight register-width
+# arguments exhaust SysV's six and AAPCS64's eight, so the narrow tail and the
+# 24-byte struct behind it land in each row's own way:
+#
+#   SysV            byval on the stack, 24 whole bytes at +24 (§3.2.3 MEMORY)
+#   AAPCS64         by reference — a pointer to a caller-owned copy (§6.8.2 C.12)
+#   Apple arm64     the same by-reference rule, but the `i8` ahead of it packs
+#                   at its natural size, so it occupies one byte, not a slot
+[[case]]
+name = "extern_import_stacked_tail_sysv"
+description = "SysV AMD64: register-exhausted tail on the stack in whole eightbytes, and a 24-byte @repr(c) struct passed byval on the stack."
+target = "x86-64-linux"
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+@repr(c)
+struct Triple {
+    a: i64,
+    b: i64,
+    c: i64,
+}
+
+extern "C" {
+    fn wide(
+        a: i64,
+        b: i64,
+        c: i64,
+        d: i64,
+        e: i64,
+        f: i64,
+        g: i64,
+        h: i64,
+        tail: i8,
+        block: Triple,
+    ) -> i64;
+}
+
+fn main() -> i32 {
+    let block = Triple { a: 1, b: 2, c: 3 };
+    let total = checked { wide(1, 2, 3, 4, 5, 6, 7, 8, 9, block) };
+    let code: i32 = @intCast(total);
+    code
+}
+"""
+expected_abi = """
+function main
+  convention rue, symbol main
+  return: i32, gp return register 0 (rax)
+
+import wide
+  convention x86-64-sysv, symbol wide
+  parameter 0: i64, by value, gp register 0 (rdi)
+  parameter 1: i64, by value, gp register 1 (rsi)
+  parameter 2: i64, by value, gp register 2 (rdx)
+  parameter 3: i64, by value, gp register 3 (rcx)
+  parameter 4: i64, by value, gp register 4 (r8)
+  parameter 5: i64, by value, gp register 5 (r9)
+  parameter 6: i64, by value, stack +0 (8 bytes, align 8)
+  parameter 7: i64, by value, stack +8 (8 bytes, align 8)
+  parameter 8: i8, by value, stack +16 (8 bytes, align 8), sign-extended from 8 bits
+  parameter 9: Triple$test_2erue, by value, stack +24 (24 bytes, align 8)
+  return: i64, gp result register 0 (rax)
+  outgoing argument area: 48 bytes
+"""
+
+[[case]]
+name = "extern_import_stacked_tail_aapcs64"
+description = "AAPCS64: eight register-width arguments fill x0-x7, the narrow tail takes a whole 8-byte stack slot, and the 24-byte struct crosses by reference (§6.8.2 C.12), its pointer itself stacked."
+target = "aarch64-linux"
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+@repr(c)
+struct Triple {
+    a: i64,
+    b: i64,
+    c: i64,
+}
+
+extern "C" {
+    fn wide(
+        a: i64,
+        b: i64,
+        c: i64,
+        d: i64,
+        e: i64,
+        f: i64,
+        g: i64,
+        h: i64,
+        tail: i8,
+        block: Triple,
+    ) -> i64;
+}
+
+fn main() -> i32 {
+    let block = Triple { a: 1, b: 2, c: 3 };
+    let total = checked { wide(1, 2, 3, 4, 5, 6, 7, 8, 9, block) };
+    let code: i32 = @intCast(total);
+    code
+}
+"""
+expected_abi = """
+function main
+  convention rue, symbol main
+  return: i32, gp return register 0 (x0)
+
+import wide
+  convention aarch64-aapcs, symbol wide
+  parameter 0: i64, by value, gp register 0 (x0)
+  parameter 1: i64, by value, gp register 1 (x1)
+  parameter 2: i64, by value, gp register 2 (x2)
+  parameter 3: i64, by value, gp register 3 (x3)
+  parameter 4: i64, by value, gp register 4 (x4)
+  parameter 5: i64, by value, gp register 5 (x5)
+  parameter 6: i64, by value, gp register 6 (x6)
+  parameter 7: i64, by value, gp register 7 (x7)
+  parameter 8: i8, by value, stack +0 (8 bytes, align 8), sign-extended from 8 bits
+  parameter 9: Triple$test_2erue, by value, indirect: pointer at stack +8 to 24 bytes (align 8)
+  return: i64, gp result register 0 (x0)
+  outgoing argument area: 16 bytes
+"""
+
+[[case]]
+name = "extern_import_stacked_tail_darwin"
+description = "Apple arm64: the same signature as the AAPCS64 case, differing only where Apple's amendment does — the stacked `i8` occupies one byte at its natural alignment instead of a whole eightbyte."
+target = "aarch64-macos"
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+@repr(c)
+struct Triple {
+    a: i64,
+    b: i64,
+    c: i64,
+}
+
+extern "C" {
+    fn wide(
+        a: i64,
+        b: i64,
+        c: i64,
+        d: i64,
+        e: i64,
+        f: i64,
+        g: i64,
+        h: i64,
+        tail: i8,
+        block: Triple,
+    ) -> i64;
+}
+
+fn main() -> i32 {
+    let block = Triple { a: 1, b: 2, c: 3 };
+    let total = checked { wide(1, 2, 3, 4, 5, 6, 7, 8, 9, block) };
+    let code: i32 = @intCast(total);
+    code
+}
+"""
+expected_abi = """
+function main
+  convention rue, symbol main
+  return: i32, gp return register 0 (x0)
+
+import wide
+  convention aarch64-aapcs-darwin, symbol wide
+  parameter 0: i64, by value, gp register 0 (x0)
+  parameter 1: i64, by value, gp register 1 (x1)
+  parameter 2: i64, by value, gp register 2 (x2)
+  parameter 3: i64, by value, gp register 3 (x3)
+  parameter 4: i64, by value, gp register 4 (x4)
+  parameter 5: i64, by value, gp register 5 (x5)
+  parameter 6: i64, by value, gp register 6 (x6)
+  parameter 7: i64, by value, gp register 7 (x7)
+  parameter 8: i8, by value, stack +0 (1 byte, align 1), sign-extended from 8 bits
+  parameter 9: Triple$test_2erue, by value, indirect: pointer at stack +8 to 24 bytes (align 8)
+  return: i64, gp result register 0 (x0)
+  outgoing argument area: 16 bytes
+"""
+
+# An export owns both halves of one crossing, so its block prints both: the C
+# entry a foreign caller writes (two eightbytes in, two result registers out)
+# and the native body the thunk forwards to, whose by-value aggregate crosses
+# reversed. Reading the two sides together is what shows the thunk has real work
+# to do even for a signature this small.
+[[case]]
+name = "export_two_field_struct_in_and_out"
+description = "A `pub extern \\\"C\\\" fn` export prints its C side and the native side it forwards to."
+target = "x86-64-linux"
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+@repr(c)
+struct Pair {
+    lo: i64,
+    hi: i64,
+}
+
+pub extern "C" fn swap(p: Pair) -> Pair {
+    Pair { lo: p.hi, hi: p.lo }
+}
+
+fn main() -> i32 {
+    0
+}
+"""
+expected_abi = """
+export swap
+  c side
+    convention x86-64-sysv, symbol swap
+    parameter 0: Pair$test_2erue, by value, gp registers 0-1 (rdi, rsi)
+    return: Pair$test_2erue, gp result registers 0-1 (rax, rdx)
+    outgoing argument area: 0 bytes
+  native side
+    convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s4_73776170t0_
+    parameter 0: Pair$test_2erue, by value, 2 slots, reversed
+      slot 1: gp register 0 (rdi)
+      slot 0: gp register 1 (rsi)
+    return: Pair$test_2erue, 2 slots
+      slot 0: gp return register 0 (rax)
+      slot 1: gp return register 1 (rdx)
+
+function main
+  convention rue, symbol main
+  return: i32, gp return register 0 (rax)
+"""
+
+# `borrow` and `inout` are one caller pointer each whatever they point at, so
+# the line names the pointee type and the register the pointer arrives in — and
+# says nothing about how many slots the pointee occupies, because the callee's
+# parameter slot holds only the pointer. A `unit` result has no place at all.
+[[case]]
+name = "by_reference_parameter_modes"
+description = "borrow and inout parameters report their mode, their pointee type, and the one register their pointer arrives in."
+target = "x86-64-linux"
+source = """
+struct Counter {
+    hits: i64,
+    misses: i64,
+}
+
+fn bump(inout c: Counter, by: i64) {
+    c.hits = c.hits + by;
+}
+
+fn total(borrow c: Counter) -> i64 {
+    c.hits + c.misses
+}
+
+fn main() -> i32 {
+    let mut c = Counter { hits: 0, misses: 0 };
+    bump(inout c, 3);
+    let sum: i32 = @intCast(total(borrow c));
+    sum
+}
+"""
+expected_abi = """
+function __rue_fn_test_2erue__bump
+  convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s4_62756d70t0_
+  parameter 0: Counter$test_2erue, inout, indirect: pointer in gp register 0 (rdi)
+  parameter 1: i64, by value, gp register 1 (rsi)
+  return: unit, no value
+
+function __rue_fn_test_2erue__total
+  convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s5_746f74616ct0_
+  parameter 0: Counter$test_2erue, borrow, indirect: pointer in gp register 0 (rdi)
+  return: i64, gp return register 0 (rax)
+
+function main
+  convention rue, symbol main
+  return: i32, gp return register 0 (rax)
+"""
+
+# A by-value aggregate the compact layout cannot express slot-identically (an
+# `[i32; 8]` field) is forced indirect by the memory-first rule: one incoming
+# pointer for a value that still occupies nine callee parameter slots. That
+# collapse is the one case where the pointee's slot count *is* an ABI fact, so
+# the line states it — and the same type returns through sret.
+[[case]]
+name = "native_compact_indirect_argument_states_its_pointee_slots"
+description = "A by-value aggregate forced indirect by the compact memory-first rule crosses as one pointer to nine slots."
+target = "x86-64-linux"
+source = """
+struct Block {
+    items: [i32; 8],
+    len: u32,
+}
+
+fn through(b: Block) -> Block {
+    b
+}
+
+fn main() -> i32 {
+    let b = Block { items: [1, 2, 3, 4, 5, 6, 7, 8], len: 8 };
+    let t = through(b);
+    t.items[7]
+}
+"""
+expected_abi = """
+function __rue_fn_test_2erue__through
+  convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s7_7468726f756768t0_
+  parameter 0: Block$test_2erue, by value, indirect: pointer in gp register 1 (rsi) to 9 slots
+  return: Block$test_2erue, sret: pointer in gp register 0 (rdi) to 9 slots (80 bytes of caller storage)
+
+function main
+  convention rue, symbol main
+  return: i32, gp return register 0 (rax)
+"""

--- a/crates/rue/src/emit.rs
+++ b/crates/rue/src/emit.rs
@@ -45,6 +45,9 @@ pub(crate) enum EmitStage {
     Asm,
     /// Emit stack frame layout per function.
     StackFrame,
+    /// Emit the calling convention and per-value placement of every reachable
+    /// function's signature.
+    Abi,
     /// Emit the source dependency graph discovered while loading imports.
     Deps,
 }
@@ -97,6 +100,7 @@ pub(crate) fn emit_requires_semantic(stages: &[EmitStage]) -> bool {
                 | EmitStage::RegAlloc
                 | EmitStage::Asm
                 | EmitStage::StackFrame
+                | EmitStage::Abi
         )
     })
 }
@@ -179,6 +183,7 @@ impl std::str::FromStr for EmitStage {
             "regalloc" => Ok(EmitStage::RegAlloc),
             "asm" => Ok(EmitStage::Asm),
             "stackframe" => Ok(EmitStage::StackFrame),
+            "abi" => Ok(EmitStage::Abi),
             "deps" => Ok(EmitStage::Deps),
             _ => Err(ParseEmitStageError(s.to_string())),
         }
@@ -187,7 +192,8 @@ impl std::str::FromStr for EmitStage {
 
 impl EmitStage {
     pub(crate) fn all_names() -> &'static str {
-        "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe, deps"
+        "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe, abi, \
+         deps"
     }
 }
 
@@ -312,6 +318,7 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
             EmitStage::RegAlloc => PresentationStage::RegAlloc,
             EmitStage::Asm => PresentationStage::Asm,
             EmitStage::StackFrame => PresentationStage::StackFrame,
+            EmitStage::Abi => PresentationStage::Abi,
             EmitStage::Deps => continue,
         };
         if matches!(stage, EmitStage::Tokens | EmitStage::Ast) {
@@ -389,6 +396,10 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
                 println!("{}", output.as_str());
             }
             EmitStage::StackFrame => {
+                print!("{}", output.as_str());
+            }
+            EmitStage::Abi => {
+                println!("=== ABI ({}) ===", compile_options.target);
                 print!("{}", output.as_str());
             }
             // Dependency presentation returns before frontend planning above.

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -3875,6 +3875,7 @@ mod tests {
             EmitStage::RegAlloc,
             EmitStage::Asm,
             EmitStage::StackFrame,
+            EmitStage::Abi,
         ] {
             assert!(emit_requires_semantic(&[stage]));
             assert_eq!(
@@ -5104,6 +5105,7 @@ mod tests {
             "stackframe".parse::<EmitStage>().unwrap(),
             EmitStage::StackFrame
         );
+        assert_eq!("abi".parse::<EmitStage>().unwrap(), EmitStage::Abi);
         assert_eq!("deps".parse::<EmitStage>().unwrap(), EmitStage::Deps);
     }
 
@@ -5117,7 +5119,8 @@ mod tests {
     fn emit_stage_all_names() {
         assert_eq!(
             EmitStage::all_names(),
-            "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe, deps"
+            "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe, \
+             abi, deps"
         );
     }
 
@@ -5137,6 +5140,12 @@ mod tests {
     fn parse_emit_stackframe() {
         let opts = unwrap_options(parse_args_from(&["--emit", "stackframe", "source.rue"]));
         assert_eq!(opts.emit_stages, vec![EmitStage::StackFrame]);
+    }
+
+    #[test]
+    fn parse_emit_abi() {
+        let opts = unwrap_options(parse_args_from(&["--emit", "abi", "source.rue"]));
+        assert_eq!(opts.emit_stages, vec![EmitStage::Abi]);
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,8 +21,20 @@ source files
 ```
 
 Use `rue --emit <stage>` to inspect `tokens`, `ast`, `rir`, `air`, `cfg`,
-`lowering`, `mir`, `liveness`, `regalloc`, `asm`, or `stackframe`. The option
-can be repeated to request several views.
+`lowering`, `mir`, `liveness`, `regalloc`, `asm`, `stackframe`, or `abi`. The
+option can be repeated to request several views.
+
+The `abi` view reports, for every function the root module reaches, the calling
+convention its signature follows and where each parameter and the result
+travels: a named register, a byte offset in the outgoing argument area, a
+pointer to a caller-owned copy, or nothing for a zero-sized value. It reads the
+artifacts code generation reads — `rue_air::lower_c_signature` for every C
+boundary, `NativeCallAbi` plus the shared slot plan for the native convention —
+and asks each backend for the name of a roster index, so it cannot describe a
+placement the compiler does not emit. `--target` selects the row, so a Darwin
+placement is readable on any host, and a `pub extern "C" fn` export prints both
+its C entry and the native body its thunk forwards to. See
+`docs/notes/ffi-abi-conformance-audit.md`.
 
 The `stackframe` view reports each frame's byte-based layout — per-slot offsets
 and sizes, callee-saved registers, and the 16-byte-aligned total — from the

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -246,6 +246,39 @@ assuming that arbitrary C signatures share the native Rue slot rules. Backend
 unit guards fail if a manifest helper exceeds the current register-only budget;
 adding such a helper requires implementing and testing target-C stack placement.
 
+## Reading a placement out of the compiler
+
+`rue --emit abi <root>` prints, for every function the root module reaches, the
+convention its signature follows and where each parameter and the result
+actually travels — a register by name, a byte offset in the outgoing argument
+area, a pointer to a caller-owned copy, or nothing at all for a zero-sized
+value. It is the answer to "why is this argument on the stack" and "which
+registers carry this return" without reading assembly.
+
+The stage honors `--target`, so a Darwin placement is readable on any host:
+
+```console
+rue --emit abi --preview c_ffi --target aarch64-macos main.rue
+```
+
+It is evidence rather than commentary because it consumes what code generation
+consumes and nothing else: a C boundary's placements come from
+`rue_air::lower_c_signature` through the same `ForeignCallInputs` /
+`ExportSignature` projections the import lowering and the export thunk build,
+and the native side's come from `NativeCallAbi` plus the shared
+`assign_abi_slots` / `ReturnPlan` slot plan. Register *names* are asked of the
+backend that owns the roster. A `pub extern "C" fn` export prints both halves of
+its crossing, so the work its entry thunk performs — the native convention's
+reversed aggregate slots against C's ascending eightbytes — is visible side by
+side.
+
+One thing the stage cannot show is an FFI-predicate failure beside the function
+that caused it: the predicates reject an `extern` or export *signature* while
+that signature is resolved, before any body is analyzed, so the compile fails
+with the ordinary `E1104` diagnostic — which carries the failing field path and
+the reject reason — and no report is printed. `emit.abi` (UI) pins the report
+text on all three rows; `cli.emit_pipeline` pins the failure path.
+
 ## Executable evidence
 
 `cli.abi_conformance` compiles and independently links one probe for each


### PR DESCRIPTION
Slice 3 of the calling-convention infrastructure epic (RUE-2030).

## What

`--emit abi` prints, for every function the root module reaches, the calling convention its signature follows and where each parameter and the result travels: a named register, a byte offset in the outgoing argument area, a pointer to a caller-owned copy, or nothing for a zero-sized value. "Why is this argument on the stack" and "which registers carry this return" are answerable without reading assembly.

The report classifies nothing of its own. A C boundary reads `rue_air::lower_c_signature` through the same `ForeignCallInputs` and `ExportSignature` projections the import lowering and the export thunk build; the native convention reads `NativeCallAbi` through `return_plan` and the shared `assign_abi_slots` / `return_slot_regs` slot plan. Register names stay in the backends, which now expose their argument and return rosters by name so the report asks for the name of a roster index instead of restating a roster.

Blocks follow the rooted CFG order `--emit air` already presents, then every reached `extern "C"` import by C symbol. An export prints both halves of its crossing, so the reversed native slots against C's ascending eightbytes are visible side by side. `--target` selects the row, so a Darwin placement is readable on any host.

An FFI-predicate failure rejects the signature before any body exists, so the stage takes the ordinary error path; the diagnostic already carries the failing field path and reason. A CLI case pins that.

## Verification

- Seven UI cases pin the full report text: a native multi-slot aggregate argument with an sret return, a compact-indirect argument, by-reference parameter modes, a two-field struct export, and one `extern "C"` import on all three rows (SysV byval-on-stack, AAPCS64 by-reference, Apple natural-size packing of a narrow tail).
- CLI cases pin the FFI-predicate error path, `--target` plumbing, and the help text.
- `scripts/rue fmt`, `scripts/rue quick`, `scripts/rue cli emit` (43), `scripts/rue cli c_ffi` (47), `scripts/rue cli abi` (68), `scripts/rue ui emit` (7), oracle-diff, `scripts/rue premerge` (214 targets; only the two sandbox-environmental CLI failures).

Follow-ups noted, not in this PR: block headings use the mangled source name as `--emit air` does; type spellings reuse the drop-glue type-name authority; no JSON projection yet, though the report is plain data.

Closes RUE-2033

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_