### PR TITLE
RUE-1991: derive every keyword list from the lexer token table

### DIFF
--- a/crates/rue-fuzz/src/generators.rs
+++ b/crates/rue-fuzz/src/generators.rs
@@ -10,42 +10,17 @@ pub fn arb_ident() -> impl Strategy<Value = String> {
     // Start with letter or underscore, followed by alphanumerics
     prop::string::string_regex("[a-z_][a-z0-9_]{0,15}")
         .expect("valid regex")
-        .prop_filter("not a keyword", |s| !is_keyword(s))
+        .prop_filter("not a reserved word", |s| !is_reserved_word(s))
 }
 
-fn is_keyword(s: &str) -> bool {
-    matches!(
-        s,
-        "fn" | "let"
-            | "mut"
-            | "if"
-            | "else"
-            | "match"
-            | "while"
-            | "loop"
-            | "break"
-            | "continue"
-            | "return"
-            | "true"
-            | "false"
-            | "struct"
-            | "enum"
-            | "impl"
-            | "drop"
-            | "linear"
-            | "self"
-            | "i8"
-            | "i16"
-            | "i32"
-            | "i64"
-            | "u8"
-            | "u16"
-            | "u32"
-            | "u64"
-            | "bool"
-            | "inout"
-            | "borrow"
-    )
+/// Whether the lexer takes `s` as something other than an identifier.
+///
+/// The keyword set is `rue_lexer::KEYWORDS`, the lexer's own token table, so
+/// this generator cannot fall behind a new keyword and emit source the parser
+/// rejects. The wildcard `_` is not a keyword (spec 2.4 lists none) but lexes
+/// to its own pattern token, so it is excluded here as well.
+fn is_reserved_word(s: &str) -> bool {
+    s == "_" || rue_lexer::is_keyword(s)
 }
 
 /// Generate a primitive type name.
@@ -318,11 +293,28 @@ mod tests {
     use proptest::test_runner::TestRunner;
 
     #[test]
-    fn test_arb_ident_not_keyword() {
+    fn test_arb_ident_lexes_as_an_identifier() {
         let mut runner = TestRunner::default();
         for _ in 0..100 {
             let val = arb_ident().new_tree(&mut runner).unwrap().current();
-            assert!(!is_keyword(&val), "generated keyword: {}", val);
+            assert!(!is_reserved_word(&val), "generated reserved word: {}", val);
+            // The filter exists so the generator never hands the parser a
+            // keyword; the lexer is the authority on whether it succeeded.
+            let (tokens, _) = rue_lexer::Lexer::new(&val)
+                .tokenize()
+                .unwrap_or_else(|error| panic!("{val} failed to lex: {error}"));
+            assert!(
+                matches!(tokens[0].kind, rue_lexer::TokenKind::Ident(_)),
+                "{val} lexed as {:?}",
+                tokens[0].kind
+            );
+        }
+    }
+
+    #[test]
+    fn test_reserved_words_cover_the_lexer_keywords() {
+        for keyword in rue_lexer::KEYWORDS {
+            assert!(is_reserved_word(keyword), "{keyword} is not filtered out");
         }
     }
 

--- a/crates/rue-fuzz/src/mutate.rs
+++ b/crates/rue-fuzz/src/mutate.rs
@@ -117,51 +117,26 @@ fn arithmetic(input: &mut Vec<u8>, rng: &mut SimpleRng) {
     input[idx] = input[idx].wrapping_add(delta as u8);
 }
 
-/// Insert a Rue keyword at a random position.
+/// Insert a Rue keyword or operator at a random position.
 fn splice_keyword(input: &mut Vec<u8>, rng: &mut SimpleRng) {
-    const KEYWORDS: &[&[u8]] = &[
-        b"fn",
-        b"let",
-        b"mut",
-        b"if",
-        b"else",
-        b"match",
-        b"while",
-        b"loop",
-        b"break",
-        b"continue",
-        b"return",
-        b"true",
-        b"false",
-        b"struct",
-        b"enum",
-        b"impl",
-        b"i32",
-        b"i64",
-        b"u32",
-        b"u64",
-        b"bool",
-        b"->",
-        b"=>",
-        b"::",
-        b"==",
-        b"!=",
-        b"<=",
-        b">=",
-        b"&&",
-        b"||",
-        b"<<",
-        b">>",
+    // Keywords come from the lexer's token table, so the mutator splices every
+    // reserved word the compiler knows rather than a stale subset.
+    const OPERATORS: &[&str] = &[
+        "->", "=>", "::", "==", "!=", "<=", ">=", "&&", "||", "<<", ">>",
     ];
 
     if input.len() >= 65536 {
         return;
     }
 
-    let keyword = KEYWORDS[rng.next_usize(KEYWORDS.len())];
+    let choice = rng.next_usize(rue_lexer::KEYWORDS.len() + OPERATORS.len());
+    let spliced = match rue_lexer::KEYWORDS.get(choice) {
+        Some(keyword) => *keyword,
+        None => OPERATORS[choice - rue_lexer::KEYWORDS.len()],
+    };
     let idx = rng.next_usize(input.len() + 1);
 
-    for (i, &b) in keyword.iter().enumerate() {
+    for (i, &b) in spliced.as_bytes().iter().enumerate() {
         input.insert(idx + i, b);
     }
 }

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -65,6 +65,92 @@ pub fn interner_exhausted_error() -> rue_error::CompileError {
     )))
 }
 
+/// Every keyword token, ordered by spelling.
+///
+/// Keywords are the reserved words of spec 2.4:2 together with the reserved
+/// type names of 2.4:3 — the words the token table takes before the identifier
+/// rule, so no program can bind one. `self` and `Self` are keywords by that
+/// rule; `_` is not, because spec 2.4 lists no wildcard and the token table
+/// classifies `Underscore` as a pattern token. A consumer that needs "may not
+/// be an identifier" therefore excludes the wildcard on its own.
+///
+/// This list and `TokenKind::keyword_spelling` are the only places a keyword
+/// is written down: [`KEYWORDS`] is computed from them, and the match in
+/// `keyword_spelling` is exhaustive, so a new `TokenKind` variant does not
+/// compile until it says whether it is a keyword.
+const KEYWORD_TOKENS: &[TokenKind] = &[
+    TokenKind::SelfType,
+    TokenKind::Bool,
+    TokenKind::Borrow,
+    TokenKind::Break,
+    TokenKind::Checked,
+    TokenKind::Comptime,
+    TokenKind::Const,
+    TokenKind::Continue,
+    TokenKind::Drop,
+    TokenKind::Else,
+    TokenKind::Enum,
+    TokenKind::Extern,
+    TokenKind::False,
+    TokenKind::Fn,
+    TokenKind::For,
+    TokenKind::I16,
+    TokenKind::I32,
+    TokenKind::I64,
+    TokenKind::I8,
+    TokenKind::If,
+    TokenKind::Impl,
+    TokenKind::In,
+    TokenKind::Inout,
+    TokenKind::Let,
+    TokenKind::Linear,
+    TokenKind::Loop,
+    TokenKind::Match,
+    TokenKind::Mut,
+    TokenKind::Ptr,
+    TokenKind::Pub,
+    TokenKind::Return,
+    TokenKind::SelfValue,
+    TokenKind::Struct,
+    TokenKind::True,
+    TokenKind::Type,
+    TokenKind::U16,
+    TokenKind::U32,
+    TokenKind::U64,
+    TokenKind::U8,
+    TokenKind::Unchecked,
+    TokenKind::While,
+    TokenKind::Yield,
+];
+
+const KEYWORD_SPELLINGS: [&str; KEYWORD_TOKENS.len()] = {
+    let mut spellings = [""; KEYWORD_TOKENS.len()];
+    let mut index = 0;
+    while index < KEYWORD_TOKENS.len() {
+        spellings[index] = match KEYWORD_TOKENS[index].keyword_spelling() {
+            Some(spelling) => spelling,
+            None => panic!("KEYWORD_TOKENS lists a token that is not a keyword"),
+        };
+        index += 1;
+    }
+    spellings
+};
+
+/// Every keyword spelling, ordered by spelling.
+///
+/// Consumers outside the lexer — the fuzz identifier generator, the
+/// specification keyword tables, the website syntax definition — read this
+/// slice or are tested against it rather than repeating the list.
+pub const KEYWORDS: &[&str] = &KEYWORD_SPELLINGS;
+
+/// Whether `word` is a keyword and so cannot be used as an identifier.
+///
+/// The wildcard `_` is not a keyword, though it is equally unavailable as an
+/// identifier; a caller that generates identifiers must reject it separately.
+pub fn is_keyword(word: &str) -> bool {
+    KEYWORDS.contains(&word)
+}
+
 /// Token kinds in the Rue language.
 ///
 /// This enum is `Copy` since all variants contain only small, copyable data:
@@ -197,6 +283,112 @@ pub enum TokenKind {
 }
 
 impl TokenKind {
+    /// The source spelling of this token when it is a keyword.
+    ///
+    /// The match is exhaustive by design: a new `TokenKind` variant does not
+    /// compile until it says whether it is a keyword, which is what keeps
+    /// [`KEYWORDS`] complete.
+    pub const fn keyword_spelling(self) -> Option<&'static str> {
+        Some(match self {
+            TokenKind::Fn => "fn",
+            TokenKind::Let => "let",
+            TokenKind::Mut => "mut",
+            TokenKind::Inout => "inout",
+            TokenKind::Borrow => "borrow",
+            TokenKind::If => "if",
+            TokenKind::Else => "else",
+            TokenKind::Match => "match",
+            TokenKind::While => "while",
+            TokenKind::Loop => "loop",
+            TokenKind::For => "for",
+            TokenKind::In => "in",
+            TokenKind::Break => "break",
+            TokenKind::Continue => "continue",
+            TokenKind::Return => "return",
+            TokenKind::Yield => "yield",
+            TokenKind::True => "true",
+            TokenKind::False => "false",
+            TokenKind::Struct => "struct",
+            TokenKind::Enum => "enum",
+            TokenKind::Impl => "impl",
+            TokenKind::Drop => "drop",
+            TokenKind::Linear => "linear",
+            TokenKind::SelfValue => "self",
+            TokenKind::SelfType => "Self",
+            TokenKind::Comptime => "comptime",
+            TokenKind::Pub => "pub",
+            TokenKind::Const => "const",
+            TokenKind::Checked => "checked",
+            TokenKind::Unchecked => "unchecked",
+            TokenKind::Ptr => "ptr",
+            TokenKind::Extern => "extern",
+            TokenKind::I8 => "i8",
+            TokenKind::I16 => "i16",
+            TokenKind::I32 => "i32",
+            TokenKind::I64 => "i64",
+            TokenKind::U8 => "u8",
+            TokenKind::U16 => "u16",
+            TokenKind::U32 => "u32",
+            TokenKind::U64 => "u64",
+            TokenKind::Bool => "bool",
+            TokenKind::Type => "type",
+            // Not keywords: the wildcard pattern, the literal and identifier
+            // classes, every operator and punctuator, and end of file.
+            TokenKind::Underscore
+            | TokenKind::Int(_)
+            | TokenKind::Float(_)
+            | TokenKind::String(_)
+            | TokenKind::Ident(_)
+            | TokenKind::Plus
+            | TokenKind::Minus
+            | TokenKind::Star
+            | TokenKind::Slash
+            | TokenKind::Percent
+            | TokenKind::Eq
+            | TokenKind::EqEq
+            | TokenKind::Bang
+            | TokenKind::BangEq
+            | TokenKind::Lt
+            | TokenKind::Gt
+            | TokenKind::LtEq
+            | TokenKind::GtEq
+            | TokenKind::AmpAmp
+            | TokenKind::PipePipe
+            | TokenKind::Amp
+            | TokenKind::Pipe
+            | TokenKind::Caret
+            | TokenKind::Tilde
+            | TokenKind::LtLt
+            | TokenKind::GtGt
+            | TokenKind::PlusEq
+            | TokenKind::MinusEq
+            | TokenKind::StarEq
+            | TokenKind::SlashEq
+            | TokenKind::PercentEq
+            | TokenKind::AmpEq
+            | TokenKind::PipeEq
+            | TokenKind::CaretEq
+            | TokenKind::LtLtEq
+            | TokenKind::GtGtEq
+            | TokenKind::LParen
+            | TokenKind::RParen
+            | TokenKind::LBrace
+            | TokenKind::RBrace
+            | TokenKind::LBracket
+            | TokenKind::RBracket
+            | TokenKind::Arrow
+            | TokenKind::FatArrow
+            | TokenKind::ColonColon
+            | TokenKind::Colon
+            | TokenKind::Semi
+            | TokenKind::Comma
+            | TokenKind::Dot
+            | TokenKind::At
+            | TokenKind::Question
+            | TokenKind::Eof => return None,
+        })
+    }
+
     /// Get a human-readable name for this token kind.
     pub fn name(&self) -> &'static str {
         match self {
@@ -413,5 +605,67 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Question => write!(f, "QUESTION"),
             TokenKind::Eof => write!(f, "EOF"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keywords_are_sorted_and_unique() {
+        let mut sorted = KEYWORDS.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted, KEYWORDS.to_vec());
+    }
+
+    #[test]
+    fn every_keyword_spelling_lexes_to_its_own_token() {
+        for spelling in KEYWORDS {
+            let (tokens, _) = Lexer::new(spelling)
+                .tokenize()
+                .unwrap_or_else(|error| panic!("keyword {spelling} failed to lex: {error}"));
+            assert_eq!(
+                tokens.len(),
+                2,
+                "keyword {spelling} lexed to {tokens:?} instead of one token and EOF"
+            );
+            assert_eq!(tokens[0].kind.keyword_spelling(), Some(*spelling));
+            assert_eq!(tokens[1].kind, TokenKind::Eof);
+        }
+    }
+
+    #[test]
+    fn the_wildcard_is_a_pattern_token_not_a_keyword() {
+        // Spec 2.4 lists no wildcard, so `_` is absent from KEYWORDS even
+        // though it is equally unavailable as an identifier.
+        let (tokens, _) = Lexer::new("_").tokenize().expect("`_` lexes");
+        assert_eq!(tokens[0].kind, TokenKind::Underscore);
+        assert_eq!(TokenKind::Underscore.keyword_spelling(), None);
+        assert!(!is_keyword("_"));
+    }
+
+    #[test]
+    fn non_keyword_tokens_have_no_keyword_spelling() {
+        for kind in [
+            TokenKind::Int(7),
+            TokenKind::Plus,
+            TokenKind::LBrace,
+            TokenKind::Arrow,
+            TokenKind::Eof,
+        ] {
+            assert_eq!(kind.keyword_spelling(), None, "{kind} is not a keyword");
+        }
+    }
+
+    #[test]
+    fn is_keyword_answers_for_reserved_words_only() {
+        assert!(is_keyword("fn"));
+        assert!(is_keyword("Self"));
+        assert!(is_keyword("type"));
+        assert!(!is_keyword("main"));
+        assert!(!is_keyword("Fn"));
+        assert!(!is_keyword(""));
     }
 }

--- a/crates/rue-spec/BUCK
+++ b/crates/rue-spec/BUCK
@@ -18,6 +18,9 @@ rue_binary(
         "//third-party:tempfile",
         "//third-party:toml",
     ],
+    # The keyword cross-checks read `rue_lexer::KEYWORDS`, the canonical
+    # keyword list, and nothing in the binary itself needs the lexer.
+    test_deps = ["//crates/rue-lexer:rue-lexer"],
 )
 
 # The spec test cases, as an input of the //:spec-tests suite (so a cases/

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -2035,6 +2035,97 @@ mod tests {
         validate_appendix_grammar(Path::new("docs/spec/src")).unwrap();
     }
 
+    /// Every word named by a keyword table in the specification's keyword
+    /// chapter: the keywords of 2.4:2 and the reserved type names of 2.4:3,
+    /// which together are the words a program cannot use as an identifier.
+    fn spec_keyword_tables(spec_dir: &Path) -> Vec<String> {
+        let path = spec_dir.join("02-lexical-structure/04-keywords.md");
+        let text = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("reading {}: {error}", path.display()));
+        let mut spellings: Vec<String> = text
+            .lines()
+            .filter_map(|line| {
+                let cell = line.strip_prefix("| `")?;
+                let (spelling, _) = cell.split_once('`')?;
+                Some(spelling.to_owned())
+            })
+            .collect();
+        assert!(
+            !spellings.is_empty(),
+            "{} has no keyword table",
+            path.display()
+        );
+        spellings.sort();
+        spellings
+    }
+
+    /// Every word the website's syntax definition highlights as a keyword,
+    /// taken from the alternations of its `keywords` and `types` contexts.
+    fn syntax_definition_keywords(path: &Path) -> Vec<String> {
+        let text = fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("reading {}: {error}", path.display()));
+        let mut context = String::new();
+        let mut spellings = Vec::new();
+        for line in text.lines() {
+            if let Some(name) = line
+                .strip_prefix("  ")
+                .filter(|rest| !rest.starts_with([' ', '-', '#']))
+                .and_then(|rest| rest.strip_suffix(':'))
+            {
+                context = name.to_owned();
+                continue;
+            }
+            if context != "keywords" && context != "types" {
+                continue;
+            }
+            // Only word alternations (`\b(a|b)\b`) name keywords; the other
+            // matches in these contexts are literal syntax such as `\(\)`.
+            let Some(alternation) = line
+                .split_once("\\b(")
+                .and_then(|(_, rest)| rest.split_once(")\\b"))
+                .map(|(alternation, _)| alternation)
+            else {
+                continue;
+            };
+            spellings.extend(alternation.split('|').map(str::to_owned));
+        }
+        assert!(
+            !spellings.is_empty(),
+            "{} has no keyword alternation",
+            path.display()
+        );
+        spellings.sort();
+        spellings
+    }
+
+    fn lexer_keywords() -> Vec<String> {
+        rue_lexer::KEYWORDS
+            .iter()
+            .map(|keyword| (*keyword).to_owned())
+            .collect()
+    }
+
+    #[test]
+    fn specification_keyword_tables_match_the_lexer() {
+        // The lexer's token table is the authority on what a keyword is; the
+        // chapter is normative text about the same set, so the two are pinned
+        // to each other rather than maintained in parallel.
+        assert_eq!(
+            spec_keyword_tables(Path::new("docs/spec/src")),
+            lexer_keywords(),
+            "docs/spec/src/02-lexical-structure/04-keywords.md and rue_lexer::KEYWORDS disagree"
+        );
+    }
+
+    #[test]
+    fn website_syntax_definition_highlights_every_keyword() {
+        assert_eq!(
+            syntax_definition_keywords(Path::new("website/syntaxes/rue.sublime-syntax")),
+            lexer_keywords(),
+            "website/syntaxes/rue.sublime-syntax and rue_lexer::KEYWORDS disagree"
+        );
+    }
+
     #[test]
     fn appendix_grammar_reports_all_undefined_symbols_in_order() {
         let spec_dir = tempfile::tempdir().unwrap();

--- a/website/syntaxes/rue.sublime-syntax
+++ b/website/syntaxes/rue.sublime-syntax
@@ -30,21 +30,30 @@ contexts:
     - match: //.*$
       scope: comment.line.double-slash.rue
 
+  # Every word matched here comes from the lexer's keyword table
+  # (`rue_lexer::KEYWORDS`); the `keywords` and `types` alternations together
+  # must name it exactly, which the rue-spec unit tests check.
   keywords:
     # Control flow
-    - match: \b(if|else|while|loop|match|return|break|continue)\b
+    - match: \b(break|continue|else|for|if|in|loop|match|return|while|yield)\b
       scope: keyword.control.rue
-    # Declaration keywords
-    - match: \b(fn|let|mut|struct|enum)\b
+    # Declarations and modifiers
+    - match: \b(borrow|checked|comptime|const|drop|enum|extern|fn|impl|inout|let|linear|mut|pub|struct|unchecked)\b
       scope: keyword.declaration.rue
     # Boolean literals
-    - match: \b(true|false)\b
+    - match: \b(false|true)\b
       scope: constant.language.boolean.rue
+    # The receiver
+    - match: \b(self)\b
+      scope: variable.language.self.rue
 
   types:
     # Primitive types
-    - match: \b(i8|i16|i32|i64|u8|u16|u32|u64|bool)\b
+    - match: \b(bool|i16|i32|i64|i8|u16|u32|u64|u8)\b
       scope: storage.type.primitive.rue
+    # The enclosing struct type, the pointer constructor, and the type of types
+    - match: \b(Self|ptr|type)\b
+      scope: storage.type.rue
     # Unit type
     - match: \(\)
       scope: storage.type.unit.rue


### PR DESCRIPTION
Fixes RUE-1991

## Why

Keyword lists outside the lexer were hand-mirrored and had drifted: the fuzz identifier generator's `is_keyword` was missing `for in yield comptime pub const checked unchecked ptr extern type Self` (so it could emit keywords and produce spurious parse failures), the fuzz mutator's `splice_keyword` held a second partial list, the website syntax definition listed 24 of the 42 keywords, and nothing checked the specification's keyword tables against the lexer.

## What

- `rue_lexer::KEYWORDS` is now the one keyword inventory. It is computed at const-eval time from a list of keyword `TokenKind` variants through `TokenKind::keyword_spelling`, an exhaustive match, so a new token variant does not compile until it says whether it is a keyword and no spelling is written twice. `is_keyword` is exposed alongside it. `_` is deliberately not a keyword (spec 2.4 lists no wildcard; the token table classifies it as a pattern token), and the doc comments say so.
- `rue-fuzz`: the identifier generator filters on `rue_lexer::is_keyword` plus the wildcard, and its test now asserts every generated identifier lexes to `Ident`; the mutator splices from `rue_lexer::KEYWORDS` with only its operator palette kept local.
- `rue-spec`: two traceability tests pin `docs/spec/src/02-lexical-structure/04-keywords.md` and `website/syntaxes/rue.sublime-syntax` to `KEYWORDS`. The rue-spec BUCK target gains a `test_deps` on rue-lexer.
- `website/syntaxes/rue.sublime-syntax`: highlights all 42 keywords, with `self`, `Self`, `ptr`, and `type` given scopes.

## Verification

- `scripts/rue unit lexer` (75 passed), `scripts/rue unit fuzz` (127 passed), `scripts/rue unit spec` (53 passed, including the two new tests).
- Negative check: removing `ptr` from the spec table and `yield` from the syntax file made exactly the two new tests fail.
- `scripts/rue quick`: Pass 36, Fail 0. `scripts/rue fmt` clean; fmt-check and clippy gates for rue-lexer, rue-fuzz, rue-spec pass.