### PR TITLE
RUE-1983: consult rue-air for the four facts CFG and codegen re-derived

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -240,7 +240,7 @@ impl<'a> NativeCallAbi<'a> {
         let abi_slots = self.type_pool.abi_slot_count(ty);
         NativeAbiTypeFacts {
             abi_slots,
-            aggregate: self.is_multislot_aggregate(ty, abi_slots),
+            aggregate: is_multislot_aggregate(ty, abi_slots),
             strbuf: matches!(
                 ty.kind(),
                 TypeKind::Struct(struct_id) if self.type_pool.is_strbuf(struct_id)
@@ -282,16 +282,22 @@ impl<'a> NativeCallAbi<'a> {
             ArgConvention::ByValue => self.type_pool.abi_slot_count(ty),
         }
     }
+}
 
-    /// The live plane's aggregate predicate: whether `ty` needs a complete
-    /// aggregate slot representation rather than a single primary vreg.
-    /// Discriminant-only enums stay scalar (oversized enums route through the
-    /// same slot-count policy per RUE-946). This is a facts *projection*; the
-    /// decisions consuming it live on [`NativeAbiTypeFacts`].
-    fn is_multislot_aggregate(&self, ty: Type, slot_count: u32) -> bool {
-        matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
-            || (ty.is_enum() && slot_count > 1)
-    }
+/// Whether `ty` needs a complete aggregate slot representation rather than a
+/// single primary vreg, given its flattened slot count `slot_count`.
+///
+/// Structs and arrays always do; a discriminant-only enum stays a scalar, and
+/// an enum with a payload becomes an aggregate exactly when its slot count says
+/// so (oversized enums route through the same slot-count policy per RUE-946).
+/// This is the single authority behind both halves of a call: the classifier
+/// that decides `Registers`/`Scalar` here and code generation's slots-versus-
+/// primary materialization, which cannot disagree about which types are
+/// aggregates without a call passing a value in a shape the other side never
+/// expects.
+pub fn is_multislot_aggregate(ty: Type, slot_count: u32) -> bool {
+    matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
+        || (ty.is_enum() && slot_count > 1)
 }
 
 /// Whether the compact physical layout of `ty` is byte-for-byte identical to

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -45,7 +45,7 @@ mod types;
 
 pub use call_abi::{
     ArgConvention, CAbiScalarKind, NativeAbiTypeFacts, NativeCallAbi, ReturnClass,
-    ScalarAbiExtension, TargetCCallAbi, aggregate_leaves, c_abi_type_facts,
+    ScalarAbiExtension, TargetCCallAbi, aggregate_leaves, c_abi_type_facts, is_multislot_aggregate,
     is_slot_identical_layout, native_return_register_budget,
 };
 pub use exact_decimal::canonical_decimal_literal;

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -958,6 +958,21 @@ impl Type {
         matches!(*self, Type::I64 | Type::U64)
     }
 
+    /// The width, in bits, at which a `switch` compares its scrutinee against
+    /// a case value.
+    ///
+    /// A 64-bit scrutinee is compared over all 64 bits; every narrower
+    /// scrutinee — the narrow integers, `bool`, and a discriminant-only enum —
+    /// is compared over its low 32 bits, which is the width its canonical
+    /// register image already agrees on. This is the single owner of that rule:
+    /// CFG simplification folds a constant `switch` to the arm the backends
+    /// would select, and the backends compare at the width the terminator plan
+    /// carries, so a change here moves both together (RUE-27).
+    #[inline]
+    pub fn switch_compare_width(&self) -> u32 {
+        if self.is_64_bit() { 64 } else { 32 }
+    }
+
     /// Check if this type can coerce to the target type.
     ///
     /// Coercion rules:

--- a/crates/rue-cfg/src/api_inventory.rs
+++ b/crates/rue-cfg/src/api_inventory.rs
@@ -97,6 +97,22 @@ fn cfg_abi_width_checks_have_one_frozen_pool_authority() {
         1,
         "CFG verifier must have exactly one ABI-width decision helper"
     );
+    // The pool is required, so there is no second, weaker width rule for a
+    // verifier built without one.
+    assert!(
+        source.contains("type_pool: &'a FrozenTypeInternPool,"),
+        "CFG verifier must hold the frozen type pool unconditionally"
+    );
+    for poolless in [
+        "type_pool: Option<",
+        "Some(pool) = self.type_pool",
+        "Some(TypeKind::PtrMut(_)) => 1",
+    ] {
+        assert!(
+            !source.contains(poolless),
+            "CFG verifier regained a poolless verification mode: {poolless}"
+        );
+    }
     assert_eq!(
         source.matches("pool.try_abi_slot_count(ty)").count(),
         1,
@@ -224,6 +240,27 @@ fn constant_folding_uses_the_air_integer_semantics_kernel() {
         assert!(
             !source.contains(helper),
             "const folding regained local helper {helper}"
+        );
+    }
+
+    // Loop unrolling reads induction constants, encodes the constants an
+    // unrolled body materializes, and bounds a trip count — all width and
+    // range decisions the same kernel owns. A private copy here would let a
+    // folded trip count disagree with the folded induction constants it feeds.
+    let unroll = include_str!("opt/unroll.rs");
+    assert!(unroll.contains("integer_semantics()"));
+    assert!(unroll.contains("canonicalize_i128("));
+    assert!(unroll.contains("fits_i128("));
+    for hand_rolled in [
+        "int_bit_width()",
+        "1i128 << width",
+        "1i128 << (width - 1)",
+        "rem_euclid",
+        "128 - width",
+    ] {
+        assert!(
+            !unroll.contains(hand_rolled),
+            "loop unrolling regained local integer width math: {hand_rolled}"
         );
     }
 }

--- a/crates/rue-cfg/src/opt/licm.rs
+++ b/crates/rue-cfg/src/opt/licm.rs
@@ -579,7 +579,7 @@ mod tests {
         // operands, computed in the loop body, must hoist to the preheader.
         let mut s = single_loop();
         let inv = push(&mut s.cfg, s.body, CfgInstData::BitOr(s.a, s.b), Type::I32);
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut s.cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 1);
@@ -587,7 +587,7 @@ mod tests {
         // (reused, since entry is an unconditional Goto to the header).
         assert_eq!(block_of(&s.cfg, inv), Some(s.entry));
         assert!(!s.cfg.get_block(s.body).insts.contains(&inv));
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -598,12 +598,12 @@ mod tests {
         // never runs. This is the core ADR-0054 §2 obligation.
         let mut s = single_loop();
         let trap = push(&mut s.cfg, s.body, CfgInstData::Add(s.a, s.b), Type::I32);
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut s.cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 0, "a trapping Add must not hoist");
         assert_eq!(block_of(&s.cfg, trap), Some(s.body));
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -624,7 +624,7 @@ mod tests {
             Type::I8,
         );
         let div = push(&mut s.cfg, s.body, CfgInstData::Div(s.a, s.b), Type::I32);
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut s.cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 0);
@@ -674,13 +674,13 @@ mod tests {
             },
         );
         cfg.set_terminator(exit, Terminator::Return { value: None });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 1, "only the invariant op hoists");
         assert_eq!(block_of(&cfg, varying), Some(body), "block-param op stays");
         assert_eq!(block_of(&cfg, invariant), Some(entry), "invariant op moved");
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -741,10 +741,10 @@ mod tests {
         let args = cfg.push_goto_args([next_o]).unwrap();
         cfg.set_terminator(o_body, Terminator::Goto { target: o, args });
         cfg.set_terminator(exit, Terminator::Return { value: None });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut cfg, &test_type_pool()).unwrap();
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         assert!(stats.invariants_hoisted >= 2);
 
         // RUE-1843: the whole-function definition-block table is built once per
@@ -850,7 +850,7 @@ mod tests {
             Type::UNIT,
         );
         let load = push(&mut s.cfg, s.body, CfgInstData::Load { slot: 0 }, Type::I32);
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
         let stats = run(&mut s.cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 1, "effect-free body: Load hoists");
         assert_eq!(block_of(&s.cfg, load), Some(s.entry));
@@ -873,7 +873,7 @@ mod tests {
             },
             Type::UNIT,
         );
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
         let stats = run(&mut s.cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 0, "same-slot store: Load stays");
         assert_eq!(block_of(&s.cfg, load), Some(s.body));
@@ -897,7 +897,7 @@ mod tests {
             },
             Type::UNIT,
         );
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
         let stats = run(&mut s.cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 1, "unrelated store: Load hoists");
         assert_eq!(stats.instructions_examined, 2);
@@ -1098,13 +1098,13 @@ mod tests {
             },
             Type::I32,
         );
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut s.cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 1, "only the direct read hoists");
         assert_eq!(block_of(&s.cfg, direct), Some(s.entry));
         assert_eq!(block_of(&s.cfg, indirect), Some(s.body));
-        s.cfg.verify().unwrap();
+        s.cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -1145,7 +1145,7 @@ mod tests {
         );
         cfg.set_terminator(body, goto(header));
         cfg.set_terminator(exit, Terminator::Return { value: None });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut cfg, &test_type_pool()).unwrap();
         assert_eq!(
@@ -1153,7 +1153,7 @@ mod tests {
             "a mutated inout param read must not hoist"
         );
         assert_eq!(block_of(&cfg, read), Some(body), "the inout read stays");
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         // A write to parameter slot 0 cannot change parameter slot 1.
         let mut cfg = Cfg::new(
@@ -1186,7 +1186,7 @@ mod tests {
         );
         cfg.set_terminator(body, goto(header));
         cfg.set_terminator(exit, Terminator::Return { value: None });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut cfg, &test_type_pool()).unwrap();
         assert_eq!(
@@ -1198,7 +1198,7 @@ mod tests {
             Some(entry),
             "the pure read moved"
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         // Writability is a permission, not itself a loop write: an inout read
         // with no reachable writer in the loop is invariant.
@@ -1340,7 +1340,7 @@ mod tests {
             }
             cfg.set_terminator(blocks[0], goto(header));
             cfg.set_terminator(exit, Terminator::Return { value: None });
-            cfg.verify().unwrap();
+            cfg.verify_with_fixture_pool().unwrap();
 
             let stats = run(&mut cfg, &test_type_pool()).unwrap();
             assert_eq!(stats.forest_computations, 1);
@@ -1357,7 +1357,7 @@ mod tests {
                     .iter()
                     .all(|&value| block_of(&cfg, value) == Some(entry))
             );
-            cfg.verify().unwrap();
+            cfg.verify_with_fixture_pool().unwrap();
         }
     }
 
@@ -1379,7 +1379,7 @@ mod tests {
             assert_eq!(stats.candidate_dependencies, 0);
             assert_eq!(stats.worklist_pops, len as u64);
             assert_eq!(stats.invariants_hoisted, len as u64);
-            s.cfg.verify().unwrap();
+            s.cfg.verify_with_fixture_pool().unwrap();
         }
     }
 
@@ -1440,7 +1440,7 @@ mod tests {
             predecessor = next;
         }
         cfg.set_terminator(predecessor, Terminator::Return { value: None });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.forest_computations, 1);
@@ -1474,7 +1474,7 @@ mod tests {
                 .zip(&bodies)
                 .all(|(&load, &body)| block_of(&cfg, load).is_some_and(|block| block != body))
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -1497,13 +1497,13 @@ mod tests {
         let invariant = push(&mut cfg, body, CfgInstData::BitOr(a, b), Type::I32);
         cfg.set_terminator(body, goto(header));
         cfg.set_terminator(exit, Terminator::Return { value: None });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let stats = run(&mut cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 1);
         assert_eq!(stats.forest_computations, 1);
         assert_ne!(block_of(&cfg, invariant), Some(body));
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]

--- a/crates/rue-cfg/src/opt/loops.rs
+++ b/crates/rue-cfg/src/opt/loops.rs
@@ -1224,7 +1224,7 @@ mod tests {
         cfg.set_terminator(inner_body, goto(inner));
         cfg.set_terminator(outer_latch, goto(outer));
         cfg.set_terminator(exit, Terminator::Return { value: None });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let before = cfg.block_count();
         let stats = normalize_preheaders(&mut cfg, &test_type_pool()).unwrap();
@@ -1243,7 +1243,7 @@ mod tests {
             "the final outer body must include the materialized inner preheader"
         );
         assert!(preheader(&cfg, outer_loop).is_some());
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let second = normalize_preheaders(&mut cfg, &test_type_pool()).unwrap();
         assert_eq!(second.preheaders_materialized, 0);
@@ -1410,7 +1410,7 @@ mod tests {
 
         assert_eq!(ph, entry, "the entry Goto is reused as the preheader");
         assert_eq!(cfg.block_count(), before, "no block inserted for reuse");
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -1508,7 +1508,7 @@ mod tests {
             cfg.get_block(body).terminator,
             Terminator::Goto { target, .. } if target == header
         ));
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -1561,7 +1561,7 @@ mod tests {
         let mut expected = vec![ph, body];
         expected.sort_by_key(|b| b.as_u32());
         assert_eq!(header_preds, expected);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -1597,7 +1597,7 @@ mod tests {
         original.set_terminator(header, branch(header_cond, body, exit));
         original.set_terminator(body, goto(header));
         original.set_terminator(exit, Terminator::Return { value: None });
-        original.verify().unwrap();
+        original.verify_with_fixture_pool().unwrap();
 
         let forest = analyze(&original);
         let lp = loop_of(&forest, header);
@@ -1702,7 +1702,7 @@ mod tests {
         let ph2 = ensure_preheader(&mut cfg, loop_of(&forest, header), &test_type_pool()).unwrap();
         assert_eq!(ph2, ph1, "the existing preheader is reused");
         assert_eq!(cfg.block_count(), base + 1, "second call inserts nothing");
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -1791,7 +1791,7 @@ mod tests {
         );
         cfg.set_terminator(exit, Terminator::Return { value: None });
 
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let dom = DominatorTree::compute(&cfg);
         let forest = loops(&cfg, &dom);
@@ -1828,7 +1828,7 @@ mod tests {
 
         // The whole rewrite is verifier-clean: arity and types agree on every
         // edge, and ph dominates the header.
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let dom = DominatorTree::compute(&cfg);
         assert!(dom.dominates(ph, header));
     }
@@ -1859,7 +1859,7 @@ mod tests {
             cfg.get_block(ph).terminator,
             Terminator::Goto { target, .. } if target == entry
         ));
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let dom = DominatorTree::compute(&cfg);
         assert!(dom.dominates(ph, entry));
     }

--- a/crates/rue-cfg/src/opt/simplify.rs
+++ b/crates/rue-cfg/src/opt/simplify.rs
@@ -17,9 +17,10 @@
 //!
 //! Case selection must be exactly what the backends execute, or folding
 //! changes behavior. Both backends materialize the case value as a full
-//! 64-bit immediate and compare at 64-bit width when the scrutinee's type is
-//! 64-bit, and at 32-bit width otherwise (RUE-27) — so this pass compares the
-//! scrutinee's canonical constant the same way.
+//! 64-bit immediate and compare at the width `Type::switch_compare_width`
+//! gives (RUE-27), which is also the width the terminator plan hands them — so
+//! this pass compares the scrutinee's canonical constant through that same
+//! authority.
 //!
 //! ## Threading and merging (RUE-911)
 //!
@@ -135,9 +136,9 @@ fn fold_terminators(cfg: &mut Cfg, stats: &mut Stats) -> Result<(), crate::CfgEd
                     _ => continue,
                 };
                 // Match at the width the backends compare at (see module
-                // docs): 64-bit types compare all 64 bits of the canonical
-                // constant, narrower types compare the low 32 bits.
-                let wide = inst.ty.is_64_bit();
+                // docs), asking the type's own switch-compare policy rather
+                // than restating it here.
+                let wide = inst.ty.switch_compare_width() == 64;
                 let matches = |case: i64| {
                     if wide {
                         scrut_val == case as u64
@@ -840,7 +841,7 @@ mod tests {
                 value: Some(else_param_a),
             },
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let stats = thread_only(&mut cfg);
         assert_eq!(stats.edges_threaded, 1);
@@ -863,7 +864,7 @@ mod tests {
             }
             other => panic!("expected Branch after threading, got {other:?}"),
         }
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -921,7 +922,7 @@ mod tests {
                 value: Some(else_param),
             },
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let stats = thread_only(&mut cfg);
         assert_eq!(stats.edges_threaded, 2);
@@ -941,7 +942,7 @@ mod tests {
             }
             other => panic!("expected Branch after threading, got {other:?}"),
         }
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -192,35 +192,25 @@ fn forest_generation_independent(
         && !b.exits.iter().any(|(_, target)| a.contains(*target))
 }
 
+/// The mathematical value of a constant induction operand, read through the
+/// AIR integer-semantics kernel so a trip count and the constants folded
+/// elsewhere in the pipeline agree about width and signedness.
 fn const_value(cfg: &Cfg, value: CfgValue, ty: Type) -> Option<i128> {
     let CfgInstData::Const(raw) = cfg.get_inst(value).data else {
         return None;
     };
-    let width = ty.int_bit_width()?;
-    if ty.is_signed() {
-        let shift = 128 - width;
-        Some(((raw as i128) << shift) >> shift)
-    } else {
-        Some(i128::from(raw))
-    }
+    let integer = ty.integer_semantics()?;
+    Some(integer.canonicalize_i128(i128::from(raw)))
 }
 
+/// The canonical 64-bit register image of `value` in `ty`, or `None` when the
+/// value does not fit the type. Constants an unrolled body materializes carry
+/// the same encoding constant folding produces.
 fn encoded_const(value: i128, ty: Type) -> Option<u64> {
-    let width = ty.int_bit_width()?;
-    let min = if ty.is_signed() {
-        -(1i128 << (width - 1))
-    } else {
-        0
-    };
-    let max = if ty.is_signed() {
-        (1i128 << (width - 1)) - 1
-    } else {
-        (1i128 << width) - 1
-    };
-    if !(min..=max).contains(&value) {
-        return None;
-    }
-    u64::try_from(value.rem_euclid(1i128 << width)).ok()
+    let integer = ty.integer_semantics()?;
+    integer
+        .fits_i128(value)
+        .then(|| integer.canonicalize_i128(value) as u64)
 }
 
 fn recognize(cfg: &Cfg, lp: &NaturalLoop) -> Option<Trip> {
@@ -529,18 +519,13 @@ fn checked_trip_count(initial: i128, bound: i128, step: i128, cmp: u8, ty: Type)
     };
     // The update executes after the final body iteration. Refuse a sequence
     // that would overflow a checked induction update (which must still trap).
-    let width = ty.int_bit_width()?;
-    let (min, max) = if ty.is_signed() {
-        (-(1i128 << (width - 1)), (1i128 << (width - 1)) - 1)
-    } else {
-        (0, (1i128 << width) - 1)
-    };
-    if initial < min || initial > max {
+    let integer = ty.integer_semantics()?;
+    if !integer.fits_i128(initial) {
         return None;
     }
     let count_i = i128::from(count);
     let final_value = step.checked_mul(count_i)?.checked_add(initial)?;
-    if final_value < min || final_value > max {
+    if !integer.fits_i128(final_value) {
         return None;
     }
     Some(count)
@@ -1814,10 +1799,10 @@ mod tests {
             (3, 0, true, 1),
         ] {
             let mut cfg = slot_loop(initial, bound, descending);
-            cfg.verify().unwrap();
+            cfg.verify_with_fixture_pool().unwrap();
             let stats = run(&mut cfg).unwrap();
             assert_eq!(stats.loops_unrolled, expected);
-            cfg.verify().unwrap();
+            cfg.verify_with_fixture_pool().unwrap();
             let dom = DominatorTree::compute(&cfg);
             assert!(loops(&cfg, &dom).is_empty());
         }
@@ -1926,7 +1911,7 @@ mod tests {
         cfg.set_branch(header, cond, exit, [], body, []);
         let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loops_unrolled, 1);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -1942,7 +1927,7 @@ mod tests {
     fn run_batches_independent_loops_in_one_forest_generation() {
         let mut cfg = independent_slot_loops(3, 2);
         let mut repeated = independent_slot_loops(3, 2);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let stats = run(&mut cfg).unwrap();
         assert_eq!(
             stats,
@@ -1959,7 +1944,7 @@ mod tests {
         );
         assert_eq!(run(&mut repeated).unwrap(), stats);
         assert_eq!(format!("{repeated:?}"), format!("{cfg:?}"));
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let dom = DominatorTree::compute(&cfg);
         assert!(loops(&cfg, &dom).is_empty());
     }
@@ -1991,7 +1976,7 @@ mod tests {
         assert_eq!(stats.shape_refusals, 2);
         assert_eq!(stats.blocks_cloned, 12);
         assert_eq!(stats.values_cloned, 40);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let dom = DominatorTree::compute(&cfg);
         let remaining = loops(&cfg, &dom);
         assert_eq!(remaining.len(), 1);
@@ -2014,7 +1999,7 @@ mod tests {
         assert_eq!(stats.blocks_cloned, 12);
         assert_eq!(stats.values_cloned, 40);
         assert_eq!(budget.used(), 256);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -2082,7 +2067,7 @@ mod tests {
     #[test]
     fn run_unrolls_a_constant_trip_inner_loop_then_its_containing_loop() {
         let mut cfg = nested_slot_loops(2, 2);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let stats = run(&mut cfg).unwrap();
         assert_eq!(
             stats,
@@ -2097,7 +2082,7 @@ mod tests {
                 instructions_cloned: 98,
             }
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let dom = DominatorTree::compute(&cfg);
         assert!(loops(&cfg, &dom).is_empty());
     }
@@ -2105,14 +2090,14 @@ mod tests {
     #[test]
     fn run_unrolls_deeper_nests_from_the_inside_out() {
         let mut cfg = nested_slot_loops(3, 1);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.forest_computations, 4);
         assert_eq!(stats.loops_analyzed, 6);
         assert_eq!(stats.loops_unrolled, 3);
         assert_eq!(stats.shape_refusals, 3);
         assert_eq!(stats.budget_refusals, 0);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let dom = DominatorTree::compute(&cfg);
         assert!(loops(&cfg, &dom).is_empty());
     }
@@ -2141,7 +2126,7 @@ mod tests {
             },
         );
         cfg.get_block_mut(inner_header).terminator = term;
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let before = format!("{:?}", cfg);
         let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.forest_computations, 1);
@@ -2170,7 +2155,7 @@ mod tests {
     #[test]
     fn run_rebuilds_a_counterfeit_loop_id_and_stale_enclosing_body() {
         let mut cfg = nested_slot_loops_with_order(2, 2, false);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let old_block_count = cfg.block_count();
         let dom = DominatorTree::compute(&cfg);
         let stale_forest = loops(&cfg, &dom);
@@ -2191,7 +2176,7 @@ mod tests {
         let trip = recognize(&cfg, stale_zero).expect("the inner loop is canonical");
         let (blocks, values, instructions) = unroll_one(&mut cfg, stale_zero, trip).unwrap();
         assert_eq!((blocks, values, instructions), (6, 20, 20));
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
 
         let dom = DominatorTree::compute(&cfg);
         let fresh_forest = loops(&cfg, &dom);
@@ -2217,7 +2202,7 @@ mod tests {
         assert_eq!(stats.loops_unrolled, 1);
         assert_eq!(stats.blocks_cloned, 24);
         assert_eq!(stats.values_cloned, 78);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -2237,7 +2222,7 @@ mod tests {
             clones, 0,
             "unrolling cloned the whole graph {clones} time(s)"
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -2294,7 +2279,7 @@ mod tests {
         );
         cfg.get_block_mut(body).terminator = Terminator::None;
         cfg.set_branch(body, cond, latch, [], exit, []);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loops_unrolled, 0);
         assert_eq!(stats.shape_refusals, 1);
@@ -2347,11 +2332,11 @@ mod tests {
             },
         );
         cfg.set_goto(join, latch, []);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
         let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loops_unrolled, 1);
         assert!(stats.values_cloned > 0);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -208,24 +208,32 @@ impl Cfg {
         count
     }
 
-    /// Verify the CFG's structural invariants, panicking with a precise,
-    /// function- and block-localized message on any violation.
+    /// Verify against an empty fixture pool: the entry point for unit tests
+    /// whose graphs mention only scalar types.
     ///
-    /// See the module docs for the invariants and the rationale for the hard
-    /// panic. This is a compiler-bug guard: a well-formed pipeline never trips
-    /// it; the check is paid to pin future lowering regressions to their source.
-    pub fn verify(&self) -> Result<(), CfgVerificationError> {
-        Verifier::new(self, None, true).verify()
+    /// The verifier reads aggregate widths, drop obligations, and projection
+    /// chains from the pool, so a graph naming a struct, array, or enum type
+    /// must be verified against the pool that defines it.
+    #[cfg(test)]
+    pub(crate) fn verify_with_fixture_pool(&self) -> Result<(), CfgVerificationError> {
+        self.verify_with_type_pool(&FrozenTypeInternPool::new())
     }
 
-    /// Verify with the active semantic type pool, enabling exact aggregate
-    /// layouts and projection-chain validation. Production callers must use
-    /// this entry point.
+    /// Verify the CFG's structural invariants against the active semantic type
+    /// pool, reporting a precise, function- and block-localized message on any
+    /// violation.
+    ///
+    /// See the module docs for the invariants and the rationale for the hard
+    /// panic callers apply to the result. This is a compiler-bug guard: a
+    /// well-formed pipeline never trips it; the check is paid to pin future
+    /// lowering regressions to their source. The pool is what makes exact
+    /// aggregate layouts and projection-chain validation possible, so it is
+    /// required rather than optional.
     pub fn verify_with_type_pool(
         &self,
         type_pool: &FrozenTypeInternPool,
     ) -> Result<(), CfgVerificationError> {
-        Verifier::new(self, Some(type_pool), true).verify()
+        Verifier::new(self, type_pool, true).verify()
     }
 
     /// Verify the optimized live graph. DCE intentionally retains dead values
@@ -236,7 +244,7 @@ impl Cfg {
         &self,
         type_pool: &FrozenTypeInternPool,
     ) -> Result<(), CfgVerificationError> {
-        Verifier::new(self, Some(type_pool), false).verify()
+        Verifier::new(self, type_pool, false).verify()
     }
 
     /// Verify a CFG edit whose only intended effect is on blocks reachable from
@@ -256,7 +264,7 @@ impl Cfg {
         &self,
         type_pool: &FrozenTypeInternPool,
     ) -> Result<(), CfgVerificationError> {
-        Verifier::materialization(self, Some(type_pool)).verify()
+        Verifier::materialization(self, type_pool).verify()
     }
 
     /// Collect every `CfgValue` operand referenced by an instruction into
@@ -356,7 +364,7 @@ enum Attachment {
 
 struct Verifier<'a> {
     cfg: &'a Cfg,
-    type_pool: Option<&'a FrozenTypeInternPool>,
+    type_pool: &'a FrozenTypeInternPool,
     require_complete_attachments: bool,
     skip_unreachable_blocks: bool,
     attachments: Vec<Option<Attachment>>,
@@ -378,7 +386,7 @@ struct Verifier<'a> {
 impl<'a> Verifier<'a> {
     fn new(
         cfg: &'a Cfg,
-        type_pool: Option<&'a FrozenTypeInternPool>,
+        type_pool: &'a FrozenTypeInternPool,
         require_complete_attachments: bool,
     ) -> Self {
         Self {
@@ -404,7 +412,7 @@ impl<'a> Verifier<'a> {
     /// `if`'s dead `else` still holding a `goto merge([arg])` after the merge
     /// block's parameter was substituted away). The final `finish_after_optimization`
     /// still sweeps those husks under strict verification once DCE has run.
-    fn materialization(cfg: &'a Cfg, type_pool: Option<&'a FrozenTypeInternPool>) -> Self {
+    fn materialization(cfg: &'a Cfg, type_pool: &'a FrozenTypeInternPool) -> Self {
         Self {
             skip_unreachable_blocks: true,
             ..Self::new(cfg, type_pool, false)
@@ -533,16 +541,14 @@ impl<'a> Verifier<'a> {
                         }
                     }
                     CfgInstData::Drop { value: dropped } => {
-                        if let Some(pool) = self.type_pool {
-                            let dropped_ty = self.cfg.get_inst(dropped).ty;
-                            // Validate nominal identities before recursive drop
-                            // queries so malformed CFG returns a typed error.
-                            self.abi_slot_count(dropped_ty, block.id, value, "Drop operand")?;
-                            if pool.type_needs_drop(dropped_ty)
-                                && droppable_value_set.insert(dropped)
-                            {
-                                droppable_values.push(dropped);
-                            }
+                        let dropped_ty = self.cfg.get_inst(dropped).ty;
+                        // Validate nominal identities before recursive drop
+                        // queries so malformed CFG returns a typed error.
+                        self.abi_slot_count(dropped_ty, block.id, value, "Drop operand")?;
+                        if self.type_pool.type_needs_drop(dropped_ty)
+                            && droppable_value_set.insert(dropped)
+                        {
+                            droppable_values.push(dropped);
                         }
                     }
                     _ => {}
@@ -1704,39 +1710,11 @@ impl<'a> Verifier<'a> {
         value: CfgValue,
         role: &str,
     ) -> Result<u32, CfgVerificationError> {
-        let Some(pool) = self.type_pool else {
-            return Ok(match ty.try_kind() {
-                Some(TypeKind::I8)
-                | Some(TypeKind::I16)
-                | Some(TypeKind::I32)
-                | Some(TypeKind::I64)
-                | Some(TypeKind::U8)
-                | Some(TypeKind::U16)
-                | Some(TypeKind::U32)
-                | Some(TypeKind::U64)
-                | Some(TypeKind::Bool)
-                | Some(TypeKind::F32)
-                | Some(TypeKind::F64)
-                | Some(TypeKind::Error)
-                | Some(TypeKind::PtrConst(_))
-                | Some(TypeKind::PtrMut(_)) => 1,
-                Some(TypeKind::Unit)
-                | Some(TypeKind::Never)
-                | Some(TypeKind::ComptimeType)
-                | Some(TypeKind::ComptimeFloat)
-                | Some(TypeKind::Module(_))
-                | Some(TypeKind::Struct(_))
-                | Some(TypeKind::Array(_))
-                | Some(TypeKind::Enum(_))
-                | None => 0,
-            });
-        };
-
-        let canonical_width = || pool.try_abi_slot_count(ty);
+        let canonical_width = || self.type_pool.try_abi_slot_count(ty);
         #[cfg(test)]
         let width = self
             .abi_slot_query_override
-            .map_or_else(canonical_width, |query| query(pool, ty));
+            .map_or_else(canonical_width, |query| query(self.type_pool, ty));
         #[cfg(not(test))]
         let width = canonical_width();
 
@@ -1764,9 +1742,7 @@ impl<'a> Verifier<'a> {
     }
 
     fn is_fixed_str_to_view_coercion(&self, source: Type, result: Type) -> bool {
-        let Some(pool) = self.type_pool else {
-            return false;
-        };
+        let pool = self.type_pool;
         let (TypeKind::Struct(source_id), TypeKind::Struct(result_id)) =
             (source.kind(), result.kind())
         else {
@@ -1822,92 +1798,91 @@ impl<'a> Verifier<'a> {
             }
         }
         let projections = self.cfg.get_place_projections(place);
-        if let Some(pool) = self.type_pool {
-            let mut current_ty = place.base_type;
-            for (projection_index, projection) in projections.iter().enumerate() {
-                current_ty = match projection {
-                    Projection::Field {
-                        struct_id,
-                        field_index,
-                    } => {
-                        let Some(def) = pool.try_struct_def(*struct_id) else {
-                            return Err(self.error(format_args!(
-                                "projection {} in place instruction {} in block {} references invalid struct id {:?}",
-                                projection_index, value, block, struct_id
-                            )));
-                        };
-                        let expected = Type::new_struct(*struct_id);
-                        if current_ty != expected {
-                            return Err(self.error(format_args!(
-                                "projection {} in place instruction {} in block {} expects container type {:?}, but previous link produced {:?}",
-                                projection_index, value, block, expected, current_ty
-                            )));
-                        }
-                        let Some(field) = def.fields.get(*field_index as usize) else {
-                            return Err(self.error(format_args!(
-                                "projection {} in place instruction {} in block {} references field {} of struct {:?}, which has {} fields",
-                                projection_index,
-                                value,
-                                block,
-                                field_index,
-                                struct_id,
-                                def.fields.len()
-                            )));
-                        };
-                        field.ty
+        let pool = self.type_pool;
+        let mut current_ty = place.base_type;
+        for (projection_index, projection) in projections.iter().enumerate() {
+            current_ty = match projection {
+                Projection::Field {
+                    struct_id,
+                    field_index,
+                } => {
+                    let Some(def) = pool.try_struct_def(*struct_id) else {
+                        return Err(self.error(format_args!(
+                            "projection {} in place instruction {} in block {} references invalid struct id {:?}",
+                            projection_index, value, block, struct_id
+                        )));
+                    };
+                    let expected = Type::new_struct(*struct_id);
+                    if current_ty != expected {
+                        return Err(self.error(format_args!(
+                            "projection {} in place instruction {} in block {} expects container type {:?}, but previous link produced {:?}",
+                            projection_index, value, block, expected, current_ty
+                        )));
                     }
-                    Projection::Index { array_type, .. } => {
-                        let TypeKind::Array(array_id) = array_type.kind() else {
-                            return Err(self.error(format_args!(
-                                "projection {} in place instruction {} in block {} has non-array container type {:?}",
-                                projection_index, value, block, array_type
-                            )));
-                        };
-                        let Some((element_ty, _)) = pool.try_array_def(array_id) else {
-                            return Err(self.error(format_args!(
-                                "projection {} in place instruction {} in block {} references invalid array id {:?}",
-                                projection_index, value, block, array_id
-                            )));
-                        };
-                        if current_ty != *array_type {
-                            return Err(self.error(format_args!(
-                                "projection {} in place instruction {} in block {} expects container type {:?}, but previous link produced {:?}",
-                                projection_index, value, block, array_type, current_ty
-                            )));
-                        }
-                        element_ty
+                    let Some(field) = def.fields.get(*field_index as usize) else {
+                        return Err(self.error(format_args!(
+                            "projection {} in place instruction {} in block {} references field {} of struct {:?}, which has {} fields",
+                            projection_index,
+                            value,
+                            block,
+                            field_index,
+                            struct_id,
+                            def.fields.len()
+                        )));
+                    };
+                    field.ty
+                }
+                Projection::Index { array_type, .. } => {
+                    let TypeKind::Array(array_id) = array_type.kind() else {
+                        return Err(self.error(format_args!(
+                            "projection {} in place instruction {} in block {} has non-array container type {:?}",
+                            projection_index, value, block, array_type
+                        )));
+                    };
+                    let Some((element_ty, _)) = pool.try_array_def(array_id) else {
+                        return Err(self.error(format_args!(
+                            "projection {} in place instruction {} in block {} references invalid array id {:?}",
+                            projection_index, value, block, array_id
+                        )));
+                    };
+                    if current_ty != *array_type {
+                        return Err(self.error(format_args!(
+                            "projection {} in place instruction {} in block {} expects container type {:?}, but previous link produced {:?}",
+                            projection_index, value, block, array_type, current_ty
+                        )));
                     }
-                };
-            }
+                    element_ty
+                }
+            };
+        }
 
-            let inst = self.cfg.get_inst(value);
-            match &inst.data {
-                CfgInstData::PlaceRead { .. }
-                    if inst.ty != current_ty
-                        && !self.is_fixed_str_to_view_coercion(current_ty, inst.ty) =>
-                {
+        let inst = self.cfg.get_inst(value);
+        match &inst.data {
+            CfgInstData::PlaceRead { .. }
+                if inst.ty != current_ty
+                    && !self.is_fixed_str_to_view_coercion(current_ty, inst.ty) =>
+            {
+                return Err(self.error(format_args!(
+                    "place-read instruction {} in block {} has result type {:?}, but its projection chain produces {:?}",
+                    value, block, inst.ty, current_ty
+                )));
+            }
+            CfgInstData::PlaceWrite { value: stored, .. } => {
+                let stored_ty = self.inst(*stored, block, "place-write value")?.ty;
+                if stored_ty != current_ty {
                     return Err(self.error(format_args!(
-                        "place-read instruction {} in block {} has result type {:?}, but its projection chain produces {:?}",
-                        value, block, inst.ty, current_ty
+                        "place-write instruction {} in block {} stores type {:?}, but its projection chain produces {:?}",
+                        value, block, stored_ty, current_ty
                     )));
                 }
-                CfgInstData::PlaceWrite { value: stored, .. } => {
-                    let stored_ty = self.inst(*stored, block, "place-write value")?.ty;
-                    if stored_ty != current_ty {
-                        return Err(self.error(format_args!(
-                            "place-write instruction {} in block {} stores type {:?}, but its projection chain produces {:?}",
-                            value, block, stored_ty, current_ty
-                        )));
-                    }
-                    if inst.ty != Type::UNIT {
-                        return Err(self.error(format_args!(
-                            "place-write instruction {} in block {} has result type {:?}, expected unit",
-                            value, block, inst.ty
-                        )));
-                    }
+                if inst.ty != Type::UNIT {
+                    return Err(self.error(format_args!(
+                        "place-write instruction {} in block {} has result type {:?}, expected unit",
+                        value, block, inst.ty
+                    )));
                 }
-                _ => {}
             }
+            _ => {}
         }
 
         if let Some(first) = projections.first() {
@@ -3813,7 +3788,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Return { value: Some(v) });
-        cfg.verify().unwrap(); // must not panic
+        cfg.verify_with_fixture_pool().unwrap(); // must not panic
     }
 
     fn cfg_with_field_place(base_type: Type, struct_id: StructId) -> Cfg {
@@ -3847,22 +3822,26 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let struct_id = register_struct(&pool, &interner, "FieldBase", &[Type::I32]);
+        let pool = pool.freeze();
         cfg_with_field_place(Type::new_struct(struct_id), struct_id)
-            .verify()
+            .verify_with_type_pool(&pool)
             .unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "first projection requires base type")]
+    #[should_panic(expected = "but previous link produced Type::I32")]
     fn verify_rejects_field_projection_with_wrong_base_type() {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let struct_id = register_struct(&pool, &interner, "WrongBase", &[Type::I32]);
-        cfg_with_field_place(Type::I32, struct_id).verify().unwrap();
+        let pool = pool.freeze();
+        cfg_with_field_place(Type::I32, struct_id)
+            .verify_with_type_pool(&pool)
+            .unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "first projection requires base type")]
+    #[should_panic(expected = "but previous link produced Type::I32")]
     fn verify_rejects_index_projection_with_wrong_base_type_on_write() {
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "index_place".to_string(), vec![]);
         let entry = cfg.new_block();
@@ -3883,9 +3862,9 @@ mod tests {
                 span: Span::new(0, 1),
             },
         );
-        let array_type = TypeInternPool::new()
-            .try_intern_array(Type::I32, 1)
-            .unwrap();
+        let pool = TypeInternPool::new();
+        let array_type = pool.try_intern_array(Type::I32, 1).unwrap();
+        let pool = pool.freeze();
         let place = cfg
             .make_place(
                 PlaceBase::Local(0),
@@ -3903,11 +3882,11 @@ mod tests {
         );
         cfg.set_terminator(entry, Terminator::Return { value: None });
 
-        cfg.verify().unwrap();
+        cfg.verify_with_type_pool(&pool).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "Index projection with non-array container type Type::I32")]
+    #[should_panic(expected = "has non-array container type Type::I32")]
     fn verify_rejects_non_array_index_projection_type() {
         let mut cfg = Cfg::new(Type::I32, 1, 0, "index_type".to_string(), vec![]);
         let entry = cfg.new_block();
@@ -3940,7 +3919,7 @@ mod tests {
         );
         cfg.set_terminator(entry, Terminator::Return { value: Some(read) });
 
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -3958,7 +3937,7 @@ mod tests {
             },
         );
         // Deliberately leave the reachable entry block with Terminator::None.
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -3977,7 +3956,7 @@ mod tests {
         cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
         // An orphan block, never wired in, with no terminator: must be skipped.
         let _orphan = cfg.new_block();
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -3998,7 +3977,7 @@ mod tests {
                 args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     /// Build `entry --goto(one arg of `arg_ty`)--> target(param: i32)`.
@@ -4024,14 +4003,18 @@ mod tests {
 
     #[test]
     fn verify_accepts_well_typed_edge() {
-        cfg_with_typed_edge(Type::I32).verify().unwrap(); // must not panic
+        cfg_with_typed_edge(Type::I32)
+            .verify_with_fixture_pool()
+            .unwrap(); // must not panic
     }
 
     #[test]
     #[should_panic(expected = "ill-typed edge")]
     fn verify_catches_edge_type_mismatch() {
         // The RUE-347 shape: a unit value passed into an i32 block parameter.
-        cfg_with_typed_edge(Type::UNIT).verify().unwrap();
+        cfg_with_typed_edge(Type::UNIT)
+            .verify_with_fixture_pool()
+            .unwrap();
     }
 
     #[test]
@@ -4077,7 +4060,7 @@ mod tests {
                 args,
             },
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4092,7 +4075,7 @@ mod tests {
             span: Span::new(0, 0),
         });
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4111,7 +4094,7 @@ mod tests {
         );
         cfg.get_block_mut(entry).insts.push(value);
         cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4123,7 +4106,7 @@ mod tests {
         let param = cfg.add_block_param(entry, Type::I32);
         cfg.get_inst_mut(param).data = CfgInstData::BlockParam { index: 1 };
         cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4135,7 +4118,7 @@ mod tests {
         let param = cfg.add_block_param(entry, Type::I32);
         cfg.get_inst_mut(param).data = CfgInstData::Const(0);
         cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4147,7 +4130,7 @@ mod tests {
         let param = cfg.add_block_param(entry, Type::I32);
         cfg.get_block_mut(entry).params[0].1 = Type::U64;
         cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4179,7 +4162,7 @@ mod tests {
                 value: Some(earlier),
             },
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4218,7 +4201,7 @@ mod tests {
         );
         cfg.set_terminator(left, Terminator::Return { value: Some(value) });
         cfg.set_terminator(right, Terminator::Return { value: Some(value) });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     /// A terminator-less reachable entry plus two *unreachable* blocks, where
@@ -4268,7 +4251,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Return { value: Some(live) });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4285,7 +4268,7 @@ mod tests {
                 value: Some(orphaned),
             },
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4314,7 +4297,7 @@ mod tests {
             },
         );
         cfg.set_terminator(target, Terminator::Unreachable);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4324,7 +4307,7 @@ mod tests {
         let entry = cfg.new_block();
         cfg.entry = entry;
         cfg.set_terminator(entry, Terminator::Return { value: None });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4342,7 +4325,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4351,7 +4334,7 @@ mod tests {
         let mut cfg = unit_cfg();
         cfg.new_block();
         cfg.entry = BlockId::from_raw(7);
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4367,7 +4350,7 @@ mod tests {
                 args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
-        cfg.verify().unwrap();
+        cfg.verify_with_fixture_pool().unwrap();
     }
 
     #[test]
@@ -4449,7 +4432,9 @@ mod tests {
     fn strict_verify_rejects_unreachable_husk_edge() {
         // The strict verifier every real pipeline boundary uses still checks
         // unreachable blocks, so the husk's stale arity is caught.
-        cfg_with_unreachable_husk_edge().verify().unwrap();
+        cfg_with_unreachable_husk_edge()
+            .verify_with_fixture_pool()
+            .unwrap();
     }
 
     #[test]
@@ -4551,7 +4536,7 @@ mod tests {
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
 
-        let mut verifier = Verifier::new(&cfg, Some(&pool), true);
+        let mut verifier = Verifier::new(&cfg, &pool, true);
         verifier.abi_slot_query_override = Some(divergent_width);
         let error = verifier.verify().unwrap_err();
         assert!(error.to_string().contains("local slot range 0..7"));
@@ -4813,7 +4798,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        let error = cfg.verify().unwrap_err();
+        let error = cfg.verify_with_fixture_pool().unwrap_err();
         assert_eq!(error.payload().unwrap().family(), "array elements");
         assert_eq!(
             error.location(),
@@ -4842,7 +4827,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        let error = cfg.verify().unwrap_err();
+        let error = cfg.verify_with_fixture_pool().unwrap_err();
         assert_eq!(error.payload().unwrap().family(), "call arguments");
         assert_eq!(
             error.location(),
@@ -4874,7 +4859,7 @@ mod tests {
                 default: entry,
             },
         );
-        let error = cfg.verify().unwrap_err();
+        let error = cfg.verify_with_fixture_pool().unwrap_err();
         assert_eq!(error.payload().unwrap().family(), "switch cases");
         assert_eq!(
             error.location(),
@@ -4902,7 +4887,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        let error = cfg.verify().unwrap_err();
+        let error = cfg.verify_with_fixture_pool().unwrap_err();
         assert_eq!(error.payload().unwrap().family(), "projections");
         assert_eq!(
             error.location(),
@@ -4927,9 +4912,9 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
-        let array_type = TypeInternPool::new()
-            .try_intern_array(Type::I32, 1)
-            .unwrap();
+        let pool = TypeInternPool::new();
+        let array_type = pool.try_intern_array(Type::I32, 1).unwrap();
+        let pool = pool.freeze();
         let place = cfg
             .make_place(
                 PlaceBase::Local(0),
@@ -4946,7 +4931,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify().unwrap();
+        cfg.verify_with_type_pool(&pool).unwrap();
     }
 
     #[test]

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -212,6 +212,24 @@ fn value_planning_uses_the_air_integer_semantics_kernel() {
 }
 
 #[test]
+fn codegen_consults_air_for_aggregate_and_switch_compare_policy() {
+    // The call planner and the value materializer must classify aggregates
+    // identically, or a call passes a value in a shape the other side never
+    // expects; AIR owns the predicate both consume.
+    let types = include_str!("types.rs");
+    assert!(types.contains("rue_air::is_multislot_aggregate(ty, type_slot_count(type_pool, ty))"));
+    assert!(!types.contains("ty.is_enum() && type_slot_count(type_pool, ty) > 1"));
+
+    // Switch case matching is one rule shared with CFG simplification's
+    // constant folding, so the arm a fold selects is the arm a backend
+    // compiles.
+    let value_plan = include_str!("value_plan.rs");
+    assert!(value_plan.contains("bits: ty.switch_compare_width(),"));
+    let terminator = include_str!("terminator_plan.rs");
+    assert!(terminator.contains("value_plan::switch_compare_width(ty)"));
+}
+
+#[test]
 fn foreign_call_and_mir_state_have_one_shared_authority() {
     let foreign = include_str!("foreign_call.rs");
     assert!(foreign.contains("pub(crate) struct ForeignCallPlan"));

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -89,7 +89,8 @@ pub enum TerminatorPlan {
     },
     Switch {
         scrutinee: VReg,
-        /// The comparison width selected by the language policy.
+        /// The comparison width selected by the language policy
+        /// ([`value_plan::switch_compare_width`]).
         width: value_plan::IntegerWidth,
         cases: Vec<SwitchCasePlan>,
         default: BlockId,
@@ -484,7 +485,7 @@ pub(crate) fn plan_terminator<A: TerminatorAdapter>(
             let value_plan = ValuePlan::for_value(ctx, *scrutinee);
             let scrutinee_vreg = adapter.materialize_value(*scrutinee, value_plan).primary;
             let ty = ctx.cfg.get_inst(*scrutinee).ty;
-            let width = value_plan::comparison_integer_width(ty);
+            let width = value_plan::switch_compare_width(ty);
             let cases = ctx
                 .cfg
                 .get_switch_cases(&block.terminator)

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -87,9 +87,13 @@ pub fn type_slot_span(type_pool: &FrozenTypeInternPool, ty: Type) -> u32 {
 
 /// Whether `ty` needs a complete aggregate slot representation rather than a
 /// single primary vreg. Discriminant-only enums remain scalar values.
+///
+/// Delegates to `rue_air::is_multislot_aggregate`, the same predicate the
+/// native call-ABI classifier applies when it decides between a register
+/// aggregate and a scalar, so the value materializer and the call planner
+/// classify every type identically.
 pub fn is_multislot_aggregate(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
-    matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
-        || (ty.is_enum() && type_slot_count(type_pool, ty) > 1)
+    rue_air::is_multislot_aggregate(ty, type_slot_count(type_pool, ty))
 }
 
 /// Return the `(Some, None)` discriminant values for an `Option`-shaped enum

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -2347,6 +2347,21 @@ pub fn comparison_integer_width(ty: Type) -> IntegerWidth {
     }
 }
 
+/// The width a `switch` terminator compares its scrutinee at.
+///
+/// The bit width comes from `Type::switch_compare_width`, the same authority
+/// CFG simplification consults when it folds a constant `switch`: a scrutinee
+/// folded to one arm before code generation and the compare the backends emit
+/// for the unfolded graph are then decided by one rule. Signedness rides along
+/// as the scrutinee's own, so a policy trace names the type it compared; the
+/// comparison itself is an equality and reads the same either way.
+pub fn switch_compare_width(ty: Type) -> IntegerWidth {
+    IntegerWidth {
+        bits: ty.switch_compare_width(),
+        signed: ty.is_signed(),
+    }
+}
+
 /// Shared signedness query for target encodings that need a flag or extension
 /// form after the integer policy has been selected.
 pub fn type_is_signed(ty: Type) -> bool {

--- a/scripts/planted-miscompile-study.py
+++ b/scripts/planted-miscompile-study.py
@@ -30,7 +30,7 @@ PATCH_TARGETS = {
 PATCH_PREIMAGE_SHA256 = {
     "RUE-348": "1d5d9990b397c5ff39c95178dbb8f24a7e82fd303aa934d466d331b98c1e6b26",
     "RUE-914": "4d93001c85ae13ef69ae9b008097737dde497310d0c5a7a4895df1c932350efc",
-    "RUE-1758": "a093afb95a27540ca01a3aabd20b721b1b8bdb4e60a464942a4c717b7f0a03d5",
+    "RUE-1758": "2cec2a810babc9cd9a2e3ff040f621b1b30c8e16a49e12441d69b887730a2eaf",
 }
 FOCUSED_CLI = {
     "RUE-348": "enum_payload_equality_across_opt_levels",


### PR DESCRIPTION
Fixes RUE-1983

## Why

Four facts rue-air already owns were re-derived locally in rue-cfg and rue-codegen. None diverged, but each was a drift hazard of the RUE-1754 shape: a policy change in one copy would silently leave the other behind.

## What

1. **`is_multislot_aggregate`**: the predicate is now a public free function in `rue_air::call_abi` (re-exported from the crate root, next to `is_slot_identical_layout`); `NativeAbiTypeFacts` and `rue-codegen/src/types.rs` both call it, so the call planner's `Registers`/`Scalar` decision and the value materializer's slots-versus-primary decision cannot disagree about which types are aggregates.
2. **`opt/unroll.rs` integer math**: `const_value`, `encoded_const`, and the range check in `checked_trip_count` go through `ty.integer_semantics()` (`canonicalize_i128`, `fits_i128`) instead of hand-built shift and mask arithmetic. `rue-cfg/src/api_inventory.rs` extends the kernel guard that pinned `constfold.rs` to cover `opt/unroll.rs`. One observable consequence: `encoded_const` now emits the canonical sign-extended 64-bit image for negative narrow constants, the same encoding constant folding produces (previously it zero-extended within the type's width).
3. **Switch case-match width**: `Type::switch_compare_width()` in rue-air is the single owner (64 for `i64`/`u64`, else 32). `rue-cfg/src/opt/simplify.rs` folds through it, and `value_plan::switch_compare_width(ty)` builds `TerminatorPlan::Switch { width }` from it, so the arm a fold selects is the arm both backends compile. Both `x86_64/cfg_lower.rs` and `aarch64/cfg_lower.rs` already consume only the plan's width, so no backend change was needed. A new `rue-codegen/src/api_inventory.rs` test pins both delegations.
4. **Poolless verifier table**: `Verifier.type_pool` is now `&FrozenTypeInternPool`, mandatory. The scalar slot-width table and the three pool-optional branches (drop obligations, projection chains, slot widths) are gone. `Cfg::verify()` is replaced by a `#[cfg(test)] verify_with_fixture_pool()` that verifies against an empty frozen pool, used by the poolless unit tests in `verify.rs` and `opt/{licm,loops,simplify,unroll}.rs`. Five verifier tests were ported to verify against their own frozen pool; three `should_panic` messages changed because the pooled projection-chain check reports a more precise error than the poolless path did. The api_inventory guard now asserts the verifier has no poolless arm.

The RUE-1816 planted-miscompile lab pins a digest of `terminator_plan.rs` before applying its RUE-1758 patch; the second commit refreshes that digest in `scripts/planted-miscompile-study.py`. The patch itself still applies unchanged.

## Verification

- `scripts/rue unit air` (883), `scripts/rue unit cfg` (422), `scripts/rue unit codegen` (879), `scripts/rue unit compiler` (1216): all pass.
- `scripts/rue spec` filtered to match, enum, loop, integer, while, for, struct, array, and call sections; `scripts/rue ui match` and `scripts/rue ui enum`: all pass.
- `scripts/rue quick` (36 targets) passes, re-run after rebasing onto current trunk. `scripts/rue fmt` clean.
- Planted-patch gate: the new digest is the file's current SHA-256 and `git apply --check` of `crates/rue-planted-miscompiles/patches/RUE-1758.patch` succeeds against it.