### PR TITLE
Reduce agreeing C exports to aliases of their native bodies

### DIFF
--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -689,20 +689,25 @@ stdout = "11\n11\ntrue\n11\n"
 exit_code = 0
 
 # ===========================================================================
-# P4: Rue-to-C export thunks (ADR-0064 P4, RUE-1058)
+# P4: Rue-to-C exports (ADR-0064 P4, RUE-1058)
 # ===========================================================================
 # A `pub extern "C" fn` exposes a Rue function to C callers under its unmangled
-# name via a C-ABI entry thunk. The proof is the inverse of every case above: a
-# C-convention caller (a synthesized archive member) invokes the Rue export and
-# observes its result. The Rue program keeps a `main` (the compiler requires one
+# name: an alias of the native body when both conventions place every value of
+# the signature identically, and a C-ABI entry thunk otherwise (ADR-0084). The
+# proof is the inverse of every case above: a C-convention caller (a synthesized
+# archive member) invokes the Rue export and observes its result. The Rue program keeps a `main` (the compiler requires one
 # and it is the process entry), imports the archive caller as an ordinary
 # `extern "C"` leaf, and prints what the C code observed. Each pinned pair
 # compiles+links+structurally-validates on every host and executes only the
 # native one.
 
+# `i32` parameters are narrower than a register, so these two exports keep an
+# entry thunk that re-extends what the C caller left: the pair below is the same
+# program with `i64` parameters, where nothing is left to do and the C symbol is
+# an alias of the native body instead.
 [[case]]
 name = "x86_64_linux_export_called_from_c"
-description = "A C caller (archive member) invokes two Rue exports through their C-ABI thunks; rue_add(3,5)=8 and the order-sensitive rue_sub(10,4)=6 encode to 806 on x86-64 (SysV)."
+description = "A C caller (archive member) invokes two narrow-parameter Rue exports through their C-ABI entry thunks; rue_add(3,5)=8 and the order-sensitive rue_sub(10,4)=6 encode to 806 on x86-64 (SysV)."
 files = [{ path = "main.rue", source = """
 pub extern "C" fn rue_add(a: i32, b: i32) -> i32 {
     a + b
@@ -730,7 +735,7 @@ exit_code = 0
 
 [[case]]
 name = "aarch64_linux_export_called_from_c"
-description = "A C caller (archive member) invokes two Rue exports through their C-ABI thunks; rue_add(3,5)=8 and the order-sensitive rue_sub(10,4)=6 encode to 806 on AArch64 (AAPCS64)."
+description = "A C caller (archive member) invokes two narrow-parameter Rue exports through their C-ABI entry thunks; rue_add(3,5)=8 and the order-sensitive rue_sub(10,4)=6 encode to 806 on AArch64 (AAPCS64)."
 files = [{ path = "main.rue", source = """
 pub extern "C" fn rue_add(a: i32, b: i32) -> i32 {
     a + b
@@ -754,6 +759,92 @@ ffi_answer_archive = true
 executable_target = "aarch64-linux"
 execute_if_native = true
 stdout = "806\n"
+exit_code = 0
+
+# The same two exports with register-width parameters and results. Every value
+# of the signature is where the other convention would have put it, so each C
+# symbol is an alias of its native body and the C caller enters that body
+# directly — the same archive member, the same observed 806, no entry thunk in
+# the image (ADR-0084).
+[[case]]
+name = "x86_64_linux_aliased_export_called_from_c"
+description = "A C caller (archive member) invokes two Rue exports whose C symbols are aliases of their native bodies; rue_add(3,5)=8 and the order-sensitive rue_sub(10,4)=6 encode to 806 on x86-64 (SysV)."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn rue_add(a: i64, b: i64) -> i64 {
+    a + b
+}
+
+pub extern "C" fn rue_sub(a: i64, b: i64) -> i64 {
+    a - b
+}
+
+extern "C" {
+    fn ffi_call_exports() -> i64;
+}
+
+fn main() -> i32 {
+    @dbg(checked { ffi_call_exports() });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "806\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_aliased_export_called_from_c"
+description = "A C caller (archive member) invokes two Rue exports whose C symbols are aliases of their native bodies; rue_add(3,5)=8 and the order-sensitive rue_sub(10,4)=6 encode to 806 on AArch64 (AAPCS64)."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn rue_add(a: i64, b: i64) -> i64 {
+    a + b
+}
+
+pub extern "C" fn rue_sub(a: i64, b: i64) -> i64 {
+    a - b
+}
+
+extern "C" {
+    fn ffi_call_exports() -> i64;
+}
+
+fn main() -> i32 {
+    @dbg(checked { ffi_call_exports() });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "806\n"
+exit_code = 0
+
+# The alias lives in the object container itself, so a real system linker has
+# to accept it: this build hands `cc` the byte objects the compiler wrote and
+# asserts the export's unmangled name is a defined symbol of the executable
+# alongside the native body's mangled one. It runs natively on every CI host,
+# which is what covers the Mach-O nlist path as well as the ELF symtab one.
+[[case]]
+name = "aliased_export_symbol_survives_a_system_link"
+description = "A `--linker cc` build defines an aliased export's unmangled C name and its native body's mangled symbol, so the extra object-container symbol is one a real linker accepts."
+requires_system_linker = true
+files = [{ path = "main.rue", source = """
+pub extern "C" fn rue_answer(seed: i64) -> i64 {
+    seed + 41
+}
+
+fn main() -> i32 {
+    if rue_answer(1) == 42 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--linker", "cc", "-o", "prog"]
+symbols_contain = [
+    "rue_answer",
+    "__rue_sem_v1_",
+]
 exit_code = 0
 
 [[case]]
@@ -810,23 +901,26 @@ exit_code = 101
 # conventions disagree about, and encodes what it observed into one integer:
 #
 #   605 -- rue_pair_swap({3,5}) = {6,5}: an 8-byte `@repr(c)` struct in one
-#          integer register each way. The native body takes and returns it
-#          indirectly (two narrow leaves cannot ride the native slot
-#          convention), so the thunk hands the C caller's own bytes to the body
-#          and the body's storage back to the caller.
+#          integer register each way. Its two narrow leaves pack into one
+#          eightbyte of its compact image, which is its C image, so the native
+#          body takes and returns exactly the register a C caller writes and
+#          reads: this export's C symbol is an alias of the body.
 #   310 --.
 #   201 --' rue_triple_rotate({10,20,30}) = {30,10,20}: a 24-byte struct, byval
 #          on the stack under SysV and by reference under AAPCS64, returned
 #          through caller storage. The trailing 1 is the SysV `rax` echo of the
 #          hidden result pointer, checked by reading the struct back through the
 #          *returned* pointer; AAPCS64 has no echo and answers 1.
-#   285 -- rue_sum9(1..9) weighted: nine scalars, so the tail is stacked under
-#          both rows (three arguments on SysV, one on AAPCS64) in both the C
-#          caller and the native forward.
+#   285 -- rue_sum9(1..9) weighted: nine register-width scalars, so the tail is
+#          stacked under both rows (three arguments on SysV, one on AAPCS64) at
+#          the same offsets of the same area — another aliased export.
+#
+# Only `rue_triple_rotate` keeps an entry thunk, because only its result is
+# placed differently by the two conventions.
 
 [[case]]
 name = "x86_64_linux_aggregate_exports_called_from_c"
-description = "A C caller passes and returns `@repr(c)` structs by value through Rue export thunks and spills a nine-scalar tail; the observed results encode to 605310201285 on x86-64 (SysV)."
+description = "A C caller passes and returns `@repr(c)` structs by value through Rue exports — two aliases and one entry thunk — and spills a nine-scalar tail; the observed results encode to 605310201285 on x86-64 (SysV)."
 files = [{ path = "main.rue", source = """
 @repr(c)
 struct Pair { a: i32, b: i32 }
@@ -864,7 +958,7 @@ exit_code = 0
 
 [[case]]
 name = "aarch64_linux_aggregate_exports_called_from_c"
-description = "A C caller passes and returns `@repr(c)` structs by value through Rue export thunks and spills a nine-scalar tail; the observed results encode to 605310201285 on AArch64 (AAPCS64)."
+description = "A C caller passes and returns `@repr(c)` structs by value through Rue exports — two aliases and one entry thunk — and spills a nine-scalar tail; the observed results encode to 605310201285 on AArch64 (AAPCS64)."
 files = [{ path = "main.rue", source = """
 @repr(c)
 struct Pair { a: i32, b: i32 }
@@ -934,7 +1028,7 @@ exit_code = 0
 
 [[case]]
 name = "aarch64_linux_wide_aggregate_return_called_from_c"
-description = "A C caller receives a 20-byte `@repr(c)` struct from a Rue export through its C entry thunk on AArch64, where both rows return it through storage addressed by the dedicated `x8`."
+description = "A C caller receives a 20-byte `@repr(c)` struct from a Rue export through its C entry thunk on AArch64, where AAPCS64 returns it through storage addressed by the dedicated `x8` and the native body returns three eightbytes."
 files = [{ path = "main.rue", source = """
 @repr(c)
 struct Five { a: i32, b: i32, c: i32, d: i32, e: i32 }

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -477,6 +477,36 @@ compile_stdout_contains = [
     "convention aarch64-aapcs-darwin, symbol answer",
 ]
 
+# ADR-0084 phase 2: an export block is headed by how its C symbol is reached.
+# `wide` places identically under both conventions and is therefore an alias of
+# its native body; `narrow` takes an `i32`, whose canonical 64-bit form no C
+# caller promises, so it keeps an entry thunk and the report says which
+# parameter kept it.
+[[case]]
+name = "emit_abi_names_each_export_entry"
+description = "ADR-0084: --emit abi reports whether an export's C symbol is an alias of the native body or a thunk, and why a thunk is kept."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn wide(a: i64, b: i64) -> i64 {
+    a + b
+}
+
+pub extern "C" fn narrow(a: i32) -> i32 {
+    a + a
+}
+
+fn main() -> i32 {
+    0
+}
+""" }]
+args = ["--emit", "abi", "--preview", "c_ffi", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "export wide",
+    "c entry: alias of the native body",
+    "export narrow",
+    "c entry: thunk, because parameter 0 is re-extended",
+]
+
 # The `--emit` help text renders the stage table, so this is what makes a stage
 # that exists but is undocumented impossible.
 [[case]]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -411,11 +411,14 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
         ));
     }
 
-    // --- P4 export-thunk C-caller members (ADR-0064 P4, RUE-1058) ------------
+    // --- P4 export C-caller members (ADR-0064 P4, RUE-1058) ------------------
     //
     // These are the *inverse* of every member above: instead of a leaf a Rue
     // program calls, each is a C-convention caller that invokes a Rue function
-    // *exported* to C (`pub extern "C" fn`) through its C-ABI entry thunk. A P4
+    // *exported* to C (`pub extern "C" fn`) through its C entry — an alias of
+    // the native body, or an entry thunk where the two conventions still
+    // disagree (ADR-0084). Which one a case gets is the export signature's
+    // answer, and both are exercised by the cases that share these drivers. A P4
     // program imports one of these as an ordinary `extern "C"` leaf; the member
     // then calls back into the Rue export, proving a separately compiled C
     // caller reaches an exported Rue function across the target-C boundary. The

--- a/crates/rue-codegen/src/abi_report.rs
+++ b/crates/rue-codegen/src/abi_report.rs
@@ -10,7 +10,7 @@
 //!   `pub extern "C" fn` export — reads [`rue_air::lower_c_signature`]'s
 //!   [`LoweredSignature`], the one placement function every C crossing site
 //!   consumes, through the very same projections the import lowering
-//!   ([`crate::foreign_call::ForeignCallInputs`]) and the export thunk
+//!   ([`crate::foreign_call::ForeignCallInputs`]) and the export entry
 //!   ([`crate::export_thunk::ExportSignature`]) build;
 //! * the native Rue convention reads [`rue_air::lower_native_signature`] for
 //!   its arguments and [`rue_air::lower_native_return`] — through
@@ -339,8 +339,8 @@ pub enum AbiFunctionKind {
     /// A reached `extern "C"` import: a C side only, since Rue compiles no body
     /// for it.
     Import,
-    /// A `pub extern "C" fn` export: the C entry thunk and the native body it
-    /// forwards to.
+    /// A `pub extern "C" fn` export: the C entry — an alias of the native body
+    /// or a thunk — and the native body itself.
     Export,
 }
 
@@ -365,6 +365,9 @@ pub struct AbiFunctionReport {
     pub c: Option<AbiSide>,
     /// The native side, present for a function and an export.
     pub native: Option<AbiSide>,
+    /// How an export's C symbol is reached — as a second name for the native
+    /// body, or through a thunk and then why. Present only for an export.
+    pub entry: Option<crate::export_thunk::CEntry>,
     /// The target whose rosters name the registers.
     pub target: Target,
 }
@@ -672,15 +675,17 @@ pub fn function_abi_report(
         kind: AbiFunctionKind::Function,
         c: None,
         native: Some(native_side(cfg, air, Some(symbol), type_pool, target)),
+        entry: None,
         target,
     }
 }
 
-/// One `pub extern "C" fn` export: the C entry the thunk implements, and the
-/// native body it forwards to.
+/// One `pub extern "C" fn` export: its C entry and the native body that entry
+/// names or forwards to.
 ///
-/// `signature` is the very [`crate::export_thunk::ExportSignature`] the thunk
-/// generator consumes, so the C side printed here is the C side emitted.
+/// `signature` is the very [`crate::export_thunk::ExportSignature`] the entry
+/// is decided and generated from, so the C side printed here is the C side
+/// emitted, and the entry line is the decision actually taken.
 pub fn export_abi_report(
     exported_symbol: &str,
     native_symbol: &str,
@@ -707,6 +712,7 @@ pub fn export_abi_report(
             return_type,
         )),
         native: Some(native),
+        entry: Some(signature.c_entry(target)),
         target,
     }
 }
@@ -764,6 +770,7 @@ pub fn import_abi_reports(
                 type_text(type_pool, Some(inst.ty)),
             )),
             native: None,
+            entry: None,
             target,
         });
     }
@@ -1082,8 +1089,20 @@ impl std::fmt::Display for AbiFunctionReport {
         let registers = TargetRegisters::new(self.target);
         writeln!(f, "{} {}", self.kind.keyword(), self.name)?;
         // An export prints both halves of the crossing it owns: the C entry
-        // callers see, then the native body the thunk forwards to.
+        // callers see, then the native body behind it.
         if self.kind == AbiFunctionKind::Export {
+            // Whether a C caller enters the native body directly is the fact
+            // the two sides below are read against (ADR-0084), so it is stated
+            // before them.
+            match &self.entry {
+                Some(crate::export_thunk::CEntry::Alias) => {
+                    writeln!(f, "  c entry: alias of the native body")?
+                }
+                Some(crate::export_thunk::CEntry::Thunk(reason)) => {
+                    writeln!(f, "  c entry: thunk, because {reason}")?
+                }
+                None => {}
+            }
             if let Some(side) = &self.c {
                 writeln!(f, "  c side")?;
                 write_side(f, side, registers, "    ")?;

--- a/crates/rue-codegen/src/export_thunk.rs
+++ b/crates/rue-codegen/src/export_thunk.rs
@@ -1,13 +1,22 @@
-//! Rue-to-C export thunks (ADR-0064 P4).
+//! Rue-to-C export entries (ADR-0064 P4, ADR-0084 phase 2).
 //!
 //! The mirror of the foreign-call path. A foreign *call* adapts the native
 //! convention to the target-C convention on the way *out* to a C callee; an
-//! *export* thunk adapts the target-C convention to the native convention on the
-//! way *in* from a C caller. A `pub extern "C" fn` is compiled like any other
-//! Rue function (a native-conventioned body under a mangled symbol); this module
-//! emits an additional, globally-visible, **unmangled** entry symbol — the C
-//! symbol — whose body receives arguments per the psABI and forwards to the
-//! native body.
+//! *export* adapts the target-C convention to the native convention on the way
+//! *in* from a C caller. A `pub extern "C" fn` is compiled like any other Rue
+//! function (a native-conventioned body under a mangled symbol) and reached
+//! under an additional, globally-visible, **unmangled** entry symbol — the C
+//! symbol.
+//!
+//! That entry is one of two things, and [`ExportSignature::c_entry`] is the one
+//! predicate that decides which:
+//!
+//! - an **alias**: a second global name at the native body's own entry, so a C
+//!   caller enters the body directly and this module emits no code at all. Both
+//!   object containers define it (`rue_linker::ObjectBuilder::alias`,
+//!   `rue_linker::StructuredObject::with_alias`).
+//! - a **thunk**: a body of its own, generated here, that receives arguments
+//!   per the psABI and forwards to the native body.
 //!
 //! ## One lowered signature, read in the callee direction
 //!
@@ -25,10 +34,11 @@
 //! answers where its result comes back. The two conventions therefore agree
 //! about every argument whenever the export names the target's own C row, and —
 //! because C's result registers are a prefix of the native bank — about every
-//! result within C's own bank. What remains of the thunk is the re-extension a
-//! narrow scalar needs and the adaptation of a result the two banks place
-//! differently. [`ExportSignature`] is the pairing of the two views, built once
-//! from the type pool by [`ExportSignature::for_types`].
+//! result within C's own bank. What is left for a thunk — and therefore what
+//! keeps one — is the re-extension a narrow scalar needs and the adaptation of
+//! a result the two banks place differently. [`ExportSignature`] is the pairing
+//! of the two views, built once from the type pool by
+//! [`ExportSignature::for_types`].
 //!
 //! ## Why the compact image is the C image
 //!
@@ -236,6 +246,193 @@ impl ExportSignature {
             LoweredReturn::Sret { .. } => NativeReturn::Sret,
         }
     }
+
+    /// Where the native side of this export's crossing puts every argument on
+    /// `target`.
+    ///
+    /// The one native lowering both the thunk plan and [`Self::c_entry`] read,
+    /// so the decision to emit an alias and the code emitted when a thunk is
+    /// kept cannot disagree about a placement. `native_return` is an input
+    /// because only one consequence of a result reaches argument placement —
+    /// the hidden indirect-result pointer's register — and the caller has
+    /// already classified the result.
+    fn native_lowering(&self, target: Target, native_return: &NativeReturn) -> LoweredSignature {
+        let pairing = ConventionSpec::native(target);
+        let spec = pairing.spec();
+        let parameters = self
+            .parameters
+            .iter()
+            .map(|parameter| (parameter.c, ArgConvention::ByValue))
+            .collect::<Vec<_>>();
+        lower_native_signature(
+            pairing,
+            &parameters,
+            if matches!(native_return, NativeReturn::Sret) {
+                LoweredReturn::Sret {
+                    register: spec.sret_register,
+                    echoed: spec.sret_pointer_echoed_in_result_register,
+                    size: 8,
+                    align: 8,
+                }
+            } else {
+                LoweredReturn::Void
+            },
+        )
+    }
+
+    /// How this export's C entry is reached on `target`: as an alias of the
+    /// native body, or through a thunk, and then why one is still needed.
+    ///
+    /// The two conventions place arguments by one row (ADR-0084 phase 1) and
+    /// results through one lowering whose C registers are a prefix of the
+    /// native bank (phase 2), so most exports leave nothing for a thunk to do
+    /// and the C symbol is emitted as a second name for the native body. What
+    /// still needs one is exactly the three disagreements this walk looks for:
+    /// a narrow scalar whose canonical 64-bit form no C caller promises, a
+    /// placement the wider return bank shifts, and a result the two banks carry
+    /// differently.
+    pub fn c_entry(&self, target: Target) -> CEntry {
+        let c = self.lowered();
+        let native_return = self.native_return(target);
+        let native = self.native_lowering(target, &native_return);
+        for (index, (parameter, (c_argument, native_argument))) in self
+            .parameters
+            .iter()
+            .zip(c.arguments().iter().zip(native.arguments()))
+            .enumerate()
+        {
+            if c_argument.location != native_argument.location {
+                return CEntry::Thunk(ThunkReason::ParameterPlacement { parameter: index });
+            }
+            // Only a value whose leaves cross as themselves reaches the body as
+            // canonically extended vregs; an eightbyte-packed image and an
+            // indirect pointer cross as whole registers, which a C caller
+            // defines in full.
+            let crosses_by_leaf = matches!(
+                c_argument.location,
+                ArgLocation::Registers { .. } | ArgLocation::Stack { .. }
+            ) && parameter.native.leaves_are_eightbytes;
+            if crosses_by_leaf && parameter.native.leaves.iter().any(|leaf| leaf.width < 8) {
+                return CEntry::Thunk(ThunkReason::NarrowParameter { parameter: index });
+            }
+        }
+        if self.return_needs_adaptation(c.ret(), target, &native_return) {
+            return CEntry::Thunk(ThunkReason::ReturnAdaptation);
+        }
+        CEntry::Alias
+    }
+
+    /// Whether the result the native body leaves behind is not already the
+    /// result a C caller reads.
+    fn return_needs_adaptation(
+        &self,
+        c_return: LoweredReturn,
+        target: Target,
+        native_return: &NativeReturn,
+    ) -> bool {
+        let native = lower_native_return(ConventionSpec::native(target), self.result);
+        match (c_return, native) {
+            (LoweredReturn::Void, LoweredReturn::Void) => false,
+            (
+                LoweredReturn::Registers { pieces: c, .. },
+                LoweredReturn::Registers { pieces: native, .. },
+            ) => {
+                if c != native {
+                    return true;
+                }
+                match native_return {
+                    // A scalar comes back in Rue's canonical 64-bit form, which
+                    // is at least as defined as any C row asks of a callee.
+                    NativeReturn::Scalar => false,
+                    // The image's eightbytes *are* the C image's eightbytes.
+                    NativeReturn::Eightbytes { .. } => false,
+                    // One register per leaf is the C image only when every leaf
+                    // fills its own eightbyte, leaving no padding byte for the
+                    // thunk to zero and no narrow slot to place inside a wider
+                    // one (ADR-0052 ruling 5).
+                    NativeReturn::Registers { leaves } => {
+                        !self.return_padding.is_empty()
+                            || leaves.iter().enumerate().any(|(index, leaf)| {
+                                leaf.width != 8 || leaf.byte_offset != (index as u32) * 8
+                            })
+                    }
+                    NativeReturn::Void | NativeReturn::Sret => true,
+                }
+            }
+            (
+                LoweredReturn::Sret {
+                    register: c_register,
+                    echoed: c_echoed,
+                    ..
+                },
+                LoweredReturn::Sret {
+                    register: native_register,
+                    echoed: native_echoed,
+                    ..
+                },
+            ) => c_register != native_register || c_echoed != native_echoed,
+            _ => true,
+        }
+    }
+}
+
+/// How a `pub extern "C" fn` export's C symbol is reached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CEntry {
+    /// A second global name for the native body itself, defined at its entry.
+    /// The two conventions place every value identically, so there is nothing
+    /// to forward.
+    Alias,
+    /// A separate entry that adapts what the two conventions disagree about
+    /// and forwards to the native body, for the reason it carries.
+    Thunk(ThunkReason),
+}
+
+impl CEntry {
+    /// Whether this entry is emitted as a thunk object rather than as a second
+    /// name for the native body.
+    pub fn is_thunk(&self) -> bool {
+        matches!(self, Self::Thunk(_))
+    }
+}
+
+/// What one export's C entry still has to do, and therefore why it is a thunk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThunkReason {
+    /// Parameter `parameter` reaches the native body as a canonically
+    /// 64-bit-extended value, and its declared width is narrower than that; a C
+    /// caller leaves the bits above the declared width unspecified, so the
+    /// entry re-extends it.
+    NarrowParameter {
+        /// The parameter's source position.
+        parameter: usize,
+    },
+    /// The two conventions place parameter `parameter` in different places,
+    /// which under ADR-0084 happens only when their results disagree about the
+    /// hidden indirect-result pointer.
+    ParameterPlacement {
+        /// The parameter's source position.
+        parameter: usize,
+    },
+    /// The result crosses back differently under the two conventions: the
+    /// native return bank is wider than C's, so a value C returns through
+    /// caller storage may come back in registers, and one the body hands over
+    /// leaf by leaf still has to be assembled into the C image.
+    ReturnAdaptation,
+}
+
+impl std::fmt::Display for ThunkReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NarrowParameter { parameter } => {
+                write!(f, "parameter {parameter} is re-extended")
+            }
+            Self::ParameterPlacement { parameter } => {
+                write!(f, "parameter {parameter} is placed differently")
+            }
+            Self::ReturnAdaptation => write!(f, "the result is adapted"),
+        }
+    }
 }
 
 /// The flattened compact-image leaves of `ty`, one per native ABI slot.
@@ -281,6 +478,10 @@ fn native_leaves_are_eightbytes(type_pool: &FrozenTypeInternPool, ty: Type) -> b
 /// `native_symbol` is the mangled symbol of the natively-conventioned body the
 /// thunk forwards to. The returned [`MachineCode`] carries one call/branch
 /// relocation targeting `native_symbol` and no string data.
+///
+/// Only an export whose [`ExportSignature::c_entry`] is a thunk needs this; one
+/// that reduces to an alias is emitted as a second name on the native body's
+/// own object instead.
 pub fn generate_export_thunk(
     target: Target,
     native_symbol: &str,
@@ -428,27 +629,7 @@ impl ThunkPlan {
         // consumes, against the very facts the C side was placed by: the two
         // conventions classify the same compact image, and the native row is
         // this target's own C row with a wider return bank (ADR-0084).
-        let native_pairing = rue_target::ConventionSpec::native(target);
-        let native_parameters = signature
-            .parameters
-            .iter()
-            .map(|parameter| (parameter.c, ArgConvention::ByValue))
-            .collect::<Vec<_>>();
-        let native_spec = native_pairing.spec();
-        let native = lower_native_signature(
-            native_pairing,
-            &native_parameters,
-            if matches!(native_return, NativeReturn::Sret) {
-                LoweredReturn::Sret {
-                    register: native_spec.sret_register,
-                    echoed: native_spec.sret_pointer_echoed_in_result_register,
-                    size: 8,
-                    align: 8,
-                }
-            } else {
-                LoweredReturn::Void
-            },
-        );
+        let native = signature.native_lowering(target, &native_return);
 
         // Every incoming general-purpose argument register is saved to a
         // contiguous cell block, so a register-passed value's eightbytes are
@@ -545,7 +726,25 @@ impl ThunkPlan {
         // and therefore the stack at the call — 16-byte aligned.
         let native_stack_bytes = native.stack_bytes();
 
-        let stage_base = native_stack_bytes;
+        // Each stacked value is written as a whole eightbyte, so a slot the
+        // convention packs narrower than eight bytes — Apple's natural-size
+        // amendment is the only row that does — writes up to seven bytes past
+        // its own footprint, and a long enough narrow tail would run past the
+        // area itself. The callee reads every slot at its own width, so those
+        // bytes are never observed; what matters is that they land in slack
+        // rather than in the staging cells, which already hold values. The
+        // slack is the reach of the widest store, so a signature that stacks
+        // nothing narrow reserves none of it.
+        let stacked_store_end = slots
+            .iter()
+            .filter_map(|(_, destination)| match destination {
+                NativeSlotDestination::Stack { offset } => Some(offset + 8),
+                _ => None,
+            })
+            .max()
+            .unwrap_or(0);
+
+        let stage_base = align_up(native_stack_bytes.max(stacked_store_end), 16);
         let save_base = stage_base + register_slots * 8;
         let mut next = save_base + save_cells * 8;
 
@@ -583,15 +782,17 @@ impl ThunkPlan {
             }),
             (LoweredReturn::Registers { pieces, .. }, NativeReturn::Registers { .. })
             | (LoweredReturn::Registers { pieces, .. }, NativeReturn::Sret)
-                if !matches!(signature.result, CAbiTypeFacts::Scalar { .. }) =>
+                if !matches!(signature.result, CAbiTypeFacts::Scalar { .. })
+                    && signature.return_needs_adaptation(c.ret(), target, &native_return) =>
             {
                 let offset = align_up(next, 16);
                 next = offset + align_up(pieces.len() * 8, 16);
                 Some(ReturnImage::Scratch { offset })
             }
-            // The native body returned the compact image's eightbytes and the C
-            // return is those same eightbytes in the same registers: C's result
-            // registers are a prefix of the native bank, so nothing crosses.
+            // Nothing crosses: the native body already left the result where a
+            // C caller reads it, whether that is the image's own eightbytes in
+            // C's result registers — which are a prefix of the native bank — or
+            // one leaf per register when every leaf fills its own eightbyte.
             _ => None,
         };
 
@@ -670,6 +871,19 @@ impl ThunkPlan {
             return_image,
             frame_bytes,
         }
+    }
+
+    /// Whether the emitted body moves the result at all, rather than leaving
+    /// what the native body returned exactly where a C caller reads it. An
+    /// indirect result under both conventions travels through the C caller's
+    /// own storage, which the native body wrote directly.
+    #[cfg(test)]
+    fn adapts_result(&self) -> bool {
+        self.return_image.is_some()
+            && !matches!(
+                (self.c.ret(), &self.native_return),
+                (LoweredReturn::Sret { .. }, NativeReturn::Sret)
+            )
     }
 
     /// Whether a parameter's image is reached through a pointer that itself
@@ -2059,6 +2273,290 @@ mod tests {
                 if target.arch() == Arch::Aarch64 {
                     assert_eq!(code.code.len() % 4, 0);
                 }
+            }
+        }
+    }
+
+    /// `count` eightbyte-wide integer leaves, in ascending image order: the
+    /// shape whose leaves are exactly the eightbytes of its image.
+    fn word_leaves(count: u32) -> Vec<ImageLeaf> {
+        (0..count)
+            .map(|index| ImageLeaf {
+                byte_offset: index * 8,
+                width: 8,
+                signed: false,
+            })
+            .collect()
+    }
+
+    /// An export of `parameters` returning an all-integer aggregate of `bytes`,
+    /// whose leaves are its eightbytes.
+    fn word_aggregate_result(parameters: Vec<ExportParameter>, bytes: u32) -> ExportSignature {
+        ExportSignature {
+            convention: CallingConvention::X86_64SysV,
+            parameters,
+            result: CAbiTypeFacts::integer_aggregate(u64::from(bytes), 8),
+            result_is_aggregate: true,
+            return_leaves_are_eightbytes: true,
+            return_bytes: bytes,
+            return_leaves: word_leaves(bytes / 8),
+            return_padding: Vec::new(),
+        }
+    }
+
+    /// An export of `parameters` returning one scalar.
+    fn scalar_result(
+        parameters: Vec<ExportParameter>,
+        kind: rue_air::CAbiScalarKind,
+        width: u32,
+        signed: bool,
+    ) -> ExportSignature {
+        ExportSignature {
+            convention: CallingConvention::X86_64SysV,
+            parameters,
+            result: scalar_facts(kind),
+            result_is_aggregate: false,
+            return_leaves_are_eightbytes: true,
+            return_bytes: width,
+            return_leaves: vec![scalar_leaf(width, signed)],
+            return_padding: Vec::new(),
+        }
+    }
+
+    /// Every row's answer for one signature, so a case reads as one line.
+    fn entries(signature: &ExportSignature) -> Vec<(Target, CEntry)> {
+        Target::all()
+            .iter()
+            .map(|&target| (target, on(target, signature).c_entry(target)))
+            .collect()
+    }
+
+    #[test]
+    fn a_signature_both_rows_place_identically_needs_no_thunk() {
+        // Register-width scalars in, a register-width scalar out: every value
+        // is where the other convention would have put it, so the C symbol is
+        // a second name for the native body on every row.
+        for (target, entry) in entries(&scalar_result(
+            vec![word_parameter(); 3],
+            rue_air::CAbiScalarKind::RegisterWidth,
+            8,
+            false,
+        )) {
+            assert_eq!(entry, CEntry::Alias, "{target:?}");
+        }
+        // A stacked tail is still the same stack: nine arguments exhaust every
+        // row's roster and the rest sit at the same offsets of the same area.
+        for (target, entry) in entries(&void_signature(vec![word_parameter(); 9])) {
+            assert_eq!(entry, CEntry::Alias, "{target:?}");
+        }
+    }
+
+    #[test]
+    fn a_narrow_scalar_parameter_keeps_its_thunk_on_every_row() {
+        // A C caller leaves the bits above a narrow argument's declared width
+        // unspecified — including Apple's row, whose stacked natural-size
+        // packing Rue does not rely on for a rule that must hold everywhere —
+        // while the native body reads the register as a canonical 64-bit value.
+        for width in [1_u32, 2, 4] {
+            let kind = match width {
+                1 => rue_air::CAbiScalarKind::I8,
+                2 => rue_air::CAbiScalarKind::I16,
+                _ => rue_air::CAbiScalarKind::I32,
+            };
+            let signature =
+                void_signature(vec![word_parameter(), scalar_parameter(kind, width, true)]);
+            for (target, entry) in entries(&signature) {
+                assert_eq!(
+                    entry,
+                    CEntry::Thunk(ThunkReason::NarrowParameter { parameter: 1 }),
+                    "{target:?} {kind:?}"
+                );
+            }
+        }
+        // The same narrow scalar past the register roster, where Apple's row
+        // packs it at its natural size and the others give it a whole slot.
+        let mut parameters = vec![word_parameter(); 9];
+        parameters.push(scalar_parameter(rue_air::CAbiScalarKind::U8, 1, false));
+        for (target, entry) in entries(&void_signature(parameters)) {
+            assert_eq!(
+                entry,
+                CEntry::Thunk(ThunkReason::NarrowParameter { parameter: 9 }),
+                "{target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_narrow_scalar_result_still_needs_no_thunk() {
+        // The other direction of the extension invariant: a native body leaves
+        // a narrow result already extended, which is at least as defined as the
+        // C row asks of a callee, so nothing is adapted on the way out.
+        for (target, entry) in entries(&scalar_result(
+            vec![word_parameter()],
+            rue_air::CAbiScalarKind::I16,
+            2,
+            true,
+        )) {
+            assert_eq!(entry, CEntry::Alias, "{target:?}");
+        }
+    }
+
+    #[test]
+    fn an_aggregate_within_cs_own_bank_needs_no_thunk() {
+        // Two eightbytes in and two out: C's result registers are a prefix of
+        // the native bank, so the leaves come back in the very registers a C
+        // caller reads.
+        let sixteen = ExportParameter {
+            c: CAbiTypeFacts::integer_aggregate(16, 8),
+            native: NativeParameter {
+                leaves: word_leaves(2),
+                leaves_are_eightbytes: true,
+            },
+        };
+        for (target, entry) in entries(&word_aggregate_result(vec![sixteen], 16)) {
+            assert_eq!(entry, CEntry::Alias, "{target:?}");
+        }
+        // A packed pair is one eightbyte of its image each way, and the image
+        // is the C image, so its narrow leaves never cross as themselves.
+        for (target, entry) in entries(&pair_signature()) {
+            assert_eq!(entry, CEntry::Alias, "{target:?}");
+        }
+    }
+
+    #[test]
+    fn a_result_only_the_native_bank_holds_keeps_its_thunk() {
+        // 24 bytes: three eightbytes fit the native bank and exceed C's, so the
+        // body returns in registers where a C caller expects caller storage.
+        for (target, entry) in entries(&triple_signature()) {
+            assert_eq!(
+                entry,
+                CEntry::Thunk(ThunkReason::ReturnAdaptation),
+                "{target:?}"
+            );
+        }
+        // 20 bytes of narrow leaves: the same disagreement, reached through the
+        // packed-eightbyte shape rather than the leaf-per-register one.
+        for (target, entry) in entries(&wide_packed_signature()) {
+            assert_eq!(
+                entry,
+                CEntry::Thunk(ThunkReason::ReturnAdaptation),
+                "{target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_result_past_both_banks_needs_no_thunk() {
+        // Nine eightbytes exceed the native bank as well, so both rows return
+        // it through the same indirect-result register with the same echo — the
+        // native convention took the C row's sret rule whole (ADR-0084).
+        for (target, entry) in entries(&word_aggregate_result(vec![word_parameter()], 72)) {
+            assert_eq!(entry, CEntry::Alias, "{target:?}");
+        }
+    }
+
+    #[test]
+    fn a_leaf_per_register_result_with_padding_keeps_its_thunk() {
+        // `{i32, i64}`: each leaf starts its own eightbyte, so the body hands
+        // back the *leaves*, and the low eightbyte of the C image is the narrow
+        // leaf beside four padding bytes the image must have zeroed.
+        let signature = ExportSignature {
+            convention: CallingConvention::X86_64SysV,
+            parameters: Vec::new(),
+            result: CAbiTypeFacts::integer_aggregate(16, 8),
+            result_is_aggregate: true,
+            return_leaves_are_eightbytes: true,
+            return_bytes: 16,
+            return_leaves: vec![
+                ImageLeaf {
+                    byte_offset: 0,
+                    width: 4,
+                    signed: true,
+                },
+                ImageLeaf {
+                    byte_offset: 8,
+                    width: 8,
+                    signed: false,
+                },
+            ],
+            return_padding: vec![PaddingRange { start: 4, end: 8 }],
+        };
+        for (target, entry) in entries(&signature) {
+            assert_eq!(
+                entry,
+                CEntry::Thunk(ThunkReason::ReturnAdaptation),
+                "{target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_thunk_is_emitted_exactly_for_the_signatures_that_need_one() {
+        // The decision and the emitter read one plan: whenever the entry is an
+        // alias the thunk the emitter would have produced does nothing but
+        // forward, which is what makes dropping it sound.
+        for signature in [
+            scalar_result(
+                vec![word_parameter(); 2],
+                rue_air::CAbiScalarKind::RegisterWidth,
+                8,
+                false,
+            ),
+            pair_signature(),
+            triple_signature(),
+            wide_packed_signature(),
+            void_signature(vec![scalar_parameter(
+                rue_air::CAbiScalarKind::I32,
+                4,
+                true,
+            )]),
+        ] {
+            for &target in Target::all() {
+                let signature = on(target, &signature);
+                let plan = ThunkPlan::new(target, &signature);
+                let identity = plan.slots.iter().all(|(source, _)| {
+                    !matches!(source, NativeSlotSource::Leaf { parameter, leaf }
+                        if plan.leaves[*parameter][*leaf].width < 8)
+                }) && !plan.adapts_result();
+                assert_eq!(
+                    identity,
+                    signature.c_entry(target) == CEntry::Alias,
+                    "{target:?} {signature:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_stacked_narrow_tail_stays_inside_the_outgoing_argument_area() {
+        // Every native value is written as a whole eightbyte, so a stacked slot
+        // narrower than eight bytes writes past its own footprint. Under
+        // Apple's natural-size packing that footprint is one byte, and a long
+        // enough narrow tail would otherwise run out of the outgoing argument
+        // area and into the staging cells above it, which already hold the
+        // register-passed values.
+        let mut parameters = vec![word_parameter(); 8];
+        parameters.extend(std::iter::repeat_n(
+            scalar_parameter(rue_air::CAbiScalarKind::I8, 1, true),
+            12,
+        ));
+        for target in Target::all() {
+            let signature = on(*target, &void_signature(parameters.clone()));
+            let plan = ThunkPlan::new(*target, &signature);
+            let stage_base = plan
+                .register_loads
+                .iter()
+                .map(|(_, offset)| *offset)
+                .min()
+                .expect("the register-passed arguments stage");
+            for (index, (_, destination)) in plan.slots.iter().enumerate() {
+                let NativeSlotDestination::Stack { offset } = destination else {
+                    continue;
+                };
+                assert!(
+                    offset + 8 <= stage_base,
+                    "{target:?} slot {index} at +{offset} writes into the staging cells at +{stage_base}"
+                );
             }
         }
     }

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -3,9 +3,10 @@
 // ============================================================================
 
 /// Collect the unmangled C symbol names of every `pub extern "C" fn` export in
-/// the lowered program (ADR-0064 P4). Each is the raw name under which a C-ABI
-/// entry thunk exposes the exported Rue function to separately compiled C
-/// callers; the name is the export's source identifier (no mangling).
+/// the lowered program (ADR-0064 P4). Each is the raw name under which the
+/// export's C entry — an alias of the native body, or a thunk — exposes the
+/// exported Rue function to separately compiled C callers; the name is the
+/// export's source identifier (no mangling).
 #[cfg(test)]
 pub(crate) fn collect_export_symbols(rir: &rue_rir::Rir, interner: &ThreadedRodeo) -> Vec<String> {
     rir.iter()
@@ -54,9 +55,14 @@ pub(crate) fn validate_backend_functions(
 /// Project one canonical `CodegenUnit` into the linker-owned object builder.
 /// The builder currently accepts owned strings and byte vectors, so this leaf
 /// makes transient copies without retaining a second compiler-side product.
+///
+/// `aliases` are additional global names defined at the unit's entry: the
+/// unmangled C symbols of the `pub extern "C" fn` exports this body is the
+/// entry of, for the exports whose two conventions agree (ADR-0084).
 pub(crate) fn project_backend_object(
     unit: &crate::codegen_query::CodegenUnit,
     target: Target,
+    aliases: &[String],
 ) -> CompileResult<Vec<u8>> {
     // Object serialization runs after code generation, so it is a sibling leaf
     // of `codegen` rather than one of its subphases (RUE-786).
@@ -76,6 +82,9 @@ pub(crate) fn project_backend_object(
     let mut obj_builder = ObjectBuilder::new(target, unit.defined_symbol.to_string())
         .code(text.atoms[0].to_vec())
         .strings(strings);
+    for alias in aliases {
+        obj_builder = obj_builder.alias(alias.clone());
+    }
 
     for reloc in unit.relocations.iter() {
         let rel_type = map_linker_relocation(target, reloc.kind)?;
@@ -196,10 +205,12 @@ fn canonical_codegen_sections(
 pub(crate) fn project_backend_structured_object(
     unit: &crate::codegen_query::CodegenUnit,
     target: Target,
+    aliases: &[String],
 ) -> CompileResult<rue_linker::StructuredObject> {
     match project_backend_structured_object_with_cancellation(
         unit,
         target,
+        aliases,
         &rue_query::CancellationToken::new(),
     ) {
         Ok(object) => Ok(object),
@@ -227,6 +238,7 @@ pub(crate) fn project_backend_structured_object(
 pub(crate) fn project_backend_structured_object_with_cancellation(
     unit: &crate::codegen_query::CodegenUnit,
     target: Target,
+    aliases: &[String],
     cancellation: &rue_query::CancellationToken,
 ) -> Result<rue_linker::StructuredObject, crate::session::PipelineRequestControl> {
     if cancellation.is_canceled() {
@@ -255,35 +267,37 @@ pub(crate) fn project_backend_structured_object_with_cancellation(
             rue_query::QueryAbort::Canceled,
         ));
     }
-    Ok(rue_linker::StructuredObject::function(
+    let mut object = rue_linker::StructuredObject::function(
         target,
         unit.defined_symbol.to_string(),
         text.atoms.clone(),
         rodata.atoms.clone(),
         relocations,
-    ))
+    );
+    for alias in aliases {
+        object = object.with_alias(alias.clone());
+    }
+    Ok(object)
 }
 
-/// Emit the C-ABI entry thunk objects for every `pub extern "C" fn` export
-/// (ADR-0064 P4).
+/// Decide the C entry of every `pub extern "C" fn` export among `functions`.
 ///
 /// Each exported function was already code-generated as an ordinary native body
-/// under its mangled `machine_name`; this adds one extra object per export whose
-/// single global symbol is the unmangled C name (the export's source identifier)
-/// and whose body receives arguments per the target-C convention and adapts them
-/// to the native convention the body follows.
+/// under its mangled `machine_name`. Its unmangled C name is either an alias of
+/// that body or a thunk object of its own, exactly as
+/// [`generate_export_entry`] decides for a rooted export.
 #[cfg(test)]
-pub(crate) fn generate_export_thunk_objects(
+pub(crate) fn generate_export_entries(
     functions: &[crate::session::RootedCfgUnit],
     options: &CompileOptions,
     export_symbols: &[String],
-) -> Vec<Vec<u8>> {
+) -> Vec<ExportEntry> {
     if export_symbols.is_empty() {
         return Vec::new();
     }
     let export_set: std::collections::BTreeSet<&str> =
         export_symbols.iter().map(String::as_str).collect();
-    let mut objects = Vec::new();
+    let mut entries = Vec::new();
     for function in functions {
         let Some(exported_symbol) = function
             .definition_source_name()
@@ -291,16 +305,94 @@ pub(crate) fn generate_export_thunk_objects(
         else {
             continue;
         };
-        objects.push(generate_export_thunk_object(
+        entries.push(generate_export_entry(
             options.target,
-            exported_symbol,
-            &function.record.codegen.defined_symbol,
-            // Exports reaching this test-only path are declared `"C"`, so the
-            // target's own row is the row their declaration resolved to.
-            &crate::session::export_signature(function, options.target.c_calling_convention()),
+            &crate::program_image_plan::RootedExport {
+                function: function.function.clone(),
+                exported_symbol: exported_symbol.to_owned(),
+                native_symbol: function.record.codegen.defined_symbol.to_string(),
+                // Exports reaching this test-only path are declared `"C"`, so
+                // the target's own row is the row their declaration resolved
+                // to.
+                signature: crate::session::export_signature(
+                    function,
+                    options.target.c_calling_convention(),
+                ),
+            },
         ));
     }
-    objects
+    entries
+}
+
+/// One `pub extern "C" fn` export's C entry, as a link consumes it.
+///
+/// An export is one of two things (ADR-0084): an *alias*, when the target's C
+/// row and the native convention place every value of its signature
+/// identically and the C symbol is therefore emitted as a second global name
+/// for the native body; or a *thunk*, an object of its own that adapts what the
+/// two rows still disagree about and forwards.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExportEntry {
+    pub(crate) exported_symbol: String,
+    pub(crate) native_symbol: String,
+    /// The thunk object's bytes, or `None` for an alias, which has no object.
+    pub(crate) object: Option<Vec<u8>>,
+}
+
+impl ExportEntry {
+    /// Whether the C symbol is a second name for the native body.
+    pub(crate) fn is_alias(&self) -> bool {
+        self.object.is_none()
+    }
+}
+
+/// Decide one export's C entry and emit its thunk object when it needs one.
+pub(crate) fn generate_export_entry(
+    target: Target,
+    export: &crate::program_image_plan::RootedExport,
+) -> ExportEntry {
+    let object = export.signature.c_entry(target).is_thunk().then(|| {
+        generate_export_thunk_object(
+            target,
+            &export.exported_symbol,
+            &export.native_symbol,
+            &export.signature,
+        )
+    });
+    ExportEntry {
+        exported_symbol: export.exported_symbol.clone(),
+        native_symbol: export.native_symbol.clone(),
+        object,
+    }
+}
+
+/// The alias names each native body carries, keyed by that body's symbol.
+///
+/// Every export whose C entry is an alias contributes its unmangled C name to
+/// the object of the body it names, which is where the definition lives.
+pub(crate) fn export_alias_names(
+    entries: &[ExportEntry],
+) -> std::collections::BTreeMap<String, Vec<String>> {
+    let mut aliases: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for entry in entries.iter().filter(|entry| entry.is_alias()) {
+        aliases
+            .entry(entry.native_symbol.clone())
+            .or_default()
+            .push(entry.exported_symbol.clone());
+    }
+    for names in aliases.values_mut() {
+        names.sort();
+    }
+    aliases
+}
+
+/// The thunk objects a link admits, one per export that still needs one.
+pub(crate) fn export_thunk_objects(entries: &[ExportEntry]) -> Vec<Vec<u8>> {
+    entries
+        .iter()
+        .filter_map(|entry| entry.object.clone())
+        .collect()
 }
 
 pub(crate) fn generate_export_thunk_object(
@@ -562,7 +654,7 @@ fn main() -> i32 {
     }
 
     fn assert_byte_projection_rejects(unit: &CodegenUnit, expected: &str) {
-        let error = project_backend_object(unit, Target::X86_64Linux).unwrap_err();
+        let error = project_backend_object(unit, Target::X86_64Linux, &[]).unwrap_err();
         assert!(
             matches!(&error.kind, ErrorKind::InternalCodegenError(message) if message.contains(expected)),
             "unexpected projection error: {error}"
@@ -571,7 +663,7 @@ fn main() -> i32 {
 
     fn assert_projection_rejects(unit: CodegenUnit, expected: &str) {
         assert_byte_projection_rejects(&unit, expected);
-        let error = project_backend_structured_object(&unit, Target::X86_64Linux).unwrap_err();
+        let error = project_backend_structured_object(&unit, Target::X86_64Linux, &[]).unwrap_err();
         assert!(
             matches!(&error.kind, ErrorKind::InternalCodegenError(message) if message.contains(expected)),
             "unexpected structured projection error: {error}"
@@ -748,7 +840,7 @@ fn main() -> i32 {
             };
             let mut unit = canonical_projection_unit(b"\x90\xc3", &atom_bytes);
             unit.relocations = relocations.into();
-            let actual = project_backend_object(&unit, target).unwrap();
+            let actual = project_backend_object(&unit, target, &[]).unwrap();
             let mut expected = ObjectBuilder::new(target, "main")
                 .code(vec![0x90, 0xc3])
                 .strings(strings.clone());
@@ -762,7 +854,7 @@ fn main() -> i32 {
     #[test]
     fn structured_projection_reuses_codegen_atoms() {
         let unit = canonical_projection_unit(b"\xC3", &[b"literal"]);
-        let object = project_backend_structured_object(&unit, Target::X86_64Linux).unwrap();
+        let object = project_backend_structured_object(&unit, Target::X86_64Linux, &[]).unwrap();
         assert!(std::sync::Arc::ptr_eq(
             &object.section_atoms(0).unwrap()[0],
             &unit.sections[0].atoms[0]
@@ -771,7 +863,7 @@ fn main() -> i32 {
             &object.section_atoms(1).unwrap()[0],
             &unit.sections[1].atoms[0]
         ));
-        let serialized = project_backend_object(&unit, Target::X86_64Linux).unwrap();
+        let serialized = project_backend_object(&unit, Target::X86_64Linux, &[]).unwrap();
         let parsed = ObjectFile::parse(&serialized).unwrap();
         assert_eq!(
             parsed.sections[parsed.section_map[".text"]].data.as_slice(),

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -1418,6 +1418,7 @@ fn add_runtime_archive_to_linker_with_cancellation(
 pub(crate) fn link_internal_structured_with_warnings_and_cancellation(
     options: &CompileOptions,
     objects: &[crate::object_query::CollectedObjectProjection],
+    export_aliases: &ExportAliasNames,
     export_thunk_objects: &[Vec<u8>],
     warnings: &[CompileWarning],
     cancellation: &rue_query::CancellationToken,
@@ -1431,7 +1432,13 @@ pub(crate) fn link_internal_structured_with_warnings_and_cancellation(
         |linker| {
             for collected in objects {
                 check_cancellation(cancellation)?;
-                admit_structured_unit(linker, &collected.unit, options.target, cancellation)?;
+                admit_structured_unit(
+                    linker,
+                    &collected.unit,
+                    options.target,
+                    export_aliases,
+                    cancellation,
+                )?;
             }
             Ok(())
         },
@@ -1441,6 +1448,7 @@ pub(crate) fn link_internal_structured_with_warnings_and_cancellation(
 pub(crate) fn link_internal_structured_units_with_warnings_and_cancellation(
     options: &CompileOptions,
     units: &[crate::codegen_query::CollectedCodegenUnit],
+    export_aliases: &ExportAliasNames,
     export_thunk_objects: &[Vec<u8>],
     warnings: &[CompileWarning],
     cancellation: &rue_query::CancellationToken,
@@ -1454,7 +1462,13 @@ pub(crate) fn link_internal_structured_units_with_warnings_and_cancellation(
         |linker| {
             for collected in units {
                 check_cancellation(cancellation)?;
-                admit_structured_unit(linker, &collected.unit, options.target, cancellation)?;
+                admit_structured_unit(
+                    linker,
+                    &collected.unit,
+                    options.target,
+                    export_aliases,
+                    cancellation,
+                )?;
             }
             Ok(())
         },
@@ -1491,6 +1505,10 @@ fn link_internal_structured_admission_with_cancellation(
     )
 }
 
+/// The unmangled C names each native body defines besides its own symbol,
+/// keyed by that symbol: the exports whose C entry is an alias (ADR-0084).
+pub(crate) type ExportAliasNames = std::collections::BTreeMap<String, Vec<String>>;
+
 fn add_export_thunks(
     linker: &mut Linker,
     export_thunk_objects: &[Vec<u8>],
@@ -1514,11 +1532,15 @@ fn admit_structured_unit(
     linker: &mut Linker,
     unit: &crate::codegen_query::CodegenUnit,
     target: Target,
+    export_aliases: &ExportAliasNames,
     cancellation: &rue_query::CancellationToken,
 ) -> CancellableLinkResult<()> {
     let object = crate::backend::project_backend_structured_object_with_cancellation(
         unit,
         target,
+        export_aliases
+            .get(unit.defined_symbol.as_ref())
+            .map_or(&[][..], Vec::as_slice),
         cancellation,
     )?;
     linker

--- a/crates/rue-compiler/src/object_query.rs
+++ b/crates/rue-compiler/src/object_query.rs
@@ -225,7 +225,10 @@ pub(crate) fn evaluate_object_projection(
         return Ok(object_failure(errors.clone()));
     };
     context.record_work(rue_query::WorkItem::new("object.projection.attempts", 1));
-    let value = match crate::backend::project_backend_object(unit, key.target) {
+    // The cached projection is keyed by the codegen unit alone, so it carries
+    // no export alias; the program image re-projects the few bodies an aliased
+    // export names.
+    let value = match crate::backend::project_backend_object(unit, key.target, &[]) {
         Ok(bytes) => {
             ObjectProjectionValue::Available(Arc::new(ObjectProjection::from_bytes(bytes)))
         }

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -2434,7 +2434,9 @@ mod tests {
         let canonical_objects = cold
             .units
             .iter()
-            .map(|unit| crate::backend::project_backend_object(&unit.unit, options.target).unwrap())
+            .map(|unit| {
+                crate::backend::project_backend_object(&unit.unit, options.target, &[]).unwrap()
+            })
             .collect::<Vec<_>>();
         let cold_image = crate::program_image_plan::ProgramImage::from_rooted(
             cold.objects,

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -131,22 +131,43 @@ impl PartialEq for ProgramImageUnit {
 
 impl Eq for ProgramImageUnit {}
 
-/// The deterministic contribution of a C-ABI export thunk.  Thunks are not
-/// codegen terminals, but their object bytes are a compiler-owned link input
-/// and therefore have a separate, explicit plan entry.
+/// The deterministic contribution of one `pub extern "C" fn` export's C entry.
+/// An entry is not a codegen terminal — it is either a thunk object, a
+/// compiler-owned link input of its own, or an alias name carried by the native
+/// body's object — so it has a separate, explicit plan entry either way.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ProgramImageExportThunk {
+pub(crate) struct ProgramImageExportEntry {
     pub(crate) exported_symbol: String,
     pub(crate) native_symbol: String,
+    /// The thunk object's bytes for a thunk entry, and the alias binding itself
+    /// for an alias entry, so a plan that switches between the two is a change.
     pub(crate) content_digest: ContentDigest,
 }
 
+/// Domain separator for an alias entry's digest, which stands in for the thunk
+/// object bytes an alias does not have.
+const EXPORT_ALIAS_DIGEST_DOMAIN: &[u8] = b"rue.program-image.export-alias\0v1\0";
+
+impl ProgramImageExportEntry {
+    fn from_entry(entry: &backend::ExportEntry) -> Self {
+        Self {
+            exported_symbol: entry.exported_symbol.clone(),
+            native_symbol: entry.native_symbol.clone(),
+            content_digest: match &entry.object {
+                Some(bytes) => bytes_digest(b"rue.program-image.export-thunk\0v1\0", bytes),
+                None => bytes_digest(EXPORT_ALIAS_DIGEST_DOMAIN, entry.native_symbol.as_bytes()),
+            },
+        }
+    }
+}
+
 /// Rooted C-export metadata projected from the exact optimized CFG terminal.
-/// It contains only the ABI facts needed to build the forwarding thunk, already
-/// resolved to sizes, offsets, and widths, so the record outlives the type pool
-/// it was projected from and compares by ABI meaning rather than by pool handle.
+/// It contains only the ABI facts needed to decide the export's C entry and
+/// build a forwarding thunk when it needs one, already resolved to sizes,
+/// offsets, and widths, so the record outlives the type pool it was projected
+/// from and compares by ABI meaning rather than by pool handle.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct RootedExportThunk {
+pub(crate) struct RootedExport {
     pub(crate) function: crate::FunctionInstanceKey,
     pub(crate) exported_symbol: String,
     pub(crate) native_symbol: String,
@@ -158,7 +179,7 @@ pub(crate) struct RootedExportThunk {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ProgramImagePlan {
     pub(crate) units: Vec<ProgramImageUnit>,
-    pub(crate) export_thunks: Vec<ProgramImageExportThunk>,
+    pub(crate) export_entries: Vec<ProgramImageExportEntry>,
     pub(crate) target: Target,
     pub(crate) object_format: ProgramObjectFormat,
     pub(crate) entry_point: &'static str,
@@ -180,9 +201,9 @@ pub(crate) struct ProgramImagePlanDelta {
     pub(crate) added: Vec<ProgramImageUnit>,
     pub(crate) changed: Vec<ProgramImageUnit>,
     pub(crate) removed: Vec<ProgramImageUnit>,
-    pub(crate) added_export_thunks: Vec<ProgramImageExportThunk>,
-    pub(crate) changed_export_thunks: Vec<ProgramImageExportThunk>,
-    pub(crate) removed_export_thunks: Vec<ProgramImageExportThunk>,
+    pub(crate) added_export_entries: Vec<ProgramImageExportEntry>,
+    pub(crate) changed_export_entries: Vec<ProgramImageExportEntry>,
+    pub(crate) removed_export_entries: Vec<ProgramImageExportEntry>,
     /// Target, object format, runtime, or entry changes invalidate the whole
     /// fresh link. They have no meaningful add/change/remove unit mapping.
     pub(crate) link_context_changed: bool,
@@ -216,28 +237,28 @@ impl ProgramImagePlan {
                 delta.removed.push((**unit).clone());
             }
         }
-        let before_thunks = previous
-            .export_thunks
+        let before_entries = previous
+            .export_entries
             .iter()
-            .map(|thunk| (thunk.exported_symbol.as_str(), thunk))
+            .map(|entry| (entry.exported_symbol.as_str(), entry))
             .collect::<BTreeMap<_, _>>();
-        let after_thunks = self
-            .export_thunks
+        let after_entries = self
+            .export_entries
             .iter()
-            .map(|thunk| (thunk.exported_symbol.as_str(), thunk))
+            .map(|entry| (entry.exported_symbol.as_str(), entry))
             .collect::<BTreeMap<_, _>>();
-        for (symbol, thunk) in &after_thunks {
-            match before_thunks.get(symbol) {
-                None => delta.added_export_thunks.push((**thunk).clone()),
-                Some(previous) if *previous != *thunk => {
-                    delta.changed_export_thunks.push((**thunk).clone())
+        for (symbol, entry) in &after_entries {
+            match before_entries.get(symbol) {
+                None => delta.added_export_entries.push((**entry).clone()),
+                Some(previous) if *previous != *entry => {
+                    delta.changed_export_entries.push((**entry).clone())
                 }
                 Some(_) => {}
             }
         }
-        for (symbol, thunk) in &before_thunks {
-            if !after_thunks.contains_key(symbol) {
-                delta.removed_export_thunks.push((**thunk).clone());
+        for (symbol, entry) in &before_entries {
+            if !after_entries.contains_key(symbol) {
+                delta.removed_export_entries.push((**entry).clone());
             }
         }
         delta.link_context_changed = self.target != previous.target
@@ -251,13 +272,15 @@ impl ProgramImagePlan {
     }
 }
 
-/// Retains the plan's canonical terminals and the already-projected export
-/// thunk bytes.  The adapter consumes this once; it never re-enters backend
+/// Retains the plan's canonical terminals and the already-decided export
+/// entries.  The adapter consumes this once; it never re-enters backend
 /// lowering, allocation, or emission.
 pub(crate) struct ProgramImage {
     pub(crate) plan: ProgramImagePlan,
     inputs: ProgramImageInputs,
-    export_thunk_objects: Vec<Vec<u8>>,
+    /// Every export's C entry: the thunk objects a link admits, and the alias
+    /// names the native bodies' own objects already carry.
+    export_entries: Vec<backend::ExportEntry>,
 }
 
 /// The durable image remains byte-backed for object consumers and future
@@ -271,7 +294,7 @@ impl ProgramImage {
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn from_rooted(
         objects: Vec<CollectedObjectProjection>,
-        exports: Vec<RootedExportThunk>,
+        exports: Vec<RootedExport>,
         options: &CompileOptions,
     ) -> MultiErrorResult<Self> {
         uncancellable(
@@ -287,7 +310,7 @@ impl ProgramImage {
 
     pub(crate) fn from_rooted_with_cancellation(
         objects: Vec<CollectedObjectProjection>,
-        exports: Vec<RootedExportThunk>,
+        exports: Vec<RootedExport>,
         options: &CompileOptions,
         cancellation: &rue_query::CancellationToken,
     ) -> CancellableImageResult<Self> {
@@ -300,28 +323,32 @@ impl ProgramImage {
             &exports,
             cancellation,
         )?;
-        let mut export_thunk_objects = Vec::with_capacity(exports.len());
+        let mut export_entries = Vec::with_capacity(exports.len());
         for export in &exports {
             check_cancellation(cancellation)?;
-            export_thunk_objects.push(backend::generate_export_thunk_object(
-                options.target,
-                &export.exported_symbol,
-                &export.native_symbol,
-                &export.signature,
-            ));
+            export_entries.push(backend::generate_export_entry(options.target, export));
         }
+        // An aliased export's C symbol is defined by the native body's own
+        // object, so the bodies that carry one are re-projected with their
+        // alias names. The cached projection is keyed by the codegen unit
+        // alone, which does not know the program's export set.
+        let objects = project_export_aliases_with_cancellation(
+            objects,
+            &export_entries,
+            options,
+            cancellation,
+        )?;
         let plan = ProgramImagePlan::from_rooted_inputs_with_cancellation(
             &objects,
             unit_identities,
-            &exports,
             options,
-            &export_thunk_objects,
+            &export_entries,
             cancellation,
         )?;
         Ok(Self {
             plan,
             inputs: objects,
-            export_thunk_objects,
+            export_entries,
         })
     }
 
@@ -334,13 +361,12 @@ impl ProgramImage {
     ) -> MultiErrorResult<Self> {
         validate_program_image_inputs(&units, functions, export_symbols)?;
         backend::validate_backend_functions(functions)?;
-        let export_thunk_objects =
-            backend::generate_export_thunk_objects(functions, options, export_symbols);
+        let export_entries = backend::generate_export_entries(functions, options, export_symbols);
         let export_set = export_symbols
             .iter()
             .map(String::as_str)
             .collect::<BTreeSet<_>>();
-        let expected_thunks = functions
+        let expected_entries = functions
             .iter()
             .filter(|function| {
                 function
@@ -348,39 +374,39 @@ impl ProgramImage {
                     .is_some_and(|name| export_set.contains(name))
             })
             .count();
-        if export_thunk_objects.len() != expected_thunks {
+        if export_entries.len() != expected_entries {
             return Err(CompileErrors::from(CompileError::without_span(
                 ErrorKind::InternalError(
-                    "C-ABI export thunk projection did not produce one object per export".into(),
+                    "C-ABI export projection did not produce one entry per export".into(),
                 ),
             )));
         }
+        let aliases = backend::export_alias_names(&export_entries);
         let objects = units
             .into_iter()
             .map(|collected| {
-                backend::project_backend_object(&collected.unit, options.target).map(|bytes| {
-                    CollectedObjectProjection {
-                        function: collected.function,
-                        unit: collected.unit,
-                        object: std::sync::Arc::new(
-                            crate::object_query::ObjectProjection::from_bytes(bytes),
-                        ),
-                    }
+                backend::project_backend_object(
+                    &collected.unit,
+                    options.target,
+                    aliases
+                        .get(collected.unit.defined_symbol.as_ref())
+                        .map_or(&[][..], Vec::as_slice),
+                )
+                .map(|bytes| CollectedObjectProjection {
+                    function: collected.function,
+                    unit: collected.unit,
+                    object: std::sync::Arc::new(crate::object_query::ObjectProjection::from_bytes(
+                        bytes,
+                    )),
                 })
             })
             .collect::<Result<Vec<_>, _>>()
             .map_err(CompileErrors::from)?;
-        let plan = ProgramImagePlan::from_inputs(
-            &objects,
-            functions,
-            export_symbols,
-            options,
-            &export_thunk_objects,
-        )?;
+        let plan = ProgramImagePlan::from_inputs(&objects, options, &export_entries)?;
         Ok(Self {
             plan,
             inputs: objects,
-            export_thunk_objects,
+            export_entries,
         })
     }
 
@@ -409,7 +435,7 @@ impl ProgramImage {
                 ))),
             ));
         }
-        let mut objects = Vec::with_capacity(self.inputs.len() + self.export_thunk_objects.len());
+        let mut objects = Vec::with_capacity(self.inputs.len() + self.export_entries.len());
         for collected in &self.inputs {
             check_cancellation(cancellation)?;
             objects.push(clone_bytes_with_cancellation(
@@ -422,9 +448,13 @@ impl ProgramImage {
             object_bytes = objects.iter().map(Vec::len).sum::<usize>(),
             "codegen complete"
         );
-        for thunk in &self.export_thunk_objects {
+        for object in self
+            .export_entries
+            .iter()
+            .filter_map(|entry| entry.object.as_ref())
+        {
             check_cancellation(cancellation)?;
-            objects.push(clone_bytes_with_cancellation(thunk, cancellation)?);
+            objects.push(clone_bytes_with_cancellation(object, cancellation)?);
         }
         Ok(objects)
     }
@@ -466,7 +496,8 @@ impl ProgramImage {
                 linking::link_internal_structured_with_warnings_and_cancellation(
                     options,
                     &self.inputs,
-                    &self.export_thunk_objects,
+                    &backend::export_alias_names(&self.export_entries),
+                    &backend::export_thunk_objects(&self.export_entries),
                     warnings,
                     cancellation,
                 )
@@ -485,6 +516,43 @@ impl ProgramImage {
     }
 }
 
+/// Re-project every native body that carries an export alias.
+///
+/// The object-projection query is keyed by one codegen unit, which is a
+/// per-function fact; whether that function's unmangled C name is an alias of
+/// it is a property of the program's export set. The image therefore re-runs the
+/// projection for the few bodies an export names, leaving every other cached
+/// projection untouched.
+fn project_export_aliases_with_cancellation(
+    objects: Vec<CollectedObjectProjection>,
+    export_entries: &[backend::ExportEntry],
+    options: &CompileOptions,
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableImageResult<Vec<CollectedObjectProjection>> {
+    let aliases = backend::export_alias_names(export_entries);
+    if aliases.is_empty() {
+        return Ok(objects);
+    }
+    let mut projected = Vec::with_capacity(objects.len());
+    for collected in objects {
+        check_cancellation(cancellation)?;
+        let Some(names) = aliases.get(collected.unit.defined_symbol.as_ref()) else {
+            projected.push(collected);
+            continue;
+        };
+        let bytes = backend::project_backend_object(&collected.unit, options.target, names)
+            .map_err(|error| {
+                crate::session::PipelineRequestControl::Compile(CompileErrors::from(error))
+            })?;
+        projected.push(CollectedObjectProjection {
+            function: collected.function,
+            unit: collected.unit,
+            object: std::sync::Arc::new(crate::object_query::ObjectProjection::from_bytes(bytes)),
+        });
+    }
+    Ok(projected)
+}
+
 fn clone_bytes_with_cancellation(
     bytes: &[u8],
     cancellation: &rue_query::CancellationToken,
@@ -501,9 +569,8 @@ impl ProgramImagePlan {
     fn from_rooted_inputs_with_cancellation(
         units: &[CollectedObjectProjection],
         unit_identities: Vec<String>,
-        exports: &[RootedExportThunk],
         options: &CompileOptions,
-        export_thunk_objects: &[Vec<u8>],
+        export_entries: &[backend::ExportEntry],
         cancellation: &rue_query::CancellationToken,
     ) -> CancellableImageResult<Self> {
         let mut plan_units = Vec::with_capacity(units.len());
@@ -520,23 +587,19 @@ impl ProgramImagePlan {
             left.identity.cmp(&right.identity)
         })?;
 
-        let mut export_thunks = Vec::with_capacity(exports.len());
-        for (export, bytes) in exports.iter().zip(export_thunk_objects) {
+        let mut plan_entries = Vec::with_capacity(export_entries.len());
+        for entry in export_entries {
             check_cancellation(cancellation)?;
-            export_thunks.push(ProgramImageExportThunk {
-                exported_symbol: export.exported_symbol.clone(),
-                native_symbol: export.native_symbol.clone(),
-                content_digest: bytes_digest(b"rue.program-image.export-thunk\0v1\0", bytes),
-            });
+            plan_entries.push(ProgramImageExportEntry::from_entry(entry));
         }
-        cancellable_sort_by(&mut export_thunks, cancellation, |left, right| {
+        cancellable_sort_by(&mut plan_entries, cancellation, |left, right| {
             left.exported_symbol
                 .cmp(&right.exported_symbol)
                 .then_with(|| left.native_symbol.cmp(&right.native_symbol))
         })?;
         Self::finish_with_cancellation(
             plan_units,
-            export_thunks,
+            plan_entries,
             units.iter().map(|unit| unit.unit.as_ref()),
             options,
             cancellation,
@@ -546,10 +609,8 @@ impl ProgramImagePlan {
     #[cfg(test)]
     fn from_inputs(
         units: &[CollectedObjectProjection],
-        functions: &[RootedCfgUnit],
-        export_symbols: &[String],
         options: &CompileOptions,
-        export_thunk_objects: &[Vec<u8>],
+        export_entries: &[backend::ExportEntry],
     ) -> MultiErrorResult<Self> {
         let mut plan_units = units
             .iter()
@@ -562,28 +623,11 @@ impl ProgramImagePlan {
             .collect::<Vec<_>>();
         plan_units.sort_by(|left, right| left.identity.cmp(&right.identity));
 
-        let export_set = export_symbols
+        let mut plan_entries = export_entries
             .iter()
-            .map(String::as_str)
-            .collect::<BTreeSet<_>>();
-        let mut export_thunks = functions
-            .iter()
-            .filter_map(|function| {
-                function
-                    .definition_source_name()
-                    .filter(|name| export_set.contains(name))
-                    .map(|name| (function, name))
-            })
-            .zip(export_thunk_objects)
-            .map(
-                |((function, exported_symbol), bytes)| ProgramImageExportThunk {
-                    exported_symbol: exported_symbol.to_owned(),
-                    native_symbol: function.record.codegen.defined_symbol.to_string(),
-                    content_digest: bytes_digest(b"rue.program-image.export-thunk\0v1\0", bytes),
-                },
-            )
+            .map(ProgramImageExportEntry::from_entry)
             .collect::<Vec<_>>();
-        export_thunks.sort_by(|left, right| {
+        plan_entries.sort_by(|left, right| {
             left.exported_symbol
                 .cmp(&right.exported_symbol)
                 .then_with(|| left.native_symbol.cmp(&right.native_symbol))
@@ -591,7 +635,7 @@ impl ProgramImagePlan {
 
         Self::finish(
             plan_units,
-            export_thunks,
+            plan_entries,
             units.iter().map(|unit| unit.unit.as_ref()),
             options,
         )
@@ -600,14 +644,14 @@ impl ProgramImagePlan {
     #[cfg_attr(not(test), allow(dead_code))]
     fn finish<'a>(
         plan_units: Vec<ProgramImageUnit>,
-        export_thunks: Vec<ProgramImageExportThunk>,
+        export_entries: Vec<ProgramImageExportEntry>,
         units: impl IntoIterator<Item = &'a crate::codegen_query::CodegenUnit>,
         options: &CompileOptions,
     ) -> MultiErrorResult<Self> {
         uncancellable(
             Self::finish_with_cancellation(
                 plan_units,
-                export_thunks,
+                export_entries,
                 units,
                 options,
                 &rue_query::CancellationToken::new(),
@@ -618,7 +662,7 @@ impl ProgramImagePlan {
 
     fn finish_with_cancellation<'a>(
         plan_units: Vec<ProgramImageUnit>,
-        export_thunks: Vec<ProgramImageExportThunk>,
+        export_entries: Vec<ProgramImageExportEntry>,
         units: impl IntoIterator<Item = &'a crate::codegen_query::CodegenUnit>,
         options: &CompileOptions,
         cancellation: &rue_query::CancellationToken,
@@ -645,7 +689,7 @@ impl ProgramImagePlan {
 
         let plan = Self {
             units: plan_units,
-            export_thunks,
+            export_entries,
             target: options.target,
             object_format: if options.target.is_macho() {
                 ProgramObjectFormat::MachO
@@ -691,14 +735,14 @@ fn validate_program_image_inputs(
     if export_set.len() != export_symbols.len() {
         return duplicate_plan_input("C-ABI export symbol", "duplicate export declaration");
     }
-    let mut thunk_identities = BTreeSet::new();
+    let mut entry_identities = BTreeSet::new();
     for exported_symbol in functions
         .iter()
         .filter_map(RootedCfgUnit::definition_source_name)
         .filter(|name| export_set.contains(name))
     {
-        if !thunk_identities.insert(exported_symbol) {
-            return duplicate_plan_input("C-ABI export thunk identity", exported_symbol);
+        if !entry_identities.insert(exported_symbol) {
+            return duplicate_plan_input("C-ABI export entry identity", exported_symbol);
         }
     }
 
@@ -746,7 +790,7 @@ fn validate_program_image_inputs(
 
 fn validate_rooted_program_image_inputs_with_cancellation(
     units: &[CollectedObjectProjection],
-    exports: &[RootedExportThunk],
+    exports: &[RootedExport],
     cancellation: &rue_query::CancellationToken,
 ) -> CancellableImageResult<Vec<String>> {
     check_cancellation(cancellation)?;
@@ -855,10 +899,10 @@ fn validate_program_image_plan(plan: &ProgramImagePlan) -> MultiErrorResult<()> 
             return duplicate_plan_input("defined symbol", &unit.defined_symbol);
         }
     }
-    let mut thunk_identities = BTreeSet::new();
-    for thunk in &plan.export_thunks {
-        if !thunk_identities.insert(thunk.exported_symbol.as_str()) {
-            return duplicate_plan_input("C-ABI export thunk identity", &thunk.exported_symbol);
+    let mut entry_identities = BTreeSet::new();
+    for entry in &plan.export_entries {
+        if !entry_identities.insert(entry.exported_symbol.as_str()) {
+            return duplicate_plan_input("C-ABI export entry identity", &entry.exported_symbol);
         }
     }
     Ok(())
@@ -1044,7 +1088,7 @@ mod tests {
     fn plan(units: Vec<ProgramImageUnit>) -> ProgramImagePlan {
         ProgramImagePlan {
             units,
-            export_thunks: Vec::new(),
+            export_entries: Vec::new(),
             target: Target::X86_64Linux,
             object_format: ProgramObjectFormat::Elf,
             entry_point: "_start",
@@ -1089,23 +1133,23 @@ mod tests {
     }
 
     #[test]
-    fn delta_covers_export_thunks_and_plan_wide_link_inputs() {
-        let thunk = |symbol: &str, digest_byte| ProgramImageExportThunk {
+    fn delta_covers_export_entries_and_plan_wide_link_inputs() {
+        let thunk = |symbol: &str, digest_byte| ProgramImageExportEntry {
             exported_symbol: symbol.to_owned(),
             native_symbol: format!("native_{symbol}"),
             content_digest: [digest_byte; 32],
         };
         let mut before = plan(vec![]);
-        before.export_thunks = vec![thunk("removed", 1), thunk("changed", 1)];
+        before.export_entries = vec![thunk("removed", 1), thunk("changed", 1)];
         let mut after = plan(vec![]);
-        after.export_thunks = vec![thunk("added", 1), thunk("changed", 2)];
+        after.export_entries = vec![thunk("added", 1), thunk("changed", 2)];
         after
             .required_runtime_symbols
             .push("__rue_memcpy".to_owned());
         let delta = after.delta_from(&before).unwrap();
-        assert_eq!(delta.added_export_thunks, vec![thunk("added", 1)]);
-        assert_eq!(delta.changed_export_thunks, vec![thunk("changed", 2)]);
-        assert_eq!(delta.removed_export_thunks, vec![thunk("removed", 1)]);
+        assert_eq!(delta.added_export_entries, vec![thunk("added", 1)]);
+        assert_eq!(delta.changed_export_entries, vec![thunk("changed", 2)]);
+        assert_eq!(delta.removed_export_entries, vec![thunk("removed", 1)]);
         assert!(delta.link_context_changed);
     }
 
@@ -1218,9 +1262,11 @@ mod tests {
 
     /// A C export's linker-visible name is the identifier its declaration
     /// spells, independently of the module-qualified internal symbol its native
-    /// body carries (ADR-0064 P4, RUE-1125).
+    /// body carries (ADR-0064 P4, RUE-1125). This signature places identically
+    /// under both conventions, so that name is an alias defined by the body's
+    /// own object, and the two containers must define it the same way.
     #[test]
-    fn export_thunks_carry_the_declared_c_name_over_a_module_qualified_body() {
+    fn export_entries_carry_the_declared_c_name_over_a_module_qualified_body() {
         let source = "pub extern \"C\" fn rue_answer() -> i32 { 42 }\n\
                       fn main() -> i32 { 0 }";
         let snapshot = crate::SourceSnapshot::single("main.rue", source).unwrap();
@@ -1254,14 +1300,14 @@ mod tests {
             "the export's native body is an ordinary module-qualified callable"
         );
         assert_eq!(
-            image.plan.export_thunks.len(),
+            image.plan.export_entries.len(),
             1,
             "{:?}",
-            image.plan.export_thunks
+            image.plan.export_entries
         );
-        assert_eq!(image.plan.export_thunks[0].exported_symbol, "rue_answer");
+        assert_eq!(image.plan.export_entries[0].exported_symbol, "rue_answer");
         assert_eq!(
-            image.plan.export_thunks[0].native_symbol,
+            image.plan.export_entries[0].native_symbol,
             exported.record.codegen.defined_symbol.as_ref()
         );
 
@@ -1272,7 +1318,7 @@ mod tests {
         let structured_link = image.fresh_link(&options, &[]).unwrap().elf;
         assert_eq!(
             structured_link, byte_link,
-            "retained units plus a serialized export thunk must match the byte-container link"
+            "retained units carrying an export alias must match the byte-container link"
         );
     }
 
@@ -1293,7 +1339,7 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_export_thunk_identities_are_rejected() {
+    fn duplicate_export_entry_identities_are_rejected() {
         let (units, mut functions, options) = session_inputs("fn main() -> i32 { 0 }");
         let exported = functions[0]
             .definition_source_name()
@@ -1306,7 +1352,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("duplicate C-ABI export thunk identity")
+                .contains("duplicate C-ABI export entry identity")
         );
     }
 

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -428,20 +428,19 @@ pub(crate) fn compile_rooted_with_session_with_cancellation(
     let provider_observations = crate::unstable::provider_observation_metrics(session);
     let mut output = match rooted.input {
         crate::session::RootedCodegenInput::Structured => {
-            let mut export_thunk_objects = Vec::with_capacity(rooted.exports.len());
+            let mut export_entries = Vec::with_capacity(rooted.exports.len());
             for export in &rooted.exports {
                 check_cancellation()?;
-                export_thunk_objects.push(crate::backend::generate_export_thunk_object(
+                export_entries.push(crate::backend::generate_export_entry(
                     options.target,
-                    &export.exported_symbol,
-                    &export.native_symbol,
-                    &export.signature,
+                    export,
                 ));
             }
             crate::linking::link_internal_structured_units_with_warnings_and_cancellation(
                 options,
                 &rooted.units,
-                &export_thunk_objects,
+                &crate::backend::export_alias_names(&export_entries),
+                &crate::backend::export_thunk_objects(&export_entries),
                 &rooted.warnings,
                 cancellation,
             )?

--- a/crates/rue-compiler/src/session/rooted_artifacts.rs
+++ b/crates/rue-compiler/src/session/rooted_artifacts.rs
@@ -155,12 +155,12 @@ impl RootedCfgOutput {
     }
 
     /// The `pub extern "C" fn` exports this rooted set carries, each with the
-    /// signature the entry thunk is generated from.
+    /// signature its C entry is decided and generated from.
     ///
     /// This is the same [`collect_rooted_exports`] intersection the codegen
     /// projection publishes, so an ABI presentation and a real link describe one
     /// export set.
-    pub(crate) fn c_export_thunks(&self) -> Vec<crate::program_image_plan::RootedExportThunk> {
+    pub(crate) fn c_exports(&self) -> Vec<crate::program_image_plan::RootedExport> {
         collect_rooted_exports(&self.graph, &self.cfgs)
     }
 
@@ -244,7 +244,7 @@ pub(crate) struct RootedCodegenOutput {
     pub(crate) objects: Vec<crate::object_query::CollectedObjectProjection>,
     #[allow(dead_code)]
     pub(crate) cfgs: Vec<RootedCfgUnit>,
-    pub(crate) exports: Vec<crate::program_image_plan::RootedExportThunk>,
+    pub(crate) exports: Vec<crate::program_image_plan::RootedExport>,
     pub(crate) warnings: Vec<CompileWarning>,
     pub(crate) work: crate::CanonicalSemanticWork,
     pub(crate) cfg_work: BackendQueryWork,
@@ -308,7 +308,7 @@ pub(super) struct RootedBodyGraph {
     pub(super) work: crate::CanonicalSemanticWork,
 }
 
-/// The C-ABI export thunks a request's image must carry.
+/// The C-ABI exports a request's image must carry an entry for.
 ///
 /// `extern "C"` exports are executable-only. The nucleus records them for every
 /// request, but only `RootSelection::Executable` roots them (ADR-0083 §1), so a
@@ -319,7 +319,7 @@ pub(super) struct RootedBodyGraph {
 pub(super) fn collect_rooted_exports(
     graph: &RootedBodyGraph,
     cfgs: &[RootedCfgUnit],
-) -> Vec<crate::program_image_plan::RootedExportThunk> {
+) -> Vec<crate::program_image_plan::RootedExport> {
     let export_roots = graph
         .c_export_roots
         .iter()
@@ -333,7 +333,7 @@ pub(super) fn collect_rooted_exports(
     cfgs.iter()
         .filter_map(|cfg| {
             let convention = *export_roots.get(&cfg.function)?;
-            Some(crate::program_image_plan::RootedExportThunk {
+            Some(crate::program_image_plan::RootedExport {
                 function: cfg.function.clone(),
                 exported_symbol: match &cfg.function {
                     crate::FunctionInstanceKey::Definition(key) => key.name().to_owned(),

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -6209,8 +6209,8 @@ fn an_excluded_test_lowers_no_body() {
     assert_eq!(errors.len(), 1);
 }
 
-/// `extern "C"` exports are executable-only (ADR-0083 §1). A test image links
-/// no export thunk, because a test request roots no c-export.
+/// `extern "C"` exports are executable-only (ADR-0083 §1). A test image carries
+/// no C entry, because a test request roots no c-export.
 #[test]
 fn a_test_request_roots_no_c_export() {
     let source = SourceSnapshot::single(
@@ -6235,10 +6235,10 @@ fn a_test_request_roots_no_c_export() {
     assert_eq!(
         exported
             .iter()
-            .map(|thunk| thunk.exported_symbol.as_str())
+            .map(|export| export.exported_symbol.as_str())
             .collect::<Vec<_>>(),
         vec!["rue_add"],
-        "an executable request links its c-export thunk"
+        "an executable request links its c-export entry"
     );
 
     let tests = session

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1157,7 +1157,7 @@ impl PresentationOutput {
 ///    function order; a signature disagreement between two call sites of one
 ///    symbol is already a semantic error, so one block per symbol is complete.
 fn write_abi_presentation(text: &mut String, rooted: &RootedCfgOutput, target: crate::Target) {
-    let exports = rooted.c_export_thunks();
+    let exports = rooted.c_exports();
     let mut imports = std::collections::BTreeMap::new();
     for function in rooted.functions() {
         let record = &function.record;
@@ -2223,7 +2223,7 @@ pub fn Buf(comptime T: type) -> type {{
             let objects = units
                 .iter()
                 .map(|unit| {
-                    crate::backend::project_backend_object(&unit.unit, options.target).unwrap()
+                    crate::backend::project_backend_object(&unit.unit, options.target, &[]).unwrap()
                 })
                 .collect::<Vec<_>>();
             (unit_identity, objects)

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -474,6 +474,28 @@ impl StructuredObject {
             format,
         }
     }
+
+    /// Define `name` as an additional global symbol at the start of this
+    /// object's code, so a reference to it resolves to the same address as the
+    /// object's own defined symbol.
+    ///
+    /// The byte-container counterpart is [`crate::ObjectBuilder::alias`]; both
+    /// exist because a `pub extern "C" fn` whose C and native placements agree
+    /// is emitted as a second name for its native body rather than as a
+    /// forwarding object (ADR-0084).
+    #[must_use]
+    pub fn with_alias(mut self, name: impl Into<String>) -> Self {
+        let (section_index, size) = (self.symbols[0].section_index, self.symbols[0].size);
+        self.symbols.push(Symbol {
+            name: name.into(),
+            section_index,
+            value: 0,
+            size,
+            binding: SymbolBinding::Global,
+            sym_type: SymbolType::Func,
+        });
+        self
+    }
 }
 
 fn atoms_size(atoms: &[Arc<[u8]>]) -> u64 {

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -110,6 +110,9 @@ pub struct ObjectBuilder {
     pub relocations: Vec<CodeRelocation>,
     /// String constants (for .rodata section).
     pub strings: Vec<String>,
+    /// Additional global names for the same code, each defined at offset 0 of
+    /// the code section alongside [`Self::name`].
+    pub aliases: Vec<String>,
 }
 
 /// A relocation in generated code.
@@ -135,7 +138,21 @@ impl ObjectBuilder {
             code: Vec::new(),
             relocations: Vec::new(),
             strings: Vec::new(),
+            aliases: Vec::new(),
         }
+    }
+
+    /// Define `name` as an additional global symbol at the start of this
+    /// object's code, so a reference to it resolves to the same address as
+    /// [`Self::name`].
+    ///
+    /// This is how a `pub extern "C" fn` whose C and native placements agree
+    /// gets its unmangled C entry (ADR-0084): the export name is a second name
+    /// for the native body rather than a forwarding object of its own.
+    #[must_use]
+    pub fn alias(mut self, name: impl Into<String>) -> Self {
+        self.aliases.push(name.into());
+        self
     }
 
     /// Set the machine code.
@@ -216,6 +233,14 @@ impl ObjectBuilder {
         strtab.extend_from_slice(self.name.as_bytes());
         strtab.push(0);
 
+        // Alias names, each a second global definition of the same code.
+        let mut alias_name_offsets = Vec::with_capacity(self.aliases.len());
+        for alias in &self.aliases {
+            alias_name_offsets.push(strtab.len());
+            strtab.extend_from_slice(alias.as_bytes());
+            strtab.push(0);
+        }
+
         // Add string constant symbol names to strtab
         let mut string_symbol_offsets = Vec::new();
         for i in 0..self.strings.len() {
@@ -252,6 +277,7 @@ impl ObjectBuilder {
         // 2: .rodata section symbol (if has_rodata)
         // 3..3+N: string constant symbols (local, in .rodata)
         // then: function symbol (global)
+        // then: alias symbols (global, same .text offset as the function)
         // then: external symbols (undefined)
 
         let mut symtab = Vec::new();
@@ -306,6 +332,18 @@ impl ObjectBuilder {
         symtab.extend_from_slice(&(self.code.len() as u64).to_le_bytes()); // st_size
         next_sym_idx += 1;
         let _ = func_sym_idx; // suppress unused warning
+
+        // Alias symbols (global): the same code start under another name, so
+        // each carries the function symbol's section, value, and size.
+        for &name_offset in &alias_name_offsets {
+            symtab.extend_from_slice(&(name_offset as u32).to_le_bytes()); // st_name
+            symtab.push(elf_st_info(STB_GLOBAL, STT_FUNC)); // st_info
+            symtab.push(0); // st_other
+            symtab.extend_from_slice(&ElfSectionLayout::TEXT.to_le_bytes()); // st_shndx: .text
+            symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
+            symtab.extend_from_slice(&(self.code.len() as u64).to_le_bytes()); // st_size
+            next_sym_idx += 1;
+        }
 
         // External symbols (undefined)
         let first_extern_sym = next_sym_idx;
@@ -673,6 +711,17 @@ impl ObjectBuilder {
         strtab.extend_from_slice(macho_name.as_bytes());
         strtab.push(0);
 
+        // Alias names, each a second global definition of the same code. They
+        // sit immediately after the function symbol so that the string and
+        // undefined-external symbols keep one contiguous block after them.
+        let mut alias_name_offsets = Vec::with_capacity(self.aliases.len());
+        for alias in &self.aliases {
+            alias_name_offsets.push(strtab.len());
+            strtab.extend_from_slice(crate::util::add_macho_underscore(alias).as_bytes());
+            strtab.push(0);
+        }
+        let num_alias_syms = alias_name_offsets.len();
+
         // String constant symbols (private external, for rodata)
         // Include function name in symbol to avoid collisions when linking multiple object files
         // IMPORTANT: Only create symbols for non-empty strings that have actual rodata content.
@@ -740,7 +789,8 @@ impl ObjectBuilder {
         // r_symbolnum=0 in relocations as invalid. By putting function first,
         // string symbols start at index 1+.
         let num_local_syms = 0; // No local symbols - all are external
-        let num_extern_syms = 1 + num_string_syms + num_extern_symbols; // function + non-empty strings + external refs
+        // function + aliases + non-empty strings + external refs
+        let num_extern_syms = 1 + num_alias_syms + num_string_syms + num_extern_symbols;
         let num_syms = num_local_syms + num_extern_syms;
 
         // String table follows symbol table
@@ -854,7 +904,7 @@ impl ObjectBuilder {
         //   - Local symbols: 0 (we have none - all are N_EXT)
         //   - External defined symbols: function + string constants
         //   - Undefined symbols: external references
-        let num_extdef = 1 + num_string_syms; // function + string symbols
+        let num_extdef = 1 + num_alias_syms + num_string_syms; // function + aliases + string symbols
         let num_undef = num_extern_symbols;
 
         macho.extend_from_slice(&LC_DYSYMTAB.to_le_bytes()); // cmd
@@ -932,21 +982,29 @@ impl ObjectBuilder {
                 // Look up the symbol index for this string
                 let sym_idx = string_sym_indices[string_id]
                     .expect("empty string relocations should have been filtered out");
-                // Non-empty string: symbol index is 1 + sym_idx (function is at 0)
-                (1 + sym_idx as u32, true)
+                // Non-empty string: the function and its aliases come first.
+                (1 + num_alias_syms as u32 + sym_idx as u32, true)
             } else {
-                // External symbol (function or undefined external)
-                // First check if it's the function itself
+                // External symbol (function, one of its aliases, or an
+                // undefined external). The function is at index 0 and its
+                // aliases follow it, in the order they were added.
                 if reloc.symbol == self.name {
-                    // Function symbol is at index 0
                     (0_u32, true)
+                } else if let Some(alias) =
+                    self.aliases.iter().position(|name| *name == reloc.symbol)
+                {
+                    (1 + alias as u32, true)
                 } else {
                     // Undefined external symbol. Every non-string relocation
                     // registered its symbol in the table above, so this lookup
                     // cannot miss.
                     let sym_idx = extern_symbol_indices[reloc.symbol.as_str()];
-                    // Undefined externals start after function and non-empty string symbols
-                    (1 + num_string_syms as u32 + sym_idx as u32, true)
+                    // Undefined externals follow the function, its aliases, and
+                    // the non-empty string symbols.
+                    (
+                        1 + num_alias_syms as u32 + num_string_syms as u32 + sym_idx as u32,
+                        true,
+                    )
                 }
             };
 
@@ -1005,7 +1063,8 @@ impl ObjectBuilder {
         // n_value: 8 bytes
 
         // All symbols are external (N_EXT set) for ARM64 relocation compatibility.
-        // Symbol table order: function, string constants, undefined externals.
+        // Symbol table order: function, aliases, string constants, undefined
+        // externals.
         // IMPORTANT: Function must be at index 0 so that string symbols start at
         // index 1+. macOS linker rejects r_symbolnum=0 in relocations as invalid.
 
@@ -1016,7 +1075,16 @@ impl ObjectBuilder {
         macho.extend_from_slice(&0_u16.to_le_bytes()); // n_desc
         macho.extend_from_slice(&0_u64.to_le_bytes()); // n_value (function start; __text is at addr 0)
 
-        // Symbols 1..N: String constant symbols, defined in the rodata section.
+        // Alias symbols: the same code start under another name.
+        for &name_offset in &alias_name_offsets {
+            macho.extend_from_slice(&(name_offset as u32).to_le_bytes()); // n_strx
+            macho.push(N_EXT | N_SECT); // n_type: external, defined in section
+            macho.push(1); // n_sect: section 1 (__text)
+            macho.extend_from_slice(&0_u16.to_le_bytes()); // n_desc
+            macho.extend_from_slice(&0_u64.to_le_bytes()); // n_value (__text is at addr 0)
+        }
+
+        // String constant symbols, defined in the rodata section.
         // These are plain N_SECT (truly local) symbols, so they are not exported,
         // avoiding duplicate symbol errors when linking multiple object files
         // that each have their own string constants.

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -2768,6 +2768,153 @@ mod tests {
     }
 
     #[test]
+    fn an_alias_reaches_the_code_it_shares_with_its_object_s_own_symbol() {
+        // A `pub extern "C" fn` whose two conventions agree is emitted as an
+        // extra global name on the native body's object (ADR-0084), so a
+        // caller that names the alias must reach exactly the code a caller that
+        // names the body reaches. The body also carries a string constant, so
+        // the alias symbol is proved not to disturb the local string symbols
+        // that follow it in either container's symbol table.
+        for target in [
+            Target::X86_64Linux,
+            Target::Aarch64Linux,
+            Target::Aarch64Macos,
+        ] {
+            let (body_code, body_relocations) = match target {
+                Target::X86_64Linux => (
+                    vec![0x48, 0x8D, 0x05, 0, 0, 0, 0, 0xC3],
+                    vec![CodeRelocation {
+                        offset: 3,
+                        symbol: ".rodata.str0".into(),
+                        rel_type: RelocationType::Pc32,
+                        addend: -4,
+                    }],
+                ),
+                Target::Aarch64Linux | Target::Aarch64Macos => (
+                    vec![0, 0, 0, 0, 0, 0, 0, 0, 0xC0, 0x03, 0x5F, 0xD6],
+                    vec![
+                        CodeRelocation {
+                            offset: 0,
+                            symbol: ".rodata.str0".into(),
+                            rel_type: RelocationType::AdrpPage21,
+                            addend: 0,
+                        },
+                        CodeRelocation {
+                            offset: 4,
+                            symbol: ".rodata.str0".into(),
+                            rel_type: RelocationType::AddLo12,
+                            addend: 0,
+                        },
+                    ],
+                ),
+            };
+            let call = |symbol: &str| match target {
+                Target::X86_64Linux => (
+                    vec![0xE8, 0, 0, 0, 0, 0xC3],
+                    vec![CodeRelocation {
+                        offset: 1,
+                        symbol: symbol.to_owned(),
+                        rel_type: RelocationType::Plt32,
+                        addend: -4,
+                    }],
+                ),
+                Target::Aarch64Linux | Target::Aarch64Macos => (
+                    vec![0, 0, 0, 0, 0xC0, 0x03, 0x5F, 0xD6],
+                    vec![CodeRelocation {
+                        offset: 0,
+                        symbol: symbol.to_owned(),
+                        rel_type: RelocationType::Call26,
+                        addend: 0,
+                    }],
+                ),
+            };
+            let body_object = |alias: Option<&str>| {
+                let mut builder = ObjectBuilder::new(target, "body")
+                    .code(body_code.clone())
+                    .strings(vec!["literal".into()]);
+                if let Some(alias) = alias {
+                    builder = builder.alias(alias);
+                }
+                for relocation in &body_relocations {
+                    builder = builder.relocation(relocation.clone());
+                }
+                builder.build()
+            };
+            let main_object = |called: &str| {
+                let (code, relocations) = call(called);
+                let mut builder = ObjectBuilder::new(target, "main").code(code);
+                for relocation in relocations {
+                    builder = builder.relocation(relocation);
+                }
+                builder.build()
+            };
+            let link = |objects: [Vec<u8>; 2]| {
+                let mut linker = Linker::new(target);
+                for bytes in objects {
+                    linker
+                        .add_object(ObjectFile::parse(&bytes).unwrap())
+                        .unwrap();
+                }
+                linker.link("main").unwrap()
+            };
+
+            // Calling the alias links to the same image as calling the body.
+            assert_eq!(
+                link([body_object(Some("entry")), main_object("entry")]),
+                link([body_object(None), main_object("body")]),
+                "{target:?}"
+            );
+
+            // The structured input the internal link admits defines the alias
+            // the same way the byte container does.
+            let mut structured_linker = Linker::new(target);
+            structured_linker
+                .add_structured_object(
+                    crate::StructuredObject::function(
+                        target,
+                        "body",
+                        Arc::from([Arc::from(body_code.as_slice())]),
+                        Arc::from([Arc::from(*b"literal")]),
+                        body_relocations
+                            .iter()
+                            .map(|relocation| crate::StructuredRelocation {
+                                offset: relocation.offset,
+                                symbol: relocation.symbol.clone(),
+                                rel_type: relocation.rel_type,
+                                addend: relocation.addend,
+                            })
+                            .collect(),
+                    )
+                    .with_alias("entry"),
+                )
+                .unwrap();
+            let (main_code, main_relocations) = call("entry");
+            structured_linker
+                .add_structured_object(crate::StructuredObject::function(
+                    target,
+                    "main",
+                    Arc::from([Arc::from(main_code.as_slice())]),
+                    Arc::from([]),
+                    main_relocations
+                        .into_iter()
+                        .map(|relocation| crate::StructuredRelocation {
+                            offset: relocation.offset,
+                            symbol: relocation.symbol,
+                            rel_type: relocation.rel_type,
+                            addend: relocation.addend,
+                        })
+                        .collect(),
+                ))
+                .unwrap();
+            assert_eq!(
+                link([body_object(Some("entry")), main_object("entry")]),
+                structured_linker.link("main").unwrap(),
+                "{target:?}"
+            );
+        }
+    }
+
+    #[test]
     fn structured_relocations_and_rodata_layout_match_serialized_objects() {
         for target in [
             Target::X86_64Linux,

--- a/crates/rue-ui-tests/cases/emit/abi.toml
+++ b/crates/rue-ui-tests/cases/emit/abi.toml
@@ -235,13 +235,15 @@ import wide
 
 # An export owns both halves of one crossing, so its block prints both: the C
 # entry a foreign caller writes (two eightbytes in, two result registers out)
-# and the native body the thunk forwards to. Both sides place the argument
-# identically — the native convention is this target's own C row — and both
-# place the result identically too, because C's result registers are a prefix
-# of the native bank, so nothing is left for the thunk to adapt.
+# and the native body behind it. Both sides place the argument identically — the
+# native convention is this target's own C row — and both place the result
+# identically too, because C's result registers are a prefix of the native bank.
+# Nothing is left to adapt, so the block is headed by the consequence: the C
+# symbol is an alias of the native body and a foreign caller enters it directly
+# (ADR-0084).
 [[case]]
 name = "export_two_field_struct_in_and_out"
-description = "A `pub extern \\\"C\\\" fn` export prints its C side and the native side it forwards to."
+description = "A `pub extern \\\"C\\\" fn` export whose two sides agree prints both of them and reports its C entry as an alias of the native body."
 target = "x86-64-linux"
 preview = "c_ffi"
 preview_should_pass = true
@@ -262,6 +264,7 @@ fn main() -> i32 {
 """
 expected_abi = """
 export swap
+  c entry: alias of the native body
   c side
     convention x86-64-sysv, symbol swap
     parameter 0: Pair$test_2erue, by value, gp registers 0-1 (rdi, rsi)
@@ -278,6 +281,145 @@ export swap
 function main
   convention rue, symbol main
   return: i32, gp return register 0 (rax)
+  outgoing argument area: 0 bytes
+"""
+
+# The two disagreements that keep an entry thunk, and the reason the report
+# gives for each:
+#
+#   scale   a narrow scalar parameter. The C row leaves the bits above `i32`
+#           unspecified — the `sign-extended from 32 bits` on its C line is what
+#           the *caller* of a C function does, not a promise to a callee — while
+#           the native body reads a canonical 64-bit value, so the entry
+#           re-extends it. The narrow *result* needs nothing: the body already
+#           leaves it extended.
+#   rotate  a result the two banks carry differently. Three eightbytes fit the
+#           native return bank and exceed SysV's two, so the body returns in
+#           registers where a C caller expects its own storage.
+[[case]]
+name = "export_entries_that_keep_a_thunk_say_why"
+description = "An export with a narrow parameter and one whose result exceeds C's return bank each report the disagreement that keeps their entry thunk."
+target = "x86-64-linux"
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+@repr(c)
+struct Triple {
+    a: i64,
+    b: i64,
+    c: i64,
+}
+
+pub extern "C" fn scale(n: i32) -> i32 {
+    n + n
+}
+
+pub extern "C" fn rotate(t: Triple) -> Triple {
+    Triple { a: t.c, b: t.a, c: t.b }
+}
+
+fn main() -> i32 {
+    0
+}
+"""
+expected_abi = """
+export scale
+  c entry: thunk, because parameter 0 is re-extended
+  c side
+    convention x86-64-sysv, symbol scale
+    parameter 0: i32, by value, gp register 0 (rdi), sign-extended from 32 bits
+    return: i32, gp result register 0 (rax), sign-extended from 32 bits
+    outgoing argument area: 0 bytes
+  native side
+    convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s5_7363616c65t0_
+    parameter 0: i32, by value, gp register 0 (rdi)
+    return: i32, gp return register 0 (rax)
+    outgoing argument area: 0 bytes
+
+export rotate
+  c entry: thunk, because the result is adapted
+  c side
+    convention x86-64-sysv, symbol rotate
+    parameter 0: Triple$test_2erue, by value, stack +0 (24 bytes, align 8)
+    return: Triple$test_2erue, sret: pointer in rdi, echoed in rax (24 bytes, align 8)
+    outgoing argument area: 32 bytes
+  native side
+    convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s6_726f74617465t0_
+    parameter 0: Triple$test_2erue, by value, stack +0 (24 bytes, align 8)
+    return: Triple$test_2erue, 3 eightbytes
+      eightbyte 0: gp return register 0 (rax)
+      eightbyte 1: gp return register 1 (rdx)
+      eightbyte 2: gp return register 2 (rcx)
+    outgoing argument area: 32 bytes
+
+function main
+  convention rue, symbol main
+  return: i32, gp return register 0 (rax)
+  outgoing argument area: 0 bytes
+"""
+
+# The same two answers on the Apple row, whose stacked natural-size packing and
+# caller-extension amendment are the two places one might expect a different
+# decision. Neither changes it: an aggregate within the C bank is an alias, and
+# a narrow scalar keeps its thunk on every row, because Rue does not rely on one
+# row's caller-extension guarantee for a rule that must hold on all of them.
+[[case]]
+name = "export_entries_answer_the_same_way_on_the_apple_row"
+description = "An aliased aggregate export and a thunked narrow-parameter export report the same entries under the Apple arm64 row."
+target = "aarch64-macos"
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+@repr(c)
+struct Pair {
+    lo: i64,
+    hi: i64,
+}
+
+pub extern "C" fn swap(p: Pair) -> Pair {
+    Pair { lo: p.hi, hi: p.lo }
+}
+
+pub extern "C" fn scale(n: i16) -> i16 {
+    n + n
+}
+
+fn main() -> i32 {
+    0
+}
+"""
+expected_abi = """
+export swap
+  c entry: alias of the native body
+  c side
+    convention aarch64-aapcs-darwin, symbol swap
+    parameter 0: Pair$test_2erue, by value, gp registers 0-1 (x0, x1)
+    return: Pair$test_2erue, gp result registers 0-1 (x0, x1)
+    outgoing argument area: 0 bytes
+  native side
+    convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s4_73776170t0_
+    parameter 0: Pair$test_2erue, by value, gp registers 0-1 (x0, x1)
+    return: Pair$test_2erue, 2 eightbytes
+      eightbyte 0: gp return register 0 (x0)
+      eightbyte 1: gp return register 1 (x1)
+    outgoing argument area: 0 bytes
+
+export scale
+  c entry: thunk, because parameter 0 is re-extended
+  c side
+    convention aarch64-aapcs-darwin, symbol scale
+    parameter 0: i16, by value, gp register 0 (x0), sign-extended from 16 bits
+    return: i16, gp result register 0 (x0), sign-extended from 16 bits
+    outgoing argument area: 0 bytes
+  native side
+    convention rue, symbol __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s5_7363616c65t0_
+    parameter 0: i16, by value, gp register 0 (x0)
+    return: i16, gp return register 0 (x0)
+    outgoing argument area: 0 bytes
+
+function main
+  convention rue, symbol main
+  return: i32, gp return register 0 (x0)
   outgoing argument area: 0 bytes
 """
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ boundary, `NativeCallAbi` plus the shared slot plan for the native convention �
 and asks each backend for the name of a roster index, so it cannot describe a
 placement the compiler does not emit. `--target` selects the row, so a Darwin
 placement is readable on any host, and a `pub extern "C" fn` export prints both
-its C entry and the native body its thunk forwards to. See
+its C entry and the native body that entry names or forwards to. See
 `docs/notes/ffi-abi-conformance-audit.md`.
 
 The `stackframe` view reports each frame's byte-based layout — per-slot offsets
@@ -102,7 +102,7 @@ aggregate rule applies. `rue_air::lower_c_signature` is the one function that
 reads that data against a type's facts and answers where every argument and the
 result of a `"C"` signature lives. All three C crossing sites consume its
 `LoweredSignature`: the `extern "C"` import planner (`foreign_call`), the
-`pub extern "C" fn` export thunk (`export_thunk`), and the stable query plane's
+`pub extern "C" fn` export entry (`export_thunk`), and the stable query plane's
 `compiler.call-abi`. The backends contribute only physical leaves — mapping a
 roster index to a register name, and emitting the loads, stores, and calls.
 Calls between Rue functions use the separate native convention, whose classifier

--- a/docs/designs/0084-native-calling-convention.md
+++ b/docs/designs/0084-native-calling-convention.md
@@ -350,12 +350,16 @@ moves in the same change as the convention it models, never in a follow-up.
   scalars-only `extern "C"` calls through the lowering, the last C crossing that
   still takes the native path — is a preliminary of this phase and may land
   earlier.
-- [ ] **Phase 2: Native returns through the shared lowering** — RUE-2038. Returns
+- [x] **Phase 2: Native returns through the shared lowering** — RUE-2038. Returns
   classify through the same lowered signature, with the wider bank and the psABI
   sret register and echo; the hidden-first-ordinary-argument sret and the
   `StrBuf` special case retire; RUE-2010 closes by construction, with its
   preview-gated spec cases landing here; export thunks reduce to aliases wherever
-  the convention allows.
+  the convention allows. An alias is a second global symbol at the native body's
+  own entry, defined by that body's object in both containers
+  (`ObjectBuilder::alias`, `StructuredObject::with_alias`), so an export that
+  reduces emits no object of its own; `--emit abi` names each export's entry and,
+  for a thunk, the disagreement that keeps it.
 - [ ] **Phase 3: One classifier, and the docs describe it** — RUE-2039. The CFG
   parameter contract drops `NativeArgClass` and the slot-oriented description;
   the native/runtime/C branching in call planning and both backends' CFG lowering

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -29,7 +29,7 @@ boundary, so naming it in an `extern` position describes no crossing.
 name table `--emit abi` prints from, so the two cannot drift. The declaration's
 convention is resolved once — when its signature is checked, against the
 compilation target — and carried from there: the stable plane's `CallAbiFacts`,
-the foreign-symbol map code generation reads, the export thunk's
+the foreign-symbol map code generation reads, the export entry's
 `ExportSignature`, and the ABI report all take the resolved row rather than
 asking the target for its C row again. Because each C row is the convention of
 exactly one supported target, an accepted name places values exactly as `"C"`
@@ -52,7 +52,7 @@ One function reads that data against a type's facts:
 `rue_air::lower_c_signature` answers where every argument and the result of a
 `"C"` signature lives, and its `LoweredSignature` is consumed by every C
 crossing site — the `extern "C"` import planner, the `pub extern "C" fn` export
-thunk, and the stable query plane's `compiler.call-abi`. That single answer is
+entry, and the stable query plane's `compiler.call-abi`. That single answer is
 ADR-0064's ratified acceptance criterion (the by-value classifier agreeing across
 calls, returns, exports, and callbacks) discharged by construction rather than by
 review; `the_c_by_value_classifier_agrees_across_sites_shapes_and_planes` pins it
@@ -172,9 +172,9 @@ indirect-result register: `rdi` with the `rax` echo on System V AMD64, the
 dedicated `x8` on AAPCS64, with the caller allocating a 16-byte-aligned buffer.
 
 Because C's result registers are a prefix of the native bank, **any result
-within C's own bank is placed identically under both rows**, so an export thunk
-for such a signature has no return adaptation left to do, and the two
-conventions differ by one stateable sentence.
+within C's own bank is placed identically under both rows**, so an export of such
+a signature has no return adaptation to do, and the two conventions differ by one
+stateable sentence.
 
 ### Preserved machine state
 
@@ -214,10 +214,10 @@ by an operating-system test inside a backend:
 - **The caller extends arguments narrower than 32 bits.** Rue's canonical
   64-bit-extension invariant already produces a value satisfying it, so the
   import side needs nothing Darwin-specific; a unit assertion pins that every C
-  row asks for the same extension. The export thunk loads every incoming narrow
-  value through its canonical extension on every row, because the native body
-  needs the canonical 64-bit form, which is stronger than Apple's 32-bit
-  guarantee.
+  row asks for the same extension. A narrow parameter is what keeps an export's
+  entry thunk on every row, and that thunk loads the incoming value through its
+  canonical extension, because the native body needs the canonical 64-bit form,
+  which is stronger than Apple's 32-bit guarantee.
 - **Variadic arguments go on the stack.** Out of scope: variadic `extern "C"`
   declarations are rejected.
 
@@ -226,21 +226,48 @@ these amendments do not change it today; they govern the `extern "C"` import and
 export paths, which do reach stacked arguments and narrow scalars. Native Rue
 continues to use its uniform 8-byte slot model on macOS.
 
-## Rue-to-C export thunks
+## Rue-to-C export entries
 
 A `pub extern "C" fn` is compiled as an ordinary native body under a mangled
-symbol, plus one extra object whose single global symbol is the unmangled C name.
-That object's body reads the export's `LoweredSignature` in the callee direction
-— the C caller has already put every argument where the lowering says it goes —
-and adapts each value to what the native body expects.
+symbol. Its unmangled C name is one of two things:
 
-The adaptation is small because both conventions place arguments by the same
-rules — the native row *is* the target's C row with a wider return bank — and
-because the compact memory image of a `@repr(c)` aggregate is its C object
-layout. The native side is placed by `rue_air::lower_native_signature` against
-the very facts the C side was placed by, so an export naming the target's own
-row moves each argument from where C left it to where the native body expects
-it and that is usually the same place:
+- an **alias**: a second global symbol at the native body's own entry, defined
+  by that body's object, so a C caller enters the body directly and no extra
+  object exists. This is the common case, because both conventions place
+  arguments by the same rules and C's result registers are a prefix of the
+  native return bank (ADR-0084).
+- a **thunk**: one extra object whose single global symbol is the C name, whose
+  body reads the export's `LoweredSignature` in the callee direction — the C
+  caller has already put every argument where the lowering says it goes — and
+  adapts each value to what the native body expects.
+
+`ExportSignature::c_entry` is the one predicate that decides, and it keeps the
+thunk whenever anything is left to do:
+
+- a **narrow scalar parameter** that reaches the body as one of its own leaves.
+  A C caller leaves the bits above the declared width unspecified — Apple's row
+  promises more, but Rue does not rely on one row's guarantee for a rule that
+  must hold on all of them — while the native body reads a canonical 64-bit
+  value, so the entry re-extends it.
+- a **result the two banks carry differently**: one that fits the native bank
+  and not C's comes back in registers where a C caller expects caller storage,
+  and one handed over leaf by leaf still has to be assembled into the C image
+  with its padding zeroed.
+- a **parameter the two rows place differently**, which under ADR-0084 happens
+  only as a consequence of such a result: a hidden indirect-result pointer that
+  is an ordinary first argument shifts every later argument one register right
+  under one row and not the other.
+
+Everything else — aggregates within C's bank, register-width scalars, stacked
+tails, an indirect result larger than either bank, and a narrow *result*, which
+the body already leaves canonically extended — reduces to an alias.
+
+What a thunk does when it is kept is small for the same reasons the alias case
+exists, and because the compact memory image of a `@repr(c)` aggregate is its C
+object layout. The native side is placed by `rue_air::lower_native_signature`
+against the very facts the C side was placed by, so the thunk moves each
+argument from where C left it to where the native body expects it and that is
+usually the same place:
 
 - A value the native convention passes by reference is handed to the body as a
   pointer to the C caller's own bytes, wherever they are: the saved incoming
@@ -254,11 +281,13 @@ it and that is usually the same place:
 - When both directions are indirect, the C caller's indirect-result storage *is*
   the native body's storage, so the result is never copied; SysV's `rax` echo is
   then a reload of the saved pointer. When the native body returns its leaves in
-  result registers, the thunk writes each into the C image at its own byte
-  position, zeroing padding first so the image is deterministic. When the native
-  body returns the value's *eightbytes* — the compact image, which is the C
-  image — they are already the C result registers if C returns in registers, and
-  are staged and copied into the caller's storage if it does not.
+  result registers and those leaves are not already the C image's eightbytes,
+  the thunk writes each into the C image at its own byte position, zeroing
+  padding first so the image is deterministic. When the native body returns the
+  value's *eightbytes* — the compact image, which is the C image — they are
+  already the C result registers if C returns in registers, and are staged and
+  copied into the caller's storage if it does not. A result the thunk would only
+  copy back where it already is keeps the export an alias instead.
 
 The signature classes semantic analysis still rejects for an export are about
 identity rather than marshaling: a generic (`comptime`) function has no single C
@@ -321,14 +350,15 @@ rue --emit abi --preview c_ffi --target aarch64-macos main.rue
 It is evidence rather than commentary because it consumes what code generation
 consumes and nothing else: a C boundary's placements come from
 `rue_air::lower_c_signature` through the same `ForeignCallInputs` /
-`ExportSignature` projections the import lowering and the export thunk build,
+`ExportSignature` projections the import lowering and the export entry build,
 and the native side's come from `rue_air::lower_native_signature` and
 `rue_air::lower_native_return` through the same `return_plan` /
 `return_registers` projections the call planner and both return paths build.
 Register *names* are asked of the backend that owns the roster. A
-`pub extern "C" fn` export prints both halves of its crossing, so what its entry
-thunk has left to do — a re-extension per narrow scalar, and the adaptation of a
-result the two banks place differently — is visible side by side.
+`pub extern "C" fn` export prints both halves of its crossing, headed by whether
+its C entry is an alias of the native body or a thunk and, when it is a thunk,
+which disagreement keeps it — a re-extension per narrow scalar, a result the two
+banks place differently, or the argument shift such a result causes.
 
 One thing the stage cannot show is an FFI-predicate failure beside the function
 that caused it: the predicates reject an `extern` or export *signature* while
@@ -356,6 +386,11 @@ The probe covers:
 
 `cli.c_ffi` covers the `extern "C"` import and export paths. Its executing
 cases pair a Rue program with a C archive on x86-64 Linux and AArch64 Linux.
+`x86_64_linux_aliased_export_called_from_c` and its AArch64 pair execute the
+alias entry: the same C caller as `x86_64_linux_export_called_from_c`, over
+exports whose parameters are register-width, so the C symbol it calls is a
+second name for the native body rather than a thunk. The narrow-parameter pair
+beside it keeps its thunks, so both entry shapes are executed under one caller.
 `x86_64_linux_aggregate_exports_called_from_c` and its AArch64 pair cover the
 export direction where the two conventions disagree most: a C caller passes an
 8-byte `@repr(c)` struct by value and receives one back, passes a 24-byte struct

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -143,10 +143,11 @@ Three sites consume that one answer, which is why an import, an export, and the
 query plane cannot disagree about a placement:
 
 - the `extern "C"` import planner, which writes the places and calls;
-- the `pub extern "C" fn` export thunk, which reads the same places in the
+- the `pub extern "C" fn` export entry, which reads the same places in the
   callee direction and adapts them to the native convention its body follows —
   itself placed by `lower_native_signature` against the same facts, so the two
-  halves usually agree outright; and
+  halves usually agree outright and the C symbol is emitted as an alias of the
+  native body rather than as a thunk (ADR-0084); and
 - the stable query plane's `compiler.call-abi`, which projects the same facts
   from canonical layout values and revision-stable type keys.
 
@@ -196,10 +197,10 @@ than by an operating-system test in a backend:
   audit note records Apple's byte-exact composite placement as still open.
 - **The caller extends arguments narrower than 32 bits.** Rue's canonical
   64-bit-extension invariant already satisfies this on the import side. On the
-  export side the thunk loads every incoming narrow value through its canonical
-  extension on every row: the native body needs the canonical 64-bit form, which
-  is stronger than what any C caller promises, and extending an already-extended
-  value is a no-op.
+  export side a narrow parameter is what keeps an entry thunk on every row, and
+  that thunk loads the incoming value through its canonical extension: the
+  native body needs the canonical 64-bit form, which is stronger than what any C
+  caller promises, and extending an already-extended value is a no-op.
 
 Apple's variadic amendment is out of scope: variadic `extern "C"` declarations
 are rejected.


### PR DESCRIPTION
Second half of ADR-0084 phase 2 (RUE-2038), following [#2988](https://github.com/rue-language/rue/pull/2988): a `pub extern "C" fn` whose C and native placements agree no longer gets a forwarding thunk. Its unmangled C name is a second global symbol at the native body's own entry.

## What changes

- **Alias mechanism.** `rue_linker::ObjectBuilder::alias(name)` defines an extra global `STT_FUNC` symbol at `.text` offset 0 (ELF) and an extra `N_EXT | N_SECT` nlist at `__text` offset 0 (Mach-O), placed right after the function symbol with `nextdefsym`, string-symbol and undefined-external indices shifted. `StructuredObject::with_alias(name)` does the same for the internal link's structured input.
- **Threading.** The alias set is a property of the program's export set, not of a codegen unit, so the memoized object projection stays alias-free and the program image re-projects only the bodies an aliased export names. `backend::ExportEntry` is the single value carrying "alias or thunk bytes"; the program-image plan keeps one entry per export either way, with alias entries in their own digest domain so alias↔thunk is a plan change.
- **The predicate.** `ExportSignature::c_entry(target)` is `Alias` exactly when every parameter's C and native `ArgLocation` match, no parameter crosses as a narrow (<8-byte) leaf, and the return needs no adaptation. Otherwise it is `Thunk(reason)`:
  - `parameter N is re-extended`: any narrow scalar parameter, register-passed or stacked, on every row including Apple arm64;
  - `parameter N is placed differently`: a parameter the sret shift moves;
  - `the result is adapted`: a result the native bank holds and C's does not (`{i64,i64,i64}`, `{i32×5}`), or a leaf-per-register result with padding or a narrow leaf.
  A narrow result aliases (the body already leaves it canonically extended); aggregates within C's own bank and results past both banks alias (the sret register and echo are now the C row's).
- **`--emit abi`** names each export's entry (alias, or thunk with the reason).
- A kept thunk no longer stages a register result the two banks already agree about.

## Bug found by the new tests

The thunk writes each stacked value as a whole eightbyte, so under Apple's natural-size packing a tail of ten or more narrow scalars ran past the outgoing argument area into the staging cells holding register-passed values. The staging cells now start above the widest stacked store; `a_stacked_narrow_tail_stays_inside_the_outgoing_argument_area` pins it on all three rows.

## Tests

- Unit: eight `export_thunk` tests enumerating alias/thunk outcomes on all three targets plus a cross-check that the emitted plan is an identity exactly when the entry is an alias; a linker test linking an alias and a caller through byte and structured containers on all three targets, with a rodata string to exercise the Mach-O index shift.
- CLI `c_ffi.toml`: an aliased scalar export called from the C archive on both arches; a `--linker cc` build asserting the alias name is in the executable's symbol table; the existing aggregate-export pair now executes an aliased small-aggregate export and an aliased nine-scalar one beside a kept thunk. `emit_pipeline.toml` and two UI cases pin the `--emit abi` report.
- Float and HFA exports are not covered because `f32`/`f64` are still rejected at the C boundary (RUE-714); integer aggregates in registers stand in.

## Docs

ADR-0084's phase-2 checkbox is ticked; `docs/runtime-abi.md`, `docs/architecture.md` and `docs/notes/ffi-abi-conformance-audit.md` describe the alias-or-thunk rule. The spec is unchanged (no observable rule changes).

## Validation

`scripts/rue premerge` passes locally apart from the two sandbox-environmental CLI cases (`remove_dir_all_permission_denied_is_not_partial_success`, `tcp_ipv6_loopback_round_trip`); the C-ABI matrix, oracle-diff and planted-miscompile validation targets pass.

Closes RUE-2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_