### PR TITLE
Generate the C-boundary ABI conformance matrix

### DIFF
--- a/crates/rue-air/src/lowered_signature.rs
+++ b/crates/rue-air/src/lowered_signature.rs
@@ -403,6 +403,16 @@ impl Placer {
         }
     }
 
+    /// Mark every remaining register of `class` used, so no later argument
+    /// takes one (AAPCS64 rule C.11 after a composite fails to fit).
+    fn exhaust(&mut self, class: CRegisterClass) {
+        let all = self.spec.argument_registers(class);
+        match class {
+            CRegisterClass::Gp => self.gp = all,
+            CRegisterClass::Fp => self.fp = all,
+        }
+    }
+
     /// Claim `count` consecutive registers of `class`, or `None` when the
     /// roster cannot hold the whole value. Register assignment is
     /// all-or-nothing: a two-eightbyte aggregate with one register left goes to
@@ -538,7 +548,14 @@ fn lower_aggregate_argument(placer: &mut Placer, size: u64, align: u64) -> ArgLo
             };
         }
         // Registers exhausted: the whole aggregate goes to memory, keeping its
-        // eightbyte image contiguous.
+        // eightbyte image contiguous. AAPCS64 rule C.11 additionally sets the
+        // next general-purpose register number to 8, so every later argument
+        // is stacked too even though a register may remain; SysV AMD64 has no
+        // such rule and a later scalar still takes the register the aggregate
+        // could not fit in.
+        if placer.spec.aggregate_rule == AggregateClassificationRule::Aapcs64Composite {
+            placer.exhaust(class);
+        }
         let (stack_size, stack_align) = placer.stack_extent(size, false);
         let (offset, size, align) = placer.claim_stack(stack_size, stack_align);
         return ArgLocation::Stack {
@@ -807,6 +824,49 @@ mod tests {
             }
         );
         assert_eq!(signature.arguments()[6].location, registers(5, 1));
+    }
+
+    #[test]
+    fn an_aapcs64_composite_that_does_not_fit_exhausts_the_register_roster() {
+        // Seven words leave `x7`; a two-eightbyte composite cannot fit, so it
+        // goes to the stack entire and, per AAPCS64 rule C.11, the next
+        // general-purpose register number becomes 8: the word after it is
+        // stacked behind the composite rather than taking the free `x7`.
+        for convention in [AAPCS, DARWIN] {
+            let signature = lower_c_signature(
+                convention,
+                &[
+                    word(),
+                    word(),
+                    word(),
+                    word(),
+                    word(),
+                    word(),
+                    word(),
+                    aggregate(16, 8),
+                    word(),
+                ],
+                CAbiTypeFacts::ZeroSized,
+            );
+            assert_eq!(
+                signature.arguments()[7].location,
+                ArgLocation::Stack {
+                    offset: 0,
+                    size: 16,
+                    align: 8
+                }
+            );
+            assert_eq!(
+                signature.arguments()[8].location,
+                ArgLocation::Stack {
+                    offset: 16,
+                    size: 8,
+                    align: 8
+                },
+                "{convention}: the register the composite could not use stays unused"
+            );
+            assert_eq!(signature.stack_bytes(), 32);
+        }
     }
 
     #[test]

--- a/crates/rue-c-abi-matrix/BUCK
+++ b/crates/rue-c-abi-matrix/BUCK
@@ -1,0 +1,39 @@
+load("//crates:defs.bzl", "rue_binary")
+load("//:test_defs.bzl", "rue_sh_test")
+
+# The generated C-boundary conformance matrix (RUE-2035). This binary IS the
+# harness: it emits the paired C and Rue sources, drives `cc`, `ar`, the real
+# compiler, and the linked executable, and compares the run against checksums it
+# computed from the same table. Its `#[cfg(test)]` module unit-tests the
+# generator itself (grid completeness, position derivation, name uniqueness,
+# literal ranges), so the macro's generated `rue-c-abi-matrix-test` target is
+# kept: those assertions need no compiler and no C toolchain.
+rue_binary(
+    name = "rue-c-abi-matrix",
+    deps = [
+        "//crates/rue-target:rue-target",
+        "//crates/rue-test-runner:rue-test-runner",
+        "//third-party:libtest2-mimic",
+        "//third-party:tempfile",
+    ],
+)
+
+# The execution matrix. `platform = "native"` because it is a host-only
+# assertion by construction: it compiles for the machine it runs on and executes
+# what it linked, so the AArch64 Linux and Apple arm64 rows are proven only by
+# the native lanes, which select this target from the live graph through the
+# label. `rue_not_quick` keeps `scripts/rue quick` meaning "unit tests only" —
+# this one spawns a C toolchain and the compiler.
+#
+# The harness speaks the libtest protocol (libtest2-mimic), which is what lets a
+# host with no `cc` on PATH report each trial as *ignored* rather than passing
+# silently or failing, matching the CLI corpus's `requires_system_linker` rule.
+rue_sh_test(
+    name = "c-abi-matrix-test",
+    platform = "native",
+    labels = ["rue_not_quick"],
+    test = ":rue-c-abi-matrix",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+    },
+)

--- a/crates/rue-c-abi-matrix/src/grid.rs
+++ b/crates/rue-c-abi-matrix/src/grid.rs
@@ -1,0 +1,1267 @@
+//! The generated C-boundary conformance grid: shapes x positions x directions.
+//!
+//! One [`Program`] is a complete pair of sources — one `.c` file and one
+//! `.rue` file — covering every shape at every position for one direction and
+//! one ABI spelling, plus the exact stdout the pair must produce. The expected
+//! output is computed here, from the same values and multipliers the two
+//! sources are emitted with, so a boundary that drops, swaps, truncates, or
+//! sign-extends a field wrongly produces a different line.
+//!
+//! # What a cell asserts
+//!
+//! Every cell reduces its whole argument list to one `u64` checksum:
+//!
+//! ```text
+//! acc = 0; for each contribution v:  acc = acc + v * multiplier
+//! ```
+//!
+//! computed with wrapping arithmetic on both sides. Contributions are the
+//! 64-bit patterns of the received values — every filler argument, and every
+//! *leaf* of the shape argument separately — each with its own odd multiplier.
+//! A swapped pair of fields, a truncated high half, a missing sign extension,
+//! or a slot read from the wrong stack offset all change the sum.
+//!
+//! The `return` position inverts the crossing: the callee builds the shape and
+//! the caller checksums it. The callee also receives a seed and returns a
+//! deliberately different ("poisoned") value when the seed did not arrive
+//! intact, so a broken argument crossing cannot hide behind a correct result.
+//!
+//! # Extending the table
+//!
+//! Floats are still rejected at Rue's C boundary. Adding them later is a table
+//! edit: one [`Leaf`] variant with its two type spellings and its conversion
+//! rules, and one [`SHAPES`] row per new shape. Nothing else in this module
+//! knows the leaf inventory.
+
+use rue_target::CConventionSpec;
+
+/// Bytes the C side exposes through `c_probe`, the only source of pointer
+/// values in the grid. A pointer's contribution is the byte it points at, not
+/// its address, so a cell's expected value stays independent of where the
+/// image happens to load.
+pub const PROBE_BYTES: [u8; 8] = [17, 47, 125, 163, 197, 233, 4, 254];
+
+/// One scalar type at the boundary, or one scalar leaf inside an aggregate.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Leaf {
+    I8,
+    U8,
+    I16,
+    U16,
+    I32,
+    U32,
+    I64,
+    U64,
+    Bool,
+    /// `ptr const u8` in Rue, `const rue_u8 *` in C.
+    Ptr,
+}
+
+impl Leaf {
+    pub fn rue_type(self) -> &'static str {
+        match self {
+            Leaf::I8 => "i8",
+            Leaf::U8 => "u8",
+            Leaf::I16 => "i16",
+            Leaf::U16 => "u16",
+            Leaf::I32 => "i32",
+            Leaf::U32 => "u32",
+            Leaf::I64 => "i64",
+            Leaf::U64 => "u64",
+            Leaf::Bool => "bool",
+            Leaf::Ptr => "ptr const u8",
+        }
+    }
+
+    /// The C spelling, always one of the data-model typedefs the generated
+    /// prelude defines, so the C side names widths the way the target's data
+    /// model does rather than assuming a fixed-width header exists.
+    pub fn c_type(self) -> &'static str {
+        match self {
+            Leaf::I8 => "rue_i8",
+            Leaf::U8 => "rue_u8",
+            Leaf::I16 => "rue_i16",
+            Leaf::U16 => "rue_u16",
+            Leaf::I32 => "rue_i32",
+            Leaf::U32 => "rue_u32",
+            Leaf::I64 => "rue_i64",
+            Leaf::U64 => "rue_u64",
+            Leaf::Bool => "rue_bool",
+            Leaf::Ptr => "const rue_u8 *",
+        }
+    }
+
+    fn integer_width(self) -> Option<u32> {
+        match self {
+            Leaf::I8 | Leaf::U8 => Some(8),
+            Leaf::I16 | Leaf::U16 => Some(16),
+            Leaf::I32 | Leaf::U32 => Some(32),
+            Leaf::I64 | Leaf::U64 => Some(64),
+            Leaf::Bool | Leaf::Ptr => None,
+        }
+    }
+
+    fn is_signed(self) -> bool {
+        matches!(self, Leaf::I8 | Leaf::I16 | Leaf::I32 | Leaf::I64)
+    }
+
+    /// The suffix a C integer literal of this type needs so the literal's own
+    /// type is the field's, rather than whatever `int` promotion would pick.
+    fn c_literal_suffix(self) -> &'static str {
+        match self {
+            Leaf::I64 => "L",
+            Leaf::U64 => "UL",
+            Leaf::U8 | Leaf::U16 | Leaf::U32 => "U",
+            _ => "",
+        }
+    }
+}
+
+/// A concrete value for one leaf.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Value {
+    Int(i128),
+    Bool(bool),
+    /// An index into [`PROBE_BYTES`]; the pointer itself is `&c_probe_bytes[i]`.
+    Ptr(u8),
+}
+
+impl Value {
+    /// The 64-bit pattern this value contributes to a checksum: an integer
+    /// sign- or zero-extended to 64 bits, a bool's 0/1, or the byte a pointer
+    /// points at.
+    pub fn contribution(self, leaf: Leaf) -> u64 {
+        match self {
+            Value::Int(v) => {
+                if leaf.is_signed() {
+                    (v as i64) as u64
+                } else {
+                    v as u64
+                }
+            }
+            Value::Bool(b) => u64::from(b),
+            Value::Ptr(index) => u64::from(PROBE_BYTES[usize::from(index)]),
+        }
+    }
+
+    fn rue_literal(self) -> String {
+        match self {
+            Value::Int(v) => v.to_string(),
+            Value::Bool(true) => "true".to_string(),
+            Value::Bool(false) => "false".to_string(),
+            Value::Ptr(index) => index.to_string(),
+        }
+    }
+
+    fn c_literal(self, leaf: Leaf) -> String {
+        match self {
+            Value::Int(v) => format!("{v}{}", leaf.c_literal_suffix()),
+            Value::Bool(b) => (if b { "1" } else { "0" }).to_string(),
+            Value::Ptr(index) => format!("&c_probe_bytes[{index}]"),
+        }
+    }
+
+    /// A different value of the same type, returned by a callee whose seed did
+    /// not arrive intact. `0`/`1` is in range for every integer type the grid
+    /// uses, so the rule needs no per-type table.
+    fn poisoned(self) -> Value {
+        match self {
+            Value::Int(0) => Value::Int(1),
+            Value::Int(_) => Value::Int(0),
+            Value::Bool(b) => Value::Bool(!b),
+            Value::Ptr(index) => Value::Ptr((index + 1) % 8),
+        }
+    }
+}
+
+/// One field of a `@repr(c)` struct in the grid.
+pub struct Field {
+    pub name: &'static str,
+    pub ty: Ty,
+}
+
+/// A `@repr(c)` struct the grid declares in both languages.
+pub struct StructDef {
+    pub name: &'static str,
+    pub fields: &'static [Field],
+}
+
+/// A type at the boundary: a scalar, a fixed array (only ever a struct field),
+/// or a struct.
+#[derive(Clone, Copy)]
+pub enum Ty {
+    Leaf(Leaf),
+    Array(Leaf, usize),
+    Struct(&'static StructDef),
+}
+
+impl Ty {
+    pub fn rue_type(self) -> String {
+        match self {
+            Ty::Leaf(leaf) => leaf.rue_type().to_string(),
+            Ty::Array(leaf, len) => format!("[{}; {len}]", leaf.rue_type()),
+            Ty::Struct(def) => def.name.to_string(),
+        }
+    }
+
+    /// The C spelling for a parameter, local, or return type. Arrays never
+    /// appear here — they exist only as struct fields, where the declarator
+    /// puts the extent after the name.
+    pub fn c_type(self) -> String {
+        match self {
+            Ty::Leaf(leaf) => leaf.c_type().to_string(),
+            Ty::Array(..) => unreachable!("an array is only ever a struct field"),
+            Ty::Struct(def) => def.name.to_string(),
+        }
+    }
+
+    /// Every scalar leaf, in memory order, as the access path that reaches it
+    /// from a value of this type. The path spelling is deliberately identical
+    /// in both languages: `.f0`, `.f0.f1`, and `.f0[2]` all parse the same way
+    /// in Rue and in C, so one string drives both sides.
+    pub fn leaves(self) -> Vec<(String, Leaf)> {
+        let mut out = Vec::new();
+        self.walk_leaves("", &mut out);
+        out
+    }
+
+    fn walk_leaves(self, path: &str, out: &mut Vec<(String, Leaf)>) {
+        match self {
+            Ty::Leaf(leaf) => out.push((path.to_string(), leaf)),
+            Ty::Array(leaf, len) => {
+                for index in 0..len {
+                    out.push((format!("{path}[{index}]"), leaf));
+                }
+            }
+            Ty::Struct(def) => {
+                for field in def.fields {
+                    field.ty.walk_leaves(&format!("{path}.{}", field.name), out);
+                }
+            }
+        }
+    }
+
+    /// Every struct this type reaches, innermost first and without repeats, so
+    /// both languages can declare them in an order where each name is already
+    /// defined where it is used.
+    fn structs(self, out: &mut Vec<&'static StructDef>) {
+        if let Ty::Struct(def) = self {
+            for field in def.fields {
+                field.ty.structs(out);
+            }
+            if !out.iter().any(|existing| existing.name == def.name) {
+                out.push(def);
+            }
+        }
+    }
+}
+
+/// One row of the shape table.
+pub struct Shape {
+    pub key: &'static str,
+    pub ty: Ty,
+}
+
+static ABI_U8: StructDef = StructDef {
+    name: "AbiU8",
+    fields: &[Field {
+        name: "f0",
+        ty: Ty::Leaf(Leaf::U8),
+    }],
+};
+
+static ABI_U8_U8: StructDef = StructDef {
+    name: "AbiU8U8",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::U8),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::U8),
+        },
+    ],
+};
+
+static ABI_I32_I32: StructDef = StructDef {
+    name: "AbiI32I32",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::I32),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::I32),
+        },
+    ],
+};
+
+static ABI_I64_U8: StructDef = StructDef {
+    name: "AbiI64U8",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::U8),
+        },
+    ],
+};
+
+static ABI_I64_I64: StructDef = StructDef {
+    name: "AbiI64I64",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+    ],
+};
+
+static ABI_I64_I64_U8: StructDef = StructDef {
+    name: "AbiI64I64U8",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+        Field {
+            name: "f2",
+            ty: Ty::Leaf(Leaf::U8),
+        },
+    ],
+};
+
+static ABI_I64_X3: StructDef = StructDef {
+    name: "AbiI64X3",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+        Field {
+            name: "f2",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+    ],
+};
+
+static ABI_U8_I64: StructDef = StructDef {
+    name: "AbiU8I64",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::U8),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+    ],
+};
+
+static ABI_NESTED: StructDef = StructDef {
+    name: "AbiNested",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Struct(&ABI_I32_I32),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+    ],
+};
+
+static ABI_ARRAY: StructDef = StructDef {
+    name: "AbiArray",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Array(Leaf::U8, 4),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::I32),
+        },
+    ],
+};
+
+/// The shape rows. Scalars first, then `@repr(c)` structs chosen to land on the
+/// classification boundaries both current psABI rows care about: one and two
+/// bytes, two fields sharing one eightbyte, a padded 16, an exact 16, a 17-byte
+/// footprint padded to 24, an exact 24 (past the two-register budget on both
+/// rows), a leading narrow field, a nested struct, and an array field.
+pub static SHAPES: &[Shape] = &[
+    Shape {
+        key: "i8",
+        ty: Ty::Leaf(Leaf::I8),
+    },
+    Shape {
+        key: "u8",
+        ty: Ty::Leaf(Leaf::U8),
+    },
+    Shape {
+        key: "i16",
+        ty: Ty::Leaf(Leaf::I16),
+    },
+    Shape {
+        key: "u16",
+        ty: Ty::Leaf(Leaf::U16),
+    },
+    Shape {
+        key: "i32",
+        ty: Ty::Leaf(Leaf::I32),
+    },
+    Shape {
+        key: "u32",
+        ty: Ty::Leaf(Leaf::U32),
+    },
+    Shape {
+        key: "i64",
+        ty: Ty::Leaf(Leaf::I64),
+    },
+    Shape {
+        key: "u64",
+        ty: Ty::Leaf(Leaf::U64),
+    },
+    Shape {
+        key: "bool",
+        ty: Ty::Leaf(Leaf::Bool),
+    },
+    Shape {
+        key: "ptr",
+        ty: Ty::Leaf(Leaf::Ptr),
+    },
+    Shape {
+        key: "s_u8",
+        ty: Ty::Struct(&ABI_U8),
+    },
+    Shape {
+        key: "s_u8u8",
+        ty: Ty::Struct(&ABI_U8_U8),
+    },
+    Shape {
+        key: "s_i32i32",
+        ty: Ty::Struct(&ABI_I32_I32),
+    },
+    Shape {
+        key: "s_i64u8",
+        ty: Ty::Struct(&ABI_I64_U8),
+    },
+    Shape {
+        key: "s_i64i64",
+        ty: Ty::Struct(&ABI_I64_I64),
+    },
+    Shape {
+        key: "s_i64i64u8",
+        ty: Ty::Struct(&ABI_I64_I64_U8),
+    },
+    Shape {
+        key: "s_i64x3",
+        ty: Ty::Struct(&ABI_I64_X3),
+    },
+    Shape {
+        key: "s_u8i64",
+        ty: Ty::Struct(&ABI_U8_I64),
+    },
+    Shape {
+        key: "s_nested",
+        ty: Ty::Struct(&ABI_NESTED),
+    },
+    Shape {
+        key: "s_array",
+        ty: Ty::Struct(&ABI_ARRAY),
+    },
+];
+
+/// Which side of the boundary the Rue code is on.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Direction {
+    /// Rue calls generated C.
+    Import,
+    /// Generated C calls `pub extern` Rue.
+    Export,
+}
+
+impl Direction {
+    pub fn key(self) -> &'static str {
+        match self {
+            Direction::Import => "import",
+            Direction::Export => "export",
+        }
+    }
+}
+
+/// Where the shape sits in the crossing.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Position {
+    /// The shape occupies argument `index`; every other argument is an `i64`
+    /// filler.
+    Argument { key: &'static str, index: usize },
+    /// The shape is the result type.
+    Return,
+}
+
+impl Position {
+    pub fn key(self) -> &'static str {
+        match self {
+            Position::Argument { key, .. } => key,
+            Position::Return => "return",
+        }
+    }
+}
+
+/// The argument positions for one convention, plus the arity every argument
+/// cell uses. Positions are named by what they exercise, and their indices come
+/// from the convention's own register budget rather than a hard-coded number.
+pub struct Positions {
+    pub arity: usize,
+    pub positions: Vec<Position>,
+}
+
+pub fn positions_for(spec: &CConventionSpec) -> Positions {
+    let registers = spec.gp_argument_registers as usize;
+    assert!(
+        registers >= 2,
+        "a C convention with fewer than two argument registers has no distinct positions"
+    );
+    // Four slots past the register budget, so `deep_stack` is genuinely deep and
+    // every cell — whatever its position — also stacks arguments.
+    let arity = registers + 4;
+    Positions {
+        arity,
+        positions: vec![
+            Position::Argument {
+                key: "arg0",
+                index: 0,
+            },
+            Position::Argument {
+                key: "last_reg",
+                index: registers - 1,
+            },
+            Position::Argument {
+                key: "first_stack",
+                index: registers,
+            },
+            Position::Argument {
+                key: "deep_stack",
+                index: registers + 3,
+            },
+            Position::Return,
+        ],
+    }
+}
+
+/// What one line of the program's stdout proves, for a mismatch report.
+#[derive(Clone, Debug)]
+pub struct Cell {
+    pub function: String,
+    pub shape: &'static str,
+    pub position: &'static str,
+    pub direction: Direction,
+    pub abi: String,
+}
+
+impl Cell {
+    pub fn describe(&self) -> String {
+        format!(
+            "{} direction, shape `{}`, position `{}`, extern \"{}\" (function `{}`)",
+            self.direction.key(),
+            self.shape,
+            self.position,
+            self.abi,
+            self.function
+        )
+    }
+}
+
+/// One generated program: a `.c` and a `.rue` source, the exact stdout they must
+/// produce, and what each of those lines means.
+pub struct Program {
+    pub c_source: String,
+    pub rue_source: String,
+    pub expected: Vec<String>,
+    pub cells: Vec<Cell>,
+}
+
+/// SplitMix64, seeded from a cell's own name, so every cell's values and
+/// multipliers are reproducible from the grid alone and independent of
+/// iteration order.
+struct Rng(u64);
+
+impl Rng {
+    fn seeded(name: &str) -> Rng {
+        // FNV-1a over the cell name.
+        let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+        for byte in name.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        Rng(hash)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    /// A value in range for `leaf`. Signed ranges deliberately exclude the type
+    /// minimum, so every value is writable as a negated positive literal in both
+    /// languages.
+    fn value(&mut self, leaf: Leaf) -> Value {
+        match leaf {
+            Leaf::Bool => Value::Bool(self.next() & 1 == 1),
+            Leaf::Ptr => Value::Ptr((self.next() % PROBE_BYTES.len() as u64) as u8),
+            _ => {
+                let width = leaf
+                    .integer_width()
+                    .expect("bool and pointer leaves are handled above");
+                let raw = u128::from(self.next());
+                if leaf.is_signed() {
+                    let span = (1u128 << width) - 1;
+                    let magnitude = (1i128 << (width - 1)) - 1;
+                    Value::Int((raw % span) as i128 - magnitude)
+                } else {
+                    Value::Int((raw % (1u128 << width)) as i128)
+                }
+            }
+        }
+    }
+
+    /// An odd multiplier below 2^62: no checksum coefficient is zero, every one
+    /// is invertible modulo 2^64, and no literal approaches the range edge of
+    /// either language's `u64` parsing.
+    fn multiplier(&mut self) -> u64 {
+        (self.next() & 0x3fff_ffff_ffff_ffff) | 1
+    }
+}
+
+/// The data-model typedefs and the assertions that hold them, plus the probe
+/// bytes every pointer value points into. No headers and no libc: the object
+/// this becomes is linked with `-nostdlib`.
+fn c_prelude() -> String {
+    let probe = PROBE_BYTES
+        .iter()
+        .map(|byte| byte.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut out = String::new();
+    out.push_str("/* Generated by //crates/rue-c-abi-matrix. Do not edit. */\n");
+    out.push_str("typedef signed char rue_i8;\n");
+    out.push_str("typedef unsigned char rue_u8;\n");
+    out.push_str("typedef short rue_i16;\n");
+    out.push_str("typedef unsigned short rue_u16;\n");
+    out.push_str("typedef int rue_i32;\n");
+    out.push_str("typedef unsigned int rue_u32;\n");
+    out.push_str("typedef long rue_i64;\n");
+    out.push_str("typedef unsigned long rue_u64;\n");
+    out.push_str("typedef _Bool rue_bool;\n\n");
+    out.push_str("_Static_assert(sizeof(rue_i8) == 1, \"signed char must be 8-bit\");\n");
+    out.push_str("_Static_assert(sizeof(rue_i16) == 2, \"short must be 16-bit\");\n");
+    out.push_str("_Static_assert(sizeof(rue_i32) == 4, \"int must be 32-bit\");\n");
+    out.push_str("_Static_assert(sizeof(rue_i64) == 8, \"long must be 64-bit under LP64\");\n");
+    out.push_str("_Static_assert(sizeof(void *) == 8, \"pointers must be 64-bit\");\n\n");
+    out.push_str(&format!(
+        "static const rue_u8 c_probe_bytes[{}] = {{ {probe} }};\n\n",
+        PROBE_BYTES.len()
+    ));
+    out.push_str("const rue_u8 *c_probe(rue_i64 index) {\n");
+    out.push_str(&format!(
+        "    return &c_probe_bytes[index & {}];\n}}\n\n",
+        PROBE_BYTES.len() - 1
+    ));
+    out
+}
+
+fn c_struct_declarations(structs: &[&'static StructDef]) -> String {
+    let mut out = String::new();
+    for def in structs {
+        out.push_str("typedef struct {\n");
+        for field in def.fields {
+            match field.ty {
+                Ty::Array(leaf, len) => {
+                    out.push_str(&format!("    {} {}[{len}];\n", leaf.c_type(), field.name));
+                }
+                other => out.push_str(&format!("    {} {};\n", other.c_type(), field.name)),
+            }
+        }
+        out.push_str(&format!("}} {};\n\n", def.name));
+    }
+    out
+}
+
+fn rue_struct_declarations(structs: &[&'static StructDef]) -> String {
+    let mut out = String::new();
+    for def in structs {
+        out.push_str("@repr(c)\n");
+        out.push_str(&format!("struct {} {{\n", def.name));
+        for (index, field) in def.fields.iter().enumerate() {
+            let comma = if index + 1 == def.fields.len() {
+                ""
+            } else {
+                ","
+            };
+            out.push_str(&format!(
+                "    {}: {}{comma}\n",
+                field.name,
+                field.ty.rue_type()
+            ));
+        }
+        out.push_str("}\n\n");
+    }
+    out
+}
+
+/// One `acc += value * multiplier` step in C, reading `expr` as `leaf`.
+fn c_mix(expr: &str, leaf: Leaf, multiplier: u64) -> String {
+    let widened = match leaf {
+        Leaf::Ptr => format!("(rue_u64)(*({expr}))"),
+        Leaf::Bool => format!("(rue_u64)(({expr}) ? 1 : 0)"),
+        _ if leaf.is_signed() => format!("(rue_u64)(rue_i64)({expr})"),
+        _ => format!("(rue_u64)({expr})"),
+    };
+    format!("    acc += {widened} * {multiplier}UL;\n")
+}
+
+/// The same step in Rue. Rue integer arithmetic traps on overflow, so the
+/// accumulation uses the wrapping intrinsics; the conversions are explicit
+/// because Rue has no implicit widening.
+fn rue_mix(index: usize, expr: &str, leaf: Leaf, multiplier: u64) -> String {
+    let mut out = String::new();
+    match leaf {
+        Leaf::Ptr => {
+            out.push_str(&format!(
+                "    let b{index}: u8 = checked {{ @ptr_read({expr}) }};\n"
+            ));
+            out.push_str(&format!("    let x{index}: u64 = @intCast(b{index});\n"));
+        }
+        Leaf::Bool => {
+            out.push_str(&format!(
+                "    let x{index}: u64 = if {expr} {{ 1 }} else {{ 0 }};\n"
+            ));
+        }
+        Leaf::I64 => {
+            out.push_str(&format!("    let x{index}: u64 = @bitCast({expr});\n"));
+        }
+        Leaf::U64 => {
+            out.push_str(&format!("    let x{index}: u64 = {expr};\n"));
+        }
+        _ if leaf.is_signed() => {
+            out.push_str(&format!("    let t{index}: i64 = @intCast({expr});\n"));
+            out.push_str(&format!("    let x{index}: u64 = @bitCast(t{index});\n"));
+        }
+        _ => {
+            out.push_str(&format!("    let x{index}: u64 = @intCast({expr});\n"));
+        }
+    }
+    out.push_str(&format!(
+        "    acc = @wrapping_add(acc, @wrapping_mul(x{index}, {multiplier}));\n"
+    ));
+    out
+}
+
+/// The Rue expression building one value of `ty` from `values` in leaf order.
+fn rue_value_literal(ty: Ty, values: &mut std::slice::Iter<'_, Value>) -> String {
+    match ty {
+        Ty::Leaf(_) => values.next().expect("one value per leaf").rue_literal(),
+        Ty::Array(_, len) => {
+            let elements: Vec<String> = (0..len)
+                .map(|_| values.next().expect("one value per leaf").rue_literal())
+                .collect();
+            format!("[{}]", elements.join(", "))
+        }
+        Ty::Struct(def) => {
+            let fields: Vec<String> = def
+                .fields
+                .iter()
+                .map(|field| format!("{}: {}", field.name, rue_value_literal(field.ty, values)))
+                .collect();
+            format!("{} {{ {} }}", def.name, fields.join(", "))
+        }
+    }
+}
+
+/// The C statements that declare `name` and fill every leaf of `ty`.
+fn c_value_definition(name: &str, ty: Ty, leaves: &[(String, Leaf)], values: &[Value]) -> String {
+    match ty {
+        Ty::Leaf(Leaf::Ptr) => format!(
+            "    const rue_u8 *{name} = {};\n",
+            values[0].c_literal(Leaf::Ptr)
+        ),
+        Ty::Leaf(leaf) => format!(
+            "    {} {name} = {};\n",
+            leaf.c_type(),
+            values[0].c_literal(leaf)
+        ),
+        _ => {
+            let mut out = format!("    {} {name};\n", ty.c_type());
+            for ((path, leaf), value) in leaves.iter().zip(values) {
+                out.push_str(&format!("    {name}{path} = {};\n", value.c_literal(*leaf)));
+            }
+            out
+        }
+    }
+}
+
+/// One cell's values, multipliers, and the checksum they must produce.
+struct CellPlan {
+    name: String,
+    shape: &'static Shape,
+    position: Position,
+    /// One value per argument slot. The slot the shape occupies is unused.
+    fillers: Vec<Value>,
+    shape_values: Vec<Value>,
+    /// Multipliers in contribution order.
+    multipliers: Vec<u64>,
+    /// The seed a return-position cell round-trips through the callee.
+    seed: i128,
+    checksum: u64,
+}
+
+fn plan_cell(
+    shape: &'static Shape,
+    position: Position,
+    arity: usize,
+    direction: Direction,
+    abi: &str,
+) -> CellPlan {
+    let name = format!(
+        "{}_{}_{}_{}",
+        direction.key(),
+        abi.replace('-', "_"),
+        shape.key,
+        position.key()
+    );
+    let mut rng = Rng::seeded(&name);
+    let leaves = shape.ty.leaves();
+
+    let (fillers, shape_values, multipliers) = match position {
+        Position::Argument { index, .. } => {
+            let mut fillers: Vec<Value> = (0..arity).map(|_| rng.value(Leaf::I64)).collect();
+            // The shape occupies this slot; its filler value is never emitted.
+            fillers[index] = Value::Int(0);
+            let shape_values: Vec<Value> =
+                leaves.iter().map(|(_, leaf)| rng.value(*leaf)).collect();
+            // One multiplier per contribution: every filler, and every leaf of
+            // the shape argument.
+            let contributions = arity - 1 + leaves.len();
+            let multipliers: Vec<u64> = (0..contributions).map(|_| rng.multiplier()).collect();
+            (fillers, shape_values, multipliers)
+        }
+        Position::Return => {
+            let shape_values: Vec<Value> =
+                leaves.iter().map(|(_, leaf)| rng.value(*leaf)).collect();
+            let multipliers: Vec<u64> = (0..leaves.len()).map(|_| rng.multiplier()).collect();
+            (Vec::new(), shape_values, multipliers)
+        }
+    };
+
+    let seed = match (position, shape.ty) {
+        // A pointer result is produced by handing the seed to `c_probe`, so the
+        // seed must be a probe index rather than an arbitrary 64-bit value.
+        (Position::Return, Ty::Leaf(Leaf::Ptr)) => match shape_values[0] {
+            Value::Ptr(index) => i128::from(index),
+            _ => unreachable!("a pointer leaf carries a pointer value"),
+        },
+        (Position::Return, _) => match rng.value(Leaf::I64) {
+            Value::Int(v) => v,
+            _ => unreachable!("an i64 leaf carries an integer value"),
+        },
+        _ => 0,
+    };
+
+    let mut checksum: u64 = 0;
+    let mut multiplier = multipliers.iter();
+    let mut mix = |value: &Value, leaf: Leaf, checksum: &mut u64| {
+        *checksum = checksum.wrapping_add(
+            value
+                .contribution(leaf)
+                .wrapping_mul(*multiplier.next().expect("a multiplier per contribution")),
+        );
+    };
+    match position {
+        Position::Argument { index, .. } => {
+            for (slot, value) in fillers.iter().enumerate() {
+                if slot == index {
+                    for ((_, leaf), leaf_value) in leaves.iter().zip(&shape_values) {
+                        mix(leaf_value, *leaf, &mut checksum);
+                    }
+                } else {
+                    mix(value, Leaf::I64, &mut checksum);
+                }
+            }
+        }
+        Position::Return => {
+            for ((_, leaf), leaf_value) in leaves.iter().zip(&shape_values) {
+                mix(leaf_value, *leaf, &mut checksum);
+            }
+        }
+    }
+
+    CellPlan {
+        name,
+        shape,
+        position,
+        fillers,
+        shape_values,
+        multipliers,
+        seed,
+        checksum,
+    }
+}
+
+/// Parameter list for an argument cell, as `(name, type)` pairs.
+fn argument_parameters(plan: &CellPlan, arity: usize, index: usize) -> Vec<(String, Ty)> {
+    (0..arity)
+        .map(|slot| {
+            let ty = if slot == index {
+                plan.shape.ty
+            } else {
+                Ty::Leaf(Leaf::I64)
+            };
+            (format!("a{slot}"), ty)
+        })
+        .collect()
+}
+
+/// The Rue statement binding `v` to the shape value an argument cell passes.
+fn rue_argument_value(plan: &CellPlan) -> String {
+    match plan.shape.ty {
+        Ty::Leaf(Leaf::Ptr) => format!(
+            "    let v = checked {{ c_probe({}) }};\n",
+            plan.shape_values[0].rue_literal()
+        ),
+        Ty::Leaf(leaf) => format!(
+            "    let v: {} = {};\n",
+            leaf.rue_type(),
+            plan.shape_values[0].rue_literal()
+        ),
+        ty => {
+            let mut values = plan.shape_values.iter();
+            format!("    let v = {};\n", rue_value_literal(ty, &mut values))
+        }
+    }
+}
+
+/// The C function a return-position import cell calls. It answers the grid's
+/// values only when the seed arrived intact and a different value otherwise, so
+/// one line proves the argument crossing as well as the result crossing.
+fn c_return_builder(plan: &CellPlan, leaves: &[(String, Leaf)]) -> String {
+    if matches!(plan.shape.ty, Ty::Leaf(Leaf::Ptr)) {
+        return format!(
+            "const rue_u8 *{}(rue_i64 seed) {{\n    return c_probe(seed);\n}}\n\n",
+            plan.name
+        );
+    }
+    let c_type = plan.shape.ty.c_type();
+    let mut out = format!("{c_type} {}(rue_i64 seed) {{\n", plan.name);
+    out.push_str(&c_value_definition(
+        "v",
+        plan.shape.ty,
+        leaves,
+        &plan.shape_values,
+    ));
+    out.push_str(&format!("    if (seed != {}L) {{\n", plan.seed));
+    for ((path, leaf), value) in leaves.iter().zip(&plan.shape_values) {
+        out.push_str(&format!(
+            "        v{path} = {};\n",
+            value.poisoned().c_literal(*leaf)
+        ));
+    }
+    out.push_str("    }\n    return v;\n}\n\n");
+    out
+}
+
+/// The Rue export a return-position export cell calls, under the same
+/// seed-or-poison contract as its C counterpart.
+fn rue_return_builder(plan: &CellPlan, abi: &str) -> String {
+    if matches!(plan.shape.ty, Ty::Leaf(Leaf::Ptr)) {
+        return format!(
+            "pub extern \"{abi}\" fn {}(seed: i64) -> ptr const u8 {{\n    let p = checked {{ c_probe(seed) }};\n    p\n}}\n\n",
+            plan.name
+        );
+    }
+    let mut good = plan.shape_values.iter();
+    let good_literal = rue_value_literal(plan.shape.ty, &mut good);
+    let poisoned: Vec<Value> = plan
+        .shape_values
+        .iter()
+        .map(|value| value.poisoned())
+        .collect();
+    let mut bad = poisoned.iter();
+    let bad_literal = rue_value_literal(plan.shape.ty, &mut bad);
+    format!(
+        "pub extern \"{abi}\" fn {}(seed: i64) -> {} {{\n    if seed == {} {{ {good_literal} }} else {{ {bad_literal} }}\n}}\n\n",
+        plan.name,
+        plan.shape.ty.rue_type(),
+        plan.seed,
+    )
+}
+
+/// Generate the paired sources and expected output for one direction and one
+/// ABI spelling.
+pub fn generate(direction: Direction, abi: &str, spec: &CConventionSpec) -> Program {
+    let layout = positions_for(spec);
+    let mut structs: Vec<&'static StructDef> = Vec::new();
+    for shape in SHAPES {
+        shape.ty.structs(&mut structs);
+    }
+
+    let plans: Vec<CellPlan> = SHAPES
+        .iter()
+        .flat_map(|shape| {
+            layout
+                .positions
+                .iter()
+                .map(move |position| (shape, *position))
+        })
+        .map(|(shape, position)| plan_cell(shape, position, layout.arity, direction, abi))
+        .collect();
+
+    let mut c_body = String::new();
+    let mut rue_extern = String::new();
+    let mut rue_body = String::new();
+    let mut rue_main = String::new();
+
+    for plan in &plans {
+        let leaves = plan.shape.ty.leaves();
+        match (direction, plan.position) {
+            // --- Rue calls C with the shape in one argument slot -------------
+            (Direction::Import, Position::Argument { index, .. }) => {
+                let parameters = argument_parameters(plan, layout.arity, index);
+                let c_params: Vec<String> = parameters
+                    .iter()
+                    .map(|(name, ty)| format!("{} {name}", ty.c_type()))
+                    .collect();
+                c_body.push_str(&format!(
+                    "rue_u64 {}({}) {{\n    rue_u64 acc = 0;\n",
+                    plan.name,
+                    c_params.join(", ")
+                ));
+                let mut multiplier = plan.multipliers.iter();
+                for slot in 0..parameters.len() {
+                    if slot == index {
+                        for (path, leaf) in &leaves {
+                            c_body.push_str(&c_mix(
+                                &format!("a{slot}{path}"),
+                                *leaf,
+                                *multiplier.next().expect("a multiplier per leaf"),
+                            ));
+                        }
+                    } else {
+                        c_body.push_str(&c_mix(
+                            &format!("a{slot}"),
+                            Leaf::I64,
+                            *multiplier.next().expect("a multiplier per filler"),
+                        ));
+                    }
+                }
+                c_body.push_str("    return acc;\n}\n\n");
+
+                let rue_params: Vec<String> = parameters
+                    .iter()
+                    .map(|(name, ty)| format!("{name}: {}", ty.rue_type()))
+                    .collect();
+                rue_extern.push_str(&format!(
+                    "    fn {}({}) -> u64;\n",
+                    plan.name,
+                    rue_params.join(", ")
+                ));
+
+                rue_body.push_str(&format!("fn call_{}() -> u64 {{\n", plan.name));
+                rue_body.push_str(&rue_argument_value(plan));
+                let arguments: Vec<String> = (0..layout.arity)
+                    .map(|slot| {
+                        if slot == index {
+                            "v".to_string()
+                        } else {
+                            plan.fillers[slot].rue_literal()
+                        }
+                    })
+                    .collect();
+                rue_body.push_str(&format!(
+                    "    let r = checked {{ {}({}) }};\n    r\n}}\n\n",
+                    plan.name,
+                    arguments.join(", ")
+                ));
+                rue_main.push_str(&format!("    @dbg(call_{}());\n", plan.name));
+            }
+
+            // --- Rue reads a shape C returned --------------------------------
+            (Direction::Import, Position::Return) => {
+                c_body.push_str(&c_return_builder(plan, &leaves));
+                rue_extern.push_str(&format!(
+                    "    fn {}(seed: i64) -> {};\n",
+                    plan.name,
+                    plan.shape.ty.rue_type()
+                ));
+                rue_body.push_str(&format!("fn call_{}() -> u64 {{\n", plan.name));
+                rue_body.push_str(&format!(
+                    "    let v = checked {{ {}({}) }};\n    let mut acc: u64 = 0;\n",
+                    plan.name, plan.seed
+                ));
+                for (step, ((path, leaf), multiplier)) in
+                    leaves.iter().zip(&plan.multipliers).enumerate()
+                {
+                    rue_body.push_str(&rue_mix(step, &format!("v{path}"), *leaf, *multiplier));
+                }
+                rue_body.push_str("    acc\n}\n\n");
+                rue_main.push_str(&format!("    @dbg(call_{}());\n", plan.name));
+            }
+
+            // --- C calls a Rue export with the shape in one argument slot ----
+            (Direction::Export, Position::Argument { index, .. }) => {
+                let parameters = argument_parameters(plan, layout.arity, index);
+                let rue_params: Vec<String> = parameters
+                    .iter()
+                    .map(|(name, ty)| format!("{name}: {}", ty.rue_type()))
+                    .collect();
+                rue_body.push_str(&format!(
+                    "pub extern \"{abi}\" fn {}({}) -> u64 {{\n    let mut acc: u64 = 0;\n",
+                    plan.name,
+                    rue_params.join(", ")
+                ));
+                let mut multiplier = plan.multipliers.iter();
+                let mut step = 0usize;
+                for slot in 0..parameters.len() {
+                    if slot == index {
+                        for (path, leaf) in &leaves {
+                            rue_body.push_str(&rue_mix(
+                                step,
+                                &format!("a{slot}{path}"),
+                                *leaf,
+                                *multiplier.next().expect("a multiplier per leaf"),
+                            ));
+                            step += 1;
+                        }
+                    } else {
+                        rue_body.push_str(&rue_mix(
+                            step,
+                            &format!("a{slot}"),
+                            Leaf::I64,
+                            *multiplier.next().expect("a multiplier per filler"),
+                        ));
+                        step += 1;
+                    }
+                }
+                rue_body.push_str("    acc\n}\n\n");
+
+                let c_params: Vec<String> = parameters
+                    .iter()
+                    .map(|(name, ty)| format!("{} {name}", ty.c_type()))
+                    .collect();
+                c_body.push_str(&format!(
+                    "rue_u64 {}({});\n",
+                    plan.name,
+                    c_params.join(", ")
+                ));
+                c_body.push_str(&format!("rue_u64 drive_{}(void) {{\n", plan.name));
+                c_body.push_str(&c_value_definition(
+                    "v",
+                    plan.shape.ty,
+                    &leaves,
+                    &plan.shape_values,
+                ));
+                let arguments: Vec<String> = (0..layout.arity)
+                    .map(|slot| {
+                        if slot == index {
+                            "v".to_string()
+                        } else {
+                            plan.fillers[slot].c_literal(Leaf::I64)
+                        }
+                    })
+                    .collect();
+                c_body.push_str(&format!(
+                    "    return {}({});\n}}\n\n",
+                    plan.name,
+                    arguments.join(", ")
+                ));
+
+                rue_extern.push_str(&format!("    fn drive_{}() -> u64;\n", plan.name));
+                rue_main.push_str(&format!("    @dbg(checked {{ drive_{}() }});\n", plan.name));
+            }
+
+            // --- C reads a shape a Rue export returned -----------------------
+            (Direction::Export, Position::Return) => {
+                rue_body.push_str(&rue_return_builder(plan, abi));
+
+                c_body.push_str(&format!(
+                    "{} {}(rue_i64 seed);\n",
+                    plan.shape.ty.c_type(),
+                    plan.name
+                ));
+                c_body.push_str(&format!(
+                    "rue_u64 drive_{}(void) {{\n    {} v = {}({}L);\n    rue_u64 acc = 0;\n",
+                    plan.name,
+                    plan.shape.ty.c_type(),
+                    plan.name,
+                    plan.seed
+                ));
+                for ((path, leaf), multiplier) in leaves.iter().zip(&plan.multipliers) {
+                    c_body.push_str(&c_mix(&format!("v{path}"), *leaf, *multiplier));
+                }
+                c_body.push_str("    return acc;\n}\n\n");
+
+                rue_extern.push_str(&format!("    fn drive_{}() -> u64;\n", plan.name));
+                rue_main.push_str(&format!("    @dbg(checked {{ drive_{}() }});\n", plan.name));
+            }
+        }
+    }
+
+    let c_source = format!(
+        "{}{}{}",
+        c_prelude(),
+        c_struct_declarations(&structs),
+        c_body
+    );
+
+    let rue_source = format!(
+        "// Generated by //crates/rue-c-abi-matrix. Do not edit.\n\n\
+         {}extern \"{abi}\" {{\n    fn c_probe(index: i64) -> ptr const u8;\n{}}}\n\n\
+         {}fn main() -> i32 {{\n{}    0\n}}\n",
+        rue_struct_declarations(&structs),
+        rue_extern,
+        rue_body,
+        rue_main,
+    );
+
+    let expected = plans.iter().map(|plan| plan.checksum.to_string()).collect();
+    let cells = plans
+        .iter()
+        .map(|plan| Cell {
+            function: plan.name.clone(),
+            shape: plan.shape.key,
+            position: plan.position.key(),
+            direction,
+            abi: abi.to_string(),
+        })
+        .collect();
+
+    Program {
+        c_source,
+        rue_source,
+        expected,
+        cells,
+    }
+}

--- a/crates/rue-c-abi-matrix/src/main.rs
+++ b/crates/rue-c-abi-matrix/src/main.rs
@@ -1,0 +1,455 @@
+//! The generated C-boundary conformance matrix (RUE-2035).
+//!
+//! Rue's existing C-boundary execution evidence is hand-written: a handful of
+//! CLI cases whose C side is hand-assembled machine code in
+//! `crates/rue-cli-tests`. That proves a boundary works; it does not scale to a
+//! matrix, and the native-ABI work this exists to protect changes the placement
+//! of every argument. So this harness *generates* the matrix instead.
+//!
+//! For one direction and one ABI spelling it emits a paired `.c` and `.rue`
+//! program covering every shape at every position (see [`grid`]), compiles the
+//! C side with the host `cc`, compiles the Rue side with the real compiler
+//! binary, links the two with `--linker cc --link-archive`, runs the executable,
+//! and compares its stdout — line for line — with values this process computed
+//! from the same table the sources were emitted from. A mismatch names the
+//! direction, the shape, the position, the ABI spelling, and the function.
+//!
+//! # Why the system linker
+//!
+//! The C objects `cc` produces carry relocation and section kinds Rue's
+//! internal linker's static subset does not promise to handle, so every program
+//! here links through `--linker cc`, which passes `-nostdlib` (plus `-static` on
+//! ELF), the supplied archives, and the Rue runtime archive to the system
+//! driver. That is also why the generated C is freestanding: no headers, no
+//! libc, fixed-width typedefs spelled from the target's own data model, and
+//! `_Static_assert`s that fail the compile if that data model is not what the
+//! generator assumed.
+//!
+//! # Scope
+//!
+//! Host-only by construction: the matrix compiles for and executes on the
+//! machine running it, and the native lanes are what give it AArch64 Linux and
+//! Apple arm64 coverage. Without a `cc` driver on `PATH` every trial reports
+//! *ignored* rather than failing, the same rule the CLI corpus's
+//! `requires_system_linker` cases follow.
+
+mod grid;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use libtest2_mimic::{Harness, RunContext, RunError, Trial};
+use rue_target::{CallingConvention, DataModel, Target};
+use rue_test_runner::{compiler_command, find_rue_binary, ice_message, run_with_timeout};
+
+use grid::{Direction, Program};
+
+/// Freestanding C: no headers, no libc, no builtins, and no stack protector —
+/// the object is linked with `-nostdlib`, so a protector call would be an
+/// undefined `__stack_chk_fail`. Position-independent code keeps the object
+/// acceptable to a driver defaulting to PIE. Identical on every row; the
+/// generated C carries no platform conditionals.
+const C_FLAGS: &[&str] = &[
+    "-std=c11",
+    "-ffreestanding",
+    "-nostdlib",
+    "-fno-builtin",
+    "-fno-stack-protector",
+    "-fPIC",
+    "-O2",
+    "-c",
+];
+
+const C_COMPILE_TIMEOUT: Duration = Duration::from_secs(120);
+const ARCHIVE_TIMEOUT: Duration = Duration::from_secs(60);
+const RUE_COMPILE_TIMEOUT: Duration = Duration::from_secs(300);
+const RUN_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Whether a system `cc` driver and an `ar` archiver are both on `PATH`, probed
+/// once per process. Both are needed: `cc` compiles the C side and performs the
+/// final link, and `ar` wraps the object in the static archive `--link-archive`
+/// documents as its input.
+fn toolchain_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| ["cc", "ar"].iter().all(|tool| responds_to_version(tool)))
+}
+
+fn responds_to_version(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+/// The compiler path, made absolute: every subprocess below runs with the
+/// program's temp directory as its working directory, where a Buck-supplied
+/// relative `RUE_BINARY` would no longer resolve.
+fn rue_binary() -> Result<PathBuf, String> {
+    let binary = find_rue_binary();
+    std::fs::canonicalize(&binary).map_err(|error| {
+        format!(
+            "RUE_BINARY `{}` does not resolve: {error}",
+            binary.display()
+        )
+    })
+}
+
+fn host_target() -> Result<Target, String> {
+    let target =
+        Target::host().ok_or("no Rue target describes this host; the matrix runs natively only")?;
+    if target.data_model() != DataModel::Lp64 {
+        return Err(format!(
+            "the generated C spells `long` as the 64-bit integer, which holds only under LP64; \
+             {target} uses {}",
+            target.data_model()
+        ));
+    }
+    Ok(target)
+}
+
+fn step_timeout(step: &str) -> Duration {
+    match step {
+        "cc" => C_COMPILE_TIMEOUT,
+        "ar" => ARCHIVE_TIMEOUT,
+        "rue" => RUE_COMPILE_TIMEOUT,
+        _ => RUN_TIMEOUT,
+    }
+}
+
+/// Run one step, turning a nonzero status, a compiler ICE, or a timeout into a
+/// failure that names the step.
+fn run_step(step: &str, command: Command) -> Result<String, String> {
+    let output = run_with_timeout(command, step_timeout(step), None)
+        .map_err(|failure| format!("{step}: {failure}"))?;
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    if let Some(ice) = ice_message(&output.status, &stderr) {
+        return Err(format!("{step}: {ice}"));
+    }
+    if !output.status.success() {
+        return Err(format!(
+            "{step} failed ({})\n--- stderr ---\n{stderr}\n--- stdout ---\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Compile, link, and run one generated program, then compare its output with
+/// the checksums the generator computed.
+fn run_program(program: &Program, directory: &Path, rue: &Path) -> Result<(), String> {
+    std::fs::write(directory.join("boundary.c"), &program.c_source)
+        .map_err(|error| format!("could not write boundary.c: {error}"))?;
+    std::fs::write(directory.join("main.rue"), &program.rue_source)
+        .map_err(|error| format!("could not write main.rue: {error}"))?;
+
+    let mut cc = Command::new("cc");
+    cc.current_dir(directory)
+        .args(C_FLAGS)
+        .args(["boundary.c", "-o", "boundary.o"]);
+    run_step("cc", cc)?;
+
+    let mut ar = Command::new("ar");
+    ar.current_dir(directory)
+        .args(["rcs", "libboundary.a", "boundary.o"]);
+    run_step("ar", ar)?;
+
+    let mut compile = compiler_command(rue);
+    compile.current_dir(directory).args([
+        "main.rue",
+        "--preview",
+        "c_ffi",
+        "--linker",
+        "cc",
+        "--link-archive",
+        "libboundary.a",
+        "-o",
+        "prog",
+    ]);
+    run_step("rue", compile)?;
+
+    let mut run = Command::new(directory.join("prog"));
+    run.current_dir(directory);
+    let stdout = run_step("program", run)?;
+
+    compare(program, &stdout)
+}
+
+/// Compare the program's stdout with the expected checksums, reporting every
+/// disagreeing cell by what it crosses rather than by line number.
+fn compare(program: &Program, stdout: &str) -> Result<(), String> {
+    let actual: Vec<&str> = stdout.lines().collect();
+    if actual.len() != program.expected.len() {
+        return Err(format!(
+            "the program printed {} lines; the grid has {} cells. Either a cell did not run, or \
+             the program aborted partway through.\n--- stdout ---\n{stdout}",
+            actual.len(),
+            program.expected.len()
+        ));
+    }
+
+    let mismatches: Vec<String> = program
+        .cells
+        .iter()
+        .zip(&program.expected)
+        .zip(&actual)
+        .filter(|((_, expected), actual)| expected.as_str() != **actual)
+        .map(|((cell, expected), actual)| {
+            format!(
+                "  {}\n    expected {expected}, got {actual}",
+                cell.describe()
+            )
+        })
+        .collect();
+
+    if mismatches.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "{} of {} C-boundary cells produced the wrong checksum:\n{}",
+        mismatches.len(),
+        program.expected.len(),
+        mismatches.join("\n")
+    ))
+}
+
+fn run_matrix(direction: Direction, abi: &str) -> Result<(), String> {
+    let target = host_target()?;
+    let spec = CallingConvention::c_for_target(target).c_spec();
+    let program = grid::generate(direction, abi, &spec);
+
+    let directory = tempfile::Builder::new()
+        .prefix("rue-c-abi-matrix-")
+        .tempdir()
+        .map_err(|error| format!("could not create a temp directory: {error}"))?;
+    let rue = rue_binary()?;
+    match run_program(&program, directory.path(), &rue) {
+        Ok(()) => Ok(()),
+        Err(failure) => {
+            // Keep the generated pair on failure: the sources are the only way
+            // to reduce a failing cell to a minimal repro.
+            let kept = directory.keep();
+            Err(format!(
+                "{failure}\n\nGenerated sources kept at {}",
+                kept.display()
+            ))
+        }
+    }
+}
+
+fn trial(direction: Direction, abi: &'static str) -> Trial {
+    let name = format!(
+        "c_abi_matrix::{}_{}",
+        direction.key(),
+        abi.replace('-', "_")
+    );
+    Trial::test(name, move |context: RunContext<'_>| {
+        // A host without a C toolchain cannot prove anything here, and saying so
+        // is not the same as passing — the rule RUE-1173 set for the CLI
+        // corpus's `--linker cc` cases.
+        if !toolchain_available() {
+            return context.ignore_for("no system `cc` and `ar` toolchain on PATH");
+        }
+        run_matrix(direction, abi).map_err(RunError::fail)
+    })
+}
+
+fn main() {
+    // The host's own C row, spelled both ways a declaration may spell it.
+    // Proving the two separately by execution is what makes `"C"` an alias
+    // rather than a second convention.
+    let explicit = match Target::host() {
+        Some(target) => CallingConvention::c_for_target(target).name(),
+        // No host row: the `"C"` trials still register and report that from
+        // `host_target`, so the harness never silently runs nothing.
+        None => "C",
+    };
+
+    let mut trials = vec![trial(Direction::Import, "C"), trial(Direction::Export, "C")];
+    if explicit != "C" {
+        trials.push(trial(Direction::Import, explicit));
+        trials.push(trial(Direction::Export, explicit));
+    }
+
+    Harness::with_env().discover(trials).main();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::grid::{
+        Direction, Leaf, PROBE_BYTES, Position, SHAPES, Ty, Value, generate, positions_for,
+    };
+    use rue_target::{CConventionSpec, CallingConvention, Target};
+
+    fn spec() -> CConventionSpec {
+        CallingConvention::X86_64SysV.c_spec()
+    }
+
+    #[test]
+    fn every_shape_reaches_every_position_in_both_directions() {
+        let layout = positions_for(&spec());
+        for direction in [Direction::Import, Direction::Export] {
+            let program = generate(direction, "C", &spec());
+            assert_eq!(
+                program.cells.len(),
+                SHAPES.len() * layout.positions.len(),
+                "the grid must be the full shape x position product"
+            );
+            assert_eq!(program.cells.len(), program.expected.len());
+            for shape in SHAPES {
+                for position in &layout.positions {
+                    assert!(
+                        program
+                            .cells
+                            .iter()
+                            .any(|cell| cell.shape == shape.key && cell.position == position.key()),
+                        "no cell for {} at {}",
+                        shape.key,
+                        position.key()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn positions_come_from_the_conventions_register_budget() {
+        for convention in [
+            CallingConvention::X86_64SysV,
+            CallingConvention::Aarch64Aapcs,
+            CallingConvention::Aarch64AapcsDarwin,
+        ] {
+            let registers = convention.c_spec().gp_argument_registers as usize;
+            let layout = positions_for(&convention.c_spec());
+            let indices: Vec<usize> = layout
+                .positions
+                .iter()
+                .filter_map(|position| match position {
+                    Position::Argument { index, .. } => Some(*index),
+                    Position::Return => None,
+                })
+                .collect();
+            assert_eq!(indices, vec![0, registers - 1, registers, registers + 3]);
+            assert!(
+                layout.arity > registers,
+                "every cell must also stack arguments"
+            );
+        }
+    }
+
+    #[test]
+    fn cell_names_are_unique_within_a_program() {
+        let program = generate(Direction::Import, "C", &spec());
+        let mut names: Vec<&str> = program
+            .cells
+            .iter()
+            .map(|cell| cell.function.as_str())
+            .collect();
+        names.sort_unstable();
+        let count = names.len();
+        names.dedup();
+        assert_eq!(names.len(), count, "generated function names collide");
+    }
+
+    #[test]
+    fn a_generated_program_declares_every_struct_before_it_is_used() {
+        let program = generate(Direction::Export, "C", &spec());
+        for shape in SHAPES {
+            if let Ty::Struct(def) = shape.ty {
+                assert!(
+                    program
+                        .rue_source
+                        .contains(&format!("struct {} {{", def.name)),
+                    "{} is missing from the Rue source",
+                    def.name
+                );
+                assert!(
+                    program.c_source.contains(&format!("}} {};", def.name)),
+                    "{} is missing from the C source",
+                    def.name
+                );
+            }
+        }
+        // The nested struct's inner type must be declared before the outer one
+        // in C, where a typedef is not usable before its definition.
+        let inner = program.c_source.find("} AbiI32I32;").expect("inner struct");
+        let outer = program.c_source.find("} AbiNested;").expect("outer struct");
+        assert!(inner < outer);
+    }
+
+    /// Whether `literal` appears in `source` as a whole number token rather
+    /// than as the tail of a longer one.
+    fn contains_literal(source: &str, literal: &str) -> bool {
+        let bytes = source.as_bytes();
+        let mut from = 0;
+        while let Some(offset) = source[from..].find(literal) {
+            let start = from + offset;
+            let end = start + literal.len();
+            let separated_before = start == 0 || !bytes[start - 1].is_ascii_digit();
+            let separated_after = end == bytes.len() || !bytes[end].is_ascii_digit();
+            if separated_before && separated_after {
+                return true;
+            }
+            from = start + 1;
+        }
+        false
+    }
+
+    #[test]
+    fn signed_values_stay_off_the_type_minimum_so_they_negate() {
+        // Every emitted signed literal must be writable as a negated positive in
+        // both languages, which the type minimum is not.
+        for direction in [Direction::Import, Direction::Export] {
+            let program = generate(direction, "C", &spec());
+            for source in [&program.rue_source, &program.c_source] {
+                for minimum in ["-9223372036854775808", "-2147483648", "-32768", "-128"] {
+                    assert!(
+                        !contains_literal(source, minimum),
+                        "{minimum} is a type minimum and has no negated-positive spelling"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn the_whole_token_literal_search_ignores_longer_numbers() {
+        assert!(contains_literal("v = -128;", "-128"));
+        assert!(!contains_literal("v = -1284;", "-128"));
+        assert!(!contains_literal("v = -3128;", "-128"));
+    }
+
+    #[test]
+    fn a_pointer_contributes_its_pointee_not_its_address() {
+        for (index, byte) in PROBE_BYTES.iter().enumerate() {
+            assert_eq!(
+                Value::Ptr(index as u8).contribution(Leaf::Ptr),
+                u64::from(*byte)
+            );
+        }
+    }
+
+    #[test]
+    fn narrow_signed_leaves_contribute_sign_extended_patterns() {
+        assert_eq!(Value::Int(-1).contribution(Leaf::I8), u64::MAX);
+        assert_eq!(Value::Int(-1).contribution(Leaf::I32), u64::MAX);
+        assert_eq!(Value::Int(255).contribution(Leaf::U8), 255);
+        assert_eq!(
+            Value::Int(i128::from(u32::MAX)).contribution(Leaf::U32),
+            u64::from(u32::MAX)
+        );
+    }
+
+    #[test]
+    fn the_host_row_is_a_convention_row_rather_than_the_alias() {
+        if let Some(target) = Target::host() {
+            let convention = CallingConvention::c_for_target(target);
+            assert!(convention.is_c());
+            assert_ne!(convention.name(), "C", "the alias is not a row name");
+        }
+    }
+}

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -325,14 +325,76 @@ exercised by the compiler-generated caller.
 `aarch64_macos_narrow_exports_build_under_the_apple_row` compiles and links a
 narrow-parameter export for AArch64 macOS, so the Apple row's export thunks are
 generated, encoded, and placed in a Mach-O image on every host and executed on
-the macOS CI host. There is no macOS C-caller archive, so the Apple row's
-stacked-argument packing is proved by unit tests over the shared signature
-lowering rather than by execution.
+the macOS CI host. That case has no C caller of its own; the generated matrix
+below supplies one, and the Apple row's stacked-argument packing is additionally
+pinned by unit tests over the shared signature lowering.
+
+### The generated conformance matrix
+
+The cases above are hand-written, and each one's C side is hand-assembled
+machine code. That does not scale to a matrix, so
+`//crates/rue-c-abi-matrix:c-abi-matrix-test` generates one. At test time it
+emits paired C and Rue sources, compiles the C side with the host `cc`, compiles
+the Rue side with the real driver, links the two with `--linker cc
+--link-archive`, runs the executable, and compares its stdout with checksums the
+generator computed from the same table it emitted both sources from.
+
+The grid is shape x position x direction x ABI spelling:
+
+- **Shapes** (20): `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `bool`,
+  `ptr const u8`, and ten `@repr(c)` structs chosen for the classification
+  boundaries — `{u8}`, `{u8,u8}`, `{i32,i32}`, `{i64,u8}`, `{i64,i64}`,
+  `{i64,i64,u8}`, `{i64,i64,i64}`, `{u8,i64}`, a nested `{{i32,i32},i64}`, and
+  `{[u8;4],i32}`. Floats are still rejected at the boundary; the table is shaped
+  so adding them is a table edit.
+- **Positions** (5): argument 0, the convention's last argument register, the
+  first stack slot, a deep stack slot, and the result type. The indices come
+  from `CConventionSpec::gp_argument_registers`, so a convention with a
+  different register budget moves them without a source edit. Every other
+  argument is an `i64` filler, and every cell also stacks arguments.
+- **Directions** (2): import (Rue calls generated C) and export (a generated C
+  driver calls a `pub extern` Rue function).
+- **ABI spellings** (2): `"C"` and the host row's own name, so the alias and the
+  explicit spelling are proven equal by execution rather than by inspection.
+
+Every cell reduces its whole argument list to one `u64` checksum: each filler,
+and each *leaf* of the shape separately, contributes its 64-bit pattern times
+its own odd multiplier, accumulated with wrapping arithmetic on both sides. A
+swapped field, a truncated half, a missing sign extension, or a slot read from
+the wrong stack offset changes the sum, and the failure report names the
+direction, shape, position, ABI spelling, and function. Return-position cells
+also round-trip a seed: the callee answers a deliberately different value when
+the seed did not arrive intact, so a broken argument crossing cannot hide behind
+a correct result.
+
+That is 400 cells in four generated programs — one per direction and spelling —
+which compile, link, and run in about five seconds. The generated C is
+freestanding on every row: no headers, no libc, fixed-width typedefs spelled
+from the target's data model with `_Static_assert`s holding them, and no
+platform conditionals. Linking goes through `cc` because the objects `cc`
+produces carry relocation and section kinds the internal linker's static subset
+does not promise to handle.
+
+The target is host-only by construction and carries the `rue_platform_native`
+label, so the native lanes run it: SysV AMD64 on linux-x64, AAPCS64 on
+linux-arm64, and the Apple arm64 row on macos-arm64. A host with no `cc` and
+`ar` on `PATH` reports every trial as ignored rather than failing. Run it with
+`./buck2 test //crates/rue-c-abi-matrix:c-abi-matrix-test`; `scripts/rue
+premerge` includes it, and `scripts/rue quick` deliberately does not.
+
+One gap the grid does *not* close is the open Apple amendment above. Every
+filler is an `i64`, so a stacked composite is followed by an 8-byte-aligned
+argument that re-aligns the outgoing area, and the difference between Apple's
+natural-size footprint and the whole-eightbyte one Rue emits is absorbed rather
+than observed. Distinguishing them needs a filler narrower than a slot next to a
+stacked composite, which is worth adding with the byte-granular marshaling that
+would make it pass.
 
 Backend tests additionally enforce that the typed runtime manifest stays within
 each backend's implemented register-only subset and that its boundary resolves
-to that backend's C convention row. The C-caller/C-callee matrix is still
-one-sided on macOS; a macOS C toolchain probe would close it.
+to that backend's C convention row. The generated matrix makes the
+C-caller/C-callee matrix two-sided on every supported host, macOS included,
+because the macOS lane compiles the same generated C with the host toolchain.
 
 ## Finding
 
@@ -361,10 +423,12 @@ signature and its executing cases. What remains open:
   byte-granular marshaling rather than the whole-eightbyte image stores the
   current path emits;
 - floating-point/vector arguments and results, which the boundary still rejects;
-- variadic calls, or an explicit diagnostic rejecting them;
-- pointer provenance, mutability, and lifetime rules; and
-- an executable Rue-to-C harness on macOS, so the C-caller/C-callee matrix is
-  two-sided on every supported target.
+- variadic calls, or an explicit diagnostic rejecting them; and
+- pointer provenance, mutability, and lifetime rules.
+
+The executable Rue-to-C harness on macOS that this list used to ask for is the
+generated conformance matrix above: it runs both directions on every native
+host, so the C-caller/C-callee matrix is no longer one-sided there.
 
 Until those paths exist, native Rue functions and native-layout values are not
 an FFI surface.

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -161,7 +161,13 @@ self-enrolls through its graph attribute. Neither requires a workflow or
 validator target-list edit. The fake-tool shell suites (`//:wrapper-script-tests`
 and its siblings) carry the same label so the macOS lane runs them under the
 stock Bash 3.2; the repetition is declared in
-`scripts/validate-test-duplication.py`.
+`scripts/validate-test-duplication.py`. So is
+`//crates/rue-c-abi-matrix:c-abi-matrix-test`, the generated C-boundary
+conformance matrix: it generates paired C and Rue sources for the host, compiles
+the C side with the host `cc`, links through it, and runs the result, so each
+psABI row — SysV AMD64, AAPCS64, and the Apple arm64 amendments — is proven only
+on the lane where that row is native. It reports every trial as ignored on a
+host with no `cc`. See `docs/notes/ffi-abi-conformance-audit.md`.
 
 The native lanes set `RUE_PLATFORM_CASE_SELECTION=native` through
 `scripts/run-native-platform-corpus.sh`. Both manifest-driven harnesses then

--- a/rust-project.json
+++ b/rust-project.json
@@ -11,39 +11,39 @@
           "name": "rue_builtins"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         },
         {
-          "crate": 131,
+          "crate": 132,
           "name": "zmij"
         }
       ],
@@ -71,51 +71,51 @@
           "name": "rue_builtins"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         },
         {
-          "crate": 98,
+          "crate": 99,
           "name": "rayon"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         },
         {
-          "crate": 131,
+          "crate": 132,
           "name": "zmij"
         }
       ],
@@ -158,39 +158,39 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_perf_schema"
         },
         {
-          "crate": 33,
+          "crate": 34,
           "name": "rue_driver"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libc"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "sha2"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml"
         }
       ],
@@ -214,7 +214,7 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         }
       ],
@@ -222,6 +222,42 @@
       "source": {
         "include_dirs": [
           "crates/rue-builtins/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-c-abi-matrix",
+      "root_module": "crates/rue-c-abi-matrix/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 28,
+          "name": "rue_target"
+        },
+        {
+          "crate": 29,
+          "name": "rue_test_runner"
+        },
+        {
+          "crate": 78,
+          "name": "libtest2_mimic"
+        },
+        {
+          "crate": 113,
+          "name": "tempfile"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-c-abi-matrix/src"
         ],
         "exclude_dirs": []
       },
@@ -242,19 +278,19 @@
           "name": "rue_air"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         }
       ],
@@ -282,19 +318,19 @@
           "name": "rue_air"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         }
       ],
@@ -318,35 +354,35 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 14,
+          "crate": 15,
           "name": "rue_linker"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 77,
+          "crate": 78,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml"
         }
       ],
@@ -374,43 +410,43 @@
           "name": "rue_air"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 59,
+          "crate": 60,
           "name": "fixedbitset"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "smallvec"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         }
       ],
@@ -442,87 +478,87 @@
           "name": "rue_builtins"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg"
         },
         {
-          "crate": 8,
+          "crate": 9,
           "name": "rue_codegen"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 14,
+          "crate": 15,
           "name": "rue_linker"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_query"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 40,
+          "crate": 41,
           "name": "annotate_snippets"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "itoa"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libc"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "sha2"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         }
       ],
@@ -546,15 +582,15 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "thiserror"
         }
       ],
@@ -578,23 +614,23 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         }
       ],
@@ -626,63 +662,63 @@
           "name": "rue_air_fuzz_support"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg"
         },
         {
-          "crate": 6,
+          "crate": 7,
           "name": "rue_cfg_fuzz_support"
         },
         {
-          "crate": 8,
+          "crate": 9,
           "name": "rue_codegen"
         },
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_oracle"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 22,
+          "crate": 23,
           "name": "rue_rir_fuzz_support"
         },
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 43,
+          "crate": 44,
           "name": "anyhow"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libc"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "proptest"
         }
       ],
@@ -706,19 +742,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         },
         {
-          "crate": 80,
+          "crate": 81,
           "name": "logos"
         }
       ],
@@ -742,15 +778,15 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         }
       ],
@@ -774,19 +810,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libc"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         }
       ],
@@ -810,35 +846,35 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_oracle"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_query"
         },
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml"
         }
       ],
@@ -866,23 +902,23 @@
           "name": "rue_air"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg"
         },
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         },
         {
-          "crate": 131,
+          "crate": 132,
           "name": "zmij"
         }
       ],
@@ -906,35 +942,35 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "smallvec"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         }
       ],
@@ -958,19 +994,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "sha2"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml"
         }
       ],
@@ -994,15 +1030,15 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "smallvec"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         }
       ],
@@ -1026,27 +1062,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         }
       ],
@@ -1070,27 +1106,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lasso"
         }
       ],
@@ -1137,11 +1173,11 @@
           "name": "rue_allocator"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 131,
+          "crate": 132,
           "name": "zmij"
         }
       ],
@@ -1184,31 +1220,31 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 77,
+          "crate": 78,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml"
         }
       ],
@@ -1251,31 +1287,31 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libc"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml"
         }
       ],
@@ -1299,11 +1335,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml"
         }
       ],
@@ -1327,11 +1363,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 77,
+          "crate": 78,
           "name": "libtest2_mimic"
         }
       ],
@@ -1374,55 +1410,55 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_perf_schema"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 33,
+          "crate": 34,
           "name": "rue_driver"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libc"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "sha2"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         },
         {
-          "crate": 123,
+          "crate": 124,
           "name": "tracing_subscriber"
         }
       ],
@@ -1446,47 +1482,47 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_perf_schema"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libc"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "sha2"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         },
         {
-          "crate": 123,
+          "crate": 124,
           "name": "tracing_subscriber"
         }
       ],
@@ -1510,7 +1546,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 81,
+          "crate": 82,
           "name": "logos_codegen"
         }
       ],
@@ -1534,15 +1570,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 90,
+          "crate": 91,
           "name": "proc_macro2"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "quote"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "syn"
         }
       ],
@@ -1567,15 +1603,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 90,
+          "crate": 91,
           "name": "proc_macro2"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "quote"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "syn"
         }
       ],
@@ -1599,15 +1635,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 90,
+          "crate": 91,
           "name": "proc_macro2"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "quote"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "syn"
         }
       ],
@@ -1631,19 +1667,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 49,
+          "crate": 50,
           "name": "cfg_if"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "getrandom"
         },
         {
-          "crate": 86,
+          "crate": 87,
           "name": "once_cell"
         },
         {
-          "crate": 130,
+          "crate": 131,
           "name": "zerocopy"
         }
       ],
@@ -1692,11 +1728,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 42,
+          "crate": 43,
           "name": "anstyle"
         },
         {
-          "crate": 127,
+          "crate": 128,
           "name": "unicode_width"
         }
       ],
@@ -1805,7 +1841,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 46,
+          "crate": 47,
           "name": "bit_vec"
         }
       ],
@@ -1873,7 +1909,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 61,
+          "crate": 62,
           "name": "generic_array"
         }
       ],
@@ -1935,11 +1971,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crossbeam_epoch"
         },
         {
-          "crate": 53,
+          "crate": 54,
           "name": "crossbeam_utils"
         }
       ],
@@ -1965,7 +2001,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 53,
+          "crate": 54,
           "name": "crossbeam_utils"
         }
       ],
@@ -2012,11 +2048,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 61,
+          "crate": 62,
           "name": "generic_array"
         },
         {
-          "crate": 124,
+          "crate": 125,
           "name": "typenum"
         }
       ],
@@ -2040,27 +2076,27 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 49,
+          "crate": 50,
           "name": "cfg_if"
         },
         {
-          "crate": 53,
+          "crate": 54,
           "name": "crossbeam_utils"
         },
         {
-          "crate": 63,
+          "crate": 64,
           "name": "hashbrown"
         },
         {
-          "crate": 78,
+          "crate": 79,
           "name": "lock_api"
         },
         {
-          "crate": 86,
+          "crate": 87,
           "name": "once_cell"
         },
         {
-          "crate": 87,
+          "crate": 88,
           "name": "parking_lot_core"
         }
       ],
@@ -2085,11 +2121,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "block_buffer"
         },
         {
-          "crate": 54,
+          "crate": 55,
           "name": "crypto_common"
         }
       ],
@@ -2196,7 +2232,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 124,
+          "crate": 125,
           "name": "typenum"
         }
       ],
@@ -2241,11 +2277,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 39,
+          "crate": 40,
           "name": "allocator_api2"
         }
       ],
@@ -2293,11 +2329,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 58,
+          "crate": 59,
           "name": "equivalent"
         },
         {
-          "crate": 64,
+          "crate": 65,
           "name": "hashbrown"
         }
       ],
@@ -2364,15 +2400,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 38,
+          "crate": 39,
           "name": "ahash"
         },
         {
-          "crate": 55,
+          "crate": 56,
           "name": "dashmap"
         },
         {
-          "crate": 63,
+          "crate": 64,
           "name": "hashbrown"
         }
       ],
@@ -2420,11 +2456,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 71,
+          "crate": 72,
           "name": "lexarg_error"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "lexarg_parser"
         }
       ],
@@ -2449,7 +2485,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 72,
+          "crate": 73,
           "name": "lexarg_parser"
         }
       ],
@@ -2515,7 +2551,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 67,
+          "crate": 68,
           "name": "json_write"
         }
       ],
@@ -2541,11 +2577,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "lexarg_error"
         }
       ],
@@ -2570,27 +2606,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 41,
+          "crate": 42,
           "name": "anstream"
         },
         {
-          "crate": 42,
+          "crate": 43,
           "name": "anstyle"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "lexarg_error"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "lexarg_parser"
         },
         {
-          "crate": 74,
+          "crate": 75,
           "name": "libtest_json"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "libtest_lexarg"
         }
       ],
@@ -2617,11 +2653,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 74,
+          "crate": 75,
           "name": "libtest_json"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "libtest2_harness"
         }
       ],
@@ -2648,7 +2684,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "scopeguard"
         }
       ],
@@ -2694,7 +2730,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 34,
+          "crate": 35,
           "name": "logos_derive"
         }
       ],
@@ -2722,31 +2758,31 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 44,
+          "crate": 45,
           "name": "beef"
         },
         {
-          "crate": 60,
+          "crate": 61,
           "name": "fnv"
         },
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lazy_static"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "proc_macro2"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "quote"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "regex_syntax"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "syn"
         }
       ],
@@ -2770,7 +2806,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 100,
+          "crate": 101,
           "name": "regex_automata"
         }
       ],
@@ -2917,7 +2953,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 130,
+          "crate": 131,
           "name": "zerocopy"
         }
       ],
@@ -2943,7 +2979,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 126,
+          "crate": 127,
           "name": "unicode_ident"
         }
       ],
@@ -2969,47 +3005,47 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 45,
+          "crate": 46,
           "name": "bit_set"
         },
         {
-          "crate": 46,
+          "crate": 47,
           "name": "bit_vec"
         },
         {
-          "crate": 47,
+          "crate": 48,
           "name": "bitflags"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "num_traits"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "rand"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rand_chacha"
         },
         {
-          "crate": 97,
+          "crate": 98,
           "name": "rand_xorshift"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "regex_syntax"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "rusty_fork"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         },
         {
-          "crate": 125,
+          "crate": 126,
           "name": "unarray"
         }
       ],
@@ -3060,7 +3096,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 90,
+          "crate": 91,
           "name": "proc_macro2"
         }
       ],
@@ -3086,7 +3122,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 96,
+          "crate": 97,
           "name": "rand_core"
         }
       ],
@@ -3113,11 +3149,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "ppv_lite86"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "rand_core"
         }
       ],
@@ -3142,7 +3178,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 62,
+          "crate": 63,
           "name": "getrandom"
         }
       ],
@@ -3168,7 +3204,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 96,
+          "crate": 97,
           "name": "rand_core"
         }
       ],
@@ -3192,11 +3228,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 57,
+          "crate": 58,
           "name": "either"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "rayon_core"
         }
       ],
@@ -3220,11 +3256,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 51,
+          "crate": 52,
           "name": "crossbeam_deque"
         },
         {
-          "crate": 53,
+          "crate": 54,
           "name": "crossbeam_utils"
         }
       ],
@@ -3248,7 +3284,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 101,
+          "crate": 102,
           "name": "regex_syntax"
         }
       ],
@@ -3307,19 +3343,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 60,
+          "crate": 61,
           "name": "fnv"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quick_error"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tempfile"
         },
         {
-          "crate": 128,
+          "crate": 129,
           "name": "wait_timeout"
         }
       ],
@@ -3364,11 +3400,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 35,
+          "crate": 36,
           "name": "serde_derive"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_core"
         }
       ],
@@ -3417,19 +3453,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 66,
+          "crate": 67,
           "name": "itoa"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "memchr"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_core"
         },
         {
-          "crate": 131,
+          "crate": 132,
           "name": "zmij"
         }
       ],
@@ -3455,7 +3491,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         }
       ],
@@ -3480,15 +3516,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 49,
+          "crate": 50,
           "name": "cfg_if"
         },
         {
-          "crate": 50,
+          "crate": 51,
           "name": "cpufeatures"
         },
         {
-          "crate": 56,
+          "crate": 57,
           "name": "digest"
         }
       ],
@@ -3512,7 +3548,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lazy_static"
         }
       ],
@@ -3555,15 +3591,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 90,
+          "crate": 91,
           "name": "proc_macro2"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "quote"
         },
         {
-          "crate": 126,
+          "crate": 127,
           "name": "unicode_ident"
         }
       ],
@@ -3618,7 +3654,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 36,
+          "crate": 37,
           "name": "thiserror_impl"
         }
       ],
@@ -3644,7 +3680,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 49,
+          "crate": 50,
           "name": "cfg_if"
         }
       ],
@@ -3668,19 +3704,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "serde_spanned"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "toml_datetime"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "toml_edit"
         }
       ],
@@ -3707,7 +3743,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         }
       ],
@@ -3732,27 +3768,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 65,
+          "crate": 66,
           "name": "indexmap"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "serde_spanned"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "toml_datetime"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "toml_write"
         },
         {
-          "crate": 129,
+          "crate": 130,
           "name": "winnow"
         }
       ],
@@ -3801,15 +3837,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 37,
+          "crate": 38,
           "name": "tracing_attributes"
         },
         {
-          "crate": 88,
+          "crate": 89,
           "name": "pin_project_lite"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "tracing_core"
         }
       ],
@@ -3837,7 +3873,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 86,
+          "crate": 87,
           "name": "once_cell"
         }
       ],
@@ -3864,15 +3900,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 79,
+          "crate": 80,
           "name": "log"
         },
         {
-          "crate": 86,
+          "crate": 87,
           "name": "once_cell"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "tracing_core"
         }
       ],
@@ -3898,11 +3934,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "tracing_core"
         }
       ],
@@ -3926,55 +3962,55 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 82,
+          "crate": 83,
           "name": "matchers"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "nu_ansi_term"
         },
         {
-          "crate": 86,
+          "crate": 87,
           "name": "once_cell"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "regex_automata"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_json"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "sharded_slab"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "smallvec"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "thread_local"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "tracing_core"
         },
         {
-          "crate": 121,
+          "crate": 122,
           "name": "tracing_log"
         },
         {
-          "crate": 122,
+          "crate": 123,
           "name": "tracing_serde"
         }
       ],

--- a/scripts/validate-test-duplication.py
+++ b/scripts/validate-test-duplication.py
@@ -155,6 +155,7 @@ ALLOWANCES = (
         kind="per-target",
         targets=(
             "//crates/rue-allocator:rue-allocator-test",
+            "//crates/rue-c-abi-matrix:c-abi-matrix-test",
             "//crates/rue-codegen:rue-codegen-test",
             "//crates/rue-linker:rue-linker-test",
             "//crates/rue-runtime-abi:rue-runtime-abi-test",
@@ -174,7 +175,10 @@ ALLOWANCES = (
             "The focused compiler host-conditional target is included because "
             "its ignored platform_native_ rows intentionally execute on Linux "
             "premerge and both native hosts; the broad compiler test selection "
-            "is Linux-only. "
+            "is Linux-only. The generated C-boundary matrix is included for the "
+            "same reason: it compiles for and executes on the host it runs on, "
+            "so each row's psABI — SysV AMD64, AAPCS64, and the Apple arm64 "
+            "amendments — is proven only where that row is native. "
             "Each target here repeats on its own; an overlap BETWEEN any two of "
             "them is a different fact and is not covered by this entry."
         ),


### PR DESCRIPTION
Slice 5 of the calling-convention infrastructure epic (RUE-2030): the safety net the native-ABI phases run under.

## What

A new crate, `rue-c-abi-matrix`, whose binary is a libtest-protocol harness. For each direction and ABI spelling it generates a paired C and Rue program covering the whole shape × position grid, compiles the C with the host `cc` (freestanding: no headers, no libc, typedefs spelled from the target data model with `_Static_assert`s), compiles the Rue with the real compiler binary, links with `--linker cc --link-archive`, runs the executable, and compares stdout line for line against checksums computed from the same table both sources were emitted from. A mismatch names the direction, shape, position, ABI spelling, and function, and keeps the generated sources.

The system linker is deliberate: compiler-produced C objects carry relocation and section kinds the internal linker's static subset does not promise to handle.

## Grid

20 shapes (`i8` through `u64`, `bool`, `ptr const u8`, and ten `@repr(c)` structs at the classification boundaries: 1, 2, 8, 16-with-padding, 16, 24-with-padding, 24 bytes, leading narrow field, nested, array field) × 5 positions (argument 0, last register, first stack slot, deep stack slot, result) × 2 directions (import, export) × 2 spellings (`"C"` and the explicit convention name), so the alias and the explicit name are proven equal by execution. Position indices derive from `CConventionSpec`, not constants. 400 cells in 4 programs, about 5 seconds.

Each cell reduces its argument list to one `u64` with a distinct odd multiplier per position and per leaf, so a swapped, truncated, or misplaced field changes the result; return cells round-trip a seed. Pointer cells contribute the pointee byte, never an address. A negative control (a shim `cc` that swaps a nested struct's two fields) fails exactly the cells it should.

## The bug it found on its first CI run

On AArch64 Linux every 16-byte struct at the last argument register failed, in both directions. The lowering already sent a composite that does not fit the remaining registers to the stack entire, but AAPCS64 rule C.11 also sets the next general-purpose register number to 8, so every later argument is stacked as well; the lowering left `x7` free and the next scalar took it while C had stacked it. The second commit marks the roster exhausted when an AAPCS64 composite spills (SysV has no such rule and keeps the free register for a later scalar, which the existing test pins) and adds the AAPCS64 and Apple-row counterpart test.

## Where it runs

`//crates/rue-c-abi-matrix:c-abi-matrix-test`, `platform = "native"`, premerge tier, `rue_not_quick`. The `native-platforms` job selects native-labeled targets from the live graph, so it runs on linux-arm64 and macos-arm64 without a workflow edit; premerge runs it on linux-x64. A host with no `cc` reports the trials as ignored, matching the CLI corpus's `requires_system_linker` rule. Registered in the test-duplication roster with its reason.

## Verification

- `./buck2 test //crates/rue-c-abi-matrix/...`: fmt, clippy, debug-assert, 9 generator unit tests, 4 matrix trials; all 400 cells pass on x86-64 Linux.
- `./buck2 bxl //test_tiers.bxl:validate`, `scripts/validate-test-duplication.py`, `scripts/validate-rust-project.py` clean.
- `scripts/rue quick`, `scripts/rue cli c_ffi` (50), `scripts/rue cli abi` (69), `scripts/rue ui emit` (7), `scripts/rue unit compiler backend`, `scripts/rue premerge` (219 targets; only the two sandbox-environmental CLI failures).
- No TOML corpus case added, so the oracle model-gap rule does not apply.

Notes: this is the first time the export direction executes on macOS at all. The grid does not exercise the one open Apple amendment (stacked composites at whole eightbytes) because every filler is an `i64`; that is documented in the audit note rather than planted as a red cell.

Closes RUE-2035

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp