### PR TITLE
RUE-2043: end a compiler session's query worker threads with its database

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4880,7 +4880,7 @@ pub(super) use register_parse_import_parse;"#;
         });
     assert_eq!(
         (declarations.len(), fingerprint),
-        (214, 1_253_032_129_469_309_576),
+        (215, 5_525_279_941_277_473_575),
         "crate-visible declaration names, signatures, fields, or phase owners changed"
     );
 
@@ -5358,6 +5358,7 @@ fn:probe_ready_body_facts
 fn:publish_lookup_root
 fn:production_declarations
 fn:durable_decl
+fn:query_runtime
 struct:DurableDeclSource
 fn:from_declarations
 fn:with_anonymous_nominals

--- a/crates/rue-compiler/src/revisioned_query_database/shared.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/shared.rs
@@ -805,6 +805,38 @@ pub(crate) struct RevisionedQueryDatabase {
     >,
 }
 
+/// The database owns the query runtime, so the database ends its worker
+/// threads.
+///
+/// Worker threads cannot wait for the last reference to the runtime core.
+/// Registered families are built in one pass, and every edge that runs
+/// backwards in that order is closed by back-patching an `Arc<OnceLock<..>>`
+/// the earlier family's evaluator already captured — the body-transaction
+/// evaluator, the semantic nucleus, and the type-facts family in
+/// `registrations`. Each back-patched value holds strong `QueryFamily` handles,
+/// and the body-transaction evaluator holds a `QueryRuntime` outright, so the
+/// registered family graph contains reference cycles that no database field can
+/// break. Dropping the database releases only part of the reference count on
+/// the core; the core, and with it the executor, survives the session.
+///
+/// A process that compiles one program per session — the oracle-diff harness
+/// compiles one per corpus case — would therefore accumulate a runtime's worth
+/// of 8 MiB threads per program until the host refused another one, which
+/// stopped 282 cases of a corpus run against `kern.num_taskthreads` (RUE-2043).
+///
+/// This database is the owner that can name the moment the threads are no
+/// longer needed: it is a plain value inside `CompilerSession`, reachable only
+/// through `&mut self` methods, so no request can be in flight when it is
+/// destroyed. Registration's own `CompilerQueryRuntime` cannot own that moment
+/// — it is a temporary the constructor drops before the database exists — and
+/// a batch dispatched onto a runtime whose owner has shut it down is refused
+/// with `rue_query::WorkerSpawnFailure` rather than served.
+impl Drop for RevisionedQueryDatabase {
+    fn drop(&mut self) {
+        self.runtime.shutdown_workers();
+    }
+}
+
 impl RevisionedQueryDatabase {
     /// Runtime-wide retention belongs to the shared database owner rather than
     /// any compiler phase. This is a read-only projection of the one canonical

--- a/crates/rue-compiler/src/revisioned_query_database/test_support.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/test_support.rs
@@ -931,3 +931,13 @@ pub(super) fn lookup_incarnation(
     .unwrap()
     .node_incarnation()
 }
+
+/// A handle on the query runtime `database` owns.
+///
+/// Cloning the handle is how a test outlives the database and still asks what
+/// became of its worker threads: the database destructor's shutdown only says
+/// something if the threads are gone while the runtime core is still reachable,
+/// which after any real compilation it is (RUE-2043).
+pub(crate) fn query_runtime(database: &RevisionedQueryDatabase) -> rue_query::QueryRuntime {
+    database.runtime.clone()
+}

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -383,12 +383,14 @@ pub(crate) fn pipeline_abort_errors(context: &str, abort: rue_query::QueryAbort)
 
 /// Renders one query abort as the message of an internal-error diagnostic.
 ///
-/// A refused physical worker thread is a condition of the host the compiler is
-/// running on rather than a defect in the compiler or the program, so it keeps
-/// its own contracted sentence: it names the operating system's refusal and the
-/// worker budget that was live, and a driver or harness can recognize it
-/// without parsing a structural dump. Every other abort keeps the structural
-/// rendering, which is a compiler-internal condition worth reading as one.
+/// A refused batch dispatch keeps its own written sentence: it names why the
+/// dispatch was refused and the worker budget that was live, and a driver or
+/// harness can recognize it without parsing a structural dump. The usual
+/// refusal is a condition of the host the compiler is running on rather than a
+/// defect in the compiler or the program, and only that one opens with
+/// `rue_query::WORKER_SPAWN_MESSAGE_PREFIX`. Every other abort keeps the
+/// structural rendering, which is a compiler-internal condition worth reading
+/// as one.
 pub(crate) fn abort_internal_message(context: &str, abort: &rue_query::QueryAbort) -> String {
     match abort {
         rue_query::QueryAbort::WorkerSpawn(failure) => failure.to_string(),

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -6376,3 +6376,79 @@ fn a_refused_query_worker_becomes_an_internal_error_diagnostic() {
     // the structural dump every other abort gets.
     assert!(!message.contains("query aborted"), "{message}");
 }
+
+/// A program wide enough that registration dispatches real parallel batches:
+/// the physical worker threads under test are created only when a batch has
+/// siblings to run beside the one the caller runs inline.
+fn parallel_batch_fixture() -> String {
+    use std::fmt::Write as _;
+
+    const HELPERS: usize = 24;
+    let mut source = String::new();
+    for index in 0..HELPERS {
+        writeln!(
+            source,
+            "fn helper_{index}(x: i32) -> i32 {{ return x + {index}; }}"
+        )
+        .expect("writing to a String cannot fail");
+    }
+    source.push_str("fn main() -> i32 {\n    let mut total: i32 = 0;\n");
+    for index in 0..HELPERS {
+        writeln!(source, "    total = total + helper_{index}(total);")
+            .expect("writing to a String cannot fail");
+    }
+    source.push_str("    return total - total;\n}\n");
+    source
+}
+
+/// RUE-2043: dropping a `CompilerSession` ends the query worker threads its
+/// database created, even though the query graph outlives the database.
+///
+/// The handles retained past each drop are what makes the assertion mean
+/// something: a compilation leaves its runtime core reachable from reference
+/// cycles among the registered families, so the core outlives the session that
+/// owned it and worker threads waiting for the last reference would never exit.
+/// The full account is at `RevisionedQueryDatabase`'s destructor.
+#[test]
+fn dropped_compiler_sessions_end_their_query_worker_threads() {
+    const SESSIONS: usize = 4;
+
+    let source = parallel_batch_fixture();
+    let mut retained = Vec::with_capacity(SESSIONS);
+    for _ in 0..SESSIONS {
+        let snapshot =
+            SourceSnapshot::single("<test>", &source).expect("the fixture is a valid snapshot");
+        // Two workers of query concurrency give the executor a capacity of
+        // exactly one physical worker, so the fixture dispatches onto a real
+        // thread on any host, including a single-CPU runner.
+        let mut session = CompilerSession::with_query_concurrency(2);
+        let published = crate::test_support::publish_test_snapshot(&mut session, &snapshot)
+            .expect("the fixture publishes");
+        crate::queries::compile_with_session(&mut session, &published, &CompileOptions::default())
+            .expect("the fixture compiles");
+        let runtime = crate::revisioned_query_database::test_support::query_runtime(
+            &session.queries.revisioned,
+        );
+        drop(session);
+        retained.push(runtime);
+    }
+
+    let births: u64 = retained
+        .iter()
+        .map(|runtime| runtime.metrics().batch_worker_thread_births)
+        .sum();
+    assert!(
+        births > 0,
+        "the fixture must dispatch batches onto physical workers, or a worker \
+         count of zero after the drop proves nothing"
+    );
+    let live: usize = retained
+        .iter()
+        .map(rue_query::QueryRuntime::live_worker_threads)
+        .sum();
+    assert_eq!(
+        live, 0,
+        "{SESSIONS} dropped sessions created {births} worker threads and must \
+         own none of them now"
+    );
+}

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -722,6 +722,28 @@ fn model_gap_observation(case: &Case, outcome: &CaseOutcome) -> model_gaps::Obse
     }
 }
 
+/// Render this process's query worker-thread budget, for a resource report.
+///
+/// The whole corpus runs in this one process, so its high-water mark of live
+/// query workers is the number that says whether a thread refusal met a run at
+/// a steady budget or one accumulating threads across cases (RUE-2043). Each
+/// worker is a kernel thread reserving a fixed stack, so the peak and its
+/// product with that reservation are the two host resources a run can exhaust,
+/// and the still-live count corroborates: one compilation needs a handful and
+/// releases them when its session drops, so a peak near the live count is a
+/// run holding onto every worker it ever made.
+fn worker_thread_budget() -> String {
+    let peak = rue_query::peak_query_worker_threads();
+    let stack_mib = rue_query::REGISTERED_BATCH_WORKER_STACK_BYTES / (1024 * 1024);
+    let reserved_mib =
+        peak.saturating_mul(rue_query::REGISTERED_BATCH_WORKER_STACK_BYTES) / (1024 * 1024);
+    format!(
+        "peak {peak} live at once ({reserved_mib} MiB of reserved stack at {stack_mib} MiB \
+         each), {} still live now",
+        rue_query::live_query_worker_threads(),
+    )
+}
+
 /// Print the tallied report and turn it into a process exit code: success when
 /// the oracle agreed with the compiler on every modeled eligible case, failure
 /// on any harness/front-end/oracle failure or disagreement. Shared by
@@ -739,6 +761,7 @@ fn finish_report(report: &Report, corpus: &str) -> ExitCode {
     for line in report.ineligible_breakdown_lines() {
         println!("{line}");
     }
+    println!("  query worker threads:     {}", worker_thread_budget());
     println!("  HARNESS FAILURES: {}", report.harness_failures.len());
     for failure in &report.harness_failures {
         println!("\n  ✗ {failure}");
@@ -769,8 +792,11 @@ fn finish_report(report: &Report, corpus: &str) -> ExitCode {
         println!(
             "\n{} case(s) stopped on a host resource condition, not a disagreement — \
              each ⚠ above carries the operating system's own refusal and the worker \
-             budget that was live. Lower in-process concurrency with {ORACLE_JOBS_VAR}=N \
-             (or run fewer corpora and worktrees at once) and rerun.",
+             budget that was live. What the host refused is a thread, so the ceiling \
+             is its per-process thread limit (macOS `sysctl kern.num_taskthreads`, \
+             Linux `ulimit -u`); read that against the query worker threads line \
+             above. Lower in-process concurrency with {ORACLE_JOBS_VAR}=N (or run \
+             fewer corpora and worktrees at once) and rerun.",
             report.harness_resource.len(),
         );
         return ExitCode::FAILURE;

--- a/crates/rue-query/src/context.rs
+++ b/crates/rue-query/src/context.rs
@@ -16,7 +16,11 @@ use crate::*;
 /// whose platform stack is materially larger than Rust's default spawned-thread
 /// stack. Keep structured batch children at that established floor so moving a
 /// valid deeply nested query onto a worker cannot create a stack overflow.
-pub(crate) const REGISTERED_BATCH_WORKER_STACK_BYTES: usize = 8 * 1024 * 1024;
+///
+/// It is public because a host-resource report is only actionable with it: a
+/// thread high-water mark is a number, and this constant is what turns that
+/// number into the address space and kernel thread slots the run asked for.
+pub const REGISTERED_BATCH_WORKER_STACK_BYTES: usize = 8 * 1024 * 1024;
 
 fn batch_completion_coordinator_residual_ns(
     wait_started: Instant,

--- a/crates/rue-query/src/executor.rs
+++ b/crates/rue-query/src/executor.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::io;
 use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -12,42 +13,107 @@ use crate::{REGISTERED_BATCH_WORKER_STACK_BYTES, lock};
 
 type Job = Box<dyn FnOnce() + Send + 'static>;
 
-/// Stable opening of every rendering of [`WorkerSpawnFailure`].
+/// Physical query-runtime worker threads alive in this process right now.
+///
+/// The count is process-wide rather than per-runtime because the resource it
+/// tracks is: every runtime in the process draws its worker threads from one
+/// host budget, and it is the *total* that a host refuses to grow.
+static LIVE_WORKER_THREADS: AtomicUsize = AtomicUsize::new(0);
+
+/// The largest value [`LIVE_WORKER_THREADS`] has ever held in this process.
+static PEAK_WORKER_THREADS: AtomicUsize = AtomicUsize::new(0);
+
+/// Physical query-runtime worker threads currently alive process-wide.
+///
+/// A long-running harness that compiles many programs in one process expects
+/// this to return to a small steady state between compilations: worker threads
+/// belong to a runtime, and a runtime releases them when it is dropped.
+pub fn live_query_worker_threads() -> usize {
+    LIVE_WORKER_THREADS.load(Ordering::Relaxed)
+}
+
+/// High-water mark of [`live_query_worker_threads`] for this process.
+///
+/// This is the number a report needs when the host refuses a thread: it says
+/// whether the refusal met a process that was accumulating threads or one that
+/// was already running at a steady, modest budget (RUE-2043).
+pub fn peak_query_worker_threads() -> usize {
+    PEAK_WORKER_THREADS.load(Ordering::Relaxed)
+}
+
+fn record_worker_birth() {
+    let live = LIVE_WORKER_THREADS.fetch_add(1, Ordering::Relaxed) + 1;
+    PEAK_WORKER_THREADS.fetch_max(live, Ordering::Relaxed);
+}
+
+fn record_worker_death() {
+    LIVE_WORKER_THREADS.fetch_sub(1, Ordering::Relaxed);
+}
+
+/// Stable opening of a [`WorkerSpawnFailure`] the HOST caused.
 ///
 /// Drivers publish the rendering as an internal-error diagnostic and harnesses
 /// match this prefix to separate a loaded host from a compiler defect, so the
-/// text is a contract rather than an incidental message.
+/// text is a contract rather than an incidental message. It is exactly the
+/// distinction [`WorkerSpawnFailure::is_host_refusal`] draws in-process: a
+/// refusal the compiler itself made must not carry this prefix, or a harness
+/// reading stderr would report a compiler bug as a busy machine.
 pub const WORKER_SPAWN_MESSAGE_PREFIX: &str = "query runtime could not spawn a worker thread";
 
-/// The host refused a query-runtime physical worker thread.
+/// The executor refused to dispatch a registered-batch job.
 ///
 /// Thread creation is the one step of registered-batch dispatch that depends on
 /// a resource the compiler does not own. `EAGAIN` under host thread or
 /// address-space pressure is a condition of the machine, not a compiler defect,
 /// so it is reported as a typed value the caller can turn into a diagnostic
-/// rather than an abort of the process.
+/// rather than an abort of the process. The same typing covers dispatch onto a
+/// runtime whose owner already ended its workers, which is a defect but still
+/// must not take the process down.
 ///
 /// The payload is a value type rather than an `io::Error` because
 /// [`QueryAbort`](crate::QueryAbort) is `Clone + Eq`: the refusal is captured
 /// as its rendering, its raw OS code, and the worker budget that was live when
-/// the host said no.
+/// it happened.
 #[derive(Clone, PartialEq, Eq)]
 pub struct WorkerSpawnFailure {
-    os_error: String,
-    raw_os_error: Option<i32>,
+    cause: RefusalCause,
     live_workers: usize,
     worker_stack_bytes: usize,
 }
 
+/// What stopped the dispatch.
+#[derive(Clone, PartialEq, Eq)]
+enum RefusalCause {
+    /// The host declined a new physical worker thread.
+    Host {
+        os_error: String,
+        raw_os_error: Option<i32>,
+    },
+    /// The runtime's owner had already ended its workers. Only a defect
+    /// reaches this — an owner shuts down when it is finished with the runtime
+    /// — so it renders WITHOUT [`WORKER_SPAWN_MESSAGE_PREFIX`]: that prefix is
+    /// how a harness tells a loaded machine from a compiler bug, and this is
+    /// the compiler bug.
+    OwnerShutdown,
+}
+
 impl fmt::Display for WorkerSpawnFailure {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "{WORKER_SPAWN_MESSAGE_PREFIX}: {}; {} workers of {} MiB stack were live",
-            self.os_error,
-            self.live_workers,
-            self.worker_stack_mib()
-        )
+        match &self.cause {
+            RefusalCause::Host { os_error, .. } => write!(
+                formatter,
+                "{WORKER_SPAWN_MESSAGE_PREFIX}: {os_error}; {} workers of {} MiB stack were live",
+                self.live_workers,
+                self.worker_stack_mib()
+            ),
+            RefusalCause::OwnerShutdown => write!(
+                formatter,
+                "query runtime received a batch job after its owner shut the workers down; \
+                 {} workers of {} MiB stack were live",
+                self.live_workers,
+                self.worker_stack_mib()
+            ),
+        }
     }
 }
 
@@ -71,24 +137,54 @@ impl WorkerSpawnFailure {
     /// they are the budget a report needs in order to be actionable.
     pub fn new(error: &io::Error, live_workers: usize, worker_stack_bytes: usize) -> Self {
         Self {
-            os_error: error.to_string(),
-            raw_os_error: error.raw_os_error(),
+            cause: RefusalCause::Host {
+                os_error: error.to_string(),
+                raw_os_error: error.raw_os_error(),
+            },
             live_workers,
             worker_stack_bytes,
         }
     }
 
-    /// The operating system's own account of the refusal.
+    /// Captures dispatch onto a runtime whose owner already shut it down.
+    fn after_owner_shutdown(live_workers: usize, worker_stack_bytes: usize) -> Self {
+        Self {
+            cause: RefusalCause::OwnerShutdown,
+            live_workers,
+            worker_stack_bytes,
+        }
+    }
+
+    /// Whether the machine, rather than the compiler, refused the dispatch.
+    ///
+    /// A harness separates a loaded host from a compiler defect on this
+    /// distinction; across a process boundary it reads the same distinction off
+    /// [`WORKER_SPAWN_MESSAGE_PREFIX`] in the rendered message.
+    pub const fn is_host_refusal(&self) -> bool {
+        matches!(self.cause, RefusalCause::Host { .. })
+    }
+
+    /// The operating system's own account of a host refusal.
+    ///
+    /// Empty when the compiler refused the dispatch itself; see
+    /// [`is_host_refusal`](Self::is_host_refusal).
     pub fn os_error(&self) -> &str {
-        &self.os_error
+        match &self.cause {
+            RefusalCause::Host { os_error, .. } => os_error,
+            RefusalCause::OwnerShutdown => "",
+        }
     }
 
     /// The raw `errno` when the host reported one.
     pub const fn raw_os_error(&self) -> Option<i32> {
-        self.raw_os_error
+        match &self.cause {
+            RefusalCause::Host { raw_os_error, .. } => *raw_os_error,
+            RefusalCause::OwnerShutdown => None,
+        }
     }
 
-    /// Physical workers this runtime already owned when the spawn was refused.
+    /// Physical workers this runtime already owned when the dispatch was
+    /// refused.
     pub const fn live_workers(&self) -> usize {
         self.live_workers
     }
@@ -110,7 +206,11 @@ impl WorkerSpawnFailure {
 /// first acquire slots from `BatchWorkerClaim`; the executor only maps those
 /// already-granted slots onto long-lived operating-system threads.
 pub(crate) struct ReusableBatchExecutor {
-    sender: Option<mpsc::Sender<Job>>,
+    /// `None` once the runtime's owner has shut the executor down. The slot is
+    /// behind a lock because shutdown reaches the executor through the shared
+    /// `Arc<RuntimeCore>` rather than through a unique borrow, and because it
+    /// is what makes shutdown and dispatch exclusive of one another.
+    sender: Mutex<Option<mpsc::Sender<Job>>>,
     receiver: Arc<Mutex<mpsc::Receiver<Job>>>,
     workers: Mutex<Vec<JoinHandle<()>>>,
     worker_capacity: usize,
@@ -132,7 +232,7 @@ impl ReusableBatchExecutor {
     pub(crate) fn new(worker_capacity: usize) -> Self {
         let (sender, receiver) = mpsc::channel::<Job>();
         Self {
-            sender: Some(sender),
+            sender: Mutex::new(Some(sender)),
             receiver: Arc::new(Mutex::new(receiver)),
             workers: Mutex::new(Vec::with_capacity(worker_capacity)),
             worker_capacity,
@@ -143,9 +243,10 @@ impl ReusableBatchExecutor {
 
     /// Dispatches one job onto this runtime's physical workers.
     ///
-    /// Returns the refusal when the host declines a new worker thread. Nothing
-    /// is queued in that case, so the caller owes no join for this job and may
-    /// surface the condition without leaving batch state behind.
+    /// Returns the refusal when the host declines a new worker thread, or when
+    /// the runtime's owner already shut the workers down. Nothing is queued in
+    /// either case, so the caller owes no join for this job and may surface the
+    /// condition without leaving batch state behind.
     pub(crate) fn submit<R>(
         &self,
         job: impl FnOnce() -> R + Send + 'static,
@@ -153,6 +254,17 @@ impl ReusableBatchExecutor {
     where
         R: Send + 'static,
     {
+        // The queue slot stays locked across the whole dispatch. That is what
+        // makes shutdown and submission exclusive of one another: a `Sender`
+        // cloned out of the slot would keep the channel connected, and
+        // `shutdown` would then join workers that never observe the close.
+        let sender = lock(&self.sender);
+        let Some(sender) = sender.as_ref() else {
+            return Err(WorkerSpawnFailure::after_owner_shutdown(
+                lock(&self.workers).len(),
+                REGISTERED_BATCH_WORKER_STACK_BYTES,
+            ));
+        };
         let mut thread_births = 0;
         {
             let mut workers = lock(&self.workers);
@@ -166,15 +278,13 @@ impl ReusableBatchExecutor {
             }
         }
         let (completed, receiver) = mpsc::sync_channel(1);
-        self.sender
-            .as_ref()
-            .expect("query runtime executor is live while its core is live")
+        sender
             .send(Box::new(move || {
                 let result = catch_unwind(AssertUnwindSafe(job));
                 let finished_at = Instant::now();
                 let _ = completed.send((result, finished_at));
             }))
-            .expect("query runtime executor workers remain live with the runtime");
+            .expect("the executor owns the receiver its queue delivers to");
         Ok((
             BatchJobHandle {
                 receiver: Some(receiver),
@@ -198,10 +308,17 @@ impl ReusableBatchExecutor {
             return Err(error);
         }
         let receiver = self.receiver.clone();
+        // The gauge is raised before the thread exists and lowered by a guard
+        // the thread owns, so the pair cannot race: a worker that exits
+        // immediately can only ever lower a count this call already raised.
+        record_worker_birth();
         thread::Builder::new()
             .name(format!("rue-query-worker-{index}"))
             .stack_size(REGISTERED_BATCH_WORKER_STACK_BYTES)
             .spawn(move || {
+                // The gauge is lowered by this guard rather than at the
+                // `return` below so an unwinding worker is still accounted for.
+                let _accounting = WorkerLifetime;
                 loop {
                     let job = {
                         // Exactly one idle worker waits on the receiver;
@@ -216,6 +333,41 @@ impl ReusableBatchExecutor {
                     job();
                 }
             })
+            .inspect_err(|_| record_worker_death())
+    }
+
+    /// Disconnects the job queue and joins every physical worker.
+    ///
+    /// Called when the runtime's owner is finished with it. `Drop` alone is not
+    /// enough: the executor lives inside the `Arc<RuntimeCore>`, which an
+    /// evaluator graph may hold in cycles, so the core is not reliably freed
+    /// when a compilation ends; the full account is at the destructor of
+    /// `rue-compiler`'s `RevisionedQueryDatabase` (RUE-2043).
+    ///
+    /// The queue slot is released before the joins, so a dispatch racing this
+    /// teardown is refused with a typed error instead of blocking; the queue is
+    /// already drained of jobs the racing caller might still be waiting on.
+    pub(crate) fn shutdown(&self) {
+        lock(&self.sender).take();
+        // The handles are taken out from under the lock before any join. A job
+        // still running is free to reach `submit`, whose refusal path reads the
+        // worker list, and joining while holding that lock would deadlock
+        // against the very thread being joined.
+        let workers = lock(&self.workers).drain(..).collect::<Vec<_>>();
+        for worker in workers {
+            worker
+                .join()
+                .expect("query runtime workers contain job panics");
+        }
+    }
+
+    /// Physical workers this executor still owns.
+    ///
+    /// Zero after [`shutdown`](Self::shutdown): every handle was joined and
+    /// drained, so the operating-system threads are gone rather than merely
+    /// unreferenced.
+    pub(crate) fn live_worker_count(&self) -> usize {
+        lock(&self.workers).len()
     }
 
     /// Makes the next physical worker creation fail with `error`.
@@ -225,17 +377,24 @@ impl ReusableBatchExecutor {
     }
 }
 
+/// Decrements the process-wide live-worker gauge when a worker thread ends.
+struct WorkerLifetime;
+
+impl Drop for WorkerLifetime {
+    fn drop(&mut self) {
+        record_worker_death();
+    }
+}
+
 impl Drop for ReusableBatchExecutor {
     fn drop(&mut self) {
         // Disconnecting the queue wakes the idle receiver. Each worker then
         // observes the same closed queue in turn and exits before runtime-owned
-        // state is destroyed.
-        self.sender.take();
-        for worker in lock(&self.workers).drain(..) {
-            worker
-                .join()
-                .expect("query runtime workers contain job panics");
-        }
+        // state is destroyed. This is the backstop for a core that does become
+        // unreachable — an executor built directly, or a runtime whose graph
+        // holds no cycle. Where an owner already ran `shutdown`, draining an
+        // emptied worker list is a no-op.
+        self.shutdown();
     }
 }
 
@@ -293,6 +452,7 @@ mod tests {
         let Err(refused) = executor.submit(|| 2) else {
             panic!("a refused worker thread must not be reported as a dispatched job")
         };
+        assert!(refused.is_host_refusal());
         assert_eq!(refused.raw_os_error(), Some(EAGAIN_LIKE_RAW_OS_ERROR));
         assert_eq!(refused.live_workers(), 1);
         assert_eq!(
@@ -320,6 +480,48 @@ mod tests {
 
     /// macOS `EAGAIN`, the code a thread-exhausted host returns in the field.
     const EAGAIN_LIKE_RAW_OS_ERROR: i32 = 35;
+
+    /// RUE-2043: after the owning runtime tears the executor down, dispatch is
+    /// refused with a value the caller can report, and no worker is created for
+    /// a job that will never run.
+    #[test]
+    fn dispatch_after_shutdown_is_a_typed_refusal_rather_than_a_panic() {
+        let executor = ReusableBatchExecutor::new(2);
+        let (first, births) = executor.submit(|| 1).unwrap();
+        assert_eq!(births, 1);
+        assert_eq!(first.join().0.unwrap(), 1);
+
+        executor.shutdown();
+        assert_eq!(
+            executor.live_worker_count(),
+            0,
+            "shutdown must join the physical workers, not merely close the queue"
+        );
+
+        let Err(refused) = executor.submit(|| 2) else {
+            panic!("a torn-down executor must not report a job as dispatched")
+        };
+        assert!(!refused.is_host_refusal());
+        assert_eq!(refused.raw_os_error(), None);
+        assert!(refused.os_error().is_empty());
+        assert_eq!(refused.live_workers(), 0);
+        let rendered = refused.to_string();
+        assert!(
+            !rendered.contains(WORKER_SPAWN_MESSAGE_PREFIX),
+            "a teardown defect must not render as the host refusal a harness \
+             classifies as a resource condition: {rendered}"
+        );
+        assert!(
+            rendered.contains("after its owner shut the workers down"),
+            "the refusal must name what actually happened: {rendered}"
+        );
+        assert_eq!(format!("{refused:?}"), rendered);
+        assert_eq!(
+            executor.live_worker_count(),
+            0,
+            "a refused dispatch must not create a worker for a job it never queued"
+        );
+    }
 
     #[test]
     fn submitted_jobs_reuse_one_physical_worker() {

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -17,7 +17,10 @@ mod task;
 mod validation;
 
 pub use context::*;
-pub use executor::{WORKER_SPAWN_MESSAGE_PREFIX, WorkerSpawnFailure};
+pub use executor::{
+    WORKER_SPAWN_MESSAGE_PREFIX, WorkerSpawnFailure, live_query_worker_threads,
+    peak_query_worker_threads,
+};
 pub use hash::*;
 pub use metrics::*;
 pub use node::*;

--- a/crates/rue-query/src/registered_batch_tests.rs
+++ b/crates/rue-query/src/registered_batch_tests.rs
@@ -163,6 +163,126 @@ fn run_registered_batch(worker_count: usize) -> QueryRequestAttempt<Arc<[u64]>> 
     attempt
 }
 
+/// RUE-2043: a runtime's owner can end its worker threads while the runtime
+/// core is still referenced.
+///
+/// An evaluator graph may hold `QueryFamily` and `QueryRuntime` handles in
+/// cycles, so workers that waited for the last reference to the core would
+/// never exit; the full account is at the destructor of `rue-compiler`'s
+/// `RevisionedQueryDatabase`.
+#[test]
+fn shutting_down_a_runtime_joins_its_workers_while_its_core_is_retained() {
+    let runtime = QueryRuntime::new(2);
+    publish_empty(&runtime, [revision(1)]);
+    let child = runtime
+        .family_with_evaluator::<Slot, u64, _>("retained-core-child", 8, |_, _, key| {
+            Ok(QueryOutput::success(key.0))
+        })
+        .unwrap();
+    let child_for_root = child.clone();
+    let root = runtime
+        .family_with_evaluator::<Key, u64, _>("retained-core-root", 8, move |context, _, _| {
+            let mut sum = 0;
+            for terminal in context.query_registered_batch(&child_for_root, [Slot(1), Slot(2)])? {
+                let QueryOutcome::Success(value) = terminal.outcome() else {
+                    unreachable!()
+                };
+                sum += *value;
+            }
+            Ok(QueryOutput::success(sum))
+        })
+        .unwrap();
+    runtime
+        .request_registered(&root, revision(1), Key("root"), CancellationToken::new())
+        .into_result()
+        .expect("the batch completes on a physical worker");
+    assert_eq!(
+        runtime.metrics().batch_worker_thread_births,
+        1,
+        "the batch must have created the physical worker whose lifetime is under test"
+    );
+    // The process-wide gauges are raised in two steps by every runtime in the
+    // process, so `peak` and `live` cannot be compared across a concurrent
+    // read. What this asserts is that both account for this runtime's worker.
+    let live_during = live_query_worker_threads();
+    let peak_during = peak_query_worker_threads();
+    assert!(
+        live_during > 0 && peak_during > 0,
+        "the process gauges must account for a live worker: {live_during} live, \
+         {peak_during} peak"
+    );
+
+    // Stand in for the retained query graph: references that outlive the owner.
+    let retained_core = runtime.core.clone();
+    let retained_graph = (child, root, runtime.clone());
+    runtime.shutdown_workers();
+    drop(runtime);
+
+    assert_eq!(
+        retained_core.batch_executor.live_worker_count(),
+        0,
+        "shutting the runtime down must join its physical workers rather than wait \
+         for the last reference to the runtime core"
+    );
+    drop(retained_graph);
+}
+
+/// RUE-2043: dispatch onto a runtime whose owner already tore it down is a
+/// typed abort, not a panic.
+///
+/// Nothing should reach this: an owner shuts down from a point at which no
+/// request can be in flight. But a teardown placed on the wrong owner would
+/// otherwise reach the queue's `expect` and abort the process during an
+/// ordinary compilation, so the refusal is a value the caller can report — and
+/// one distinguishable from the loaded host that `WORKER_SPAWN_MESSAGE_PREFIX`
+/// classifies, because this is a compiler defect and that is not.
+#[test]
+fn a_batch_dispatched_after_shutdown_aborts_without_panicking() {
+    let runtime = QueryRuntime::new(2);
+    publish_empty(&runtime, [revision(1)]);
+    let child = runtime
+        .family_with_evaluator::<Slot, u64, _>("after-shutdown-child", 8, |_, _, key| {
+            Ok(QueryOutput::success(key.0))
+        })
+        .unwrap();
+    let child_for_root = child.clone();
+    let root = runtime
+        .family_with_evaluator::<Key, u64, _>("after-shutdown-root", 8, move |context, _, _| {
+            let mut sum = 0;
+            for terminal in context.query_registered_batch(&child_for_root, [Slot(1), Slot(2)])? {
+                let QueryOutcome::Success(value) = terminal.outcome() else {
+                    unreachable!()
+                };
+                sum += *value;
+            }
+            Ok(QueryOutput::success(sum))
+        })
+        .unwrap();
+
+    runtime.shutdown_workers();
+    let abort = runtime
+        .request_registered(&root, revision(1), Key("root"), CancellationToken::new())
+        .into_result()
+        .expect_err("a torn-down runtime must refuse the batch rather than serve it");
+    let QueryAbort::WorkerSpawn(failure) = abort else {
+        panic!("a torn-down runtime must report the refusal it made: {abort:?}")
+    };
+    assert!(
+        !failure.is_host_refusal() && failure.raw_os_error().is_none(),
+        "the machine refused nothing here: {failure}"
+    );
+    assert!(
+        !failure.to_string().contains(WORKER_SPAWN_MESSAGE_PREFIX),
+        "a compiler-side teardown defect must not render as a host resource \
+         condition, which is what a harness matches that prefix for: {failure}"
+    );
+    assert_eq!(
+        runtime.metrics().batch_worker_thread_births,
+        0,
+        "a refused dispatch must not have created a worker thread"
+    );
+}
+
 #[test]
 fn a_refused_worker_thread_aborts_the_batch_without_panicking() {
     let runtime = QueryRuntime::new(2);

--- a/crates/rue-query/src/revision.rs
+++ b/crates/rue-query/src/revision.rs
@@ -498,6 +498,36 @@ impl QueryRuntime {
         }
     }
 
+    /// Ends this runtime's physical worker threads.
+    ///
+    /// Thread creation is the one host resource a query runtime holds, and its
+    /// owner must be able to release it at a point it chooses, because dropping
+    /// the last reference to the core is not a moment that reliably arrives: an
+    /// evaluator graph is free to hold `QueryFamily` and `QueryRuntime` handles
+    /// in cycles. The full account is at the destructor of `rue-compiler`'s
+    /// `RevisionedQueryDatabase` (RUE-2043).
+    ///
+    /// Call this from the owner that can prove no request is in flight; for the
+    /// compiler that is the destructor of the database holding the runtime. The
+    /// runtime stays a valid value afterwards but owns no workers, and a
+    /// registered batch dispatched onto it is refused with a
+    /// [`WorkerSpawnFailure`](crate::WorkerSpawnFailure) rather than served:
+    /// this is teardown by an owner that is finished, not a way to pause.
+    pub fn shutdown_workers(&self) {
+        self.core.batch_executor.shutdown();
+    }
+
+    /// Physical worker threads this runtime owns right now.
+    ///
+    /// Zero before the first registered batch dispatches one, and zero again
+    /// after [`shutdown_workers`](Self::shutdown_workers) joins them. Paired
+    /// with [`RuntimeMetrics::batch_worker_thread_births`](crate::RuntimeMetrics)
+    /// it is the per-runtime statement of the ownership invariant: the threads
+    /// a runtime created are gone, not merely unreferenced.
+    pub fn live_worker_threads(&self) -> usize {
+        self.core.batch_executor.live_worker_count()
+    }
+
     /// Creates a typed family with deterministic FIFO terminal retention.
     ///
     /// This convenience form assigns no heap-owned success-value charge. A


### PR DESCRIPTION
A compilation leaves its runtime core reachable from reference cycles among the
registered families. Families are built in one pass, and every edge that runs
backwards in that order is closed by back-patching an `Arc<OnceLock<..>>` that an
earlier family's evaluator already captured; those back-patched values hold
strong `QueryFamily` handles, and the body-transaction evaluator holds a
`QueryRuntime` outright. Dropping the database therefore releases only part of
the reference count on the core, the core is never freed, and the worker threads
that waited for its last reference never exited. A process that compiles one
program per session accumulated a runtime's worth of 8 MiB threads per program —
the oracle-diff harness builds one session per corpus case and stopped 282 of
them against the host's per-process thread limit.

The fix is an ownership invariant rather than a structural one: the
`RevisionedQueryDatabase` owns the query runtime's worker threads and ends them
in its destructor. It is the outermost owner that can name that moment — a plain
value inside `CompilerSession`, reachable only through `&mut self` methods, so no
request can be in flight when it is destroyed — and it is constructed in exactly
one place and never cloned, so one session owns exactly one runtime's threads.
Weakening the cycle-forming holders would fix the underlying retention too, but
it touches 45 registered families and introduces a new failure mode (an evaluator
whose weak upgrade fails mid-request); that is a change of its own size.

A registered batch dispatched onto a runtime whose owner already shut it down is
now a typed `WorkerSpawnFailure` refusal instead of a panic. It deliberately
renders without `WORKER_SPAWN_MESSAGE_PREFIX`: the harness matches that prefix to
classify a loaded host, and a post-shutdown dispatch is a compiler defect, so it
must surface as a front-end failure. A host `EAGAIN` still carries the prefix and
still classifies as HARNESS RESOURCE, unchanged.

The executor keeps process-wide live and peak worker-thread gauges, and every
oracle-diff summary now prints a `query worker threads:` line ("peak N live at
once (N × 8 MiB of reserved stack), M still live now"), so the next thread
refusal says whether it met a run at a steady budget or one accumulating threads
across cases.

Verified on the full corpus: `oracle-diff-test` passes with zero stopped cases,
the harness process peaked at 13 OS threads against a `kern.num_taskthreads`
ceiling of 8192, and the run took 12 minutes.

Follow-up, worth its own issue: the query graph itself still leaks per session.
This change fixes the thread consequence, not the retention — every memo node,
terminal, AIR/CFG artifact and interned type from every compiled program stays
resident for the life of the process. The structural fix (weakening the
back-patched holders and the body-transaction evaluator's `runtime` field) is
what would address both.

Fixes RUE-2043
