### PR TITLE
RUE-2059: check the frame budget before expanding a repeat literal

### DIFF
--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -2058,7 +2058,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // work proportional to a value the compiler is required to reject.
         // This is the same checked materialization boundary used for locals,
         // temporaries, by-value parameters, and type-layout intrinsics.
-        self.require_layout_slots(array_type, span)?;
+        let array_slots = self.require_layout_slots(array_type, span)?;
 
         // Require the element type to be Copy (RUE-235).
         if !self.is_type_copy(elem_type) {
@@ -2079,6 +2079,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             span,
             ctx,
         )?;
+
+        // The single-object limit above admits layouts the *function frame*
+        // cannot hold — either on their own (it is one slot looser) or once
+        // earlier locals have spent part of the budget. Such a repeat is
+        // rejected by the binding's or temporary's `reserve_frame_slots`, but
+        // only after this expansion has already built one element reference
+        // per element: `[0; 268435455]` cost about 8 s and 2 GB to produce a
+        // diagnostic that depends on nothing but the layout (RUE-2059). Ask
+        // the frame budget first so rejecting an unrepresentable repeat is
+        // O(1); accepted repeats are unaffected, since a region that fits here
+        // still fits when the owning storage reserves it.
+        self.require_frame_slots_fit(ctx.next_slot, array_slots, span)?;
 
         // Desugar to ArrayInit: `length` elements, each the single value.
         let elem_refs = vec![value_result.air_ref; length as usize];

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -646,6 +646,7 @@ mod tests {
         let layout_methods = [
             "require_layout_slots",
             "reserve_frame_slots",
+            "require_frame_slots_fit",
             "checked_abi_slot_count",
             "abi_slot_count",
         ];
@@ -699,6 +700,28 @@ mod tests {
 
         let reserve = method_item(engine_owner, "reserve_frame_slots");
         assert!(reserve.contains("crate::layout::checked_function_frame_slots(start, additional)"));
+
+        let probe = method_item(engine_owner, "require_frame_slots_fit");
+        assert!(
+            probe.contains("self.reserve_frame_slots(&mut probe, additional, span)"),
+            "the non-consuming frame probe asks the reserving path, not a second budget rule"
+        );
+
+        // RUE-2059: an array-repeat literal expands one element reference per
+        // element, so the frame budget must be asked before that expansion,
+        // not after. Rejecting `[0; 268435455]` otherwise costs seconds and
+        // gigabytes for a diagnostic decided entirely by the layout.
+        let repeat = method_item(AGGREGATES_SOURCE, "analyze_array_repeat");
+        let probe_at = repeat
+            .find("self.require_frame_slots_fit(")
+            .expect("the repeat path asks the frame budget");
+        let expand_at = repeat
+            .find("vec![value_result.air_ref;")
+            .expect("the repeat path expands one element reference per element");
+        assert!(
+            probe_at < expand_at,
+            "the frame-budget check must precede the per-element payload expansion"
+        );
 
         let checked = method_item(engine_owner, "checked_abi_slot_count");
         for edge in [

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1076,6 +1076,28 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(start)
     }
 
+    /// Ask the frame budget the same question [`Self::reserve_frame_slots`]
+    /// answers, without consuming any of it.
+    ///
+    /// A value whose per-element representation is expensive to build — an
+    /// array-repeat literal expands one element reference per element — must
+    /// learn that the frame cannot hold it *before* paying that cost, not
+    /// after (RUE-2059). The reservation itself stays at the binding or
+    /// temporary that owns the storage; `next_slot` only ever advances, so a
+    /// region that does not fit at the current watermark cannot fit at the
+    /// later one either, and this check rejects exactly what that reservation
+    /// would have rejected.
+    pub(crate) fn require_frame_slots_fit(
+        &self,
+        current: u32,
+        additional: u32,
+        span: Span,
+    ) -> CompileResult<()> {
+        let mut probe = current;
+        self.reserve_frame_slots(&mut probe, additional, span)?;
+        Ok(())
+    }
+
     /// Checked companion to [`Self::abi_slot_count`]: `None` when the type's
     /// layout overflows or exceeds [`MAX_TYPE_SLOTS`] (RUE-561). Computed in
     /// u64 with checked arithmetic so large array lengths cannot truncate to

--- a/crates/rue-ui-tests/cases/diagnostics/function_frame_too_large.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/function_frame_too_large.toml
@@ -18,3 +18,22 @@ compile_fail = true
 # a load-sensitive latency gate.
 timeout_ms = 30000
 error_contains = ["[E0907]", "function stack frame or outgoing call area", "2147483632"]
+
+[[case]]
+name = "oversized_repeat_literal_rejected_before_expansion"
+source = """
+fn main() -> i32 {
+    let xs: [i8; 268435455] = [0; 268435455];
+    0
+}
+"""
+compile_fail = true
+# RUE-2059: this array is one slot past the frame budget, so the diagnostic is
+# decided by the layout alone — yet rejecting it took ~8s and ~2GB because the
+# repeat expanded a 268-million-entry element payload before the budget was
+# checked. The check now precedes the expansion and the case runs in tens of
+# milliseconds. The timeout is a regression guard with two orders of magnitude
+# of headroom, not a latency gate: only a return to per-element cost can trip
+# it.
+timeout_ms = 5000
+error_contains = ["[E0907]", "function stack frame or outgoing call area", "2147483632"]


### PR DESCRIPTION
An array-repeat literal desugars to an `ArrayInit` carrying one element reference per element, so building it is O(count). The guard before that expansion checks the single-object limit `MAX_TYPE_SLOTS`, which is one slot looser than the function-frame budget that actually rejects `[0; 268435455]`; that program therefore paid about 8 s and 2 GB to produce a diagnostic that depends on nothing but the layout. Profiling confirmed every sample in `vec::from_elem` under `analyze_array_repeat`. The nested `[[i8; 16383]; 16385]` form was fast only because its outer count is small.

`require_frame_slots_fit` asks `reserve_frame_slots` the same question on a scratch counter, and `analyze_array_repeat` calls it immediately before the expansion. `next_slot` only advances, so a region that does not fit at the repeat cannot fit when the owning storage reserves it; the check rejects exactly what the later reservation would have rejected, after the Copy check and value analysis so diagnostic precedence is unchanged. The E0907 span moves from the binding to the repeat literal.

Before and after on x86-64:

| Program | Before | After |
|---|---|---|
| `let xs: [i8; 268435455] = [0; 268435455]` | 8.35 s, 2083 MB | 0.048 s, 37 MB |
| `let _ = [0; 268435455]` | OOM-killed at 300 s / 13 GB | 0.024 s, 37 MB |
| `[[i8; 16383]; 16385]` nested form | 0.034 s | 0.036 s |

Accepted programs are unaffected: 1M and 10M element repeats produce byte-identical objects before and after. Those accepted repeats still lower to one store per element (the 100M case OOMs at 13 GB, valid or not); that codegen half is measured and tracked separately.

Guards: a consistency test asserts the probe precedes the expansion inside `analyze_array_repeat`, and a UI case pins the flat program under a 5 s timeout, two orders of magnitude above its fixed cost.

Verified: fmt, `unit air` (884), full `ui` (365), `spec arrays`, `spec implementation-limits`, `spec index`, `spec repeat`, `cli array`, `cli repeat`, quick. Re-run after rebasing onto current trunk.

Fixes RUE-2059