### PR TITLE
RUE-2009: fail CI setup when the remote cache is configured but the daemon has no engine address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,10 @@ jobs:
       # merge_group and workflow_dispatch runs. That is where it matters: the
       # merge queue serializes on this workflow. The cold fallback is
       # mandatory; this step must never fail because the secret is absent.
+      # With the secret present it must fail rather than build cache-free:
+      # `verify` asks the daemon for its remote-cache engine address, because
+      # provisioning is lazy and a daemon that loaded none is invisible in a
+      # green job (RUE-2009). Every other job below follows the same shape.
       - name: Provision remote build cache
         if: steps.sel.outputs.run == 'true'
         env:
@@ -192,6 +196,7 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       - name: Run clippy
         if: steps.sel.outputs.run == 'true'
@@ -247,6 +252,7 @@ jobs:
             exit 1
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       - name: Build compiler remotely
         env:
@@ -326,6 +332,7 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       # RUE-1130: materialize the determinator's impacted-target closure so the
       # heavy steps below can run exactly it. `narrowed` is the determinator's
@@ -634,6 +641,7 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       - name: Check the performance series is still advancing
         # Is the series *already* stalled? A repository-wide condition, so this
@@ -810,6 +818,7 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       - name: Build native compiler and linker
         if: steps.sel.outputs.run == 'true'
@@ -963,6 +972,7 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       - name: Check rue_program digest sensitivity
         if: steps.sel.outputs.run == 'true'
@@ -1031,6 +1041,7 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       - name: Decide affected corpus targets
         # Fail-open: the script always exits 0 with a decision (full on any
@@ -1105,6 +1116,7 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       - name: Run ${{ matrix.name }} corpus
         if: steps.sel.outputs.run == 'true'
@@ -1171,6 +1183,7 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       # Direct RUE-277 guard: inspect Buck's analyzed rustc_cfg actions instead
       # of inferring optimization from complete binary bytes. This performs no
@@ -1223,6 +1236,7 @@ jobs:
             exit 0
           fi
           scripts/provision-build-cache install
+          scripts/provision-build-cache verify
 
       - name: Install valgrind
         if: steps.sel.outputs.run == 'true'

--- a/buck2
+++ b/buck2
@@ -6,6 +6,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 args=("$@")
 
 execution_command=0
+audit_command=0
 explicit_preference=0
 remote_cache_disabled=0
 if [[ "${#args[@]}" -gt 0 ]]; then
@@ -13,6 +14,7 @@ if [[ "${#args[@]}" -gt 0 ]]; then
         [[ "$arg" == "--" ]] && break
         case "$arg" in
             build|test|run|install) execution_command=1 ;;
+            audit) audit_command=1 ;;
             --prefer-local|--prefer-remote|--remote-only) explicit_preference=1 ;;
             --local-only) explicit_preference=1; remote_cache_disabled=1 ;;
             --no-remote-cache) remote_cache_disabled=1 ;;
@@ -61,9 +63,16 @@ fi
 # symlink or file, belongs to the user and is left alone, and a config another
 # account can read is refused with a warning rather than linked; neither ever
 # blocks a local build.
+#
+# `audit` links too, because it is how the configuration is read back:
+# `scripts/provision-build-cache verify` asks the daemon for its remote-cache
+# engine address before a job's first build (RUE-2009), and an audit that saw a
+# different configuration than the following build would report exactly the
+# absence it exists to detect. Commands that neither execute actions nor report
+# configuration still write nothing into the checkout.
 central_config="${RUE_BUILDBUDDY_CONFIG:-${XDG_CONFIG_HOME:-${HOME:-}/.config}/rue/buildbuddy.buckconfig}"
 local_config="$repo_root/.buckconfig.local"
-if [[ "$execution_command" -eq 1 ]] && [[ "${RUE_NO_REMOTE_CACHE:-}" != 1 ]] &&
+if [[ "$execution_command" -eq 1 || "$audit_command" -eq 1 ]] && [[ "${RUE_NO_REMOTE_CACHE:-}" != 1 ]] &&
    [[ -f "$central_config" ]] && [[ ! -e "$local_config" ]] && [[ ! -L "$local_config" ]]; then
     # GNU stat first, then the BSD spelling.
     mode="$(stat -c '%a' "$central_config" 2>/dev/null || stat -f '%Lp' "$central_config" 2>/dev/null || true)"

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -33,8 +33,10 @@ scripts/rue cache install       # prompts without echo for the BuildBuddy key
 `${XDG_CONFIG_HOME:-~/.config}/rue/buildbuddy.buckconfig` with mode `0600`;
 re-run it to replace the file, and it never prints the key. That is the only
 step: the repository `./buck2` wrapper links `.buckconfig.local` (gitignored)
-to that file in any worktree on the first `build`, `test`, `run`, or `install`
-there, so the credential is never copied between worktrees or stored in Git.
+to that file in any worktree on the first `build`, `test`, `run`, `install`, or
+`audit` there, so the credential is never copied between worktrees or stored in
+Git (`audit` links because it is how the configuration is read back, and it
+must report what a build would get — see the CI verification below).
 The link, rather than a per-command `--config-file`, is the delivery mechanism
 because `[buck2] digest_algorithms` and `[buck2_re_client]` are daemon-startup
 settings: a `--config-file` leaves the daemon on SHA1 digests (which
@@ -353,6 +355,32 @@ Availability rules, which the workflow steps must respect:
   independent job lets the ordinary linux-x64 build and tests use the shared
   cache without changing the reproducibility contract.
 
+### Verifying that the daemon actually got the config (RUE-2009)
+
+The delivery mechanism is a lazy `.buckconfig.local` link, so a job can reach
+its build with a daemon that never loaded the config: it then has no remote
+cache, executes everything locally, and passes. `CI` run 33774551666 did that in
+seventeen jobs, each logging `Internal error (stage: remote_action_cache) …
+Error: (No engine address)` while going green. Nothing was red and the summary
+said nothing, so the only evidence was a raw log — the same reconstruction
+RUE-2003 had to do.
+
+Every provisioning step therefore runs `scripts/provision-build-cache verify`
+immediately after `install`. It asks Buck for one key,
+`buck2 audit config buck2_re_client.engine_address`, and fails the setup step
+when the secret is present and the daemon reports no address, naming that cause
+and the two paths involved. Only the address key is requested and no audit
+output is ever echoed, because the section as a whole carries the credential
+header. The `./buck2` wrapper links the installed config for `audit` as well as
+for `build`/`test`/`run`/`install`, so the daemon that answers is configured
+exactly as the build that follows will be; a changed `.buckconfig.local`
+restarts the daemon, which is what makes the answer a fresh one.
+
+Where no cache is expected the check passes with an explanatory line rather
+than failing: a fork `pull_request` without the secret, and `RUE_NO_REMOTE_CACHE=1`.
+It confirms configuration, not reachability — an engine address the daemon
+cannot reach still fails later, in the build, with Buck's own diagnostic.
+
 `scripts/check-reproducible-build-metadata.py` is a separate, opt-in diagnostic
 for investigating reproducibility below that final binary. It requires a clean
 working tree, records `HEAD`, and archives that same tracked revision into two
@@ -445,10 +473,19 @@ Each summary separates the four costs that a single wall-time number conflates:
 
 | Column | Question it answers |
 | --- | --- |
+| Action cache | whether this step had a cache at all, and used it |
 | Cached | how many actions the remote cache served |
 | Remote | how many executed on the BuildBuddy worker |
 | Local | how many executed on the runner |
 | Test time | how long the test processes themselves ran |
+
+`Action cache` reads `used` for a step whose Buck invocations obtained actions
+from BuildBuddy, `unused` for a step configured for the cache that obtained
+none, and `off` for a step with no engine address in the checkout's
+`.buckconfig.local` — a fork pull request, `RUE_NO_REMOTE_CACHE=1`, or an
+explicit `--no-remote-cache`/`--local-only`, as the remote-execution canary
+uses. A cache-free lane is then visible in the summary instead of only in a raw
+log (RUE-2009).
 
 The first three are Buck's own accounting of how each action was *obtained*.
 The fourth is not: Rue's spec, UI, and CLI corpora are entire harnesses behind a

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -186,6 +186,15 @@ compiler-reproducibility job is the deliberate exception: its two independently
 materialized compiler builds stay local and cache-free, while the ordinary
 linux-x64 test lane may use BuildBuddy.
 
+Each provisioning step runs `scripts/provision-build-cache verify` after
+`install`. Provisioning is a lazy `.buckconfig.local` link, so a daemon can
+reach the build having loaded none of it — seventeen jobs in run 33774551666
+built with no remote cache and went green (RUE-2009). `verify` asks Buck for
+`buck2_re_client.engine_address` and fails the setup step when the secret is
+present and the daemon has none; where no cache is expected — a fork pull
+request without the secret, or `RUE_NO_REMOTE_CACHE=1` — it passes with an
+explanatory line.
+
 Required release coverage is intentionally focused (RUE-1129). The
 `release (linux-x64)` job analyzes Buck's configured `rustc_cfg` actions and
 fails unless `//platforms:release` supplies `-Copt-level=3 -Clto=thin` while
@@ -760,8 +769,9 @@ shard summaries also show the number of measured cases next to wall time. Read
 wall time together with hit count: a small number of invalidated ThinLTO actions
 can dominate a release build even when its hit rate is above 90 percent.
 
-Each summary also reports the action-cache hit rate and the summed duration of
-the test processes themselves. That last figure is deliberately separate from
+Each summary also reports whether the step had an action cache at all
+(`used`, `unused`, or `off`), the action-cache hit rate, and the summed duration
+of the test processes themselves. That last figure is deliberately separate from
 the cached/remote/local counters, which describe only how Buck *obtained* each
 action: a corpus lane whose wall time is one harness process is a sharding
 problem, and a lane whose wall time is uncached actions is a cache problem.

--- a/scripts/ci-timed
+++ b/scripts/ci-timed
@@ -116,6 +116,39 @@ if [[ -n "$network" ]]; then
     network_down="${network##* }"
 fi
 
+# Whether this step had an action cache at all. A daemon that never loaded the
+# BuildBuddy config builds everything locally and turns nothing red: seventeen
+# jobs in CI run 33774551666 did exactly that, and only a raw log said so
+# (RUE-2009). `scripts/provision-build-cache verify` fails a job's setup when
+# the secret is present and the daemon has no engine address; this column
+# reports the same fact per step, for the lanes where no cache is expected too.
+# The configuration is read from the checkout's .buckconfig.local -- the
+# wrapper links it lazily, so it is read after the command rather than before,
+# and only the address key is matched, never the credential header beside it.
+action_cache="off"
+cache_configured=0
+if [[ "${RUE_NO_REMOTE_CACHE:-}" != 1 ]] && [[ -r "$PWD/.buckconfig.local" ]] &&
+   grep -Eq '^[[:space:]]*engine_address[[:space:]]*=[[:space:]]*[^[:space:]]' "$PWD/.buckconfig.local"; then
+    cache_configured=1
+fi
+# Buck's own cache opt-outs are part of the step's identity: the merge-group
+# remote-execution canary runs --no-remote-cache deliberately.
+for arg in "$@"; do
+    [[ "$arg" == "--" ]] && break
+    case "$arg" in
+        --no-remote-cache|--local-only) cache_configured=0 ;;
+    esac
+done
+if [[ "$cache_configured" -eq 1 ]]; then
+    if [[ "$invocations" -eq 0 ]]; then
+        action_cache="configured"
+    elif [[ $((cached + remote)) -gt 0 ]]; then
+        action_cache="used"
+    else
+        action_cache="unused"
+    fi
+fi
+
 if [[ "$status" -eq 0 && "${RUE_CI_REQUIRE_REMOTE_ACTIONS:-0}" == "1" && "$remote" -eq 0 ]]; then
     echo "::error::remote-execution canary completed without any remotely executed Buck actions" >&2
     status=1
@@ -132,11 +165,16 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     {
         echo "### CI timing: $safe_label"
         echo
-        echo "| Result | Wall time | Test time | Cache hits | CLI cases | Buck invocations | Commands | Cached | Remote | Local | Net down | Net up |"
-        echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
-        echo "| $result | ${elapsed}s | $test_time | $hit_rate | $cli_cases | $invocations | $commands | $cached | $remote | $local_actions | $network_down | $network_up |"
+        echo "| Result | Wall time | Test time | Cache hits | Action cache | CLI cases | Buck invocations | Commands | Cached | Remote | Local | Net down | Net up |"
+        echo "| --- | ---: | ---: | ---: | :---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+        echo "| $result | ${elapsed}s | $test_time | $hit_rate | $action_cache | $cli_cases | $invocations | $commands | $cached | $remote | $local_actions | $network_down | $network_up |"
         echo
-        echo "<sup>Cached/Remote/Local count Buck actions by how each was obtained."
+        echo "<sup>Action cache: <code>used</code> is a step whose Buck invocations"
+        echo "obtained actions from BuildBuddy, <code>unused</code> a step configured"
+        echo "for it that obtained none, <code>off</code> a step with no engine address"
+        echo "at all — a fork pull request, or a deliberately cache-free lane — and"
+        echo "<code>configured</code> a step that ran no Buck invocation to measure."
+        echo "Cached/Remote/Local count Buck actions by how each was obtained."
         echo "Test time is the summed duration Buck reports for the test processes"
         echo "themselves — opaque to those counters, and where a corpus lane's wall"
         echo "time actually goes. Net down/up is Buck's own byte count for the"

--- a/scripts/provision-build-cache
+++ b/scripts/provision-build-cache
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
-# Install one private BuildBuddy Buck config for the current user. The
-# repository ./buck2 wrapper links .buckconfig.local to that file in any
-# worktree on the first execution command there, so installing it is the whole
-# provisioning step.
+# Install one private BuildBuddy Buck config for the current user, and verify
+# that Buck actually picked it up. The repository ./buck2 wrapper links
+# .buckconfig.local to that file in any worktree on the first command there
+# that needs it, so installing it is the whole provisioning step; `verify`
+# exists because that link is lazy and a daemon without it is silent.
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 config_home="${XDG_CONFIG_HOME:-${HOME:?HOME must be set}/.config}"
 central_config="${RUE_BUILDBUDDY_CONFIG:-$config_home/rue/buildbuddy.buckconfig}"
+local_config="$repo_root/.buckconfig.local"
+
+# The engine address is the one [buck2_re_client] key that says the daemon can
+# reach BuildBuddy at all. Ask Buck for exactly it: the section as a whole
+# carries the credential header.
+engine_address_key='buck2_re_client.engine_address'
 
 usage() {
     cat <<'USAGE'
 usage: scripts/provision-build-cache install
+       scripts/provision-build-cache verify
 
 install reads BUILDBUDDY_API_KEY, or prompts without echo on a terminal, and
 atomically writes the private config with mode 0600 to
@@ -18,6 +27,11 @@ ${XDG_CONFIG_HOME:-~/.config}/rue/buildbuddy.buckconfig (RUE_BUILDBUDDY_CONFIG
 names another path). Re-run it to replace an existing config. The credential
 is never printed. Remove the file to stop using the remote cache, or set
 RUE_NO_REMOTE_CACHE=1 to keep one command cache-free.
+
+verify asks the Buck daemon whether it actually has a remote-cache engine
+address and fails when BUILDBUDDY_API_KEY is set but the daemon has none. It
+passes with an explanatory line where no cache is expected: a fork pull
+request without the secret, or RUE_NO_REMOTE_CACHE=1.
 USAGE
 }
 
@@ -77,10 +91,72 @@ CONFIG
     echo "Installed private BuildBuddy config at $central_config"
 }
 
+# A daemon that never loaded the BuildBuddy config builds everything locally
+# and turns nothing red: CI run 33774551666 had seventeen such jobs, reporting
+# `Internal error (stage: remote_action_cache) ... Error: (No engine address)`
+# in their logs while every one of them went green (RUE-2009). Provisioning is
+# lazy -- the ./buck2 wrapper links .buckconfig.local on the first command that
+# needs it -- so the only trustworthy answer comes from Buck itself. This runs
+# before a job's first build, and the wrapper links the config for `audit` too,
+# so the daemon that answers is configured exactly as the build will be.
+verify_daemon_cache() {
+    if [[ "${RUE_NO_REMOTE_CACHE:-}" == 1 ]]; then
+        echo "RUE_NO_REMOTE_CACHE=1: this run is deliberately cache-free, so there is no remote cache to verify."
+        return 0
+    fi
+    if [[ -z "${BUILDBUDDY_API_KEY:-}" ]]; then
+        echo "BUILDBUDDY_API_KEY unavailable (fork PR or unset); building without the remote cache, so there is nothing to verify."
+        return 0
+    fi
+
+    local prefix='error: '
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        prefix='::error::'
+    fi
+
+    local audit_output status=0
+    audit_output="$(mktemp "${TMPDIR:-/tmp}/rue-cache-verify.XXXXXX")"
+    trap 'rm -f "$audit_output"' EXIT
+    # Only Buck's stdout is captured, and it holds nothing but the requested
+    # key. Buck's own progress and diagnostics stay on stderr, where the job
+    # log shows them as they happen.
+    "$repo_root/buck2" audit config "$engine_address_key" >"$audit_output" || status=$?
+
+    if [[ "$status" -ne 0 ]]; then
+        {
+            printf '%sbuck2 audit config %s failed (exit %s), so this job cannot confirm it has a remote action cache.\n' \
+                "$prefix" "$engine_address_key" "$status"
+            printf "Re-run it by hand to see Buck's own diagnosis.\n"
+        } >&2
+        exit 1
+    fi
+
+    # Match the address key only, and never echo the audit output.
+    if ! grep -Eq '(^|[.[:space:]])engine_address[[:space:]]*=[[:space:]]*[^[:space:]]' "$audit_output" &&
+       ! grep -Eq '^[[:space:]]*grpc://[^[:space:]]+[[:space:]]*$' "$audit_output"; then
+        {
+            printf '%sthe Buck daemon reports no %s while BUILDBUDDY_API_KEY is set: this job has no remote action cache, would rebuild everything locally, and would pass silently.\n' \
+                "$prefix" "$engine_address_key"
+            printf 'Provisioning writes %s, and the ./buck2 wrapper links %s to it. Check that scripts/provision-build-cache install ran in this job and that the link exists.\n' \
+                "$central_config" "$local_config"
+            printf 'Set RUE_NO_REMOTE_CACHE=1 for a deliberately cache-free run.\n'
+        } >&2
+        exit 1
+    fi
+
+    rm -f "$audit_output"
+    trap - EXIT
+    echo "Remote action cache verified: the Buck daemon reports a $engine_address_key."
+}
+
 case "${1:-}" in
     install)
         [[ $# -eq 1 ]] || { usage >&2; exit 2; }
         install_config
+        ;;
+    verify)
+        [[ $# -eq 1 ]] || { usage >&2; exit 2; }
+        verify_daemon_cache
         ;;
     -h|--help|help)
         usage

--- a/scripts/rue
+++ b/scripts/rue
@@ -27,6 +27,7 @@
 #                                  (status | plan [age] | clean [age] | reset ROOT ...)
 #   scripts/rue gc [age]           Compatibility alias for host-wide stale cleanup
 #   scripts/rue cache install      Install the private BuildBuddy cache config
+#   scripts/rue cache verify       Check that the Buck daemon has a cache engine address
 #   scripts/rue path               Print the absolute binary path (build if needed)
 #
 set -euo pipefail

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -187,7 +187,98 @@ test_cache_install() {
     rc=0
     HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
         "$SRC_ROOT/scripts/provision-build-cache" apply >/dev/null 2>&1 || rc=$?
-    check "cache: install is the only subcommand" "$([ "$rc" -eq 2 ] && echo 0 || echo 1)"
+    check "cache: an unknown subcommand is refused" "$([ "$rc" -eq 2 ] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+# RUE-2009: provisioning is lazy, so a job can reach its build with a daemon
+# that never loaded the BuildBuddy config -- no remote cache, everything built
+# locally, nothing red. `verify` asks Buck itself, before the build, and fails
+# the setup step when the secret is present and the daemon has no engine
+# address. The fake buck2 stands in for that answer; no daemon runs here.
+test_cache_verify() {
+    local sb key out rc
+    sb="$(mktemp -d)"
+    key='test-secret-that-must-not-be-printed'
+    mkdir -p "$sb/scripts"
+    cp "$SRC_ROOT/scripts/provision-build-cache" "$sb/scripts/provision-build-cache"
+    chmod +x "$sb/scripts/provision-build-cache"
+    cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$BUCK_AUDIT_ARGS"
+if [[ -f "$BUCK_AUDIT_OUTPUT" ]]; then cat "$BUCK_AUDIT_OUTPUT"; fi
+exit "${BUCK_AUDIT_STATUS:-0}"
+EOF
+    chmod +x "$sb/buck2"
+
+    # A daemon that loaded the config reports the address, and the check asks
+    # for that one key: the section as a whole carries the credential header.
+    printf 'buck2_re_client.engine_address = grpc://remote.buildbuddy.io\n' >"$sb/audit.out"
+    rc=0
+    out="$(cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
+        BUCK_AUDIT_ARGS="$sb/audit.args" BUCK_AUDIT_OUTPUT="$sb/audit.out" \
+        scripts/provision-build-cache verify 2>&1)" || rc=$?
+    check "cache: a daemon with an engine address passes verification" \
+        "$([ "$rc" -eq 0 ] && grep -Fq 'Remote action cache verified' <<<"$out" && echo 0 || echo 1)"
+    check "cache: verification asks Buck for the address key alone" \
+        "$([ "$(cat "$sb/audit.args")" = 'audit config buck2_re_client.engine_address' ] && echo 0 || echo 1)"
+
+    # The RUE-2009 signature: the secret is present, the daemon is not
+    # configured, and every build would silently be a local one.
+    : >"$sb/audit.out"
+    rc=0
+    out="$(cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
+        BUCK_AUDIT_ARGS="$sb/audit.args" BUCK_AUDIT_OUTPUT="$sb/audit.out" \
+        scripts/provision-build-cache verify 2>&1)" || rc=$?
+    check "cache: a daemon with no engine address fails verification" \
+        "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+    check "cache: the failure names the missing engine address and its consequence" \
+        "$(grep -Fq 'no buck2_re_client.engine_address' <<<"$out" &&
+           grep -Fq 'pass silently' <<<"$out" && echo 0 || echo 1)"
+
+    # Whatever Buck prints, the credential never reaches the log.
+    printf 'buck2_re_client.http_headers = x-buildbuddy-api-key:%s\n' "$key" >"$sb/audit.out"
+    rc=0
+    out="$(cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
+        BUCK_AUDIT_ARGS="$sb/audit.args" BUCK_AUDIT_OUTPUT="$sb/audit.out" \
+        scripts/provision-build-cache verify 2>&1)" || rc=$?
+    check "cache: verification never echoes Buck's configuration or the key" \
+        "$([ "$rc" -ne 0 ] && [[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
+
+    printf 'buck2_re_client.engine_address = grpc://remote.buildbuddy.io\n' >>"$sb/audit.out"
+    rc=0
+    out="$(cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
+        BUCK_AUDIT_ARGS="$sb/audit.args" BUCK_AUDIT_OUTPUT="$sb/audit.out" \
+        scripts/provision-build-cache verify 2>&1)" || rc=$?
+    check "cache: a passing verification does not echo the key either" \
+        "$([ "$rc" -eq 0 ] && [[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
+
+    # An audit that cannot answer is not an answer.
+    printf 'buck2_re_client.engine_address = grpc://remote.buildbuddy.io\n' >"$sb/audit.out"
+    rc=0
+    out="$(cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
+        BUCK_AUDIT_ARGS="$sb/audit.args" BUCK_AUDIT_OUTPUT="$sb/audit.out" BUCK_AUDIT_STATUS=2 \
+        scripts/provision-build-cache verify 2>&1)" || rc=$?
+    check "cache: a failed audit fails verification rather than passing it" \
+        "$([ "$rc" -ne 0 ] && grep -Fq 'cannot confirm' <<<"$out" && echo 0 || echo 1)"
+
+    # Fork pull requests have no secret by design, and the reproducibility job
+    # opts out on purpose. Both are passes with an explanation, not failures.
+    : >"$sb/audit.out"
+    rc=0
+    out="$(cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY= \
+        BUCK_AUDIT_ARGS="$sb/audit.args" BUCK_AUDIT_OUTPUT="$sb/audit.out" \
+        scripts/provision-build-cache verify 2>&1)" || rc=$?
+    check "cache: a missing secret passes with the fork explanation" \
+        "$([ "$rc" -eq 0 ] && grep -Fq 'fork PR or unset' <<<"$out" && echo 0 || echo 1)"
+
+    rc=0
+    out="$(cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
+        RUE_NO_REMOTE_CACHE=1 BUCK_AUDIT_ARGS="$sb/audit.args" BUCK_AUDIT_OUTPUT="$sb/audit.out" \
+        scripts/provision-build-cache verify 2>&1)" || rc=$?
+    check "cache: a deliberately cache-free run passes with its own explanation" \
+        "$([ "$rc" -eq 0 ] && grep -Fq 'cache-free' <<<"$out" && echo 0 || echo 1)"
+
     rm -rf "$sb"
 }
 
@@ -234,9 +325,20 @@ test_buck_wrapper_links_installed_config() {
     config="$sb/config/rue/buildbuddy.buckconfig"
     write_central_config "$config"
 
-    run_wrapper "$sb" audit.args audit config build.execution_platforms
-    check "buck wrapper: non-execution commands never provision" \
+    run_wrapper "$sb" clean.args clean
+    check "buck wrapper: a command that neither builds nor reports configuration never provisions" \
         "$([ ! -e "$sb/.buckconfig.local" ] && [ ! -L "$sb/.buckconfig.local" ] && echo 0 || echo 1)"
+
+    # RUE-2009: `provision-build-cache verify` reads the daemon's remote-cache
+    # engine address through `buck2 audit config` before a job's first build, so
+    # an audit must see the configuration that build will get -- otherwise the
+    # check reports exactly the absence it exists to detect.
+    run_wrapper "$sb" audit.args audit config buck2_re_client.engine_address
+    check "buck wrapper: an audit is configured like the build it precedes" \
+        "$([[ -L "$sb/.buckconfig.local" ]] && [ "$(readlink "$sb/.buckconfig.local")" = "$config" ] && echo 0 || echo 1)"
+    check "buck wrapper: an audit still receives no execution preference" \
+        "$(! grep -Fxq -- '--prefer-local' "$sb/audit.args" && echo 0 || echo 1)"
+    rm "$sb/.buckconfig.local"
 
     run_wrapper "$sb" build.args build //:probe
     check "buck wrapper: the first execution command links .buckconfig.local to the installed config" \
@@ -506,6 +608,7 @@ EOF
 }
 
 test_cache_install
+test_cache_verify
 test_buck_wrapper_prefers_local_cache_misses
 test_buck_wrapper_links_installed_config
 test_buck_wrapper_retries_only_truncated_cas_materialization

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -1010,6 +1010,59 @@ EOF
   rm -rf "$sb"
 }
 
+# RUE-2009: a lane whose daemon never loaded the BuildBuddy config builds
+# everything locally and turns nothing red, and the summary said nothing about
+# it. The action-cache column reports the state per step, so a cache-free lane
+# is readable next to the counters that explain it. Each case runs from its own
+# sandbox because the state is read from that checkout's .buckconfig.local.
+test_ci_timed_reports_action_cache_state() {
+  local sb; sb="$(mktemp -d)"
+  cp "$SRC_ROOT/scripts/ci-timed" "$sb/ci-timed"; chmod +x "$sb/ci-timed"
+  cat >"$sb/served" <<'EOF'
+#!/usr/bin/env bash
+echo 'Commands: 10 (cached: 7, remote: 1, local: 2)'
+EOF
+  cat >"$sb/cache-free" <<'EOF'
+#!/usr/bin/env bash
+echo 'Commands: 10 (cached: 0, remote: 0, local: 10)'
+EOF
+  chmod +x "$sb/served" "$sb/cache-free"
+
+  ( cd "$sb" && GITHUB_STEP_SUMMARY="$sb/summary" ./ci-timed "unconfigured" -- ./served ) >/dev/null 2>&1
+  check "ci-timed: a step with no engine address reports the cache off" \
+    "$(grep -Fq '| off |' "$sb/summary" && echo 0 || echo 1)"
+
+  cat >"$sb/.buckconfig.local" <<'EOF'
+[buck2_re_client]
+engine_address = grpc://remote.buildbuddy.io
+EOF
+  : >"$sb/summary"
+  ( cd "$sb" && GITHUB_STEP_SUMMARY="$sb/summary" ./ci-timed "served" -- ./served ) >/dev/null 2>&1
+  check "ci-timed: a configured step that obtained actions reports the cache used" \
+    "$(grep -Fq '| used |' "$sb/summary" && echo 0 || echo 1)"
+
+  # The silent case the column exists for: configured, and nothing came from
+  # the cache or a worker.
+  : >"$sb/summary"
+  ( cd "$sb" && GITHUB_STEP_SUMMARY="$sb/summary" ./ci-timed "cache-free" -- ./cache-free ) >/dev/null 2>&1
+  check "ci-timed: a configured step that obtained nothing reports the cache unused" \
+    "$(grep -Fq '| unused |' "$sb/summary" && echo 0 || echo 1)"
+
+  # The merge-group canary disables cache reads on purpose; that is off, not a
+  # cache that failed to serve anything.
+  : >"$sb/summary"
+  ( cd "$sb" && GITHUB_STEP_SUMMARY="$sb/summary" ./ci-timed "canary" -- ./cache-free --no-remote-cache ) >/dev/null 2>&1
+  check "ci-timed: an explicit cache opt-out reports the cache off" \
+    "$(grep -Fq '| off |' "$sb/summary" && echo 0 || echo 1)"
+
+  : >"$sb/summary"
+  ( cd "$sb" && RUE_NO_REMOTE_CACHE=1 GITHUB_STEP_SUMMARY="$sb/summary" ./ci-timed "opt-out" -- ./served ) >/dev/null 2>&1
+  check "ci-timed: RUE_NO_REMOTE_CACHE reports the cache off" \
+    "$(grep -Fq '| off |' "$sb/summary" && echo 0 || echo 1)"
+
+  rm -rf "$sb"
+}
+
 # The cache probe must distinguish a genuine same-run cold-to-warm conversion
 # from an already-warm shared cache or a second build that did no better.
 test_cache_probe_counter_validation() {
@@ -1628,6 +1681,7 @@ test_rue_unit_zero_match_fails_loud
 test_rue_unit_failing_test_propagates_exit
 test_rue_unit_unknown_crate_errors_cleanly
 test_ci_timed_preserves_status_and_summarizes_actions
+test_ci_timed_reports_action_cache_state
 test_cache_probe_counter_validation
 test_ci_heavy_suite_audits_its_target
 test_ci_corpus_inventory_is_graph_derived_and_fails_closed


### PR DESCRIPTION
Fixes RUE-2009

## Why

Provisioning is a lazy `.buckconfig.local` link made by the `./buck2` wrapper, so a CI job can reach its build with a daemon that never loaded the BuildBuddy config. It then has no remote cache, rebuilds everything locally, and passes. Seventeen jobs in CI run 33774551666 did exactly that, logging `Error: (No engine address)` while going green, and the only evidence was a raw log.

## What

- `scripts/provision-build-cache verify`: asks Buck for one key, `audit config buck2_re_client.engine_address`, and fails the provisioning step when `BUILDBUDDY_API_KEY` is set and the daemon reports none, naming the cause and the paths involved. It requests the address key alone and never echoes the audit output, because the section as a whole carries the credential header. Where no cache is expected it passes with an explanatory line: a fork pull request without the secret, and `RUE_NO_REMOTE_CACHE=1`.
- `.github/workflows/ci.yml`: every one of the ten provisioning steps runs `verify` after `install`.
- `./buck2`: the wrapper now links the installed config for `audit` as well as for build/test/run/install, so the daemon that answers the check is configured exactly as the following build will be. `--prefer-local`, the disk floor, and the CAS retry stay gated on execution commands; `clean` and friends still write nothing.
- `scripts/ci-timed`: a new `Action cache` column in each step's job summary (`used`, `unused`, `off`, or `configured` for a step that ran no Buck invocation), derived from the checkout's `.buckconfig.local` engine address after the command runs, with `RUE_NO_REMOTE_CACHE=1` and an explicit `--no-remote-cache`/`--local-only` counting as `off`. RUE-2003's `Net down`/`Net up` counters already landed; this adds the cache-in-use half.
- Docs: `docs/process/build-cache.md`, `docs/process/ci.md`, and the `scripts/rue` usage line describe the verification step, the `audit` link, and the new column.

## Verification

New shell tests in `scripts/test-build-sharing.sh` and `scripts/test-wrapper-scripts.sh` use fake `buck2` binaries and cover: verify passes with an engine address and requests only the single key; fails when the daemon reports none, with a message naming the cause; fails on a failed audit; never echoes the key on either path; passes with the fork explanation when the secret is absent; passes under `RUE_NO_REMOTE_CACHE=1`; the wrapper links for `audit` but adds no execution preference, while `clean` provisions nothing; ci-timed reports off/used/unused for each state.

```
bash scripts/test-build-sharing.sh                    all 72 checks passed
bash scripts/test-wrapper-scripts.sh                  all 177 checks passed
bash scripts/test-cleanup-scripts.sh                  all 18 checks passed
bash scripts/test-affected-targets.sh                 PASSED (124 checks)
scripts/validate-shell-pipefail-pipelines.py          valid (52 scripts)
scripts/validate-shell-bash-baseline.py               valid (59 files)
scripts/validate-ci-gate.py .github/workflows/ci.yml  valid
python3 scripts/test-validate-ci-gate.py              OK (40)
python3 scripts/test-check-scheduled-workflows.py     OK (51)
scripts/validate-doc-links.py                         valid
```

The real `./buck2 audit config buck2_re_client.engine_address` was exercised once locally (no build): with no `.buckconfig.local` the audit prints nothing and `verify` fails with the intended message; with a hand-written engine address it passes. That confirmed the `section.key` form and the output shape the matcher expects.

Not verifiable locally: `actionlint` (no Docker here; the YAML change is one added line per step and passes `validate-ci-gate.py`), and the end-to-end path of an installed config reaching a fresh CI daemon. `verify` confirms configuration, not reachability, and the docs say so. `cache-probe.yml`'s two install steps were left as they are, since the probe already fails when its counters do not move.