### PR TITLE
RUE-1986: supervise every harness child process through one loop

### DIFF
--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -27,12 +27,14 @@ use rue_oracle::{
     MAX_STDERR_BYTES, MAX_STDOUT_BYTES, RunSourceError, TrapKind, Unsupported, UnsupportedKind,
     run_source_cfg_differential,
 };
+use rue_test_runner::supervise::{
+    Outcome as SupervisedOutcome, OverflowPolicy, SupervisionError, Supervisor,
+};
 use std::fmt;
-use std::io::Read;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, ExitCode, ExitStatus, Stdio};
-use std::time::{Duration, Instant};
+use std::process::{Command, ExitCode, ExitStatus, Stdio};
+use std::time::Duration;
 
 /// Compiler optimization lanes covered by the native differential.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -700,103 +702,50 @@ enum ProcessOutcome {
     TimedOut,
 }
 
-/// Spawn a configured command, drain any piped stdout/stderr **concurrently**
-/// via reader threads, and wait with a manual timeout.
+/// Run a configured command under the shared supervisor
+/// ([`rue_test_runner::supervise`]), retaining a bounded prefix of each stream.
 ///
-/// Draining concurrently is essential (RUE-338): if the pipes were only read
-/// after the child exits, a program that writes more than the OS pipe capacity
-/// (~64KB on Linux) would block on `write()` forever, `try_wait` would never
-/// report an exit. This applies to the Rue compiler as well as to generated
-/// binaries: compiler diagnostics can also exceed a pipe's capacity.
+/// The differential runs [`OverflowPolicy::Truncate`]: a program past its
+/// retention budget keeps running and the capture records that it was cut, so
+/// the comparison can refuse the prefix rather than let a divergence past the
+/// cap read as agreement. Draining while the child runs is what keeps a program
+/// writing more than a pipe's capacity (~64KB on Linux) from blocking in
+/// `write` forever and turning into a manufactured timeout (RUE-338); this
+/// applies to the compiler as much as to a generated binary, since diagnostics
+/// can also outgrow a pipe.
 ///
-/// The reader threads start immediately after `spawn` so the child always has
-/// a consumer. On timeout or a wait error, kill/reap happens before joining the
-/// readers; the closed write ends give them EOF, so no child or thread leaks.
-fn run_process_with_timeout(
-    mut cmd: Command,
-    timeout: Duration,
-) -> std::io::Result<ProcessOutcome> {
-    rue_test_runner::configure_process_group(&mut cmd);
-    let child = cmd.spawn()?;
-    wait_for_process(child, timeout)
-}
+/// The group is SIGKILLed once the direct child is gone, so a linker or a
+/// native grandchild that inherited a pipe cannot outlive the run.
+fn run_process_with_timeout(cmd: Command, timeout: Duration) -> std::io::Result<ProcessOutcome> {
+    let run = Supervisor::new(cmd, timeout)
+        .stream_budgets(MAX_STDOUT_BYTES, MAX_STDERR_BYTES)
+        .overflow_policy(OverflowPolicy::Truncate)
+        .reap_group(true)
+        .run()
+        .map_err(SupervisionError::into_io)?;
 
-fn wait_for_process(mut child: Child, timeout: Duration) -> std::io::Result<ProcessOutcome> {
-    // When piped, stdout and stderr are drained to EOF while retaining fixed
-    // prefixes; compiler stdout is configured as null. Both readers run on
-    // their own thread so neither pipe can fill and block the child.
-    let stdout_pipe = child.stdout.take();
-    let stderr_pipe = child.stderr.take();
-    let stdout_reader = std::thread::spawn(move || {
-        stdout_pipe.map_or_else(CappedRead::default, |out| {
-            read_capped(out, MAX_STDOUT_BYTES)
-        })
-    });
-    let stderr_reader = std::thread::spawn(move || {
-        stderr_pipe.map_or_else(CappedRead::default, |err| {
-            read_capped(err, MAX_STDERR_BYTES)
-        })
-    });
-
-    let start = Instant::now();
-    let status: std::io::Result<Option<ExitStatus>> = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                // The direct child is authoritative for success even if it
-                // crossed the deadline concurrently with this poll. Tear down
-                // any descendants it left in its private process group before
-                // joining readers, because an inherited pipe fd would
-                // otherwise keep those joins blocked forever.
-                terminate_and_reap(&mut child);
-                break Ok(Some(status));
-            }
-            Ok(None) if start.elapsed() >= timeout => {
-                terminate_and_reap(&mut child);
-                break Ok(None);
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
-            Err(error) => {
-                terminate_and_reap(&mut child);
-                break Err(error);
-            }
-        }
-    };
-
-    // Whether the child exited, timed out, or hit a wait error, it has been
-    // reaped before these joins. Its write ends are closed, so both readers hit
-    // EOF and finish promptly.
-    let stdout_capture = stdout_reader.join().unwrap_or_default();
-    let stderr_capture = stderr_reader.join().unwrap_or_default();
-    // Keep stdout raw through ProcessOutcome and Compiled. Lossy conversion is
-    // reserved for diagnostics, so invalid bytes cannot collapse into a false
-    // differential agreement.
-    let stdout = stdout_capture.bytes;
-    let stderr = String::from_utf8_lossy(&stderr_capture.bytes).into_owned();
-
-    match status? {
-        Some(status) => Ok(ProcessOutcome::Exited {
-            status,
-            stdout,
-            stdout_truncated: stdout_capture.truncated,
-            stderr,
-            stderr_truncated: stderr_capture.truncated,
-        }),
-        None => Ok(ProcessOutcome::TimedOut),
-    }
-}
-
-fn terminate_and_reap(child: &mut Child) {
-    // The canonical helper signals the child's private process group before
-    // reaping the direct child. This closes pipe fds inherited by compiler
-    // linkers or native grandchildren as well as handling a natural-exit race.
-    rue_test_runner::kill_process_group(child);
+    Ok(match run.outcome {
+        SupervisedOutcome::TimedOut => ProcessOutcome::TimedOut,
+        // `Truncate` never stops a child, so every other ending is the child's
+        // own.
+        SupervisedOutcome::Exited | SupervisedOutcome::Overflowed(_) => ProcessOutcome::Exited {
+            status: run
+                .status
+                .expect("a child that exited reported its own status"),
+            // Keep stdout raw through ProcessOutcome and Compiled. Lossy
+            // conversion is reserved for diagnostics, so invalid bytes cannot
+            // collapse into a false differential agreement.
+            stdout: run.stdout.bytes,
+            stdout_truncated: run.stdout.truncated,
+            stderr: String::from_utf8_lossy(&run.stderr.bytes).into_owned(),
+            stderr_truncated: run.stderr.truncated,
+        },
+    })
 }
 
 /// Run one generated native binary using the shared bounded subprocess path.
 fn run_with_timeout(mut cmd: Command, timeout: Duration) -> std::io::Result<Compiled> {
-    cmd.stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     Ok(match run_process_with_timeout(cmd, timeout)? {
         ProcessOutcome::TimedOut => Compiled::Timeout,
         ProcessOutcome::Exited {
@@ -816,41 +765,6 @@ fn run_with_timeout(mut cmd: Command, timeout: Duration) -> std::io::Result<Comp
             None => Compiled::Crash(status.signal().unwrap_or(0)),
         },
     })
-}
-
-/// Read `r` to EOF, retaining at most `cap` bytes. Reading all the way to EOF
-/// (rather than stopping after `cap`, as `Read::take` would) is what prevents a
-/// drain-deadlock: a program that writes more than `cap` to this pipe must still
-/// have every byte consumed or it blocks on a full pipe forever (RUE-338). The
-/// cap bounds only the memory we keep, not how much we drain; `truncated` records
-/// whether any bytes were discarded after the retained prefix.
-#[derive(Default)]
-struct CappedRead {
-    bytes: Vec<u8>,
-    truncated: bool,
-}
-
-fn read_capped<R: Read>(mut r: R, cap: usize) -> CappedRead {
-    let mut capture = CappedRead::default();
-    let mut chunk = [0u8; 8192];
-    loop {
-        match r.read(&mut chunk) {
-            Ok(0) => break,
-            Ok(n) => {
-                if capture.bytes.len() < cap {
-                    let take = (cap - capture.bytes.len()).min(n);
-                    capture.bytes.extend_from_slice(&chunk[..take]);
-                    capture.truncated |= take < n;
-                } else {
-                    capture.truncated = true;
-                }
-                // Bytes beyond `cap` are read and discarded — draining, not
-                // storing — so the pipe never fills.
-            }
-            Err(_) => break,
-        }
-    }
-    capture
 }
 
 struct Disagreement {
@@ -1074,6 +988,7 @@ mod tests {
     use super::*;
     use rue_oracle::Outcome;
     use std::os::unix::fs::PermissionsExt;
+    use std::time::Instant;
 
     fn make_executable(path: &Path) {
         let mut permissions = std::fs::metadata(path)
@@ -1612,7 +1527,7 @@ mod tests {
 
         assert!(
             start.elapsed() < Duration::from_secs(5),
-            "compiler kill/reap/join must return promptly"
+            "the compiler kill and bounded collection must return promptly"
         );
         assert!(
             matches!(result, Compiled::CompileTimeout),
@@ -1652,7 +1567,7 @@ mod tests {
         assert!(matches!(result, Compiled::CompileTimeout));
         assert!(
             start.elapsed() < Duration::from_secs(5),
-            "process-group kill must close descendant-held pipes before reader joins"
+            "the process-group kill must close descendant-held pipes before collection"
         );
     }
 
@@ -1873,7 +1788,8 @@ mod tests {
         // Run the writer directly so killing the timed child closes the only
         // pipe write end. This is the adversarial always-on-smoke case: a
         // miscompiled binary can print forever, but retained memory stays at
-        // MAX_STDOUT_BYTES and kill/reap/join still returns promptly.
+        // MAX_STDOUT_BYTES and the kill and bounded collection still return
+        // promptly.
         let mut cmd = Command::new("yes");
         cmd.arg("y");
         let start = Instant::now();
@@ -1919,34 +1835,12 @@ mod tests {
     }
 
     #[test]
-    fn read_capped_drains_to_eof_but_keeps_only_cap() {
-        // The drain-vs-keep contract in isolation: given more bytes than the cap,
-        // we consume all of them (Cursor reaches EOF) but retain exactly `cap`.
-        let data = vec![b'z'; 100_000];
-        let kept = read_capped(std::io::Cursor::new(data), MAX_STDERR_BYTES);
-        assert_eq!(kept.bytes.len(), MAX_STDERR_BYTES);
-        assert!(kept.bytes.iter().all(|&b| b == b'z'));
-        assert!(kept.truncated);
-        // Fewer bytes than the cap: keep them all.
-        let kept = read_capped(std::io::Cursor::new(vec![b'q'; 10]), MAX_STDERR_BYTES);
-        assert_eq!(kept.bytes.len(), 10);
-        assert!(!kept.truncated);
-        // Exactly the cap is still complete, not truncated.
-        let kept = read_capped(
-            std::io::Cursor::new(vec![b'x'; MAX_STDERR_BYTES]),
-            MAX_STDERR_BYTES,
-        );
-        assert_eq!(kept.bytes.len(), MAX_STDERR_BYTES);
-        assert!(!kept.truncated);
-    }
-
-    #[test]
     fn timeout_still_reported_for_a_hung_child() {
         // A genuine non-terminating program must still yield `Timeout` (and the
-        // reader threads must be joined, not leaked). We exec `sleep` directly
+        // drains must be collected, not left running). We exec `sleep` directly
         // (not via `sh -c`): the harness always runs a single-process compiled
-        // binary, so killing the child closes every pipe write-end, the readers
-        // hit EOF, and the post-kill join returns at once. `sleep` writes
+        // binary, so killing the child closes every pipe write-end, the drains
+        // hit EOF, and collection returns at once. `sleep` writes
         // nothing, so this is the honest timeout path, distinct from the false
         // one the large-output tests guard against.
         let mut cmd = Command::new("sleep");
@@ -1955,7 +1849,7 @@ mod tests {
         let result = run_with_timeout(cmd, Duration::from_millis(200)).expect("spawn");
         assert!(
             start.elapsed() < Duration::from_secs(5),
-            "kill-then-join must return promptly, not block on the child's full runtime"
+            "the kill and the collection after it must return promptly, not block on the child's full runtime"
         );
         assert!(
             matches!(result, Compiled::Timeout),

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -4,11 +4,12 @@
 //! including test case parsing, execution, and output comparison.
 
 pub mod pipe_drain;
+pub mod supervise;
 
-use pipe_drain::{PIPE_DRAIN_FINISH_TIMEOUT, spawn_pipe_drain};
 use rue_error::{PreviewFeature, error_code_metadata};
 use rue_target::Target;
 use serde::{Deserialize, Deserializer};
+use supervise::{CaptureStream, Outcome, OverflowPolicy, Supervisor};
 
 /// Default timeout for test execution in milliseconds (10 seconds).
 pub const DEFAULT_TIMEOUT_MS: u64 = 10_000;
@@ -23,7 +24,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// The coordinates of one slice in a sharded test corpus (RUE-1116).
 ///
@@ -2696,21 +2697,9 @@ pub fn kill_process_group(child: &mut std::process::Child) {
 
 /// Run a command with a timeout and optional stdin input.
 ///
-/// This function spawns a child process (in its own process group), drains its
-/// stdout and stderr on dedicated reader threads, feeds it stdin (if provided)
-/// on its own writer thread, and polls for completion, killing the whole
-/// process group if it exceeds the specified timeout.
-///
-/// # Why the reader/writer threads (RUE-338 deadlock class)
-///
-/// Draining stdout AND stderr **concurrently**, starting immediately after
-/// spawn, is essential: if the pipes were read only after the child exits, a
-/// program that writes more than the OS pipe capacity (~64KB on Linux) would
-/// block forever in `write()`, `try_wait` would never report an exit, and the
-/// timeout would manufacture a false failure. For the same reason stdin is
-/// written on its own thread — a large input can't block the drain, and the
-/// drain can't block the stdin write. Mirrors the oracle-diff fuzzer's
-/// `run_with_timeout` (RUE-338).
+/// A thin adapter over [`supervise::Supervisor`]: the child runs in its own
+/// process group with its pipes drained concurrently, and the group is killed
+/// if it outlives `timeout`.
 ///
 /// # Arguments
 /// * `cmd` - The command to run (already configured with arguments)
@@ -2734,10 +2723,11 @@ pub fn run_with_timeout(
 /// from each of stdout and stderr.
 ///
 /// Unlike checking [`Output`] after [`run_with_timeout`] returns, this limit is
-/// enforced by the pipe-drain threads as bytes arrive. Once either stream
-/// exceeds the limit, further bytes are discarded, the process group is
-/// killed, and the function returns a fatal failure identifying the stream.
-/// The limit applies independently to stdout and stderr.
+/// enforced by the pipe-drain threads as bytes arrive. This harness runs
+/// [`supervise::OverflowPolicy::Fail`]: once either stream exceeds the limit,
+/// further bytes are discarded, the process group is killed, and the function
+/// returns a fatal failure identifying the stream. The limit applies
+/// independently to stdout and stderr.
 pub fn run_with_timeout_and_output_limit(
     cmd: Command,
     timeout: Duration,
@@ -2753,106 +2743,49 @@ fn run_with_timeout_impl(
     stdin_input: Option<&str>,
     output_limit: Option<usize>,
 ) -> TestResult<Output> {
-    configure_process_group(&mut cmd);
-    let mut child = cmd
-        .stdin(if stdin_input.is_some() {
-            Stdio::piped()
-        } else {
-            Stdio::null()
-        })
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| TestFailure::fatal(format!("Failed to spawn process: {}", e)))?;
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut supervisor = Supervisor::new(cmd, timeout).overflow_policy(OverflowPolicy::Fail);
+    if let Some(limit) = output_limit {
+        supervisor = supervisor.stream_budget(limit);
+    }
+    if let Some(input) = stdin_input {
+        supervisor = supervisor.stdin_input(input);
+    }
+    let run = supervisor
+        .run()
+        .map_err(|error| TestFailure::fatal(error.to_string()))?;
 
-    // Drain stdout and stderr on their own threads, started right after spawn so
-    // neither pipe can fill and wedge the child (see the RUE-338 note above).
-    // The drains send chunks over channels instead of being joined directly:
-    // if a descendant process inherits a pipe fd and keeps it open after the
-    // direct child exits, a reader thread can block forever waiting for EOF.
-    let mut stdout_drain = spawn_pipe_drain(child.stdout.take(), output_limit);
-    let mut stderr_drain = spawn_pipe_drain(child.stderr.take(), output_limit);
-
-    // Feed stdin on its own thread so a large input can't block the drain (and
-    // vice versa). A program may exit without reading all of its input; a broken
-    // pipe here is not a test failure, so errors are ignored (matching the CLI
-    // harness). Dropping the pipe when the closure ends closes it, signaling EOF.
-    let stdin_writer = child.stdin.take().map(|mut stdin| {
-        let input = stdin_input.unwrap_or_default().to_string();
-        std::thread::spawn(move || {
-            let _ = stdin.write_all(input.as_bytes());
-        })
-    });
-
-    let start = Instant::now();
-
-    loop {
-        stdout_drain.poll();
-        stderr_drain.poll();
-        if stdout_drain.overflowed() || stderr_drain.overflowed() {
-            kill_process_group(&mut child);
-            let stream = match (stdout_drain.overflowed(), stderr_drain.overflowed()) {
-                (true, true) => "stdout and stderr",
-                (true, false) => "stdout",
-                (false, true) => "stderr",
-                (false, false) => unreachable!(),
+    match run.outcome {
+        Outcome::Exited => Ok(Output {
+            status: run
+                .status
+                .expect("a child that exited reported its own status"),
+            stdout: run.stdout.bytes,
+            stderr: run.stderr.bytes,
+        }),
+        Outcome::TimedOut => Err(TestFailure::fatal(format!(
+            "{} test execution timed out after {} ms (process group killed)",
+            TIMEOUT_PREFIX,
+            timeout.as_millis()
+        ))),
+        Outcome::Overflowed(overflow) => {
+            let stream = match overflow.stream {
+                CaptureStream::Stdout => "stdout",
+                CaptureStream::Stderr => "stderr",
+                // No caller of this entry point adds one.
+                CaptureStream::Extra(index) => unreachable!("unexpected extra capture {index}"),
             };
-            return Err(TestFailure::fatal(format!(
-                "OUTPUT LIMIT: {stream} exceeded the {}-byte capture limit (process group killed)",
-                output_limit.expect("overflow requires an output limit")
-            )));
-        }
-
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                // Process finished: collect any fully-drained output, but do
-                // not wait forever if a descendant inherited a pipe fd.
-                stdout_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
-                stderr_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
-                drop(stdin_writer);
-                if stdout_drain.overflowed() || stderr_drain.overflowed() {
-                    let stream = match (stdout_drain.overflowed(), stderr_drain.overflowed()) {
-                        (true, true) => "stdout and stderr",
-                        (true, false) => "stdout",
-                        (false, true) => "stderr",
-                        (false, false) => unreachable!(),
-                    };
-                    return Err(TestFailure::fatal(format!(
-                        "OUTPUT LIMIT: {stream} exceeded the {}-byte capture limit",
-                        output_limit.expect("overflow requires an output limit")
-                    )));
-                }
-                return Ok(Output {
-                    status,
-                    stdout: stdout_drain.into_bytes(),
-                    stderr: stderr_drain.into_bytes(),
-                });
-            }
-            Ok(None) => {
-                // Still running - check timeout
-                if start.elapsed() > timeout {
-                    // Kill the whole process group, then collect whatever the
-                    // drain helpers already captured without waiting forever
-                    // for EOF from an escaped descendant.
-                    kill_process_group(&mut child);
-                    stdout_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
-                    stderr_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
-                    drop(stdin_writer);
-                    return Err(TestFailure::fatal(format!(
-                        "{} test execution timed out after {} ms (process group killed)",
-                        TIMEOUT_PREFIX,
-                        timeout.as_millis()
-                    )));
-                }
-                // Sleep briefly before polling again
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            Err(e) => {
-                return Err(TestFailure::fatal(format!(
-                    "Failed to wait for process: {}",
-                    e
-                )));
-            }
+            // A process still running when its budget was exceeded was killed
+            // to stop the flood; one that had already exited was not.
+            let killed = if run.status.is_none() {
+                " (process group killed)"
+            } else {
+                ""
+            };
+            Err(TestFailure::fatal(format!(
+                "OUTPUT LIMIT: {stream} exceeded the {}-byte capture limit{killed}",
+                overflow.budget
+            )))
         }
     }
 }
@@ -3446,6 +3379,7 @@ pub fn find_rue_binary() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Instant;
 
     const VALID_TEST_FILE: &str = r#"
 [section]

--- a/crates/rue-test-runner/src/supervise.rs
+++ b/crates/rue-test-runner/src/supervise.rs
@@ -1,0 +1,703 @@
+//! One supervision loop for every child process the tree starts.
+//!
+//! Spawning a test process, draining its pipes so it cannot wedge on a full
+//! one, enforcing a wall-clock budget, and tearing down its process group is a
+//! single mechanism with a single failure class (RUE-338). It lives here so the
+//! specification and CLI harnesses, the `rue test` runner in the compiler
+//! driver (ADR-0083 §3), and the differential fuzzer share it rather than
+//! keeping loops that drift apart under load.
+//!
+//! What varies between those consumers is policy, not mechanism, so the
+//! variation is parameters:
+//!
+//! - [`OverflowPolicy`] decides what a stream outgrowing its retention budget
+//!   means: a harness failure, a reported verdict, or a truncated capture.
+//! - [`Supervisor::extra_capture`] adds pipes beyond stdout and stderr, which
+//!   is how the `rue test` runner drains its structured failure channel.
+//! - [`Supervisor::reap_group`] adds a post-exit SIGKILL to the child's group,
+//!   for a consumer that wants stragglers gone rather than merely bounded.
+//! - [`GroupObserver`] hands the consumer the two instants only the supervisor
+//!   knows: the child is running under a known process-group id, and that id
+//!   has been reaped and may be reused.
+//!
+//! The caller configures stdout and stderr on its own [`Command`]; a stream it
+//! leaves un-piped simply produces an empty capture, which is how the
+//! differential harness discards compiler stdout. Stdin belongs to the
+//! supervisor, because feeding it is what its writer thread does.
+
+use std::io::{self, Read, Write};
+use std::process::{Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::pipe_drain::{PIPE_DRAIN_FINISH_TIMEOUT, PipeDrain, spawn_pipe_drain};
+use crate::{configure_process_group, kill_process_group};
+
+/// How often the loop wakes to collect drained output and re-check the child.
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// What a capture outgrowing its retention budget means to the consumer.
+///
+/// The two stopping policies both kill the process group the moment a budget is
+/// exceeded; they differ in what the supervisor owes afterwards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverflowPolicy {
+    /// Stop the process group and return at once. The run is a harness failure,
+    /// so the retained prefix has no reader and the bounded finish would only
+    /// delay the report.
+    Fail,
+    /// Stop the process group, then complete the bounded finish: the retained
+    /// prefixes and byte totals are published with the verdict that names the
+    /// overflow.
+    Verdict,
+    /// Let the process run to its own end. Each capture records that bytes were
+    /// discarded, so a consumer can refuse to treat a prefix as a complete
+    /// result.
+    Truncate,
+}
+
+impl OverflowPolicy {
+    /// Whether an overflow ends the run rather than being recorded on the
+    /// capture.
+    fn stops_the_child(self) -> bool {
+        matches!(self, Self::Fail | Self::Verdict)
+    }
+}
+
+/// Which capture a report is about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureStream {
+    Stdout,
+    Stderr,
+    /// A pipe added with [`Supervisor::extra_capture`], in the order added.
+    Extra(usize),
+}
+
+/// The capture that outgrew its budget, and the budget it exceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Overflow {
+    pub stream: CaptureStream,
+    pub budget: usize,
+}
+
+/// One drained stream.
+#[derive(Debug, Default)]
+pub struct Capture {
+    /// The retained prefix: at most the configured budget.
+    pub bytes: Vec<u8>,
+    /// Every byte the process wrote to this stream, budget or no budget.
+    pub total: u64,
+    /// Whether bytes were read and discarded past the budget, making `bytes` a
+    /// prefix rather than the whole stream.
+    pub truncated: bool,
+}
+
+/// How supervision ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The child reported its own status.
+    Exited,
+    /// The wall-clock budget expired and the process group was killed.
+    TimedOut,
+    /// A capture exceeded its budget under a stopping [`OverflowPolicy`].
+    Overflowed(Overflow),
+}
+
+/// What one supervised process produced.
+#[derive(Debug)]
+pub struct SupervisedRun {
+    pub outcome: Outcome,
+    /// The status the child reported for itself, present whenever it reported
+    /// one. A run the supervisor stopped has none: the group was killed, so the
+    /// outcome decides the result ahead of any status.
+    ///
+    /// An overflow noticed only after the child had already exited keeps its
+    /// status, because the process still spoke for itself.
+    pub status: Option<ExitStatus>,
+    pub stdout: Capture,
+    pub stderr: Capture,
+    /// The extra captures, in the order they were added.
+    pub extra: Vec<Capture>,
+    /// Wall-clock time from just before the spawn to the end of the loop, so a
+    /// consumer reports the process's own duration rather than the teardown's.
+    pub duration: Duration,
+}
+
+/// Why supervision could not produce an outcome.
+///
+/// Both variants carry the operating system's error so a consumer working in
+/// [`io::Result`] can hand it on unchanged.
+#[derive(Debug)]
+pub enum SupervisionError {
+    /// The child could not be started.
+    Spawn(io::Error),
+    /// Waiting on a running child failed.
+    Wait(io::Error),
+}
+
+impl SupervisionError {
+    /// The underlying operating-system error.
+    pub fn into_io(self) -> io::Error {
+        match self {
+            Self::Spawn(error) | Self::Wait(error) => error,
+        }
+    }
+}
+
+impl std::fmt::Display for SupervisionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn(error) => write!(formatter, "Failed to spawn process: {error}"),
+            Self::Wait(error) => write!(formatter, "Failed to wait for process: {error}"),
+        }
+    }
+}
+
+/// The two instants a consumer may need that only the supervisor observes.
+///
+/// The default implementations do nothing, so a consumer overrides only the
+/// half it cares about.
+pub trait GroupObserver {
+    /// The child is running and leads the process group `pgid`. Called before
+    /// anything can block, so a consumer that must be able to tear the group
+    /// down from a signal handler is already able to.
+    fn spawned(&mut self, pgid: i32) {
+        let _ = pgid;
+    }
+
+    /// The child has been reaped and `pgid` may be reused by the operating
+    /// system from here on, so a consumer holding it must let it go now.
+    fn reaped(&mut self, pgid: i32) {
+        let _ = pgid;
+    }
+}
+
+struct ExtraCapture {
+    reader: Box<dyn Read + Send>,
+    budget: usize,
+}
+
+/// A pipe being drained, with the identity and budget its overflow is reported
+/// against.
+struct Tracked {
+    drain: PipeDrain,
+    stream: CaptureStream,
+    budget: Option<usize>,
+}
+
+impl Tracked {
+    fn capture(self) -> Capture {
+        Capture {
+            total: self.drain.bytes_total(),
+            truncated: self.drain.overflowed(),
+            bytes: self.drain.into_bytes(),
+        }
+    }
+}
+
+/// One child process, supervised to an [`Outcome`].
+///
+/// Built from a configured [`Command`] and a wall-clock budget; every other
+/// knob has a default that suits a harness running one bounded test process.
+pub struct Supervisor<'a> {
+    cmd: Command,
+    timeout: Duration,
+    poll_interval: Duration,
+    stdin_input: Option<&'a str>,
+    stdout_budget: Option<usize>,
+    stderr_budget: Option<usize>,
+    extra: Vec<ExtraCapture>,
+    overflow: OverflowPolicy,
+    reap_group: bool,
+    observer: Option<&'a mut dyn GroupObserver>,
+}
+
+impl<'a> Supervisor<'a> {
+    /// Supervise `cmd`, killing its process group if it runs past `timeout`.
+    pub fn new(cmd: Command, timeout: Duration) -> Self {
+        Self {
+            cmd,
+            timeout,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            stdin_input: None,
+            stdout_budget: None,
+            stderr_budget: None,
+            extra: Vec::new(),
+            overflow: OverflowPolicy::Fail,
+            reap_group: false,
+            observer: None,
+        }
+    }
+
+    /// Feed `input` to the child's stdin from a writer thread.
+    ///
+    /// Without this the child's stdin is an immediate end of file.
+    pub fn stdin_input(mut self, input: &'a str) -> Self {
+        self.stdin_input = Some(input);
+        self
+    }
+
+    /// Retain at most `budget` bytes of stdout and of stderr.
+    pub fn stream_budget(mut self, budget: usize) -> Self {
+        self.stdout_budget = Some(budget);
+        self.stderr_budget = Some(budget);
+        self
+    }
+
+    /// Retain at most `stdout` bytes of stdout and `stderr` bytes of stderr,
+    /// for a consumer whose two streams are worth different amounts.
+    pub fn stream_budgets(mut self, stdout: usize, stderr: usize) -> Self {
+        self.stdout_budget = Some(stdout);
+        self.stderr_budget = Some(stderr);
+        self
+    }
+
+    /// Drain one more pipe alongside stdout and stderr, retaining at most
+    /// `budget` bytes of it.
+    ///
+    /// The reader is drained on its own thread from the moment the child is
+    /// running, exactly like the standard streams, and its overflow is reported
+    /// as [`CaptureStream::Extra`] with the index it was added at.
+    pub fn extra_capture(mut self, reader: impl Read + Send + 'static, budget: usize) -> Self {
+        self.extra.push(ExtraCapture {
+            reader: Box::new(reader),
+            budget,
+        });
+        self
+    }
+
+    /// What an exceeded retention budget means to this consumer.
+    pub fn overflow_policy(mut self, policy: OverflowPolicy) -> Self {
+        self.overflow = policy;
+        self
+    }
+
+    /// How often to collect drained output and re-check the child.
+    pub fn poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    /// SIGKILL the child's process group once the child is gone.
+    ///
+    /// Hygiene rather than containment: the bounded finish already keeps an
+    /// escaped descendant from stalling the caller, and this additionally stops
+    /// it from outliving the run.
+    pub fn reap_group(mut self, reap: bool) -> Self {
+        self.reap_group = reap;
+        self
+    }
+
+    /// Observe the child's process-group id while it is live.
+    pub fn observer(mut self, observer: &'a mut dyn GroupObserver) -> Self {
+        self.observer = Some(observer);
+        self
+    }
+
+    /// Run the child to an outcome.
+    ///
+    /// The stdout and stderr drains start on their own threads immediately
+    /// after the spawn, and stdin is written from a third. That concurrency is
+    /// the point (RUE-338): a child writing more than a pipe's capacity while
+    /// the parent waited for its exit would block in `write` forever, never
+    /// report a status, and turn into a manufactured timeout.
+    pub fn run(self) -> Result<SupervisedRun, SupervisionError> {
+        let Self {
+            mut cmd,
+            timeout,
+            poll_interval,
+            stdin_input,
+            stdout_budget,
+            stderr_budget,
+            extra,
+            overflow,
+            reap_group,
+            mut observer,
+        } = self;
+
+        configure_process_group(&mut cmd);
+        cmd.stdin(if stdin_input.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        });
+
+        let start = Instant::now();
+        let mut child = cmd.spawn().map_err(SupervisionError::Spawn)?;
+        // The child leads its own group, so its pid is its process-group id.
+        let pgid = child.id() as i32;
+        if let Some(observer) = observer.as_deref_mut() {
+            observer.spawned(pgid);
+        }
+
+        let mut captures = Vec::with_capacity(2 + extra.len());
+        captures.push(Tracked {
+            drain: spawn_pipe_drain(child.stdout.take(), stdout_budget),
+            stream: CaptureStream::Stdout,
+            budget: stdout_budget,
+        });
+        captures.push(Tracked {
+            drain: spawn_pipe_drain(child.stderr.take(), stderr_budget),
+            stream: CaptureStream::Stderr,
+            budget: stderr_budget,
+        });
+        for (index, capture) in extra.into_iter().enumerate() {
+            captures.push(Tracked {
+                drain: spawn_pipe_drain(Some(capture.reader), Some(capture.budget)),
+                stream: CaptureStream::Extra(index),
+                budget: Some(capture.budget),
+            });
+        }
+
+        // A program may exit without reading all of its input, so a broken pipe
+        // here is not a failure. Dropping the pipe at the end of the closure
+        // closes it, which is the child's end of file.
+        let stdin_writer = child.stdin.take().map(|mut stdin| {
+            let input = stdin_input.unwrap_or_default().to_string();
+            std::thread::spawn(move || {
+                let _ = stdin.write_all(input.as_bytes());
+            })
+        });
+
+        let mut outcome = Outcome::Exited;
+        let mut status = None;
+        loop {
+            for tracked in &mut captures {
+                tracked.drain.poll();
+            }
+            if overflow.stops_the_child()
+                && let Some(record) = first_overflow(&captures)
+            {
+                kill_process_group(&mut child);
+                outcome = Outcome::Overflowed(record);
+                break;
+            }
+
+            match child.try_wait() {
+                Ok(Some(exited)) => {
+                    status = Some(exited);
+                    break;
+                }
+                Ok(None) => {
+                    if start.elapsed() >= timeout {
+                        kill_process_group(&mut child);
+                        outcome = Outcome::TimedOut;
+                        break;
+                    }
+                    std::thread::sleep(poll_interval);
+                }
+                Err(error) => {
+                    // A child we can no longer wait on is a child we can no
+                    // longer supervise; kill the group rather than leave it
+                    // running behind a returning caller.
+                    kill_process_group(&mut child);
+                    return Err(SupervisionError::Wait(error));
+                }
+            }
+        }
+        let duration = start.elapsed();
+
+        if reap_group {
+            reap_process_group(pgid);
+        }
+        if let Some(observer) = observer.as_deref_mut() {
+            observer.reaped(pgid);
+        }
+
+        // Under `Fail` the retained prefix has no reader, so the run reports as
+        // soon as the group is dead. Every other ending collects what the drain
+        // threads still hold, bounded so a descendant that inherited a pipe and
+        // never closes it cannot stall the answer.
+        if !(overflow == OverflowPolicy::Fail && matches!(outcome, Outcome::Overflowed(_))) {
+            for tracked in &mut captures {
+                tracked.drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
+            }
+        }
+        drop(stdin_writer);
+
+        // The budget is enforced by the drain threads, which hand their verdict
+        // over a channel, so a process that floods a stream and exits at once
+        // can be reaped before the overflow message arrives. Re-reading the
+        // flags after the bounded finish is what keeps such a run from
+        // reporting as a clean exit whose capture silently covers a prefix.
+        if overflow.stops_the_child()
+            && outcome == Outcome::Exited
+            && let Some(record) = first_overflow(&captures)
+        {
+            outcome = Outcome::Overflowed(record);
+        }
+
+        let mut captures = captures.into_iter();
+        let stdout = captures.next().expect("stdout is always tracked").capture();
+        let stderr = captures.next().expect("stderr is always tracked").capture();
+        Ok(SupervisedRun {
+            outcome,
+            status,
+            stdout,
+            stderr,
+            extra: captures.map(Tracked::capture).collect(),
+            duration,
+        })
+    }
+}
+
+/// The first capture to outgrow its budget, in the order stdout, stderr, then
+/// the extra pipes.
+fn first_overflow(captures: &[Tracked]) -> Option<Overflow> {
+    captures
+        .iter()
+        .find(|tracked| tracked.drain.overflowed())
+        .map(|tracked| Overflow {
+            stream: tracked.stream,
+            budget: tracked
+                .budget
+                .expect("a stream can only overflow a budget it was given"),
+        })
+}
+
+/// Best-effort teardown of anything the child left running in its group.
+#[cfg(unix)]
+fn reap_process_group(pgid: i32) {
+    // SAFETY: a negative pid names the process group led by `pgid`. Failure
+    // (an already-empty group) is the ordinary case and carries no obligation.
+    unsafe {
+        libc::kill(-pgid, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reap_process_group(_pgid: i32) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECONDS_5: Duration = Duration::from_secs(5);
+
+    fn shell(script: &str) -> Command {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg(script)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        cmd
+    }
+
+    /// The ordinary ending: the child speaks for itself and both streams are
+    /// captured whole.
+    #[test]
+    fn an_exiting_child_reports_its_own_status_and_output() {
+        let run = Supervisor::new(shell("printf out; printf err >&2; exit 7"), SECONDS_5)
+            .run()
+            .expect("spawn");
+        assert_eq!(run.outcome, Outcome::Exited);
+        assert_eq!(run.status.and_then(|status| status.code()), Some(7));
+        assert_eq!(run.stdout.bytes, b"out");
+        assert_eq!(run.stderr.bytes, b"err");
+        assert!(!run.stdout.truncated);
+        assert_eq!(run.stdout.total, 3);
+    }
+
+    /// `Fail` stops the flood as it happens and names the stream that caused
+    /// it, so a consumer can report a harness failure rather than a result.
+    #[test]
+    fn the_fail_policy_stops_an_overflowing_child_without_a_status() {
+        let run = Supervisor::new(shell("head -c 200000 /dev/zero"), SECONDS_5)
+            .stream_budget(16 * 1024)
+            .overflow_policy(OverflowPolicy::Fail)
+            .run()
+            .expect("spawn");
+        assert_eq!(
+            run.outcome,
+            Outcome::Overflowed(Overflow {
+                stream: CaptureStream::Stdout,
+                budget: 16 * 1024,
+            })
+        );
+        assert!(run.status.is_none(), "the supervisor stopped the child");
+    }
+
+    /// `Verdict` stops the child too, but owes the consumer the prefix and the
+    /// true byte count its verdict publishes.
+    #[test]
+    fn the_verdict_policy_stops_the_child_and_still_collects_the_prefix() {
+        let run = Supervisor::new(shell("yes e >&2"), SECONDS_5)
+            .stream_budget(8 * 1024)
+            .overflow_policy(OverflowPolicy::Verdict)
+            .run()
+            .expect("spawn");
+        assert_eq!(
+            run.outcome,
+            Outcome::Overflowed(Overflow {
+                stream: CaptureStream::Stderr,
+                budget: 8 * 1024,
+            })
+        );
+        assert_eq!(run.stderr.bytes.len(), 8 * 1024);
+        assert!(run.stderr.truncated);
+        assert!(run.stderr.total >= 8 * 1024);
+    }
+
+    /// `Truncate` lets the child finish; the capture says it is a prefix, which
+    /// is what keeps a consumer from comparing it as a complete result.
+    #[test]
+    fn the_truncate_policy_lets_the_child_finish_and_marks_the_prefix() {
+        let run = Supervisor::new(shell("head -c 200000 /dev/zero; exit 3"), SECONDS_5)
+            .stream_budget(16 * 1024)
+            .overflow_policy(OverflowPolicy::Truncate)
+            .run()
+            .expect("spawn");
+        assert_eq!(run.outcome, Outcome::Exited);
+        assert_eq!(run.status.and_then(|status| status.code()), Some(3));
+        assert_eq!(run.stdout.bytes.len(), 16 * 1024);
+        assert!(run.stdout.truncated);
+        assert_eq!(run.stdout.total, 200_000);
+    }
+
+    /// A stream that stays inside its budget is complete under every policy.
+    #[test]
+    fn a_stream_inside_its_budget_is_never_truncated() {
+        let run = Supervisor::new(shell("printf hello"), SECONDS_5)
+            .stream_budget(16 * 1024)
+            .overflow_policy(OverflowPolicy::Truncate)
+            .run()
+            .expect("spawn");
+        assert_eq!(run.stdout.bytes, b"hello");
+        assert!(!run.stdout.truncated);
+    }
+
+    /// A process past its budget is killed with its whole group, and the loop
+    /// returns rather than waiting for the child's own end.
+    #[test]
+    fn a_timeout_kills_the_group_and_reports_no_status() {
+        let start = Instant::now();
+        let run = Supervisor::new(shell("sleep 30"), Duration::from_millis(100))
+            .run()
+            .expect("spawn");
+        assert_eq!(run.outcome, Outcome::TimedOut);
+        assert!(run.status.is_none());
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "the timeout must not wait for the child: {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// An extra pipe is drained on equal terms with the standard streams and
+    /// reported in the order it was added.
+    #[test]
+    fn an_extra_capture_is_drained_alongside_the_standard_streams() {
+        let run = Supervisor::new(shell("printf ordinary"), SECONDS_5)
+            .extra_capture(std::io::Cursor::new(b"extra".to_vec()), 1024)
+            .run()
+            .expect("spawn");
+        assert_eq!(run.stdout.bytes, b"ordinary");
+        assert_eq!(run.extra.len(), 1);
+        assert_eq!(run.extra[0].bytes, b"extra");
+        assert!(!run.extra[0].truncated);
+    }
+
+    /// An extra pipe over its budget is reported by its index, so a consumer
+    /// with several can say which one flooded — and it stops the child on the
+    /// same terms as stdout or stderr would.
+    #[test]
+    fn an_extra_capture_overflows_under_its_own_index() {
+        let run = Supervisor::new(shell("sleep 30"), SECONDS_5)
+            .extra_capture(std::io::Cursor::new(vec![b'x'; 64 * 1024]), 1024)
+            .overflow_policy(OverflowPolicy::Verdict)
+            .run()
+            .expect("spawn");
+        assert_eq!(
+            run.outcome,
+            Outcome::Overflowed(Overflow {
+                stream: CaptureStream::Extra(0),
+                budget: 1024,
+            })
+        );
+        assert!(run.status.is_none(), "the supervisor stopped the child");
+        assert_eq!(run.extra[0].bytes.len(), 1024);
+    }
+
+    /// The observer sees the group while it is live and is told when the id is
+    /// no longer safe to hold.
+    #[test]
+    fn an_observer_sees_the_group_appear_and_be_reaped() {
+        #[derive(Default)]
+        struct Recorder {
+            spawned: Option<i32>,
+            reaped: Option<i32>,
+        }
+        impl GroupObserver for Recorder {
+            fn spawned(&mut self, pgid: i32) {
+                self.spawned = Some(pgid);
+            }
+            fn reaped(&mut self, pgid: i32) {
+                assert_eq!(self.spawned, Some(pgid), "reaped before spawned");
+                self.reaped = Some(pgid);
+            }
+        }
+
+        let mut recorder = Recorder::default();
+        let run = Supervisor::new(shell("exit 0"), SECONDS_5)
+            .observer(&mut recorder)
+            .reap_group(true)
+            .run()
+            .expect("spawn");
+        assert_eq!(run.outcome, Outcome::Exited);
+        assert!(recorder.spawned.is_some_and(|pgid| pgid > 0));
+        assert_eq!(recorder.reaped, recorder.spawned);
+    }
+
+    /// Stdin is fed from its own thread, so a large input and a large output
+    /// proceed at the same time instead of deadlocking against each other.
+    #[test]
+    fn stdin_is_written_while_stdout_is_drained() {
+        let input = "a".repeat(200_000);
+        let mut cmd = Command::new("cat");
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let run = Supervisor::new(cmd, Duration::from_secs(10))
+            .stdin_input(&input)
+            .run()
+            .expect("spawn");
+        assert_eq!(run.outcome, Outcome::Exited);
+        assert_eq!(run.stdout.bytes.len(), 200_000);
+    }
+
+    /// A descendant holding the write end open must not hold the caller: the
+    /// finish is bounded, so the run returns with what it has.
+    #[test]
+    fn an_inherited_pipe_cannot_stall_the_run() {
+        let start = Instant::now();
+        let run = Supervisor::new(shell("sleep 5 & printf done"), Duration::from_secs(10))
+            .run()
+            .expect("spawn");
+        assert_eq!(run.outcome, Outcome::Exited);
+        assert_eq!(run.stdout.bytes, b"done");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "the run waited for an inherited pipe: {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// The post-exit reap is what stops a descendant from outliving the run.
+    #[test]
+    fn the_group_reap_removes_a_descendant_the_child_left_behind() {
+        let marker =
+            std::env::temp_dir().join(format!("rue-supervise-reap-{}", std::process::id()));
+        let _ = std::fs::remove_file(&marker);
+        let script = format!(
+            "(sleep 1; printf survived > {}) & printf done",
+            marker.display()
+        );
+        let run = Supervisor::new(shell(&script), Duration::from_secs(10))
+            .reap_group(true)
+            .run()
+            .expect("spawn");
+        assert_eq!(run.outcome, Outcome::Exited);
+        std::thread::sleep(Duration::from_millis(1500));
+        assert!(
+            !marker.exists(),
+            "the reap must kill a descendant the child left running"
+        );
+    }
+}

--- a/crates/rue-test-runner/src/supervise.rs
+++ b/crates/rue-test-runner/src/supervise.rs
@@ -399,7 +399,7 @@ impl<'a> Supervisor<'a> {
         if reap_group {
             reap_process_group(pgid);
         }
-        if let Some(observer) = observer.as_deref_mut() {
+        if let Some(observer) = observer {
             observer.reaped(pgid);
         }
 

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -63,10 +63,10 @@ rue_binary(
     crate_root = "src/main.rs",
     deps = _DEPS + _COMPILER_ALLOCATOR_DEPS + [
         ":rue-driver",
-        # `rue test` supervises one process per test with the same bounded
-        # pipe-drain, process-group, and timeout mechanics the harnesses use
-        # (ADR-0083 §3 adopts them as contract). One implementation, in
-        # //crates/rue-test-runner:pipe_drain, rather than a second copy here.
+        # `rue test` supervises one process per test through the same loop the
+        # harnesses use — bounded pipe drains, process group, timeout, group
+        # reap (ADR-0083 §3 adopts them as contract). One implementation, in
+        # rue-test-runner's `supervise` module, rather than a second copy here.
         "//crates/rue-test-runner:rue-test-runner",
     ],
     test_deps = [

--- a/crates/rue/src/test_mode/exec.rs
+++ b/crates/rue/src/test_mode/exec.rs
@@ -12,9 +12,13 @@
 //! consumption deterministic when the deferred verdict cache (§6) needs it.
 //!
 //! The supervision mechanics — the process group, the SIGKILL on expiry, the
-//! bounded concurrent drains, the post-exit group kill — are `rue-test-runner`'s
-//! and are used from there rather than reimplemented, so the harness and the
-//! product runner cannot drift on the deadlock class RUE-338 closed.
+//! bounded concurrent drains, the post-exit group kill — are
+//! `rue_test_runner::supervise`'s and are driven from there rather than
+//! reimplemented, so the harnesses and the product runner cannot drift on the
+//! deadlock class RUE-338 closed. This module supplies the policy that is this
+//! runner's own: the failure channel as an extra capture, a flood as a verdict
+//! rather than a runner error, and the live-group registry the signal handler
+//! walks.
 
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
@@ -22,10 +26,11 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicI32, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use rue_test_runner::pipe_drain::{PIPE_DRAIN_FINISH_TIMEOUT, PipeDrain, spawn_pipe_drain};
-use rue_test_runner::{configure_process_group, kill_process_group};
+use rue_test_runner::supervise::{
+    GroupObserver, Outcome, OverflowPolicy, SupervisionError, Supervisor,
+};
 
 use super::verdict::{
     CaptureStream, ChannelFrames, Classification, Observation, Overflow, Supervision, classify,
@@ -329,107 +334,63 @@ pub(crate) fn run_one(dispatch: Dispatch<'_>) -> io::Result<Execution> {
             command.pre_exec(move || install_channel(channel_write_fd, channel_read_fd));
         }
     }
-    configure_process_group(&mut command);
 
-    let start = Instant::now();
-    let mut child = command.spawn()?;
-    // The parent's copy of the write end must go now: while it is open, the
-    // reader below can never see end of stream.
-    drop(channel_write);
-    let pid = child.id() as i32;
-    // The child leads its own group, so its pid is its pgid. Registered before
-    // anything can block, so a signal arriving during the drain below still
-    // finds this test.
-    let group_slot = register_group(pid);
-
-    let mut stdout_drain = spawn_pipe_drain(child.stdout.take(), Some(dispatch.stream_budget));
-    let mut stderr_drain = spawn_pipe_drain(child.stderr.take(), Some(dispatch.stream_budget));
-    // Ownership of the read end moves to the drain thread, which closes it at
-    // end of stream. The runner holds it open until then on purpose: a test
-    // writing to a channel whose reader had closed would die of SIGPIPE.
-    let mut channel_drain = spawn_pipe_drain(
-        Some(std::fs::File::from(channel_read)),
-        Some(CHANNEL_BUDGET),
-    );
-
-    let mut supervision = Supervision::Exited;
-    let status = loop {
-        stdout_drain.poll();
-        stderr_drain.poll();
-        channel_drain.poll();
-
-        if let Some(overflow) = overflowed(
-            &stdout_drain,
-            &stderr_drain,
-            &channel_drain,
-            dispatch.stream_budget,
-        ) {
-            supervision = Supervision::OutputOverflow(overflow);
-            kill_process_group(&mut child);
-            break None;
-        }
-
-        match child.try_wait()? {
-            Some(status) => break Some(status),
-            None => {
-                if start.elapsed() > dispatch.timeout {
-                    supervision = Supervision::TimedOut;
-                    kill_process_group(&mut child);
-                    break None;
-                }
-                std::thread::sleep(POLL_INTERVAL);
-            }
-        }
+    let mut live = LiveGroup {
+        channel_write: Some(channel_write),
+        slot: None,
     };
-    let duration = start.elapsed();
+    let run = Supervisor::new(command, dispatch.timeout)
+        .stream_budget(dispatch.stream_budget)
+        // The failure channel is drained on the same terms as the streams and
+        // against its own budget, so a test that floods stdout cannot truncate
+        // its own failure record (ADR-0083 §2). Budgeting it here rather than
+        // leaving it to the frame parser (RUE-2025) is what makes a flooded
+        // channel report as a flood instead of as an unreadable frame.
+        //
+        // Ownership of the read end moves to the drain thread, which closes it
+        // at end of stream. It stays open until then on purpose: a test writing
+        // to a channel whose reader had closed would die of SIGPIPE.
+        .extra_capture(std::fs::File::from(channel_read), CHANNEL_BUDGET)
+        // A capture past its budget is this test's verdict, not a runner
+        // failure: the run continues and the flood is reported.
+        .overflow_policy(OverflowPolicy::Verdict)
+        .poll_interval(POLL_INTERVAL)
+        // Post-exit group SIGKILL for stragglers: hygiene, not containment
+        // (ADR-0083 §3).
+        .reap_group(true)
+        .observer(&mut live)
+        .run()
+        .map_err(SupervisionError::into_io)?;
 
-    // Post-exit group SIGKILL for stragglers: hygiene, not containment
-    // (ADR-0083 §3). A descendant that outlived its parent would otherwise keep
-    // a pipe open and stall the bounded finish below for no useful reason.
-    reap_process_group(pid);
-    if let Some(slot) = group_slot {
-        unregister_group(slot, pid);
-    }
-
-    finish(&mut stdout_drain);
-    finish(&mut stderr_drain);
-    finish(&mut channel_drain);
-
-    // The budget is enforced by the drain threads, which hand their verdict
-    // over a channel — so a test that floods its stdout and then exits
-    // immediately can be reaped before the overflow message arrives. Reading
-    // the flag again after the bounded finish is what keeps such a test from
-    // reporting as a pass whose digest silently covers a truncated prefix.
-    if supervision == Supervision::Exited
-        && let Some(overflow) = overflowed(
-            &stdout_drain,
-            &stderr_drain,
-            &channel_drain,
-            dispatch.stream_budget,
-        )
-    {
-        supervision = Supervision::OutputOverflow(overflow);
-    }
-
-    let (exit_code, signal) = match &status {
+    let supervision = match run.outcome {
+        Outcome::Exited => Supervision::Exited,
+        Outcome::TimedOut => Supervision::TimedOut,
+        Outcome::Overflowed(record) => Supervision::OutputOverflow(overflow(record)),
+    };
+    let (exit_code, signal) = match &run.status {
         Some(status) => {
             use std::os::unix::process::ExitStatusExt;
             (status.code(), status.signal())
         }
+        // The runner killed the group, so there is no self-reported status.
         None => (None, None),
     };
-    let frames = super::verdict::parse_channel(channel_drain.bytes());
+    let channel = run
+        .extra
+        .into_iter()
+        .next()
+        .expect("the failure channel is always captured");
+    let frames = super::verdict::parse_channel(&channel.bytes);
     let status_for_classification = match (exit_code, signal) {
         (Some(code), _) => Ok(code),
         (None, Some(signal)) => Err(signal),
-        // The runner killed the group, so there is no self-reported status.
         // Supervision decides these, ahead of the status, in `classify`.
         (None, None) => Err(libc::SIGKILL),
     };
     let classification = classify(Observation {
         supervision,
         status: status_for_classification,
-        stderr: stderr_drain.bytes(),
+        stderr: &run.stderr.bytes,
         frames: &frames,
     });
 
@@ -438,41 +399,64 @@ pub(crate) fn run_one(dispatch: Dispatch<'_>) -> io::Result<Execution> {
         exit_code,
         signal,
         frames,
-        stdout_total: stdout_drain.bytes_total(),
-        stderr_total: stderr_drain.bytes_total(),
-        stdout: stdout_drain.into_bytes(),
-        stderr: stderr_drain.into_bytes(),
-        duration,
+        stdout_total: run.stdout.total,
+        stderr_total: run.stderr.total,
+        stdout: run.stdout.bytes,
+        stderr: run.stderr.bytes,
+        duration: run.duration,
         scratch_dir: scratch,
     })
 }
 
-fn finish(drain: &mut PipeDrain) {
-    drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
+/// The runner's stake in one live test process.
+///
+/// Both halves exist only while the child does: the parent's copy of the
+/// channel's write end, which must be released the moment the child owns its
+/// own, and the registry slot the signal handler walks.
+struct LiveGroup {
+    channel_write: Option<OwnedFd>,
+    slot: Option<usize>,
 }
 
-/// The first capture to outgrow its budget, if any.
+impl GroupObserver for LiveGroup {
+    fn spawned(&mut self, pgid: i32) {
+        // While the parent's write end is open, the channel's reader can never
+        // see end of stream.
+        self.channel_write = None;
+        // Published before anything can block, so a signal arriving during the
+        // drain still finds this test.
+        self.slot = register_group(pgid);
+    }
+
+    fn reaped(&mut self, pgid: i32) {
+        // A pid is reusable the moment its group is empty, so a stale entry
+        // would aim a SIGKILL at whatever unrelated process inherited the
+        // number. Withdraw it as soon as the group is gone.
+        if let Some(slot) = self.slot.take() {
+            unregister_group(slot, pgid);
+        }
+    }
+}
+
+/// Name the capture that flooded in the runner's own vocabulary.
 ///
-/// The channel is checked with the streams rather than left to the frame parser
-/// (RUE-2025): a channel truncated mid-line surfaces as a malformed frame, which
-/// reports the test as a bare `exit` with a runner note about an unreadable
-/// channel — a description of the symptom, not of the test writing a quarter of
-/// a megabyte of failure records.
-fn overflowed(
-    stdout: &PipeDrain,
-    stderr: &PipeDrain,
-    channel: &PipeDrain,
-    stream_budget: usize,
-) -> Option<Overflow> {
-    let candidates = [
-        (stdout, CaptureStream::Stdout, stream_budget),
-        (stderr, CaptureStream::Stderr, stream_budget),
-        (channel, CaptureStream::Channel, CHANNEL_BUDGET),
-    ];
-    candidates
-        .into_iter()
-        .find(|(drain, _, _)| drain.overflowed())
-        .map(|(_, stream, budget)| Overflow { stream, budget })
+/// The supervisor knows the failure channel as the first extra capture; the
+/// event stream knows it as the channel, because that is what a reader of a
+/// verdict needs told.
+fn overflow(record: rue_test_runner::supervise::Overflow) -> Overflow {
+    use rue_test_runner::supervise::CaptureStream as Captured;
+    let stream = match record.stream {
+        Captured::Stdout => CaptureStream::Stdout,
+        Captured::Stderr => CaptureStream::Stderr,
+        Captured::Extra(0) => CaptureStream::Channel,
+        Captured::Extra(index) => {
+            unreachable!("a test process has one extra capture, not {}", index + 1)
+        }
+    };
+    Overflow {
+        stream,
+        budget: record.budget,
+    }
 }
 
 /// A fresh pipe for one test's failure channel.
@@ -567,18 +551,10 @@ fn install_channel(write_fd: i32, read_fd: i32) -> io::Result<()> {
     Ok(())
 }
 
-/// Best-effort teardown of anything the test left running in its group.
-fn reap_process_group(pid: i32) {
-    // SAFETY: a negative pid names the process group led by `pid`. Failure
-    // (an already-empty group) is the ordinary case and carries no obligation.
-    unsafe {
-        libc::kill(-pid, libc::SIGKILL);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Instant;
 
     /// The dispatcher parses a fixed-width, lowercase, sixteen-digit selector
     /// and rejects everything else, so this rendering is contract.
@@ -639,38 +615,36 @@ mod tests {
         assert_ne!(DEFAULT_STREAM_BUDGET, CHANNEL_BUDGET);
     }
 
-    fn drained(bytes: usize, budget: usize) -> PipeDrain {
-        let mut drain =
-            spawn_pipe_drain(Some(std::io::Cursor::new(vec![b'x'; bytes])), Some(budget));
-        drain.finish(Duration::from_secs(5));
-        drain
-    }
-
     /// A channel past its budget is the same supervision outcome as a flooded
     /// stream, and names its own budget: before RUE-2025 it was not checked at
     /// all, so it surfaced as a truncated frame and a bare `exit`.
     #[test]
     fn a_channel_past_its_budget_overflows_naming_the_channel() {
-        let quiet = drained(16, DEFAULT_STREAM_BUDGET);
-        let flooded = drained(CHANNEL_BUDGET + 1, CHANNEL_BUDGET);
-        let overflow = overflowed(&quiet, &quiet, &flooded, DEFAULT_STREAM_BUDGET)
-            .expect("a channel past its budget is an overflow");
-        assert_eq!(overflow.stream, CaptureStream::Channel);
-        assert_eq!(overflow.budget, CHANNEL_BUDGET);
+        let reported = overflow(rue_test_runner::supervise::Overflow {
+            stream: rue_test_runner::supervise::CaptureStream::Extra(0),
+            budget: CHANNEL_BUDGET,
+        });
+        assert_eq!(reported.stream, CaptureStream::Channel);
+        assert_eq!(reported.budget, CHANNEL_BUDGET);
     }
 
     /// Each capture reports its own budget, which is the whole reason the
     /// overflow carries one: the channel's is a quarter of a stream's.
     #[test]
     fn an_overflowing_stream_reports_the_budget_it_exceeded() {
-        let quiet = drained(16, 64);
-        let flooded = drained(128, 64);
-        let stdout = overflowed(&flooded, &quiet, &quiet, 64).expect("stdout overflowed");
-        assert_eq!(stdout.stream, CaptureStream::Stdout);
-        assert_eq!(stdout.budget, 64);
-        let stderr = overflowed(&quiet, &flooded, &quiet, 64).expect("stderr overflowed");
-        assert_eq!(stderr.stream, CaptureStream::Stderr);
-        assert!(overflowed(&quiet, &quiet, &quiet, 64).is_none());
+        use rue_test_runner::supervise::CaptureStream as Captured;
+
+        for (captured, expected) in [
+            (Captured::Stdout, CaptureStream::Stdout),
+            (Captured::Stderr, CaptureStream::Stderr),
+        ] {
+            let reported = overflow(rue_test_runner::supervise::Overflow {
+                stream: captured,
+                budget: DEFAULT_STREAM_BUDGET,
+            });
+            assert_eq!(reported.stream, expected);
+            assert_eq!(reported.budget, DEFAULT_STREAM_BUDGET);
+        }
     }
 
     /// A pipe both of whose ends leaked into an unrelated concurrent spawn


### PR DESCRIPTION
Fixes RUE-1986

## Why

Three child-process supervision loops (drain pipes, `try_wait`, timeout, kill group) had grown in `rue-test-runner`, the `rue test` runner in `crates/rue/src/test_mode/exec.rs`, and `rue-oracle-diff/src/fuzz.rs`, each with its own poll interval, comparison operator, collection bound, and overflow handling. Mechanism drifted where only policy should differ.

## What

- New `rue_test_runner::supervise` module: one `Supervisor` builder (`stream_budget`/`stream_budgets`, `stdin_input`, `extra_capture`, `overflow_policy`, `poll_interval`, `reap_group`, `observer`), `OverflowPolicy::{Fail, Verdict, Truncate}`, `SupervisedRun` with per-stream `Capture { bytes, total, truncated }`, and a `GroupObserver` hook for the two instants only the supervisor knows (group spawned, group reaped). Twelve unit tests cover the policies, timeout kill, extra drains, and the post-exit overflow re-check.
- `rue-test-runner/src/lib.rs`: `run_with_timeout_impl` is a thin adapter under `Fail`; message text is unchanged, including the `(process group killed)` suffix only when the supervisor stopped the child.
- `crates/rue/src/test_mode/exec.rs`: `run_one` drives the supervisor under `Verdict`, with the failure channel as an extra capture on its own 256 KiB budget, the 5 ms poll, the post-exit group reap, and the `LIVE_GROUPS` registry implemented as a `GroupObserver`. Local `finish`/`overflowed`/`reap_process_group` copies are deleted.
- `rue-oracle-diff/src/fuzz.rs`: `run_process_with_timeout` is a supervisor call under `Truncate` with the asymmetric 256 KiB / 8 KiB caps; `wait_for_process`, `terminate_and_reap`, and `read_capped` are deleted.
- `crates/rue/BUCK`: the dependency comment now names the `supervise` module.

No new crate edges: both `crates/rue` and `crates/rue-oracle-diff` already depended on rue-test-runner for `pipe_drain` and the process-group helpers, and rue-test-runner has no compiler-crate dependencies.

Deliberate per-consumer behavior is kept: the `rue test` verdict and channel pipe, the spec/CLI harness failure, and the fuzzer's truncate-without-killing policy. The issue's claim that oracle-diff compares a truncated result as complete is stale: `fuzz::classify` already fails closed on either truncation flag, with a test pinning it, so that policy is preserved rather than changed. Accidental differences (`>` vs `>=` timeout, unbounded vs bounded collection, kill on wait error) are unified. The supervisor reports only the first overflowing capture, so the old combined "stdout and stderr" wording is gone; nothing depended on it.

Not in scope: the `--watch` child-process site in `crates/rue-cli-tests` (an event-driven wait, not a run-to-completion supervisor) and `rue-mcp`'s two-line private `configure_process_group` copy.

## Verification

| Command | Result |
|---|---|
| `scripts/rue unit test-runner` | 138 passed (12 new) |
| `scripts/rue unit rue test_mode`, `scripts/rue unit rue exec` | 111 / 15 passed |
| `scripts/rue unit oracle-diff` | 105 passed |
| `scripts/rue quick` | Pass 36, Fail 0 (re-run after rebasing onto current trunk) |
| `scripts/rue cli rue_test` | 91 passed, including the flooding-test and flooded-channel overflow cases |
| `scripts/rue spec 4.1` | 28 passed |
| `./buck2 test //:oracle-diff-generated-smoke //crates/rue-oracle-diff:oracle-diff-planted-miscompile-test` | Pass 2 |
| `./buck2 build` of rue-frontend-diff, rue-cli-tests, rue-c-abi-matrix, rue-spec, rue-benchmark, rue-driver | succeeded |
| `scripts/rue fmt` | clean |