### PR TITLE
RUE-2060: strip the harness attribution footer from PR bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,10 @@ git push -u origin RUE-NNN-short-slug
 Open and merge the PR with whatever GitHub access the session has: the `gh`
 CLI where it is installed and authenticated, otherwise the GitHub API tools
 the harness provides. A sandboxed authentication failure is not authoritative;
-retry with host access before reporting a blocker.
+retry with host access before reporting a blocker. Harness GitHub tools may
+append an attribution footer to the body they create; re-read the PR after
+opening it and remove any footer with a body update before enabling
+auto-merge, so the published text stays tool-neutral.
 
 ### Jujutsu checkouts
 


### PR DESCRIPTION
AGENTS.md requires PR text to be tool-neutral, but cloud sessions without `gh` open PRs through harness GitHub tools that append an attribution footer to the body after creation. Three recent PRs merged with that footer on their pages (trunk history was unaffected because the squash commits carry the branch commit messages).

The Git-checkouts publication flow now says to re-read a PR opened through a harness tool and remove any appended footer with a body update before enabling auto-merge. Documentation only; `scripts/validate-doc-links.py` passes.

Fixes RUE-2060