### PR TITLE
Route every extern "C" call through the lowered signature

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1205,13 +1205,6 @@ impl<'a> CfgLower<'a> {
                 imm: 0,
             });
         }
-        // Target-C boundary (ADR-0064 P2): re-extend a foreign scalar return to
-        // Rue's canonical 64-bit form. A C callee leaves the bits above the
-        // return's declared width unspecified, so the caller extends per the
-        // shared classifier's rule.
-        if let Some(ext) = plan.foreign_return_extension {
-            self.emit_c_return_extension(primary, ext);
-        }
         crate::value_plan::MaterializedValue { primary, slots }
     }
 

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -371,14 +371,6 @@ pub struct CallPlan {
     /// call, before the sret read-back. Zero when no argument crosses
     /// indirectly.
     pub caller_indirect_bytes: u32,
-    /// For a call across an `extern "C"` target-C boundary (ADR-0064 P2), the
-    /// narrow-integer extension the caller must apply to a **scalar** return so
-    /// it becomes Rue's canonical 64-bit form — a C callee leaves the bits above
-    /// the return's declared width unspecified. `None` for a native Rue call, a
-    /// non-scalar return, or a register-width scalar that needs no extension. The
-    /// value is resolved from the shared [`rue_air::TargetCCallAbi`] classifier so
-    /// both backends apply the same rule.
-    pub foreign_return_extension: Option<rue_air::ScalarAbiExtension>,
 }
 
 /// Input metadata for one CFG call argument. This is copied out of the CFG
@@ -800,9 +792,6 @@ impl CallPlan {
             stack_slot_count,
             stack_bytes,
             caller_indirect_bytes,
-            // Set by the caller (the value-plan Call arm) for an `extern "C"`
-            // foreign target with a scalar return; native calls leave it None.
-            foreign_return_extension: None,
         }
     }
 
@@ -844,7 +833,6 @@ impl CallPlan {
             )
             .expect("call stack area must pass frame-budget preflight"),
             caller_indirect_bytes: 0,
-            foreign_return_extension: None,
         }
     }
 }
@@ -1041,7 +1029,6 @@ mod tests {
             stack_slot_count: 0,
             stack_bytes: 0,
             caller_indirect_bytes: 0,
-            foreign_return_extension: None,
         };
 
         assert!(plan.user_args[0].slots.is_empty());

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -139,11 +139,7 @@ pub(crate) fn validate_pre_lowering_budget_for_target(
             continue;
         };
         let call_args = cfg.get_call_args(&inst.data);
-        if let Some(convention) = foreign_symbol_convention(*name)
-            && crate::foreign_call::ForeignCallInputs::call_touches_aggregate(
-                cfg, inst.ty, call_args,
-            )
-        {
+        if let Some(convention) = foreign_symbol_convention(*name) {
             crate::foreign_call::ForeignCallInputs::checked_call_area_bytes(
                 cfg, type_pool, inst.ty, call_args, convention,
             )

--- a/crates/rue-codegen/src/export_thunk.rs
+++ b/crates/rue-codegen/src/export_thunk.rs
@@ -1355,6 +1355,76 @@ mod tests {
     }
 
     #[test]
+    fn a_scalars_only_signature_lowers_identically_as_an_import_and_an_export() {
+        // Both directions of one `extern "C"` signature read the same
+        // `LoweredSignature`, whatever the shapes involved: a scalars-only
+        // signature has no aggregate to route it anywhere else. Nine arguments
+        // reach the stacked tail on every row, and the narrow ones are where the
+        // Apple row's natural-size packing would differ if the two directions
+        // ever classified separately.
+        use crate::foreign_call::{ForeignArg, ForeignCallInputs, ForeignReturn};
+        use rue_air::CAbiScalarKind;
+        use rue_cfg::CfgValue;
+
+        let kinds = [
+            CAbiScalarKind::RegisterWidth,
+            CAbiScalarKind::I8,
+            CAbiScalarKind::U16,
+            CAbiScalarKind::I32,
+            CAbiScalarKind::Bool,
+            CAbiScalarKind::RegisterWidth,
+            CAbiScalarKind::U32,
+            CAbiScalarKind::I16,
+            CAbiScalarKind::U8,
+        ];
+        let result = scalar_facts(CAbiScalarKind::I16);
+        for target in Target::all() {
+            let convention = target.c_calling_convention();
+            let import = ForeignCallInputs::new(
+                "f".into(),
+                convention,
+                kinds
+                    .iter()
+                    .enumerate()
+                    .map(|(index, &kind)| ForeignArg::Scalar {
+                        value: CfgValue::from_raw(index as u32),
+                        kind,
+                    })
+                    .collect(),
+                ForeignReturn::Scalar,
+                result,
+            );
+            let export = ExportSignature {
+                convention,
+                parameters: kinds
+                    .iter()
+                    .map(|&kind| ExportParameter {
+                        c: scalar_facts(kind),
+                        native: NativeParameter::Direct {
+                            leaves: vec![scalar_leaf(kind.extension().natural_bytes(), false)],
+                            reversed: false,
+                        },
+                    })
+                    .collect(),
+                result,
+                return_facts: NativeAbiTypeFacts {
+                    abi_slots: 1,
+                    aggregate: false,
+                    strbuf: false,
+                    slot_identical: false,
+                },
+                return_leaves: vec![scalar_leaf(2, true)],
+                return_padding: Vec::new(),
+            };
+            assert_eq!(
+                *import.signature(),
+                export.lowered(),
+                "{target:?}: an import and an export of one signature place it identically"
+            );
+        }
+    }
+
+    #[test]
     fn a_scalar_passthrough_forwards_with_one_call_relocation() {
         for (target, kind) in [
             (Target::X86_64Linux, RelocationKind::X86Plt32),

--- a/crates/rue-codegen/src/foreign_call.rs
+++ b/crates/rue-codegen/src/foreign_call.rs
@@ -1,13 +1,10 @@
 //! Lowering for `extern "C"` foreign calls (ADR-0064 P3).
 //!
-//! A target-C crossing disagrees with the native slot model — the native
-//! planner decomposes an aggregate one slot per leaf and *reverses* the slots
-//! (the register-packing audit's key finding), whereas C packs fields into
-//! eightbytes in ascending memory order. So a foreign call that touches an
-//! aggregate is planned here, entirely separate from the native `CallPlan`, and
-//! lowered through each aggregate's **physical memory image** (which, for a
-//! `@repr(c)` struct of scalar/pointer fields, is exactly the C object layout
-//! under the compact-layout default).
+//! Every `extern "C"` call is planned here, whatever its argument and result
+//! shapes, so one crossing has one plan: the target-C convention places the
+//! call's values and each by-value aggregate is lowered through its **physical
+//! memory image** (which, for a `@repr(c)` struct of scalar/pointer fields, is
+//! exactly the C object layout under the compact-layout default).
 //!
 //! ## Where the classification lives
 //!
@@ -386,8 +383,8 @@ pub(crate) trait ForeignCallLoweringBackend {
     fn foreign_move_primary(&mut self, primary: VReg, slot: VReg);
 }
 
-/// Lower one aggregate-crossing foreign call through the single shared event
-/// sequence. Concrete backends provide only instruction-selection leaves via
+/// Lower one foreign call through the single shared event sequence. Concrete
+/// backends provide only instruction-selection leaves via
 /// [`ForeignCallLoweringBackend`].
 pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
     backend: &mut B,
@@ -505,22 +502,11 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
 }
 
 impl ForeignCallInputs {
-    /// Whether a foreign call to `return_ty` with `args` needs the aggregate
-    /// path at all: true when the return or any argument is an aggregate
-    /// (struct/array) type. A scalars-only foreign call keeps the native-plan
-    /// route with a boundary return extension.
-    pub(crate) fn call_touches_aggregate(cfg: &Cfg, return_ty: Type, args: &[CfgCallArg]) -> bool {
-        is_aggregate(return_ty)
-            || args
-                .iter()
-                .any(|arg| is_aggregate(cfg.get_inst(arg.value).ty))
-    }
-
-    /// Compute the simultaneous transient area of an aggregate foreign call
-    /// from the same lowered signature the lowerers consume. This accounts for
-    /// hidden sret storage, byval stack cells, caller-owned by-reference
-    /// copies, and argument-register exhaustion that spills pointers and
-    /// eightbytes to the outgoing stack area.
+    /// Compute the simultaneous transient area of a foreign call from the same
+    /// lowered signature the lowerers consume. This accounts for hidden sret
+    /// storage, byval stack cells, caller-owned by-reference copies, and
+    /// argument-register exhaustion that spills pointers and eightbytes to the
+    /// outgoing stack area.
     pub(crate) fn checked_call_area_bytes(
         cfg: &Cfg,
         type_pool: &FrozenTypeInternPool,

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -462,10 +462,11 @@ pub trait ValueLowerAdapter:
     fn return_register_banks(&self) -> crate::call_plan::AbiRegisterBanks;
     fn emit_value(&mut self, plan: ValueEmissionPlan) -> ValueResult;
     fn emit_call(&mut self, plan: CallPlan) -> ValueResult;
-    /// Emit an `extern "C"` foreign call that crosses one or more aggregates by
-    /// value (ADR-0064 P3). The classification comes from the shared
-    /// [`ForeignCallInputs`](crate::foreign_call::ForeignCallInputs) authority;
-    /// the backend owns only the physical register/stack/sret sequence.
+    /// Emit an `extern "C"` foreign call (ADR-0064 P3). Every foreign call
+    /// arrives here, whatever its argument and result shapes: the
+    /// classification comes from the shared
+    /// [`ForeignCallInputs`](crate::foreign_call::ForeignCallInputs) authority
+    /// and the backend owns only the physical register/stack/sret sequence.
     /// `result` is the pre-reserved result vreg.
     fn emit_foreign_call(
         &mut self,
@@ -1771,18 +1772,13 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             } else {
                 let symbol = adapter.resolve_symbol(*name);
                 let foreign_convention = adapter.foreign_symbol_convention(&symbol);
-                // A foreign call that crosses an aggregate by value takes the
-                // dedicated C path (ADR-0064 P3): the native slot plan reverses
-                // multi-slot aggregates, disagreeing with C packing, so
-                // aggregates are marshaled through their physical memory image in
-                // C field order. A scalars-only foreign call keeps P2's native
-                // plan with a boundary return extension. Either way the
-                // convention is the declaration's own.
-                if let Some(convention) = foreign_convention
-                    && crate::foreign_call::ForeignCallInputs::call_touches_aggregate(
-                        ctx.cfg, inst.ty, call_args,
-                    )
-                {
+                // Every `extern "C"` call crosses through the one lowered
+                // signature (ADR-0064 P3): each argument and the return travel
+                // where that signature places them, marshaled through their
+                // compact physical memory image in C field order whatever their
+                // shapes. The convention is the declaration's own, resolved once
+                // when its signature was checked.
+                if let Some(convention) = foreign_convention {
                     let foreign_inputs = crate::foreign_call::ForeignCallInputs::from_cfg(
                         symbol,
                         ctx.cfg,
@@ -1794,21 +1790,6 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     let result_vreg = adapter.reserve_typed_value_result(float_width(inst.ty));
                     adapter.emit_foreign_call(foreign_inputs, result_vreg)
                 } else {
-                    // An `extern` scalar/pointer call (ADR-0064 P2): a scalar
-                    // return is re-extended to Rue's canonical 64-bit form because
-                    // a C callee leaves the bits above the return's declared width
-                    // unspecified. The rule comes from the shared `TargetCCallAbi`
-                    // classifier reading the declaration's convention, not a
-                    // backend-local choice.
-                    let foreign_return_extension = foreign_convention
-                        .filter(|_| {
-                            matches!(inputs.return_plan, crate::call_plan::ReturnPlan::Scalar)
-                        })
-                        .map(|convention| {
-                            rue_air::TargetCCallAbi::new(convention)
-                                .scalar_return_extension(inst.ty)
-                        })
-                        .filter(|ext| !ext.is_noop());
                     // The result vreg mirrors the return's logical slot 0, so its
                     // class follows that slot's LEAF: a float-leaf aggregate
                     // result lands in an FP vreg, not a general-purpose one, and
@@ -1841,7 +1822,6 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                             adapter.return_register_banks(),
                         );
                     }
-                    plan.foreign_return_extension = foreign_return_extension;
                     adapter.emit_call(plan)
                 }
             };

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1459,13 +1459,6 @@ impl<'a> CfgLower<'a> {
                 imm: 0,
             });
         }
-        // Target-C boundary (ADR-0064 P2): re-extend a foreign scalar return to
-        // Rue's canonical 64-bit form. A C callee leaves the bits above the
-        // return's declared width unspecified, so the caller extends per the
-        // shared classifier's rule.
-        if let Some(ext) = plan.foreign_return_extension {
-            self.emit_c_return_extension(primary, ext);
-        }
         crate::value_plan::MaterializedValue { primary, slots }
     }
 


### PR DESCRIPTION
Preliminary of phase 1 of ADR-0084 (RUE-2030 epic).

## What

A scalars-only `extern "C"` call was the one C crossing that did not go through `lower_c_signature`: it built a native `CallPlan` and attached a boundary return extension, a design from before the lowering existed. Every `extern "C"` call now routes through `ForeignCallPlan` regardless of argument shape. `call_touches_aggregate` and the branch that consulted it are deleted, as is `CallPlan::foreign_return_extension`, which only that branch reached; the narrow-return re-extension is emitted at the same point by the shared driver's `foreign_scalar_result` leaf.

On the Linux rows the placement is identical (disassembly of a scalars-only call is unchanged on both backends). On the Apple row a call with more than eight scalar arguments now packs the stacked tail at natural size, as the export side and the aggregate import side already did.

A new unit test lowers a nine-scalar signature with narrow members once as an import and once as an export on every target row and asserts the two `LoweredSignature`s are equal, which is the four-site agreement for the last site that lacked it.

## Verification

`scripts/rue fmt`, `scripts/rue quick`, `scripts/rue cli c_ffi` (50), `scripts/rue cli abi` (69), `scripts/rue cli aggregate_abi_matrix` (37), `scripts/rue cli drop`/`destructor`/`enum`, `scripts/rue ui emit` (7), `scripts/rue spec` (2828), `./buck2 test //crates/rue-c-abi-matrix/...` (400 cells), all six oracle-diff targets, `scripts/rue premerge` (only the two sandbox-environmental CLI failures).

Closes RUE-2046

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_