### PR TITLE
RUE-2058: let explanation examples declare the preview features they need

### DIFF
--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -831,17 +831,20 @@ compile_stdout_contains = ["E0950: Bit cast width mismatch", "Reinterpret across
 compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
-# The linker/target tranche covers both active codes in E1000-E1099. Neither
-# has a Rue program that produces it — E1000 is raised by the linker over
-# objects and archives, and nothing constructs E1001's kind — so both pages
-# omit the examples section and state their reproduction controls in prose.
+# The linker/target tranche covers both active codes in E1000-E1099. E1000's
+# examples are the preview-gated pair: a foreign call whose symbol no archive
+# defines, and a program whose C-boundary symbol is defined in the link. Both
+# need `--preview c_ffi`, so the rendered explanation states that requirement
+# beside each example title. E1001 has no Rue program that produces it —
+# nothing constructs its kind — so its page omits the examples section and
+# states its reproduction controls in prose.
 [[case]]
 name = "link_error_code_is_explained"
 files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
 args = ["explain", "E1000"]
 compile_only = true
-compile_stdout_contains = ["E1000: Link error", "--link-archive", "docs/spec/src/09-unchecked-code/03-foreign-boundary.md (spec rule 9.3:5)", "docs/designs/0034-cross-target-runtime.md", "docs/designs/0055-typed-runtime-abi-manifest.md"]
-compile_stdout_not_contains = ["Compiled", "Examples:"]
+compile_stdout_contains = ["E1000: Link error", "--link-archive", "Examples:", "Foreign symbol nothing linked defines (requires --preview c_ffi):", "Link a definition for the C-boundary symbol (requires --preview c_ffi):", "docs/spec/src/09-unchecked-code/03-foreign-boundary.md (spec rule 9.3:5)", "docs/designs/0034-cross-target-runtime.md", "docs/designs/0055-typed-runtime-abi-manifest.md"]
+compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
 [[case]]

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -59,6 +59,22 @@ mod integration_tests {
         SourceSnapshot::new(metadata, contents).unwrap()
     }
 
+    /// The options one explanation example is compiled under, honouring the
+    /// `--preview` names it declares. `ErrorCodeExample::preview_features`
+    /// resolves them with the parse the driver uses, so a stale declaration
+    /// fails here instead of compiling the example under the stable language.
+    fn explanation_example_options(
+        code: rue_error::ErrorCode,
+        example: &rue_error::ErrorCodeExample,
+    ) -> CompileOptions {
+        CompileOptions {
+            preview_features: example
+                .preview_features()
+                .unwrap_or_else(|error| panic!("{code} example {:?}: {error}", example.title)),
+            ..CompileOptions::default()
+        }
+    }
+
     #[test]
     fn multi_file_explanation_examples_have_the_declared_outcome() {
         for code in [
@@ -88,8 +104,8 @@ mod integration_tests {
                 } else {
                     crate::test_support::publish_test_snapshot(&mut session, &snapshot)
                 };
-                let result = published
-                    .and_then(|_| session.rooted_cfg(&CompileOptions::default()).map(|_| ()));
+                let options = explanation_example_options(code, example);
+                let result = published.and_then(|_| session.rooted_cfg(&options).map(|_| ()));
                 match example.outcome {
                     rue_error::ErrorCodeExampleOutcome::EmitsThisCode => {
                         let errors = result.unwrap_err();
@@ -170,7 +186,8 @@ mod integration_tests {
                 } else {
                     SourceSnapshot::single("main.rue", example.source).unwrap()
                 };
-                let result = crate::test_compile_snapshot(&snapshot, &CompileOptions::default());
+                let options = explanation_example_options(metadata.code, example);
+                let result = crate::test_compile_snapshot(&snapshot, &options);
                 match example.outcome {
                     rue_error::ErrorCodeExampleOutcome::EmitsThisCode => {
                         let errors = match result {

--- a/crates/rue-compiler/tests/error_explanation_examples.rs
+++ b/crates/rue-compiler/tests/error_explanation_examples.rs
@@ -1,5 +1,26 @@
 use rue_compiler::{CompileOptions, SourceSnapshot, compile_snapshot};
-use rue_error::{ErrorCodeExampleOutcome, error_code_explanation, error_code_metadata};
+use rue_error::{
+    ErrorCode, ErrorCodeExample, ErrorCodeExampleOutcome, error_code_explanation,
+    error_code_metadata,
+};
+
+/// The options one example is compiled under.
+///
+/// An example that exercises a language feature still behind a preview gate
+/// declares the `--preview` names it needs, and this is where a declaration
+/// becomes an enabled feature. Resolving the names through
+/// `ErrorCodeExample::preview_features` keeps the harness on the same parse
+/// the driver applies to `--preview <name>`; a declaration that no longer
+/// names a real feature fails loudly here rather than silently compiling the
+/// example under the stable language and reporting the gate diagnostic.
+fn example_options(code: ErrorCode, example: &ErrorCodeExample) -> CompileOptions {
+    CompileOptions {
+        preview_features: example
+            .preview_features()
+            .unwrap_or_else(|error| panic!("{code} example {:?}: {error}", example.title)),
+        ..CompileOptions::default()
+    }
+}
 
 #[test]
 fn compiler_owned_explanation_examples_have_the_declared_outcome() {
@@ -27,13 +48,15 @@ fn compiler_owned_explanation_examples_have_the_declared_outcome() {
                     | 800..=802
                     | 900..=908
                     | 950
+                    | 1000
             )
     }) {
         let explanation = error_code_explanation(metadata.code)
             .unwrap_or_else(|| panic!("{} must have an explanation", metadata.code));
         for example in explanation.examples {
             let snapshot = SourceSnapshot::single("main.rue", example.source).unwrap();
-            let result = compile_snapshot(&snapshot, &CompileOptions::default());
+            let options = example_options(metadata.code, example);
+            let result = compile_snapshot(&snapshot, &options);
             match example.outcome {
                 ErrorCodeExampleOutcome::EmitsThisCode => {
                     let errors = match result {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -197,6 +197,46 @@ pub struct ErrorCodeExample {
     pub source: &'static str,
     /// The result the canonical compiler must produce for this example.
     pub outcome: ErrorCodeExampleOutcome,
+    /// Preview feature names this example must be compiled with, spelled as
+    /// [`PreviewFeature::name`] spells them for `--preview`. Empty for the
+    /// overwhelming majority of examples, which are stable-language programs.
+    /// Names rather than a `PreviewFeature` set, because a declaration is
+    /// data: consumers parse them with the same [`std::str::FromStr`]
+    /// implementation the driver uses for `--preview`, so an unspelled
+    /// feature fails loudly in the example harness.
+    pub preview: &'static [&'static str],
+}
+
+impl ErrorCodeExample {
+    /// The preview features this example must be compiled with.
+    ///
+    /// The names are resolved with the same [`std::str::FromStr`] the driver
+    /// applies to `--preview <name>`, so every consumer that compiles an
+    /// example — the example harnesses in particular — agrees with the
+    /// command line about what a declared name means, and a name that no
+    /// longer resolves is reported rather than quietly dropped.
+    pub fn preview_features(&self) -> Result<PreviewFeatures, ParsePreviewFeatureError> {
+        self.preview.iter().map(|name| name.parse()).collect()
+    }
+
+    /// The command-line flags a reader must add to reproduce this example,
+    /// for instance `--preview c_ffi`, or `None` when the example needs none.
+    ///
+    /// Both renderers of an explanation — `rue explain` and the generated
+    /// error pages — project this one spelling, so a preview-gated example
+    /// states the same requirement wherever it is read.
+    pub fn preview_flags(&self) -> Option<String> {
+        if self.preview.is_empty() {
+            return None;
+        }
+        Some(
+            self.preview
+                .iter()
+                .map(|feature| format!("--preview {feature}"))
+                .collect::<Vec<_>>()
+                .join(" "),
+        )
+    }
 }
 
 /// The compiler result promised by an [`ErrorCodeExample`].
@@ -255,7 +295,13 @@ macro_rules! define_error_codes {
     (retired: [$($retired:literal),* $(,)?]; $( $(#[$meta:meta])* $name:ident = $value:literal $(=> {
         explanation: $explanation:literal,
         likely_cause: $likely_cause:literal,
-        examples: [$($example:expr),* $(,)?],
+        examples: [$(ErrorCodeExample {
+            title: $example_title:literal,
+            source: $example_source:literal,
+            outcome: $example_outcome:path
+            $(, preview: [$($example_preview:literal),* $(,)?])?
+            $(,)?
+        }),* $(,)?],
         references: [$($reference:expr),* $(,)?] $(,)?
     })?; )*) => {
         impl ErrorCode {
@@ -281,7 +327,12 @@ macro_rules! define_error_codes {
                     code: ErrorCode::$name,
                     explanation: $explanation,
                     likely_cause: $likely_cause,
-                    examples: &[$($example),*],
+                    examples: &[$(ErrorCodeExample {
+                        title: $example_title,
+                        source: $example_source,
+                        outcome: $example_outcome,
+                        preview: &[$($($example_preview),*)?],
+                    }),*],
                     references: &[$($reference),*],
                 },
             )?)*
@@ -2094,7 +2145,10 @@ define_error_codes! {
     LINK_ERROR = 1000 => {
         explanation: "E1000 reports a failure in the last stage of a compile: turning the generated objects, the embedded per-target Rue runtime archive, and any `--link-archive` inputs into an executable. One code covers the whole link step, and the message carries the specific failure — a symbol no linked archive defines, an archive that cannot be opened or parsed, a relocation the linker cannot apply, an invalid or empty embedded runtime archive, or a failure to spawn, wait on, or read the output of the external linker selected with `--linker <command>`. Rue links with its own internal linker by default, so most E1000 text comes from that linker rather than from a host toolchain; when a system linker is selected instead, its stderr is captured and forwarded verbatim inside the message. E1000 carries no source span, because the link step operates on objects rather than on source text and there is no expression to point at.",
         likely_cause: "The common cause is an `extern \"C\"` foreign declaration (preview feature `c_ffi`) whose symbol nothing linked defines. The message names the symbol and lists everything searched — the bundled Rue runtime archive followed by each `--link-archive <path>` in the order given — so supply the archive that defines the symbol, or correct the symbol's spelling. A `--link-archive` path that cannot be opened, and an archive whose members cannot be parsed, report under the same code and name the path. When `--linker <command>` selects a system linker, the text quoted after `linker '<command>' failed:` is that linker's own stderr and states the real cause.",
-        examples: [],
+        examples: [
+            ErrorCodeExample { title: "Foreign symbol nothing linked defines", source: "extern \"C\" {\n    fn missing_symbol() -> i32;\n}\n\nfn main() -> i32 {\n    checked { missing_symbol() }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode, preview: ["c_ffi"] },
+            ErrorCodeExample { title: "Link a definition for the C-boundary symbol", source: "pub extern \"C\" fn answer() -> i32 {\n    42\n}\n\nfn main() -> i32 {\n    answer()\n}", outcome: ErrorCodeExampleOutcome::Compiles, preview: ["c_ffi"] },
+        ],
         references: [
             ErrorCodeReference { title: "Foreign declarations link one definition", path: "docs/spec/src/09-unchecked-code/03-foreign-boundary.md", rule: Some("9.3:5") },
             ErrorCodeReference { title: "Per-target runtime archives", path: "docs/designs/0034-cross-target-runtime.md", rule: None },
@@ -4588,15 +4642,16 @@ mod tests {
             assert!(std::ptr::eq(explanation.metadata, metadata));
             assert!(!explanation.explanation.is_empty());
             assert!(!explanation.likely_cause.is_empty());
-            // Every explanation carries at most two worked examples. The
-            // linker/target tranche is the one band that carries none: E1000
-            // is raised by the linker over objects and archives, and no path
-            // constructs the kind behind E1001 at all, so neither has a Rue
-            // program the example harness could compile.
+            // Every explanation carries at most two worked examples. E1001 is
+            // the one code that carries none: nothing constructs the kind
+            // behind it, so no Rue program reaches it. E1000 does have one —
+            // a foreign call whose symbol no archive defines — and, like any
+            // example that needs a language feature still under preview, it
+            // declares the `--preview` names it must be compiled with.
             assert!(explanation.examples.len() <= 2);
             assert_eq!(
                 explanation.examples.is_empty(),
-                (1000..=1001).contains(&declaration.code.0),
+                declaration.code.0 == 1001,
                 "{} example presence must match its tranche",
                 declaration.code
             );
@@ -4604,6 +4659,12 @@ mod tests {
             for example in explanation.examples {
                 assert!(!example.title.is_empty());
                 assert!(!example.source.is_empty());
+                assert!(
+                    example.preview_features().is_ok(),
+                    "{} example {:?} names an unknown preview feature",
+                    declaration.code,
+                    example.title
+                );
             }
             for reference in explanation.references {
                 assert!(!reference.title.is_empty());

--- a/crates/rue-spec/src/error_pages.rs
+++ b/crates/rue-spec/src/error_pages.rs
@@ -155,10 +155,14 @@ pub fn generate(spec_dir: &Path, designs_dir: &Path) -> Result<Vec<GeneratedPage
                             example.title
                         ));
                     }
-                    page.push_str(&format!(
-                        "\n### {}\n\n```rue\n{}\n```\n",
-                        example.title, example.source
-                    ));
+                    page.push_str(&format!("\n### {}\n", example.title));
+                    // An example of a feature still behind a preview gate
+                    // reproduces only with that gate open; `rue explain`
+                    // states the same requirement from the same declaration.
+                    if let Some(flags) = example.preview_flags() {
+                        page.push_str(&format!("\nRequires `{flags}`.\n"));
+                    }
+                    page.push_str(&format!("\n```rue\n{}\n```\n", example.source));
                 }
             }
             if !explanation.references.is_empty() {

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1133,13 +1133,20 @@ fn render_error_code_explanation(explanation: &ErrorCodeExplanation) -> String {
     );
     writeln!(output, "\nLikely cause:\n{}", explanation.likely_cause)
         .expect("writing to a String cannot fail");
-    // A diagnostic that no Rue program can produce — a link failure over
-    // objects, an unservable target — declares no examples, so the heading is
-    // omitted rather than printed empty.
+    // A diagnostic that no Rue program can produce — E1001's unservable
+    // target — declares no examples, so the heading is omitted rather than
+    // printed empty.
     if !explanation.examples.is_empty() {
         output.push_str("\nExamples:\n");
         for example in explanation.examples {
-            writeln!(output, "\n{}:", example.title).expect("writing to a String cannot fail");
+            // An example of a feature still behind a preview gate reproduces
+            // only with that gate open, so the flags travel with the title
+            // rather than leaving a reader to hit the gate diagnostic.
+            match example.preview_flags() {
+                Some(flags) => writeln!(output, "\n{} (requires {flags}):", example.title),
+                None => writeln!(output, "\n{}:", example.title),
+            }
+            .expect("writing to a String cannot fail");
             for line in example.source.lines() {
                 writeln!(output, "    {line}").expect("writing to a String cannot fail");
             }


### PR DESCRIPTION
The explanation example harness compiled every example under `CompileOptions::default()`, so a diagnostic reachable only behind a preview gate could not carry a validated example. E1000 `LINK_ERROR` is exactly that: a two-line `extern "C"` program produces it under `--preview c_ffi` and E1100 without, so it shipped with no examples.

`ErrorCodeExample` gains `preview: &'static [&'static str]`, a list of preview names (plain data, so rue-error keeps no compiler dependency). `define_error_codes!` now destructures example literals and defaults the field to empty, so none of the 224 existing declarations change. Two helpers keep one canonical spelling for both consumers: `preview_features()` parses the names through the same `FromStr` the driver's `--preview` arm uses, and `preview_flags()` renders `--preview c_ffi` for the explanation renderers. The single-file harness, the multi-file and control-flow validators in `integration_tests.rs`, and the rue-error invariant test all resolve declared names and fail loudly on an unknown one.

E1000 gets a failing example (a foreign call whose symbol nothing linked defines, verified by hand as exactly one E1000 under the preview) and a compiling control (a self-defined `extern "C"` export, verified to link and run). `1000` joins the harness's code filter and the empty-examples pin now covers only E1001. `rue explain` prints `(requires --preview c_ffi)` beside a gated example's title and the error-pages generator emits a `Requires` line; across all generated pages only `E1000/index.md` differs, and `rue explain E0950` is byte-identical before and after.

Verified: fmt, `unit error`, `error-explanation-examples-test`, `unit compiler explanation`, `cli explain` (88), `//crates/rue-spec:error-pages`, `unit spec`, `//crates/rue:rue-test`, oracle-diff, quick.

Fixes RUE-2058