### PR TITLE
One classifier for every call crossing

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -6,11 +6,10 @@
 //! convention description in `rue-target` (ADR-0064, ADR-0084). This module is
 //! the other half: the *facts* those functions classify. It projects a live
 //! type onto [`CAbiTypeFacts`] ([`c_abi_type_facts`], [`aggregate_leaves`]),
-//! answers the per-convention scalar extension questions a C crossing asks
-//! ([`TargetCCallAbi`], [`CAbiScalarKind`]), and keeps the native
-//! value-decomposition width the CFG parameter contract and the oracle's call
-//! contract track ([`NativeCallAbi::arg_slot_width`]) — a layout measure, not a
-//! placement.
+//! names the width-and-signedness class the extension table is keyed by
+//! ([`CAbiScalarKind`]), and keeps the native value-decomposition width the CFG
+//! parameter contract and the oracle's call contract track
+//! ([`NativeCallAbi::arg_slot_width`]) — a layout measure, not a placement.
 //!
 //! Which convention governs a boundary is named by exactly one value type,
 //! [`rue_target::CallingConvention`], whose rows are the native Rue convention
@@ -29,7 +28,7 @@
 
 use crate::lowered_signature::CAbiTypeFacts;
 use crate::{FrozenTypeInternPool, Type, TypeKind};
-use rue_target::{CConventionSpec, CRegisterClass, CallingConvention, StackedArgumentPacking};
+use rue_target::{CRegisterClass, CallingConvention};
 
 /// How an argument is presented at the source level, before ABI classification.
 ///
@@ -226,7 +225,7 @@ impl CAbiScalarKind {
 
     /// The scalar's own width in bytes: the footprint a stacked copy takes
     /// under a row that packs the outgoing argument area at natural size
-    /// ([`StackedArgumentPacking::NaturalSize`]).
+    /// ([`rue_target::StackedArgumentPacking::NaturalSize`]).
     pub const fn natural_bytes(self) -> u32 {
         match self {
             Self::I8 | Self::U8 | Self::Bool => 1,
@@ -258,8 +257,8 @@ impl CAbiScalarKind {
 /// target-C boundary (ADR-0064 P2). "Narrow" means any value smaller than the
 /// register: the sub-64-bit integers and `bool`. The extension is the same
 /// operation whether it is applied by the caller before an argument crosses or
-/// by the caller after a return crosses — see [`TargetCCallAbi`] for *who*
-/// applies it under each psABI.
+/// by the caller after a return crosses; [`c_abi_type_facts`] documents which
+/// side each row leaves owing it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScalarAbiExtension {
     /// The value already fills its 64-bit register (`i64`/`u64`/pointer): no
@@ -291,7 +290,7 @@ impl ScalarAbiExtension {
     /// is extended *from*, or the full 8-byte register for a register-width
     /// value. This is the size a stacked argument occupies under a psABI that
     /// packs the outgoing argument area at natural size
-    /// ([`StackedArgumentPacking::NaturalSize`]).
+    /// ([`rue_target::StackedArgumentPacking::NaturalSize`]).
     pub const fn natural_bytes(self) -> u32 {
         match self {
             Self::None => 8,
@@ -300,187 +299,29 @@ impl ScalarAbiExtension {
     }
 }
 
-/// The guaranteed target-C call-ABI classifier: the classifier for one C row of
-/// [`CallingConvention`] (ADR-0064).
-///
-/// This answers the per-convention *facts* a scalar crossing needs — the
-/// narrow-integer extension, the argument-register budget, the sret register and
-/// echo, the call-boundary alignment — each read from the convention's
-/// [`CConventionSpec`]. It is constructed from a convention, and a target
-/// reaches it through the one `"C"` alias table ([`Self::for_target`]), so the
-/// two AArch64 targets, which share an architecture, get their own rows.
-///
-/// *Where* a value crosses is not this type's answer: that is
-/// [`lower_c_signature`](crate::lower_c_signature), the one placement function
-/// every C crossing site consumes.
-///
-/// ## What P2 fixes, and why scalars need only the return re-extension
+/// The narrow-integer extension every C row asks for, and who owes it.
 ///
 /// Every supported scalar (`c_passable_by_value`: the full integer set, `bool`,
-/// pointers) occupies exactly one general-purpose integer register — the first
-/// six on SysV (`rdi, rsi, rdx, rcx, r8, r9`), the first eight on AAPCS64
-/// (`x0..x7`) — and spills to the outgoing argument area only once that budget
-/// is exhausted. Rue's
-/// internal scalar invariant already keeps a narrow value canonically extended
-/// in its 64-bit vreg (signed values sign-extended, unsigned/`bool`
-/// zero-extended), which is a *stronger* guarantee than either psABI asks of an
-/// argument, so **argument passing needs no boundary instruction**. The one
-/// direction that does is the **return**: a C callee leaves the bits above the
-/// result's declared width unspecified (SysV) — or extended only to 32 bits
-/// (AAPCS64) — so the caller must re-extend the returned scalar to Rue's
-/// canonical 64-bit form. [`Self::scalar_return_extension`] names that
-/// operation; applying it at the boundary is what preserves the program-wide
-/// scalar invariant across a foreign call.
+/// pointers) occupies exactly one general-purpose register, and Rue's internal
+/// invariant keeps a narrow value canonically 64-bit-extended in its vreg
+/// (signed sign-extended, unsigned and `bool` zero-extended). That is a
+/// *stronger* guarantee than any row asks of an argument, so **argument passing
+/// needs no boundary instruction** on any of them — including Apple's row,
+/// which makes the caller extend an argument narrower than 32 bits.
 ///
-/// ## Narrow-integer extension: who extends
-///
-/// - **SysV AMD64.** Arguments narrower than the register have unspecified high
-///   bits; a callee that needs a wider value re-extends. Rue over-satisfies the
-///   argument rule by always passing a canonically extended value. For a return,
-///   the bits above the type width are callee-visible garbage, so the **caller
-///   re-extends** (this classifier's return extension).
-/// - **AAPCS64.** A callee is required to extend a narrow return value to 32
-///   bits, but bits 32..63 stay unspecified, so re-extending from the value's
-///   *own* declared width is still correct (bits already agree up to 32). The
-///   caller therefore applies the same [`ScalarAbiExtension`].
-/// - **Apple arm64.** The *caller* must extend an argument narrower than 32
-///   bits. Rue's canonical 64-bit form already satisfies that, so the import
-///   side needs no extra instruction, and the export thunk re-extends on every
-///   row because the native body needs the stronger 64-bit form regardless.
-///
-/// ## `_Bool`
+/// The one direction that does need an instruction is the **return**: SysV
+/// AMD64 leaves the bits above a narrow result unspecified, and AAPCS64 defines
+/// only bits 0..31, so the caller re-extends the returned scalar to Rue's
+/// canonical form. That operation is the [`ScalarAbiExtension`] the lowered
+/// signature carries ([`LoweredReturn::Registers`](crate::LoweredReturn)), and
+/// applying it at the boundary is what preserves the program-wide scalar
+/// invariant across a C call.
 ///
 /// C `_Bool` is one byte whose only valid values are 0 and 1. Passing Rue's
 /// `bool` (a 0/1 word) satisfies that directly; a `_Bool` return is
 /// zero-extended from its low byte, materializing exactly 0/1
 /// ([`ScalarAbiExtension::Unsigned`] `{ from_bits: 8 }`).
-#[derive(Debug, Clone, Copy)]
-pub struct TargetCCallAbi {
-    convention: CallingConvention,
-}
-
-impl TargetCCallAbi {
-    /// Build the classifier for one platform C convention.
-    ///
-    /// `convention` must be a C row; [`CallingConvention::Rue`] is the native
-    /// convention and is classified by [`NativeCallAbi`] instead.
-    pub const fn new(convention: CallingConvention) -> Self {
-        assert!(
-            convention.is_c(),
-            "TargetCCallAbi classifies a C boundary; the native Rue convention \
-             is NativeCallAbi's authority"
-        );
-        Self { convention }
-    }
-
-    /// The classifier for the convention `target`'s `"C"` boundary follows.
-    pub const fn for_target(target: rue_target::Target) -> Self {
-        Self::new(CallingConvention::c_for_target(target))
-    }
-
-    /// The SysV AMD64 classifier (x86-64 Linux).
-    pub const fn sysv_amd64() -> Self {
-        Self::new(CallingConvention::X86_64SysV)
-    }
-
-    /// The AAPCS64 classifier (AArch64 Linux).
-    pub const fn aapcs64() -> Self {
-        Self::new(CallingConvention::Aarch64Aapcs)
-    }
-
-    /// The Apple arm64 classifier (AArch64 macOS): AAPCS64 with Apple's
-    /// amendments.
-    pub const fn aapcs64_darwin() -> Self {
-        Self::new(CallingConvention::Aarch64AapcsDarwin)
-    }
-
-    /// The convention this classifier implements.
-    pub const fn convention(&self) -> CallingConvention {
-        self.convention
-    }
-
-    /// How this psABI lays a stacked (byval / register-overflow) argument out in
-    /// the outgoing argument area. Every C row answers; the packing rule is the
-    /// convention's, so no backend needs an operating-system test.
-    pub const fn stacked_argument_packing(&self) -> StackedArgumentPacking {
-        self.convention.stacked_argument_packing()
-    }
-
-    /// This convention's complete psABI description, the one table every
-    /// predicate below reads.
-    pub const fn spec(&self) -> CConventionSpec {
-        self.convention.c_spec()
-    }
-
-    /// The number of general-purpose integer registers used for arguments
-    /// before the outgoing stack area begins: 6 on SysV (`rdi..r9`), 8 on
-    /// AAPCS64 (`x0..x7`).
-    pub const fn int_arg_register_budget(&self) -> u32 {
-        self.spec().gp_argument_registers
-    }
-
-    /// Whether the callee echoes the hidden sret pointer back in the primary
-    /// return register: SysV requires `rax` to hold the sret pointer on return;
-    /// AAPCS64 uses the dedicated indirect-result register `x8`, which is **not**
-    /// echoed. Reachable from P3: an aggregate return >16 bytes takes the sret
-    /// path; scalars in P2 never do.
-    pub const fn sret_pointer_echoed_in_result_register(&self) -> bool {
-        self.spec().sret_pointer_echoed_in_result_register
-    }
-
-    /// Whether the hidden sret pointer is passed in a **dedicated** indirect-
-    /// result register rather than the first ordinary integer argument register.
-    /// AAPCS64 uses the dedicated `x8` (§6.9), so the sret pointer does not
-    /// consume `x0` and the ordinary arguments still start at `x0`. SysV AMD64
-    /// passes the sret pointer as the hidden first argument in `rdi`, consuming
-    /// the first integer argument register. P3 aggregate returns exercise both.
-    pub const fn sret_pointer_in_dedicated_register(&self) -> bool {
-        !self.spec().sret_pointer_in_argument_register()
-    }
-
-    /// The stack alignment required at a `call` instruction on this psABI: 16
-    /// bytes on both SysV AMD64 and AAPCS64.
-    pub const fn call_stack_alignment(&self) -> u32 {
-        self.spec().call_stack_alignment
-    }
-
-    /// The extension a scalar *return* value needs to become Rue's canonical
-    /// 64-bit form after crossing back from C. `None` for register-width scalars
-    /// (`i64`/`u64`/pointer); a sign/zero extension for a narrow integer; a
-    /// zero-extend-from-8 for `bool`/`_Bool`.
-    ///
-    /// The argument-side extension is the same operation
-    /// ([`Self::scalar_arg_extension`]); the two are separated only so the
-    /// "who extends" documentation can differ per direction.
-    pub fn scalar_return_extension(&self, ty: Type) -> ScalarAbiExtension {
-        Self::canonical_extension(ty)
-    }
-
-    /// The extension a scalar *argument* value must already carry when it
-    /// crosses into C. Identical to [`Self::scalar_return_extension`]; Rue's
-    /// internal scalar invariant already satisfies it, so the caller emits no
-    /// extra instruction for arguments in P2.
-    pub fn scalar_arg_extension(&self, ty: Type) -> ScalarAbiExtension {
-        Self::canonical_extension(ty)
-    }
-
-    /// The live plane's projection of a supported target-C scalar onto its
-    /// width-and-signedness class; the extension operation itself lives on
-    /// [`CAbiScalarKind::extension`], shared with the stable query plane.
-    fn canonical_extension(ty: Type) -> ScalarAbiExtension {
-        CAbiScalarKind::for_live_type(ty)
-            .unwrap_or_else(|| {
-                panic!(
-                    "TargetCCallAbi scalar classification called on non-scalar type {:?}; \
-                     aggregates and unsupported types are gated by c_passable_by_value \
-                     before lowering",
-                    ty.kind()
-                )
-            })
-            .extension()
-    }
-}
-
+///
 /// The live plane's projection of `ty` onto the target-C classification facts
 /// [`lower_c_signature`](crate::lower_c_signature) consumes.
 ///
@@ -615,6 +456,7 @@ fn push_leaves(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_target::StackedArgumentPacking;
 
     // Behavioral coverage that exercises the classifier against a real type
     // pool lives with the backend ABI/oracle suites (which own program
@@ -696,49 +538,52 @@ mod tests {
         assert_eq!(leaves, crate::AggregateLeaves::all_integer(size));
     }
 
+    /// The extension a scalar crossing `convention` needs in each direction,
+    /// read out of the one lowering every C crossing consumes.
+    fn scalar_extensions(
+        convention: CallingConvention,
+        ty: Type,
+    ) -> (ScalarAbiExtension, ScalarAbiExtension) {
+        let pool = crate::TypeInternPool::new().freeze();
+        let facts = c_abi_type_facts(&pool, ty);
+        let lowered =
+            crate::lower_c_signature(convention, &[(facts, ArgConvention::ByValue)], facts);
+        let crate::LoweredReturn::Registers { extension, .. } = lowered.ret() else {
+            panic!("a C scalar comes back in a result register");
+        };
+        (lowered.arguments()[0].extension, extension)
+    }
+
     #[test]
     fn target_c_scalar_return_extension_table() {
-        let sysv = TargetCCallAbi::sysv_amd64();
+        let ret = |ty| scalar_extensions(CallingConvention::X86_64SysV, ty).1;
+        assert_eq!(ret(Type::I8), ScalarAbiExtension::Signed { from_bits: 8 });
+        assert_eq!(ret(Type::U8), ScalarAbiExtension::Unsigned { from_bits: 8 });
+        assert_eq!(ret(Type::I16), ScalarAbiExtension::Signed { from_bits: 16 });
         assert_eq!(
-            sysv.scalar_return_extension(Type::I8),
-            ScalarAbiExtension::Signed { from_bits: 8 }
-        );
-        assert_eq!(
-            sysv.scalar_return_extension(Type::U8),
-            ScalarAbiExtension::Unsigned { from_bits: 8 }
-        );
-        assert_eq!(
-            sysv.scalar_return_extension(Type::I16),
-            ScalarAbiExtension::Signed { from_bits: 16 }
-        );
-        assert_eq!(
-            sysv.scalar_return_extension(Type::U16),
+            ret(Type::U16),
             ScalarAbiExtension::Unsigned { from_bits: 16 }
         );
+        assert_eq!(ret(Type::I32), ScalarAbiExtension::Signed { from_bits: 32 });
         assert_eq!(
-            sysv.scalar_return_extension(Type::I32),
-            ScalarAbiExtension::Signed { from_bits: 32 }
-        );
-        assert_eq!(
-            sysv.scalar_return_extension(Type::U32),
+            ret(Type::U32),
             ScalarAbiExtension::Unsigned { from_bits: 32 }
         );
         // The 1-byte `_Bool` 0/1 contract: zero-extend from its byte.
         assert_eq!(
-            sysv.scalar_return_extension(Type::BOOL),
+            ret(Type::BOOL),
             ScalarAbiExtension::Unsigned { from_bits: 8 }
         );
         // Register-width scalars need no extension.
-        assert!(sysv.scalar_return_extension(Type::I64).is_noop());
-        assert!(sysv.scalar_return_extension(Type::U64).is_noop());
+        assert!(ret(Type::I64).is_noop());
+        assert!(ret(Type::U64).is_noop());
     }
 
     #[test]
-    fn both_flavors_agree_on_the_scalar_extension_operation() {
-        // The narrow-integer extension is the same operation on both psABIs; the
-        // flavors differ only in documented "who extends" / sret-echo details.
-        let sysv = TargetCCallAbi::sysv_amd64();
-        let aapcs = TargetCCallAbi::aapcs64();
+    fn every_row_agrees_on_the_scalar_extension_operation() {
+        // The narrow-integer extension is the same operation on every C row and
+        // in both directions; the rows differ only in documented "who extends"
+        // and sret-echo details, which the convention description carries.
         for ty in [
             Type::I8,
             Type::U8,
@@ -750,81 +595,78 @@ mod tests {
             Type::U64,
             Type::BOOL,
         ] {
+            let sysv = scalar_extensions(CallingConvention::X86_64SysV, ty);
             assert_eq!(
-                sysv.scalar_return_extension(ty),
-                aapcs.scalar_return_extension(ty),
-                "flavors must agree on the extension for {ty:?}"
-            );
-            assert_eq!(
-                sysv.scalar_arg_extension(ty),
-                sysv.scalar_return_extension(ty),
+                sysv.0, sysv.1,
                 "arg and return extension are the same operation for {ty:?}"
             );
+            for convention in [
+                CallingConvention::Aarch64Aapcs,
+                CallingConvention::Aarch64AapcsDarwin,
+            ] {
+                assert_eq!(
+                    scalar_extensions(convention, ty),
+                    sysv,
+                    "{convention} must agree with SysV on the extension for {ty:?}"
+                );
+            }
         }
     }
 
     #[test]
-    fn flavor_specific_register_and_sret_echo_facts() {
-        let sysv = TargetCCallAbi::sysv_amd64();
-        let aapcs = TargetCCallAbi::aapcs64();
-        assert_eq!(sysv.int_arg_register_budget(), 6);
-        assert_eq!(aapcs.int_arg_register_budget(), 8);
-        // SysV echoes the sret pointer in rax; AAPCS64's x8 is not echoed.
-        assert!(sysv.sret_pointer_echoed_in_result_register());
-        assert!(!aapcs.sret_pointer_echoed_in_result_register());
+    fn each_row_carries_its_own_register_budget_and_sret_rule() {
+        let sysv = CallingConvention::X86_64SysV.c_spec();
+        let aapcs = CallingConvention::Aarch64Aapcs.c_spec();
+        assert_eq!(sysv.gp_argument_registers, 6);
+        assert_eq!(aapcs.gp_argument_registers, 8);
+        // SysV passes the sret pointer as the hidden first argument in `rdi`
+        // and echoes it in `rax`; AAPCS64 uses the dedicated `x8`, unechoed.
+        assert!(sysv.sret_pointer_in_argument_register());
+        assert!(sysv.sret_pointer_echoed_in_result_register);
+        assert!(!aapcs.sret_pointer_in_argument_register());
+        assert!(!aapcs.sret_pointer_echoed_in_result_register);
         // 16-byte call alignment on both.
-        assert_eq!(sysv.call_stack_alignment(), 16);
-        assert_eq!(aapcs.call_stack_alignment(), 16);
-        assert_eq!(sysv.convention(), CallingConvention::X86_64SysV);
-        assert_eq!(aapcs.convention(), CallingConvention::Aarch64Aapcs);
+        assert_eq!(sysv.call_stack_alignment, 16);
+        assert_eq!(aapcs.call_stack_alignment, 16);
     }
 
     #[test]
-    fn sret_pointer_register_and_echo_diverge_by_psabi() {
-        let sysv = TargetCCallAbi::sysv_amd64();
-        let aapcs = TargetCCallAbi::aapcs64();
-        // SysV: sret pointer in rdi (first arg reg), echoed in rax.
-        assert!(!sysv.sret_pointer_in_dedicated_register());
-        assert!(sysv.sret_pointer_echoed_in_result_register());
-        // AAPCS64: dedicated x8, not echoed.
-        assert!(aapcs.sret_pointer_in_dedicated_register());
-        assert!(!aapcs.sret_pointer_echoed_in_result_register());
-    }
-
-    #[test]
-    fn the_classifier_follows_the_target_c_alias_not_the_architecture() {
+    fn the_row_follows_the_target_c_alias_not_the_architecture() {
         use rue_target::Target;
         assert_eq!(
-            TargetCCallAbi::for_target(Target::X86_64Linux).convention(),
+            CallingConvention::c_for_target(Target::X86_64Linux),
             CallingConvention::X86_64SysV
         );
         assert_eq!(
-            TargetCCallAbi::for_target(Target::Aarch64Linux).convention(),
+            CallingConvention::c_for_target(Target::Aarch64Linux),
             CallingConvention::Aarch64Aapcs
         );
         assert_eq!(
-            TargetCCallAbi::for_target(Target::Aarch64Macos).convention(),
+            CallingConvention::c_for_target(Target::Aarch64Macos),
             CallingConvention::Aarch64AapcsDarwin
         );
     }
 
     #[test]
     fn the_two_aapcs_rows_agree_except_on_stacked_argument_packing() {
-        let aapcs = TargetCCallAbi::aapcs64();
-        let darwin = TargetCCallAbi::aapcs64_darwin();
+        let aapcs = CallingConvention::Aarch64Aapcs;
+        let darwin = CallingConvention::Aarch64AapcsDarwin;
         assert_eq!(
-            aapcs.int_arg_register_budget(),
-            darwin.int_arg_register_budget()
+            aapcs.c_spec().gp_argument_registers,
+            darwin.c_spec().gp_argument_registers
         );
         assert_eq!(
-            aapcs.sret_pointer_in_dedicated_register(),
-            darwin.sret_pointer_in_dedicated_register()
+            aapcs.c_spec().sret_pointer_in_argument_register(),
+            darwin.c_spec().sret_pointer_in_argument_register()
         );
         assert_eq!(
-            aapcs.sret_pointer_echoed_in_result_register(),
-            darwin.sret_pointer_echoed_in_result_register()
+            aapcs.c_spec().sret_pointer_echoed_in_result_register,
+            darwin.c_spec().sret_pointer_echoed_in_result_register
         );
-        assert_eq!(aapcs.call_stack_alignment(), darwin.call_stack_alignment());
+        assert_eq!(
+            aapcs.c_spec().call_stack_alignment,
+            darwin.c_spec().call_stack_alignment
+        );
         // Apple's amendment: a stacked argument occupies its natural size at
         // its natural alignment rather than a whole 8-byte slot.
         assert_eq!(
@@ -836,41 +678,10 @@ mod tests {
             StackedArgumentPacking::NaturalSize
         );
         assert_eq!(
-            TargetCCallAbi::sysv_amd64().stacked_argument_packing(),
+            CallingConvention::X86_64SysV.stacked_argument_packing(),
             StackedArgumentPacking::EightByteSlots,
             "x86-64 is unaffected by the Apple amendment"
         );
-    }
-
-    #[test]
-    fn every_c_row_agrees_on_the_caller_side_narrow_extension() {
-        // Apple requires the caller to extend an argument narrower than 32 bits;
-        // Rue's canonical 64-bit-extension invariant already produces that, and
-        // every C row asks for the same operation, so the import side needs no
-        // Darwin-specific work.
-        for convention in [
-            CallingConvention::X86_64SysV,
-            CallingConvention::Aarch64Aapcs,
-            CallingConvention::Aarch64AapcsDarwin,
-        ] {
-            let abi = TargetCCallAbi::new(convention);
-            assert_eq!(
-                abi.scalar_arg_extension(Type::I8),
-                ScalarAbiExtension::Signed { from_bits: 8 },
-                "{convention} must sign-extend a narrow signed argument"
-            );
-            assert_eq!(
-                abi.scalar_arg_extension(Type::U16),
-                ScalarAbiExtension::Unsigned { from_bits: 16 },
-                "{convention} must zero-extend a narrow unsigned argument"
-            );
-            assert_eq!(
-                abi.scalar_arg_extension(Type::BOOL),
-                ScalarAbiExtension::Unsigned { from_bits: 8 },
-                "{convention} must materialize the 1-byte `_Bool` 0/1 contract"
-            );
-            assert!(abi.scalar_arg_extension(Type::I64).is_noop());
-        }
     }
 
     #[test]

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -44,8 +44,8 @@ mod type_properties;
 mod types;
 
 pub use call_abi::{
-    ArgConvention, CAbiScalarKind, NativeCallAbi, ScalarAbiExtension, TargetCCallAbi,
-    aggregate_leaves, c_abi_type_facts, is_multislot_aggregate, is_slot_identical_layout,
+    ArgConvention, CAbiScalarKind, NativeCallAbi, ScalarAbiExtension, aggregate_leaves,
+    c_abi_type_facts, is_multislot_aggregate, is_slot_identical_layout,
 };
 pub use exact_decimal::canonical_decimal_literal;
 pub use exact_decimal::finite_float_literal_bits;

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -244,9 +244,13 @@ pub struct SourceParamAbi {
     /// Physical value-decomposition width: the frame slots the parameter's
     /// leaves occupy, equal to [`crate::NativeCallAbi::arg_slot_width`].
     pub slot_count: u32,
-    /// The parameter's source type, or `None` when the analyzed body recovered
-    /// none for it (a by-reference pointer, whose pointee the convention never
-    /// consults, and a slot no `Param` instruction or drop entry names).
+    /// The parameter's source type, or `None` when the parameter is one
+    /// register-width slot the convention needs no type for: a by-reference
+    /// pointer, whose pointee the convention never consults; a leaf of a
+    /// cleanup callee's flattened parameter list; or a slot no `Param`
+    /// instruction or drop entry names. A typeless descriptor always has
+    /// `slot_count == 1`, so every parameter is one value the convention places
+    /// as a whole.
     ///
     /// Where the parameter's incoming value travels is not recorded here: code
     /// generation recomputes it from this type through the one placement
@@ -418,7 +422,14 @@ pub enum AnalyzedCallableKind {
 }
 
 impl AnalyzedCallableKind {
-    pub fn uses_direct_slot_abi(self) -> bool {
+    /// Whether this callable's parameter list is the flattened decomposition of
+    /// one owner value rather than a list of source parameters.
+    ///
+    /// A destructor and a drop glue body address their owner's leaves by slot
+    /// index — the synthesized glue reads a field, an element, or a variant
+    /// payload straight out of a parameter slot — so each slot is its own
+    /// register-width parameter on both sides of the call.
+    pub fn has_flattened_leaf_parameters(self) -> bool {
         matches!(self, Self::Destructor | Self::DropGlue)
     }
 }

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -802,16 +802,14 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
     let num_params = builder.cfg.num_params();
     let by_ref: Vec<bool> = builder.cfg.param_modes().to_vec();
 
-    // Destructors and drop glue are invoked exclusively through the cleanup
-    // convention (`CallPlan::from_slot_values`), which passes an aggregate's
-    // already-materialized leaves DIRECTLY and flattened (RUE-998 / RUE-311):
-    // the callee walks those leaves rather than reconstructing a value, so it
-    // must receive one register-width leaf per slot. Withholding the type is
-    // what selects that arm on the callee side; these synthetic symbols are
-    // compiler-reserved (`__rue_drop_*` glue, `<Type>.__drop` destructors), the
-    // same identity code generation already resolves them by. Retires with
-    // RUE-2039.
-    let direct_slot_abi = builder.callable_kind.uses_direct_slot_abi();
+    // A cleanup callee — a destructor or a drop glue body — addresses its
+    // owner's decomposition one slot at a time (RUE-998 / RUE-311), so its
+    // parameter list *is* those leaves: one register-width parameter per slot,
+    // which is exactly what its caller `CallPlan::from_slot_values` hands over.
+    // These synthetic symbols are compiler-reserved (`__rue_drop_*` glue,
+    // `<Type>.__drop` destructors), the same identity code generation already
+    // resolves them by.
+    let flattened_leaf_parameters = builder.callable_kind.has_flattened_leaf_parameters();
 
     // Slot -> source type. A parameter's own extent is what groups the slots,
     // so every by-value parameter needs one: the drop schedule and the body's
@@ -837,12 +835,11 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
         // parameter the body can observe, so an unrecovered one is unread, and
         // the only shape that reaches this arm is the `str` view a `borrow str`
         // parameter is passed by value as — two register-width slots either way,
-        // so the split leaves every later parameter's placement unchanged.
-        let (slot_count, ty) = match (is_by_ref, ty_at.get(&slot)) {
-            (false, Some(&ty)) => {
-                let width = type_pool.abi_slot_count(ty).max(1);
-                (width, (!direct_slot_abi).then_some(ty))
-            }
+        // so the split leaves every later parameter's placement unchanged. A
+        // typeless descriptor therefore always spans exactly one slot, which is
+        // what lets code generation place every parameter as a single value.
+        let (slot_count, ty) = match (is_by_ref || flattened_leaf_parameters, ty_at.get(&slot)) {
+            (false, Some(&ty)) => (type_pool.abi_slot_count(ty).max(1), Some(ty)),
             _ => (1, None),
         };
         descriptors.push(SourceParamAbi {

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -211,7 +211,7 @@ mod sharding;
 ///   echoes for the P2 round-trips. Each returns its argument in the low bits of
 ///   the result register **with the bits above 32 deliberately dirtied**, so the
 ///   round-trip is a genuine conformance probe: only a caller that applies the
-///   target-C narrow-integer extension (the `TargetCCallAbi` classifier) reads
+///   target-C narrow-integer extension the lowered signature carries reads
 ///   the right value back.
 /// - `ffi_bool_norm(int) -> _Bool` — a `_Bool` normalizer returning `x != 0` as a
 ///   1-byte 0/1 value, again with dirty high bits; the `false`/dirty case is the

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -75,6 +75,36 @@ pub(super) const RET_REGS: [Reg; 8] = [
     Reg::X7,
 ];
 
+/// The general-purpose argument-roster index a lowered placement names.
+///
+/// Every value a runtime helper takes is one general-purpose register; that is
+/// the manifest's own property, tested where the manifest is.
+fn gp_argument_index(location: rue_air::ArgLocation) -> usize {
+    let rue_air::ArgLocation::Registers { pieces } = location else {
+        panic!("a runtime-helper argument is register-passed: {location:?}");
+    };
+    assert_eq!(pieces.len(), 1, "a runtime-helper argument is one register");
+    let piece = pieces.as_slice()[0];
+    assert_eq!(
+        piece.class,
+        rue_target::CRegisterClass::Gp,
+        "a runtime-helper argument is general-purpose"
+    );
+    piece.index as usize
+}
+
+/// The general-purpose result-roster index a lowered return names.
+fn gp_result_index(pieces: rue_air::RegisterPieces) -> usize {
+    assert_eq!(pieces.len(), 1, "a runtime-helper result is one register");
+    let piece = pieces.as_slice()[0];
+    assert_eq!(
+        piece.class,
+        rue_target::CRegisterClass::Gp,
+        "a runtime-helper result is general-purpose"
+    );
+    piece.index as usize
+}
+
 /// Floating-point return registers. A float-classed return slot travels in the
 /// same V bank a float argument does — `v0` is already the scalar float return
 /// register — so the two directions name one register file.
@@ -382,22 +412,14 @@ impl<'a> CfgLower<'a> {
         &mut self,
         plan: crate::runtime_call_plan::RuntimeCallPlan,
     ) -> crate::value_plan::MaterializedValue {
-        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallPlan, RuntimeCallResult};
+        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallResult};
 
-        assert!(
-            matches!(
-                RuntimeCallPlan::calling_convention(self.target),
-                rue_target::CallingConvention::Aarch64Aapcs
-                    | rue_target::CallingConvention::Aarch64AapcsDarwin
-            ),
-            "this lowering implements the AAPCS64 rows; the runtime-helper boundary on \
-             {} must resolve to one of them",
-            self.target
-        );
-        assert!(
-            plan.args().len() <= ARG_REGS.len(),
-            "runtime manifest exceeds the AArch64 target-C register budget"
-        );
+        // A helper boundary is a C call, so where its arguments and result
+        // travel is the one classifier's answer against the manifest signature
+        // (ADR-0055, ADR-0084). Nothing here assumes a register budget: the
+        // manifest's own test pins that every helper's signature places wholly
+        // in registers.
+        let signature = plan.lowered_signature(self.target);
 
         let out_shape = plan.out_shape();
         let out_bytes = out_shape
@@ -466,8 +488,13 @@ impl<'a> CfgLower<'a> {
             })
             .collect::<Vec<_>>();
 
-        for (index, (arg, value)) in plan.args().iter().zip(&materialized).enumerate() {
-            let dst = Operand::Physical(ARG_REGS[index]);
+        for ((arg, value), argument) in plan
+            .args()
+            .iter()
+            .zip(&materialized)
+            .zip(signature.arguments())
+        {
+            let dst = Operand::Physical(ARG_REGS[gp_argument_index(argument.location)]);
             match *arg {
                 RuntimeCallArg::Slot { .. }
                 | RuntimeCallArg::Scaled { .. }
@@ -526,11 +553,19 @@ impl<'a> CfgLower<'a> {
                 }
             }
             RuntimeCallResult::Scalar(_) => {
+                let rue_air::LoweredReturn::Registers { pieces, extension } = signature.ret()
+                else {
+                    panic!("a scalar runtime result comes back in result registers");
+                };
                 let primary = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovRR {
                     dst: Operand::Virtual(primary),
-                    src: Operand::Physical(Reg::X0),
+                    src: Operand::Physical(RET_REGS[gp_result_index(pieces)]),
                 });
+                // A C callee leaves the bits above a narrow result unspecified;
+                // Rue's canonical 64-bit form is restored here, by the same
+                // extension every other C return crossing applies.
+                self.emit_c_return_extension(primary, extension);
                 crate::value_plan::MaterializedValue {
                     primary,
                     slots: Vec::new(),
@@ -589,7 +624,7 @@ impl<'a> CfgLower<'a> {
         for (param_slot, class, location) in self.ctx.param_entry_copies() {
             let (vreg, copy) = match (class, location) {
                 (
-                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::abi_slot_class::AbiSlotClass::Gp,
                     crate::call_plan::AbiSlotLocation::GpReg(class_index),
                 ) => {
                     let vreg = self.mir.alloc_vreg();
@@ -602,7 +637,7 @@ impl<'a> CfgLower<'a> {
                     )
                 }
                 (
-                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::abi_slot_class::AbiSlotClass::Fp(width),
                     crate::call_plan::AbiSlotLocation::FpReg(class_index),
                 ) => {
                     let vreg = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
@@ -642,10 +677,6 @@ impl<'a> CfgLower<'a> {
             crate::call_plan::CallTarget::rue(symbol),
             arg_vregs,
             rue_target::ConventionSpec::native(self.target),
-            crate::call_plan::AbiRegisterBanks {
-                gp: ARG_REGS.len(),
-                fp: FP_ARG_REGS.len(),
-            },
             self.target.c_calling_convention(),
         );
         let _ = self.lower_call_plan(plan);
@@ -1067,7 +1098,7 @@ impl<'a> CfgLower<'a> {
             };
             let offset = checked_displacement_bytes(u64::from(*offset))
                 .expect("call stack slot offset must fit displacement");
-            if let crate::call_plan::AbiSlotClass::Fp(width) = class {
+            if let crate::abi_slot_class::AbiSlotClass::Fp(width) = class {
                 self.mir.push(Aarch64Inst::FloatStore {
                     src: Operand::Virtual(*arg),
                     base: Reg::Sp,
@@ -1090,7 +1121,7 @@ impl<'a> CfgLower<'a> {
         {
             match (class, location) {
                 (
-                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::abi_slot_class::AbiSlotClass::Fp(width),
                     crate::call_plan::AbiSlotLocation::FpReg(index),
                 ) => self.mir.push(Aarch64Inst::FloatMov {
                     dst: Operand::Physical(FP_ARG_REGS[*index]),
@@ -1098,7 +1129,7 @@ impl<'a> CfgLower<'a> {
                     width: *width,
                 }),
                 (
-                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::abi_slot_class::AbiSlotClass::Gp,
                     crate::call_plan::AbiSlotLocation::GpReg(index),
                 ) => self.mir.push(Aarch64Inst::MovRR {
                     dst: Operand::Physical(ARG_REGS[*index]),

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -567,7 +567,7 @@ impl<'a> Emitter<'a> {
             (0..self.num_params)
                 .map(|slot| crate::codegen_pipeline::ParamHoming {
                     start_slot: slot,
-                    class: crate::call_plan::AbiSlotClass::Gp,
+                    class: crate::abi_slot_class::AbiSlotClass::Gp,
                     narrow_stack_load: None,
                     location: if slot < 8 {
                         crate::call_plan::AbiSlotLocation::GpReg(slot as usize)
@@ -952,7 +952,7 @@ impl<'a> Emitter<'a> {
 
             match (homing.class, homing.location) {
                 (
-                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::abi_slot_class::AbiSlotClass::Gp,
                     crate::call_plan::AbiSlotLocation::GpReg(abi_index),
                 ) => {
                     self.begin_inst();
@@ -960,7 +960,7 @@ impl<'a> Emitter<'a> {
                     end_inst!(self, "str {}, [x29, #{}]", param_regs[abi_index], offset);
                 }
                 (
-                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::abi_slot_class::AbiSlotClass::Fp(width),
                     crate::call_plan::AbiSlotLocation::FpReg(abi_index),
                 ) => {
                     self.begin_inst();
@@ -3629,7 +3629,7 @@ mod tests {
         let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
             .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                 start_slot: 0,
-                class: crate::call_plan::AbiSlotClass::Gp,
+                class: crate::abi_slot_class::AbiSlotClass::Gp,
                 narrow_stack_load: None,
                 location: crate::call_plan::AbiSlotLocation::stack_slot(0),
             }])
@@ -3653,7 +3653,7 @@ mod tests {
             let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
                 .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                     start_slot: 0,
-                    class: crate::call_plan::AbiSlotClass::Gp,
+                    class: crate::abi_slot_class::AbiSlotClass::Gp,
                     narrow_stack_load: Some(crate::types::NarrowScalar { width, signed }),
                     location: crate::call_plan::AbiSlotLocation::Stack {
                         offset: 0,

--- a/crates/rue-codegen/src/abi_report.rs
+++ b/crates/rue-codegen/src/abi_report.rs
@@ -47,8 +47,9 @@ use rue_air::{
 use rue_cfg::{CfgInstData, CfgValue, ValidatedCfg};
 use rue_target::{Arch, CRegisterClass, CallingConvention, SretRegisterKind, Target};
 
-use crate::call_plan::{AbiSlotClass, ReturnPlan, ReturnSlotReg, return_plan, return_registers};
-use crate::native_abi::{NativeArg, native_by_value_arg};
+use crate::abi_slot_class::AbiSlotClass;
+use crate::call_plan::{ReturnPlan, ReturnSlotReg, return_plan, return_registers};
+use crate::native_abi::native_by_value_arg;
 
 // ============================================================================
 // Register naming
@@ -267,12 +268,6 @@ pub enum NativePlacement {
     None,
     /// One argument, placed by the target's own C rules.
     Argument(CPlacement),
-    /// One already-flattened value of the cleanup convention: each leaf is a
-    /// register-width argument of its own, in ascending order.
-    PerLeaf {
-        /// One placement per leaf.
-        leaves: Vec<CPlacement>,
-    },
     /// The result is written to caller storage whose address travels in the
     /// target row's own indirect-result register.
     Sret {
@@ -475,52 +470,41 @@ fn native_side(
             })
         })
         .collect();
-    let mut parameters_facts = Vec::new();
-    let mut spans = Vec::with_capacity(descriptors.len());
-    for (descriptor, mode) in descriptors.iter().zip(&modes) {
-        let convention = if *mode == AbiParameterMode::ByValue {
-            rue_air::ArgConvention::ByValue
-        } else {
-            rue_air::ArgConvention::ByReference
-        };
-        let native = match (convention, descriptor.ty) {
-            (rue_air::ArgConvention::ByValue, Some(ty)) => native_by_value_arg(type_pool, ty),
-            (rue_air::ArgConvention::ByValue, None) => NativeArg::PerLeaf {
-                count: descriptor.slot_count.max(1),
-            },
-            _ => NativeArg::Scalar {
-                kind: rue_air::CAbiScalarKind::RegisterWidth,
-                class: AbiSlotClass::Gp,
-            },
-        };
-        let start = parameters_facts.len();
-        parameters_facts.extend(native.facts().into_iter().map(|facts| (facts, convention)));
-        spans.push(start..parameters_facts.len());
-    }
+    // One parameter, one placement: the native convention places every value as
+    // a whole, so the lowered signature's arguments line up with the
+    // descriptors one-for-one.
+    let parameters_facts = descriptors
+        .iter()
+        .zip(&modes)
+        .map(|(descriptor, mode)| {
+            let convention = if *mode == AbiParameterMode::ByValue {
+                rue_air::ArgConvention::ByValue
+            } else {
+                rue_air::ArgConvention::ByReference
+            };
+            let native = match (convention, descriptor.ty) {
+                (rue_air::ArgConvention::ByValue, Some(ty)) => native_by_value_arg(type_pool, ty),
+                _ => crate::call_plan::register_width_leaf(),
+            };
+            (native.facts(), convention)
+        })
+        .collect::<Vec<_>>();
     let signature =
         rue_air::lower_native_signature(pairing, &parameters_facts, native_incoming_return(plan));
 
     let parameters = modes
         .iter()
         .zip(&types)
-        .zip(spans)
+        .zip(signature.arguments())
         .enumerate()
-        .map(|(index, ((mode, ty), span))| {
-            let mut leaves = signature.arguments()[span]
-                .iter()
-                .map(|argument| CPlacement::from(argument.location))
-                .collect::<Vec<_>>();
-            AbiParameter {
-                index: index as u32,
-                ty: type_text(type_pool, *ty),
-                mode: *mode,
-                placement: AbiPlacement::Native(if leaves.len() == 1 {
-                    NativePlacement::Argument(leaves.remove(0))
-                } else {
-                    NativePlacement::PerLeaf { leaves }
-                }),
-                extension: ScalarAbiExtension::None,
-            }
+        .map(|(index, ((mode, ty), argument))| AbiParameter {
+            index: index as u32,
+            ty: type_text(type_pool, *ty),
+            mode: *mode,
+            placement: AbiPlacement::Native(NativePlacement::Argument(CPlacement::from(
+                argument.location,
+            ))),
+            extension: ScalarAbiExtension::None,
         })
         .collect();
 
@@ -991,16 +975,6 @@ fn native_placement_text(
         NativePlacement::Argument(placement) => {
             (c_placement_text(registers, *placement), Vec::new())
         }
-        NativePlacement::PerLeaf { leaves } => (
-            format!("{}, one per leaf", counted(leaves.len() as u32, "leaf")),
-            leaves
-                .iter()
-                .enumerate()
-                .map(|(index, placement)| {
-                    format!("leaf {index}: {}", c_placement_text(registers, *placement))
-                })
-                .collect(),
-        ),
         NativePlacement::Sret {
             register,
             echoed,

--- a/crates/rue-codegen/src/abi_slot_class.rs
+++ b/crates/rue-codegen/src/abi_slot_class.rs
@@ -1,0 +1,49 @@
+//! The register bank and move width one ABI-placed value travels in.
+//!
+//! This is a **code-generation detail, not a convention fact**. Where a value
+//! crosses is `rue_air::lower_c_signature` /
+//! `rue_air::lower_native_signature`'s answer, and that answer names a bank as
+//! [`rue_target::CRegisterClass`]. What the backends additionally need is the
+//! *width* of the move that puts the value there: an `f32` leaf and an `f64`
+//! leaf both travel in the floating-point file, but they are moved by different
+//! instructions. This type is that pair — a bank plus, for the floating-point
+//! bank, the leaf's own width — and it exists so both backends, the parameter
+//! homing plan, and the `--emit abi` reporter select a register file the same
+//! way.
+//!
+//! It has exactly one owner (this module) and one construction rule
+//! ([`AbiSlotClass::for_leaf`]); nothing outside `rue-codegen` sees it.
+
+use rue_air::Type;
+use rue_target::CRegisterClass;
+
+use crate::value_plan::FloatWidth;
+
+/// The register file, and the width of the move, one placed value uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbiSlotClass {
+    /// The general-purpose file, moved at register width.
+    Gp,
+    /// The floating-point file, moved at this width.
+    Fp(FloatWidth),
+}
+
+impl AbiSlotClass {
+    /// The class of a value carrying `leaf`, the one rule every direction of a
+    /// crossing uses: a float leaf goes to the FP bank, at its own width;
+    /// everything else to the GP bank.
+    pub fn for_leaf(leaf: Type) -> Self {
+        match crate::value_plan::float_width(leaf) {
+            Some(width) => Self::Fp(width),
+            None => Self::Gp,
+        }
+    }
+
+    /// The bank the classifier named this value's placement in.
+    pub const fn bank(self) -> CRegisterClass {
+        match self {
+            Self::Gp => CRegisterClass::Gp,
+            Self::Fp(_) => CRegisterClass::Fp,
+        }
+    }
+}

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -312,7 +312,6 @@ fn foreign_call_and_mir_state_have_one_shared_authority() {
             "ForeignArg",
             "ForeignReturn",
             "ForeignCallPlan",
-            "TargetCCallAbi",
             "ForeignArgPlacement",
             "used_registers",
             "register_budget",
@@ -329,7 +328,7 @@ fn foreign_call_and_mir_state_have_one_shared_authority() {
             !production.contains("fn lower_foreign_call("),
             "backend must not define a local foreign-call sequencer"
         );
-        for forbidden in ["ForeignArg", "ForeignReturn", "TargetCCallAbi"] {
+        for forbidden in ["ForeignArg", "ForeignReturn"] {
             assert!(
                 !production.contains(forbidden),
                 "backend production source must not own foreign-call classification: {forbidden}"

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -15,6 +15,7 @@ use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, Type};
 use rue_runtime_abi::{ReservedExportClass, ReservedExportId};
 use rue_target::{CRegisterClass, CallingConvention, ConventionSpec, SretRegisterKind};
 
+use crate::abi_slot_class::AbiSlotClass;
 use crate::native_abi::{
     NativeArg, NativeArgMarshal, NativeImage, native_arg, native_by_value_arg,
 };
@@ -24,19 +25,23 @@ use crate::vreg::VReg;
 
 use crate::frame_layout::checked_aligned_cell_region_bytes;
 
-/// The convention a call target's callee follows.
+/// The description a call target's callee is placed by.
 ///
-/// A Rue-compiled function uses the native convention, which places every
-/// argument where the compilation target's own C row places it (ADR-0084). A
-/// compiler-built C memory routine crosses that C row directly; which row it is
-/// comes from the compilation target, so the caller supplies it.
-const fn callee_convention(
+/// This is the only branch left in call planning, and it chooses a *description*
+/// rather than an algorithm: one lowering (`lower_native_signature`) walks
+/// whichever `ConventionSpec` this returns. A Rue-compiled function is placed by
+/// `ConventionSpec::native` — the compilation target's own C description with
+/// the native amendments (ADR-0084) — and a compiler-built C memory routine by
+/// that target's plain C row, which the caller supplies because the row comes
+/// from the whole target rather than from the architecture.
+const fn callee_pairing(
     target: &CallTarget,
+    native: ConventionSpec,
     c_convention: CallingConvention,
-) -> CallingConvention {
+) -> ConventionSpec {
     match target {
-        CallTarget::Rue(_) => CallingConvention::Rue,
-        CallTarget::MemoryBuiltin(_) => c_convention,
+        CallTarget::Rue(_) => native,
+        CallTarget::MemoryBuiltin(_) => ConventionSpec::c(c_convention),
     }
 }
 
@@ -163,32 +168,6 @@ impl From<i32> for AbiRegisterBanks {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AbiSlotClass {
-    Gp,
-    Fp(crate::value_plan::FloatWidth),
-}
-
-impl AbiSlotClass {
-    /// The class of an ABI slot carrying `leaf`, the one rule every direction
-    /// of the native convention uses: a float leaf goes to the FP bank, at its
-    /// own width; everything else to the GP bank.
-    pub fn for_leaf(leaf: Type) -> Self {
-        match crate::value_plan::float_width(leaf) {
-            Some(width) => Self::Fp(width),
-            None => Self::Gp,
-        }
-    }
-
-    /// The register bank this class travels in.
-    pub const fn bank(self) -> CRegisterClass {
-        match self {
-            Self::Gp => CRegisterClass::Gp,
-            Self::Fp(_) => CRegisterClass::Fp,
-        }
-    }
-}
-
 /// Where one native ABI slot travels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AbiSlotLocation {
@@ -276,7 +255,7 @@ pub fn return_registers(
     pairing: ConventionSpec,
 ) -> ReturnRegisters {
     let native = native_by_value_arg(type_pool, ty);
-    let lowered = rue_air::lower_native_return(pairing, native.facts()[0]);
+    let lowered = rue_air::lower_native_return(pairing, native.facts());
     let LoweredReturn::Registers { pieces, .. } = lowered else {
         panic!("only a register return names result registers");
     };
@@ -698,7 +677,7 @@ fn stacked_pieces(location: ArgLocation, scalar: bool, count: usize) -> Vec<AbiS
 fn place_argument<M: CallMaterializer>(
     arg: &CallArgInput,
     native: &NativeArg,
-    placements: &[ArgLocation],
+    location: ArgLocation,
     materializer: &mut M,
     caller_indirect_bytes: &mut u32,
 ) -> (
@@ -707,7 +686,6 @@ fn place_argument<M: CallMaterializer>(
     Vec<AbiSlotClass>,
     Vec<AbiSlotLocation>,
 ) {
-    let location = placements[0];
     if let CallArgInput::ByRef { mode, address } = arg {
         // A reference is an ABI pointer even when the pointee has no storage
         // slots, so this precedes zero-sized omission.
@@ -728,23 +706,6 @@ fn place_argument<M: CallMaterializer>(
     else {
         unreachable!("a by-reference argument was handled above");
     };
-
-    if let NativeArg::PerLeaf { count } = native {
-        // The cleanup convention hands each already-materialized leaf to its
-        // own register-width placement, in ascending order.
-        let values = materializer.materialize_aggregate(*value);
-        assert_eq!(
-            values.len(),
-            *count as usize,
-            "cleanup-convention materialization must produce every leaf"
-        );
-        return (
-            UserArgMode::Value,
-            values,
-            vec![AbiSlotClass::Gp; *count as usize],
-            placements.iter().copied().map(scalar_location).collect(),
-        );
-    }
 
     if let ArgLocation::Indirect { pointer, .. } = location {
         let NativeArg::Aggregate { image } = native else {
@@ -843,6 +804,15 @@ fn place_argument<M: CallMaterializer>(
     (UserArgMode::Value, values, classes, locations)
 }
 
+/// One already-materialized leaf of a cleanup callee's flattened parameter
+/// list: a register-width general-purpose scalar.
+pub(crate) const fn register_width_leaf() -> NativeArg {
+    NativeArg::Scalar {
+        kind: rue_air::CAbiScalarKind::RegisterWidth,
+        class: AbiSlotClass::Gp,
+    }
+}
+
 /// The position of a value that occupies exactly one register or one stacked
 /// placement.
 fn scalar_location(location: ArgLocation) -> AbiSlotLocation {
@@ -918,22 +888,20 @@ impl CallPlan {
             natives.len(),
             "every call argument carries its native description"
         );
-        let callee_convention = callee_convention(&target, materializer.target_c_convention());
-        let pairing = match callee_convention {
-            CallingConvention::Rue => materializer.native_convention(),
-            row => ConventionSpec::c(row),
-        };
-        // Every argument contributes one placement, except the cleanup
-        // convention's already-flattened leaves, which contribute one each; the
-        // spans map an argument back to the run of placements it owns.
-        let mut parameters = Vec::with_capacity(args.len());
-        let mut spans = Vec::with_capacity(args.len());
-        for (arg, native) in args.iter().zip(natives) {
-            let start = parameters.len();
-            let convention = arg.arg_convention();
-            parameters.extend(native.facts().into_iter().map(|facts| (facts, convention)));
-            spans.push(start..parameters.len());
-        }
+        let pairing = callee_pairing(
+            &target,
+            materializer.native_convention(),
+            materializer.target_c_convention(),
+        );
+        let callee_convention = pairing.convention();
+        // One argument, one placement: the convention places every value as a
+        // whole, so the lowered signature's arguments line up with these
+        // one-for-one.
+        let parameters = args
+            .iter()
+            .zip(natives)
+            .map(|(arg, native)| (native.facts(), arg.arg_convention()))
+            .collect::<Vec<_>>();
         let signature = lower_native_signature(pairing, &parameters, lowered_return(return_plan));
 
         let mut hidden_sret = None;
@@ -974,15 +942,11 @@ impl CallPlan {
 
         let mut user_args = Vec::with_capacity(args.len());
         let mut caller_indirect_bytes = 0u32;
-        for ((arg, native), span) in args.iter().zip(natives).zip(spans) {
-            let placements = signature.arguments()[span]
-                .iter()
-                .map(|argument| argument.location)
-                .collect::<Vec<_>>();
+        for ((arg, native), argument) in args.iter().zip(natives).zip(signature.arguments()) {
             let (mode, slots, classes, locations) = place_argument(
                 arg,
                 native,
-                &placements,
+                argument.location,
                 materializer,
                 &mut caller_indirect_bytes,
             );
@@ -1033,26 +997,18 @@ impl CallPlan {
     /// drop glue body — whose slots have already been materialized by the
     /// canonical aggregate leaves.
     ///
-    /// A cleanup callee receives those leaves directly rather than a
-    /// reconstructed value ([`NativeArg::PerLeaf`]), so each leaf is placed as
-    /// one register-width argument by the same lowering every other call goes
-    /// through. The callee's own parameter plan reads the same arm, so the two
-    /// ends cannot disagree.
+    /// A cleanup callee's parameters *are* those leaves: the synthesized body
+    /// addresses an owner's decomposition one slot at a time, so its signature
+    /// is one register-width scalar per leaf. That signature goes through the
+    /// same lowering every other call uses, and the callee's own parameter plan
+    /// reads the same per-slot descriptors, so the two ends cannot disagree.
     pub fn from_slot_values(
         target: CallTarget,
         slots: &[VReg],
         native_convention: ConventionSpec,
-        arg_register_banks: impl Into<AbiRegisterBanks>,
         c_convention: CallingConvention,
     ) -> Self {
-        let _ = arg_register_banks.into();
-        let count = u32::try_from(slots.len()).expect("cleanup leaf count must fit u32");
-        let native = NativeArg::PerLeaf { count };
-        let parameters = native
-            .facts()
-            .into_iter()
-            .map(|facts| (facts, ArgConvention::ByValue))
-            .collect::<Vec<_>>();
+        let parameters = vec![(register_width_leaf().facts(), ArgConvention::ByValue); slots.len()];
         let signature = lower_native_signature(native_convention, &parameters, LoweredReturn::Void);
         let abi_classes = vec![AbiSlotClass::Gp; slots.len()];
         let abi_locations = signature
@@ -1065,7 +1021,8 @@ impl CallPlan {
             .filter(|location| matches!(location, AbiSlotLocation::Stack { .. }))
             .count();
         Self {
-            callee_convention: callee_convention(&target, c_convention),
+            callee_convention: callee_pairing(&target, native_convention, c_convention)
+                .convention(),
             target,
             hidden_sret: None,
             user_args: vec![UserArgPlan {
@@ -1104,7 +1061,7 @@ pub fn return_plan(
 ) -> ReturnPlan {
     let native = native_by_value_arg(type_pool, ty);
     let slot_count = type_pool.abi_slot_count(ty);
-    match rue_air::lower_native_return(pairing, native.facts()[0]) {
+    match rue_air::lower_native_return(pairing, native.facts()) {
         LoweredReturn::Void => ReturnPlan::ZeroSized,
         LoweredReturn::Registers { .. } => {
             if matches!(native, NativeArg::Aggregate { .. }) {
@@ -1297,7 +1254,6 @@ mod tests {
             CallTarget::rue("drop"),
             &slots,
             ConventionSpec::native(rue_target::Target::X86_64Linux),
-            6,
             CallingConvention::X86_64SysV,
         );
 
@@ -1309,8 +1265,8 @@ mod tests {
 
     #[test]
     fn every_row_places_a_cleanup_leaf_in_a_whole_ascending_eightbyte() {
-        // The cleanup convention (destructors and drop glue) passes an
-        // aggregate's already-flattened leaves one register-width value per
+        // A cleanup callee (a destructor, a drop glue body) takes an
+        // aggregate's leaves as one register-width parameter per
         // leaf, each carrying a canonically 64-bit-extended value, so a leaf the
         // roster cannot hold claims one whole eightbyte from its convention's
         // argument area — under Apple's natural-size packing as much as under
@@ -1322,7 +1278,6 @@ mod tests {
                 CallTarget::rue("drop"),
                 &slots,
                 ConventionSpec::native(*target),
-                6,
                 target.c_calling_convention(),
             );
             let registers =
@@ -1624,11 +1579,21 @@ mod tests {
         // A memory builtin crosses the caller's `"C"` boundary, so it takes
         // whichever row the compilation target resolves the alias to.
         assert_eq!(
-            callee_convention(&target, CallingConvention::Aarch64AapcsDarwin),
+            callee_pairing(
+                &target,
+                ConventionSpec::native(rue_target::Target::Aarch64Macos),
+                CallingConvention::Aarch64AapcsDarwin
+            )
+            .convention(),
             CallingConvention::Aarch64AapcsDarwin
         );
         assert_eq!(
-            callee_convention(&CallTarget::rue("f"), CallingConvention::Aarch64AapcsDarwin),
+            callee_pairing(
+                &CallTarget::rue("f"),
+                ConventionSpec::native(rue_target::Target::Aarch64Macos),
+                CallingConvention::Aarch64AapcsDarwin
+            )
+            .convention(),
             CallingConvention::Rue
         );
         assert!(matches!(

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -373,7 +373,7 @@ impl<'a> CfgLowerContext<'a> {
         &self,
     ) -> Vec<(
         u32,
-        crate::call_plan::AbiSlotClass,
+        crate::abi_slot_class::AbiSlotClass,
         crate::call_plan::AbiSlotLocation,
     )> {
         match self.param_storage {

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -30,7 +30,7 @@ use crate::frame_layout::{FrameLayout, FramePointer, SavedRegScheme};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ParamHoming {
     pub(crate) start_slot: u32,
-    pub(crate) class: crate::call_plan::AbiSlotClass,
+    pub(crate) class: crate::abi_slot_class::AbiSlotClass,
     pub(crate) location: crate::call_plan::AbiSlotLocation,
     /// The narrow load a stacked value narrower than an eightbyte needs, so the
     /// frame slot holds Rue's canonical 64-bit form. `None` for a whole

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -57,6 +57,7 @@ macro_rules! roster_names {
 pub(crate) use roster_names;
 
 pub mod abi_report;
+mod abi_slot_class;
 mod allocation;
 mod backend;
 pub mod call_plan;

--- a/crates/rue-codegen/src/native_abi.rs
+++ b/crates/rue-codegen/src/native_abi.rs
@@ -30,7 +30,7 @@ use rue_air::{
 };
 use rue_target::CRegisterClass;
 
-use crate::call_plan::AbiSlotClass;
+use crate::abi_slot_class::AbiSlotClass;
 use crate::frame_layout::checked_aligned_region_bytes;
 use crate::types::{self, DispatchImage, PhysicalEnumSlot};
 use crate::value_plan::FloatWidth;
@@ -139,48 +139,21 @@ pub enum NativeArg {
         /// The compact image.
         image: NativeImage,
     },
-    /// An already-flattened value crossing one register-width leaf at a time —
-    /// the cleanup convention destructors and drop glue are invoked under.
-    ///
-    /// A destructor and a drop glue body receive an aggregate's leaves
-    /// directly, in ascending order, because the caller has already
-    /// materialized them and the callee walks them as leaves rather than
-    /// reconstructing a value. Placement is still the convention's: each leaf
-    /// is one register-width value, so the leaves take consecutive argument
-    /// registers and then the argument area's own packing, exactly as that many
-    /// separate `i64` arguments would. Tracked for retirement with RUE-2039,
-    /// which collapses the remaining convention branches.
-    PerLeaf {
-        /// How many leaves cross.
-        count: u32,
-    },
 }
 
 impl NativeArg {
-    /// The classification facts this argument presents, one entry per value
-    /// the convention places.
+    /// The classification facts this argument presents.
     ///
-    /// Every shape but the cleanup convention's presents exactly one: a value
-    /// is placed as a whole. [`PerLeaf`](Self::PerLeaf) presents one
-    /// register-width entry per leaf, which is what makes its leaves take the
-    /// registers and stack slots that many separate scalars would.
-    pub fn facts(&self) -> Vec<CAbiTypeFacts> {
+    /// Exactly one value reaches the classifier per argument, whatever its
+    /// shape: the convention places a value as a whole.
+    pub fn facts(&self) -> CAbiTypeFacts {
         match self {
-            Self::Omitted => vec![CAbiTypeFacts::ZeroSized],
-            Self::Scalar { kind, .. } => vec![CAbiTypeFacts::Scalar {
+            Self::Omitted => CAbiTypeFacts::ZeroSized,
+            Self::Scalar { kind, .. } => CAbiTypeFacts::Scalar {
                 kind: *kind,
                 class: kind.register_class(),
-            }],
-            Self::Aggregate { image } => vec![image.facts()],
-            Self::PerLeaf { count } => {
-                vec![
-                    CAbiTypeFacts::Scalar {
-                        kind: CAbiScalarKind::RegisterWidth,
-                        class: CRegisterClass::Gp,
-                    };
-                    *count as usize
-                ]
-            }
+            },
+            Self::Aggregate { image } => image.facts(),
         }
     }
 
@@ -189,9 +162,7 @@ impl NativeArg {
     pub fn extension(&self) -> rue_air::ScalarAbiExtension {
         match self {
             Self::Scalar { kind, .. } => kind.extension(),
-            Self::Omitted | Self::Aggregate { .. } | Self::PerLeaf { .. } => {
-                rue_air::ScalarAbiExtension::None
-            }
+            Self::Omitted | Self::Aggregate { .. } => rue_air::ScalarAbiExtension::None,
         }
     }
 
@@ -254,9 +225,6 @@ impl NativeArg {
             },
             Self::Scalar { class, .. } => NativeArgMarshal::Direct {
                 classes: vec![*class],
-            },
-            Self::PerLeaf { count } => NativeArgMarshal::Direct {
-                classes: vec![AbiSlotClass::Gp; *count as usize],
             },
             Self::Aggregate { image } => match image.direct_leaves() {
                 Some(classes) => NativeArgMarshal::Direct { classes },
@@ -437,12 +405,7 @@ pub fn native_call_area_bytes(
     let parameters: Vec<(CAbiTypeFacts, ArgConvention)> = natives
         .iter()
         .zip(arguments)
-        .flat_map(|(native, (_, convention))| {
-            native
-                .facts()
-                .into_iter()
-                .map(move |facts| (facts, *convention))
-        })
+        .map(|(native, (_, convention))| (native.facts(), *convention))
         .collect();
     let ret = if sret_storage_bytes == 0 {
         rue_air::LoweredReturn::Void
@@ -455,13 +418,6 @@ pub fn native_call_area_bytes(
             align: 8,
         }
     };
-    assert_eq!(
-        parameters.len(),
-        natives.len(),
-        "an ordinary call places one value per argument; only the cleanup \
-         convention's already-flattened leaves place more, and it reaches no \
-         aggregate"
-    );
     let signature = rue_air::lower_native_signature(pairing, &parameters, ret);
     let mut indirect = 0u64;
     let mut scratch = 0u64;

--- a/crates/rue-codegen/src/param_storage.rs
+++ b/crates/rue-codegen/src/param_storage.rs
@@ -44,7 +44,8 @@ use rue_air::{
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, PlaceBase};
 use rue_target::ConventionSpec;
 
-use crate::call_plan::{AbiRegisterBanks, AbiSlotClass, AbiSlotLocation};
+use crate::abi_slot_class::AbiSlotClass;
+use crate::call_plan::{AbiRegisterBanks, AbiSlotLocation, register_width_leaf};
 use crate::codegen_pipeline::ParamHoming;
 use crate::native_abi::{NativeArg, NativeArgMarshal, NativeImage, native_by_value_arg};
 
@@ -134,36 +135,31 @@ fn incoming_return(pairing: ConventionSpec, has_sret: bool) -> LoweredReturn {
 /// The native description of one source parameter.
 ///
 /// A by-reference parameter is one pointer whatever it points at. A by-value
-/// parameter with no recovered type is one register-width slot, which is what
-/// the direct-slot cleanup convention (destructors and drop glue) presents for
-/// every one of an aggregate's already-flattened leaves, and what a synthetic
-/// CFG without descriptors presents for each of its slots.
+/// parameter with no recovered type is one register-width slot — a leaf of a
+/// cleanup callee's flattened parameter list (a destructor or drop glue body,
+/// whose caller `CallPlan::from_slot_values` hands over one leaf per
+/// parameter), or a slot of a synthetic CFG without descriptors. The CFG
+/// derivation guarantees such a descriptor spans exactly one slot, which is
+/// what makes every parameter a single value the convention places as a whole.
 fn parameter_native(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
     descriptor: &SourceParamAbi,
 ) -> (NativeArg, ArgConvention) {
     if cfg.is_param_by_ref(descriptor.start_slot) {
-        return (
-            NativeArg::Scalar {
-                kind: rue_air::CAbiScalarKind::RegisterWidth,
-                class: AbiSlotClass::Gp,
-            },
-            ArgConvention::ByReference,
-        );
+        return (register_width_leaf(), ArgConvention::ByReference);
     }
     match descriptor.ty {
         Some(ty) => (native_by_value_arg(type_pool, ty), ArgConvention::ByValue),
-        // A typeless by-value descriptor spans already-flattened leaves: the
-        // cleanup convention's parameters, whose caller
-        // (`CallPlan::from_slot_values`) hands each leaf its own register-width
-        // placement.
-        None => (
-            NativeArg::PerLeaf {
-                count: descriptor.slot_count.max(1),
-            },
-            ArgConvention::ByValue,
-        ),
+        None => {
+            assert_eq!(
+                descriptor.slot_count, 1,
+                "a by-value parameter with no type is one register-width slot; \
+                 anything wider must reach code generation with the type the \
+                 convention classifies it by"
+            );
+            (register_width_leaf(), ArgConvention::ByValue)
+        }
     }
 }
 
@@ -178,45 +174,11 @@ fn parameter_native(
 /// the unmarshal reads through it.
 fn parameter_homing(
     native: &NativeArg,
-    placements: &[ArgLocation],
+    location: ArgLocation,
     param_slot: u32,
     area_slot: u32,
     slot_count: u32,
 ) -> (Vec<ParamHoming>, Option<ParamUnmarshal>) {
-    if let NativeArg::PerLeaf { .. } = native {
-        // Each already-flattened leaf arrives in its own register-width
-        // placement and homes into its own frame slot.
-        return (
-            placements
-                .iter()
-                .enumerate()
-                .map(|(index, placement)| ParamHoming {
-                    start_slot: area_slot + index as u32,
-                    class: AbiSlotClass::Gp,
-                    location: match *placement {
-                        ArgLocation::Registers { pieces } => {
-                            AbiSlotLocation::GpReg(pieces.as_slice()[0].index as usize)
-                        }
-                        ArgLocation::Stack {
-                            offset,
-                            size,
-                            align,
-                        } => AbiSlotLocation::Stack {
-                            offset,
-                            size,
-                            align,
-                        },
-                        ArgLocation::Omitted | ArgLocation::Indirect { .. } => {
-                            panic!("a register-width leaf is never omitted or indirect")
-                        }
-                    },
-                    narrow_stack_load: None,
-                })
-                .collect(),
-            None,
-        );
-    }
-    let location = placements[0];
     let marshal = native.marshal(location);
     let image = match native {
         NativeArg::Aggregate { image } => Some(image.clone()),
@@ -362,11 +324,8 @@ impl ParamStoragePlan {
         native_convention: ConventionSpec,
         register_banks: AbiRegisterBanks,
     ) -> Self {
-        let native = NativeArg::Scalar {
-            kind: rue_air::CAbiScalarKind::RegisterWidth,
-            class: AbiSlotClass::Gp,
-        };
-        let parameters = vec![(native.facts()[0], ArgConvention::ByValue); num_params as usize];
+        let native = register_width_leaf();
+        let parameters = vec![(native.facts(), ArgConvention::ByValue); num_params as usize];
         let signature = lower_native_signature(
             native_convention,
             &parameters,
@@ -376,7 +335,7 @@ impl ParamStoragePlan {
         let mut homing = Vec::new();
         for (slot, argument) in signature.arguments().iter().enumerate() {
             let (entries, _) =
-                parameter_homing(&native, &[argument.location], slot as u32, slot as u32, 1);
+                parameter_homing(&native, argument.location, slot as u32, slot as u32, 1);
             homing.extend(entries);
         }
         Self {
@@ -427,16 +386,13 @@ impl ParamStoragePlan {
             .iter()
             .map(|descriptor| parameter_native(cfg, type_pool, descriptor))
             .collect();
-        // Every parameter contributes one placement, except the cleanup
-        // convention's already-flattened leaves, which contribute one each; the
-        // spans map a parameter back to the run of placements it owns.
-        let mut parameters: Vec<(CAbiTypeFacts, ArgConvention)> = Vec::new();
-        let mut spans = Vec::with_capacity(natives.len());
-        for (native, mode) in &natives {
-            let start = parameters.len();
-            parameters.extend(native.facts().into_iter().map(|facts| (facts, *mode)));
-            spans.push(start..parameters.len());
-        }
+        // One parameter, one placement: the convention places every value as a
+        // whole, so the lowered signature's arguments line up with the
+        // descriptors one-for-one.
+        let parameters: Vec<(CAbiTypeFacts, ArgConvention)> = natives
+            .iter()
+            .map(|(native, mode)| (native.facts(), *mode))
+            .collect();
         let signature = lower_native_signature(
             native_convention,
             &parameters,
@@ -448,14 +404,12 @@ impl ParamStoragePlan {
         let mut homing = Vec::new();
         let mut unmarshals = Vec::new();
         let mut area = 0u32;
-        for ((descriptor, (native, _)), span) in descriptors.iter().zip(&natives).zip(spans) {
+        for ((descriptor, (native, _)), argument) in
+            descriptors.iter().zip(&natives).zip(signature.arguments())
+        {
             let slot = descriptor.start_slot;
-            let placements = signature.arguments()[span]
-                .iter()
-                .map(|argument| argument.location)
-                .collect::<Vec<_>>();
             let (entries, unmarshal) =
-                parameter_homing(native, &placements, slot, area, descriptor.slot_count);
+                parameter_homing(native, argument.location, slot, area, descriptor.slot_count);
             // A register-only parameter must be a single slot arriving in a
             // single register that actually is a register (not stack-passed)
             // and needing no image. A by-reference parameter's slot holds only
@@ -572,10 +526,9 @@ struct ParamReferenceScan {
 /// A reference rooted at a parameter's first ABI slot can span the
 /// parameter's whole type — a multi-slot `Param` read, a place access, or a
 /// by-value `ParamStore` addresses `[index, index + slot_count)` as one
-/// contiguous frame region. Under the direct-slot cleanup convention
-/// (destructors and drop glue) those slots are described by *separate*
-/// single-slot descriptors, so every mark covers the referenced type's full
-/// slot span, not just the base slot.
+/// contiguous frame region. A cleanup callee (a destructor or drop glue body)
+/// describes those same slots as *separate* single-slot parameters, so every
+/// mark covers the referenced type's full slot span, not just the base slot.
 fn scan_param_references(cfg: &Cfg, type_pool: &FrozenTypeInternPool) -> ParamReferenceScan {
     let num_params = cfg.num_params() as usize;
     let num_locals = cfg.num_locals();
@@ -607,9 +560,9 @@ fn scan_param_references(cfg: &Cfg, type_pool: &FrozenTypeInternPool) -> ParamRe
                     mark_span(&mut used, *index, span);
                     // A multi-slot by-value read loads the value out of its
                     // contiguous frame region, so the whole span must be
-                    // homed even when the cleanup convention split it into
-                    // single-slot descriptors. A scalar read consumes the
-                    // register copy and needs no home.
+                    // homed even when the parameter list describes it as
+                    // single-slot leaves. A scalar read consumes the register
+                    // copy and needs no home.
                     if !cfg.is_param_by_ref(*index) && span > 1 {
                         mark_span(&mut needs_home, *index, span);
                     }
@@ -730,6 +683,37 @@ mod tests {
 
     fn pool() -> rue_air::FrozenTypeInternPool {
         TypeInternPool::new().freeze()
+    }
+
+    /// A pool holding one two-slot `{i64, i64}` probe struct.
+    fn pool_with_pair() -> (rue_air::FrozenTypeInternPool, Type) {
+        let interner = lasso::ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let (id, _) = pool.register_struct(
+            interner.get_or_intern("Pair"),
+            rue_air::StructDef {
+                name: "Pair".into(),
+                fields: vec![
+                    rue_air::StructField {
+                        name: "a".into(),
+                        ty: Type::I64,
+                    },
+                    rue_air::StructField {
+                        name: "b".into(),
+                        ty: Type::I64,
+                    },
+                ],
+                is_copy: true,
+                is_linear: false,
+                declared_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: rue_span::FileId::DEFAULT,
+            },
+        );
+        let ty = Type::new_struct(id);
+        (pool.freeze(), ty)
     }
 
     fn scalar_descriptors(count: u32) -> Vec<SourceParamAbi> {
@@ -1010,10 +994,10 @@ mod tests {
         );
     }
 
-    /// The direct-slot cleanup convention (destructors, drop glue) describes
-    /// one source aggregate as SEPARATE single-slot descriptors. A place or
-    /// multi-slot `Param` reference rooted at the first slot addresses the
-    /// whole contiguous region, so the scan must home the full type span —
+    /// A cleanup callee (a destructor, a drop glue body) describes one source
+    /// aggregate as SEPARATE single-slot parameters. A place or multi-slot
+    /// `Param` reference rooted at the first slot addresses the whole
+    /// contiguous region, so the scan must home the full type span —
     /// homing only the base slot leaves the tail slots reading garbage (the
     /// RUE-1170 ArrayBuf destructor regression).
     #[test]
@@ -1047,8 +1031,8 @@ mod tests {
         let pool = type_pool.freeze();
 
         let mut cfg = Cfg::new(Type::UNIT, 0, 2, "split".into(), vec![false, false]);
-        // Two single-slot descriptors for one two-slot source value, the
-        // direct-slot cleanup shape.
+        // Two single-slot descriptors for one two-slot source value: the
+        // shape a cleanup callee's flattened parameter list has.
         cfg.set_source_param_abi(scalar_descriptors(2));
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -1076,12 +1060,13 @@ mod tests {
     fn aggregates_and_raw_slot_references_keep_homes() {
         // Param 0 is a two-slot aggregate; param slot 2 is referenced as a
         // raw frame slot (num_locals + 2).
+        let (pool, pair) = pool_with_pair();
         let mut cfg = Cfg::new(Type::I64, 1, 3, "agg".into(), vec![false, false, false]);
         cfg.set_source_param_abi(vec![
             SourceParamAbi {
                 start_slot: 0,
                 slot_count: 2,
-                ty: None,
+                ty: Some(pair),
             },
             SourceParamAbi {
                 start_slot: 2,
@@ -1100,7 +1085,7 @@ mod tests {
             },
         );
 
-        let plan = ParamStoragePlan::plan(&cfg, &pool(), false, SYSV, 6);
+        let plan = ParamStoragePlan::plan(&cfg, &pool, false, SYSV, 6);
         assert_eq!(plan.slot(0), ParamSlotStorage::Frame { area_slot: 0 });
         assert_eq!(plan.slot(1), ParamSlotStorage::Frame { area_slot: 1 });
         assert_eq!(plan.slot(2), ParamSlotStorage::Frame { area_slot: 2 });

--- a/crates/rue-codegen/src/runtime_call_plan.rs
+++ b/crates/rue-codegen/src/runtime_call_plan.rs
@@ -5,6 +5,7 @@
 //! against that helper's complete manifest signature, and retains logical
 //! argument materialization until a target adapter assigns physical registers.
 
+use rue_air::{ArgConvention, CAbiScalarKind, CAbiTypeFacts, LoweredSignature, lower_c_signature};
 use rue_runtime_abi::{
     AbiParameter, AbiResult, AbiType, AggregateShapeId, ParameterMode, ReturnBehavior,
     RuntimeHelperId, RuntimeTarget,
@@ -133,6 +134,79 @@ impl RuntimeCallArg {
             Self::OutPointer { shape } => AbiParameter::out_pointer(shape),
         }
     }
+}
+
+/// The width-and-signedness class one manifest scalar presents to the C
+/// classifier.
+///
+/// The manifest's own vocabulary is deliberately narrow: an `i32`/`u32` value
+/// is the only sub-register scalar a helper takes or returns, and every pointer
+/// and canonical boolean word fills its register. `Byte` names a pointee, never
+/// a value, so it reaches this table only through a pointer mode.
+const fn scalar_kind(ty: AbiType) -> CAbiScalarKind {
+    match ty {
+        AbiType::I32 => CAbiScalarKind::I32,
+        AbiType::U32 => CAbiScalarKind::U32,
+        AbiType::Byte => CAbiScalarKind::U8,
+        AbiType::I64
+        | AbiType::U64
+        | AbiType::Usize
+        | AbiType::BoolWordI64
+        | AbiType::MutBytePointer => CAbiScalarKind::RegisterWidth,
+    }
+}
+
+/// The classification facts one manifest parameter presents.
+///
+/// A helper boundary is a C call (ADR-0055), so its parameters reach exactly
+/// the facts every other C crossing presents. A pointer parameter — a const or
+/// mutable pointee, or the caller's out-pointer — is one register-width
+/// pointer whatever it points at; a value parameter is its own scalar class.
+fn parameter_facts(parameter: AbiParameter) -> CAbiTypeFacts {
+    let kind = match parameter.mode {
+        ParameterMode::ConstPointer | ParameterMode::MutPointer | ParameterMode::OutPointer(_) => {
+            CAbiScalarKind::RegisterWidth
+        }
+        ParameterMode::Value => scalar_kind(parameter.ty),
+    };
+    CAbiTypeFacts::Scalar {
+        kind,
+        class: kind.register_class(),
+    }
+}
+
+/// The classification facts one manifest result presents.
+fn result_facts(result: AbiResult) -> CAbiTypeFacts {
+    match result {
+        AbiResult::Void => CAbiTypeFacts::ZeroSized,
+        AbiResult::Scalar(ty) => {
+            let kind = scalar_kind(ty);
+            CAbiTypeFacts::Scalar {
+                kind,
+                class: kind.register_class(),
+            }
+        }
+    }
+}
+
+/// Where every argument and the result of `helper` travel on `target`.
+///
+/// This is [`lower_c_signature`] against the helper's own manifest signature —
+/// the same classifier a foreign call, a compiler-built memory routine, and
+/// (through `ConventionSpec::native`) an ordinary Rue call consume. The backend
+/// reads the placements out of it and chooses no register of its own.
+pub fn manifest_signature(helper: RuntimeHelperId, target: Target) -> LoweredSignature {
+    let manifest = helper.helper();
+    let parameters = manifest
+        .parameters
+        .iter()
+        .map(|parameter| (parameter_facts(*parameter), ArgConvention::ByValue))
+        .collect::<Vec<_>>();
+    lower_c_signature(
+        RuntimeCallPlan::calling_convention(target),
+        &parameters,
+        result_facts(manifest.result),
+    )
 }
 
 /// Manifest-derived result materialization.
@@ -353,6 +427,12 @@ impl RuntimeCallPlan {
         self.helper.symbol()
     }
 
+    /// Where this call's arguments and result travel on `target`
+    /// ([`manifest_signature`]).
+    pub fn lowered_signature(&self, target: Target) -> LoweredSignature {
+        manifest_signature(self.helper, target)
+    }
+
     pub fn out_shape(&self) -> Option<AggregateShapeId> {
         match self.result() {
             RuntimeCallResult::OutPointer(shape) => Some(shape),
@@ -419,6 +499,61 @@ mod tests {
             RuntimeCallPlan::calling_convention(Target::X86_64Linux),
             CallingConvention::X86_64SysV
         );
+    }
+
+    /// The manifest's own registers-only property.
+    ///
+    /// Both backends lower a helper call by reading the placements out of
+    /// [`manifest_signature`], so nothing there assumes a register budget. What
+    /// keeps the lowering total is a property of the manifest itself: on every
+    /// supported target every helper's arguments fit its row's argument
+    /// registers, one general-purpose register each, with no outgoing argument
+    /// area, and every result comes back in registers rather than through the
+    /// row's indirect-result pointer. A helper added past the budget fails
+    /// here, where the manifest is, rather than in a backend assertion.
+    #[test]
+    fn every_helper_places_its_whole_signature_in_registers_on_every_target() {
+        use rue_air::{ArgLocation, LoweredReturn};
+        for target in Target::all() {
+            for helper in RuntimeHelperId::ALL {
+                let signature = manifest_signature(helper, *target);
+                assert_eq!(
+                    signature.stack_bytes(),
+                    0,
+                    "{helper} takes outgoing stack arguments on {target:?}"
+                );
+                for (index, argument) in signature.arguments().iter().enumerate() {
+                    let ArgLocation::Registers { pieces } = argument.location else {
+                        panic!(
+                            "{helper} argument {index} is not register-passed on \
+                             {target:?}: {:?}",
+                            argument.location
+                        );
+                    };
+                    assert_eq!(
+                        pieces.len(),
+                        1,
+                        "{helper} argument {index} spans more than one register on {target:?}"
+                    );
+                    assert_eq!(
+                        pieces.as_slice()[0].class,
+                        rue_target::CRegisterClass::Gp,
+                        "{helper} argument {index} is not general-purpose on {target:?}"
+                    );
+                }
+                match signature.ret() {
+                    LoweredReturn::Void => {}
+                    LoweredReturn::Registers { pieces, .. } => assert_eq!(
+                        pieces.len(),
+                        1,
+                        "{helper} returns more than one register on {target:?}"
+                    ),
+                    LoweredReturn::Sret { .. } => {
+                        panic!("{helper} returns indirectly on {target:?}")
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1117,9 +1117,9 @@ fn drop_plan<A: ValueLowerAdapter>(
             });
         }
         TypeKind::Enum(enum_id) => {
-            // Enum drop glue receives the enum's leaves already flattened, one
-            // register-width value each, under the cleanup convention
-            // (`CallPlan::from_slot_values`). A frame-resident aggregate ascends
+            // Enum drop glue's parameter list is the enum's leaves, one
+            // register-width parameter each, which is what
+            // `CallPlan::from_slot_values` hands over. A frame-resident aggregate ascends
             // in address with its logical slots while frame slot numbers descend
             // (ADR-0040), so handing the leaves over in reverse is what lands
             // them in the glue's own parameter area in logical order (RUE-998).

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -92,6 +92,36 @@ fn foreign_argument_register(class: rue_target::CRegisterClass, index: u32) -> R
 /// instead; see `crate::cfg_lower::type_uses_sret_return`.
 pub(super) const RET_REGS: [Reg; 6] = [Reg::Rax, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9, Reg::R10];
 
+/// The general-purpose argument-roster index a lowered placement names.
+///
+/// Every value a runtime helper takes is one general-purpose register; that is
+/// the manifest's own property, tested where the manifest is.
+fn gp_argument_index(location: rue_air::ArgLocation) -> usize {
+    let rue_air::ArgLocation::Registers { pieces } = location else {
+        panic!("a runtime-helper argument is register-passed: {location:?}");
+    };
+    assert_eq!(pieces.len(), 1, "a runtime-helper argument is one register");
+    let piece = pieces.as_slice()[0];
+    assert_eq!(
+        piece.class,
+        rue_target::CRegisterClass::Gp,
+        "a runtime-helper argument is general-purpose"
+    );
+    piece.index as usize
+}
+
+/// The general-purpose result-roster index a lowered return names.
+fn gp_result_index(pieces: rue_air::RegisterPieces) -> usize {
+    assert_eq!(pieces.len(), 1, "a runtime-helper result is one register");
+    let piece = pieces.as_slice()[0];
+    assert_eq!(
+        piece.class,
+        rue_target::CRegisterClass::Gp,
+        "a runtime-helper result is general-purpose"
+    );
+    piece.index as usize
+}
+
 /// Floating-point return registers. A float-classed return slot travels in the
 /// same XMM bank a float argument does — `xmm0` is already the scalar float
 /// return register — so the two directions name one register file.
@@ -388,18 +418,14 @@ impl<'a> CfgLower<'a> {
         &mut self,
         plan: crate::runtime_call_plan::RuntimeCallPlan,
     ) -> crate::value_plan::MaterializedValue {
-        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallPlan, RuntimeCallResult};
+        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallResult};
 
-        assert_eq!(
-            RuntimeCallPlan::calling_convention(X86_64_TARGET),
-            rue_target::CallingConvention::X86_64SysV,
-            "this lowering implements SysV AMD64, the convention the runtime-helper \
-             boundary resolves to on x86-64"
-        );
-        assert!(
-            plan.args().len() <= ARG_REGS.len(),
-            "runtime manifest exceeds the x86-64 target-C register budget"
-        );
+        // A helper boundary is a C call, so where its arguments and result
+        // travel is the one classifier's answer against the manifest signature
+        // (ADR-0055, ADR-0084). Nothing here assumes a register budget: the
+        // manifest's own test pins that every helper's signature places wholly
+        // in registers.
+        let signature = plan.lowered_signature(X86_64_TARGET);
 
         let out_shape = plan.out_shape();
         let out_bytes = out_shape
@@ -467,8 +493,13 @@ impl<'a> CfgLower<'a> {
             })
             .collect::<Vec<_>>();
 
-        for (index, (arg, value)) in plan.args().iter().zip(&materialized).enumerate() {
-            let dst = Operand::Physical(ARG_REGS[index]);
+        for ((arg, value), argument) in plan
+            .args()
+            .iter()
+            .zip(&materialized)
+            .zip(signature.arguments())
+        {
+            let dst = Operand::Physical(ARG_REGS[gp_argument_index(argument.location)]);
             match *arg {
                 RuntimeCallArg::Slot { .. }
                 | RuntimeCallArg::Scaled { .. }
@@ -536,11 +567,19 @@ impl<'a> CfgLower<'a> {
                 }
             }
             RuntimeCallResult::Scalar(_) => {
+                let rue_air::LoweredReturn::Registers { pieces, extension } = signature.ret()
+                else {
+                    panic!("a scalar runtime result comes back in result registers");
+                };
                 let primary = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Virtual(primary),
-                    src: Operand::Physical(Reg::Rax),
+                    src: Operand::Physical(RET_REGS[gp_result_index(pieces)]),
                 });
+                // A C callee leaves the bits above a narrow result unspecified;
+                // Rue's canonical 64-bit form is restored here, by the same
+                // extension every other C return crossing applies.
+                self.emit_c_return_extension(primary, extension);
                 crate::value_plan::MaterializedValue {
                     primary,
                     slots: Vec::new(),
@@ -600,7 +639,7 @@ impl<'a> CfgLower<'a> {
         for (param_slot, class, location) in self.ctx.param_entry_copies() {
             let (vreg, copy) = match (class, location) {
                 (
-                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::abi_slot_class::AbiSlotClass::Gp,
                     crate::call_plan::AbiSlotLocation::GpReg(class_index),
                 ) => {
                     let vreg = self.mir.alloc_vreg();
@@ -613,7 +652,7 @@ impl<'a> CfgLower<'a> {
                     )
                 }
                 (
-                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::abi_slot_class::AbiSlotClass::Fp(width),
                     crate::call_plan::AbiSlotLocation::FpReg(class_index),
                 ) => {
                     let vreg = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
@@ -653,10 +692,6 @@ impl<'a> CfgLower<'a> {
             crate::call_plan::CallTarget::rue(symbol),
             arg_vregs,
             rue_target::ConventionSpec::native(X86_64_TARGET),
-            crate::call_plan::AbiRegisterBanks {
-                gp: ARG_REGS.len(),
-                fp: FP_ARG_REGS.len(),
-            },
             x86_64_target_c_convention(),
         );
         let _ = self.lower_call_plan(plan);
@@ -1271,7 +1306,7 @@ impl<'a> CfgLower<'a> {
             );
             let offset = checked_displacement_bytes(u64::from(*offset))
                 .expect("call stack slot offset must fit displacement");
-            if let crate::call_plan::AbiSlotClass::Fp(width) = class {
+            if let crate::abi_slot_class::AbiSlotClass::Fp(width) = class {
                 self.mir.push(X86Inst::FloatStore {
                     base: Reg::Rsp,
                     offset,
@@ -1302,7 +1337,7 @@ impl<'a> CfgLower<'a> {
             .zip(&plan.abi_locations)
             .filter_map(|((arg, class), location)| match (class, location) {
                 (
-                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::abi_slot_class::AbiSlotClass::Fp(width),
                     crate::call_plan::AbiSlotLocation::FpReg(index),
                 ) => Some((*index, *arg, *width)),
                 _ => None,
@@ -6553,13 +6588,13 @@ mod tests {
                 // eightbyte lands in the parameter's LAST slot.
                 crate::codegen_pipeline::ParamHoming {
                     start_slot: 2,
-                    class: crate::call_plan::AbiSlotClass::Gp,
+                    class: crate::abi_slot_class::AbiSlotClass::Gp,
                     narrow_stack_load: None,
                     location: crate::call_plan::AbiSlotLocation::GpReg(0),
                 },
                 crate::codegen_pipeline::ParamHoming {
                     start_slot: 1,
-                    class: crate::call_plan::AbiSlotClass::Gp,
+                    class: crate::abi_slot_class::AbiSlotClass::Gp,
                     narrow_stack_load: None,
                     location: crate::call_plan::AbiSlotLocation::GpReg(1),
                 },
@@ -6573,7 +6608,7 @@ mod tests {
         assert_eq!(
             plan.slot(3),
             crate::param_storage::ParamSlotStorage::Register {
-                class: crate::call_plan::AbiSlotClass::Gp,
+                class: crate::abi_slot_class::AbiSlotClass::Gp,
                 location: crate::call_plan::AbiSlotLocation::GpReg(2),
             }
         );

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -593,7 +593,7 @@ impl<'a> Emitter<'a> {
             (0..self.num_params)
                 .map(|slot| crate::codegen_pipeline::ParamHoming {
                     start_slot: slot,
-                    class: crate::call_plan::AbiSlotClass::Gp,
+                    class: crate::abi_slot_class::AbiSlotClass::Gp,
                     narrow_stack_load: None,
                     location: if (slot + abi_shift) < 6 {
                         crate::call_plan::AbiSlotLocation::GpReg((slot + abi_shift) as usize)
@@ -705,7 +705,7 @@ impl<'a> Emitter<'a> {
 
             match (homing.class, homing.location) {
                 (
-                    crate::call_plan::AbiSlotClass::Gp,
+                    crate::abi_slot_class::AbiSlotClass::Gp,
                     crate::call_plan::AbiSlotLocation::GpReg(index),
                 ) => {
                     let reg = ARG_REGS[index];
@@ -715,7 +715,7 @@ impl<'a> Emitter<'a> {
                     end_inst!(self, "mov [rbp{}], {}", offset, reg);
                 }
                 (
-                    crate::call_plan::AbiSlotClass::Fp(width),
+                    crate::abi_slot_class::AbiSlotClass::Fp(width),
                     crate::call_plan::AbiSlotLocation::FpReg(index),
                 ) => {
                     self.begin_inst();
@@ -3651,7 +3651,7 @@ mod tests {
         let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
             .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                 start_slot: 0,
-                class: crate::call_plan::AbiSlotClass::Gp,
+                class: crate::abi_slot_class::AbiSlotClass::Gp,
                 narrow_stack_load: None,
                 location: crate::call_plan::AbiSlotLocation::stack_slot(0),
             }])
@@ -3677,7 +3677,7 @@ mod tests {
             let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
                 .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
                     start_slot: 0,
-                    class: crate::call_plan::AbiSlotClass::Gp,
+                    class: crate::abi_slot_class::AbiSlotClass::Gp,
                     narrow_stack_load: Some(crate::types::NarrowScalar { width, signed }),
                     location: crate::call_plan::AbiSlotLocation::Stack {
                         offset: 0,

--- a/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/backend.rs
@@ -820,7 +820,7 @@ fn the_c_by_value_classifier_agrees_across_sites_shapes_and_planes() {
                 super::super::semantic::stable_c_abi_type_facts(canonical, stable_key);
             let live_facts =
                 rue_codegen::native_abi::native_arg(&pool, *live_ty, ArgConvention::ByValue)
-                    .facts()[0];
+                    .facts();
             // A discriminant-only enum is the one projection the two planes
             // spell differently — the live plane calls its single tag a scalar
             // — and no such shape is in this set, so the facts must agree.
@@ -1323,7 +1323,7 @@ fn live_native_placements(
         .iter()
         .map(|(convention, ty)| {
             (
-                rue_codegen::native_abi::native_arg(pool, *ty, *convention).facts()[0],
+                rue_codegen::native_abi::native_arg(pool, *ty, *convention).facts(),
                 *convention,
             )
         })
@@ -1344,7 +1344,7 @@ fn live_native_return(
 ) -> rue_air::LoweredReturn {
     rue_air::lower_native_return(
         rue_target::ConventionSpec::native(target),
-        rue_codegen::native_abi::native_by_value_arg(pool, result).facts()[0],
+        rue_codegen::native_abi::native_by_value_arg(pool, result).facts(),
     )
 }
 
@@ -1691,7 +1691,7 @@ fn call_abi_native_classification_matches_the_live_classifier_on_both_targets() 
 #[test]
 fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets() {
     use lasso::ThreadedRodeo;
-    use rue_air::{StructDef, StructField, TargetCCallAbi, Type, TypeInternPool};
+    use rue_air::{StructDef, StructField, Type, TypeInternPool};
     let source = source_snapshot(
         &[(
             1,
@@ -1760,20 +1760,35 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
     let ptr_mut_u8 = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::U8));
     let pool = pool.freeze();
 
+    // The stable plane's scalar extensions must be the ones the live plane's
+    // own signature lowering carries: one classifier, read from both planes.
     let assert_scalar_args = |facts: &crate::type_queries::CallAbiFacts,
-                              abi: &TargetCCallAbi,
+                              convention: rue_target::CallingConvention,
                               live_params: &[Type],
                               live_result: Type,
                               name: &str| {
         use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
+        let parameters = live_params
+            .iter()
+            .map(|ty| {
+                (
+                    rue_air::c_abi_type_facts(&pool, *ty),
+                    rue_air::ArgConvention::ByValue,
+                )
+            })
+            .collect::<Vec<_>>();
+        let lowered = rue_air::lower_c_signature(
+            convention,
+            &parameters,
+            rue_air::c_abi_type_facts(&pool, live_result),
+        );
         assert_eq!(facts.arguments.len(), live_params.len(), "arity of {name}");
-        for (argument, live_ty) in facts.arguments.iter().zip(live_params) {
+        for (argument, lowered_argument) in facts.arguments.iter().zip(lowered.arguments()) {
             let A::ScalarRegister { extension } = argument.class else {
                 panic!("{name} argument is a target-C scalar: {:?}", argument.class);
             };
             assert_eq!(
-                extension,
-                abi.scalar_arg_extension(*live_ty),
+                extension, lowered_argument.extension,
                 "argument extension parity for {name}"
             );
         }
@@ -1783,9 +1798,15 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
                 facts.return_class
             );
         };
+        let rue_air::LoweredReturn::Registers {
+            extension: lowered_extension,
+            ..
+        } = lowered.ret()
+        else {
+            panic!("{name} returns a scalar in a result register");
+        };
         assert_eq!(
-            extension,
-            abi.scalar_return_extension(live_result),
+            extension, lowered_extension,
             "return extension parity for {name}"
         );
     };
@@ -1865,7 +1886,6 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
     let revision = revision_for(&mut database, &source);
     for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
         let convention = rue_target::CallingConvention::c_for_target(target);
-        let abi = TargetCCallAbi::new(convention);
         let request = |name: &str| {
             request_call_abi(
                 &database,
@@ -1879,21 +1899,21 @@ fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets(
         assert_eq!(signed.convention, convention);
         assert_scalar_args(
             &signed,
-            &abi,
+            convention,
             &[Type::I8, Type::I16, Type::I32, Type::I64],
             Type::I16,
             "c_signed",
         );
         assert_scalar_args(
             &request("c_unsigned"),
-            &abi,
+            convention,
             &[Type::U8, Type::U16, Type::U32, Type::U64, Type::BOOL],
             Type::U16,
             "c_unsigned",
         );
         assert_scalar_args(
             &request("c_pointers"),
-            &abi,
+            convention,
             &[ptr_const_u8, ptr_mut_u8],
             ptr_mut_u8,
             "c_pointers",

--- a/crates/rue-spec/cases/appendices/implementation-limits.toml
+++ b/crates/rue-spec/cases/appendices/implementation-limits.toml
@@ -385,6 +385,27 @@ fn main() -> i32 { @size_of([i8; 268435456]) }
 compile_fail = true
 error_contains = ["[E0906]", "268435455", "ABI slots"]
 
+# C.4:2 says what an "ABI slot" measures: a layout's 8-byte frame cells, not
+# where a value travels when it crosses a call. This case pins the distinction
+# from the side a program can observe — a four-field one-byte struct spends four
+# layout slots and four bytes, and still round-trips through an ordinary call,
+# whose convention places the whole value by the compilation target's own rules
+# (ADR-0084). The ceiling is a frame-addressing bound, so no convention change
+# moves it.
+[[case]]
+name = "the_slot_measure_describes_a_layout_not_a_crossing"
+spec = ["C.4:2", "4.13:12"]
+description = "A four-field u8 struct is four bytes by @size_of, spends one layout slot per field, and still crosses a call by value unchanged"
+source = """
+struct Quad { a: u8, b: u8, c: u8, d: u8 }
+fn total(q: Quad) -> i32 { @intCast(q.a) + @intCast(q.b) + @intCast(q.c) + @intCast(q.d) }
+fn main() -> i32 {
+    let q = Quad { a: 1, b: 2, c: 3, d: 4 };
+    if @size_of(Quad) == 4 { if total(q) == 10 { 0 } else { 1 } } else { 1 }
+}
+"""
+exit_code = 0
+
 # =============================================================================
 # Syntactic Nesting Depth (C.6:3) -- RUE-42
 # =============================================================================

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,9 +29,9 @@ convention its signature follows and where each parameter and the result
 travels: a named register, a byte offset in the outgoing argument area, a
 pointer to a caller-owned copy, or nothing for a zero-sized value. It reads the
 artifacts code generation reads — `rue_air::lower_c_signature` for every C
-boundary, `NativeCallAbi` plus the shared slot plan for the native convention —
-and asks each backend for the name of a roster index, so it cannot describe a
-placement the compiler does not emit. `--target` selects the row, so a Darwin
+boundary, `rue_air::lower_native_signature` and `rue_air::lower_native_return`
+for the native one — and asks each backend for the name of a roster index, so it
+cannot describe a placement the compiler does not emit. `--target` selects the row, so a Darwin
 placement is readable on any host, and a `pub extern "C" fn` export prints both
 its C entry and the native body that entry names or forwards to. See
 `docs/notes/ffi-abi-conformance-audit.md`.
@@ -100,13 +100,23 @@ indirect-result pointer travels and whether it is echoed, stack alignment and
 shadow space, outgoing-argument packing, narrow-integer extension, and which
 aggregate rule applies. `rue_air::lower_c_signature` is the one function that
 reads that data against a type's facts and answers where every argument and the
-result of a `"C"` signature lives. All three C crossing sites consume its
+result of a `"C"` signature lives. Every C crossing site consumes its
 `LoweredSignature`: the `extern "C"` import planner (`foreign_call`), the
-`pub extern "C" fn` export entry (`export_thunk`), and the stable query plane's
-`compiler.call-abi`. The backends contribute only physical leaves — mapping a
-roster index to a register name, and emitting the loads, stores, and calls.
-Calls between Rue functions use the separate native convention, whose classifier
-is `rue_air::NativeCallAbi`.
+`pub extern "C" fn` export entry (`export_thunk`), the runtime-helper boundary
+and the compiler-built memory routines (`runtime_call_plan`, whose type facts
+are the manifest's own `AbiType`s and pointer modes), and the stable query
+plane's `compiler.call-abi`. The backends contribute only physical leaves —
+mapping a roster index to a register name, and emitting the loads, stores, and
+calls.
+
+Calls between Rue functions consume the same walk. The native convention is the
+compilation target's C row plus a wider return bank (ADR-0084), described by
+`ConventionSpec::native` and placed by `rue_air::lower_native_signature` and
+`rue_air::lower_native_return`. There is therefore one classifier in the
+compiler, not a native one beside a C one: a call, a return, an export, and a
+runtime helper all read placements out of one `LoweredSignature`, which is what
+makes a disagreement between two halves of a crossing impossible rather than
+merely fixed.
 
 The supported targets are:
 

--- a/docs/designs/0084-native-calling-convention.md
+++ b/docs/designs/0084-native-calling-convention.md
@@ -317,17 +317,21 @@ object-size ceiling (E0906) is spelled in those slots: C.4:3 limits an object to
 frame-displacement range divided by the 8-byte slot width, and C.4:2 explains the
 count as "one 8-byte slot per scalar, per struct field, and per array element".
 
-**The limit's wording does need to change**, and the change is deferred to phase
-3. The ceiling itself does not move: it is a frame-addressing bound, it is
-independent of how a value crosses a call, and changing which programs it accepts
-would be a language-visible change this ADR does not make. What becomes wrong is
-the *name and the justification*: once no call decomposes a value into one slot
-per leaf, "ABI slot" names a measure with no ABI in it, and a reader who follows
-the term to the calling convention will find nothing that matches. Phase 3, which
-is where the documentation catches up with the architecture, decides whether to
-rename the measure, restate the ceiling's derivation without the word, or leave
-the spelling and correct the prose — and lands that answer in
-`docs/spec/src/appendices/C-implementation-limits.md` with its traceability.
+**The limit's wording does need to change**, and phase 3 answers it: **the
+spelling is kept and the prose is corrected.** The ceiling does not move — it is
+a frame-addressing bound, independent of how a value crosses a call — so what
+was wrong was never the number but the implication a reader drew from the name.
+C.4:2 now says outright that an "ABI slot" measures a layout's 8-byte frame
+cells, that the ceiling is therefore about addressing a value in a frame, and
+that a calling convention places whole values by the target's own rules and
+never decomposes one into these slots. The spelling stays because it is the one
+the E0906 diagnostic, `--explain E0906`, and the compiler's own
+`abi_slot_count` query all use; renaming it in the specification alone would
+create a fresh mismatch between the published limit and the diagnostic C.1:2
+requires to name it, and renaming it everywhere would be a consumer-visible
+diagnostic change that buys no precision the prose does not.
+`the_slot_measure_describes_a_layout_not_a_crossing` (C.4:2) is the traceability
+for the distinction.
 
 ## Implementation Phases
 
@@ -360,7 +364,7 @@ moves in the same change as the convention it models, never in a follow-up.
   (`ObjectBuilder::alias`, `StructuredObject::with_alias`), so an export that
   reduces emits no object of its own; `--emit abi` names each export's entry and,
   for a thunk, the disagreement that keeps it.
-- [ ] **Phase 3: One classifier, and the docs describe it** — RUE-2039. The CFG
+- [x] **Phase 3: One classifier, and the docs describe it** — RUE-2039. The CFG
   parameter contract drops `NativeArgClass` and the slot-oriented description;
   the native/runtime/C branching in call planning and both backends' CFG lowering
   collapses to one classifier; the runtime helper path consumes it as a C call
@@ -369,6 +373,23 @@ moves in the same change as the convention it models, never in a follow-up.
   the present architecture with no old-versus-new narration, and the Appendix
   C.4 wording question above is answered. RUE-2030 closes with the matrices green
   on all three native hosts.
+
+  **Status.** Landed. Every argument and every parameter now presents exactly one
+  value to the classifier: `NativeArg::PerLeaf` and `NativePlacement::PerLeaf`
+  are gone, a CFG parameter descriptor without a type is exactly one
+  register-width slot (asserted where code generation reads it), and
+  `TargetCCallAbi` is deleted in favour of `lower_c_signature`. The runtime
+  helper path lowers the manifest signature through `lower_c_signature`
+  (`runtime_call_plan::manifest_signature`) and the backends read placements out
+  of it; the registers-only guard is now a manifest property test. `AbiSlotClass`
+  is a codegen-internal register-bank-and-width selector with one owner
+  (`rue-codegen`'s `abi_slot_class`). One thing the phase did not do: a cleanup
+  entry point still crosses as one register-width scalar per leaf rather than as
+  its owner's aggregate image, because the synthesized drop-glue body addresses
+  its owner's leaves as individual parameter slots. Giving it a single aggregate
+  parameter means re-authoring the glue AIR and its frame-image indexing, which
+  is a separate slice; what retired here is the *convention* branch, not the
+  flattened glue signature.
 
 ## Consequences
 

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -52,7 +52,11 @@ One function reads that data against a type's facts:
 `rue_air::lower_c_signature` answers where every argument and the result of a
 `"C"` signature lives, and its `LoweredSignature` is consumed by every C
 crossing site — the `extern "C"` import planner, the `pub extern "C" fn` export
-entry, and the stable query plane's `compiler.call-abi`. That single answer is
+entry, the runtime-helper boundary and the compiler-built memory routines, and
+the stable query plane's `compiler.call-abi`. A Rue-to-Rue call reads the same
+walk under `ConventionSpec::native` (`lower_native_signature` /
+`lower_native_return`), so the compiler has **one** classifier rather than a
+native one beside a C one. That single answer is
 ADR-0064's ratified acceptance criterion (the by-value classifier agreeing across
 calls, returns, exports, and callbacks) discharged by construction rather than by
 review; `the_c_by_value_classifier_agrees_across_sites_shapes_and_planes` pins it
@@ -86,7 +90,7 @@ supported representation.
 | Stack arguments | The row's own argument-area packing | The row's own argument-area packing | Not implemented; every current helper fits registers |
 | Scalar result | `rax` | `x0` | `rax` or `x0`/`w0` |
 | Multi-slot result | Up to six slots in `rax`, `rdx`, `rcx`, `r8`, `r9`, `r10` | Up to eight slots in `x0`-`x7` | No direct aggregate results |
-| Aggregate result storage | Hidden first ordinary slot (`rdi`) | Hidden first ordinary slot (`x0`) | Explicit first out-pointer parameter where required |
+| Aggregate result storage | The row's own indirect-result register (`rdi`, echoed in `rax`) | The row's own dedicated `x8` | Explicit first out-pointer parameter where required |
 | Aggregate argument order | Ascending memory order, eightbyte by eightbyte | Ascending memory order, eightbyte by eightbyte | The same order |
 | Call-site stack alignment | 16 bytes | 16 bytes | 16 bytes |
 | Red zone use | None | None | None |
@@ -139,15 +143,24 @@ what packs `{u8, u8, u8, u8}` into one register; the callee lays that image back
 down in its frame and reads the leaves out of it. `NativeImage::direct_leaves`
 is the one predicate that chooses between the two, consulted from both ends.
 
-### The cleanup convention
+### Cleanup entry points
 
-Destructors and drop glue are invoked with an aggregate's leaves already
-flattened: the caller has materialized them and the callee walks them as leaves
-rather than reconstructing a value, so each leaf crosses as its own
-register-width argument. That is `NativeArg::PerLeaf`, an explicit arm of the
-same classifier both ends read (`CallPlan::from_slot_values` at the caller,
-`ParamStoragePlan` at the callee), and it is transitional: RUE-2039 collapses the
-remaining convention branches.
+A destructor and a drop glue body address their owner's decomposition one slot
+at a time: the synthesized glue reads a field, an array element, or a variant
+payload straight out of a parameter slot, and the destructor's `self` spans the
+whole run. Their *signature* is therefore one register-width scalar per leaf,
+and the convention places that signature exactly as it places any other list of
+register-width scalars — the roster in order, then the row's own argument-area
+packing. There is no cleanup arm in the classifier: `CallPlan::from_slot_values`
+at the caller and `ParamStoragePlan` at the callee both present one
+register-width value per leaf to `lower_native_signature`, and the CFG's own
+parameter descriptors say the same thing, one slot each.
+
+Every by-value parameter the CFG describes with a type is placed by that type
+(`SourceParamAbi::ty`); a descriptor with no type is exactly one register-width
+slot — a by-reference pointer, a cleanup leaf, or a slot no instruction names —
+which is asserted where code generation reads it. Nothing reaches placement as a
+run of untyped slots.
 
 ### Returns
 
@@ -320,17 +333,28 @@ ABI:
 - no helper is variadic or requires a stack argument. The largest current
   signature has five physical parameters.
 
-The x86-64 lowerer maps those parameters to the System V integer registers and
-returns scalars in `rax`. The AArch64 lowerer maps them to `x0`-`x7` and returns
-scalars in `x0`/`w0`. Caller-owned aggregate-result storage is rounded to a
-16-byte call-frame allocation. When source `i8`/`u8` values feed debugging
-helpers, the call adapter sign- or zero-extends them to the manifest's 64-bit
-parameter before the C call.
+Where a helper's arguments and result travel is not a backend decision:
+`runtime_call_plan::manifest_signature` projects each manifest parameter and
+result onto the same `CAbiTypeFacts` every other C crossing presents — a pointer
+mode is one register-width pointer, a value parameter is its own scalar class —
+and lowers them with `lower_c_signature` against the target's `"C"` row. Each
+backend reads the roster index out of that placement and names its own register;
+a narrow result is re-extended to Rue's canonical 64-bit form by the extension
+the lowered return carries, the same one an `extern "C"` return applies.
+Caller-owned aggregate-result storage is rounded to a 16-byte call-frame
+allocation. When source `i8`/`u8` values feed debugging helpers, the call
+adapter sign- or zero-extends them to the manifest's 64-bit parameter before the
+C call.
 
-This subset conforms for all signatures currently present. It must not grow by
-assuming that arbitrary C signatures share the native Rue slot rules. Backend
-unit guards fail if a manifest helper exceeds the current register-only budget;
-adding such a helper requires implementing and testing target-C stack placement.
+That the whole subset fits registers is a property **of the manifest**, tested
+where the manifest is:
+`every_helper_places_its_whole_signature_in_registers_on_every_target` lowers
+every `RuntimeHelperId` on every target and requires one general-purpose
+register per argument, no outgoing argument area, and a result in registers
+rather than through the row's indirect-result pointer. A helper added past the
+budget fails that test rather than tripping an assertion inside a code
+generator, and admitting one requires implementing and testing target-C stack
+placement.
 
 ## Reading a placement out of the compiler
 
@@ -353,7 +377,9 @@ consumes and nothing else: a C boundary's placements come from
 `ExportSignature` projections the import lowering and the export entry build,
 and the native side's come from `rue_air::lower_native_signature` and
 `rue_air::lower_native_return` through the same `return_plan` /
-`return_registers` projections the call planner and both return paths build.
+`return_registers` projections the call planner and both return paths build. A
+native parameter prints one placement, because the convention places one value
+per parameter.
 Register *names* are asked of the backend that owns the roster. A
 `pub extern "C" fn` export prints both halves of its crossing, headed by whether
 its C entry is an alias of the native body or a thunk and, when it is a thunk,

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -19,9 +19,11 @@ target rules without duplicating that contract's helper table.
 
 Compiler phases carry `RuntimeHelperId` and typed runtime-call adaptations.
 AIR and CFG do not discover runtime behavior from symbol strings. Shared call
-planning validates the manifest signature before the x86-64 or AArch64 backend
-assigns physical registers and stack locations. A helper symbol is materialized
-only at presentation and MIR relocation boundaries.
+planning validates the manifest signature, and
+`runtime_call_plan::manifest_signature` lowers it through the same classifier
+every other crossing consumes, before the x86-64 or AArch64 backend maps a
+roster index to one of its own registers. A helper symbol is materialized only
+at presentation and MIR relocation boundaries.
 
 The runtime's exported wrappers and compile-time Rust function-type assertions
 are generated from the same manifest rows. The runtime implementation remains
@@ -53,7 +55,8 @@ classified by the same rules through `rue_air::lower_native_return`, read
 against the wider result roster `ConventionSpec::native` describes, and a result
 that does not fit that bank travels through the target row's own
 indirect-result register. The runtime helper boundary below is unaffected — its
-helpers are C calls and already follow the target's C row.
+helpers are C calls, so they follow the target's C row through the same
+classifier the native side now reads.
 
 Both boundaries name their convention with one value type,
 `rue_target::CallingConvention`, whose members are concrete conventions:
@@ -101,6 +104,15 @@ always knows the target — resolves the row through the same alias table. That
 keeps one mapping table for foreign calls, compiler-built memory routines, and
 runtime helpers alike.
 
+Because the row is resolved that way, "every helper is register-only" is a
+property *of the manifest*, not an assumption in a backend. It is tested where
+the manifest is: `every_helper_places_its_whole_signature_in_registers_on_every_target`
+lowers every `RuntimeHelperId` on every target and requires each argument in one
+general-purpose register, no outgoing argument area, and a result in registers
+rather than through the row's indirect-result pointer. A helper added past the
+budget fails that test rather than tripping an assertion inside a code
+generator.
+
 The [FFI ABI conformance audit](notes/ffi-abi-conformance-audit.md) records the
 native convention, compares both boundaries with System V AMD64, AAPCS64, and
 Apple's arm64 amendments, and defines the executable evidence required before
@@ -139,17 +151,24 @@ roster index, a byte offset and footprint in the outgoing argument area, or a
 pointer to a caller-owned copy) plus the narrow-integer extension its value
 carries, and gives the result registers, indirect caller storage, or nothing.
 
-Three sites consume that one answer, which is why an import, an export, and the
-query plane cannot disagree about a placement:
+Every C crossing consumes that one answer, which is why an import, an export, a
+runtime helper, and the query plane cannot disagree about a placement:
 
 - the `extern "C"` import planner, which writes the places and calls;
 - the `pub extern "C" fn` export entry, which reads the same places in the
   callee direction and adapts them to the native convention its body follows —
   itself placed by `lower_native_signature` against the same facts, so the two
   halves usually agree outright and the C symbol is emitted as an alias of the
-  native body rather than as a thunk (ADR-0084); and
+  native body rather than as a thunk (ADR-0084);
+- the runtime-helper boundary, whose type facts are the manifest's own
+  `AbiType`s and pointer modes (`runtime_call_plan::manifest_signature`), and
+  the compiler-built memory routines, which cross the same row; and
 - the stable query plane's `compiler.call-abi`, which projects the same facts
   from canonical layout values and revision-stable type keys.
+
+A Rue-to-Rue call reads the same walk under `ConventionSpec::native`
+(`lower_native_signature` / `lower_native_return`), so there is one classifier
+for every crossing in the compiler rather than a native one and a C one.
 
 The floating-point rosters and the classifier's SSE eightbyte class are reached
 by the *native* convention, which has floats to place; no `"C"` signature reaches

--- a/docs/spec/src/appendices/C-implementation-limits.md
+++ b/docs/spec/src/appendices/C-implementation-limits.md
@@ -59,9 +59,11 @@ An array length is a compile-time value of type `u64`, so the language itself ad
 
 An array whose element count is legal for the type system may still be rejected: the binding constraint is the number of ABI slots the array type's layout occupies (C.4:3), not available memory. A layout spends one 8-byte slot per scalar, per struct field, and per array element, *whatever the element's own width* — so for an array the slot count is exactly the element count times the element type's own slot count, and for an array of scalars it is exactly the element count. A narrow element type therefore buys no extra headroom: `[i8; N]` and `[i64; N]` reach the ceiling at the same `N`.
 
+An "ABI slot" here is a **measure of a layout's storage**, not a description of a call. It counts the 8-byte frame cells a value of the type occupies, which is what makes the ceiling a frame-addressing bound (C.4:3). It says nothing about where a value travels when it crosses a call: a calling convention places whole values by the target's own rules and never decomposes one into these slots. The name is kept because it is the one the diagnostic, `--explain E0906`, and the compiler's own layout query all spell; the measure it names is a layout measure.
+
 {{ rule(id="C.4:3", cat="normative") }}
 
-The current implementation limits any single object (including an array type) to 268,435,455 ABI slots. That ceiling is the code generator's frame-offset addressing range (`i32::MAX`, 2,147,483,647 bytes) divided by the 8-byte slot width, so a layout that fits it is always addressable by a signed 32-bit displacement. A type whose layout needs more slots is rejected with a diagnostic (E0906) wherever a value of the type would be materialized — a variable, a parameter, or a `@size_of`/`@align_of` query — and the diagnostic names the slot ceiling, as C.1:2 requires.
+The current implementation limits any single object (including an array type) to 268,435,455 ABI slots. That ceiling is the code generator's frame-offset addressing range (`i32::MAX`, 2,147,483,647 bytes) divided by the 8-byte slot width, so a layout that fits it is always addressable by a signed 32-bit displacement. The bound is therefore about *addressing a value in a frame*, and it is independent of how a value crosses a call boundary: changing a calling convention neither moves the ceiling nor changes which programs it accepts. A type whose layout needs more slots is rejected with a diagnostic (E0906) wherever a value of the type would be materialized — a variable, a parameter, or a `@size_of`/`@align_of` query — and the diagnostic names the slot ceiling, as C.1:2 requires.
 
 Because the check counts slots rather than bytes, it binds well below 2,147,483,647 bytes for any element narrower than 8 bytes: `[i8; 268435455]` is accepted and reports `@size_of` of 268,435,455 (about 256 MiB), while `[i8; 268435456]` — one element more, and still only about 256 MiB — is rejected. Only an object built entirely from 8-byte scalars reaches the ceiling and the byte range together.
 
@@ -128,7 +130,7 @@ The compiler stores syntax, untyped IR, and typed IR in compact index-based form
 | Variants of one enum | 4,294,967,295 | 1 payload word per variant; the discriminant tag widens to at most `u32` | E1401, via the shared word store |
 | Elements of one array literal | 4,294,967,295 | 1 payload word per element | E1401, via the shared word store |
 | Distinct composite types (structs, enums, arrays, pointers, modules) | 16,777,216 | `Type` is a `u32`: an 8-bit kind tag plus a 24-bit type-pool index | E1401, at the semantic boundary |
-| ABI slots in one object's layout | 268,435,455 slots | signed 32-bit frame displacement divided by the 8-byte slot width; one slot per scalar, struct field, and array element (C.4:2) | E0906 |
+| ABI slots in one object's layout | 268,435,455 slots | signed 32-bit frame displacement divided by the 8-byte slot width; one slot per scalar, struct field, and array element, a layout measure rather than a call description (C.4:2) | E0906 |
 | Cumulative storage of one function | 2,147,483,632 bytes | signed 32-bit frame displacement, 16-byte aligned | E0907 |
 | Syntactic nesting depth | 256 | guarded recursion depth in the parser and RIR lowering | E0482 |
 


### PR DESCRIPTION
Phase 3 of ADR-0084 (RUE-2039), the cleanup phase of the calling-convention epic (RUE-2030), following [#2988](https://github.com/rue-language/rue/pull/2988) and [#2989](https://github.com/rue-language/rue/pull/2989).

## What changes

- **`PerLeaf` retires.** `NativeArg::PerLeaf`, `NativePlacement::PerLeaf` and every arm keyed on them (call planning, parameter homing, `native_abi`, the ABI report) are deleted. `NativeArg::facts()` returns one `CAbiTypeFacts`, which removes the argument-to-placement span bookkeeping from the three sites that carried it: one argument, one placement.
- **CFG parameter contract is type-and-mode.** `uses_direct_slot_abi` becomes `has_flattened_leaf_parameters`: a destructor or drop-glue callable's parameter list is its owner's leaves, so `derive_source_param_abi` emits one register-width descriptor per leaf instead of one wide typeless descriptor. A `SourceParamAbi` without a type spans exactly one slot, `debug_assert`ed where code generation reads it, so a run of untyped slots can no longer reach placement. `start_slot`/`slot_count` stay because parameter homes are addressed by them.
- **One classifier.** Call planning's last branch chooses a `ConventionSpec` (`native(target)` for a Rue callee, `c(row)` for a memory builtin) and one `lower_native_signature` walks it; `CallPlan::callee_convention` reads back off the pairing. Both backends consume only `ArgLocation`/`LoweredReturn`. `AbiSlotClass` moves into a codegen-internal `abi_slot_class` module as a register-bank-plus-width selector with one construction rule. `TargetCCallAbi` is deleted; its tests read extensions and roster facts from `lower_c_signature` and `CallingConvention::c_spec()`.
- **Runtime helpers are C calls of the manifest.** `runtime_call_plan::manifest_signature(helper, target)` projects each manifest parameter and result onto `CAbiTypeFacts` and lowers through `lower_c_signature`. Both backends' `lower_runtime_call` drop their hardcoded convention and register-budget assertions and index the rosters by the lowered locations. The registers-only guard is now a manifest property test over every helper on every target (no stack bytes, every argument one GP register, return void or one register). A narrow scalar helper result is re-extended by the extension the lowered return carries, exactly as an `extern "C"` return is; previously the backends moved the whole result register.
- **Appendix C.4 wording.** The spelling "ABI slot" is kept and the prose corrected: C.4:2 now says an ABI slot measures a layout's 8-byte frame cells, the ceiling is a frame-addressing bound, and a calling convention never decomposes a value into these slots. Renaming would create a mismatch with the E0906 diagnostic that C.1:2 requires to name the ceiling. Traceability is the new spec case `the_slot_measure_describes_a_layout_not_a_crossing` (C.4:2). The ADR records the answer.
- **Docs describe the present.** `docs/runtime-abi.md`, `docs/architecture.md` and `docs/notes/ffi-abi-conformance-audit.md` describe the classifier, where the rows live, the crossings that consume it, the manifest's registers-only property, exports as aliases or thunks, and `--emit abi`, with no old-versus-new narration. ADR-0084's phase-3 checkbox is ticked with a status paragraph.

## Not in this change

A cleanup entry point (destructor, drop glue) still crosses as one register-width scalar per leaf rather than as its owner's aggregate image, because the synthesized drop-glue body addresses its owner's leaves as individual parameter slots (reversed offsets, discriminant last). Giving it a single aggregate parameter means re-authoring the glue AIR and its frame-image indexing, tracked as RUE-2074. What retired here is the convention branch, not the flattened glue signature.

## Validation

`scripts/rue premerge` passes locally apart from the two sandbox-environmental CLI cases (`remove_dir_all_permission_denied_is_not_partial_success`, `tcp_ipv6_loopback_round_trip`); the C-ABI matrix, oracle-diff and planted-miscompile validation targets pass. No planted-miscompile preimage moved.

Closes RUE-2039
Closes RUE-2030

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp