### PR TITLE
RUE-2034: name a calling convention in an extern ABI string

### DIFF
--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -59,6 +59,71 @@ execute_if_native = true
 stdout = "42\n"
 exit_code = 0
 
+# --- Explicitly named calling conventions (9.3:1b-1c, ADR-0064 Amendment 2) ---
+# The same proof program with the convention named outright instead of `"C"`.
+# Each name belongs to one target, so each runs against its own; naming another
+# target's row is a compile error rather than a fallback.
+
+[[case]]
+name = "x86_64_linux_extern_named_convention_returns_42"
+description = "`extern \"x86-64-sysv\"` names the SysV AMD64 row outright and links and runs like `\"C\"` does on x86-64."
+files = [{ path = "main.rue", source = """
+extern "x86-64-sysv" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 {
+    let result = checked { answer() };
+    @dbg(result);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "42\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_extern_named_convention_returns_42"
+description = "`extern \"aarch64-aapcs\"` names AAPCS64 outright and links and runs like `\"C\"` does on AArch64 Linux."
+files = [{ path = "main.rue", source = """
+extern "aarch64-aapcs" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 {
+    let result = checked { answer() };
+    @dbg(result);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "42\n"
+exit_code = 0
+
+[[case]]
+name = "extern_named_convention_not_implemented_by_target_rejected"
+description = "Naming a convention the `--target` does not implement is an error naming both (E1110), never a fallback to the target's own row."
+files = [{ path = "main.rue", source = """
+extern "aarch64-aapcs" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 {
+    let result = checked { answer() };
+    @dbg(result);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--target", "x86-64-linux", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1110", "aarch64-aapcs", "x86-64-linux"]
+
 # --- Diagnostics -----------------------------------------------------------
 
 [[case]]
@@ -292,7 +357,7 @@ exit_code = 0
 
 [[case]]
 name = "extern_unsupported_abi_rejected"
-description = "Only the \"C\" ABI is accepted in v0."
+description = "An ABI string that names no calling convention is rejected, listing the ones that do."
 files = [{ path = "main.rue", source = """
 extern "Rust" {
     fn answer() -> i64;
@@ -881,7 +946,7 @@ error_contains = ["E0435", "_start", "reserved"]
 
 [[case]]
 name = "export_c_unwind_abi_rejected"
-description = "`\"C-unwind\"` stays reserved: an export declared with it is rejected, only `\"C\"` is accepted (ADR-0064)."
+description = "`\"C-unwind\"` stays reserved: an export declared with it names no accepted calling convention and is rejected (ADR-0064)."
 files = [{ path = "main.rue", source = """
 pub extern "C-unwind" fn f() -> i32 {
     0

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -445,6 +445,38 @@ compile_stdout_contains = [
     "parameter 8: i8, by value, stack +0 (1 byte, align 1), sign-extended from 8 bits",
 ]
 
+# RUE-2034: a declaration may name its convention outright, and the report reads
+# the convention the declaration named rather than re-deriving the target's `"C"`
+# row. Both directions are pinned, because the import planner and the export
+# thunk carry the row by separate routes.
+[[case]]
+name = "emit_abi_prints_an_explicitly_named_convention"
+description = "RUE-2034: an import and an export declared with an explicit convention name print that name in their blocks."
+files = [{ path = "main.rue", source = """
+extern "aarch64-aapcs-darwin" {
+    fn answer() -> i64;
+}
+
+pub extern "aarch64-aapcs-darwin" fn twice(a: i32) -> i32 {
+    a + a
+}
+
+fn main() -> i32 {
+    let total = checked { answer() };
+    let code: i32 = @intCast(total);
+    code
+}
+""" }]
+args = ["--emit", "abi", "--preview", "c_ffi", "--target", "aarch64-macos", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "=== ABI (aarch64-macos) ===",
+    "export twice",
+    "convention aarch64-aapcs-darwin, symbol twice",
+    "import answer",
+    "convention aarch64-aapcs-darwin, symbol answer",
+]
+
 # The `--emit` help text renders the stage table, so this is what makes a stage
 # that exists but is undocumented impossible.
 [[case]]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3877,8 +3877,11 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn resolve_named_symbol(&self, symbol: &str) -> String {
         self.symbols.resolve(symbol)
     }
-    fn is_foreign_symbol(&self, machine_symbol: &str) -> bool {
-        self.symbols.is_foreign(machine_symbol)
+    fn foreign_symbol_convention(
+        &self,
+        machine_symbol: &str,
+    ) -> Option<rue_target::CallingConvention> {
+        self.symbols.foreign_convention(machine_symbol)
     }
     fn call_arg_register_banks(&self) -> crate::call_plan::AbiRegisterBanks {
         crate::call_plan::AbiRegisterBanks {

--- a/crates/rue-codegen/src/abi_report.rs
+++ b/crates/rue-codegen/src/abi_report.rs
@@ -736,7 +736,7 @@ pub fn export_abi_report(
         name: exported_symbol.to_owned(),
         kind: AbiFunctionKind::Export,
         c: Some(c_side(
-            &signature.lowered(target),
+            &signature.lowered(),
             Some(exported_symbol),
             &parameter_types,
             return_type,
@@ -759,7 +759,6 @@ pub fn import_abi_reports(
     type_pool: &FrozenTypeInternPool,
     target: Target,
 ) -> Vec<AbiFunctionReport> {
-    let convention = target.c_calling_convention();
     let mut reports = Vec::new();
     for raw in 0..cfg.value_count() {
         let value = CfgValue::from_raw(raw as u32);
@@ -771,9 +770,12 @@ pub fn import_abi_reports(
             continue;
         }
         let symbol = symbols.resolve(interner.resolve(name));
-        if !symbols.is_foreign(&symbol) {
+        // The convention is the import declaration's own, resolved from its ABI
+        // string once in semantic analysis (spec 9.3:1b), so the report prints
+        // the row the call sequence is actually written under.
+        let Some(convention) = symbols.foreign_convention(&symbol) else {
             continue;
-        }
+        };
         let args = cfg.get_call_args(&inst.data);
         let inputs = crate::foreign_call::ForeignCallInputs::from_cfg(
             symbol.clone(),

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -112,8 +112,7 @@ pub(crate) fn validate_pre_lowering_budget(
         arg_reg_count,
         return_reg_count,
         scheme,
-        rue_target::CallingConvention::X86_64SysV,
-        &|_| false,
+        &|_| None,
     )
 }
 
@@ -123,8 +122,7 @@ pub(crate) fn validate_pre_lowering_budget_for_target(
     arg_reg_count: u32,
     return_reg_count: u32,
     scheme: SavedRegScheme,
-    target_c_convention: rue_target::CallingConvention,
-    is_foreign_symbol: &dyn Fn(lasso::Spur) -> bool,
+    foreign_symbol_convention: &dyn Fn(lasso::Spur) -> Option<rue_target::CallingConvention>,
 ) -> CompileResult<bool> {
     let return_class =
         NativeCallAbi::new(type_pool, return_reg_count).classify_return(cfg.return_type());
@@ -141,17 +139,13 @@ pub(crate) fn validate_pre_lowering_budget_for_target(
             continue;
         };
         let call_args = cfg.get_call_args(&inst.data);
-        if is_foreign_symbol(*name)
+        if let Some(convention) = foreign_symbol_convention(*name)
             && crate::foreign_call::ForeignCallInputs::call_touches_aggregate(
                 cfg, inst.ty, call_args,
             )
         {
             crate::foreign_call::ForeignCallInputs::checked_call_area_bytes(
-                cfg,
-                type_pool,
-                inst.ty,
-                call_args,
-                target_c_convention,
+                cfg, type_pool, inst.ty, call_args, convention,
             )
             .map_err(|_| frame_budget_error(cfg, Some(value)))?;
             continue;
@@ -219,8 +213,7 @@ pub(crate) fn prepare_mir_with_backend<B: crate::backend::Backend>(
         B::ARG_REG_COUNT,
         B::RETURN_REG_COUNT,
         B::SAVED_REG_SCHEME,
-        target.c_calling_convention(),
-        &|name| symbols.is_foreign(&symbols.resolve(interner.resolve(&name))),
+        &|name| symbols.foreign_convention(&symbols.resolve(interner.resolve(&name))),
     )?;
     let param_storage = crate::param_storage::ParamStoragePlan::plan(
         cfg,
@@ -642,8 +635,7 @@ mod tests {
                 arg_regs,
                 ret_regs,
                 scheme,
-                convention,
-                &|_| true,
+                &|_| Some(convention),
             )
             .unwrap_err();
             assert!(matches!(
@@ -726,8 +718,7 @@ mod tests {
                     arg_regs,
                     ret_regs,
                     scheme,
-                    convention,
-                    &|_| true,
+                    &|_| Some(convention),
                 )
                 .is_err(),
                 "foreign scratch must count against the {convention:?} live sret area"

--- a/crates/rue-codegen/src/export_thunk.rs
+++ b/crates/rue-codegen/src/export_thunk.rs
@@ -54,7 +54,7 @@ use rue_air::{
     LoweredSignature, NativeAbiTypeFacts, NativeCallAbi, PaddingRange, PointerLocation, Type,
     lower_c_signature, native_return_register_budget,
 };
-use rue_target::{Arch, CRegisterClass, SretRegisterKind, Target};
+use rue_target::{Arch, CRegisterClass, CallingConvention, SretRegisterKind, Target};
 
 #[cfg(test)]
 use rue_air::ScalarAbiExtension;
@@ -126,6 +126,12 @@ pub struct ExportParameter {
 /// resolved so the description outlives the type pool it was projected from.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExportSignature {
+    /// The convention the export's C entry follows, resolved once from the
+    /// declaration's ABI string against the compilation target (spec 9.3:1b).
+    /// The thunk places the C side from this row rather than re-deriving the
+    /// target's own C row, so an explicitly named convention and the `"C"` alias
+    /// reach the emitter by one route.
+    convention: CallingConvention,
     parameters: Vec<ExportParameter>,
     result: CAbiTypeFacts,
     /// The return's native classification kernel input. The native decision
@@ -144,9 +150,11 @@ impl ExportSignature {
     /// and `return_type` its result. Semantic analysis has already gated the
     /// signature through `c_passable_by_value`, so every type here is a
     /// C-passable scalar, pointer, or `@repr(c)` aggregate, and every parameter
-    /// is by value.
+    /// is by value; `convention` is the row it already resolved the export's ABI
+    /// string to.
     pub fn for_types(
         type_pool: &FrozenTypeInternPool,
+        convention: CallingConvention,
         param_types: &[Type],
         return_type: Type,
     ) -> Self {
@@ -173,6 +181,7 @@ impl ExportSignature {
             })
             .collect();
         Self {
+            convention,
             parameters,
             result: rue_air::c_abi_type_facts(type_pool, return_type),
             return_facts: native_return_facts(type_pool, return_type),
@@ -182,14 +191,14 @@ impl ExportSignature {
     }
 
     /// The lowered C signature a caller of this export writes and this thunk
-    /// reads, under `target`'s `"C"` alias.
-    pub fn lowered(&self, target: Target) -> LoweredSignature {
+    /// reads, under the convention the declaration named.
+    pub fn lowered(&self) -> LoweredSignature {
         let parameters = self
             .parameters
             .iter()
             .map(|parameter| (parameter.c, ArgConvention::ByValue))
             .collect::<Vec<_>>();
-        lower_c_signature(target.c_calling_convention(), &parameters, self.result)
+        lower_c_signature(self.convention, &parameters, self.result)
     }
 
     /// How the native body returns on `target`, whose architecture fixes the
@@ -355,7 +364,14 @@ enum ReturnImage {
 
 impl ThunkPlan {
     fn new(target: Target, signature: &ExportSignature) -> Self {
-        let c = signature.lowered(target);
+        assert!(
+            signature.convention.is_implemented_by(target),
+            "an export thunk for {target:?} cannot be emitted under {}: semantic \
+             analysis rejects a declaration naming a convention this target does \
+             not implement (spec 9.3:1c)",
+            signature.convention
+        );
+        let c = signature.lowered();
         let spec = c.spec();
         let native_return = signature.native_return(target);
         let native_arg_registers = native_argument_register_count(target);
@@ -1232,8 +1248,23 @@ mod tests {
         scalar_parameter(rue_air::CAbiScalarKind::RegisterWidth, 8, false)
     }
 
+    /// Re-key a shared test signature to `target`'s own C row.
+    ///
+    /// These signatures are type facts, and the same facts are exercised on
+    /// every target; the convention a real export carries comes from its
+    /// declaration, and semantic analysis has already rejected a declaration
+    /// naming a row the target does not implement, so a signature reaching the
+    /// thunk always names one of the target's own rows.
+    fn on(target: Target, signature: &ExportSignature) -> ExportSignature {
+        ExportSignature {
+            convention: target.c_calling_convention(),
+            ..signature.clone()
+        }
+    }
+
     fn void_signature(parameters: Vec<ExportParameter>) -> ExportSignature {
         ExportSignature {
+            convention: CallingConvention::X86_64SysV,
             parameters,
             result: CAbiTypeFacts::ZeroSized,
             return_facts: NativeAbiTypeFacts {
@@ -1269,6 +1300,7 @@ mod tests {
             },
         ];
         ExportSignature {
+            convention: CallingConvention::X86_64SysV,
             parameters: vec![ExportParameter {
                 c: CAbiTypeFacts::Aggregate { size: 24, align: 8 },
                 native: NativeParameter::Direct {
@@ -1305,6 +1337,7 @@ mod tests {
             },
         ];
         ExportSignature {
+            convention: CallingConvention::X86_64SysV,
             parameters: vec![ExportParameter {
                 c: CAbiTypeFacts::Aggregate { size: 8, align: 4 },
                 native: NativeParameter::Indirect,
@@ -1331,7 +1364,10 @@ mod tests {
             let code = generate_export_thunk(
                 target,
                 "__rue_sem_native",
-                &void_signature(vec![word_parameter(), word_parameter()]),
+                &on(
+                    target,
+                    &void_signature(vec![word_parameter(), word_parameter()]),
+                ),
             );
             assert_eq!(code.relocations.len(), 1, "{target:?}");
             assert_eq!(code.relocations[0].kind, kind);
@@ -1348,8 +1384,18 @@ mod tests {
         // they agree.
         let registers = void_signature(vec![word_parameter(); 4]);
         assert_eq!(
-            generate_export_thunk(Target::Aarch64Linux, "native", &registers).code,
-            generate_export_thunk(Target::Aarch64Macos, "native", &registers).code
+            generate_export_thunk(
+                Target::Aarch64Linux,
+                "native",
+                &on(Target::Aarch64Linux, &registers)
+            )
+            .code,
+            generate_export_thunk(
+                Target::Aarch64Macos,
+                "native",
+                &on(Target::Aarch64Macos, &registers)
+            )
+            .code
         );
 
         let narrow = void_signature(
@@ -1358,8 +1404,16 @@ mod tests {
                 .chain([scalar_parameter(rue_air::CAbiScalarKind::I8, 1, true)])
                 .collect(),
         );
-        let linux = generate_export_thunk(Target::Aarch64Linux, "native", &narrow);
-        let darwin = generate_export_thunk(Target::Aarch64Macos, "native", &narrow);
+        let linux = generate_export_thunk(
+            Target::Aarch64Linux,
+            "native",
+            &on(Target::Aarch64Linux, &narrow),
+        );
+        let darwin = generate_export_thunk(
+            Target::Aarch64Macos,
+            "native",
+            &on(Target::Aarch64Macos, &narrow),
+        );
         // Both rows read a one-byte stacked argument at offset 0, so the codes
         // agree here too; what differs is where a *second* stacked argument
         // would land, which the lowered-signature tests pin directly.
@@ -1391,7 +1445,7 @@ mod tests {
     fn a_nine_scalar_export_spills_its_tail_on_both_rows() {
         let signature = void_signature(vec![word_parameter(); 9]);
         for target in [Target::X86_64Linux, Target::Aarch64Linux] {
-            let plan = ThunkPlan::new(target, &signature);
+            let plan = ThunkPlan::new(target, &on(target, &signature));
             assert_eq!(plan.slots.len(), 9);
             let registers = native_argument_register_count(target);
             assert_eq!(plan.register_slots, registers);
@@ -1414,7 +1468,7 @@ mod tests {
     #[test]
     fn a_direct_multislot_parameter_reaches_the_body_in_reversed_slot_order() {
         for target in [Target::X86_64Linux, Target::Aarch64Linux] {
-            let plan = ThunkPlan::new(target, &triple_signature());
+            let plan = ThunkPlan::new(target, &on(target, &triple_signature()));
             // The native return is three slot-identical slots, under both
             // budgets, so it comes back in registers and there is no hidden
             // pointer ahead of the user argument.
@@ -1456,16 +1510,22 @@ mod tests {
         // SysV passes it byval on the stack; AAPCS64 passes a pointer to a
         // caller-owned copy. Either way the thunk reads the C caller's bytes in
         // place and never repacks them.
-        let sysv = ThunkPlan::new(Target::X86_64Linux, &triple_signature());
+        let sysv = ThunkPlan::new(
+            Target::X86_64Linux,
+            &on(Target::X86_64Linux, &triple_signature()),
+        );
         assert!(matches!(sysv.bases[0], ImageBase::Incoming { offset: 0 }));
-        let aapcs = ThunkPlan::new(Target::Aarch64Linux, &triple_signature());
+        let aapcs = ThunkPlan::new(
+            Target::Aarch64Linux,
+            &on(Target::Aarch64Linux, &triple_signature()),
+        );
         assert!(matches!(aapcs.bases[0], ImageBase::SavedPointer { .. }));
     }
 
     #[test]
     fn an_indirect_native_pair_forwards_the_caller_bytes_and_its_own_storage() {
         for target in [Target::X86_64Linux, Target::Aarch64Linux] {
-            let plan = ThunkPlan::new(target, &pair_signature());
+            let plan = ThunkPlan::new(target, &on(target, &pair_signature()));
             // Eight bytes of narrow fields: the native convention cannot express
             // it in registers, so both directions cross through memory.
             assert_eq!(plan.native_return, NativeReturn::Sret);
@@ -1491,7 +1551,10 @@ mod tests {
 
     #[test]
     fn only_sysv_echoes_the_indirect_result_pointer() {
-        let sysv = ThunkPlan::new(Target::X86_64Linux, &triple_signature());
+        let sysv = ThunkPlan::new(
+            Target::X86_64Linux,
+            &on(Target::X86_64Linux, &triple_signature()),
+        );
         assert!(matches!(
             sysv.c.ret(),
             LoweredReturn::Sret {
@@ -1503,7 +1566,10 @@ mod tests {
         // The pointer is argument register zero, so it is already saved there.
         assert_eq!(sysv.c_sret_offset, Some(sysv.save_base));
 
-        let aapcs = ThunkPlan::new(Target::Aarch64Linux, &triple_signature());
+        let aapcs = ThunkPlan::new(
+            Target::Aarch64Linux,
+            &on(Target::Aarch64Linux, &triple_signature()),
+        );
         assert!(matches!(
             aapcs.c.ret(),
             LoweredReturn::Sret {
@@ -1529,7 +1595,7 @@ mod tests {
                 Target::Aarch64Linux,
                 Target::Aarch64Macos,
             ] {
-                let plan = ThunkPlan::new(target, &signature);
+                let plan = ThunkPlan::new(target, &on(target, &signature));
                 assert_eq!(
                     plan.frame_bytes % 16,
                     0,
@@ -1544,7 +1610,7 @@ mod tests {
         let code = generate_export_thunk(
             Target::X86_64Linux,
             "native",
-            &void_signature(vec![word_parameter()]),
+            &on(Target::X86_64Linux, &void_signature(vec![word_parameter()])),
         );
         // push rbp ; mov rbp, rsp ; sub rsp, imm32
         assert_eq!(&code.code[..4], &[0x55, 0x48, 0x89, 0xE5]);
@@ -1561,7 +1627,10 @@ mod tests {
         let code = generate_export_thunk(
             Target::Aarch64Linux,
             "native",
-            &void_signature(vec![word_parameter()]),
+            &on(
+                Target::Aarch64Linux,
+                &void_signature(vec![word_parameter()]),
+            ),
         );
         assert_eq!(code.code.len() % 4, 0);
         let word = |index: usize| {
@@ -1593,6 +1662,7 @@ mod tests {
                 signed,
             }];
             let signature = ExportSignature {
+                convention: CallingConvention::X86_64SysV,
                 parameters: vec![ExportParameter {
                     c: CAbiTypeFacts::Aggregate {
                         size: width.into(),
@@ -1620,7 +1690,7 @@ mod tests {
                 }],
             };
             for target in [Target::X86_64Linux, Target::Aarch64Linux] {
-                let code = generate_export_thunk(target, "native", &signature);
+                let code = generate_export_thunk(target, "native", &on(target, &signature));
                 assert!(
                     !code.code.is_empty(),
                     "{target:?} must encode a {width}-byte leaf"

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -137,14 +137,16 @@ pub struct EmittedRelocation {
 /// Borrowed compiler authority for projecting legacy live callable names to
 /// canonical machine symbols. Runtime helpers never pass through this map.
 ///
-/// It also carries the set of `extern "C"` foreign symbols (ADR-0064): a call to
-/// one of these resolves to its raw (unmangled) C name and crosses under the
-/// target-C ABI, so the backend must apply the boundary's narrow-integer
-/// extension to a scalar return ([`is_foreign`](Self::is_foreign)).
+/// It also carries the `extern` foreign symbols (ADR-0064) with the calling
+/// convention each one's declaration named: a call to one of these resolves to
+/// its raw (unmangled) C name and crosses under that convention, so the backend
+/// places its arguments and applies the boundary's narrow-integer extension from
+/// the row recorded here ([`foreign_convention`](Self::foreign_convention))
+/// rather than from the target's own C row.
 #[derive(Clone, Copy, Default)]
 pub struct MachineSymbolResolver<'a> {
     mappings: Option<&'a std::collections::BTreeMap<String, String>>,
-    foreign: Option<&'a std::collections::BTreeSet<String>>,
+    foreign: Option<&'a std::collections::BTreeMap<String, rue_target::CallingConvention>>,
 }
 
 impl<'a> MachineSymbolResolver<'a> {
@@ -155,11 +157,12 @@ impl<'a> MachineSymbolResolver<'a> {
         }
     }
 
-    /// Build a resolver that also knows which resolved symbols are `extern "C"`
-    /// foreign declarations (ADR-0064 C FFI). `foreign` holds their raw C names.
+    /// Build a resolver that also knows which resolved symbols are `extern`
+    /// foreign declarations (ADR-0064 C FFI) and which calling convention each
+    /// one's declaration named. `foreign` is keyed by their raw C names.
     pub fn new_with_foreign(
         mappings: &'a std::collections::BTreeMap<String, String>,
-        foreign: &'a std::collections::BTreeSet<String>,
+        foreign: &'a std::collections::BTreeMap<String, rue_target::CallingConvention>,
     ) -> Self {
         Self {
             mappings: Some(mappings),
@@ -174,12 +177,19 @@ impl<'a> MachineSymbolResolver<'a> {
             .unwrap_or_else(|| legacy_or_canonical.to_owned())
     }
 
-    /// Whether `machine_symbol` (already resolved via [`resolve`](Self::resolve))
-    /// names an `extern "C"` foreign function. A foreign symbol maps to itself,
-    /// so the resolved name is its raw C name.
-    pub fn is_foreign(&self, machine_symbol: &str) -> bool {
+    /// The calling convention `machine_symbol` (already resolved via
+    /// [`resolve`](Self::resolve)) crosses under when it names an `extern`
+    /// foreign function, or `None` when it does not. A foreign symbol maps to
+    /// itself, so the resolved name is its raw C name; the row is the one its
+    /// declaration named, resolved once in semantic analysis (spec 9.3:1b) and
+    /// never re-derived from the target here.
+    pub fn foreign_convention(
+        &self,
+        machine_symbol: &str,
+    ) -> Option<rue_target::CallingConvention> {
         self.foreign
-            .is_some_and(|foreign| foreign.contains(machine_symbol))
+            .and_then(|foreign| foreign.get(machine_symbol))
+            .copied()
     }
 }
 

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -444,10 +444,15 @@ pub trait ValueLowerAdapter:
     /// single ABI slot names: floating-point when `float_width` is `Some`.
     fn reserve_typed_value_result(&mut self, float_width: Option<FloatWidth>) -> VReg;
     fn resolve_symbol(&self, symbol: Spur) -> String;
-    /// Whether `machine_symbol` (already resolved via
-    /// [`resolve_symbol`](Self::resolve_symbol)) names an `extern "C"` foreign
-    /// function, so its call crosses under the target-C ABI (ADR-0064 P2).
-    fn is_foreign_symbol(&self, machine_symbol: &str) -> bool;
+    /// The calling convention `machine_symbol` (already resolved via
+    /// [`resolve_symbol`](Self::resolve_symbol)) crosses under when it names an
+    /// `extern` foreign function, or `None` when it does not (ADR-0064 P2). The
+    /// row is the one its declaration named, resolved once in semantic analysis
+    /// (spec 9.3:1b), not re-derived from the backend's target.
+    fn foreign_symbol_convention(
+        &self,
+        machine_symbol: &str,
+    ) -> Option<rue_target::CallingConvention>;
     fn resolve_named_symbol(&self, symbol: &str) -> String;
     fn call_arg_register_banks(&self) -> crate::call_plan::AbiRegisterBanks;
     /// The target's RETURN register file, one bank per register class. Its
@@ -1765,14 +1770,15 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                 adapter.emit_runtime_call(plan)
             } else {
                 let symbol = adapter.resolve_symbol(*name);
-                let is_foreign = adapter.is_foreign_symbol(&symbol);
+                let foreign_convention = adapter.foreign_symbol_convention(&symbol);
                 // A foreign call that crosses an aggregate by value takes the
-                // dedicated target-C path (ADR-0064 P3): the native slot plan
-                // reverses multi-slot aggregates, disagreeing with C packing, so
+                // dedicated C path (ADR-0064 P3): the native slot plan reverses
+                // multi-slot aggregates, disagreeing with C packing, so
                 // aggregates are marshaled through their physical memory image in
                 // C field order. A scalars-only foreign call keeps P2's native
-                // plan with a boundary return extension.
-                if is_foreign
+                // plan with a boundary return extension. Either way the
+                // convention is the declaration's own.
+                if let Some(convention) = foreign_convention
                     && crate::foreign_call::ForeignCallInputs::call_touches_aggregate(
                         ctx.cfg, inst.ty, call_args,
                     )
@@ -1783,25 +1789,26 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         ctx.type_pool,
                         inst.ty,
                         call_args,
-                        adapter.target_c_convention(),
+                        convention,
                     );
                     let result_vreg = adapter.reserve_typed_value_result(float_width(inst.ty));
                     adapter.emit_foreign_call(foreign_inputs, result_vreg)
                 } else {
-                    // An `extern "C"` scalar/pointer call (ADR-0064 P2): a scalar
+                    // An `extern` scalar/pointer call (ADR-0064 P2): a scalar
                     // return is re-extended to Rue's canonical 64-bit form because
                     // a C callee leaves the bits above the return's declared width
                     // unspecified. The rule comes from the shared `TargetCCallAbi`
-                    // classifier, not a backend-local choice.
-                    let foreign_return_extension = if is_foreign
-                        && matches!(inputs.return_plan, crate::call_plan::ReturnPlan::Scalar)
-                    {
-                        let ext = rue_air::TargetCCallAbi::new(adapter.target_c_convention())
-                            .scalar_return_extension(inst.ty);
-                        (!ext.is_noop()).then_some(ext)
-                    } else {
-                        None
-                    };
+                    // classifier reading the declaration's convention, not a
+                    // backend-local choice.
+                    let foreign_return_extension = foreign_convention
+                        .filter(|_| {
+                            matches!(inputs.return_plan, crate::call_plan::ReturnPlan::Scalar)
+                        })
+                        .map(|convention| {
+                            rue_air::TargetCCallAbi::new(convention)
+                                .scalar_return_extension(inst.ty)
+                        })
+                        .filter(|ext| !ext.is_noop());
                     // The result vreg mirrors the return's logical slot 0, so its
                     // class follows that slot's LEAF: a float-leaf aggregate
                     // result lands in an FP vreg, not a general-purpose one, and

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -4011,8 +4011,11 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn resolve_named_symbol(&self, symbol: &str) -> String {
         self.symbols.resolve(symbol)
     }
-    fn is_foreign_symbol(&self, machine_symbol: &str) -> bool {
-        self.symbols.is_foreign(machine_symbol)
+    fn foreign_symbol_convention(
+        &self,
+        machine_symbol: &str,
+    ) -> Option<rue_target::CallingConvention> {
+        self.symbols.foreign_convention(machine_symbol)
     }
     fn call_arg_register_banks(&self) -> crate::call_plan::AbiRegisterBanks {
         crate::call_plan::AbiRegisterBanks {

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4880,7 +4880,7 @@ pub(super) use register_parse_import_parse;"#;
         });
     assert_eq!(
         (declarations.len(), fingerprint),
-        (213, 209_895_908_114_665_903),
+        (214, 1_253_032_129_469_309_576),
         "crate-visible declaration names, signatures, fields, or phase owners changed"
     );
 
@@ -5212,6 +5212,7 @@ struct:FrontierChildExecution
 enum:WarningBodyReferencesFailure
 enum:DeclarationShellBatchFailure
 enum:SemanticNucleusBatchFailure
+struct:DurableCExportRoot
 struct:SemanticNucleusProjection
 struct:LookupNameKey
 struct:LookupImportKey

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -295,7 +295,9 @@ pub(crate) fn generate_export_thunk_objects(
             options.target,
             exported_symbol,
             &function.record.codegen.defined_symbol,
-            &crate::session::export_signature(function),
+            // Exports reaching this test-only path are declared `"C"`, so the
+            // target's own row is the row their declaration resolved to.
+            &crate::session::export_signature(function, options.target.c_calling_convention()),
         ));
     }
     objects

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -644,7 +644,13 @@ impl CfgRecord {
 pub(crate) struct CfgCodegenDomain {
     pub(crate) defined_symbol: Arc<str>,
     pub(crate) symbol_mappings: Arc<std::collections::BTreeMap<String, String>>,
-    pub(crate) foreign_symbols: Arc<std::collections::BTreeSet<String>>,
+    /// Each `extern` foreign symbol this unit calls, mapped to the calling
+    /// convention its declaration named (9.3:1b). Code generation reads the row
+    /// from here rather than re-deriving the target's own C row, so an
+    /// explicitly named convention and the `"C"` alias reach the backend the
+    /// same way.
+    pub(crate) foreign_symbols:
+        Arc<std::collections::BTreeMap<String, rue_target::CallingConvention>>,
 }
 
 impl CfgCodegenDomain {
@@ -654,7 +660,7 @@ impl CfgCodegenDomain {
     pub(crate) fn is_foreign_source_symbol(&self, source: &str) -> bool {
         self.symbol_mappings
             .get(source)
-            .is_some_and(|machine| self.foreign_symbols.contains(machine))
+            .is_some_and(|machine| self.foreign_symbols.contains_key(machine))
     }
 }
 
@@ -1998,7 +2004,7 @@ struct CfgSpliceState {
         AHashMap<rue_air::LocalAtomId<crate::StableDefinitionKey, crate::ModuleId>, usize>,
     symbol_mappings: std::collections::BTreeMap<String, String>,
     source_by_machine: std::collections::BTreeMap<String, String>,
-    foreign_symbols: std::collections::BTreeSet<String>,
+    foreign_symbols: std::collections::BTreeMap<String, rue_target::CallingConvention>,
     materialization_warnings: Vec<rue_error::CompileWarning>,
     warnings: Vec<rue_error::CompileWarning>,
     implicit_destructor_targets: std::collections::BTreeSet<crate::TypeInstanceKey>,
@@ -2274,8 +2280,7 @@ fn splice_callee(
     }
     for (source, machine) in callee.codegen.symbol_mappings.iter() {
         if state.symbol_mappings.get(source) == Some(machine)
-            && state.foreign_symbols.contains(machine)
-                != callee.codegen.foreign_symbols.contains(machine)
+            && state.foreign_symbols.get(machine) != callee.codegen.foreign_symbols.get(machine)
         {
             return Err(SpliceCalleeFailure::ConflictingForeignSymbol);
         }
@@ -2289,8 +2294,8 @@ fn splice_callee(
         .codegen
         .foreign_symbols
         .iter()
-        .filter(|symbol| !state.foreign_symbols.contains(*symbol))
-        .cloned()
+        .filter(|(symbol, _)| !state.foreign_symbols.contains_key(*symbol))
+        .map(|(symbol, convention)| (symbol.clone(), *convention))
         .collect::<Vec<_>>();
     let mut materialization_warning_additions = Vec::new();
     let mut warning_additions = Vec::new();
@@ -4057,9 +4062,10 @@ mod accessor_graph_tests {
                 source.clone(),
                 format!("{machine}__conflict"),
             )])),
-            foreign_symbols: Arc::new(std::collections::BTreeSet::from([
-                "__staged_foreign".to_owned()
-            ])),
+            foreign_symbols: Arc::new(std::collections::BTreeMap::from([(
+                "__staged_foreign".to_owned(),
+                rue_target::CallingConvention::X86_64SysV,
+            )])),
         });
         poisoned.implicit_destructor_targets = Arc::from([crate::TypeInstanceKey::I32]);
         poisoned.implicit_drop_glue_targets = Arc::from([crate::TypeInstanceKey::I64]);
@@ -4118,7 +4124,7 @@ mod accessor_graph_tests {
         );
 
         let mut poisoned = (*callee).clone();
-        let foreign_conflict = !state.foreign_symbols.contains(&machine);
+        let foreign_conflict = !state.foreign_symbols.contains_key(&machine);
         poisoned.codegen = Arc::new(CfgCodegenDomain {
             defined_symbol: poisoned.codegen.defined_symbol.clone(),
             symbol_mappings: Arc::new(std::collections::BTreeMap::from([(
@@ -4126,9 +4132,12 @@ mod accessor_graph_tests {
                 machine.clone(),
             )])),
             foreign_symbols: if foreign_conflict {
-                Arc::new(std::collections::BTreeSet::from([machine.clone()]))
+                Arc::new(std::collections::BTreeMap::from([(
+                    machine.clone(),
+                    rue_target::CallingConvention::X86_64SysV,
+                )]))
             } else {
-                Arc::new(std::collections::BTreeSet::new())
+                Arc::new(std::collections::BTreeMap::new())
             },
         });
         assert!(matches!(
@@ -4285,7 +4294,10 @@ mod accessor_graph_tests {
                 "foreign".to_owned(),
                 "ffi_symbol".to_owned(),
             )])),
-            foreign_symbols: Arc::new(std::collections::BTreeSet::from(["ffi_symbol".to_owned()])),
+            foreign_symbols: Arc::new(std::collections::BTreeMap::from([(
+                "ffi_symbol".to_owned(),
+                rue_target::CallingConvention::X86_64SysV,
+            )])),
         };
         assert!(foreign_domain.is_foreign_source_symbol("foreign"));
         assert!(!foreign_domain.is_foreign_source_symbol("missing"));

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -940,7 +940,7 @@ impl CfgDomainProjection {
             ))
         };
         let mut symbol_mappings = std::collections::BTreeMap::new();
-        let mut foreign_symbols = std::collections::BTreeSet::new();
+        let mut foreign_symbols = std::collections::BTreeMap::new();
         for (live, stable) in &self.symbols {
             let source = interner.resolve(live).to_owned();
             let (machine, foreign) = match stable {
@@ -949,8 +949,10 @@ impl CfgDomainProjection {
                     // native symbol come from the same facts, and this map is
                     // keyed by a recursive callable identity.
                     let abi = call_abis.get(callable);
-                    let foreign = abi.is_some_and(|facts| facts.convention.is_c());
-                    let machine = if foreign {
+                    let foreign = abi
+                        .map(|facts| facts.convention)
+                        .filter(|convention| convention.is_c());
+                    let machine = if foreign.is_some() {
                         foreign_callable_symbol(callable).ok_or(CfgDomainFailure::Shape)?
                     } else if source == "main" {
                         source.clone()
@@ -972,8 +974,10 @@ impl CfgDomainProjection {
                         crate::semantic_identity::function_instance_from_specialization(identity)
                             .ok_or(CfgDomainFailure::Shape)?;
                     let abi = call_abis.get(&callable);
-                    let foreign = abi.is_some_and(|facts| facts.convention.is_c());
-                    let machine = if foreign {
+                    let foreign = abi
+                        .map(|facts| facts.convention)
+                        .filter(|convention| convention.is_c());
+                    let machine = if foreign.is_some() {
                         foreign_callable_symbol(&callable).ok_or(CfgDomainFailure::Shape)?
                     } else if source == "main" {
                         source.clone()
@@ -991,11 +995,11 @@ impl CfgDomainProjection {
                     (machine, foreign)
                 }
                 StableCfgSymbol::Runtime(symbol) | StableCfgSymbol::Intrinsic(symbol) => {
-                    (symbol.to_string(), false)
+                    (symbol.to_string(), None)
                 }
             };
-            if foreign {
-                foreign_symbols.insert(machine.clone());
+            if let Some(convention) = foreign {
+                foreign_symbols.insert(machine.clone(), convention);
             }
             if let Some(previous) = symbol_mappings.insert(source, machine.clone())
                 && previous != machine

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -472,6 +472,11 @@ pub enum ParsedDeclarationAstRef<'a> {
     },
     ExternFunction {
         function: &'a rue_parser::ast::ExternFn,
+        /// The ABI string its enclosing `extern` block wrote. A foreign
+        /// declaration's convention is a property of the block, so the member's
+        /// signature producer reads it from here rather than re-finding the
+        /// block.
+        abi: &'a str,
     },
     /// A `test "name" { .. }` declaration (ADR-0083 §1).
     Test(&'a rue_parser::ast::TestDecl),
@@ -909,7 +914,10 @@ impl ParsedModule {
                 (span_matches(function.span)
                     && name_matches(function.name.name, key.name.as_ref())
                     && key.owner.is_none())
-                .then_some(ParsedDeclarationAstRef::ExternFunction { function })
+                .then_some(ParsedDeclarationAstRef::ExternFunction {
+                    function,
+                    abi: block.abi.as_str(),
+                })
             }
             (
                 ParsedDeclarationAstLocator::TopLevel { item: ordinal },
@@ -3043,7 +3051,12 @@ fn build_definition_index(
                         false,
                         Arc::from([]),
                         function.span,
-                        vec![function.span],
+                        // The block's ABI string is part of every member's
+                        // signature: it selects the calling convention a call
+                        // to that member crosses under (spec 9.3:1b), so
+                        // editing it invalidates each member's signature
+                        // fingerprint exactly as editing a parameter type does.
+                        vec![block.abi_span, function.span],
                         None,
                         None,
                         Arc::from([]),
@@ -3525,7 +3538,7 @@ extern "C" { fn getpid() -> i32; }
                     );
                     (key.category, method.span)
                 }
-                ParsedDeclarationAstRef::ExternFunction { function } => {
+                ParsedDeclarationAstRef::ExternFunction { function, .. } => {
                     (C::ExternFunction, function.span)
                 }
                 ParsedDeclarationAstRef::Test(value) => (C::Test, value.span),

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -299,7 +299,8 @@ zero_charge!(
     rue_span::FileId,
     rue_span::Span,
     rue_query::Revision,
-    rue_cfg::BlockId
+    rue_cfg::BlockId,
+    rue_target::CallingConvention
 );
 
 impl<'a> RetainedCharge for Cow<'a, str> {
@@ -1559,6 +1560,12 @@ impl RetainedCharge for rue_error::ErrorKind {
             } => left
                 .retained_charge()
                 .saturating_add(right.retained_charge()),
+
+            // The convention and target names are borrowed table entries; only
+            // the rendered target list is owned.
+            E::CallingConventionUnsupportedOnTarget { implemented_by, .. } => {
+                implemented_by.retained_charge()
+            }
 
             E::UnexpectedToken { expected, found } => expected
                 .retained_charge()

--- a/crates/rue-compiler/src/revisioned_query_database/body/closure_nucleus.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/closure_nucleus.rs
@@ -1169,17 +1169,23 @@ impl RevisionedQueryDatabase {
                         }
                     }
                     dependencies.extend(signature.dependencies.iter().cloned());
-                    let is_c_export = matches!(
-                        &signature.signature,
+                    let export_convention = match &signature.signature {
                         crate::semantic_query_nucleus::DeclarationSignatureProjection::Callable {
                             is_c_export: true,
+                            foreign_convention,
                             ..
-                        }
-                    );
+                        } => *foreign_convention,
+                        _ => None,
+                    };
                     let semantic =
                         DeclarationSemanticValue::from_signature(identity, signature.signature);
-                    if is_c_export {
-                        c_export_roots.insert(semantic.identity.key.clone());
+                    if let Some(convention) = export_convention {
+                        c_export_roots.insert(
+                            crate::revisioned_query_database::DurableCExportRoot {
+                                key: semantic.identity.key.clone(),
+                                convention,
+                            },
+                        );
                     }
                     semantic
                 };

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -2506,6 +2506,7 @@ pub(in crate::revisioned_query_database) fn resolve_parsed_semantic_signature(
             is_unchecked,
             is_extern,
             is_c_export,
+            foreign_abi,
             is_accessor,
             accessor_result_mode,
             accessor_body,
@@ -2663,6 +2664,34 @@ pub(in crate::revisioned_query_database) fn resolve_parsed_semantic_signature(
                     },
                 }));
             }
+            // The written ABI, resolved exactly once. It is either the `"C"`
+            // alias, which this target answers with its own psABI row, or a row
+            // named outright (9.3:1b), which is ill-formed here unless this
+            // target implements it (9.3:1c) — never a silent fallback to the
+            // target's own row. Everything downstream carries the row this
+            // produces.
+            let foreign_convention = match foreign_abi {
+                None => None,
+                Some(abi) => {
+                    let target = provider.configuration.target;
+                    let convention = abi.resolve(target);
+                    if !convention.is_implemented_by(target) {
+                        return Err(diagnostic(
+                            rue_error::ErrorKind::CallingConventionUnsupportedOnTarget {
+                                convention: convention.name(),
+                                target: target.name(),
+                                implemented_by: convention
+                                    .implementing_targets()
+                                    .map(|target| format!("`{}`", target.name()))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                                    .into(),
+                            },
+                        ));
+                    }
+                    Some(convention)
+                }
+            };
             if *is_extern || *is_c_export {
                 let check =
                     |provider: &mut SemanticNucleusTypeProvider<'_>,
@@ -2776,6 +2805,7 @@ pub(in crate::revisioned_query_database) fn resolve_parsed_semantic_signature(
                 is_unchecked: *is_unchecked,
                 is_extern: *is_extern,
                 is_c_export: *is_c_export,
+                foreign_convention,
             })
         }
         Input::Struct {

--- a/crates/rue-compiler/src/revisioned_query_database/parse_import.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/parse_import.rs
@@ -572,6 +572,24 @@ pub(crate) enum SemanticNucleusBatchFailure {
     },
 }
 
+/// One `pub extern` export root, with the convention its C entry follows.
+///
+/// The convention was resolved from the export's written ABI string against the
+/// compilation target when its signature was checked (spec 9.3:1b); carrying it
+/// with the root is what lets the entry thunk be emitted under the declaration's
+/// own row instead of re-deriving the target's `"C"` alias at generation time.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DurableCExportRoot {
+    pub(crate) key: crate::StableDefinitionKey,
+    pub(crate) convention: rue_target::CallingConvention,
+}
+
+impl RetainedCharge for DurableCExportRoot {
+    fn retained_charge(&self) -> u64 {
+        self.key.retained_charge()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SemanticNucleusProjection {
     pub(crate) declarations: Arc<[crate::DurableDeclarationSemantic]>,
@@ -579,7 +597,7 @@ pub(crate) struct SemanticNucleusProjection {
         Arc<crate::local_semantic_materialization::SharedDeclarationFactIndex>,
     pub(crate) anonymous_nominals: Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
     pub(crate) dependencies: Arc<[crate::semantic_query_nucleus::SemanticDeclarationDependency]>,
-    pub(crate) c_export_roots: Arc<[crate::StableDefinitionKey]>,
+    pub(crate) c_export_roots: Arc<[DurableCExportRoot]>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/rue-compiler/src/revisioned_query_database/semantic.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/semantic.rs
@@ -1395,7 +1395,12 @@ pub(super) struct StableCallableSignature {
         crate::TypeInstanceKey,
     )>,
     pub(super) result: crate::TypeInstanceKey,
-    pub(super) target_c: bool,
+    /// The C convention this callable is *entered* under, already resolved from
+    /// the declaration's ABI string against the compilation target, or `None`
+    /// for a callable entered under Rue's native convention. Only a foreign
+    /// declaration is a C entry: a `pub extern` export's own body is native and
+    /// its separate thunk is the crossing.
+    pub(super) foreign_convention: Option<rue_target::CallingConvention>,
 }
 
 pub(super) fn named_callable_owner_type(
@@ -1596,7 +1601,7 @@ pub(super) fn query_callable_signature(
         crate::FunctionInstanceKey::DropGlue(owner) => Ok(Ok(StableCallableSignature {
             parameters: vec![(DurableParameterMode::Value, owner.as_ref().clone())],
             result: crate::TypeInstanceKey::Unit,
-            target_c: false,
+            foreign_convention: None,
         })),
         // A structural printer takes the error value and hands back a borrowed
         // `{ptr, len}` view of the rendering it wrote (ADR-0083 §1).
@@ -1606,7 +1611,7 @@ pub(super) fn query_callable_signature(
                 kind: crate::AnonymousNominalKind::Struct,
                 name: Arc::from("str"),
             },
-            target_c: false,
+            foreign_convention: None,
         })),
         crate::FunctionInstanceKey::Definition(definition)
             if definition.kind() == crate::StableDefinitionKind::Destructor =>
@@ -1619,7 +1624,7 @@ pub(super) fn query_callable_signature(
             Ok(Ok(StableCallableSignature {
                 parameters: vec![(DurableParameterMode::Value, owner)],
                 result: crate::TypeInstanceKey::Unit,
-                target_c: false,
+                foreign_convention: None,
             }))
         }
         crate::FunctionInstanceKey::AnonymousMember { owner, member } => {
@@ -1679,7 +1684,7 @@ pub(super) fn query_callable_signature(
             Ok(Ok(StableCallableSignature {
                 parameters,
                 result: anonymous_method_type(&signature.result, owner),
-                target_c: false,
+                foreign_convention: None,
             }))
         }
         callable => {
@@ -1742,6 +1747,7 @@ pub(super) fn query_callable_signature(
                 self_mode,
                 is_extern,
                 is_c_export: _,
+                foreign_convention,
                 ..
             } = &signature.signature
             else {
@@ -1803,8 +1809,9 @@ pub(super) fn query_callable_signature(
                 parameters: runtime_parameters,
                 result: crate::type_queries::type_instance(&result),
                 // A C export's source body uses Rue's native ABI. The separate
-                // entry thunk is the Target-C boundary.
-                target_c: *is_extern,
+                // entry thunk is the C boundary, and carries the declaration's
+                // convention on its own.
+                foreign_convention: is_extern.then_some(*foreign_convention).flatten(),
             }))
         }
     }
@@ -1931,14 +1938,13 @@ pub(super) fn evaluate_call_abi(
                 .with_terminal_kind(QueryTerminalKind::Failure));
         }
     };
-    // `"C"` is an alias resolved by the whole target, not by its architecture:
-    // AArch64 Linux and AArch64 macOS share an architecture and follow different
-    // conventions. The stable plane consults the same table code generation does.
-    let convention = if signature.target_c {
-        CallingConvention::c_for_target(key.configuration.target)
-    } else {
-        CallingConvention::Rue
-    };
+    // A foreign declaration's convention was resolved once, from its written ABI
+    // string against this compilation target, when its signature was checked
+    // (9.3:1b); the stable plane carries that row rather than re-deriving the
+    // target's own C row here. Everything else is entered natively.
+    let convention = signature
+        .foreign_convention
+        .unwrap_or(CallingConvention::Rue);
     // Every layout this ABI needs, in one batch: each by-value parameter in
     // signature order, then the result. A reference parameter is passed as a
     // pointer whatever it points at, so it contributes no key and no layout

--- a/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
@@ -728,10 +728,10 @@ fn the_c_by_value_classifier_agrees_across_sites_shapes_and_planes() {
 
             let mut param_types = vec![*live_ty];
             param_types.extend(std::iter::repeat_n(Type::I64, 9));
-            let export = ExportSignature::for_types(&pool, &param_types, *live_ty);
+            let export = ExportSignature::for_types(&pool, convention, &param_types, *live_ty);
             assert_eq!(
                 call,
-                export.lowered(target),
+                export.lowered(),
                 "{target:?}/{name}: an export must read the placement a call writes"
             );
 

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -58,6 +58,13 @@ pub(crate) enum ParsedSemanticSignature {
         is_unchecked: bool,
         is_extern: bool,
         is_c_export: bool,
+        /// The ABI the declaration wrote, still unresolved: `Some` exactly when
+        /// this is a foreign declaration or a C export, `None` for an ordinary
+        /// Rue callable. The parser has already rejected any string that names
+        /// no convention (9.3:1b), and signature resolution turns this into the
+        /// concrete [`rue_target::CallingConvention`] against the compilation
+        /// target — the one place the `"C"` alias is resolved.
+        foreign_abi: Option<rue_target::ForeignAbi>,
         is_accessor: bool,
         /// The declared accessor result qualifier. `Value` means no
         /// place-returning qualifier; it is retained even for invalid
@@ -403,6 +410,7 @@ pub(crate) fn project_semantic_signature(
                     is_unchecked,
                     is_extern,
                     is_c_export,
+                    abi: Option<&str>,
                     is_accessor,
                     accessor_result_mode,
                     body: Option<&rue_parser::ast::Expr>|
@@ -424,6 +432,11 @@ pub(crate) fn project_semantic_signature(
             is_unchecked,
             is_extern,
             is_c_export,
+            // The parser accepts only the ABI strings this table names, so a
+            // declaration that reached semantic analysis spells one of them;
+            // a program whose ABI string was rejected has already failed.
+            foreign_abi: abi
+                .map(|abi| rue_target::ForeignAbi::parse(abi).unwrap_or(rue_target::ForeignAbi::C)),
             is_accessor,
             accessor_result_mode,
             accessor_body: if is_accessor {
@@ -446,6 +459,7 @@ pub(crate) fn project_semantic_signature(
             function.is_unchecked,
             false,
             function.export_abi.is_some(),
+            function.export_abi.as_deref(),
             function.place_return.is_some(),
             if function.place_return.is_some_and(|mode| mode.is_inout()) {
                 crate::declaration_candidate::DeclarationParameterMode::Inout
@@ -456,7 +470,7 @@ pub(crate) fn project_semantic_signature(
             },
             Some(&function.body),
         ),
-        ParsedDeclarationAstRef::ExternFunction { function } => callable(
+        ParsedDeclarationAstRef::ExternFunction { function, abi } => callable(
             &function.params,
             function.return_type.as_ref(),
             false,
@@ -464,6 +478,7 @@ pub(crate) fn project_semantic_signature(
             false,
             true,
             false,
+            Some(abi),
             false,
             crate::declaration_candidate::DeclarationParameterMode::Value,
             None,
@@ -479,6 +494,7 @@ pub(crate) fn project_semantic_signature(
             false,
             false,
             false,
+            None,
             method.place_return.is_some(),
             if method.place_return.is_some_and(|mode| mode.is_inout()) {
                 crate::declaration_candidate::DeclarationParameterMode::Inout
@@ -584,6 +600,7 @@ pub(crate) fn project_semantic_signature(
             false,
             false,
             false,
+            None,
             false,
             crate::declaration_candidate::DeclarationParameterMode::Value,
             None,
@@ -878,6 +895,13 @@ pub(crate) enum DeclarationSignatureProjection {
         is_unchecked: bool,
         is_extern: bool,
         is_c_export: bool,
+        /// The convention this declaration's C boundary follows, already
+        /// resolved against the compilation target: `Some` exactly when
+        /// `is_extern` or `is_c_export`. Every later ABI consumer reads this
+        /// row instead of re-deriving "the C row for this target", so an
+        /// explicitly named convention and the `"C"` alias arrive at the same
+        /// place by the same route (9.3:1b).
+        foreign_convention: Option<rue_target::CallingConvention>,
     },
     Struct {
         fields: Arc<[(Arc<str>, DurableType)]>,
@@ -1140,6 +1164,7 @@ impl DeclarationSemanticValue {
                 is_unchecked,
                 is_extern: _,
                 is_c_export: _,
+                foreign_convention: _,
             } => DurableDeclarationPayload::Callable {
                 parameters,
                 result,

--- a/crates/rue-compiler/src/session/rooted_artifacts.rs
+++ b/crates/rue-compiler/src/session/rooted_artifacts.rs
@@ -283,7 +283,7 @@ pub(super) struct RootedBodyGraph {
     pub(super) anonymous_nominals: Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
     pub(super) declaration_dependencies:
         Arc<[crate::semantic_query_nucleus::SemanticDeclarationDependency]>,
-    pub(super) c_export_roots: Arc<[crate::StableDefinitionKey]>,
+    pub(super) c_export_roots: Arc<[crate::revisioned_query_database::DurableCExportRoot]>,
     pub(super) modules: Arc<[Arc<crate::parsed_modules::ParsedModule>]>,
     /// The program entry point, present only for a `RootSelection::Executable`
     /// request. A test request has no entry point (ADR-0083 §1).
@@ -318,19 +318,25 @@ pub(super) fn collect_rooted_exports(
     let export_roots = graph
         .c_export_roots
         .iter()
-        .cloned()
-        .map(crate::FunctionInstanceKey::Definition)
-        .collect::<BTreeSet<_>>();
+        .map(|export| {
+            (
+                crate::FunctionInstanceKey::Definition(export.key.clone()),
+                export.convention,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
     cfgs.iter()
-        .filter(|cfg| export_roots.contains(&cfg.function))
-        .map(|cfg| crate::program_image_plan::RootedExportThunk {
-            function: cfg.function.clone(),
-            exported_symbol: match &cfg.function {
-                crate::FunctionInstanceKey::Definition(key) => key.name().to_owned(),
-                _ => unreachable!("C export roots are source definitions"),
-            },
-            native_symbol: cfg.record.codegen.defined_symbol.to_string(),
-            signature: export_signature(cfg),
+        .filter_map(|cfg| {
+            let convention = *export_roots.get(&cfg.function)?;
+            Some(crate::program_image_plan::RootedExportThunk {
+                function: cfg.function.clone(),
+                exported_symbol: match &cfg.function {
+                    crate::FunctionInstanceKey::Definition(key) => key.name().to_owned(),
+                    _ => unreachable!("C export roots are source definitions"),
+                },
+                native_symbol: cfg.record.codegen.defined_symbol.to_string(),
+                signature: export_signature(cfg, convention),
+            })
         })
         .collect()
 }
@@ -344,7 +350,10 @@ pub(super) fn collect_rooted_exports(
 /// type from. A C export's parameters are all by value (semantic analysis
 /// rejects `borrow`/`inout` in an export signature), so every one carries a
 /// type.
-pub(crate) fn export_signature(cfg: &RootedCfgUnit) -> rue_codegen::export_thunk::ExportSignature {
+pub(crate) fn export_signature(
+    cfg: &RootedCfgUnit,
+    convention: rue_target::CallingConvention,
+) -> rue_codegen::export_thunk::ExportSignature {
     let types = rue_air::body_parameter_types(&cfg.record.air);
     let parameter_types = cfg
         .record
@@ -362,6 +371,7 @@ pub(crate) fn export_signature(cfg: &RootedCfgUnit) -> rue_codegen::export_thunk
         .collect::<Vec<_>>();
     rue_codegen::export_thunk::ExportSignature::for_types(
         &cfg.record.type_pool,
+        convention,
         &parameter_types,
         cfg.record.cfg.return_type(),
     )

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -97,8 +97,7 @@ impl CompilerSession {
                     projection
                         .c_export_roots
                         .iter()
-                        .cloned()
-                        .map(crate::FunctionInstanceKey::Definition),
+                        .map(|export| crate::FunctionInstanceKey::Definition(export.key.clone())),
                 );
                 (Some(main), roots)
             }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -2149,6 +2149,18 @@ define_error_codes! {
     // marker for a typed float operation that a not-yet-shipped ADR-0065
     // phase would lower, and every such operation now lowers on both backends
     // (ADR-0065 Phase 10). The number stays retired rather than reused.
+    /// An `extern` declaration or a `pub extern` export names a calling
+    /// convention the selected compilation target does not implement (RUE-2034,
+    /// spec 9.3:1c). Each platform psABI Rue knows is the C convention of
+    /// exactly one target, so `extern "aarch64-aapcs"` describes a crossing an
+    /// x86-64 build cannot make. Named conventions exist so a declaration can
+    /// say which psABI it means instead of relying on the `"C"` alias; silently
+    /// substituting the target's own row would make the two spellings mean the
+    /// same thing and lose the statement, so the declaration is rejected
+    /// instead. Sits in the FFI band beside the other `extern` rules, and is
+    /// distinct from an ABI string that names no convention at all, which the
+    /// parser rejects before any target is consulted.
+    CALLING_CONVENTION_UNSUPPORTED_ON_TARGET = 1110;
 
     // ========================================================================
     // Comptime errors (E1200-E1299)
@@ -3764,6 +3776,30 @@ pub enum ErrorKind {
     )]
     ForeignEntryPointDeclaration,
 
+    /// An `extern` declaration or `pub extern` export names a calling
+    /// convention the compilation target does not implement (RUE-2034, spec
+    /// 9.3:1c). The ABI string may be the `"C"` alias, which every target
+    /// resolves to its own psABI, or one convention's own name, which denotes
+    /// that row and nothing else. Since each row is the C convention of exactly
+    /// one target, naming another target's row states a crossing this build
+    /// cannot make; falling back to the target's own row would erase the
+    /// difference between the two spellings, so the declaration is rejected.
+    #[error(
+        "calling convention `{convention}` is not implemented by the target `{target}`: \
+         it is the C calling convention of {implemented_by} (spec 9.3:1c)"
+    )]
+    CallingConventionUnsupportedOnTarget {
+        /// The convention named in the declaration, in its canonical spelling.
+        /// Both names are table entries rather than user text, so they are
+        /// borrowed and this variant stays inside the inline size budget.
+        convention: &'static str,
+        /// The compilation target's name.
+        target: &'static str,
+        /// The targets that do implement the convention, already rendered as a
+        /// list of backtick-quoted names.
+        implemented_by: Box<str>,
+    },
+
     /// A `@repr(c)` struct failed the reject-don't-guess eligibility check
     /// (ADR-0064 Amendment 1): an empty struct, an enum/aggregate field without
     /// its own `@repr(c)` marker, or a linear / destructor-bearing field. The
@@ -4072,6 +4108,9 @@ impl ErrorKind {
             ErrorKind::ExportSignatureUnsupported { .. } => ErrorCode::EXPORT_SIGNATURE_UNSUPPORTED,
             ErrorKind::ForeignSignatureConflict(_) => ErrorCode::FOREIGN_SIGNATURE_CONFLICT,
             ErrorKind::ForeignEntryPointDeclaration => ErrorCode::FOREIGN_ENTRY_POINT_DECLARATION,
+            ErrorKind::CallingConventionUnsupportedOnTarget { .. } => {
+                ErrorCode::CALLING_CONVENTION_UNSUPPORTED_ON_TARGET
+            }
             ErrorKind::ReprCStructIneligible(_) => ErrorCode::REPR_C_STRUCT_INELIGIBLE,
             ErrorKind::SliceReturnNotAllowed => ErrorCode::SLICE_RETURN_NOT_ALLOWED,
             ErrorKind::SliceInAggregateField => ErrorCode::SLICE_IN_AGGREGATE_FIELD,

--- a/crates/rue-parser/BUCK
+++ b/crates/rue-parser/BUCK
@@ -6,6 +6,7 @@ rue_crate(
         "//crates/rue-error:rue-error",
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-span:rue-span",
+        "//crates/rue-target:rue-target",
         "//third-party:ahash",
         "//third-party:lasso",
         "//third-party:smallvec",

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -352,11 +352,11 @@ pub struct Function {
     pub place_return: Option<PlaceReturn>,
     /// Function body
     pub body: Expr,
-    /// The C ABI string when this function is a `pub extern "C" fn` export
-    /// (ADR-0064 P4): `Some("C")` for an export exposed to C callers under its
-    /// unmangled name, `None` for an ordinary Rue function. The slot reserves
-    /// room for later ABI variants without a re-spelling, exactly as the import
-    /// `extern` block does.
+    /// The ABI string as written when this function is a `pub extern` export
+    /// (ADR-0064 P4): `Some` for an export exposed to C callers under its
+    /// unmangled name, `None` for an ordinary Rue function. Its accepted values
+    /// are the import `extern` block's (spec 9.3:1b), and semantic analysis
+    /// resolves the string to a concrete convention the same way.
     pub export_abi: Option<String>,
     /// Span covering the entire function
     pub span: Span,
@@ -371,9 +371,11 @@ pub struct Function {
 /// A foreign-declaration block: `extern "C" { fn getpid() -> i32; }`.
 ///
 /// Groups body-less foreign function declarations that share an ABI. The ABI
-/// string is a first-class part of the grammar (`"C"` is the only value the
-/// current C FFI phase accepts, ADR-0064). Everything inside the block is a
-/// foreign import lowered to an undefined linker symbol.
+/// string is a first-class part of the grammar: `"C"`, which the compilation
+/// target resolves to its own psABI, or a calling convention named outright
+/// (spec 9.3:1b, ADR-0064). The string is kept as written for diagnostics;
+/// semantic analysis resolves it to the concrete convention. Everything inside
+/// the block is a foreign import lowered to an undefined linker symbol.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternBlock {
     /// The ABI string as written (e.g. `"C"`).

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -136,10 +136,11 @@ impl Parser {
 
     /// Parse a `pub extern "C" fn name(...) { body }` Rue-to-C export
     /// (ADR-0064 P4). The `extern` token is consumed here, then the ABI string
-    /// is captured verbatim and validated (`"C"` only) exactly as the import
-    /// block does, and the rest is an ordinary function with a body. The parsed
-    /// ABI is attached to the `Function` so semantic analysis can gate it behind
-    /// the `c_ffi` preview and validate the C-boundary signature.
+    /// is captured verbatim and checked against the one convention-name table
+    /// exactly as the import block does, and the rest is an ordinary function
+    /// with a body. The written string is attached to the `Function` so semantic
+    /// analysis can gate it behind the `c_ffi` preview, resolve it against the
+    /// compilation target, and validate the C-boundary signature.
     fn extern_export_fn(
         &mut self,
         start: u32,
@@ -157,15 +158,7 @@ impl Parser {
                 return Err(());
             }
         };
-        if abi != "C" {
-            self.error_at(
-                format!(
-                    "unsupported extern ABI \"{abi}\": only \"C\" is supported \
-                     (ADR-0064 C FFI)"
-                ),
-                abi_span,
-            );
-        }
+        self.check_foreign_abi(&abi, abi_span);
         self.function_inner(start, directives, visibility, Some(abi))
     }
 
@@ -218,10 +211,37 @@ impl Parser {
         Ok((Some(self.ty()?), place_return))
     }
 
+    /// Reject an ABI string that names no foreign calling convention (spec
+    /// 9.3:1b).
+    ///
+    /// The accepted set comes from [`rue_target::ForeignAbi`], the one table
+    /// that also spells the convention names `--emit abi` and the ABI
+    /// diagnostics print, so there is no second list to keep in sync. Whether
+    /// the *compilation target* implements a named convention is a separate,
+    /// later question: the parser has no target, so semantic analysis owns that
+    /// rejection (E1110, spec 9.3:1c) and this one stays a vocabulary check.
+    fn check_foreign_abi(&mut self, abi: &str, abi_span: Span) {
+        if rue_target::ForeignAbi::parse(abi).is_some() {
+            return;
+        }
+        let accepted = rue_target::ForeignAbi::accepted_abi_strings()
+            .map(|name| format!("\"{name}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.error_at(
+            format!(
+                "unsupported extern ABI \"{abi}\": the ABI string must be one of \
+                 {accepted} (ADR-0064 C FFI)"
+            ),
+            abi_span,
+        );
+    }
+
     /// Parse a foreign-declaration block: `extern "C" { fn name(...) -> T; }`.
     ///
-    /// The ABI string is captured verbatim (validated in semantic analysis so
-    /// the diagnostic can name the unsupported ABI). Each member is a body-less
+    /// The ABI string is captured verbatim and checked against the one
+    /// convention-name table; the string travels to semantic analysis, which
+    /// resolves it against the compilation target. Each member is a body-less
     /// function signature terminated by `;`.
     fn extern_block(&mut self, start: u32) -> PResult<ExternBlock> {
         self.expect(TokenKind::Extern)?;
@@ -235,17 +255,7 @@ impl Parser {
                 return Err(());
             }
         };
-        // `"C"` is the only ABI the current C FFI phase accepts (ADR-0064). The
-        // slot reserves room for later `"C-unwind"` or platform variants.
-        if abi != "C" {
-            self.error_at(
-                format!(
-                    "unsupported extern ABI \"{abi}\": only \"C\" is supported \
-                     (ADR-0064 C FFI)"
-                ),
-                abi_span,
-            );
-        }
+        self.check_foreign_abi(&abi, abi_span);
         self.expect(TokenKind::LBrace)?;
         let mut fns = Vec::new();
         while !self.at(TokenKind::RBrace) && !self.at(TokenKind::Eof) {

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -979,7 +979,10 @@ impl<'a> AstGen<'a> {
                 FnDeclFlags {
                     is_pub: func.visibility == Visibility::Public,
                     is_unchecked: func.is_unchecked,
-                    // `pub extern "C" fn` marks a Rue-to-C export (ADR-0064 P4).
+                    // A `pub extern` ABI string marks a Rue-to-C export
+                    // (ADR-0064 P4). Which convention it names is resolved
+                    // against the compilation target later; RIR records only
+                    // that the export exists.
                     is_c_export: func.export_abi.is_some(),
                     returns_borrow: func.place_return.is_some_and(|mode| mode.is_borrow()),
                     returns_inout: func.place_return.is_some_and(|mode| mode.is_inout()),

--- a/crates/rue-rir/src/inst/printer.rs
+++ b/crates/rue-rir/src/inst/printer.rs
@@ -445,8 +445,14 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     returns_borrow,
                     returns_inout,
                 } => {
+                    // The ABI string is not a RIR fact: which convention a
+                    // declaration names is resolved against the compilation
+                    // target while its signature is checked (spec 9.3:1b), and
+                    // RIR is target-independent. Both directions therefore
+                    // render the bare keyword rather than a spelling that could
+                    // disagree with the source.
                     let pub_str = if *is_c_export {
-                        "pub extern \"C\" "
+                        "pub extern "
                     } else if *is_pub {
                         "pub "
                     } else {

--- a/crates/rue-rir/src/inst/schema.rs
+++ b/crates/rue-rir/src/inst/schema.rs
@@ -572,6 +572,10 @@ pub enum InstData {
         /// `is_extern`, an export keeps a real body, is analyzed, gets a CFG,
         /// and is code-generated; the flag only marks that a C entry thunk must
         /// be emitted and that the signature is validated for the C boundary.
+        ///
+        /// Neither flag records *which* convention the declaration named: the
+        /// ABI string is resolved against the compilation target while the
+        /// signature is checked (spec 9.3:1b), and RIR is target-independent.
         is_c_export: bool,
         /// Whether this declaration is a `test "name" { .. }` item (ADR-0083
         /// §1) rather than a `fn`. A test lowers to an ordinary `FnDecl` — no

--- a/crates/rue-spec/cases/runtime/foreign-boundary.toml
+++ b/crates/rue-spec/cases/runtime/foreign-boundary.toml
@@ -3,25 +3,126 @@
 # Most of § 9.3 is not coverable here: the abort-at-boundary proof needs a C
 # caller linked to a Rue export, and the reverse-direction and ownership rules
 # describe undefined / programmer-responsibility behavior (see
-# KNOWN_UNCOVERED_NORMATIVE). The redeclaration rule is an ordinary
-# compile-time rejection, so it is pinned directly.
+# KNOWN_UNCOVERED_NORMATIVE). The ABI-string and redeclaration rules are
+# ordinary compile-time decisions, so they are pinned directly.
 
 [section]
 id = "runtime.foreign_boundary"
 spec_chapter = "9.3"
 name = "Foreign-Boundary Semantics"
-description = "Rules governing the target-C foreign boundary: foreign redeclaration agreement and the reserved entry-point symbol."
+description = "Rules governing the C foreign boundary: which ABI strings a declaration may write, foreign redeclaration agreement, and the reserved entry-point symbol."
 
 # =============================================================================
-# ABI legality (9.3:1b)
+# ABI legality (9.3:1b, 9.3:1c)
+#
+# The accepted spellings are `"C"` and the three calling-convention names. Each
+# named convention belongs to one target, so the accepting cases declare that
+# target and stop at the executable rather than running it.
 # =============================================================================
+
+[[case]]
+name = "foreign_c_abi_is_accepted"
+spec = ["9.3:1b"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "`\"C\"` names the compilation target's own C calling convention and is accepted"
+source = """
+extern "C" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_only = true
+
+[[case]]
+name = "foreign_x86_64_sysv_abi_is_accepted_on_its_target"
+spec = ["9.3:1b"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "`\"x86-64-sysv\"` names the SysV AMD64 convention and is accepted while targeting x86-64 Linux"
+source = """
+extern "x86-64-sysv" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+target = "x86-64-linux"
+compile_only = true
+
+[[case]]
+name = "foreign_aarch64_aapcs_abi_is_accepted_on_its_target"
+spec = ["9.3:1b"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "`\"aarch64-aapcs\"` names AAPCS64 and is accepted while targeting AArch64 Linux"
+source = """
+extern "aarch64-aapcs" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+target = "aarch64-linux"
+compile_only = true
+
+[[case]]
+name = "export_aarch64_aapcs_darwin_abi_is_accepted_on_its_target"
+spec = ["9.3:1b"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "`\"aarch64-aapcs-darwin\"` names Apple's arm64 row and is accepted, in export position, while targeting AArch64 macOS"
+source = """
+pub extern "aarch64-aapcs-darwin" fn twice(a: i32) -> i32 {
+    a + a
+}
+
+fn main() -> i32 { 0 }
+"""
+target = "aarch64-macos"
+compile_only = true
+
+[[case]]
+name = "foreign_convention_not_implemented_by_target_is_rejected"
+spec = ["9.3:1b", "9.3:1c"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "A named convention the compilation target does not implement is rejected, never replaced by the target's own"
+source = """
+extern "aarch64-aapcs" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+target = "x86-64-linux"
+compile_fail = true
+error_contains = ["aarch64-aapcs", "x86-64-linux"]
+
+[[case]]
+name = "export_convention_of_another_target_is_rejected"
+spec = ["9.3:1c"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "An export naming AAPCS64 while targeting AArch64 macOS is rejected: the Darwin row is a different convention"
+source = """
+pub extern "aarch64-aapcs" fn twice(a: i32) -> i32 {
+    a + a
+}
+
+fn main() -> i32 { 0 }
+"""
+target = "aarch64-macos"
+compile_fail = true
+error_contains = ["aarch64-aapcs", "aarch64-macos"]
 
 [[case]]
 name = "foreign_unsupported_abi_is_rejected"
 spec = ["9.3:1b"]
 preview = "c_ffi"
 preview_should_pass = true
-description = "A foreign declaration with an ABI string other than C is rejected"
+description = "A foreign declaration with an ABI string that names no calling convention is rejected"
 source = """
 extern "Rust" {
     fn answer() -> i64;
@@ -31,6 +132,38 @@ fn main() -> i32 { 0 }
 """
 compile_fail = true
 error_contains = ["unsupported extern ABI", "\"C\""]
+
+[[case]]
+name = "foreign_c_unwind_abi_is_rejected"
+spec = ["9.3:1b"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "`\"C-unwind\"` is reserved (9.3:2) and names no accepted convention"
+source = """
+extern "C-unwind" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["unsupported extern ABI", "C-unwind"]
+
+[[case]]
+name = "foreign_native_convention_name_is_rejected"
+spec = ["9.3:1b"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "`\"rue\"` is the native convention, not a foreign boundary, so it is not an accepted ABI string"
+source = """
+extern "rue" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["unsupported extern ABI", "rue"]
 
 # =============================================================================
 # Foreign redeclaration (9.3:5, RUE-1218)

--- a/crates/rue-target/src/calling_convention.rs
+++ b/crates/rue-target/src/calling_convention.rs
@@ -62,7 +62,10 @@ use crate::Target;
 /// The variants are concrete conventions, not families: there is no "target C"
 /// row to be resolved later. `"C"` is an alias that a [`Target`] resolves to one
 /// of these rows through [`CallingConvention::c_for_target`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// The ordering is declaration order and carries no meaning; it exists so a
+/// convention can sit inside the ordered durable facts that carry it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum CallingConvention {
     /// The native, unstable, compiler-chosen Rue convention (RUE-106): a
     /// by-value aggregate is returned one flattened ABI slot per return
@@ -325,6 +328,117 @@ impl CallingConvention {
             Self::Aarch64AapcsDarwin => "aarch64-aapcs-darwin",
         }
     }
+
+    /// The convention an `extern` ABI string names outright, or `None` when the
+    /// string names no foreign convention.
+    ///
+    /// This is [`name`](Self::name) read backwards, restricted to the psABI
+    /// rows: `"rue"` does not parse, because the native convention is not a
+    /// foreign boundary and an `extern` declaration naming it would describe no
+    /// crossing. `"C"` does not parse here either — it is not a convention but
+    /// an alias for one, which [`ForeignAbi`] resolves against a target.
+    pub fn parse_abi_string(name: &str) -> Option<Self> {
+        Self::C_ROWS
+            .into_iter()
+            .find(|convention| convention.name() == name)
+    }
+
+    /// The platform C conventions, in the order diagnostics list them. The
+    /// native row is deliberately absent: every member of this table is a
+    /// foreign boundary.
+    const C_ROWS: [Self; 3] = [
+        Self::X86_64SysV,
+        Self::Aarch64Aapcs,
+        Self::Aarch64AapcsDarwin,
+    ];
+
+    /// Whether `target` implements this convention.
+    ///
+    /// Answered from the one `"C"` alias table rather than a second list, so a
+    /// new target answers this question by answering that one. The native row is
+    /// implemented everywhere; each psABI row belongs to the single target whose
+    /// C boundary follows it.
+    pub fn is_implemented_by(self, target: Target) -> bool {
+        self.is_rue() || Self::c_for_target(target) == self
+    }
+
+    /// Every target that implements this convention, in [`Target::all`] order.
+    /// Diagnostics use it to say which target a rejected convention belongs to.
+    pub fn implementing_targets(self) -> impl Iterator<Item = Target> {
+        Target::all()
+            .iter()
+            .copied()
+            .filter(move |target| self.is_implemented_by(*target))
+    }
+}
+
+/// The calling convention an `extern` declaration names in source.
+///
+/// A foreign declaration writes either the alias `"C"`, which denotes whichever
+/// psABI the compilation target's C boundary follows, or one convention's own
+/// [`CallingConvention::name`] spelling, which denotes that row outright. The
+/// two forms stay apart only up to resolution: [`resolve`](Self::resolve) is the
+/// single place a declaration's written ABI becomes a [`CallingConvention`], and
+/// everything past it carries the row rather than the string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ForeignAbi {
+    /// `"C"`: the compilation target's own C convention.
+    C,
+    /// A psABI row named outright by its canonical name.
+    Explicit(CallingConvention),
+}
+
+impl ForeignAbi {
+    /// The ABI string that spells the target-C alias.
+    pub const C_ABI_STRING: &'static str = "C";
+
+    /// The declaration ABI `text` names, or `None` when no foreign boundary is
+    /// spelled that way.
+    ///
+    /// The accepted set is exactly `"C"` plus the psABI rows' own names, so the
+    /// spellings a declaration may write and the spellings `--emit abi` and
+    /// diagnostics print come from one table. `"C-unwind"` stays reserved and
+    /// does not parse (9.3:2), and neither does `"rue"`.
+    pub fn parse(text: &str) -> Option<Self> {
+        if text == Self::C_ABI_STRING {
+            return Some(Self::C);
+        }
+        CallingConvention::parse_abi_string(text).map(Self::Explicit)
+    }
+
+    /// Every ABI string a foreign declaration may write, in the order
+    /// diagnostics list them.
+    pub fn accepted_abi_strings() -> impl Iterator<Item = &'static str> {
+        std::iter::once(Self::C_ABI_STRING).chain(
+            CallingConvention::C_ROWS
+                .into_iter()
+                .map(CallingConvention::name),
+        )
+    }
+
+    /// The convention this declaration follows when compiled for `target`.
+    ///
+    /// This is the one place the `"C"` alias is resolved on a declaration's
+    /// behalf; an explicit row resolves to itself. Resolving does not ask
+    /// whether `target` implements the result —
+    /// [`is_implemented_by`](Self::is_implemented_by) is that question, and
+    /// 9.3:1b makes a declaration naming an unimplemented row ill-formed.
+    pub const fn resolve(self, target: Target) -> CallingConvention {
+        match self {
+            Self::C => CallingConvention::c_for_target(target),
+            Self::Explicit(convention) => convention,
+        }
+    }
+
+    /// The source spelling of this ABI: `"C"`, or the row's canonical name.
+    /// The inverse of [`parse`](Self::parse), which is what makes the written
+    /// spelling and the printed one one table.
+    pub const fn abi_string(self) -> &'static str {
+        match self {
+            Self::C => Self::C_ABI_STRING,
+            Self::Explicit(convention) => convention.name(),
+        }
+    }
 }
 
 impl core::fmt::Display for CallingConvention {
@@ -484,6 +598,97 @@ mod tests {
     #[should_panic(expected = "not a psABI row")]
     fn the_native_row_has_no_psabi_description() {
         let _ = CallingConvention::Rue.c_spec();
+    }
+
+    #[test]
+    fn every_c_row_parses_back_from_its_own_name() {
+        for target in Target::all() {
+            let convention = target.c_calling_convention();
+            assert_eq!(
+                CallingConvention::parse_abi_string(convention.name()),
+                Some(convention),
+                "the ABI string table and the name table must be one table"
+            );
+            assert_eq!(
+                ForeignAbi::parse(convention.name()),
+                Some(ForeignAbi::Explicit(convention))
+            );
+        }
+    }
+
+    #[test]
+    fn the_native_convention_is_not_a_foreign_abi() {
+        assert_eq!(CallingConvention::Rue.name(), "rue");
+        assert_eq!(CallingConvention::parse_abi_string("rue"), None);
+        assert_eq!(ForeignAbi::parse("rue"), None);
+    }
+
+    #[test]
+    fn only_the_declared_abi_spellings_parse() {
+        assert_eq!(ForeignAbi::parse("C"), Some(ForeignAbi::C));
+        for rejected in ["C-unwind", "Rust", "system", "c", "sysv64", ""] {
+            assert_eq!(
+                ForeignAbi::parse(rejected),
+                None,
+                "{rejected} must not parse"
+            );
+        }
+        assert_eq!(
+            ForeignAbi::accepted_abi_strings().collect::<Vec<_>>(),
+            vec!["C", "x86-64-sysv", "aarch64-aapcs", "aarch64-aapcs-darwin"]
+        );
+        for text in ForeignAbi::accepted_abi_strings() {
+            assert_eq!(
+                ForeignAbi::parse(text).map(ForeignAbi::abi_string),
+                Some(text),
+                "every listed spelling round-trips"
+            );
+        }
+    }
+
+    #[test]
+    fn the_c_alias_resolves_per_target_and_an_explicit_row_resolves_to_itself() {
+        for target in Target::all() {
+            assert_eq!(
+                ForeignAbi::C.resolve(*target),
+                target.c_calling_convention()
+            );
+            assert!(
+                ForeignAbi::C.resolve(*target).is_implemented_by(*target),
+                "the alias is implemented by every target by construction"
+            );
+        }
+        assert_eq!(
+            ForeignAbi::Explicit(CallingConvention::Aarch64Aapcs).resolve(Target::X86_64Linux),
+            CallingConvention::Aarch64Aapcs,
+            "resolution never falls back to the target's own row"
+        );
+    }
+
+    #[test]
+    fn each_c_row_is_implemented_by_exactly_one_target() {
+        for target in Target::all() {
+            let convention = target.c_calling_convention();
+            assert_eq!(
+                convention.implementing_targets().collect::<Vec<_>>(),
+                vec![*target]
+            );
+            for other in Target::all() {
+                assert_eq!(
+                    ForeignAbi::Explicit(convention)
+                        .resolve(*other)
+                        .is_implemented_by(*other),
+                    other == target,
+                    "a named row never resolves to the compiling target's own"
+                );
+            }
+        }
+        assert!(
+            Target::all()
+                .iter()
+                .all(|target| CallingConvention::Rue.is_implemented_by(*target)),
+            "the native row is not a foreign boundary and is never target-rejected"
+        );
     }
 
     #[test]

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -10,7 +10,7 @@
 mod calling_convention;
 
 pub use calling_convention::{
-    AggregateClassificationRule, CConventionSpec, CRegisterClass, CallingConvention,
+    AggregateClassificationRule, CConventionSpec, CRegisterClass, CallingConvention, ForeignAbi,
     NarrowIntegerExtension, SretRegisterKind, StackedArgumentPacking,
 };
 

--- a/crates/rue-ui-tests/cases/diagnostics/extern_abi_string.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/extern_abi_string.toml
@@ -1,0 +1,173 @@
+[section]
+id = "diagnostics.extern-abi-string"
+name = "The extern ABI string names a calling convention (spec 9.3:1b, 9.3:1c)"
+description = """
+An `extern` block or a `pub extern` export writes an ABI string. It may be
+`"C"`, the alias the compilation target resolves to its own psABI, or one
+calling convention's own name — the very names `--emit abi` prints
+(`rue_target::CallingConvention::name`). Two rejections keep those two claims
+apart, and these cases pin which one a reader gets.
+
+A string that names no convention at all is a *vocabulary* error. The parser
+owns it: it has the name table but no target, so it can say what the accepted
+spellings are and nothing about this build. The message lists them, and the span
+underlines the string itself. `"C-unwind"` (reserved, spec 9.3:2) and `"rue"`
+(the native convention, which is not a foreign boundary) are both this
+rejection.
+
+A string that names a real convention the selected `--target` does not implement
+is a *target* error, E1110, and only semantic analysis can raise it because only
+it knows the target. Naming a convention is a statement about which psABI the
+declaration means, so the compiler never substitutes the target's own row for
+it; the diagnostic names the convention, this target, and the target the
+convention does belong to.
+"""
+
+[[case]]
+name = "unknown_abi_string_lists_the_accepted_spellings"
+description = "An ABI string naming no convention is rejected by the parser, listing every accepted spelling."
+source = """
+extern "Rust" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "unsupported extern ABI \"Rust\"",
+    "\"C\", \"x86-64-sysv\", \"aarch64-aapcs\", \"aarch64-aapcs-darwin\"",
+    "ADR-0064",
+]
+
+[[case]]
+name = "unknown_abi_string_span_underlines_the_string"
+description = "The caret underlines the ABI string literal, quotes included, at 1:8."
+source = """
+extern "Rust" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["1:8", "^^^^^^"]
+
+[[case]]
+name = "c_unwind_abi_string_is_the_vocabulary_rejection"
+description = "`\"C-unwind\"` stays reserved and is rejected as a string that names no convention, not as a target mismatch."
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+extern "C-unwind" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["unsupported extern ABI \"C-unwind\"", "must be one of"]
+
+[[case]]
+name = "native_convention_name_is_not_a_foreign_abi"
+description = "`\"rue\"` names the native convention, which is not a foreign boundary, so it is not an accepted ABI string."
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+extern "rue" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["unsupported extern ABI \"rue\"", "must be one of"]
+
+[[case]]
+name = "export_unknown_abi_string_is_rejected_too"
+description = "The export position reads the same table: an unknown ABI string on `pub extern` gets the same diagnostic."
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+pub extern "fastcall" fn twice(a: i32) -> i32 {
+    a + a
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["unsupported extern ABI \"fastcall\"", "\"aarch64-aapcs-darwin\""]
+
+[[case]]
+name = "convention_not_implemented_by_target_is_e1110"
+description = "Naming AAPCS64 while targeting x86-64 Linux is E1110, naming the convention, this target, and the target it belongs to."
+preview = "c_ffi"
+preview_should_pass = true
+target = "x86-64-linux"
+source = """
+extern "aarch64-aapcs" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E1110",
+    "calling convention `aarch64-aapcs` is not implemented by the target `x86-64-linux`",
+    "it is the C calling convention of `aarch64-linux`",
+    "9.3:1c",
+]
+
+[[case]]
+name = "sibling_aarch64_row_is_still_a_mismatch"
+description = "The two AArch64 rows are distinct conventions: AAPCS64 named while targeting AArch64 macOS is rejected, not silently accepted as the Darwin row."
+preview = "c_ffi"
+preview_should_pass = true
+target = "aarch64-macos"
+source = """
+extern "aarch64-aapcs" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E1110",
+    "`aarch64-aapcs` is not implemented by the target `aarch64-macos`",
+]
+
+[[case]]
+name = "export_convention_not_implemented_by_target_is_e1110"
+description = "The export position is checked the same way: an export naming another target's row is E1110."
+preview = "c_ffi"
+preview_should_pass = true
+target = "x86-64-linux"
+source = """
+pub extern "aarch64-aapcs-darwin" fn twice(a: i32) -> i32 {
+    a + a
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E1110",
+    "`aarch64-aapcs-darwin` is not implemented by the target `x86-64-linux`",
+    "`aarch64-macos`",
+]
+
+[[case]]
+name = "preview_gate_is_reported_before_the_convention_is_checked"
+description = "Without `--preview c_ffi` the reader is told the feature is gated (E1100), not which conventions this target implements."
+target = "x86-64-linux"
+source = """
+extern "aarch64-aapcs" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["c_ffi"]

--- a/docs/designs/0064-c-ffi.md
+++ b/docs/designs/0064-c-ffi.md
@@ -9,7 +9,7 @@ accepted: 2026-07-19
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-742", "RUE-745", "RUE-714", "RUE-738", "RUE-987", "RUE-881", "RUE-504", "ADR-0052", "ADR-0028", "ADR-0038", "ADR-0005", "ADR-0035", "ADR-0042", "ADR-0043", "ADR-0055"]
+relates: ["RUE-742", "RUE-745", "RUE-714", "RUE-738", "RUE-987", "RUE-881", "RUE-504", "RUE-2034", "ADR-0052", "ADR-0028", "ADR-0038", "ADR-0005", "ADR-0035", "ADR-0042", "ADR-0043", "ADR-0055"]
 ---
 
 # ADR-0064: C FFI — a guaranteed target-C boundary
@@ -43,6 +43,12 @@ the original draft skipped: the `@repr(c)` marker, the three FFI-safety predicat
 the `std.c` transparent scalar aliases, and the target data-model descriptor. It is
 additive — the accepted v0 surface above is unchanged in substance — and is
 recorded in [Amendment 1: C representation guarantees (RUE-742)](#amendment-1-2026-07-19-c-representation-guarantees-rue-742).
+
+**Amendment 2 (2026-09-05)** spends the ABI string's reserved room on platform
+variants: a declaration may name a calling convention outright, using the
+compiler's own name for it, instead of relying on the `"C"` alias. It is
+additive — `"C"` is unchanged and `"C-unwind"` stays reserved — and is recorded in
+[Amendment 2: named calling conventions in the ABI string (RUE-2034)](#amendment-2-2026-09-05-named-calling-conventions-in-the-abi-string-rue-2034).
 
 ## Summary
 
@@ -172,9 +178,11 @@ extern "C" {
 }
 ```
 
-The ABI string is a first-class part of the grammar (`"C"` is the only accepted
-value in v0; the slot reserves room for later `"C-unwind"` or platform variants
-without a re-spelling). A block groups declarations that share an ABI and a
+The ABI string is a first-class part of the grammar. `"C"` is the alias the
+compilation target resolves to its own psABI; a convention may also be named
+outright, and `"C-unwind"` stays reserved (see
+[Amendment 2](#amendment-2-2026-09-05-named-calling-conventions-in-the-abi-string-rue-2034)).
+A block groups declarations that share an ABI and a
 future `link_name`/library attribute, and it reads as a boundary — everything
 inside is foreign. A symbol-rename escape (`fn puts(...) = "c_puts";` shape, exact
 syntax deferred to P1) covers the case where the Rue identifier and the C symbol
@@ -424,6 +432,42 @@ classification would need SSE classes is a hard error until floats (P5).
 This amendment **supersedes RUE-742 / RUE-745's original `cstruct` scoping**.
 RUE-742's surviving implementation scope is: the `@repr(c)` marker, the three
 predicates, the `std.c` transparent aliases, and the target data-model descriptor.
+
+## Amendment 2 (2026-09-05): named calling conventions in the ABI string (RUE-2034)
+
+The accepted draft made `"C"` the only ABI string and said the slot reserved
+room for later `"C-unwind"` or platform variants. This amendment spends that
+room on the platform variants, and is otherwise additive: `"C"` keeps its
+meaning, `"C-unwind"` stays reserved and rejected, and
+[the `extern` declaration surface](#the-extern-declaration-surface) above is
+reworded to match.
+
+An ABI string may now also name a calling convention outright, using the same
+names the compiler already prints for those conventions — `"x86-64-sysv"`,
+`"aarch64-aapcs"`, `"aarch64-aapcs-darwin"` (spec 9.3:1b). Three consequences of
+that choice:
+
+- **One naming table.** `rue_target::CallingConvention::name()` already spells
+  every convention for `--emit abi` and for diagnostics; the declaration surface
+  reads the same table back (`parse_abi_string`), so a convention has exactly one
+  spelling and no second list can drift from it.
+- **Target-keyed names, not a flat family.** Zig keys its convention names by
+  target; Rust's flat `"sysv64"` / `"aapcs"` family cannot name Apple's arm64 row
+  at all, and Rue needs that row named — `Aarch64AapcsDarwin` amends AAPCS64's
+  stacked-argument packing and narrow-integer extension, so it is a distinct
+  convention, not a spelling of AAPCS64. Rue follows Zig here.
+- **`"rue"` is not an `extern` ABI.** The native convention is named in the same
+  table, but naming it in an `extern` position would describe no foreign
+  crossing, so it does not parse as an ABI string.
+
+`"C"` remains the alias resolved by the compilation target; a named convention
+denotes that convention and nothing else. Naming a convention the target does not
+implement is a compile error (E1110, spec 9.3:1c) rather than a quiet fallback
+to the target's own row — a fallback would make the two spellings synonymous and
+throw away what the declaration said. Because each convention Rue implements is
+the C convention of exactly one supported target, an accepted named convention
+places values exactly as `"C"` does on that target; the resolution is what became
+explicit, not the placement.
 
 ## Open questions for acceptance
 

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -5,21 +5,36 @@ Status: verified against the compiler and runtime source for RUE-738.
 One value type names every calling convention in the tree,
 `rue_target::CallingConvention`, and its members are concrete conventions:
 
-| Member | Convention |
-| --- | --- |
-| `Rue` | the private native convention for calls between Rue functions |
-| `X86_64SysV` | System V AMD64 psABI |
-| `Aarch64Aapcs` | AAPCS64 as on Linux |
-| `Aarch64AapcsDarwin` | AAPCS64 with Apple's arm64 amendments |
+| Member | Name (`name()`) | Convention |
+| --- | --- | --- |
+| `Rue` | `rue` | the private native convention for calls between Rue functions |
+| `X86_64SysV` | `x86-64-sysv` | System V AMD64 psABI |
+| `Aarch64Aapcs` | `aarch64-aapcs` | AAPCS64 as on Linux |
+| `Aarch64AapcsDarwin` | `aarch64-aapcs-darwin` | AAPCS64 with Apple's arm64 amendments |
 
 `"C"` is an alias, not a member. One table, `CallingConvention::c_for_target`,
 resolves it from the whole compilation target — `x86-64-linux` to `X86_64SysV`,
 `aarch64-linux` to `Aarch64Aapcs`, `aarch64-macos` to `Aarch64AapcsDarwin` —
-and every C boundary consults it: `extern "C"` imports and exports, the
+and every C boundary consults it: `extern` imports and exports, the
 compiler-built memory routines, and the typed runtime-helper subset the compiler
 and runtime share through `rue-runtime-abi`. The alias is keyed by target rather
 than by architecture because the two AArch64 targets share an architecture and
 do not share a convention.
+
+An `extern` declaration may also name a C convention outright, writing that row's
+name from the middle column above instead of `"C"` (spec 9.3:1b, ADR-0064
+Amendment 2). `rue` is not among them: the native convention is not a foreign
+boundary, so naming it in an `extern` position describes no crossing.
+`rue_target::ForeignAbi` is that surface, and `parse_abi_string` reads the same
+name table `--emit abi` prints from, so the two cannot drift. The declaration's
+convention is resolved once — when its signature is checked, against the
+compilation target — and carried from there: the stable plane's `CallAbiFacts`,
+the foreign-symbol map code generation reads, the export thunk's
+`ExportSignature`, and the ABI report all take the resolved row rather than
+asking the target for its C row again. Because each C row is the convention of
+exactly one supported target, an accepted name places values exactly as `"C"`
+would on that target; naming a row the target does not implement is E1110
+(spec 9.3:1c).
 
 The native `Rue` convention borrows target register and stack rules but
 deliberately is not a C ABI.

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -47,12 +47,19 @@ that is intentionally not C-compatible or stable across compiler revisions.
 Both boundaries name their convention with one value type,
 `rue_target::CallingConvention`, whose members are concrete conventions:
 
-| Member | Convention |
-| --- | --- |
-| `Rue` | the native, unstable, compiler-chosen convention |
-| `X86_64SysV` | System V AMD64 psABI |
-| `Aarch64Aapcs` | AAPCS64 as on Linux |
-| `Aarch64AapcsDarwin` | AAPCS64 with Apple's arm64 amendments |
+| Member | Name (`name()`) | Convention |
+| --- | --- | --- |
+| `Rue` | `rue` | the native, unstable, compiler-chosen convention |
+| `X86_64SysV` | `x86-64-sysv` | System V AMD64 psABI |
+| `Aarch64Aapcs` | `aarch64-aapcs` | AAPCS64 as on Linux |
+| `Aarch64AapcsDarwin` | `aarch64-aapcs-darwin` | AAPCS64 with Apple's arm64 amendments |
+
+The names in the middle column are the one spelling of each convention: they are
+what `--emit abi` prints, what an ABI diagnostic names, and what an `extern`
+declaration may write (spec 9.3:1b). `CallingConvention::parse_abi_string` reads
+the same table backwards, so the declaration surface cannot drift from the
+printed names. `rue` is not among the strings a declaration may write: the native
+convention is not a foreign boundary.
 
 There is no "target C" member. `"C"` is an **alias**, resolved from the whole
 compilation target by the single table `CallingConvention::c_for_target`
@@ -66,6 +73,15 @@ compilation target by the single table `CallingConvention::c_for_target`
 
 The alias is keyed by target rather than by architecture because the two
 AArch64 targets share an architecture and do not share a convention.
+
+`rue_target::ForeignAbi` is the declaration's-eye view of the same table: an
+`extern` ABI string is either `"C"`, resolved through the alias above, or one
+convention named outright. Resolution happens once, while a declaration's
+signature is checked, and everything past it — the stable plane's call-ABI facts,
+the import planner, the export thunk, `--emit abi` — carries the resolved
+`CallingConvention` rather than re-deriving the target's own row. A named
+convention the compilation target does not implement is rejected (E1110, spec
+9.3:1c) rather than replaced.
 
 `rue-runtime-abi` is the `no_std`, dependency-free manifest crate (ADR-0055), so
 it cannot name a `Target` and does not carry a convention field: every

--- a/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
+++ b/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
@@ -46,9 +46,29 @@ extern_export = "pub" "extern" STRING [ "unchecked" ] "fn" IDENT
 
 {{ rule(id="9.3:1b", cat="legality-rule") }}
 
-The ABI `STRING` in a foreign declaration or export **MUST** have the value
-`"C"`. Any other ABI string is unsupported in this version and is rejected at
-compile time.
+The ABI `STRING` in a foreign declaration or export **MUST** be either `"C"`,
+which denotes the compilation target's own C calling convention, or one of the
+calling-convention names `"x86-64-sysv"`, `"aarch64-aapcs"`, and
+`"aarch64-aapcs-darwin"`, each of which denotes that convention. A declaration
+whose ABI `STRING` is none of these is rejected at compile time; `"C-unwind"` is
+reserved (§ 9.3:2) and is one such rejection.
+
+{{ rule(id="9.3:1c", cat="legality-rule") }}
+
+A declaration whose ABI `STRING` names a calling convention the compilation
+target does not implement is ill-formed and **MUST** be rejected. The convention
+is never replaced by the target's own; `"C"` is the spelling that adapts to the
+target, and a named convention is the spelling that does not.
+
+{{ rule(id="9.3:1d", cat="informative") }}
+
+The convention names are the names the implementation already uses for these
+conventions elsewhere, so a declaration, a diagnostic, and an ABI dump spell one
+convention one way. Each named convention is the C convention of exactly one
+target Rue supports, so on that target `"C"` and the convention's own name
+denote the same convention and place values identically; the difference is what
+the declaration *says*, which is why the mismatched case is a rejection rather
+than a substitution.
 
 ## Abort at the boundary
 

--- a/rust-project.json
+++ b/rust-project.json
@@ -41,6 +41,10 @@
         {
           "crate": 119,
           "name": "tracing"
+        },
+        {
+          "crate": 131,
+          "name": "zmij"
         }
       ],
       "is_workspace_member": true,
@@ -109,6 +113,10 @@
         {
           "crate": 119,
           "name": "tracing"
+        },
+        {
+          "crate": 131,
+          "name": "zmij"
         }
       ],
       "is_workspace_member": true,
@@ -814,6 +822,10 @@
           "name": "rue_oracle"
         },
         {
+          "crate": 20,
+          "name": "rue_query"
+        },
+        {
           "crate": 28,
           "name": "rue_test_runner"
         },
@@ -868,6 +880,10 @@
         {
           "crate": 68,
           "name": "lasso"
+        },
+        {
+          "crate": 131,
+          "name": "zmij"
         }
       ],
       "is_workspace_member": true,
@@ -900,6 +916,10 @@
         {
           "crate": 25,
           "name": "rue_span"
+        },
+        {
+          "crate": 27,
+          "name": "rue_target"
         },
         {
           "crate": 38,
@@ -1119,6 +1139,10 @@
         {
           "crate": 23,
           "name": "rue_runtime_abi"
+        },
+        {
+          "crate": 131,
+          "name": "zmij"
         }
       ],
       "is_workspace_member": true,
@@ -1364,6 +1388,10 @@
         {
           "crate": 27,
           "name": "rue_target"
+        },
+        {
+          "crate": 28,
+          "name": "rue_test_runner"
         },
         {
           "crate": 33,


### PR DESCRIPTION
Slice 4 of the calling-convention infrastructure epic (RUE-2030). A language change under the existing `c_ffi` preview gate, recorded as ADR-0064 Amendment 2.

## What

An `extern` block or `pub extern fn` export may name a calling convention outright, using the same names the compiler already prints for `--emit abi` and diagnostics: `"x86-64-sysv"`, `"aarch64-aapcs"`, `"aarch64-aapcs-darwin"`. `"C"` keeps resolving to the compilation target's own row; `"C-unwind"` stays reserved; `"rue"` does not parse as a foreign ABI. The names are target-keyed like Zig's rather than Rust's flat `"sysv64"`/`"aapcs"` family, which cannot name Apple's arm64 row, and they come from one table (`CallingConvention::name` and its inverse `parse_abi_string`) so no second spelling can drift.

Naming a convention the target does not implement is a hard error, new code **E1110**, naming the convention, the target, and the target that does implement it. It is never a quiet fallback to `"C"`.

The string is resolved exactly once, at the canonical declaration seam that already gates `c_ffi` and validates C-boundary signatures, and the resolved `CallingConvention` is carried from there: through the semantic signature projection, the stable query plane's call-ABI facts, the codegen domain's foreign-symbol map, the import planner, the export thunk, and `--emit abi`. Every former "the C row for this target" call site now reads the declaration's convention. RIR stays target-independent and does not carry it; its dump prints bare `extern` rather than a hardcoded `"C"`.

Also fixes a signature-fingerprint gap found on the way: an `extern` block member's fingerprint covered only the function span, so editing the block's ABI string alone would not have invalidated the member.

## Spec and docs

- 9.3:1b rewritten to list the accepted strings normatively; new 9.3:1c (legality) for the unsupported-on-target rejection; 9.3:1d (informative) for the rationale. Grammar unchanged.
- ADR-0064 Amendment 2 records the decision and the reasoning; the stale "`"C"` is the only accepted value" sentence is reworded.
- `docs/runtime-abi.md` and the conformance audit describe the surface.

## Verification

- 8 spec cases on 9.3:1b/1c; traceability unchanged at the pre-existing allowlisted set.
- 9 UI cases for the E1110 and unknown-string diagnostics.
- `c_ffi` CLI: executing cases with `extern "x86-64-sysv"` on x86-64 Linux and `extern "aarch64-aapcs"` on AArch64 Linux against the archive; an `--emit abi` case shows the explicit name.
- `scripts/rue quick`, `spec 9.3`, `ui extern-abi`, `cli c_ffi` (50), `cli emit` (44), `unit target calling` (13), oracle-diff, `scripts/rue premerge` (214 targets; only the two sandbox-environmental CLI failures).

Follow-ups noted, not in this PR: E1110 underlines the declaration rather than the ABI string itself, since the declaration seam does not carry the string's span durably.

Closes RUE-2034

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_