### PR TITLE
RUE-1969: drive batch, emit, and watch compiles through one gated cycle

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -349,6 +349,32 @@ pub fn t() -> i32 { 1 }
 compile_fail = true
 error_contains = ["E0704", "imported with its extension", "@import(\"thing.rue\")"]
 
+# RUE-1969: `--emit` printed the same discovery diagnostics without the
+# migration help, because the help was applied per entry point and only the
+# batch compile applied it. The help now belongs to the renderer, so the JSON
+# `helps` array is populated wherever the diagnostic is published.
+[[case]]
+name = "extensionless_file_miss_suggests_extensioned_spelling_under_emit"
+description = "RUE-1969: an `--emit` stopped by a discovery failure reports the same E0704 as a batch compile, migration help included, with `helps` populated in the JSON surface."
+files = [
+    { path = "main.rue", source = """
+const thing = @import("thing");
+fn main() -> i32 { 0 }
+""" },
+    { path = "thing.rue", source = """
+pub fn t() -> i32 { 1 }
+""" },
+]
+args = ["--error-format", "json", "--emit", "ast", "main.rue"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0704 main.rue:1:15"]
+error_contains = [
+    "\"code\":\"E0704\"",
+    "imported with its extension: @import(\\\"thing.rue\\\")",
+]
+compile_stderr_not_contains = ["\"helps\":[]"]
+
 [[case]]
 name = "import_escaping_root_is_e0713"
 description = "ADR-0078: a relative import whose normalized candidate leaves the project root is E0713 with no filesystem probe."

--- a/crates/rue-cli-tests/cases/output_guard.toml
+++ b/crates/rue-cli-tests/cases/output_guard.toml
@@ -81,3 +81,20 @@ fn main() -> i32 { h.value() }
 args = ["main.rue", "-o", "helper.rue"]
 compile_fail = true
 error_contains = ["also an input source file"]
+
+[[case]]
+# RUE-1969: the refusal had three spellings — two bare `Error:` lines in the
+# batch driver and two more in the watch loop, none of them a diagnostic, so
+# under `--error-format json` the batch one was a raw line in a stream every
+# other line of which is a JSON array. There is now one message, carried by
+# the publication error itself and rendered like every other publication
+# failure, so it names the output path and is framed for the chosen format.
+name = "output_alias_refusal_is_one_coded_diagnostic"
+files = [{ path = "a.rue", source = "fn main() -> i32 { 1 }\n" }]
+args = ["--error-format", "json", "a.rue", "-o", "a.rue"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E1403 -"]
+error_contains = [
+  "output path 'a.rue' is also an input source file; refusing to overwrite it",
+]

--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -169,3 +169,31 @@ source = "pub fn answer() -> i32 { 2 }\n"
 [[case.watch.edits]]
 path = "helper.rue"
 source = "pub fn answer() -> i32 { 3 }\n"
+
+# RUE-1969. Watch used to assemble its own compile orchestration and never
+# gated on the discovery status, so a root whose import graph did not close
+# reached the compiler and came back with the driver's own internal-input
+# error: `E1400 invalid compiler input: compilation requires a closed-valid
+# import discovery revision`. The user never saw the unresolved `@import` that
+# actually failed, nor the ADR-0078 migration help a batch compile prints for
+# it. The gate now lives in the host's compile-scope entry points, so every
+# driver reports the program's own diagnostic.
+[[case]]
+name = "discovery_failure_reports_the_unresolved_import_with_its_help"
+files = [
+    { path = "main.rue", source = "const util = @import(\"util\");\nfn main() -> i32 { util.value() }\n" },
+    { path = "util.rue", source = "pub fn value() -> i32 { 7 }\n" },
+]
+
+[case.watch]
+kind = "initial_failure"
+stderr_contains = [
+    "E0704",
+    "cannot find module 'util'",
+    "imported with its extension: @import(\"util.rue\")",
+]
+expected_exit_codes = [7]
+
+[[case.watch.edits]]
+path = "main.rue"
+source = "const util = @import(\"util.rue\");\nfn main() -> i32 { util.value() }\n"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -1298,6 +1298,14 @@ struct WatchScenario {
     #[serde(default)]
     acquire_delay_ms: Option<u64>,
     edits: Vec<WatchEdit>,
+    /// Substrings the watch process's stderr must contain. The milestone
+    /// protocol says which boundary a cycle reached; this pins what the cycle
+    /// told the user when it got there.
+    #[serde(default)]
+    stderr_contains: Vec<String>,
+    /// The exit status the published program has at each publication the
+    /// scenario waits for. An `initial_failure` scenario publishes only once,
+    /// so it declares one; every other kind declares two.
     expected_exit_codes: Vec<i32>,
 }
 
@@ -1310,6 +1318,10 @@ enum WatchScenarioKind {
     SymlinkRetarget,
     SupersedeReobserve,
     SupersedeAcquire,
+    /// The FIRST cycle fails, so the watcher publishes nothing before the
+    /// edit repairs the program. Every other kind opens with a publication,
+    /// which is exactly what a first-cycle failure cannot produce.
+    InitialFailure,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -2853,9 +2865,19 @@ fn run_watch_case(
     rue_binary: &Path,
     real_std: &Path,
 ) -> TestResult {
-    if scenario.expected_exit_codes.len() != 2 || scenario.edits.len() < 1 {
+    let expected_publications = if scenario.kind == WatchScenarioKind::InitialFailure {
+        1
+    } else {
+        2
+    };
+    if scenario.expected_exit_codes.len() != expected_publications || scenario.edits.is_empty() {
+        return Err(TestFailure::assertion(format!(
+            "watch scenario requires {expected_publications} expected exit(s) and at least one edit"
+        )));
+    }
+    if scenario.kind == WatchScenarioKind::InitialFailure && scenario.edits.len() != 1 {
         return Err(TestFailure::assertion(
-            "watch scenario requires two expected exits and at least one edit",
+            "initial-failure watch scenario requires exactly one repairing edit",
         ));
     }
     if scenario.kind == WatchScenarioKind::Cancel && scenario.edits.len() != 2 {
@@ -3008,13 +3030,25 @@ fn run_watch_case(
     let deadline = Instant::now() + contract.runtime_timeout().min(Duration::from_secs(30));
     let result = (|| -> Result<(), String> {
         wait_for_watch_event(&mut child, &protocol, "ready", 1, deadline)?;
-        wait_for_watch_event(&mut child, &protocol, "published", 1, deadline)?;
         let program = dir.join(output_name);
-        assert_watch_program(contract, &program, scenario.expected_exit_codes[0])
-            .map_err(|error| error.to_string())?;
+        if scenario.kind == WatchScenarioKind::InitialFailure {
+            // The very first cycle is the one that fails, so there is no
+            // opening publication to wait for and nothing on disk to run.
+            wait_for_watch_event(&mut child, &protocol, "compile-error", 1, deadline)?;
+            if program.exists() {
+                return Err("a failed first watch cycle must publish nothing".to_string());
+            }
+        } else {
+            wait_for_watch_event(&mut child, &protocol, "published", 1, deadline)?;
+            assert_watch_program(contract, &program, scenario.expected_exit_codes[0])
+                .map_err(|error| error.to_string())?;
+        }
 
         write_watch_edit(dir, &scenario.edits[0])?;
         match scenario.kind {
+            WatchScenarioKind::InitialFailure => {
+                wait_for_watch_event(&mut child, &protocol, "published", 1, deadline)?;
+            }
             WatchScenarioKind::Edit => {
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
             }
@@ -3138,8 +3172,8 @@ fn run_watch_case(
                 assert_fresh_cycle_after_supersession(&events, superseded)?;
             }
         }
-        assert_watch_program(contract, &program, scenario.expected_exit_codes[1])
-            .map_err(|error| error.to_string())?;
+        let final_exit = scenario.expected_exit_codes[expected_publications - 1];
+        assert_watch_program(contract, &program, final_exit).map_err(|error| error.to_string())?;
         if matches!(
             scenario.kind,
             WatchScenarioKind::Cancel
@@ -3157,10 +3191,15 @@ fn run_watch_case(
 
     let (status, stdout_bytes, stderr_bytes) = finish_watch_child(child, stdout, stderr, true);
     let result = result.and_then(|()| {
+        let stderr = String::from_utf8_lossy(&stderr_bytes);
+        for expected in &scenario.stderr_contains {
+            if !stderr.contains(expected.as_str()) {
+                return Err(format!("watch stderr did not contain {expected:?}"));
+            }
+        }
         if scenario.error_format.as_deref() == Some("json") {
-            let diagnostics =
-                validate_json_diagnostic_stream(&String::from_utf8_lossy(&stderr_bytes))
-                    .map_err(|error| format!("watch JSON stderr validation failed: {error}"))?;
+            let diagnostics = validate_json_diagnostic_stream(&stderr)
+                .map_err(|error| format!("watch JSON stderr validation failed: {error}"))?;
             if diagnostics.is_empty() {
                 return Err("watch JSON stderr contained no diagnostics".to_string());
             }

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -145,8 +145,10 @@ pub(crate) enum Supersession {
 /// diagnostic stream; the report says what happened so the caller can pick an
 /// exit status or a progress line.
 pub(crate) enum CycleReport {
-    /// The executable reached the output path.
-    Published(PublishedExecutable),
+    /// The executable reached the output path. Boxed because the one-shot
+    /// metrics it carries dwarf every other outcome, and a report is built
+    /// once per cycle.
+    Published(Box<PublishedExecutable>),
     /// The program was rejected, or the destination or publication was
     /// refused.
     Failed,
@@ -246,7 +248,7 @@ pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
     match publication.result {
         Ok(published) => {
             announce(announcement, source_path, output_path, options);
-            CycleReport::Published(published)
+            CycleReport::Published(Box::new(published))
         }
         Err(PublishError::InputsChanged) => CycleReport::Superseded(Supersession::AtPublication),
         Err(error) => {

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -1,33 +1,19 @@
+use std::path::Path;
+use std::time::Instant;
+
 use rue_compiler::unstable::{CancellableCompileOutcome, CompilationCancellation, OneShotMetrics};
-use rue_compiler::{CompileErrors, CompileOptions, CompileWarning};
+use rue_compiler::{CompileOptions, CompileWarning, LinkerMode};
 use rue_driver::{FilesystemCompilerHost, WatchInput};
 
+use crate::DiagnosticOutput;
 use crate::output::{
-    PublicationDestination, PublishRequest, publish_executable, publish_watch_executable,
+    PublicationDestination, PublishError, PublishRequest, publish_executable,
+    publish_watch_executable,
 };
 
-/// Typed ownership boundary for the compile/link/publish operation.
-pub(crate) struct CompileRequest<'a> {
-    pub(crate) host: &'a mut FilesystemCompilerHost,
-    pub(crate) options: CompileOptions,
-    pub(crate) destination: PublicationDestination,
-}
-
-pub(crate) struct CancellableCompileRequest<'a> {
-    pub(crate) host: &'a mut FilesystemCompilerHost,
-    pub(crate) options: CompileOptions,
-    pub(crate) destination: PublicationDestination,
-    pub(crate) cancellation: CompilationCancellation,
-    pub(crate) watch_inputs: Vec<WatchInput>,
-}
-
-pub(crate) enum CompileCycleOutcome {
-    Linked(Box<LinkedExecutable>),
-    Errors(CompileErrors),
-    Canceled,
-}
-
-pub(crate) struct LinkedExecutable {
+/// Linked bytes and everything publication needs, held between the compiler's
+/// timing root closing and the atomic write.
+struct LinkedExecutable {
     target: rue_target::Target,
     warnings: Vec<CompileWarning>,
     metrics: OneShotMetrics,
@@ -45,50 +31,14 @@ pub(crate) struct PublishedExecutable {
     metrics: OneShotMetrics,
 }
 
-pub(crate) struct PublicationAttempt {
-    pub(crate) warnings: Vec<CompileWarning>,
-    pub(crate) result: Result<PublishedExecutable, crate::output::PublishError>,
-}
-
-/// Execute the canonical compiler session through linking.
-pub(crate) fn execute(request: CompileRequest<'_>) -> Result<LinkedExecutable, CompileErrors> {
-    let output = request.host.executable_in_compile_scope(&request.options)?;
-    let metrics = output.unstable_metrics();
-    Ok(LinkedExecutable {
-        target: request.options.target,
-        warnings: output.warnings,
-        metrics,
-        linked_bytes: output.elf,
-        destination: request.destination,
-        observation: PublicationObservation::OneShot,
-    })
-}
-
-pub(crate) fn execute_cancellable(request: CancellableCompileRequest<'_>) -> CompileCycleOutcome {
-    let output = request
-        .host
-        .cancellable_executable_in_compile_scope(&request.options, request.cancellation);
-    match output {
-        CancellableCompileOutcome::Completed(output) => {
-            let output = *output;
-            let metrics = output.unstable_metrics();
-            CompileCycleOutcome::Linked(Box::new(LinkedExecutable {
-                target: request.options.target,
-                warnings: output.warnings,
-                metrics,
-                linked_bytes: output.elf,
-                destination: request.destination,
-                observation: PublicationObservation::Watch(request.watch_inputs),
-            }))
-        }
-        CancellableCompileOutcome::Errors(errors) => CompileCycleOutcome::Errors(errors),
-        CancellableCompileOutcome::Canceled => CompileCycleOutcome::Canceled,
-    }
+struct PublicationAttempt {
+    warnings: Vec<CompileWarning>,
+    result: Result<PublishedExecutable, PublishError>,
 }
 
 impl LinkedExecutable {
     /// Finalize and publish the linked bytes after compiler timing/accounting closes.
-    pub(crate) fn publish(self) -> PublicationAttempt {
+    fn publish(self) -> PublicationAttempt {
         let LinkedExecutable {
             target,
             warnings,
@@ -122,5 +72,246 @@ impl LinkedExecutable {
 impl PublishedExecutable {
     pub(crate) fn unstable_metrics(&self) -> OneShotMetrics {
         self.metrics
+    }
+}
+
+/// One compile cycle: destination preflight, compile, publish, warnings, and
+/// the success line.
+///
+/// The batch driver runs it once and the watch loop runs it per revision, so
+/// there is one implementation of each of those steps rather than two that
+/// drift. What a watch cycle adds — the change monitor, cancellation,
+/// re-observation, and the cycle's own progress text — stays in `watch`, which
+/// reads the report this returns and decides what to say and whether to keep
+/// looping.
+///
+/// The discovery gate is not a step here: the host's compile-scope entry
+/// points refuse an unclosed import graph and hand back discovery's own
+/// diagnostics, so a cycle reports the unresolved `@import` through the
+/// ordinary compile-failure path whichever driver runs it (RUE-1969).
+pub(crate) struct CycleRequest<'a, 'diagnostics> {
+    pub(crate) host: &'a mut FilesystemCompilerHost,
+    pub(crate) options: &'a CompileOptions,
+    pub(crate) diagnostics: &'a DiagnosticOutput<'diagnostics>,
+    pub(crate) source_path: &'a str,
+    pub(crate) output_path: &'a str,
+    pub(crate) observation: CycleObservation<'a>,
+    pub(crate) announcement: Announcement,
+}
+
+/// How this cycle observes its inputs, which decides how the destination is
+/// validated, whether compilation can be canceled, and whether publication
+/// revalidates the accepted-read closure.
+pub(crate) enum CycleObservation<'a> {
+    /// A one-shot build: the destination is checked against the closed
+    /// snapshot's own paths and the compile runs to completion.
+    OneShot,
+    /// A watch cycle: the destination is checked against the accepted-read
+    /// closure, the compile is cancellable, and publication refuses to install
+    /// bytes built from inputs that have since changed. `superseded` reports
+    /// whether a newer revision landed while this one compiled; a superseded
+    /// cycle publishes nothing and says nothing, because its diagnostics
+    /// describe source the user has already replaced.
+    Watch {
+        inputs: Vec<WatchInput>,
+        cancellation: CompilationCancellation,
+        superseded: &'a dyn Fn() -> bool,
+    },
+}
+
+/// What the cycle says on success.
+pub(crate) enum Announcement {
+    /// Nothing: `--benchmark-json` owns stdout and a banner would corrupt it.
+    Silent,
+    /// The one-shot success line.
+    Completed,
+    /// The watch success line, which additionally reports how long the cycle
+    /// took. Carries the cycle's start, so the time it reports is measured at
+    /// the moment the executable actually reached the output path.
+    Cycle(Instant),
+}
+
+/// Which boundary caught a newer revision. Both refuse to publish; they differ
+/// only in what the watcher's progress protocol calls them.
+pub(crate) enum Supersession {
+    /// Observed after the compile, before anything was written.
+    BeforePublication,
+    /// The publication guard refused to install bytes built from inputs that
+    /// had already changed.
+    AtPublication,
+}
+
+/// The outcome of a cycle. Every diagnostic it produced is already on the
+/// diagnostic stream; the report says what happened so the caller can pick an
+/// exit status or a progress line.
+pub(crate) enum CycleReport {
+    /// The executable reached the output path.
+    Published(PublishedExecutable),
+    /// The program was rejected, or the destination or publication was
+    /// refused.
+    Failed,
+    /// A newer source revision arrived before this one could publish. Nothing
+    /// was written and nothing was reported.
+    Superseded(Supersession),
+    /// Compilation was canceled without a newer revision being observed.
+    Canceled,
+}
+
+pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
+    let CycleRequest {
+        host,
+        options,
+        diagnostics,
+        source_path,
+        output_path,
+        observation,
+        announcement,
+    } = request;
+
+    // A revision whose import graph did not close valid is reported as that
+    // and nothing else: the unresolved `@import` is the user's problem, and
+    // the destination preflight's answer about the output path would only bury
+    // it (RUE-810). The host refuses such a revision at every compile-scope
+    // entry point regardless, so a driver that forgot to ask still cannot
+    // reach the compiler with one; asking here only fixes the order.
+    if let Some(errors) = host.discovery_refusal() {
+        diagnostics.print_errors(&errors);
+        return CycleReport::Failed;
+    }
+
+    // Closed discovery fixes the complete source identity set, so the
+    // destination can be validated before any semantic, codegen, or link work
+    // and the set retained for mandatory revalidation immediately before the
+    // atomic publication.
+    let destination = match preflight(Path::new(output_path), host, &observation) {
+        Ok(destination) => destination,
+        Err(error) => {
+            diagnostics.print_error(&error.into_compile_error());
+            return CycleReport::Failed;
+        }
+    };
+
+    let linked = match observation {
+        CycleObservation::OneShot => match host.executable_in_compile_scope(options) {
+            Ok(output) => linked_executable(
+                output,
+                options,
+                destination,
+                PublicationObservation::OneShot,
+            ),
+            Err(errors) => {
+                diagnostics.print_errors(&errors);
+                return CycleReport::Failed;
+            }
+        },
+        CycleObservation::Watch {
+            ref inputs,
+            ref cancellation,
+            superseded,
+        } => {
+            let outcome =
+                host.cancellable_executable_in_compile_scope(options, cancellation.clone());
+            // A superseded cycle describes bytes that no longer exist. Check
+            // before reporting, so a transient error the user has already
+            // fixed never reaches the terminal.
+            if superseded() {
+                return CycleReport::Superseded(Supersession::BeforePublication);
+            }
+            match outcome {
+                CancellableCompileOutcome::Completed(output) => linked_executable(
+                    *output,
+                    options,
+                    destination,
+                    PublicationObservation::Watch(inputs.clone()),
+                ),
+                CancellableCompileOutcome::Errors(errors) => {
+                    diagnostics.print_errors(&errors);
+                    return CycleReport::Failed;
+                }
+                CancellableCompileOutcome::Canceled => return CycleReport::Canceled,
+            }
+        }
+    };
+
+    // Publication runs after the compiler's timing root closes, so it is
+    // measured as a driver phase: it breaks down process-minus-root overhead
+    // without becoming a second timing root (RUE-786).
+    let publication = {
+        let _span = tracing::info_span!("output_write", driver_phase = true).entered();
+        linked.publish()
+    };
+    // Warnings live outside the publication result so a failure cannot discard
+    // them; present them before inspecting the publication outcome.
+    diagnostics.print_warnings(&publication.warnings);
+    match publication.result {
+        Ok(published) => {
+            announce(announcement, source_path, output_path, options);
+            CycleReport::Published(published)
+        }
+        Err(PublishError::InputsChanged) => CycleReport::Superseded(Supersession::AtPublication),
+        Err(error) => {
+            diagnostics.print_error(&error.into_compile_error());
+            CycleReport::Failed
+        }
+    }
+}
+
+fn preflight(
+    path: &Path,
+    host: &FilesystemCompilerHost,
+    observation: &CycleObservation<'_>,
+) -> Result<PublicationDestination, PublishError> {
+    match observation {
+        CycleObservation::OneShot => crate::output::preflight_destination(
+            path,
+            host.source_snapshot().files().map(|source| source.path),
+        ),
+        CycleObservation::Watch { inputs, .. } => {
+            crate::output::preflight_watch_destination(path, inputs)
+        }
+    }
+}
+
+fn linked_executable(
+    output: rue_compiler::CompileOutput,
+    options: &CompileOptions,
+    destination: PublicationDestination,
+    observation: PublicationObservation,
+) -> LinkedExecutable {
+    let metrics = output.unstable_metrics();
+    LinkedExecutable {
+        target: options.target,
+        warnings: output.warnings,
+        metrics,
+        linked_bytes: output.elf,
+        destination,
+        observation,
+    }
+}
+
+fn announce(
+    announcement: Announcement,
+    source_path: &str,
+    output_path: &str,
+    options: &CompileOptions,
+) {
+    let target = options.target;
+    let linker = linker_name(&options.linker);
+    match announcement {
+        Announcement::Silent => {}
+        Announcement::Completed => {
+            println!("Compiled {source_path} -> {output_path} (target: {target}, linker: {linker})")
+        }
+        Announcement::Cycle(started) => println!(
+            "Compiled {source_path} -> {output_path} in {} ms (target: {target}, linker: {linker})",
+            started.elapsed().as_millis()
+        ),
+    }
+}
+
+fn linker_name(linker: &LinkerMode) -> &str {
+    match linker {
+        LinkerMode::Internal => "internal",
+        LinkerMode::System(command) => command,
     }
 }

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -165,11 +165,41 @@ impl FilesystemCompilerHost {
         self.state.session.unstable_present(request)
     }
 
+    /// Discovery's own diagnostics when this revision's import graph did not
+    /// close valid, and nothing when it did.
+    ///
+    /// The compiler answers a compile request made against an uncommitted
+    /// revision with its internal-input error (`E1400`), which describes the
+    /// driver's mistake rather than the user's program. Every compile-scope
+    /// entry point below refuses on this first, so no driver can reach the
+    /// compiler with an unclosed graph: the unresolved `@import` that actually
+    /// failed is what the caller receives, whichever endpoint it called.
+    ///
+    /// It is public because a driver also wants to ask before it starts
+    /// preparing an output the revision will never produce — a program that
+    /// will not resolve its imports is reported as that, not as whatever the
+    /// destination preflight would have said about the path it was given
+    /// (RUE-810).
+    pub fn discovery_refusal(&self) -> Option<CompileErrors> {
+        if self.discovery_status() == ImportDiscoveryStatus::ClosedValid {
+            return None;
+        }
+        Some(self.discovery_revision().diagnostics().clone())
+    }
+
+    fn closed_discovery(&self) -> Result<(), CompileErrors> {
+        match self.discovery_refusal() {
+            Some(errors) => Err(errors),
+            None => Ok(()),
+        }
+    }
+
     /// Preserve the command-line compiler's existing one-shot timed adapter.
     pub fn executable_in_compile_scope(
         &mut self,
         options: &CompileOptions,
     ) -> MultiErrorResult<CompileOutput> {
+        self.closed_discovery()?;
         executable_in_compile_scope(&mut self.state.session, options)
     }
 
@@ -178,6 +208,9 @@ impl FilesystemCompilerHost {
         options: &CompileOptions,
         cancellation: CompilationCancellation,
     ) -> CancellableCompileOutcome {
+        if let Err(errors) = self.closed_discovery() {
+            return CancellableCompileOutcome::Errors(errors);
+        }
         cancellable_executable_in_compile_scope(&mut self.state.session, options, cancellation)
     }
 
@@ -185,6 +218,7 @@ impl FilesystemCompilerHost {
     /// (ADR-0083 §2's `--list`), without codegen or linking, alongside the
     /// diagnostics of every body in the closure that failed to analyze.
     pub fn test_inventory(&mut self, options: &CompileOptions) -> MultiErrorResult<TestListing> {
+        self.closed_discovery()?;
         test_inventory(&mut self.state.session, options)
     }
 
@@ -195,6 +229,7 @@ impl FilesystemCompilerHost {
         &mut self,
         options: &CompileOptions,
     ) -> MultiErrorResult<TestImage> {
+        self.closed_discovery()?;
         test_image_in_compile_scope(&mut self.state.session, options)
     }
 
@@ -429,6 +464,42 @@ mod tests {
 
         assert!(!errors.is_empty());
         assert!(errors.to_string().contains("missing_name"));
+    }
+
+    /// A revision whose import graph did not close valid never reaches the
+    /// compiler: every compile-scope entry point answers with discovery's own
+    /// diagnostics instead of the compiler's internal-input error (RUE-1969).
+    /// The watch loop compiles through the cancellable endpoint and the batch
+    /// driver through the plain one, so both are pinned here.
+    #[test]
+    fn unclosed_discovery_reports_the_unresolved_import_at_every_entry_point() {
+        let dir = TestDir::new("unclosed-discovery");
+        dir.write(
+            "main.rue",
+            "const helper = @import(\"missing.rue\");\nfn main() -> i32 { helper.value() }\n",
+        );
+        let mut host = dir.open();
+        assert_ne!(host.discovery_status(), ImportDiscoveryStatus::ClosedValid);
+
+        let options = CompileOptions::default();
+        let batch = match host.executable_in_compile_scope(&options) {
+            Err(errors) => errors,
+            Ok(_) => panic!("an unresolved import must not compile"),
+        };
+        let watch = match host
+            .cancellable_executable_in_compile_scope(&options, CompilationCancellation::new())
+        {
+            CancellableCompileOutcome::Errors(errors) => errors,
+            _ => panic!("an unresolved import must not compile"),
+        };
+
+        for rendered in [batch.to_string(), watch.to_string()] {
+            assert!(rendered.contains("missing.rue"), "{rendered}");
+            assert!(
+                !rendered.contains("closed-valid import discovery revision"),
+                "the driver's internal-input error must not reach a user: {rendered}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -36,8 +36,8 @@ use rue_driver::{
 };
 
 use rue_compiler::{
-    CompileErrors, CompileOptions, CompileWarning, FileId, ImportDiscoveryStatus, LinkerMode,
-    OptLevel, PreviewFeature, PreviewFeatures, configure_thread_pool,
+    CompileErrors, CompileOptions, CompileWarning, FileId, LinkerMode, OptLevel, PreviewFeature,
+    PreviewFeatures, configure_thread_pool,
 };
 #[cfg(test)]
 use rue_compiler::{CompilerSession, SourceMetadata, SourceSnapshot};
@@ -1183,6 +1183,13 @@ fn validate_watch_modes(options: &Options) -> Result<(), &'static str> {
 /// probe is presentation-only: it runs after discovery has closed, feeds no
 /// observation ledger, and creates no dependency edge, so it can never affect
 /// resolution, closure, or reuse.
+///
+/// `DiagnosticOutput` is its only caller, so the help reaches the reader
+/// whatever produced the diagnostic and whichever renderer presents it — a
+/// batch compile, an `--emit`, a watch cycle, a `rue test` image, and the JSON
+/// copies a `compile_error` event carries. Applying it per entry point instead
+/// is what let `--emit` and `--watch` publish the same `ModuleNotFound`
+/// without it (RUE-1969).
 fn with_import_migration_helps(errors: &CompileErrors) -> CompileErrors {
     let mut enriched = CompileErrors::new();
     for error in errors.iter() {
@@ -1273,6 +1280,7 @@ impl<'a> DiagnosticOutput<'a> {
         batches
             .iter()
             .map(|errors| {
+                let errors = with_import_migration_helps(errors);
                 self.in_source_order(errors.as_slice())
                     .into_iter()
                     .map(|error| {
@@ -1356,6 +1364,7 @@ impl<'a> DiagnosticOutput<'a> {
     }
 
     fn render_errors(&self, errors: &CompileErrors) -> String {
+        let errors = with_import_migration_helps(errors);
         let errors = CompileErrors::from(
             self.in_source_order(errors.as_slice())
                 .into_iter()
@@ -2642,17 +2651,13 @@ fn main() {
         return;
     }
 
-    if compiler_host.discovery_status() != ImportDiscoveryStatus::ClosedValid {
-        diagnostics.print_errors(&with_import_migration_helps(
-            compiler_host.discovery_revision().diagnostics(),
-        ));
-        // Compile mode's rejected-program status is `1` and stays that way.
-        // For `rue test` a program that will not compile is the same outcome as
-        // a link failure or a runner error — the run could not be performed —
-        // and ADR-0083 §2 gives that one code, so an agent branching on the
-        // exit status never has to also parse stderr to tell them apart.
-        std::process::exit(driver_failure_exit_code(&options.mode));
-    }
+    // An import graph that did not close valid never reaches the compiler:
+    // every compile-scope entry point of the host refuses it and publishes
+    // discovery's own diagnostics instead. Compile mode reports that as its
+    // ordinary rejected-program status `1`; `rue test` reports it as a runner
+    // error, because ADR-0083 §2 gives a program that will not compile the same
+    // status as a link failure — the run could not be performed — so an agent
+    // branching on the exit status never has to also parse stderr.
 
     // `rue test` owns the rest of this process: it links the test image, runs
     // one process per selected test, and publishes the event stream on stdout
@@ -2681,38 +2686,29 @@ fn main() {
         std::process::exit(exit.code());
     }
 
-    // Closed discovery fixes the complete source identity set. Validate the
-    // destination before semantic/codegen/link work, then retain that set for
-    // mandatory revalidation immediately before atomic publication.
-    let publication_destination = match output::preflight_destination(
-        Path::new(&options.output_path),
-        source_snapshot.files().map(|source| source.path),
-    ) {
-        Ok(destination) => destination,
-        Err(output::PublishError::WouldClobberSource) => {
-            eprintln!(
-                "Error: output path '{}' is also an input source file; refusing to overwrite it",
-                options.output_path
-            );
-            std::process::exit(1);
-        }
-        Err(error) => {
-            diagnostics.print_error(&error.into_compile_error());
-            std::process::exit(1);
-        }
-    };
-
-    // Normal compilation - uses multi-file compilation for all source files
+    // One shared cycle drives the destination preflight, the compile, the
+    // publication, and the success line; `watch::run` drives the same one per
+    // revision (RUE-1969).
     #[cfg(rue_benchmark_allocations)]
     if options.benchmark_json {
         allocation::resume();
     }
-    let compile_result = {
+    let report = {
         let _compile = compile_span.enter();
-        compile::execute(compile::CompileRequest {
+        compile::drive_cycle(compile::CycleRequest {
             host: &mut compiler_host,
-            options: compile_options,
-            destination: publication_destination,
+            options: &compile_options,
+            diagnostics: &diagnostics,
+            source_path: &options.source_path,
+            output_path: &options.output_path,
+            observation: compile::CycleObservation::OneShot,
+            // `--benchmark-json` owns stdout, so the human success line would
+            // corrupt the envelope a consumer is parsing.
+            announcement: if options.benchmark_json {
+                compile::Announcement::Silent
+            } else {
+                compile::Announcement::Completed
+            },
         })
     };
     drop(compile_span);
@@ -2720,86 +2716,46 @@ fn main() {
     if options.benchmark_json {
         allocation::finish();
     }
-    match compile_result {
-        Ok(output) => {
-            // Publication runs after the compiler's timing root closes, so it
-            // is measured as a driver phase: it breaks down process-minus-root
-            // overhead without becoming a second timing root (RUE-786).
-            let publication = {
-                let _span = tracing::info_span!("output_write", driver_phase = true).entered();
-                output.publish()
-            };
-            // Warnings live outside the publication result so failures cannot
-            // discard them; present them before inspecting and reporting the
-            // publication outcome.
-            diagnostics.print_warnings(&publication.warnings);
-            let output = match publication.result {
-                Ok(output) => output,
-                Err(output::PublishError::WouldClobberSource) => {
-                    eprintln!(
-                        "Error: output path '{}' is also an input source file; refusing to overwrite it",
-                        options.output_path
-                    );
-                    std::process::exit(1);
-                }
-                Err(error) => {
-                    diagnostics.print_error(&error.into_compile_error());
-                    std::process::exit(1);
-                }
-            };
+    let compile::CycleReport::Published(output) = report else {
+        // Every diagnostic is already on the diagnostic stream. A one-shot
+        // cycle is never canceled and never superseded, so the only remaining
+        // outcome is a rejected program or a refused publication.
+        std::process::exit(1);
+    };
 
-            // Don't print normal compilation message when using --benchmark-json
-            // as it would interfere with JSON parsing
-            if !options.benchmark_json {
-                let linker_str = match &options.linker {
-                    LinkerMode::Internal => "internal".to_string(),
-                    LinkerMode::System(cmd) => cmd.clone(),
-                };
-                println!(
-                    "Compiled {} -> {} (target: {}, linker: {})",
-                    options.source_path, options.output_path, options.target, linker_str
+    // Publication may perform target-specific finalization (notably ad-hoc
+    // Mach-O signing) after the linker produced its byte buffer. Benchmark
+    // evidence must describe the artifact users can actually execute, so both
+    // compiler and runner hash the published file rather than the
+    // pre-publication linker buffer.
+    let benchmark_emitted_output = if options.benchmark_json {
+        match std::fs::read(&options.output_path) {
+            Ok(bytes) => Some(EmittedOutput::of(&bytes)),
+            Err(error) => {
+                eprintln!(
+                    "Error: could not verify published benchmark output '{}': {error}",
+                    options.output_path
                 );
+                std::process::exit(1);
             }
-
-            // Publication may perform target-specific finalization (notably
-            // ad-hoc Mach-O signing) after the linker produced its byte
-            // buffer. Benchmark evidence must describe the artifact users can
-            // actually execute, so both compiler and runner hash the published
-            // file rather than the pre-publication linker buffer.
-            let benchmark_emitted_output = if options.benchmark_json {
-                match std::fs::read(&options.output_path) {
-                    Ok(bytes) => Some(EmittedOutput::of(&bytes)),
-                    Err(error) => {
-                        eprintln!(
-                            "Error: could not verify published benchmark output '{}': {error}",
-                            options.output_path
-                        );
-                        std::process::exit(1);
-                    }
-                }
-            } else {
-                None
-            };
-
-            let report = match (timing_data.as_ref(), benchmark_emitted_output) {
-                (Some(timing), Some(emitted_output)) => Some(benchmark_report(
-                    timing,
-                    &options,
-                    resolved_workers,
-                    &source_snapshot,
-                    output.unstable_metrics(),
-                    emitted_output,
-                )),
-                _ => None,
-            };
-            print_timing_output(&timing_data, options.time_passes, report.as_ref());
-            exit_successful_native_compile();
         }
-        Err(errors) => {
-            diagnostics.print_errors(&with_import_migration_helps(&errors));
-            std::process::exit(1);
-        }
-    }
+    } else {
+        None
+    };
+
+    let report = match (timing_data.as_ref(), benchmark_emitted_output) {
+        (Some(timing), Some(emitted_output)) => Some(benchmark_report(
+            timing,
+            &options,
+            resolved_workers,
+            &source_snapshot,
+            output.unstable_metrics(),
+            emitted_output,
+        )),
+        _ => None,
+    };
+    print_timing_output(&timing_data, options.time_passes, report.as_ref());
+    exit_successful_native_compile();
 }
 
 #[cfg(test)]
@@ -3272,42 +3228,49 @@ mod tests {
         .unwrap();
         let options = CompileOptions::default();
 
+        // The watch loop's own cycle, minus the monitor: nothing supersedes it,
+        // so every outcome is the cycle's own.
         let compile_cycle = |host: &mut FilesystemCompilerHost| {
-            let publication = output::preflight_destination(
-                &destination,
-                host.source_snapshot().files().map(|source| source.path),
+            let snapshot = host.source_snapshot().clone();
+            let source_infos = snapshot
+                .files()
+                .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+                .collect();
+            let diagnostics = DiagnosticOutput::new(ErrorFormat::Text, source_infos);
+            let inputs = host.watch_inputs();
+            let settled = || false;
+            matches!(
+                compile::drive_cycle(compile::CycleRequest {
+                    host,
+                    options: &options,
+                    diagnostics: &diagnostics,
+                    source_path: "main.rue",
+                    output_path: destination.to_str().unwrap(),
+                    observation: compile::CycleObservation::Watch {
+                        inputs,
+                        cancellation: rue_compiler::unstable::CompilationCancellation::new(),
+                        superseded: &settled,
+                    },
+                    announcement: compile::Announcement::Silent,
+                }),
+                compile::CycleReport::Published(_)
             )
-            .unwrap();
-            let watch_inputs = host.watch_inputs();
-            compile::execute_cancellable(compile::CancellableCompileRequest {
-                host,
-                options: options.clone(),
-                destination: publication,
-                cancellation: rue_compiler::unstable::CompilationCancellation::new(),
-                watch_inputs,
-            })
         };
 
-        let compile::CompileCycleOutcome::Linked(linked) = compile_cycle(&mut host) else {
-            panic!("initial watch cycle must compile")
-        };
-        (*linked).publish().result.unwrap();
+        assert!(compile_cycle(&mut host), "initial watch cycle must publish");
         let first = fs::read(&destination).unwrap();
 
         fs::write(&main, "fn main() -> i32 { missing }\n").unwrap();
         host.reobserve().unwrap();
-        assert!(matches!(
-            compile_cycle(&mut host),
-            compile::CompileCycleOutcome::Errors(_)
-        ));
+        assert!(
+            !compile_cycle(&mut host),
+            "a rejected program must not publish"
+        );
         assert_eq!(fs::read(&destination).unwrap(), first);
 
         fs::write(&main, "fn main() -> i32 { 2 }\n").unwrap();
         host.reobserve().unwrap();
-        let compile::CompileCycleOutcome::Linked(linked) = compile_cycle(&mut host) else {
-            panic!("fixed watch cycle must compile")
-        };
-        (*linked).publish().result.unwrap();
+        assert!(compile_cycle(&mut host), "fixed watch cycle must publish");
         assert_ne!(fs::read(&destination).unwrap(), first);
     }
 

--- a/crates/rue/src/output.rs
+++ b/crates/rue/src/output.rs
@@ -24,7 +24,12 @@ pub(crate) struct PublicationDestination {
 
 #[derive(Debug)]
 pub(crate) enum PublishError {
-    WouldClobberSource,
+    /// The destination is, or became, one of the program's own input sources.
+    /// The refused path travels with the variant so every driver renders one
+    /// message naming the output the user asked for.
+    WouldClobberSource {
+        path: PathBuf,
+    },
     InputsChanged,
     Io {
         operation: &'static str,
@@ -48,9 +53,10 @@ impl PublishError {
 
     pub(crate) fn into_compile_error(self) -> CompileError {
         let message = match self {
-            Self::WouldClobberSource => {
-                "output path is also an input source file; refusing to overwrite it".to_owned()
-            }
+            Self::WouldClobberSource { path } => format!(
+                "output path '{}' is also an input source file; refusing to overwrite it",
+                path.display()
+            ),
             Self::InputsChanged => "an accepted input changed before output publication".to_owned(),
             Self::Io {
                 operation,
@@ -120,7 +126,9 @@ fn validate_destination(destination: &PublicationDestination) -> Result<(), Publ
         .iter()
         .any(|source| output_would_clobber(&output_key, output_metadata.as_ref(), source))
     {
-        return Err(PublishError::WouldClobberSource);
+        return Err(PublishError::WouldClobberSource {
+            path: destination.path.clone(),
+        });
     }
     Ok(())
 }
@@ -488,7 +496,7 @@ mod tests {
 
         assert!(matches!(
             preflight_watch_destination(&destination, &inputs),
-            Err(PublishError::WouldClobberSource)
+            Err(PublishError::WouldClobberSource { .. })
         ));
         assert!(!destination.exists());
         fs::remove_dir_all(directory).unwrap();
@@ -514,7 +522,7 @@ mod tests {
                 bytes: b"executable",
                 target: Target::X86_64Linux,
             }),
-            Err(PublishError::WouldClobberSource)
+            Err(PublishError::WouldClobberSource { .. })
         ));
         assert_eq!(
             fs::read_to_string(&source).unwrap(),

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -246,7 +246,7 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
     let image = match host.test_image_in_compile_scope(&compile_options) {
         Ok(image) => image,
         Err(errors) => {
-            diagnostics.print_errors(&crate::with_import_migration_helps(&errors));
+            diagnostics.print_errors(&errors);
             return TestExitCode::RunnerError;
         }
     };
@@ -275,7 +275,7 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
     // silently swallowed a broken test file would be the papercut the
     // unimported-test-file warning exists to prevent.
     if !failure_diagnostics.is_empty() {
-        diagnostics.print_errors(&crate::with_import_migration_helps(&failure_diagnostics));
+        diagnostics.print_errors(&failure_diagnostics);
     }
     let compile_errors = CompileErrorVerdicts::new(&compile_failures, diagnostics);
 
@@ -529,7 +529,7 @@ fn list(
     let listing = match host.test_inventory(compile_options) {
         Ok(listing) => listing,
         Err(errors) => {
-            diagnostics.print_errors(&crate::with_import_migration_helps(&errors));
+            diagnostics.print_errors(&errors);
             return TestExitCode::RunnerError;
         }
     };
@@ -544,7 +544,7 @@ fn list(
     // a reader inspecting a suite would see nothing wrong with tests the run
     // will report as `compile_error`.
     if !failure_diagnostics.is_empty() {
-        diagnostics.print_errors(&crate::with_import_migration_helps(&failure_diagnostics));
+        diagnostics.print_errors(&failure_diagnostics);
     }
     let selected = selection::select(&inventory.entries, &options.filters, options.shard);
     if selected.is_empty() {

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -7,16 +7,17 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use rue_compiler::CompileOptions;
 use rue_compiler::unstable::{CompilationCancellation, SourceInfo};
-use rue_compiler::{CompileOptions, LinkerMode};
 #[cfg(test)]
 use rue_driver::watch_inputs_changed_with_reader;
 use rue_driver::{
     FilesystemCompilerHost, SourceLoadError, WatchFingerprint, WatchInput, watch_inputs_changed,
 };
 
-use crate::compile::{CancellableCompileRequest, CompileCycleOutcome, execute_cancellable};
-use crate::output;
+use crate::compile::{
+    Announcement, CycleObservation, CycleReport, CycleRequest, Supersession, drive_cycle,
+};
 use crate::{DiagnosticOutput, ErrorFormat, render_source_load_error};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -292,115 +293,67 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
             .collect();
         let diagnostics = DiagnosticOutput::new(request.error_format, source_infos);
 
-        let destination = match output::preflight_watch_destination(
-            Path::new(&request.output_path),
-            &inputs,
-        ) {
-            Ok(destination) => destination,
-            Err(output::PublishError::WouldClobberSource) => {
-                print_watch_status(
-                    request.error_format,
-                    format!(
-                        "Error: output path '{}' is also an input source file; refusing to overwrite it",
-                        request.output_path
-                    ),
-                );
-                wait_for_change(&inputs);
-                debounce(&inputs);
-                needs_reobserve = true;
-                continue;
-            }
-            Err(error) => {
-                diagnostics.print_error(&error.into_compile_error());
-                wait_for_change(&inputs);
-                debounce(&inputs);
-                needs_reobserve = true;
-                continue;
-            }
-        };
-
         let cancellation = CompilationCancellation::new();
         let monitor = ChangeMonitor::start(inputs.clone(), cancellation.clone());
         test_event("compile-started");
         test_compile_delay();
-        let outcome = execute_cancellable(CancellableCompileRequest {
+        // A cycle is superseded once the monitor has seen an edit, or once a
+        // fresh read of the closure disagrees with what this cycle observed.
+        let superseded = || monitor.changed() || inputs_changed(&inputs);
+        let report = drive_cycle(CycleRequest {
             host: &mut request.host,
-            options: request.compile_options.clone(),
-            destination,
-            cancellation,
-            watch_inputs: inputs.clone(),
+            options: &request.compile_options,
+            diagnostics: &diagnostics,
+            source_path: &request.source_path,
+            output_path: &request.output_path,
+            observation: CycleObservation::Watch {
+                inputs: inputs.clone(),
+                cancellation,
+                superseded: &superseded,
+            },
+            announcement: Announcement::Cycle(cycle_started),
         });
 
-        let changed_before_publication = monitor.changed() || inputs_changed(&inputs);
         let mut publication_changed = false;
-        if changed_before_publication {
-            test_event("canceled-before-publication");
-            print_watch_status(
-                request.error_format,
-                format!(
-                    "Watch cycle canceled after {} ms; a newer source revision is available",
-                    cycle_started.elapsed().as_millis()
-                ),
-            );
-        } else {
-            match outcome {
-                CompileCycleOutcome::Linked(output) => {
-                    let publication = (*output).publish();
-                    diagnostics.print_warnings(&publication.warnings);
-                    match publication.result {
-                        Ok(_) => {
-                            test_event("published");
-                            println!(
-                                "Compiled {} -> {} in {} ms (target: {}, linker: {})",
-                                request.source_path,
-                                request.output_path,
-                                cycle_started.elapsed().as_millis(),
-                                request.compile_options.target,
-                                linker_name(&request.compile_options.linker),
-                            );
-                        }
-                        Err(output::PublishError::WouldClobberSource) => print_watch_status(
-                            request.error_format,
-                            format!(
-                                "Error: output path '{}' became an input source; keeping the last successful executable",
-                                request.output_path
-                            ),
-                        ),
-                        Err(output::PublishError::InputsChanged) => {
-                            publication_changed = true;
-                            test_event("canceled-at-publication");
-                            print_watch_status(
-                                request.error_format,
-                                format!(
-                                    "Watch cycle canceled after {} ms; a newer source revision is available",
-                                    cycle_started.elapsed().as_millis()
-                                ),
-                            );
-                        }
-                        Err(error) => diagnostics.print_error(&error.into_compile_error()),
-                    }
-                }
-                CompileCycleOutcome::Canceled => {
-                    test_event("canceled");
-                    print_watch_status(
-                        request.error_format,
-                        format!(
-                            "Watch cycle canceled after {} ms",
-                            cycle_started.elapsed().as_millis()
-                        ),
-                    );
-                }
-                CompileCycleOutcome::Errors(errors) => {
-                    test_event("compile-error");
-                    diagnostics.print_errors(&errors);
-                    print_watch_status(
-                        request.error_format,
-                        format!(
-                            "Watch cycle failed after {} ms; keeping the last successful executable",
-                            cycle_started.elapsed().as_millis()
-                        ),
-                    );
-                }
+        match report {
+            CycleReport::Published(_) => test_event("published"),
+            CycleReport::Superseded(boundary) => {
+                // The compile monitor and the publication guard both refuse to
+                // publish a stale revision; the milestone says which of them
+                // caught it, and only the publication guard's answer feeds the
+                // cycle-boundary decision below.
+                publication_changed = matches!(boundary, Supersession::AtPublication);
+                test_event(match boundary {
+                    Supersession::AtPublication => "canceled-at-publication",
+                    Supersession::BeforePublication => "canceled-before-publication",
+                });
+                print_watch_status(
+                    request.error_format,
+                    format!(
+                        "Watch cycle canceled after {} ms; a newer source revision is available",
+                        cycle_started.elapsed().as_millis()
+                    ),
+                );
+            }
+            CycleReport::Canceled => {
+                test_event("canceled");
+                print_watch_status(
+                    request.error_format,
+                    format!(
+                        "Watch cycle canceled after {} ms",
+                        cycle_started.elapsed().as_millis()
+                    ),
+                );
+            }
+            CycleReport::Failed => {
+                test_event("compile-error");
+                print_watch_status(
+                    request.error_format,
+                    format!(
+                        "Watch cycle failed after {} ms; keeping the last successful executable",
+                        cycle_started.elapsed().as_millis()
+                    ),
+                );
             }
         }
 
@@ -423,13 +376,6 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
         }
         debounce(&inputs);
         needs_reobserve = true;
-    }
-}
-
-fn linker_name(linker: &LinkerMode) -> &str {
-    match linker {
-        LinkerMode::Internal => "internal",
-        LinkerMode::System(command) => command,
     }
 }
 


### PR DESCRIPTION
Fixes RUE-1969

## Why

The driver assembled "gate on discovery, compile, publish, print" by hand in four places, and they had drifted. With `main.rue` containing `const util = @import("util");` beside `util.rue`:

| Invocation | Before | After |
|---|---|---|
| `rue main.rue -o out` | `E0704 cannot find module 'util'` with the migration help | unchanged |
| `rue --emit ast main.rue` | `E0704`, no help (`"helps": []` in JSON) | `E0704` with the same help; JSON `helps` populated |
| `rue --watch main.rue -o out` | `error: [E1400]: invalid compiler input: compilation requires a closed-valid import discovery revision` | `E0704` with the same help, then the watch cycle-failed line |

All three now print byte-identical E0704 text and help. `rue test`, `rue test --list`, and `--emit deps` on the same input print the same diagnostic.

## What

- `crates/rue/src/host.rs`: `discovery_refusal()` returns discovery's own diagnostics for a revision that is not `ClosedValid`. `executable_in_compile_scope`, `cancellable_executable_in_compile_scope`, `test_inventory`, and `test_image_in_compile_scope` all refuse on it, so no driver can reach the compiler with an unclosed graph. It is public because the cycle driver also asks before the destination preflight, keeping the RUE-810 ordering that `cli.modules::missing_import_precedes_output_clobber_validation` pins. A unit test covers both executable endpoints.
- `crates/rue/src/main.rs`: the import-migration help moved into `DiagnosticOutput` (`render_errors` and `json_diagnostic_batches`), so every renderer applies it. The standalone gate and the preflight/compile/publish/success-line tail are replaced by one `drive_cycle` call.
- `crates/rue/src/compile.rs`: new `drive_cycle` owns gate, destination preflight, compile, publish, warnings, and success line, parameterized by `CycleObservation::{OneShot, Watch}` and `Announcement`, returning `CycleReport::{Published, Failed, Superseded, Canceled}`. `CompileRequest`, `CancellableCompileRequest`, `CompileCycleOutcome`, `execute`, and `execute_cancellable` are gone; `linker_name` has one definition.
- `crates/rue/src/watch.rs`: the loop keeps only the change monitor, cancellation, re-observation, and progress text.
- `crates/rue/src/output.rs`: `PublishError::WouldClobberSource { path }` carries the refused path, so the "output path is also an input source file" refusal has one spelling, names the path, and is a proper E1403 (the existing output-publication code) framed for the chosen `--error-format` rather than a bare stderr line.
- `crates/rue/src/test_mode/mod.rs`: its four per-call-site help applications are dropped.
- `crates/rue-cli-tests`: a watch scenario kind `initial_failure` plus `stderr_contains` for watch scenarios; new cases `watch.toml::discovery_failure_reports_the_unresolved_import_with_its_help`, `modules.toml::extensionless_file_miss_suggests_extensioned_spelling_under_emit` (asserts `helps` is populated in JSON), and `output_guard.toml::output_alias_refusal_is_one_coded_diagnostic`.

No `--error-format json` schema field changed; `helps` is populated where it was empty. Not gated: the ADR-0068 capability endpoints (`codegen_ready`, `objects_ready`, `runnable_ready`) used by benchmarks and host tests. `emit.rs` keeps its own check because `--emit deps` must publish its envelope before reporting; it now gets the help from the renderer.

## Verification

| Command | Result |
|---|---|
| `./buck2 test //crates/rue:rue-driver-test //crates/rue:rue-test` | pass |
| `scripts/rue cli watch` / `emit` / `import` / `modules` | 9 / 47 / 79 / 145 passed |
| `scripts/rue cli output` / `output_guard` / `rue_test` / `diagnostic_json` | 25 / 8 / 91 / 19 passed |
| `scripts/rue cli` (full, 2673 cases) | 2664 passed; the 2 failures are environmental to the build container (runs as uid 0, so `remove_dir_all_permission_denied_is_not_partial_success` cannot deny; no IPv6, so `tcp_ipv6_loopback_round_trip` cannot bind) and untouched by this change |
| `scripts/rue ui` (full) | 395 passed |
| `scripts/rue quick` | Pass 36, Fail 0, re-run after rebasing onto current trunk |
| `./buck2 test //crates/rue-oracle-diff:oracle-diff-test` | pass, no model gap needed |
| `scripts/rue fmt`, fmt-check, clippy for rue, rue-driver, rue-cli-tests | clean |