### PR TITLE
RUE-2044: keep an owning materialization out of the optimizer's reusable set

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -3952,6 +3952,19 @@ impl FrozenTypeInternPool {
             .needs_drop
     }
 
+    /// Whether dropping `ty` requires a destructor or nested drop glue, or
+    /// `None` when `ty` is not a complete root carrying finalized containment
+    /// metadata.
+    ///
+    /// A caller that queries every type it encounters — an optimizer pass
+    /// classifying each instruction's result type, say — needs the total
+    /// answer, because a handle it did not choose must fail closed rather than
+    /// abort the compilation that [`Self::type_needs_drop`] asserts against.
+    pub fn try_type_needs_drop(&self, ty: Type) -> Option<bool> {
+        self.inner.validate_complete_root(ty).ok()?;
+        self.inner.facts_for_type(ty).map(|facts| facts.needs_drop)
+    }
+
     /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
     pub fn abi_slot_count(&self, ty: Type) -> u32 {
         self.try_abi_slot_count(ty)

--- a/crates/rue-cfg/src/opt/classify.rs
+++ b/crates/rue-cfg/src/opt/classify.rs
@@ -1,13 +1,14 @@
-//! Shared trap / speculation classifier for optimizer passes.
+//! Shared trap / speculation / ownership classifier for optimizer passes.
 //!
-//! DCE, LICM (RUE-927), and unrolling (RUE-928) all need to reason about whether
-//! a CFG instruction can *trap* — either abort with a Rue-defined runtime panic
-//! or fault during an unsafe memory access. The latter is a conservative
-//! classification for speculation and DCE safety, not a statement about Rue's
-//! raw-pointer semantics. Historically that knowledge lived only inside DCE's
-//! private `has_side_effects` predicate, which conflated two independent axes.
-//! ADR-0054 §2 makes this module the single place that names the trapping set,
-//! so the two axes cannot drift apart across the passes that consult them.
+//! DCE, CSE, LICM (RUE-927), and unrolling (RUE-928) all need to reason about
+//! whether a CFG instruction can *trap* — either abort with a Rue-defined
+//! runtime panic or fault during an unsafe memory access — whether it is
+//! *observable*, and whether it *materializes a value that owns resources*. The
+//! fault case is a conservative classification for speculation and DCE safety,
+//! not a statement about Rue's raw-pointer semantics. ADR-0054 §2 makes this
+//! module the single place that names those sets, so the axes cannot drift apart
+//! across the passes that consult them and no pass grows a private purity model
+//! of its own.
 //!
 //! ## Why a module in `opt` (not `CfgInstData` methods)
 //!
@@ -21,7 +22,7 @@
 //! function taking `(&Cfg, CfgValue)` matches DCE's existing call shape exactly
 //! and lets LICM/unrolling reuse it verbatim.
 //!
-//! ## The two axes (defined independently)
+//! ## The three axes (defined independently)
 //!
 //! - [`may_trap`]: the instruction can panic or fault at runtime — overflow-checked
 //!   arithmetic (`Add`/`Sub`/`Mul`/`Neg`), division checks (`Div`/`Mod`), the
@@ -34,12 +35,22 @@
 //!   result value — `Call`, `Intrinsic`, `Alloc`, `Store`, `ParamStore`,
 //!   `PlaceWrite`, `Drop`, `StorageLive`/`StorageDead`. This is the axis DCE
 //!   needs to keep an op live even when its result is unused.
+//! - [`materializes_owned_value`]: the instruction's result type carries drop
+//!   glue, so the value it produces owns resources and the CFG owes it exactly
+//!   one `Drop` per materialization. This is the axis CSE and LICM need: a pass
+//!   that lets one evaluation stand in for several — merging two occurrences,
+//!   or hoisting one out of a loop — turns that one obligation into many, and
+//!   the ownership verifier rejects the result.
 //!
-//! These axes are orthogonal: arithmetic is *pure but trapping* (`may_trap` yet
-//! no observable effect), while `Store` is *effecting but non-trapping*. That
-//! pure-but-trapping case is exactly what motivates the split — DCE must keep it,
-//! LICM must refuse to hoist it, and neither can be expressed with a single
-//! "has effects" bit.
+//! The axes are orthogonal: arithmetic is *pure but trapping* (`may_trap` yet no
+//! observable effect), while `Store` is *effecting but non-trapping*. That
+//! pure-but-trapping case is exactly what motivates the first split — DCE must
+//! keep it, LICM must refuse to hoist it, and neither can be expressed with a
+//! single "has effects" bit. Ownership is a third independent direction: a
+//! `StringConst` typed as an owning struct, and any aggregate constructor built
+//! from one, neither traps nor is observable, yet is still not a reusable
+//! computation. Each consumer takes the axes it needs — DCE the first two, CSE
+//! the third, LICM the speculation combination and the third.
 //!
 //! ## `is_speculatable`
 //!
@@ -53,8 +64,11 @@
 //!
 //! Bitwise ops, shifts (counts are masked per spec, so they never trap),
 //! comparisons, `Not`/`BitNot`, constants, direct non-indexed `PlaceRead`/`Load`,
-//! and the aggregate constructors are the speculatable set — the ops LICM may
-//! hoist.
+//! and the aggregate constructors are the speculatable set. Speculation is about
+//! *when* an op may run, so it says nothing about ownership; LICM combines it
+//! with [`materializes_owned_value`] to decide what it may hoist.
+
+use rue_air::FrozenTypeInternPool;
 
 use crate::{Cfg, CfgInstData, CfgValue, Projection};
 
@@ -141,6 +155,34 @@ pub(crate) fn is_speculatable(cfg: &Cfg, value: CfgValue) -> bool {
     !may_trap(cfg, value) && !has_observable_side_effect(cfg, value)
 }
 
+/// Returns `true` if `value` materializes a value that owns resources — one
+/// whose type carries drop glue.
+///
+/// The CFG's ownership discipline pairs each such materialization with exactly
+/// one `Drop` on every path that produced it. A transform that lets a single
+/// evaluation serve several dynamic occurrences therefore may not touch these
+/// values, whatever the other two axes say: CSE merging two occurrences would
+/// leave the second consumer reading a value the first already dropped, and
+/// LICM hoisting one into a preheader would leave a single materialization
+/// dropped once per iteration.
+///
+/// The answer comes from the frozen type pool's canonical `needs_drop` fact —
+/// the same fact CFG construction uses to place drops and the verifier uses to
+/// check them — so the optimizer cannot disagree with either about what owns
+/// resources.
+///
+/// A frozen pool answers for every type an optimized graph can name, so the
+/// missing-fact arm is unreachable; it fails closed as owning, which costs
+/// optimization rather than soundness.
+pub(crate) fn materializes_owned_value(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    value: CfgValue,
+) -> bool {
+    let ty = cfg.get_inst(value).ty;
+    type_pool.try_type_needs_drop(ty).unwrap_or(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,6 +212,52 @@ mod tests {
 
     fn konst(cfg: &mut Cfg, v: u64) -> CfgValue {
         add(cfg, CfgInstData::Const(v), Type::I32)
+    }
+
+    // --- The ownership axis: independent of the other two, and read from the
+    //     type pool's canonical `needs_drop` fact. ---
+
+    #[test]
+    fn owning_result_types_are_materializations() {
+        let interner = lasso::ThreadedRodeo::default();
+        let pool = rue_air::TypeInternPool::new();
+        let register = |name: &str, destructor: Option<&str>| {
+            rue_air::Type::new_struct(
+                pool.register_struct(
+                    interner.get_or_intern(name),
+                    rue_air::StructDef {
+                        name: name.into(),
+                        fields: Vec::new(),
+                        is_copy: false,
+                        is_linear: false,
+                        declared_linear: false,
+                        destructor: destructor.map(Into::into),
+                        is_builtin: false,
+                        is_pub: false,
+                        file_id: rue_span::FileId::DEFAULT,
+                    },
+                )
+                .0,
+            )
+        };
+        let owning = register("Owning", Some("Owning.__drop"));
+        let plain = register("Plain", None);
+        let pool = pool.freeze();
+
+        let mut cfg = make_cfg();
+        let owned_literal = add(&mut cfg, CfgInstData::StringConst(0), owning);
+        let plain_literal = add(&mut cfg, CfgInstData::StringConst(0), plain);
+        let number = konst(&mut cfg, 1);
+
+        assert!(materializes_owned_value(&cfg, &pool, owned_literal));
+        assert!(!materializes_owned_value(&cfg, &pool, plain_literal));
+        assert!(!materializes_owned_value(&cfg, &pool, number));
+
+        // Orthogonal to the other two axes: the owning literal neither traps
+        // nor is observable, so speculation alone would let a pass move it.
+        assert!(!may_trap(&cfg, owned_literal));
+        assert!(!has_observable_side_effect(&cfg, owned_literal));
+        assert!(is_speculatable(&cfg, owned_literal));
     }
 
     // --- The trap axis: every trapping op reports may_trap and is NOT

--- a/crates/rue-cfg/src/opt/cse.rs
+++ b/crates/rue-cfg/src/opt/cse.rs
@@ -34,6 +34,20 @@
 //! * everything else (allocs, stores, struct/array/enum construction, casts,
 //!   drops, storage markers) — either side-effecting or not a pure value.
 //!
+//! ### Owning results are never keyed
+//!
+//! A keyed opcode is not automatically a reusable computation: a `StringConst`
+//! typed as an owning struct (a `StrBuf` literal, say) materializes a value with
+//! drop glue, and a `Param` read can name an owning parameter. The CFG owes each
+//! such materialization exactly one `Drop` on every path that produced it, so
+//! merging two of them makes one value answer for two drops — the second scope
+//! then initializes its local from a value the first scope already dropped, and
+//! the ownership verifier rejects the CFG. Every candidate is therefore filtered
+//! by [`super::classify::materializes_owned_value`], the shared ownership axis
+//! LICM consults for the same reason, before its key is computed. The predicate
+//! reads the type pool's canonical `needs_drop` fact, so this pass and the
+//! verifier cannot disagree about which values own resources.
+//!
 //! ### Never-written parameter reads (RUE-914)
 //!
 //! Each `Param { index }` re-materializes the parameter's ABI-slot value, so two
@@ -86,9 +100,12 @@
 //! [`super::simplify`], RUE-794). DCE then removes the now-unused `Const(0)`
 //! placeholders.
 
-use crate::{BlockId, Cfg, CfgInstData, CfgValue, Type};
 use ahash::AHashMap;
+use rue_air::FrozenTypeInternPool;
 
+use crate::{BlockId, Cfg, CfgInstData, CfgValue, Type};
+
+use super::classify;
 use super::slot_facts;
 
 /// Work counters for one run (RUE-794 convention): a single forward scan of
@@ -149,13 +166,22 @@ fn commutative(tag: u8, a: CfgValue, b: CfgValue, ty: Type) -> VnKey {
 
 /// Compute the value-number key for `value`, resolving operands through the
 /// substitution map. Returns `None` for instructions this pass does not number
-/// (memory reads, calls, and everything with side effects or non-value results).
+/// (memory reads, calls, everything with side effects or non-value results, and
+/// anything whose result owns resources).
 fn key_of(
     cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
     value: CfgValue,
     never_written_param: &[bool],
     r: impl Fn(CfgValue) -> CfgValue,
 ) -> Option<VnKey> {
+    // An owning result is materialized, not computed: its single-drop
+    // obligation is per occurrence, so no two occurrences are interchangeable
+    // however identical their operands. Filtering here covers every keyed
+    // opcode at once rather than trusting each arm to stay scalar.
+    if classify::materializes_owned_value(cfg, type_pool, value) {
+        return None;
+    }
     let inst = cfg.get_inst(value);
     let ty = inst.ty;
     Some(match inst.data {
@@ -210,6 +236,7 @@ fn key_of(
 /// which the dominator-tree walk removes when it exits the block's subtree.
 fn scan_block(
     cfg: &mut Cfg,
+    type_pool: &FrozenTypeInternPool,
     block_id: BlockId,
     never_written_param: &[bool],
     subst: &mut [Option<CfgValue>],
@@ -221,7 +248,9 @@ fn scan_block(
         let value = cfg.get_block(block_id).insts[i];
         stats.insts_scanned += 1;
 
-        let Some(key) = key_of(cfg, value, never_written_param, |v| resolve(subst, v)) else {
+        let Some(key) = key_of(cfg, type_pool, value, never_written_param, |v| {
+            resolve(subst, v)
+        }) else {
             continue;
         };
 
@@ -245,7 +274,7 @@ fn scan_block(
 
 /// Run dominator-scoped CSE. Call at `-O2`/`-O3` after simplification and
 /// before DCE (which sweeps the dead placeholders).
-pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
+pub fn run(cfg: &mut Cfg, type_pool: &FrozenTypeInternPool) -> Result<Stats, crate::CfgEditError> {
     let mut stats = Stats::default();
     // `subst[dup] = first` for every replaced duplicate. Each entry points to a
     // definition that dominates it, so global chain resolution stays valid.
@@ -279,6 +308,7 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
             Event::Enter(block) => {
                 let introduced = scan_block(
                     cfg,
+                    type_pool,
                     block,
                     &never_written_param,
                     &mut subst,
@@ -311,6 +341,7 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
         }
         let introduced = scan_block(
             cfg,
+            type_pool,
             block,
             &never_written_param,
             &mut subst,
@@ -340,8 +371,51 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
 mod tests {
     use super::*;
     use crate::{CfgArgMode, CfgCallArg, CfgInst, Terminator, Type};
-    use lasso::{Key, Spur};
+    use lasso::{Key, Spur, ThreadedRodeo};
+    use rue_air::{StructDef, TypeInternPool};
     use rue_span::Span;
+
+    /// The scalar types every value-numbering test uses carry no drop glue, so
+    /// an empty pool answers the ownership axis for all of them.
+    fn test_type_pool() -> FrozenTypeInternPool {
+        TypeInternPool::new().freeze()
+    }
+
+    /// A pool holding one struct with a destructor and one without, so a test
+    /// can put an owning and a non-owning result type side by side.
+    fn owning_and_plain_struct_pool() -> (FrozenTypeInternPool, Type, Type) {
+        let interner = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let register = |name: &str, destructor: Option<&str>| {
+            Type::new_struct(
+                pool.register_struct(
+                    interner.get_or_intern(name),
+                    StructDef {
+                        name: name.into(),
+                        fields: Vec::new(),
+                        is_copy: false,
+                        is_linear: false,
+                        declared_linear: false,
+                        destructor: destructor.map(Into::into),
+                        is_builtin: false,
+                        is_pub: false,
+                        file_id: rue_span::FileId::DEFAULT,
+                    },
+                )
+                .0,
+            )
+        };
+        let owning = register("Owning", Some("Owning.__drop"));
+        let plain = register("Plain", None);
+        let pool = pool.freeze();
+        assert!(pool.type_needs_drop(owning));
+        assert!(!pool.type_needs_drop(plain));
+        (pool, owning, plain)
+    }
+
+    fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
+        super::run(cfg, &test_type_pool())
+    }
 
     fn make_cfg() -> Cfg {
         let mut cfg = Cfg::new(Type::I32, 0, 0, "test".to_string(), vec![]);
@@ -381,6 +455,102 @@ mod tests {
             else_block,
             else_args: crate::payload::CfgElseArgs::EMPTY,
         }
+    }
+
+    #[test]
+    fn test_owning_string_constant_is_not_merged() {
+        // Two identical `StrBuf`-shaped literals: each materialization owes its
+        // own drop, so neither is keyed however identical the constant. A plain
+        // integer constant beside them still collapses, which is what pins the
+        // guard to ownership rather than to the `StringConst` opcode.
+        let (pool, owning, _) = owning_and_plain_struct_pool();
+        let mut cfg = make_cfg();
+        let first = push(&mut cfg, CfgInstData::StringConst(0), owning);
+        let second = push(&mut cfg, CfgInstData::StringConst(0), owning);
+        let number = push(&mut cfg, CfgInstData::Const(7), Type::I32);
+        let duplicate_number = push(&mut cfg, CfgInstData::Const(7), Type::I32);
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Return {
+                value: Some(duplicate_number),
+            },
+        );
+
+        let stats = super::run(&mut cfg, &pool).unwrap();
+        assert_eq!(
+            stats.duplicates_replaced, 1,
+            "only the integer constant is a reusable computation"
+        );
+        assert!(matches!(
+            cfg.get_inst(first).data,
+            CfgInstData::StringConst(0)
+        ));
+        assert!(matches!(
+            cfg.get_inst(second).data,
+            CfgInstData::StringConst(0)
+        ));
+        assert!(matches!(cfg.get_inst(number).data, CfgInstData::Const(7)));
+        assert!(matches!(
+            cfg.get_inst(duplicate_number).data,
+            CfgInstData::Const(0)
+        ));
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == number
+        ));
+    }
+
+    #[test]
+    fn test_non_owning_struct_string_constant_still_merges() {
+        // The guard reads the result type's drop glue, not the opcode: a
+        // `StringConst` typed as a struct without a destructor — the shape a
+        // `str` slice has — remains an ordinary keyed constant.
+        let (pool, _, plain) = owning_and_plain_struct_pool();
+        let mut cfg = make_cfg();
+        let first = push(&mut cfg, CfgInstData::StringConst(0), plain);
+        let second = push(&mut cfg, CfgInstData::StringConst(0), plain);
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Return {
+                value: Some(second),
+            },
+        );
+
+        let stats = super::run(&mut cfg, &pool).unwrap();
+        assert_eq!(stats.duplicates_replaced, 1);
+        assert!(matches!(cfg.get_inst(second).data, CfgInstData::Const(0)));
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == first
+        ));
+    }
+
+    #[test]
+    fn test_owning_parameter_reads_are_not_merged() {
+        // A never-written parameter of an owning type is still a per-read
+        // materialization: keying it would hand two consumers one value to
+        // drop.
+        let (pool, owning, _) = owning_and_plain_struct_pool();
+        let mut cfg = make_cfg();
+        let first = push(&mut cfg, CfgInstData::Param { index: 0 }, owning);
+        let second = push(&mut cfg, CfgInstData::Param { index: 0 }, owning);
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Return {
+                value: Some(second),
+            },
+        );
+
+        let stats = super::run(&mut cfg, &pool).unwrap();
+        assert_eq!(stats.duplicates_replaced, 0);
+        assert!(matches!(
+            cfg.get_inst(first).data,
+            CfgInstData::Param { index: 0 }
+        ));
+        assert!(matches!(
+            cfg.get_inst(second).data,
+            CfgInstData::Param { index: 0 }
+        ));
     }
 
     #[test]

--- a/crates/rue-cfg/src/opt/licm.rs
+++ b/crates/rue-cfg/src/opt/licm.rs
@@ -5,18 +5,30 @@
 //! instead of once per iteration. This pass implements the **trap-free-only**
 //! variant ADR-0054 §2 specifies: it is the first `-O3`-only pass.
 //!
-//! ## The governing rule — never manufacture a trap
+//! ## The governing rule
 //!
 //! Hoisting moves an op from "once per iteration" to "once in the preheader,
-//! before the loop's entry test". If the loop runs **zero** iterations, a
-//! hoisted op executes on a path the source never took. For a *trapping* op that
-//! invents a trap out of thin air — the exact inverse of RUE-57, where DCE
-//! *deleted* a mandatory trap. So **only [`classify::is_speculatable`] ops move**
-//! (neither `may_trap` nor observable). Every trapping invariant op —
+//! before the loop's entry test", so one evaluation answers for every iteration
+//! and also for none. Two obligations follow, and together they say **only
+//! speculatable ops that do not materialize an owned value move**.
+//!
+//! *Never manufacture a trap.* If the loop runs **zero** iterations, a hoisted
+//! op executes on a path the source never took. For a *trapping* op that invents
+//! a trap out of thin air — the exact inverse of RUE-57, where DCE *deleted* a
+//! mandatory trap. So a candidate must be [`classify::is_speculatable`] (neither
+//! `may_trap` nor observable), and every trapping invariant op —
 //! `Add`/`Sub`/`Mul`/`Div`/`Mod`/`Neg`, `IntCast`, an indirect or indexed
 //! `PlaceRead` — stays in the loop body even when invariant. Guarded hoisting of
 //! trapping ops is RUE-934, after loop rotation lands; there is no cleverness
 //! here.
+//!
+//! *Never make one materialization answer for many drops.* A value whose type
+//! carries drop glue owes the CFG one `Drop` per materialization, so a candidate
+//! must also not be a [`classify::materializes_owned_value`]: hoisted, its single
+//! preheader evaluation would be dropped once per iteration, which the ownership
+//! verifier rejects (RUE-2044). Speculation does not cover this — a `StrBuf`
+//! literal, and the aggregate constructors that build one, neither trap nor are
+//! observable — so ownership is a separate test beside the speculation test.
 //!
 //! ## Invariance
 //!
@@ -142,11 +154,8 @@ pub struct Stats {
 /// Run loop-invariant code motion. Call at `-O3` only, after the `-O2` passes
 /// and before DCE (see the module docs). The caller must first establish
 /// canonical preheaders with `loops::normalize_preheaders`. Returns its work
-/// counters. The type-pool parameter is retained for the pass API contract.
-pub fn run(
-    cfg: &mut Cfg,
-    _type_pool: &FrozenTypeInternPool,
-) -> Result<Stats, CfgOptimizationError> {
+/// counters. The type pool answers the ownership axis of the hoist test.
+pub fn run(cfg: &mut Cfg, type_pool: &FrozenTypeInternPool) -> Result<Stats, CfgOptimizationError> {
     // Every directed cycle contains an edge whose target is no later than its
     // source in the total block-id order. Proving that no such edge exists is
     // therefore enough to skip both dominator construction and loop discovery.
@@ -192,6 +201,7 @@ pub fn run(
         stats.loops_analyzed += 1;
         hoist_loop(
             cfg,
+            type_pool,
             forest.get(id),
             &mut def_block,
             &reachable,
@@ -287,6 +297,7 @@ impl HoistWorkspace {
 
 fn hoist_loop(
     cfg: &mut Cfg,
+    type_pool: &FrozenTypeInternPool,
     lp: &NaturalLoop,
     def_block: &mut Vec<Option<BlockId>>,
     reachable: &super::dce::BitSet,
@@ -322,7 +333,7 @@ fn hoist_loop(
     for &block in &lp.body {
         for &value in &cfg.get_block(block).insts {
             stats.instructions_examined += 1;
-            if is_hoist_candidate(cfg, value, &slot_facts) {
+            if is_hoist_candidate(cfg, type_pool, value, &slot_facts) {
                 candidate[value.as_u32() as usize] = true;
                 candidate_values.push(value);
             }
@@ -413,13 +424,27 @@ fn hoist_loop(
 }
 
 /// Whether `value` is eligible to hoist on its own merits, independent of its
-/// operands: speculatable (never traps, no observable effect), not a block
-/// parameter, and — for a memory read — only when its direct root is invariant.
-fn is_hoist_candidate(cfg: &Cfg, value: CfgValue, slot_facts: &LoopSlotFacts) -> bool {
+/// operands: speculatable (never traps, no observable effect), not the
+/// materialization of an owning value, not a block parameter, and — for a
+/// memory read — only when its direct root is invariant.
+fn is_hoist_candidate(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    value: CfgValue,
+    slot_facts: &LoopSlotFacts,
+) -> bool {
     // Trapping or observable ops never move (ADR-0054 §2). This already excludes
     // arithmetic, IntCast, indirect/indexed PlaceRead, calls, stores, allocs,
     // drops, and the storage markers.
     if !classify::is_speculatable(cfg, value) {
+        return false;
+    }
+    // A value that owns resources is materialized once per drop. Speculation
+    // says nothing about that: a `StringConst` typed as an owning struct, or an
+    // aggregate built from one, neither traps nor is observable, yet hoisting it
+    // into the preheader would leave one materialization answering for a drop on
+    // every iteration.
+    if classify::materializes_owned_value(cfg, type_pool, value) {
         return false;
     }
     match &cfg.get_inst(value).data {
@@ -476,6 +501,73 @@ mod tests {
 
     fn test_type_pool() -> FrozenTypeInternPool {
         rue_air::TypeInternPool::new().freeze()
+    }
+
+    /// Two single-field structs that differ only in drop glue, for the
+    /// ownership axis of the hoist test. Both carry one `i32` field so a
+    /// `StructInit` over [`LoopShape::a`] is verifier-clean.
+    struct OwnershipTypes {
+        pool: FrozenTypeInternPool,
+        owning: Type,
+        owning_id: rue_air::StructId,
+        plain: Type,
+        plain_id: rue_air::StructId,
+    }
+
+    fn ownership_types() -> OwnershipTypes {
+        let interner = lasso::ThreadedRodeo::default();
+        let pool = rue_air::TypeInternPool::new();
+        let register = |name: &str, destructor: Option<&str>| {
+            let id = pool
+                .register_struct(
+                    interner.get_or_intern(name),
+                    rue_air::StructDef {
+                        name: name.into(),
+                        fields: vec![rue_air::StructField {
+                            name: "v".to_string(),
+                            ty: Type::I32,
+                        }],
+                        is_copy: false,
+                        is_linear: false,
+                        declared_linear: false,
+                        destructor: destructor.map(Into::into),
+                        is_builtin: false,
+                        is_pub: false,
+                        file_id: rue_span::FileId::DEFAULT,
+                    },
+                )
+                .0;
+            (Type::new_struct(id), id)
+        };
+        let (owning, owning_id) = register("Owning", Some("Owning.__drop"));
+        let (plain, plain_id) = register("Plain", None);
+        let pool = pool.freeze();
+        assert!(pool.type_needs_drop(owning));
+        assert!(!pool.type_needs_drop(plain));
+        OwnershipTypes {
+            pool,
+            owning,
+            owning_id,
+            plain,
+            plain_id,
+        }
+    }
+
+    /// Push a one-field `StructInit` of `ty` over `field` into `block`.
+    fn struct_init(
+        cfg: &mut Cfg,
+        block: BlockId,
+        struct_id: rue_air::StructId,
+        ty: Type,
+        field: CfgValue,
+    ) -> CfgValue {
+        let fields = cfg.push_struct_fields([field]).unwrap();
+        push(
+            cfg,
+            block,
+            CfgInstData::StructInit { struct_id, fields },
+            ty,
+        )
     }
 
     /// Exercise LICM through the same canonical-preheader boundary as O3.
@@ -588,6 +680,50 @@ mod tests {
         assert_eq!(block_of(&s.cfg, inv), Some(s.entry));
         assert!(!s.cfg.get_block(s.body).insts.contains(&inv));
         s.cfg.verify_with_fixture_pool().unwrap();
+    }
+
+    #[test]
+    fn refuses_to_hoist_an_owning_materialization() {
+        // A `StringConst` typed as an owning struct is speculatable — it cannot
+        // trap and has no observable effect — and it is loop-invariant. It must
+        // still stay in the body: one preheader materialization would answer for
+        // a drop on every iteration.
+        let t = ownership_types();
+        let mut s = single_loop();
+        let literal = push(&mut s.cfg, s.body, CfgInstData::StringConst(0), t.owning);
+        s.cfg.verify_with_type_pool(&t.pool).unwrap();
+
+        let stats = run(&mut s.cfg, &t.pool).unwrap();
+        assert_eq!(stats.invariants_hoisted, 0);
+        assert_eq!(block_of(&s.cfg, literal), Some(s.body));
+        s.cfg.verify_with_type_pool(&t.pool).unwrap();
+    }
+
+    #[test]
+    fn refuses_to_hoist_an_owning_aggregate_constructor() {
+        // An aggregate constructor is speculatable too, and invariant when its
+        // fields are, so the ownership axis is the only thing separating these
+        // two runs: the same `StructInit` over a struct without drop glue still
+        // hoists. This is what keeps a user `drop fn` struct literal, an
+        // `Option(StrBuf)` construction, and a `[StrBuf; N]` literal in the loop
+        // body — none of them a `StringConst`.
+        let t = ownership_types();
+
+        let mut owned = single_loop();
+        let kept = struct_init(&mut owned.cfg, owned.body, t.owning_id, t.owning, owned.a);
+        owned.cfg.verify_with_type_pool(&t.pool).unwrap();
+        let stats = run(&mut owned.cfg, &t.pool).unwrap();
+        assert_eq!(stats.invariants_hoisted, 0);
+        assert_eq!(block_of(&owned.cfg, kept), Some(owned.body));
+        owned.cfg.verify_with_type_pool(&t.pool).unwrap();
+
+        let mut plain = single_loop();
+        let hoisted = struct_init(&mut plain.cfg, plain.body, t.plain_id, t.plain, plain.a);
+        plain.cfg.verify_with_type_pool(&t.pool).unwrap();
+        let stats = run(&mut plain.cfg, &t.pool).unwrap();
+        assert_eq!(stats.invariants_hoisted, 1);
+        assert_eq!(block_of(&plain.cfg, hoisted), Some(plain.entry));
+        plain.cfg.verify_with_type_pool(&t.pool).unwrap();
     }
 
     #[test]

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -312,14 +312,16 @@ fn simplify_made_progress(stats: simplify::Stats) -> bool {
 /// true fixpoint, subject to the explicit round bound.
 fn run_cleanup_to_fixpoint(
     cfg: &mut crate::CfgEditor,
+    type_pool: &FrozenTypeInternPool,
     stats: &mut OptimizationStats,
     sequence: CleanupSequence,
 ) -> Result<(), CfgOptimizationError> {
-    run_cleanup_to_fixpoint_with_limit(cfg, stats, sequence, MAX_CLEANUP_ROUNDS)
+    run_cleanup_to_fixpoint_with_limit(cfg, type_pool, stats, sequence, MAX_CLEANUP_ROUNDS)
 }
 
 fn run_cleanup_to_fixpoint_with_limit(
     cfg: &mut crate::CfgEditor,
+    type_pool: &FrozenTypeInternPool,
     stats: &mut OptimizationStats,
     sequence: CleanupSequence,
     max_rounds: usize,
@@ -365,7 +367,7 @@ fn run_cleanup_to_fixpoint_with_limit(
                     let peephole_stats = peephole::run(cfg)?;
                     let peephole_progress = peephole_made_progress(peephole_stats);
                     stats.add_peephole(peephole_stats);
-                    let cse_stats = cse::run(cfg)?;
+                    let cse_stats = cse::run(cfg, type_pool)?;
                     let cse_progress = cse_made_progress(cse_stats);
                     stats.add_cse(cse_stats);
                     (forward_progress, peephole_progress, cse_progress)
@@ -645,7 +647,12 @@ pub fn optimize_with_budget(
                 // newly unreachable ownership actions are removed before
                 // forwarding and CSE inspect the graph.
                 if control_flow_folded {
-                    run_cleanup_to_fixpoint(&mut cfg, &mut stats, CleanupSequence::ControlFlow)?;
+                    run_cleanup_to_fixpoint(
+                        &mut cfg,
+                        type_pool,
+                        &mut stats,
+                        CleanupSequence::ControlFlow,
+                    )?;
                 }
 
                 // Value forwarding / copy propagation (RUE-914), at -O2/-O3 only.
@@ -665,7 +672,12 @@ pub fn optimize_with_budget(
                     // selector branch is folded.
                     let forwarding_made_progress = forward_made_progress(forward_stats);
                     if forwarding_made_progress {
-                        run_cleanup_to_fixpoint(&mut cfg, &mut stats, CleanupSequence::Forwarding)?;
+                        run_cleanup_to_fixpoint(
+                            &mut cfg,
+                            type_pool,
+                            &mut stats,
+                            CleanupSequence::Forwarding,
+                        )?;
                     }
                 }
 
@@ -676,7 +688,7 @@ pub fn optimize_with_budget(
                 // dead placeholders each replaced duplicate (and each forwarded
                 // load) leaves behind.
                 if matches!(level, OptLevel::O2 | OptLevel::O3) {
-                    let cse_stats = cse::run(&mut cfg)?;
+                    let cse_stats = cse::run(&mut cfg, type_pool)?;
                     stats.add_cse(cse_stats);
                 }
 
@@ -689,12 +701,15 @@ pub fn optimize_with_budget(
                 // the whole -O1/-O2 sequence so the invariant operands it keys
                 // on are as exposed as constant folding, simplification,
                 // forwarding, and CSE can make them, and before DCE, which
-                // sweeps anything the moves orphan. It hoists ONLY trap-free
-                // (`is_speculatable`) invariant ops into each loop's preheader;
-                // trapping invariant ops never move, because hoisting one into
-                // a zero-trip preheader would manufacture a trap the source
-                // never runs (the inverse of RUE-57). It recomputes dominators
-                // + loops per the ADR's recompute rule.
+                // sweeps anything the moves orphan. It hoists ONLY invariant
+                // ops that are both trap-free (`is_speculatable`) and not the
+                // materialization of an owned value, into each loop's
+                // preheader; trapping invariant ops never move, because
+                // hoisting one into a zero-trip preheader would manufacture a
+                // trap the source never runs (the inverse of RUE-57), and an
+                // owning materialization never moves, because one preheader
+                // evaluation would answer for a drop on every iteration. It
+                // recomputes dominators + loops per the ADR's recompute rule.
                 if matches!(level, OptLevel::O3) {
                     let preheader_stats = loops::normalize_preheaders(&mut cfg, type_pool)?;
                     stats.add_preheader_normalization(preheader_stats);
@@ -713,6 +728,7 @@ pub fn optimize_with_budget(
                         budget.used_blocks().saturating_sub(initial_blocks);
                     run_cleanup_to_fixpoint(
                         &mut cfg,
+                        type_pool,
                         &mut stats,
                         CleanupSequence::Unrolling {
                             revisit_clones: unroll.loops_unrolled > 0,
@@ -1033,6 +1049,7 @@ mod tests {
 
         run_cleanup_to_fixpoint_with_limit(
             &mut cfg,
+            &pool,
             &mut stats,
             CleanupSequence::Unrolling {
                 revisit_clones: true,
@@ -1070,8 +1087,14 @@ mod tests {
         let mut cfg = cfg.finish(&pool).unwrap().into_editor();
         let mut stats = OptimizationStats::default();
 
-        run_cleanup_to_fixpoint_with_limit(&mut cfg, &mut stats, CleanupSequence::Forwarding, 4)
-            .unwrap();
+        run_cleanup_to_fixpoint_with_limit(
+            &mut cfg,
+            &pool,
+            &mut stats,
+            CleanupSequence::Forwarding,
+            4,
+        )
+        .unwrap();
 
         assert_eq!(
             stats,
@@ -1095,6 +1118,7 @@ mod tests {
 
         run_cleanup_to_fixpoint_with_limit(
             &mut cfg,
+            &pool,
             &mut stats,
             CleanupSequence::Unrolling {
                 revisit_clones: true,
@@ -1122,21 +1146,33 @@ mod tests {
     #[cfg(debug_assertions)]
     #[should_panic(expected = "still made progress after the maximum of 1 rounds")]
     fn cleanup_reports_bound_exhaustion_after_mutating_final_round() {
-        let (cfg, _) = cleanup_generation_cfg(2);
+        let (cfg, pool) = cleanup_generation_cfg(2);
         let mut cfg = cfg.into_editor();
         let mut stats = OptimizationStats::default();
-        run_cleanup_to_fixpoint_with_limit(&mut cfg, &mut stats, CleanupSequence::ControlFlow, 1)
-            .unwrap();
+        run_cleanup_to_fixpoint_with_limit(
+            &mut cfg,
+            &pool,
+            &mut stats,
+            CleanupSequence::ControlFlow,
+            1,
+        )
+        .unwrap();
     }
 
     #[test]
     #[cfg(not(debug_assertions))]
     fn cleanup_release_build_stops_at_bound_after_mutating_final_round() {
-        let (cfg, _) = cleanup_generation_cfg(2);
+        let (cfg, pool) = cleanup_generation_cfg(2);
         let mut cfg = cfg.into_editor();
         let mut stats = OptimizationStats::default();
-        run_cleanup_to_fixpoint_with_limit(&mut cfg, &mut stats, CleanupSequence::ControlFlow, 1)
-            .unwrap();
+        run_cleanup_to_fixpoint_with_limit(
+            &mut cfg,
+            &pool,
+            &mut stats,
+            CleanupSequence::ControlFlow,
+            1,
+        )
+        .unwrap();
         assert!(stats.simplify_branches_folded > 0);
     }
 

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -1831,8 +1831,10 @@ mod tests {
         // the newly added clone-revisit passes are enabled.
         let mut control = cfg.clone();
         let mut control_stats = super::super::OptimizationStats::default();
+        let type_pool = rue_air::TypeInternPool::new().freeze();
         super::super::run_cleanup_to_fixpoint(
             &mut control,
+            &type_pool,
             &mut control_stats,
             super::super::CleanupSequence::Unrolling {
                 revisit_clones: false,
@@ -1843,6 +1845,7 @@ mod tests {
 
         super::super::run_cleanup_to_fixpoint(
             &mut cfg,
+            &type_pool,
             &mut stats,
             super::super::CleanupSequence::Unrolling {
                 revisit_clones: true,

--- a/crates/rue-cli-tests/cases/opt.toml
+++ b/crates/rue-cli-tests/cases/opt.toml
@@ -1,14 +1,21 @@
 # Optimization-correctness regression tests.
 #
-# These compile at -O2 and assert that mandatory runtime traps (overflow,
-# divide-by-zero, out-of-bounds) still fire even when the trapping op's result
-# is unused. DCE used to eliminate these (RUE-57), silently turning exit 101
-# into exit 0 at -O1+. See crates/rue-cfg/src/opt/dce.rs has_side_effects.
+# Two obligations the optimizer must not optimize away.
+#
+# The trap cases compile at -O2 and assert that mandatory runtime traps
+# (overflow, divide-by-zero, out-of-bounds) still fire even when the trapping
+# op's result is unused. DCE used to eliminate these (RUE-57), silently turning
+# exit 101 into exit 0 at -O1+. See crates/rue-cfg/src/opt/dce.rs
+# has_side_effects.
+#
+# The ownership cases (RUE-2044) run at every level via `differential_opt` and
+# assert that a value with drop glue is materialized once per drop. See
+# crates/rue-cfg/src/opt/classify.rs materializes_owned_value.
 
 [section]
 id = "cli.opt"
 name = "Optimization correctness"
-description = "Mandatory runtime traps must survive optimization passes."
+description = "Mandatory runtime traps and single-owner materialization must survive optimization passes."
 
 [[case]]
 name = "dce_keeps_overflow_panic_at_O2"
@@ -157,3 +164,239 @@ fn main() -> i32 {
 args = ["main.rue", "-O2", "-o", "prog"]
 exit_code = 101
 runtime_error_contains = ["integer overflow"]
+
+# ---------------------------------------------------------------------------
+# Owning literals are materialized once per drop (RUE-2044).
+#
+# A `StrBuf` literal lowers to a `StringConst` whose result type carries drop
+# glue, so the CFG owes it one `Drop` on every path that produced it. It is
+# nonetheless a constant-shaped, non-trapping, non-observable instruction, which
+# is exactly what made the optimizer treat it as a reusable pure computation:
+# CSE merged two identical literals in sibling scopes, leaving the second scope
+# initializing its local from a value the first had already dropped, and LICM
+# hoisted one out of a loop body, leaving a single materialization answering for
+# a drop per iteration. The ownership verifier rejected both as an internal
+# error, so these cases fail by refusing to compile at the affected level rather
+# than by printing the wrong text.
+#
+# The obligation is about the result type, not the opcode: `struct_init`,
+# `enum_init` and `array_init` of an owning type carry it too, and hoisting one
+# of those out of a loop is how a user `drop fn` struct, an `Option(StrBuf)` and
+# a `[StrBuf; N]` reached the same verifier rejection with no `StringConst` in
+# the program at all.
+#
+# Each block below keeps its literal unused, which is what lets forwarding move
+# the drop onto the literal itself; a block that borrows its local instead (the
+# controls at the end) never reached the verifier. Every case is
+# `differential_opt`, so the -O2/-O3 result must match the -O0 baseline, and the
+# printed lines pin the number of times each scope actually ran.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "owning_literals_in_sibling_scopes"
+differential_opt = true
+description = "RUE-2044 repro: two identical StrBuf literals in sibling scopes, each dropped at its scope end."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn main() -> i32 {
+    { let _k: StrBuf = "a-local"; println("one"); }
+    { let _k: StrBuf = "a-local"; println("two"); }
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "one\ntwo\n"
+exit_code = 0
+
+[[case]]
+name = "owning_literals_in_a_scope_then_a_branch_arm"
+differential_opt = true
+description = "The dominating scope's literal must not be reused by the branch arm below it, which the dominator-scoped value-number table still has it available for."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn main() -> i32 {
+    { let _k: StrBuf = "a-local"; println("one"); }
+    let n: i32 = 1;
+    if n > 0 { let _k: StrBuf = "a-local"; println("two"); }
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "one\ntwo\n"
+exit_code = 0
+
+[[case]]
+name = "owning_literal_in_loop_body"
+differential_opt = true
+description = "One StrBuf literal per iteration, with nothing to merge it against: hoisting it to the preheader would leave a single materialization dropped three times."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn main() -> i32 {
+    let mut i: i32 = 0;
+    while i < 3 {
+        let _k: StrBuf = "seed";
+        println("tick");
+        i = i + 1;
+    }
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "tick\ntick\ntick\n"
+exit_code = 0
+
+[[case]]
+name = "owning_literals_in_an_accessor_body_outside_main"
+differential_opt = true
+description = "The same pair inside a helper whose body also splices an ArrayBuf accessor: the merge is about two allocations in one function, not about main or about a particular statement shape."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const B = std.arraybuf.ArrayBuf(i64);
+fn head(borrow b: B) -> i64 {
+    { let _k: StrBuf = "a-local"; }
+    { let _k: StrBuf = "a-local"; }
+    b.get_ref(0) + 0
+}
+fn main() -> i32 {
+    let mut b = B.new();
+    b.push(42);
+    println("head " + @to_string(head(borrow b)));
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "head 42\n"
+exit_code = 0
+
+[[case]]
+name = "owning_struct_literals_in_scopes_and_a_loop"
+differential_opt = true
+description = "A user `drop fn` struct literal is an owning materialization with no StringConst anywhere: its aggregate constructor must stay one per scope and one per iteration, which the printed drops count."
+files = [{ path = "main.rue", source = """
+struct Res { v: i32 }
+drop fn Res(self) { println("drop"); }
+fn main() -> i32 {
+    { let _r = Res { v: 1 }; }
+    { let _r = Res { v: 1 }; }
+    let mut i: i32 = 0;
+    while i < 2 { let _r = Res { v: 5 }; i = i + 1; }
+    0
+}
+""" }]
+stdout = "drop\ndrop\ndrop\ndrop\n"
+exit_code = 0
+
+[[case]]
+name = "owning_enum_payloads_in_a_loop"
+differential_opt = true
+description = "The same obligation through `enum_init`: an Option(StrBuf) construction owns its payload, so neither variant may be built once in the preheader for a loop that drops one per iteration."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const O = std.option.Option(StrBuf);
+fn main() -> i32 {
+    let mut i: i32 = 0;
+    while i < 3 {
+        let _o: O = O.None;
+        let _p: O = O.Some("seed");
+        i = i + 1;
+    }
+    println("ok");
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "ok\n"
+exit_code = 0
+
+[[case]]
+name = "owning_array_literals_in_scopes_and_a_loop"
+differential_opt = true
+description = "The same obligation through `array_init`: an array of StrBuf owns its elements, so the array literal is materialized once per scope and once per iteration."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn main() -> i32 {
+    { let _a: [StrBuf; 2] = ["x", "x"]; }
+    { let _a: [StrBuf; 2] = ["x", "x"]; }
+    let mut i: i32 = 0;
+    while i < 2 { let _a: [StrBuf; 1] = ["x"]; i = i + 1; }
+    println("ok");
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "ok\n"
+exit_code = 0
+
+[[case]]
+name = "distinct_owning_literals_in_sibling_scopes"
+differential_opt = true
+description = "Control: two scopes whose literals differ never keyed equal, so this shape compiled all along and must keep its independent contents."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn main() -> i32 {
+    { let k: StrBuf = "a-local"; println(k); }
+    { let k: StrBuf = "b-local"; println(k); }
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "a-local\nb-local\n"
+exit_code = 0
+
+[[case]]
+name = "owning_literals_in_sibling_scopes_that_use_their_local"
+differential_opt = true
+description = "The same shape with each scope reading its own literal: the contents must stay independent, so a merge would show up as text."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn main() -> i32 {
+    { let k: StrBuf = "a-local"; println(k); }
+    { let mut k: StrBuf = "a-local"; k.push_str("!"); println(k); }
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "a-local\na-local!\n"
+exit_code = 0
+
+[[case]]
+name = "owning_literals_inside_repeated_struct_literals"
+differential_opt = true
+description = "A field-held owning literal is a keyed StringConst like any other: on trunk one materialization fed both struct initializers, which the verifier never saw because the Drop sits on the struct. Each struct must now get its own."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+struct Holder { name: StrBuf }
+fn main() -> i32 {
+    { let h: Holder = Holder { name: "a-local" }; println(h.name); }
+    { let h: Holder = Holder { name: "a-local" }; println(h.name); }
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "a-local\na-local\n"
+exit_code = 0
+
+[[case]]
+name = "non_owning_string_literals_stay_shareable"
+differential_opt = true
+description = "Control: a `str` literal carries no drop glue, so the ownership guard leaves the ordinary constant path alone."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: str = "a-local";
+    let b: str = "a-local";
+    println(a);
+    println(b);
+    if a == b { 0 } else { 1 }
+}
+""" }]
+stdout = "a-local\na-local\n"
+exit_code = 0

--- a/docs/designs/0054-loop-optimizations.md
+++ b/docs/designs/0054-loop-optimizations.md
@@ -278,7 +278,9 @@ path" principle applied to trap classification.
    `may_trap` (arithmetic, `IntCast`, indexed `PlaceRead`) and with no observable
    side effect (`Call`, `Intrinsic`, `Store`, `PlaceWrite`, `Alloc`, `Drop`,
    `StorageLive`/`StorageDead`). Bitwise/shift/comparison/`Not`/`BitNot` on
-   invariant operands are the sweet spot.
+   invariant operands are the sweet spot. Amended by RUE-2044: the candidate test
+   also rejects an op whose result type carries drop glue, because one preheader
+   materialization would answer for a `Drop` on every iteration.
 2. **Trapping invariant ops: do NOT hoist, initially.** Every `may_trap` op —
    `Add`/`Sub`/`Mul`/`Div`/`Mod`/`Neg`, `IntCast`, and indexed reads — stays in
    the loop body even when invariant, in the first version. This is


### PR DESCRIPTION

Two identical `StrBuf` literals in sibling scopes ICEd at -O2:

    error: [E9000]: internal compiler error: CFG optimization failed: CFG
    verification failed in `main`: allocation initializer v1 in instruction v9
    in block bb0 was already dropped on a reaching path

A `StrBuf` literal lowers to a `StringConst` whose result type carries drop glue, so
the CFG owes it one `Drop` on every path that produced it. It is nonetheless
constant-shaped, non-trapping and non-observable, which is exactly why two optimizer
passes treated it as a reusable pure computation. There were two independent holes:

- **CSE** keyed the literal like any other constant and merged the second scope's
  occurrence into the first's, leaving `alloc $3 = v1` reading a value `drop v1` had
  already consumed.
- **LICM**, whose candidate test was the shared classifier's speculation axis, hoisted a
  lone loop-body literal into the preheader, leaving one materialization to answer for a
  drop per iteration. That shape ICEs at -O3 with a single literal in the whole program
  and nothing merged, so it is a second hole rather than a second symptom of the first.

`opt::classify` gains a third axis beside `may_trap` and `has_observable_side_effect`:
`materializes_owned_value` reports whether an instruction's result type carries drop
glue, reading the frozen type pool's canonical `needs_drop` fact — the same fact CFG
construction uses to place drops and the verifier uses to check them, so the optimizer
cannot disagree with either about what owns resources. A type the pool cannot answer for
fails closed as owning, which the new total `FrozenTypeInternPool::try_type_needs_drop`
expresses without the assertion the whole-compilation query carries; that arm is
unreachable for a frozen pool and asserts in debug builds, so a pool regression surfaces
as a test failure rather than as silently disabled CSE and LICM.

CSE consults the axis once, ahead of the key computation, so every keyed opcode is
covered rather than each arm being trusted to stay scalar; that also closes the same hole
for a `Param` read of an owning parameter. LICM consults it beside the speculation test.
Ownership is genuinely a third direction: speculation asks *when* an op may run and says
nothing about how many drops one evaluation may answer for. DCE is unaffected — it asks
which ops must stay live, which the first two axes still decide.

Because the axis reads the result type rather than the opcode, it also covers the
aggregate constructors. A user `drop fn` struct literal, an `Option(StrBuf)` construction
and a `[StrBuf; N]` literal each reached the same verifier rejection at -O3 through LICM's
aggregate-constructor hoist, with no `StringConst` in the program at all; all three are
fixed here and pinned as cases.

**A design departure worth confirming.** The issue preferred making the `Alloc` copy its
seed so the SSA value becomes genuinely shareable. That was not done. The seed is a
static-backed `{ptr, len, cap}` triple, not a heap copy, so copying it would not make the
value shareable under the verifier's contract — the CFG has exactly one notion of "owns
resources" (`type_needs_drop`), and "a value with drop glue that is nevertheless freely
duplicable" would be a second ownership story repeated at every consumer of an owning SSA
value. Decisively, a copy at `Alloc` does nothing for the LICM hole, where there is one
literal and nothing merged. Please confirm the third-axis design rather than the seed copy.

Shapes covered by eleven `differential_opt` cases in `opt.toml`, each anchored to exact
stdout and exit code across -O0..-O3. Seven fail on trunk: two literals in sibling scopes;
a scope then a branch arm; a lone literal in a loop body; a helper body outside `main` that
also splices an `ArrayBuf` accessor; and the struct, enum and array constructors of an
owning type in scopes and loops. Four more pin what must keep working: two *different*
literals, a scope that borrows its local, a `str` literal (no drop glue, still shared), and
identical struct literals whose owning field trunk merged without the verifier ever seeing
it. Six unit tests pin the pass-level rule — in both directions for CSE, and for LICM in
both directions over `StructInit`.

Nothing that does not own resources is blocked. An adversarial review over 30 shapes
compared the optimized `--emit cfg` at -O2 and -O3 before and after for a `str` literal in
a loop, a `@copy` struct plus `Option(i32)` in a loop, and a non-owning struct with a `str`
field in a loop: byte-identical. `--emit asm` at -O2 and -O3 for all 28 example roots
(`examples/*.rue` and `examples/*/main.rue`, caldera included) is byte-identical between
trunk and this change — 56/56 pairs, no function grew. The added work is one O(1) pool
lookup per scanned CSE instruction and per LICM candidate. The change is target-independent
CFG work with no codegen edits; every shape also cross-emits for `--target x86-64-linux`.

Verified locally: `scripts/rue unit cfg` 428/428, `scripts/rue cli opt` 83/83,
`scripts/rue cli basics` 8/8, `scripts/rue quick` 36/36 targets, `scripts/rue fmt` clean;
the repro, the three aggregate shapes and the earlier variants compile and agree at
-O0/-O1/-O2/-O3. `opt.toml` changed, so CI's oracle-diff gate applies and
`//crates/rue-oracle-diff:oracle-diff-test` must be green before merge.

Fixes RUE-2044
