### PR TITLE
Place native arguments by the target's C rules

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -1,17 +1,21 @@
 //! Canonical native call-ABI classifier (ADR-0052 phase 5).
 //!
 //! One authority that answers a single question: *how does a value of a given
-//! type cross a call boundary on this target* — returned in registers, returned
-//! indirectly through caller storage (sret), passed by value across argument
-//! slots, or passed as one by-reference pointer. ADR-0052's third
-//! representation ("call ABI classification") is deliberately separate from the
-//! physical slot *count*: today the two coincide (an aggregate return uses sret
-//! exactly when its flattened slot count exceeds the return-register budget, and
-//! an argument occupies one slot per leaf), and this authority reproduces that
-//! decision byte-for-byte. Its value is that both code-generation backends, the
+//! type come back from a call on this target* — in registers, or indirectly
+//! through caller storage (sret). ADR-0052's third representation ("call ABI
+//! classification") is deliberately separate from the physical slot *count*: an
+//! aggregate return uses sret exactly when its flattened slot count exceeds the
+//! return-register budget. Its value is that both code-generation backends, the
 //! sret/return-budget decision sites, and the oracle's model of the call
 //! contract consult *one* place instead of each rediscovering
 //! `slot_count > budget`.
+//!
+//! *Arguments* are not classified here. The native convention places them
+//! exactly where the compilation target's C row places them (ADR-0084), which
+//! is [`lower_native_signature`](crate::lower_native_signature)'s answer against
+//! the same [`CAbiTypeFacts`] a C crossing presents; this module keeps the
+//! physical parameter-slot width the CFG contract and the oracle track
+//! ([`NativeCallAbi::arg_slot_width`]). The return joins them in RUE-2038.
 //!
 //! Which convention governs a boundary is named by exactly one value type,
 //! [`rue_target::CallingConvention`], whose rows are the native Rue convention
@@ -37,16 +41,10 @@
 //!
 //! ## Memory-first transitional rule (ADR-0052 ratified ruling 9)
 //!
-//! The preserved slot call convention stays in force unchanged while memory
-//! layout migrates. Under the compact layout preview an aggregate whose compact
-//! representation is *not* slot-identical cannot be expressed by the preserved
-//! register convention, so this classifier rules it **indirect** (by-reference /
-//! sret). That composes with RUE-974's loud refusal: a compact aggregate
-//! crossing a call is either expressible slot-identically (classified and
-//! marshaled exactly as today), passed indirectly (this rule), or refused
-//! loudly by code generation because the narrow indirect marshaling is not yet
-//! implemented — never silently wrong. Slot-identical aggregates keep the
-//! historical register classification byte-for-byte.
+//! The rule survives on the *return* only, until RUE-2038 places returns through
+//! the shared lowering as well: a multi-slot aggregate whose compact
+//! representation is not slot-identical cannot be expressed by the register
+//! return bank, so this classifier rules it indirect (sret).
 
 use crate::lowered_signature::CAbiTypeFacts;
 use crate::{FrozenTypeInternPool, Type, TypeKind};
@@ -120,27 +118,6 @@ impl NativeAbiTypeFacts {
         }
     }
 
-    /// Classify one argument: a by-reference `inout` / `borrow` is one pointer
-    /// slot; a by-value argument is omitted when zero-sized, forced indirect
-    /// when the compact layout cannot express it slot-identically, and passed
-    /// directly across its flattened slots otherwise.
-    pub const fn classify_arg(self, convention: ArgConvention) -> ArgClass {
-        match convention {
-            ArgConvention::ByReference => ArgClass::Indirect,
-            ArgConvention::ByValue => {
-                if self.abi_slots == 0 {
-                    ArgClass::Omitted
-                } else if self.crosses_indirectly_under_compact() {
-                    ArgClass::Indirect
-                } else {
-                    ArgClass::Direct {
-                        slot_count: self.abi_slots,
-                    }
-                }
-            }
-        }
-    }
-
     /// Physical parameter-slot width of one argument (ADR-0052
     /// representation 2): one pointer slot by reference, the flattened slot
     /// count by value. Deliberately independent of the compact transitional
@@ -152,11 +129,12 @@ impl NativeAbiTypeFacts {
         }
     }
 
-    /// The memory-first rule (ADR-0052 ruling 9): a multi-slot aggregate whose
-    /// compact representation is not slot-identical cannot cross the preserved
-    /// register convention and must go indirect — *unless it occupies exactly
-    /// one ABI slot* (RUE-1035), where one register transports the compact
-    /// image losslessly and the one-slot path stays byte-for-byte correct.
+    /// The memory-first rule (ADR-0052 ruling 9) as the *return* still applies
+    /// it: a multi-slot aggregate whose compact representation is not
+    /// slot-identical cannot come back through the register return bank and must
+    /// use sret — unless it occupies exactly one ABI slot (RUE-1035), where one
+    /// register transports the compact image losslessly. RUE-2038 replaces this
+    /// with the shared lowering, as ADR-0084 replaced the argument half.
     const fn crosses_indirectly_under_compact(self) -> bool {
         self.abi_slots > 1 && self.aggregate && !self.slot_identical
     }
@@ -209,41 +187,6 @@ pub enum ArgConvention {
     ByValue,
     /// An `inout` or `borrow` argument, represented by one caller pointer.
     ByReference,
-}
-
-/// How one argument crosses the call boundary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ArgClass {
-    /// Occupies no ABI slot (a zero-sized by-value argument).
-    Omitted,
-    /// Passed by value across `slot_count` flattened ABI slots: the first
-    /// `arg_reg_budget` in argument registers, the remainder on the stack.
-    Direct {
-        /// Number of flattened ABI slots the value occupies.
-        slot_count: u32,
-    },
-    /// Passed as one caller-provided pointer slot: a by-reference `inout` /
-    /// `borrow`, or — transitionally under the compact layout — a by-value
-    /// aggregate the preserved slot convention cannot express directly (see the
-    /// module memory-first rule).
-    Indirect,
-}
-
-impl ArgClass {
-    /// Number of ABI *crossing* slots this classification presents: a direct
-    /// value's slot count, one pointer for indirect, none when omitted.
-    ///
-    /// This is the representation-3 crossing width. The physical
-    /// value-decomposition width the CFG and the oracle track is
-    /// [`NativeCallAbi::arg_slot_width`], which is unaffected by the compact
-    /// transitional rule.
-    pub const fn crossing_slots(self) -> u32 {
-        match self {
-            Self::Omitted => 0,
-            Self::Direct { slot_count } => slot_count,
-            Self::Indirect => 1,
-        }
-    }
 }
 
 /// The native call-ABI classifier: the [`CallingConvention::Rue`] implementation.
@@ -322,21 +265,6 @@ impl<'a> NativeCallAbi<'a> {
     /// the boolean.
     pub fn return_is_sret(&self, ty: Type) -> bool {
         self.classify_return(ty).uses_sret()
-    }
-
-    /// Classify how one argument crosses the boundary.
-    ///
-    /// A by-reference `inout` / `borrow` is one pointer slot. A by-value
-    /// argument is omitted when zero-sized, otherwise passed directly across its
-    /// flattened slots — except that under the compact layout a non-slot-
-    /// identical aggregate is forced indirect (memory-first rule).
-    pub fn classify_arg(&self, ty: Type, convention: ArgConvention) -> ArgClass {
-        match convention {
-            // The kernel's by-reference rule is convention-only, so the facts
-            // projection (a pool walk) is skipped for it.
-            ArgConvention::ByReference => ArgClass::Indirect,
-            ArgConvention::ByValue => self.facts(ty).classify_arg(ArgConvention::ByValue),
-        }
     }
 
     /// Physical parameter-slot width of one argument: the value-decomposition
@@ -438,6 +366,10 @@ pub enum CAbiScalarKind {
     U32,
     /// The 1-byte C `_Bool` whose byte is 0/1 by contract.
     Bool,
+    /// A 32-bit binary floating-point value.
+    F32,
+    /// A 64-bit binary floating-point value.
+    F64,
     /// A value that already fills its 64-bit register: `i64`/`u64`, pointers,
     /// and the recovery scalar.
     RegisterWidth,
@@ -445,9 +377,13 @@ pub enum CAbiScalarKind {
 
 impl CAbiScalarKind {
     /// The live plane's projection of a type onto its width-and-signedness
-    /// class, or `None` when the type is not a target-C-passable scalar (an
-    /// aggregate, or a type `c_passable_by_value` rejects). The stable query
-    /// plane makes the same projection from its own type keys.
+    /// class, or `None` when the type is not a scalar (an aggregate, or a
+    /// compile-time-only type). The stable query plane makes the same
+    /// projection from its own type keys.
+    ///
+    /// The float classes are part of the projection because the native
+    /// convention places floats by these same rules (ADR-0084); the C boundary
+    /// rejects them earlier, in `c_passable_by_value`.
     pub fn for_live_type(ty: Type) -> Option<Self> {
         Some(match ty.kind() {
             TypeKind::I8 => Self::I8,
@@ -457,6 +393,8 @@ impl CAbiScalarKind {
             TypeKind::U16 => Self::U16,
             TypeKind::U32 => Self::U32,
             TypeKind::Bool => Self::Bool,
+            TypeKind::F32 => Self::F32,
+            TypeKind::F64 => Self::F64,
             TypeKind::I64
             | TypeKind::U64
             | TypeKind::PtrConst(_)
@@ -466,11 +404,32 @@ impl CAbiScalarKind {
         })
     }
 
-    /// The register bank this scalar travels in. Every scalar the C boundary
-    /// currently admits is an integer or a pointer, so every one is
-    /// general-purpose; floats join this projection when they cross.
+    /// The register bank this scalar travels in: the floating-point file for a
+    /// float, the general-purpose one for every integer, `bool`, and pointer.
     pub const fn register_class(self) -> CRegisterClass {
-        CRegisterClass::Gp
+        match self {
+            Self::F32 | Self::F64 => CRegisterClass::Fp,
+            Self::I8
+            | Self::I16
+            | Self::I32
+            | Self::U8
+            | Self::U16
+            | Self::U32
+            | Self::Bool
+            | Self::RegisterWidth => CRegisterClass::Gp,
+        }
+    }
+
+    /// The scalar's own width in bytes: the footprint a stacked copy takes
+    /// under a row that packs the outgoing argument area at natural size
+    /// ([`StackedArgumentPacking::NaturalSize`]).
+    pub const fn natural_bytes(self) -> u32 {
+        match self {
+            Self::I8 | Self::U8 | Self::Bool => 1,
+            Self::I16 | Self::U16 => 2,
+            Self::I32 | Self::U32 | Self::F32 => 4,
+            Self::F64 | Self::RegisterWidth => 8,
+        }
     }
 
     /// The canonical 64-bit extension for this scalar at a target-C boundary.
@@ -485,7 +444,8 @@ impl CAbiScalarKind {
             Self::U8 | Self::Bool => ScalarAbiExtension::Unsigned { from_bits: 8 },
             Self::U16 => ScalarAbiExtension::Unsigned { from_bits: 16 },
             Self::U32 => ScalarAbiExtension::Unsigned { from_bits: 32 },
-            Self::RegisterWidth => ScalarAbiExtension::None,
+            // A float fills its register: nothing is extended into or out of it.
+            Self::F32 | Self::F64 | Self::RegisterWidth => ScalarAbiExtension::None,
         }
     }
 }
@@ -1148,18 +1108,9 @@ mod tests {
                 slot_identical: true,
             };
             assert_eq!(zero.classify_return(budget), ReturnClass::ZeroSized);
-            assert_eq!(zero.classify_arg(ArgConvention::ByValue), ArgClass::Omitted);
 
             assert_eq!(scalar.classify_return(budget), ReturnClass::Scalar);
-            assert_eq!(
-                scalar.classify_arg(ArgConvention::ByValue),
-                ArgClass::Direct { slot_count: 1 }
-            );
             // By-reference is one pointer slot regardless of the facts.
-            assert_eq!(
-                aggregate(budget + 1, true).classify_arg(ArgConvention::ByReference),
-                ArgClass::Indirect
-            );
             assert_eq!(
                 aggregate(budget + 1, true).arg_slot_width(ArgConvention::ByReference),
                 1
@@ -1183,31 +1134,17 @@ mod tests {
                     slot_count: budget + 1
                 }
             );
-            assert_eq!(
-                aggregate(budget + 1, true).classify_arg(ArgConvention::ByValue),
-                ArgClass::Direct {
-                    slot_count: budget + 1
-                }
-            );
 
-            // The compact memory-first rule: a multi-slot non-slot-identical
-            // aggregate goes indirect in both positions; a single-slot one
-            // stays direct (RUE-1035).
+            // The compact memory-first rule on the return: a multi-slot
+            // non-slot-identical aggregate comes back through sret; a
+            // single-slot one still fits one register (RUE-1035).
             assert_eq!(
                 aggregate(2, false).classify_return(budget),
                 ReturnClass::Indirect { slot_count: 2 }
             );
             assert_eq!(
-                aggregate(2, false).classify_arg(ArgConvention::ByValue),
-                ArgClass::Indirect
-            );
-            assert_eq!(
                 aggregate(1, false).classify_return(budget),
                 ReturnClass::Registers { slot_count: 1 }
-            );
-            assert_eq!(
-                aggregate(1, false).classify_arg(ArgConvention::ByValue),
-                ArgClass::Direct { slot_count: 1 }
             );
 
             // Canonical StrBuf always returns through sret, even under budget.
@@ -1221,10 +1158,7 @@ mod tests {
                 strbuf.classify_return(budget),
                 ReturnClass::Indirect { slot_count: 3 }
             );
-            assert_eq!(
-                strbuf.classify_arg(ArgConvention::ByValue),
-                ArgClass::Direct { slot_count: 3 }
-            );
+            assert_eq!(strbuf.arg_slot_width(ArgConvention::ByValue), 3);
         }
     }
 
@@ -1261,14 +1195,5 @@ mod tests {
             ScalarAbiExtension::Unsigned { from_bits: 8 }
         );
         assert!(K::RegisterWidth.extension().is_noop());
-    }
-
-    #[test]
-    fn arg_class_crossing_width_matches_the_slot_contract() {
-        assert_eq!(ArgClass::Omitted.crossing_slots(), 0);
-        assert_eq!(ArgClass::Direct { slot_count: 4 }.crossing_slots(), 4);
-        // A by-reference argument and a transitional indirect aggregate both
-        // cross as one pointer.
-        assert_eq!(ArgClass::Indirect.crossing_slots(), 1);
     }
 }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -44,7 +44,7 @@ mod type_properties;
 mod types;
 
 pub use call_abi::{
-    ArgClass, ArgConvention, CAbiScalarKind, NativeAbiTypeFacts, NativeCallAbi, ReturnClass,
+    ArgConvention, CAbiScalarKind, NativeAbiTypeFacts, NativeCallAbi, ReturnClass,
     ScalarAbiExtension, TargetCCallAbi, aggregate_leaves, c_abi_type_facts,
     is_slot_identical_layout, native_return_register_budget,
 };
@@ -124,19 +124,19 @@ pub use sema::{
     DurableSignatureParameter, DurableTryProducer, FunctionInfo, ImplicitDropDependencySourceEvent,
     ImplicitNamedDestructorDependencyEvent, ImportResolution, MAX_COMPTIME_CALL_DEPTH,
     MemberCandidate, MemberKind, MethodInfo, NameCandidate, NameResolution,
-    NamedConstDependencyEvent, NamedConstDependencyTargetEvent, NativeArgClass,
-    NominalWellFormedness, OperatorMemberCandidate, OperatorName, ParamSlotModes,
-    ProviderAggregateFacts, ProviderAnonymousBody, ProviderBodyAnalysisState, ProviderBodyWork,
-    ProviderCallFacts, ProviderDefinitionKind, ProviderEndpointFacts, ProviderIdentityContext,
-    ProviderModuleMember, ProviderNamespace, ProviderOrdinaryBody, ProviderSpecializedBody,
-    ProviderStructHead, ProviderWellKnownOptionFacts, RirDeclarationIndexWork,
-    SemanticAnonymousNominalIdentity, SemanticBindingManifestWork, SemanticDeclarationShell,
-    SemanticDeclarationShellIdentity, SemanticDefinitionIdentity, SemanticExportType,
-    SemanticNominalIdentity, SemanticParameterMode, SemanticProducedAnonymousMethodSignature,
-    SemanticProducedAnonymousMethodType, SemanticProducedAnonymousNominal,
-    SemanticProducedAnonymousNominalShape, SourceParamAbi, analyze_provider_anonymous_body,
-    analyze_provider_ordinary_body, analyze_provider_specialized_body, body_parameter_types,
-    by_reference_parameter_pointee_types, comptime_depth_over_limit, next_comptime_depth,
+    NamedConstDependencyEvent, NamedConstDependencyTargetEvent, NominalWellFormedness,
+    OperatorMemberCandidate, OperatorName, ParamSlotModes, ProviderAggregateFacts,
+    ProviderAnonymousBody, ProviderBodyAnalysisState, ProviderBodyWork, ProviderCallFacts,
+    ProviderDefinitionKind, ProviderEndpointFacts, ProviderIdentityContext, ProviderModuleMember,
+    ProviderNamespace, ProviderOrdinaryBody, ProviderSpecializedBody, ProviderStructHead,
+    ProviderWellKnownOptionFacts, RirDeclarationIndexWork, SemanticAnonymousNominalIdentity,
+    SemanticBindingManifestWork, SemanticDeclarationShell, SemanticDeclarationShellIdentity,
+    SemanticDefinitionIdentity, SemanticExportType, SemanticNominalIdentity, SemanticParameterMode,
+    SemanticProducedAnonymousMethodSignature, SemanticProducedAnonymousMethodType,
+    SemanticProducedAnonymousNominal, SemanticProducedAnonymousNominalShape, SourceParamAbi,
+    analyze_provider_anonymous_body, analyze_provider_ordinary_body,
+    analyze_provider_specialized_body, body_parameter_types, by_reference_parameter_pointee_types,
+    comptime_depth_over_limit, next_comptime_depth, occupying_body_parameter_types,
 };
 pub use sema::{
     ComptimeDiagnosticSite, ComptimeIntegerOperation, ComptimeMatchPattern,

--- a/crates/rue-air/src/lowered_signature.rs
+++ b/crates/rue-air/src/lowered_signature.rs
@@ -1023,8 +1023,7 @@ fn lower_argument(placer: &mut Placer, facts: CAbiTypeFacts) -> ArgLocation {
                     pieces: RegisterPieces::one(class, index),
                 };
             }
-            let natural = u64::from(kind.extension().natural_bytes());
-            ArgLocation::stacked(placer.area.claim_scalar(natural))
+            ArgLocation::stacked(placer.area.claim_scalar(u64::from(kind.natural_bytes())))
         }
         CAbiTypeFacts::Aggregate {
             size,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -104,8 +104,8 @@ pub use output::{
     DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
     DeclarationTypeDependencyTargetKind, ImplicitDropDependencySourceEvent,
     ImplicitNamedDestructorDependencyEvent, NamedConstDependencyEvent,
-    NamedConstDependencyTargetEvent, NativeArgClass, ParamSlotModes, SourceParamAbi,
-    body_parameter_types, by_reference_parameter_pointee_types,
+    NamedConstDependencyTargetEvent, ParamSlotModes, SourceParamAbi, body_parameter_types,
+    by_reference_parameter_pointee_types, occupying_body_parameter_types,
 };
 pub use provider::{
     BodyFactProvider, DropCopyMetadata, ImportResolution, MemberCandidate, MemberKind,

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -228,53 +228,31 @@ pub struct ImplicitNamedDestructorDependencyEvent {
     pub target_owner_name: String,
 }
 
-/// Per-source-parameter native ABI descriptor carried from semantic analysis
-/// into code generation (ADR-0052 phase 5.8, RUE-1005).
+/// Per-source-parameter descriptor carried from semantic analysis into code
+/// generation.
 ///
 /// The per-ABI-slot [`ParamSlotModes::by_ref`] vector tells code generation
 /// which *slots* transport a pointer, but not how a *source parameter* groups
-/// its slots — which the callee prologue needs to map incoming argument
-/// registers onto frame parameter slots. A by-value non-slot-identical compact
-/// aggregate crosses as one [`ArgClass::Indirect`] pointer (one incoming
-/// register) while occupying `slot_count` frame slots, so the prologue cannot
-/// assume one incoming register per parameter slot. This descriptor carries the
-/// classifier's decision plus the parameter's slot span so the prologue can
-/// compute per-parameter incoming-register widths from the classifier authority
-/// rather than re-deriving them. With the gate off every parameter is
-/// [`ArgClass::Direct`] (or a single by-reference pointer slot) and
-/// `arg_class.crossing_slots() == slot_count`, so the plumbing is behaviourally
-/// inert and the emitted prologue is byte-identical.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NativeArgClass {
-    Gp,
-    Fp32,
-    Fp64,
-}
-
+/// its slots — which the callee prologue needs, because a parameter is placed as
+/// a whole and its eightbytes are what arrive. This descriptor is that grouping
+/// plus the parameter's type; where the value lands is code generation's own
+/// question, asked of the one placement function (ADR-0084).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceParamAbi {
     /// First parameter ABI slot this source parameter occupies.
     pub start_slot: u32,
-    /// Physical value-decomposition width (frame slots reserved), equal to
-    /// [`crate::NativeCallAbi::arg_slot_width`].
+    /// Physical value-decomposition width: the frame slots the parameter's
+    /// leaves occupy, equal to [`crate::NativeCallAbi::arg_slot_width`].
     pub slot_count: u32,
-    /// Number of incoming argument registers this parameter consumes, equal to
-    /// the classifier's [`crate::ArgClass::crossing_slots`]. For a direct
-    /// parameter this equals `slot_count`; for a by-reference pointer or a
-    /// by-value indirect compact aggregate it is one (the pointer), which is why
-    /// `crossing_regs < slot_count` distinguishes exactly the by-value indirect
-    /// aggregate the callee must unmarshal.
-    pub crossing_regs: u32,
-    /// Register-bank class of each crossing slot, in source order. Pointer
-    /// transports are GP; direct scalar float leaves retain their width.
-    pub crossing_classes: Vec<NativeArgClass>,
-    /// The aggregate type — carried *only* for a by-value indirect parameter, so
-    /// code generation can build its compact memory image; `None` for every
-    /// direct parameter and every by-reference pointer. Withholding the type
-    /// from a pointer-only or direct parameter keeps that CFG layout-independent
-    /// and reusable when an unrelated pointee struct's layout changes; a by-value
-    /// indirect aggregate already depends on its own layout (it reads its
-    /// fields), so carrying the type adds no new dependency.
+    /// The parameter's source type, or `None` when the analyzed body recovered
+    /// none for it (a by-reference pointer, whose pointee the convention never
+    /// consults, and a slot no `Param` instruction or drop entry names).
+    ///
+    /// Where the parameter's incoming value travels is not recorded here: code
+    /// generation recomputes it from this type through the one placement
+    /// function every crossing consumes
+    /// ([`crate::lower_native_signature`], ADR-0084), so a caller and its
+    /// callee cannot classify one signature two ways.
     pub ty: Option<crate::Type>,
 }
 
@@ -289,14 +267,35 @@ pub struct SourceParamAbi {
 /// be rediscovered two different ways — the export thunk in particular must see
 /// exactly the types the callee's own parameter layout was derived from.
 pub fn body_parameter_types(air: &crate::Air) -> ahash::AHashMap<u32, crate::Type> {
+    occupying_body_parameter_types(air, |_| true)
+}
+
+/// [`body_parameter_types`] restricted to the parameters that actually occupy
+/// an ABI slot.
+///
+/// A zero-sized by-value parameter occupies no slot, so the slot it is recorded
+/// against is the *next* parameter's. `occupies_slot` reports whether a type has
+/// any slot at all, and a parameter it rejects never claims one — which leaves
+/// each slot to the parameter that owns it. Every consumer that derives a
+/// physical layout from these types asks this way; the unrestricted spelling
+/// above is for presentation, where naming a zero-sized parameter is the point.
+pub fn occupying_body_parameter_types(
+    air: &crate::Air,
+    occupies_slot: impl Fn(crate::Type) -> bool,
+) -> ahash::AHashMap<u32, crate::Type> {
     let mut types: ahash::AHashMap<u32, crate::Type> = ahash::AHashMap::new();
+    let record = |slot: u32, ty: crate::Type, types: &mut ahash::AHashMap<u32, crate::Type>| {
+        if occupies_slot(ty) {
+            types.entry(slot).or_insert(ty);
+        }
+    };
     for &(slot, ty) in air.param_drops() {
-        types.entry(slot).or_insert(ty);
+        record(slot, ty, &mut types);
     }
     for index in 0..air.len() {
         let inst = air.get(crate::AirRef::from_raw(index as u32));
         if let crate::AirInstData::Param { index } = inst.data {
-            types.entry(index).or_insert(inst.ty);
+            record(index, inst.ty, &mut types);
         }
     }
     types
@@ -324,17 +323,6 @@ pub fn by_reference_parameter_pointee_types(air: &crate::Air) -> ahash::AHashMap
         }
     }
     types
-}
-
-impl SourceParamAbi {
-    /// Whether this parameter is a by-value aggregate the classifier forced
-    /// indirect: it reserves `slot_count` frame slots but arrives as one pointer
-    /// register, so the callee unmarshals its compact image at entry (RUE-1005).
-    /// A by-reference pointer (`crossing_regs == slot_count == 1`) and a direct
-    /// parameter (`crossing_regs == slot_count`) are both excluded.
-    pub const fn is_by_value_indirect(&self) -> bool {
-        self.crossing_regs < self.slot_count
-    }
 }
 
 /// Per-ABI-slot parameter access metadata preserved into CFG.

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -7,8 +7,8 @@ use ahash::{AHashMap, AHashSet};
 use lasso::{Spur, ThreadedRodeo};
 use rue_air::{
     AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
-    AnalyzedCallableKind, ArgConvention, FrozenTypeInternPool, NativeArgClass, NativeCallAbi,
-    ParamSlotModes, SourceParamAbi, StructId, Type, TypeKind, ValidatedAir,
+    AnalyzedCallableKind, FrozenTypeInternPool, ParamSlotModes, SourceParamAbi, StructId, Type,
+    TypeKind, ValidatedAir,
 };
 use rue_error::{CompileError, CompileWarning, ErrorKind, WarningKind};
 use std::cell::RefCell;
@@ -779,130 +779,80 @@ fn accessor_yield_spine(
     spine
 }
 
-/// Derive the grouped per-source-parameter ABI descriptors (ADR-0052 phase 5.8,
-/// RUE-1005) from the AIR and the per-slot by-reference vector.
+/// Derive the grouped per-source-parameter ABI descriptors from the AIR and the
+/// per-slot by-reference vector.
 ///
 /// The parameter type at each slot span comes from the AIR: every by-value
 /// (`Normal`) parameter — used or not — is recorded in `param_drops` with its
-/// start slot and type, and any additional used parameter (a destructor `self`,
-/// whose drops are cleared) is recovered from its `Param` instruction. Each
-/// parameter's incoming-register crossing width is decided by the native
-/// call-ABI classifier and stored as a plain integer; the descriptor carries no
-/// `Type`, so a pointer-only consumer's CFG stays layout-independent and
-/// reusable when a pointee struct's layout changes. Walking the slots and
-/// advancing by each parameter's decomposition width reconstructs the exact
-/// grouping identically for a fresh analysis and a durable/imported body, since
-/// both rebuild from the same AIR.
+/// start slot and type, any additional used parameter (a destructor `self`,
+/// whose drops are cleared) is recovered from its `Param` instruction, and one
+/// the body only forwards is recovered from the place that reads it. Each
+/// parameter spans its type's value-decomposition width, so walking the slots
+/// and advancing by that width reconstructs the exact grouping identically for
+/// a fresh analysis and a durable/imported body, since both rebuild from the
+/// same AIR.
+///
+/// The descriptor says *what* each parameter is, never where it arrives: code
+/// generation asks `rue_air::lower_native_signature` where the incoming value
+/// travels, so the callee's prologue and its callers read one placement
+/// (ADR-0084).
 fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
     let air = builder.air;
     let type_pool = builder.type_pool;
     let num_params = builder.cfg.num_params();
     let by_ref: Vec<bool> = builder.cfg.param_modes().to_vec();
-    let abi = NativeCallAbi::for_arguments(type_pool);
 
-    // Drop glue and destructors are invoked exclusively through the cleanup
-    // call convention (`CallPlan::from_slot_values`), which passes an
-    // aggregate's already-materialized slots DIRECTLY and flattened (RUE-998 /
-    // RUE-311), never the ordinary indirect compact-aggregate transport
-    // (RUE-1005). Their by-value parameters must therefore home one incoming
-    // register per slot; letting the compact classifier force a multi-slot
-    // element parameter indirect (one pointer) desynchronizes the direct-slot
-    // caller from an indirect-unmarshalling callee and miscompiles — an array
-    // drop glue dereferenced its element values as addresses and overflowed the
-    // stack (RUE-1035 M3). These synthetic symbols are compiler-reserved
-    // (`__rue_drop_*` glue, `<Type>.__drop` destructors), so this is the same
-    // identity codegen already resolves them by. Gate-off the classifier is
-    // already Direct, so this is inert there.
+    // Destructors and drop glue are invoked exclusively through the cleanup
+    // convention (`CallPlan::from_slot_values`), which passes an aggregate's
+    // already-materialized leaves DIRECTLY and flattened (RUE-998 / RUE-311):
+    // the callee walks those leaves rather than reconstructing a value, so it
+    // must receive one register-width leaf per slot. Withholding the type is
+    // what selects that arm on the callee side; these synthetic symbols are
+    // compiler-reserved (`__rue_drop_*` glue, `<Type>.__drop` destructors), the
+    // same identity code generation already resolves them by. Retires with
+    // RUE-2039.
     let direct_slot_abi = builder.callable_kind.uses_direct_slot_abi();
 
-    // Slot -> source type, from the one recovery the C-export thunk also reads,
-    // so a callee's parameter layout and the thunk that calls it cannot derive
-    // a parameter's type differently.
-    let ty_at: AHashMap<u32, Type> = rue_air::body_parameter_types(air);
+    // Slot -> source type. A parameter's own extent is what groups the slots,
+    // so every by-value parameter needs one: the drop schedule and the body's
+    // `Param` instructions name most of them, and a parameter the body only
+    // ever *forwards* — a `borrow` of it as a call argument, say — is named by
+    // the place that reads it. A zero-sized parameter occupies no slot, so it
+    // never claims the slot it shares with the parameter that follows it.
+    let occupies = |ty: Type| type_pool.abi_slot_count(ty) > 0;
+    let mut ty_at: AHashMap<u32, Type> = rue_air::occupying_body_parameter_types(air, occupies);
+    for (slot, ty) in rue_air::by_reference_parameter_pointee_types(air) {
+        if occupies(ty) {
+            ty_at.entry(slot).or_insert(ty);
+        }
+    }
 
     let mut descriptors = Vec::new();
     let mut slot = 0u32;
     while slot < num_params {
         let is_by_ref = by_ref.get(slot as usize).copied().unwrap_or(false);
-        let (slot_count, crossing_regs, ty, crossing_classes) = if is_by_ref {
-            // A by-reference parameter is always one pointer slot; its type is
-            // never consulted by code generation.
-            (1, 1, None, vec![NativeArgClass::Gp])
-        } else if let Some(&ty) = ty_at.get(&slot) {
-            let width = type_pool.abi_slot_count(ty).max(1);
-            let crossing = if direct_slot_abi {
-                // Cleanup-slot callees receive every slot directly (see above),
-                // so the incoming-register width is the full decomposition.
-                width
-            } else {
-                abi.classify_arg(ty, ArgConvention::ByValue)
-                    .crossing_slots()
-                    .max(1)
-            };
-            // Carry the type only when the parameter crosses indirectly (one
-            // pointer over a multi-slot span), so a direct parameter's CFG stays
-            // layout-independent.
-            let carried_ty = (crossing < width).then_some(ty);
-            let crossing_classes = if crossing < width {
-                vec![NativeArgClass::Gp]
-            } else {
-                let mut classes = native_arg_leaf_classes(type_pool, ty);
-                classes.reverse();
-                // Unit occupies one historical parameter slot even though it
-                // has no ABI leaf. Keep that synthetic slot in the GP bank so
-                // the parameter metadata remains a total description of the
-                // existing slot-oriented CFG contract.
-                if classes.is_empty() && crossing == 1 {
-                    classes.push(NativeArgClass::Gp);
-                }
-                classes
-            };
-            (width, crossing, carried_ty, crossing_classes)
-        } else {
-            // No recorded type for a by-value slot: a single direct slot, which
-            // homes exactly as the historical prologue.
-            (1, 1, None, vec![NativeArgClass::Gp])
+        // A by-reference parameter is always one pointer slot; its type is
+        // never consulted by code generation. A by-value slot with no recorded
+        // type is a single register-width slot: the recoveries above name every
+        // parameter the body can observe, so an unrecovered one is unread, and
+        // the only shape that reaches this arm is the `str` view a `borrow str`
+        // parameter is passed by value as — two register-width slots either way,
+        // so the split leaves every later parameter's placement unchanged.
+        let (slot_count, ty) = match (is_by_ref, ty_at.get(&slot)) {
+            (false, Some(&ty)) => {
+                let width = type_pool.abi_slot_count(ty).max(1);
+                (width, (!direct_slot_abi).then_some(ty))
+            }
+            _ => (1, None),
         };
         descriptors.push(SourceParamAbi {
             start_slot: slot,
             slot_count,
-            crossing_regs,
-            crossing_classes,
             ty,
         });
         slot += slot_count;
     }
     descriptors
-}
-
-fn native_arg_leaf_classes(type_pool: &FrozenTypeInternPool, ty: Type) -> Vec<NativeArgClass> {
-    fn push(type_pool: &FrozenTypeInternPool, ty: Type, out: &mut Vec<NativeArgClass>) {
-        match ty.kind() {
-            TypeKind::Unit | TypeKind::Never => {}
-            TypeKind::F32 => out.push(NativeArgClass::Fp32),
-            TypeKind::F64 => out.push(NativeArgClass::Fp64),
-            TypeKind::Struct(id) => {
-                for field in &type_pool.struct_def(id).fields {
-                    push(type_pool, field.ty, out);
-                }
-            }
-            TypeKind::Array(id) => {
-                let (element, len) = type_pool.array_def(id);
-                for _ in 0..len {
-                    push(type_pool, element, out);
-                }
-            }
-            // Enums always carry an integer tag and may overlay unlike payload
-            // classes, so their stable internal call image remains GP-shaped.
-            TypeKind::Enum(_) => {
-                out.extend((0..type_pool.abi_slot_count(ty)).map(|_| NativeArgClass::Gp));
-            }
-            _ => out.push(NativeArgClass::Gp),
-        }
-    }
-    let mut out = Vec::new();
-    push(type_pool, ty, &mut out);
-    out
 }
 
 impl<'a> CfgBuilder<'a> {

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -2472,8 +2472,6 @@ mod tests {
             cfg.set_source_param_abi(vec![SourceParamAbi {
                 start_slot: 0,
                 slot_count: 2,
-                crossing_regs: 2,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp; 2],
                 ty: None,
             }]);
             let entry = cfg.new_block();
@@ -3201,8 +3199,6 @@ mod tests {
             cfg.set_source_param_abi(vec![SourceParamAbi {
                 start_slot: 0,
                 slot_count: 2,
-                crossing_regs: 2,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp; 2],
                 ty: None,
             }]);
             let entry = cfg.new_block();

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -1162,8 +1162,6 @@ impl Cfg {
                 Ok(rue_air::SourceParamAbi {
                     start_slot: param.start_slot,
                     slot_count: param.slot_count,
-                    crossing_regs: param.crossing_regs,
-                    crossing_classes: param.crossing_classes.clone(),
                     ty: match param.ty {
                         Some(t) => Some(ty(t).map_err(CfgRemapError::Domain)?),
                         None => None,

--- a/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
+++ b/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
@@ -716,3 +716,409 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "204\n"
+
+# =============================================================================
+# ARGPLACE — the placements ADR-0084's phase 1 gave native arguments
+# =============================================================================
+#
+# Each case fixes one shape the switch to the target C row's argument placement
+# changes most, and observes every field on the callee side, so a value that
+# arrives in the wrong register, the wrong half of an eightbyte, or the wrong
+# stack byte fails immediately. They run on both backends; the aarch64 rows
+# execute only on a native aarch64 CI host.
+
+# Four `u8` fields are four bytes: one eightbyte, so the whole struct now
+# arrives in ONE register and the callee reads its leaves back out of the
+# image. Under the retired slot model this took four registers.
+[[case]]
+name = "argplace_four_u8_fields_share_one_register"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Quad { a: u8, b: u8, c: u8, d: u8 }
+fn read(q: Quad) -> i32 {
+    let a: i32 = @intCast(q.a);
+    let b: i32 = @intCast(q.b);
+    let c: i32 = @intCast(q.c);
+    let d: i32 = @intCast(q.d);
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    @dbg(d);
+    0
+}
+fn main() -> i32 {
+    read(Quad { a: 1, b: 2, c: 3, d: 250 })
+}
+""" }]
+stdout = "1\n2\n3\n250\n"
+
+# `{i32, i32}` is one eightbyte too. The first call leaves it in the LAST
+# argument register of both rows (five scalars ahead of it on SysV, seven on
+# AAPCS64 — the SysV call therefore also proves a later argument still takes a
+# register the packed struct did not need); the second pushes it past both
+# rosters, to the first stack position.
+[[case]]
+name = "argplace_i32_pair_at_the_last_register_and_on_the_stack"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Pair { x: i32, y: i32 }
+fn last_register(p0: i64, p1: i64, p2: i64, p3: i64, p4: i64, p: Pair) -> i32 {
+    let n: i32 = @intCast(p0 + p1 + p2 + p3 + p4);
+    @dbg(n);
+    @dbg(p.x);
+    @dbg(p.y);
+    0
+}
+fn stacked(
+    p0: i64,
+    p1: i64,
+    p2: i64,
+    p3: i64,
+    p4: i64,
+    p5: i64,
+    p6: i64,
+    p7: i64,
+    p: Pair,
+) -> i32 {
+    let n: i32 = @intCast(p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7);
+    @dbg(n);
+    @dbg(p.x);
+    @dbg(p.y);
+    0
+}
+fn main() -> i32 {
+    let a = last_register(1, 2, 3, 4, 5, Pair { x: 11, y: 22 });
+    let b = stacked(1, 2, 3, 4, 5, 6, 7, 8, Pair { x: 33, y: 44 });
+    a + b
+}
+""" }]
+stdout = "15\n11\n22\n36\n33\n44\n"
+
+# `{f64, i64}` classifies SSE then INTEGER on SysV, so its two eightbytes take
+# registers of DIFFERENT banks; AAPCS64 passes the same composite in two
+# consecutive integer registers, which is why the float leaf crosses as the
+# image's bits there. Both ends must agree either way.
+[[case]]
+name = "argplace_float_and_integer_split_across_banks"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Split { v: f64, n: i64 }
+fn read(s: Split, tail: i64) -> i32 {
+    let v: i32 = @float_to_int(s.v * 2.0);
+    let n: i32 = @intCast(s.n);
+    let t: i32 = @intCast(tail);
+    @dbg(v);
+    @dbg(n);
+    @dbg(t);
+    0
+}
+fn main() -> i32 {
+    read(Split { v: 3.5, n: 9 }, 4)
+}
+""" }]
+stdout = "7\n9\n4\n"
+
+# 24 bytes is past every row's register-passed aggregate: SysV MEMORY class
+# byval in the outgoing argument area, an AAPCS64 caller-owned copy behind one
+# pointer. The trailing scalar proves SysV still hands a later argument the
+# register the stacked aggregate consumed none of.
+[[case]]
+name = "argplace_twenty_four_byte_struct_crosses_through_memory"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Wide { a: i64, b: i64, c: i64 }
+fn read(w: Wide, tail: i64) -> i32 {
+    let a: i32 = @intCast(w.a);
+    let b: i32 = @intCast(w.b);
+    let c: i32 = @intCast(w.c);
+    let t: i32 = @intCast(tail);
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    @dbg(t);
+    0
+}
+fn main() -> i32 {
+    read(Wide { a: 10, b: 20, c: 30 }, 40)
+}
+""" }]
+stdout = "10\n20\n30\n40\n"
+
+# Nine arguments with a narrow tail: the roster runs out and the tail lands in
+# the outgoing argument area, where every row but Apple's packs it in whole
+# eightbytes. The callee re-extends each one into Rue's canonical form, so a
+# negative `i8` must still read as -7 and not as 249.
+[[case]]
+name = "argplace_nine_arguments_with_a_narrow_tail"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn nine(
+    a: i64,
+    b: i64,
+    c: i64,
+    d: i64,
+    e: i64,
+    f: i64,
+    g: i8,
+    h: u16,
+    i: i32,
+) -> i32 {
+    let s: i32 = @intCast(a + b + c + d + e + f);
+    let gg: i32 = @intCast(g);
+    let hh: i32 = @intCast(h);
+    @dbg(s);
+    @dbg(gg);
+    @dbg(hh);
+    @dbg(i);
+    0
+}
+fn main() -> i32 {
+    nine(1, 2, 3, 4, 5, 6, -7, 65535, -9)
+}
+""" }]
+stdout = "21\n-7\n65535\n-9\n"
+
+# A payload enum argument: the tag and the active variant's fields are read
+# back out of the image the convention placed, at every roster position the
+# call reaches.
+[[case]]
+name = "argplace_enum_argument_in_registers_and_on_the_stack"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape.Circle(r) => r * r,
+        Shape.Rect(w, h) => w * h,
+        Shape.Empty => 0,
+    }
+}
+fn stacked(
+    p0: i64,
+    p1: i64,
+    p2: i64,
+    p3: i64,
+    p4: i64,
+    p5: i64,
+    p6: i64,
+    p7: i64,
+    s: Shape,
+) -> i32 {
+    let n: i32 = @intCast(p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7);
+    @dbg(n);
+    area(s)
+}
+fn main() -> i32 {
+    @dbg(area(Shape.Circle(5)));
+    @dbg(area(Shape.Rect(3, 4)));
+    @dbg(area(Shape.Empty));
+    @dbg(stacked(1, 2, 3, 4, 5, 6, 7, 8, Shape.Rect(6, 7)));
+    0
+}
+""" }]
+stdout = "25\n12\n0\n36\n42\n"
+
+# The same six placements on the AArch64 row, where the convention's answers
+# differ: a composite travels in consecutive INTEGER registers whatever its
+# members are, a composite over sixteen bytes crosses by reference, and rule
+# C.11's roster exhaustion stacks every later argument. These compile and link
+# for aarch64-linux; a native aarch64 CI host also executes them.
+[[case]]
+name = "argplace_aarch64_four_u8_fields_share_one_register"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Quad { a: u8, b: u8, c: u8, d: u8 }
+fn read(q: Quad) -> i32 {
+    let a: i32 = @intCast(q.a);
+    let b: i32 = @intCast(q.b);
+    let c: i32 = @intCast(q.c);
+    let d: i32 = @intCast(q.d);
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    @dbg(d);
+    0
+}
+fn main() -> i32 {
+    read(Quad { a: 1, b: 2, c: 3, d: 250 })
+}
+""" }]
+stdout = "1\n2\n3\n250\n"
+
+# `{i32, i32}` is one eightbyte too. The first call leaves it in the LAST
+# argument register of both rows (five scalars ahead of it on SysV, seven on
+# AAPCS64 — the SysV call therefore also proves a later argument still takes a
+# register the packed struct did not need); the second pushes it past both
+# rosters, to the first stack position.
+[[case]]
+name = "argplace_aarch64_i32_pair_at_the_last_register_and_on_the_stack"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Pair { x: i32, y: i32 }
+fn last_register(p0: i64, p1: i64, p2: i64, p3: i64, p4: i64, p: Pair) -> i32 {
+    let n: i32 = @intCast(p0 + p1 + p2 + p3 + p4);
+    @dbg(n);
+    @dbg(p.x);
+    @dbg(p.y);
+    0
+}
+fn stacked(
+    p0: i64,
+    p1: i64,
+    p2: i64,
+    p3: i64,
+    p4: i64,
+    p5: i64,
+    p6: i64,
+    p7: i64,
+    p: Pair,
+) -> i32 {
+    let n: i32 = @intCast(p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7);
+    @dbg(n);
+    @dbg(p.x);
+    @dbg(p.y);
+    0
+}
+fn main() -> i32 {
+    let a = last_register(1, 2, 3, 4, 5, Pair { x: 11, y: 22 });
+    let b = stacked(1, 2, 3, 4, 5, 6, 7, 8, Pair { x: 33, y: 44 });
+    a + b
+}
+""" }]
+stdout = "15\n11\n22\n36\n33\n44\n"
+
+# `{f64, i64}` classifies SSE then INTEGER on SysV, so its two eightbytes take
+# registers of DIFFERENT banks; AAPCS64 passes the same composite in two
+# consecutive integer registers, which is why the float leaf crosses as the
+# image's bits there. Both ends must agree either way.
+[[case]]
+name = "argplace_aarch64_float_and_integer_split_across_banks"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Split { v: f64, n: i64 }
+fn read(s: Split, tail: i64) -> i32 {
+    let v: i32 = @float_to_int(s.v * 2.0);
+    let n: i32 = @intCast(s.n);
+    let t: i32 = @intCast(tail);
+    @dbg(v);
+    @dbg(n);
+    @dbg(t);
+    0
+}
+fn main() -> i32 {
+    read(Split { v: 3.5, n: 9 }, 4)
+}
+""" }]
+stdout = "7\n9\n4\n"
+
+# 24 bytes is past every row's register-passed aggregate: SysV MEMORY class
+# byval in the outgoing argument area, an AAPCS64 caller-owned copy behind one
+# pointer. The trailing scalar proves SysV still hands a later argument the
+# register the stacked aggregate consumed none of.
+[[case]]
+name = "argplace_aarch64_twenty_four_byte_struct_crosses_through_memory"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Wide { a: i64, b: i64, c: i64 }
+fn read(w: Wide, tail: i64) -> i32 {
+    let a: i32 = @intCast(w.a);
+    let b: i32 = @intCast(w.b);
+    let c: i32 = @intCast(w.c);
+    let t: i32 = @intCast(tail);
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    @dbg(t);
+    0
+}
+fn main() -> i32 {
+    read(Wide { a: 10, b: 20, c: 30 }, 40)
+}
+""" }]
+stdout = "10\n20\n30\n40\n"
+
+# Nine arguments with a narrow tail: the roster runs out and the tail lands in
+# the outgoing argument area, where every row but Apple's packs it in whole
+# eightbytes. The callee re-extends each one into Rue's canonical form, so a
+# negative `i8` must still read as -7 and not as 249.
+[[case]]
+name = "argplace_aarch64_nine_arguments_with_a_narrow_tail"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+fn nine(
+    a: i64,
+    b: i64,
+    c: i64,
+    d: i64,
+    e: i64,
+    f: i64,
+    g: i8,
+    h: u16,
+    i: i32,
+) -> i32 {
+    let s: i32 = @intCast(a + b + c + d + e + f);
+    let gg: i32 = @intCast(g);
+    let hh: i32 = @intCast(h);
+    @dbg(s);
+    @dbg(gg);
+    @dbg(hh);
+    @dbg(i);
+    0
+}
+fn main() -> i32 {
+    nine(1, 2, 3, 4, 5, 6, -7, 65535, -9)
+}
+""" }]
+stdout = "21\n-7\n65535\n-9\n"
+
+# A payload enum argument: the tag and the active variant's fields are read
+# back out of the image the convention placed, at every roster position the
+# call reaches.
+[[case]]
+name = "argplace_aarch64_enum_argument_in_registers_and_on_the_stack"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape.Circle(r) => r * r,
+        Shape.Rect(w, h) => w * h,
+        Shape.Empty => 0,
+    }
+}
+fn stacked(
+    p0: i64,
+    p1: i64,
+    p2: i64,
+    p3: i64,
+    p4: i64,
+    p5: i64,
+    p6: i64,
+    p7: i64,
+    s: Shape,
+) -> i32 {
+    let n: i32 = @intCast(p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7);
+    @dbg(n);
+    area(s)
+}
+fn main() -> i32 {
+    @dbg(area(Shape.Circle(5)));
+    @dbg(area(Shape.Rect(3, 4)));
+    @dbg(area(Shape.Empty));
+    @dbg(stacked(1, 2, 3, 4, 5, 6, 7, 8, Shape.Rect(6, 7)));
+    0
+}
+""" }]
+stdout = "25\n12\n0\n36\n42\n"

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -188,22 +188,51 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         pointer
     }
 
-    fn materialize_indirect_value_arg(
+    fn materialize_image_eightbytes(
         &mut self,
         value: CfgValue,
-        image: &[crate::types::PhysicalEnumSlot],
-        padding: &[rue_air::layout::PaddingRange],
-        storage_bytes: u32,
+        image: &crate::native_abi::NativeImage,
+    ) -> Vec<VReg> {
+        // Reserve a scratch buffer, write the aggregate's compact image into it
+        // — each leaf truncated to its physical width at its compact byte
+        // offset — and read the eightbytes the convention places back out. The
+        // buffer is released immediately: only the eightbytes cross.
+        self.mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("native argument image must fit displacement"),
+        });
+        let pointer = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(pointer),
+            src: Operand::Physical(Reg::Sp),
+        });
+        self.write_native_image(value, pointer, image);
+        let eightbytes =
+            crate::agg_slots::load_slots_through_ptr(self, pointer, image.eightbytes());
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("native argument image must fit displacement"),
+        });
+        eightbytes
+    }
+
+    fn materialize_indirect_image(
+        &mut self,
+        value: CfgValue,
+        image: &crate::native_abi::NativeImage,
     ) -> VReg {
-        // Reserve a caller-owned buffer just below the sret storage (RUE-1005),
-        // capture its address, and write the aggregate's compact image into it —
-        // each slot truncated to its physical width at its compact byte offset,
-        // exactly the image the callee prologue unmarshals. The image's padding is
+        // Reserve a caller-owned buffer just below the sret storage, capture its
+        // address, and write the aggregate's compact image into it — exactly the
+        // image the callee reads through the pointer. The image's padding is
         // zeroed first (ADR-0052 ruling 5) so the buffer is fully initialized.
         self.mir.push(Aarch64Inst::SubImm {
             dst: Operand::Physical(Reg::Sp),
             src: Operand::Physical(Reg::Sp),
-            imm: checked_displacement_bytes(u64::from(storage_bytes))
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
                 .expect("indirect argument storage must fit displacement"),
         });
         let pointer = self.mir.alloc_vreg();
@@ -211,33 +240,18 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
             dst: Operand::Virtual(pointer),
             src: Operand::Physical(Reg::Sp),
         });
-        let slots = self.require_aggregate_slots(value);
-        crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image, padding);
+        self.write_native_image(value, pointer, image);
         pointer
     }
 
-    fn materialize_indirect_value_arg_dispatch(
-        &mut self,
-        value: CfgValue,
-        image: &crate::types::DispatchImage,
-        storage_bytes: u32,
-    ) -> VReg {
-        // As `materialize_indirect_value_arg`, but the caller-owned buffer is
-        // written with a per-variant tag dispatch (RUE-1037).
-        self.mir.push(Aarch64Inst::SubImm {
-            dst: Operand::Physical(Reg::Sp),
-            src: Operand::Physical(Reg::Sp),
-            imm: checked_displacement_bytes(u64::from(storage_bytes))
-                .expect("indirect argument storage must fit displacement"),
+    fn materialize_eightbyte_as_float(&mut self, bits: VReg) -> VReg {
+        let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+        self.mir.push(Aarch64Inst::BitsToFloat {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(bits),
+            width: FloatWidth::F64,
         });
-        let pointer = self.mir.alloc_vreg();
-        self.mir.push(Aarch64Inst::MovRR {
-            dst: Operand::Virtual(pointer),
-            src: Operand::Physical(Reg::Sp),
-        });
-        let slots = self.require_aggregate_slots(value);
-        crate::agg_slots::store_dispatch_image(self, &slots, pointer, image);
-        pointer
+        dst
     }
 }
 
@@ -1264,10 +1278,30 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Materialize an aggregate argument's eightbytes (ADR-0064 P3): write its
-    /// native slots into a scratch buffer as the compact C image, then load the
-    /// whole eightbytes back so they pack in ascending C field order. rsp-neutral
-    /// — a register aggregate argument's bytes live only in the returned vregs.
+    /// Write the aggregate `value`'s leaves into the compact image at
+    /// `pointer`, through whichever of the two image shapes the type has.
+    fn write_native_image(
+        &mut self,
+        value: CfgValue,
+        pointer: VReg,
+        image: &crate::native_abi::NativeImage,
+    ) {
+        let slots = self.require_aggregate_slots(value);
+        match &image.kind {
+            crate::native_abi::NativeImageKind::Map { map, padding } => {
+                crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, map, padding);
+            }
+            crate::native_abi::NativeImageKind::Dispatch(dispatch) => {
+                crate::agg_slots::store_dispatch_image(self, &slots, pointer, dispatch);
+            }
+        }
+    }
+
+    /// Materialize a foreign aggregate argument's eightbytes (ADR-0064 P3):
+    /// write its native slots into a scratch buffer as the compact C image, then
+    /// load the whole eightbytes back so they pack in ascending C field order.
+    /// sp-neutral — a register aggregate argument's bytes live only in the
+    /// returned vregs.
     fn image_arg_eightbytes(
         &mut self,
         value: CfgValue,
@@ -3791,16 +3825,20 @@ impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
 impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
     fn preload_by_ref_params(&mut self) {
         self.preload_by_ref_param_ptrs();
-        // Unmarshal each by-value indirect compact aggregate parameter from the
-        // homed pointer into its frame slots at entry (RUE-1005), so field
-        // projection and whole-value reads see the correct decomposition.
-        for (base_slot, map) in crate::value_plan::indirect_value_params(&self.ctx) {
-            crate::agg_slots::unmarshal_indirect_value_param(self, base_slot, &map);
-        }
-        // Heterogeneous by-value indirect params unmarshal with a tag dispatch
-        // (RUE-1037).
-        for (base_slot, image) in crate::value_plan::indirect_value_params_dispatch(&self.ctx) {
-            crate::agg_slots::unmarshal_indirect_value_param_dispatch(self, base_slot, &image);
+        // Read each by-value aggregate parameter whose leaves are not its
+        // eightbytes back out of the compact image the prologue laid down, so
+        // field projection and whole-value reads see the correct decomposition
+        // (ADR-0084).
+        for (base_slot, image_slot_offset, through_pointer, image) in
+            crate::value_plan::param_image_unmarshals(&self.ctx)
+        {
+            crate::agg_slots::unmarshal_param_image(
+                self,
+                base_slot,
+                image_slot_offset,
+                through_pointer,
+                &image,
+            );
         }
     }
 
@@ -4281,6 +4319,15 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
                 offset,
             });
         }
+    }
+
+    fn emit_slot_addr(&mut self, dst: VReg, slot: u32) {
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Virtual(dst),
+            src: Operand::Physical(Reg::Fp),
+            imm: offset,
+        });
     }
     fn emit_typed_float_load_slot(&mut self, dst: VReg, slot: u32, width: FloatWidth) {
         self.mir.push(Aarch64Inst::FloatLoad {
@@ -4989,8 +5036,6 @@ mod tests {
             .map(|slot| SourceParamAbi {
                 start_slot: slot,
                 slot_count: 1,
-                crossing_regs: 1,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()
@@ -6210,13 +6255,14 @@ mod tests {
         );
     }
 
-    /// RUE-1005 callee side on AArch64: the receiving function unmarshals the
-    /// compact image (narrow loads) from the homed pointer into its frame slots
-    /// at entry.
+    /// ADR-0084 callee side on AArch64: the receiving function reads its
+    /// by-value aggregate's leaves back out of the compact image (narrow loads)
+    /// the prologue laid down in its frame slots.
     #[test]
     fn aggregate_layout_allows_by_value_compact_struct_arg_callee() {
-        // The callee side: `fn sum(p: Padded) -> i32 { p.b }`, whose by-value
-        // indirect parameter reserves three frame slots behind one pointer.
+        // The callee side: `fn sum(p: Padded) -> i32 { p.b }`. `Padded` is 12
+        // bytes whose leaves sit at 0, 4 and 8, so it crosses as two eightbytes
+        // and the entry unmarshal recovers the three leaves from them.
         let interner = ThreadedRodeo::new();
         let pool = TypeInternPool::new();
         let padded_id = register_struct(
@@ -6235,8 +6281,6 @@ mod tests {
             vec![SourceParamAbi {
                 start_slot: 0,
                 slot_count: 3,
-                crossing_regs: 1,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: Some(padded_ty),
             }],
             &pool,
@@ -6252,14 +6296,12 @@ mod tests {
             Type::I32,
         );
         fixture.ret(Some(b));
-        let mir = fixture
-            .lower()
-            .expect("the callee of a by-value compact struct argument must lower");
+        let mir = fixture.lower_with_plan();
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, Aarch64Inst::NarrowLoadIndexed { width: 1, .. })),
-            "the callee must unmarshal the u8 fields narrow from the homed pointer"
+            "the callee must read the u8 leaves narrow out of the frame image"
         );
     }
 

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -567,6 +567,7 @@ impl<'a> Emitter<'a> {
                 .map(|slot| crate::codegen_pipeline::ParamHoming {
                     start_slot: slot,
                     class: crate::call_plan::AbiSlotClass::Gp,
+                    narrow_stack_load: None,
                     location: if (slot + abi_shift) < 8 {
                         crate::call_plan::AbiSlotLocation::GpReg((slot + abi_shift) as usize)
                     } else {
@@ -973,13 +974,41 @@ impl<'a> Emitter<'a> {
                     );
                 }
                 (_, crate::call_plan::AbiSlotLocation::Stack { offset: area, .. }) => {
-                    // Stack-passed arg: copy from above the frame into the param area
+                    // Stack-passed value: copy the eightbyte from above the
+                    // frame into the param area. Apple's amendment packs a
+                    // stacked scalar at its own width, so such a value is
+                    // re-extended on the way in and the frame slot holds Rue's
+                    // canonical 64-bit form.
                     let src_offset =
                         crate::frame_layout::checked_incoming_stack_arg_byte_offset(16, area)
                             .expect("incoming stack argument offset must fit displacement");
                     self.begin_inst();
-                    self.emit_ldr(Reg::X9, Reg::Fp, src_offset);
-                    end_inst!(self, "ldr x9, [x29, #{}]", src_offset);
+                    match homing.narrow_stack_load {
+                        Some(narrow) => {
+                            self.emit_narrow_load(
+                                Reg::X9,
+                                Reg::Fp,
+                                src_offset,
+                                narrow.width,
+                                narrow.signed,
+                            );
+                            end_inst!(
+                                self,
+                                "ldr{}{} x9, [x29, #{}]",
+                                if narrow.signed { "s" } else { "" },
+                                match narrow.width {
+                                    1 => "b",
+                                    2 => "h",
+                                    _ => "w",
+                                },
+                                src_offset
+                            );
+                        }
+                        None => {
+                            self.emit_ldr(Reg::X9, Reg::Fp, src_offset);
+                            end_inst!(self, "ldr x9, [x29, #{}]", src_offset);
+                        }
+                    }
                     self.begin_inst();
                     self.emit_str(Reg::X9, Reg::Fp, offset);
                     end_inst!(self, "str x9, [x29, #{}]", offset);
@@ -3602,11 +3631,42 @@ mod tests {
             .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                 start_slot: 0,
                 class: crate::call_plan::AbiSlotClass::Gp,
+                narrow_stack_load: None,
                 location: crate::call_plan::AbiSlotLocation::stack_slot(0),
             }])
             .emit_all()
             .expect("stack argument homing must emit");
         assert!(emitted.to_asm().contains("ldr x9, [x29, #16]"));
+    }
+
+    /// Apple's amendment packs a stacked scalar at its natural size, so a value
+    /// narrower than an eightbyte is re-extended on the way into the frame slot
+    /// — Rue's canonical 64-bit form is stronger than what any C row promises.
+    #[test]
+    fn a_narrow_stacked_argument_is_re_extended_into_its_frame_slot() {
+        for (width, signed, mnemonic) in [
+            (1u8, true, "ldrsb x9, [x29, #16]"),
+            (2u8, false, "ldrh x9, [x29, #16]"),
+            (4u8, true, "ldrsw x9, [x29, #16]"),
+        ] {
+            let mut mir = Aarch64Mir::new();
+            mir.push(Aarch64Inst::Ret);
+            let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
+                .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
+                    start_slot: 0,
+                    class: crate::call_plan::AbiSlotClass::Gp,
+                    narrow_stack_load: Some(crate::types::NarrowScalar { width, signed }),
+                    location: crate::call_plan::AbiSlotLocation::Stack {
+                        offset: 0,
+                        size: u32::from(width),
+                        align: u32::from(width),
+                    },
+                }])
+                .emit_all()
+                .expect("a narrow stacked argument must home");
+            let asm = emitted.to_asm();
+            assert!(asm.contains(mnemonic), "{width}/{signed}: {asm}");
+        }
     }
 
     fn emit_single_with_callee_saved(inst: Aarch64Inst, callee_saved: &[Reg]) -> Vec<u8> {

--- a/crates/rue-codegen/src/abi_report.rs
+++ b/crates/rue-codegen/src/abi_report.rs
@@ -12,10 +12,12 @@
 //!   consumes, through the very same projections the import lowering
 //!   ([`crate::foreign_call::ForeignCallInputs`]) and the export thunk
 //!   ([`crate::export_thunk::ExportSignature`]) build;
-//! * the native Rue convention reads [`rue_air::NativeCallAbi`] through
-//!   [`return_plan`] for the classification and [`assign_abi_slots`] /
-//!   [`crate::call_plan::return_slot_regs`] for the physical slot plan, over the
-//!   same class vector the callee's parameter storage plan builds.
+//! * the native Rue convention reads [`rue_air::lower_native_signature`] for
+//!   its arguments — the same placement the callee's parameter storage plan and
+//!   every caller of that signature read (ADR-0084) — and
+//!   [`rue_air::NativeCallAbi`] through [`return_plan`] and
+//!   [`crate::call_plan::return_slot_regs`] for the result, which keeps its own
+//!   wider bank until RUE-2038.
 //!
 //! Physical register *names* stay in the two backends: this module asks
 //! [`TargetRegisters`] for the name of a roster index and never restates a
@@ -47,9 +49,10 @@ use rue_cfg::{CfgInstData, CfgValue, ValidatedCfg};
 use rue_target::{Arch, CRegisterClass, CallingConvention, SretRegisterKind, Target};
 
 use crate::call_plan::{
-    AbiRegisterBanks, AbiSlotClass, AbiSlotLocation, ReturnPlan, ReturnSlotReg, assign_abi_slots,
-    return_plan, return_slot_regs,
+    AbiRegisterBanks, AbiSlotClass, AbiSlotLocation, ReturnPlan, ReturnSlotReg, return_plan,
+    return_slot_regs,
 };
+use crate::native_abi::{NativeArg, native_by_value_arg};
 
 // ============================================================================
 // Register naming
@@ -136,17 +139,6 @@ impl TargetRegisters {
         match self.arch {
             Arch::X86_64 => crate::x86_64::DEDICATED_SRET_REGISTER_NAME,
             Arch::Aarch64 => crate::aarch64::DEDICATED_SRET_REGISTER_NAME,
-        }
-    }
-
-    fn argument_banks(self) -> AbiRegisterBanks {
-        AbiRegisterBanks {
-            gp: self
-                .roster(RegisterRole::Argument, CRegisterClass::Gp)
-                .len(),
-            fp: self
-                .roster(RegisterRole::Argument, CRegisterClass::Fp)
-                .len(),
         }
     }
 
@@ -270,43 +262,27 @@ impl From<LoweredReturn> for CPlacement {
     }
 }
 
-/// One flattened native ABI slot's physical position, and which logical slot of
-/// its value rides there.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NativeSlot {
-    /// The value's own logical slot index. The native convention reverses a
-    /// multi-slot by-value aggregate, so this descends across such a
-    /// parameter's positions.
-    pub logical: u32,
-    /// The position the shared slot assignment gave it.
-    pub location: AbiSlotLocation,
-}
-
 /// Where one value of the native Rue convention travels.
+///
+/// The native convention places every argument exactly where the compilation
+/// target's C row places it (ADR-0084), so an argument's placement *is* a
+/// [`CPlacement`]. The result still classifies natively — the wider return bank
+/// and the hidden-first-argument sret — so it keeps its own arms until phase 2
+/// retires them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NativePlacement {
     /// No slot at all (a zero-sized result).
     None,
-    /// The value's flattened slots, in ABI order.
-    Slots {
-        slots: Vec<NativeSlot>,
-        /// Whether the slots cross in reverse logical order, which the native
-        /// convention does for every multi-slot by-value aggregate.
-        reversed: bool,
-    },
-    /// One pointer slot standing for caller storage: a `borrow` / `inout`
-    /// parameter, or a by-value aggregate the compact layout forces indirect.
-    Pointer {
-        location: AbiSlotLocation,
-        /// How many of the callee's parameter slots the pointed-at value
-        /// occupies, for the by-value indirect case where the classifier
-        /// collapsed a wider value onto one incoming register. `None` for a
-        /// by-reference parameter, whose single slot holds only the pointer and
-        /// says nothing about the pointee.
-        pointee_slots: Option<u32>,
+    /// One argument, placed by the target's own C rules.
+    Argument(CPlacement),
+    /// One already-flattened value of the cleanup convention: each leaf is a
+    /// register-width argument of its own, in ascending order.
+    PerLeaf {
+        /// One placement per leaf.
+        leaves: Vec<CPlacement>,
     },
     /// The result is written to caller storage whose address is the hidden
-    /// first ABI slot.
+    /// first argument register.
     Sret {
         location: AbiSlotLocation,
         slot_count: u32,
@@ -437,8 +413,6 @@ fn parameter_descriptors(cfg: &ValidatedCfg) -> Vec<SourceParamAbi> {
         .map(|slot| SourceParamAbi {
             start_slot: slot,
             slot_count: 1,
-            crossing_regs: 1,
-            crossing_classes: vec![rue_air::NativeArgClass::Gp],
             ty: None,
         })
         .collect()
@@ -463,11 +437,11 @@ fn parameter_mode(cfg: &ValidatedCfg, descriptor: &SourceParamAbi) -> AbiParamet
 
 /// Project one function's native ABI from its CFG.
 ///
-/// The parameter grouping is the CFG's own [`SourceParamAbi`] descriptors — the
-/// classification semantic analysis recorded — and the physical positions come
-/// from [`assign_abi_slots`] over the same class vector
-/// `crate::param_storage::ParamStoragePlan` builds, so the report and the
-/// prologue read one assignment rather than two.
+/// The parameter grouping is the CFG's own [`SourceParamAbi`] descriptors, and
+/// the placements come from the one signature lowering the prologue and every
+/// caller consume ([`rue_air::lower_native_signature`]), so the report prints
+/// the placement that will actually be emitted rather than a second opinion
+/// about it.
 fn native_side(
     cfg: &ValidatedCfg,
     air: &ValidatedAir,
@@ -483,57 +457,84 @@ fn native_side(
         native_return_register_budget(target.arch()),
     );
 
-    let descriptors = parameter_descriptors(cfg);
-    let mut classes = Vec::new();
-    if plan.uses_sret() {
-        classes.push(AbiSlotClass::Gp);
-    }
-    for descriptor in &descriptors {
-        classes.extend(
-            descriptor
-                .crossing_classes
-                .iter()
-                .copied()
-                .map(AbiSlotClass::from),
-        );
-    }
-    let locations = assign_abi_slots(
-        rue_target::ConventionSpec::native(target),
-        classes.iter().copied(),
-        registers.argument_banks(),
-    );
-
     // Two recoveries, because a body records the two parameter kinds
     // differently: a by-value parameter through its drop entry or `Param`
     // instruction, a by-reference one only through the pointee type on the
     // places that read it.
     let value_types = rue_air::body_parameter_types(air);
     let pointee_types = rue_air::by_reference_parameter_pointee_types(air);
-    let mut cursor = usize::from(plan.uses_sret());
-    let mut parameters = Vec::with_capacity(descriptors.len());
-    for (index, descriptor) in descriptors.iter().enumerate() {
-        let crossing = descriptor.crossing_regs as usize;
-        let positions = &locations[cursor..cursor + crossing];
-        cursor += crossing;
-        let mode = parameter_mode(cfg, descriptor);
-        let ty = descriptor.ty.or_else(|| {
-            let recovered = if mode == AbiParameterMode::ByValue {
-                &value_types
-            } else {
-                &pointee_types
-            };
-            recovered.get(&descriptor.start_slot).copied()
-        });
-        parameters.push(AbiParameter {
-            index: index as u32,
-            ty: type_text(type_pool, ty),
-            mode,
-            placement: AbiPlacement::Native(native_parameter_placement(
-                descriptor, mode, ty, type_pool, positions,
-            )),
-            extension: ScalarAbiExtension::None,
-        });
+
+    let descriptors = parameter_descriptors(cfg);
+    let modes: Vec<AbiParameterMode> = descriptors
+        .iter()
+        .map(|descriptor| parameter_mode(cfg, descriptor))
+        .collect();
+    let types: Vec<Option<Type>> = descriptors
+        .iter()
+        .zip(&modes)
+        .map(|(descriptor, mode)| {
+            descriptor.ty.or_else(|| {
+                let recovered = if *mode == AbiParameterMode::ByValue {
+                    &value_types
+                } else {
+                    &pointee_types
+                };
+                recovered.get(&descriptor.start_slot).copied()
+            })
+        })
+        .collect();
+    let mut parameters_facts = Vec::new();
+    let mut spans = Vec::with_capacity(descriptors.len());
+    for (descriptor, mode) in descriptors.iter().zip(&modes) {
+        let convention = if *mode == AbiParameterMode::ByValue {
+            rue_air::ArgConvention::ByValue
+        } else {
+            rue_air::ArgConvention::ByReference
+        };
+        let native = match (convention, descriptor.ty) {
+            (rue_air::ArgConvention::ByValue, Some(ty)) => native_by_value_arg(type_pool, ty),
+            (rue_air::ArgConvention::ByValue, None) => NativeArg::PerLeaf {
+                count: descriptor.slot_count.max(1),
+            },
+            _ => NativeArg::Scalar {
+                kind: rue_air::CAbiScalarKind::RegisterWidth,
+                class: AbiSlotClass::Gp,
+            },
+        };
+        let start = parameters_facts.len();
+        parameters_facts.extend(native.facts().into_iter().map(|facts| (facts, convention)));
+        spans.push(start..parameters_facts.len());
     }
+    let pairing = rue_target::ConventionSpec::native(target);
+    let signature = rue_air::lower_native_signature(
+        pairing,
+        &parameters_facts,
+        native_incoming_return(pairing, plan),
+    );
+
+    let parameters = modes
+        .iter()
+        .zip(&types)
+        .zip(spans)
+        .enumerate()
+        .map(|(index, ((mode, ty), span))| {
+            let mut leaves = signature.arguments()[span]
+                .iter()
+                .map(|argument| CPlacement::from(argument.location))
+                .collect::<Vec<_>>();
+            AbiParameter {
+                index: index as u32,
+                ty: type_text(type_pool, *ty),
+                mode: *mode,
+                placement: AbiPlacement::Native(if leaves.len() == 1 {
+                    NativePlacement::Argument(leaves.remove(0))
+                } else {
+                    NativePlacement::PerLeaf { leaves }
+                }),
+                extension: ScalarAbiExtension::None,
+            }
+        })
+        .collect();
 
     AbiSide {
         convention: CallingConvention::Rue,
@@ -546,54 +547,26 @@ fn native_side(
                 type_pool,
                 return_type,
                 registers,
-                locations.first().copied(),
             )),
             extension: ScalarAbiExtension::None,
         },
-        stack_bytes: None,
+        stack_bytes: Some(signature.stack_bytes()),
     }
 }
 
-fn native_parameter_placement(
-    descriptor: &SourceParamAbi,
-    mode: AbiParameterMode,
-    ty: Option<Type>,
-    type_pool: &FrozenTypeInternPool,
-    positions: &[AbiSlotLocation],
-) -> NativePlacement {
-    // One incoming pointer standing for a wider value: a by-reference
-    // parameter, or a by-value aggregate the compact layout forced indirect
-    // (`crossing_regs < slot_count`).
-    if mode != AbiParameterMode::ByValue || descriptor.is_by_value_indirect() {
-        return match positions.first() {
-            Some(&location) => NativePlacement::Pointer {
-                location,
-                pointee_slots: descriptor
-                    .is_by_value_indirect()
-                    .then_some(descriptor.slot_count),
-            },
-            None => NativePlacement::None,
-        };
+/// The already-decided return the native argument placement is computed
+/// against: only the hidden indirect-result pointer affects where arguments go.
+fn native_incoming_return(pairing: rue_target::ConventionSpec, plan: ReturnPlan) -> LoweredReturn {
+    if !plan.uses_sret() {
+        return LoweredReturn::Void;
     }
-    // The native convention reverses a multi-slot by-value aggregate's slots so
-    // the callee reconstructs the ascending frame layout (`CallPlan` reverses
-    // the materialized slots before assigning them), so ABI position `k` of
-    // such a parameter carries logical slot `count - 1 - k`.
-    let reversed = positions.len() > 1
-        && ty.is_some_and(|ty| crate::types::is_multislot_aggregate(type_pool, ty));
-    let slots = positions
-        .iter()
-        .enumerate()
-        .map(|(position, &location)| NativeSlot {
-            logical: if reversed {
-                positions.len() as u32 - 1 - position as u32
-            } else {
-                position as u32
-            },
-            location,
-        })
-        .collect();
-    NativePlacement::Slots { slots, reversed }
+    let spec = pairing.spec();
+    LoweredReturn::Sret {
+        register: spec.sret_register,
+        echoed: spec.sret_pointer_echoed_in_result_register,
+        size: rue_air::SLOT_BYTES as u32,
+        align: rue_air::SLOT_BYTES as u32,
+    }
 }
 
 fn native_return_placement(
@@ -601,7 +574,6 @@ fn native_return_placement(
     type_pool: &FrozenTypeInternPool,
     ty: Type,
     registers: TargetRegisters,
-    hidden_slot: Option<AbiSlotLocation>,
 ) -> NativePlacement {
     match plan {
         ReturnPlan::ZeroSized => NativePlacement::None,
@@ -621,9 +593,9 @@ fn native_return_placement(
             slot_count,
             storage_bytes,
         } => NativePlacement::Sret {
-            // The hidden pointer is ABI slot 0 by construction, so the first
-            // assigned location is its own.
-            location: hidden_slot.unwrap_or(AbiSlotLocation::GpReg(0)),
+            // The hidden pointer is the hidden first ordinary argument, so it
+            // takes the first general-purpose argument register.
+            location: AbiSlotLocation::GpReg(0),
             slot_count,
             storage_bytes,
         },
@@ -913,12 +885,17 @@ fn slots(count: u32) -> String {
     counted(count, "slot")
 }
 
+/// `1 <noun>` / `N <noun>s`, with the one irregular plural the report needs:
+/// `leaf` becomes `leaves`.
 fn counted(count: u32, noun: &str) -> String {
     if count == 1 {
-        format!("1 {noun}")
-    } else {
-        format!("{count} {noun}s")
+        return format!("1 {noun}");
     }
+    let plural = match noun.strip_suffix('f') {
+        Some(stem) => format!("{stem}ves"),
+        None => format!("{noun}s"),
+    };
+    format!("{count} {plural}")
 }
 
 /// The one-line rendering of a placement, plus any continuation lines it needs.
@@ -998,52 +975,18 @@ fn native_placement_text(
 ) -> (String, Vec<String>) {
     match placement {
         NativePlacement::None => ("no value".to_owned(), Vec::new()),
-        NativePlacement::Slots {
-            slots: value_slots,
-            reversed,
-        } => match value_slots.as_slice() {
-            [] => ("omitted (no ABI slot)".to_owned(), Vec::new()),
-            [only] => (native_slot_text(registers, only.location), Vec::new()),
-            many => (
-                // Whether a multi-slot value crosses reversed is the native
-                // convention's least guessable rule, so it is stated either
-                // way rather than implied by its absence.
-                format!(
-                    "{}, {}",
-                    slots(many.len() as u32),
-                    if *reversed {
-                        "reversed"
-                    } else {
-                        "in logical order"
-                    }
-                ),
-                many.iter()
-                    .map(|slot| {
-                        format!(
-                            "slot {}: {}",
-                            slot.logical,
-                            native_slot_text(registers, slot.location)
-                        )
-                    })
-                    .collect(),
-            ),
-        },
-        NativePlacement::Pointer {
-            location,
-            pointee_slots,
-        } => (
-            match pointee_slots {
-                Some(count) => format!(
-                    "indirect: pointer in {} to {}",
-                    native_slot_text(registers, *location),
-                    slots(*count)
-                ),
-                None => format!(
-                    "indirect: pointer in {}",
-                    native_slot_text(registers, *location)
-                ),
-            },
-            Vec::new(),
+        NativePlacement::Argument(placement) => {
+            (c_placement_text(registers, *placement), Vec::new())
+        }
+        NativePlacement::PerLeaf { leaves } => (
+            format!("{}, one per leaf", counted(leaves.len() as u32, "leaf")),
+            leaves
+                .iter()
+                .enumerate()
+                .map(|(index, placement)| {
+                    format!("leaf {index}: {}", c_placement_text(registers, *placement))
+                })
+                .collect(),
         ),
         NativePlacement::Sret {
             location,
@@ -1262,36 +1205,29 @@ mod tests {
     }
 
     #[test]
-    fn a_reversed_multislot_parameter_names_the_logical_slot_each_register_carries() {
+    fn a_native_argument_reads_like_a_c_one() {
+        // The native convention places an argument exactly where the target's C
+        // row places it (ADR-0084), so its block prints the same placement text.
         let registers = TargetRegisters::new(Target::X86_64Linux);
         let (line, continuation) = native_placement_text(
             registers,
-            &NativePlacement::Slots {
-                slots: vec![
-                    NativeSlot {
-                        logical: 2,
-                        location: AbiSlotLocation::GpReg(0),
-                    },
-                    NativeSlot {
-                        logical: 1,
-                        location: AbiSlotLocation::GpReg(1),
-                    },
-                    NativeSlot {
-                        logical: 0,
-                        location: AbiSlotLocation::stack_slot(0),
-                    },
-                ],
-                reversed: true,
-            },
+            &NativePlacement::Argument(CPlacement::Registers {
+                class: CRegisterClass::Gp,
+                first: 0,
+                count: 2,
+            }),
         );
-        assert_eq!(line, "3 slots, reversed");
-        assert_eq!(
-            continuation,
-            [
-                "slot 2: gp register 0 (rdi)",
-                "slot 1: gp register 1 (rsi)",
-                "slot 0: stack +0 (8 bytes, align 8)",
-            ]
+        assert_eq!(line, "gp registers 0-1 (rdi, rsi)");
+        assert!(continuation.is_empty());
+
+        let (line, _) = native_placement_text(
+            registers,
+            &NativePlacement::Argument(CPlacement::Stack {
+                offset: 8,
+                size: 24,
+                align: 8,
+            }),
         );
+        assert_eq!(line, "stack +8 (24 bytes, align 8)");
     }
 }

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -51,6 +51,9 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
     /// Emit a load of frame slot `slot` into `dst`.
     fn emit_load_slot(&mut self, dst: VReg, slot: u32);
 
+    /// Emit the address of frame slot `slot` into `dst`.
+    fn emit_slot_addr(&mut self, dst: VReg, slot: u32);
+
     fn emit_typed_float_load_slot(
         &mut self,
         dst: VReg,
@@ -264,27 +267,48 @@ pub(crate) fn load_enum_slots_through_ptr<B: SlotBackend>(
     vregs
 }
 
-/// Unmarshal a by-value indirect compact aggregate parameter into its frame
-/// slots at function entry (ADR-0052 phase 5.8, RUE-1005).
+/// Read one by-value aggregate parameter's leaves back out of its compact image
+/// at function entry (ADR-0084).
 ///
-/// The callee prologue homed a single incoming pointer to the parameter's base
-/// frame slot `base_slot`. This reads that pointer, loads the aggregate's
-/// compact memory image through it (each slot extended from its physical width
-/// at its compact byte offset), and stores the resulting slot-shaped values back
-/// into the parameter's frame region in the ascending layout every consumer
-/// reads — so ordinary field projection and whole-value materialization both see
-/// the correct decomposition without a special parameter path. The pointer is
-/// fully consumed (its loads emitted) before the frame stores overwrite
-/// `base_slot`.
-pub(crate) fn unmarshal_indirect_value_param<B: SlotBackend>(
+/// The prologue has already laid the argument down as an image: for a
+/// register- or stack-placed aggregate it copied the eightbytes the convention
+/// placed it in into the parameter's own frame slots, and for a by-reference
+/// copy it homed the caller's pointer into the first of them. This reads every
+/// leaf out of that image at its compact byte offset and width — sign- or
+/// zero-extending a narrow one into Rue's canonical 64-bit form — and stores
+/// the leaves back into the frame region in the ascending order every consumer
+/// reads, so ordinary field projection and whole-value materialization both see
+/// the correct decomposition without a special parameter path.
+///
+/// Every load precedes every store, which is what makes reading and writing the
+/// same frame region safe: the image spans at most as many eightbytes as the
+/// value has leaves.
+pub(crate) fn unmarshal_param_image<B: SlotBackend>(
     b: &mut B,
     base_slot: u32,
-    map: &[crate::types::PhysicalEnumSlot],
+    image_slot_offset: u32,
+    through_pointer: bool,
+    image: &crate::native_abi::NativeImage,
 ) {
     let ptr = b.alloc_vreg();
-    b.emit_load_slot(ptr, base_slot);
-    let vals = load_enum_slots_through_ptr(b, ptr, map);
-    store_slots(b, &vals, base_slot);
+    if through_pointer {
+        b.emit_load_slot(ptr, base_slot);
+    } else {
+        // The frame parameter area addresses descend with the slot index, so
+        // the image the prologue laid down starts at the last of the slots it
+        // used and runs upward from there.
+        b.emit_slot_addr(ptr, base_slot + image_slot_offset);
+    }
+    match &image.kind {
+        crate::native_abi::NativeImageKind::Map { map, .. } => {
+            let vals = load_enum_slots_through_ptr(b, ptr, map);
+            store_slots(b, &vals, base_slot);
+        }
+        crate::native_abi::NativeImageKind::Dispatch(dispatch) => {
+            let vals = load_dispatch_image(b, ptr, dispatch);
+            store_slots(b, &vals, base_slot);
+        }
+    }
 }
 
 /// Get or compute the slot vregs for a multi-slot aggregate value
@@ -731,20 +755,6 @@ pub(crate) fn store_dispatch_image_to_sret<B: SlotBackend>(
     let sret_slot = b.ctx().sret_ptr_slot();
     b.emit_load_slot(ptr, sret_slot);
     store_dispatch_image(b, vals, ptr, image);
-}
-
-/// Tag-dispatched counterpart of [`unmarshal_indirect_value_param`] (RUE-1037):
-/// read the homed pointer, load the aggregate's tag-dispatched compact image
-/// through it, and store the slot-shaped values into the parameter's frame region.
-pub(crate) fn unmarshal_indirect_value_param_dispatch<B: SlotBackend>(
-    b: &mut B,
-    base_slot: u32,
-    image: &crate::types::DispatchImage,
-) {
-    let ptr = b.alloc_vreg();
-    b.emit_load_slot(ptr, base_slot);
-    let vals = load_dispatch_image(b, ptr, image);
-    store_slots(b, &vals, base_slot);
 }
 
 /// Load `count` slots through `ptr` at ASCENDING byte offsets (slot k at

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -5,12 +5,17 @@
 //! lowerers consume the normalized slot vector and only choose how to marshal
 //! those slots for their ABI.
 
-use rue_air::{ArgClass, ArgConvention, FrozenTypeInternPool, NativeCallAbi, ReturnClass};
+use rue_air::{
+    ArgConvention, ArgLocation, FrozenTypeInternPool, LoweredReturn, NativeCallAbi,
+    PointerLocation, RegisterPiece, ReturnClass, lower_native_signature,
+};
 // `ScalarAbiExtension` is referenced by fully-qualified path in the struct so it
 // stays visible to readers of the field; no direct import is needed.
 use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, Type};
 use rue_runtime_abi::{ReservedExportClass, ReservedExportId};
-use rue_target::{CallingConvention, ConventionSpec};
+use rue_target::{CRegisterClass, CallingConvention, ConventionSpec};
+
+use crate::native_abi::{NativeArg, NativeArgMarshal, NativeImage, native_arg};
 
 use crate::types;
 use crate::vreg::VReg;
@@ -19,11 +24,10 @@ use crate::frame_layout::checked_aligned_cell_region_bytes;
 
 /// The convention a call target's callee follows.
 ///
-/// A Rue-compiled function uses the native convention, whose aggregate
-/// arguments are in reversed ABI slot order so the callee reconstructs the
-/// ascending logical frame layout. A compiler-built C memory routine crosses
-/// the platform C boundary, in natural C slot order; which C row that is comes
-/// from the compilation target, so the caller supplies it.
+/// A Rue-compiled function uses the native convention, which places every
+/// argument where the compilation target's own C row places it (ADR-0084). A
+/// compiler-built C memory routine crosses that C row directly; which row it is
+/// comes from the compilation target, so the caller supplies it.
 const fn callee_convention(
     target: &CallTarget,
     c_convention: CallingConvention,
@@ -173,14 +177,12 @@ impl AbiSlotClass {
             None => Self::Gp,
         }
     }
-}
 
-impl From<rue_air::NativeArgClass> for AbiSlotClass {
-    fn from(value: rue_air::NativeArgClass) -> Self {
-        match value {
-            rue_air::NativeArgClass::Gp => Self::Gp,
-            rue_air::NativeArgClass::Fp32 => Self::Fp(crate::value_plan::FloatWidth::F32),
-            rue_air::NativeArgClass::Fp64 => Self::Fp(crate::value_plan::FloatWidth::F64),
+    /// The register bank this class travels in.
+    pub const fn bank(self) -> CRegisterClass {
+        match self {
+            Self::Gp => CRegisterClass::Gp,
+            Self::Fp(_) => CRegisterClass::Fp,
         }
     }
 }
@@ -206,7 +208,7 @@ impl AbiSlotLocation {
     /// under every supported row's stacked-argument packing — Apple's
     /// natural-size amendment included, since eight bytes *is* the slot's
     /// natural size. That is what lets a caller holding only a slot index name
-    /// the same place [`assign_abi_slots`] gives it.
+    /// the place the convention's own argument area gives it.
     pub const fn stack_slot(index: usize) -> Self {
         Self::Stack {
             offset: (index * rue_air::SLOT_BYTES as usize) as u32,
@@ -216,39 +218,7 @@ impl AbiSlotLocation {
     }
 }
 
-/// Assign every native ABI slot to a register of its bank, or to the outgoing
-/// argument area once that bank's roster is spent.
-///
-/// `banks` is the roster this assignment draws on — the argument banks for a
-/// call or a prologue, the wider return banks for
-/// [`return_slot_regs`] — and `convention` is the convention whose
-/// argument-area packing the stacked slots follow, claimed through the one
-/// cursor every stacked placement in the tree claims through
-/// (`rue_air::ArgumentArea`).
-pub fn assign_abi_slots(
-    convention: ConventionSpec,
-    classes: impl IntoIterator<Item = AbiSlotClass>,
-    banks: AbiRegisterBanks,
-) -> Vec<AbiSlotLocation> {
-    // A native ABI slot carries a canonically 64-bit-extended value, so every
-    // slot the roster cannot hold claims one whole eightbyte from the
-    // convention's own argument area.
-    let mut area = rue_air::ArgumentArea::new(convention.spec());
-    claim_bank_registers(classes, banks)
-        .map(|assigned| {
-            assigned.unwrap_or_else(|| {
-                let placement = area.claim_scalar(rue_air::SLOT_BYTES);
-                AbiSlotLocation::Stack {
-                    offset: placement.offset,
-                    size: placement.size,
-                    align: placement.align,
-                }
-            })
-        })
-        .collect()
-}
-
-/// Assign each slot class a register of its own bank, in order, or `None` once
+/// Assign each result slot a register of its own bank, in order, or `None` once
 /// that bank's roster is spent. A spent roster still counts the slot, so the
 /// banks stay independent of each other.
 fn claim_bank_registers(
@@ -426,34 +396,11 @@ pub struct CallPlan {
 pub enum CallArgInput {
     Value {
         value: rue_cfg::CfgValue,
+        /// The argument's own type, which the convention classifies.
+        ty: Type,
         slot_count: u32,
         is_multislot_aggregate: bool,
         slot_types: Vec<Type>,
-    },
-    /// A by-value non-slot-identical compact aggregate the classifier forces
-    /// indirect under `aggregate_layout` (RUE-976/RUE-1005): the caller writes
-    /// its compact memory `image` into a caller-owned buffer of `storage_bytes`
-    /// and passes one pointer to the callee, which unmarshals it in its
-    /// prologue. Kept separate from `Value` so the single pointer ABI slot and
-    /// the buffer accounting cannot be confused with an N-slot direct value.
-    IndirectValue {
-        value: rue_cfg::CfgValue,
-        image: Vec<crate::types::PhysicalEnumSlot>,
-        /// Byte ranges of the compact image that hold padding, zeroed before the
-        /// field stores so the caller-owned buffer is deterministically
-        /// initialized (ADR-0052 ruling 5).
-        padding: Vec<rue_air::layout::PaddingRange>,
-        storage_bytes: u32,
-    },
-    /// A by-value HETEROGENEOUS compact aggregate argument the classifier forces
-    /// indirect (RUE-1037): the caller writes its tag-dispatched compact `image`
-    /// into a caller-owned buffer and passes one pointer, exactly like
-    /// [`Self::IndirectValue`] but with a per-variant tag dispatch instead of a
-    /// single variant-independent map.
-    IndirectValueDispatch {
-        value: rue_cfg::CfgValue,
-        image: crate::types::DispatchImage,
-        storage_bytes: u32,
     },
     ByRef {
         mode: ByRefMode,
@@ -461,10 +408,23 @@ pub enum CallArgInput {
     },
 }
 
+impl CallArgInput {
+    /// The source-level mode the convention classifies this argument under.
+    fn arg_convention(&self) -> ArgConvention {
+        match self {
+            Self::Value { .. } => ArgConvention::ByValue,
+            Self::ByRef { .. } => ArgConvention::ByReference,
+        }
+    }
+}
+
 /// Shared policy inputs copied from a CFG before backend materialization.
 #[derive(Debug, Clone)]
 pub struct CallInputs {
     pub args: Vec<CallArgInput>,
+    /// The native description of each argument, in source order: the facts the
+    /// convention classifies and the marshaling that reaches its placement.
+    pub natives: Vec<NativeArg>,
     pub return_plan: ReturnPlan,
     /// The compact sret image for the return type, when it is a non-slot-identical
     /// aggregate returned via sret under `aggregate_layout` (RUE-1004). See
@@ -489,55 +449,19 @@ impl CallInputs {
             by_ref_plans.len(),
             "call argument classification must cover every CFG argument"
         );
-        let args = args
+        let args: Vec<CallArgInput> = args
             .iter()
             .zip(by_ref_plans)
             .map(|(arg, by_ref_plan)| {
                 let arg_ty = cfg.get_inst(arg.value).ty;
-                // A by-value aggregate the classifier forces indirect under the
-                // compact layout crosses through a caller-owned compact image
-                // buffer (RUE-1005), not as N direct decomposition slots. The
-                // refusal scan has already guaranteed such an aggregate has a
-                // variant-independent image before lowering reaches here.
-                if matches!(arg.mode, CfgArgMode::Normal)
-                    && matches!(
-                        NativeCallAbi::for_arguments(type_pool)
-                            .classify_arg(arg_ty, ArgConvention::ByValue),
-                        ArgClass::Indirect
-                    )
-                {
-                    let storage_bytes = crate::frame_layout::checked_aligned_region_bytes(
-                        types::type_size_bytes(type_pool, arg_ty),
-                    )
-                    .expect("indirect argument storage must pass frame-budget preflight");
-                    // A heterogeneous compact aggregate has no single map; it
-                    // marshals its buffer with a per-variant tag dispatch (RUE-1037).
-                    if let Some(image) = types::aggregate_physical_slot_map(type_pool, arg_ty) {
-                        let padding = type_pool.compact_image_padding_ranges(arg_ty);
-                        return CallArgInput::IndirectValue {
-                            value: arg.value,
-                            image,
-                            padding,
-                            storage_bytes,
-                        };
-                    }
-                    let image = types::aggregate_dispatch_image(type_pool, arg_ty).expect(
-                        "a by-value indirect compact aggregate argument must have a \
-                         variant-independent or tag-dispatched memory image (guaranteed by \
-                         the refusal scan)",
-                    );
-                    return CallArgInput::IndirectValueDispatch {
-                        value: arg.value,
-                        image,
-                        storage_bytes,
-                    };
-                }
+                let aggregate = types::is_multislot_aggregate(type_pool, arg_ty);
                 normalize_call_arg(
                     arg.mode,
                     arg.value,
+                    arg_ty,
                     types::type_slot_count(type_pool, arg_ty),
-                    types::is_multislot_aggregate(type_pool, arg_ty),
-                    if types::is_multislot_aggregate(type_pool, arg_ty) {
+                    aggregate,
+                    if aggregate {
                         types::aggregate_leaf_types(type_pool, arg_ty)
                     } else {
                         vec![arg_ty]
@@ -545,6 +469,17 @@ impl CallInputs {
                     by_ref_plan.clone(),
                 )
                 .unwrap_or_else(|message| panic!("{message}"))
+            })
+            .collect();
+        let natives = args
+            .iter()
+            .map(|arg| match arg {
+                CallArgInput::Value { ty, .. } => {
+                    native_arg(type_pool, *ty, ArgConvention::ByValue)
+                }
+                CallArgInput::ByRef { .. } => {
+                    native_arg(type_pool, Type::I64, ArgConvention::ByReference)
+                }
             })
             .collect();
         let return_plan = return_plan(type_pool, return_ty, ret_reg_budget);
@@ -564,6 +499,7 @@ impl CallInputs {
         };
         Self {
             args,
+            natives,
             return_plan,
             compact_return_image,
             compact_return_dispatch,
@@ -571,9 +507,11 @@ impl CallInputs {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn normalize_call_arg(
     mode: CfgArgMode,
     value: rue_cfg::CfgValue,
+    ty: Type,
     slot_count: u32,
     is_multislot_aggregate: bool,
     slot_types: Vec<Type>,
@@ -582,6 +520,7 @@ fn normalize_call_arg(
     match (mode, by_ref_plan) {
         (CfgArgMode::Normal, None) => Ok(CallArgInput::Value {
             value,
+            ty,
             slot_count,
             is_multislot_aggregate,
             slot_types,
@@ -616,33 +555,279 @@ pub trait CallMaterializer {
 
     /// The native convention on this backend's compilation target, paired with
     /// the description it places by: the target's own C description with the
-    /// native amendments (`ConventionSpec::native`). It is what decides how the
-    /// outgoing argument area is packed once the register rosters are spent.
+    /// native amendments (`ConventionSpec::native`).
     fn native_convention(&self) -> ConventionSpec;
     fn materialize_scalar(&mut self, value: rue_cfg::CfgValue) -> VReg;
     fn materialize_aggregate(&mut self, value: rue_cfg::CfgValue) -> Vec<VReg>;
     fn materialize_by_ref(&mut self, plan: &crate::value_plan::ByRefAddressPlan) -> VReg;
     fn materialize_sret_pointer(&mut self, storage_bytes: u32) -> VReg;
-    /// Reserve a `storage_bytes` caller-owned buffer, write the aggregate
-    /// `value`'s compact `image` into it, and return a pointer to it (RUE-1005).
-    /// The single pointer becomes the argument's ABI slot; the callee prologue
-    /// homes it and unmarshals the image into its frame parameter slots.
-    fn materialize_indirect_value_arg(
+    /// Write the aggregate `value`'s leaves into a scratch stack image and read
+    /// its eightbytes back out, one vreg per eightbyte in ascending memory
+    /// order. This is the marshaling that packs `{u8, u8, u8, u8}` into one
+    /// register; the scratch buffer is released before the call sequence
+    /// begins.
+    fn materialize_image_eightbytes(
         &mut self,
         value: rue_cfg::CfgValue,
-        image: &[crate::types::PhysicalEnumSlot],
-        padding: &[rue_air::layout::PaddingRange],
-        storage_bytes: u32,
-    ) -> VReg;
-    /// Tag-dispatched counterpart of [`Self::materialize_indirect_value_arg`] for
-    /// a heterogeneous compact aggregate argument (RUE-1037): reserve the buffer,
-    /// write the tag-dispatched compact `image`, and return the pointer.
-    fn materialize_indirect_value_arg_dispatch(
-        &mut self,
-        value: rue_cfg::CfgValue,
-        image: &crate::types::DispatchImage,
-        storage_bytes: u32,
-    ) -> VReg;
+        image: &NativeImage,
+    ) -> Vec<VReg>;
+    /// Reserve a caller-owned buffer, write the aggregate `value`'s compact
+    /// image into it, and return a pointer to it. The buffer stays live across
+    /// the call, because the callee reads the aggregate through the pointer
+    /// (AAPCS64 section 6.8.2 C.12).
+    fn materialize_indirect_image(&mut self, value: rue_cfg::CfgValue, image: &NativeImage)
+    -> VReg;
+    /// Move the 64 bits of a marshaled eightbyte into a floating-point vreg.
+    ///
+    /// An eightbyte read out of a compact image is an integer-shaped lane; when
+    /// the classification puts it in the floating-point bank the whole lane
+    /// crosses, so the move is a bit pattern rather than a numeric conversion.
+    fn materialize_eightbyte_as_float(&mut self, bits: VReg) -> VReg;
+}
+
+/// The already-decided return a native signature is placed against.
+///
+/// Phase 1 of ADR-0084 switches arguments only, so return classification stays
+/// [`ReturnPlan`]'s and this projects it onto the one fact argument placement
+/// depends on: whether a hidden indirect-result pointer takes an ordinary
+/// argument register ahead of every user argument.
+fn lowered_return(pairing: ConventionSpec, plan: ReturnPlan) -> LoweredReturn {
+    let spec = pairing.spec();
+    match plan {
+        ReturnPlan::ZeroSized => LoweredReturn::Void,
+        ReturnPlan::Scalar => LoweredReturn::Registers {
+            class: CRegisterClass::Gp,
+            count: 1,
+            extension: rue_air::ScalarAbiExtension::None,
+        },
+        ReturnPlan::Registers { slot_count } => LoweredReturn::Registers {
+            class: CRegisterClass::Gp,
+            count: slot_count,
+            extension: rue_air::ScalarAbiExtension::None,
+        },
+        ReturnPlan::Sret {
+            slot_count,
+            storage_bytes: _,
+        } => LoweredReturn::Sret {
+            register: spec.sret_register,
+            echoed: spec.sret_pointer_echoed_in_result_register,
+            size: slot_count.saturating_mul(rue_air::SLOT_BYTES as u32),
+            align: rue_air::SLOT_BYTES as u32,
+        },
+    }
+}
+
+/// Where one register piece of a value travels.
+const fn register_piece_location(piece: RegisterPiece) -> AbiSlotLocation {
+    match piece.class {
+        CRegisterClass::Gp => AbiSlotLocation::GpReg(piece.index as usize),
+        CRegisterClass::Fp => AbiSlotLocation::FpReg(piece.index as usize),
+    }
+}
+
+/// The stack placements one value's eightbytes occupy inside `location`.
+///
+/// A stacked scalar occupies exactly the footprint the convention's packing
+/// gave it — one byte for an `i8` under Apple's amendment. A stacked aggregate
+/// crosses through its eightbyte image, so each eightbyte claims its own whole
+/// slot at an ascending offset inside the argument's placement.
+fn stacked_pieces(location: ArgLocation, scalar: bool, count: usize) -> Vec<AbiSlotLocation> {
+    let ArgLocation::Stack {
+        offset,
+        size,
+        align,
+    } = location
+    else {
+        panic!("stacked pieces are only taken from a stacked placement");
+    };
+    if scalar {
+        assert_eq!(count, 1, "a stacked scalar occupies one placement");
+        return vec![AbiSlotLocation::Stack {
+            offset,
+            size,
+            align,
+        }];
+    }
+    (0..count)
+        .map(|piece| AbiSlotLocation::Stack {
+            offset: offset + u32::try_from(piece * 8).expect("stack offset must fit u32"),
+            size: rue_air::SLOT_BYTES as u32,
+            align: rue_air::SLOT_BYTES as u32,
+        })
+        .collect()
+}
+
+/// Materialize one argument's values and give each the position the lowered
+/// signature named for it.
+fn place_argument<M: CallMaterializer>(
+    arg: &CallArgInput,
+    native: &NativeArg,
+    placements: &[ArgLocation],
+    materializer: &mut M,
+    caller_indirect_bytes: &mut u32,
+) -> (
+    UserArgMode,
+    Vec<VReg>,
+    Vec<AbiSlotClass>,
+    Vec<AbiSlotLocation>,
+) {
+    let location = placements[0];
+    if let CallArgInput::ByRef { mode, address } = arg {
+        // A reference is an ABI pointer even when the pointee has no storage
+        // slots, so this precedes zero-sized omission.
+        let pointer = materializer.materialize_by_ref(address);
+        return (
+            (*mode).into(),
+            vec![pointer],
+            vec![AbiSlotClass::Gp],
+            vec![scalar_location(location)],
+        );
+    }
+    let CallArgInput::Value {
+        value,
+        slot_count,
+        is_multislot_aggregate,
+        ..
+    } = arg
+    else {
+        unreachable!("a by-reference argument was handled above");
+    };
+
+    if let NativeArg::PerLeaf { count } = native {
+        // The cleanup convention hands each already-materialized leaf to its
+        // own register-width placement, in ascending order.
+        let values = materializer.materialize_aggregate(*value);
+        assert_eq!(
+            values.len(),
+            *count as usize,
+            "cleanup-convention materialization must produce every leaf"
+        );
+        return (
+            UserArgMode::Value,
+            values,
+            vec![AbiSlotClass::Gp; *count as usize],
+            placements.iter().copied().map(scalar_location).collect(),
+        );
+    }
+
+    if let ArgLocation::Indirect { pointer, .. } = location {
+        let NativeArg::Aggregate { image } = native else {
+            panic!("only an aggregate crosses by reference under a composite rule");
+        };
+        *caller_indirect_bytes = caller_indirect_bytes
+            .checked_add(image.storage_bytes)
+            .expect("indirect argument area must fit u32");
+        let address = materializer.materialize_indirect_image(*value, image);
+        let position = match pointer {
+            PointerLocation::Register { index } => AbiSlotLocation::GpReg(index as usize),
+            PointerLocation::Stack { offset } => AbiSlotLocation::Stack {
+                offset,
+                size: rue_air::SLOT_BYTES as u32,
+                align: rue_air::SLOT_BYTES as u32,
+            },
+        };
+        return (
+            UserArgMode::Value,
+            vec![address],
+            vec![AbiSlotClass::Gp],
+            vec![position],
+        );
+    }
+
+    if matches!(location, ArgLocation::Omitted) {
+        return (UserArgMode::Value, Vec::new(), Vec::new(), Vec::new());
+    }
+
+    // The eightbytes the placement wants: the value's own leaf vregs when every
+    // leaf starts its own eightbyte, and the marshaled image otherwise.
+    let marshal = native.marshal(location);
+    let mut values = match (&marshal, native) {
+        (NativeArgMarshal::Image { .. }, NativeArg::Aggregate { image }) => {
+            materializer.materialize_image_eightbytes(*value, image)
+        }
+        _ if *is_multislot_aggregate => {
+            let slots = materializer.materialize_aggregate(*value);
+            assert_eq!(
+                slots.len(),
+                *slot_count as usize,
+                "aggregate materialization must produce every logical ABI slot"
+            );
+            slots
+        }
+        _ => vec![materializer.materialize_scalar(*value)],
+    };
+    assert_eq!(
+        values.len(),
+        marshal.eightbyte_count(),
+        "one value per eightbyte the classification placed"
+    );
+
+    let (classes, locations) = match location {
+        ArgLocation::Registers { pieces } => {
+            assert_eq!(
+                pieces.len() as usize,
+                values.len(),
+                "one value per register the classification named"
+            );
+            let classes = pieces
+                .as_slice()
+                .iter()
+                .enumerate()
+                .map(|(index, piece)| marshal.class(index, piece.class))
+                .collect::<Vec<_>>();
+            // A marshaled eightbyte comes out of memory integer-shaped; a piece
+            // in the floating-point bank takes its bits as a whole lane.
+            if matches!(marshal, NativeArgMarshal::Image { .. }) {
+                for (value, class) in values.iter_mut().zip(&classes) {
+                    if matches!(class, AbiSlotClass::Fp(_)) {
+                        *value = materializer.materialize_eightbyte_as_float(*value);
+                    }
+                }
+            }
+            (
+                classes,
+                pieces
+                    .as_slice()
+                    .iter()
+                    .copied()
+                    .map(register_piece_location)
+                    .collect::<Vec<_>>(),
+            )
+        }
+        ArgLocation::Stack { .. } => (
+            (0..values.len())
+                .map(|index| marshal.class(index, marshal.stacked_bank(index)))
+                .collect::<Vec<_>>(),
+            stacked_pieces(location, native.packs_as_scalar(), values.len()),
+        ),
+        ArgLocation::Omitted | ArgLocation::Indirect { .. } => {
+            unreachable!("both were handled above")
+        }
+    };
+    (UserArgMode::Value, values, classes, locations)
+}
+
+/// The position of a value that occupies exactly one register or one stacked
+/// placement.
+fn scalar_location(location: ArgLocation) -> AbiSlotLocation {
+    match location {
+        ArgLocation::Registers { pieces } => {
+            assert_eq!(pieces.len(), 1, "a scalar occupies one register");
+            register_piece_location(pieces.as_slice()[0])
+        }
+        ArgLocation::Stack {
+            offset,
+            size,
+            align,
+        } => AbiSlotLocation::Stack {
+            offset,
+            size,
+            align,
+        },
+        ArgLocation::Omitted | ArgLocation::Indirect { .. } => {
+            panic!("a pointer-sized argument is never omitted and never indirect")
+        }
+    }
 }
 
 impl CallPlan {
@@ -656,7 +841,7 @@ impl CallPlan {
         target: CallTarget,
         return_plan: ReturnPlan,
         args: &[CallArgInput],
-        arg_register_banks: impl Into<AbiRegisterBanks>,
+        natives: &[NativeArg],
         materializer: &mut M,
     ) -> Self {
         Self::from_inputs_with_result(
@@ -665,32 +850,72 @@ impl CallPlan {
             None,
             None,
             args,
-            arg_register_banks.into(),
+            natives,
             materializer,
             None,
         )
     }
 
+    /// Place and marshal every argument of one native (or compiler-built C)
+    /// call.
+    ///
+    /// Placement is [`lower_native_signature`]'s answer against the facts each
+    /// argument projects, under the convention the target follows: the native
+    /// row for a Rue callee, the compilation target's own C row for a
+    /// compiler-built memory routine. Marshaling is this function's: a value
+    /// whose leaves are its eightbytes hands its own vregs over, one whose
+    /// leaves pack together goes through its compact image, and one the
+    /// convention passes by reference goes through a caller-owned copy.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_inputs_with_result<M: CallMaterializer>(
         target: CallTarget,
         return_plan: ReturnPlan,
         compact_return_image: Option<Vec<crate::types::PhysicalEnumSlot>>,
         compact_return_dispatch: Option<crate::types::DispatchImage>,
         args: &[CallArgInput],
-        arg_register_banks: impl Into<AbiRegisterBanks>,
+        natives: &[NativeArg],
         materializer: &mut M,
         result: Option<VReg>,
     ) -> Self {
+        assert_eq!(
+            args.len(),
+            natives.len(),
+            "every call argument carries its native description"
+        );
         let callee_convention = callee_convention(&target, materializer.target_c_convention());
+        let pairing = match callee_convention {
+            CallingConvention::Rue => materializer.native_convention(),
+            row => ConventionSpec::c(row),
+        };
+        // Every argument contributes one placement, except the cleanup
+        // convention's already-flattened leaves, which contribute one each; the
+        // spans map an argument back to the run of placements it owns.
+        let mut parameters = Vec::with_capacity(args.len());
+        let mut spans = Vec::with_capacity(args.len());
+        for (arg, native) in args.iter().zip(natives) {
+            let start = parameters.len();
+            let convention = arg.arg_convention();
+            parameters.extend(native.facts().into_iter().map(|facts| (facts, convention)));
+            spans.push(start..parameters.len());
+        }
+        let signature =
+            lower_native_signature(pairing, &parameters, lowered_return(pairing, return_plan));
+
         let mut hidden_sret = None;
         let mut abi_slots = Vec::new();
         let mut abi_classes = Vec::new();
+        let mut abi_locations = Vec::new();
 
         if let ReturnPlan::Sret {
             slot_count,
             storage_bytes,
         } = return_plan
         {
+            assert!(
+                signature.sret_in_argument_register(),
+                "the native convention passes its indirect-result pointer as the \
+                 hidden first ordinary argument"
+            );
             let pointer = materializer.materialize_sret_pointer(storage_bytes);
             hidden_sret = Some(HiddenSretPlan {
                 pointer,
@@ -700,106 +925,26 @@ impl CallPlan {
             });
             abi_slots.push(pointer);
             abi_classes.push(AbiSlotClass::Gp);
+            abi_locations.push(AbiSlotLocation::GpReg(0));
         }
 
         let mut user_args = Vec::with_capacity(args.len());
         let mut caller_indirect_bytes = 0u32;
-        for arg in args {
-            let (mode, slots, classes) = match arg {
-                CallArgInput::ByRef { mode, address } => (
-                    (*mode).into(),
-                    // A reference is an ABI pointer even when the pointee has
-                    // no storage slots. This branch precedes ZST omission.
-                    vec![materializer.materialize_by_ref(address)],
-                    vec![AbiSlotClass::Gp],
-                ),
-                CallArgInput::IndirectValue {
-                    value,
-                    image,
-                    padding,
-                    storage_bytes,
-                } => {
-                    // The caller writes the aggregate's compact image into its
-                    // own buffer and passes one pointer (RUE-1005). The buffers
-                    // are reserved below the sret storage and freed together
-                    // after the call.
-                    caller_indirect_bytes = caller_indirect_bytes
-                        .checked_add(*storage_bytes)
-                        .expect("indirect argument area must fit u32");
-                    let pointer = materializer.materialize_indirect_value_arg(
-                        *value,
-                        image,
-                        padding,
-                        *storage_bytes,
-                    );
-                    (UserArgMode::Value, vec![pointer], vec![AbiSlotClass::Gp])
-                }
-                CallArgInput::IndirectValueDispatch {
-                    value,
-                    image,
-                    storage_bytes,
-                } => {
-                    // As IndirectValue, but the buffer is written with a per-variant
-                    // tag dispatch (RUE-1037).
-                    caller_indirect_bytes = caller_indirect_bytes
-                        .checked_add(*storage_bytes)
-                        .expect("indirect argument area must fit u32");
-                    let pointer = materializer.materialize_indirect_value_arg_dispatch(
-                        *value,
-                        image,
-                        *storage_bytes,
-                    );
-                    (UserArgMode::Value, vec![pointer], vec![AbiSlotClass::Gp])
-                }
-                CallArgInput::Value {
-                    value,
-                    slot_count,
-                    is_multislot_aggregate,
-                    slot_types,
-                } => {
-                    let slots = if *slot_count == 0 {
-                        Vec::new()
-                    } else if *is_multislot_aggregate {
-                        let slots = materializer.materialize_aggregate(*value);
-                        assert_eq!(
-                            slots.len(),
-                            *slot_count as usize,
-                            "aggregate materialization must produce every logical ABI slot"
-                        );
-                        if callee_convention.is_rue() {
-                            slots.into_iter().rev().collect()
-                        } else {
-                            slots
-                        }
-                    } else {
-                        vec![materializer.materialize_scalar(*value)]
-                    };
-                    // A zero-sized normal argument has no ABI slot. Its
-                    // semantic type can still appear in `slot_types`, but it
-                    // must not consume a register-bank index or a stack slot.
-                    let mut classes = if slots.is_empty() {
-                        Vec::new()
-                    } else {
-                        slot_types
-                            .iter()
-                            .copied()
-                            .map(AbiSlotClass::for_leaf)
-                            .collect::<Vec<_>>()
-                    };
-                    if *is_multislot_aggregate && callee_convention.is_rue() {
-                        classes.reverse();
-                    }
-                    assert_eq!(
-                        slots.len(),
-                        classes.len(),
-                        "value argument ABI slots and classes must have equal cardinality"
-                    );
-                    (UserArgMode::Value, slots, classes)
-                }
-            };
-
+        for ((arg, native), span) in args.iter().zip(natives).zip(spans) {
+            let placements = signature.arguments()[span]
+                .iter()
+                .map(|argument| argument.location)
+                .collect::<Vec<_>>();
+            let (mode, slots, classes, locations) = place_argument(
+                arg,
+                native,
+                &placements,
+                materializer,
+                &mut caller_indirect_bytes,
+            );
             abi_slots.extend(slots.iter().copied());
             abi_classes.extend(classes);
+            abi_locations.extend(locations);
             user_args.push(UserArgPlan { mode, slots });
         }
 
@@ -807,11 +952,6 @@ impl CallPlan {
             abi_slots.len(),
             abi_classes.len(),
             "call ABI slots and classes must have equal cardinality"
-        );
-        let abi_locations = assign_abi_slots(
-            materializer.native_convention(),
-            abi_classes.iter().copied(),
-            arg_register_banks.into(),
         );
         assert_eq!(
             abi_slots.len(),
@@ -822,10 +962,6 @@ impl CallPlan {
             .iter()
             .filter(|location| matches!(location, AbiSlotLocation::Stack { .. }))
             .count();
-        let stack_bytes = checked_aligned_cell_region_bytes(
-            u64::try_from(stack_slot_count).expect("call stack slot count must fit u64"),
-        )
-        .expect("call stack area must pass frame-budget preflight");
 
         Self {
             target,
@@ -844,13 +980,20 @@ impl CallPlan {
             result,
             result_float_width: None,
             stack_slot_count,
-            stack_bytes,
+            stack_bytes: signature.stack_bytes(),
             caller_indirect_bytes,
         }
     }
 
-    /// Build the same normalized shape for drop/glue calls whose slots have
-    /// already been materialized by the canonical aggregate leaves.
+    /// Build the same normalized shape for a cleanup call — a destructor or a
+    /// drop glue body — whose slots have already been materialized by the
+    /// canonical aggregate leaves.
+    ///
+    /// A cleanup callee receives those leaves directly rather than a
+    /// reconstructed value ([`NativeArg::PerLeaf`]), so each leaf is placed as
+    /// one register-width argument by the same lowering every other call goes
+    /// through. The callee's own parameter plan reads the same arm, so the two
+    /// ends cannot disagree.
     pub fn from_slot_values(
         target: CallTarget,
         slots: &[VReg],
@@ -858,12 +1001,21 @@ impl CallPlan {
         arg_register_banks: impl Into<AbiRegisterBanks>,
         c_convention: CallingConvention,
     ) -> Self {
+        let _ = arg_register_banks.into();
+        let count = u32::try_from(slots.len()).expect("cleanup leaf count must fit u32");
+        let native = NativeArg::PerLeaf { count };
+        let parameters = native
+            .facts()
+            .into_iter()
+            .map(|facts| (facts, ArgConvention::ByValue))
+            .collect::<Vec<_>>();
+        let signature = lower_native_signature(native_convention, &parameters, LoweredReturn::Void);
         let abi_classes = vec![AbiSlotClass::Gp; slots.len()];
-        let abi_locations = assign_abi_slots(
-            native_convention,
-            abi_classes.iter().copied(),
-            arg_register_banks.into(),
-        );
+        let abi_locations = signature
+            .arguments()
+            .iter()
+            .map(|argument| scalar_location(argument.location))
+            .collect::<Vec<_>>();
         let stack_slot_count = abi_locations
             .iter()
             .filter(|location| matches!(location, AbiSlotLocation::Stack { .. }))
@@ -886,10 +1038,7 @@ impl CallPlan {
             result: None,
             result_float_width: None,
             stack_slot_count,
-            stack_bytes: checked_aligned_cell_region_bytes(
-                u64::try_from(stack_slot_count).expect("call stack slot count must fit u64"),
-            )
-            .expect("call stack area must pass frame-budget preflight"),
+            stack_bytes: signature.stack_bytes(),
             caller_indirect_bytes: 0,
         }
     }
@@ -917,6 +1066,7 @@ pub fn return_plan(type_pool: &FrozenTypeInternPool, ty: Type, ret_reg_budget: u
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_air::{StructDef, StructField, TypeInternPool};
 
     struct TestMaterializer;
 
@@ -945,24 +1095,75 @@ mod tests {
             VReg::new(40)
         }
 
-        fn materialize_indirect_value_arg(
+        fn materialize_image_eightbytes(
             &mut self,
             _value: rue_cfg::CfgValue,
-            _image: &[crate::types::PhysicalEnumSlot],
-            _padding: &[rue_air::layout::PaddingRange],
-            _storage_bytes: u32,
-        ) -> VReg {
-            VReg::new(50)
+            image: &NativeImage,
+        ) -> Vec<VReg> {
+            (0..image.eightbytes()).map(|i| VReg::new(50 + i)).collect()
         }
 
-        fn materialize_indirect_value_arg_dispatch(
+        fn materialize_indirect_image(
             &mut self,
             _value: rue_cfg::CfgValue,
-            _image: &crate::types::DispatchImage,
-            _storage_bytes: u32,
+            _image: &NativeImage,
         ) -> VReg {
-            VReg::new(51)
+            VReg::new(60)
         }
+
+        fn materialize_eightbyte_as_float(&mut self, bits: VReg) -> VReg {
+            VReg::new(200 + bits.index())
+        }
+    }
+
+    /// A pool holding one probe struct of the given field types.
+    fn pool_with_struct(fields: &[Type]) -> (FrozenTypeInternPool, Type) {
+        let interner = lasso::ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let (id, _) = pool.register_struct(
+            interner.get_or_intern("Probe"),
+            StructDef {
+                name: "Probe".into(),
+                fields: fields
+                    .iter()
+                    .enumerate()
+                    .map(|(index, ty)| StructField {
+                        name: format!("f{index}"),
+                        ty: *ty,
+                    })
+                    .collect(),
+                is_copy: true,
+                is_linear: false,
+                declared_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: rue_span::FileId::DEFAULT,
+            },
+        );
+        let ty = Type::new_struct(id);
+        (pool.freeze(), ty)
+    }
+
+    fn scalar_arg(value: u32, ty: Type) -> CallArgInput {
+        CallArgInput::Value {
+            value: rue_cfg::CfgValue::from_raw(value),
+            ty,
+            slot_count: 1,
+            is_multislot_aggregate: false,
+            slot_types: vec![ty],
+        }
+    }
+
+    fn natives_of(pool: &FrozenTypeInternPool, args: &[CallArgInput]) -> Vec<NativeArg> {
+        args.iter()
+            .map(|arg| match arg {
+                CallArgInput::Value { ty, .. } => native_arg(pool, *ty, ArgConvention::ByValue),
+                CallArgInput::ByRef { .. } => {
+                    native_arg(pool, Type::I64, ArgConvention::ByReference)
+                }
+            })
+            .collect()
     }
 
     #[test]
@@ -974,6 +1175,7 @@ mod tests {
         let value = normalize_call_arg(
             CfgArgMode::Normal,
             rue_cfg::CfgValue::from_raw(1),
+            Type::I32,
             1,
             false,
             vec![Type::I32],
@@ -985,6 +1187,7 @@ mod tests {
         let by_ref = normalize_call_arg(
             CfgArgMode::Borrow,
             rue_cfg::CfgValue::from_raw(2),
+            Type::I32,
             1,
             false,
             vec![Type::I32],
@@ -1003,6 +1206,7 @@ mod tests {
             normalize_call_arg(
                 CfgArgMode::Normal,
                 rue_cfg::CfgValue::from_raw(3),
+                Type::I32,
                 1,
                 false,
                 vec![Type::I32],
@@ -1014,6 +1218,7 @@ mod tests {
             normalize_call_arg(
                 CfgArgMode::Inout,
                 rue_cfg::CfgValue::from_raw(4),
+                Type::I32,
                 1,
                 false,
                 vec![Type::I32],
@@ -1041,96 +1246,47 @@ mod tests {
     }
 
     #[test]
-    fn abi_register_banks_fill_independently_and_share_stack_order() {
-        let classes = [
-            AbiSlotClass::Fp(crate::value_plan::FloatWidth::F32),
-            AbiSlotClass::Gp,
-            AbiSlotClass::Gp,
-            AbiSlotClass::Fp(crate::value_plan::FloatWidth::F64),
-            AbiSlotClass::Gp,
-            AbiSlotClass::Fp(crate::value_plan::FloatWidth::F32),
-        ];
-        assert_eq!(
-            assign_abi_slots(
-                ConventionSpec::native(rue_target::Target::X86_64Linux),
-                classes,
-                AbiRegisterBanks { gp: 2, fp: 2 }
-            ),
-            vec![
-                AbiSlotLocation::FpReg(0),
-                AbiSlotLocation::GpReg(0),
-                AbiSlotLocation::GpReg(1),
-                AbiSlotLocation::FpReg(1),
-                AbiSlotLocation::stack_slot(0),
-                AbiSlotLocation::stack_slot(1),
-            ]
-        );
-    }
-
-    #[test]
-    fn every_row_places_a_native_stack_slot_in_whole_ascending_eightbytes() {
-        // A native ABI slot carries a canonically 64-bit-extended value, so it
-        // claims one whole eightbyte from its convention's argument area —
-        // under Apple's natural-size packing as much as under the eight-byte
-        // slot rows, because eight bytes is the slot's natural size.
-        let classes = [AbiSlotClass::Gp; 4];
+    fn every_row_places_a_cleanup_leaf_in_a_whole_ascending_eightbyte() {
+        // The cleanup convention (destructors and drop glue) passes an
+        // aggregate's already-flattened leaves one register-width value per
+        // leaf, each carrying a canonically 64-bit-extended value, so a leaf the
+        // roster cannot hold claims one whole eightbyte from its convention's
+        // argument area — under Apple's natural-size packing as much as under
+        // the eight-byte slot rows, because eight bytes is a register-width
+        // value's natural size.
+        let slots: Vec<_> = (0..10).map(VReg::new).collect();
         for target in rue_target::Target::all() {
-            let locations = assign_abi_slots(
+            let plan = CallPlan::from_slot_values(
+                CallTarget::rue("drop"),
+                &slots,
                 ConventionSpec::native(*target),
-                classes,
-                AbiRegisterBanks { gp: 1, fp: 0 },
+                6,
+                target.c_calling_convention(),
+            );
+            let registers =
+                usize::try_from(ConventionSpec::native(*target).spec().gp_argument_registers)
+                    .expect("a roster size fits usize");
+            let stacked = &plan.abi_locations[registers..];
+            assert_eq!(
+                stacked,
+                (0..stacked.len())
+                    .map(AbiSlotLocation::stack_slot)
+                    .collect::<Vec<_>>(),
+                "{target:?}: cleanup leaves stack in whole ascending eightbytes"
             );
             assert_eq!(
-                locations,
-                vec![
-                    AbiSlotLocation::GpReg(0),
-                    AbiSlotLocation::stack_slot(0),
-                    AbiSlotLocation::stack_slot(1),
-                    AbiSlotLocation::stack_slot(2),
-                ],
-                "{target:?}: native stack slots are whole ascending eightbytes"
+                &plan.abi_locations[..registers],
+                (0..registers)
+                    .map(AbiSlotLocation::GpReg)
+                    .collect::<Vec<_>>(),
+                "{target:?}: cleanup leaves take the roster in order"
             );
         }
     }
 
     #[test]
-    fn zero_sized_normal_arguments_are_omitted_but_by_ref_is_preserved() {
-        let slots = vec![VReg::new(7)];
-        let plan = CallPlan {
-            target: CallTarget::rue("test"),
-            callee_convention: CallingConvention::Rue,
-            hidden_sret: None,
-            user_args: vec![
-                UserArgPlan {
-                    mode: UserArgMode::Value,
-                    slots: vec![],
-                },
-                UserArgPlan {
-                    mode: UserArgMode::Borrow,
-                    slots: slots.clone(),
-                },
-            ],
-            abi_slots: slots.clone(),
-            abi_classes: vec![AbiSlotClass::Gp],
-            abi_locations: vec![AbiSlotLocation::GpReg(0)],
-            return_plan: ReturnPlan::ZeroSized,
-            return_slot_regs: Vec::new(),
-            compact_return_image: None,
-            compact_return_dispatch: None,
-            result: None,
-            result_float_width: None,
-            stack_slot_count: 0,
-            stack_bytes: 0,
-            caller_indirect_bytes: 0,
-        };
-
-        assert!(plan.user_args[0].slots.is_empty());
-        assert_eq!(plan.user_args[1].slots, slots);
-        assert_eq!(plan.abi_slots.len(), 1);
-    }
-
-    #[test]
     fn zero_sized_normal_arguments_do_not_consume_abi_locations() {
+        let (pool, _) = pool_with_struct(&[Type::I64]);
         let mut args = Vec::new();
         for value in 1..=9 {
             if value == 4 {
@@ -1138,25 +1294,22 @@ mod tests {
                 // value has no physical ABI slot.
                 args.push(CallArgInput::Value {
                     value: rue_cfg::CfgValue::from_raw(100),
+                    ty: Type::UNIT,
                     slot_count: 0,
                     is_multislot_aggregate: false,
                     slot_types: vec![Type::UNIT],
                 });
             }
-            args.push(CallArgInput::Value {
-                value: rue_cfg::CfgValue::from_raw(value),
-                slot_count: 1,
-                is_multislot_aggregate: false,
-                slot_types: vec![Type::I32],
-            });
+            args.push(scalar_arg(value, Type::I32));
         }
+        let natives = natives_of(&pool, &args);
 
         let mut materializer = TestMaterializer;
         let plan = CallPlan::from_inputs(
             CallTarget::rue("callee"),
             ReturnPlan::ZeroSized,
             &args,
-            AbiRegisterBanks { gp: 6, fp: 8 },
+            &natives,
             &mut materializer,
         );
 
@@ -1199,10 +1352,15 @@ mod tests {
     }
 
     #[test]
-    fn cfg_plan_orders_aggregate_slots_by_callee_abi_and_keeps_hidden_sret_first() {
+    fn a_packed_aggregate_argument_crosses_through_its_image_and_sret_stays_first() {
+        // `{i32, i32}` is one eightbyte: its leaves do not start their own
+        // eightbytes, so the caller marshals them through the compact image and
+        // hands the placement a single register (ADR-0084).
+        let (pool, packed) = pool_with_struct(&[Type::I32, Type::I32]);
         let args = [
             CallArgInput::Value {
                 value: rue_cfg::CfgValue::from_raw(1),
+                ty: packed,
                 slot_count: 2,
                 is_multislot_aggregate: true,
                 slot_types: vec![Type::I32, Type::I32],
@@ -1216,11 +1374,13 @@ mod tests {
             },
             CallArgInput::Value {
                 value: rue_cfg::CfgValue::from_raw(3),
+                ty: Type::UNIT,
                 slot_count: 0,
                 is_multislot_aggregate: false,
                 slot_types: Vec::new(),
             },
         ];
+        let natives = natives_of(&pool, &args);
         let mut materializer = TestMaterializer;
         let rue = CallPlan::from_inputs(
             CallTarget::rue("callee"),
@@ -1229,40 +1389,83 @@ mod tests {
                 storage_bytes: 32,
             },
             &args,
-            3,
+            &natives,
             &mut materializer,
         );
 
+        // The hidden sret pointer takes the first argument register, the packed
+        // struct the second, and the borrow pointer the third.
         assert_eq!(
             rue.abi_slots,
-            vec![VReg::new(40), VReg::new(11), VReg::new(10), VReg::new(30)]
+            vec![VReg::new(40), VReg::new(50), VReg::new(30)]
+        );
+        assert_eq!(
+            rue.abi_locations,
+            vec![
+                AbiSlotLocation::GpReg(0),
+                AbiSlotLocation::GpReg(1),
+                AbiSlotLocation::GpReg(2),
+            ]
         );
         assert_eq!(rue.hidden_sret.unwrap().abi_slot, 0);
-        assert_eq!(rue.stack_slot_count, 1);
-        assert_eq!(rue.stack_bytes, 16);
+        assert_eq!(rue.stack_slot_count, 0);
+        assert_eq!(rue.stack_bytes, 0);
         assert_eq!(rue.user_args[1].mode, UserArgMode::Borrow);
         assert!(rue.user_args[2].slots.is_empty());
     }
 
     #[test]
-    fn generated_rue_symbols_do_not_trigger_runtime_abi_by_prefix() {
+    fn an_eightbyte_aligned_aggregate_hands_its_own_leaves_to_the_registers() {
+        // `{i64, i64}` has one leaf per eightbyte, in ascending memory order,
+        // so the leaf vregs are the eightbytes and nothing is marshaled.
+        let (pool, wide) = pool_with_struct(&[Type::I64, Type::I64]);
         let args = [CallArgInput::Value {
             value: rue_cfg::CfgValue::from_raw(1),
+            ty: wide,
             slot_count: 2,
             is_multislot_aggregate: true,
-            slot_types: vec![Type::I32, Type::I32],
+            slot_types: vec![Type::I64, Type::I64],
         }];
+        let natives = natives_of(&pool, &args);
+        let mut materializer = TestMaterializer;
+        let plan = CallPlan::from_inputs(
+            CallTarget::rue("callee"),
+            ReturnPlan::ZeroSized,
+            &args,
+            &natives,
+            &mut materializer,
+        );
+        // Ascending memory order: leaf 0 in the first register, leaf 1 in the
+        // second. No reversal (ADR-0084).
+        assert_eq!(plan.abi_slots, vec![VReg::new(10), VReg::new(11)]);
+        assert_eq!(
+            plan.abi_locations,
+            vec![AbiSlotLocation::GpReg(0), AbiSlotLocation::GpReg(1)]
+        );
+    }
+
+    #[test]
+    fn generated_rue_symbols_do_not_trigger_runtime_abi_by_prefix() {
+        let (pool, wide) = pool_with_struct(&[Type::I64, Type::I64]);
+        let args = [CallArgInput::Value {
+            value: rue_cfg::CfgValue::from_raw(1),
+            ty: wide,
+            slot_count: 2,
+            is_multislot_aggregate: true,
+            slot_types: vec![Type::I64, Type::I64],
+        }];
+        let natives = natives_of(&pool, &args);
 
         let mut materializer = TestMaterializer;
         let generated_rue = CallPlan::from_inputs(
             CallTarget::rue("__rue_drop_generated"),
             ReturnPlan::ZeroSized,
             &args,
-            8,
+            &natives,
             &mut materializer,
         );
         assert_eq!(generated_rue.callee_convention, CallingConvention::Rue);
-        assert_eq!(generated_rue.abi_slots, vec![VReg::new(11), VReg::new(10)]);
+        assert_eq!(generated_rue.abi_slots, vec![VReg::new(10), VReg::new(11)]);
     }
 
     #[test]

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -537,6 +537,13 @@ impl<'a> CfgLowerContext<'a> {
 
     /// The emitted frame slot of parameter ABI slot `index`, which must be
     /// homed (RUE-1170).
+    /// The by-value aggregate parameters whose leaves must be read back out of
+    /// their compact image at entry (ADR-0084). Empty when no storage plan was
+    /// supplied.
+    pub(crate) fn param_unmarshals(&self) -> &[crate::param_storage::ParamUnmarshal] {
+        self.param_storage.map_or(&[], |plan| plan.unmarshals())
+    }
+
     pub fn param_frame_slot(&self, index: u32) -> u32 {
         let area_slot = match self.param_storage {
             None => index,

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -5,33 +5,38 @@
 //! those passes run — and the distinction between spill-placement slots and
 //! emitted-frame locals — is common to every machine-code emission entry point.
 
-use rue_air::{ArgClass, ArgConvention, FrozenTypeInternPool, NativeCallAbi, ReturnClass};
+use rue_air::{ArgConvention, FrozenTypeInternPool, NativeCallAbi, ReturnClass};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, ValidatedCfg};
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use tracing::info_span;
 
 use crate::frame_layout::{FrameLayout, FramePointer, SavedRegScheme};
 
-/// How the callee prologue homes one source parameter's incoming argument
-/// registers into its frame parameter slots (ADR-0052 phase 5.8, RUE-1005).
+/// How the callee prologue moves one eightbyte of an incoming argument into
+/// the frame parameter area.
 ///
-/// The historical prologue assumed one incoming register per parameter slot. A
-/// by-value indirect compact aggregate breaks that: it arrives as one pointer
-/// register (`reg_count == 1`) yet reserves `slot_count` frame slots, so
-/// subsequent parameters' incoming registers shift. Each entry homes `reg_count`
-/// consecutive incoming registers starting at ABI argument index `abi_start`
-/// (sret shift included, RUE-1170) into frame parameter slots
-/// `[start_slot, start_slot + reg_count)`; the parameter's remaining reserved
-/// slots (for an indirect aggregate) are filled lazily by the body from the
-/// homed pointer. `start_slot` is the parameter's position within the
-/// *compacted* frame parameter area: register-only parameters (RUE-1170) get
-/// no entry at all and reserve no slots, so homed parameters pack together
-/// while their `abi_start` still names the original incoming register.
+/// A source parameter arrives as the placement the native convention gave it —
+/// one register per eightbyte, a run of eightbytes in the incoming argument
+/// area, or one pointer — and the prologue copies each of those eightbytes into
+/// a frame parameter slot. When the parameter's leaves *are* its eightbytes the
+/// copy is the whole homing; otherwise the body's entry unmarshal reads the
+/// leaves back out of the image the copies just laid down
+/// (`ParamStoragePlan::unmarshals`).
+///
+/// `start_slot` is the eightbyte's position within the *compacted* frame
+/// parameter area: register-only parameters (RUE-1170) get no entry at all and
+/// reserve no slots, so homed parameters pack together while the placement
+/// still names the original incoming register.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ParamHoming {
     pub(crate) start_slot: u32,
     pub(crate) class: crate::call_plan::AbiSlotClass,
     pub(crate) location: crate::call_plan::AbiSlotLocation,
+    /// The narrow load a stacked value narrower than an eightbyte needs, so the
+    /// frame slot holds Rue's canonical 64-bit form. `None` for a whole
+    /// eightbyte, which is every stacked value under a row that packs the
+    /// argument area in 8-byte slots.
+    pub(crate) narrow_stack_load: Option<crate::types::NarrowScalar>,
 }
 
 /// Decide whether the final frame needs a frame pointer and a slot region, or
@@ -102,14 +107,14 @@ pub(crate) fn checked_slot_sum(parts: impl IntoIterator<Item = u32>) -> Option<u
 pub(crate) fn validate_pre_lowering_budget(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
-    arg_reg_count: u32,
+    native_convention: rue_target::ConventionSpec,
     return_reg_count: u32,
     scheme: SavedRegScheme,
 ) -> CompileResult<bool> {
     validate_pre_lowering_budget_for_target(
         cfg,
         type_pool,
-        arg_reg_count,
+        native_convention,
         return_reg_count,
         scheme,
         &|_| None,
@@ -119,7 +124,7 @@ pub(crate) fn validate_pre_lowering_budget(
 pub(crate) fn validate_pre_lowering_budget_for_target(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
-    arg_reg_count: u32,
+    native_convention: rue_target::ConventionSpec,
     return_reg_count: u32,
     scheme: SavedRegScheme,
     foreign_symbol_convention: &dyn Fn(lasso::Spur) -> Option<rue_target::CallingConvention>,
@@ -131,7 +136,6 @@ pub(crate) fn validate_pre_lowering_budget_for_target(
         .ok_or_else(|| frame_budget_error(cfg, None))?;
     FrameLayout::try_new(scheme, 0, base_slots).map_err(|_| frame_budget_error(cfg, None))?;
 
-    let argument_abi = NativeCallAbi::for_arguments(type_pool);
     for raw in 0..cfg.value_count() {
         let value = CfgValue::from_raw(raw as u32);
         let inst = cfg.get_inst(value);
@@ -146,39 +150,33 @@ pub(crate) fn validate_pre_lowering_budget_for_target(
             .map_err(|_| frame_budget_error(cfg, Some(value)))?;
             continue;
         }
-        let return_class = NativeCallAbi::new(type_pool, return_reg_count).classify_return(inst.ty);
-        let (mut abi_slots, sret_bytes) = match return_class {
-            ReturnClass::Indirect { slot_count } => {
-                let bytes =
+        let sret_bytes =
+            match NativeCallAbi::new(type_pool, return_reg_count).classify_return(inst.ty) {
+                ReturnClass::Indirect { slot_count } => u64::from(
                     crate::frame_layout::checked_aligned_cell_region_bytes(u64::from(slot_count))
-                        .map_err(|_| frame_budget_error(cfg, Some(value)))?;
-                (1_u32, u64::from(bytes))
-            }
-            _ => (0_u32, 0),
-        };
-        let mut indirect_bytes = 0_u64;
-        for arg in call_args {
-            let ty = cfg.get_inst(arg.value).ty;
-            let convention = match arg.mode {
-                CfgArgMode::Normal => ArgConvention::ByValue,
-                CfgArgMode::Inout | CfgArgMode::Borrow => ArgConvention::ByReference,
+                        .map_err(|_| frame_budget_error(cfg, Some(value)))?,
+                ),
+                _ => 0,
             };
-            let class = argument_abi.classify_arg(ty, convention);
-            abi_slots = abi_slots
-                .checked_add(class.crossing_slots())
-                .ok_or_else(|| frame_budget_error(cfg, Some(value)))?;
-            if arg.mode == CfgArgMode::Normal && class == ArgClass::Indirect {
-                let bytes =
-                    crate::frame_layout::checked_aligned_region_bytes(type_pool.layout(ty).size)
-                        .map_err(|_| frame_budget_error(cfg, Some(value)))?;
-                indirect_bytes = indirect_bytes
-                    .checked_add(u64::from(bytes))
-                    .ok_or_else(|| frame_budget_error(cfg, Some(value)))?;
-            }
-        }
-        let stack_slots = u64::from(abi_slots.saturating_sub(arg_reg_count));
-        crate::frame_layout::checked_call_area_bytes(stack_slots, sret_bytes, indirect_bytes)
-            .map_err(|_| frame_budget_error(cfg, Some(value)))?;
+        let arguments = call_args
+            .iter()
+            .map(|arg| {
+                (
+                    cfg.get_inst(arg.value).ty,
+                    match arg.mode {
+                        CfgArgMode::Normal => ArgConvention::ByValue,
+                        CfgArgMode::Inout | CfgArgMode::Borrow => ArgConvention::ByReference,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        crate::native_abi::native_call_area_bytes(
+            type_pool,
+            native_convention,
+            sret_bytes,
+            &arguments,
+        )
+        .map_err(|_| frame_budget_error(cfg, Some(value)))?;
     }
     Ok(has_sret)
 }
@@ -206,7 +204,7 @@ pub(crate) fn prepare_mir_with_backend<B: crate::backend::Backend>(
     let has_sret = validate_pre_lowering_budget_for_target(
         cfg,
         type_pool,
-        B::ARG_REG_COUNT,
+        rue_target::ConventionSpec::native(target),
         B::RETURN_REG_COUNT,
         B::SAVED_REG_SCHEME,
         &|name| symbols.foreign_convention(&symbols.resolve(interner.resolve(&name))),
@@ -346,6 +344,15 @@ pub(crate) fn generate_with_backend<B: crate::backend::Backend>(
 
 #[cfg(test)]
 mod tests {
+    /// The native pairing of each supported target, which is what decides where
+    /// a call's arguments land and therefore how much outgoing area it needs.
+    const X86_64_NATIVE: rue_target::ConventionSpec =
+        rue_target::ConventionSpec::native(rue_target::Target::X86_64Linux);
+    const AARCH64_NATIVE: rue_target::ConventionSpec =
+        rue_target::ConventionSpec::native(rue_target::Target::Aarch64Linux);
+    const AARCH64_DARWIN_NATIVE: rue_target::ConventionSpec =
+        rue_target::ConventionSpec::native(rue_target::Target::Aarch64Macos);
+
     use std::cell::RefCell;
 
     use lasso::Spur;
@@ -551,17 +558,37 @@ mod tests {
         let cfg = Cfg::new(Type::UNIT, max_slots, 0, "boundary".into(), vec![]);
 
         assert!(
-            validate_pre_lowering_budget(&cfg, &type_pool, 6, 6, SavedRegScheme::X86_64,).is_ok()
+            validate_pre_lowering_budget(
+                &cfg,
+                &type_pool,
+                X86_64_NATIVE,
+                6,
+                SavedRegScheme::X86_64,
+            )
+            .is_ok()
         );
         assert!(
-            validate_pre_lowering_budget(&cfg, &type_pool, 8, 8, SavedRegScheme::Aarch64,).is_err(),
+            validate_pre_lowering_budget(
+                &cfg,
+                &type_pool,
+                AARCH64_NATIVE,
+                8,
+                SavedRegScheme::Aarch64,
+            )
+            .is_err(),
             "AArch64's mandatory FP/LR save must count against the same budget"
         );
 
         let over_boundary = Cfg::new(Type::UNIT, max_slots + 1, 0, "over_boundary".into(), vec![]);
         assert!(
-            validate_pre_lowering_budget(&over_boundary, &type_pool, 6, 6, SavedRegScheme::X86_64,)
-                .is_err(),
+            validate_pre_lowering_budget(
+                &over_boundary,
+                &type_pool,
+                X86_64_NATIVE,
+                6,
+                SavedRegScheme::X86_64,
+            )
+            .is_err(),
             "an oversized production CFG must be rejected before backend lowering"
         );
 
@@ -570,7 +597,7 @@ mod tests {
             validate_pre_lowering_budget(
                 &param_boundary,
                 &type_pool,
-                6,
+                X86_64_NATIVE,
                 6,
                 SavedRegScheme::X86_64,
             )
@@ -606,21 +633,21 @@ mod tests {
         cfg.append_call(entry, None, Spur::default(), args, huge, Span::default())
             .unwrap();
 
-        for (arg_regs, ret_regs, scheme, convention) in [
+        for (native, ret_regs, scheme, convention) in [
             (
-                6,
+                X86_64_NATIVE,
                 6,
                 SavedRegScheme::X86_64,
                 rue_target::CallingConvention::X86_64SysV,
             ),
             (
-                8,
+                AARCH64_NATIVE,
                 8,
                 SavedRegScheme::Aarch64,
                 rue_target::CallingConvention::Aarch64Aapcs,
             ),
             (
-                8,
+                AARCH64_DARWIN_NATIVE,
                 8,
                 SavedRegScheme::Aarch64,
                 rue_target::CallingConvention::Aarch64AapcsDarwin,
@@ -629,7 +656,7 @@ mod tests {
             let error = super::validate_pre_lowering_budget_for_target(
                 &cfg,
                 &type_pool,
-                arg_regs,
+                native,
                 ret_regs,
                 scheme,
                 &|_| Some(convention),
@@ -643,8 +670,14 @@ mod tests {
 
         // Keep the native planner's cumulative indirect+sret guard covered as
         // well; the target-C cases above exercise the distinct foreign shapes.
-        let error = validate_pre_lowering_budget(&cfg, &type_pool, 6, 6, SavedRegScheme::X86_64)
-            .unwrap_err();
+        let error = validate_pre_lowering_budget(
+            &cfg,
+            &type_pool,
+            X86_64_NATIVE,
+            6,
+            SavedRegScheme::X86_64,
+        )
+        .unwrap_err();
         assert!(matches!(
             error.kind,
             rue_error::ErrorKind::FunctionFrameTooLarge { .. }
@@ -688,21 +721,21 @@ mod tests {
         // aggregate argument's 16-byte image scratch is live alongside it
         // during lowering. Both target-C lowerers must reject that peak before
         // their stack adjustments are emitted.
-        for (arg_regs, ret_regs, scheme, convention) in [
+        for (native, ret_regs, scheme, convention) in [
             (
-                6,
+                X86_64_NATIVE,
                 6,
                 SavedRegScheme::X86_64,
                 rue_target::CallingConvention::X86_64SysV,
             ),
             (
-                8,
+                AARCH64_NATIVE,
                 8,
                 SavedRegScheme::Aarch64,
                 rue_target::CallingConvention::Aarch64Aapcs,
             ),
             (
-                8,
+                AARCH64_DARWIN_NATIVE,
                 8,
                 SavedRegScheme::Aarch64,
                 rue_target::CallingConvention::Aarch64AapcsDarwin,
@@ -712,7 +745,7 @@ mod tests {
                 super::validate_pre_lowering_budget_for_target(
                     &cfg,
                     &type_pool,
-                    arg_regs,
+                    native,
                     ret_regs,
                     scheme,
                     &|_| Some(convention),

--- a/crates/rue-codegen/src/export_thunk.rs
+++ b/crates/rue-codegen/src/export_thunk.rs
@@ -17,13 +17,15 @@
 //! signature and an export of the same signature agree by construction, which
 //! is ADR-0064's ratified acceptance criterion.
 //!
-//! The native side is the *other* convention, and it is unchanged by this
-//! module: a by-value aggregate the native classifier rules indirect crosses as
-//! one pointer to its compact memory image; a direct multi-slot aggregate
-//! crosses one slot per flattened leaf with the slots **reversed**; a hidden
-//! sret pointer is native ABI slot 0; every scalar slot carries Rue's canonical
-//! 64-bit extension. [`ExportSignature`] is the pairing of the two views, built
-//! once from the type pool by [`ExportSignature::for_types`].
+//! The native side is placed by the *same* function, against the same facts:
+//! the native convention is the compilation target's C convention with a wider
+//! return bank (ADR-0084), so [`rue_air::lower_native_signature`] answers where
+//! the native body expects each argument, exactly as the callee's own parameter
+//! plan (`crate::param_storage`) asks it. The two conventions therefore agree
+//! about every argument whenever the export names the target's own C row, and
+//! what remains of the thunk is the re-extension a narrow scalar needs and the
+//! return adaptation phase 2 owns. [`ExportSignature`] is the pairing of the two
+//! views, built once from the type pool by [`ExportSignature::for_types`].
 //!
 //! ## Why the compact image is the C image
 //!
@@ -33,8 +35,8 @@
 //! exact image through memory. So the thunk never repacks those: it hands the C
 //! caller's own bytes to the native body, and hands the native body's sret
 //! storage — the C caller's storage, when the C return is also indirect — back.
-//! Only a *direct* native crossing needs marshaling, and then only the leaf
-//! loads and stores the compact image map already describes.
+//! Only a native crossing that reads the value apart needs marshaling, and then
+//! only the leaf loads and stores the compact image map already describes.
 //!
 //! ## Abort at the boundary (ratified, ADR-0064 ruling 3)
 //!
@@ -51,8 +53,8 @@
 
 use rue_air::{
     ArgConvention, ArgLocation, CAbiTypeFacts, FrozenTypeInternPool, LoweredReturn,
-    LoweredSignature, NativeAbiTypeFacts, NativeCallAbi, PaddingRange, PointerLocation, Type,
-    lower_c_signature, native_return_register_budget,
+    LoweredSignature, NativeAbiTypeFacts, PaddingRange, PointerLocation, Type, lower_c_signature,
+    lower_native_signature, native_return_register_budget,
 };
 use rue_target::{Arch, CRegisterClass, CallingConvention, SretRegisterKind, Target};
 
@@ -76,21 +78,20 @@ pub struct ImageLeaf {
     pub signed: bool,
 }
 
-/// How the native body receives one parameter.
+/// How the native body reads one parameter apart.
+///
+/// *Where* the parameter travels is the native lowering's answer, the same one
+/// the callee's own parameter plan reads; this is the other half — whether the
+/// value's leaves are its eightbytes, and where each leaf sits in the compact
+/// image either way.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NativeParameter {
-    /// One native ABI slot per flattened leaf, in ascending image order. A
-    /// multi-slot aggregate's slots are **reversed** before placement, which is
-    /// the native convention's rule.
-    Direct {
-        /// The value's flattened leaves, in ascending image order.
-        leaves: Vec<ImageLeaf>,
-        /// Whether the native convention reverses this value's slots.
-        reversed: bool,
-    },
-    /// One pointer to the value's compact memory image, which the callee
-    /// unmarshals at entry.
-    Indirect,
+pub struct NativeParameter {
+    /// The value's flattened leaves, in ascending image order.
+    pub leaves: Vec<ImageLeaf>,
+    /// Whether each leaf starts its own eightbyte, so the leaves themselves
+    /// cross in Rue's canonical 64-bit form rather than the image's eightbytes
+    /// crossing whole (`crate::native_abi::NativeImage::direct_leaves`).
+    pub leaves_are_eightbytes: bool,
 }
 
 /// How the native body returns.
@@ -158,25 +159,13 @@ impl ExportSignature {
         param_types: &[Type],
         return_type: Type,
     ) -> Self {
-        let native = NativeCallAbi::for_arguments(type_pool);
         let parameters = param_types
             .iter()
             .map(|&ty| ExportParameter {
                 c: rue_air::c_abi_type_facts(type_pool, ty),
-                native: match native.classify_arg(ty, ArgConvention::ByValue) {
-                    rue_air::ArgClass::Indirect => NativeParameter::Indirect,
-                    // A zero-sized by-value parameter still occupies one
-                    // incoming argument slot in the callee's parameter layout
-                    // (`SourceParamAbi` clamps its width to one), so the thunk
-                    // supplies one, holding no meaningful value.
-                    rue_air::ArgClass::Omitted => NativeParameter::Direct {
-                        leaves: Vec::new(),
-                        reversed: false,
-                    },
-                    rue_air::ArgClass::Direct { .. } => NativeParameter::Direct {
-                        leaves: image_leaves(type_pool, ty),
-                        reversed: crate::types::is_multislot_aggregate(type_pool, ty),
-                    },
+                native: NativeParameter {
+                    leaves: image_leaves(type_pool, ty),
+                    leaves_are_eightbytes: native_leaves_are_eightbytes(type_pool, ty),
                 },
             })
             .collect();
@@ -241,6 +230,21 @@ fn image_leaves(type_pool: &FrozenTypeInternPool, ty: Type) -> Vec<ImageLeaf> {
         .collect()
 }
 
+/// Whether the native convention hands `ty`'s leaves over as themselves rather
+/// than packing them into the image's eightbytes.
+///
+/// This is the one predicate both ends of a native crossing consult
+/// (`crate::native_abi::NativeImage::direct_leaves`); a scalar is trivially its
+/// own eightbyte. Every export type is C-passable, so every leaf is
+/// general-purpose and the bank agreement the predicate also checks is
+/// automatic.
+fn native_leaves_are_eightbytes(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
+    match crate::native_abi::native_by_value_arg(type_pool, ty) {
+        crate::native_abi::NativeArg::Aggregate { image } => image.direct_leaves().is_some(),
+        _ => true,
+    }
+}
+
 /// The native classification kernel input for an export's return type.
 fn native_return_facts(type_pool: &FrozenTypeInternPool, ty: Type) -> NativeAbiTypeFacts {
     let abi_slots = type_pool.abi_slot_count(ty);
@@ -283,18 +287,28 @@ pub fn generate_export_thunk(
 // The target-independent thunk plan
 // ============================================================================
 
-/// Where one native ABI slot's value comes from.
+/// Where one value the native convention places comes from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NativeSlotSource {
     /// The address of the hidden return storage the native body writes.
     ReturnStorage,
     /// The address of parameter `parameter`'s compact image.
     ImageAddress { parameter: usize },
-    /// Leaf `leaf` of parameter `parameter`'s compact image.
+    /// Leaf `leaf` of parameter `parameter`'s compact image, extended to Rue's
+    /// canonical 64-bit form.
     Leaf { parameter: usize, leaf: usize },
-    /// A slot the callee's parameter layout reserves for a zero-sized by-value
-    /// parameter, which holds no value.
-    Empty,
+    /// Eightbyte `index` of parameter `parameter`'s compact image, whole.
+    Eightbyte { parameter: usize, index: usize },
+}
+
+/// Where the native convention puts one of those values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NativeSlotDestination {
+    /// Native argument register `index` of the general-purpose roster. Every
+    /// export type is C-passable, so no value reaches the floating-point one.
+    Register { index: u32 },
+    /// Byte `offset` of the outgoing native argument area.
+    Stack { offset: u32 },
 }
 
 /// How to reach one parameter's compact image.
@@ -328,16 +342,19 @@ struct ThunkPlan {
     bases: Vec<ImageBase>,
     /// The leaves of each parameter, in source order.
     leaves: Vec<Vec<ImageLeaf>>,
-    /// Every native ABI slot, in native order.
-    slots: Vec<NativeSlotSource>,
+    /// Every value the native convention places, in native order, and where it
+    /// places it.
+    slots: Vec<(NativeSlotSource, NativeSlotDestination)>,
     /// The return value's leaves, when the native body returns in registers.
     return_leaves: Vec<ImageLeaf>,
     return_padding: Vec<PaddingRange>,
-    /// Frame offset of the staging cell for native slot `k` (`k` < the native
-    /// argument roster), or the outgoing native stack offset otherwise.
+    /// Frame offset each native value is assembled at: a staging cell for a
+    /// register-passed one, its own position in the outgoing native argument
+    /// area for a stacked one.
     slot_offsets: Vec<u32>,
-    /// How many native slots travel in argument registers.
-    register_slots: u32,
+    /// `(native argument register, staging cell)` for every register-passed
+    /// value, in placement order.
+    register_loads: Vec<(u32, u32)>,
     /// Frame offset of the incoming C argument register save block.
     save_base: u32,
     /// Frame offset holding the C caller's indirect-result pointer, when the C
@@ -374,61 +391,125 @@ impl ThunkPlan {
         let c = signature.lowered();
         let spec = c.spec();
         let native_return = signature.native_return(target);
-        let native_arg_registers = native_argument_register_count(target);
+
+        // The native side is placed by the one lowering every crossing
+        // consumes, against the very facts the C side was placed by: the two
+        // conventions classify the same compact image, and the native row is
+        // this target's own C row with a wider return bank (ADR-0084).
+        let native_pairing = rue_target::ConventionSpec::native(target);
+        let native_parameters = signature
+            .parameters
+            .iter()
+            .map(|parameter| (parameter.c, ArgConvention::ByValue))
+            .collect::<Vec<_>>();
+        let native_spec = native_pairing.spec();
+        let native = lower_native_signature(
+            native_pairing,
+            &native_parameters,
+            if matches!(native_return, NativeReturn::Sret) {
+                LoweredReturn::Sret {
+                    register: native_spec.sret_register,
+                    echoed: native_spec.sret_pointer_echoed_in_result_register,
+                    size: 8,
+                    align: 8,
+                }
+            } else {
+                LoweredReturn::Void
+            },
+        );
 
         // Every incoming general-purpose argument register is saved to a
         // contiguous cell block, so a register-passed value's eightbytes are
         // addressable as one image with no repacking.
         let save_cells = spec.gp_argument_registers + 1;
 
-        let mut slots = Vec::new();
+        let mut slots: Vec<(NativeSlotSource, NativeSlotDestination)> = Vec::new();
         if matches!(native_return, NativeReturn::Sret) {
-            slots.push(NativeSlotSource::ReturnStorage);
+            assert!(
+                native.sret_in_argument_register(),
+                "the native convention passes its indirect-result pointer as the \
+                 hidden first ordinary argument"
+            );
+            slots.push((
+                NativeSlotSource::ReturnStorage,
+                NativeSlotDestination::Register { index: 0 },
+            ));
         }
         let mut leaves = Vec::with_capacity(signature.parameters.len());
-        for (parameter, description) in signature.parameters.iter().enumerate() {
-            match &description.native {
-                NativeParameter::Indirect => {
-                    slots.push(NativeSlotSource::ImageAddress { parameter });
-                    leaves.push(Vec::new());
-                }
-                NativeParameter::Direct {
-                    leaves: value_leaves,
-                    reversed,
-                } => {
-                    if value_leaves.is_empty() {
-                        slots.push(NativeSlotSource::Empty);
-                    } else {
-                        let indices = 0..value_leaves.len();
-                        let ordered: Vec<usize> = if *reversed {
-                            indices.rev().collect()
-                        } else {
-                            indices.collect()
-                        };
-                        slots.extend(
-                            ordered
-                                .into_iter()
-                                .map(|leaf| NativeSlotSource::Leaf { parameter, leaf }),
-                        );
+        for (parameter, (description, placement)) in signature
+            .parameters
+            .iter()
+            .zip(native.arguments())
+            .enumerate()
+        {
+            let value_leaves = &description.native.leaves;
+            let source = |index: usize| {
+                if description.native.leaves_are_eightbytes {
+                    NativeSlotSource::Leaf {
+                        parameter,
+                        leaf: index,
                     }
-                    leaves.push(value_leaves.clone());
+                } else {
+                    NativeSlotSource::Eightbyte { parameter, index }
                 }
+            };
+            match placement.location {
+                ArgLocation::Omitted => {}
+                ArgLocation::Registers { pieces } => {
+                    assert_eq!(
+                        pieces.uniform_class(),
+                        Some(CRegisterClass::Gp),
+                        "an export argument still crosses only in general-purpose registers"
+                    );
+                    for (index, piece) in pieces.as_slice().iter().enumerate() {
+                        slots.push((
+                            source(index),
+                            NativeSlotDestination::Register { index: piece.index },
+                        ));
+                    }
+                }
+                ArgLocation::Stack { offset, size, .. } => {
+                    let count = if value_leaves.len() == 1 && size < 8 {
+                        1
+                    } else {
+                        (size as usize).div_ceil(8)
+                    };
+                    for index in 0..count {
+                        slots.push((
+                            source(index),
+                            NativeSlotDestination::Stack {
+                                offset: offset + (index as u32) * 8,
+                            },
+                        ));
+                    }
+                }
+                ArgLocation::Indirect { pointer, .. } => slots.push((
+                    NativeSlotSource::ImageAddress { parameter },
+                    match pointer {
+                        PointerLocation::Register { index } => {
+                            NativeSlotDestination::Register { index }
+                        }
+                        PointerLocation::Stack { offset } => {
+                            NativeSlotDestination::Stack { offset }
+                        }
+                    },
+                )),
             }
+            leaves.push(value_leaves.clone());
         }
 
-        let slot_count = u32::try_from(slots.len()).expect("an export has fewer than 2^32 slots");
-        let register_slots = slot_count.min(native_arg_registers);
-        let stack_slots = slot_count - register_slots;
+        let register_slots = slots
+            .iter()
+            .filter(|(_, destination)| {
+                matches!(destination, NativeSlotDestination::Register { .. })
+            })
+            .count() as u32;
         // The outgoing native argument area sits at the base of the frame, so
         // it is the block the native callee addresses from its own entry stack
-        // pointer. Rounding it to the call-boundary alignment is what keeps the
-        // whole frame, and therefore the stack at the call, 16-byte aligned.
-        let native_stack_bytes = align_up(
-            stack_slots
-                .checked_mul(8)
-                .expect("an export thunk frame fits u32"),
-            16,
-        );
+        // pointer. Its size is the native lowering's own answer, already rounded
+        // to the call-boundary alignment, which is what keeps the whole frame —
+        // and therefore the stack at the call — 16-byte aligned.
+        let native_stack_bytes = native.stack_bytes();
 
         let stage_base = native_stack_bytes;
         let save_base = stage_base + register_slots * 8;
@@ -495,15 +576,23 @@ impl ThunkPlan {
             })
             .collect::<Vec<_>>();
 
-        let slot_offsets = (0..slot_count)
-            .map(|index| {
-                if index < register_slots {
-                    stage_base + index * 8
-                } else {
-                    (index - register_slots) * 8
+        // A register-passed value is assembled in its own staging cell and
+        // loaded into its register once every image read is done; a stacked one
+        // is written straight into the outgoing argument area.
+        let mut staged = 0u32;
+        let mut slot_offsets = Vec::with_capacity(slots.len());
+        let mut register_loads = Vec::new();
+        for (_, destination) in &slots {
+            match *destination {
+                NativeSlotDestination::Register { index } => {
+                    let offset = stage_base + staged * 8;
+                    staged += 1;
+                    register_loads.push((index, offset));
+                    slot_offsets.push(offset);
                 }
-            })
-            .collect();
+                NativeSlotDestination::Stack { offset } => slot_offsets.push(offset),
+            }
+        }
 
         Self {
             c,
@@ -514,7 +603,7 @@ impl ThunkPlan {
             return_leaves: signature.return_leaves.clone(),
             return_padding: signature.return_padding.clone(),
             slot_offsets,
-            register_slots,
+            register_loads,
             save_base,
             c_sret_offset,
             return_image,
@@ -554,10 +643,9 @@ impl ThunkPlan {
             emitter.save_sret_register(save_base + spec.gp_argument_registers * 8);
         }
 
-        for (index, source) in self.slots.iter().enumerate() {
+        for (index, (source, _)) in self.slots.iter().enumerate() {
             let destination = self.slot_offsets[index];
             match *source {
-                NativeSlotSource::Empty => emitter.zero_slot(destination),
                 NativeSlotSource::ReturnStorage => {
                     match self.return_image.expect("an sret return names its storage") {
                         ReturnImage::CallerStorage { pointer_offset } => {
@@ -576,11 +664,24 @@ impl ThunkPlan {
                     let leaf = self.leaves[parameter][leaf];
                     emitter.load_leaf(leaf, destination);
                 }
+                NativeSlotSource::Eightbyte { parameter, index } => {
+                    // The leaves pack together, so the image's eightbyte crosses
+                    // whole and the callee reads the leaves back out of it.
+                    self.set_base(emitter, parameter);
+                    emitter.load_leaf(
+                        ImageLeaf {
+                            byte_offset: (index as u32) * 8,
+                            width: 8,
+                            signed: false,
+                        },
+                        destination,
+                    );
+                }
             }
         }
 
-        for index in 0..self.register_slots {
-            emitter.load_argument_register(index, self.slot_offsets[index as usize]);
+        for (register, offset) in &self.register_loads {
+            emitter.load_argument_register(*register, *offset);
         }
         emitter.call(native_symbol);
 
@@ -656,16 +757,6 @@ impl ThunkPlan {
     }
 }
 
-/// How many general-purpose argument registers the native convention uses on
-/// `target`. The native roster is the target's ordinary integer argument
-/// roster, which is the same size as the platform C one.
-fn native_argument_register_count(target: Target) -> u32 {
-    match target.arch() {
-        Arch::X86_64 => 6,
-        Arch::Aarch64 => 8,
-    }
-}
-
 // ============================================================================
 // The per-target instruction leaves
 // ============================================================================
@@ -704,8 +795,6 @@ trait ThunkEmitter {
     fn load_leaf(&mut self, leaf: ImageLeaf, destination: u32);
     /// frame + `destination` := base.
     fn store_base(&mut self, destination: u32);
-    /// frame + `destination` := 0.
-    fn zero_slot(&mut self, destination: u32);
     /// Native argument register `index` := frame + `offset`.
     fn load_argument_register(&mut self, index: u32, offset: u32);
     /// Call the native body.
@@ -897,19 +986,6 @@ impl ThunkEmitter for X86Emitter {
 
     fn store_base(&mut self, destination: u32) {
         self.store_frame(X86_BASE, destination);
-    }
-
-    fn zero_slot(&mut self, destination: u32) {
-        // mov qword [rsp + destination], 0
-        self.mem(
-            &[0xC7],
-            0,
-            X86_RSP,
-            Self::frame_disp(destination),
-            true,
-            false,
-        );
-        self.code.extend_from_slice(&0u32.to_le_bytes());
     }
 
     fn load_argument_register(&mut self, index: u32, offset: u32) {
@@ -1143,10 +1219,6 @@ impl ThunkEmitter for Aarch64Emitter {
         self.store64(A64_BASE, A64_SP, destination);
     }
 
-    fn zero_slot(&mut self, destination: u32) {
-        self.store64(A64_SP, A64_SP, destination); // `xzr` shares the encoding
-    }
-
     fn load_argument_register(&mut self, index: u32, offset: u32) {
         self.load64(index, A64_SP, offset);
     }
@@ -1235,9 +1307,9 @@ mod tests {
     ) -> ExportParameter {
         ExportParameter {
             c: scalar_facts(kind),
-            native: NativeParameter::Direct {
+            native: NativeParameter {
                 leaves: vec![scalar_leaf(width, signed)],
-                reversed: false,
+                leaves_are_eightbytes: true,
             },
         }
     }
@@ -1276,9 +1348,9 @@ mod tests {
         }
     }
 
-    /// A `{i64, i64, i64}`-shaped export: 24 bytes, three slot-identical
-    /// leaves, so the native side is direct-and-reversed and the C side is
-    /// byval-on-stack (SysV) or by-reference (AAPCS64), returning through sret.
+    /// A `{i64, i64, i64}`-shaped export: 24 bytes, three leaves that are its
+    /// own eightbytes, so both sides place it byval-on-stack (SysV) or
+    /// by-reference (AAPCS64), returning through sret.
     fn triple_signature() -> ExportSignature {
         let leaves = vec![
             ImageLeaf {
@@ -1301,9 +1373,9 @@ mod tests {
             convention: CallingConvention::X86_64SysV,
             parameters: vec![ExportParameter {
                 c: CAbiTypeFacts::integer_aggregate(24, 8),
-                native: NativeParameter::Direct {
+                native: NativeParameter {
                     leaves: leaves.clone(),
-                    reversed: true,
+                    leaves_are_eightbytes: true,
                 },
             }],
             result: CAbiTypeFacts::integer_aggregate(24, 8),
@@ -1338,7 +1410,10 @@ mod tests {
             convention: CallingConvention::X86_64SysV,
             parameters: vec![ExportParameter {
                 c: CAbiTypeFacts::integer_aggregate(8, 4),
-                native: NativeParameter::Indirect,
+                native: NativeParameter {
+                    leaves: leaves.clone(),
+                    leaves_are_eightbytes: false,
+                },
             }],
             result: CAbiTypeFacts::integer_aggregate(8, 4),
             return_facts: NativeAbiTypeFacts {
@@ -1398,9 +1473,9 @@ mod tests {
                     .iter()
                     .map(|&kind| ExportParameter {
                         c: scalar_facts(kind),
-                        native: NativeParameter::Direct {
-                            leaves: vec![scalar_leaf(kind.extension().natural_bytes(), false)],
-                            reversed: false,
+                        native: NativeParameter {
+                            leaves: vec![scalar_leaf(kind.natural_bytes(), false)],
+                            leaves_are_eightbytes: true,
                         },
                     })
                     .collect(),
@@ -1515,9 +1590,12 @@ mod tests {
         for target in [Target::X86_64Linux, Target::Aarch64Linux] {
             let plan = ThunkPlan::new(target, &on(target, &signature));
             assert_eq!(plan.slots.len(), 9);
-            let registers = native_argument_register_count(target);
-            assert_eq!(plan.register_slots, registers);
-            // The stacked native slots start at the base of the outgoing area.
+            let registers = plan.register_loads.len() as u32;
+            assert_eq!(
+                registers,
+                u32::from(target.c_calling_convention().c_spec().gp_argument_registers)
+            );
+            // The stacked native values start at the base of the outgoing area.
             assert_eq!(plan.slot_offsets[registers as usize], 0);
             // Every C argument beyond the roster is read from the caller's own
             // outgoing area.
@@ -1534,7 +1612,7 @@ mod tests {
     }
 
     #[test]
-    fn a_direct_multislot_parameter_reaches_the_body_in_reversed_slot_order() {
+    fn a_direct_multislot_parameter_reaches_the_body_in_ascending_memory_order() {
         for target in [Target::X86_64Linux, Target::Aarch64Linux] {
             let plan = ThunkPlan::new(target, &on(target, &triple_signature()));
             // The native return is three slot-identical slots, under both
@@ -1546,23 +1624,35 @@ mod tests {
                     leaves: plan.return_leaves.clone()
                 }
             );
-            assert_eq!(
-                plan.slots,
+            // 24 bytes: SysV stacks the value byval, so its three leaves cross
+            // in ascending memory order; AAPCS64 passes one pointer to a
+            // caller-owned copy, so only the image address crosses.
+            let sources = plan
+                .slots
+                .iter()
+                .map(|(source, _)| *source)
+                .collect::<Vec<_>>();
+            let expected = if target == Target::X86_64Linux {
                 vec![
                     NativeSlotSource::Leaf {
                         parameter: 0,
-                        leaf: 2
+                        leaf: 0,
                     },
                     NativeSlotSource::Leaf {
                         parameter: 0,
-                        leaf: 1
+                        leaf: 1,
                     },
                     NativeSlotSource::Leaf {
                         parameter: 0,
-                        leaf: 0
+                        leaf: 2,
                     },
-                ],
-                "the native convention reverses a multi-slot value's slots"
+                ]
+            } else {
+                vec![NativeSlotSource::ImageAddress { parameter: 0 }]
+            };
+            assert_eq!(
+                sources, expected,
+                "the native convention places a value's leaves in ascending memory order"
             );
             // The C return is 24 bytes, so it crosses through caller storage,
             // which is where the thunk assembles the image.
@@ -1591,19 +1681,27 @@ mod tests {
     }
 
     #[test]
-    fn an_indirect_native_pair_forwards_the_caller_bytes_and_its_own_storage() {
+    fn a_packed_pair_crosses_as_one_eightbyte_of_its_image() {
         for target in [Target::X86_64Linux, Target::Aarch64Linux] {
             let plan = ThunkPlan::new(target, &on(target, &pair_signature()));
-            // Eight bytes of narrow fields: the native convention cannot express
-            // it in registers, so both directions cross through memory.
+            // Eight bytes of narrow fields: the return still crosses through
+            // caller storage, and the argument's two leaves pack into the one
+            // eightbyte the convention gives them.
             assert_eq!(plan.native_return, NativeReturn::Sret);
             assert_eq!(
-                plan.slots,
+                plan.slots
+                    .iter()
+                    .map(|(source, _)| *source)
+                    .collect::<Vec<_>>(),
                 vec![
                     NativeSlotSource::ReturnStorage,
-                    NativeSlotSource::ImageAddress { parameter: 0 },
+                    NativeSlotSource::Eightbyte {
+                        parameter: 0,
+                        index: 0
+                    },
                 ],
-                "the hidden return pointer is native ABI slot zero"
+                "the hidden return pointer takes the first argument register, and \
+                 the packed pair the second"
             );
             // The C side returns the eight bytes in one register, so the image
             // is assembled in the thunk's own frame.
@@ -1733,9 +1831,9 @@ mod tests {
                 convention: CallingConvention::X86_64SysV,
                 parameters: vec![ExportParameter {
                     c: CAbiTypeFacts::integer_aggregate(width.into(), width.into()),
-                    native: NativeParameter::Direct {
+                    native: NativeParameter {
                         leaves: leaves.clone(),
-                        reversed: true,
+                        leaves_are_eightbytes: true,
                     },
                 }],
                 result: CAbiTypeFacts::integer_aggregate(width.into(), width.into()),

--- a/crates/rue-codegen/src/foreign_call.rs
+++ b/crates/rue-codegen/src/foreign_call.rs
@@ -36,7 +36,7 @@ use crate::vreg::VReg;
 /// its C object layout under the compact-layout default. Every by-value
 /// aggregate crossing (register-packed, byval-stack, by-reference, and every
 /// aggregate return) is marshaled through this image, so C field order is
-/// honored by construction and the native reversed-slot packing is never used.
+/// honored by construction and no value is repacked on the way out.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AggregateImage {
     /// Internal-slot → physical-byte map (the compact/C image). Writing an

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -64,6 +64,7 @@ mod codegen_pipeline;
 pub mod export_thunk;
 pub mod foreign_call;
 mod local_storage;
+pub mod native_abi;
 mod param_storage;
 pub mod runtime_call_plan;
 mod schedule_core;

--- a/crates/rue-codegen/src/native_abi.rs
+++ b/crates/rue-codegen/src/native_abi.rs
@@ -1,0 +1,476 @@
+//! The native Rue convention's argument description (ADR-0084).
+//!
+//! The native convention places every argument exactly where the compilation
+//! target's C row places it, so *where* a value goes is
+//! [`rue_air::lower_native_signature`]'s answer against the
+//! [`CAbiTypeFacts`] this module projects. What this module adds is the other
+//! half of the crossing: *how* a value reaches that placement, which the C
+//! boundary answers with its own [`crate::foreign_call::AggregateImage`] and
+//! the native side answers here, because a native aggregate may be an enum and
+//! therefore may need a tag-dispatched image.
+//!
+//! ## Leaves, eightbytes, and the two marshaling shapes
+//!
+//! A native value is held as one canonically 64-bit-extended vreg per scalar
+//! leaf. A placement is expressed in *eightbytes*. The two coincide exactly
+//! when every leaf starts its own eightbyte — `{i64, i64}`, `StrBuf`, a
+//! one-field struct, a scalar — and then the leaf vregs are the eightbytes and
+//! nothing is marshaled ([`NativeArgMarshal::Direct`]). Otherwise the value's
+//! leaves are written into a stack image at their compact byte offsets and the
+//! eightbytes are read back out of it ([`NativeArgMarshal::Image`]), which is
+//! what packs `{u8, u8, u8, u8}` into one register.
+//!
+//! The callee undoes whichever shape the caller used, so the predicate that
+//! chooses between them ([`NativeArg::marshal`]) is consulted from both ends
+//! and has exactly one home.
+
+use rue_air::{
+    AggregateLeaves, ArgConvention, ArgLocation, CAbiScalarKind, CAbiTypeFacts,
+    FrozenTypeInternPool, Type, aggregate_leaves,
+};
+use rue_target::CRegisterClass;
+
+use crate::call_plan::AbiSlotClass;
+use crate::frame_layout::checked_aligned_region_bytes;
+use crate::types::{self, DispatchImage, PhysicalEnumSlot};
+use crate::value_plan::FloatWidth;
+
+/// The compact memory image of one native by-value aggregate: the bytes the
+/// convention classifies and the marshaling both ends run against them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeImage {
+    /// How the image's bytes are written and read.
+    pub kind: NativeImageKind,
+    /// The aggregate's `@size_of`.
+    pub size: u32,
+    /// The aggregate's `@align_of`.
+    pub align: u32,
+    /// The aggregate's internal value-decomposition slot count.
+    pub slot_count: u32,
+    /// Backing-buffer size: `size` rounded to the 16-byte call-stack granule,
+    /// so whole-eightbyte loads and stores never run past the buffer.
+    pub storage_bytes: u32,
+    /// The scalar leaves the convention classifies the eightbytes by.
+    pub leaves: AggregateLeaves,
+}
+
+/// How one aggregate's compact image is written and read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeImageKind {
+    /// A single variant-independent internal-slot → physical-byte map.
+    Map {
+        /// One entry per internal slot, in decomposition order.
+        map: Vec<PhysicalEnumSlot>,
+        /// Padding byte ranges zeroed before the leaf stores, so the buffer is
+        /// deterministically initialized (ADR-0052 ruling 5).
+        padding: Vec<rue_air::layout::PaddingRange>,
+    },
+    /// A per-variant tag dispatch, for an aggregate whose variants place their
+    /// payloads differently (RUE-1037).
+    Dispatch(DispatchImage),
+}
+
+impl NativeImage {
+    /// How many eightbytes the image spans.
+    pub fn eightbytes(&self) -> u32 {
+        self.size.div_ceil(8)
+    }
+
+    /// The classification facts this image presents.
+    pub fn facts(&self) -> CAbiTypeFacts {
+        CAbiTypeFacts::Aggregate {
+            size: u64::from(self.size),
+            align: u64::from(self.align),
+            leaves: self.leaves,
+        }
+    }
+
+    /// The bank and width each leaf's own vreg travels in when the leaves *are*
+    /// the eightbytes, or `None` when the image must be marshaled.
+    ///
+    /// The leaves are the eightbytes exactly when leaf *i* starts at byte
+    /// `8 * i`: there is then one leaf per eightbyte, in ascending memory
+    /// order, and the leaf's canonically extended vreg already holds every byte
+    /// the eightbyte's classification can observe. (Bytes above a narrow leaf
+    /// are padding, which no reader of the image looks at.) A tag-dispatched
+    /// image is never direct: its leaves move with the active variant.
+    pub fn direct_leaves(&self) -> Option<Vec<AbiSlotClass>> {
+        let NativeImageKind::Map { map, .. } = &self.kind else {
+            return None;
+        };
+        let direct = map
+            .iter()
+            .enumerate()
+            .all(|(index, leaf)| leaf.byte_offset == i32::try_from(index * 8).unwrap_or(i32::MAX));
+        if !direct {
+            return None;
+        }
+        Some(map.iter().map(leaf_slot_class).collect())
+    }
+}
+
+/// The bank one image leaf's own vreg belongs to: an enum's union payload is a
+/// general-purpose bit carrier whatever its variants hold, a float leaf rides
+/// in the floating-point file at its own width, everything else is
+/// general-purpose.
+fn leaf_slot_class(leaf: &PhysicalEnumSlot) -> AbiSlotClass {
+    match leaf.float_width {
+        Some(width) if !leaf.bit_carrier => AbiSlotClass::Fp(width),
+        _ => AbiSlotClass::Gp,
+    }
+}
+
+/// What one native argument is, and how it reaches the placement the lowered
+/// signature gives it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeArg {
+    /// A zero-sized by-value argument: no register, no stack byte, no pointer.
+    Omitted,
+    /// A scalar or a by-reference pointer: one vreg, one register.
+    Scalar {
+        /// Its width-and-signedness class, which fixes the footprint a stacked
+        /// copy takes under Apple's natural-size packing.
+        kind: CAbiScalarKind,
+        /// The bank and move width its vreg uses.
+        class: AbiSlotClass,
+    },
+    /// An aggregate, classified and marshaled through its compact image.
+    Aggregate {
+        /// The compact image.
+        image: NativeImage,
+    },
+    /// An already-flattened value crossing one register-width leaf at a time —
+    /// the cleanup convention destructors and drop glue are invoked under.
+    ///
+    /// A destructor and a drop glue body receive an aggregate's leaves
+    /// directly, in ascending order, because the caller has already
+    /// materialized them and the callee walks them as leaves rather than
+    /// reconstructing a value. Placement is still the convention's: each leaf
+    /// is one register-width value, so the leaves take consecutive argument
+    /// registers and then the argument area's own packing, exactly as that many
+    /// separate `i64` arguments would. Tracked for retirement with RUE-2039,
+    /// which collapses the remaining convention branches.
+    PerLeaf {
+        /// How many leaves cross.
+        count: u32,
+    },
+}
+
+impl NativeArg {
+    /// The classification facts this argument presents, one entry per value
+    /// the convention places.
+    ///
+    /// Every shape but the cleanup convention's presents exactly one: a value
+    /// is placed as a whole. [`PerLeaf`](Self::PerLeaf) presents one
+    /// register-width entry per leaf, which is what makes its leaves take the
+    /// registers and stack slots that many separate scalars would.
+    pub fn facts(&self) -> Vec<CAbiTypeFacts> {
+        match self {
+            Self::Omitted => vec![CAbiTypeFacts::ZeroSized],
+            Self::Scalar { kind, .. } => vec![CAbiTypeFacts::Scalar {
+                kind: *kind,
+                class: kind.register_class(),
+            }],
+            Self::Aggregate { image } => vec![image.facts()],
+            Self::PerLeaf { count } => {
+                vec![
+                    CAbiTypeFacts::Scalar {
+                        kind: CAbiScalarKind::RegisterWidth,
+                        class: CRegisterClass::Gp,
+                    };
+                    *count as usize
+                ]
+            }
+        }
+    }
+
+    /// The canonical 64-bit extension this value carries: a narrow scalar's
+    /// sign or zero extension, and none for an aggregate or a zero-sized value.
+    pub fn extension(&self) -> rue_air::ScalarAbiExtension {
+        match self {
+            Self::Scalar { kind, .. } => kind.extension(),
+            Self::Omitted | Self::Aggregate { .. } | Self::PerLeaf { .. } => {
+                rue_air::ScalarAbiExtension::None
+            }
+        }
+    }
+
+    /// Whether a stacked copy is packed at the scalar's own width (Apple's
+    /// natural-size amendment) rather than as whole eightbytes.
+    pub fn packs_as_scalar(&self) -> bool {
+        matches!(self, Self::Scalar { .. })
+    }
+
+    /// The bank and move width of each eightbyte the value presents to
+    /// `location`, and whether they are the value's own leaf vregs.
+    ///
+    /// A value's leaves are its eightbytes only if they also travel in the
+    /// banks the placement named: an aggregate whose leaves start their own
+    /// eightbytes still marshals through its image when the convention puts an
+    /// eightbyte in a bank its leaf does not live in — AAPCS64 passes a
+    /// composite in integer registers whatever its members are (section 6.8.2
+    /// rules C.13 and C.14), and an enum's union payload is a general-purpose
+    /// bit carrier even where every variant puts a float there.
+    pub fn marshal(&self, location: ArgLocation) -> NativeArgMarshal {
+        let marshal = self.eightbyte_classes();
+        let (NativeArgMarshal::Direct { classes }, ArgLocation::Registers { pieces }) =
+            (&marshal, location)
+        else {
+            return marshal;
+        };
+        let banks_agree = classes.len() == pieces.len() as usize
+            && classes
+                .iter()
+                .zip(pieces.as_slice())
+                .all(|(class, piece)| class.bank() == piece.class);
+        if banks_agree {
+            return marshal;
+        }
+        match self {
+            Self::Aggregate { image } => NativeArgMarshal::Image {
+                eightbytes: image.eightbytes(),
+            },
+            _ => marshal,
+        }
+    }
+
+    /// The banks the value's own leaf vregs live in, before the placement is
+    /// consulted.
+    fn eightbyte_classes(&self) -> NativeArgMarshal {
+        match self {
+            Self::Omitted => NativeArgMarshal::Direct {
+                classes: Vec::new(),
+            },
+            Self::Scalar { class, .. } => NativeArgMarshal::Direct {
+                classes: vec![*class],
+            },
+            Self::PerLeaf { count } => NativeArgMarshal::Direct {
+                classes: vec![AbiSlotClass::Gp; *count as usize],
+            },
+            Self::Aggregate { image } => match image.direct_leaves() {
+                Some(classes) => NativeArgMarshal::Direct { classes },
+                // A marshaled eightbyte is a 64-bit lane of the image, so an
+                // SSE-classified one moves as a whole double even when the
+                // leaves inside it are `f32`s.
+                None => NativeArgMarshal::Image {
+                    eightbytes: image.eightbytes(),
+                },
+            },
+        }
+    }
+}
+
+/// Whether an argument's eightbytes are its own leaf vregs or must be marshaled
+/// through its compact image.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeArgMarshal {
+    /// The leaf vregs are the eightbytes, with these banks and move widths.
+    Direct {
+        /// One class per leaf, in ascending memory order.
+        classes: Vec<AbiSlotClass>,
+    },
+    /// The leaves are written to a stack image and this many eightbytes are
+    /// read back from it.
+    Image {
+        /// How many eightbytes the image spans.
+        eightbytes: u32,
+    },
+}
+
+impl NativeArgMarshal {
+    /// The bank and move width of eightbyte `index`.
+    pub fn class(&self, index: usize, eightbyte_class: CRegisterClass) -> AbiSlotClass {
+        match self {
+            Self::Direct { classes } => classes[index],
+            Self::Image { .. } => match eightbyte_class {
+                CRegisterClass::Gp => AbiSlotClass::Gp,
+                CRegisterClass::Fp => AbiSlotClass::Fp(FloatWidth::F64),
+            },
+        }
+    }
+
+    /// The bank a stacked eightbyte's store uses: the value's own leaf bank
+    /// when the leaves are the eightbytes, and the general-purpose file for a
+    /// marshaled image, whose eightbytes are already integer-shaped lanes read
+    /// out of memory.
+    pub fn stacked_bank(&self, index: usize) -> CRegisterClass {
+        match self {
+            Self::Direct { classes } => classes[index].bank(),
+            Self::Image { .. } => CRegisterClass::Gp,
+        }
+    }
+
+    /// How many eightbytes the value presents.
+    pub fn eightbyte_count(&self) -> usize {
+        match self {
+            Self::Direct { classes } => classes.len(),
+            Self::Image { eightbytes } => *eightbytes as usize,
+        }
+    }
+}
+
+/// Project the native description of a by-value argument or parameter of type
+/// `ty`.
+///
+/// The aggregate predicate is [`crate::types::is_multislot_aggregate`], the same
+/// one the value plane materializes by, so an argument's description and its
+/// vregs cannot disagree about whether it has leaves.
+pub fn native_by_value_arg(type_pool: &FrozenTypeInternPool, ty: Type) -> NativeArg {
+    if types::is_multislot_aggregate(type_pool, ty) {
+        return NativeArg::Aggregate {
+            image: native_image(type_pool, ty),
+        };
+    }
+    if type_pool.abi_slot_count(ty) == 0 {
+        return NativeArg::Omitted;
+    }
+    let kind = native_scalar_kind(type_pool, ty);
+    NativeArg::Scalar {
+        kind,
+        class: match kind {
+            CAbiScalarKind::F32 => AbiSlotClass::Fp(FloatWidth::F32),
+            CAbiScalarKind::F64 => AbiSlotClass::Fp(FloatWidth::F64),
+            _ => AbiSlotClass::Gp,
+        },
+    }
+}
+
+/// The native description of one argument under its source-level mode: a
+/// by-reference `inout` / `borrow` is one register-width pointer whatever it
+/// points at.
+pub fn native_arg(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+    convention: ArgConvention,
+) -> NativeArg {
+    match convention {
+        ArgConvention::ByReference => NativeArg::Scalar {
+            kind: CAbiScalarKind::RegisterWidth,
+            class: AbiSlotClass::Gp,
+        },
+        ArgConvention::ByValue => native_by_value_arg(type_pool, ty),
+    }
+}
+
+/// The width-and-signedness class of a native scalar.
+///
+/// A discriminant-only enum is a scalar whose compact image is its tag, so it
+/// presents that tag's own unsigned width; every other scalar presents its own
+/// type's class.
+fn native_scalar_kind(type_pool: &FrozenTypeInternPool, ty: Type) -> CAbiScalarKind {
+    if let Some(kind) = CAbiScalarKind::for_live_type(ty) {
+        return kind;
+    }
+    if ty.is_enum() {
+        return match type_pool.layout(ty).size {
+            0 | 1 => CAbiScalarKind::U8,
+            2 => CAbiScalarKind::U16,
+            3..=4 => CAbiScalarKind::U32,
+            _ => CAbiScalarKind::RegisterWidth,
+        };
+    }
+    panic!(
+        "the native convention classifies every value type; {:?} is neither a \
+         scalar nor an aggregate",
+        ty.kind()
+    )
+}
+
+/// The compact image of a native by-value aggregate.
+///
+/// Every aggregate that reaches a call boundary has one: the compact-access
+/// scan (`crate::types::compact_physical_access_unsupported`) refuses a
+/// crossing aggregate that has neither a variant-independent map nor a
+/// tag-dispatched image before code generation reaches here.
+pub fn native_image(type_pool: &FrozenTypeInternPool, ty: Type) -> NativeImage {
+    let layout = type_pool.layout(ty);
+    let size = u32::try_from(layout.size).expect("native aggregate size must fit u32");
+    let kind = match types::aggregate_physical_slot_map(type_pool, ty) {
+        Some(map) => NativeImageKind::Map {
+            map,
+            padding: type_pool.compact_image_padding_ranges(ty),
+        },
+        None => NativeImageKind::Dispatch(types::aggregate_dispatch_image(type_pool, ty).expect(
+            "a by-value aggregate crossing a call has a variant-independent or \
+             tag-dispatched memory image (guaranteed by the compact-access scan)",
+        )),
+    };
+    NativeImage {
+        kind,
+        size,
+        align: u32::try_from(layout.alignment).expect("native aggregate alignment must fit u32"),
+        slot_count: type_pool.abi_slot_count(ty),
+        storage_bytes: checked_aligned_region_bytes(layout.size)
+            .expect("native aggregate storage must pass frame-budget preflight"),
+        leaves: aggregate_leaves(type_pool, ty, layout.size),
+    }
+}
+
+/// The simultaneous transient stack a native call needs, from the same
+/// placement its lowering will use.
+///
+/// Four regions can be live at once: the caller's indirect-result storage, the
+/// caller-owned copies of by-reference aggregate arguments, the scratch image
+/// one aggregate is marshaled through (released before the next one is taken,
+/// so only the largest counts), and the outgoing argument area.
+pub fn native_call_area_bytes(
+    type_pool: &FrozenTypeInternPool,
+    pairing: rue_target::ConventionSpec,
+    sret_storage_bytes: u64,
+    arguments: &[(Type, ArgConvention)],
+) -> Result<u32, crate::frame_layout::FrameBudgetExceeded> {
+    let natives: Vec<NativeArg> = arguments
+        .iter()
+        .map(|(ty, convention)| native_arg(type_pool, *ty, *convention))
+        .collect();
+    let parameters: Vec<(CAbiTypeFacts, ArgConvention)> = natives
+        .iter()
+        .zip(arguments)
+        .flat_map(|(native, (_, convention))| {
+            native
+                .facts()
+                .into_iter()
+                .map(move |facts| (facts, *convention))
+        })
+        .collect();
+    let ret = if sret_storage_bytes == 0 {
+        rue_air::LoweredReturn::Void
+    } else {
+        let spec = pairing.spec();
+        rue_air::LoweredReturn::Sret {
+            register: spec.sret_register,
+            echoed: spec.sret_pointer_echoed_in_result_register,
+            size: 8,
+            align: 8,
+        }
+    };
+    assert_eq!(
+        parameters.len(),
+        natives.len(),
+        "an ordinary call places one value per argument; only the cleanup \
+         convention's already-flattened leaves place more, and it reaches no \
+         aggregate"
+    );
+    let signature = rue_air::lower_native_signature(pairing, &parameters, ret);
+    let mut indirect = 0u64;
+    let mut scratch = 0u64;
+    for (native, argument) in natives.iter().zip(signature.arguments()) {
+        let NativeArg::Aggregate { image } = native else {
+            continue;
+        };
+        match argument.location {
+            ArgLocation::Indirect { .. } => {
+                indirect = indirect.saturating_add(u64::from(image.storage_bytes));
+            }
+            location if matches!(native.marshal(location), NativeArgMarshal::Image { .. }) => {
+                scratch = scratch.max(u64::from(image.storage_bytes));
+            }
+            _ => {}
+        }
+    }
+    crate::frame_layout::checked_call_area_from_stack_bytes(
+        u64::from(signature.stack_bytes()),
+        sret_storage_bytes,
+        indirect.saturating_add(scratch),
+    )
+}

--- a/crates/rue-codegen/src/param_storage.rs
+++ b/crates/rue-codegen/src/param_storage.rs
@@ -5,8 +5,10 @@
 //! Unused and read-only register arguments paid entry stores, frame growth,
 //! and per-read reloads for nothing.
 //!
-//! This module decides, once per function and target, where each parameter
-//! ABI slot lives:
+//! This module decides, once per function and target, *where each parameter
+//! arrives* — [`rue_air::lower_native_signature`]'s answer against the facts the
+//! parameter's own type projects, which is the same answer every caller of that
+//! signature computes (ADR-0084) — and where each of its ABI slots then lives:
 //!
 //! - **Frame**: the prologue homes the slot into the (compacted) frame
 //!   parameter area, exactly as before. Everything that can address memory —
@@ -25,14 +27,26 @@
 //! `--emit stackframe` reporter, so the frame layout and the code that
 //! addresses it cannot drift apart.
 //!
+//! An aggregate whose leaves are not its eightbytes needs one more step: the
+//! prologue lays the argument's eightbytes down as a contiguous frame image and
+//! the body's entry unmarshal reads the leaves back out of it
+//! ([`ParamStoragePlan::unmarshals`]), which is the exact inverse of the
+//! marshaling the caller did.
+//!
 //! A CFG without grouped source-parameter descriptors (a directly constructed
-//! CFG in synthetic tests) falls back to homing every slot, reproducing the
-//! historical prologue exactly.
+//! CFG in synthetic tests) falls back to homing one register-width value per
+//! slot.
 
-use rue_air::FrozenTypeInternPool;
+use rue_air::{
+    ArgConvention, ArgLocation, CAbiTypeFacts, FrozenTypeInternPool, LoweredReturn,
+    PointerLocation, SLOT_BYTES, SourceParamAbi, lower_native_signature,
+};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, PlaceBase};
+use rue_target::{ConventionSpec, SretRegisterKind};
 
+use crate::call_plan::{AbiRegisterBanks, AbiSlotClass, AbiSlotLocation};
 use crate::codegen_pipeline::ParamHoming;
+use crate::native_abi::{NativeArg, NativeArgMarshal, NativeImage, native_by_value_arg};
 
 /// Where one parameter ABI slot lives inside the function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,12 +55,42 @@ pub(crate) enum ParamSlotStorage {
     /// `area_slot` (0-based within the area, after register-only slots are
     /// compacted away).
     Frame { area_slot: u32 },
-    /// Register-only: the slot arrives in incoming ABI argument register
-    /// `abi_index` (sret shift included) and has no frame home.
+    /// Register-only: the slot arrives in one incoming ABI argument register
+    /// and has no frame home.
     Register {
-        class: crate::call_plan::AbiSlotClass,
-        location: crate::call_plan::AbiSlotLocation,
+        class: AbiSlotClass,
+        location: AbiSlotLocation,
     },
+}
+
+/// Where the entry unmarshal of one parameter reads its compact image from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ImageSource {
+    /// The parameter's own frame slots, into which the prologue copied the
+    /// eightbytes the convention placed it in.
+    FrameImage,
+    /// A caller-owned copy, whose pointer the prologue homed into the
+    /// parameter's first frame slot (AAPCS64 section 6.8.2 C.12).
+    Pointer,
+}
+
+/// One by-value aggregate parameter whose leaves are not its eightbytes, and so
+/// must be read back out of its compact image at function entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParamUnmarshal {
+    /// The parameter's first ABI slot, which names its frame home.
+    pub(crate) param_slot: u32,
+    /// How many frame slots past the parameter's first the image begins at.
+    ///
+    /// A frame-resident aggregate is laid out ascending in address with its
+    /// logical slots (ADR-0040) while frame slot numbers descend in address, so
+    /// its low end — byte 0 of the image — is its last slot. Zero for an image
+    /// reached through a pointer, which addresses the copy directly.
+    pub(crate) image_slot_offset: u32,
+    /// Where the image lives.
+    pub(crate) source: ImageSource,
+    /// The image the leaves are read out of.
+    pub(crate) image: NativeImage,
 }
 
 /// The complete per-function parameter storage decision.
@@ -62,54 +106,298 @@ pub(crate) struct ParamStoragePlan {
     homed_area_slots: u32,
     /// Prologue homing entries for the homed source parameters.
     homing: Vec<ParamHoming>,
+    /// Entry unmarshals for the parameters whose leaves pack together.
+    unmarshals: Vec<ParamUnmarshal>,
+}
+
+/// The already-decided return a callee's parameters are placed against: phase 1
+/// of ADR-0084 switches arguments only, so all argument placement needs to know
+/// is whether a hidden indirect-result pointer takes an ordinary argument
+/// register ahead of every user parameter.
+fn incoming_return(pairing: ConventionSpec, has_sret: bool) -> LoweredReturn {
+    if !has_sret {
+        return LoweredReturn::Void;
+    }
+    let spec = pairing.spec();
+    LoweredReturn::Sret {
+        register: spec.sret_register,
+        echoed: spec.sret_pointer_echoed_in_result_register,
+        size: SLOT_BYTES as u32,
+        align: SLOT_BYTES as u32,
+    }
+}
+
+/// The native description of one source parameter.
+///
+/// A by-reference parameter is one pointer whatever it points at. A by-value
+/// parameter with no recovered type is one register-width slot, which is what
+/// the direct-slot cleanup convention (destructors and drop glue) presents for
+/// every one of an aggregate's already-flattened leaves, and what a synthetic
+/// CFG without descriptors presents for each of its slots.
+fn parameter_native(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    descriptor: &SourceParamAbi,
+) -> (NativeArg, ArgConvention) {
+    if cfg.is_param_by_ref(descriptor.start_slot) {
+        return (
+            NativeArg::Scalar {
+                kind: rue_air::CAbiScalarKind::RegisterWidth,
+                class: AbiSlotClass::Gp,
+            },
+            ArgConvention::ByReference,
+        );
+    }
+    match descriptor.ty {
+        Some(ty) => (native_by_value_arg(type_pool, ty), ArgConvention::ByValue),
+        // A typeless by-value descriptor spans already-flattened leaves: the
+        // cleanup convention's parameters, whose caller
+        // (`CallPlan::from_slot_values`) hands each leaf its own register-width
+        // placement.
+        None => (
+            NativeArg::PerLeaf {
+                count: descriptor.slot_count.max(1),
+            },
+            ArgConvention::ByValue,
+        ),
+    }
+}
+
+/// The prologue copies one parameter's incoming eightbytes make, and the entry
+/// unmarshal it needs, given the placement the convention gave it.
+///
+/// `area_slot` is the parameter's first slot in the compacted frame parameter
+/// area. Every shape reduces to the same two steps: lay the argument's
+/// eightbytes down as a contiguous frame image, then — when the leaves are not
+/// those eightbytes — read the leaves back out of it. A by-reference copy is
+/// the one shape whose image is elsewhere: the prologue homes its pointer and
+/// the unmarshal reads through it.
+fn parameter_homing(
+    native: &NativeArg,
+    placements: &[ArgLocation],
+    param_slot: u32,
+    area_slot: u32,
+    slot_count: u32,
+) -> (Vec<ParamHoming>, Option<ParamUnmarshal>) {
+    if let NativeArg::PerLeaf { .. } = native {
+        // Each already-flattened leaf arrives in its own register-width
+        // placement and homes into its own frame slot.
+        return (
+            placements
+                .iter()
+                .enumerate()
+                .map(|(index, placement)| ParamHoming {
+                    start_slot: area_slot + index as u32,
+                    class: AbiSlotClass::Gp,
+                    location: match *placement {
+                        ArgLocation::Registers { pieces } => {
+                            AbiSlotLocation::GpReg(pieces.as_slice()[0].index as usize)
+                        }
+                        ArgLocation::Stack {
+                            offset,
+                            size,
+                            align,
+                        } => AbiSlotLocation::Stack {
+                            offset,
+                            size,
+                            align,
+                        },
+                        ArgLocation::Omitted | ArgLocation::Indirect { .. } => {
+                            panic!("a register-width leaf is never omitted or indirect")
+                        }
+                    },
+                    narrow_stack_load: None,
+                })
+                .collect(),
+            None,
+        );
+    }
+    let location = placements[0];
+    let marshal = native.marshal(location);
+    let image = match native {
+        NativeArg::Aggregate { image } => Some(image.clone()),
+        _ => None,
+    };
+    match location {
+        ArgLocation::Omitted => (Vec::new(), None),
+        ArgLocation::Indirect { pointer, .. } => (
+            vec![ParamHoming {
+                start_slot: area_slot,
+                class: AbiSlotClass::Gp,
+                location: match pointer {
+                    PointerLocation::Register { index } => AbiSlotLocation::GpReg(index as usize),
+                    PointerLocation::Stack { offset } => AbiSlotLocation::Stack {
+                        offset,
+                        size: SLOT_BYTES as u32,
+                        align: SLOT_BYTES as u32,
+                    },
+                },
+                narrow_stack_load: None,
+            }],
+            image.map(|image| ParamUnmarshal {
+                param_slot,
+                image_slot_offset: 0,
+                source: ImageSource::Pointer,
+                image,
+            }),
+        ),
+        ArgLocation::Registers { pieces } => {
+            let homing = pieces
+                .as_slice()
+                .iter()
+                .enumerate()
+                .map(|(index, piece)| ParamHoming {
+                    start_slot: eightbyte_home_slot(area_slot, slot_count, index),
+                    class: marshal.class(index, piece.class),
+                    location: match piece.class {
+                        rue_target::CRegisterClass::Gp => {
+                            AbiSlotLocation::GpReg(piece.index as usize)
+                        }
+                        rue_target::CRegisterClass::Fp => {
+                            AbiSlotLocation::FpReg(piece.index as usize)
+                        }
+                    },
+                    narrow_stack_load: None,
+                })
+                .collect();
+            (
+                homing,
+                packed_unmarshal(&marshal, image, param_slot, slot_count),
+            )
+        }
+        ArgLocation::Stack {
+            offset,
+            size,
+            align,
+        } => {
+            if native.packs_as_scalar() {
+                // Apple's amendment stacks a scalar at its own width, so the
+                // copy into the frame slot re-extends it to Rue's canonical
+                // 64-bit form.
+                let narrow = (size < SLOT_BYTES as u32).then(|| crate::types::NarrowScalar {
+                    width: size as u8,
+                    signed: matches!(
+                        native.extension(),
+                        rue_air::ScalarAbiExtension::Signed { .. }
+                    ),
+                });
+                return (
+                    vec![ParamHoming {
+                        start_slot: area_slot,
+                        class: marshal.class(0, marshal.stacked_bank(0)),
+                        location: AbiSlotLocation::Stack {
+                            offset,
+                            size,
+                            align,
+                        },
+                        narrow_stack_load: narrow,
+                    }],
+                    None,
+                );
+            }
+            let homing = (0..marshal.eightbyte_count())
+                .map(|index| ParamHoming {
+                    start_slot: eightbyte_home_slot(area_slot, slot_count, index),
+                    class: marshal.class(index, marshal.stacked_bank(index)),
+                    location: AbiSlotLocation::Stack {
+                        offset: offset + (index as u32) * SLOT_BYTES as u32,
+                        size: SLOT_BYTES as u32,
+                        align: SLOT_BYTES as u32,
+                    },
+                    narrow_stack_load: None,
+                })
+                .collect();
+            (
+                homing,
+                packed_unmarshal(&marshal, image, param_slot, slot_count),
+            )
+        }
+    }
+}
+
+/// The entry unmarshal a register- or stack-placed aggregate needs: none when
+/// its leaves are its eightbytes, and a read of the frame image otherwise.
+fn packed_unmarshal(
+    marshal: &NativeArgMarshal,
+    image: Option<NativeImage>,
+    param_slot: u32,
+    slot_count: u32,
+) -> Option<ParamUnmarshal> {
+    match marshal {
+        NativeArgMarshal::Direct { .. } => None,
+        NativeArgMarshal::Image { .. } => Some(ParamUnmarshal {
+            param_slot,
+            image_slot_offset: slot_count.saturating_sub(1),
+            source: ImageSource::FrameImage,
+            image: image.expect("only an aggregate marshals through an image"),
+        }),
+    }
+}
+
+/// The frame slot eightbyte `index` of an incoming value lands in.
+///
+/// A frame-resident aggregate is laid out ascending in address with its logical
+/// slots (ADR-0040) while frame slot numbers descend in address, so the
+/// parameter's low end is its last slot and eightbyte `index` — which is
+/// `index * 8` bytes into the value — lands `index` slots back from there. That
+/// holds whether the eightbytes are the value's own leaves or the image its
+/// leaves are read out of, so the prologue lays down one ascending copy either
+/// way.
+const fn eightbyte_home_slot(area_slot: u32, slot_count: u32, index: usize) -> u32 {
+    area_slot + slot_count.saturating_sub(1) - index as u32
 }
 
 impl ParamStoragePlan {
-    /// The historical plan: every parameter ABI slot is homed at its own
-    /// index and every slot is treated as used. This is both the fallback
-    /// for synthetic CFGs without source-parameter descriptors and the
-    /// baseline the planned path must shrink from.
+    /// The plan for a CFG with no grouped source-parameter descriptors: every
+    /// parameter ABI slot is one register-width value homed at its own index.
+    /// This is the fallback for synthetic CFGs, and the baseline the planned
+    /// path shrinks from.
     pub(crate) fn all_homed(
         num_params: u32,
         has_sret: bool,
-        native_convention: rue_target::ConventionSpec,
-        register_banks: crate::call_plan::AbiRegisterBanks,
+        native_convention: ConventionSpec,
+        register_banks: AbiRegisterBanks,
     ) -> Self {
-        let mut classes = Vec::with_capacity(num_params as usize + has_sret as usize);
-        if has_sret {
-            classes.push(crate::call_plan::AbiSlotClass::Gp);
+        let native = NativeArg::Scalar {
+            kind: rue_air::CAbiScalarKind::RegisterWidth,
+            class: AbiSlotClass::Gp,
+        };
+        let parameters = vec![(native.facts()[0], ArgConvention::ByValue); num_params as usize];
+        let signature = lower_native_signature(
+            native_convention,
+            &parameters,
+            incoming_return(native_convention, has_sret),
+        );
+        let _ = register_banks;
+        let mut homing = Vec::new();
+        for (slot, argument) in signature.arguments().iter().enumerate() {
+            let (entries, _) =
+                parameter_homing(&native, &[argument.location], slot as u32, slot as u32, 1);
+            homing.extend(entries);
         }
-        classes.extend(std::iter::repeat_n(
-            crate::call_plan::AbiSlotClass::Gp,
-            num_params as usize,
-        ));
-        let locations =
-            crate::call_plan::assign_abi_slots(native_convention, classes, register_banks);
-        let abi_shift = has_sret as usize;
         Self {
             slots: (0..num_params)
                 .map(|slot| ParamSlotStorage::Frame { area_slot: slot })
                 .collect(),
             used: vec![true; num_params as usize],
             homed_area_slots: num_params,
-            homing: (0..num_params)
-                .map(|slot| ParamHoming {
-                    start_slot: slot,
-                    class: crate::call_plan::AbiSlotClass::Gp,
-                    location: locations[slot as usize + abi_shift],
-                })
-                .collect(),
+            homing,
+            unmarshals: Vec::new(),
         }
     }
 
-    /// Decide storage for every parameter of `cfg` on a target with
-    /// `arg_reg_count` incoming argument registers.
+    /// Decide storage for every parameter of `cfg`.
+    ///
+    /// Where each parameter's incoming value arrives is
+    /// [`lower_native_signature`]'s answer against the facts the parameter's
+    /// own type projects — the same answer every caller of this function
+    /// computes for the same signature (ADR-0084).
     pub(crate) fn plan(
         cfg: &Cfg,
         type_pool: &FrozenTypeInternPool,
         has_sret: bool,
-        native_convention: rue_target::ConventionSpec,
-        register_banks: impl Into<crate::call_plan::AbiRegisterBanks>,
+        native_convention: ConventionSpec,
+        register_banks: impl Into<AbiRegisterBanks>,
     ) -> Self {
         let register_banks = register_banks.into();
         let num_params = cfg.num_params();
@@ -117,12 +405,6 @@ impl ParamStoragePlan {
         if descriptors.is_empty() {
             return Self::all_homed(num_params, has_sret, native_convention, register_banks);
         }
-        assert!(
-            descriptors
-                .iter()
-                .all(|d| d.crossing_classes.len() == d.crossing_regs as usize),
-            "parameter ABI class metadata must classify every crossing slot"
-        );
         // Defensive: the descriptors must tile the parameter area exactly;
         // anything else falls back to the historical all-homed plan rather
         // than planning against inconsistent metadata.
@@ -137,76 +419,82 @@ impl ParamStoragePlan {
             return Self::all_homed(num_params, has_sret, native_convention, register_banks);
         }
 
+        let natives: Vec<(NativeArg, ArgConvention)> = descriptors
+            .iter()
+            .map(|descriptor| parameter_native(cfg, type_pool, descriptor))
+            .collect();
+        // Every parameter contributes one placement, except the cleanup
+        // convention's already-flattened leaves, which contribute one each; the
+        // spans map a parameter back to the run of placements it owns.
+        let mut parameters: Vec<(CAbiTypeFacts, ArgConvention)> = Vec::new();
+        let mut spans = Vec::with_capacity(natives.len());
+        for (native, mode) in &natives {
+            let start = parameters.len();
+            parameters.extend(native.facts().into_iter().map(|facts| (facts, *mode)));
+            spans.push(start..parameters.len());
+        }
+        let signature = lower_native_signature(
+            native_convention,
+            &parameters,
+            incoming_return(native_convention, has_sret),
+        );
+        if has_sret {
+            assert_eq!(
+                signature.spec().sret_register,
+                SretRegisterKind::ArgumentRegister,
+                "the native convention takes its indirect-result pointer in the \
+                 first ordinary argument register"
+            );
+        }
+
         let scan = scan_param_references(cfg, type_pool);
         let mut slots = Vec::with_capacity(num_params as usize);
         let mut homing = Vec::new();
-        let mut classes = Vec::new();
-        if has_sret {
-            classes.push(crate::call_plan::AbiSlotClass::Gp);
-        }
-        for d in descriptors {
-            classes.extend(
-                d.crossing_classes
-                    .iter()
-                    .copied()
-                    .map(crate::call_plan::AbiSlotClass::from),
-            );
-        }
-        let locations = crate::call_plan::assign_abi_slots(
-            native_convention,
-            classes.iter().copied(),
-            register_banks,
-        );
-        let mut crossing_index = has_sret as usize;
+        let mut unmarshals = Vec::new();
         let mut area = 0u32;
-        for d in descriptors {
-            let slot = d.start_slot;
+        for ((descriptor, (native, _)), span) in descriptors.iter().zip(&natives).zip(spans) {
+            let slot = descriptor.start_slot;
+            let placements = signature.arguments()[span]
+                .iter()
+                .map(|argument| argument.location)
+                .collect::<Vec<_>>();
+            let (entries, unmarshal) =
+                parameter_homing(native, &placements, slot, area, descriptor.slot_count);
             // A register-only parameter must be a single slot arriving in a
-            // single register that actually is a register (not stack-passed).
-            // A by-reference parameter's slot holds only the incoming
-            // pointer, which nothing may address (every consumer goes through
-            // `ensure_by_ref_param_ptr`); a by-value slot must additionally
-            // be immutable and never addressed.
-            let parameter_locations =
-                &locations[crossing_index..crossing_index + d.crossing_regs as usize];
-            let parameter_classes =
-                &classes[crossing_index..crossing_index + d.crossing_regs as usize];
-            let eligible = d.slot_count == 1
-                && d.crossing_regs == 1
-                && !matches!(
-                    parameter_locations[0],
-                    crate::call_plan::AbiSlotLocation::Stack { .. }
-                )
+            // single register that actually is a register (not stack-passed)
+            // and needing no image. A by-reference parameter's slot holds only
+            // the incoming pointer, which nothing may address (every consumer
+            // goes through `ensure_by_ref_param_ptr`); a by-value slot must
+            // additionally be immutable and never addressed.
+            let eligible = descriptor.slot_count == 1
+                && unmarshal.is_none()
+                && entries.len() == 1
+                && !matches!(entries[0].location, AbiSlotLocation::Stack { .. })
                 && !scan.needs_home[slot as usize]
                 && (cfg.is_param_by_ref(slot)
                     || (!cfg.is_param_writable(slot) && !cfg.is_param_address_taken(slot)));
             if eligible {
                 slots.push(ParamSlotStorage::Register {
-                    class: parameter_classes[0],
-                    location: parameter_locations[0],
+                    class: entries[0].class,
+                    location: entries[0].location,
                 });
-            } else {
-                for j in 0..d.slot_count {
-                    slots.push(ParamSlotStorage::Frame {
-                        area_slot: area + j,
-                    });
-                }
-                for j in 0..d.crossing_regs {
-                    homing.push(ParamHoming {
-                        start_slot: area + j,
-                        class: parameter_classes[j as usize],
-                        location: parameter_locations[j as usize],
-                    });
-                }
-                area += d.slot_count;
+                continue;
             }
-            crossing_index += d.crossing_regs as usize;
+            for j in 0..descriptor.slot_count {
+                slots.push(ParamSlotStorage::Frame {
+                    area_slot: area + j,
+                });
+            }
+            homing.extend(entries);
+            unmarshals.extend(unmarshal);
+            area += descriptor.slot_count;
         }
         Self {
             slots,
             used: scan.used,
             homed_area_slots: area,
             homing,
+            unmarshals,
         }
     }
 
@@ -240,8 +528,14 @@ impl ParamStoragePlan {
         &self.homing
     }
 
+    /// Entry unmarshals for the parameters whose leaves are not their
+    /// eightbytes.
+    pub(crate) fn unmarshals(&self) -> &[ParamUnmarshal] {
+        &self.unmarshals
+    }
+
     /// Register-only parameter slots needing an entry copy, as
-    /// `(param ABI slot, incoming ABI index)`.
+    /// `(param ABI slot, class, location)`.
     ///
     /// A by-reference pointer is copied whether or not it is used, mirroring
     /// the unconditional by-ref preload of the homed path; a by-value slot is
@@ -249,13 +543,7 @@ impl ParamStoragePlan {
     pub(crate) fn entry_copies<'a>(
         &'a self,
         cfg: &'a Cfg,
-    ) -> impl Iterator<
-        Item = (
-            u32,
-            crate::call_plan::AbiSlotClass,
-            crate::call_plan::AbiSlotLocation,
-        ),
-    > + 'a {
+    ) -> impl Iterator<Item = (u32, AbiSlotClass, AbiSlotLocation)> + 'a {
         self.slots
             .iter()
             .enumerate()
@@ -453,8 +741,6 @@ mod tests {
             .map(|slot| SourceParamAbi {
                 start_slot: slot,
                 slot_count: 1,
-                crossing_regs: 1,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()
@@ -799,15 +1085,11 @@ mod tests {
             SourceParamAbi {
                 start_slot: 0,
                 slot_count: 2,
-                crossing_regs: 2,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp; 2],
                 ty: None,
             },
             SourceParamAbi {
                 start_slot: 2,
                 slot_count: 1,
-                crossing_regs: 1,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             },
         ]);

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -646,8 +646,6 @@ mod tests {
             .map(|slot| SourceParamAbi {
                 start_slot: slot,
                 slot_count: 1,
-                crossing_regs: 1,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()

--- a/crates/rue-codegen/src/runtime_call_plan.rs
+++ b/crates/rue-codegen/src/runtime_call_plan.rs
@@ -250,16 +250,6 @@ impl RuntimeCallPlan {
                 CallArgInput::ByRef { address, .. } => {
                     slots.push(materializer.materialize_by_ref(address));
                 }
-                // A by-value indirect compact aggregate (RUE-1005) only arises
-                // for a Rue-target call under `aggregate_layout`; the register-
-                // only TargetC memory builtins take scalars and pointers, never a
-                // by-value compact aggregate, so it cannot reach a runtime call.
-                CallArgInput::IndirectValue { .. } | CallArgInput::IndirectValueDispatch { .. } => {
-                    unreachable!(
-                        "a compiler-built memory routine cannot take a by-value indirect \
-                         compact aggregate argument"
-                    )
-                }
                 CallArgInput::Value {
                     value,
                     slot_count,

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -736,8 +736,6 @@ mod tests {
             .map(|slot| SourceParamAbi {
                 start_slot: slot,
                 slot_count: 1,
-                crossing_regs: 1,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()
@@ -1607,8 +1605,6 @@ mod tests {
         cfg.set_source_param_abi(vec![SourceParamAbi {
             start_slot: 0,
             slot_count: 3,
-            crossing_regs: 1,
-            crossing_classes: vec![rue_air::NativeArgClass::Gp],
             ty: Some(shape_ty),
         }]);
         let entry = cfg.new_block();
@@ -1758,9 +1754,9 @@ mod tests {
         //         x
         //     }
         //
-        // The two-slot `Pair` parameter crosses as one indirect pointer
-        // (`crossing_regs: 1` over `slot_count: 2`), so the callee unmarshals
-        // it into homed frame slots at entry.
+        // The two-slot `Pair` is eight bytes, so it crosses in ONE register and
+        // the callee reads its two leaves back out of the image the prologue
+        // laid down in its frame slots (ADR-0084).
         let interner = ThreadedRodeo::new();
         let pool = TypeInternPool::new();
         let pair_id = register_struct(
@@ -1781,8 +1777,6 @@ mod tests {
         cfg.set_source_param_abi(vec![SourceParamAbi {
             start_slot: 0,
             slot_count: 2,
-            crossing_regs: 1,
-            crossing_classes: vec![rue_air::NativeArgClass::Gp],
             ty: Some(pair_ty),
         }]);
         let entry = cfg.new_block();

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -1041,13 +1041,10 @@ pub(crate) fn compact_physical_access_unsupported(
             }
             // An aggregate crossing a call boundary. A by-reference (`inout` /
             // `borrow`) argument uses the same slot-shaped by-ref transport as a
-            // by-ref parameter (RUE-1004). A by-value non-slot-identical aggregate
-            // crosses indirectly by the classifier (RUE-976): the caller writes
-            // its compact image to a caller-owned buffer and passes one pointer,
-            // and the callee prologue homes that pointer and unmarshals the image
-            // (RUE-1005, per-source-parameter ABI descriptors now plumbed). Both
-            // are allowed exactly when the aggregate has a variant-independent
-            // compact image; arrays and imageless enums stay refused.
+            // by-ref parameter (RUE-1004). A by-value aggregate is classified by
+            // its compact image (ADR-0084) and marshaled through it, so it is
+            // allowed exactly when it has a variant-independent or
+            // tag-dispatched one; an array without an image stays refused.
             CfgInstData::Call { .. } => {
                 for arg in cfg.get_call_args(&inst.data) {
                     let arg_ty = cfg.get_inst(arg.value).ty;

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1122,11 +1122,12 @@ fn drop_plan<A: ValueLowerAdapter>(
             });
         }
         TypeKind::Enum(enum_id) => {
-            // Enum drop glue receives the complete flattened enum as one Rue
-            // by-value argument. Match ordinary call lowering's aggregate ABI:
-            // the callee's flat parameter slots contain the logical enum slots
-            // in reverse order. The synthesized glue maps the discriminant and
-            // active payload fields back out of that reversed area (RUE-998).
+            // Enum drop glue receives the enum's leaves already flattened, one
+            // register-width value each, under the cleanup convention
+            // (`CallPlan::from_slot_values`). A frame-resident aggregate ascends
+            // in address with its logical slots while frame slot numbers descend
+            // (ADR-0040), so handing the leaves over in reverse is what lands
+            // them in the glue's own parameter area in logical order (RUE-998).
             slots.reverse();
             actions.push(DropAction {
                 symbol: adapter.resolve_named_symbol(
@@ -1804,7 +1805,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         inputs.compact_return_image.clone(),
                         inputs.compact_return_dispatch.clone(),
                         &inputs.args,
-                        adapter.call_arg_register_banks(),
+                        &inputs.natives,
                         adapter,
                         Some(result_vreg),
                     );
@@ -2445,51 +2446,26 @@ pub(crate) fn by_ref_param_slots(ctx: &CfgLowerContext<'_>) -> Vec<u32> {
         .collect()
 }
 
-/// Return each by-value indirect compact aggregate parameter's base frame slot
-/// and compact memory image (ADR-0052 phase 5.8, RUE-1005), for the entry-time
-/// unmarshalling both backends perform before the block walk.
+/// Return each by-value aggregate parameter whose leaves are not its eightbytes,
+/// as its base frame slot, whether its image is reached through a homed pointer,
+/// and the image itself — the entry-time unmarshalling both backends perform
+/// before the block walk (ADR-0084).
 ///
-/// The CFG's grouped descriptors flag which parameters cross as one pointer over
-/// a multi-slot span ([`rue_air::SourceParamAbi::is_by_value_indirect`]). The
-/// parameter's type — needed only to build its compact image — is recovered from
-/// its `Param` instruction; a parameter never read has no such instruction and
-/// needs no unmarshalling (nothing observes its frame slots), so it is skipped.
-/// Empty with the gate off, for functions with no such parameter, and for a
-/// directly constructed CFG with no grouped layout.
-pub(crate) fn indirect_value_params(
+/// The parameter storage plan owns the decision, because it is the same
+/// placement the prologue homed the argument by. Empty for a function with no
+/// such parameter and for a directly constructed CFG with no grouped layout.
+pub(crate) fn param_image_unmarshals(
     ctx: &CfgLowerContext<'_>,
-) -> Vec<(u32, Vec<crate::types::PhysicalEnumSlot>)> {
-    ctx.cfg
-        .source_param_abi()
+) -> Vec<(u32, u32, bool, crate::native_abi::NativeImage)> {
+    ctx.param_unmarshals()
         .iter()
-        .filter(|param| param.is_by_value_indirect())
-        .filter_map(|param| {
-            let ty = param.ty?;
-            let map = crate::types::aggregate_physical_slot_map(ctx.type_pool, ty)?;
-            Some((ctx.param_frame_slot(param.start_slot), map))
-        })
-        .collect()
-}
-
-/// Callee-side by-value indirect aggregate parameters whose compact image is
-/// HETEROGENEOUS (no single variant-independent map, RUE-1037): the frame base
-/// slot and the tag-dispatched image to unmarshal from the homed pointer. The
-/// complement of [`indirect_value_params`] (which handles the single-map case),
-/// so between them every by-value indirect aggregate parameter is unmarshalled.
-pub(crate) fn indirect_value_params_dispatch(
-    ctx: &CfgLowerContext<'_>,
-) -> Vec<(u32, crate::types::DispatchImage)> {
-    ctx.cfg
-        .source_param_abi()
-        .iter()
-        .filter(|param| param.is_by_value_indirect())
-        .filter_map(|param| {
-            let ty = param.ty?;
-            if crate::types::aggregate_physical_slot_map(ctx.type_pool, ty).is_some() {
-                return None;
-            }
-            let image = crate::types::aggregate_dispatch_image(ctx.type_pool, ty)?;
-            Some((ctx.param_frame_slot(param.start_slot), image))
+        .map(|unmarshal| {
+            (
+                ctx.param_frame_slot(unmarshal.param_slot),
+                unmarshal.image_slot_offset,
+                unmarshal.source == crate::param_storage::ImageSource::Pointer,
+                unmarshal.image.clone(),
+            )
         })
         .collect()
 }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -37,7 +37,7 @@ use crate::allocation;
 use crate::cfg_lower::CfgLowerContext;
 use crate::frame_layout::{
     checked_aligned_cell_region_bytes, checked_cell_byte_offset, checked_cell_region_bytes,
-    checked_cell_region_padding_bytes, checked_displacement_bytes,
+    checked_displacement_bytes,
 };
 use crate::vreg::BLOCK_LABEL_BASE;
 
@@ -207,21 +207,48 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         pointer
     }
 
-    fn materialize_indirect_value_arg(
+    fn materialize_image_eightbytes(
         &mut self,
         value: CfgValue,
-        image: &[crate::types::PhysicalEnumSlot],
-        padding: &[rue_air::layout::PaddingRange],
-        storage_bytes: u32,
+        image: &crate::native_abi::NativeImage,
+    ) -> Vec<VReg> {
+        // Reserve a scratch buffer, write the aggregate's compact image into it
+        // — each leaf truncated to its physical width at its compact byte
+        // offset — and read the eightbytes the convention places back out. The
+        // buffer is released immediately: only the eightbytes cross.
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: -checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("native argument image must fit displacement"),
+        });
+        let pointer = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(pointer),
+            src: Operand::Physical(Reg::Rsp),
+        });
+        self.write_native_image(value, pointer, image);
+        let eightbytes =
+            crate::agg_slots::load_slots_through_ptr(self, pointer, image.eightbytes());
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("native argument image must fit displacement"),
+        });
+        eightbytes
+    }
+
+    fn materialize_indirect_image(
+        &mut self,
+        value: CfgValue,
+        image: &crate::native_abi::NativeImage,
     ) -> VReg {
-        // Reserve a caller-owned buffer just below the sret storage (RUE-1005),
-        // capture its address, and write the aggregate's compact image into it —
-        // each slot truncated to its physical width at its compact byte offset,
-        // exactly the image the callee prologue unmarshals. The image's padding is
+        // Reserve a caller-owned buffer just below the sret storage, capture its
+        // address, and write the aggregate's compact image into it — exactly the
+        // image the callee reads through the pointer. The image's padding is
         // zeroed first (ADR-0052 ruling 5) so the buffer is fully initialized.
         self.mir.push(X86Inst::AddRI {
             dst: Operand::Physical(Reg::Rsp),
-            imm: -checked_displacement_bytes(u64::from(storage_bytes))
+            imm: -checked_displacement_bytes(u64::from(image.storage_bytes))
                 .expect("indirect argument storage must fit displacement"),
         });
         let pointer = self.mir.alloc_vreg();
@@ -229,32 +256,18 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
             dst: Operand::Virtual(pointer),
             src: Operand::Physical(Reg::Rsp),
         });
-        let slots = self.require_aggregate_slots(value);
-        crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image, padding);
+        self.write_native_image(value, pointer, image);
         pointer
     }
 
-    fn materialize_indirect_value_arg_dispatch(
-        &mut self,
-        value: CfgValue,
-        image: &crate::types::DispatchImage,
-        storage_bytes: u32,
-    ) -> VReg {
-        // As `materialize_indirect_value_arg`, but the caller-owned buffer is
-        // written with a per-variant tag dispatch (RUE-1037).
-        self.mir.push(X86Inst::AddRI {
-            dst: Operand::Physical(Reg::Rsp),
-            imm: -checked_displacement_bytes(u64::from(storage_bytes))
-                .expect("indirect argument storage must fit displacement"),
+    fn materialize_eightbyte_as_float(&mut self, bits: VReg) -> VReg {
+        let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+        self.mir.push(X86Inst::BitsToFloat {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(bits),
+            width: FloatWidth::F64,
         });
-        let pointer = self.mir.alloc_vreg();
-        self.mir.push(X86Inst::MovRR {
-            dst: Operand::Virtual(pointer),
-            src: Operand::Physical(Reg::Rsp),
-        });
-        let slots = self.require_aggregate_slots(value);
-        crate::agg_slots::store_dispatch_image(self, &slots, pointer, image);
-        pointer
+        dst
     }
 }
 
@@ -1226,84 +1239,45 @@ impl<'a> CfgLower<'a> {
     ) -> crate::value_plan::MaterializedValue {
         use crate::call_plan::ReturnPlan;
         let primary = plan.result.unwrap_or_else(|| self.mir.alloc_vreg());
-        let num_stack_args = plan.stack_slot_count;
-        let has_fp_stack_arg =
-            plan.abi_classes
-                .iter()
-                .zip(&plan.abi_locations)
-                .any(|(class, location)| {
-                    matches!(class, crate::call_plan::AbiSlotClass::Fp(_))
-                        && matches!(location, crate::call_plan::AbiSlotLocation::Stack { .. })
-                });
-        let stack_cell_bytes = checked_cell_region_bytes(
-            u64::try_from(num_stack_args).expect("call stack slot count must fit u64"),
-        )
-        .expect("call stack area must fit displacement");
-        let needs_alignment = plan.stack_bytes > stack_cell_bytes;
-        if has_fp_stack_arg {
+        // Reserve the outgoing argument area the convention sized, then commit
+        // every stacked value at the byte offset the placement gave it. The
+        // area is already rounded to the call-boundary alignment, so this one
+        // adjustment both places the arguments and aligns the call.
+        if plan.stack_bytes > 0 {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
                 imm: -checked_displacement_bytes(u64::from(plan.stack_bytes))
                     .expect("call stack area must fit displacement"),
             });
-            for ((arg, class), location) in plan
-                .abi_slots
-                .iter()
-                .zip(&plan.abi_classes)
-                .zip(&plan.abi_locations)
-            {
-                let crate::call_plan::AbiSlotLocation::Stack { offset, .. } = location else {
-                    continue;
-                };
-                let offset = checked_displacement_bytes(u64::from(*offset))
-                    .expect("call stack slot offset must fit displacement");
-                if let crate::call_plan::AbiSlotClass::Fp(width) = class {
-                    self.mir.push(X86Inst::FloatStore {
-                        base: Reg::Rsp,
-                        offset,
-                        src: Operand::Virtual(*arg),
-                        width: *width,
-                    });
-                } else {
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rsp,
-                        offset,
-                        src: Operand::Virtual(*arg),
-                    });
-                }
-            }
-        } else if needs_alignment {
-            self.mir.push(X86Inst::AddRI {
-                dst: Operand::Physical(Reg::Rsp),
-                imm: -i32::try_from(
-                    checked_cell_region_padding_bytes(
-                        u64::try_from(num_stack_args).expect("call stack slot count must fit u64"),
-                    )
-                    .expect("call stack alignment padding must fit displacement"),
-                )
-                .expect("call stack alignment padding must fit i32"),
-            });
         }
-        if !has_fp_stack_arg {
-            for (arg, location) in plan.abi_slots.iter().zip(&plan.abi_locations).rev() {
-                let crate::call_plan::AbiSlotLocation::Stack { offset, size, .. } = location else {
-                    continue;
-                };
-                // Pushing the stacked slots in reverse leaves slot 0 nearest
-                // `rsp`, which is the offset the assignment gave it: the push
-                // sequence is only correct while the area is whole ascending
-                // eightbytes, which is what a native slot claims.
-                assert_eq!(
-                    (*size, offset % 8),
-                    (8, 0),
-                    "a pushed native stack slot occupies one whole eightbyte"
-                );
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rax),
+        for ((arg, class), location) in plan
+            .abi_slots
+            .iter()
+            .zip(&plan.abi_classes)
+            .zip(&plan.abi_locations)
+        {
+            let crate::call_plan::AbiSlotLocation::Stack { offset, size, .. } = location else {
+                continue;
+            };
+            assert_eq!(
+                *size,
+                rue_air::SLOT_BYTES as u32,
+                "SysV AMD64 packs its outgoing argument area in whole eightbytes"
+            );
+            let offset = checked_displacement_bytes(u64::from(*offset))
+                .expect("call stack slot offset must fit displacement");
+            if let crate::call_plan::AbiSlotClass::Fp(width) = class {
+                self.mir.push(X86Inst::FloatStore {
+                    base: Reg::Rsp,
+                    offset,
                     src: Operand::Virtual(*arg),
+                    width: *width,
                 });
-                self.mir.push(X86Inst::Push {
-                    src: Operand::Physical(Reg::Rax),
+            } else {
+                self.mir.push(X86Inst::MovMR {
+                    base: Reg::Rsp,
+                    offset,
+                    src: Operand::Virtual(*arg),
                 });
             }
         }
@@ -1329,6 +1303,9 @@ impl<'a> CfgLower<'a> {
                 _ => None,
             })
             .collect();
+        // The argument registers are reserved, so a value already sitting in
+        // one cannot be clobbered by an earlier move: staging through the stack
+        // keeps every source readable until its own move runs.
         for (_, arg) in gp_args.iter().rev() {
             self.mir.push(X86Inst::MovRR {
                 dst: Operand::Physical(Reg::Rax),
@@ -1356,7 +1333,7 @@ impl<'a> CfgLower<'a> {
         }
         let symbol_id = self.intern_symbol(plan.target.symbol());
         self.mir.push(X86Inst::call(symbol_id));
-        if num_stack_args > 0 || needs_alignment {
+        if plan.stack_bytes > 0 {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
                 imm: checked_displacement_bytes(u64::from(plan.stack_bytes))
@@ -1528,11 +1505,31 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Materialize an aggregate argument's eightbytes (ADR-0064 P3): write its
-    /// native slots into a scratch buffer as the compact C image, then load the
-    /// whole eightbytes back so they pack in ascending C field order. The scratch
-    /// buffer is freed immediately — a register/byval aggregate argument's bytes
-    /// live only in the returned eightbyte vregs, so this is rsp-neutral.
+    /// Write the aggregate `value`'s leaves into the compact image at
+    /// `pointer`, through whichever of the two image shapes the type has.
+    fn write_native_image(
+        &mut self,
+        value: CfgValue,
+        pointer: VReg,
+        image: &crate::native_abi::NativeImage,
+    ) {
+        let slots = self.require_aggregate_slots(value);
+        match &image.kind {
+            crate::native_abi::NativeImageKind::Map { map, padding } => {
+                crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, map, padding);
+            }
+            crate::native_abi::NativeImageKind::Dispatch(dispatch) => {
+                crate::agg_slots::store_dispatch_image(self, &slots, pointer, dispatch);
+            }
+        }
+    }
+
+    /// Materialize a foreign aggregate argument's eightbytes (ADR-0064 P3):
+    /// write its native slots into a scratch buffer as the compact C image, then
+    /// load the whole eightbytes back so they pack in ascending C field order.
+    /// The scratch buffer is freed immediately — a register/byval aggregate
+    /// argument's bytes live only in the returned eightbyte vregs, so this is
+    /// rsp-neutral.
     fn image_arg_eightbytes(
         &mut self,
         value: CfgValue,
@@ -3933,16 +3930,20 @@ impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
 impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
     fn preload_by_ref_params(&mut self) {
         self.preload_by_ref_param_ptrs();
-        // Unmarshal each by-value indirect compact aggregate parameter from the
-        // homed pointer into its frame slots at entry (RUE-1005), so field
-        // projection and whole-value reads see the correct decomposition.
-        for (base_slot, map) in crate::value_plan::indirect_value_params(&self.ctx) {
-            crate::agg_slots::unmarshal_indirect_value_param(self, base_slot, &map);
-        }
-        // Heterogeneous by-value indirect params unmarshal with a tag dispatch
-        // (RUE-1037).
-        for (base_slot, image) in crate::value_plan::indirect_value_params_dispatch(&self.ctx) {
-            crate::agg_slots::unmarshal_indirect_value_param_dispatch(self, base_slot, &image);
+        // Read each by-value aggregate parameter whose leaves are not its
+        // eightbytes back out of the compact image the prologue laid down, so
+        // field projection and whole-value reads see the correct decomposition
+        // (ADR-0084).
+        for (base_slot, image_slot_offset, through_pointer, image) in
+            crate::value_plan::param_image_unmarshals(&self.ctx)
+        {
+            crate::agg_slots::unmarshal_param_image(
+                self,
+                base_slot,
+                image_slot_offset,
+                through_pointer,
+                &image,
+            );
         }
     }
 
@@ -4368,6 +4369,15 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
                 offset,
             });
         }
+    }
+
+    fn emit_slot_addr(&mut self, dst: VReg, slot: u32) {
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(X86Inst::Lea {
+            dst: Operand::Virtual(dst),
+            base: Reg::Rbp,
+            disp: offset,
+        });
     }
     fn emit_typed_float_load_slot(&mut self, dst: VReg, slot: u32, width: FloatWidth) {
         self.mir.push(X86Inst::FloatLoad {
@@ -5105,8 +5115,6 @@ mod tests {
             .map(|slot| SourceParamAbi {
                 start_slot: slot,
                 slot_count: 1,
-                crossing_regs: 1,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: None,
             })
             .collect()
@@ -6230,13 +6238,14 @@ mod tests {
         );
     }
 
-    /// RUE-1005 callee side: the function receiving a by-value compact aggregate
-    /// unmarshals its compact image (narrow loads) from the homed pointer into
-    /// its frame slots at entry.
+    /// ADR-0084 callee side: the function receiving a by-value aggregate whose
+    /// leaves are not its eightbytes reads them back out of the compact image
+    /// (narrow loads) the prologue laid down in its frame slots.
     #[test]
     fn aggregate_layout_allows_by_value_compact_struct_arg_callee() {
-        // The callee side: `fn sum(p: Padded) -> i32 { p.b }`, whose by-value
-        // indirect parameter reserves three frame slots behind one pointer.
+        // The callee side: `fn sum(p: Padded) -> i32 { p.b }`. `Padded` is 12
+        // bytes whose leaves sit at 0, 4 and 8, so it crosses as two eightbytes
+        // and the entry unmarshal recovers the three leaves from them.
         let interner = ThreadedRodeo::new();
         let pool = TypeInternPool::new();
         let padded_id = register_struct(
@@ -6255,8 +6264,6 @@ mod tests {
             vec![SourceParamAbi {
                 start_slot: 0,
                 slot_count: 3,
-                crossing_regs: 1,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp],
                 ty: Some(padded_ty),
             }],
             &pool,
@@ -6272,14 +6279,12 @@ mod tests {
             Type::I32,
         );
         fixture.ret(Some(b));
-        let mir = fixture
-            .lower()
-            .expect("the callee of a by-value compact struct argument must lower");
+        let mir = fixture.lower_with_plan();
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, X86Inst::NarrowLoadIndexed { width: 1, .. })),
-            "the callee must unmarshal the u8 fields narrow from the homed pointer"
+            "the callee must read the u8 leaves narrow out of the frame image"
         );
     }
 
@@ -6367,11 +6372,11 @@ mod tests {
         );
     }
 
-    /// RUE-1005 descriptor plumbing: a compact struct parameter crosses as one
-    /// indirect pointer, so its plan entry consumes a single register while still
-    /// reserving all three frame slots.
+    /// ADR-0084 descriptor plumbing: a 12-byte struct parameter crosses as two
+    /// eightbyte registers, and its plan homes both while still reserving all
+    /// three frame slots for the leaves the entry unmarshal writes there.
     #[test]
-    fn param_homing_plan_collapses_indirect_compact_aggregate() {
+    fn param_homing_plan_packs_a_compact_aggregate_into_its_eightbytes() {
         // `fn take(p: Padded, q: i32) -> i32 { p.b + q }` over the compact
         // `Padded { a: u8, b: i32, c: u8 }`.
         let interner = ThreadedRodeo::new();
@@ -6393,15 +6398,11 @@ mod tests {
                 SourceParamAbi {
                     start_slot: 0,
                     slot_count: 3,
-                    crossing_regs: 1,
-                    crossing_classes: vec![rue_air::NativeArgClass::Gp],
                     ty: Some(padded_ty),
                 },
                 SourceParamAbi {
                     start_slot: 3,
                     slot_count: 1,
-                    crossing_regs: 1,
-                    crossing_classes: vec![rue_air::NativeArgClass::Gp],
                     ty: None,
                 },
             ],
@@ -6424,27 +6425,43 @@ mod tests {
         let plan =
             crate::param_storage::ParamStoragePlan::plan(&cfg, &pool, false, PLAN_CONVENTION, 6);
 
-        // The compact struct parameter collapses to one incoming pointer
-        // register while its three frame slots stay reserved. The scalar `q`
-        // is a read-only register argument, so it keeps no frame home at all
-        // (RUE-1170) and appears in no homing entry — but its incoming
-        // register is still the second one (`abi_index` 1), after the
-        // struct's pointer.
+        // The 12-byte struct occupies the first two argument registers while
+        // its three frame slots stay reserved for the leaves. The scalar `q` is
+        // a read-only register argument, so it keeps no frame home at all
+        // (RUE-1170) and appears in no homing entry — but its incoming register
+        // is still the third one, after the struct's two eightbytes.
         assert_eq!(cfg.num_params(), 4, "Padded (3 slots) + i32 (1 slot)");
         assert_eq!(plan.homed_area_slots(), 3, "only the aggregate is homed");
         assert_eq!(
             plan.homing(),
-            [crate::codegen_pipeline::ParamHoming {
-                start_slot: 0,
-                class: crate::call_plan::AbiSlotClass::Gp,
-                location: crate::call_plan::AbiSlotLocation::GpReg(0),
-            }]
+            [
+                // A frame-resident aggregate ascends in address with its
+                // logical slots while frame slot numbers descend, so the first
+                // eightbyte lands in the parameter's LAST slot.
+                crate::codegen_pipeline::ParamHoming {
+                    start_slot: 2,
+                    class: crate::call_plan::AbiSlotClass::Gp,
+                    narrow_stack_load: None,
+                    location: crate::call_plan::AbiSlotLocation::GpReg(0),
+                },
+                crate::codegen_pipeline::ParamHoming {
+                    start_slot: 1,
+                    class: crate::call_plan::AbiSlotClass::Gp,
+                    narrow_stack_load: None,
+                    location: crate::call_plan::AbiSlotLocation::GpReg(1),
+                },
+            ]
+        );
+        assert_eq!(
+            plan.unmarshals().len(),
+            1,
+            "the packed aggregate's leaves are read back out of its frame image"
         );
         assert_eq!(
             plan.slot(3),
             crate::param_storage::ParamSlotStorage::Register {
                 class: crate::call_plan::AbiSlotClass::Gp,
-                location: crate::call_plan::AbiSlotLocation::GpReg(1),
+                location: crate::call_plan::AbiSlotLocation::GpReg(2),
             }
         );
     }
@@ -6622,9 +6639,9 @@ mod tests {
 
     #[test]
     fn ordinary_call_uses_checked_aligned_stack_area() {
-        // Seven scalar arguments leave one stack cell. The x86 lowering must
-        // reserve 8 bytes of checked alignment padding, then restore the full
-        // 16-byte aligned outgoing area after the call.
+        // Seven scalar arguments leave one stacked eightbyte. The x86 lowering
+        // reserves the convention's whole 16-byte-aligned outgoing area, stores
+        // the stacked argument into it, and releases it after the call.
         let interner = ThreadedRodeo::new();
         let pool = FrozenTypeInternPool::new();
         let mut fixture = FixtureCfg::new(
@@ -6645,11 +6662,6 @@ mod tests {
         let result = fixture.call("callee", args, Type::I64);
         fixture.ret(Some(result));
         let mir = fixture.lower().expect("ordinary call must lower");
-        let expected_padding = -i32::try_from(
-            crate::frame_layout::checked_cell_region_padding_bytes(1)
-                .expect("test call padding must fit the frame budget"),
-        )
-        .expect("test call padding must fit i32");
         let call_index = mir
             .instructions()
             .iter()
@@ -6662,7 +6674,7 @@ mod tests {
                     dst: Operand::Physical(Reg::Rsp),
                     imm,
                 }
-                if *imm == expected_padding
+                if *imm == -16
             )
         }));
         assert!(mir.instructions()[call_index + 1..].iter().any(|inst| {

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -594,6 +594,7 @@ impl<'a> Emitter<'a> {
                 .map(|slot| crate::codegen_pipeline::ParamHoming {
                     start_slot: slot,
                     class: crate::call_plan::AbiSlotClass::Gp,
+                    narrow_stack_load: None,
                     location: if (slot + abi_shift) < 6 {
                         crate::call_plan::AbiSlotLocation::GpReg((slot + abi_shift) as usize)
                     } else {
@@ -732,13 +733,36 @@ impl<'a> Emitter<'a> {
                     end_inst!(self, "mov float [rbp{}], {}", offset, FP_ARG_REGS[index]);
                 }
                 (_, crate::call_plan::AbiSlotLocation::Stack { offset: area, .. }) => {
-                    // Stack-passed arg: copy from above the frame into the param area
+                    // Stack-passed value: copy the eightbyte from above the
+                    // frame into the param area. A value the convention packed
+                    // narrower than an eightbyte is re-extended on the way in,
+                    // so the frame slot holds Rue's canonical 64-bit form.
                     let src_offset =
                         crate::frame_layout::checked_incoming_stack_arg_byte_offset(16, area)
                             .expect("incoming stack argument offset must fit displacement");
                     self.begin_inst();
-                    self.emit_mov_rm(Reg::Rax, Reg::Rbp, src_offset);
-                    end_inst!(self, "mov rax, [rbp+{}]", src_offset);
+                    match homing.narrow_stack_load {
+                        Some(narrow) => {
+                            self.emit_narrow_load_rm(
+                                Reg::Rax,
+                                Reg::Rbp,
+                                src_offset,
+                                narrow.width,
+                                narrow.signed,
+                            );
+                            end_inst!(
+                                self,
+                                "mov{} rax, {} ptr [rbp+{}]",
+                                if narrow.signed { "sx" } else { "zx" },
+                                narrow.width,
+                                src_offset
+                            );
+                        }
+                        None => {
+                            self.emit_mov_rm(Reg::Rax, Reg::Rbp, src_offset);
+                            end_inst!(self, "mov rax, [rbp+{}]", src_offset);
+                        }
+                    }
                     self.begin_inst();
                     self.emit_mov_mr(Reg::Rbp, offset, Reg::Rax);
                     end_inst!(self, "mov [rbp{}], rax", offset);
@@ -3628,11 +3652,44 @@ mod tests {
             .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                 start_slot: 0,
                 class: crate::call_plan::AbiSlotClass::Gp,
+                narrow_stack_load: None,
                 location: crate::call_plan::AbiSlotLocation::stack_slot(0),
             }])
             .emit_all()
             .expect("stack argument homing must emit");
         assert!(emitted.to_asm().contains("mov rax, [rbp+16]"));
+    }
+
+    /// Apple's amendment packs a stacked scalar at its natural size, so a value
+    /// narrower than an eightbyte is re-extended on the way into the frame slot
+    /// — Rue's canonical 64-bit form is stronger than what any C row promises.
+    /// SysV packs whole eightbytes and never reaches this, but the prologue is
+    /// one path and the encoding is pinned on both backends.
+    #[test]
+    fn a_narrow_stacked_argument_is_re_extended_into_its_frame_slot() {
+        for (width, signed, mnemonic) in [
+            (1u8, true, "movsx rax, 1 ptr [rbp+16]"),
+            (2u8, false, "movzx rax, 2 ptr [rbp+16]"),
+            (4u8, true, "movsx rax, 4 ptr [rbp+16]"),
+        ] {
+            let mut mir = X86Mir::new();
+            mir.push(X86Inst::Ret);
+            let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
+                .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
+                    start_slot: 0,
+                    class: crate::call_plan::AbiSlotClass::Gp,
+                    narrow_stack_load: Some(crate::types::NarrowScalar { width, signed }),
+                    location: crate::call_plan::AbiSlotLocation::Stack {
+                        offset: 0,
+                        size: u32::from(width),
+                        align: u32::from(width),
+                    },
+                }])
+                .emit_all()
+                .expect("a narrow stacked argument must home");
+            let asm = emitted.to_asm();
+            assert!(asm.contains(mnemonic), "{width}/{signed}: {asm}");
+        }
     }
 
     #[test]

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -815,18 +815,7 @@ impl RetainedCharge for rue_cfg::ValidatedCfg {
             .saturating_add(self.fn_name().len() as u64)
             .saturating_add((self.param_modes().len() * 2 * std::mem::size_of::<bool>()) as u64)
             .saturating_add(std::mem::size_of_val(self.source_param_abi()) as u64)
-            .saturating_add(source_param_abi_nested_retained_charge(
-                self.source_param_abi(),
-            ))
     }
-}
-
-fn source_param_abi_nested_retained_charge(params: &[rue_air::SourceParamAbi]) -> u64 {
-    params.iter().fold(0u64, |charge, param| {
-        charge.saturating_add(
-            (param.crossing_classes.len() * std::mem::size_of::<rue_air::NativeArgClass>()) as u64,
-        )
-    })
 }
 
 impl RetainedCharge for rue_air::FrozenTypeInternPool {
@@ -3672,30 +3661,6 @@ fn resolve_splice_block(
 #[cfg(test)]
 mod accessor_graph_tests {
     use super::*;
-
-    #[test]
-    fn source_param_abi_charges_nested_crossing_class_vectors() {
-        let params = vec![
-            rue_air::SourceParamAbi {
-                start_slot: 0,
-                slot_count: 2,
-                crossing_regs: 2,
-                crossing_classes: vec![rue_air::NativeArgClass::Gp, rue_air::NativeArgClass::Fp64],
-                ty: None,
-            },
-            rue_air::SourceParamAbi {
-                start_slot: 2,
-                slot_count: 1,
-                crossing_regs: 1,
-                crossing_classes: vec![rue_air::NativeArgClass::Fp32],
-                ty: None,
-            },
-        ];
-        assert_eq!(
-            source_param_abi_nested_retained_charge(&params),
-            (3 * std::mem::size_of::<rue_air::NativeArgClass>()) as u64
-        );
-    }
 
     #[test]
     fn accessor_interner_copy_preserves_ordinals_without_mutating_the_source() {

--- a/crates/rue-compiler/src/revisioned_query_database/semantic.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/semantic.rs
@@ -1110,9 +1110,25 @@ pub(super) fn scalar_layout(ty: &crate::TypeInstanceKey) -> crate::type_queries:
         T::I8 | T::U8 | T::Bool => 1,
         T::I16 | T::U16 => 2,
         T::I32 | T::U32 => 4,
-        T::I64 | T::U64 => 8,
+        T::F32 => 4,
+        T::I64 | T::U64 | T::F64 => 8,
         T::Unit | T::Never => 0,
         _ => 8,
+    };
+    // A zero-sized scalar contributes no leaf; every other one is a single leaf
+    // at offset zero, and its kind is what an eightbyte's bank is decided by.
+    let leaves: Vec<rue_air::CAbiLeaf> = if size == 0 {
+        Vec::new()
+    } else {
+        vec![rue_air::CAbiLeaf {
+            offset: 0,
+            width: size,
+            kind: match ty {
+                T::F32 => rue_air::CAbiLeafKind::F32,
+                T::F64 => rue_air::CAbiLeafKind::F64,
+                _ => rue_air::CAbiLeafKind::Integer,
+            },
+        }]
     };
     crate::type_queries::CanonicalLayout {
         size,
@@ -1120,8 +1136,39 @@ pub(super) fn scalar_layout(ty: &crate::TypeInstanceKey) -> crate::type_queries:
         stride: size,
         abi_slots: u32::from(size != 0),
         slot_identical: matches!(ty, T::I64 | T::U64 | T::Unit | T::Never),
+        leaves: leaves.into(),
         kind: crate::type_queries::CanonicalLayoutKind::Scalar,
     }
+}
+
+/// Rebase a component's leaves into an enclosing aggregate at `base`, dropping
+/// the whole projection once the aggregate is larger than any row's answer
+/// depends on.
+///
+/// Past [`rue_air::MAX_LEAF_CLASSIFIED_BYTES`] every supported row places an
+/// aggregate through memory whatever its leaves are, so the walk stops rather
+/// than carrying a leaf per element of a large array — the same bound the live
+/// projection (`rue_air::aggregate_leaves`) takes.
+fn extend_leaves(out: &mut Vec<rue_air::CAbiLeaf>, base: u64, leaves: &[rue_air::CAbiLeaf]) {
+    if base > rue_air::MAX_LEAF_CLASSIFIED_BYTES {
+        return;
+    }
+    out.extend(leaves.iter().map(|leaf| rue_air::CAbiLeaf {
+        offset: leaf.offset.saturating_add(base),
+        ..*leaf
+    }));
+}
+
+/// The leaves of an aggregate of `size` bytes, or none when the aggregate is
+/// past the bound above and classifies all-integer regardless.
+fn classified_leaves(
+    size: u64,
+    leaves: Vec<rue_air::CAbiLeaf>,
+) -> std::sync::Arc<[rue_air::CAbiLeaf]> {
+    if size > rue_air::MAX_LEAF_CLASSIFIED_BYTES {
+        return std::sync::Arc::from([]);
+    }
+    leaves.into()
 }
 
 pub(super) fn layout_from_terminal(
@@ -1155,6 +1202,7 @@ pub(super) fn evaluate_layout(
                 stride: 8,
                 abi_slots: 1,
                 slot_identical: true,
+                leaves: Arc::from([rue_air::CAbiLeaf::integer(0, 8)]),
                 kind: CanonicalLayoutKind::Pointer,
             },
         )));
@@ -1169,6 +1217,10 @@ pub(super) fn evaluate_layout(
                 stride: 16,
                 abi_slots: 2,
                 slot_identical: true,
+                leaves: Arc::from([
+                    rue_air::CAbiLeaf::integer(0, 8),
+                    rue_air::CAbiLeaf::integer(8, 8),
+                ]),
                 kind: CanonicalLayoutKind::Slice,
             },
         )));
@@ -1209,6 +1261,7 @@ pub(super) fn evaluate_layout(
                         stride: 0,
                         abi_slots: 0,
                         slot_identical: true,
+                        leaves: Arc::from([]),
                         kind: CanonicalLayoutKind::Array {
                             element: None,
                             count: 0,
@@ -1226,6 +1279,22 @@ pub(super) fn evaluate_layout(
             match layout_from_terminal(&element) {
                 Ok(element) => {
                     let size = element.stride.saturating_mul(*len);
+                    // Only the elements inside the leaf bound can change any
+                    // row's answer, so the walk stops there rather than running
+                    // the length of a large array.
+                    let classified = if element.stride == 0 || element.leaves.is_empty() {
+                        0
+                    } else {
+                        (*len).min(rue_air::MAX_LEAF_CLASSIFIED_BYTES / element.stride + 1)
+                    };
+                    let mut leaves = Vec::new();
+                    for index in 0..classified {
+                        extend_leaves(
+                            &mut leaves,
+                            element.stride.saturating_mul(index),
+                            &element.leaves,
+                        );
+                    }
                     LayoutValue::Available(CanonicalLayout {
                         size,
                         alignment: element.alignment,
@@ -1233,6 +1302,7 @@ pub(super) fn evaluate_layout(
                         abi_slots: u32::try_from(u64::from(element.abi_slots).saturating_mul(*len))
                             .unwrap_or(u32::MAX),
                         slot_identical: element.slot_identical,
+                        leaves: classified_leaves(size, leaves),
                         kind: CanonicalLayoutKind::Array {
                             element: Some(Box::new(element.clone())),
                             count: *len,
@@ -1258,6 +1328,7 @@ pub(super) fn evaluate_layout(
             let mut slot_identical = true;
             let mut offsets = Vec::with_capacity(terminals.len());
             let mut padding_ranges = Vec::new();
+            let mut leaves = Vec::new();
             for terminal in &terminals {
                 let layout = match layout_from_terminal(terminal) {
                     Ok(layout) => layout,
@@ -1274,6 +1345,7 @@ pub(super) fn evaluate_layout(
                     });
                 }
                 offsets.push(placed);
+                extend_leaves(&mut leaves, placed, &layout.leaves);
                 offset = placed.saturating_add(layout.size);
                 alignment = alignment.max(layout.alignment);
                 slots = slots.saturating_add(layout.abi_slots);
@@ -1292,6 +1364,7 @@ pub(super) fn evaluate_layout(
                 stride: size,
                 abi_slots: slots,
                 slot_identical,
+                leaves: classified_leaves(size, leaves),
                 kind: CanonicalLayoutKind::Struct {
                     field_offsets: offsets.into(),
                     padding_ranges: padding_ranges.into(),
@@ -1319,6 +1392,13 @@ pub(super) fn evaluate_layout(
             let mut payload_alignment = 1u64;
             let mut max_slots = 0u32;
             let mut projected = Vec::with_capacity(variants.len());
+            // The tag is an integer leaf at offset zero, and the payload is the
+            // *union* of every variant's leaves at that variant's own offsets:
+            // a union's eightbyte is classified by every leaf that can occupy
+            // it, which is the merge SysV AMD64 section 3.2.3 applies to a C
+            // union. The payload offsets below are relative to the payload, and
+            // are rebased once the payload's own offset is known.
+            let mut payload_leaves: Vec<rue_air::CAbiLeaf> = Vec::new();
             for (_, fields) in variants.iter() {
                 let mut offset = 0u64;
                 let mut variant_slots = 0u32;
@@ -1334,6 +1414,7 @@ pub(super) fn evaluate_layout(
                     cursor += 1;
                     offset = crate::type_queries::align_to(offset, layout.alignment);
                     offsets.push(offset);
+                    extend_leaves(&mut payload_leaves, offset, &layout.leaves);
                     offset = offset.saturating_add(layout.size);
                     payload_alignment = payload_alignment.max(layout.alignment);
                     variant_slots = variant_slots.saturating_add(layout.abi_slots);
@@ -1348,6 +1429,8 @@ pub(super) fn evaluate_layout(
                 payload_offset.saturating_add(payload_size),
                 alignment,
             );
+            let mut leaves = vec![rue_air::CAbiLeaf::integer(0, tag_size)];
+            extend_leaves(&mut leaves, payload_offset, &payload_leaves);
             LayoutValue::Available(CanonicalLayout {
                 size,
                 alignment,
@@ -1356,6 +1439,7 @@ pub(super) fn evaluate_layout(
                 // Compact enums always carry a narrow tag rather than the
                 // eight-byte discriminant slot used by value decomposition.
                 slot_identical: false,
+                leaves: classified_leaves(size, leaves),
                 kind: CanonicalLayoutKind::Enum {
                     tag_size,
                     payload_offset,
@@ -1855,6 +1939,8 @@ pub(super) fn c_scalar_kind(ty: &crate::TypeInstanceKey) -> rue_air::CAbiScalarK
         T::Bool => K::Bool,
         T::U16 => K::U16,
         T::U32 => K::U32,
+        T::F32 => K::F32,
+        T::F64 => K::F64,
         // Register-width scalars (i64/u64, pointers) and every remaining key
         // this projection can see need no extension.
         _ => K::RegisterWidth,
@@ -1874,14 +1960,20 @@ pub(super) fn stable_c_abi_type_facts(
     ty: &crate::TypeInstanceKey,
 ) -> rue_air::CAbiTypeFacts {
     if stable_type_is_aggregate(ty) {
-        // The canonical layout carries every byte offset of the aggregate but
-        // not the *kind* of the scalar at each one, which is what an eightbyte
-        // classification and the homogeneous-float rule read. The stable plane
-        // reports every leaf an integer, which is exact for every type that
-        // reaches a C boundary: the boundary rejects `f32`/`f64`
-        // (`c_passable_by_value`), and this projection classifies C boundaries
-        // only — a native signature keeps the native decision tree below.
-        return rue_air::CAbiTypeFacts::integer_aggregate(layout.size, layout.alignment);
+        // The canonical layout carries the aggregate's scalar leaves — each at
+        // its own byte offset, width, and kind — which is exactly what an
+        // eightbyte classification and the homogeneous-float rule read. An
+        // aggregate past the leaf bound carries none and classifies all-integer,
+        // the same answer the live projection gives it.
+        return rue_air::CAbiTypeFacts::Aggregate {
+            size: layout.size,
+            align: layout.alignment,
+            leaves: if layout.leaves.is_empty() {
+                rue_air::AggregateLeaves::all_integer(layout.size)
+            } else {
+                rue_air::AggregateLeaves::from_leaves(layout.size, layout.leaves.iter().copied())
+            },
+        };
     }
     if layout.abi_slots == 0 {
         return rue_air::CAbiTypeFacts::ZeroSized;
@@ -2011,35 +2103,65 @@ pub(super) fn evaluate_call_abi(
         }
     };
 
-    // A C boundary is placed by the one classification function every crossing
-    // site consumes; the native convention keeps its own decision tree. The
-    // stable plane projects the facts from canonical layout values and stable
-    // type keys, and the live classifier projects the same facts from the
+    // Every argument of every convention is placed by the one classification
+    // function each crossing site consumes: a C boundary through
+    // `lower_c_signature`, and the native convention — which places arguments by
+    // exactly the compilation target's own C rules (ADR-0084) — through
+    // `lower_native_signature` against the return the native tree still decides.
+    // The stable plane projects the facts from canonical layout values and
+    // stable type keys, and the live classifier projects the same facts from the
     // request-scoped type pool, so the two planes classify identically.
-    let lowered = (!convention.is_rue()).then(|| {
-        let parameters = signature
-            .parameters
-            .iter()
-            .zip(&layouts)
-            .map(|((mode, ty), layout)| match (mode, layout) {
-                (DurableParameterMode::Value, Some(layout)) => (
-                    stable_c_abi_type_facts(layout, ty),
-                    rue_air::ArgConvention::ByValue,
-                ),
-                // A reference parameter is one pointer whatever it points at,
-                // so it contributes no layout and needs none.
-                _ => (
-                    rue_air::CAbiTypeFacts::by_reference_pointer(),
-                    rue_air::ArgConvention::ByReference,
-                ),
-            })
-            .collect::<Vec<_>>();
+    let parameters = signature
+        .parameters
+        .iter()
+        .zip(&layouts)
+        .map(|((mode, ty), layout)| match (mode, layout) {
+            (DurableParameterMode::Value, Some(layout)) => (
+                stable_c_abi_type_facts(layout, ty),
+                rue_air::ArgConvention::ByValue,
+            ),
+            // A reference parameter is one pointer whatever it points at,
+            // so it contributes no layout and needs none.
+            _ => (
+                rue_air::CAbiTypeFacts::by_reference_pointer(),
+                rue_air::ArgConvention::ByReference,
+            ),
+        })
+        .collect::<Vec<_>>();
+    let native_return_budget =
+        rue_air::native_return_register_budget(key.configuration.target.arch());
+    let native_return = stable_native_abi_facts(return_layout, &signature.result)
+        .classify_return(native_return_budget);
+    let lowered = if convention.is_rue() {
+        let pairing = rue_target::ConventionSpec::native(key.configuration.target);
+        let spec = pairing.spec();
+        // Only one fact about the return reaches argument placement: whether a
+        // hidden indirect-result pointer takes an ordinary argument register
+        // ahead of every user argument. Phase 2 (RUE-2038) replaces the rest.
+        let ret = match native_return {
+            rue_air::ReturnClass::ZeroSized => rue_air::LoweredReturn::Void,
+            rue_air::ReturnClass::Scalar | rue_air::ReturnClass::Registers { .. } => {
+                rue_air::LoweredReturn::Registers {
+                    class: rue_target::CRegisterClass::Gp,
+                    count: native_return.slot_count().max(1),
+                    extension: rue_air::ScalarAbiExtension::None,
+                }
+            }
+            rue_air::ReturnClass::Indirect { slot_count } => rue_air::LoweredReturn::Sret {
+                register: spec.sret_register,
+                echoed: spec.sret_pointer_echoed_in_result_register,
+                size: slot_count.saturating_mul(rue_air::SLOT_BYTES as u32),
+                align: rue_air::SLOT_BYTES as u32,
+            },
+        };
+        rue_air::lower_native_signature(pairing, &parameters, ret)
+    } else {
         rue_air::lower_c_signature(
             convention,
             &parameters,
             stable_c_abi_type_facts(return_layout, &signature.result),
         )
-    });
+    };
 
     let mut arguments = Vec::with_capacity(signature.parameters.len());
     for (index, ((mode, ty), layout)) in signature.parameters.iter().zip(&layouts).enumerate() {
@@ -2051,34 +2173,23 @@ pub(super) fn evaluate_call_abi(
             });
             continue;
         };
-        let class = match &lowered {
-            None => match stable_native_abi_facts(layout, ty)
-                .classify_arg(rue_air::ArgConvention::ByValue)
-            {
-                rue_air::ArgClass::Omitted => A::Omitted,
-                rue_air::ArgClass::Direct { slot_count } => A::NativeDirect { slots: slot_count },
-                rue_air::ArgClass::Indirect => A::NativeIndirect,
+        let argument = lowered.arguments()[index];
+        let class = match argument.location {
+            rue_air::ArgLocation::Omitted => A::Omitted,
+            _ if !stable_type_is_aggregate(ty) => A::ScalarRegister {
+                extension: argument.extension,
             },
-            Some(lowered) => {
-                let argument = lowered.arguments()[index];
-                match argument.location {
-                    rue_air::ArgLocation::Omitted => A::Omitted,
-                    _ if !stable_type_is_aggregate(ty) => A::CScalar {
-                        extension: argument.extension,
-                    },
-                    rue_air::ArgLocation::Registers { pieces } => A::CIntegerRegisters {
-                        eightbytes: pieces.len(),
-                    },
-                    rue_air::ArgLocation::Stack { size, align, .. } => A::CByValueStack {
-                        size,
-                        alignment: align,
-                    },
-                    rue_air::ArgLocation::Indirect { size, align, .. } => A::CByReferenceCopy {
-                        size,
-                        alignment: align,
-                    },
-                }
-            }
+            rue_air::ArgLocation::Registers { pieces } => A::Registers {
+                eightbytes: pieces.len(),
+            },
+            rue_air::ArgLocation::Stack { size, align, .. } => A::ByValueStack {
+                size,
+                alignment: align,
+            },
+            rue_air::ArgLocation::Indirect { size, align, .. } => A::ByReferenceCopy {
+                size,
+                alignment: align,
+            },
         };
         arguments.push(CallAbiArgument {
             mode: *mode,
@@ -2086,24 +2197,23 @@ pub(super) fn evaluate_call_abi(
             class,
         });
     }
-    let return_class = match &lowered {
-        None => {
-            let budget = rue_air::native_return_register_budget(key.configuration.target.arch());
-            match stable_native_abi_facts(return_layout, &signature.result).classify_return(budget)
-            {
-                rue_air::ReturnClass::ZeroSized => R::ZeroSized,
-                rue_air::ReturnClass::Scalar => R::Scalar {
-                    extension: rue_air::ScalarAbiExtension::None,
-                },
-                rue_air::ReturnClass::Registers { slot_count } => {
-                    R::NativeRegisters { slots: slot_count }
-                }
-                rue_air::ReturnClass::Indirect { slot_count } => {
-                    R::NativeIndirect { slots: slot_count }
-                }
+    // The return still classifies by convention: the native bank is wider than
+    // any C row's and the phase that unifies them is RUE-2038.
+    let return_class = if convention.is_rue() {
+        match native_return {
+            rue_air::ReturnClass::ZeroSized => R::ZeroSized,
+            rue_air::ReturnClass::Scalar => R::Scalar {
+                extension: rue_air::ScalarAbiExtension::None,
+            },
+            rue_air::ReturnClass::Registers { slot_count } => {
+                R::NativeRegisters { slots: slot_count }
+            }
+            rue_air::ReturnClass::Indirect { slot_count } => {
+                R::NativeIndirect { slots: slot_count }
             }
         }
-        Some(lowered) => match lowered.ret() {
+    } else {
+        match lowered.ret() {
             rue_air::LoweredReturn::Void => R::ZeroSized,
             rue_air::LoweredReturn::Registers {
                 count, extension, ..
@@ -2118,7 +2228,7 @@ pub(super) fn evaluate_call_abi(
                 size,
                 alignment: align,
             },
-        },
+        }
     };
     Ok(QueryOutput::success(CallAbiValue::Available(
         CallAbiFacts {

--- a/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
@@ -582,7 +582,11 @@ fn the_c_by_value_classifier_agrees_across_sites_shapes_and_planes() {
              struct TwentyFour { a: i64, b: i64, c: i64 }\n\
              struct Padded { a: u8, b: u32, c: u16 }\n\
              struct Nested { p: Padded, q: Eight }\n\
-             struct Arrayed { xs: [i32; 5] }",
+             struct Arrayed { xs: [i32; 5] }\n\
+             struct MixedFloat { a: f64, b: i64 }\n\
+             struct FloatPair { a: f32, b: f32 }\n\
+             struct FloatQuad { a: f64, b: f64, c: f64, d: f64 }\n\
+             enum Tagged { Small(u8), Wide(i64, i64) }",
         )],
         1,
     );
@@ -634,6 +638,34 @@ fn the_c_by_value_classifier_agrees_across_sites_shapes_and_planes() {
     );
     let nested = register("Nested", vec![("p", padded), ("q", eight)]);
     let arrayed = register("Arrayed", vec![("xs", ints5)]);
+    // The native convention is the first consumer to reach the SSE eightbyte
+    // class and AAPCS64's homogeneous-float rule, and the first to classify an
+    // enum, so the shape set carries all three.
+    let mixed_float = register("MixedFloat", vec![("a", Type::F64), ("b", Type::I64)]);
+    let float_pair = register("FloatPair", vec![("a", Type::F32), ("b", Type::F32)]);
+    let float_quad = register(
+        "FloatQuad",
+        vec![
+            ("a", Type::F64),
+            ("b", Type::F64),
+            ("c", Type::F64),
+            ("d", Type::F64),
+        ],
+    );
+    let tagged = Type::new_enum(
+        pool.register_enum(
+            interner.get_or_intern("Tagged"),
+            rue_air::EnumDef {
+                name: "Tagged".into(),
+                variants: Arc::from(["Small".into(), "Wide".into()]),
+                variant_payloads: vec![vec![Type::U8], vec![Type::I64, Type::I64]],
+                is_pub: false,
+                is_non_exhaustive: false,
+                file_id: rue_span::FileId::DEFAULT,
+            },
+        )
+        .0,
+    );
     let pointee = Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::I32));
     let mut_pointee = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::I32));
     let pool = pool.freeze();
@@ -751,6 +783,89 @@ fn the_c_by_value_classifier_agrees_across_sites_shapes_and_planes() {
         "the shape set must reach every placement class: registers={seen_registers} \
          stack={seen_stack} indirect={seen_indirect} sret={seen_sret}"
     );
+
+    // The native row: the same agreement over the shapes the C boundary cannot
+    // carry. The native convention places arguments by exactly the target's own
+    // C rules (ADR-0084), so the two planes must project one set of facts for a
+    // float-carrying struct and an enum as well, and place them identically.
+    let native_shapes: Vec<(&str, crate::TypeInstanceKey, Type)> = shapes
+        .iter()
+        .cloned()
+        .chain([
+            ("MixedFloat", named("MixedFloat"), mixed_float),
+            ("FloatPair", named("FloatPair"), float_pair),
+            ("FloatQuad", named("FloatQuad"), float_quad),
+            (
+                "Tagged",
+                named_type_instance(&module, "Tagged", crate::StableDefinitionKind::Enum),
+                tagged,
+            ),
+        ])
+        .collect();
+    let mut seen_fp_registers = false;
+    for target in crate::Target::all().iter().copied() {
+        let pairing = rue_target::ConventionSpec::native(target);
+        for (name, stable_key, live_ty) in &native_shapes {
+            let attempt =
+                request_layout_for_target(&database, revision, stable_key.clone(), target);
+            let terminal = attempt.terminal().unwrap();
+            let rue_query::QueryOutcome::Success(crate::type_queries::LayoutValue::Available(
+                canonical,
+            )) = terminal.outcome()
+            else {
+                panic!("layout query failed for {name}: {terminal:?}");
+            };
+            let stable_facts =
+                super::super::semantic::stable_c_abi_type_facts(canonical, stable_key);
+            let live_facts =
+                rue_codegen::native_abi::native_arg(&pool, *live_ty, ArgConvention::ByValue)
+                    .facts()[0];
+            // A discriminant-only enum is the one projection the two planes
+            // spell differently — the live plane calls its single tag a scalar
+            // — and no such shape is in this set, so the facts must agree.
+            assert_eq!(
+                stable_facts, live_facts,
+                "{target:?}/{name}: the two planes must project one set of native facts"
+            );
+
+            let mut parameters = vec![(live_facts, ArgConvention::ByValue)];
+            parameters.extend(std::iter::repeat_n(
+                (
+                    CAbiTypeFacts::Scalar {
+                        kind: rue_air::CAbiScalarKind::RegisterWidth,
+                        class: rue_target::CRegisterClass::Gp,
+                    },
+                    ArgConvention::ByValue,
+                ),
+                9,
+            ));
+            let call =
+                rue_air::lower_native_signature(pairing, &parameters, rue_air::LoweredReturn::Void);
+            let mut stable_parameters = parameters.clone();
+            stable_parameters[0] = (stable_facts, ArgConvention::ByValue);
+            assert_eq!(
+                call,
+                rue_air::lower_native_signature(
+                    pairing,
+                    &stable_parameters,
+                    rue_air::LoweredReturn::Void
+                ),
+                "{target:?}/{name}: the stable plane must place every native value identically"
+            );
+            for argument in call.arguments() {
+                if let rue_air::ArgLocation::Registers { pieces } = argument.location {
+                    seen_fp_registers |= pieces
+                        .as_slice()
+                        .iter()
+                        .any(|piece| piece.class == rue_target::CRegisterClass::Fp);
+                }
+            }
+        }
+    }
+    assert!(
+        seen_fp_registers,
+        "the native shape set must reach the floating-point roster"
+    );
 }
 
 #[test]
@@ -809,7 +924,7 @@ fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_ta
         );
         assert!(matches!(
             foreign.arguments[0].class,
-            A::CScalar {
+            A::ScalarRegister {
                 extension: rue_air::ScalarAbiExtension::Unsigned { from_bits: 32 }
             }
         ));
@@ -828,7 +943,7 @@ fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_ta
         assert_eq!(destructor.arguments.len(), 1);
         assert!(matches!(
             destructor.arguments[0].class,
-            A::NativeDirect { slots: 1 }
+            A::Registers { eightbytes: 1 }
         ));
 
         let glue = request_call_abi(
@@ -841,7 +956,7 @@ fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_ta
         assert_eq!(glue.return_class, R::ZeroSized);
         assert!(matches!(
             glue.arguments[0].class,
-            A::NativeDirect { slots: 1 }
+            A::Registers { eightbytes: 1 }
         ));
     }
 }
@@ -888,11 +1003,18 @@ fn call_abi_batches_layouts_across_mixed_modes_and_duplicate_parameter_types() {
         assert_eq!(mixed.arguments[1].class, mixed.arguments[3].class);
         assert_eq!(mixed.arguments[1].value_slots, 7);
         assert_eq!(mixed.arguments[3].value_slots, 7);
+        // 56 bytes: SysV stacks it byval, AAPCS64 takes a caller-owned copy.
         assert!(matches!(
             mixed.arguments[1].class,
-            A::NativeDirect { slots: 7 } | A::NativeIndirect
+            A::ByValueStack {
+                size: 56,
+                alignment: 8
+            } | A::ByReferenceCopy {
+                size: 56,
+                alignment: 8
+            }
         ));
-        assert_eq!(mixed.arguments[4].class, A::NativeDirect { slots: 1 });
+        assert!(matches!(mixed.arguments[4].class, A::ScalarRegister { .. }));
         // The result layout is the last entry of the same batch.
         assert_eq!(
             mixed.return_class,
@@ -909,13 +1031,13 @@ fn call_abi_batches_layouts_across_mixed_modes_and_duplicate_parameter_types() {
         assert_eq!(scalars.arguments[0].class, scalars.arguments[1].class);
         assert_eq!(
             scalars.arguments[0].class,
-            A::CScalar {
+            A::ScalarRegister {
                 extension: rue_air::ScalarAbiExtension::Unsigned { from_bits: 32 }
             }
         );
         assert_eq!(
             scalars.arguments[2].class,
-            A::CScalar {
+            A::ScalarRegister {
                 extension: rue_air::ScalarAbiExtension::None
             }
         );
@@ -967,7 +1089,7 @@ fn call_abi_resolves_value_specialized_array_layout_on_both_targets() {
             named
                 .arguments
                 .iter()
-                .all(|argument| matches!(argument.class, A::NativeDirect { slots: 1 }))
+                .all(|argument| matches!(argument.class, A::ScalarRegister { .. }))
         );
 
         let facts = request_call_abi(&database, revision, callable.clone(), target);
@@ -981,14 +1103,19 @@ fn call_abi_resolves_value_specialized_array_layout_on_both_targets() {
             }
         );
         assert_eq!(facts.arguments.len(), 2);
-        assert!(matches!(
-            facts.arguments[0].class,
-            A::NativeDirect { slots: 1 }
-        ));
+        assert!(matches!(facts.arguments[0].class, A::ScalarRegister { .. }));
         assert_eq!(facts.arguments[0].value_slots, 1);
+        // `[u64; 7]` is 56 bytes: SysV stacks it byval, AAPCS64 takes a
+        // caller-owned copy.
         assert!(matches!(
             facts.arguments[1].class,
-            A::NativeDirect { slots: 7 }
+            A::ByValueStack {
+                size: 56,
+                alignment: 8
+            } | A::ByReferenceCopy {
+                size: 56,
+                alignment: 8
+            }
         ));
         assert_eq!(facts.arguments[1].value_slots, 7);
     }
@@ -1044,17 +1171,23 @@ fn call_abi_derives_anonymous_destructor_signature_from_its_exact_producer() {
         assert_eq!(facts.arguments.len(), 1);
         assert!(matches!(
             facts.arguments[0].class,
-            A::NativeDirect { slots: 1 }
+            A::Registers { eightbytes: 1 }
         ));
     }
 }
 
-/// One stable argument classification against the live classifier's answer
-/// for the same type under the same convention.
+/// One stable argument classification against the placement the live plane
+/// gives the same value under the same convention.
+///
+/// Both planes place through `rue_air::lower_native_signature`; this checks that
+/// the stable plane's own projection of the argument's facts reached the same
+/// answer, and that a by-reference parameter is still described as one pointer
+/// whatever the placement says about it.
 fn assert_native_arg_parity(
     stable: &crate::type_queries::CallAbiArgument,
-    live_class: rue_air::ArgClass,
+    live_location: rue_air::ArgLocation,
     live_width: u32,
+    by_reference: bool,
     context: &str,
 ) {
     use crate::type_queries::CallAbiArgumentClass as A;
@@ -1062,17 +1195,105 @@ fn assert_native_arg_parity(
         stable.value_slots, live_width,
         "value-slot width parity for {context}"
     );
-    match (stable.class, live_class) {
-        (A::Omitted, rue_air::ArgClass::Omitted) => {}
-        (A::NativeDirect { slots }, rue_air::ArgClass::Direct { slot_count }) => {
-            assert_eq!(slots, slot_count, "direct slot parity for {context}");
+    if by_reference {
+        assert!(
+            matches!(stable.class, A::Reference),
+            "a by-reference parameter is one pointer for {context}"
+        );
+        return;
+    }
+    match (stable.class, live_location) {
+        (A::Omitted, rue_air::ArgLocation::Omitted) => {}
+        // A scalar and a one-eightbyte aggregate reach the same register; the
+        // two classes differ only in whether the plane calls the value an
+        // aggregate, which is a projection difference and not a placement one.
+        (A::ScalarRegister { .. }, rue_air::ArgLocation::Registers { pieces }) => {
+            assert_eq!(
+                pieces.len(),
+                1,
+                "a scalar occupies one register for {context}"
+            );
         }
-        (A::NativeIndirect, rue_air::ArgClass::Indirect) => {}
-        (A::Reference, rue_air::ArgClass::Indirect) => {}
+        (A::ScalarRegister { .. }, rue_air::ArgLocation::Stack { .. }) => {}
+        (A::Registers { eightbytes }, rue_air::ArgLocation::Registers { pieces }) => {
+            assert_eq!(
+                eightbytes,
+                pieces.len(),
+                "register-count parity for {context}"
+            );
+        }
+        (
+            A::ByValueStack { size, alignment },
+            rue_air::ArgLocation::Stack {
+                size: live_size,
+                align,
+                ..
+            },
+        ) => {
+            assert_eq!(
+                (size, alignment),
+                (live_size, align),
+                "stacked footprint parity for {context}"
+            );
+        }
+        (
+            A::ByReferenceCopy { size, alignment },
+            rue_air::ArgLocation::Indirect {
+                size: live_size,
+                align,
+                ..
+            },
+        ) => {
+            assert_eq!(
+                (size, alignment),
+                (live_size, align),
+                "by-reference copy parity for {context}"
+            );
+        }
         (stable, live) => {
-            panic!("argument classification parity mismatch for {context}: {stable:?} != {live:?}")
+            panic!("argument placement parity mismatch for {context}: {stable:?} != {live:?}")
         }
     }
+}
+
+/// The placements the live plane gives one native signature's arguments.
+fn live_native_placements(
+    pool: &rue_air::FrozenTypeInternPool,
+    target: crate::Target,
+    parameters: &[(rue_air::ArgConvention, rue_air::Type)],
+    result: rue_air::Type,
+    budget: u32,
+) -> Vec<rue_air::ArgLocation> {
+    let pairing = rue_target::ConventionSpec::native(target);
+    let spec = pairing.spec();
+    let facts = parameters
+        .iter()
+        .map(|(convention, ty)| {
+            (
+                rue_codegen::native_abi::native_arg(pool, *ty, *convention).facts()[0],
+                *convention,
+            )
+        })
+        .collect::<Vec<_>>();
+    let ret = match rue_air::NativeCallAbi::new(pool, budget).classify_return(result) {
+        rue_air::ReturnClass::ZeroSized => rue_air::LoweredReturn::Void,
+        rue_air::ReturnClass::Indirect { slot_count } => rue_air::LoweredReturn::Sret {
+            register: spec.sret_register,
+            echoed: spec.sret_pointer_echoed_in_result_register,
+            size: slot_count.saturating_mul(rue_air::SLOT_BYTES as u32),
+            align: rue_air::SLOT_BYTES as u32,
+        },
+        other => rue_air::LoweredReturn::Registers {
+            class: rue_target::CRegisterClass::Gp,
+            count: other.slot_count().max(1),
+            extension: rue_air::ScalarAbiExtension::None,
+        },
+    };
+    rue_air::lower_native_signature(pairing, &facts, ret)
+        .arguments()
+        .iter()
+        .map(|argument| argument.location)
+        .collect()
 }
 
 /// One stable return classification against the live classifier's answer.
@@ -1268,11 +1489,15 @@ fn call_abi_native_classification_matches_the_live_classifier_on_both_targets() 
                 "{name} is a native callable"
             );
             assert_eq!(facts.arguments.len(), params.len(), "arity of {name}");
-            for (argument, (convention, ty)) in facts.arguments.iter().zip(params) {
+            let placements = live_native_placements(&pool, target, params, *result, budget);
+            for ((argument, (convention, ty)), location) in
+                facts.arguments.iter().zip(params).zip(&placements)
+            {
                 assert_native_arg_parity(
                     argument,
-                    live.classify_arg(*ty, *convention),
+                    *location,
                     live.arg_slot_width(*ty, *convention),
+                    *convention == ArgConvention::ByReference,
                     &format!("{name} on {target:?}"),
                 );
             }
@@ -1284,10 +1509,9 @@ fn call_abi_native_classification_matches_the_live_classifier_on_both_targets() 
         }
 
         // The discriminant-only enum is the one deliberate projection
-        // divergence between the planes: the live classifier reports its
-        // single tag slot as `Scalar`, while the stable projection keeps
-        // reporting the aggregate as one register slot. The physical
-        // crossing is identical (one register); this pin keeps the
+        // divergence between the planes: the live plane reports its single tag
+        // as a scalar, while the stable projection reports the aggregate. Both
+        // place it in one general-purpose register, and the pin keeps the
         // divergence visible instead of letting it drift silently.
         let flag_facts = request_call_abi(
             &database,
@@ -1307,16 +1531,16 @@ fn call_abi_native_classification_matches_the_live_classifier_on_both_targets() 
         );
         assert_native_arg_parity(
             &flag_facts.arguments[0],
-            live.classify_arg(flag, ArgConvention::ByValue),
+            live_native_placements(&pool, target, &[(by_value, flag)], flag, budget)[0],
             live.arg_slot_width(flag, ArgConvention::ByValue),
+            false,
             &format!("flag argument on {target:?}"),
         );
 
         // Pin the classification outcomes themselves, not only the
-        // cross-plane agreement: zero-sized values vanish, a slot-identical
-        // aggregate stays direct, a multi-slot narrow-leaf aggregate is
-        // forced indirect by the compact memory-first rule, and a
-        // single-slot narrow aggregate stays direct (RUE-1035).
+        // cross-plane agreement: zero-sized values vanish, a 16-byte aggregate
+        // takes two registers, an 8-byte one takes one whatever its fields'
+        // widths are, and a `borrow`/`inout` parameter is one pointer.
         use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
         let request = |name: &str| {
             request_call_abi(
@@ -1332,25 +1556,32 @@ fn call_abi_native_classification_matches_the_live_classifier_on_both_targets() 
         let wide_facts = request("wide");
         assert!(matches!(
             wide_facts.arguments[0].class,
-            A::NativeDirect { slots: 2 }
+            A::Registers { eightbytes: 2 }
         ));
         assert_eq!(wide_facts.return_class, R::NativeRegisters { slots: 2 });
+        // `{u32, u32}` is eight bytes: one register, its two leaves packed into
+        // the one eightbyte. Its return still classifies natively.
         let narrow_facts = request("narrow");
-        assert!(matches!(narrow_facts.arguments[0].class, A::NativeIndirect));
+        assert!(matches!(
+            narrow_facts.arguments[0].class,
+            A::Registers { eightbytes: 1 }
+        ));
         assert_eq!(narrow_facts.return_class, R::NativeIndirect { slots: 2 });
         let one_narrow_facts = request("one_narrow");
         assert!(matches!(
             one_narrow_facts.arguments[0].class,
-            A::NativeDirect { slots: 1 }
+            A::Registers { eightbytes: 1 }
         ));
         assert_eq!(
             one_narrow_facts.return_class,
             R::NativeRegisters { slots: 1 }
         );
+        // `{{u32, u32}, u64}` is sixteen bytes: two registers on SysV, and two
+        // consecutive integer registers under the AAPCS64 composite rule.
         let nested_narrow_facts = request("nested_narrow");
         assert!(matches!(
             nested_narrow_facts.arguments[0].class,
-            A::NativeIndirect
+            A::Registers { eightbytes: 2 }
         ));
         let refs_facts = request("refs");
         assert!(matches!(refs_facts.arguments[0].class, A::Reference));
@@ -1454,7 +1685,7 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
         use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
         assert_eq!(facts.arguments.len(), live_params.len(), "arity of {name}");
         for (argument, live_ty) in facts.arguments.iter().zip(live_params) {
-            let A::CScalar { extension } = argument.class else {
+            let A::ScalarRegister { extension } = argument.class else {
                 panic!("{name} argument is a target-C scalar: {:?}", argument.class);
             };
             assert_eq!(
@@ -1490,11 +1721,11 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
             live_facts,
         );
         match (facts.arguments[0].class, lowered.arguments()[0].location) {
-            (A::CIntegerRegisters { eightbytes }, rue_air::ArgLocation::Registers { pieces }) => {
+            (A::Registers { eightbytes }, rue_air::ArgLocation::Registers { pieces }) => {
                 assert_eq!(eightbytes, pieces.len(), "eightbyte parity for {name}")
             }
             (
-                A::CByValueStack { size, alignment },
+                A::ByValueStack { size, alignment },
                 rue_air::ArgLocation::Stack {
                     size: live_size,
                     align: live_align,
@@ -1506,7 +1737,7 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
                 "byval parity for {name}"
             ),
             (
-                A::CByReferenceCopy { size, alignment },
+                A::ByReferenceCopy { size, alignment },
                 rue_air::ArgLocation::Indirect {
                     size: live_size,
                     align: live_align,
@@ -1653,15 +1884,12 @@ fn call_abi_strbuf_return_uses_sret_on_both_planes() {
     ] {
         let live = NativeCallAbi::new(&pool, budget);
         // The canonical StrBuf always returns through sret even though its
-        // three slots fit the return-register budget, and its slot-identical
-        // layout keeps by-value arguments direct.
+        // three slots fit the return-register budget. Its 24 bytes are past
+        // every row's register-passed aggregate, so a by-value argument is SysV
+        // MEMORY class or an AAPCS64 caller-owned copy.
         assert_eq!(
             live.classify_return(strbuf),
             rue_air::ReturnClass::Indirect { slot_count: 3 }
-        );
-        assert_eq!(
-            live.classify_arg(strbuf, ArgConvention::ByValue),
-            rue_air::ArgClass::Direct { slot_count: 3 }
         );
         let facts = request_call_abi(
             &database,
@@ -1676,8 +1904,15 @@ fn call_abi_strbuf_return_uses_sret_on_both_planes() {
         );
         assert_native_arg_parity(
             &facts.arguments[0],
-            live.classify_arg(strbuf, ArgConvention::ByValue),
+            live_native_placements(
+                &pool,
+                target,
+                &[(ArgConvention::ByValue, strbuf)],
+                strbuf,
+                budget,
+            )[0],
             live.arg_slot_width(strbuf, ArgConvention::ByValue),
+            false,
             &format!("StrBuf echo argument on {target:?}"),
         );
     }

--- a/crates/rue-compiler/src/type_queries.rs
+++ b/crates/rue-compiler/src/type_queries.rs
@@ -89,6 +89,15 @@ pub(crate) struct CanonicalLayout {
     /// Whether the compact memory image is byte-for-byte identical to the
     /// flattened eight-byte slot representation used by the native call ABI.
     pub(crate) slot_identical: bool,
+    /// Every scalar leaf of the type's memory image, at its own byte offset and
+    /// width, in ascending order — the facts a calling convention classifies an
+    /// aggregate's eightbytes and its homogeneous-float rule by.
+    ///
+    /// Empty for a type larger than
+    /// [`rue_air::MAX_LEAF_CLASSIFIED_BYTES`], because no supported row's answer
+    /// for one that large depends on its leaves; the projection reports such a
+    /// type all-integer rather than carrying a leaf per array element.
+    pub(crate) leaves: Arc<[rue_air::CAbiLeaf]>,
     pub(crate) kind: CanonicalLayoutKind,
 }
 
@@ -186,27 +195,26 @@ pub(crate) struct CallAbiArgument {
     pub(crate) class: CallAbiArgumentClass,
 }
 
+/// Where one argument of a classified signature travels.
+///
+/// The native convention places arguments by the compilation target's own C
+/// rules (ADR-0084), so both rows are described by the same classes; only the
+/// return still spells the two conventions apart.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CallAbiArgumentClass {
+    /// Zero-sized: no register, no stack byte, no pointer.
     Omitted,
-    NativeDirect {
-        slots: u32,
-    },
-    NativeIndirect,
-    CScalar {
+    /// One scalar in one register, carrying `extension`.
+    ScalarRegister {
         extension: rue_air::ScalarAbiExtension,
     },
-    CIntegerRegisters {
-        eightbytes: u32,
-    },
-    CByValueStack {
-        size: u32,
-        alignment: u32,
-    },
-    CByReferenceCopy {
-        size: u32,
-        alignment: u32,
-    },
+    /// An aggregate packed into `eightbytes` registers.
+    Registers { eightbytes: u32 },
+    /// An aggregate by value in the outgoing argument area.
+    ByValueStack { size: u32, alignment: u32 },
+    /// An aggregate through a pointer to a caller-owned copy.
+    ByReferenceCopy { size: u32, alignment: u32 },
+    /// A `borrow` / `inout` parameter: one pointer, whatever it points at.
     Reference,
 }
 

--- a/crates/rue-ui-tests/cases/emit/abi.toml
+++ b/crates/rue-ui-tests/cases/emit/abi.toml
@@ -14,7 +14,7 @@ description = "Per-function convention and per-value placement for native functi
 
 [[case]]
 name = "native_multislot_aggregate_argument_and_sret_return"
-description = "A 7-slot by-value aggregate crosses the native convention reversed, spilling past the six SysV argument registers; the same aggregate returns through sret, whose hidden pointer takes argument register 0."
+description = "A 56-byte by-value aggregate is SysV MEMORY class natively as well, so it crosses byval in the outgoing argument area consuming no register; the same aggregate returns through sret, whose hidden pointer takes argument register 0."
 target = "x86-64-linux"
 source = """
 struct Wide {
@@ -41,19 +41,14 @@ fn main() -> i32 {
 expected_abi = """
 function __rue_fn_test_2erue__through
   convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s7_7468726f756768t0_
-  parameter 0: Wide$test_2erue, by value, 7 slots, reversed
-    slot 6: gp register 1 (rsi)
-    slot 5: gp register 2 (rdx)
-    slot 4: gp register 3 (rcx)
-    slot 3: gp register 4 (r8)
-    slot 2: gp register 5 (r9)
-    slot 1: stack +0 (8 bytes, align 8)
-    slot 0: stack +8 (8 bytes, align 8)
+  parameter 0: Wide$test_2erue, by value, stack +0 (56 bytes, align 8)
   return: Wide$test_2erue, sret: pointer in gp register 0 (rdi) to 7 slots (64 bytes of caller storage)
+  outgoing argument area: 64 bytes
 
 function main
   convention rue, symbol main
   return: i32, gp return register 0 (rax)
+  outgoing argument area: 0 bytes
 """
 
 # The same `extern "C"` signature on all three rows. Eight register-width
@@ -104,6 +99,7 @@ expected_abi = """
 function main
   convention rue, symbol main
   return: i32, gp return register 0 (rax)
+  outgoing argument area: 0 bytes
 
 import wide
   convention x86-64-sysv, symbol wide
@@ -161,6 +157,7 @@ expected_abi = """
 function main
   convention rue, symbol main
   return: i32, gp return register 0 (x0)
+  outgoing argument area: 0 bytes
 
 import wide
   convention aarch64-aapcs, symbol wide
@@ -218,6 +215,7 @@ expected_abi = """
 function main
   convention rue, symbol main
   return: i32, gp return register 0 (x0)
+  outgoing argument area: 0 bytes
 
 import wide
   convention aarch64-aapcs-darwin, symbol wide
@@ -237,9 +235,10 @@ import wide
 
 # An export owns both halves of one crossing, so its block prints both: the C
 # entry a foreign caller writes (two eightbytes in, two result registers out)
-# and the native body the thunk forwards to, whose by-value aggregate crosses
-# reversed. Reading the two sides together is what shows the thunk has real work
-# to do even for a signature this small.
+# and the native body the thunk forwards to. Both sides place the argument
+# identically — the native convention is this target's own C row — so what is
+# left for the thunk is the return, which the wider native bank still spells
+# differently.
 [[case]]
 name = "export_two_field_struct_in_and_out"
 description = "A `pub extern \\\"C\\\" fn` export prints its C side and the native side it forwards to."
@@ -270,16 +269,16 @@ export swap
     outgoing argument area: 0 bytes
   native side
     convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s4_73776170t0_
-    parameter 0: Pair$test_2erue, by value, 2 slots, reversed
-      slot 1: gp register 0 (rdi)
-      slot 0: gp register 1 (rsi)
+    parameter 0: Pair$test_2erue, by value, gp registers 0-1 (rdi, rsi)
     return: Pair$test_2erue, 2 slots
       slot 0: gp return register 0 (rax)
       slot 1: gp return register 1 (rdx)
+    outgoing argument area: 0 bytes
 
 function main
   convention rue, symbol main
   return: i32, gp return register 0 (rax)
+  outgoing argument area: 0 bytes
 """
 
 # `borrow` and `inout` are one caller pointer each whatever they point at, so
@@ -314,28 +313,31 @@ fn main() -> i32 {
 expected_abi = """
 function __rue_fn_test_2erue__bump
   convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s4_62756d70t0_
-  parameter 0: Counter$test_2erue, inout, indirect: pointer in gp register 0 (rdi)
+  parameter 0: Counter$test_2erue, inout, gp register 0 (rdi)
   parameter 1: i64, by value, gp register 1 (rsi)
   return: unit, no value
+  outgoing argument area: 0 bytes
 
 function __rue_fn_test_2erue__total
   convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s5_746f74616ct0_
-  parameter 0: Counter$test_2erue, borrow, indirect: pointer in gp register 0 (rdi)
+  parameter 0: Counter$test_2erue, borrow, gp register 0 (rdi)
   return: i64, gp return register 0 (rax)
+  outgoing argument area: 0 bytes
 
 function main
   convention rue, symbol main
   return: i32, gp return register 0 (rax)
+  outgoing argument area: 0 bytes
 """
 
-# A by-value aggregate the compact layout cannot express slot-identically (an
-# `[i32; 8]` field) is forced indirect by the memory-first rule: one incoming
-# pointer for a value that still occupies nine callee parameter slots. That
-# collapse is the one case where the pointee's slot count *is* an ABI fact, so
-# the line states it — and the same type returns through sret.
+# A by-value aggregate whose leaves pack together (an `[i32; 8]` field) is
+# classified by its compact image like any other value: 40 bytes is past SysV's
+# sixteen, so it is MEMORY class and crosses byval in the outgoing argument area
+# — and the same type returns through sret, whose hidden pointer is the first
+# argument register even though no user argument takes one.
 [[case]]
 name = "native_compact_indirect_argument_states_its_pointee_slots"
-description = "A by-value aggregate forced indirect by the compact memory-first rule crosses as one pointer to nine slots."
+description = "A 40-byte by-value aggregate crosses natively where SysV puts it: byval in the outgoing argument area, past the hidden sret pointer."
 target = "x86-64-linux"
 source = """
 struct Block {
@@ -356,10 +358,12 @@ fn main() -> i32 {
 expected_abi = """
 function __rue_fn_test_2erue__through
   convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s7_7468726f756768t0_
-  parameter 0: Block$test_2erue, by value, indirect: pointer in gp register 1 (rsi) to 9 slots
+  parameter 0: Block$test_2erue, by value, stack +0 (40 bytes, align 8)
   return: Block$test_2erue, sret: pointer in gp register 0 (rdi) to 9 slots (80 bytes of caller storage)
+  outgoing argument area: 48 bytes
 
 function main
   convention rue, symbol main
   return: i32, gp return register 0 (rax)
+  outgoing argument area: 0 bytes
 """

--- a/docs/designs/0084-native-calling-convention.md
+++ b/docs/designs/0084-native-calling-convention.md
@@ -340,7 +340,7 @@ matrices (`crates/rue-cli-tests/cases/aggregate_abi_matrix.toml`,
 (`//crates/rue-oracle-diff:oracle-diff-test`). The oracle's call-contract model
 moves in the same change as the convention it models, never in a follow-up.
 
-- [ ] **Phase 1: Native argument classification adopts the C row's placement** —
+- [x] **Phase 1: Native argument classification adopts the C row's placement** —
   RUE-2037. By-value aggregates pack into eightbytes in ascending memory order
   (SysV) or follow the AAPCS64 composite rules; the reversal retires at both
   ends, along with the drop-glue and value-plan reversals that mirror it; narrow

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -81,12 +81,13 @@ supported representation.
 | Property | Native Rue: x86-64 Linux | Native Rue: AArch64 Linux/macOS | Current target-C runtime subset |
 | --- | --- | --- | --- |
 | Integer/pointer argument registers | `rdi`, `rsi`, `rdx`, `rcx`, `r8`, `r9` | `x0`-`x7` | Same target registers |
-| Stack arguments | 8-byte slots, first overflow slot nearest return address | 8-byte slots beginning at incoming `sp` | Not implemented; every current helper fits registers |
-| Stacked target-C arguments (`extern "C"`) | 8-byte slots | 8-byte slots on Linux; scalars at natural size and alignment, packed, on macOS | Not reached |
+| Floating-point argument registers | `xmm0`-`xmm7` | `v0`-`v7` | Not reached; the C boundary rejects floats |
+| Argument placement | SysV eightbyte classification | AAPCS64 composite rules, with Apple's amendments on the Darwin row | The same rows |
+| Stack arguments | The row's own argument-area packing | The row's own argument-area packing | Not implemented; every current helper fits registers |
 | Scalar result | `rax` | `x0` | `rax` or `x0`/`w0` |
 | Multi-slot result | Up to six slots in `rax`, `rdx`, `rcx`, `r8`, `r9`, `r10` | Up to eight slots in `x0`-`x7` | No direct aggregate results |
 | Aggregate result storage | Hidden first ordinary slot (`rdi`) | Hidden first ordinary slot (`x0`) | Explicit first out-pointer parameter where required |
-| Aggregate argument order | Logical slots reversed within each value | Logical slots reversed within each value | Natural order; current parameters are scalars and pointers |
+| Aggregate argument order | Ascending memory order, eightbyte by eightbyte | Ascending memory order, eightbyte by eightbyte | The same order |
 | Call-site stack alignment | 16 bytes | 16 bytes | 16 bytes |
 | Red zone use | None | None | None |
 
@@ -97,50 +98,69 @@ indirect-result conventions — through the one lowered signature.
 
 ## Native Rue convention
 
-The convention this section and the matrix above describe is the one
-[ADR-0084](../designs/0084-native-calling-convention.md) replaces: the native
-convention becomes the compilation target's C convention plus a return bank
-wider than C's, so the slot flattening, the reversal, and the
-hidden-first-ordinary-argument sret below all retire. The description here stays
-accurate until that migration's return phase (RUE-2038) lands, and is rewritten
-with it.
+The native `Rue` convention is **the compilation target's C convention with a
+return-register bank wider than C's** ([ADR-0084](../designs/0084-native-calling-convention.md)).
+Its *arguments* are placed by exactly the rules that target's C row places them
+by, computed by `rue_air::lower_native_signature` — the same walk over the same
+placement state `lower_c_signature` runs, differing only in that the return is
+handed in rather than decided. Its *returns* keep the wider bank and the
+hidden-first-ordinary-argument sret described below; the return phase (RUE-2038)
+retires those, and the return rows here are rewritten with it.
 
-The canonical native call planner flattens a source value into logical 8-byte
-slots. Scalars occupy one slot, each aggregate leaf occupies one slot, zero-size
-value parameters occupy none, and `borrow`/`inout` parameters occupy one pointer
-slot. This is a compiler representation, not the target C layout algorithm.
+### Arguments
 
-This logical 8-byte slot flattening is the *call-ABI value decomposition*, which
-ADR-0052 deliberately separates from the *physical memory layout* of a type. The
-call convention is preserved unchanged while memory layout migrates to the
-compact representation (previewed by the `aggregate_layout` feature; the
-canonical native classifier is RUE-976), so the slot counts above stay valid
-even after `@size_of`, field offsets, and stack frames adopt natural byte
-widths. Physical layout alone never certifies that a value can be passed by
-value through this convention.
+Every Rue type is classified by its compact physical layout (ADR-0052) — not
+only `@repr(c)` types, which is a guarantee about layout rather than a
+precondition for classification:
 
-For a multi-slot value, the call planner reverses that value's slots before
-assigning argument locations. The callee reconstructs logical field order. This
-means that even an aggregate small enough to remain in registers is not passed
-like the corresponding C struct. C ABIs instead classify and place aggregates
-according to target layout, padding, and register classes.
+- **x86-64 SysV**: eightbyte classification with the INTEGER and SSE classes. An
+  aggregate of at most sixteen bytes travels in registers of its eightbytes'
+  classified banks; a larger one, or one with a misaligned field, is MEMORY class
+  and travels by value in the outgoing argument area consuming no register.
+- **AAPCS64**: the composite rules, including a homogeneous floating-point
+  aggregate in consecutive floating-point registers, rule C.11's roster
+  exhaustion, and a by-reference caller-owned copy for a composite over sixteen
+  bytes.
+- **Apple arm64**: AAPCS64 with Apple's amendments — a stacked scalar packed at
+  its natural size and alignment, which the callee re-extends into Rue's
+  canonical form on the way in.
+- Narrow integers, `bool`, and pointers take one register each; past the register
+  budget the row's own stack packing applies.
+- **Zero-sized values are omitted** — no register, no stack byte, no pointer —
+  and **`borrow`/`inout` is one pointer**, whatever it points at.
+- Every scalar is held **64-bit-extended** in registers and in the callee's frame
+  slots, which is stronger than any C row requires.
 
-On x86-64, the first six slots use `rdi`, `rsi`, `rdx`, `rcx`, `r8`, and `r9`.
-Remaining slots are pushed in reverse call order so the first overflow slot is
-at `[rbp+16]` in a conventional callee frame, followed by successive 8-byte
-slots. On AArch64, the first eight slots use `x0`-`x7`; overflow slots begin at
-the incoming `sp` and increase by 8 bytes. Both backends maintain 16-byte stack
-alignment at calls.
+A value is held as one canonically extended vreg per scalar leaf. When each leaf
+starts its own eightbyte — `{i64, i64}`, `StrBuf`, a one-field struct, a scalar —
+the leaves *are* the eightbytes and cross as themselves. Otherwise the leaves are
+written into the value's compact memory image and its eightbytes cross, which is
+what packs `{u8, u8, u8, u8}` into one register; the callee lays that image back
+down in its frame and reads the leaves out of it. `NativeImage::direct_leaves`
+is the one predicate that chooses between the two, consulted from both ends.
 
-Native direct aggregate results use logical order, not the argument reversal.
-x86-64 extends the result register set to six slots (`rax`, `rdx`, `rcx`, `r8`,
-`r9`, `r10`), although System V AMD64 supplies at most two integer eightbytes.
-AArch64 extends direct results through `x0`-`x7`, although AAPCS64 integer-like
-composite results are limited to `x0` and `x1` before indirect return is needed.
+### The cleanup convention
+
+Destructors and drop glue are invoked with an aggregate's leaves already
+flattened: the caller has materialized them and the callee walks them as leaves
+rather than reconstructing a value, so each leaf crosses as its own
+register-width argument. That is `NativeArg::PerLeaf`, an explicit arm of the
+same classifier both ends read (`CallPlan::from_slot_values` at the caller,
+`ParamStoragePlan` at the callee), and it is transitional: RUE-2039 collapses the
+remaining convention branches.
+
+### Returns (phase 2 territory)
+
+Native direct aggregate results use logical order. x86-64 extends the result
+register set to six slots (`rax`, `rdx`, `rcx`, `r8`, `r9`, `r10`), although
+System V AMD64 supplies at most two integer eightbytes. AArch64 extends direct
+results through `x0`-`x7`, although AAPCS64 integer-like composite results are
+limited to `x0` and `x1` before indirect return is needed.
 
 `StrBuf` and sufficiently large structs and arrays use native indirect return.
 The caller allocates a 16-byte-aligned buffer and supplies its address as a
-hidden first native slot, shifting user arguments. This differs on both targets:
+hidden first native argument, shifting user arguments. This differs on both
+targets:
 
 - System V AMD64 uses `rdi` for the hidden address and requires the callee to
   return that address in `rax`; native Rue does not promise the `rax` echo.
@@ -208,18 +228,23 @@ That object's body reads the export's `LoweredSignature` in the callee direction
 — the C caller has already put every argument where the lowering says it goes —
 and adapts each value to what the native body expects.
 
-The adaptation is small because the compact memory image of a `@repr(c)`
-aggregate *is* its C object layout, and the native convention's indirect
-transports already move that exact image through memory:
+The adaptation is small because both conventions place arguments by the same
+rules — the native row *is* the target's C row with a wider return bank — and
+because the compact memory image of a `@repr(c)` aggregate is its C object
+layout. The native side is placed by `rue_air::lower_native_signature` against
+the very facts the C side was placed by, so an export naming the target's own
+row moves each argument from where C left it to where the native body expects
+it and that is usually the same place:
 
-- A by-value aggregate the native classifier rules indirect is handed to the body
-  as a pointer to the C caller's own bytes, wherever they are: the saved incoming
+- A value the native convention passes by reference is handed to the body as a
+  pointer to the C caller's own bytes, wherever they are: the saved incoming
   argument registers, the caller's outgoing argument area, or the caller-owned
   copy an AAPCS64 by-reference argument points at. Nothing is repacked.
-- A direct native crossing is marshaled leaf by leaf through the compact image
-  map — each leaf loaded at its physical width through its canonical extension —
-  and a multi-slot value's slots are reversed, which is the native convention's
-  rule.
+- A value whose leaves are its eightbytes is marshaled leaf by leaf through the
+  compact image map, each leaf loaded at its physical width through its canonical
+  extension, in ascending memory order.
+- A value whose leaves pack together crosses as the image's eightbytes, loaded
+  whole.
 - When both directions are indirect, the C caller's indirect-result storage *is*
   the native body's sret storage, so the result is never copied; SysV's `rax`
   echo is then a reload of the saved pointer. When the native body returns in
@@ -288,12 +313,11 @@ It is evidence rather than commentary because it consumes what code generation
 consumes and nothing else: a C boundary's placements come from
 `rue_air::lower_c_signature` through the same `ForeignCallInputs` /
 `ExportSignature` projections the import lowering and the export thunk build,
-and the native side's come from `NativeCallAbi` plus the shared
-`assign_abi_slots` / `ReturnPlan` slot plan. Register *names* are asked of the
+and the native side's come from `rue_air::lower_native_signature` plus the
+`ReturnPlan` the return phase still owns. Register *names* are asked of the
 backend that owns the roster. A `pub extern "C" fn` export prints both halves of
-its crossing, so the work its entry thunk performs — the native convention's
-reversed aggregate slots against C's ascending eightbytes — is visible side by
-side.
+its crossing, so what its entry thunk has left to do — a re-extension per narrow
+scalar, and the return adaptation — is visible side by side.
 
 One thing the stage cannot show is an FFI-predicate failure beside the function
 that caused it: the predicates reject an `extern` or export *signature* while

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -45,9 +45,13 @@ This document describes only the typed C boundary from generated Rue code to
 that is intentionally not C-compatible or stable across compiler revisions.
 [ADR-0084](designs/0084-native-calling-convention.md) is the reference for that
 convention: it stays unspecified and free to change between revisions, and it is
-being migrated to the compilation target's C convention plus a return bank wider
-than C's. The runtime helper boundary below is unaffected — its helpers are C
-calls and already follow the target's C row.
+the compilation target's C convention plus a return bank wider than C's. Its
+*arguments* are already placed by exactly those C rules, computed by
+`rue_air::lower_native_signature` — the same placement walk `lower_c_signature`
+runs, with the return handed in rather than decided, because the native return
+bank is wider than any `CConventionSpec` describes. Its *returns* still classify
+natively, which RUE-2038 finishes. The runtime helper boundary below is
+unaffected — its helpers are C calls and already follow the target's C row.
 
 Both boundaries name their convention with one value type,
 `rue_target::CallingConvention`, whose members are concrete conventions:
@@ -138,14 +142,16 @@ query plane cannot disagree about a placement:
 
 - the `extern "C"` import planner, which writes the places and calls;
 - the `pub extern "C" fn` export thunk, which reads the same places in the
-  callee direction and adapts them to the native convention its body follows;
-  and
+  callee direction and adapts them to the native convention its body follows —
+  itself placed by `lower_native_signature` against the same facts, so the two
+  halves usually agree outright; and
 - the stable query plane's `compiler.call-abi`, which projects the same facts
   from canonical layout values and revision-stable type keys.
 
-Floating-point rosters and the classifier's SSE eightbyte class are carried but
-unreached: the C boundary still rejects `f32`/`f64`, so every eightbyte
-classifies INTEGER and every scalar is general-purpose today.
+The floating-point rosters and the classifier's SSE eightbyte class are reached
+by the *native* convention, which has floats to place; no `"C"` signature reaches
+them, because the C boundary still rejects `f32`/`f64`, so every eightbyte of a C
+crossing classifies INTEGER and every C scalar is general-purpose today.
 
 ## Target C calling conventions
 


### PR DESCRIPTION
Phase 1 of ADR-0084 (RUE-2030 epic): the native caller and callee switch, steps C and D of the RUE-2037 split.

## What the convention now is

Every native Rue call places its arguments through `rue_air::lower_native_signature`, the same walk C calls use, against the target's C row with the hidden result pointer in argument register 0 (phase 1's rule). One `CAbiTypeFacts` per argument in, one placement out. Four sites ask that one walk: the caller (`CallPlan`), the callee prologue (`ParamStoragePlan`), the export thunk (`ThunkPlan`), and `--emit abi`. Returns are untouched; phase 2 (RUE-2038) owns them.

The new `native_abi` module is the single home of the native description and of the directness predicate: an aggregate's leaves travel directly in registers only when every register piece's bank equals the bank of the leaf sitting in it; otherwise the value is written to its compact image and read back as eightbytes. That one rule packs `{u8,u8,u8,u8}` into one register, splits `{f64,i64}` across SSE and GP on SysV while sending it through the image on AAPCS64, and keeps a float-payload enum out of an SSE piece as a bit carrier.

Enums cross through the compact image on both ends, tag-dispatched where RUE-1037 gives one; no transitional arm was needed. Destructors and drop glue keep their per-leaf convention as an explicit internal arm the same classifier answers and the same walk places, pinned by a unit test and visible in `--emit abi`; RUE-2039 owns collapsing it.

The callee plan is shared data between the MIR prologue and the raw-emitter export thunk (`ParamHoming` per piece plus `ParamUnmarshal` per aggregate), with two emit paths. The per-value reversal, the per-leaf native classification, and ADR-0052's memory-first argument rule are deleted.

## What retired

`ArgClass`, `NativeCallAbi::classify_arg`, `native_arg_leaf_classes`, the reversal at both ends, `assign_abi_slots`, `SourceParamAbi`'s per-leaf classes, and x86-64's push-based outgoing sequence (now `sub rsp` plus stores at true area offsets, which the C row requires).

## Evidence

- Twelve new executing cases in `aggregate_abi_matrix.toml` (six shapes, both backends): four `u8` fields in one register, an `{i32,i32}` at the last register and on the stack, `{f64,i64}` split across banks, a 24-byte struct through memory, nine arguments with a narrow tail, and an enum in registers and on the stack.
- The four-site agreement test now covers the native row on both planes, including float-carrying structs and an enum; the stable plane projects real leaves through `CanonicalLayout.leaves`.
- `scripts/rue fmt`, `quick` (36), `spec` (2828), full `cli` (2635 pass, only the two sandbox-environmental failures), `cli aggregate_abi_matrix` (49), `abi` (81), `c_ffi` (50), `drop` (148), `destructor` (63), `enum` (109), `ui emit` (7), `ui abi` (16), the C matrix (400 cells), all oracle-diff targets, `scripts/rue premerge` (219 targets).
- AArch64 evidence is encoding tests, cross-target structural cases, and disassembly review; native execution is CI's to confirm.

Docs: the audit note's argument rows and prose, ADR-0084's phase-1 checkbox, `docs/runtime-abi.md`.

Closes RUE-2063
Closes RUE-2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_