### PR TITLE
RUE-1978: convert between SemanticImportType and TypeInstanceKey in one place

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4880,7 +4880,7 @@ pub(super) use register_parse_import_parse;"#;
         });
     assert_eq!(
         (declarations.len(), fingerprint),
-        (215, 5_525_279_941_277_473_575),
+        (214, 11_207_454_508_476_726_153),
         "crate-visible declaration names, signatures, fields, or phase owners changed"
     );
 
@@ -4979,10 +4979,6 @@ fn revisioned_body_and_program_assembly_have_exact_source_owners() {
             "body_closure_nucleus",
         ),
         (
-            "pub(crate) fn durable_type_from_instance_key(",
-            "body_durable_comptime_adapters",
-        ),
-        (
             "pub(crate) fn durable_value_from_argument(",
             "body_durable_comptime_adapters",
         ),
@@ -4994,7 +4990,6 @@ fn revisioned_body_and_program_assembly_have_exact_source_owners() {
             "pub(in crate::revisioned_query_database) struct DurableComptimeRootAuthority",
             "body_durable_comptime_adapters",
         ),
-        ("fn body_type_instance(", "body_provider_body"),
         (
             "pub(in crate::revisioned_query_database) fn collect_published_body_references(",
             "body_provider_body",
@@ -5234,7 +5229,6 @@ use:provider_body
 use:transactions
 fn:semantic_nucleus_failure_is_internal_error
 fn:collect_instance_anonymous_nominals
-fn:durable_type_from_instance_key
 fn:durable_value_from_argument
 fn:semantic_candidate_import_occurrences
 fn:with_declaration_memo_retention
@@ -8435,6 +8429,61 @@ fn durable_named_array_length_consumers_share_one_conversion_kernel() {
     }
 }
 
+/// Count the match arms that relocate an anonymous-nominal identity between
+/// `SemanticImportType` and `TypeInstanceKey`.
+///
+/// Every conversion ladder between those two enums spells that arm in one
+/// direction or the other, and nothing else in the crate pairs the two
+/// spellings, so this is the number of ladders a module owns. Path prefixes
+/// and formatting are normalized away first, so an aliased or reformatted
+/// copy is still counted.
+fn semantic_type_instance_ladders(source: &str) -> usize {
+    const SEMANTIC_ARM: &str = "AnonymousNominal(";
+    const INSTANCE_ARM: &str = "Nominal(NominalInstanceKey::Anonymous(";
+
+    let code = rust_code_only(source)
+        .replace("crate::", "")
+        .replace("rue_air::", "");
+    let arms = code
+        .split("=>")
+        .map(|arm| arm.split_whitespace().collect::<String>())
+        .collect::<Vec<_>>();
+    arms.windows(2)
+        .filter(|arm| {
+            (arm[0].contains(SEMANTIC_ARM) && arm[1].contains(INSTANCE_ARM))
+                || (arm[0].contains(INSTANCE_ARM) && arm[1].contains(SEMANTIC_ARM))
+        })
+        .count()
+}
+
+/// `SemanticImportType` and `TypeInstanceKey` name the same types in two
+/// vocabularies, and every query family needs both. One owner keeps layout,
+/// drop glue, CFG dependencies, and comptime deriving the same key for the
+/// same type, so a new variant is one edit rather than one per family.
+#[test]
+fn semantic_import_type_and_type_instance_convert_in_one_place() {
+    let identity = include_str!("semantic_identity.rs");
+    for (direction, definition) in [
+        ("forward", "pub(crate) fn type_instance_from_semantic("),
+        ("reverse", "pub(crate) fn semantic_type_from_instance("),
+    ] {
+        assert_eq!(
+            identity.matches(definition).count(),
+            1,
+            "semantic_identity must own exactly one {direction} conversion"
+        );
+    }
+    for (module, source) in PRODUCTION_MODULES {
+        let expected = usize::from(*module == "semantic_identity") * 2;
+        assert_eq!(
+            semantic_type_instance_ladders(source),
+            expected,
+            "{module} must convert between SemanticImportType and TypeInstanceKey \
+             through semantic_identity instead of its own ladder"
+        );
+    }
+}
+
 #[test]
 fn durable_specialized_producer_issuance_has_one_ordered_kernel() {
     let durable = DURABLE_COMPTIME_LIFECYCLE_SOURCE;
@@ -8660,11 +8709,6 @@ fn durable_comptime_responsibilities_have_exact_module_owners() {
             "pub(crate) fn finalize_registered_imports(",
             "lifecycle",
             DURABLE_COMPTIME_LIFECYCLE_SOURCE,
-        ),
-        (
-            "pub(crate) fn durable_type_from_instance_key(",
-            "projection",
-            DURABLE_COMPTIME_PROJECTION_SOURCE,
         ),
         (
             "pub(crate) enum DurableComptimeValueFitFailure",

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1045,7 +1045,7 @@ pub(crate) fn collect_type_dependencies(
     ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
     output: &mut Vec<crate::TypeInstanceKey>,
 ) {
-    output.push(type_instance_from_semantic(ty));
+    output.push(crate::semantic_identity::type_instance_from_semantic(ty));
     // Array representation and CFG indexing depend on the element layout.
     // Pointer and slice representation does not depend on the pointee.
     if let rue_air::SemanticImportType::Array { element, .. } = ty {
@@ -1058,7 +1058,7 @@ pub(crate) fn collect_type_and_drop_dependencies(
     layout_output: &mut Vec<crate::TypeInstanceKey>,
     drop_output: &mut Vec<crate::TypeInstanceKey>,
 ) {
-    let instance = type_instance_from_semantic(ty);
+    let instance = crate::semantic_identity::type_instance_from_semantic(ty);
     if type_may_need_drop_glue(ty) {
         drop_output.push(instance.clone());
     }
@@ -1119,58 +1119,6 @@ fn type_may_need_drop_glue<K, M>(ty: &rue_air::SemanticImportType<K, M>) -> bool
             rue_air::drop_glue::DropGlueShape::Trivial,
             [],
         ),
-    }
-}
-
-fn type_instance_from_semantic(
-    ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
-) -> crate::TypeInstanceKey {
-    use rue_air::SemanticImportType as T;
-    match ty {
-        T::I8 => crate::TypeInstanceKey::I8,
-        T::I16 => crate::TypeInstanceKey::I16,
-        T::I32 => crate::TypeInstanceKey::I32,
-        T::I64 => crate::TypeInstanceKey::I64,
-        T::U8 => crate::TypeInstanceKey::U8,
-        T::U16 => crate::TypeInstanceKey::U16,
-        T::U32 => crate::TypeInstanceKey::U32,
-        T::U64 => crate::TypeInstanceKey::U64,
-        T::Bool => crate::TypeInstanceKey::Bool,
-        T::Unit => crate::TypeInstanceKey::Unit,
-        T::Never => crate::TypeInstanceKey::Never,
-        T::ComptimeType => crate::TypeInstanceKey::ComptimeType,
-        T::F32 => crate::TypeInstanceKey::F32,
-        T::F64 => crate::TypeInstanceKey::F64,
-        T::ComptimeFloat => crate::TypeInstanceKey::ComptimeFloat,
-        T::BuiltinNominal { kind, name } => crate::TypeInstanceKey::BuiltinNominal {
-            kind: match kind {
-                rue_air::SemanticImportNominalKind::Struct => crate::AnonymousNominalKind::Struct,
-                rue_air::SemanticImportNominalKind::Enum => crate::AnonymousNominalKind::Enum,
-            },
-            name: name.clone(),
-        },
-        T::Nominal(definition) => {
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(definition.clone()))
-        }
-        T::AnonymousNominal(identity) => crate::TypeInstanceKey::Nominal(
-            crate::NominalInstanceKey::Anonymous(Node::new(identity.clone())),
-        ),
-        T::Array { element, len } => crate::TypeInstanceKey::Array {
-            element: Node::new(type_instance_from_semantic(element)),
-            len: *len,
-        },
-        T::Slice { element, name } => crate::TypeInstanceKey::Slice {
-            element: Node::new(type_instance_from_semantic(element)),
-            name: name.clone(),
-        },
-        T::PtrConst(element) => {
-            crate::TypeInstanceKey::PtrConst(Node::new(type_instance_from_semantic(element)))
-        }
-        T::PtrMut(element) => {
-            crate::TypeInstanceKey::PtrMut(Node::new(type_instance_from_semantic(element)))
-        }
-        T::Module(module) => crate::TypeInstanceKey::Module(module.clone()),
-        T::GenericParameter(index) => crate::TypeInstanceKey::GenericParameter(*index),
     }
 }
 

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -39,115 +39,6 @@ use std::sync::Arc;
 type IssuedTypeInstanceKey =
     rue_air::TypeInstanceKey<rue_air::SemanticDefinitionToken, rue_air::SemanticModuleToken>;
 
-pub(crate) fn semantic_type_from_instance(
-    ty: &crate::TypeInstanceKey,
-) -> rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId> {
-    use crate::TypeInstanceKey as T;
-    use rue_air::SemanticImportType as S;
-    match ty {
-        T::I8 => S::I8,
-        T::I16 => S::I16,
-        T::I32 => S::I32,
-        T::I64 => S::I64,
-        T::U8 => S::U8,
-        T::U16 => S::U16,
-        T::U32 => S::U32,
-        T::U64 => S::U64,
-        T::Bool => S::Bool,
-        T::Unit => S::Unit,
-        T::Never => S::Never,
-        T::ComptimeType => S::ComptimeType,
-        T::F32 => S::F32,
-        T::F64 => S::F64,
-        T::ComptimeFloat => S::ComptimeFloat,
-        T::BuiltinNominal { kind, name } => S::BuiltinNominal {
-            kind: match kind {
-                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
-                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
-            },
-            name: name.clone(),
-        },
-        T::Nominal(crate::NominalInstanceKey::Named(key)) => S::Nominal(key.clone()),
-        T::Nominal(crate::NominalInstanceKey::Anonymous(key)) => {
-            S::AnonymousNominal((**key).clone())
-        }
-        T::Nominal(crate::NominalInstanceKey::Builtin { kind, name }) => S::BuiltinNominal {
-            kind: match kind {
-                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
-                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
-            },
-            name: name.clone(),
-        },
-        T::Array { element, len } => S::Array {
-            element: Arc::new(semantic_type_from_instance(element)),
-            len: *len,
-        },
-        T::Slice { element, name } => S::Slice {
-            element: Arc::new(semantic_type_from_instance(element)),
-            name: name.clone(),
-        },
-        T::PtrConst(element) => S::PtrConst(Arc::new(semantic_type_from_instance(element))),
-        T::PtrMut(element) => S::PtrMut(Arc::new(semantic_type_from_instance(element))),
-        T::Module(module) => S::Module(module.clone()),
-        T::GenericParameter(index) => S::GenericParameter(*index),
-    }
-}
-
-/// Relocate one durable semantic type into the type-instance vocabulary.
-///
-/// The inverse of [`semantic_type_from_instance`], kept beside it so the two
-/// directions of the same correspondence cannot drift apart. Declaration facts
-/// spell a field's type as a `SemanticImportType`, while layouts, drop plans,
-/// and printer plans key on `TypeInstanceKey`.
-pub(crate) fn type_instance_from_semantic(
-    ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
-) -> crate::TypeInstanceKey {
-    use crate::TypeInstanceKey as T;
-    use rue_air::SemanticImportType as S;
-    match ty {
-        S::I8 => T::I8,
-        S::I16 => T::I16,
-        S::I32 => T::I32,
-        S::I64 => T::I64,
-        S::U8 => T::U8,
-        S::U16 => T::U16,
-        S::U32 => T::U32,
-        S::U64 => T::U64,
-        S::F32 => T::F32,
-        S::F64 => T::F64,
-        S::ComptimeFloat => T::ComptimeFloat,
-        S::Bool => T::Bool,
-        S::Unit => T::Unit,
-        S::Never => T::Never,
-        S::ComptimeType => T::ComptimeType,
-        S::BuiltinNominal { kind, name } => T::BuiltinNominal {
-            kind: match kind {
-                rue_air::SemanticImportNominalKind::Struct => crate::AnonymousNominalKind::Struct,
-                rue_air::SemanticImportNominalKind::Enum => crate::AnonymousNominalKind::Enum,
-            },
-            name: name.clone(),
-        },
-        S::Nominal(key) => T::Nominal(crate::NominalInstanceKey::Named(key.clone())),
-        S::AnonymousNominal(key) => T::Nominal(crate::NominalInstanceKey::Anonymous(
-            rue_air::Node::new(key.clone()),
-        )),
-        S::Array { element, len } => T::Array {
-            element: rue_air::Node::new(type_instance_from_semantic(element)),
-            len: *len,
-        },
-        S::Slice { element, name } => T::Slice {
-            element: rue_air::Node::new(type_instance_from_semantic(element)),
-            name: name.clone(),
-        },
-        S::PtrConst(element) => {
-            T::PtrConst(rue_air::Node::new(type_instance_from_semantic(element)))
-        }
-        S::PtrMut(element) => T::PtrMut(rue_air::Node::new(type_instance_from_semantic(element))),
-        S::Module(module) => T::Module(module.clone()),
-        S::GenericParameter(index) => T::GenericParameter(*index),
-    }
-}
-
 /// Build the canonical AIR-shaped body for one exact drop-glue fact. Layout
 /// slots are supplied by registered Layout dependencies observed by the CFG
 /// evaluator, so this path never needs a caller-owned frozen pool.
@@ -182,7 +73,7 @@ pub(crate) fn synthesize_canonical_drop_glue(
             for field in fields.iter() {
                 let width = slots(&field.ty)?;
                 if field.drop {
-                    let ty = semantic_type_from_instance(&field.ty);
+                    let ty = crate::semantic_identity::semantic_type_from_instance(&field.ty);
                     let param = add(SemanticBodyInstData::Param { index: current }, ty.clone());
                     statements.push(add(SemanticBodyInstData::Drop { value: param }, ty));
                 }
@@ -197,7 +88,7 @@ pub(crate) fn synthesize_canonical_drop_glue(
             let width = slots(element)?;
             if *drop_element {
                 for index in 0..*len {
-                    let ty = semantic_type_from_instance(element);
+                    let ty = crate::semantic_identity::semantic_type_from_instance(element);
                     let param = add(
                         SemanticBodyInstData::Param {
                             index: u32::try_from(index)
@@ -239,7 +130,7 @@ pub(crate) fn synthesize_canonical_drop_glue(
                 for field in variant.fields.iter() {
                     let width = slots(&field.ty)?;
                     if field.drop {
-                        let ty = semantic_type_from_instance(&field.ty);
+                        let ty = crate::semantic_identity::semantic_type_from_instance(&field.ty);
                         let param = add(
                             SemanticBodyInstData::Param {
                                 index: num_param_slots

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -179,72 +179,15 @@ fn canonical_type_from_live_cached(
             aggregates,
             stable_by_live,
         )?)),
-        K::Struct(_) | K::Enum(_) => canonical_type_from_instance(
+        K::Struct(_) | K::Enum(_) => crate::semantic_identity::semantic_type_from_instance(
             aggregates
                 .aggregate_type(ty)
                 .ok_or(CfgDomainFailure::Missing)?,
-        )?,
+        ),
         K::Module(_) | K::Error => return Err(CfgDomainFailure::Unsupported),
     };
     stable_by_live.insert(ty, stable.clone());
     Ok(stable)
-}
-
-fn canonical_type_from_instance(
-    value: &crate::TypeInstanceKey,
-) -> Result<CanonicalType, CfgDomainFailure> {
-    use crate::TypeInstanceKey as T;
-    Ok(match value {
-        T::I8 => CanonicalType::I8,
-        T::I16 => CanonicalType::I16,
-        T::I32 => CanonicalType::I32,
-        T::I64 => CanonicalType::I64,
-        T::U8 => CanonicalType::U8,
-        T::U16 => CanonicalType::U16,
-        T::U32 => CanonicalType::U32,
-        T::U64 => CanonicalType::U64,
-        T::Bool => CanonicalType::Bool,
-        T::Unit => CanonicalType::Unit,
-        T::Never => CanonicalType::Never,
-        T::ComptimeType => CanonicalType::ComptimeType,
-        T::F32 => CanonicalType::F32,
-        T::F64 => CanonicalType::F64,
-        T::ComptimeFloat => CanonicalType::ComptimeFloat,
-        T::BuiltinNominal { kind, name }
-        | T::Nominal(crate::NominalInstanceKey::Builtin { kind, name }) => {
-            CanonicalType::BuiltinNominal {
-                kind: match kind {
-                    crate::AnonymousNominalKind::Struct => {
-                        rue_air::SemanticImportNominalKind::Struct
-                    }
-                    crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
-                },
-                name: name.clone(),
-            }
-        }
-        T::Nominal(crate::NominalInstanceKey::Named(definition)) => {
-            CanonicalType::Nominal(definition.clone())
-        }
-        T::Nominal(crate::NominalInstanceKey::Anonymous(identity)) => {
-            CanonicalType::AnonymousNominal((**identity).clone())
-        }
-        T::Array { element, len } => CanonicalType::Array {
-            element: Arc::new(canonical_type_from_instance(element)?),
-            len: *len,
-        },
-        T::Slice { element, name } => CanonicalType::Slice {
-            element: Arc::new(canonical_type_from_instance(element)?),
-            name: name.clone(),
-        },
-        T::PtrConst(element) => {
-            CanonicalType::PtrConst(Arc::new(canonical_type_from_instance(element)?))
-        }
-        T::PtrMut(element) => {
-            CanonicalType::PtrMut(Arc::new(canonical_type_from_instance(element)?))
-        }
-        T::Module(module) => CanonicalType::Module(module.clone()),
-        T::GenericParameter(index) => CanonicalType::GenericParameter(*index),
-    })
 }
 
 fn record_cfg_type(
@@ -311,55 +254,6 @@ fn live_primitive(ty: &CanonicalType) -> Option<Type> {
 fn foreign_callable_symbol(callable: &crate::FunctionInstanceKey) -> Option<String> {
     crate::semantic_identity::function_base_definition(callable)
         .map(|definition| definition.name().to_owned())
-}
-
-fn canonical_type_instance(ty: &CanonicalType) -> Option<crate::TypeInstanceKey> {
-    Some(match ty {
-        CanonicalType::I8 => crate::TypeInstanceKey::I8,
-        CanonicalType::I16 => crate::TypeInstanceKey::I16,
-        CanonicalType::I32 => crate::TypeInstanceKey::I32,
-        CanonicalType::I64 => crate::TypeInstanceKey::I64,
-        CanonicalType::U8 => crate::TypeInstanceKey::U8,
-        CanonicalType::U16 => crate::TypeInstanceKey::U16,
-        CanonicalType::U32 => crate::TypeInstanceKey::U32,
-        CanonicalType::U64 => crate::TypeInstanceKey::U64,
-        CanonicalType::Bool => crate::TypeInstanceKey::Bool,
-        CanonicalType::Unit => crate::TypeInstanceKey::Unit,
-        CanonicalType::Never => crate::TypeInstanceKey::Never,
-        CanonicalType::ComptimeType => crate::TypeInstanceKey::ComptimeType,
-        CanonicalType::F32 => crate::TypeInstanceKey::F32,
-        CanonicalType::F64 => crate::TypeInstanceKey::F64,
-        CanonicalType::ComptimeFloat => crate::TypeInstanceKey::ComptimeFloat,
-        CanonicalType::BuiltinNominal { kind, name } => crate::TypeInstanceKey::BuiltinNominal {
-            kind: match kind {
-                rue_air::SemanticImportNominalKind::Struct => crate::AnonymousNominalKind::Struct,
-                rue_air::SemanticImportNominalKind::Enum => crate::AnonymousNominalKind::Enum,
-            },
-            name: name.clone(),
-        },
-        CanonicalType::Nominal(definition) => {
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(definition.clone()))
-        }
-        CanonicalType::AnonymousNominal(identity) => crate::TypeInstanceKey::Nominal(
-            crate::NominalInstanceKey::Anonymous(Node::new(identity.clone())),
-        ),
-        CanonicalType::Array { element, len } => crate::TypeInstanceKey::Array {
-            element: Node::new(canonical_type_instance(element)?),
-            len: *len,
-        },
-        CanonicalType::PtrConst(element) => {
-            crate::TypeInstanceKey::PtrConst(Node::new(canonical_type_instance(element)?))
-        }
-        CanonicalType::PtrMut(element) => {
-            crate::TypeInstanceKey::PtrMut(Node::new(canonical_type_instance(element)?))
-        }
-        CanonicalType::Slice { element, name } => crate::TypeInstanceKey::Slice {
-            element: Node::new(canonical_type_instance(element)?),
-            name: name.clone(),
-        },
-        CanonicalType::Module(module) => crate::TypeInstanceKey::Module(module.clone()),
-        CanonicalType::GenericParameter(index) => crate::TypeInstanceKey::GenericParameter(*index),
-    })
 }
 
 fn deduplicate_type_mappings(
@@ -1011,9 +905,7 @@ impl CfgDomainProjection {
         // from aggregate metadata after AIR symbol collection. Project those
         // exact aliases from the same local type pool and stable type domain.
         for (current, stable) in &self.types {
-            let Some(owner) = canonical_type_instance(stable) else {
-                continue;
-            };
+            let owner = crate::semantic_identity::type_instance_from_semantic(stable);
             let drop_glue_source = match current.kind() {
                 TypeKind::Struct(id) => {
                     if let (Some(source), CanonicalType::AnonymousNominal(identity)) =

--- a/crates/rue-compiler/src/durable_comptime/lifecycle.rs
+++ b/crates/rue-compiler/src/durable_comptime/lifecycle.rs
@@ -36,7 +36,6 @@ pub(crate) struct DurableComptimeCallContext {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DurableComptimeProducerIssuanceError {
     ProgramMismatch,
-    InvalidTypeArgument,
     InvalidValueArgument,
 }
 
@@ -59,8 +58,7 @@ pub(crate) fn canonical_specialized_function_instance(
     let types = type_arguments
         .iter()
         .map(|(_, value)| crate::semantic_identity::type_instance_from_semantic(value))
-        .collect::<Option<Vec<_>>>()
-        .ok_or(DurableComptimeProducerIssuanceError::InvalidTypeArgument)?
+        .collect::<Vec<_>>()
         .into();
     let values = value_arguments
         .iter()

--- a/crates/rue-compiler/src/durable_comptime/projection.rs
+++ b/crates/rue-compiler/src/durable_comptime/projection.rs
@@ -144,63 +144,6 @@ fn durable_parameter_mode(
     }
 }
 
-/// Convert the canonical type-instance representation into the durable type
-/// domain used by call binding. This is kept beside the binding policy so
-/// diagnostics and substitution never acquire a second local conversion.
-pub(crate) fn durable_type_from_instance_key(
-    value: &crate::TypeInstanceKey,
-) -> Option<DurableType> {
-    use crate::TypeInstanceKey as T;
-    use crate::durable_semantics::DurableType as D;
-    Some(match value {
-        T::I8 => D::I8,
-        T::I16 => D::I16,
-        T::I32 => D::I32,
-        T::I64 => D::I64,
-        T::U8 => D::U8,
-        T::U16 => D::U16,
-        T::U32 => D::U32,
-        T::U64 => D::U64,
-        T::Bool => D::Bool,
-        T::Unit => D::Unit,
-        T::Never => D::Never,
-        T::ComptimeType => D::ComptimeType,
-        T::F32 => D::F32,
-        T::F64 => D::F64,
-        T::ComptimeFloat => D::ComptimeFloat,
-        T::BuiltinNominal { kind, name } => D::BuiltinNominal {
-            name: name.clone(),
-            kind: match kind {
-                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
-                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
-            },
-        },
-        T::Nominal(crate::NominalInstanceKey::Builtin { kind, name }) => D::BuiltinNominal {
-            name: name.clone(),
-            kind: match kind {
-                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
-                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
-            },
-        },
-        T::Nominal(crate::NominalInstanceKey::Named(key)) => D::Nominal(key.clone()),
-        T::Nominal(crate::NominalInstanceKey::Anonymous(key)) => {
-            D::AnonymousNominal((**key).clone())
-        }
-        T::Array { element, len } => D::Array {
-            element: Arc::new(durable_type_from_instance_key(element)?),
-            len: *len,
-        },
-        T::Slice { element, name } => D::Slice {
-            element: Arc::new(durable_type_from_instance_key(element)?),
-            name: name.clone(),
-        },
-        T::PtrConst(value) => D::PtrConst(Arc::new(durable_type_from_instance_key(value)?)),
-        T::PtrMut(value) => D::PtrMut(Arc::new(durable_type_from_instance_key(value)?)),
-        T::Module(value) => D::Module(value.clone()),
-        T::GenericParameter(index) => D::GenericParameter(*index),
-    })
-}
-
 fn durable_type_diagnostic_name_kernel(ty: &DurableType) -> String {
     use crate::durable_semantics::DurableType as T;
 
@@ -236,7 +179,7 @@ fn durable_type_diagnostic_name_kernel(ty: &DurableType) -> String {
                         applied
                             .types
                             .iter()
-                            .filter_map(durable_type_from_instance_key)
+                            .map(crate::semantic_identity::semantic_type_from_instance)
                             .map(|ty| durable_type_diagnostic_name(&ty))
                             .collect::<Vec<_>>()
                     })
@@ -249,9 +192,10 @@ fn durable_type_diagnostic_name_kernel(ty: &DurableType) -> String {
                             crate::CanonicalArgumentValue::Integer(value) => value.to_string(),
                             crate::CanonicalArgumentValue::Bool(value) => value.to_string(),
                             crate::CanonicalArgumentValue::Type(value) => {
-                                durable_type_from_instance_key(value.as_ref()).map_or_else(
-                                    || "type".to_owned(),
-                                    |ty| durable_type_diagnostic_name(&ty),
+                                durable_type_diagnostic_name(
+                                    &crate::semantic_identity::semantic_type_from_instance(
+                                        value.as_ref(),
+                                    ),
                                 )
                             }
                             crate::CanonicalArgumentValue::Function(_) => "function".to_owned(),
@@ -315,8 +259,9 @@ pub(crate) fn durable_type_diagnostic_name_with_parameters(
         parameters,
         identity.producer_arguments(),
         |argument| {
-            durable_type_from_instance_key(argument)
-                .map(|argument| durable_type_diagnostic_name(&argument))
+            Some(durable_type_diagnostic_name(
+                &crate::semantic_identity::semantic_type_from_instance(argument),
+            ))
         },
     )
     .unwrap_or_else(|| durable_type_diagnostic_name(ty))

--- a/crates/rue-compiler/src/error_printer.rs
+++ b/crates/rue-compiler/src/error_printer.rs
@@ -53,7 +53,7 @@ use rue_air::{
     SemanticBodyMatchArm, SemanticBodyPattern, SemanticBodyPlace, SemanticBodyProjection,
 };
 
-use crate::drop_glue::semantic_type_from_instance;
+use crate::semantic_identity::semantic_type_from_instance;
 
 type Ty = rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>;
 type Body = rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>;
@@ -218,7 +218,7 @@ pub(crate) fn plan_error_printer(
                 fields: payloads
                     .iter()
                     .map(|ty| {
-                        let ty = crate::drop_glue::type_instance_from_semantic(ty);
+                        let ty = crate::semantic_identity::type_instance_from_semantic(ty);
                         PrinterField {
                             name: Arc::from(""),
                             render: leaf_render(&ty, types),
@@ -246,7 +246,7 @@ pub(crate) fn plan_error_printer(
         let fields = fields
             .into_iter()
             .map(|(name, ty)| {
-                let ty = crate::drop_glue::type_instance_from_semantic(&ty);
+                let ty = crate::semantic_identity::type_instance_from_semantic(&ty);
                 PrinterField {
                     name,
                     render: leaf_render(&ty, types),
@@ -356,7 +356,8 @@ fn byte_pointer_projections(
     let inner_index = unique_field(fields, |field| {
         matches!(field, Ty::Nominal(_) | Ty::AnonymousNominal(_))
     })?;
-    let inner_ty = crate::drop_glue::type_instance_from_semantic(&fields[inner_index as usize].1);
+    let inner_ty =
+        crate::semantic_identity::type_instance_from_semantic(&fields[inner_index as usize].1);
     // Guard against a self-referential shape rather than recursing forever.
     if inner_ty == *ty {
         return None;

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -266,7 +266,7 @@ impl crate::error_printer::ErrorPrinterTypes for LocalFactSelectionIndex<'_> {
 
     fn type_name(&self, ty: &crate::TypeInstanceKey) -> Arc<str> {
         Arc::from(crate::durable_comptime::durable_type_diagnostic_name(
-            &crate::drop_glue::semantic_type_from_instance(ty),
+            &crate::semantic_identity::semantic_type_from_instance(ty),
         ))
     }
 }
@@ -382,15 +382,15 @@ fn collect_slice_sources(
     work.type_nodes_scanned += 1;
     match ty {
         T::Slice { element, name } => {
-            if let Some(element) = crate::semantic_identity::type_instance_from_semantic(element) {
-                output.insert(
-                    name.clone(),
-                    crate::TypeInstanceKey::Slice {
-                        element: Node::new(element),
-                        name: name.clone(),
-                    },
-                );
-            }
+            output.insert(
+                name.clone(),
+                crate::TypeInstanceKey::Slice {
+                    element: Node::new(crate::semantic_identity::type_instance_from_semantic(
+                        element,
+                    )),
+                    name: name.clone(),
+                },
+            );
             collect_slice_sources(element, output, work);
         }
         T::Array { element, .. } | T::PtrConst(element) | T::PtrMut(element) => {
@@ -1284,7 +1284,7 @@ pub(crate) fn materialize_semantic_body_with_indexes_in_space(
                         .map(|(name, ty)| {
                             (
                                 name.clone(),
-                                crate::drop_glue::semantic_type_from_instance(ty),
+                                crate::semantic_identity::semantic_type_from_instance(ty),
                             )
                         })
                         .collect::<Vec<_>>()
@@ -1312,7 +1312,7 @@ pub(crate) fn materialize_semantic_body_with_indexes_in_space(
                                 name.clone(),
                                 fields
                                     .iter()
-                                    .map(crate::drop_glue::semantic_type_from_instance)
+                                    .map(crate::semantic_identity::semantic_type_from_instance)
                                     .collect::<Vec<_>>()
                                     .into(),
                             )
@@ -1333,7 +1333,7 @@ pub(crate) fn materialize_semantic_body_with_indexes_in_space(
                         (
                             Arc::from("ptr"),
                             rue_air::SemanticImportType::PtrConst(Arc::new(
-                                crate::drop_glue::semantic_type_from_instance(element),
+                                crate::semantic_identity::semantic_type_from_instance(element),
                             )),
                         ),
                         (Arc::from("len"), rue_air::SemanticImportType::U64),
@@ -1978,11 +1978,14 @@ pub(crate) fn select_drop_glue_materialization_facts(
     interner: &mut LocalMaterializationFactInterner,
 ) -> Result<LocalMaterializationFacts, LocalFactSelectionFailure> {
     let identity = FunctionInstanceKey::DropGlue(Node::new(owner.clone()));
-    let mut roots = vec![(0, crate::drop_glue::semantic_type_from_instance(owner))];
+    let mut roots = vec![(
+        0,
+        crate::semantic_identity::semantic_type_from_instance(owner),
+    )];
     roots.extend(facts.nested.iter().enumerate().map(|(index, ty)| {
         (
             u32::try_from(index + 1).expect("drop-glue fact count fits u32"),
-            crate::drop_glue::semantic_type_from_instance(ty),
+            crate::semantic_identity::semantic_type_from_instance(ty),
         )
     }));
     let body = rue_air::SemanticBody {

--- a/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
@@ -6,12 +6,6 @@
 
 use super::super::*;
 
-pub(crate) fn durable_type_from_instance_key(
-    value: &crate::TypeInstanceKey,
-) -> Option<crate::durable_semantics::DurableType> {
-    crate::durable_comptime::durable_type_from_instance_key(value)
-}
-
 pub(crate) fn durable_value_from_argument(
     value: &crate::CanonicalArgumentValue,
 ) -> Option<crate::durable_semantics::DurableConstValue> {
@@ -20,7 +14,7 @@ pub(crate) fn durable_value_from_argument(
     Some(match value {
         V::Integer(value) => D::Integer(*value),
         V::Bool(value) => D::Bool(*value),
-        V::Type(value) => D::Type(durable_type_from_instance_key(value)?),
+        V::Type(value) => D::Type(crate::semantic_identity::semantic_type_from_instance(value)),
         V::Function(value) => {
             let crate::FunctionInstanceKey::Definition(key) = value.as_ref() else {
                 return None;
@@ -95,7 +89,10 @@ pub(in crate::revisioned_query_database) fn comptime_call_for_anonymous_function
         if parameter.ty == crate::durable_semantics::DurableType::ComptimeType
             && let Some(value) = type_arguments.next()
         {
-            types.push((header.name.clone(), durable_type_from_instance_key(value)?));
+            types.push((
+                header.name.clone(),
+                crate::semantic_identity::semantic_type_from_instance(value),
+            ));
         } else {
             values.push((
                 header.name.clone(),

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -6,65 +6,13 @@
 
 use super::super::*;
 
-fn body_type_instance(
-    ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
-) -> crate::TypeInstanceKey {
-    use rue_air::SemanticImportType as T;
-    match ty {
-        T::I8 => crate::TypeInstanceKey::I8,
-        T::I16 => crate::TypeInstanceKey::I16,
-        T::I32 => crate::TypeInstanceKey::I32,
-        T::I64 => crate::TypeInstanceKey::I64,
-        T::U8 => crate::TypeInstanceKey::U8,
-        T::U16 => crate::TypeInstanceKey::U16,
-        T::U32 => crate::TypeInstanceKey::U32,
-        T::U64 => crate::TypeInstanceKey::U64,
-        T::Bool => crate::TypeInstanceKey::Bool,
-        T::Unit => crate::TypeInstanceKey::Unit,
-        T::Never => crate::TypeInstanceKey::Never,
-        T::ComptimeType => crate::TypeInstanceKey::ComptimeType,
-        T::F32 => crate::TypeInstanceKey::F32,
-        T::F64 => crate::TypeInstanceKey::F64,
-        T::ComptimeFloat => crate::TypeInstanceKey::ComptimeFloat,
-        T::BuiltinNominal { name, kind } => crate::TypeInstanceKey::BuiltinNominal {
-            kind: match kind {
-                rue_air::SemanticImportNominalKind::Struct => rue_air::AnonymousNominalKind::Struct,
-                rue_air::SemanticImportNominalKind::Enum => rue_air::AnonymousNominalKind::Enum,
-            },
-            name: name.clone(),
-        },
-        T::Nominal(definition) => {
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(definition.clone()))
-        }
-        T::AnonymousNominal(identity) => crate::TypeInstanceKey::Nominal(
-            crate::NominalInstanceKey::Anonymous(Node::new(identity.clone())),
-        ),
-        T::Array { element, len } => crate::TypeInstanceKey::Array {
-            element: Node::new(body_type_instance(element)),
-            len: *len,
-        },
-        T::Slice { element, name } => crate::TypeInstanceKey::Slice {
-            element: Node::new(body_type_instance(element)),
-            name: name.clone(),
-        },
-        T::PtrConst(element) => {
-            crate::TypeInstanceKey::PtrConst(Node::new(body_type_instance(element)))
-        }
-        T::PtrMut(element) => {
-            crate::TypeInstanceKey::PtrMut(Node::new(body_type_instance(element)))
-        }
-        T::Module(module) => crate::TypeInstanceKey::Module(module.clone()),
-        T::GenericParameter(index) => crate::TypeInstanceKey::GenericParameter(*index),
-    }
-}
-
 fn collect_body_type_reference(
     ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
     references: &mut BTreeSet<crate::body_query::BodyReference>,
 ) {
-    references.insert(crate::body_query::BodyReference::Type(body_type_instance(
-        ty,
-    )));
+    references.insert(crate::body_query::BodyReference::Type(
+        crate::semantic_identity::type_instance_from_semantic(ty),
+    ));
     use rue_air::SemanticImportType as T;
     match ty {
         T::Array { element, .. }
@@ -88,7 +36,7 @@ pub(in crate::revisioned_query_database) fn collect_published_body_references(
          references: &mut BTreeSet<crate::body_query::BodyReference>| {
             if let Some(value) = body.instructions.get(value as usize) {
                 references.insert(crate::body_query::BodyReference::DropGlue(
-                    body_type_instance(&value.ty),
+                    crate::semantic_identity::type_instance_from_semantic(&value.ty),
                 ));
             }
         };
@@ -153,7 +101,7 @@ pub(in crate::revisioned_query_database) fn collect_published_body_references(
     for (_, ty) in body.param_drops.iter() {
         collect_body_type_reference(ty, references);
         references.insert(crate::body_query::BodyReference::DropGlue(
-            body_type_instance(ty),
+            crate::semantic_identity::type_instance_from_semantic(ty),
         ));
     }
 }
@@ -701,7 +649,7 @@ impl SemanticNucleusTypeProvider<'_> {
         let terminal = match self.context.query_registered(
             type_facts,
             crate::type_queries::TypeQueryKey {
-                ty: crate::type_queries::type_instance(ty),
+                ty: crate::semantic_identity::type_instance_from_semantic(ty),
                 configuration: self.configuration.clone(),
             },
         ) {

--- a/crates/rue-compiler/src/revisioned_query_database/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/provider.rs
@@ -1935,8 +1935,7 @@ pub(super) fn project_provider_produced_anonymous_nominals(
         rue_air::SemanticModuleToken,
     >| {
         let ty = ty.try_map_identities(&definition, &module)?;
-        durable_type_from_instance_key(&ty)
-            .ok_or(rue_air::SemanticStableResolutionFailure::WrongKind)
+        Ok(crate::semantic_identity::semantic_type_from_instance(&ty))
     };
     let map_value = |value: &rue_air::CanonicalArgumentValue<
         rue_air::SemanticDefinitionToken,

--- a/crates/rue-compiler/src/revisioned_query_database/semantic.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/semantic.rs
@@ -693,7 +693,7 @@ pub(super) fn evaluate_type_shape(
                             fields: fields
                                 .iter()
                                 .map(|(name, ty)| {
-                                    (name.clone(), crate::type_queries::type_instance(ty))
+                                    (name.clone(), crate::semantic_identity::type_instance_from_semantic(ty))
                                 })
                                 .collect::<Vec<_>>()
                                 .into(),
@@ -706,7 +706,7 @@ pub(super) fn evaluate_type_shape(
                                         name.clone(),
                                         fields
                                             .iter()
-                                            .map(crate::type_queries::type_instance)
+                                            .map(crate::semantic_identity::type_instance_from_semantic)
                                             .collect::<Vec<_>>()
                                             .into(),
                                     )
@@ -743,7 +743,12 @@ pub(super) fn evaluate_type_shape(
                 S::Struct { fields, .. } => TypeShape::Struct {
                     fields: fields
                         .iter()
-                        .map(|(name, ty)| (name.clone(), crate::type_queries::type_instance(ty)))
+                        .map(|(name, ty)| {
+                            (
+                                name.clone(),
+                                crate::semantic_identity::type_instance_from_semantic(ty),
+                            )
+                        })
                         .collect::<Vec<_>>()
                         .into(),
                 },
@@ -755,7 +760,7 @@ pub(super) fn evaluate_type_shape(
                                 name.clone(),
                                 fields
                                     .iter()
-                                    .map(crate::type_queries::type_instance)
+                                    .map(crate::semantic_identity::type_instance_from_semantic)
                                     .collect::<Vec<_>>()
                                     .into(),
                             )
@@ -1509,7 +1514,7 @@ pub(super) fn anonymous_method_type(
     match ty {
         crate::durable_semantics::DurableAnonymousMethodType::SelfType => owner.clone(),
         crate::durable_semantics::DurableAnonymousMethodType::Concrete(ty) => {
-            crate::type_queries::type_instance(ty)
+            crate::semantic_identity::type_instance_from_semantic(ty)
         }
     }
 }
@@ -1585,7 +1590,7 @@ pub(super) fn exact_specialized_callable_types(
         if parameter.ty == crate::durable_semantics::DurableType::ComptimeType {
             let Some(argument) = type_arguments
                 .next()
-                .and_then(durable_type_from_instance_key)
+                .map(crate::semantic_identity::semantic_type_from_instance)
             else {
                 return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
                     "specialized callable has an invalid comptime type argument stream",
@@ -1886,12 +1891,15 @@ pub(super) fn query_callable_signature(
                     .filter(|parameter| durable_parameter_is_runtime(parameter))
                     .zip(runtime_types)
                     .map(|(parameter, ty)| {
-                        (parameter.mode, crate::type_queries::type_instance(&ty))
+                        (
+                            parameter.mode,
+                            crate::semantic_identity::type_instance_from_semantic(&ty),
+                        )
                     }),
             );
             Ok(Ok(StableCallableSignature {
                 parameters: runtime_parameters,
-                result: crate::type_queries::type_instance(&result),
+                result: crate::semantic_identity::type_instance_from_semantic(&result),
                 // A C export's source body uses Rue's native ABI. The separate
                 // entry thunk is the C boundary, and carries the declaration's
                 // convention on its own.

--- a/crates/rue-compiler/src/revisioned_query_database/tests/body_provider/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/body_provider/provider.rs
@@ -329,7 +329,7 @@ fn durable_copy_and_drop_facts_match_the_air_composite_policy() {
             &database.type_facts,
             revision,
             crate::type_queries::TypeQueryKey {
-                ty: crate::drop_glue::type_instance_from_semantic(ty),
+                ty: crate::semantic_identity::type_instance_from_semantic(ty),
                 configuration: semantic_configuration(),
             },
             CancellationToken::new(),

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -9,6 +9,7 @@
 
 use rue_air::Node;
 use std::fmt::Write as _;
+use std::sync::Arc;
 
 use crate::{ModuleId, StableDefinitionKey, bound_definitions::StableNamedTypeKey};
 
@@ -342,11 +343,19 @@ pub(crate) fn named_nominal_source_symbol(identity: &StableDefinitionKey) -> Opt
     ))
 }
 
+/// Relocate one durable semantic type into the type-instance vocabulary.
+///
+/// Declaration facts, signatures, and comptime arguments spell a type as a
+/// `SemanticImportType`, while layouts, drop plans, CFG dependencies, and
+/// printer plans key on `TypeInstanceKey`. The two enums describe the same
+/// domain, so this is the crate's only forward ladder: every query family
+/// derives the same key for the same type, and a new `SemanticImportType`
+/// variant is one edit rather than one per family.
 pub(crate) fn type_instance_from_semantic(
     value: &rue_air::SemanticImportType<StableDefinitionKey, ModuleId>,
-) -> Option<TypeInstanceKey> {
+) -> TypeInstanceKey {
     use rue_air::SemanticImportType as T;
-    Some(match value {
+    match value {
         T::I8 => TypeInstanceKey::I8,
         T::I16 => TypeInstanceKey::I16,
         T::I32 => TypeInstanceKey::I32,
@@ -374,22 +383,81 @@ pub(crate) fn type_instance_from_semantic(
             TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(Node::new(key.clone())))
         }
         T::Array { element, len } => TypeInstanceKey::Array {
-            element: Node::new(type_instance_from_semantic(element)?),
+            element: Node::new(type_instance_from_semantic(element)),
             len: *len,
         },
         T::Slice { element, name } => TypeInstanceKey::Slice {
-            element: Node::new(type_instance_from_semantic(element)?),
+            element: Node::new(type_instance_from_semantic(element)),
             name: name.clone(),
         },
         T::PtrConst(pointee) => {
-            TypeInstanceKey::PtrConst(Node::new(type_instance_from_semantic(pointee)?))
+            TypeInstanceKey::PtrConst(Node::new(type_instance_from_semantic(pointee)))
         }
         T::PtrMut(pointee) => {
-            TypeInstanceKey::PtrMut(Node::new(type_instance_from_semantic(pointee)?))
+            TypeInstanceKey::PtrMut(Node::new(type_instance_from_semantic(pointee)))
         }
         T::Module(module) => TypeInstanceKey::Module(module.clone()),
         T::GenericParameter(index) => TypeInstanceKey::GenericParameter(*index),
-    })
+    }
+}
+
+/// Relocate one type instance back into the durable semantic vocabulary.
+///
+/// The exact inverse of [`type_instance_from_semantic`] and the crate's only
+/// reverse ladder. `NominalInstanceKey::Builtin` and the separate
+/// `TypeInstanceKey::BuiltinNominal` spelling name the same builtin nominal,
+/// so both project onto `SemanticImportType::BuiltinNominal`.
+pub(crate) fn semantic_type_from_instance(
+    value: &TypeInstanceKey,
+) -> rue_air::SemanticImportType<StableDefinitionKey, ModuleId> {
+    use rue_air::SemanticImportType as S;
+    match value {
+        TypeInstanceKey::I8 => S::I8,
+        TypeInstanceKey::I16 => S::I16,
+        TypeInstanceKey::I32 => S::I32,
+        TypeInstanceKey::I64 => S::I64,
+        TypeInstanceKey::U8 => S::U8,
+        TypeInstanceKey::U16 => S::U16,
+        TypeInstanceKey::U32 => S::U32,
+        TypeInstanceKey::U64 => S::U64,
+        TypeInstanceKey::Bool => S::Bool,
+        TypeInstanceKey::Unit => S::Unit,
+        TypeInstanceKey::Never => S::Never,
+        TypeInstanceKey::ComptimeType => S::ComptimeType,
+        TypeInstanceKey::F32 => S::F32,
+        TypeInstanceKey::F64 => S::F64,
+        TypeInstanceKey::ComptimeFloat => S::ComptimeFloat,
+        TypeInstanceKey::BuiltinNominal { kind, name }
+        | TypeInstanceKey::Nominal(NominalInstanceKey::Builtin { kind, name }) => {
+            S::BuiltinNominal {
+                kind: match kind {
+                    AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
+                    AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
+                },
+                name: name.clone(),
+            }
+        }
+        TypeInstanceKey::Nominal(NominalInstanceKey::Named(key)) => S::Nominal(key.clone()),
+        TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(key)) => {
+            S::AnonymousNominal((**key).clone())
+        }
+        TypeInstanceKey::Array { element, len } => S::Array {
+            element: Arc::new(semantic_type_from_instance(element)),
+            len: *len,
+        },
+        TypeInstanceKey::Slice { element, name } => S::Slice {
+            element: Arc::new(semantic_type_from_instance(element)),
+            name: name.clone(),
+        },
+        TypeInstanceKey::PtrConst(pointee) => {
+            S::PtrConst(Arc::new(semantic_type_from_instance(pointee)))
+        }
+        TypeInstanceKey::PtrMut(pointee) => {
+            S::PtrMut(Arc::new(semantic_type_from_instance(pointee)))
+        }
+        TypeInstanceKey::Module(module) => S::Module(module.clone()),
+        TypeInstanceKey::GenericParameter(index) => S::GenericParameter(*index),
+    }
 }
 
 pub(crate) fn argument_value_from_semantic(
@@ -400,7 +468,7 @@ pub(crate) fn argument_value_from_semantic(
         V::Integer(value) => CanonicalArgumentValue::Integer(*value),
         V::Bool(value) => CanonicalArgumentValue::Bool(*value),
         V::Type(value) => {
-            CanonicalArgumentValue::Type(Node::new(type_instance_from_semantic(value)?))
+            CanonicalArgumentValue::Type(Node::new(type_instance_from_semantic(value)))
         }
         V::Function(value) => CanonicalArgumentValue::Function(Node::new(
             FunctionInstanceKey::Definition(value.clone()),
@@ -418,7 +486,7 @@ pub(crate) fn function_instance_from_specialization(
         .type_arguments
         .iter()
         .map(type_instance_from_semantic)
-        .collect::<Option<Vec<_>>>()?;
+        .collect::<Vec<_>>();
     let values = value
         .value_arguments
         .iter()

--- a/crates/rue-compiler/src/type_queries.rs
+++ b/crates/rue-compiler/src/type_queries.rs
@@ -4,7 +4,6 @@
 //! handles and pool indexes are materialization details and never cross this
 //! boundary.
 
-use rue_air::Node;
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -529,52 +528,6 @@ impl RetainedCharge for DropGlueValue {
             Self::Available(facts) => facts.retained_charge(),
             Self::Failure(failure) => failure.retained_charge(),
         }
-    }
-}
-
-pub(crate) fn type_instance(ty: &crate::durable_semantics::DurableType) -> crate::TypeInstanceKey {
-    use crate::durable_semantics::DurableType as T;
-    match ty {
-        T::I8 => crate::TypeInstanceKey::I8,
-        T::I16 => crate::TypeInstanceKey::I16,
-        T::I32 => crate::TypeInstanceKey::I32,
-        T::I64 => crate::TypeInstanceKey::I64,
-        T::U8 => crate::TypeInstanceKey::U8,
-        T::U16 => crate::TypeInstanceKey::U16,
-        T::U32 => crate::TypeInstanceKey::U32,
-        T::U64 => crate::TypeInstanceKey::U64,
-        T::Bool => crate::TypeInstanceKey::Bool,
-        T::Unit => crate::TypeInstanceKey::Unit,
-        T::Never => crate::TypeInstanceKey::Never,
-        T::ComptimeType => crate::TypeInstanceKey::ComptimeType,
-        T::F32 => crate::TypeInstanceKey::F32,
-        T::F64 => crate::TypeInstanceKey::F64,
-        T::ComptimeFloat => crate::TypeInstanceKey::ComptimeFloat,
-        T::BuiltinNominal { kind, name } => crate::TypeInstanceKey::BuiltinNominal {
-            kind: match kind {
-                rue_air::SemanticImportNominalKind::Struct => rue_air::AnonymousNominalKind::Struct,
-                rue_air::SemanticImportNominalKind::Enum => rue_air::AnonymousNominalKind::Enum,
-            },
-            name: name.clone(),
-        },
-        T::Nominal(definition) => {
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(definition.clone()))
-        }
-        T::AnonymousNominal(identity) => crate::TypeInstanceKey::Nominal(
-            crate::NominalInstanceKey::Anonymous(Node::new(identity.clone())),
-        ),
-        T::Array { element, len } => crate::TypeInstanceKey::Array {
-            element: Node::new(type_instance(element)),
-            len: *len,
-        },
-        T::Slice { element, name } => crate::TypeInstanceKey::Slice {
-            element: Node::new(type_instance(element)),
-            name: name.clone(),
-        },
-        T::PtrConst(element) => crate::TypeInstanceKey::PtrConst(Node::new(type_instance(element))),
-        T::PtrMut(element) => crate::TypeInstanceKey::PtrMut(Node::new(type_instance(element))),
-        T::Module(module) => crate::TypeInstanceKey::Module(module.clone()),
-        T::GenericParameter(index) => crate::TypeInstanceKey::GenericParameter(*index),
     }
 }
 


### PR DESCRIPTION
Fixes RUE-1978

## Why

`SemanticImportType<StableDefinitionKey, ModuleId>` and `TypeInstanceKey` name the same types in two vocabularies, and the conversion between them was written nine times across rue-compiler's query families (six forward, three reverse), differing only in return shape. All nine were byte-equivalent, but a new `SemanticImportType` variant needed nine coordinated edits, and a miss in one would give layout, drop glue, CFG dependencies, or comptime a different key for the same type.

## What

- `semantic_identity.rs` owns the pair: `type_instance_from_semantic` forward and `semantic_type_from_instance` back, both infallible.
- The other copies are deleted and their call sites routed through the pair: `cfg_query.rs`, `drop_glue.rs`, `durable_cfg.rs`, `type_queries.rs`, `revisioned_query_database/body/provider_body.rs`, `durable_comptime/projection.rs`, and the forwarding shim in `body/durable_comptime_adapters.rs`; consumers in `error_printer.rs`, `local_semantic_materialization.rs`, `revisioned_query_database/{provider,semantic}.rs`, and `durable_comptime/lifecycle.rs` follow.
- The `Option`/`Result` shapes whose failure branches could never fire collapse into their callers, which makes `DurableComptimeProducerIssuanceError::InvalidTypeArgument` unconstructible, so it is removed.
- `api_inventory.rs` gains a guard that counts the anonymous-nominal relocation arm every such ladder must spell (normalized for path prefixes and formatting) across every production module and pins the total to exactly one forward and one reverse ladder, both in `semantic_identity`. Validated against the parent commit, where it counts nine. Three stale inventory entries are removed and the crate-visible declaration fingerprint is refreshed for the deleted adapter.

Left as-is, outside this issue: `argument_value_from_semantic` and `function_instance_from_specialization` keep their `Option` shapes (flattening cascades into six call sites), and `durable_cfg.rs` still has two ladders for a different pair (`rue_air::TypeKind` to `CanonicalType`).

## Verification

- `scripts/rue unit compiler`: 1224 passed, 0 failed, 59 ignored (one structural fingerprint test updated for the removed declaration).
- `scripts/rue quick`: Pass 36, Fail 0.
- `scripts/rue cli drop` (148), `scripts/rue cli generic` (86), `scripts/rue spec drop` (61), `scripts/rue spec generic` (35): all pass.
- `scripts/rue fmt` clean; suites re-run after formatting.