### PR TITLE
RUE-2070: anchor E0711 at the earliest demand across every std wrapper, and stop offering absent remedies

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -60,6 +60,127 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
     }
 
+    /// Which of E0711's three messages fits the callable that states an
+    /// element-type gate on `element` ([`rue_error::ElementGateShape`]).
+    ///
+    /// The gate is one intrinsic written at many entry points, and the way out
+    /// differs by what the entry point does with the element. Nothing in the
+    /// source says which, so this reads the callable's own declared signature —
+    /// receiver, return type, and, for the one message that names methods, the
+    /// receiver's method set:
+    ///
+    /// * A callable that returns nothing cannot be handing an element back, so
+    ///   whatever it duplicates it duplicates internally: `extend_from` copying
+    ///   one container's cells into another, a `RawBuf` range copy, a heap
+    ///   `push` sifting by copy, a sort shifting elements past one another.
+    ///   There is no accessor to redirect the programmer to, so the neutral
+    ///   `Duplicate` wording offers no remedy.
+    /// * A `self` receiver whose declared return type is the element itself
+    ///   (`get_or -> T`) or an option of it (`get -> Option(T)`) hands one
+    ///   stored element back by copy. The `Read` message names `get_ref` and
+    ///   `pop`/`pop_or` as the ways out, so it is used only for a receiver that
+    ///   actually has them: `Stack::peek`, `Queue::peek`/`dequeue` and
+    ///   `BinaryHeap::peek`/`pop` share this signature while spelling the
+    ///   in-place read differently (`peek_ref`) or not offering one at all, and
+    ///   naming a method the container does not have is worse than naming none.
+    ///   Those fall to `Duplicate`, which describes the copy without
+    ///   prescribing a cure.
+    /// * Anything else — an associated function, a free function, or a `-> type`
+    ///   producer — has no stored element to borrow and is building a value out
+    ///   of copies, so only a trivially droppable element type will do.
+    ///
+    /// The receiver probed is the one belonging to the body that states the
+    /// gate, and that is the type whose methods the message names, while the
+    /// diagnostic itself is anchored at the caller. A wrapper that delegates to
+    /// a gated body therefore inherits that body's wording, so a wrapper whose
+    /// own type cannot offer the remedies states its own gate instead of
+    /// inheriting them (`Grid2D::get` and `Stack::peek` both read through
+    /// `ArrayBuf::get`, and both classify on themselves).
+    fn element_gate_shape(
+        &self,
+        element: Type,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<rue_error::ElementGateShape> {
+        use rue_error::ElementGateShape;
+
+        if ctx.return_type == Type::UNIT {
+            return Ok(ElementGateShape::Duplicate);
+        }
+        // `self` is a keyword, so the receiver is the only parameter that can
+        // carry it.
+        let receiver_name = self.intern_body_symbol("self")?;
+        let receiver = ctx
+            .params
+            .first()
+            .filter(|param| param.name == receiver_name);
+        let Some(receiver) = receiver else {
+            return Ok(ElementGateShape::Construction);
+        };
+        if ctx.return_type != element && !self.is_option_of_element(ctx.return_type, element) {
+            return Ok(ElementGateShape::Construction);
+        }
+        Ok(if self.offers_by_copy_read_remedies(receiver.ty)? {
+            ElementGateShape::Read
+        } else {
+            ElementGateShape::Duplicate
+        })
+    }
+
+    /// Whether `receiver` has the two members E0711's by-copy-read message
+    /// tells the programmer to use: `get_ref` for an in-place read, and `pop`
+    /// or `pop_or` to move the element out instead of copying it.
+    ///
+    /// This matches members on the receiver type by name alone; it does not
+    /// check that they have the signatures the message implies. Those names are
+    /// conventional across the standard library's containers, and a user type
+    /// that spells an unrelated `get_ref`/`pop` pair is told to use them — a
+    /// worse message than the neutral one, not an unsound one, and cheaper than
+    /// a signature probe.
+    ///
+    /// The names are interned rather than looked up: the shared symbol space is
+    /// append-only and its handles are equality-only, so interning a name the
+    /// body has not mentioned costs one entry and changes nothing observable,
+    /// while a lookup would answer "absent" for a member of a named struct
+    /// whose spelling this body has had no other reason to intern.
+    fn offers_by_copy_read_remedies(&self, receiver: Type) -> CompileResult<bool> {
+        let Some(struct_id) = receiver.as_struct() else {
+            return Ok(false);
+        };
+        let has_member = |name: &str| -> CompileResult<bool> {
+            Ok(self.has_method((struct_id, self.intern_body_symbol(name)?)))
+        };
+        Ok(has_member("get_ref")? && (has_member("pop")? || has_member("pop_or")?))
+    }
+
+    /// Whether `ty` is an option carrying exactly `element`.
+    ///
+    /// The element-type gate classifies its enclosing callable from that
+    /// callable's declared return type, and a by-copy read states its result as
+    /// `Option(T)` (`ArrayBuf(T)::get`) as readily as `T` (`get_or`). The shape
+    /// is read structurally — a two-variant `Some`/`None` enum whose `Some`
+    /// carries the element alone — rather than through the well-known-`Option`
+    /// registry, which is populated only for the payloads the fallible
+    /// intrinsics demanded and would answer `None` for an ordinary container
+    /// element type.
+    fn is_option_of_element(&self, ty: Type, element: Type) -> bool {
+        let Some(enum_id) = ty.as_enum() else {
+            return false;
+        };
+        let Some(def) = self.body_type_pool().try_enum_def(enum_id) else {
+            return false;
+        };
+        if def.variant_count() != 2 {
+            return false;
+        }
+        let Some(some_index) = def.variants.iter().position(|name| &**name == "Some") else {
+            return false;
+        };
+        if !def.variants.iter().any(|name| &**name == "None") {
+            return false;
+        }
+        def.variant_payload(some_index) == [element]
+    }
+
     /// Analyze a type intrinsic (@size_of, @align_of, @require_droppable,
     /// @require_trivially_droppable). Resolves the type argument through the
     /// current analysis context so a type parameter (`T` in a monomorphized
@@ -94,32 +215,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // `@require_trivially_droppable(T)` is the element-type gate (RUE-651).
         // Unlike `@require_droppable`, this one normally *does* reach runtime
-        // analysis: it lives in `ArrayBuf(T)`'s `get`/`get_or` method bodies and
-        // in `Grid2D(T)`'s `new`, and demand-driven analysis (ADR-0045)
-        // monomorphizes those bodies with the concrete element type only when a
-        // program actually calls one. If that `T` has drop glue, duplicating it
-        // would alias its owned resources (double-free), so reject it (E0711).
-        // It has no runtime value and evaluates to unit.
-        //
-        // Which of E0711's two messages is right depends on what the enclosing
-        // callable does with `T`, and its receiver says which: a body with a
-        // `self` receiver reads an element already stored in that receiver, so
-        // `get_ref`/`pop` are real alternatives; an associated function has no
-        // stored element to borrow and is building a container out of copies,
-        // so only a trivially droppable element type will do. `self` is a
-        // keyword, so the receiver is the only parameter that can carry it.
+        // analysis: it is stated at the entry point of every standard-library
+        // operation that duplicates an element — `ArrayBuf(T)`'s
+        // `get`/`get_or`/`extend_from`/`index_of`/`contains`, the sifting and
+        // scanning entry points of `binary_heap` and `sort`, the
+        // filler-duplicating constructors (`Grid2D`, `Deque`, `IntMap`,
+        // `StrMap`), the by-copy readers on `Stack` and `Queue`, and the
+        // directory-private `rawbuf.copy_rawbuf_range(_within)` shims — and
+        // demand-driven analysis (ADR-0045) monomorphizes those bodies with the
+        // concrete element type only when a program actually calls one. If that
+        // `T` has drop glue, duplicating it would alias its owned resources
+        // (double-free), so reject it (E0711). It has no runtime value and
+        // evaluates to unit.
         if intrinsic_name == "require_trivially_droppable" {
-            let receiver = self.intern_body_symbol("self")?;
-            let shape = if ctx
-                .params
-                .first()
-                .is_some_and(|param| param.name == receiver)
-            {
-                rue_error::ElementGateShape::Read
-            } else {
-                rue_error::ElementGateShape::Construction
-            };
-            self.check_trivially_droppable(ty, span, shape)?;
+            // The shape decides only which message a rejection renders, so it
+            // is classified in the failure arm; a passing gate pays nothing for
+            // it.
+            self.check_trivially_droppable(ty, span, |engine| engine.element_gate_shape(ty, ctx))?;
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::Const(0),
                 ty: Type::UNIT,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1254,13 +1254,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// and the still-live original both run drop glue at scope exit — a
     /// double-free. E0711 rejects the duplication.
     ///
-    /// Two shapes state the gate and both reach here. A by-copy *read*
+    /// Three shapes state the gate and all of them reach here. A by-copy *read*
     /// (`ArrayBuf(T)`'s `get`/`get_or` copy the element out with `@ptr_read`
     /// while the slot stays live) has `get_ref` for an in-place read and
     /// `pop`/`pop_or` to *move* it out. A *construction* (`Grid2D(T)::new` fills
     /// every cell from one `fill`) has neither, so only a trivially droppable
-    /// element type will do. Mirrors Swift's rule that a non-copyable element
-    /// cannot use a by-value `get` subscript.
+    /// element type will do. Every other *duplication* — `ArrayBuf(T)`'s
+    /// `extend_from` and the `RawBuf(T)` range copies underneath it, a
+    /// `BinaryHeap(T)` sift, a `std.sort` pass, and a by-copy read on a
+    /// container with no `get_ref`/`pop` pair to name (`Stack(T)::peek`) —
+    /// has no accessor to redirect the programmer to, so it names the
+    /// requirement and offers no remedy. Mirrors Swift's rule that a
+    /// non-copyable element cannot use a by-value `get` subscript.
     ///
     /// The gate is deliberately placed in method bodies rather than the
     /// constructor, so demand-driven analysis (ADR-0045) fires it only when a
@@ -1273,19 +1278,25 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// A `linear` `T` never reaches here: `@require_droppable` already rejects it
     /// at instantiation, so `ArrayBuf(linear)` cannot be constructed to be read.
     ///
-    /// `shape` is what the gate guards, and it decides which of E0711's two
-    /// messages is rendered: the caller classifies it from the shape of the
-    /// callable stating the gate (a `self` receiver reads a stored element;
-    /// anything else duplicates the element into a container).
+    /// `shape` classifies what the gate guards, and it decides which of E0711's
+    /// three messages is rendered. It is a thunk because classifying costs
+    /// interned lookups over the receiver's method set while the overwhelming
+    /// majority of gate evaluations pass: only a rejection asks for it. The
+    /// caller classifies from the declared shape of the callable stating the
+    /// gate — see `OrdinaryBodyEngine::element_gate_shape` for the rule and
+    /// [`ElementGateShape`] for what each message commits to.
     pub(crate) fn check_trivially_droppable(
         &mut self,
         ty: Type,
         span: Span,
-        shape: ElementGateShape,
+        shape: impl FnOnce(&Self) -> CompileResult<ElementGateShape>,
     ) -> CompileResult<()> {
         if self.declaration_binding_active() {
             match self.known_drop_glue_during_binding(ty) {
-                Some(true) => return Err(self.trivially_droppable_error(ty, span, shape)),
+                Some(true) => {
+                    let shape = shape(self)?;
+                    return Err(self.trivially_droppable_error(ty, span, shape));
+                }
                 Some(false) => return Ok(()),
                 None => {
                     self.defer_ownership_gate(
@@ -1304,9 +1315,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         &self,
         ty: Type,
         span: Span,
-        shape: ElementGateShape,
+        shape: impl FnOnce(&Self) -> CompileResult<ElementGateShape>,
     ) -> CompileResult<()> {
         if self.type_has_drop_glue(ty) {
+            let shape = shape(self)?;
             return Err(self.trivially_droppable_error(ty, span, shape));
         }
         Ok(())
@@ -2523,12 +2535,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeTypeAlgebra for OrdinaryBodyEngine
     ) -> ComptimeHostResult<(), Self::Failure> {
         // A comptime type-constructor body has no receiver: a gate reduced here
         // guards the element type of the container being produced.
-        OrdinaryBodyEngine::check_trivially_droppable(
-            self,
-            ty,
-            site.span(),
-            ElementGateShape::Construction,
-        )
+        OrdinaryBodyEngine::check_trivially_droppable(self, ty, site.span(), |_| {
+            Ok(ElementGateShape::Construction)
+        })
         .map_err(Into::into)
     }
     fn type_name(&self, ty: &Type) -> String {

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -786,8 +786,9 @@ env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
 compile_fail = true
 # The gate is stated inside `std/arraybuf.rue`, but the diagnostic is anchored
-# at the call that demanded that body — line 11 of this program — with the gate
-# line kept as a labelled secondary span (RUE-2026).
+# at the earliest call, in source order, that demanded that body — line 11 of
+# this program — with the gate line kept as a labelled secondary span
+# (RUE-2026).
 error_contains = [
     "E0711",
     "by copy",
@@ -811,3 +812,62 @@ fn main() -> i32 {
     @intCast(n)
 }
 """ }]
+
+# The same gate guards `extend_from`, which copies a run of elements from one
+# container into another. `get_ref`/`pop` are the way out of a by-copy *read*
+# and neither applies here: a bulk copy hands no element back to borrow, and
+# popping one element does not make the copy of the rest sound. The message for
+# that shape therefore names the requirement and suggests nothing, and this case
+# pins the absence of the read advice as well as the presence of the copy
+# wording (RUE-2070).
+[[case]]
+name = "arraybuf_extend_from_on_drop_glue_element_rejected"
+description = "A bulk `extend_from` of drop-glue elements (StrBuf) is rejected with E0711 in the neutral copy wording, without prescribing the `get_ref`/`pop` remedies that do not apply to a bulk copy."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "E0711",
+    "cannot copy an element of type `StrBuf` here",
+    "this operation duplicates elements while the originals stay live",
+    "the element type must be trivially droppable",
+    "main.rue:9:",
+    "the element type is required to be trivially droppable here",
+]
+compile_stderr_not_contains = ["get_ref", "pop_or", "by copy"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let Buf = std.arraybuf.ArrayBuf(StrBuf);
+    let mut a = Buf.new();
+    let mut b = Buf.new();
+    b.push(StrBuf.new());
+    a.extend_from(borrow b);
+    @intCast(a.len())
+}
+""" }]
+
+# The same bulk copy is legal for a trivially droppable element type, and the
+# copied elements read back.
+[[case]]
+name = "arraybuf_extend_from_copy_elements_runs"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let Buf = std.arraybuf.ArrayBuf(i64);
+    let OI = std.option.Option(i64);
+    let mut a = Buf.new();
+    a.push(1);
+    let mut b = Buf.new();
+    b.push(2);
+    b.push(4);
+    a.extend_from(borrow b);
+    match a.get(2) { OI.Some(v) => @intCast(v + @intCast(a.len())), OI.None => 0 }
+}
+""" }]
+exit_code = 7

--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -661,8 +661,14 @@ name = "nontrivial_container_element_code_is_explained"
 files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
 args = ["explain", "E0711"]
 compile_only = true
-compile_stdout_contains = ["E0711: Container element not trivially droppable", "Copy an element that has drop glue:", "Copy a trivially droppable element:", "duplicates one value into every cell of a new container", "docs/spec/src/03-types/09-destructors.md (spec rule 3.9:7)"]
-compile_stdout_not_contains = ["Compiled"]
+# Explanations carry at most two worked examples, so the worked pair is the
+# duplication shape and its trivially-droppable control; the prose is what
+# covers all three messages, and these entries pin a clause of each (RUE-2070).
+compile_stdout_contains = ["E0711: Container element not trivially droppable", "Copy an element in place:", "Copy a trivially droppable element:", "duplicates one value into every cell of a new container", "a by-copy read such as `Stack(T)::peek` on a container with no `get_ref`/`pop` pair", "Read the element in place through `get_ref`, or transfer its ownership with `pop` or `pop_or`", "hold the owning values in an `ArrayBuf` and store an index instead", "docs/spec/src/03-types/09-destructors.md (spec rule 3.9:7)"]
+# "Compiled" would mean the driver ran a build instead of the explainer. The
+# second entry is a wording pin: a borrowed value cannot be stored in a struct
+# field (spec 6.1:140), so the construction remedy must not offer one.
+compile_stdout_not_contains = ["Compiled", "store an index or a borrow instead"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
 [[case]]

--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -414,3 +414,42 @@ compile_stderr_not_contains = [
   '"severity":"error"',
   '"primary":true',
 ]
+
+[[case]]
+name = "element_gate_relocation_keeps_gate_as_secondary_span"
+description = """
+RUE-2026: the element-type gate (E0711) is stated inside `std/arraybuf.rue`,
+but the diagnostic is anchored at the earliest call, in source order, that
+demanded that body, so `spans[0]` is the programmer's own `a.get(0)` and the
+gate line survives as a labelled non-primary span. The consumer-visible shape is
+two spans, not one: this pins that a JSON consumer keeps a primary in the user's
+file and gains exactly one labelled secondary. The library span's `file`,
+`line`, `start` and `end` are deliberately unasserted — the std path is absolute
+and its line numbers move with unrelated library edits — so the secondary is
+matched by its `"primary":false` flag and its label text instead.
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut a = A.new();
+    let _ = a.get(0);
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0711 main.rue:7:13"]
+compile_stderr_contains = [
+  '"code":"E0711"',
+  # spans[0]: the demanding call in the programmer's own file, primary.
+  '''"spans":[{"column":13,"end":170,"file":"main.rue","label":null,"line":7,"primary":true,"start":162},{''',
+  # spans[1]: the gate inside the standard library, secondary and labelled.
+  '"primary":false',
+  '"label":"the element type is required to be trivially droppable here"',
+]
+compile_stderr_not_contains = ["error: [E0711]", " --> "]

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -30,12 +30,24 @@ impl CompilerSession {
     /// order, that names the failing instance. Source positions therefore never
     /// enter query identity (ADR-0063); they are read back out of it.
     ///
-    /// A container that delegates (`Grid2D::get` reading through
+    /// A method that delegates (`ArrayBuf::first` reading through
     /// `ArrayBuf::get`) puts one or more standard-library frames between the
-    /// gate and the programmer, so the walk climbs until it reaches a call
-    /// written outside the trusted standard library. It reports nothing rather
-    /// than a guess when the chain runs out, which leaves the gate's own span
-    /// primary exactly as before.
+    /// gate and the programmer, so the walk climbs until it reaches calls
+    /// written outside the trusted standard library. The climb is
+    /// breadth-first over *every* standard-library caller at each hop, not one
+    /// of them: several wrappers reach one accessor (`ArrayBuf::first` and
+    /// `ArrayBuf::last` both read through `ArrayBuf::get`), and following only
+    /// the caller that sorts first would report whichever demand that one
+    /// wrapper leads to rather than the earliest the programmer wrote.
+    ///
+    /// Every hop up to the cap is walked and every user-side call found along
+    /// the way is a candidate, so the answer does not depend on how many
+    /// library frames a demand happens to sit behind: a direct `a.get(0)` does
+    /// not outrank an earlier `a.first()` merely for being one hop nearer. The
+    /// winner is the earliest candidate in source order — by file path, then by
+    /// offset — which is the same path-then-offset rule the driver already
+    /// sorts a diagnostic batch by. It reports nothing rather than a guess when
+    /// the chain runs out, which leaves the gate's own span primary.
     fn element_gate_demand_site(
         &self,
         revision: rue_query::Revision,
@@ -44,88 +56,106 @@ impl CompilerSession {
         trusted_files: &ahash::AHashSet<rue_span::FileId>,
         cancellation: &rue_query::CancellationToken,
     ) -> Result<Option<rue_span::Span>, SemanticRequestControl> {
-        /// Delegation depth the walk will cross. Standard-library containers
-        /// wrap one another a few layers deep at most; the bound keeps a
-        /// pathological or cyclic graph from turning a diagnostic into a scan.
+        /// Hops out of the gated body the walk takes. The eighth is the last
+        /// one examined, so at most seven standard-library frames stand between
+        /// the gate and a call the walk can report; past that it answers
+        /// nothing and the gate's own span stays primary. Standard-library
+        /// containers wrap one another a few layers deep at most, and the bound
+        /// keeps a pathological or cyclic graph from turning a diagnostic into
+        /// a scan.
         const MAX_DEMAND_HOPS: usize = 8;
 
-        let mut callee = failing.instance.clone();
-        let mut visited = BTreeSet::new();
+        // The frontier is a `BTreeSet` and every answer is chosen by a total
+        // source-identity order, so nothing about the result depends on the
+        // closure's reachability order or on any hash iteration.
+        let mut visited = BTreeSet::from([failing.instance.clone()]);
+        let mut frontier = visited.clone();
+        let mut demands = Vec::new();
         for _ in 0..MAX_DEMAND_HOPS {
-            if !visited.insert(callee.clone()) {
+            if frontier.is_empty() {
                 break;
             }
-            let mut candidates = Vec::new();
-            for caller in closure.bodies.iter() {
-                if caller.key.instance == callee {
-                    continue;
-                }
-                let rue_query::QueryOutcome::Success(bundle) = caller.bundle.outcome() else {
-                    continue;
-                };
-                let crate::body_query::BodyTransaction::Success { body, .. } = &bundle.transaction
-                else {
-                    continue;
-                };
-                // Instruction anchors are relative to the body an export was
-                // taken from. An ordinary or specialized body starts at its
-                // locator's body span; an anonymous member's body is a fragment
-                // inside the producer the locator describes, so its own anchor
-                // is the extra offset.
-                let (semantic, anchor_base) = match body.as_ref() {
-                    crate::body_query::CanonicalBody::Ordinary { body, .. } => (body, 0),
-                    crate::body_query::CanonicalBody::Anonymous {
-                        body, body_anchor, ..
-                    } => (body, body_anchor.start),
-                    crate::body_query::CanonicalBody::Specialization { body, .. } => (body, 0),
-                };
-                let Some(anchor) = earliest_call_anchor(semantic, &callee) else {
-                    continue;
-                };
-                let locator = self
-                    .queries
-                    .revisioned
-                    .body_source_basis_projection(
-                        revision,
-                        caller.key.clone(),
-                        cancellation.clone(),
-                    )
-                    .map_err(SemanticRequestControl::Abort)?;
-                let rue_query::QueryOutcome::Success(locator) = locator.outcome() else {
-                    unreachable!("BodySourceLocator publishes typed values")
-                };
-                let Some(locator) = locator.as_ref() else {
-                    continue;
-                };
-                let start = locator.body_start + anchor_base;
-                candidates.push((
-                    locator.physical_path.clone(),
-                    rue_span::Span::with_file(
+            let mut next_frontier = BTreeSet::new();
+            for callee in frontier.iter() {
+                for caller in closure.bodies.iter() {
+                    if caller.key.instance == *callee {
+                        continue;
+                    }
+                    let rue_query::QueryOutcome::Success(bundle) = caller.bundle.outcome() else {
+                        continue;
+                    };
+                    let crate::body_query::BodyTransaction::Success { body, .. } =
+                        &bundle.transaction
+                    else {
+                        continue;
+                    };
+                    // Instruction anchors are relative to the body an export was
+                    // taken from. An ordinary or specialized body starts at its
+                    // locator's body span; an anonymous member's body is a
+                    // fragment inside the producer the locator describes, so its
+                    // own anchor is the extra offset.
+                    let (semantic, anchor_base) = match body.as_ref() {
+                        crate::body_query::CanonicalBody::Ordinary { body, .. } => (body, 0),
+                        crate::body_query::CanonicalBody::Anonymous {
+                            body, body_anchor, ..
+                        } => (body, body_anchor.start),
+                        crate::body_query::CanonicalBody::Specialization { body, .. } => (body, 0),
+                    };
+                    let Some(anchor) = earliest_call_anchor(semantic, callee) else {
+                        continue;
+                    };
+                    let locator = self
+                        .queries
+                        .revisioned
+                        .body_source_basis_projection(
+                            revision,
+                            caller.key.clone(),
+                            cancellation.clone(),
+                        )
+                        .map_err(SemanticRequestControl::Abort)?;
+                    let rue_query::QueryOutcome::Success(locator) = locator.outcome() else {
+                        unreachable!("BodySourceLocator publishes typed values")
+                    };
+                    let Some(locator) = locator.as_ref() else {
+                        continue;
+                    };
+                    let start = locator.body_start + anchor_base;
+                    let span = rue_span::Span::with_file(
                         locator.file_id,
                         start + anchor.start,
                         start + anchor.end,
-                    ),
-                    caller.key.instance.clone(),
-                ));
+                    );
+                    if trusted_files.contains(&span.file_id) {
+                        // Another library frame between the gate and the
+                        // programmer. Keep it for the next hop; the visited
+                        // guard makes a shared or cyclic wrapper cost one
+                        // expansion rather than one per path into it.
+                        if visited.insert(caller.key.instance.clone()) {
+                            next_frontier.insert(caller.key.instance.clone());
+                        }
+                        continue;
+                    }
+                    demands.push((
+                        locator.physical_path.clone(),
+                        span,
+                        caller.key.instance.clone(),
+                    ));
+                }
             }
-            // Reachability order is a scheduling artifact, so the winner is
-            // chosen by source identity — the same path-then-offset rule the
-            // driver already sorts a diagnostic batch by.
-            candidates.sort_by(|left, right| {
-                (&left.0, left.1.start, &left.2).cmp(&(&right.0, right.1.start, &right.2))
-            });
-            if let Some((_, span, _)) = candidates
-                .iter()
-                .find(|(_, span, _)| !trusted_files.contains(&span.file_id))
-            {
-                return Ok(Some(*span));
-            }
-            let Some((_, _, next)) = candidates.into_iter().next() else {
-                break;
-            };
-            callee = next;
+            frontier = next_frontier;
         }
-        Ok(None)
+        // Every candidate the whole walk found competes, so a demand written
+        // earlier is not beaten by a later one that happens to be fewer hops
+        // away. Reachability order is a scheduling artifact, so the winner is
+        // chosen by source identity — the same path-then-offset rule the driver
+        // already sorts a diagnostic batch by — with the body instance breaking
+        // a tie between two calls at one position.
+        Ok(demands
+            .iter()
+            .min_by(|left, right| {
+                (&left.0, left.1.start, &left.2).cmp(&(&right.0, right.1.start, &right.2))
+            })
+            .map(|(_, span, _)| *span))
     }
 
     fn rooted_body_graph_attempt(

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1845,10 +1845,10 @@ define_error_codes! {
         ],
     };
     CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE = 711 => {
-        explanation: "`@require_trivially_droppable(T)` rejects an element type that owns resources. Duplicating such an element leaves two values cleaning up the same owned buffer, a double-free, so the gate rejects the duplication before it happens. It guards two shapes and the message says which. A by-copy read (`ArrayBuf(T)::get`, `get_or`) duplicates one stored element while the slot stays live; a construction (`Grid2D(T)::new`, or a `-> type` producer that gates its element type) duplicates one value into every cell of a new container.",
-        likely_cause: "For a read: a by-copy accessor such as `get` or `get_or` was called on a container whose element type has a destructor or nested drop glue. Read the element in place through `get_ref`, or transfer its ownership with `pop` or `pop_or`. For a construction: the container stores its cells by copy and has no by-reference form to offer, so the element type itself must be trivially droppable — hold the owning values in an `ArrayBuf` and store an index or a borrow instead. The diagnostic points at the call that demanded the container, with the gate itself labelled in the library that states it.",
+        explanation: "`@require_trivially_droppable(T)` rejects an element type that owns resources. Duplicating such an element leaves two values cleaning up the same owned buffer, a double-free, so the gate rejects the duplication before it happens. It guards three shapes and the message says which. A by-copy read on a container that offers alternatives (`ArrayBuf(T)::get`, `get_or`) duplicates one stored element while the slot stays live; a construction (`Grid2D(T)::new`, or a `-> type` producer that gates its element type) duplicates one value into every cell of a new container; every other duplicating operation — `ArrayBuf(T)::extend_from` copying a run of elements from one container into another, a `BinaryHeap(T)` sift, a `std.sort` pass, or a by-copy read such as `Stack(T)::peek` on a container with no `get_ref`/`pop` pair — copies elements while the originals stay live and has no accessor to redirect you to.",
+        likely_cause: "For a read: a by-copy accessor such as `get` or `get_or` was called on a container whose element type has a destructor or nested drop glue. Read the element in place through `get_ref`, or transfer its ownership with `pop` or `pop_or`. For a construction: the container stores its cells by copy and has no by-reference form to offer, so the element type itself must be trivially droppable — hold the owning values in an `ArrayBuf` and store an index instead. For any other duplicating operation: there is no by-reference or move form of it to fall back to, so either use an element type without drop glue, or move the elements yourself (`pop` from the source, `push` onto the destination), which empties the source instead of copying it; where the container does have an in-place reader under another name, such as `Stack(T)::peek_ref` or `Queue(T)::peek_ref`, that reader is ungated and stays available. The diagnostic points at the earliest call, in source order, that demanded the gated body, with the gate itself labelled in the library that states it.",
         examples: [
-            ErrorCodeExample { title: "Copy an element that has drop glue", source: "struct Resource { value: i32 }\ndrop fn Resource(self) {}\nfn Reader(comptime T: type) -> type {\n    struct {\n        value: T,\n        fn first(borrow self) -> T {\n            @require_trivially_droppable(T);\n            self.value\n        }\n    }\n}\nfn main() -> i32 {\n    let R = Reader(Resource);\n    let reader = R { value: Resource { value: 42 } };\n    let value = reader.first();\n    value.value\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Copy an element in place", source: "struct Resource { value: i32 }\ndrop fn Resource(self) {}\nfn Cells(comptime T: type) -> type {\n    struct {\n        first: T,\n        second: T,\n        fn copy_first_into_second(inout self) {\n            @require_trivially_droppable(T);\n            self.second = self.first;\n        }\n    }\n}\nfn main() -> i32 {\n    let C = Cells(Resource);\n    let mut cells = C { first: Resource { value: 1 }, second: Resource { value: 2 } };\n    cells.copy_first_into_second();\n    0\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
             ErrorCodeExample { title: "Copy a trivially droppable element", source: "fn Reader(comptime T: type) -> type {\n    struct {\n        value: T,\n        fn first(borrow self) -> T {\n            @require_trivially_droppable(T);\n            self.value\n        }\n    }\n}\nfn main() -> i32 {\n    let R = Reader(i32);\n    let reader = R { value: 42 };\n    reader.first()\n}", outcome: ErrorCodeExampleOutcome::Compiles },
         ],
         references: [
@@ -3048,21 +3048,42 @@ pub struct PrivateUnqualifiedAccessData {
 
 /// What an `@require_trivially_droppable(T)` gate is guarding.
 ///
-/// The gate is one intrinsic with one error code, but it is written in two
-/// kinds of callable and the way out differs. Classification is the shape of
-/// the callable that states it: a gate in a body with a `self` receiver guards
-/// a by-copy read of a stored element, and a gate in an associated function or
-/// a `-> type` producer guards a container whose representation duplicates the
-/// element itself.
+/// The gate is one intrinsic with one error code, stated at entry points that
+/// duplicate an element for different reasons, and the way out differs. The
+/// classifier reads the declared shape of the callable that states the gate:
+/// a callable returning nothing duplicates elements without handing one back,
+/// a `self` receiver returning the element (or an option of it) hands one
+/// stored element back by copy, and anything else is building a value out of
+/// copies.
+///
+/// Only one of the three messages names a method to use instead, and naming a
+/// method the container does not have is worse than naming none. So [`Read`]
+/// is reserved for a receiver that really offers `get_ref` and `pop`/`pop_or`,
+/// and a by-copy read on a container that spells them differently — or has no
+/// in-place read at all — falls to the neutral [`Duplicate`] wording.
+///
+/// [`Read`]: ElementGateShape::Read
+/// [`Duplicate`]: ElementGateShape::Duplicate
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ElementGateShape {
-    /// A by-copy read of a stored element, e.g. `ArrayBuf(T)::get`. `get_ref`
-    /// reads it in place and `pop` moves it out.
+    /// A by-copy read of one stored element handed back to the caller by a
+    /// container that offers both remedies this message names:
+    /// `ArrayBuf(T)::get` (`-> Option(T)`) and `get_or` (`-> T`), whose
+    /// receiver has `get_ref` for an in-place read and `pop`/`pop_or` to move
+    /// the element out.
     Read,
-    /// A container whose cells are duplicated from one element, e.g.
-    /// `Grid2D(T)::new`, or a `-> type` producer that gates its element type
-    /// outright. There is no by-reference alternative to offer.
+    /// A value built out of copies of the element, e.g. `Grid2D(T)::new`
+    /// duplicating one `fill` into every cell, or a `-> type` producer that
+    /// gates its element type outright. There is no by-reference alternative to
+    /// offer, so only a trivially droppable element type will do.
     Construction,
+    /// An operation that duplicates elements with no accessor to redirect the
+    /// programmer to: `ArrayBuf(T)::extend_from` and the `RawBuf(T)` range
+    /// copies underneath it, a heap `push` or a sort sifting elements past one
+    /// another, and a by-copy read whose container has no `get_ref`/`pop` pair
+    /// to name (`Stack(T)::peek`, `BinaryHeap(T)::pop`). The message describes
+    /// the copy and states the requirement without prescribing a cure.
+    Duplicate,
 }
 
 /// The rendered message for an element-type gate rejection (E0711).
@@ -3073,6 +3094,9 @@ fn element_gate_message(ty: &str, shape: ElementGateShape) -> String {
         ),
         ElementGateShape::Construction => format!(
             "cannot use an element of type `{ty}` here: elements are duplicated by copy, so the element type must be trivially droppable, and `{ty}` owns resources (has drop glue) — use an element type without drop glue (RUE-651)"
+        ),
+        ElementGateShape::Duplicate => format!(
+            "cannot copy an element of type `{ty}` here: this operation duplicates elements while the originals stay live, and `{ty}` owns resources (has drop glue), so the copy would alias the owned value and double-free it at scope exit — the element type must be trivially droppable (RUE-651)"
         ),
     }
 }
@@ -3414,15 +3438,19 @@ pub enum ErrorKind {
     /// still-live original both pointing at the same owned buffer, so both run
     /// drop glue at scope exit: a double-free (RUE-651).
     ///
-    /// One code, two situations, because the gate guards two shapes and the
-    /// remedies differ ([`ElementGateShape`]). A by-copy *read*
-    /// (`ArrayBuf(T)::get`/`get_or`) has an in-place alternative: `get_ref`
-    /// borrows the element, and `pop`/`pop_or` moves it out, leaving one owner.
-    /// Mirrors Swift's rule that a non-copyable element cannot use a by-value
-    /// `get` subscript. A *construction* (`Grid2D(T)::new`, or a `-> type`
-    /// producer that gates its whole element type) has neither: the container
-    /// duplicates the element into every cell, so nothing short of a
-    /// trivially droppable element type will do.
+    /// One code, three situations, because the gate guards three shapes and the
+    /// remedies differ ([`ElementGateShape`]). A by-copy *read* on a container
+    /// that offers the alternatives (`ArrayBuf(T)::get`/`get_or`) is told about
+    /// them: `get_ref` borrows the element, and `pop`/`pop_or` moves it out,
+    /// leaving one owner. Mirrors Swift's rule that a non-copyable element
+    /// cannot use a by-value `get` subscript. A *construction*
+    /// (`Grid2D(T)::new`, or a `-> type` producer that gates its whole element
+    /// type) has neither: the value duplicates the element into every cell, so
+    /// nothing short of a trivially droppable element type will do. Everything
+    /// else that duplicates an element — `ArrayBuf(T)::extend_from` and the
+    /// `RawBuf(T)` range copies, a sifting heap operation, a sort, and a
+    /// by-copy read whose container has no `get_ref`/`pop` pair to name —
+    /// states the requirement and suggests nothing.
     #[error("{}", element_gate_message(ty, *shape))]
     ContainerElementNotTriviallyDroppable { ty: String, shape: ElementGateShape },
     /// Inout argument is not an lvalue (variable, field, or array element)

--- a/crates/rue-ui-tests/cases/diagnostics/std_element_gates.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/std_element_gates.toml
@@ -32,6 +32,33 @@ The last group here pins the operations deliberately left UNGATED, which must
 keep working for an owning element type: `Stack`/`Queue` push, pop and
 `peek_ref`, and `ArrayBuf.swap`/`reverse`, which exchange slots rather than
 duplicating them.
+
+E0711 has three messages and each case pins the one its site renders, so a
+classification change shows up here as a test failure rather than as worse
+prose. The message is chosen from the declared shape of the gated callable
+(RUE-2070). "cannot copy an element of type `T` here" is the neutral wording for
+an operation that duplicates elements with no accessor to redirect the
+programmer to: everything that returns nothing (`sort.quicksort`,
+`sort.insertion_sort`, `BinaryHeap.push`, `PriorityQueue.push`) and every
+by-copy read whose container has no `get_ref`/`pop` pair for the message to name
+(`Stack.peek`, `Queue.peek`/`dequeue`, `BinaryHeap.peek`/`pop` — their in-place
+read is spelled `peek_ref`, or is absent). "cannot use an element of type `T`
+here" is the construction wording for a callable that builds a value out of
+copies (`Deque`/`IntMap`/`StrMap.new`), and the entry points that scan by copy
+without handing an element back — `ArrayBuf.index_of`/`contains`,
+`sort.is_sorted`/`binary_search` — currently land there too; every clause of
+that message is true of them, but the neutral copy wording would describe them
+better and the signature alone does not separate the two (RUE-2070).
+`ArrayBuf.get`/`get_or` are the only sites that render the third message,
+"cannot read an element of type `T` by copy", which names `get_ref` and
+`pop`/`pop_or`; `trivially_droppable_gate.toml` pins that one. A message is
+chosen from the body that STATES the gate while the diagnostic is anchored at
+the caller, so a wrapper that reached those accessors without a gate of its own
+would inherit their wording, method names included. That is why a wrapper whose
+own type cannot offer both remedies states the gate itself: `Grid2D.get` has a
+`get_ref` and no `pop` at all, and `Stack.peek` spells the in-place read
+`peek_ref`, so both read through `ArrayBuf.get` and both render the neutral
+wording against themselves (RUE-2070).
 """
 
 # --- std.sort: all four public entry points ---
@@ -55,7 +82,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot copy an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -79,7 +106,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot copy an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -103,7 +130,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot use an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -127,7 +154,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot use an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -200,7 +227,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot use an element of type `StrBuf` here",
     "test.rue:8:",
     "the element type is required to be trivially droppable here",
 ]
@@ -225,7 +252,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot use an element of type `StrBuf` here",
     "test.rue:8:",
     "the element type is required to be trivially droppable here",
 ]
@@ -269,7 +296,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot use an element of type `StrBuf` here",
     "test.rue:6:",
     "the element type is required to be trivially droppable here",
 ]
@@ -313,7 +340,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot use an element of type `StrBuf` here",
     "test.rue:6:",
     "the element type is required to be trivially droppable here",
 ]
@@ -354,7 +381,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot use an element of type `StrBuf` here",
     "test.rue:6:",
     "the element type is required to be trivially droppable here",
 ]
@@ -400,7 +427,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot copy an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -424,7 +451,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot copy an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -468,7 +495,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot copy an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -514,7 +541,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot copy an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -538,7 +565,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot copy an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -562,7 +589,7 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot copy an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]
@@ -606,7 +633,36 @@ real_std = true
 expected_error_code = "E0711"
 error_contains = [
     "E0711",
-    "`StrBuf`",
+    "cannot copy an element of type `StrBuf` here",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+]
+
+# `PriorityQueue.pop` returns `Option(Pair(P, V))`, which is neither `P` nor
+# `V` nor an option of either, so it renders the construction wording. Every
+# clause of it is true here — the pair is copied out and the sift-down compares
+# by-copy reads — but the neutral copy wording would fit better, and the
+# signature does not say so (RUE-2070).
+[[case]]
+name = "e0711_priority_queue_pop_owning_payload_rejected"
+description = "`PriorityQueue.pop` gates `P` and `V` separately like `push`; it hands back a pair rather than either half, so it renders the construction wording."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let PQ = std.binary_heap.PriorityQueue(i64, StrBuf);
+    let mut q = PQ.new();
+    let top = q.pop();
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "cannot use an element of type `StrBuf` here",
     "test.rue:7:",
     "the element type is required to be trivially droppable here",
 ]

--- a/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
@@ -4,28 +4,81 @@ name = "Trivially-droppable element-type gate (E0711)"
 description = """
 `@require_trivially_droppable(T)` (E0711, RUE-651) rejects an element type that
 owns resources, because duplicating such an element leaves the copy and the
-original both running drop glue at scope exit — a double-free. One code, two
-messages, chosen by the shape of the callable that states the gate. A body with a
-`self` receiver is reading a stored element by copy (`ArrayBuf(T)::get`/`get_or`
-copy it out with `@ptr_read` while the slot stays live), so the message offers
-`get_ref` for an in-place read and `pop` to move it out, leaving one owner. An
-associated function or a `-> type` producer has no stored element to borrow and is
-duplicating one value into a container's cells (`Grid2D(T)::new`), so the message
-says only a trivially droppable element type will do. Because the gate lives in a
-method body, demand-driven analysis (ADR-0045) fires it only when that method is
-actually called — storing/pushing/popping/dropping a drop-glue element stays legal
-(RUE-646). The rejected body belongs to the library, not the caller, so the
-diagnostic is anchored at the call that demanded it and keeps the gate line as a
-labelled secondary span (RUE-2026). Mirrors Swift's rule that a non-copyable
-element cannot use a by-value `get` subscript. Most cases here use a self-contained
-minimal container so the gate is tested independent of the std `ArrayBuf` source;
-the `real_std` cases at the end pin the same gate where `std/grid.rue` states it
-for a whole element type.
+original both running drop glue at scope exit — a double-free. One code, three
+messages, chosen by the declared shape of the callable that states the gate. A
+`self` receiver whose return type is the element (`get_or -> T`) or an option of
+it (`get -> Option(T)`) hands one stored element back by copy; that message names
+`get_ref` and `pop`/`pop_or` as the ways out, so it is used only when the
+receiver really has them. An associated function, a free function or a `-> type`
+producer has no stored element to borrow and is building a value out of copies
+(`Grid2D(T)::new`), so the message says only a trivially droppable element type
+will do. Everything else that duplicates an element — a callable that returns
+nothing (`ArrayBuf(T)::extend_from`, a heap sift, a sort), and a by-copy read on
+a container with no `get_ref`/`pop` pair to name — gets neutral wording that
+describes the copy and prescribes nothing, because naming a method the container
+does not have is worse than naming none. Because the gate lives in a method
+body, demand-driven analysis (ADR-0045) fires it only when that method is
+actually called — storing/pushing/popping/dropping a drop-glue element stays
+legal (RUE-646). The rejected body belongs to the library, not the caller, so the
+diagnostic is anchored at the earliest call, in source order, that demanded that
+body and keeps the gate line as a labelled secondary span (RUE-2026); one library
+accessor can be demanded through several wrappers, and the climb out of the
+library is breadth-first across all of them and runs to the hop cap rather than
+stopping at the first hop that reaches user code, so the earliest demand wins
+whether it is reached through the wrapper that sorts first or through a longer
+chain than a later demand (RUE-2070). Mirrors Swift's rule
+that a non-copyable element cannot use a by-value `get` subscript. Most cases
+here use a self-contained minimal container so the gate is tested independent of
+the std `ArrayBuf` source; the `real_std` cases at the end pin the same gate
+where `std/grid.rue` and `std/arraybuf.rue` state it.
 """
 
+# A by-copy read on a container that has both remedies the read message names.
+# `Slot` really does offer `get_ref` (a `-> borrow` accessor) and a `pop` that
+# moves the resource out, so E0711 names them.
 [[case]]
 name = "e0711_drop_glue_element_read_rejected"
-description = "Calling a by-copy read whose element type has drop glue is rejected with E0711 at the call, pointed at `get_ref` or `pop`, with the gate line labelled."
+description = "Calling a by-copy read whose element type has drop glue is rejected with E0711 at the call, pointed at the `get_ref` and `pop` the receiver actually has, with the gate line labelled."
+source = """
+struct D { v: i32 }
+drop fn D(self) {}
+struct Slot {
+    item: D,
+    fn get_ref(borrow self) -> borrow D {
+        yield self.item;
+    }
+    fn pop(self) -> D {
+        self.item
+    }
+    fn get(borrow self) -> D {
+        @require_trivially_droppable(D);
+        self.item
+    }
+}
+fn main() -> i32 {
+    let slot = Slot { item: D { v: 5 } };
+    let copy = slot.get();
+    copy.v
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0711",
+    "cannot read an element of type `D` by copy",
+    "use `get_ref` for an in-place read, or move it out with `pop`/`pop_or`",
+    # The primary span is `slot.get()`, not the gate inside `Slot::get`.
+    "test.rue:18:",
+    "the element type is required to be trivially droppable here",
+]
+
+# The same by-copy read on a container that offers neither remedy. `Reader` has
+# no `get_ref` and no `pop`, so the read message's advice would name methods
+# that do not exist; the neutral wording describes the copy and prescribes
+# nothing instead. This is what `Stack(T)::peek` and `BinaryHeap(T)::peek` get
+# from the real std, where the in-place read is spelled `peek_ref` or missing.
+[[case]]
+name = "e0711_read_without_remedies_uses_neutral_wording"
+description = "A by-copy read whose receiver has no `get_ref`/`pop` pair renders the neutral copy wording rather than prescribing accessors the container does not have."
 source = """
 struct D { v: i32 }
 drop fn D(self) {}
@@ -48,8 +101,9 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = [
     "E0711",
-    "cannot read an element of type `D` by copy",
-    "use `get_ref` for an in-place read, or move it out with `pop`/`pop_or`",
+    "cannot copy an element of type `D` here",
+    "this operation duplicates elements while the originals stay live",
+    "the element type must be trivially droppable",
     # The primary span is `r.first()`, not the gate inside `Reader`.
     "test.rue:15:",
     "the element type is required to be trivially droppable here",
@@ -443,3 +497,183 @@ fn main() -> i32 {
 compile_fail = false
 real_std = true
 exit_code = 3
+
+# `Grid2D(T)::get` reads a cell through `ArrayBuf(T)::get`, and it states the
+# gate itself rather than inheriting the one underneath. The inherited message
+# would name `get_ref` and `pop`/`pop_or` on a grid that has `get_ref` and no
+# `pop` at all, because the remedy probe answers for the receiver of the body
+# that states the gate while the diagnostic is anchored at the caller's own
+# wrapper (RUE-2070). Stating the gate here classifies the grid on itself: a
+# by-copy read whose receiver cannot offer both remedies, so the neutral copy
+# wording.
+[[case]]
+name = "e0711_grid2d_owning_element_read_uses_neutral_wording"
+description = "`Grid2D(StrBuf)::get` states its own gate, so E0711 lands on the caller's `g.get(0, 0)` with the neutral copy wording rather than the inherited `ArrayBuf` wording naming a `pop` the grid does not have."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let G = std.grid.Grid2D(StrBuf);
+    let g = G.new(1, 1, "x");
+    let _ = g.get(0, 0);
+    0
+}
+"""
+compile_fail = true
+real_std = true
+# Two E0711s, one per gate, so the case pins both messages rather than
+# asserting a single diagnostic.
+error_contains = [
+    "E0711",
+    "cannot copy an element of type `StrBuf` here",
+    "this operation duplicates elements while the originals stay live",
+    "test.rue:7:",
+    "the element type is required to be trivially droppable here",
+    # `Grid2D(T)::new` states its own gate, so the construction is a separate
+    # diagnostic at its own demanding call and keeps the construction wording.
+    "cannot use an element of type `StrBuf` here",
+    "test.rue:6:",
+]
+
+# Two wrappers over one accessor. `ArrayBuf(T)::first` and `ArrayBuf(T)::last`
+# both read through `ArrayBuf(T)::get`, which is where the gate is stated, so
+# one gate is demanded by two calls in this program. `first` is written above
+# `last` in `arraybuf.rue`, so a climb that followed a single chain would leave
+# the library through `first` and report `a.first()` on line 10 — the LATER of
+# the two demands. The climb is breadth-first over every library caller at each
+# hop, so both wrappers are expanded together and the earlier demand,
+# `a.last()` on line 8, wins.
+[[case]]
+name = "e0711_shared_accessor_reports_earliest_demand"
+description = "When two std wrappers demand one by-copy accessor, E0711 is anchored at the earliest demanding call in source order (`a.last()` on line 8), not at the later one reached through the library caller that sorts first."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let a = A.new();
+
+    let _ = a.last();
+
+    let _ = a.first();
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "cannot read an element of type `StrBuf` by copy",
+    "test.rue:8:",
+    "the element type is required to be trivially droppable here",
+]
+
+# The same gate demanded at two different depths. `a.first()` on line 8 reaches
+# `ArrayBuf(T)::get` through one library frame; `a.get(0)` on line 10 calls the
+# gated body directly, one hop nearer. A walk that answered at the first hop
+# reaching user code would report the nearer, later call. Every hop up to the
+# cap is walked instead and all the candidates compete on source position, so
+# the earlier call wins however many library frames stand behind it.
+[[case]]
+name = "e0711_earlier_demand_wins_over_nearer_later_one"
+description = "A demand one library frame deep on line 8 outranks a direct demand on line 10: the climb collects candidates from every hop and anchors E0711 at the earliest in source order, not at the nearest."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let a = A.new();
+
+    let _ = a.first();
+
+    let _ = a.get(0);
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "cannot read an element of type `StrBuf` by copy",
+    "test.rue:8:",
+    "the element type is required to be trivially droppable here",
+]
+
+# `extend_from` copies a run of elements from one container into another and
+# hands none of them back. `get_ref` has nothing to borrow here and `pop` would
+# not make the copy sound, so the message states the requirement and offers
+# neither remedy.
+[[case]]
+name = "e0711_bulk_copy_gate_uses_neutral_wording"
+description = "`ArrayBuf(StrBuf)::extend_from` returns nothing, so E0711 renders the neutral bulk-copy message rather than the by-copy-read one that would prescribe `get_ref`/`pop`."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut a = A.new();
+    let b = A.new();
+    a.extend_from(borrow b);
+    0
+}
+"""
+compile_fail = true
+real_std = true
+expected_error_code = "E0711"
+error_contains = [
+    "E0711",
+    "cannot copy an element of type `StrBuf` here",
+    "this operation duplicates elements while the originals stay live",
+    "the element type must be trivially droppable",
+    "test.rue:8:",
+    "the element type is required to be trivially droppable here",
+]
+
+[[case]]
+name = "arraybuf_extend_from_copy_element_compiles"
+description = "The same bulk copy compiles and runs for a trivially-droppable element type."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let A = std.arraybuf.ArrayBuf(i64);
+    let mut a = A.new();
+    a.push(1);
+    let mut b = A.new();
+    b.push(2);
+    b.push(4);
+    a.extend_from(borrow b);
+    let OI = std.option.Option(i64);
+    match a.get(2) { OI.Some(v) => @intCast(v + @intCast(a.len())), OI.None => 0 }
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 7
+
+[[case]]
+name = "grid2d_copy_element_delegated_read_compiles"
+description = "`Grid2D(i64)::get` states its own gate and delegates to `ArrayBuf(i64)::get`, and both the in-bounds and out-of-bounds reads pass both gates for a trivially-droppable element type."
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let OI = std.option.Option(i64);
+    let G = std.grid.Grid2D(i64);
+    let mut g = G.new(2, 3, 5);
+    g.set(0, 0, 11);
+    let a = match g.get(0, 0) { OI.Some(v) => v, OI.None => 0 };
+    let b = match g.get(1, 2) { OI.Some(v) => v, OI.None => 0 };
+    let c = match g.get(9, 9) { OI.Some(v) => v, OI.None => 100 };
+    @intCast(a + b + c)
+}
+"""
+compile_fail = false
+real_std = true
+exit_code = 116

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -63,7 +63,7 @@ Expression intrinsics (usable in any expression position):
 | `@size_of` | Get type size in bytes | 1 type | `i32` |
 | `@align_of` | Get type alignment in bytes | 1 type | `i32` |
 | `@require_droppable` | Enforce the owning-container element-type gate | 1 type | `()` |
-| `@require_trivially_droppable` | Enforce the trivially-droppable element-type gate (a by-copy read, or a container built from copies) | 1 type | `()` |
+| `@require_trivially_droppable` | Enforce the trivially-droppable element-type gate (a by-copy read, a value built from copies, or any other duplication of elements) | 1 type | `()` |
 | `@int_max` | Largest value of an integer type (§4.13:126) | 1 type (integer) | that integer type |
 | `@int_min` | Smallest value of an integer type (§4.13:126) | 1 type (integer) | that integer type |
 | `@offset_of` | Get a struct field's byte offset | 1 type, 1 field name | `u64` |

--- a/std/grid.rue
+++ b/std/grid.rue
@@ -26,8 +26,10 @@
 // a `new_with(rows, cols, f)` that computes each cell instead needs function
 // values (RUE-643).
 //
-// `get` reads a cell by copy and `set` overwrites one; `get_ref` borrows a
-// cell in place.
+// `get` reads a cell by copy and states the same gate for the same reason, so
+// an owning `T` is named against the grid rather than against the ArrayBuf
+// accessor underneath it; `set` overwrites a cell and `get_ref` borrows one in
+// place.
 //
 //     const std = @import("std");
 //     let G = std.grid.Grid2D(i64);
@@ -84,8 +86,12 @@ pub fn Grid2D(comptime T: type) -> type {
             r < self.rows && c < self.cols
         }
 
-        // Cell `(r, c)` by copy, or `None` when out of bounds.
+        // Cell `(r, c)` by copy, or `None` when out of bounds. COPY-`T` ONLY
+        // (RUE-651); the gate is stated first so an owning `T` is named here
+        // rather than inside `ArrayBuf.get`, whose own wording offers a `pop`
+        // this grid does not have (RUE-2070). `get_ref` reads a cell in place.
         fn get(borrow self, r: u64, c: u64) -> option.Option(T) {
+            @require_trivially_droppable(T);
             let O = option.Option(T);
             if r < self.rows && c < self.cols {
                 self.cells.get(r * self.cols + c)


### PR DESCRIPTION

E0711 is stated inside the standard library and re-anchored at the call that
demanded it. Two follow-ups from the RUE-2026 review, plus a reassessment of
the message-shape rule now that RUE-2049 has added gates to the heaps, the
sorts and the queue adapters.

The climb out of the library followed one chain and stopped at the first hop
that reached user code, so a demand written earlier lost to a later one that
sat fewer frames from the gate, and a wrapper that sorted first decided the
answer among wrappers at one depth. The climb now walks every library caller
at every hop up to an eight-hop bound — cycle-guarded, so a shared or cyclic
wrapper costs one expansion — collects every call it finds outside the
library, and answers with the minimum in (path, offset) order. Depth no
longer ranks candidates: `a.first()` above `a.get(0)` reports `a.first()`.
The walk runs only when the gate has already rejected.

E0711 gains a third message. Only one of its messages names methods to use
instead (`get_ref`, `pop`/`pop_or`), and several gated entry points have no
such methods to name: `ArrayBuf::extend_from` and the `RawBuf` range copies
hand no element back at all, `BinaryHeap::push` and the sorts return
nothing, and `Stack::peek`, `Queue::peek`/`dequeue` and
`BinaryHeap::peek`/`pop` spell the in-place read `peek_ref` or do not offer
one. All of them now get neutral wording that describes the copy and states
the requirement without prescribing a cure. The read wording is reserved for
a receiver that really has the two members it names, and the shape is
classified only when the gate rejects, so a passing gate pays nothing for it.

A message is chosen from the body that states the gate, while the diagnostic
is anchored at the caller, so a wrapper delegating to a gated body inherits
its wording — method names included. `Grid2D(T)::get` read through
`ArrayBuf(T)::get` and so offered a `pop` no grid has; it states its own gate
now and renders the neutral wording against itself, as `Stack::peek` already
did. A pass over every std generic container's methods at a drop-glue element
type found no other wrapper inheriting a remedy it cannot offer.

Every std gate site is pinned by a UI case naming the message it renders, so
a classification change shows up as a test diff:

| shape | sites | first clause |
| --- | --- | --- |
| by-copy read with both remedies | `ArrayBuf::get`, `ArrayBuf::get_or` | cannot read an element of type `T` by copy |
| duplication with no remedy to name | `ArrayBuf::extend_from`, the two `RawBuf` range copies, `Stack::peek`, `Queue::peek`/`dequeue`, `BinaryHeap::push`/`peek`/`pop`, `PriorityQueue::push`, `Grid2D::get`, `sort.insertion_sort`, `sort.quicksort` | cannot copy an element of type `T` here |
| construction out of copies | `Grid2D::new`, `Deque::new`, `IntMap::new`, `StrMap::new`, `ArrayBuf::index_of`/`contains`, `sort.is_sorted`, `sort.binary_search`, `PriorityQueue::pop` | cannot use an element of type `T` here |

Five of those sites keep the construction wording by choice rather than by
fit: `ArrayBuf::index_of`/`contains`, `sort.is_sorted`, `sort.binary_search`
and `PriorityQueue::pop` scan or pair by copy rather than build a value out
of copies. Every clause of the message they render is true of them and none
of it names a method they lack, but the neutral copy wording would describe
them better, and no rule over declared signatures separates the two without
demoting the `-> type` producer that gates its own element type. Each of the
five pins the wording it gets, so a maintainer's decision to reclassify them
surfaces as a test diff rather than as a silent change.

`--error-format json` gains and changes no field.

Fixes RUE-2070
