### PR TITLE
Pair conventions with their descriptions and classify placements from leaves

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -735,6 +735,7 @@ pub fn c_abi_type_facts(type_pool: &FrozenTypeInternPool, ty: Type) -> CAbiTypeF
         return CAbiTypeFacts::Aggregate {
             size: layout.size,
             align: layout.alignment,
+            leaves: aggregate_leaves(type_pool, ty, layout.size),
         };
     }
     if type_pool.abi_slot_count(ty) == 0 {
@@ -753,13 +754,183 @@ pub fn c_abi_type_facts(type_pool: &FrozenTypeInternPool, ty: Type) -> CAbiTypeF
     }
 }
 
+/// The live plane's projection of an aggregate's scalar leaves.
+///
+/// Classification asks which bank each eightbyte belongs to and whether the
+/// whole aggregate is a homogeneous floating-point aggregate, and both answers
+/// come from the leaves: a scalar field's byte offset, its width, and whether
+/// it is an integer, an `f32` or an `f64`. The walk reads the same canonical
+/// layout every other physical consumer reads — struct field offsets, array
+/// element stride, the enum tag and per-variant payload offsets — so the leaves
+/// describe the type's actual memory image.
+///
+/// An aggregate larger than [`crate::MAX_LEAF_CLASSIFIED_BYTES`] is reported all
+/// integer without a walk: no supported row's answer for one that large depends
+/// on its leaves, so this bounds the cost of a large array.
+pub fn aggregate_leaves(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+    size: u64,
+) -> crate::AggregateLeaves {
+    if size > crate::MAX_LEAF_CLASSIFIED_BYTES {
+        return crate::AggregateLeaves::all_integer(size);
+    }
+    let mut leaves = Vec::new();
+    push_leaves(type_pool, ty, 0, &mut leaves);
+    crate::AggregateLeaves::from_leaves(size, leaves)
+}
+
+/// The classification kind of one scalar leaf: the floats are told apart from
+/// each other because AAPCS64's homogeneous rule is keyed by member width, and
+/// everything else — integers, `bool`, pointers — is one kind.
+fn leaf_kind(ty: Type) -> crate::CAbiLeafKind {
+    match ty.kind() {
+        TypeKind::F32 => crate::CAbiLeafKind::F32,
+        TypeKind::F64 => crate::CAbiLeafKind::F64,
+        _ => crate::CAbiLeafKind::Integer,
+    }
+}
+
+/// Append every scalar leaf of `ty`, placed at `base` bytes, to `out`.
+///
+/// An enum contributes its tag as an integer leaf and then the *union* of every
+/// variant's payload leaves, each at that variant's own offsets: a union's
+/// eightbyte is classified by every leaf that can occupy it, which is the same
+/// merge SysV AMD64 section 3.2.3 applies to a C union.
+fn push_leaves(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+    base: u64,
+    out: &mut Vec<crate::CAbiLeaf>,
+) {
+    match ty.kind() {
+        TypeKind::Unit | TypeKind::Never => {}
+        TypeKind::Struct(struct_id) => {
+            let layout = type_pool.layout(ty);
+            let crate::LayoutKind::Struct { field_offsets, .. } = &layout.kind else {
+                return;
+            };
+            let struct_def = type_pool.struct_def(struct_id);
+            for (field, offset) in struct_def.fields.iter().zip(field_offsets) {
+                push_leaves(type_pool, field.ty, base.saturating_add(*offset), out);
+            }
+        }
+        TypeKind::Array(array_id) => {
+            let (element, count) = type_pool.array_def(array_id);
+            let stride = type_pool.layout(element).stride;
+            for index in 0..count {
+                push_leaves(
+                    type_pool,
+                    element,
+                    base.saturating_add(index.saturating_mul(stride)),
+                    out,
+                );
+            }
+        }
+        TypeKind::Enum(enum_id) => {
+            let layout = type_pool.layout(ty);
+            let crate::LayoutKind::Enum { tag, variants, .. } = &layout.kind else {
+                return;
+            };
+            out.push(crate::CAbiLeaf::integer(base, tag.size));
+            let enum_def = type_pool.enum_def(enum_id);
+            for (variant, offsets) in variants.iter().enumerate() {
+                for (payload, offset) in enum_def.variant_payload(variant).iter().zip(offsets) {
+                    push_leaves(type_pool, *payload, base.saturating_add(*offset), out);
+                }
+            }
+        }
+        _ => out.push(crate::CAbiLeaf {
+            offset: base,
+            width: type_pool.layout(ty).size,
+            kind: leaf_kind(ty),
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     // Behavioral coverage that exercises the classifier against a real type
     // pool lives with the backend ABI/oracle suites (which own program
-    // fixtures); these unit checks pin the pure classification algebra.
+    // fixtures); these unit checks pin the pure classification algebra, and the
+    // leaf projection against a small pool of its own.
+
+    fn pool_with_struct(fields: &[(&str, Type)]) -> (crate::FrozenTypeInternPool, Type) {
+        let interner = lasso::ThreadedRodeo::new();
+        let pool = crate::TypeInternPool::new();
+        let (id, _) = pool.register_struct(
+            interner.get_or_intern("Probe"),
+            crate::StructDef {
+                name: "Probe".into(),
+                fields: fields
+                    .iter()
+                    .map(|(name, ty)| crate::StructField {
+                        name: (*name).to_string(),
+                        ty: *ty,
+                    })
+                    .collect(),
+                is_copy: true,
+                is_linear: false,
+                declared_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: rue_span::FileId::DEFAULT,
+            },
+        );
+        let ty = Type::new_struct(id);
+        let pool = pool.freeze();
+        (pool, ty)
+    }
+
+    #[test]
+    fn the_live_plane_projects_each_leaf_at_its_own_offset_and_kind() {
+        let (pool, mixed) = pool_with_struct(&[("a", Type::F64), ("b", Type::I64)]);
+        let facts = c_abi_type_facts(&pool, mixed);
+        let CAbiTypeFacts::Aggregate { size, leaves, .. } = facts else {
+            panic!("a struct projects aggregate facts, got {facts:?}");
+        };
+        assert_eq!(
+            leaves.eightbyte_class(0),
+            crate::EightbyteClass::Sse,
+            "the `f64` field's eightbyte carries no integer leaf"
+        );
+        assert_eq!(
+            leaves.eightbyte_class(size.div_ceil(8) as u32 - 1),
+            crate::EightbyteClass::Integer
+        );
+        assert_eq!(leaves.homogeneous_floats(), None);
+        assert!(!leaves.has_unaligned_leaf());
+
+        // Two floats of one width are a homogeneous floating-point aggregate,
+        // whatever the layout in force spaces them at.
+        let (pool, floats) = pool_with_struct(&[("a", Type::F64), ("b", Type::F64)]);
+        let facts = c_abi_type_facts(&pool, floats);
+        let CAbiTypeFacts::Aggregate { leaves, .. } = facts else {
+            panic!("a struct projects aggregate facts, got {facts:?}");
+        };
+        assert_eq!(leaves.homogeneous_floats(), Some((8, 2)));
+        assert_eq!(leaves.eightbyte_class(0), crate::EightbyteClass::Sse);
+        assert_eq!(leaves.eightbyte_class(1), crate::EightbyteClass::Sse);
+    }
+
+    #[test]
+    fn an_aggregate_past_the_leaf_bound_is_projected_all_integer() {
+        // Nothing any row does with an aggregate this large depends on its
+        // leaves, so the projection stops rather than walking it.
+        let pool = crate::TypeInternPool::new();
+        let array = pool.intern_array_from_type(Type::F64, 64);
+        let pool = pool.freeze();
+        let ty = Type::new_array(array);
+        assert!(pool.layout(ty).size > crate::MAX_LEAF_CLASSIFIED_BYTES);
+        let facts = c_abi_type_facts(&pool, ty);
+        let CAbiTypeFacts::Aggregate { size, leaves, .. } = facts else {
+            panic!("an array projects aggregate facts, got {facts:?}");
+        };
+        assert_eq!(leaves, crate::AggregateLeaves::all_integer(size));
+    }
 
     #[test]
     fn target_c_scalar_return_extension_table() {

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -45,8 +45,8 @@ mod types;
 
 pub use call_abi::{
     ArgClass, ArgConvention, CAbiScalarKind, NativeAbiTypeFacts, NativeCallAbi, ReturnClass,
-    ScalarAbiExtension, TargetCCallAbi, c_abi_type_facts, is_slot_identical_layout,
-    native_return_register_budget,
+    ScalarAbiExtension, TargetCCallAbi, aggregate_leaves, c_abi_type_facts,
+    is_slot_identical_layout, native_return_register_budget,
 };
 pub use exact_decimal::canonical_decimal_literal;
 pub use exact_decimal::finite_float_literal_bits;
@@ -82,8 +82,10 @@ pub use intrinsic::{
 };
 pub use layout::{Layout, LayoutKind, PaddingRange, SLOT_BYTES};
 pub use lowered_signature::{
-    ArgLocation, CAbiTypeFacts, EightbyteClass, EightbyteClasses, LoweredArgument, LoweredReturn,
-    LoweredSignature, PointerLocation, lower_c_signature, lower_native_signature,
+    AggregateLeaves, ArgLocation, ArgumentArea, CAbiLeaf, CAbiLeafKind, CAbiTypeFacts,
+    EightbyteClass, EightbyteClasses, LoweredArgument, LoweredReturn, LoweredSignature,
+    MAX_LEAF_CLASSIFIED_BYTES, PointerLocation, RegisterPiece, RegisterPieces, StackedPlacement,
+    lower_c_signature, lower_native_signature,
 };
 pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange, ParamRangeData};

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -83,7 +83,7 @@ pub use intrinsic::{
 pub use layout::{Layout, LayoutKind, PaddingRange, SLOT_BYTES};
 pub use lowered_signature::{
     ArgLocation, CAbiTypeFacts, EightbyteClass, EightbyteClasses, LoweredArgument, LoweredReturn,
-    LoweredSignature, PointerLocation, lower_c_signature,
+    LoweredSignature, PointerLocation, lower_c_signature, lower_native_signature,
 };
 pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange, ParamRangeData};

--- a/crates/rue-air/src/lowered_signature.rs
+++ b/crates/rue-air/src/lowered_signature.rs
@@ -1,5 +1,5 @@
-//! The one target-C signature classifier and the lowered signature it produces
-//! (ADR-0064 P2/P3/P4).
+//! The one signature classifier and the lowered signature it produces
+//! (ADR-0064 P2/P3/P4, ADR-0084).
 //!
 //! [`lower_c_signature`] is the single function that answers *where every value
 //! of a `"C"` signature lives*: which register bank and roster index, which
@@ -9,6 +9,18 @@
 //! trampoline — which is ADR-0064's ratified acceptance criterion that the
 //! by-value classifier agree across all four sites. There is no second placement
 //! algorithm in the tree.
+//!
+//! ## Two entry points, one placement walk
+//!
+//! The native Rue convention is the compilation target's C convention plus a
+//! wider return bank (ADR-0084), so it places arguments by exactly these rules
+//! and differs only in its result. That is the shape of the two entry points:
+//! [`lower_c_signature`] takes a C row and classifies both halves of the
+//! signature, while [`lower_native_signature`] takes a
+//! [`ConventionSpec`] and an already-decided [`LoweredReturn`], because the
+//! native return bank is wider than any [`CConventionSpec`] describes. Both run
+//! the same walk over the same [`Placer`], so a native argument and a C
+//! argument of the same shape land in the same place by construction.
 //!
 //! ## Why this crate is the home
 //!
@@ -38,7 +50,7 @@
 
 use rue_target::{
     AggregateClassificationRule, CConventionSpec, CRegisterClass, CallingConvention,
-    SretRegisterKind, StackedArgumentPacking,
+    ConventionSpec, SretRegisterKind, StackedArgumentPacking,
 };
 
 use crate::call_abi::{ArgConvention, CAbiScalarKind, ScalarAbiExtension};
@@ -284,21 +296,28 @@ impl LoweredReturn {
 /// thunk (callee direction: read these places, then adapt to the native body).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoweredSignature {
-    convention: CallingConvention,
+    convention: ConventionSpec,
     arguments: Vec<LoweredArgument>,
     ret: LoweredReturn,
     stack_bytes: u32,
 }
 
 impl LoweredSignature {
-    /// The convention that produced this lowering. Always a C row.
+    /// The convention that produced this lowering.
     pub fn convention(&self) -> CallingConvention {
-        self.convention
+        self.convention.convention()
     }
 
-    /// The convention's psABI description.
+    /// The description this lowering placed by. For a C row it is that row's
+    /// own psABI entry; for the native convention it is the target's C entry
+    /// with the native amendments (`ConventionSpec::native`).
     pub fn spec(&self) -> CConventionSpec {
-        self.convention.c_spec()
+        self.convention.spec()
+    }
+
+    /// The convention and description this lowering placed by, as one value.
+    pub fn convention_spec(&self) -> ConventionSpec {
+        self.convention
     }
 
     /// Every argument's placement, in source order.
@@ -466,21 +485,51 @@ impl Placer {
 ///
 /// `parameters` are the source parameters in declaration order, each already
 /// reduced to the facts its plane projected and the mode it is passed under;
-/// `result` is the return type's facts. `convention` must be a C row —
-/// [`CallingConvention::Rue`] is the native convention and is classified by
-/// [`NativeCallAbi`](crate::NativeCallAbi).
+/// `result` is the return type's facts. `convention` must be a C row: the
+/// pairing [`ConventionSpec::c`] is what asserts it, because a C boundary is
+/// exactly a convention that describes itself.
 pub fn lower_c_signature(
     convention: CallingConvention,
     parameters: &[(CAbiTypeFacts, ArgConvention)],
     result: CAbiTypeFacts,
 ) -> LoweredSignature {
-    assert!(
-        convention.is_c(),
-        "lower_c_signature classifies a C boundary; the native Rue convention \
-         is the native classifier's authority"
-    );
-    let spec = convention.c_spec();
-    let ret = lower_return(&spec, result);
+    let pairing = ConventionSpec::c(convention);
+    let ret = lower_return(&pairing.spec(), result);
+    place_signature(pairing, parameters, ret)
+}
+
+/// Classify one whole *native* signature's arguments into placements, against
+/// an already-decided return.
+///
+/// Arguments are placed by exactly the rules `pairing` describes, which for
+/// [`ConventionSpec::native`] are the compilation target's own C rules
+/// (ADR-0084). The return is an input rather than a decision because the native
+/// return bank is wider than any C row's and no [`CConventionSpec`] describes
+/// it: the caller classifies the return and hands it in, and this function
+/// honors the one consequence a return has for argument placement — a native
+/// sret pointer is the hidden first ordinary argument, so it shifts every user
+/// argument one general-purpose register right.
+pub fn lower_native_signature(
+    pairing: ConventionSpec,
+    parameters: &[(CAbiTypeFacts, ArgConvention)],
+    result: LoweredReturn,
+) -> LoweredSignature {
+    place_signature(pairing, parameters, result)
+}
+
+/// Place every argument of a signature whose result crosses as `ret`, under
+/// `pairing`.
+///
+/// The one placement walk both entry points run: the sret shift, the argument
+/// classification in declaration order, and the outgoing argument area's final
+/// size. What differs between a C boundary and a native one is only where `ret`
+/// came from.
+fn place_signature(
+    pairing: ConventionSpec,
+    parameters: &[(CAbiTypeFacts, ArgConvention)],
+    ret: LoweredReturn,
+) -> LoweredSignature {
+    let spec = pairing.spec();
     let mut placer = Placer::new(spec);
     if ret.uses_sret() && spec.sret_pointer_in_argument_register() {
         // The hidden pointer is the hidden *first* argument, so it shifts every
@@ -500,7 +549,7 @@ pub fn lower_c_signature(
         .collect();
 
     LoweredSignature {
-        convention,
+        convention: pairing,
         arguments,
         ret,
         stack_bytes: saturate_u32(align_up(placer.stack, u64::from(spec.call_stack_alignment))),
@@ -633,6 +682,7 @@ fn lower_return(spec: &CConventionSpec, result: CAbiTypeFacts) -> LoweredReturn 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_target::Target;
 
     const SYSV: CallingConvention = CallingConvention::X86_64SysV;
     const AAPCS: CallingConvention = CallingConvention::Aarch64Aapcs;
@@ -1021,8 +1071,146 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "classifies a C boundary")]
-    fn the_native_convention_is_not_lowered_here() {
+    #[should_panic(expected = "a C pairing names a psABI row")]
+    fn the_native_convention_is_not_a_c_boundary() {
         let _ = lower_c_signature(CallingConvention::Rue, &[], CAbiTypeFacts::ZeroSized);
+    }
+
+    #[test]
+    fn a_void_native_signature_places_arguments_exactly_as_its_targets_c_row() {
+        // ADR-0084's argument rule, stated as an equality: with nothing forced
+        // by the return, every native placement is the target C placement.
+        let params = vec![
+            word(),
+            aggregate(16, 8),
+            aggregate(24, 8),
+            word(),
+            word(),
+            word(),
+            word(),
+            word(),
+            word(),
+            scalar(CAbiScalarKind::I8),
+        ];
+        for target in Target::all() {
+            let c = lower_c_signature(
+                target.c_calling_convention(),
+                &params,
+                CAbiTypeFacts::ZeroSized,
+            );
+            let native = lower_native_signature(
+                ConventionSpec::native(*target),
+                &params,
+                LoweredReturn::Void,
+            );
+            assert_eq!(
+                native.arguments(),
+                c.arguments(),
+                "{target:?}: the native convention places arguments by its C row"
+            );
+            assert_eq!(native.stack_bytes(), c.stack_bytes());
+            assert_eq!(native.convention(), CallingConvention::Rue);
+            assert_eq!(native.ret(), LoweredReturn::Void);
+            assert_eq!(
+                native.spec().gp_argument_registers,
+                c.spec().gp_argument_registers
+            );
+        }
+    }
+
+    #[test]
+    fn a_native_sret_shifts_user_arguments_on_every_target() {
+        // The native hidden indirect-result pointer is an ordinary first
+        // argument on both architectures, so it costs the first
+        // general-purpose argument register everywhere — unlike AAPCS64's
+        // dedicated `x8`, which leaves user arguments at roster index 0.
+        let sret = LoweredReturn::Sret {
+            register: SretRegisterKind::ArgumentRegister,
+            echoed: false,
+            size: 64,
+            align: 8,
+        };
+        for target in Target::all() {
+            let native =
+                lower_native_signature(ConventionSpec::native(*target), &[word(), word()], sret);
+            assert!(native.sret_in_argument_register());
+            assert_eq!(native.arguments()[0].location, registers(1, 1));
+            assert_eq!(native.arguments()[1].location, registers(2, 1));
+        }
+        // The same shape at the AAPCS64 C boundary keeps `x0` for the user's
+        // first argument, which is the difference the pairing carries.
+        let c = lower_c_signature(
+            CallingConvention::Aarch64Aapcs,
+            &[word(), word()],
+            CAbiTypeFacts::Aggregate { size: 64, align: 8 },
+        );
+        assert!(!c.sret_in_argument_register());
+        assert_eq!(c.arguments()[0].location, registers(0, 1));
+    }
+
+    #[test]
+    fn a_native_signature_fills_its_targets_roster_before_the_argument_area() {
+        // Nine words: SysV stacks the last three, AAPCS64 the last one, and the
+        // Apple row packs a narrow stacked scalar at its natural size just as
+        // it does at its C boundary.
+        let params = vec![word(); 9];
+        let native = |target: Target| {
+            lower_native_signature(ConventionSpec::native(target), &params, LoweredReturn::Void)
+        };
+        let sysv = native(Target::X86_64Linux);
+        assert_eq!(sysv.arguments()[5].location, registers(5, 1));
+        assert_eq!(
+            sysv.arguments()[6].location,
+            ArgLocation::Stack {
+                offset: 0,
+                size: 8,
+                align: 8
+            }
+        );
+        assert_eq!(sysv.stack_bytes(), 32);
+        let aapcs = native(Target::Aarch64Linux);
+        assert_eq!(aapcs.arguments()[7].location, registers(7, 1));
+        assert_eq!(
+            aapcs.arguments()[8].location,
+            ArgLocation::Stack {
+                offset: 0,
+                size: 8,
+                align: 8
+            }
+        );
+
+        let mut narrow = vec![word(); 8];
+        narrow.push(scalar(CAbiScalarKind::I8));
+        let darwin = lower_native_signature(
+            ConventionSpec::native(Target::Aarch64Macos),
+            &narrow,
+            LoweredReturn::Void,
+        );
+        assert_eq!(
+            darwin.arguments()[8].location,
+            ArgLocation::Stack {
+                offset: 0,
+                size: 1,
+                align: 1
+            }
+        );
+    }
+
+    #[test]
+    fn a_native_register_return_costs_no_argument_register() {
+        // Only an sret return shifts arguments; a return that fits the native
+        // bank leaves the whole roster to the user's arguments.
+        for target in Target::all() {
+            let native = lower_native_signature(
+                ConventionSpec::native(*target),
+                &[word()],
+                LoweredReturn::Registers {
+                    class: CRegisterClass::Gp,
+                    count: 6,
+                    extension: ScalarAbiExtension::None,
+                },
+            );
+            assert_eq!(native.arguments()[0].location, registers(0, 1));
+        }
     }
 }

--- a/crates/rue-air/src/lowered_signature.rs
+++ b/crates/rue-air/src/lowered_signature.rs
@@ -42,11 +42,13 @@
 //!
 //! ## Floats
 //!
-//! The C boundary still rejects `f32`/`f64` (`c_passable_by_value`), so
-//! [`CRegisterClass::Fp`] and [`EightbyteClass::Sse`] are unreachable today.
-//! They exist because the float slice is then an extension of this model —
-//! project an `Fp` scalar, classify an eightbyte `Sse` — rather than a rewrite
-//! of it.
+//! Classification is complete over floating-point values: an eightbyte whose
+//! every leaf is a float classifies [`EightbyteClass::Sse`] and travels in
+//! [`CRegisterClass::Fp`], and AAPCS64's homogeneous floating-point aggregates
+//! travel in consecutive floating-point registers. No *C* signature reaches
+//! that surface, because the C boundary rejects `f32`/`f64`
+//! (`c_passable_by_value`); the native convention is what has floats to place,
+//! and it places them by these same rules.
 
 use rue_target::{
     AggregateClassificationRule, CConventionSpec, CRegisterClass, CallingConvention,
@@ -71,13 +73,17 @@ pub enum CAbiTypeFacts {
         /// C boundary currently admits.
         class: CRegisterClass,
     },
-    /// A C-classifiable aggregate (`@repr(c)` struct or array) of `size` bytes
-    /// at `align` alignment.
+    /// An aggregate (struct, array, or enum) of `size` bytes at `align`
+    /// alignment, with the scalar-leaf facts its eightbyte and
+    /// homogeneous-float classification reads.
     Aggregate {
         /// The aggregate's `@size_of`.
         size: u64,
         /// The aggregate's `@align_of`.
         align: u64,
+        /// What the aggregate's scalar leaves are, folded to what
+        /// classification asks of them.
+        leaves: AggregateLeaves,
     },
 }
 
@@ -88,6 +94,17 @@ impl CAbiTypeFacts {
         Self::Scalar {
             kind: CAbiScalarKind::RegisterWidth,
             class: CRegisterClass::Gp,
+        }
+    }
+
+    /// The facts for an aggregate whose every leaf is an integer or a pointer:
+    /// every eightbyte classifies INTEGER and no row's floating-point rule
+    /// applies.
+    pub const fn integer_aggregate(size: u64, align: u64) -> Self {
+        Self::Aggregate {
+            size,
+            align,
+            leaves: AggregateLeaves::all_integer(size),
         }
     }
 
@@ -108,6 +125,248 @@ impl CAbiTypeFacts {
             Self::ZeroSized | Self::Aggregate { .. } => ScalarAbiExtension::None,
         }
     }
+}
+
+/// The largest aggregate whose scalar leaves can still change where it
+/// travels.
+///
+/// Every supported row places a larger aggregate through memory whatever its
+/// leaves are: past
+/// [`CConventionSpec::max_aggregate_register_bytes`] (16) an aggregate is
+/// SysV MEMORY class or an AAPCS64 by-reference copy, AAPCS64's widest
+/// homogeneous floating-point aggregate is four eight-byte members, and the
+/// widest native return bank is eight eightbytes. So a projection may stop
+/// walking an aggregate this large and report every eightbyte INTEGER without
+/// changing any placement, which bounds the cost of projecting the leaves of a
+/// large array.
+pub const MAX_LEAF_CLASSIFIED_BYTES: u64 = 64;
+
+/// The kind of one scalar leaf of an aggregate, as classification sees it.
+///
+/// The distinction is the one the psABIs draw and no finer: a leaf either
+/// forces its eightbyte into an integer register or it is a float that may
+/// leave the eightbyte in the floating-point bank, and the two float widths are
+/// told apart because AAPCS64's homogeneous floating-point aggregate rule is
+/// keyed by member width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CAbiLeafKind {
+    /// An integer, `bool`, or pointer leaf.
+    Integer,
+    /// An `f32` leaf.
+    F32,
+    /// An `f64` leaf.
+    F64,
+}
+
+impl CAbiLeafKind {
+    /// The leaf's width in bytes when it is a float, `None` when it is not.
+    pub const fn float_bytes(self) -> Option<u32> {
+        match self {
+            Self::Integer => None,
+            Self::F32 => Some(4),
+            Self::F64 => Some(8),
+        }
+    }
+}
+
+/// One scalar leaf of an aggregate: `width` bytes of `kind` at `offset` bytes
+/// into the aggregate's memory image.
+///
+/// This is what a plane projects; [`AggregateLeaves`] is what classification
+/// reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CAbiLeaf {
+    /// Byte offset of the leaf within the aggregate.
+    pub offset: u64,
+    /// The leaf's byte width.
+    pub width: u64,
+    /// The leaf's classification kind.
+    pub kind: CAbiLeafKind,
+}
+
+impl CAbiLeaf {
+    /// One integer or pointer leaf.
+    pub const fn integer(offset: u64, width: u64) -> Self {
+        Self {
+            offset,
+            width,
+            kind: CAbiLeafKind::Integer,
+        }
+    }
+
+    /// One `f32` leaf.
+    pub const fn f32(offset: u64) -> Self {
+        Self {
+            offset,
+            width: 4,
+            kind: CAbiLeafKind::F32,
+        }
+    }
+
+    /// One `f64` leaf.
+    pub const fn f64(offset: u64) -> Self {
+        Self {
+            offset,
+            width: 8,
+            kind: CAbiLeafKind::F64,
+        }
+    }
+}
+
+/// Whether an aggregate's leaves are all floats of one width — the AAPCS64
+/// homogeneous floating-point aggregate question, answered before the
+/// convention decides what to do about it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FloatMembers {
+    /// Some leaf is not a float, or two float leaves have different widths.
+    Mixed,
+    /// Every leaf folded so far is a float of `width` bytes, and there are
+    /// `count` of them. `count == 0` is the fold's identity: an aggregate with
+    /// no leaves at all.
+    Homogeneous { width: u32, count: u32 },
+}
+
+/// What classification needs to know about an aggregate's scalar leaves.
+///
+/// A plane projects the leaves themselves ([`CAbiLeaf`]) and this folds them
+/// into the two questions every supported row asks: *which bank does each
+/// eightbyte belong to* (SysV AMD64 section 3.2.3) and *is the whole aggregate
+/// a homogeneous floating-point aggregate* (AAPCS64 section 6.8.2 rule C.3).
+/// The fold is what keeps the facts a small `Copy` value, and it keeps the
+/// psABI decisions themselves in the classifier: an eightbyte's bank is a fact
+/// about the type, what a convention does with it is not.
+///
+/// Only the first `MAX_LEAF_CLASSIFIED_BYTES / 8` eightbytes are recorded,
+/// because no row's answer for a larger aggregate depends on its leaves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AggregateLeaves {
+    /// Bit *i* is set when eightbyte *i* holds at least one integer leaf.
+    integer_eightbytes: u64,
+    /// Bit *i* is set when eightbyte *i* holds at least one float leaf.
+    float_eightbytes: u64,
+    /// The homogeneous floating-point summary.
+    floats: FloatMembers,
+    /// Whether some leaf sits at an offset its own width does not divide, which
+    /// SysV AMD64 section 3.2.3 makes MEMORY class outright.
+    unaligned: bool,
+}
+
+impl AggregateLeaves {
+    /// How many eightbytes the bitmaps hold.
+    const RECORDED_EIGHTBYTES: u32 = (MAX_LEAF_CLASSIFIED_BYTES / 8) as u32;
+
+    /// The leaves of an aggregate whose every leaf is an integer or a pointer.
+    ///
+    /// This is both the answer for an integer-only aggregate and the answer a
+    /// plane projects when it cannot enumerate leaf kinds: every eightbyte
+    /// INTEGER, no homogeneous float rule, nothing unaligned.
+    pub const fn all_integer(size: u64) -> Self {
+        Self {
+            integer_eightbytes: eightbyte_mask(size),
+            float_eightbytes: 0,
+            floats: FloatMembers::Mixed,
+            unaligned: false,
+        }
+    }
+
+    /// Fold `leaves` — in any order — into the classification facts of a
+    /// `size`-byte aggregate.
+    pub fn from_leaves(size: u64, leaves: impl IntoIterator<Item = CAbiLeaf>) -> Self {
+        let mut folded = Self {
+            integer_eightbytes: 0,
+            float_eightbytes: 0,
+            floats: FloatMembers::Homogeneous { width: 0, count: 0 },
+            unaligned: false,
+        };
+        let mut any = false;
+        for leaf in leaves {
+            any = true;
+            folded.push(leaf);
+        }
+        if !any {
+            // An aggregate of nothing but padding classifies as its size says,
+            // in the integer bank: no leaf asked for the float one.
+            return Self::all_integer(size);
+        }
+        folded
+    }
+
+    fn push(&mut self, leaf: CAbiLeaf) {
+        if leaf.width != 0 && leaf.offset % leaf.width != 0 {
+            self.unaligned = true;
+        }
+        let first = leaf.offset / 8;
+        let last = leaf
+            .offset
+            .saturating_add(leaf.width.saturating_sub(1))
+            .max(leaf.offset)
+            / 8;
+        for eightbyte in first..=last.min(u64::from(Self::RECORDED_EIGHTBYTES - 1)) {
+            let bit = 1_u64 << eightbyte;
+            match leaf.kind {
+                CAbiLeafKind::Integer => self.integer_eightbytes |= bit,
+                CAbiLeafKind::F32 | CAbiLeafKind::F64 => self.float_eightbytes |= bit,
+            }
+        }
+        self.floats = match (self.floats, leaf.kind.float_bytes()) {
+            (FloatMembers::Mixed, _) | (_, None) => FloatMembers::Mixed,
+            (FloatMembers::Homogeneous { count: 0, .. }, Some(width)) => {
+                FloatMembers::Homogeneous { width, count: 1 }
+            }
+            (FloatMembers::Homogeneous { width, count }, Some(leaf_width))
+                if width == leaf_width =>
+            {
+                FloatMembers::Homogeneous {
+                    width,
+                    count: count.saturating_add(1),
+                }
+            }
+            (FloatMembers::Homogeneous { .. }, Some(_)) => FloatMembers::Mixed,
+        };
+    }
+
+    /// The class of eightbyte `index`, per SysV AMD64 section 3.2.3's merge: an
+    /// eightbyte holding any integer or pointer leaf is INTEGER, one holding
+    /// only floats is SSE. An eightbyte no leaf reaches — padding, or past what
+    /// the projection recorded — is INTEGER, so a value never rides in a
+    /// floating-point register on a fact no plane supplied.
+    pub const fn eightbyte_class(&self, index: u32) -> EightbyteClass {
+        if index >= Self::RECORDED_EIGHTBYTES {
+            return EightbyteClass::Integer;
+        }
+        let bit = 1_u64 << index;
+        if self.integer_eightbytes & bit != 0 {
+            return EightbyteClass::Integer;
+        }
+        if self.float_eightbytes & bit != 0 {
+            return EightbyteClass::Sse;
+        }
+        EightbyteClass::Integer
+    }
+
+    /// Whether some leaf sits at an offset its own width does not divide.
+    pub const fn has_unaligned_leaf(&self) -> bool {
+        self.unaligned
+    }
+
+    /// The `(member width, member count)` of the homogeneous floating-point
+    /// aggregate this is, or `None` when its leaves are not all floats of one
+    /// width. The member *count bound* is the convention's, not this fact's.
+    pub const fn homogeneous_floats(&self) -> Option<(u32, u32)> {
+        match self.floats {
+            FloatMembers::Homogeneous { width, count } if count > 0 => Some((width, count)),
+            FloatMembers::Homogeneous { .. } | FloatMembers::Mixed => None,
+        }
+    }
+}
+
+/// The bits of an eightbyte bitmap a `size`-byte aggregate occupies.
+const fn eightbyte_mask(size: u64) -> u64 {
+    let count = size.div_ceil(8);
+    if count >= AggregateLeaves::RECORDED_EIGHTBYTES as u64 {
+        return u64::MAX;
+    }
+    (1_u64 << count) - 1
 }
 
 /// The register class of one eightbyte of an aggregate.
@@ -135,27 +394,53 @@ impl EightbyteClass {
     }
 }
 
-/// The classes of a register-passed aggregate's eightbytes, in ascending memory
-/// order. A register-passed aggregate spans at most
-/// [`CConventionSpec::max_aggregate_register_bytes`] (16) bytes, so at most two.
+/// The classes of an aggregate's eightbytes, in ascending memory order.
+///
+/// A register-passed *argument* spans at most
+/// [`CConventionSpec::max_aggregate_register_bytes`] (16) bytes, so at most two
+/// eightbytes. The capacity is the widest return bank instead, because the
+/// native convention's bank is wider than any C row's (ADR-0084).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EightbyteClasses {
-    classes: [EightbyteClass; 2],
+    classes: [EightbyteClass; Self::CAPACITY as usize],
     len: u32,
 }
 
 impl EightbyteClasses {
-    /// The classification of an aggregate whose every eightbyte is INTEGER —
-    /// the only case the integer-only C surface reaches.
+    /// The widest classification this type holds: the eight general-purpose
+    /// registers of the native AArch64 return bank.
+    pub const CAPACITY: u32 = 8;
+
+    /// The classification of an aggregate whose every eightbyte is INTEGER.
     pub const fn all_integer(count: u32) -> Self {
         assert!(
-            count >= 1 && count <= 2,
-            "a register-passed aggregate spans one or two eightbytes"
+            count >= 1 && count <= Self::CAPACITY,
+            "a classified aggregate spans at least one eightbyte and at most \
+             the widest return bank"
         );
         Self {
-            classes: [EightbyteClass::Integer; 2],
+            classes: [EightbyteClass::Integer; Self::CAPACITY as usize],
             len: count,
         }
+    }
+
+    /// The classification of a `count`-eightbyte aggregate whose leaves are
+    /// `leaves`, per SysV AMD64 section 3.2.3: an eightbyte is SSE when every
+    /// leaf overlapping it is a float, and INTEGER as soon as one is not.
+    pub fn classify(leaves: AggregateLeaves, count: u32) -> Self {
+        let mut classified = Self::all_integer(count);
+        for index in 0..count {
+            classified.classes[index as usize] = leaves.eightbyte_class(index);
+        }
+        classified
+    }
+
+    /// How many registers of `class` this classification needs.
+    pub fn registers_in(&self, class: CRegisterClass) -> u32 {
+        self.as_slice()
+            .iter()
+            .filter(|eightbyte| eightbyte.register_class() == class)
+            .count() as u32
     }
 
     /// How many eightbytes the aggregate spans.
@@ -185,6 +470,102 @@ impl EightbyteClasses {
     }
 }
 
+/// One register a value occupies: roster `index` of bank `class`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisterPiece {
+    /// The register bank.
+    pub class: CRegisterClass,
+    /// Roster index within that bank's argument registers.
+    pub index: u32,
+}
+
+/// The registers one value occupies, one piece per eightbyte or per
+/// homogeneous floating-point member, in ascending memory order.
+///
+/// A value is a list of pieces rather than a run of one bank because SysV
+/// AMD64 classifies each eightbyte independently: a `{f64, i64}` struct travels
+/// with its first eightbyte in an SSE register and its second in an integer
+/// one. [`consecutive`](Self::consecutive) is the common case where every piece
+/// is in one bank.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisterPieces {
+    pieces: [RegisterPiece; Self::CAPACITY],
+    len: u32,
+}
+
+impl RegisterPieces {
+    /// The widest value this holds: AAPCS64's four-member homogeneous
+    /// floating-point aggregate is the widest register-passed argument, and the
+    /// capacity matches [`EightbyteClasses::CAPACITY`] so a classification and
+    /// its placement cannot disagree about how much they can carry.
+    pub const CAPACITY: usize = EightbyteClasses::CAPACITY as usize;
+
+    const EMPTY_PIECE: RegisterPiece = RegisterPiece {
+        class: CRegisterClass::Gp,
+        index: 0,
+    };
+
+    /// `count` consecutive registers of one bank, starting at `first_index`.
+    pub fn consecutive(class: CRegisterClass, first_index: u32, count: u32) -> Self {
+        let mut pieces = Self {
+            pieces: [Self::EMPTY_PIECE; Self::CAPACITY],
+            len: 0,
+        };
+        for offset in 0..count {
+            pieces.push(RegisterPiece {
+                class,
+                index: first_index.saturating_add(offset),
+            });
+        }
+        pieces
+    }
+
+    /// One register of `class` at roster index `index`.
+    pub fn one(class: CRegisterClass, index: u32) -> Self {
+        Self::consecutive(class, index, 1)
+    }
+
+    fn push(&mut self, piece: RegisterPiece) {
+        assert!(
+            (self.len as usize) < Self::CAPACITY,
+            "a register-passed value spans at most the widest return bank"
+        );
+        self.pieces[self.len as usize] = piece;
+        self.len += 1;
+    }
+
+    /// How many registers the value occupies.
+    pub const fn len(&self) -> u32 {
+        self.len
+    }
+
+    /// Whether the value occupies no register. Never true for a placed value;
+    /// present so `len` reads as a length.
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The pieces in ascending memory order.
+    pub fn as_slice(&self) -> &[RegisterPiece] {
+        &self.pieces[..self.len as usize]
+    }
+
+    /// The single bank every piece travels in, or `None` when the value is
+    /// split across banks.
+    pub fn uniform_class(&self) -> Option<CRegisterClass> {
+        let first = self.as_slice().first()?.class;
+        self.as_slice()
+            .iter()
+            .all(|piece| piece.class == first)
+            .then_some(first)
+    }
+
+    /// The roster index of the first register, or `None` for an empty run.
+    pub fn first_index(&self) -> Option<u32> {
+        self.as_slice().first().map(|piece| piece.index)
+    }
+}
+
 /// Where the pointer of an indirectly-passed argument lives.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PointerLocation {
@@ -206,16 +587,12 @@ pub enum PointerLocation {
 pub enum ArgLocation {
     /// A zero-sized value: no register, no stack byte, no pointer.
     Omitted,
-    /// `count` consecutive registers of `class`, starting at roster index
-    /// `first_index`. A scalar is one register; an aggregate is one register per
-    /// eightbyte in ascending memory order, i.e. C field order.
+    /// In registers: one piece per eightbyte, or per homogeneous
+    /// floating-point member, in ascending memory order — that is, C field
+    /// order. A scalar is one piece.
     Registers {
-        /// The register bank.
-        class: CRegisterClass,
-        /// Roster index of the first register.
-        first_index: u32,
-        /// How many consecutive registers the value occupies.
-        count: u32,
+        /// The registers the value occupies.
+        pieces: RegisterPieces,
     },
     /// By value in the outgoing argument area: `size` bytes at `offset`, whose
     /// alignment the placement already satisfied.
@@ -387,13 +764,97 @@ fn eightbytes(size: u64) -> u32 {
     saturate_u32(size.div_ceil(8))
 }
 
+/// Where one value sits in the outgoing argument area.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StackedPlacement {
+    /// Byte offset from the base of the outgoing argument area.
+    pub offset: u32,
+    /// Footprint in bytes, per the convention's stacked-argument packing.
+    pub size: u32,
+    /// Alignment the offset satisfies.
+    pub align: u32,
+}
+
+/// One call's outgoing argument area: the single rule for where a stacked
+/// value lands under a convention's packing, and how many bytes the caller
+/// reserves for it.
+///
+/// Every stacked placement in the tree claims through this cursor — the C
+/// signature lowering below, and the native call planner in `rue-codegen` —
+/// so the two cannot pack an argument area differently.
+#[derive(Debug, Clone, Copy)]
+pub struct ArgumentArea {
+    spec: CConventionSpec,
+    offset: u64,
+}
+
+impl ArgumentArea {
+    /// An empty area under `spec`, positioned past any callee shadow space the
+    /// row reserves at its base.
+    pub fn new(spec: CConventionSpec) -> Self {
+        Self {
+            spec,
+            offset: u64::from(spec.shadow_space_bytes),
+        }
+    }
+
+    /// Claim the next `natural_size` bytes for a stacked scalar.
+    ///
+    /// Under [`StackedArgumentPacking::EightByteSlots`] the scalar starts at
+    /// the next 8-byte boundary and occupies a whole eightbyte. Under Apple's
+    /// [`NaturalSize`](StackedArgumentPacking::NaturalSize) amendment it
+    /// occupies exactly its own width at its own alignment, so a stacked `i8`
+    /// takes one byte and an `i16` starts at the next even offset.
+    pub fn claim_scalar(&mut self, natural_size: u64) -> StackedPlacement {
+        let (size, align) = match self.spec.stacked_argument_packing {
+            StackedArgumentPacking::NaturalSize => {
+                let bytes = natural_size.clamp(1, 8);
+                (bytes, bytes)
+            }
+            StackedArgumentPacking::EightByteSlots => {
+                (u64::from(eightbytes(natural_size)).saturating_mul(8), 8)
+            }
+        };
+        self.claim(size, align)
+    }
+
+    /// Claim the next `size` bytes for a stacked aggregate.
+    ///
+    /// A composite keeps whole eightbytes at 8-byte alignment under every row:
+    /// it crosses through its eightbyte image, and a byte-exact copy needs
+    /// marshaling this path does not have. That one open Apple amendment is
+    /// recorded in `docs/notes/ffi-abi-conformance-audit.md`.
+    pub fn claim_aggregate(&mut self, size: u64) -> StackedPlacement {
+        self.claim(u64::from(eightbytes(size)).saturating_mul(8), 8)
+    }
+
+    fn claim(&mut self, size: u64, align: u64) -> StackedPlacement {
+        let offset = align_up(self.offset, align);
+        self.offset = offset.saturating_add(size);
+        StackedPlacement {
+            offset: saturate_u32(offset),
+            size: saturate_u32(size),
+            align: saturate_u32(align),
+        }
+    }
+
+    /// Bytes the caller reserves for the area, rounded to the convention's
+    /// call-boundary alignment.
+    pub fn reserved_bytes(&self) -> u32 {
+        saturate_u32(align_up(
+            self.offset,
+            u64::from(self.spec.call_stack_alignment),
+        ))
+    }
+}
+
 /// Running state of the placement walk: the register rosters consumed so far
 /// and the outgoing argument area's cursor.
 struct Placer {
     spec: CConventionSpec,
     gp: u32,
     fp: u32,
-    stack: u64,
+    area: ArgumentArea,
 }
 
 impl Placer {
@@ -402,9 +863,7 @@ impl Placer {
             spec,
             gp: 0,
             fp: 0,
-            // The callee's shadow space, when a row has one, sits at the base of
-            // the outgoing area ahead of the first stacked argument.
-            stack: u64::from(spec.shadow_space_bytes),
+            area: ArgumentArea::new(spec),
         }
     }
 
@@ -445,38 +904,37 @@ impl Placer {
         Some(first)
     }
 
-    /// Claim `size` bytes at `align` alignment in the outgoing argument area.
-    fn claim_stack(&mut self, size: u64, align: u64) -> (u32, u32, u32) {
-        let offset = align_up(self.stack, align);
-        self.stack = offset.saturating_add(size);
-        (
-            saturate_u32(offset),
-            saturate_u32(size),
-            saturate_u32(align),
-        )
-    }
-
-    /// The footprint a value of `natural_size` bytes claims in the outgoing
-    /// argument area.
+    /// Claim one register per eightbyte of `classes`, each from its own bank,
+    /// or `None` when either roster cannot hold its share.
     ///
-    /// Under [`StackedArgumentPacking::EightByteSlots`] every stacked argument
-    /// starts at the next 8-byte boundary and occupies whole eightbytes. Under
-    /// Apple's [`NaturalSize`](StackedArgumentPacking::NaturalSize) amendment a
-    /// stacked *scalar* occupies exactly its C width at its own alignment, so a
-    /// stacked `i8` takes one byte and an `i16` starts at the next even offset.
-    /// A composite keeps whole eightbytes at 8-byte alignment under every row:
-    /// it crosses through its eightbyte image, and a byte-exact copy needs
-    /// marshaling this path does not have. That one open Apple amendment is
-    /// recorded in `docs/notes/ffi-abi-conformance-audit.md`.
-    fn stack_extent(&self, natural_size: u64, scalar: bool) -> (u64, u64) {
-        match self.spec.stacked_argument_packing {
-            StackedArgumentPacking::NaturalSize if scalar => {
-                let bytes = natural_size.clamp(1, 8);
-                (bytes, bytes)
+    /// All-or-nothing spans both banks: a `{f64, i64}` argument with an SSE
+    /// register but no integer register left goes to memory entire and spends
+    /// neither.
+    fn claim_classified_registers(&mut self, classes: &EightbyteClasses) -> Option<RegisterPieces> {
+        for class in [CRegisterClass::Gp, CRegisterClass::Fp] {
+            let needed = classes.registers_in(class);
+            if self.used(class).saturating_add(needed) > self.spec.argument_registers(class) {
+                return None;
             }
-            StackedArgumentPacking::EightByteSlots | StackedArgumentPacking::NaturalSize => {
-                (u64::from(eightbytes(natural_size)).saturating_mul(8), 8)
-            }
+        }
+        let mut pieces = RegisterPieces::consecutive(CRegisterClass::Gp, 0, 0);
+        for eightbyte in classes.as_slice() {
+            let class = eightbyte.register_class();
+            let index = self.used(class);
+            self.consume(class, 1);
+            pieces.push(RegisterPiece { class, index });
+        }
+        Some(pieces)
+    }
+}
+
+impl ArgLocation {
+    /// A value in the outgoing argument area at `placement`.
+    fn stacked(placement: StackedPlacement) -> Self {
+        Self::Stack {
+            offset: placement.offset,
+            size: placement.size,
+            align: placement.align,
         }
     }
 }
@@ -552,7 +1010,7 @@ fn place_signature(
         convention: pairing,
         arguments,
         ret,
-        stack_bytes: saturate_u32(align_up(placer.stack, u64::from(spec.call_stack_alignment))),
+        stack_bytes: placer.area.reserved_bytes(),
     }
 }
 
@@ -560,41 +1018,74 @@ fn lower_argument(placer: &mut Placer, facts: CAbiTypeFacts) -> ArgLocation {
     match facts {
         CAbiTypeFacts::ZeroSized => ArgLocation::Omitted,
         CAbiTypeFacts::Scalar { kind, class } => {
-            if let Some(first_index) = placer.claim_registers(class, 1) {
+            if let Some(index) = placer.claim_registers(class, 1) {
                 return ArgLocation::Registers {
-                    class,
-                    first_index,
-                    count: 1,
+                    pieces: RegisterPieces::one(class, index),
                 };
             }
             let natural = u64::from(kind.extension().natural_bytes());
-            let (size, align) = placer.stack_extent(natural, true);
-            let (offset, size, align) = placer.claim_stack(size, align);
-            ArgLocation::Stack {
-                offset,
-                size,
-                align,
-            }
+            ArgLocation::stacked(placer.area.claim_scalar(natural))
         }
-        CAbiTypeFacts::Aggregate { size, align } => lower_aggregate_argument(placer, size, align),
+        CAbiTypeFacts::Aggregate {
+            size,
+            align,
+            leaves,
+        } => lower_aggregate_argument(placer, size, align, leaves),
     }
 }
 
-fn lower_aggregate_argument(placer: &mut Placer, size: u64, align: u64) -> ArgLocation {
+/// The homogeneous floating-point aggregate `size` bytes of `leaves` form, as a
+/// member count, or `None` when they do not form one.
+///
+/// AAPCS64 section 6.8.2 admits one to four members of one fundamental
+/// floating-point type. Requiring the members to fill the aggregate keeps a
+/// padded composite on the ordinary composite rule, where the psABI's "the
+/// same fundamental data type" reading is not in doubt.
+fn homogeneous_float_members(size: u64, leaves: AggregateLeaves) -> Option<u32> {
+    let (width, count) = leaves.homogeneous_floats()?;
+    (count <= 4 && u64::from(width) * u64::from(count) == size).then_some(count)
+}
+
+fn lower_aggregate_argument(
+    placer: &mut Placer,
+    size: u64,
+    align: u64,
+    leaves: AggregateLeaves,
+) -> ArgLocation {
     if size == 0 {
         return ArgLocation::Omitted;
     }
-    if size <= placer.spec.max_aggregate_register_bytes {
-        let classes = EightbyteClasses::all_integer(eightbytes(size));
-        let class = classes
-            .uniform_register_class()
-            .expect("an integer-only eightbyte classification names one bank");
-        if let Some(first_index) = placer.claim_registers(class, classes.len()) {
+    let aapcs = placer.spec.aggregate_rule == AggregateClassificationRule::Aapcs64Composite;
+    if aapcs && let Some(members) = homogeneous_float_members(size, leaves) {
+        // AAPCS64 rule C.3: a homogeneous floating-point aggregate travels in
+        // consecutive floating-point registers whatever its size, and when the
+        // roster cannot hold it the whole aggregate is stacked and the roster
+        // is exhausted, so no later argument takes a register it left free.
+        if let Some(first) = placer.claim_registers(CRegisterClass::Fp, members) {
             return ArgLocation::Registers {
-                class,
-                first_index,
-                count: classes.len(),
+                pieces: RegisterPieces::consecutive(CRegisterClass::Fp, first, members),
             };
+        }
+        placer.exhaust(CRegisterClass::Fp);
+        return ArgLocation::stacked(placer.area.claim_aggregate(size));
+    }
+
+    // SysV AMD64 section 3.2.3 makes an aggregate with an unaligned field
+    // MEMORY class outright, whatever its size.
+    let memory_by_alignment = !aapcs && leaves.has_unaligned_leaf();
+    if !memory_by_alignment && size <= placer.spec.max_aggregate_register_bytes {
+        let count = eightbytes(size);
+        // AAPCS64 passes a composite that is not a homogeneous floating-point
+        // aggregate in consecutive *integer* registers whatever its fields are
+        // (section 6.8.2 rules C.13 and C.14); only SysV classifies an
+        // aggregate's eightbytes by their leaves.
+        let classes = if aapcs {
+            EightbyteClasses::all_integer(count)
+        } else {
+            EightbyteClasses::classify(leaves, count)
+        };
+        if let Some(pieces) = placer.claim_classified_registers(&classes) {
+            return ArgLocation::Registers { pieces };
         }
         // Registers exhausted: the whole aggregate goes to memory, keeping its
         // eightbyte image contiguous. AAPCS64 rule C.11 additionally sets the
@@ -602,41 +1093,27 @@ fn lower_aggregate_argument(placer: &mut Placer, size: u64, align: u64) -> ArgLo
         // is stacked too even though a register may remain; SysV AMD64 has no
         // such rule and a later scalar still takes the register the aggregate
         // could not fit in.
-        if placer.spec.aggregate_rule == AggregateClassificationRule::Aapcs64Composite {
-            placer.exhaust(class);
+        if aapcs {
+            placer.exhaust(CRegisterClass::Gp);
         }
-        let (stack_size, stack_align) = placer.stack_extent(size, false);
-        let (offset, size, align) = placer.claim_stack(stack_size, stack_align);
-        return ArgLocation::Stack {
-            offset,
-            size,
-            align,
-        };
+        return ArgLocation::stacked(placer.area.claim_aggregate(size));
     }
 
     match placer.spec.aggregate_rule {
         AggregateClassificationRule::SysVEightbyte => {
             // MEMORY class: by value in the outgoing argument area, consuming
             // no register.
-            let (stack_size, stack_align) = placer.stack_extent(size, false);
-            let (offset, stack_size, stack_align) = placer.claim_stack(stack_size, stack_align);
             let _ = align;
-            ArgLocation::Stack {
-                offset,
-                size: stack_size,
-                align: stack_align,
-            }
+            ArgLocation::stacked(placer.area.claim_aggregate(size))
         }
         AggregateClassificationRule::Aapcs64Composite => {
             // One pointer to a caller-owned copy; the pointer itself is an
             // ordinary register-width argument and spills like one.
             let pointer = match placer.claim_registers(CRegisterClass::Gp, 1) {
                 Some(index) => PointerLocation::Register { index },
-                None => {
-                    let (slot_size, slot_align) = placer.stack_extent(8, true);
-                    let (offset, _, _) = placer.claim_stack(slot_size, slot_align);
-                    PointerLocation::Stack { offset }
-                }
+                None => PointerLocation::Stack {
+                    offset: placer.area.claim_scalar(8).offset,
+                },
             };
             ArgLocation::Indirect {
                 pointer,
@@ -655,16 +1132,40 @@ fn lower_return(spec: &CConventionSpec, result: CAbiTypeFacts) -> LoweredReturn 
             count: 1,
             extension: kind.extension(),
         },
-        CAbiTypeFacts::Aggregate { size, align } => {
+        CAbiTypeFacts::Aggregate {
+            size,
+            align,
+            leaves,
+        } => {
             if size == 0 {
                 return LoweredReturn::Void;
             }
-            if size <= spec.max_aggregate_register_bytes {
-                let classes = EightbyteClasses::all_integer(eightbytes(size));
+            let aapcs = spec.aggregate_rule == AggregateClassificationRule::Aapcs64Composite;
+            // AAPCS64 returns a homogeneous floating-point aggregate in
+            // consecutive floating-point result registers, one per member.
+            if aapcs
+                && let Some(members) = homogeneous_float_members(size, leaves)
+                && members <= spec.return_registers(CRegisterClass::Fp)
+            {
                 return LoweredReturn::Registers {
-                    class: classes
-                        .uniform_register_class()
-                        .expect("an integer-only eightbyte classification names one bank"),
+                    class: CRegisterClass::Fp,
+                    count: members,
+                    extension: ScalarAbiExtension::None,
+                };
+            }
+            let memory_by_alignment = !aapcs && leaves.has_unaligned_leaf();
+            if !memory_by_alignment && size <= spec.max_aggregate_register_bytes {
+                let count = eightbytes(size);
+                let classes = if aapcs {
+                    EightbyteClasses::all_integer(count)
+                } else {
+                    EightbyteClasses::classify(leaves, count)
+                };
+                return LoweredReturn::Registers {
+                    class: classes.uniform_register_class().expect(
+                        "a result split across register banks needs the per-piece \
+                         return locations RUE-2038 gives it",
+                    ),
                     count: classes.len(),
                     extension: ScalarAbiExtension::None,
                 };
@@ -704,16 +1205,50 @@ mod tests {
 
     fn aggregate(size: u64, align: u64) -> (CAbiTypeFacts, ArgConvention) {
         (
-            CAbiTypeFacts::Aggregate { size, align },
+            CAbiTypeFacts::integer_aggregate(size, align),
             ArgConvention::ByValue,
         )
     }
 
+    /// An aggregate whose leaves are exactly `leaves`, sized to cover them.
+    fn leafy(leaves: &[CAbiLeaf]) -> (CAbiTypeFacts, ArgConvention) {
+        (leafy_facts(leaves), ArgConvention::ByValue)
+    }
+
+    fn leafy_facts(leaves: &[CAbiLeaf]) -> CAbiTypeFacts {
+        let size = leaves
+            .iter()
+            .map(|leaf| leaf.offset + leaf.width)
+            .max()
+            .unwrap_or(0);
+        let align = leaves.iter().map(|leaf| leaf.width).max().unwrap_or(1);
+        CAbiTypeFacts::Aggregate {
+            size,
+            align,
+            leaves: AggregateLeaves::from_leaves(size, leaves.iter().copied()),
+        }
+    }
+
     fn registers(first_index: u32, count: u32) -> ArgLocation {
         ArgLocation::Registers {
-            class: CRegisterClass::Gp,
-            first_index,
-            count,
+            pieces: RegisterPieces::consecutive(CRegisterClass::Gp, first_index, count),
+        }
+    }
+
+    fn fp_registers(first_index: u32, count: u32) -> ArgLocation {
+        ArgLocation::Registers {
+            pieces: RegisterPieces::consecutive(CRegisterClass::Fp, first_index, count),
+        }
+    }
+
+    fn pieces(location: ArgLocation) -> Vec<(CRegisterClass, u32)> {
+        match location {
+            ArgLocation::Registers { pieces } => pieces
+                .as_slice()
+                .iter()
+                .map(|piece| (piece.class, piece.index))
+                .collect(),
+            other => panic!("expected registers, got {other:?}"),
         }
     }
 
@@ -937,7 +1472,7 @@ mod tests {
 
     #[test]
     fn a_sysv_sret_pointer_shifts_user_arguments_and_aapcs64_does_not() {
-        let big = CAbiTypeFacts::Aggregate { size: 24, align: 8 };
+        let big = CAbiTypeFacts::integer_aggregate(24, 8);
         let sysv = lower_c_signature(SYSV, &[word(), word()], big);
         assert_eq!(
             sysv.ret(),
@@ -985,8 +1520,7 @@ mod tests {
             }
         );
         for (size, count) in [(1_u64, 1_u32), (8, 1), (9, 2), (16, 2)] {
-            let signature =
-                lower_c_signature(SYSV, &[], CAbiTypeFacts::Aggregate { size, align: 8 });
+            let signature = lower_c_signature(SYSV, &[], CAbiTypeFacts::integer_aggregate(size, 8));
             assert_eq!(
                 signature.ret(),
                 LoweredReturn::Registers {
@@ -1007,10 +1541,7 @@ mod tests {
         let signature = lower_c_signature(
             SYSV,
             &[(
-                CAbiTypeFacts::Aggregate {
-                    size: 4096,
-                    align: 8,
-                },
+                CAbiTypeFacts::integer_aggregate(4096, 8),
                 ArgConvention::ByReference,
             )],
             CAbiTypeFacts::ZeroSized,
@@ -1033,7 +1564,293 @@ mod tests {
             Some(CRegisterClass::Gp),
             "an integer-only classification names the general-purpose bank"
         );
+        assert_eq!(classes.registers_in(CRegisterClass::Gp), 2);
+        assert_eq!(classes.registers_in(CRegisterClass::Fp), 0);
         assert_eq!(EightbyteClass::Sse.register_class(), CRegisterClass::Fp);
+    }
+
+    #[test]
+    fn an_eightbyte_is_sse_only_when_every_leaf_over_it_is_a_float() {
+        let mixed = AggregateLeaves::from_leaves(16, [CAbiLeaf::f64(0), CAbiLeaf::integer(8, 8)]);
+        assert_eq!(mixed.eightbyte_class(0), EightbyteClass::Sse);
+        assert_eq!(mixed.eightbyte_class(1), EightbyteClass::Integer);
+        assert_eq!(mixed.homogeneous_floats(), None);
+
+        // Two `f32`s share one eightbyte and leave it SSE; a narrow integer
+        // beside one of them pulls that eightbyte into the integer bank.
+        let packed = AggregateLeaves::from_leaves(8, [CAbiLeaf::f32(0), CAbiLeaf::f32(4)]);
+        assert_eq!(packed.eightbyte_class(0), EightbyteClass::Sse);
+        assert_eq!(packed.homogeneous_floats(), Some((4, 2)));
+        let contaminated =
+            AggregateLeaves::from_leaves(8, [CAbiLeaf::f32(0), CAbiLeaf::integer(4, 4)]);
+        assert_eq!(contaminated.eightbyte_class(0), EightbyteClass::Integer);
+        assert_eq!(contaminated.homogeneous_floats(), None);
+
+        // An eightbyte no leaf reaches stays in the integer bank, and so does
+        // every eightbyte of an aggregate whose leaves a plane did not
+        // enumerate.
+        assert_eq!(
+            AggregateLeaves::all_integer(16).eightbyte_class(1),
+            EightbyteClass::Integer
+        );
+        assert_eq!(
+            AggregateLeaves::from_leaves(16, []).eightbyte_class(0),
+            EightbyteClass::Integer
+        );
+        assert!(!AggregateLeaves::all_integer(16).has_unaligned_leaf());
+        assert!(
+            AggregateLeaves::from_leaves(16, [CAbiLeaf::integer(3, 4)]).has_unaligned_leaf(),
+            "a leaf its own width does not divide is unaligned"
+        );
+    }
+
+    #[test]
+    fn a_two_eightbyte_struct_splits_across_banks_on_sysv_and_not_on_aapcs64() {
+        for leaves in [
+            [CAbiLeaf::f64(0), CAbiLeaf::integer(8, 8)],
+            [CAbiLeaf::integer(0, 8), CAbiLeaf::f64(8)],
+        ] {
+            let argument = leafy(&leaves);
+            let sysv = lower_c_signature(SYSV, &[argument], CAbiTypeFacts::ZeroSized);
+            let expected = leaves
+                .iter()
+                .map(|leaf| match leaf.kind {
+                    CAbiLeafKind::Integer => (CRegisterClass::Gp, 0),
+                    _ => (CRegisterClass::Fp, 0),
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                pieces(sysv.arguments()[0].location),
+                expected,
+                "SysV classifies each eightbyte by its own leaves"
+            );
+            for convention in [AAPCS, DARWIN] {
+                let aapcs = lower_c_signature(convention, &[argument], CAbiTypeFacts::ZeroSized);
+                assert_eq!(
+                    aapcs.arguments()[0].location,
+                    registers(0, 2),
+                    "{convention}: a composite that is not an HFA travels in \
+                     integer registers"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_float_pair_is_one_sse_eightbyte_on_sysv_and_a_two_member_hfa_on_aapcs64() {
+        let argument = leafy(&[CAbiLeaf::f32(0), CAbiLeaf::f32(4)]);
+        let sysv = lower_c_signature(SYSV, &[argument], CAbiTypeFacts::ZeroSized);
+        assert_eq!(sysv.arguments()[0].location, fp_registers(0, 1));
+        for convention in [AAPCS, DARWIN] {
+            let aapcs = lower_c_signature(convention, &[argument], CAbiTypeFacts::ZeroSized);
+            assert_eq!(aapcs.arguments()[0].location, fp_registers(0, 2));
+        }
+    }
+
+    #[test]
+    fn three_doubles_are_an_aapcs64_hfa_and_sysv_memory() {
+        let argument = leafy(&[CAbiLeaf::f64(0), CAbiLeaf::f64(8), CAbiLeaf::f64(16)]);
+        let sysv = lower_c_signature(SYSV, &[argument], CAbiTypeFacts::ZeroSized);
+        assert_eq!(
+            sysv.arguments()[0].location,
+            ArgLocation::Stack {
+                offset: 0,
+                size: 24,
+                align: 8
+            },
+            "24 bytes exceeds the two-eightbyte register budget: MEMORY class"
+        );
+        for convention in [AAPCS, DARWIN] {
+            let aapcs = lower_c_signature(convention, &[argument], CAbiTypeFacts::ZeroSized);
+            assert_eq!(
+                aapcs.arguments()[0].location,
+                fp_registers(0, 3),
+                "{convention}: rule C.3 takes an HFA in registers past 16 bytes"
+            );
+        }
+        // Five members are not an HFA: over four, the ordinary composite rule
+        // applies and 40 bytes is a by-reference copy.
+        let five = leafy(&[
+            CAbiLeaf::f64(0),
+            CAbiLeaf::f64(8),
+            CAbiLeaf::f64(16),
+            CAbiLeaf::f64(24),
+            CAbiLeaf::f64(32),
+        ]);
+        assert_eq!(
+            lower_c_signature(AAPCS, &[five], CAbiTypeFacts::ZeroSized).arguments()[0].location,
+            ArgLocation::Indirect {
+                pointer: PointerLocation::Register { index: 0 },
+                size: 40,
+                align: 8
+            }
+        );
+    }
+
+    #[test]
+    fn an_hfa_that_does_not_fit_exhausts_the_floating_point_roster() {
+        // Six single-`f64` arguments leave two floating-point registers; a
+        // three-member HFA cannot fit, so it stacks entire and rule C.3
+        // exhausts the roster: the single float after it stacks too, rather
+        // than taking a register the HFA left free.
+        let one = leafy(&[CAbiLeaf::f64(0)]);
+        let three = leafy(&[CAbiLeaf::f64(0), CAbiLeaf::f64(8), CAbiLeaf::f64(16)]);
+        let mut params = vec![one; 6];
+        params.push(three);
+        params.push(one);
+        let signature = lower_c_signature(AAPCS, &params, CAbiTypeFacts::ZeroSized);
+        assert_eq!(signature.arguments()[5].location, fp_registers(5, 1));
+        assert_eq!(
+            signature.arguments()[6].location,
+            ArgLocation::Stack {
+                offset: 0,
+                size: 24,
+                align: 8
+            }
+        );
+        assert_eq!(
+            signature.arguments()[7].location,
+            ArgLocation::Stack {
+                offset: 24,
+                size: 8,
+                align: 8
+            }
+        );
+        assert_eq!(signature.stack_bytes(), 32);
+    }
+
+    #[test]
+    fn a_split_aggregate_takes_both_banks_or_neither() {
+        // SysV: five integer words and eight doubles leave one integer
+        // register and no SSE register, so a `{f64, i64}` argument goes to
+        // memory entire and spends neither bank; the integer word after it
+        // still takes the register it left.
+        let split = leafy(&[CAbiLeaf::f64(0), CAbiLeaf::integer(8, 8)]);
+        let one = leafy(&[CAbiLeaf::f64(0)]);
+        let mut params = vec![word(); 5];
+        params.extend(vec![one; 8]);
+        params.push(split);
+        params.push(word());
+        let signature = lower_c_signature(SYSV, &params, CAbiTypeFacts::ZeroSized);
+        assert_eq!(
+            signature.arguments()[13].location,
+            ArgLocation::Stack {
+                offset: 0,
+                size: 16,
+                align: 8
+            }
+        );
+        assert_eq!(signature.arguments()[14].location, registers(5, 1));
+    }
+
+    #[test]
+    fn a_native_signature_places_floats_by_its_targets_row() {
+        // The native convention is the one caller that has floats to place, and
+        // it places them by exactly the rules above.
+        let pair = leafy(&[CAbiLeaf::f32(0), CAbiLeaf::f32(4)]);
+        let sysv = lower_native_signature(
+            ConventionSpec::native(Target::X86_64Linux),
+            &[pair],
+            LoweredReturn::Void,
+        );
+        assert_eq!(sysv.arguments()[0].location, fp_registers(0, 1));
+        for target in [Target::Aarch64Linux, Target::Aarch64Macos] {
+            let native = lower_native_signature(
+                ConventionSpec::native(target),
+                &[pair],
+                LoweredReturn::Void,
+            );
+            assert_eq!(native.arguments()[0].location, fp_registers(0, 2));
+        }
+    }
+
+    #[test]
+    fn a_returned_aggregate_classifies_by_the_same_leaves() {
+        // The return path reads the same facts: an SSE eightbyte returns in the
+        // floating-point bank, and AAPCS64 returns an HFA one register per
+        // member.
+        let pair = leafy_facts(&[CAbiLeaf::f32(0), CAbiLeaf::f32(4)]);
+        assert_eq!(
+            lower_c_signature(SYSV, &[], pair).ret(),
+            LoweredReturn::Registers {
+                class: CRegisterClass::Fp,
+                count: 1,
+                extension: ScalarAbiExtension::None
+            }
+        );
+        assert_eq!(
+            lower_c_signature(AAPCS, &[], pair).ret(),
+            LoweredReturn::Registers {
+                class: CRegisterClass::Fp,
+                count: 2,
+                extension: ScalarAbiExtension::None
+            }
+        );
+        let three = leafy_facts(&[CAbiLeaf::f64(0), CAbiLeaf::f64(8), CAbiLeaf::f64(16)]);
+        assert_eq!(
+            lower_c_signature(AAPCS, &[], three).ret(),
+            LoweredReturn::Registers {
+                class: CRegisterClass::Fp,
+                count: 3,
+                extension: ScalarAbiExtension::None
+            }
+        );
+        assert!(
+            lower_c_signature(SYSV, &[], three).ret().uses_sret(),
+            "24 bytes exceeds SysV's two-eightbyte result budget"
+        );
+    }
+
+    #[test]
+    fn the_argument_area_packs_by_its_rows_rule_and_agrees_on_whole_eightbytes() {
+        // The Apple row packs a stacked scalar at its own width; the other rows
+        // give it a whole eightbyte. The rows therefore differ only for a
+        // value narrower than eight bytes, which is why a native ABI slot —
+        // canonically 64-bit-extended, so eight bytes wide — lands in the same
+        // place on every row.
+        let narrow = |target: Target| {
+            let mut area = ArgumentArea::new(ConventionSpec::native(target).spec());
+            let first = area.claim_scalar(1);
+            let second = area.claim_scalar(2);
+            (first, second, area.reserved_bytes())
+        };
+        let whole = |target: Target| {
+            let mut area = ArgumentArea::new(ConventionSpec::native(target).spec());
+            let first = area.claim_scalar(8);
+            let second = area.claim_scalar(8);
+            (first, second, area.reserved_bytes())
+        };
+        let slot = |offset: u32| StackedPlacement {
+            offset,
+            size: 8,
+            align: 8,
+        };
+        for target in [Target::X86_64Linux, Target::Aarch64Linux] {
+            assert_eq!(narrow(target), (slot(0), slot(8), 16));
+        }
+        assert_eq!(
+            narrow(Target::Aarch64Macos),
+            (
+                StackedPlacement {
+                    offset: 0,
+                    size: 1,
+                    align: 1
+                },
+                StackedPlacement {
+                    offset: 2,
+                    size: 2,
+                    align: 2
+                },
+                16
+            )
+        );
+        for target in Target::all() {
+            assert_eq!(
+                whole(*target),
+                (slot(0), slot(8), 16),
+                "{target:?}: an eight-byte value is packed the same by every row"
+            );
+        }
     }
 
     #[test]
@@ -1045,10 +1862,7 @@ mod tests {
         let signature = lower_c_signature(
             SYSV,
             &[aggregate(huge, 8)],
-            CAbiTypeFacts::Aggregate {
-                size: huge,
-                align: 8,
-            },
+            CAbiTypeFacts::integer_aggregate(huge, 8),
         );
         assert_eq!(
             signature.arguments()[0].location,
@@ -1142,7 +1956,7 @@ mod tests {
         let c = lower_c_signature(
             CallingConvention::Aarch64Aapcs,
             &[word(), word()],
-            CAbiTypeFacts::Aggregate { size: 64, align: 8 },
+            CAbiTypeFacts::integer_aggregate(64, 8),
         );
         assert!(!c.sret_in_argument_register());
         assert_eq!(c.arguments()[0].location, registers(0, 1));

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -43,6 +43,22 @@ pub(super) const FP_ARG_REGS: [Reg; 8] = [
     Reg::V7,
 ];
 
+/// The physical register a foreign call's classified register piece names.
+///
+/// A foreign argument is marshaled through its compact memory image, whose
+/// pieces are whole eightbytes in general-purpose vregs, so a floating-point
+/// piece has no value to move: the C boundary rejects `f32`/`f64`
+/// (`c_passable_by_value`), which is what keeps every piece integer-classed.
+fn foreign_argument_register(class: rue_target::CRegisterClass, index: u32) -> Reg {
+    assert_eq!(
+        class,
+        rue_target::CRegisterClass::Gp,
+        "a foreign argument crosses through its eightbyte image in the \
+         general-purpose bank"
+    );
+    ARG_REGS[index as usize]
+}
+
 /// Return value registers for the internal Rue convention (AAPCS64 only
 /// defines x0/x1; we extend with the remaining arg registers for multi-slot
 /// aggregate returns). Aggregates with more slots than this — and builtin
@@ -139,6 +155,10 @@ pub struct CfgLower<'a> {
 impl crate::call_plan::CallMaterializer for CfgLower<'_> {
     fn target_c_convention(&self) -> rue_target::CallingConvention {
         self.target.c_calling_convention()
+    }
+
+    fn native_convention(&self) -> rue_target::ConventionSpec {
+        rue_target::ConventionSpec::native(self.target)
     }
 
     fn materialize_scalar(&mut self, value: CfgValue) -> VReg {
@@ -598,6 +618,7 @@ impl<'a> CfgLower<'a> {
         let plan = crate::call_plan::CallPlan::from_slot_values(
             crate::call_plan::CallTarget::rue(symbol),
             arg_vregs,
+            rue_target::ConventionSpec::native(self.target),
             crate::call_plan::AbiRegisterBanks {
                 gp: ARG_REGS.len(),
                 fp: FP_ARG_REGS.len(),
@@ -1022,10 +1043,10 @@ impl<'a> CfgLower<'a> {
             .zip(&plan.abi_classes)
             .zip(&plan.abi_locations)
         {
-            let crate::call_plan::AbiSlotLocation::Stack(index) = location else {
+            let crate::call_plan::AbiSlotLocation::Stack { offset, .. } = location else {
                 continue;
             };
-            let offset = checked_cell_byte_offset(*index as u64)
+            let offset = checked_displacement_bytes(u64::from(*offset))
                 .expect("call stack slot offset must fit displacement");
             if let crate::call_plan::AbiSlotClass::Fp(width) = class {
                 self.mir.push(Aarch64Inst::FloatStore {
@@ -4107,11 +4128,14 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         }
     }
 
-    fn foreign_emit_register_args(&mut self, int_ops: &[VReg]) {
-        for (index, v) in int_ops.iter().enumerate() {
+    fn foreign_emit_register_args(
+        &mut self,
+        register_args: &[crate::foreign_call::ForeignRegisterArg],
+    ) {
+        for arg in register_args {
             self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Physical(ARG_REGS[index]),
-                src: Operand::Virtual(*v),
+                dst: Operand::Physical(foreign_argument_register(arg.class, arg.index)),
+                src: Operand::Virtual(arg.value),
             });
         }
     }
@@ -4778,6 +4802,12 @@ mod tests {
     use rue_cfg::{CfgArgMode, CfgCallArg, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_span::{FileId, Span};
 
+    /// The convention a test's parameter-storage plan places by: this
+    /// backend's own target, whose native pairing decides how the incoming
+    /// argument area is packed.
+    const PLAN_CONVENTION: rue_target::ConventionSpec =
+        rue_target::ConventionSpec::native(rue_target::Target::Aarch64Linux);
+
     #[test]
     fn zero32_consumers_use_canonical_uxtw_not_shift_pair() {
         let source = include_str!("cfg_lower.rs");
@@ -5157,6 +5187,7 @@ mod tests {
                 &cfg,
                 self.pool,
                 false,
+                PLAN_CONVENTION,
                 ARG_REGS.len() as u32,
             );
             CfgLower::new(&cfg, self.pool, self.interner, Target::Aarch64Linux)
@@ -6943,6 +6974,7 @@ mod tests {
                 size: 8,
                 align: 8,
                 storage_bytes: 16,
+                leaves: rue_air::AggregateLeaves::all_integer(8),
             },
         }];
         args.extend((1..8).map(|index| ForeignArg::Scalar {

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -570,7 +570,9 @@ impl<'a> Emitter<'a> {
                     location: if (slot + abi_shift) < 8 {
                         crate::call_plan::AbiSlotLocation::GpReg((slot + abi_shift) as usize)
                     } else {
-                        crate::call_plan::AbiSlotLocation::Stack((slot + abi_shift - 8) as usize)
+                        crate::call_plan::AbiSlotLocation::stack_slot(
+                            (slot + abi_shift - 8) as usize,
+                        )
                     },
                 })
                 .collect()
@@ -970,16 +972,11 @@ impl<'a> Emitter<'a> {
                         offset
                     );
                 }
-                (_, crate::call_plan::AbiSlotLocation::Stack(stack_index)) => {
+                (_, crate::call_plan::AbiSlotLocation::Stack { offset: area, .. }) => {
                     // Stack-passed arg: copy from above the frame into the param area
-                    let src_offset = crate::frame_layout::checked_incoming_stack_arg_offset(
-                        16,
-                        u32::try_from(param_regs.len() + stack_index)
-                            .expect("ABI index must fit u32"),
-                        u32::try_from(param_regs.len())
-                            .expect("argument register count must fit u32"),
-                    )
-                    .expect("incoming stack argument offset must fit displacement");
+                    let src_offset =
+                        crate::frame_layout::checked_incoming_stack_arg_byte_offset(16, area)
+                            .expect("incoming stack argument offset must fit displacement");
                     self.begin_inst();
                     self.emit_ldr(Reg::X9, Reg::Fp, src_offset);
                     end_inst!(self, "ldr x9, [x29, #{}]", src_offset);
@@ -3605,7 +3602,7 @@ mod tests {
             .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                 start_slot: 0,
                 class: crate::call_plan::AbiSlotClass::Gp,
-                location: crate::call_plan::AbiSlotLocation::Stack(0),
+                location: crate::call_plan::AbiSlotLocation::stack_slot(0),
             }])
             .emit_all()
             .expect("stack argument homing must emit");

--- a/crates/rue-codegen/src/abi_report.rs
+++ b/crates/rue-codegen/src/abi_report.rs
@@ -221,14 +221,12 @@ impl From<ArgLocation> for CPlacement {
     fn from(location: ArgLocation) -> Self {
         match location {
             ArgLocation::Omitted => Self::Omitted,
-            ArgLocation::Registers {
-                class,
-                first_index,
-                count,
-            } => Self::Registers {
-                class,
-                first: first_index,
-                count,
+            ArgLocation::Registers { pieces } => Self::Registers {
+                class: pieces.uniform_class().expect(
+                    "a C argument's registers are one bank while the boundary rejects floats",
+                ),
+                first: pieces.first_index().unwrap_or(0),
+                count: pieces.len(),
             },
             ArgLocation::Stack {
                 offset,
@@ -499,7 +497,11 @@ fn native_side(
                 .map(AbiSlotClass::from),
         );
     }
-    let locations = assign_abi_slots(classes.iter().copied(), registers.argument_banks());
+    let locations = assign_abi_slots(
+        rue_target::ConventionSpec::native(target),
+        classes.iter().copied(),
+        registers.argument_banks(),
+    );
 
     // Two recoveries, because a body records the two parameter kinds
     // differently: a by-value parameter through its drop entry or `Param`
@@ -872,7 +874,11 @@ fn native_slot_text(registers: TargetRegisters, location: AbiSlotLocation) -> St
             1,
             "register",
         ),
-        AbiSlotLocation::Stack(index) => format!("stack slot {index}"),
+        AbiSlotLocation::Stack {
+            offset,
+            size,
+            align,
+        } => format!("stack +{offset} ({}, align {align})", bytes(size)),
     }
 }
 
@@ -1272,7 +1278,7 @@ mod tests {
                     },
                     NativeSlot {
                         logical: 0,
-                        location: AbiSlotLocation::Stack(0),
+                        location: AbiSlotLocation::stack_slot(0),
                     },
                 ],
                 reversed: true,
@@ -1284,7 +1290,7 @@ mod tests {
             [
                 "slot 2: gp register 0 (rdi)",
                 "slot 1: gp register 1 (rsi)",
-                "slot 0: stack slot 0",
+                "slot 0: stack +0 (8 bytes, align 8)",
             ]
         );
     }

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -10,7 +10,7 @@ use rue_air::{ArgClass, ArgConvention, FrozenTypeInternPool, NativeCallAbi, Retu
 // stays visible to readers of the field; no direct import is needed.
 use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, Type};
 use rue_runtime_abi::{ReservedExportClass, ReservedExportId};
-use rue_target::CallingConvention;
+use rue_target::{CallingConvention, ConventionSpec};
 
 use crate::types;
 use crate::vreg::VReg;
@@ -185,47 +185,90 @@ impl From<rue_air::NativeArgClass> for AbiSlotClass {
     }
 }
 
+/// Where one native ABI slot travels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AbiSlotLocation {
+    /// Argument register `index` of the general-purpose bank.
     GpReg(usize),
+    /// Argument register `index` of the floating-point bank.
     FpReg(usize),
-    Stack(usize),
+    /// In the outgoing argument area: `size` bytes at `offset`, whose
+    /// alignment the placement already satisfied — the same description a
+    /// stacked C argument carries (`rue_air::ArgLocation::Stack`).
+    Stack { offset: u32, size: u32, align: u32 },
 }
 
+impl AbiSlotLocation {
+    /// The `index`-th eight-byte slot of the outgoing argument area.
+    ///
+    /// A native ABI slot carries a canonically 64-bit-extended value
+    /// (ADR-0084), so it occupies one whole eightbyte at eight-byte alignment
+    /// under every supported row's stacked-argument packing — Apple's
+    /// natural-size amendment included, since eight bytes *is* the slot's
+    /// natural size. That is what lets a caller holding only a slot index name
+    /// the same place [`assign_abi_slots`] gives it.
+    pub const fn stack_slot(index: usize) -> Self {
+        Self::Stack {
+            offset: (index * rue_air::SLOT_BYTES as usize) as u32,
+            size: rue_air::SLOT_BYTES as u32,
+            align: rue_air::SLOT_BYTES as u32,
+        }
+    }
+}
+
+/// Assign every native ABI slot to a register of its bank, or to the outgoing
+/// argument area once that bank's roster is spent.
+///
+/// `banks` is the roster this assignment draws on — the argument banks for a
+/// call or a prologue, the wider return banks for
+/// [`return_slot_regs`] — and `convention` is the convention whose
+/// argument-area packing the stacked slots follow, claimed through the one
+/// cursor every stacked placement in the tree claims through
+/// (`rue_air::ArgumentArea`).
 pub fn assign_abi_slots(
+    convention: ConventionSpec,
     classes: impl IntoIterator<Item = AbiSlotClass>,
     banks: AbiRegisterBanks,
 ) -> Vec<AbiSlotLocation> {
-    let mut gp = 0usize;
-    let mut fp = 0usize;
-    let mut stack = 0usize;
-    classes
-        .into_iter()
-        .map(|class| match class {
-            AbiSlotClass::Gp if gp < banks.gp => {
-                let index = gp;
-                gp += 1;
-                AbiSlotLocation::GpReg(index)
-            }
-            AbiSlotClass::Fp(_) if fp < banks.fp => {
-                let index = fp;
-                fp += 1;
-                AbiSlotLocation::FpReg(index)
-            }
-            AbiSlotClass::Gp => {
-                gp += 1;
-                let index = stack;
-                stack += 1;
-                AbiSlotLocation::Stack(index)
-            }
-            AbiSlotClass::Fp(_) => {
-                fp += 1;
-                let index = stack;
-                stack += 1;
-                AbiSlotLocation::Stack(index)
-            }
+    // A native ABI slot carries a canonically 64-bit-extended value, so every
+    // slot the roster cannot hold claims one whole eightbyte from the
+    // convention's own argument area.
+    let mut area = rue_air::ArgumentArea::new(convention.spec());
+    claim_bank_registers(classes, banks)
+        .map(|assigned| {
+            assigned.unwrap_or_else(|| {
+                let placement = area.claim_scalar(rue_air::SLOT_BYTES);
+                AbiSlotLocation::Stack {
+                    offset: placement.offset,
+                    size: placement.size,
+                    align: placement.align,
+                }
+            })
         })
         .collect()
+}
+
+/// Assign each slot class a register of its own bank, in order, or `None` once
+/// that bank's roster is spent. A spent roster still counts the slot, so the
+/// banks stay independent of each other.
+fn claim_bank_registers(
+    classes: impl IntoIterator<Item = AbiSlotClass>,
+    banks: AbiRegisterBanks,
+) -> impl Iterator<Item = Option<AbiSlotLocation>> {
+    let mut gp = 0usize;
+    let mut fp = 0usize;
+    classes.into_iter().map(move |class| match class {
+        AbiSlotClass::Gp => {
+            let index = gp;
+            gp += 1;
+            (index < banks.gp).then_some(AbiSlotLocation::GpReg(index))
+        }
+        AbiSlotClass::Fp(_) => {
+            let index = fp;
+            fp += 1;
+            (index < banks.fp).then_some(AbiSlotLocation::FpReg(index))
+        }
+    })
 }
 
 /// Where one logical slot of a REGISTER-RETURNED aggregate travels.
@@ -274,12 +317,14 @@ pub fn return_slot_regs(
     banks: AbiRegisterBanks,
 ) -> Vec<ReturnSlotReg> {
     let classes = aggregate_slot_classes(type_pool, ty);
-    assign_abi_slots(classes.iter().copied(), banks)
-        .into_iter()
+    // A result has no argument area to overflow into, so the bank assignment
+    // is the whole answer and a slot that does not fit is a classification
+    // error rather than a stacked slot.
+    claim_bank_registers(classes.clone(), banks)
         .zip(classes)
         .map(|(location, class)| match (location, class) {
-            (AbiSlotLocation::GpReg(index), _) => ReturnSlotReg::Gp(index),
-            (AbiSlotLocation::FpReg(index), AbiSlotClass::Fp(width)) => {
+            (Some(AbiSlotLocation::GpReg(index)), _) => ReturnSlotReg::Gp(index),
+            (Some(AbiSlotLocation::FpReg(index)), AbiSlotClass::Fp(width)) => {
                 ReturnSlotReg::Fp { index, width }
             }
             _ => panic!("a register-returned aggregate slot must fit a return register bank"),
@@ -568,6 +613,12 @@ pub trait CallMaterializer {
     /// comes from the target rather than the architecture, so AArch64 Linux and
     /// AArch64 macOS answer differently.
     fn target_c_convention(&self) -> CallingConvention;
+
+    /// The native convention on this backend's compilation target, paired with
+    /// the description it places by: the target's own C description with the
+    /// native amendments (`ConventionSpec::native`). It is what decides how the
+    /// outgoing argument area is packed once the register rosters are spent.
+    fn native_convention(&self) -> ConventionSpec;
     fn materialize_scalar(&mut self, value: rue_cfg::CfgValue) -> VReg;
     fn materialize_aggregate(&mut self, value: rue_cfg::CfgValue) -> Vec<VReg>;
     fn materialize_by_ref(&mut self, plan: &crate::value_plan::ByRefAddressPlan) -> VReg;
@@ -757,8 +808,11 @@ impl CallPlan {
             abi_classes.len(),
             "call ABI slots and classes must have equal cardinality"
         );
-        let abi_locations =
-            assign_abi_slots(abi_classes.iter().copied(), arg_register_banks.into());
+        let abi_locations = assign_abi_slots(
+            materializer.native_convention(),
+            abi_classes.iter().copied(),
+            arg_register_banks.into(),
+        );
         assert_eq!(
             abi_slots.len(),
             abi_locations.len(),
@@ -766,7 +820,7 @@ impl CallPlan {
         );
         let stack_slot_count = abi_locations
             .iter()
-            .filter(|location| matches!(location, AbiSlotLocation::Stack(_)))
+            .filter(|location| matches!(location, AbiSlotLocation::Stack { .. }))
             .count();
         let stack_bytes = checked_aligned_cell_region_bytes(
             u64::try_from(stack_slot_count).expect("call stack slot count must fit u64"),
@@ -800,15 +854,19 @@ impl CallPlan {
     pub fn from_slot_values(
         target: CallTarget,
         slots: &[VReg],
+        native_convention: ConventionSpec,
         arg_register_banks: impl Into<AbiRegisterBanks>,
         c_convention: CallingConvention,
     ) -> Self {
         let abi_classes = vec![AbiSlotClass::Gp; slots.len()];
-        let abi_locations =
-            assign_abi_slots(abi_classes.iter().copied(), arg_register_banks.into());
+        let abi_locations = assign_abi_slots(
+            native_convention,
+            abi_classes.iter().copied(),
+            arg_register_banks.into(),
+        );
         let stack_slot_count = abi_locations
             .iter()
-            .filter(|location| matches!(location, AbiSlotLocation::Stack(_)))
+            .filter(|location| matches!(location, AbiSlotLocation::Stack { .. }))
             .count();
         Self {
             callee_convention: callee_convention(&target, c_convention),
@@ -863,6 +921,10 @@ mod tests {
     struct TestMaterializer;
 
     impl CallMaterializer for TestMaterializer {
+        fn native_convention(&self) -> ConventionSpec {
+            ConventionSpec::native(rue_target::Target::X86_64Linux)
+        }
+
         fn target_c_convention(&self) -> CallingConvention {
             CallingConvention::X86_64SysV
         }
@@ -967,6 +1029,7 @@ mod tests {
         let plan = CallPlan::from_slot_values(
             CallTarget::rue("drop"),
             &slots,
+            ConventionSpec::native(rue_target::Target::X86_64Linux),
             6,
             CallingConvention::X86_64SysV,
         );
@@ -988,16 +1051,46 @@ mod tests {
             AbiSlotClass::Fp(crate::value_plan::FloatWidth::F32),
         ];
         assert_eq!(
-            assign_abi_slots(classes, AbiRegisterBanks { gp: 2, fp: 2 }),
+            assign_abi_slots(
+                ConventionSpec::native(rue_target::Target::X86_64Linux),
+                classes,
+                AbiRegisterBanks { gp: 2, fp: 2 }
+            ),
             vec![
                 AbiSlotLocation::FpReg(0),
                 AbiSlotLocation::GpReg(0),
                 AbiSlotLocation::GpReg(1),
                 AbiSlotLocation::FpReg(1),
-                AbiSlotLocation::Stack(0),
-                AbiSlotLocation::Stack(1),
+                AbiSlotLocation::stack_slot(0),
+                AbiSlotLocation::stack_slot(1),
             ]
         );
+    }
+
+    #[test]
+    fn every_row_places_a_native_stack_slot_in_whole_ascending_eightbytes() {
+        // A native ABI slot carries a canonically 64-bit-extended value, so it
+        // claims one whole eightbyte from its convention's argument area —
+        // under Apple's natural-size packing as much as under the eight-byte
+        // slot rows, because eight bytes is the slot's natural size.
+        let classes = [AbiSlotClass::Gp; 4];
+        for target in rue_target::Target::all() {
+            let locations = assign_abi_slots(
+                ConventionSpec::native(*target),
+                classes,
+                AbiRegisterBanks { gp: 1, fp: 0 },
+            );
+            assert_eq!(
+                locations,
+                vec![
+                    AbiSlotLocation::GpReg(0),
+                    AbiSlotLocation::stack_slot(0),
+                    AbiSlotLocation::stack_slot(1),
+                    AbiSlotLocation::stack_slot(2),
+                ],
+                "{target:?}: native stack slots are whole ascending eightbytes"
+            );
+        }
     }
 
     #[test]
@@ -1080,9 +1173,9 @@ mod tests {
                 AbiSlotLocation::GpReg(3),
                 AbiSlotLocation::GpReg(4),
                 AbiSlotLocation::GpReg(5),
-                AbiSlotLocation::Stack(0),
-                AbiSlotLocation::Stack(1),
-                AbiSlotLocation::Stack(2),
+                AbiSlotLocation::stack_slot(0),
+                AbiSlotLocation::stack_slot(1),
+                AbiSlotLocation::stack_slot(2),
             ]
         );
         assert_eq!(plan.stack_slot_count, 3);

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -215,6 +215,7 @@ pub(crate) fn prepare_mir_with_backend<B: crate::backend::Backend>(
         cfg,
         type_pool,
         has_sret,
+        rue_target::ConventionSpec::native(target),
         crate::call_plan::AbiRegisterBanks {
             gp: B::ARG_REG_COUNT as usize,
             fp: B::FP_ARG_REG_COUNT as usize,

--- a/crates/rue-codegen/src/export_thunk.rs
+++ b/crates/rue-codegen/src/export_thunk.rs
@@ -466,20 +466,18 @@ impl ThunkPlan {
             .iter()
             .zip(c.arguments())
             .map(|(_, argument)| match argument.location {
-                ArgLocation::Registers {
-                    class, first_index, ..
-                } => {
+                ArgLocation::Registers { pieces } => {
                     // The register save block holds the general-purpose roster,
                     // and a register-passed value's eightbytes are contiguous in
                     // it, so its image needs no repacking. Nothing reaches the
                     // floating-point roster while the C boundary rejects floats.
                     assert_eq!(
-                        class,
-                        CRegisterClass::Gp,
+                        pieces.uniform_class(),
+                        Some(CRegisterClass::Gp),
                         "an export argument still crosses only in general-purpose registers"
                     );
                     ImageBase::Frame {
-                        offset: save_base + first_index * 8,
+                        offset: save_base + pieces.first_index().unwrap_or(0) * 8,
                     }
                 }
                 ArgLocation::Stack { offset, .. } => ImageBase::Incoming { offset },
@@ -1302,13 +1300,13 @@ mod tests {
         ExportSignature {
             convention: CallingConvention::X86_64SysV,
             parameters: vec![ExportParameter {
-                c: CAbiTypeFacts::Aggregate { size: 24, align: 8 },
+                c: CAbiTypeFacts::integer_aggregate(24, 8),
                 native: NativeParameter::Direct {
                     leaves: leaves.clone(),
                     reversed: true,
                 },
             }],
-            result: CAbiTypeFacts::Aggregate { size: 24, align: 8 },
+            result: CAbiTypeFacts::integer_aggregate(24, 8),
             return_facts: NativeAbiTypeFacts {
                 abi_slots: 3,
                 aggregate: true,
@@ -1339,10 +1337,10 @@ mod tests {
         ExportSignature {
             convention: CallingConvention::X86_64SysV,
             parameters: vec![ExportParameter {
-                c: CAbiTypeFacts::Aggregate { size: 8, align: 4 },
+                c: CAbiTypeFacts::integer_aggregate(8, 4),
                 native: NativeParameter::Indirect,
             }],
-            result: CAbiTypeFacts::Aggregate { size: 8, align: 4 },
+            result: CAbiTypeFacts::integer_aggregate(8, 4),
             return_facts: NativeAbiTypeFacts {
                 abi_slots: 2,
                 aggregate: true,
@@ -1734,19 +1732,13 @@ mod tests {
             let signature = ExportSignature {
                 convention: CallingConvention::X86_64SysV,
                 parameters: vec![ExportParameter {
-                    c: CAbiTypeFacts::Aggregate {
-                        size: width.into(),
-                        align: width.into(),
-                    },
+                    c: CAbiTypeFacts::integer_aggregate(width.into(), width.into()),
                     native: NativeParameter::Direct {
                         leaves: leaves.clone(),
                         reversed: true,
                     },
                 }],
-                result: CAbiTypeFacts::Aggregate {
-                    size: width.into(),
-                    align: width.into(),
-                },
+                result: CAbiTypeFacts::integer_aggregate(width.into(), width.into()),
                 return_facts: NativeAbiTypeFacts {
                     abi_slots: 1,
                     aggregate: true,

--- a/crates/rue-codegen/src/foreign_call.rs
+++ b/crates/rue-codegen/src/foreign_call.rs
@@ -24,7 +24,7 @@ use rue_air::{
     LoweredSignature, PointerLocation, ScalarAbiExtension, Type, lower_c_signature,
 };
 use rue_cfg::{Cfg, CfgCallArg, CfgValue};
-use rue_target::CallingConvention;
+use rue_target::{CRegisterClass, CallingConvention};
 
 use crate::frame_layout::{
     FrameBudgetExceeded, checked_aligned_region_bytes, checked_call_area_from_stack_bytes,
@@ -55,6 +55,9 @@ pub struct AggregateImage {
     /// Backing-buffer size: `size` rounded up to the 16-byte call-stack
     /// alignment, so whole-eightbyte loads/stores never run past the buffer.
     pub storage_bytes: u32,
+    /// The scalar leaves of the image, which is what classifies its eightbytes
+    /// and answers the homogeneous-float rule.
+    pub leaves: rue_air::AggregateLeaves,
 }
 
 impl AggregateImage {
@@ -73,6 +76,7 @@ impl AggregateImage {
                 .expect("foreign aggregate alignment must fit u32"),
             storage_bytes: checked_aligned_region_bytes(layout.size)
                 .expect("foreign aggregate storage must pass frame-budget preflight"),
+            leaves: rue_air::aggregate_leaves(type_pool, ty, layout.size),
         }
     }
 
@@ -87,6 +91,7 @@ impl AggregateImage {
         CAbiTypeFacts::Aggregate {
             size: u64::from(self.size),
             align: u64::from(self.align),
+            leaves: self.leaves,
         }
     }
 }
@@ -342,6 +347,22 @@ impl ForeignCallPlan {
     }
 }
 
+/// One value crossing in a register: which bank, which roster index within it,
+/// and the vreg holding the value.
+///
+/// The roster index is the lowered signature's, not the position of this entry:
+/// a value's register is decided by the classification, and a backend maps the
+/// pair to a physical register rather than counting the values it has seen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ForeignRegisterArg {
+    /// The register bank.
+    pub(crate) class: CRegisterClass,
+    /// Roster index within that bank's argument registers.
+    pub(crate) index: u32,
+    /// The vreg holding the value.
+    pub(crate) value: VReg,
+}
+
 /// Target-specific leaves for the shared foreign-call lowering driver.
 ///
 /// The driver below owns the call's event order and all target-independent
@@ -364,7 +385,9 @@ pub(crate) trait ForeignCallLoweringBackend {
     /// decision, made once by the lowered signature; the backend chooses only
     /// the instructions.
     fn foreign_emit_stack_args(&mut self, stack: &ForeignStackArea);
-    fn foreign_emit_register_args(&mut self, int_ops: &[VReg]);
+    /// Move every register-passed value into the register the classification
+    /// named for it.
+    fn foreign_emit_register_args(&mut self, register_args: &[ForeignRegisterArg]);
     fn foreign_assign_sret(&mut self, sret_ptr: VReg);
     fn foreign_issue_call(&mut self, symbol: &str);
     /// Release the outgoing argument area reserved by
@@ -416,13 +439,20 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
         _ => None,
     };
 
-    let mut int_ops = Vec::new();
+    let mut register_args: Vec<ForeignRegisterArg> = Vec::new();
     let mut stack = ForeignStackArea {
         stores: Vec::new(),
         bytes: stack_area_bytes,
     };
     if sret_in_argument_register {
-        int_ops.push(sret_ptr.expect("SysV sret placement requires storage"));
+        // The hidden indirect-result pointer is the hidden first argument, so
+        // it takes the first general-purpose argument register and the
+        // classification already shifted every user argument past it.
+        register_args.push(ForeignRegisterArg {
+            class: CRegisterClass::Gp,
+            index: 0,
+            value: sret_ptr.expect("SysV sret placement requires storage"),
+        });
     }
     for (arg_index, (arg, argument)) in inputs
         .args
@@ -441,11 +471,28 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
             }
         };
         match argument.location {
-            ArgLocation::Registers { .. } => int_ops.extend(values),
+            ArgLocation::Registers { pieces } => {
+                assert_eq!(
+                    pieces.len() as usize,
+                    values.len(),
+                    "one value per register the classification named"
+                );
+                register_args.extend(pieces.as_slice().iter().zip(&values).map(
+                    |(piece, value)| ForeignRegisterArg {
+                        class: piece.class,
+                        index: piece.index,
+                        value: *value,
+                    },
+                ));
+            }
             ArgLocation::Indirect {
-                pointer: PointerLocation::Register { .. },
+                pointer: PointerLocation::Register { index },
                 ..
-            } => int_ops.extend(values),
+            } => register_args.push(ForeignRegisterArg {
+                class: CRegisterClass::Gp,
+                index,
+                value: values[0],
+            }),
             ArgLocation::Stack { .. } => stack.stores.extend(plan.stack_stores(arg_index, &values)),
             ArgLocation::Indirect {
                 pointer: PointerLocation::Stack { offset },
@@ -463,7 +510,7 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
     // driver fixes the shared boundary order: outgoing stack, integer args,
     // hidden sret assignment, call, then stack/byref cleanup.
     backend.foreign_emit_stack_args(&stack);
-    backend.foreign_emit_register_args(&int_ops);
+    backend.foreign_emit_register_args(&register_args);
     if let Some(sret_ptr) = sret_ptr {
         if !sret_in_argument_register {
             backend.foreign_assign_sret(sret_ptr);
@@ -666,6 +713,7 @@ mod tests {
             size,
             align,
             storage_bytes: size.div_ceil(16) * 16,
+            leaves: rue_air::AggregateLeaves::all_integer(u64::from(size)),
         }
     }
 
@@ -967,8 +1015,12 @@ mod tests {
             self.record(format!("stack[{}]:{}", stack.bytes, stores.join(",")));
         }
 
-        fn foreign_emit_register_args(&mut self, int_ops: &[VReg]) {
-            self.record(format!("registers:{int_ops:?}"));
+        fn foreign_emit_register_args(&mut self, register_args: &[ForeignRegisterArg]) {
+            let moves = register_args
+                .iter()
+                .map(|arg| format!("{:?}{}={}", arg.class, arg.index, arg.value))
+                .collect::<Vec<_>>();
+            self.record(format!("registers:{}", moves.join(",")));
         }
 
         fn foreign_assign_sret(&mut self, _sret_ptr: VReg) {
@@ -1055,7 +1107,7 @@ mod tests {
                 "get:CfgValue(3)",
                 "get:CfgValue(4)",
                 "stack[16]:v106@0+8",
-                "registers:[VReg(100), VReg(101), VReg(102), VReg(103), VReg(104), VReg(105)]",
+                "registers:Gp0=v100,Gp1=v101,Gp2=v102,Gp3=v103,Gp4=v104,Gp5=v105",
                 "call:sysv_fn",
                 "cleanup_stack:16",
                 "cleanup_byref:0",
@@ -1099,7 +1151,7 @@ mod tests {
                 "get:CfgValue(8)",
                 "get:CfgValue(9)",
                 "stack[16]:v109@0+8,v110@8+8",
-                "registers:[VReg(101), VReg(102), VReg(103), VReg(104), VReg(105), VReg(106), VReg(107), VReg(108)]",
+                "registers:Gp0=v101,Gp1=v102,Gp2=v103,Gp3=v104,Gp4=v105,Gp5=v106,Gp6=v107,Gp7=v108",
                 "assign_sret",
                 "call:aapcs_fn",
                 "cleanup_stack:16",
@@ -1123,7 +1175,7 @@ mod tests {
             register_return.events,
             vec![
                 "stack[0]:",
-                "registers:[]",
+                "registers:",
                 "call:aapcs_register_fn",
                 "cleanup_stack:0",
                 "cleanup_byref:0",

--- a/crates/rue-codegen/src/frame_layout.rs
+++ b/crates/rue-codegen/src/frame_layout.rs
@@ -123,6 +123,26 @@ pub fn checked_incoming_stack_arg_offset(
     .map_err(|_| FrameBudgetExceeded)
 }
 
+/// Checked positive FP-relative offset of an incoming stack argument at
+/// `area_offset` bytes into the incoming argument area.
+///
+/// `entry_base_bytes` is the ABI-specific distance from the frame pointer to
+/// the base of that area — the x86 return-address base (16) and the AArch64
+/// entry base (16). The offset within it is the placement's own, so the
+/// prologue reads exactly where the caller's assignment wrote.
+#[inline]
+pub fn checked_incoming_stack_arg_byte_offset(
+    entry_base_bytes: u64,
+    area_offset: u32,
+) -> Result<i32, FrameBudgetExceeded> {
+    i32::try_from(
+        entry_base_bytes
+            .checked_add(u64::from(area_offset))
+            .ok_or(FrameBudgetExceeded)?,
+    )
+    .map_err(|_| FrameBudgetExceeded)
+}
+
 /// Validate one outgoing call's simultaneous stack reservation: hidden return
 /// storage, compact by-value argument copies, and stack-passed ABI slots.
 pub fn checked_call_area_bytes(

--- a/crates/rue-codegen/src/param_storage.rs
+++ b/crates/rue-codegen/src/param_storage.rs
@@ -72,6 +72,7 @@ impl ParamStoragePlan {
     pub(crate) fn all_homed(
         num_params: u32,
         has_sret: bool,
+        native_convention: rue_target::ConventionSpec,
         register_banks: crate::call_plan::AbiRegisterBanks,
     ) -> Self {
         let mut classes = Vec::with_capacity(num_params as usize + has_sret as usize);
@@ -82,7 +83,8 @@ impl ParamStoragePlan {
             crate::call_plan::AbiSlotClass::Gp,
             num_params as usize,
         ));
-        let locations = crate::call_plan::assign_abi_slots(classes, register_banks);
+        let locations =
+            crate::call_plan::assign_abi_slots(native_convention, classes, register_banks);
         let abi_shift = has_sret as usize;
         Self {
             slots: (0..num_params)
@@ -106,13 +108,14 @@ impl ParamStoragePlan {
         cfg: &Cfg,
         type_pool: &FrozenTypeInternPool,
         has_sret: bool,
+        native_convention: rue_target::ConventionSpec,
         register_banks: impl Into<crate::call_plan::AbiRegisterBanks>,
     ) -> Self {
         let register_banks = register_banks.into();
         let num_params = cfg.num_params();
         let descriptors = cfg.source_param_abi();
         if descriptors.is_empty() {
-            return Self::all_homed(num_params, has_sret, register_banks);
+            return Self::all_homed(num_params, has_sret, native_convention, register_banks);
         }
         assert!(
             descriptors
@@ -131,7 +134,7 @@ impl ParamStoragePlan {
                 .any(|(a, b)| a.start_slot + a.slot_count != b.start_slot)
             || descriptors.first().is_some_and(|d| d.start_slot != 0)
         {
-            return Self::all_homed(num_params, has_sret, register_banks);
+            return Self::all_homed(num_params, has_sret, native_convention, register_banks);
         }
 
         let scan = scan_param_references(cfg, type_pool);
@@ -149,7 +152,11 @@ impl ParamStoragePlan {
                     .map(crate::call_plan::AbiSlotClass::from),
             );
         }
-        let locations = crate::call_plan::assign_abi_slots(classes.iter().copied(), register_banks);
+        let locations = crate::call_plan::assign_abi_slots(
+            native_convention,
+            classes.iter().copied(),
+            register_banks,
+        );
         let mut crossing_index = has_sret as usize;
         let mut area = 0u32;
         for d in descriptors {
@@ -168,7 +175,7 @@ impl ParamStoragePlan {
                 && d.crossing_regs == 1
                 && !matches!(
                     parameter_locations[0],
-                    crate::call_plan::AbiSlotLocation::Stack(_)
+                    crate::call_plan::AbiSlotLocation::Stack { .. }
                 )
                 && !scan.needs_home[slot as usize]
                 && (cfg.is_param_by_ref(slot)
@@ -429,6 +436,14 @@ mod tests {
 
     use super::{ParamSlotStorage, ParamStoragePlan};
 
+    /// The two native pairings a plan is exercised under: the plan's stacked
+    /// slots are packed by the convention, so a test names the row whose
+    /// argument roster it is filling.
+    const SYSV: rue_target::ConventionSpec =
+        rue_target::ConventionSpec::native(rue_target::Target::X86_64Linux);
+    const AAPCS: rue_target::ConventionSpec =
+        rue_target::ConventionSpec::native(rue_target::Target::Aarch64Linux);
+
     fn pool() -> rue_air::FrozenTypeInternPool {
         TypeInternPool::new().freeze()
     }
@@ -459,7 +474,7 @@ mod tests {
     #[test]
     fn synthetic_cfg_without_descriptors_homes_every_slot() {
         let cfg = Cfg::new(Type::UNIT, 1, 2, "synthetic".into(), vec![false, false]);
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, SYSV, 6);
         assert_eq!(plan.homed_area_slots(), 2);
         assert_eq!(plan.slot(0), ParamSlotStorage::Frame { area_slot: 0 });
         assert_eq!(plan.slot(1), ParamSlotStorage::Frame { area_slot: 1 });
@@ -477,6 +492,7 @@ mod tests {
             &cfg,
             &pool(),
             false,
+            AAPCS,
             crate::call_plan::AbiRegisterBanks { gp: 8, fp: 8 },
         );
         assert_eq!(arm.homing().len(), 8);
@@ -493,15 +509,16 @@ mod tests {
             &cfg,
             &pool(),
             false,
+            SYSV,
             crate::call_plan::AbiRegisterBanks { gp: 6, fp: 8 },
         );
         assert_eq!(
             x86.homing()[6].location,
-            crate::call_plan::AbiSlotLocation::Stack(0)
+            crate::call_plan::AbiSlotLocation::stack_slot(0)
         );
         assert_eq!(
             x86.homing()[7].location,
-            crate::call_plan::AbiSlotLocation::Stack(1)
+            crate::call_plan::AbiSlotLocation::stack_slot(1)
         );
     }
 
@@ -514,7 +531,7 @@ mod tests {
         // Param 0 is read; param 1 is never referenced.
         push_param(&mut cfg, entry, 0);
 
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, SYSV, 6);
         assert!(matches!(plan.slot(0), ParamSlotStorage::Register { .. }));
         assert!(matches!(plan.slot(1), ParamSlotStorage::Register { .. }));
         assert!(plan.is_used(0));
@@ -535,7 +552,7 @@ mod tests {
         cfg.entry = entry;
         push_param(&mut cfg, entry, 0);
 
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), true, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool(), true, SYSV, 6);
         assert!(matches!(
             plan.slot(0),
             ParamSlotStorage::Register {
@@ -563,7 +580,7 @@ mod tests {
         }
 
         // Six argument registers: slots 6 and 7 are stack-passed.
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, SYSV, 6);
         for slot in 0..6 {
             assert!(matches!(plan.slot(slot), ParamSlotStorage::Register { .. }));
         }
@@ -573,15 +590,15 @@ mod tests {
         // The homed entries still name their original incoming ABI indices.
         assert_eq!(
             plan.homing()[0].location,
-            crate::call_plan::AbiSlotLocation::Stack(0)
+            crate::call_plan::AbiSlotLocation::stack_slot(0)
         );
         assert_eq!(
             plan.homing()[1].location,
-            crate::call_plan::AbiSlotLocation::Stack(1)
+            crate::call_plan::AbiSlotLocation::stack_slot(1)
         );
 
         // With eight argument registers (AArch64) everything is register-only.
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 8);
+        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, AAPCS, 8);
         assert_eq!(plan.homed_area_slots(), 0);
     }
 
@@ -628,7 +645,7 @@ mod tests {
         // Param 2: plain read.
         push_param(&mut cfg, entry, 2);
 
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, SYSV, 6);
         assert_eq!(plan.slot(0), ParamSlotStorage::Frame { area_slot: 0 });
         assert_eq!(plan.slot(1), ParamSlotStorage::Frame { area_slot: 1 });
         assert!(matches!(
@@ -657,7 +674,7 @@ mod tests {
         push_param(&mut cfg, entry, 0);
         push_param(&mut cfg, entry, 1);
 
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, SYSV, 6);
         assert_eq!(plan.slot(0), ParamSlotStorage::Frame { area_slot: 0 });
         assert_eq!(plan.slot(1), ParamSlotStorage::Frame { area_slot: 1 });
     }
@@ -696,7 +713,7 @@ mod tests {
             },
         );
 
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, SYSV, 6);
         assert!(matches!(
             plan.slot(0),
             ParamSlotStorage::Register {
@@ -763,7 +780,7 @@ mod tests {
             },
         );
 
-        let plan = ParamStoragePlan::plan(&cfg, &pool, false, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool, false, SYSV, 6);
         assert_eq!(plan.slot(0), ParamSlotStorage::Frame { area_slot: 0 });
         assert_eq!(
             plan.slot(1),
@@ -805,7 +822,7 @@ mod tests {
             },
         );
 
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, SYSV, 6);
         assert_eq!(plan.slot(0), ParamSlotStorage::Frame { area_slot: 0 });
         assert_eq!(plan.slot(1), ParamSlotStorage::Frame { area_slot: 1 });
         assert_eq!(plan.slot(2), ParamSlotStorage::Frame { area_slot: 2 });

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -57,6 +57,7 @@ pub(super) const fn x86_64_target_c_convention() -> rue_target::CallingConventio
 }
 
 pub(super) const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9];
+
 pub(super) const FP_ARG_REGS: [Reg; 8] = [
     Reg::Xmm0,
     Reg::Xmm1,
@@ -67,6 +68,22 @@ pub(super) const FP_ARG_REGS: [Reg; 8] = [
     Reg::Xmm6,
     Reg::Xmm7,
 ];
+
+/// The physical register a foreign call's classified register piece names.
+///
+/// A foreign argument is marshaled through its compact memory image, whose
+/// pieces are whole eightbytes in general-purpose vregs, so an SSE-classed
+/// piece has no value to move: the C boundary rejects `f32`/`f64`
+/// (`c_passable_by_value`), which is what keeps every piece integer-classed.
+fn foreign_argument_register(class: rue_target::CRegisterClass, index: u32) -> Reg {
+    assert_eq!(
+        class,
+        rue_target::CRegisterClass::Gp,
+        "a foreign argument crosses through its eightbyte image in the \
+         general-purpose bank"
+    );
+    ARG_REGS[index as usize]
+}
 
 /// Return value registers for the internal Rue convention (SysV only defines
 /// rax/rdx; the rest are caller-saved scratch regs we extend the convention
@@ -158,6 +175,10 @@ pub struct CfgLower<'a> {
 impl crate::call_plan::CallMaterializer for CfgLower<'_> {
     fn target_c_convention(&self) -> rue_target::CallingConvention {
         x86_64_target_c_convention()
+    }
+
+    fn native_convention(&self) -> rue_target::ConventionSpec {
+        rue_target::ConventionSpec::native(X86_64_TARGET)
     }
 
     fn materialize_scalar(&mut self, value: CfgValue) -> VReg {
@@ -613,6 +634,7 @@ impl<'a> CfgLower<'a> {
         let plan = crate::call_plan::CallPlan::from_slot_values(
             crate::call_plan::CallTarget::rue(symbol),
             arg_vregs,
+            rue_target::ConventionSpec::native(X86_64_TARGET),
             crate::call_plan::AbiRegisterBanks {
                 gp: ARG_REGS.len(),
                 fp: FP_ARG_REGS.len(),
@@ -1211,7 +1233,7 @@ impl<'a> CfgLower<'a> {
                 .zip(&plan.abi_locations)
                 .any(|(class, location)| {
                     matches!(class, crate::call_plan::AbiSlotClass::Fp(_))
-                        && matches!(location, crate::call_plan::AbiSlotLocation::Stack(_))
+                        && matches!(location, crate::call_plan::AbiSlotLocation::Stack { .. })
                 });
         let stack_cell_bytes = checked_cell_region_bytes(
             u64::try_from(num_stack_args).expect("call stack slot count must fit u64"),
@@ -1230,10 +1252,10 @@ impl<'a> CfgLower<'a> {
                 .zip(&plan.abi_classes)
                 .zip(&plan.abi_locations)
             {
-                let crate::call_plan::AbiSlotLocation::Stack(index) = location else {
+                let crate::call_plan::AbiSlotLocation::Stack { offset, .. } = location else {
                     continue;
                 };
-                let offset = checked_cell_byte_offset(*index as u64)
+                let offset = checked_displacement_bytes(u64::from(*offset))
                     .expect("call stack slot offset must fit displacement");
                 if let crate::call_plan::AbiSlotClass::Fp(width) = class {
                     self.mir.push(X86Inst::FloatStore {
@@ -1264,9 +1286,18 @@ impl<'a> CfgLower<'a> {
         }
         if !has_fp_stack_arg {
             for (arg, location) in plan.abi_slots.iter().zip(&plan.abi_locations).rev() {
-                if !matches!(location, crate::call_plan::AbiSlotLocation::Stack(_)) {
+                let crate::call_plan::AbiSlotLocation::Stack { offset, size, .. } = location else {
                     continue;
-                }
+                };
+                // Pushing the stacked slots in reverse leaves slot 0 nearest
+                // `rsp`, which is the offset the assignment gave it: the push
+                // sequence is only correct while the area is whole ascending
+                // eightbytes, which is what a native slot claims.
+                assert_eq!(
+                    (*size, offset % 8),
+                    (8, 0),
+                    "a pushed native stack slot occupies one whole eightbyte"
+                );
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Physical(Reg::Rax),
                     src: Operand::Virtual(*arg),
@@ -4189,19 +4220,25 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         }
     }
 
-    fn foreign_emit_register_args(&mut self, int_ops: &[VReg]) {
-        for v in int_ops.iter().rev() {
+    fn foreign_emit_register_args(
+        &mut self,
+        register_args: &[crate::foreign_call::ForeignRegisterArg],
+    ) {
+        // Staging every value on the stack first and popping it into its
+        // register afterwards keeps one argument's move from clobbering
+        // another's source, whatever order the classification named.
+        for arg in register_args.iter().rev() {
             self.mir.push(X86Inst::MovRR {
                 dst: Operand::Physical(Reg::Rax),
-                src: Operand::Virtual(*v),
+                src: Operand::Virtual(arg.value),
             });
             self.mir.push(X86Inst::Push {
                 src: Operand::Physical(Reg::Rax),
             });
         }
-        for (index, _) in int_ops.iter().enumerate() {
+        for arg in register_args {
             self.mir.push(X86Inst::Pop {
-                dst: Operand::Physical(ARG_REGS[index]),
+                dst: Operand::Physical(foreign_argument_register(arg.class, arg.index)),
             });
         }
     }
@@ -4885,6 +4922,12 @@ mod tests {
     use rue_cfg::{CfgArgMode, CfgCallArg, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_span::{FileId, Span};
 
+    /// The convention a test's parameter-storage plan places by: this
+    /// backend's own target, whose native pairing decides how the incoming
+    /// argument area is packed.
+    const PLAN_CONVENTION: rue_target::ConventionSpec =
+        rue_target::ConventionSpec::native(X86_64_TARGET);
+
     #[test]
     fn zero32_consumers_use_canonical_move_not_shift_pair() {
         let source = include_str!("cfg_lower.rs");
@@ -5244,6 +5287,7 @@ mod tests {
                 &cfg,
                 self.pool,
                 false,
+                PLAN_CONVENTION,
                 ARG_REGS.len() as u32,
             );
             CfgLower::new(&cfg, self.pool, self.interner)
@@ -6377,7 +6421,8 @@ mod tests {
         let sum = fixture.value(CfgInstData::Add(b, q), Type::I32);
         fixture.ret(Some(sum));
         let cfg = fixture.cfg.finish(&pool).expect("test CFG must verify");
-        let plan = crate::param_storage::ParamStoragePlan::plan(&cfg, &pool, false, 6);
+        let plan =
+            crate::param_storage::ParamStoragePlan::plan(&cfg, &pool, false, PLAN_CONVENTION, 6);
 
         // The compact struct parameter collapses to one incoming pointer
         // register while its three frame slots stay reserved. The scalar `q`
@@ -7230,6 +7275,7 @@ mod tests {
                 size: 8,
                 align: 8,
                 storage_bytes: 16,
+                leaves: rue_air::AggregateLeaves::all_integer(8),
             },
         }];
         args.extend((1..6).map(|index| ForeignArg::Scalar {

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -597,7 +597,9 @@ impl<'a> Emitter<'a> {
                     location: if (slot + abi_shift) < 6 {
                         crate::call_plan::AbiSlotLocation::GpReg((slot + abi_shift) as usize)
                     } else {
-                        crate::call_plan::AbiSlotLocation::Stack((slot + abi_shift) as usize - 6)
+                        crate::call_plan::AbiSlotLocation::stack_slot(
+                            (slot + abi_shift) as usize - super::cfg_lower::ARG_REGS.len(),
+                        )
                     },
                 })
                 .collect()
@@ -729,16 +731,11 @@ impl<'a> Emitter<'a> {
                     );
                     end_inst!(self, "mov float [rbp{}], {}", offset, FP_ARG_REGS[index]);
                 }
-                (_, crate::call_plan::AbiSlotLocation::Stack(stack_index)) => {
+                (_, crate::call_plan::AbiSlotLocation::Stack { offset: area, .. }) => {
                     // Stack-passed arg: copy from above the frame into the param area
-                    let src_offset = crate::frame_layout::checked_incoming_stack_arg_offset(
-                        16,
-                        u32::try_from(ARG_REGS.len() + stack_index)
-                            .expect("incoming stack argument index must fit u32"),
-                        u32::try_from(ARG_REGS.len())
-                            .expect("argument register count must fit u32"),
-                    )
-                    .expect("incoming stack argument offset must fit displacement");
+                    let src_offset =
+                        crate::frame_layout::checked_incoming_stack_arg_byte_offset(16, area)
+                            .expect("incoming stack argument offset must fit displacement");
                     self.begin_inst();
                     self.emit_mov_rm(Reg::Rax, Reg::Rbp, src_offset);
                     end_inst!(self, "mov rax, [rbp+{}]", src_offset);
@@ -3631,7 +3628,7 @@ mod tests {
             .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                 start_slot: 0,
                 class: crate::call_plan::AbiSlotClass::Gp,
-                location: crate::call_plan::AbiSlotLocation::Stack(0),
+                location: crate::call_plan::AbiSlotLocation::stack_slot(0),
             }])
             .emit_all()
             .expect("stack argument homing must emit");

--- a/crates/rue-compiler/src/revisioned_query_database/semantic.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/semantic.rs
@@ -1874,10 +1874,14 @@ pub(super) fn stable_c_abi_type_facts(
     ty: &crate::TypeInstanceKey,
 ) -> rue_air::CAbiTypeFacts {
     if stable_type_is_aggregate(ty) {
-        return rue_air::CAbiTypeFacts::Aggregate {
-            size: layout.size,
-            align: layout.alignment,
-        };
+        // The canonical layout carries every byte offset of the aggregate but
+        // not the *kind* of the scalar at each one, which is what an eightbyte
+        // classification and the homogeneous-float rule read. The stable plane
+        // reports every leaf an integer, which is exact for every type that
+        // reaches a C boundary: the boundary rejects `f32`/`f64`
+        // (`c_passable_by_value`), and this projection classifies C boundaries
+        // only — a native signature keeps the native decision tree below.
+        return rue_air::CAbiTypeFacts::integer_aggregate(layout.size, layout.alignment);
     }
     if layout.abi_slots == 0 {
         return rue_air::CAbiTypeFacts::ZeroSized;
@@ -2062,9 +2066,9 @@ pub(super) fn evaluate_call_abi(
                     _ if !stable_type_is_aggregate(ty) => A::CScalar {
                         extension: argument.extension,
                     },
-                    rue_air::ArgLocation::Registers { count, .. } => {
-                        A::CIntegerRegisters { eightbytes: count }
-                    }
+                    rue_air::ArgLocation::Registers { pieces } => A::CIntegerRegisters {
+                        eightbytes: pieces.len(),
+                    },
                     rue_air::ArgLocation::Stack { size, align, .. } => A::CByValueStack {
                         size,
                         alignment: align,

--- a/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
@@ -1490,10 +1490,9 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
             live_facts,
         );
         match (facts.arguments[0].class, lowered.arguments()[0].location) {
-            (
-                A::CIntegerRegisters { eightbytes },
-                rue_air::ArgLocation::Registers { count, .. },
-            ) => assert_eq!(eightbytes, count, "eightbyte parity for {name}"),
+            (A::CIntegerRegisters { eightbytes }, rue_air::ArgLocation::Registers { pieces }) => {
+                assert_eq!(eightbytes, pieces.len(), "eightbyte parity for {name}")
+            }
             (
                 A::CByValueStack { size, alignment },
                 rue_air::ArgLocation::Stack {

--- a/crates/rue-target/src/calling_convention.rs
+++ b/crates/rue-target/src/calling_convention.rs
@@ -42,6 +42,14 @@
 //! reads it against a type's size, alignment, and scalar kind is
 //! `rue_air::lowered_signature`, which is where type facts first exist.
 //!
+//! ## The convention and its description travel together
+//!
+//! A placement is made by a convention *and* the description it places by, and
+//! for the native Rue convention those are not the same row: ADR-0084 defines
+//! the native convention as the compilation target's C row plus a wider return
+//! bank, so it borrows a description rather than owning one.
+//! [`ConventionSpec`] is that pair, and it is what the classifier takes.
+//!
 //! ## Apple's arm64 amendments
 //!
 //! `Aarch64Aapcs` and `Aarch64AapcsDarwin` are separate rows because Apple's
@@ -372,6 +380,88 @@ impl CallingConvention {
     }
 }
 
+/// A calling convention paired with the psABI description that governs its
+/// placements.
+///
+/// A placement needs both halves: which convention a boundary follows, and the
+/// register rosters, sret rule, stack packing and aggregate rule it places by.
+/// For a C row the second half is the first half's own
+/// [`c_spec`](CallingConvention::c_spec) entry. For the native Rue convention
+/// it is not, because the native convention is *the compilation target's C row*
+/// plus a wider return bank (ADR-0084) rather than a psABI of its own; there is
+/// no `CallingConvention::Rue` row of that table to look up. Pairing the two
+/// values is what lets one classifier place a signature under either
+/// convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConventionSpec {
+    convention: CallingConvention,
+    spec: CConventionSpec,
+}
+
+impl ConventionSpec {
+    /// The pairing for one platform C row: the row beside its own psABI
+    /// description.
+    ///
+    /// Panics on [`CallingConvention::Rue`], which is not a psABI row —
+    /// [`native`](Self::native) is how the native convention is paired.
+    pub const fn c(convention: CallingConvention) -> Self {
+        assert!(
+            convention.is_c(),
+            "a C pairing names a psABI row; the native Rue convention pairs \
+             through ConventionSpec::native"
+        );
+        Self {
+            convention,
+            spec: convention.c_spec(),
+        }
+    }
+
+    /// The pairing for the C boundary of `target`.
+    pub const fn c_for_target(target: Target) -> Self {
+        Self::c(CallingConvention::c_for_target(target))
+    }
+
+    /// The pairing for the native Rue convention on `target`: the target's own
+    /// C description, amended where the native convention differs from it.
+    ///
+    /// The native convention places arguments exactly as the target's C row
+    /// does, so every other field of the description is the C row's verbatim.
+    /// The two amendments are the sret rule: the hidden indirect-result
+    /// pointer is the hidden *first ordinary argument*, so it shifts every user
+    /// argument one general-purpose register right on every target, and it is
+    /// not echoed in the primary result register. AAPCS64's dedicated `x8` and
+    /// SysV's `rax` echo belong to the C rows; the native return bank is wider
+    /// than C's and is fed to the classifier rather than derived from this
+    /// description (RUE-2038 owns the native return classification that moves
+    /// AAPCS64 onto `x8`).
+    pub const fn native(target: Target) -> Self {
+        let spec = CallingConvention::c_for_target(target).c_spec();
+        Self {
+            convention: CallingConvention::Rue,
+            spec: CConventionSpec {
+                sret_register: SretRegisterKind::ArgumentRegister,
+                sret_pointer_echoed_in_result_register: false,
+                ..spec
+            },
+        }
+    }
+
+    /// The convention this pairing names.
+    pub const fn convention(self) -> CallingConvention {
+        self.convention
+    }
+
+    /// The psABI description this pairing places by.
+    pub const fn spec(self) -> CConventionSpec {
+        self.spec
+    }
+
+    /// Whether this pairing names the native Rue convention.
+    pub const fn is_native(self) -> bool {
+        self.convention.is_rue()
+    }
+}
+
 /// The calling convention an `extern` declaration names in source.
 ///
 /// A foreign declaration writes either the alias `"C"`, which denotes whichever
@@ -598,6 +688,70 @@ mod tests {
     #[should_panic(expected = "not a psABI row")]
     fn the_native_row_has_no_psabi_description() {
         let _ = CallingConvention::Rue.c_spec();
+    }
+
+    #[test]
+    fn a_c_pairing_is_its_row_beside_its_own_description() {
+        for target in Target::all() {
+            let convention = target.c_calling_convention();
+            let pairing = ConventionSpec::c(convention);
+            assert_eq!(pairing.convention(), convention);
+            assert_eq!(pairing.spec(), convention.c_spec());
+            assert!(!pairing.is_native());
+            assert_eq!(ConventionSpec::c_for_target(*target), pairing);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "a C pairing names a psABI row")]
+    fn the_native_convention_has_no_c_pairing() {
+        let _ = ConventionSpec::c(CallingConvention::Rue);
+    }
+
+    #[test]
+    fn the_native_pairing_amends_exactly_the_sret_rule_of_its_targets_c_row() {
+        for target in Target::all() {
+            let c = target.c_calling_convention().c_spec();
+            let native = ConventionSpec::native(*target);
+            assert_eq!(native.convention(), CallingConvention::Rue);
+            assert!(native.is_native());
+            let spec = native.spec();
+            // The hidden indirect-result pointer is the hidden first ordinary
+            // argument on every target, with no echo.
+            assert_eq!(spec.sret_register, SretRegisterKind::ArgumentRegister);
+            assert!(spec.sret_pointer_in_argument_register());
+            assert!(!spec.sret_pointer_echoed_in_result_register);
+            // Everything else is the target's own C description verbatim.
+            assert_eq!(
+                CConventionSpec {
+                    sret_register: c.sret_register,
+                    sret_pointer_echoed_in_result_register: c
+                        .sret_pointer_echoed_in_result_register,
+                    ..spec
+                },
+                c,
+                "{target:?}: the native convention places arguments by its \
+                 target's C row"
+            );
+        }
+    }
+
+    #[test]
+    fn the_native_pairing_differs_from_the_c_pairing_only_on_aarch64() {
+        // SysV already puts the hidden pointer in the first argument register
+        // and echoes it; the native convention keeps the placement and drops
+        // the echo. AAPCS64's dedicated `x8` is a C-row rule the native
+        // convention does not share.
+        let sysv = ConventionSpec::native(Target::X86_64Linux).spec();
+        assert_eq!(sysv.gp_argument_registers, 6);
+        assert!(sysv.sret_pointer_in_argument_register());
+        for target in [Target::Aarch64Linux, Target::Aarch64Macos] {
+            let c = ConventionSpec::c_for_target(target).spec();
+            let native = ConventionSpec::native(target).spec();
+            assert!(!c.sret_pointer_in_argument_register());
+            assert!(native.sret_pointer_in_argument_register());
+            assert_eq!(native.stacked_argument_packing, c.stacked_argument_packing);
+        }
     }
 
     #[test]

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -10,8 +10,8 @@
 mod calling_convention;
 
 pub use calling_convention::{
-    AggregateClassificationRule, CConventionSpec, CRegisterClass, CallingConvention, ForeignAbi,
-    NarrowIntegerExtension, SretRegisterKind, StackedArgumentPacking,
+    AggregateClassificationRule, CConventionSpec, CRegisterClass, CallingConvention,
+    ConventionSpec, ForeignAbi, NarrowIntegerExtension, SretRegisterKind, StackedArgumentPacking,
 };
 
 use std::fmt;

--- a/crates/rue-ui-tests/cases/emit/abi.toml
+++ b/crates/rue-ui-tests/cases/emit/abi.toml
@@ -47,8 +47,8 @@ function __rue_fn_test_2erue__through
     slot 4: gp register 3 (rcx)
     slot 3: gp register 4 (r8)
     slot 2: gp register 5 (r9)
-    slot 1: stack slot 0
-    slot 0: stack slot 1
+    slot 1: stack +0 (8 bytes, align 8)
+    slot 0: stack +8 (8 bytes, align 8)
   return: Wide$test_2erue, sret: pointer in gp register 0 (rdi) to 7 slots (64 bytes of caller storage)
 
 function main


### PR DESCRIPTION
Steps A and B of phase 1 of ADR-0084 (the RUE-2037 split, RUE-2030 epic). Two commits. Neither switches a native consumer, and no placement on any C row changes; the C matrix, `c_ffi`, `abi`, and the four-site agreement test pin that.

## Commit 1: the convention pairing and the native entry (RUE-2061)

ADR-0084 defines the native row as the compilation target's C row, which a row-only `c_spec()` cannot express. `ConventionSpec { convention, spec }` pairs the two: `c(convention)` asserts a C row (the assertion `lower_c_signature` used to make now lives with the pairing), `c_for_target(target)`, and `native(target)`, which is the target's C spec with the hidden result pointer in argument register 0 and no result-register echo, phase 1's rule until RUE-2038 moves AAPCS64 to `x8`. `LoweredSignature` stores the pairing. A new `lower_native_signature` takes an already-decided `LoweredReturn` and runs the same placer, so a native sret shifts argument register 0 on both architectures. Nothing calls it in production yet; unit tests cover it on all three targets.

## Commit 2: leaf-derived classification, per-piece registers, byte-offset native stacks (RUE-2062)

- `CAbiTypeFacts::Aggregate` carries its leaves as a `Copy` summary (`AggregateLeaves`: per-eightbyte integer/float bitmaps, a homogeneous-float summary, an unaligned-leaf flag) folded from `(offset, width, kind)` leaves. The live plane projects them from the canonical layout, including the union of an enum's variants; the stable plane projects all-integer, which is exact for every type reaching a C boundary today and is a named prerequisite for RUE-2063.
- Classification: SysV per-eightbyte SSE/INTEGER from the leaves, MEMORY past sixteen bytes or on an unaligned leaf; AAPCS64 homogeneous floating-point aggregates of one to four members in consecutive FP registers or stacked entire with the FP roster exhausted, every other composite in integer registers as C.13/C.14 say. `lower_return` reads the same leaves. Unit tests pin `{f64,i64}`, `{i64,f64}`, `{f32,f32}`, `{f64,f64,f64}`, and an HFA that does not fit, on every row.
- `ArgLocation::Registers` is a list of `(class, index)` pieces; `EightbyteClasses` widens from two to eight (the wider native return bank's size); register claims are all-or-nothing across banks. Both backends' foreign register-argument leaves are bank-aware.
- Native `AbiSlotLocation::Stack` is a byte offset with size and alignment, claimed from one shared `ArgumentArea` cursor extracted from the placer, so the C lowering and the native planner pack an argument area by one rule. Both backends' outgoing stores, both prologues' incoming reads, `param_storage`, frame layout, and the native `--emit abi` text follow.

The Apple native stack-packing difference does not materialize in this step: a native slot is a 64-bit-extended scalar, so its natural size is eight bytes on every row. It arrives with RUE-2063, when a native argument is described by its type. Two unit tests pin that the rows differ for a narrow scalar and agree at eight bytes.

## Verification

`scripts/rue fmt`; `unit target calling` (17), `unit air lowered_signature` (27), `unit air call_abi` (14), codegen `call_plan`/`param_storage`/`abi_report`/`export_thunk`/`foreign_call`; `scripts/rue quick` (36); `cli abi` (69), `cli c_ffi` (50), `cli aggregate_abi_matrix` (37); `ui emit` (7), `ui abi` (16); `./buck2 test //crates/rue-c-abi-matrix/...` (400 cells); oracle-diff; `scripts/rue premerge` (219 targets; only the two sandbox-environmental CLI failures). AArch64 execution is CI's to confirm.

Follow-ups noted, not in this PR: the stable plane needs field kinds before RUE-2063 can classify `Rue` through it; FP pieces in the foreign path assert `Gp` until floats cross the C boundary; a split-bank return awaits RUE-2038's per-piece return locations.

Closes RUE-2061
Closes RUE-2062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_