### PR TITLE
RUE-2049: gate the Copy-assuming std generics at their entry points

### DIFF
--- a/crates/rue-ui-tests/cases/diagnostics/std_element_gates.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/std_element_gates.toml
@@ -1,0 +1,696 @@
+[section]
+id = "diagnostics.std-element-gates"
+name = "std Copy-element gates (E0711)"
+description = """
+Several std generics read their element by copy, or duplicate a `filler` into
+every slot, and so require a Copy element type. Until RUE-2049 most of them
+stated that only in a comment, and a non-Copy instantiation failed several
+frames deep inside std with an unrelated error: `std.sort.quicksort(StrBuf, ..)`
+reported E0206 "expected integer type" against a `get_or(hi, 0)` default in
+`std/sort.rue`, and `Deque(StrBuf).new(fill)` reported E0437 "cannot move out of
+inout parameter `self`" against the filler copy in `_grow_to`.
+
+Rue has no intrinsic that gates on Copy, so each of those entry points now
+states the half it can as its FIRST statement — `@require_trivially_droppable`
+(E0711), the same gate `ArrayBuf.get`/`get_or` and `Grid2D.new` already carried.
+An owning element type is named at the entry point instead of surfacing as an
+unrelated error deeper in std. The gate line belongs to the library, not the
+caller, so each `e0711_` case pins the user-call anchor (RUE-2026): the primary
+span is the caller's own `test.rue` line and the gate keeps the labelled
+secondary span "the element type is required to be trivially droppable here".
+
+The gate covers the drop-glue half of Copy only. A struct that is not marked
+`@copy` has no drop glue, so it passes the gate, and what happens next depends
+on the container (RUE-2028): `Stack.peek`, `Queue.peek` and `Queue.dequeue`
+copy it bitwise with no diagnostic at all, `sort` and `BinaryHeap` reject it
+with E0206 against the `<` that orders it, the filler-duplicating constructors
+reject it with E0437 at the filler copy, and only `Grid2D` reaches E0205 — the
+residual gap `trivially_droppable_gate.toml` pins. Marking such a struct
+`@copy` is the fix in every case.
+
+The last group here pins the operations deliberately left UNGATED, which must
+keep working for an owning element type: `Stack`/`Queue` push, pop and
+`peek_ref`, and `ArrayBuf.swap`/`reverse`, which exchange slots rather than
+duplicating them.
+"""
+
+# --- std.sort: all four public entry points ---
+
+[[case]]
+name = "e0711_sort_quicksort_owning_element_rejected"
+description = "`quicksort` names the owning element type at its own gate instead of reporting E0206 against a `get_or` integer default inside std/sort.rue."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut v = A.new();
+    std.sort.quicksort(StrBuf, inout v);
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "e0711_sort_insertion_sort_owning_element_rejected"
+description = "`insertion_sort` carries the same gate."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut v = A.new();
+    std.sort.insertion_sort(StrBuf, inout v);
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "e0711_sort_is_sorted_owning_element_rejected"
+description = "`is_sorted` reads both comparison operands by copy and carries the same gate."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut v = A.new();
+    let ok = std.sort.is_sorted(StrBuf, borrow v);
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "e0711_sort_binary_search_owning_element_rejected"
+description = "`binary_search` is gated too, in place of the E0205 moved-value error its `target` default used to raise."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut v = A.new();
+    let hit = std.sort.binary_search(StrBuf, borrow v, "needle");
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "sort_copy_element_compiles"
+description = "The Copy control: sorting, ordering check and search over `i64` still compile and run."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(i64);
+    let O = std.option.Option(u64);
+    let mut v = A.new();
+    v.push(5); v.push(1); v.push(4); v.push(1); v.push(5); v.push(9); v.push(2); v.push(6);
+    std.sort.quicksort(i64, inout v);
+    if !std.sort.is_sorted(i64, borrow v) {
+        return 90;
+    }
+    let mut w = A.new();
+    w.push(3); w.push(1); w.push(2);
+    std.sort.insertion_sort(i64, inout w);
+    if !std.sort.is_sorted(i64, borrow w) {
+        return 91;
+    }
+    match std.sort.binary_search(i64, borrow v, 6) { O.Some(i) => @intCast(i), O.None => 99 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 6
+
+[[case]]
+name = "sort_float_element_compiles"
+description = "`std.sort` no longer assumes an INTEGER element: the reads go through `ArrayBuf.get` rather than an `get_or(i, 0)` integer default, so a float buffer sorts."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(f64);
+    let mut v = A.new();
+    v.push(3.5); v.push(1.25); v.push(2.75);
+    std.sort.quicksort(f64, inout v);
+    if std.sort.is_sorted(f64, borrow v) { 7 } else { 0 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 7
+
+# --- std.arraybuf: the searching reads that were missing a gate ---
+
+[[case]]
+name = "e0711_arraybuf_index_of_owning_element_rejected"
+description = "`ArrayBuf.index_of` compares a by-copy read with `==`; before RUE-2049 it was ungated and ran the element's drop glue once per comparison AND again with the buffer — a double drop."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut v = A.new();
+    let needle: StrBuf = "a";
+    let hit = v.index_of(needle);
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:8:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "e0711_arraybuf_contains_owning_element_rejected"
+description = "`contains` repeats the gate so the error names this call rather than one inside `index_of`."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut v = A.new();
+    let needle: StrBuf = "a";
+    let hit = v.contains(needle);
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:8:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "arraybuf_search_copy_element_compiles"
+description = "The Copy control for the searching reads."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(i64);
+    let O = std.option.Option(u64);
+    let mut v = A.new();
+    v.push(10); v.push(20); v.push(30);
+    let at = match v.index_of(30) { O.Some(i) => @intCast(i), O.None => 99 };
+    if v.contains(20) { at + 40 } else { 0 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 42
+
+# --- filler-duplicating representations: the constructor is the gate ---
+
+[[case]]
+name = "e0711_deque_owning_element_rejected_at_new"
+description = "`Deque.new(filler)` copies the filler into every ring slot, so the whole representation is Copy-only; the gate replaces E0437 against `self.filler` inside `_grow_to`."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let D = std.deque.Deque(StrBuf);
+    let mut d = D.new("filler");
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:6:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "deque_copy_element_compiles"
+description = "The Copy control for `Deque`."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let D = std.deque.Deque(i64);
+    let O = std.option.Option(i64);
+    let mut d = D.new(0);
+    d.push_back(2);
+    d.push_front(1);
+    let a = match d.pop_front() { O.Some(x) => @intCast(x), O.None => 0 };
+    let b = match d.pop_back() { O.Some(x) => @intCast(x), O.None => 0 };
+    a * 10 + b
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 12
+
+[[case]]
+name = "e0711_intmap_owning_value_rejected_at_new"
+description = "`IntMap.new(filler)` fills a fresh table with the filler on every rehash, so the value type is gated at the constructor."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let M = std.intmap.IntMap(StrBuf);
+    let mut m = M.new("filler");
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:6:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "intmap_copy_value_compiles"
+description = "The Copy control for `IntMap`."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let M = std.intmap.IntMap(i64);
+    let O = std.option.Option(i64);
+    let mut m = M.new(0);
+    m.insert(42, 7);
+    match m.get(42) { O.Some(v) => @intCast(v), O.None => 0 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 7
+
+[[case]]
+name = "e0711_strmap_owning_value_rejected_at_new"
+description = "`StrMap` gates its VALUE type the same way; its `StrBuf` keys are pooled by the module itself and are unaffected."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let M = std.strmap.StrMap(StrBuf);
+    let mut m = M.new("filler");
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:6:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "strmap_copy_value_compiles"
+description = "The Copy control for `StrMap`: an owning key with a Copy value is still fine."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let M = std.strmap.StrMap(u64);
+    let O = std.option.Option(u64);
+    let mut m = M.new(0);
+    let k: StrBuf = "hello";
+    m.insert(borrow k, 11);
+    match m.get(borrow k) { O.Some(v) => @intCast(v), O.None => 0 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 11
+
+# --- by-copy readers on the ArrayBuf-backed adapters ---
+
+[[case]]
+name = "e0711_queue_dequeue_owning_element_rejected"
+description = "`Queue.dequeue` leaves the head slot live and takes the element by copy, so it is gated; `peek_ref` and a moving drain stay available."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let Q = std.queue.Queue(StrBuf);
+    let mut q = Q.new();
+    let front = q.dequeue();
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "e0711_queue_peek_owning_element_rejected"
+description = "`Queue.peek` is gated at the queue rather than reporting from `ArrayBuf.get` a frame deeper."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let Q = std.queue.Queue(StrBuf);
+    let mut q = Q.new();
+    let front = q.peek();
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "queue_copy_element_compiles"
+description = "The Copy control for `Queue`."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let Q = std.queue.Queue(i64);
+    let O = std.option.Option(i64);
+    let mut q = Q.new();
+    q.enqueue(3); q.enqueue(4);
+    let p = match q.peek() { O.Some(x) => @intCast(x), O.None => 0 };
+    let d = match q.dequeue() { O.Some(x) => @intCast(x), O.None => 0 };
+    p * 10 + d
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 33
+
+[[case]]
+name = "e0711_stack_peek_owning_element_rejected"
+description = "`Stack.peek` is the only Copy-only operation on `Stack`; it is gated at the stack."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let S = std.stack.Stack(StrBuf);
+    let mut s = S.new();
+    let top = s.peek();
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "stack_copy_element_compiles"
+description = "The Copy control for `Stack`."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let S = std.stack.Stack(i64);
+    let O = std.option.Option(i64);
+    let mut s = S.new();
+    s.push(1); s.push(2);
+    let p = match s.peek() { O.Some(x) => @intCast(x), O.None => 0 };
+    let q = match s.pop() { O.Some(x) => @intCast(x), O.None => 0 };
+    p * 10 + q
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 22
+
+# --- binary heaps: every sifting entry point ---
+
+[[case]]
+name = "e0711_binary_heap_push_owning_element_rejected"
+description = "`BinaryHeap.push` sifts up through by-copy comparisons; the gate replaces E0206 against `a < b` inside `_less`."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let H = std.binary_heap.BinaryHeap(StrBuf);
+    let mut h = H.new();
+    h.push("a");
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "e0711_binary_heap_pop_owning_element_rejected"
+description = "`BinaryHeap.pop` sifts down and is gated the same way."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let H = std.binary_heap.BinaryHeap(StrBuf);
+    let mut h = H.new();
+    let smallest = h.pop();
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "e0711_binary_heap_peek_owning_element_rejected"
+description = "`BinaryHeap.peek` reads the root by copy."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let H = std.binary_heap.BinaryHeap(StrBuf);
+    let mut h = H.new();
+    let smallest = h.peek();
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "binary_heap_copy_element_compiles"
+description = "The Copy control for `BinaryHeap`."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let H = std.binary_heap.BinaryHeap(i64);
+    let O = std.option.Option(i64);
+    let mut h = H.new();
+    h.push(5); h.push(1); h.push(3);
+    let p = match h.peek() { O.Some(x) => @intCast(x), O.None => 0 };
+    let q = match h.pop() { O.Some(x) => @intCast(x), O.None => 0 };
+    p * 10 + q
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 11
+
+[[case]]
+name = "e0711_priority_queue_owning_payload_rejected"
+description = "`PriorityQueue` gates `P` and `V` separately, so an owning PAYLOAD is named as `StrBuf` rather than folded into `Pair(i64, StrBuf)`."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let PQ = std.binary_heap.PriorityQueue(i64, StrBuf);
+    let mut q = PQ.new();
+    q.push(1, "payload");
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "`StrBuf`",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "priority_queue_copy_types_compile"
+description = "The Copy control for `PriorityQueue`: the smallest priority's payload comes back first."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let PQ = std.binary_heap.PriorityQueue(i64, i64);
+    let Item = std.tuple.Pair(i64, i64);
+    let O = std.option.Option(Item);
+    let mut q = PQ.new();
+    q.push(5, 50);
+    q.push(1, 10);
+    match q.pop() { O.Some(it) => @intCast(it.second), O.None => 0 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 10
+
+# --- deliberately UNGATED: operations that never duplicate an element ---
+
+[[case]]
+name = "stack_of_owning_elements_stays_ungated"
+description = "`Stack` push/pop/`peek_ref` never duplicate an element, so a stack of `StrBuf` keeps working (RUE-646) — the gate is on `peek` alone."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let S = std.stack.Stack(StrBuf);
+    let O = std.option.Option(StrBuf);
+    let mut s = S.new();
+    let a: StrBuf = "alpha";
+    s.push(a);
+    let n: u64 = s.peek_ref().len();
+    match s.pop() { O.Some(v) => @intCast(n), O.None => 0 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 5
+
+[[case]]
+name = "queue_of_owning_elements_stays_ungated"
+description = "`Queue` enqueue and `peek_ref` are ungated for the same reason."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let Q = std.queue.Queue(StrBuf);
+    let mut q = Q.new();
+    let a: StrBuf = "abcd";
+    q.enqueue(a);
+    @intCast(q.peek_ref().len())
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 4
+
+[[case]]
+name = "arraybuf_swap_and_reverse_of_owning_elements_stay_ungated"
+description = "`ArrayBuf.swap` writes each slot's value into the OTHER slot, an exchange of ownership rather than a copy, so it and `reverse` stay ungated and sound for an owning element type."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut v = A.new();
+    let a: StrBuf = "aa";
+    let b: StrBuf = "bbb";
+    v.push(a); v.push(b);
+    v.swap(0, 1);
+    v.reverse();
+    @intCast(v.get_ref(1).len())
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 3

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -70,9 +70,13 @@
 //     drop-glue `T` is a compile error (E0711, via `@require_trivially_droppable`
 //     in their bodies) that directs you to `get_ref` for a read, or `pop` to move
 //     it out. This is exactly Swift's rule
-//     that a non-copyable element cannot use a by-value `get` subscript. Storing,
+//     that a non-copyable element cannot use a by-value `get` subscript. The
+//     searching reads `index_of`/`contains` compare a by-copy read with `==`
+//     and carry the same gate (RUE-2049). Storing,
 //     pushing, popping, and dropping a drop-glue element stay legal (RUE-646) —
-//     only the by-copy *read* is gated. Lifting that to borrow-returning reads
+//     only the by-copy *read* is gated; `swap`/`reverse` exchange slots rather
+//     than duplicating them, so they stay ungated and work for any `T`.
+//     Lifting the gated reads to borrow-returning reads
 //     (a projection/yield accessor, Hylo-style) is now `get_ref` (RUE-1017).
 //   * Multi-slot aggregate element types (e.g. a two-field struct) work as long
 //     as they are trivially droppable: every aggregate is laid out
@@ -310,9 +314,13 @@ pub fn ArrayBuf(comptime T: type) -> type {
 
         // --- extra operations (Standard library v1, RUE-673) ---
 
-        // Exchange the elements at `i` and `j` (both must be in bounds). Uses a
-        // by-copy read of each slot, so this is for trivially-droppable (`Copy`)
-        // `T` (RUE-651); a swap of owned elements would need in-place borrows.
+        // Exchange the elements at `i` and `j` (both must be in bounds). Each
+        // slot's value is read out and then written back into the OTHER slot,
+        // so every element still has exactly one owner and neither read leaves
+        // an aliasing duplicate behind: unlike `get`/`get_or` this is an
+        // exchange of ownership, not a copy, and it is ungated and sound for a
+        // drop-glue `T` (RUE-2049). The writes deliberately bypass `set`, which
+        // would drop the value the other read already moved out.
         fn swap(inout self, i: u64, j: u64) {
             if i < self.len && j < self.len && i != j {
                 let a = self.core.read_at(i);
@@ -322,7 +330,8 @@ pub fn ArrayBuf(comptime T: type) -> type {
             }
         }
 
-        // Reverse the elements in place. COPY-`T` (uses `swap`).
+        // Reverse the elements in place. Sound for any `T`: it only exchanges
+        // slots through `swap`, never duplicating an element.
         fn reverse(inout self) {
             if self.len > 1 {
                 let mut i: u64 = 0;
@@ -348,9 +357,15 @@ pub fn ArrayBuf(comptime T: type) -> type {
             }
         }
 
-        // Index of the first element equal to `x`, or `None`. COPY-`T` ONLY
-        // (compares by-copy reads with `==`).
+        // Index of the first element equal to `x`, or `None`. COPY-`T` ONLY:
+        // each candidate is read out by copy to compare it with `==`, and that
+        // copy aliases the still-live slot, so a drop-glue element would run
+        // its destructor once per comparison and again when the buffer is
+        // dropped — a double-free (RUE-651). The gate is stated first, so an
+        // owning element type is named here rather than silently miscompiled
+        // (RUE-2049); it was missing while `get`/`get_or` carried theirs.
         fn index_of(borrow self, x: T) -> option.Option(u64) {
+            @require_trivially_droppable(T);
             let O = option.Option(u64);
             let mut i: u64 = 0;
             while i < self.len {
@@ -363,8 +378,11 @@ pub fn ArrayBuf(comptime T: type) -> type {
             O.None
         }
 
-        // Whether any element equals `x`. COPY-`T` ONLY.
+        // Whether any element equals `x`. COPY-`T` ONLY, for `index_of`'s
+        // reason; the gate is repeated here so the error names this call rather
+        // than one inside `index_of`.
         fn contains(borrow self, x: T) -> bool {
+            @require_trivially_droppable(T);
             let O = option.Option(u64);
             match self.index_of(x) {
                 O.Some(i) => true,

--- a/std/binary_heap.rue
+++ b/std/binary_heap.rue
@@ -2,9 +2,26 @@
 // ArrayBuf(T), and PriorityQueue(P, V): a min-heap keyed by an integer priority
 // `P` carrying a payload `V`.
 //
-// Both read elements by copy while sifting, so they are for trivially-droppable
-// (`Copy`) element/payload types (RUE-651). A custom-comparator heap is the M4
-// follow-up (needs function values, RUE-643).
+// COPY-ELEMENT-ONLY. Every sift compares two elements read out of the buffer by
+// copy (`_less` uses the by-copy `ArrayBuf.get`), so an element that stays live
+// in its slot is duplicated rather than consumed — what a Copy type does
+// (3.8:1). Reading a drop-glue element that way would alias its owned buffer
+// and double-free at scope exit (RUE-651).
+//
+// Rue has no intrinsic that gates on Copy, so `push`, `pop` and `peek` — every
+// entry point that sifts or reads — state the half they can as their FIRST
+// statement: `@require_trivially_droppable` (E0711) rejects an owning element
+// type and names it, instead of the E0206 the `a < b` comparison inside `_less`
+// used to raise several frames deeper (RUE-2049). `PriorityQueue` gates `P` and
+// `V` separately so the message names the offending half rather than the
+// enclosing `Pair(P, V)`. The gate covers the drop-glue half only: a
+// `@copy`-less struct has no drop glue and passes it, because the language has
+// no Copy gate (RUE-2028) — but such a struct has no `<` either, so the sift
+// still rejects it with E0206 against the `a < b` inside `_less`, and it cannot
+// be heap-ordered in any case.
+//
+// `new`, `len` and `is_empty` never read an element, so they stay ungated. A
+// custom-comparator heap is the M4 follow-up (needs function values, RUE-643).
 //
 //     const std = @import("std");
 //     let H = std.binary_heap.BinaryHeap(i64);
@@ -72,8 +89,10 @@ pub fn BinaryHeap(comptime T: type) -> type {
             }
         }
 
-        // Insert `x`.
+        // Insert `x`. COPY-`T` ONLY (the sift-up compares by-copy reads).
         fn push(inout self, x: T) {
+            // Gated first, so an owning `T` is named here (module header).
+            @require_trivially_droppable(T);
             self.data.push(x);
             let mut i = self.data.len() - 1;
             while i > 0 {
@@ -89,11 +108,16 @@ pub fn BinaryHeap(comptime T: type) -> type {
 
         // The smallest element by copy, or `None`. COPY-`T` ONLY.
         fn peek(borrow self) -> option.Option(T) {
+            // Gated first, so an owning `T` is named here (module header).
+            @require_trivially_droppable(T);
             self.data.get(0)
         }
 
         // Remove and return the smallest element, or `None` when empty.
+        // COPY-`T` ONLY (the sift-down compares by-copy reads).
         fn pop(inout self) -> option.Option(T) {
+            // Gated first, so an owning `T` is named here (module header).
+            @require_trivially_droppable(T);
             let O = option.Option(T);
             let n = self.data.len();
             if n == 0 {
@@ -111,8 +135,12 @@ pub fn BinaryHeap(comptime T: type) -> type {
 }
 
 // A min-priority queue: a `BinaryHeap` of `(priority, payload)` pairs ordered by
-// priority. `P` and `V` must be `Copy` (RUE-651). `pop` returns the whole
-// `Pair(P, V)` — read `.first` (priority) and `.second` (payload).
+// priority. COPY-ONLY in both parameters, for `BinaryHeap`'s reason: sifting
+// compares `Pair(P, V)` values read out of the buffer by copy (RUE-651).
+// `push`/`pop` gate `P` and `V` separately as their first statements, so an
+// owning payload is named as `V` rather than folded into `Pair(P, V)`
+// (RUE-2049). `pop` returns the whole `Pair(P, V)` — read `.first` (priority)
+// and `.second` (payload).
 pub fn PriorityQueue(comptime P: type, comptime V: type) -> type {
     let Item = tuple.Pair(P, V);
     let Buf = arraybuf.ArrayBuf(Item);
@@ -171,6 +199,10 @@ pub fn PriorityQueue(comptime P: type, comptime V: type) -> type {
 
         // Insert `payload` with priority `prio`.
         fn push(inout self, prio: P, payload: V) {
+            // Gated first and per parameter, so the offending half is the one
+            // named rather than the enclosing `Pair(P, V)` (module header).
+            @require_trivially_droppable(P);
+            @require_trivially_droppable(V);
             let it = Item.new(prio, payload);
             self.data.push(it);
             let mut i = self.data.len() - 1;
@@ -187,6 +219,10 @@ pub fn PriorityQueue(comptime P: type, comptime V: type) -> type {
 
         // Remove and return the min-priority `(priority, payload)` pair.
         fn pop(inout self) -> option.Option(Item) {
+            // Gated first and per parameter, so the offending half is the one
+            // named rather than the enclosing `Pair(P, V)` (module header).
+            @require_trivially_droppable(P);
+            @require_trivially_droppable(V);
             let O = option.Option(Item);
             let n = self.data.len();
             if n == 0 {

--- a/std/bitset.rue
+++ b/std/bitset.rue
@@ -8,6 +8,10 @@
 //     bs.set(5);
 //     bs.test(5);      // true
 //     bs.count();      // 1
+//
+// Not generic in an element type: the backing store is a fixed `ArrayBuf(u64)`
+// of words and the API speaks in bit indices, so there is no element type to
+// gate (RUE-2049). Its by-copy word reads are always `u64` reads.
 
 const arraybuf = @import("arraybuf.rue");
 

--- a/std/cmp.rue
+++ b/std/cmp.rue
@@ -1,13 +1,25 @@
 // std.cmp — ordering and comparison utilities.
 //
 // Comparison and the min/max/clamp helpers are generic over any type whose
-// values support the built-in relational operators (`<`, `>`, `==`) — every
-// integer type today. `Ordering` is the three-way comparison result.
+// values support the built-in relational operators (`<`, `>`, `==`) — the
+// integer and floating-point types today. `Ordering` is the three-way
+// comparison result.
 //
 //     const std = @import("std");
 //     let o = std.cmp.cmp(i64, 3, 7);        // Ordering.Less
 //     let m = std.cmp.min(i64, 3, 7);        // 3
 //     let c = std.cmp.clamp(i64, 12, 0, 9);  // 9
+//
+// UNGATED ON PURPOSE. These take their operands BY VALUE and return one of
+// them, so nothing here duplicates a value: an argument that is not returned is
+// simply dropped, and even an owning `T` would be sound. The real restriction
+// is the operator — `<`/`>`/`==` are defined for integers and floats only — and
+// Rue has no intrinsic that expresses "orderable". The drop-glue gate the
+// containers use is neither necessary nor sufficient for that (RUE-2049), so
+// there is none here. Calling one of these with, say, a `StrBuf` still reports
+// the operator mismatch (E0206, "expected integer or floating-point type")
+// against the comparison in this file. Gating that honestly needs traits
+// (RUE-246); until then this comment is the contract.
 
 // The result of a three-way comparison.
 pub enum Ordering {

--- a/std/deque.rue
+++ b/std/deque.rue
@@ -1,9 +1,23 @@
 // std.collections — Deque(T): a growable double-ended queue over a ring buffer.
 //
-// Elements are read by copy (get_or), so `T` must be trivially-droppable
-// (`Copy`) — RUE-651. `new(filler)` takes a throwaway `T` used to initialise the
-// unused ring slots (Rue has no generic zero-init, same convention as IntMap);
-// it is never read as a live value (the `count` guards that).
+// COPY-`T` ONLY. The ring itself duplicates elements: `new(filler)` takes one
+// throwaway `T` and `_grow_to` pushes it into every unused slot (Rue has no
+// generic zero-init, the same convention IntMap and StrMap use), and every
+// read — `front`, `back`, `pop_front`, `pop_back` — goes through the by-copy
+// `ArrayBuf.get_or`. Duplicating a value rather than consuming it is what a
+// Copy type does (3.8:1); the filler is never read as a live element (`count`
+// guards that), but it is still copied per slot.
+//
+// Rue has no intrinsic that gates on Copy, so `new` — the only constructor, so
+// the only way to reach any of the above — states the half it can as its FIRST
+// statement: `@require_trivially_droppable(T)` (E0711) rejects a `T` with drop
+// glue and names it, instead of the E0437 "cannot move out of inout parameter
+// `self`" that copying `self.filler` inside `_grow_to` used to raise several
+// frames deeper (RUE-2049). The gate covers the drop-glue half only: a
+// move-only `T` with no drop glue is exactly a struct not marked `@copy`
+// (3.8:3), and it passes the gate and then fails at the filler copy, because
+// the language has no Copy gate (RUE-2028). Marking such a struct `@copy` is
+// the fix.
 //
 // Deque intentionally has no `front_ref`/`back_ref` yet (RUE-1017): growth
 // rebuilds the ring by copying from a filler-populated buffer. The current
@@ -30,7 +44,14 @@ pub fn Deque(comptime T: type) -> type {
         cap: u64,
         filler: T,
 
+        // COPY-`T` ONLY: the gate is stated ahead of everything else so an
+        // owning element type is named at this call rather than reported from
+        // the filler copy inside `_grow_to` (RUE-2049). Gating the constructor
+        // rather than the individual readers is right here because the
+        // REPRESENTATION duplicates elements — there is no way to hold a
+        // non-Copy `T` in a `Deque` at all.
         fn new(filler: T) -> Self {
+            @require_trivially_droppable(T);
             let b = arraybuf.ArrayBuf(T);
             let mut d = Self {
                 buf: b.new(),

--- a/std/intmap.rue
+++ b/std/intmap.rue
@@ -3,9 +3,23 @@
 // (M4) needs function values / traits (RUE-643/RUE-246); this covers the common
 // integer-keyed case now.
 //
-// `new(filler)` takes a throwaway `V` used to initialise empty value slots (Rue
-// has no generic zero-init); it is never read as a real value — the per-slot
-// state guards that.
+// COPY-`V` ONLY. The table duplicates values: `new(filler)` takes one throwaway
+// `V` and `_grow_to` pushes it into every slot of a fresh table (Rue has no
+// generic zero-init; it is never read as a real value — the per-slot state
+// guards that), and every read goes through the by-copy `ArrayBuf.get_or`.
+// Duplicating a value rather than consuming it is what a Copy type does
+// (3.8:1).
+//
+// Rue has no intrinsic that gates on Copy, so `new` — the only constructor, so
+// the only way to reach any of the above — states the half it can as its FIRST
+// statement: `@require_trivially_droppable(V)` (E0711) rejects a `V` with drop
+// glue and names it, instead of the E0437 "cannot move out of inout parameter
+// `self`" that copying `self.filler` inside `_grow_to` used to raise several
+// frames deeper (RUE-2049). The gate covers the drop-glue half only: a
+// move-only `V` with no drop glue is exactly a struct not marked `@copy`
+// (3.8:3), and it passes the gate and then fails at the filler copy, because
+// the language has no Copy gate (RUE-2028). Marking such a struct `@copy` is
+// the fix.
 //
 // IntMap intentionally has no `get_ref` yet (RUE-1017): values live in a
 // filler-populated parallel array and rehashing copies occupied entries into a
@@ -47,7 +61,7 @@ fn _TOMBSTONE() -> u8 {
 // rather than `(0 - k) - 1` — `k + 1` is in range even at `i64::MIN`, so the
 // subtraction never overflows and the result @intCasts cleanly. `~` is a
 // bitwise op and never traps. (Same shape as `fs._i64_bits`, which rebuilds a
-// seek offset; that one still negates first and so keeps the MIN hole.)
+// seek offset and now spells the magnitude the same way.)
 fn _key_bits(k: i64) -> u64 {
     if k >= 0 {
         @intCast(k)
@@ -84,7 +98,13 @@ pub fn IntMap(comptime V: type) -> type {
         cap: u64,
         filler: V,
 
+        // COPY-`V` ONLY: the gate is stated ahead of everything else so an
+        // owning value type is named at this call rather than reported from the
+        // filler copy inside `_grow_to` (RUE-2049). The REPRESENTATION
+        // duplicates values, so the constructor is the right place — there is
+        // no way to hold a non-Copy `V` in an `IntMap` at all.
         fn new(filler: V) -> Self {
+            @require_trivially_droppable(V);
             let kb = arraybuf.ArrayBuf(i64);
             let vb = arraybuf.ArrayBuf(V);
             let sb = arraybuf.ArrayBuf(u8);

--- a/std/math.rue
+++ b/std/math.rue
@@ -16,6 +16,16 @@
 // NOTE: calling a generic (`comptime T`) helper here from another module with a
 // bare integer literal currently fails to coerce the literal (RUE-693); bind a
 // typed local until that lands.
+//
+// UNGATED ON PURPOSE, like `std.cmp`. Every generic helper here takes its
+// operands by value and returns a computed value, so nothing duplicates an
+// argument; the restriction is arithmetic, not ownership — `T` has to be an
+// integer type (or, in the float section, `f32`/`f64`). Rue has no intrinsic
+// that expresses that, and `@require_trivially_droppable` would state the wrong
+// thing: it is neither necessary nor sufficient for "is an integer" (RUE-2049).
+// A non-numeric `T` therefore still reports the operator mismatch (E0206,
+// "expected integer type") against the arithmetic in this file. An honest gate
+// needs traits (RUE-246).
 
 const option = @import("option.rue");
 

--- a/std/queue.rue
+++ b/std/queue.rue
@@ -1,8 +1,22 @@
 // std.collections — Queue(T): a FIFO queue over ArrayBuf.
 //
 // Implemented as a growing buffer with a front cursor (`enqueue` pushes at the
-// back, `dequeue` advances a head index). `dequeue`/`peek` read the front
-// element by copy, so they are for trivially-droppable (`Copy`) `T` (RUE-651).
+// back, `dequeue` advances a head index).
+//
+// `dequeue`/`peek` read the front element BY COPY, so `T` must be a Copy type
+// for those two: the copy would otherwise alias a still-live owned element and
+// double-free it at scope exit (RUE-651). Both state the half Rue can gate as
+// their FIRST statement — `@require_trivially_droppable(T)` (E0711), which
+// rejects a `T` with drop glue and names it at the call instead of reporting it
+// from `ArrayBuf.get` a frame deeper (RUE-2049). The gate covers the drop-glue
+// half only; a `@copy`-less struct has no drop glue, so it passes the gate and
+// both reads copy it bitwise with no diagnostic at all until the language has a
+// Copy gate (RUE-2028). Marking such a struct `@copy` is the fix.
+//
+// `new`, `enqueue`, `len`, `is_empty` and the borrowing `peek_ref` never
+// duplicate an element, so they are ungated and work for any `T` (RUE-646) — a
+// queue of owning values is legal as long as you read it with `peek_ref` and
+// drain it by moving elements out.
 //
 // NOTE (v1): consumed slots at the front are not reclaimed until the queue
 // empties — the head cursor only advances. A compacting/circular variant is a
@@ -40,8 +54,12 @@ pub fn Queue(comptime T: type) -> type {
             self.buf.push(x);
         }
 
-        // Remove and return the front element, or `None` when empty. COPY-`T`.
+        // Remove and return the front element, or `None` when empty. COPY-`T`
+        // ONLY: the head slot stays live (the cursor only advances), so the
+        // element leaves by copy rather than by move. The gate is stated first
+        // so an owning `T` is named here (RUE-2049).
         fn dequeue(inout self) -> option.Option(T) {
+            @require_trivially_droppable(T);
             let O = option.Option(T);
             if self.head >= self.buf.len() {
                 O.None
@@ -57,8 +75,10 @@ pub fn Queue(comptime T: type) -> type {
             }
         }
 
-        // The front element by copy, or `None`. COPY-`T` ONLY.
+        // The front element by copy, or `None`. COPY-`T` ONLY; use `peek_ref`
+        // to read an owning element in place.
         fn peek(borrow self) -> option.Option(T) {
+            @require_trivially_droppable(T);
             let O = option.Option(T);
             if self.head >= self.buf.len() {
                 O.None

--- a/std/sort.rue
+++ b/std/sort.rue
@@ -14,43 +14,67 @@
 //     std.sort.quicksort(i64, inout v);
 //     let hit = std.sort.binary_search(i64, v, target);   // Option(u64)
 //
-// COPY-ELEMENT-ONLY. Every element access here is a by-copy read
-// (`ArrayBuf.get_or`), which the container gates to trivially-droppable element
-// types (E0711, RUE-651): reading a drop-glue element out by copy while its
-// slot stays live would alias its owned buffer (double-free). So these routines
-// are for `Copy` element types — integers and other trivially-droppable
-// scalars/aggregates. Sorting owned (drop-glue) elements needs a
-// borrow-returning element accessor (the RUE-651 follow-up); it is out of scope
-// here. The unused out-of-bounds defaults passed to `get_or` are integer `0`
-// literals, so the element type must additionally admit `0` as a value; for
-// `binary_search` the default is `target`, so it is generic over any `Copy` `T`.
+// COPY-`T` ONLY. Every comparison reads its two operands out of the buffer by
+// copy while the slots stay live, so a use of an element duplicates it rather
+// than consuming it — that is what a Copy type does (3.8:1). Ordering also
+// needs the built-in `<`, which restricts `T` further to an integer or
+// floating-point type; that half is not expressible as a gate, the same gap
+// `std.cmp` and `std.math` document.
+//
+// Rue has no intrinsic that gates on Copy, so each public entry point states
+// the half it can as its FIRST statement: `@require_trivially_droppable(T)`
+// (E0711) rejects a `T` with drop glue — an owning element such as `StrBuf`, or
+// a struct with a `drop fn` — and names that element type, instead of the
+// E0206/E0205 a comparison or a by-copy read would raise several frames deeper
+// inside this module (RUE-2049). A by-copy read of a drop-glue element while
+// its slot stays live would alias the element's owned buffer and double-free at
+// scope exit (RUE-651); sorting owned elements needs an ordering that reads
+// through `get_ref` borrows and is out of scope here.
+//
+// The gate covers the drop-glue half only. A move-only `T` with no drop glue is
+// exactly a struct not marked `@copy` (3.8:3, 3.8:19): it passes the gate,
+// because the language has no Copy gate (RUE-2028). Such a struct has no `<`
+// either, so the comparison still rejects it with E0206 and it is not sortable
+// in any case.
+//
+// Element reads go through `_at`, which reads via `ArrayBuf.get` and traps on
+// an out-of-bounds index, and exchanges go through `ArrayBuf.swap`, which moves
+// both slots rather than duplicating them. Neither needs an out-of-bounds
+// default value, so nothing here assumes `T` admits the literal `0` — the
+// integer-only restriction the earlier `get_or(i, 0)` reads carried.
 
 const arraybuf = @import("arraybuf.rue");
-const mem = @import("mem.rue");
 const option = @import("option.rue");
 
-// Exchange elements `i` and `j` (both assumed in bounds). Routes the exchange
-// through `std.mem.swap` on two typed locals, then writes them back.
-fn swap_at(comptime T: type, inout xs: arraybuf.ArrayBuf(T), i: u64, j: u64) {
-    let mut a = xs.get_or(i, 0);
-    let mut b = xs.get_or(j, 0);
-    mem.swap(T, inout a, inout b);
-    xs.set(i, a);
-    xs.set(j, b);
+// Element `i`, which every caller here has already proved in bounds. Reading
+// through `ArrayBuf.get` and trapping on `None` keeps the read generic over
+// every Copy `T`. The `get_or(i, 0)` reads this replaced needed an
+// out-of-bounds default, and the literal `0` narrowed the contract to element
+// types that admit it — integers, silently (RUE-2049). The by-copy gate itself
+// lives in `ArrayBuf.get`.
+fn _at(comptime T: type, borrow xs: arraybuf.ArrayBuf(T), i: u64) -> T {
+    let O = option.Option(T);
+    match xs.get(i) {
+        O.Some(v) => v,
+        O.None => @panic("index out of bounds"),
+    }
 }
 
 // Insertion sort: stable, O(n^2), good on small or nearly-sorted inputs.
 // Shifts each element left past larger predecessors.
 pub fn insertion_sort(comptime T: type, inout xs: arraybuf.ArrayBuf(T)) {
+    // COPY-`T` ONLY (module header): stated first so an owning element type is
+    // named here rather than deeper in, at a comparison or a by-copy read.
+    @require_trivially_droppable(T);
     let n = xs.len();
     let mut i: u64 = 1;
     while i < n {
         let mut j = i;
         while j > 0 {
-            let prev = xs.get_or(j - 1, 0);
-            let cur = xs.get_or(j, 0);
+            let prev = _at(T, borrow xs, j - 1);
+            let cur = _at(T, borrow xs, j);
             if cur < prev {
-                swap_at(T, inout xs, j - 1, j);
+                xs.swap(j - 1, j);
                 j -= 1;
             } else {
                 j = 0;
@@ -65,9 +89,9 @@ pub fn insertion_sort(comptime T: type, inout xs: arraybuf.ArrayBuf(T)) {
 // inputs away from the fixed-endpoint quadratic partition pattern while
 // retaining deterministic, comparison-only ordering.
 fn median_of_three(comptime T: type, borrow xs: arraybuf.ArrayBuf(T), a: u64, b: u64, c: u64) -> u64 {
-    let va = xs.get_or(a, 0);
-    let vb = xs.get_or(b, 0);
-    let vc = xs.get_or(c, 0);
+    let va = _at(T, borrow xs, a);
+    let vb = _at(T, borrow xs, b);
+    let vc = _at(T, borrow xs, c);
     if va < vb {
         if vb < vc {
             return b;
@@ -98,19 +122,19 @@ fn qsort_range(comptime T: type, inout xs: arraybuf.ArrayBuf(T), lo: u64, hi: u6
     while lo < hi {
         let mid = lo + (hi - lo) / 2;
         let pivot_index = median_of_three(T, borrow xs, lo, mid, hi);
-        swap_at(T, inout xs, pivot_index, hi);
-        let pivot = xs.get_or(hi, 0);
+        xs.swap(pivot_index, hi);
+        let pivot = _at(T, borrow xs, hi);
         let mut store = lo;
         let mut j = lo;
         while j < hi {
-            let vj = xs.get_or(j, 0);
+            let vj = _at(T, borrow xs, j);
             if vj < pivot {
-                swap_at(T, inout xs, store, j);
+                xs.swap(store, j);
                 store += 1;
             }
             j += 1;
         }
-        swap_at(T, inout xs, store, hi);
+        xs.swap(store, hi);
 
         // For an inclusive range, these differences are the partition sizes:
         // `store - lo` and `hi - store` are safe because `lo <= store <= hi`.
@@ -138,6 +162,9 @@ fn qsort_range(comptime T: type, inout xs: arraybuf.ArrayBuf(T), lo: u64, hi: u6
 
 // Quicksort: average O(n log n), in place. Not stable.
 pub fn quicksort(comptime T: type, inout xs: arraybuf.ArrayBuf(T)) {
+    // COPY-`T` ONLY (module header): stated first so an owning element type is
+    // named here rather than deeper in, at a comparison or a by-copy read.
+    @require_trivially_droppable(T);
     let n = xs.len();
     if n > 1 {
         qsort_range(T, inout xs, 0, n - 1);
@@ -146,14 +173,17 @@ pub fn quicksort(comptime T: type, inout xs: arraybuf.ArrayBuf(T)) {
 
 // Whether `xs` is in non-decreasing order under `<`.
 pub fn is_sorted(comptime T: type, borrow xs: arraybuf.ArrayBuf(T)) -> bool {
+    // COPY-`T` ONLY (module header): stated first so an owning element type is
+    // named here rather than deeper in, at a comparison or a by-copy read.
+    @require_trivially_droppable(T);
     let n = xs.len();
     if n < 2 {
         return true;
     }
     let mut i: u64 = 1;
     while i < n {
-        let prev = xs.get_or(i - 1, 0);
-        let cur = xs.get_or(i, 0);
+        let prev = _at(T, borrow xs, i - 1);
+        let cur = _at(T, borrow xs, i);
         if cur < prev {
             return false;
         }
@@ -164,16 +194,18 @@ pub fn is_sorted(comptime T: type, borrow xs: arraybuf.ArrayBuf(T)) -> bool {
 
 // Binary search for `target` in a buffer that is already sorted ascending.
 // Returns `Some(i)` for some index `i` with `xs[i] == target` (equality is
-// tested as `!(a < b) && !(b < a)`), or `None` if absent. Generic over any
-// `Copy` `T`: the unused out-of-bounds default is `target` itself.
+// tested as `!(a < b) && !(b < a)`), or `None` if absent.
 pub fn binary_search(comptime T: type, borrow xs: arraybuf.ArrayBuf(T), target: T) -> option.Option(u64) {
+    // COPY-`T` ONLY (module header): stated first so an owning element type is
+    // named here rather than deeper in, at a comparison or a by-copy read.
+    @require_trivially_droppable(T);
     let O = option.Option(u64);
     let n = xs.len();
     let mut lo: u64 = 0;
     let mut hi = n;
     while lo < hi {
         let mid = lo + (hi - lo) / 2;
-        let v = xs.get_or(mid, target);
+        let v = _at(T, borrow xs, mid);
         if v < target {
             lo = mid + 1;
         } else if target < v {

--- a/std/stack.rue
+++ b/std/stack.rue
@@ -7,9 +7,18 @@
 //     s.push(20);
 //     let top = s.pop();     // Some(20)
 //
-// `push`/`pop` work for any element type. `peek` reads the top element BY COPY,
-// so it is usable only for trivially-droppable (`Copy`) `T` — reading an owned
-// element by copy is rejected (RUE-651); use `pop` to move an owned element out.
+// `new`, `push`, `pop`, `clear` and the borrowing `peek_ref` work for any
+// element type and are deliberately ungated, so a stack of owning values is
+// legal (RUE-646). `peek` reads the top element BY COPY, so it needs a Copy
+// `T`: the copy would otherwise alias the still-live top slot and double-free
+// it at scope exit (RUE-651). It states the half Rue can gate as its FIRST
+// statement — `@require_trivially_droppable(T)` (E0711), which names an owning
+// `T` at the `peek` call instead of reporting it from `ArrayBuf.get` a frame
+// deeper (RUE-2049). The gate covers the drop-glue half only; a `@copy`-less
+// struct has no drop glue, so it passes the gate and `peek` copies it bitwise
+// with no diagnostic at all until the language has a Copy gate (RUE-2028).
+// Marking such a struct `@copy` is the fix. Use `peek_ref` to read an owning
+// top element in place, or `pop` to move it out.
 
 const arraybuf = @import("arraybuf.rue");
 const option = @import("option.rue");
@@ -42,8 +51,12 @@ pub fn Stack(comptime T: type) -> type {
             self.buf.pop()
         }
 
-        // The top element by copy, or `None` when empty. COPY-`T` ONLY (RUE-651).
+        // The top element by copy, or `None` when empty. COPY-`T` ONLY
+        // (RUE-651); the gate is stated first so an owning `T` is named here
+        // rather than inside `ArrayBuf.get` (RUE-2049). `peek_ref` reads an
+        // owning element in place and `pop` moves it out.
         fn peek(borrow self) -> option.Option(T) {
+            @require_trivially_droppable(T);
             let O = option.Option(T);
             let n = self.buf.len();
             if n == 0 {

--- a/std/strmap.rue
+++ b/std/strmap.rue
@@ -3,9 +3,24 @@
 // (M4) needs function values / traits (RUE-643/RUE-246); this covers the common
 // string-keyed case now, alongside the integer-keyed `IntMap(V)`.
 //
-// `new(filler)` takes a throwaway `V` used to initialise empty value slots (Rue
-// has no generic zero-init); it is never read as a real value — the per-slot
-// state guards that.
+// COPY-`V` ONLY. The table duplicates values: `new(filler)` takes one throwaway
+// `V` and `_grow_to` pushes it into every slot of a fresh table (Rue has no
+// generic zero-init; it is never read as a real value — the per-slot state
+// guards that), and every read goes through the by-copy `ArrayBuf.get_or`.
+// Duplicating a value rather than consuming it is what a Copy type does
+// (3.8:1). Note this constrains the VALUE type only; keys are `StrBuf`, which
+// this module owns and pools itself (see STORAGE below).
+//
+// Rue has no intrinsic that gates on Copy, so `new` — the only constructor, so
+// the only way to reach any of the above — states the half it can as its FIRST
+// statement: `@require_trivially_droppable(V)` (E0711) rejects a `V` with drop
+// glue and names it, instead of the E0437 "cannot move out of inout parameter
+// `self`" that copying `self.filler` inside `_grow_to` used to raise several
+// frames deeper (RUE-2049). The gate covers the drop-glue half only: a
+// move-only `V` with no drop glue is exactly a struct not marked `@copy`
+// (3.8:3), and it passes the gate and then fails at the filler copy, because
+// the language has no Copy gate (RUE-2028). Marking such a struct `@copy` is
+// the fix.
 //
 //     const std = @import("std");
 //     let M = std.strmap.StrMap(u64);
@@ -81,7 +96,13 @@ pub fn StrMap(comptime V: type) -> type {
         cap: u64,
         filler: V,
 
+        // COPY-`V` ONLY: the gate is stated ahead of everything else so an
+        // owning value type is named at this call rather than reported from the
+        // filler copy inside `_grow_to` (RUE-2049). The REPRESENTATION
+        // duplicates values, so the constructor is the right place — there is
+        // no way to hold a non-Copy `V` in a `StrMap` at all.
         fn new(filler: V) -> Self {
+            @require_trivially_droppable(V);
             let ub = arraybuf.ArrayBuf(u64);
             let vb = arraybuf.ArrayBuf(V);
             let sb = arraybuf.ArrayBuf(u8);

--- a/std/tuple.rue
+++ b/std/tuple.rue
@@ -7,6 +7,14 @@
 //     const std = @import("std");
 //     let P = std.tuple.Pair(i64, i64);
 //     let p = P.new(40, 2);          // p.first == 40, p.second == 2
+//
+// ANY-`T`, deliberately ungated. `new` MOVES its components into the fields and
+// nothing here reads a field back out, so a pair or triple never duplicates a
+// component: an owning component such as a `StrBuf` is legal and is dropped
+// exactly once with the aggregate. A `Pair`/`Triple` is Copy exactly when all
+// of its components are (3.8:2), which is why the by-copy readers of the
+// containers that STORE one — `ArrayBuf.get`, `BinaryHeap`, `PriorityQueue` —
+// carry the element gate instead (RUE-2049).
 
 // A 2-tuple.
 pub fn Pair(comptime A: type, comptime B: type) -> type {


### PR DESCRIPTION
Fixes RUE-2049

`std.sort`, `ArrayBuf.index_of`/`contains`, `Deque`/`IntMap`/`StrMap.new`,
`Queue.dequeue`/`peek`, `Stack.peek`, `BinaryHeap.push`/`pop`/`peek` and
`PriorityQueue.push`/`pop` all read their element by copy, or duplicate a
`filler` into every slot, so they admit only a Copy element type. Each stated
that in a comment only, so a non-Copy instantiation failed several frames deep
inside std with an unrelated error: `std.sort.quicksort(StrBuf, ..)` reported
E0206 "expected integer type" against a `get_or(hi, 0)` default in
`std/sort.rue`, and `Deque(StrBuf).new(fill)` reported E0437 "cannot move out
of inout parameter `self`" against the filler copy in `_grow_to`.

## Gates added

Rue has no intrinsic that gates on Copy, so each of those entry points now
states the half it can as its FIRST statement: `@require_trivially_droppable`
(E0711), the same gate `ArrayBuf.get`/`get_or` and `Grid2D.new` already
carried. Because the gate lives in the method body, demand-driven analysis
(ADR-0045) fires it only when the operation is actually called, and the
diagnostic anchors at the caller's own line with the gate line as a labelled
secondary span. `PriorityQueue` gates `P` and `V` separately so the message
names the offending half rather than the enclosing `Pair(P, V)`.

`std.sort`'s element reads move from `get_or(i, 0)` to `ArrayBuf.get` through a
trapping `_at` helper, so nothing there assumes the element type admits the
literal `0` — a float buffer now sorts.

## Deliberately ungated

Operations that never duplicate an element keep working for an owning element
type (RUE-646): `Stack`/`Queue` `push`/`enqueue`, `pop` and the borrowing
`peek_ref`, and `ArrayBuf.swap`/`reverse`, which exchange slot contents rather
than copying them. `std.cmp`, `std.math`, `std.tuple` and `std.bitset` receive
comment-only changes.

## Tests

A new UI section `diagnostics.std-element-gates` pins one E0711 case per newly
gated entry point, each asserting the primary span lands on the user's call and
the gate line carries the "required to be trivially droppable here" label, plus
a Copy control per container and cases for the ungated operations. 29 cases;
the full UI suite is 394, the std suite 154, and the `arraybuf`/`sort`/`heap`/
`std_`/`examples` CLI groups are green.

## Notes

- Drive-by: `std/intmap.rue`'s `_key_bits` comment described `fs._i64_bits` as
  still negating first and keeping the `i64::MIN` hole. `std/fs.rue` uses
  `0 - (x + 1)` (RUE-1759), so the remark was stale; corrected. No behaviour
  change.
- The gate covers the drop-glue half of Copy only. A struct that is neither
  `@copy` nor drop-glue passes it; the module comments now state what actually
  happens next per container rather than a uniform E0205 claim (RUE-2028).
- Every gated method has a `self` receiver, so the heap and sort gates render
  the by-copy-read wording ("use `get_ref` ... or `pop`") even where that advice
  does not apply — a `push` on a type with no `get_ref`. Those sites want the
  `Duplicate` gate shape; RUE-2070 refines the wording.

