### PR TITLE
RUE-2019: give @panic its own failure site and let the runtime traps report their class

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -1245,6 +1245,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
 
+        // `@panic` reports its own site. The runtime writes the `trap:panic`
+        // record from inside the panic helper, so the staging call is the whole
+        // of the lowering's addition and it is the same in a test image and in
+        // an ordinary executable: there is no descriptor 3 in the latter, the
+        // record write fails with `EBADF` as designed, and the pinned stderr
+        // line spec 4.13:5c fixes is the whole report (RUE-2019).
+        let str_ty = self.get_or_create_str_struct(span)?;
+
         if args.is_empty() {
             // Panic with no message: still a real trap (RUE-319). Emitting an
             // Intrinsic with zero args (not a UnitConst) is what makes cfg_lower
@@ -1252,13 +1260,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // silent no-op. `@panic` has type `!` (never): it diverges and never
             // returns, so it participates in never coercion just like a `-> !`
             // call, `return`, or `break` (spec 3.4:2, 4.13:5c; RUE-512).
-            let air_ref = air.add_intrinsic(
+            let site = self.stage_failure_site(air, ctx, str_ty, span)?;
+            let panic_ref = air.add_intrinsic(
                 crate::IntrinsicOperation::PanicNoMessage,
                 self.known_symbols().panic,
                 &[],
                 Type::NEVER,
                 span,
             )?;
+            let air_ref = air.add_block(&[site], panic_ref, Type::NEVER, span)?;
             ctx.divergence_kinds
                 .insert(super::super::context::DivergenceKind::Panic);
             return Ok(AnalysisResult::diverged(air_ref, Type::NEVER));
@@ -1284,6 +1294,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         } else {
             (arg_result.air_ref, Vec::new())
         };
+        // The message is materialized before the site is staged, never after:
+        // evaluating it can itself abort — a bounds check inside it traps
+        // without staging anything — and a site staged first would be adopted
+        // by that inner failure and report this line for it.
+        let site = self.stage_failure_site(air, ctx, str_ty, span)?;
         let intrinsic_ref = air.add_intrinsic(
             crate::IntrinsicOperation::Panic,
             self.known_symbols().panic,
@@ -1291,8 +1306,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Type::NEVER,
             span,
         )?;
+        let reported = air.add_block(&[arg_ref, site], intrinsic_ref, Type::NEVER, span)?;
         let air_ref =
-            self.wrap_value_with_temp_scope(air, intrinsic_ref, Type::NEVER, span, temp_scope)?;
+            self.wrap_value_with_temp_scope(air, reported, Type::NEVER, span, temp_scope)?;
         // An operand that diverges prevents the explicit panic call from
         // being reached; the context already records that operand's edge.
         // Only a normally evaluated message establishes the panic exemption.
@@ -1428,31 +1444,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AirRef> {
         let str_ty = self.get_or_create_str_struct(span)?;
-        // A site the host cannot resolve is reported as the empty file at 0:0
-        // rather than as a compile error: the ABI accepts an absent location,
-        // and a report that cannot name its line is still a better failure than
-        // no report.
-        let (path, line, column) = self
-            .body_source_coordinate(span)
-            .unwrap_or_else(|| (std::sync::Arc::from(""), 0, 0));
-        let file = self.synthesized_string(air, ctx, &path, str_ty, span);
-        let line = air.add_inst(AirInst {
-            data: AirInstData::Const(u64::from(line)),
-            ty: Type::U32,
-            span,
-        });
-        let column = air.add_inst(AirInst {
-            data: AirInstData::Const(u64::from(column)),
-            ty: Type::U32,
-            span,
-        });
-        let site = self.runtime_channel_call(
-            air,
-            crate::RuntimeCallKind::TestFailureSite,
-            &[file, line, column],
-            Type::UNIT,
-            span,
-        )?;
+        let site = self.stage_failure_site(air, ctx, str_ty, span)?;
 
         // Which of the two pinned stderr forms this is, stated rather than
         // inferred from the message's length: `@assert(cond, "")` is the
@@ -1752,30 +1744,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let right_text = render(air, right)?;
 
         // A site the host cannot resolve is reported as the empty file at 0:0
-        // rather than as a compile error: the ABI accepts an absent location,
-        // and a report that cannot name its line is still a better failure than
-        // no report.
-        let (path, line, column) = self
-            .body_source_coordinate(span)
-            .unwrap_or_else(|| (std::sync::Arc::from(""), 0, 0));
-        let file = self.synthesized_string(air, ctx, &path, str_ty, span);
-        let line = air.add_inst(AirInst {
-            data: AirInstData::Const(u64::from(line)),
-            ty: Type::U32,
-            span,
-        });
-        let column = air.add_inst(AirInst {
-            data: AirInstData::Const(u64::from(column)),
-            ty: Type::U32,
-            span,
-        });
-        let site = self.runtime_channel_call(
-            air,
-            crate::RuntimeCallKind::TestFailureSite,
-            &[file, line, column],
-            Type::UNIT,
-            span,
-        )?;
+        let site = self.stage_failure_site(air, ctx, str_ty, span)?;
 
         // The message is pinned by the kind inside the runtime helper, which is
         // what keeps this terminal call to the six registers every runtime

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -2052,31 +2052,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
         };
 
-        // A site the host cannot resolve is reported as the empty file at 0:0
-        // rather than as a compile error: the ABI accepts an absent location
-        // (the staging helper's file view may be empty), and a report that
-        // cannot name its line is still a better failure than no report.
-        let (path, line, column) = self
-            .body_source_coordinate(span)
-            .unwrap_or_else(|| (Arc::from(""), 0, 0));
-        let file = self.synthesized_string(air, ctx, &path, str_ty, span);
-        let line = air.add_inst(AirInst {
-            data: AirInstData::Const(u64::from(line)),
-            ty: Type::U32,
-            span,
-        });
-        let column = air.add_inst(AirInst {
-            data: AirInstData::Const(u64::from(column)),
-            ty: Type::U32,
-            span,
-        });
-        let site = self.runtime_channel_call(
-            air,
-            crate::RuntimeCallKind::TestFailureSite,
-            &[file, line, column],
-            Type::UNIT,
-            span,
-        )?;
+        let site = self.stage_failure_site(air, ctx, str_ty, span)?;
 
         let kind = self.synthesized_string(air, ctx, TEST_FAILURE_KIND, str_ty, span);
         let message = self.synthesized_string(air, ctx, TEST_FAILURE_MESSAGE, str_ty, span);
@@ -2131,6 +2107,51 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             })
             .collect::<Vec<_>>();
         Ok(air.add_call(Some(runtime), name, &args, ty, span)?)
+    }
+
+    /// Stage the source location the next failure record will carry.
+    ///
+    /// Every producer of an ADR-0083 §5.1 report reaches this: a test body's
+    /// `?` failure arm, the assertion family, and — since RUE-2019 — `@panic`
+    /// and the slice bounds check, whose records the runtime writes from inside
+    /// the trap helper. The staged site is consumed by whatever aborts next, so
+    /// this call must be the last thing before that terminal call: anything
+    /// evaluated in between could abort on a path that stages nothing and would
+    /// then adopt this site.
+    ///
+    /// A site the host cannot resolve is staged as the empty file at 0:0 rather
+    /// than reported as a compile error: the ABI accepts an absent location,
+    /// and a report that cannot name its line is still a better failure than no
+    /// report. The runner answers an empty location from the test declaration's
+    /// header.
+    pub(in crate::sema) fn stage_failure_site(
+        &mut self,
+        air: &mut Air,
+        ctx: &mut AnalysisContext,
+        str_ty: Type,
+        span: Span,
+    ) -> CompileResult<AirRef> {
+        let (path, line, column) = self
+            .body_source_coordinate(span)
+            .unwrap_or_else(|| (Arc::from(""), 0, 0));
+        let file = self.synthesized_string(air, ctx, &path, str_ty, span);
+        let line = air.add_inst(AirInst {
+            data: AirInstData::Const(u64::from(line)),
+            ty: Type::U32,
+            span,
+        });
+        let column = air.add_inst(AirInst {
+            data: AirInstData::Const(u64::from(column)),
+            ty: Type::U32,
+            span,
+        });
+        self.runtime_channel_call(
+            air,
+            crate::RuntimeCallKind::TestFailureSite,
+            &[file, line, column],
+            Type::UNIT,
+            span,
+        )
     }
 
     /// Materialize one compiler-authored `str` run in this body.

--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -261,7 +261,12 @@ runtime_error_contains = ["panic: "]
 
 [[case]]
 name = "a_panicking_test_is_kind_trap_panic"
-description = "`@panic(msg)` writes the pinned `panic: <msg>` prefix and exits 101."
+description = """
+`@panic(msg)` writes the pinned `panic: <msg>` prefix and exits 101, and since
+RUE-2019 it reports that on the §5.1 channel with its own site. The kind and the
+message are what the stderr classification already produced; `location` is what
+the record adds, and it names the `@panic` rather than the `test` header.
+"""
 files = [
     { path = "main.rue", source = """
 const tests = @import("tests.rue");
@@ -272,13 +277,123 @@ fn main() -> i32 {
 """ },
     { path = "tests.rue", source = """
 test "gives up" {
+    let attempts: i32 = 3;
     @panic("boom");
 }
 """ },
 ]
 args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 1
-compile_stdout_contains = ['"kind":"trap:panic"', '"message":"panic: boom"']
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"trap:panic","location":{"column":5,"file":"tests.rue","line":3}',
+    '"message":"panic: boom"}',
+    '"stderr":{"bytes_total":12,"data":"panic: boom\n","encoding":"utf8"}',
+    '"verdict":"fail"',
+]
+
+[[case]]
+name = "a_message_less_panic_names_its_own_line"
+description = """
+`@panic()` has its own pinned stderr line — the bare `panic` — and reports the
+same `trap:panic` kind under that message with its own site (RUE-2019). Stating
+the form rather than inferring it keeps the record and stderr identical.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "gives up without a word" {
+    let attempts: i32 = 3;
+    let limit: i32 = 1;
+    @panic();
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"trap:panic","location":{"column":5,"file":"tests.rue","line":4}',
+    '"message":"panic"}',
+    '"stderr":{"bytes_total":6,"data":"panic\n","encoding":"utf8"}',
+]
+
+[[case]]
+name = "a_panic_reached_through_a_call_names_the_panics_own_file"
+description = """
+The site is the `@panic`'s, not the caller's and not the test declaration's, so
+a panic inside a helper in another module names that module's line. Falling back
+to the header would have named `tests.rue` and the `test` line for a failure
+that happened somewhere else entirely.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "helper.rue", source = """
+pub fn open(port: i32) -> i32 {
+    if port == 0 {
+        @panic("port must be assigned");
+    }
+    port
+}
+""" },
+    { path = "tests.rue", source = """
+const helper = @import("helper.rue");
+
+test "opens the port" {
+    @assert(helper.open(0) == 1);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"trap:panic","location":{"column":9,"file":"helper.rue","line":3}',
+    '"message":"panic: port must be assigned"}',
+]
+
+[[case]]
+name = "an_out_of_bounds_index_takes_its_class_from_the_channel"
+description = """
+`__rue_bounds_check` writes its own `trap:bounds_check` record, so the class is
+the runtime's own statement rather than a match against a stderr line. The
+fixed-array check the compiler emits below AIR stages no site, so `location` is
+still the `test` declaration's header — the gap RUE-2019 documents rather than
+closes, because both ways to stage a site there cost the passing path.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "reads past the end" {
+    let values: [i32; 3] = [1, 2, 3];
+    let mut index: u64 = 0;
+    index = index + 5;
+    @assert(values[index] == 0);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"trap:bounds_check","location":{"column":1,"file":"tests.rue","line":1}',
+    '"message":"error: index out of bounds"}',
+    '"stderr":{"bytes_total":27,"data":"error: index out of bounds\n","encoding":"utf8"}',
+]
 
 [[case]]
 name = "a_trapping_test_is_classified_by_its_runtime_message"

--- a/crates/rue-compiler/src/test_image_tests.rs
+++ b/crates/rue-compiler/src/test_image_tests.rs
@@ -215,15 +215,28 @@ fn platform_native_an_early_exit_produces_no_completion_frame() {
     );
 }
 
-/// A trapping body takes the ordinary runtime abort path and writes no frame.
+/// A trapping body takes the ordinary runtime abort path, and reports it on
+/// the channel with the site of the `@panic` that caused it (RUE-2019).
+///
+/// The record's kind and message are exactly what the runner would otherwise
+/// have read off stderr, so what the frame adds is the location — without it
+/// the failure could only name the `test` declaration's header. The pinned
+/// stderr line and the exit status are unchanged (spec 4.13:5c).
 #[test]
 #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
-fn platform_native_a_trapping_test_exits_101_without_a_frame() {
+fn platform_native_a_trapping_test_reports_its_site_and_exits_101() {
     let (image, _) = dispatch_fixture();
     let run = run_test_image(&image, "trap", "0000000000000002");
     assert_eq!(run.status, Some(101));
     assert_eq!(run.stderr, "panic: boom\n");
-    assert_eq!(run.channel, "");
+    assert_eq!(
+        run.channel,
+        concat!(
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"trap:panic\",",
+            "\"message\":\"panic: boom\",",
+            "\"location\":{\"file\":\"main.rue\",\"line\":3,\"column\":24}}\n",
+        )
+    );
 }
 
 /// Every malformed or out-of-range selector is one pinned diagnostic and exit

--- a/crates/rue-runtime/src/error.rs
+++ b/crates/rue-runtime/src/error.rs
@@ -202,8 +202,17 @@ crate::define_runtime_implementation! {
     ///
     /// # Behavior
     ///
-    /// 1. Writes `"error: index out of bounds\n"` to stderr (best-effort)
-    /// 2. Exits with code 101
+    /// 1. Writes a `trap:bounds_check` failure record to the channel
+    ///    (best-effort)
+    /// 2. Writes `"error: index out of bounds\n"` to stderr (best-effort)
+    /// 3. Exits with code 101
+    ///
+    /// The record carries whatever site
+    /// [`crate::test_channel::__rue_test_failure_site`] staged (RUE-2019). A
+    /// slice index stages its own before it traps; the fixed-array check the
+    /// compiler emits below AIR stages none, so its record names no file and
+    /// the runner answers from the test declaration's header, exactly as it
+    /// did when the class was read off stderr.
     ///
     /// # ABI
     ///
@@ -220,6 +229,7 @@ crate::define_runtime_implementation! {
     /// already performs compile-time checks for constant indices, so this
     /// handler is only reached for dynamic indices that fail at runtime.
     pub extern "C" fn __rue_bounds_check() -> ! {
+        crate::test_channel::report_bounds_check();
         // Build error message byte-by-byte to avoid macOS linker bug with byte strings
         let mut msg = [0u8; 27];
         msg[0] = b'e';
@@ -305,18 +315,55 @@ crate::define_runtime_implementation! {
     }
 }
 
+/// Write the pinned `panic: {message}` line to stderr and exit 101.
+///
+/// This is [`__rue_panic`]'s stderr half without the ADR-0083 §5.1 channel
+/// report the exported helper writes first. The assertion family reaches it
+/// directly: each of those helpers has already written its own, more specific
+/// `failure` frame, and a second `trap:panic` frame from the same aborting
+/// process would be noise on a channel whose first frame is the verdict.
+pub(crate) fn panic_stderr(message: &[u8]) -> ! {
+    // "panic: " built byte-by-byte to avoid the macOS byte-string linker bug.
+    let mut prefix = [0u8; 7];
+    prefix[0] = b'p';
+    prefix[1] = b'a';
+    prefix[2] = b'n';
+    prefix[3] = b'i';
+    prefix[4] = b'c';
+    prefix[5] = b':';
+    prefix[6] = b' ';
+    platform::write_stderr(&prefix);
+    if !message.is_empty() {
+        platform::write_stderr(message);
+    }
+    let newline = [b'\n'];
+    platform::write_stderr(&newline);
+    platform::exit(101)
+}
+
 crate::define_runtime_implementation! {
     /// Runtime error: explicit `@panic(msg)` with a message.
     ///
-    /// Called by code generated for the `@panic("...")` intrinsic. Writes
-    /// `"panic: "`, the user-supplied message bytes, and a trailing newline to
-    /// stderr, then exits with code 101 (the same abort path as the other
-    /// runtime traps: division by zero, overflow, bounds, cast overflow).
+    /// Called by code generated for the `@panic("...")` intrinsic. Writes a
+    /// `trap:panic` failure record on the ADR-0083 §5.1 channel carrying
+    /// whatever site [`crate::test_channel::__rue_test_failure_site`] staged,
+    /// then `"panic: "`, the user-supplied message bytes, and a trailing
+    /// newline to stderr, then exits with code 101 (the same abort path as the
+    /// other runtime traps: division by zero, overflow, bounds, cast overflow).
+    ///
+    /// The record goes first so a failure is recorded even if the stderr write
+    /// is lost, and it carries the pinned stderr line as its message, so a test
+    /// runner reading the channel and one reading stderr publish the same kind
+    /// and the same text — the record adds only the site (RUE-2019). In an
+    /// ordinary executable there is no descriptor 3 and the record write fails
+    /// with `EBADF` as designed, which is why `@panic` lowers the same way in
+    /// every build.
     ///
     /// # Behavior
     ///
-    /// 1. Writes `"panic: {msg}\n"` to stderr (best-effort)
-    /// 2. Exits with code 101
+    /// 1. Writes a `trap:panic` failure record to the channel (best-effort)
+    /// 2. Writes `"panic: {msg}\n"` to stderr (best-effort)
+    /// 3. Exits with code 101
     ///
     /// # ABI
     ///
@@ -334,38 +381,30 @@ crate::define_runtime_implementation! {
     /// initialized bytes that stay valid for the call. `ptr` may be null when
     /// `len == 0`.
     pub unsafe extern "C" fn __rue_panic(ptr: *const u8, len: u64) -> ! {
-        // "panic: " built byte-by-byte to avoid the macOS byte-string linker bug.
-        let mut prefix = [0u8; 7];
-        prefix[0] = b'p';
-        prefix[1] = b'a';
-        prefix[2] = b'n';
-        prefix[3] = b'i';
-        prefix[4] = b'c';
-        prefix[5] = b':';
-        prefix[6] = b' ';
-        platform::write_stderr(&prefix);
-        // SAFETY: the caller guarantees `ptr`/`len` describe a valid byte range.
-        if len > 0 {
+        let message = if len > 0 {
             // SAFETY: the caller guarantees a non-null pointer valid for `len`
             // initialized bytes when the length is positive.
-            let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
-            platform::write_stderr(bytes);
-        }
-        let newline = [b'\n'];
-        platform::write_stderr(&newline);
-        platform::exit(101)
+            unsafe { core::slice::from_raw_parts(ptr, len as usize) }
+        } else {
+            &[]
+        };
+        crate::test_channel::report_panic(message);
+        panic_stderr(message)
     }
 }
 
 crate::define_runtime_implementation! {
     /// Runtime error: explicit `@panic()` with no message.
     ///
-    /// Called by code generated for the message-less `@panic()` intrinsic.
+    /// Called by code generated for the message-less `@panic()` intrinsic. It
+    /// reports the same `trap:panic` record [`__rue_panic`] does, under this
+    /// form's own pinned stderr line (RUE-2019).
     ///
     /// # Behavior
     ///
-    /// 1. Writes `"panic\n"` to stderr (best-effort)
-    /// 2. Exits with code 101
+    /// 1. Writes a `trap:panic` failure record to the channel (best-effort)
+    /// 2. Writes `"panic\n"` to stderr (best-effort)
+    /// 3. Exits with code 101
     ///
     /// # ABI
     ///
@@ -375,6 +414,7 @@ crate::define_runtime_implementation! {
     ///
     /// No arguments. Never returns.
     pub extern "C" fn __rue_panic_no_msg() -> ! {
+        crate::test_channel::report_panic_no_message();
         let mut msg = [0u8; 6];
         msg[0] = b'p';
         msg[1] = b'a';

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -87,6 +87,24 @@ const ASSERT_EQ_MESSAGE: [u8; 31] = *b"assertion failed: left == right";
 const ASSERT_NE_MESSAGE: [u8; 31] = *b"assertion failed: left != right";
 const ASSERT_MESSAGE: [u8; 16] = *b"assertion failed";
 
+/// The kinds the runtime traps report under (RUE-2019).
+///
+/// These are the `trap:<class>` spellings the runner already publishes for a
+/// trap it classified from stderr, so a trap that reports its own site changes
+/// the record's `location` and nothing else: the same kind, and the same
+/// message, reach the event stream either way.
+const TRAP_PANIC_KIND: [u8; 10] = *b"trap:panic";
+const TRAP_BOUNDS_CHECK_KIND: [u8; 17] = *b"trap:bounds_check";
+
+/// The pinned stderr text each trap frame reports as its message, without the
+/// trailing newline stderr carries.
+///
+/// A trap's record message is the line the runner would otherwise have read off
+/// stderr, so the two agree byte for byte and the record adds only the site.
+const PANIC_PREFIX: [u8; 7] = *b"panic: ";
+const PANIC_MESSAGE: [u8; 5] = *b"panic";
+const BOUNDS_CHECK_MESSAGE: [u8; 26] = *b"error: index out of bounds";
+
 /// The pinned malformed-selector diagnostic (ADR-0083 §3).
 const USAGE_MESSAGE: [u8; 50] = *b"rue-test: expected one 16-hex-digit test selector\n";
 
@@ -198,11 +216,18 @@ fn complete_frame(emit: &mut dyn FnMut(&[u8])) {
     writer.raw(&COMPLETE_FRAME);
 }
 
-/// Write every field both failure shapes share, through the open location
-/// object: the two differ only in what follows the column.
+/// Write every field the failure shapes share, through the open location
+/// object: they differ only in what follows the column.
+///
+/// The message arrives as two runs rather than one so a trap can report the
+/// whole of its pinned stderr line — `panic: ` and the programmer's own bytes —
+/// with no staging buffer and no bound on the message's length. Every producer
+/// whose message is one piece passes an empty prefix, which costs no write.
+#[allow(clippy::too_many_arguments)]
 fn failure_head(
     writer: &mut FrameWriter<'_>,
     kind: &[u8],
+    message_prefix: &[u8],
     message: &[u8],
     file: &[u8],
     line: u32,
@@ -211,6 +236,7 @@ fn failure_head(
     writer.raw(&FAILURE_HEAD);
     writer.escaped(kind);
     writer.raw(&MESSAGE_FIELD);
+    writer.escaped(message_prefix);
     writer.escaped(message);
     writer.raw(&LOCATION_FIELD);
     writer.escaped(file);
@@ -235,7 +261,7 @@ fn failure_frame(
     payload: &[u8],
 ) {
     let mut writer = FrameWriter::new(emit);
-    failure_head(&mut writer, kind, message, file, line, column);
+    failure_head(&mut writer, kind, &[], message, file, line, column);
     writer.raw(&PAYLOAD_FIELD);
     writer.escaped(payload);
     writer.raw(&FRAME_TAIL);
@@ -266,6 +292,7 @@ fn comparison_frame(
     failure_head(
         &mut writer,
         kind,
+        &[],
         comparison_message(kind),
         file,
         line,
@@ -302,8 +329,98 @@ fn comparison_message(kind: &[u8]) -> &'static [u8] {
 /// `payload` would claim otherwise.
 fn assert_frame(emit: &mut dyn FnMut(&[u8]), message: &[u8], file: &[u8], line: u32, column: u32) {
     let mut writer = FrameWriter::new(emit);
-    failure_head(&mut writer, &ASSERT_KIND, message, file, line, column);
+    failure_head(&mut writer, &ASSERT_KIND, &[], message, file, line, column);
     writer.raw(&LOCATION_TAIL);
+}
+
+/// Write one runtime-trap failure frame (RUE-2019).
+///
+/// The shape is the bare assertion's: a trap has no operands to report and
+/// nothing structured for the open `payload`, so the record ends at the
+/// location object. The message arrives as two runs rather than one so
+/// `@panic(msg)` can report the whole pinned stderr line — the `panic: `
+/// prefix and the programmer's own bytes — with no staging buffer and no bound
+/// on the message's length.
+fn trap_frame(
+    emit: &mut dyn FnMut(&[u8]),
+    kind: &[u8],
+    message_prefix: &[u8],
+    message: &[u8],
+    file: &[u8],
+    line: u32,
+    column: u32,
+) {
+    let mut writer = FrameWriter::new(emit);
+    failure_head(
+        &mut writer,
+        kind,
+        message_prefix,
+        message,
+        file,
+        line,
+        column,
+    );
+    writer.raw(&LOCATION_TAIL);
+}
+
+/// The site [`__rue_test_failure_site`] most recently staged.
+///
+/// An unstaged site is the null-with-zero-length form the ABI permits, which
+/// reads back as the empty file at 0:0 — the shape every reporting helper
+/// already writes when its caller could not name a location, and the one the
+/// runner answers by falling back to the test declaration's header.
+fn staged_site() -> (&'static [u8], u32, u32) {
+    let position = SITE_POSITION.load(Ordering::Relaxed);
+    // SAFETY: a staged site's bytes stay readable across the pair, and an
+    // unstaged one is the null-with-zero-length form `view` accepts.
+    let file = unsafe {
+        view(
+            SITE_FILE.load(Ordering::Relaxed) as *const u8,
+            SITE_FILE_LEN.load(Ordering::Relaxed),
+        )
+    };
+    (file, (position >> 32) as u32, position as u32)
+}
+
+/// Report one runtime trap on the §5.1 channel, ahead of its pinned stderr
+/// line and its abort (RUE-2019).
+///
+/// The kind is the `trap:<class>` spelling the runner already publishes for a
+/// trap it classified from stderr, and the message is that same pinned stderr
+/// line without its newline, so a trap that reports here changes the record's
+/// `location` and nothing else.
+///
+/// The frame is written whether or not a site was staged, exactly as the
+/// assertion helpers write theirs: a trap reached without one — an allocation
+/// failure, or a check the compiler emits below AIR — still reports, with the
+/// empty location the runner answers from the test's header.
+fn report_trap(kind: &[u8], message_prefix: &[u8], message: &[u8]) {
+    let (file, line, column) = staged_site();
+    trap_frame(
+        &mut emit_to_channel,
+        kind,
+        message_prefix,
+        message,
+        file,
+        line,
+        column,
+    );
+}
+
+/// Report a `@panic(msg)` as a `trap:panic` failure (RUE-2019).
+pub(crate) fn report_panic(message: &[u8]) {
+    report_trap(&TRAP_PANIC_KIND, &PANIC_PREFIX, message);
+}
+
+/// Report a `@panic()` as a `trap:panic` failure, under the message-less
+/// form's own pinned stderr line.
+pub(crate) fn report_panic_no_message() {
+    report_trap(&TRAP_PANIC_KIND, &PANIC_MESSAGE, &[]);
+}
+
+/// Report a failed bounds check as a `trap:bounds_check` failure.
+pub(crate) fn report_bounds_check() {
+    report_trap(&TRAP_BOUNDS_CHECK_KIND, &BOUNDS_CHECK_MESSAGE, &[]);
 }
 
 /// Best-effort write of already-framed bytes to the inherited channel.
@@ -422,26 +539,17 @@ crate::define_runtime_implementation! {
                 view(payload_ptr, payload_len),
             )
         };
-        let position = SITE_POSITION.load(Ordering::Relaxed);
-        // SAFETY: a staged site's bytes stay readable across the pair, and an
-        // unstaged one is the null-with-zero-length form `view` accepts.
-        let file = unsafe {
-            view(
-                SITE_FILE.load(Ordering::Relaxed) as *const u8,
-                SITE_FILE_LEN.load(Ordering::Relaxed),
-            )
-        };
+        let (file, line, column) = staged_site();
         failure_frame(
             &mut emit_to_channel,
             kind,
             message,
             file,
-            (position >> 32) as u32,
-            position as u32,
+            line,
+            column,
             payload,
         );
-        // SAFETY: `message` is a live borrow of the caller's bytes.
-        unsafe { crate::error::__rue_panic(message.as_ptr(), message.len() as u64) }
+        crate::error::panic_stderr(message)
     }
 }
 
@@ -490,27 +598,17 @@ crate::define_runtime_implementation! {
                 view(right_ptr, right_len),
             )
         };
-        let position = SITE_POSITION.load(Ordering::Relaxed);
-        // SAFETY: a staged site's bytes stay readable across the pair, and an
-        // unstaged one is the null-with-zero-length form `view` accepts.
-        let file = unsafe {
-            view(
-                SITE_FILE.load(Ordering::Relaxed) as *const u8,
-                SITE_FILE_LEN.load(Ordering::Relaxed),
-            )
-        };
+        let (file, line, column) = staged_site();
         comparison_frame(
             &mut emit_to_channel,
             kind,
             file,
-            (position >> 32) as u32,
-            position as u32,
+            line,
+            column,
             left,
             right,
         );
-        let message = comparison_message(kind);
-        // SAFETY: `message` is a `'static` run of this module's own bytes.
-        unsafe { crate::error::__rue_panic(message.as_ptr(), message.len() as u64) }
+        crate::error::panic_stderr(comparison_message(kind))
     }
 }
 
@@ -557,15 +655,7 @@ crate::define_runtime_implementation! {
     ) -> ! {
         // SAFETY: the caller guarantees the pair describes readable bytes.
         let message = unsafe { view(message_ptr, message_len) };
-        let position = SITE_POSITION.load(Ordering::Relaxed);
-        // SAFETY: a staged site's bytes stay readable across the pair, and an
-        // unstaged one is the null-with-zero-length form `view` accepts.
-        let file = unsafe {
-            view(
-                SITE_FILE.load(Ordering::Relaxed) as *const u8,
-                SITE_FILE_LEN.load(Ordering::Relaxed),
-            )
-        };
+        let (file, line, column) = staged_site();
         let framed = if with_message == 0 {
             &ASSERT_MESSAGE[..]
         } else {
@@ -575,14 +665,13 @@ crate::define_runtime_implementation! {
             &mut emit_to_channel,
             framed,
             file,
-            (position >> 32) as u32,
-            position as u32,
+            line,
+            column,
         );
         if with_message == 0 {
             crate::error::__rue_assert_failed()
         } else {
-            // SAFETY: `message` is a live borrow of the caller's bytes.
-            unsafe { crate::error::__rue_panic(message.as_ptr(), message.len() as u64) }
+            crate::error::panic_stderr(message)
         }
     }
 }
@@ -868,6 +957,82 @@ mod tests {
             )
         };
         assert_eq!(staged, file);
+    }
+
+    /// A trap's frame is the bare assertion's shape — no `payload`, no operands
+    /// — under the `trap:<class>` kind the runner already publishes, carrying
+    /// the pinned stderr line as its message (RUE-2019).
+    #[test]
+    fn a_trap_frame_carries_its_class_and_pinned_message() {
+        let bytes = frame_bytes(|emit| {
+            trap_frame(
+                emit,
+                &TRAP_PANIC_KIND,
+                &PANIC_PREFIX,
+                b"boom",
+                b"app/parser_tests.rue",
+                21,
+                5,
+            )
+        });
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"trap:panic\",\
+             \"message\":\"panic: boom\",\
+             \"location\":{\"file\":\"app/parser_tests.rue\",\"line\":21,\"column\":5}}\n"
+        );
+    }
+
+    /// The two-run message is one JSON string, and each run is escaped: a
+    /// programmer's own text reaches the record intact however it is spelled.
+    #[test]
+    fn a_trap_message_escapes_both_of_its_runs() {
+        let bytes = frame_bytes(|emit| {
+            trap_frame(emit, &TRAP_PANIC_KIND, b"a\"b", b"c\nd", b"a.rue", 1, 1)
+        });
+        assert!(
+            std::str::from_utf8(&bytes)
+                .unwrap()
+                .contains("\"message\":\"a\\\"bc\\u000ad\""),
+            "{}",
+            std::str::from_utf8(&bytes).unwrap()
+        );
+    }
+
+    /// A trap reached with no staged site — an allocation failure, or a check
+    /// the compiler emits below AIR — still reports. The empty location is what
+    /// the runner answers from the test declaration's header, so the record is
+    /// never worse than the stderr classification it replaces.
+    #[test]
+    fn an_unstaged_trap_frame_names_no_file() {
+        let bytes = frame_bytes(|emit| {
+            trap_frame(
+                emit,
+                &TRAP_BOUNDS_CHECK_KIND,
+                &BOUNDS_CHECK_MESSAGE,
+                b"",
+                b"",
+                0,
+                0,
+            )
+        });
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "{\"record\":\"failure\",\"schema\":\"1.0\",\"kind\":\"trap:bounds_check\",\
+             \"message\":\"error: index out of bounds\",\
+             \"location\":{\"file\":\"\",\"line\":0,\"column\":0}}\n"
+        );
+    }
+
+    /// Each pinned trap message is the stderr line `error.rs` writes, without
+    /// its newline: the record and stderr must not be able to drift apart.
+    #[test]
+    fn pinned_trap_messages_match_the_stderr_lines() {
+        assert_eq!(&PANIC_PREFIX[..], b"panic: ");
+        assert_eq!(&PANIC_MESSAGE[..], b"panic");
+        assert_eq!(&BOUNDS_CHECK_MESSAGE[..], b"error: index out of bounds");
+        assert_eq!(&TRAP_PANIC_KIND[..], b"trap:panic");
+        assert_eq!(&TRAP_BOUNDS_CHECK_KIND[..], b"trap:bounds_check");
     }
 
     #[test]

--- a/crates/rue/src/test_mode/verdict.rs
+++ b/crates/rue/src/test_mode/verdict.rs
@@ -42,6 +42,18 @@ const ASSERT_MESSAGE: &str = "assertion failed";
 /// `__rue_panic`'s prefix, ahead of the user's message text.
 const PANIC_PREFIX: &str = "panic: ";
 
+/// The `trap:` namespace a runtime trap's own failure frame reports under.
+const TRAP_PREFIX: &str = "trap:";
+
+/// The trap class this name identifies, or `None` when the taxonomy has no such
+/// class — a producer other than the runtime, whose kind is published verbatim.
+fn trap_class(name: &str) -> Option<&'static str> {
+    TRAP_MESSAGES
+        .iter()
+        .map(|(_, class)| *class)
+        .find(|class| *class == name)
+}
+
 /// The runtime's abort status. Every trap, `@panic`, and failed `@assert`
 /// exits with it (ADR-0083 Context: the failure model is abort-only).
 const RUNTIME_ERROR_EXIT_CODE: i32 = rue_test_runner::RUNTIME_ERROR_EXIT_CODE;
@@ -90,7 +102,14 @@ impl FailureKind {
             "assert" => Self::Assert,
             "assert_eq" => Self::AssertEq,
             "assert_ne" => Self::AssertNe,
-            other => Self::Reported(other.to_owned()),
+            other => match other.strip_prefix(TRAP_PREFIX).and_then(trap_class) {
+                // A trap that reported its own site (RUE-2019) names the same
+                // `trap:<class>` the stderr classification below produces, so
+                // the two routes to one trap reach one variant rather than
+                // publishing the same spelling from two.
+                Some(class) => Self::Trap(class),
+                None => Self::Reported(other.to_owned()),
+            },
         }
     }
 }
@@ -564,6 +583,26 @@ mod tests {
         assert_eq!(
             observe(Ok(101), "panic: unhandled error\n", &frames).verdict,
             Verdict::Fail(FailureKind::UnhandledError)
+        );
+    }
+
+    /// A trap that reported its own site names its class in the frame, and that
+    /// reaches the same variant the stderr classification produces — so one
+    /// trap has one spelling however the runner learned of it (RUE-2019).
+    #[test]
+    fn a_reported_trap_class_normalizes_to_the_taxonomy_variant() {
+        assert_eq!(
+            FailureKind::reported("trap:panic"),
+            FailureKind::Trap("panic")
+        );
+        assert_eq!(
+            FailureKind::reported("trap:bounds_check"),
+            FailureKind::Trap("bounds_check")
+        );
+        // Only the classes the taxonomy names; anything else stays verbatim.
+        assert_eq!(
+            FailureKind::reported("trap:nonesuch"),
+            FailureKind::Reported("trap:nonesuch".to_owned())
         );
     }
 

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -97,9 +97,15 @@ budget. Two record kinds exist in this version, and `failure` has two shapes:
 
 The `complete` record is written by the dispatcher's epilogue alone, after the
 selected test body returns normally. `failure` records are written by assertion
-sugar and by the test-body `?` failure arm before aborting; `kind` is an open
-field, so a user assertion library's own kind is published verbatim rather than
-flattened (ADR-0083 §5.1).
+sugar, by the test-body `?` failure arm, and by the runtime trap helpers before
+aborting; `kind` is an open field, so a user assertion library's own kind is
+published verbatim rather than flattened (ADR-0083 §5.1).
+
+A trap's record uses the bare assertion's shape and the `trap:<class>` kind the
+taxonomy below already names, and its `message` is the pinned stderr line
+without the newline. The two routes to one trap therefore agree: a runner
+reading the channel and a runner reading stderr publish the same kind and the
+same text, and the record adds only the site (RUE-2019).
 
 A `failure` record carries **at most one of** `payload` and the pair
 `left`/`right`, and a bare `@assert` carries neither: its record ends at the
@@ -240,7 +246,7 @@ consumers already handle instead of adding one.
 | `message` | string | The pinned runtime message, the frame's message, or the runner's description. |
 | `exit_code` | integer | The process's exit status. **Absent** when it did not exit normally. |
 | `signal` | integer | The signal that killed it. **Absent** otherwise. |
-| `location` | object | `{"file","line","column"}` — the test declaration's header, unless a failure frame carried its own site. |
+| `location` | object | `{"file","line","column"}` — the failure frame's own site, or the test declaration's header when no frame named one. |
 | `payload` | string | The channel's open payload. **Absent** when empty, and a bare `@assert` writes none. |
 | `left` | string | A comparison assertion's left operand, rendered. **Absent** on every other failure. |
 | `right` | string | Its right operand, rendered. Present exactly when `left` is. |
@@ -250,10 +256,29 @@ consumers already handle instead of adding one.
 `line` and `column` are both 1-based, and `column` counts Unicode scalars rather
 than bytes — the same coordinate the compiler's own diagnostics print for the
 same position, so a report and a diagnostic never disagree about where something
-is. An `unhandled_error` record is the one that routinely carries a site of its
-own: the failure arm of a test body's `?` stages the position of the `?`
-operator's operand, so `location` names the failing expression rather than the
-`test` line the runner would otherwise fall back to (spec 6.7:14).
+is.
+
+Which failures carry a site of their own, and which still fall back to the
+`test` declaration's header:
+
+| Failure | `location` |
+|---------|------------|
+| `assert`, `assert_eq`, `assert_ne` | The intrinsic's own site (RUE-1953, ADR-0083 Phase 2.5). |
+| `unhandled_error` | The position of the `?` operator's operand, so the location names the failing expression (spec 6.7:14). |
+| `trap:panic` | The `@panic` intrinsic's own site, both spellings alike (RUE-2019). |
+| Every other `trap:<class>` | The `test` declaration's header. |
+
+The remaining traps are the checks the compiler emits below AIR — the
+fixed-array bounds check in the place lowering, and the division-by-zero,
+overflow, and `@intCast` range checks the CFG and codegen insert. None of them
+is an AIR call carrying a span, and the two ways to give them one both cost the
+*passing* path: staging a site beside the check runs on every access, and
+staging it inside the failing arm costs a branch on the negated condition and
+the arm's register pressure in every function that indexes. Until the trap edge
+can carry a site the passing path does not pay for, those failures name the
+header, and their `kind` is still exact — `__rue_bounds_check` writes its
+`trap:bounds_check` record whether or not a site was staged, so the class comes
+from the channel rather than from matching a stderr line.
 
 `timeout` and `crash` verdicts also carry a failure record, with kind `timeout`
 and `signal` respectively.
@@ -401,7 +426,7 @@ of stderr, and the frames read from the failure channel.
 | `fail` | `assert` | A `failure` frame from a failed `@assert`, carrying the intrinsic's own site and its message. Falls back to the last stderr line being exactly `assertion failed` — which is what a comptime-decidable `@assert_eq` still reports as, and what an older image writes. |
 | `fail` | `assert_eq` | A `failure` frame from a failed `@assert_eq`, carrying `left` and `right`. |
 | `fail` | `assert_ne` | The same, from a failed `@assert_ne`. |
-| `fail` | `trap:<class>` | The last stderr line is another pinned runtime message. |
+| `fail` | `trap:<class>` | A `failure` frame with that kind — `@panic` and the bounds check write one — or the last stderr line being another pinned runtime message. |
 | `fail` | `unhandled_error` | A `failure` frame with that kind — the test-body `?` failure arm. |
 | `fail` | *(verbatim)* | A `failure` frame with a kind the runner does not know (ADR-0083 §5.1). |
 | `fail` | `exit` | Any other nonzero exit. |
@@ -414,7 +439,10 @@ of stderr, and the frames read from the failure channel.
 messages they match are the ones `crates/rue-runtime/src/error.rs` and `entry.rs`
 write before `exit(101)`; `crates/rue-cli-tests/cases/rue_test.toml` runs real
 programs down those paths, so a reworded runtime message fails a case rather than
-silently reclassifying a trap as a bare `exit`.
+silently reclassifying a trap as a bare `exit`. A frame naming one of those
+classes reaches the same kind the stderr match produces, so one trap has one
+spelling however the runner learned of it; a `trap:` name outside the list is
+some other producer's and is published verbatim like any unknown kind.
 
 Precedence, in order:
 

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -304,6 +304,22 @@ whether the request is a test one: an ordinary process simply has no descriptor
 3, so the frame write fails with `EBADF` as designed and the pinned stderr
 message plus exit 101 is the whole report.
 
+`@panic(msg)` and `@panic()` compile to `__rue_test_failure_site` followed by
+the panic helper, under the same adjacency rule and the same build-independent
+rule (RUE-2019). The panic helpers are not channel exports and their signatures
+are unchanged; what changed is that `__rue_panic` and `__rue_panic_no_msg` now
+write a `trap:panic` record carrying the staged site *before* their pinned
+stderr line, and `__rue_bounds_check` writes a `trap:bounds_check` record the
+same way. Each record's message is that helper's own stderr line without the
+newline, so nothing a consumer already read changes. The site is staged by the
+`@panic` lowering alone: an allocation failure, and the fixed-array bounds
+check codegen emits from a place projection, reach these helpers with nothing
+staged and report the empty location the runner answers from the test
+declaration's header. Because the panic helpers now report, the three terminal
+channel helpers take the stderr half of the panic path directly rather than
+calling `__rue_panic` — a second `trap:panic` frame after their own would be
+noise on a channel whose first frame is the verdict.
+
 The completion and failure records go to a dedicated inherited descriptor,
 number 3, one JSON object per line. Writes are best-effort: a test image run by
 hand has no such descriptor, so `EBADF` is expected rather than exceptional.


### PR DESCRIPTION
Fixes RUE-2019

A `@panic` inside a test body, and every runtime trap, reported the `test` header as its location: only the assertion family and the `?` failure arm staged a site, and the traps abort from the runtime with a pinned stderr line and nothing else.

## What changes

- **`@panic` has a site.** Both spellings stage the intrinsic's own site with `__rue_test_failure_site` and then call the panic helper, the same build-independent lowering the assertion family uses. The message is materialized before the site is staged so an abort inside the message expression cannot adopt this line.
- **Traps report their class on the channel.** `__rue_panic`, `__rue_panic_no_msg`, and `__rue_bounds_check` write a failure record before their stderr line, under the `trap:<class>` kind the runner already publishes and with the pinned stderr text as the message, so the record adds only the site. The three terminal channel helpers take the panic path's stderr half directly, so a failed assertion still writes exactly one frame. The runner folds a frame naming a known trap class into the same `Trap` variant the stderr match produces. Stderr bytes and exit 101 are unchanged everywhere.
- **Honest about the rest.** The fixed-array bounds check emitted below AIR and the division, overflow, and `@intCast` checks still name the header: none is an AIR call carrying a span, and both ways to stage one would cost the passing path. `test-events.md` now tabulates which failures carry a site and why the others do not; `runtime-abi.md` records the helpers' new channel write.

```
main.rue::panic with message    | trap:panic        | main.rue:5:5   | panic: boom
main.rue::panic without message | trap:panic        | main.rue:9:5   | panic
main.rue::array index oob       | trap:bounds_check | main.rue:11:1  | error: index out of bounds   (header)
main.rue::division by zero      | trap:div_by_zero  | main.rue:17:1  | error: division by zero      (header)
```

## Verified

Locations by execution as above; a plain executable prints `panic: boom` and exits 101; test_mode unit tests 95/95; runtime and test-image unit tests green; `scripts/rue cli rue_test` 79/79, `panic` 35/35, `assert` 45/45, `trap` 69/69; `scripts/rue spec 4.13` 223/223; `scripts/rue quick` green; rustfmt clean. No `exec.rs` changes, to stay clear of RUE-2025.

Local oracle-diff is host-blocked (RUE-2043, fix in flight); CI's corpus gate is the authority for the new `cli.rue_test` cases, which are driver-exit cases.
