### PR TITLE
RUE-1972: spell live symbols through one owner per family

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -1460,6 +1460,7 @@ fn comptime_instdata_evaluation_has_one_production_authority() {
         ("intrinsic", include_str!("intrinsic.rs")),
         ("layout", include_str!("layout.rs")),
         ("lib", include_str!("lib.rs")),
+        ("live_symbols", include_str!("live_symbols.rs")),
         ("lowered_signature", include_str!("lowered_signature.rs")),
         ("module_registry", include_str!("module_registry.rs")),
         ("param_arena", include_str!("param_arena.rs")),
@@ -3723,6 +3724,82 @@ fn retired_source_owned_sema_plane_cannot_return() {
     assert!(
         provider_host.contains("OrdinaryBodyEngine::new"),
         "the provider host must construct the shared body engine"
+    );
+}
+
+/// Live symbol spelling has one owner per family. A second nominal
+/// qualification, member separator, or drop-glue fragment grammar does not
+/// fail to compile: it spells a definition one way and its call the other, and
+/// the miss surfaces at link time or as a `CfgDomainFailure::Shape`.
+#[test]
+fn live_symbol_spelling_has_one_owner_per_family() {
+    let live = include_str!("live_symbols.rs");
+    for owner in [
+        "pub fn module_symbol_component(",
+        "pub fn named_nominal_symbol(",
+        "pub fn enum_keeps_bare_symbol(",
+        "pub fn member_callable_name(",
+    ] {
+        assert_eq!(
+            live.matches(owner).count(),
+            1,
+            "live_symbols must own exactly one {owner}"
+        );
+    }
+
+    // The retired second owners cannot come back under their old names.
+    let pool = include_str!("intern_pool.rs");
+    let provider = include_str!("sema/provider_body_host.rs");
+    assert!(
+        !pool.contains("\"{}${}\""),
+        "the type pool must not spell a qualified nominal of its own"
+    );
+    assert!(
+        !provider.contains("fn member_callable_name_for_owner("),
+        "member callable rendering must live in live_symbols"
+    );
+
+    // Both nominal exemptions are registry membership reached through one
+    // predicate each, and the pool asks for a module component only when the
+    // nominal is qualified.
+    assert_eq!(
+        pool.matches("live_symbols::named_nominal_symbol(").count(),
+        2
+    );
+    assert!(pool.contains("live_symbols::enum_keeps_bare_symbol(&data.def.name)"));
+    assert!(pool.contains("live_symbols::module_symbol_component(path)"));
+
+    // The drop-glue fragment grammar is spelled once and driven from both type
+    // vocabularies through the shared shape.
+    let names = include_str!("drop_glue_names.rs");
+    assert_eq!(names.matches("pub fn drop_glue_type_fragment<").count(), 1);
+    assert_eq!(
+        names.matches("pub trait DropGlueTypeShapeSource").count(),
+        1
+    );
+    for fragment in ["array_{}_{len}", "ptr_const_{}", "ptr_mut_{}"] {
+        assert_eq!(
+            names.matches(fragment).count(),
+            1,
+            "the drop-glue grammar must spell {fragment} exactly once"
+        );
+    }
+
+    // The engine names member callables through the host, so the definition
+    // side and the call side share the renderer and its memo.
+    let engine = include_str!("sema/ordinary_engine.rs");
+    assert!(engine.contains("fn body_member_callable_name("));
+    assert!(engine.contains("fn try_member_callable_symbol("));
+    assert!(
+        !engine.contains("format!(\"{type_name}"),
+        "the engine must not render a member callable name of its own"
+    );
+    assert_eq!(
+        provider
+            .matches("fn try_member_callable_symbol_for_issued_owner(")
+            .count(),
+        1,
+        "member callable handles must have one memo policy"
     );
 }
 

--- a/crates/rue-air/src/drop_glue_names.rs
+++ b/crates/rue-air/src/drop_glue_names.rs
@@ -10,76 +10,145 @@
 //! consumer derives names here instead of re-deriving the `__rue_drop_*` format
 //! string, so the external ABI cannot drift between phases. The names are a
 //! function of the type alone — they do not depend on the target architecture.
+//!
+//! Two type vocabularies reach the grammar: the live type pool during semantic
+//! analysis and code generation, and the durable type instances `rue-compiler`
+//! names rooted callables from. [`DropGlueTypeShape`] is what they have in
+//! common, so the recursion and every fragment separator are spelled once here
+//! while each vocabulary contributes only its own leaves.
 
 use crate::{ArrayTypeId, EnumId, FrozenTypeInternPool, StructId, Type, TypeKind};
 
+/// One node of the drop-glue fragment grammar.
+///
+/// A leaf spells itself — scalars, nominals, and the compile-time-only kinds
+/// that never reach real glue. The composite arms carry the structure the
+/// fragment encodes, and nothing else: a vocabulary decides what its types
+/// *are*, never how the fragment reads.
+pub enum DropGlueTypeShape<T> {
+    Leaf(String),
+    Array { element: T, len: u64 },
+    PtrConst(T),
+    PtrMut(T),
+}
+
+/// A type vocabulary that can be spelled as a drop-glue fragment.
+///
+/// `None` marks a type with no drop-glue spelling in that vocabulary: the
+/// durable instances carry kinds (slices, generic parameters) that never name
+/// glue, and a caller that reaches one falls back to its own naming.
+pub trait DropGlueTypeShapeSource: Sized {
+    fn drop_glue_shape(&self) -> Option<DropGlueTypeShape<Self>>;
+}
+
+/// The structural name fragment for a type, used to build drop-glue symbols.
+///
+/// Nominal types use their live nominal symbol, so two same-named types
+/// declared in different modules receive distinct glue and distinct
+/// array-element fragments (RUE-571). Arrays and pointers recurse into their
+/// element/pointee.
+pub fn drop_glue_type_fragment<T: DropGlueTypeShapeSource>(ty: &T) -> Option<String> {
+    Some(match ty.drop_glue_shape()? {
+        DropGlueTypeShape::Leaf(name) => name,
+        DropGlueTypeShape::Array { element, len } => {
+            format!("array_{}_{len}", drop_glue_type_fragment(&element)?)
+        }
+        DropGlueTypeShape::PtrConst(pointee) => {
+            format!("ptr_const_{}", drop_glue_type_fragment(&pointee)?)
+        }
+        DropGlueTypeShape::PtrMut(pointee) => {
+            format!("ptr_mut_{}", drop_glue_type_fragment(&pointee)?)
+        }
+    })
+}
+
+/// The drop-glue symbol built from an already-spelled type fragment.
+pub fn drop_glue_symbol(type_fragment: &str) -> String {
+    format!("__rue_drop_{type_fragment}")
+}
+
+/// One live pool type, the vocabulary sema and codegen spell glue from.
+#[derive(Clone, Copy)]
+struct PoolType<'a> {
+    ty: Type,
+    type_pool: &'a FrozenTypeInternPool,
+}
+
+impl DropGlueTypeShapeSource for PoolType<'_> {
+    fn drop_glue_shape(&self) -> Option<DropGlueTypeShape<Self>> {
+        let leaf = |name: &str| Some(DropGlueTypeShape::Leaf(name.to_owned()));
+        let nested = |ty: Type| PoolType {
+            ty,
+            type_pool: self.type_pool,
+        };
+        match self.ty.kind() {
+            TypeKind::I8 => leaf("i8"),
+            TypeKind::I16 => leaf("i16"),
+            TypeKind::I32 => leaf("i32"),
+            TypeKind::I64 => leaf("i64"),
+            TypeKind::U8 => leaf("u8"),
+            TypeKind::U16 => leaf("u16"),
+            TypeKind::U32 => leaf("u32"),
+            TypeKind::U64 => leaf("u64"),
+            TypeKind::Bool => leaf("bool"),
+            TypeKind::Unit => leaf("unit"),
+            TypeKind::Never => leaf("never"),
+            TypeKind::Error => leaf("error"),
+            // ComptimeType only exists at compile time, no runtime representation.
+            TypeKind::ComptimeType => leaf("comptime_type"),
+            TypeKind::ComptimeFloat => leaf("comptime_float"),
+            TypeKind::F32 => leaf("f32"),
+            TypeKind::F64 => leaf("f64"),
+            TypeKind::Enum(enum_id) => Some(DropGlueTypeShape::Leaf(
+                self.type_pool.enum_symbol_name(enum_id),
+            )),
+            // Struct types include builtin types like String.
+            TypeKind::Struct(struct_id) => Some(DropGlueTypeShape::Leaf(
+                self.type_pool.struct_symbol_name(struct_id),
+            )),
+            // Module types should never reach drop glue (compile-time only).
+            TypeKind::Module(_) => leaf("module"),
+            TypeKind::Array(array_id) => {
+                let (element_type, length) = self.type_pool.array_def(array_id);
+                Some(DropGlueTypeShape::Array {
+                    element: nested(element_type),
+                    len: length,
+                })
+            }
+            TypeKind::PtrConst(ptr_id) => Some(DropGlueTypeShape::PtrConst(nested(
+                self.type_pool.ptr_const_def(ptr_id),
+            ))),
+            TypeKind::PtrMut(ptr_id) => Some(DropGlueTypeShape::PtrMut(nested(
+                self.type_pool.ptr_mut_def(ptr_id),
+            ))),
+        }
+    }
+}
+
 /// Drop-glue symbol for a struct type, e.g. `__rue_drop_Container`.
 pub fn struct_drop_glue_name(struct_id: StructId, type_pool: &FrozenTypeInternPool) -> String {
-    format!("__rue_drop_{}", type_pool.struct_symbol_name(struct_id))
+    drop_glue_symbol(&type_pool.struct_symbol_name(struct_id))
 }
 
 /// Drop-glue symbol for an enum type, e.g. `__rue_drop_Choice`.
 pub fn enum_drop_glue_name(enum_id: EnumId, type_pool: &FrozenTypeInternPool) -> String {
-    format!("__rue_drop_{}", type_pool.enum_symbol_name(enum_id))
+    drop_glue_symbol(&type_pool.enum_symbol_name(enum_id))
 }
 
 /// Drop-glue symbol for an array type.
 ///
 /// The name encodes the element type and length, e.g. `__rue_drop_array_String_3`.
 pub fn array_drop_glue_name(array_id: ArrayTypeId, type_pool: &FrozenTypeInternPool) -> String {
-    let (element_type, length) = type_pool.array_def(array_id);
-    format!(
-        "__rue_drop_array_{}_{}",
-        type_name(element_type, type_pool),
-        length
-    )
+    drop_glue_symbol(&type_name(Type::new_array(array_id), type_pool))
 }
 
-/// The structural name fragment for a type, used to build drop-glue symbols.
+/// The structural name fragment for one live pool type.
 ///
-/// Nominal types (struct and enum) use their file-qualified symbol name, so two
-/// same-named types declared in different files receive distinct glue and
-/// distinct array-element fragments (RUE-571). Arrays and pointers recurse into
-/// their element/pointee.
+/// The pool vocabulary spells every kind it has, so this never fails; the
+/// grammar itself is [`drop_glue_type_fragment`].
 pub fn type_name(ty: Type, type_pool: &FrozenTypeInternPool) -> String {
-    match ty.kind() {
-        TypeKind::I8 => "i8".to_string(),
-        TypeKind::I16 => "i16".to_string(),
-        TypeKind::I32 => "i32".to_string(),
-        TypeKind::I64 => "i64".to_string(),
-        TypeKind::U8 => "u8".to_string(),
-        TypeKind::U16 => "u16".to_string(),
-        TypeKind::U32 => "u32".to_string(),
-        TypeKind::U64 => "u64".to_string(),
-        TypeKind::Bool => "bool".to_string(),
-        TypeKind::Unit => "unit".to_string(),
-        TypeKind::Never => "never".to_string(),
-        TypeKind::Error => "error".to_string(),
-        // ComptimeType only exists at compile time, no runtime representation.
-        TypeKind::ComptimeType => "comptime_type".to_string(),
-        TypeKind::ComptimeFloat => "comptime_float".to_string(),
-        TypeKind::F32 => "f32".to_string(),
-        TypeKind::F64 => "f64".to_string(),
-        TypeKind::Enum(enum_id) => type_pool.enum_symbol_name(enum_id),
-        // Struct types include builtin types like String. File-qualified when
-        // the struct name spans files (RUE-571), so arrays of two same-named
-        // element types get distinct glue.
-        TypeKind::Struct(struct_id) => type_pool.struct_symbol_name(struct_id),
-        TypeKind::Array(array_id) => {
-            let (element_type, length) = type_pool.array_def(array_id);
-            format!("array_{}_{}", type_name(element_type, type_pool), length)
-        }
-        // Module types should never reach drop glue (compile-time only).
-        TypeKind::Module(_) => "module".to_string(),
-        TypeKind::PtrConst(ptr_id) => {
-            let pointee = type_pool.ptr_const_def(ptr_id);
-            format!("ptr_const_{}", type_name(pointee, type_pool))
-        }
-        TypeKind::PtrMut(ptr_id) => {
-            let pointee = type_pool.ptr_mut_def(ptr_id);
-            format!("ptr_mut_{}", type_name(pointee, type_pool))
-        }
-    }
+    drop_glue_type_fragment(&PoolType { ty, type_pool })
+        .expect("every live pool type has a drop-glue fragment")
 }
 
 #[cfg(test)]

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -33,9 +33,7 @@ use std::sync::{Arc, LazyLock, PoisonError, RwLock};
 use lasso::Spur;
 use rue_span::FileId;
 
-use crate::builtin_universe::BuiltinUniverse;
 use crate::layout::{Layout, LayoutKind, PaddingRange};
-use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::type_encoding;
 use crate::types::{
     ArrayTypeId, EnumDef, EnumId, LangItem, PtrConstTypeId, PtrMutTypeId, StructDef, StructField,
@@ -2427,7 +2425,7 @@ impl TypeInternPoolInner {
     fn file_symbol_component(&self, file_id: FileId) -> String {
         self.symbol_paths
             .get(&file_id)
-            .map(|path| mangle_symbol_component(&normalize_module_path(path)))
+            .map(|path| crate::live_symbols::module_symbol_component(path))
             // Standalone TypeInternPool is a phase-local test/embedding API.
             // Supported semantic construction installs complete logical paths
             // before nominal symbols can be requested.
@@ -2439,11 +2437,12 @@ impl TypeInternPoolInner {
             TypeData::DeclaredStruct(data) | TypeData::Struct(data) => data,
             other => panic!("Expected struct at pool index {}, got {:?}", id.0, other),
         };
-        // Every named user nominal is unconditionally file-qualified (ADR-0066,
-        // RUE-1089): producer-nominal identity means two same-named types in
-        // different files are distinct, so their symbols must never depend on
-        // whether a collision happened to be observed. Builtins keep their bare
-        // source names because they pair with runtime-provided definitions.
+        // `live_symbols::named_nominal_symbol` owns the qualification rule
+        // (ADR-0066, RUE-1089); this decides only which pool entries are exempt.
+        // Builtins keep their bare source names because they pair with
+        // runtime-provided definitions, and language-item builtins (`str`,
+        // `StrBuf`, `Str(N)`) do the same — the lang-item marker survives
+        // durable import even when `is_builtin` is not carried.
         // Generated anonymous structs already carry a globally-unique synthetic
         // name (`__anon_struct_<digest>`) that distinguishes every producer, and
         // their destructor/member symbols are spelled from that bare name;
@@ -2453,20 +2452,12 @@ impl TypeInternPoolInner {
         // and `_start` are reserved, RUE-125), and a prefix test hands such a
         // declaration the bare symbol of a generated type it collides with
         // (RUE-1050, RUE-1193).
-        // Language-item builtins (`str`, `StrBuf`, `Str(N)`) also keep their bare
-        // names: they pair with runtime-provided definitions, and the lang-item
-        // marker survives durable import even when `is_builtin` is not carried.
-        if data.def.is_builtin
+        let keeps_bare_symbol = data.def.is_builtin
             || self.struct_lang_items.contains_key(&id)
-            || self.is_anonymous_struct(id)
-        {
-            return data.def.name.to_string();
-        }
-        format!(
-            "{}${}",
-            data.def.name,
+            || self.is_anonymous_struct(id);
+        crate::live_symbols::named_nominal_symbol(&data.def.name, keeps_bare_symbol, || {
             self.file_symbol_component(data.def.file_id)
-        )
+        })
     }
 
     fn enum_symbol_name(&self, id: EnumId) -> String {
@@ -2477,14 +2468,11 @@ impl TypeInternPoolInner {
         // See `struct_symbol_name`: unconditional qualification, with the
         // reserved built-in enums and the registry-marked generated anonymous
         // enums (`__anon_enum_<digest>`) keeping their bare names.
-        if BuiltinUniverse::builtin_enum_name(&data.def.name) || self.is_anonymous_enum(id) {
-            return data.def.name.to_string();
-        }
-        format!(
-            "{}${}",
-            data.def.name,
+        let keeps_bare_symbol = crate::live_symbols::enum_keeps_bare_symbol(&data.def.name)
+            || self.is_anonymous_enum(id);
+        crate::live_symbols::named_nominal_symbol(&data.def.name, keeps_bare_symbol, || {
             self.file_symbol_component(data.def.file_id)
-        )
+        })
     }
 
     fn safe_type_name(&self, ty: Type) -> String {
@@ -3635,15 +3623,15 @@ impl TypeInternPool {
     /// (`P.__drop`), and drop glue (`__rue_drop_P`) — RUE-571.
     ///
     /// Same-named nominal types across files are legal (RUE-558), but these
-    /// symbols are program-wide identities. Every named user nominal is
-    /// unconditionally qualified with the defining file
-    /// (`P$left_2fmodel_2erue`) (ADR-0066, RUE-1089). `$` cannot appear in a
-    /// source identifier, so a qualified name can never collide with a real
-    /// type. Builtins remain bare so their symbols pair with runtime-provided
-    /// definitions.
+    /// symbols are program-wide identities, so the spelling comes from
+    /// [`crate::live_symbols::named_nominal_symbol`] — the one owner of live
+    /// nominal spelling, shared with the durable identities `rue-compiler`
+    /// names rooted callables from. This entry point supplies the pool's own
+    /// exemption facts; builtins remain bare so their symbols pair with
+    /// runtime-provided definitions.
     ///
-    /// Every layer that names a function after a type — sema (definition and
-    /// call sites), the drop-glue generator in `rue-compiler`, and both
+    /// Every layer that names a function after a *pool* type — sema (definition
+    /// and call sites), the drop-glue generator in `rue-compiler`, and both
     /// codegen backends — must derive the name through this ONE helper so
     /// definitions and calls meet at link time.
     pub fn struct_symbol_name(&self, struct_id: StructId) -> String {
@@ -3652,9 +3640,9 @@ impl TypeInternPool {
     }
 
     /// The symbol-name component for an enum's drop glue (`__rue_drop_E`),
-    /// unconditionally file-qualified for named user enums (ADR-0066,
-    /// RUE-1089), while builtins remain bare. See
-    /// [`Self::struct_symbol_name`] — same rule, same reason.
+    /// unconditionally file-qualified for named user enums, while the reserved
+    /// built-in enums remain bare. See [`Self::struct_symbol_name`] — same
+    /// owner, same reason.
     pub fn enum_symbol_name(&self, enum_id: EnumId) -> String {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.enum_symbol_name(enum_id)

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -25,6 +25,7 @@ pub mod integer_semantics;
 mod intern_pool;
 mod intrinsic;
 pub mod layout;
+pub mod live_symbols;
 pub mod lowered_signature;
 mod module_registry;
 mod param_arena;

--- a/crates/rue-air/src/live_symbols.rs
+++ b/crates/rue-air/src/live_symbols.rs
@@ -1,0 +1,152 @@
+//! The one owner of live symbol spelling.
+//!
+//! A *live* symbol is the presentation-and-join name a callable or nominal
+//! carries through AIR and the CFG: what `--emit air` and `--emit cfg` print,
+//! what `durable_cfg` keys its symbol mappings on, and what a synthesized drop
+//! glue or member callable is looked up by. It is a separate surface from the
+//! machine symbol, which `rue-compiler`'s stable encoder owns.
+//!
+//! Two vocabularies name the same entities: the live type pool during semantic
+//! analysis and code generation, and the durable semantic identities the rooted
+//! projection spells callables from. Both spell through this module, so a
+//! nominal cannot be qualified in one phase and bare in the other, and a member
+//! callable cannot pick up a second separator policy.
+//!
+//! [`crate::drop_glue_names`] owns the `__rue_drop_*` family the same way and
+//! builds its nominal fragments from the spellings here.
+
+/// The mangled module component every qualified nominal symbol carries.
+///
+/// Module paths are normalized before mangling so an aliased or relatively
+/// spelled import cannot produce a second component for one module.
+pub fn module_symbol_component(logical_module_path: &str) -> String {
+    crate::path_norm::mangle_symbol_component(&crate::path_norm::normalize_module_path(
+        logical_module_path,
+    ))
+}
+
+/// The live symbol of a named nominal type.
+///
+/// Every named user nominal is unconditionally qualified with the module it is
+/// declared in (`P$left_2fmodel_2erue`, ADR-0066, RUE-1089): producer-nominal
+/// identity makes two same-named types in different files distinct, so their
+/// symbols must never depend on whether a collision happened to be observed.
+/// `$` cannot appear in a source identifier, so a qualified name can never
+/// collide with a real type.
+///
+/// `keeps_bare_symbol` marks the nominals that pair with a definition named
+/// outside this rule and therefore keep their unqualified source name — see
+/// [`enum_keeps_bare_symbol`] and the type pool's registry membership tests.
+/// An exempt nominal never asks for its module component, which is why that
+/// component arrives as a thunk: deriving it costs a path normalization and a
+/// mangle, and nominal symbols are spelled once per member call site.
+pub fn named_nominal_symbol(
+    name: &str,
+    keeps_bare_symbol: bool,
+    module_component: impl FnOnce() -> String,
+) -> String {
+    if keeps_bare_symbol {
+        return name.to_owned();
+    }
+    let module_component = module_component();
+    let mut symbol = String::with_capacity(name.len() + 1 + module_component.len());
+    symbol.push_str(name);
+    symbol.push('$');
+    symbol.push_str(&module_component);
+    symbol
+}
+
+/// Whether an enum keeps its bare source name as its live symbol.
+///
+/// The reserved built-in enums (`Arch`, `Os`, `DataModel`) are injected by the
+/// compiler, so their symbols pair with definitions this rule does not spell.
+/// The builtin universe owns that membership test and this is its one exported
+/// face, so a newly reserved enum cannot be exempt in one phase and qualified
+/// in another.
+pub fn enum_keeps_bare_symbol(name: &str) -> bool {
+    crate::builtin_universe::BuiltinUniverse::builtin_enum_name(name)
+}
+
+/// The live symbol of a callable that belongs to a nominal — a method
+/// (`P.get`), an associated function (`P::make`), or a destructor
+/// (`P.__drop`).
+///
+/// The separator carries the receiver: `.` when the callable takes `self`,
+/// `::` when it does not. Both components are already-rendered symbols, which
+/// is what lets a caller that spells several members of one owner render that
+/// owner once; the exact final capacity is reserved up front, so joining never
+/// reallocates.
+pub fn member_callable_name(owner: &str, member: &str, has_self: bool) -> String {
+    let separator = if has_self { "." } else { "::" };
+    let mut name = String::with_capacity(owner.len() + separator.len() + member.len());
+    name.push_str(owner);
+    name.push_str(separator);
+    name.push_str(member);
+    name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn named_nominals_are_qualified_unless_exempt() {
+        assert_eq!(
+            named_nominal_symbol("Record", false, || "pkg_2fmain_2erue".to_owned()),
+            "Record$pkg_2fmain_2erue"
+        );
+        assert_eq!(
+            named_nominal_symbol("StrBuf", true, || unreachable!(
+                "an exempt nominal never derives a module component"
+            )),
+            "StrBuf"
+        );
+    }
+
+    #[test]
+    fn module_components_normalize_before_mangling() {
+        assert_eq!(module_symbol_component("pkg/main.rue"), "pkg_2fmain_2erue");
+        assert_eq!(
+            module_symbol_component("./pkg/main.rue"),
+            module_symbol_component("pkg/main.rue")
+        );
+    }
+
+    #[test]
+    fn only_the_builtin_universe_exempts_an_enum() {
+        for reserved in ["Arch", "Os", "DataModel"] {
+            assert!(enum_keeps_bare_symbol(reserved));
+        }
+        assert!(!enum_keeps_bare_symbol("Choice"));
+    }
+
+    #[test]
+    fn member_separators_carry_the_receiver() {
+        assert_eq!(member_callable_name("Owner", "get", true), "Owner.get");
+        assert_eq!(member_callable_name("Owner", "make", false), "Owner::make");
+        assert_eq!(
+            member_callable_name("Owner", "__drop", true),
+            "Owner.__drop"
+        );
+    }
+
+    /// The anonymous owner spelling the member installation loops hoist, with
+    /// the three member shapes they install: method, associated function, and
+    /// destructor. One rendered owner spells all of them.
+    #[test]
+    fn member_names_extend_the_rendered_owner_spelling() {
+        let owner = "__anon_struct_0123456789abcdef0123456789abcdef";
+        assert_eq!(
+            member_callable_name(owner, "len", true),
+            "__anon_struct_0123456789abcdef0123456789abcdef.len"
+        );
+        assert_eq!(
+            member_callable_name(owner, "make", false),
+            "__anon_struct_0123456789abcdef0123456789abcdef::make"
+        );
+        assert_eq!(
+            member_callable_name(owner, "__drop", true),
+            "__anon_struct_0123456789abcdef0123456789abcdef.__drop"
+        );
+    }
+}

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -472,8 +472,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let struct_id = ty.as_struct().expect("StrBuf is a struct");
         let method = self.intern_body_symbol("equals_borrowed")?;
         ctx.referenced_methods.insert((struct_id, method));
-        let call_name =
-            self.intern_body_symbol(&self.method_symbol(struct_id, "equals_borrowed", false))?;
+        let call_name = self.method_symbol_handle(struct_id, "equals_borrowed", false)?;
         Ok(air.add_call(
             None,
             call_name,

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -111,8 +111,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
         ctx.referenced_methods.insert((struct_id, method));
         self.record_body_method_dependency((struct_id, method))?;
-        let call_name =
-            self.intern_body_symbol(&self.method_symbol(struct_id, "concat_borrowed", false))?;
+        let call_name = self.method_symbol_handle(struct_id, "concat_borrowed", false)?;
         let arg_mode = AirArgMode::Borrow;
 
         let (lhs_arg, mut temp_scope) =

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -1310,11 +1310,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut temp_scope = receiver_temp_scope;
         temp_scope.extend(args_result.temp_scope);
 
-        // Generate the method call symbol: `Type.method`, file-qualified when
-        // the type name spans files (RUE-571) — must match the definition
-        // side, which builds its name through the same helper.
-        let call_name = self.method_symbol(struct_id, &method_name_str, true);
-        let call_name_sym = self.intern_body_symbol(&call_name)?;
+        // The method call symbol `Type.method`, module-qualified when the type
+        // name spans files (RUE-571). The host renders and interns it, so the
+        // call meets the definition it names.
+        let call_name_sym = self.method_symbol_handle(struct_id, &method_name_str, true)?;
 
         let call = self.emit_call_result(
             air,
@@ -1660,13 +1659,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ctx,
         )?;
 
-        // Generate the associated-function call symbol: `Type::function`.
-        // Uses the internal struct name (e.g. "__anon_struct_0") for anonymous
-        // structs — not the user-visible type variable name — and the
-        // file-qualified name when the type name spans files (RUE-571),
-        // matching the definition side.
-        let call_name = self.method_symbol(struct_id, &function_name_str, false);
-        let call_name_sym = self.intern_body_symbol(&call_name)?;
+        // The associated-function call symbol `Type::function`. The owner
+        // component is the internal struct name (`__anon_struct_<digest>`) for
+        // anonymous structs — not the user-visible type variable name — and the
+        // module-qualified name when the type name spans files (RUE-571); the
+        // host renders both, so the call meets the definition it names.
+        let call_name_sym = self.method_symbol_handle(struct_id, &function_name_str, false)?;
 
         let result = self.emit_call_result(
             air,

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -894,7 +894,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
                 ctx,
             )?;
-            let call_name = self.intern_body_symbol(&self.method_symbol(struct_id, "len", true))?;
+            let call_name = self.method_symbol_handle(struct_id, "len", true)?;
             let call_ref = air.add_call(
                 None,
                 call_name,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1020,9 +1020,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             self.record_body_method_dependency((struct_id, len_method))?;
         }
         let (receiver, prefix) = self.materialize_borrow_argument(air, value, ty, span, ctx)?;
-        let ptr_call_name =
-            self.intern_body_symbol(&self.method_symbol(struct_id, "as_ptr", true))?;
-        let len_call_name = self.intern_body_symbol(&self.method_symbol(struct_id, "len", true))?;
+        let ptr_call_name = self.method_symbol_handle(struct_id, "as_ptr", true)?;
+        let len_call_name = self.method_symbol_handle(struct_id, "len", true)?;
         let ptr_ref = air.add_call(
             None,
             ptr_call_name,
@@ -1552,8 +1551,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .call_method_info(struct_id, method)
             .expect("accessor expansion follows a successful method lookup");
         let method_name_str = self.body_interner().resolve(&method).to_string();
-        let call_name = self.method_symbol(struct_id, &method_name_str, true);
-        let call_name = self.intern_body_symbol(&call_name)?;
+        let call_name = self.method_symbol_handle(struct_id, &method_name_str, true)?;
         if self.function_identity(call_name).is_ok_and(|identity| {
             ctx.canonical_function_identity == crate::FunctionInstanceKey::Definition(identity)
         }) {
@@ -4492,8 +4490,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         self.record_body_method_dependency((struct_id, method))?;
         let (receiver, temp_scope) =
             self.materialize_borrow_argument(air, base_result.air_ref, base_result.ty, span, ctx)?;
-        let call_name =
-            self.intern_body_symbol(&self.method_symbol(struct_id, "byte_at_borrowed", false))?;
+        let call_name = self.method_symbol_handle(struct_id, "byte_at_borrowed", false)?;
         let receiver_mode = AirArgMode::Borrow;
         let call_ref = air.add_call(
             None,

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -1403,7 +1403,12 @@ where
                 // rather than marking the whole pool stale.
                 let destructor = has_destructor.then(|| {
                     Arc::<str>::from(
-                        format!("{}.__drop", self.type_pool.struct_symbol_name(id)).as_str(),
+                        crate::live_symbols::member_callable_name(
+                            &self.type_pool.struct_symbol_name(id),
+                            "__drop",
+                            true,
+                        )
+                        .as_str(),
                     )
                 });
                 self.type_pool.complete_declared_struct(
@@ -1565,7 +1570,12 @@ where
                 // completion eligible for incremental containment facts.
                 let destructor = has_destructor.then(|| {
                     Arc::<str>::from(
-                        format!("{}.__drop", self.type_pool.struct_symbol_name(id)).as_str(),
+                        crate::live_symbols::member_callable_name(
+                            &self.type_pool.struct_symbol_name(id),
+                            "__drop",
+                            true,
+                        )
+                        .as_str(),
                     )
                 });
                 self.type_pool.complete_declared_struct(
@@ -2053,7 +2063,7 @@ where
         });
         let destructor = has_destructor.then(|| {
             self.space.keyed_name(digest, ANON_DESTRUCTOR_SPELLING, || {
-                format!("{name}.__drop")
+                crate::live_symbols::member_callable_name(&name, "__drop", true)
             })
         });
 

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -141,6 +141,34 @@ pub(crate) trait BodyAuthority {
 
     fn body_type_pool(&self) -> &TypeInternPool;
 
+    /// The live symbol of a callable owned by `struct_id` — a method
+    /// (`P.get`), an associated function (`P::make`), or a destructor
+    /// (`P.__drop`).
+    ///
+    /// Definition sites and call sites are one spelling family: the host
+    /// renders both, so a second separator policy cannot appear on the call
+    /// side and unjoin a map keyed by a member callable symbol (RUE-1236).
+    fn body_member_callable_name(
+        &self,
+        struct_id: StructId,
+        method: &str,
+        has_self: bool,
+    ) -> String;
+
+    /// The interned handle for that spelling.
+    ///
+    /// Separate from rendering because a host may hold the generation's
+    /// derived-spelling memo: an owner and member the shared space already
+    /// issued handles for answer without rendering the join at all.
+    fn try_member_callable_symbol(
+        &self,
+        struct_id: StructId,
+        method: &str,
+        has_self: bool,
+    ) -> Result<Spur, lasso::LassoErrorKind> {
+        self.try_intern_body_symbol(self.body_member_callable_name(struct_id, method, has_self))
+    }
+
     fn body_rir_ref(&self) -> &Rir;
 
     /// Whole-arena census of inline type-constructor head shapes (RUE-596),
@@ -763,8 +791,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         let Some(info) = self.method_info(key) else {
             return Ok(());
         };
-        let symbol = self.method_symbol(key.0, self.body_interner().resolve(&key.1), info.has_self);
-        let symbol = self.intern_body_symbol(&symbol)?;
+        let symbol =
+            self.method_symbol_handle(key.0, self.body_interner().resolve(&key.1), info.has_self)?;
         self.record_body_callable_dependency(symbol);
         Ok(())
     }
@@ -1396,7 +1424,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             && fields
                 .iter()
                 .all(|field| field.ty.is_copy_in_pool(self.storage.body_type_pool()));
-        let destructor = has_destructor.then(|| Arc::from(format!("{name}.__drop").as_str()));
+        let destructor = has_destructor.then(|| {
+            Arc::from(crate::live_symbols::member_callable_name(&name, "__drop", true).as_str())
+        });
         let def = crate::types::StructDef {
             name: Arc::from(name.as_str()),
             fields: fields.to_vec(),
@@ -1629,21 +1659,23 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn has_method(&self, key: (StructId, Spur)) -> bool {
         self.method_info(key).is_some()
     }
-    pub(crate) fn symbol_type_name(&self, struct_id: StructId) -> String {
-        self.body_type_pool().struct_symbol_name(struct_id)
-    }
-    pub(crate) fn method_symbol(
+    /// The handle for a member callable's live symbol, taken through the host
+    /// that also names the definition — and through its derived-spelling memo
+    /// rather than by re-rendering and re-interning the join.
+    pub(crate) fn method_symbol_handle(
         &self,
         struct_id: StructId,
         method: &str,
         has_self: bool,
-    ) -> String {
-        let type_name = self.symbol_type_name(struct_id);
-        if has_self {
-            format!("{type_name}.{method}")
-        } else {
-            format!("{type_name}::{method}")
-        }
+    ) -> CompileResult<Spur> {
+        self.storage
+            .try_member_callable_symbol(struct_id, method, has_self)
+            .map_err(|kind| {
+                CompileError::without_span(rue_error::interner_error_kind(
+                    kind,
+                    "body symbol interning failed",
+                ))
+            })
     }
     pub(crate) fn is_type_copy(&self, ty: Type) -> bool {
         ty.is_copy_in_pool(self.body_type_pool())

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -201,22 +201,6 @@ fn intern_synthetic_argument_name_in_space(
     space.try_intern(name).ok()
 }
 
-/// The one spelling of a member callable name, built from an already-rendered
-/// owner component.
-///
-/// Taking the owner by reference is what lets a caller that spells several
-/// members of the same owner render that owner once; the exact final capacity
-/// is reserved up front, so joining never reallocates the way appending onto an
-/// exactly-sized owner string did.
-fn member_callable_name_for_owner(owner: &str, method: &str, has_self: bool) -> String {
-    let separator = if has_self { "." } else { "::" };
-    let mut name = String::with_capacity(owner.len() + separator.len() + method.len());
-    name.push_str(owner);
-    name.push_str(separator);
-    name.push_str(method);
-    name
-}
-
 fn check_shared_interner(
     space: &rue_rir::SharedSymbolSpace,
     phase: &'static str,
@@ -435,35 +419,6 @@ mod type_syntax_provider_trace_tests {
         assert_eq!(result.unwrap(), None);
         assert_eq!(host.symbol_lookups, 0);
     }
-}
-
-#[cfg(test)]
-#[test]
-fn member_callable_names_extend_the_rendered_owner_spelling() {
-    assert_eq!(
-        member_callable_name_for_owner("Owner", "method", true),
-        "Owner.method"
-    );
-    assert_eq!(
-        member_callable_name_for_owner("Owner", "make", false),
-        "Owner::make"
-    );
-    // The anonymous owner spelling the installation loops hoist, with the
-    // three member shapes they install: method, associated function, and
-    // destructor. One rendered owner spells all of them.
-    let owner = "__anon_struct_0123456789abcdef0123456789abcdef";
-    assert_eq!(
-        member_callable_name_for_owner(owner, "len", true),
-        "__anon_struct_0123456789abcdef0123456789abcdef.len"
-    );
-    assert_eq!(
-        member_callable_name_for_owner(owner, "make", false),
-        "__anon_struct_0123456789abcdef0123456789abcdef::make"
-    );
-    assert_eq!(
-        member_callable_name_for_owner(owner, "__drop", true),
-        "__anon_struct_0123456789abcdef0123456789abcdef.__drop"
-    );
 }
 
 #[cfg(test)]
@@ -2027,10 +1982,15 @@ where
     /// analysis uses. Every map keyed by a member callable symbol
     /// (`anonymous_function_identities`, `function_tokens`) must write and
     /// read through the one spelling in
-    /// [`member_callable_name_for_owner`] (RUE-1236); a second renderer would
-    /// reintroduce a join that only holds while two policies agree.
+    /// [`crate::live_symbols::member_callable_name`] (RUE-1236); a second
+    /// renderer would reintroduce a join that only holds while two policies
+    /// agree.
     fn member_callable_name(&self, struct_id: StructId, method: &str, has_self: bool) -> String {
-        member_callable_name_for_owner(&self.member_callable_owner(struct_id), method, has_self)
+        crate::live_symbols::member_callable_name(
+            &self.member_callable_owner(struct_id),
+            method,
+            has_self,
+        )
     }
 
     /// The owner component every member callable symbol of `struct_id` shares.
@@ -2063,7 +2023,8 @@ where
         method: &str,
         has_self: bool,
     ) -> Option<Spur> {
-        self.intern_name(member_callable_name_for_owner(owner, method, has_self))
+        self.try_member_callable_symbol_for_issued_owner(None, owner, None, method, has_self)
+            .ok()
     }
 
     /// The handle for a member callable of an owner whose own spelling the
@@ -2076,13 +2037,6 @@ where
     /// spelling, the member spelling, and the separator, so the generation's
     /// derived-spelling memo holds that association and only the first body to
     /// spell a member renders it.
-    ///
-    /// `owner_symbol` and `method_symbol` are the handles the space already
-    /// issued for the two components. A caller without an owner handle falls
-    /// back to rendering, which is what
-    /// [`Self::member_callable_symbol_for_owner`] has always done — both arms
-    /// spell through [`member_callable_name_for_owner`], the one renderer
-    /// (RUE-1236).
     fn member_callable_symbol_for_issued_owner(
         &self,
         owner_symbol: Option<Spur>,
@@ -2091,15 +2045,40 @@ where
         method: &str,
         has_self: bool,
     ) -> Option<Spur> {
-        let Some(owner_symbol) = owner_symbol else {
-            return self.member_callable_symbol_for_owner(owner, method, has_self);
-        };
-        self.state
-            .symbol_space()
-            .try_derived_symbol(owner_symbol, method_symbol, u8::from(has_self), || {
-                member_callable_name_for_owner(owner, method, has_self)
-            })
-            .ok()
+        self.try_member_callable_symbol_for_issued_owner(
+            owner_symbol,
+            owner,
+            Some(method_symbol),
+            method,
+            has_self,
+        )
+        .ok()
+    }
+
+    /// The one memo policy for member callable handles.
+    ///
+    /// `owner_symbol` and `method_symbol` are the handles the shared space
+    /// already issued for the two components; a caller missing either falls
+    /// back to rendering the join and interning it. Both arms spell through
+    /// [`crate::live_symbols::member_callable_name`], the one renderer
+    /// (RUE-1236), so definition sites and call sites cannot disagree about a
+    /// spelling the memo then keys.
+    fn try_member_callable_symbol_for_issued_owner(
+        &self,
+        owner_symbol: Option<Spur>,
+        owner: &str,
+        method_symbol: Option<Spur>,
+        method: &str,
+        has_self: bool,
+    ) -> Result<Spur, lasso::LassoErrorKind> {
+        let render = || crate::live_symbols::member_callable_name(owner, method, has_self);
+        match (owner_symbol, method_symbol) {
+            (Some(owner_symbol), Some(method_symbol)) => self
+                .state
+                .symbol_space()
+                .try_derived_symbol(owner_symbol, method_symbol, u8::from(has_self), render),
+            _ => self.state.symbol_space().try_intern(render()),
+        }
     }
 
     /// The handle the shared space already holds for an owner's own spelling,
@@ -4459,6 +4438,34 @@ where
             .finalize_containment_metadata()
             .expect("provider type materialization must produce an acyclic containment graph");
         &self.type_pool
+    }
+
+    fn body_member_callable_name(
+        &self,
+        struct_id: StructId,
+        method: &str,
+        has_self: bool,
+    ) -> String {
+        self.member_callable_name(struct_id, method, has_self)
+    }
+
+    /// Call sites reach the same derived-spelling memo the installation loops
+    /// use, so a member named from a body the generation already spelled it in
+    /// costs a memo probe rather than a render and a hash of the join.
+    fn try_member_callable_symbol(
+        &self,
+        struct_id: StructId,
+        method: &str,
+        has_self: bool,
+    ) -> Result<Spur, lasso::LassoErrorKind> {
+        let owner = self.member_callable_owner(struct_id);
+        self.try_member_callable_symbol_for_issued_owner(
+            self.member_callable_owner_symbol(&owner),
+            &owner,
+            self.interner.get(method),
+            method,
+            has_self,
+        )
     }
 
     fn body_rir_ref(&self) -> &Rir {

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -8484,6 +8484,67 @@ fn semantic_import_type_and_type_instance_convert_in_one_place() {
     }
 }
 
+/// Live symbol spelling belongs to `rue-air`, and this crate reaches it as an
+/// adapter over durable identities rather than as a second policy.
+///
+/// The two sides join for real: `durable_cfg` keys one body's symbol mappings
+/// on both, and drop glue defined under the rooted spelling is called under
+/// the pool's. A re-derived rule here spells a definition one way and its call
+/// the other.
+#[test]
+fn live_symbol_spelling_is_adapted_from_rue_air_not_re_derived() {
+    let identity = include_str!("semantic_identity.rs");
+    let materialization = include_str!("local_semantic_materialization.rs");
+
+    // One entry point per identity shape, both over one exemption rule.
+    for owner in [
+        "pub(crate) fn named_nominal_source_symbol(",
+        "pub(crate) fn named_type_source_symbol(",
+        "fn named_nominal_symbol(",
+    ] {
+        assert_eq!(
+            identity.matches(owner).count(),
+            1,
+            "semantic_identity must own exactly one {owner}"
+        );
+    }
+    assert!(identity.contains("rue_air::live_symbols::named_nominal_symbol("));
+    assert!(identity.contains("rue_air::live_symbols::enum_keeps_bare_symbol("));
+    assert!(identity.contains("rue_air::live_symbols::member_callable_name("));
+
+    // The drop-glue fragment grammar is rue-air's; this crate only relocates
+    // the instance and answers its own leaves.
+    assert_eq!(
+        materialization
+            .matches("rue_air::drop_glue_names::drop_glue_type_fragment(")
+            .count(),
+        1,
+        "durable drop-glue names must come from the rue-air grammar"
+    );
+    assert!(
+        materialization.contains("semantic_type_from_instance(ty)"),
+        "the durable adapter must reach the grammar through the conversion ladder"
+    );
+
+    // No module-qualification, member-separator, or drop-glue prefix rule of
+    // this crate's own.
+    for (module, source) in PRODUCTION_MODULES {
+        let code = rust_code_only(source);
+        assert!(
+            !code.contains("\"{}${}\""),
+            "{module} spells a qualified nominal instead of adapting rue-air's"
+        );
+        assert!(
+            !code.contains("__rue_drop_{"),
+            "{module} spells a drop-glue symbol instead of adapting rue-air's"
+        );
+    }
+    assert!(
+        !materialization.contains("fn named_type_live_symbol("),
+        "the retired second nominal spelling must not return"
+    );
+}
+
 #[test]
 fn durable_specialized_producer_issuance_has_one_ordered_kernel() {
     let durable = DURABLE_COMPTIME_LIFECYCLE_SOURCE;

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -776,7 +776,9 @@ pub(crate) fn fallback_callable_symbol(identity: &FunctionInstanceKey) -> Arc<st
         crate::StableCallableId::Function(identity.clone()),
     ));
     if callable_kind_for_identity(identity) == rue_air::AnalyzedCallableKind::Destructor {
-        Arc::from(format!("{encoded}.__drop"))
+        Arc::from(rue_air::live_symbols::member_callable_name(
+            &encoded, "__drop", true,
+        ))
     } else {
         Arc::from(encoded)
     }
@@ -798,22 +800,24 @@ fn live_callable_symbol(identity: &FunctionInstanceKey) -> Option<String> {
     match identity {
         FunctionInstanceKey::Definition(definition) => match definition.kind() {
             StableDefinitionKind::Function => {
-                let module = rue_air::mangle_symbol_component(&rue_air::normalize_module_path(
+                let module = rue_air::live_symbols::module_symbol_component(
                     definition.module().logical_path(),
-                ));
+                );
                 Some(format!("__rue_fn_{module}__{}", definition.name()))
             }
             StableDefinitionKind::Destructor
             | StableDefinitionKind::Method
             | StableDefinitionKind::AssociatedFunction => {
-                let owner = named_type_live_symbol(definition.owner()?);
-                let (separator, member) = match definition.kind() {
-                    StableDefinitionKind::Destructor => (".", "__drop"),
-                    StableDefinitionKind::Method => (".", definition.name()),
-                    StableDefinitionKind::AssociatedFunction => ("::", definition.name()),
+                let owner = crate::semantic_identity::named_type_source_symbol(definition.owner()?);
+                let (has_self, member) = match definition.kind() {
+                    StableDefinitionKind::Destructor => (true, "__drop"),
+                    StableDefinitionKind::Method => (true, definition.name()),
+                    StableDefinitionKind::AssociatedFunction => (false, definition.name()),
                     _ => unreachable!(),
                 };
-                Some(format!("{owner}{separator}{member}"))
+                Some(rue_air::live_symbols::member_callable_name(
+                    &owner, member, has_self,
+                ))
             }
             // A test declaration's linker symbol is
             // `__rue_test_{module}__{digest}` (ADR-0083 §1): the same mangled
@@ -826,15 +830,27 @@ fn live_callable_symbol(identity: &FunctionInstanceKey) -> Option<String> {
             // identity, not the digest, stays the semantic authority; this only
             // decides how the symbol is spelled.
             StableDefinitionKind::Test => {
-                let module = rue_air::mangle_symbol_component(&rue_air::normalize_module_path(
+                let module = rue_air::live_symbols::module_symbol_component(
                     definition.module().logical_path(),
-                ));
+                );
                 let digest =
                     rue_air::stable_digest::stable_test_name_digest_component(definition.name());
                 Some(format!("__rue_test_{module}__{digest}"))
             }
             _ => None,
         },
+        // A specialization's rooted symbol appends one `.`-separated segment per
+        // canonical argument, spelled from the argument's CONTENT.
+        //
+        // `specialize::mangle_specialized_name` spells the same shape inside
+        // one body analysis, but from live pool handles (`struct3`), and this
+        // side has no pool: a rooted callable is named from durable identities
+        // alone, and a handle's numeric value is scheduling-dependent once one
+        // interner and one pool are shared across a revision's bodies
+        // (ADR-0076). The two spellings never have to meet — a call site's live
+        // name reaches its callee through the stable identity `durable_cfg`
+        // records beside it, not by matching the callee's own name — so each
+        // vocabulary keeps the spelling its inputs can support.
         FunctionInstanceKey::Specialization { base, arguments } => {
             let mut symbol = live_callable_symbol(base)?;
             for ty in arguments.types.iter() {
@@ -850,9 +866,9 @@ fn live_callable_symbol(identity: &FunctionInstanceKey) -> Option<String> {
         FunctionInstanceKey::AnonymousMember { .. } => {
             crate::semantic_identity::anonymous_member_source_symbol(identity)
         }
-        FunctionInstanceKey::DropGlue(owner) => {
-            Some(format!("__rue_drop_{}", drop_glue_type_name(owner)?))
-        }
+        FunctionInstanceKey::DropGlue(owner) => Some(rue_air::drop_glue_names::drop_glue_symbol(
+            &drop_glue_type_name(owner)?,
+        )),
         // A structural printer's linker symbol is
         // `__rue_error_printer__{digest}` (ADR-0083 §1): the 32-hex fixed-seed
         // FNV-1a digest of the stable symbol encoding of this exact identity.
@@ -881,71 +897,62 @@ fn live_callable_symbol(identity: &FunctionInstanceKey) -> Option<String> {
     }
 }
 
-fn named_type_live_symbol(owner: &crate::bound_definitions::StableNamedTypeKey) -> String {
-    let bare = match owner.kind() {
-        StableDefinitionKind::Struct => {
-            owner.module().is_trusted_standard_library()
-                && rue_air::LangItem::from_standard_library_nominal(
-                    owner.module().logical_path(),
-                    owner.name(),
-                )
-                .is_some()
-        }
-        StableDefinitionKind::Enum => rue_builtins::is_reserved_enum_name(owner.name()),
-        _ => false,
-    };
-    if bare {
-        owner.name().to_owned()
-    } else {
-        format!(
-            "{}${}",
-            owner.name(),
-            rue_air::mangle_symbol_component(&rue_air::normalize_module_path(
-                owner.module().logical_path()
-            ))
-        )
-    }
+/// The drop-glue type fragment for one durable type instance.
+///
+/// The fragment grammar belongs to `rue_air::drop_glue_names`, which sema and
+/// both codegen backends spell glue through; this side only relocates the
+/// instance into the semantic vocabulary and answers the leaves a durable
+/// identity spells for itself. A type with no fragment — a slice, a module, or
+/// a generic parameter, none of which ever own glue — has no live glue symbol,
+/// and its callable falls back to the stable encoding.
+fn drop_glue_type_name(ty: &crate::TypeInstanceKey) -> Option<String> {
+    rue_air::drop_glue_names::drop_glue_type_fragment(&DurableDropGlueType(
+        &crate::semantic_identity::semantic_type_from_instance(ty),
+    ))
 }
 
-fn drop_glue_type_name(ty: &crate::TypeInstanceKey) -> Option<String> {
-    use crate::{NominalInstanceKey, TypeInstanceKey};
-    Some(match ty {
-        TypeInstanceKey::I8 => "i8".to_owned(),
-        TypeInstanceKey::I16 => "i16".to_owned(),
-        TypeInstanceKey::I32 => "i32".to_owned(),
-        TypeInstanceKey::I64 => "i64".to_owned(),
-        TypeInstanceKey::U8 => "u8".to_owned(),
-        TypeInstanceKey::U16 => "u16".to_owned(),
-        TypeInstanceKey::U32 => "u32".to_owned(),
-        TypeInstanceKey::U64 => "u64".to_owned(),
-        TypeInstanceKey::Bool => "bool".to_owned(),
-        TypeInstanceKey::Unit => "unit".to_owned(),
-        TypeInstanceKey::Never => "never".to_owned(),
-        TypeInstanceKey::ComptimeType => "comptime_type".to_owned(),
-        TypeInstanceKey::F32 => "f32".to_owned(),
-        TypeInstanceKey::F64 => "f64".to_owned(),
-        TypeInstanceKey::ComptimeFloat => "comptime_float".to_owned(),
-        TypeInstanceKey::BuiltinNominal { name, .. }
-        | TypeInstanceKey::Nominal(NominalInstanceKey::Builtin { name, .. }) => name.to_string(),
-        TypeInstanceKey::Nominal(NominalInstanceKey::Named(definition)) => {
-            crate::semantic_identity::named_nominal_source_symbol(definition)?
-        }
-        TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(identity)) => {
-            crate::semantic_identity::anonymous_nominal_source_symbol(identity)
-        }
-        TypeInstanceKey::Array { element, len } => {
-            format!("array_{}_{len}", drop_glue_type_name(element)?)
-        }
-        TypeInstanceKey::PtrConst(pointee) => {
-            format!("ptr_const_{}", drop_glue_type_name(pointee)?)
-        }
-        TypeInstanceKey::PtrMut(pointee) => {
-            format!("ptr_mut_{}", drop_glue_type_name(pointee)?)
-        }
-        TypeInstanceKey::Slice { .. }
-        | TypeInstanceKey::Module(_)
-        | TypeInstanceKey::GenericParameter(_) => return None,
-    })
+/// One durable semantic type, the vocabulary a rooted callable is named from.
+struct DurableDropGlueType<'a>(
+    &'a rue_air::SemanticImportType<StableDefinitionKey, crate::ModuleId>,
+);
+
+impl rue_air::drop_glue_names::DropGlueTypeShapeSource for DurableDropGlueType<'_> {
+    fn drop_glue_shape(&self) -> Option<rue_air::drop_glue_names::DropGlueTypeShape<Self>> {
+        use rue_air::SemanticImportType as T;
+        use rue_air::drop_glue_names::DropGlueTypeShape as Shape;
+        let leaf = |name: &str| Some(Shape::Leaf(name.to_owned()));
+        Some(match self.0 {
+            T::I8 => return leaf("i8"),
+            T::I16 => return leaf("i16"),
+            T::I32 => return leaf("i32"),
+            T::I64 => return leaf("i64"),
+            T::U8 => return leaf("u8"),
+            T::U16 => return leaf("u16"),
+            T::U32 => return leaf("u32"),
+            T::U64 => return leaf("u64"),
+            T::Bool => return leaf("bool"),
+            T::Unit => return leaf("unit"),
+            T::Never => return leaf("never"),
+            T::ComptimeType => return leaf("comptime_type"),
+            T::F32 => return leaf("f32"),
+            T::F64 => return leaf("f64"),
+            T::ComptimeFloat => return leaf("comptime_float"),
+            T::BuiltinNominal { name, .. } => Shape::Leaf(name.to_string()),
+            T::Nominal(definition) => Shape::Leaf(
+                crate::semantic_identity::named_nominal_source_symbol(definition)?,
+            ),
+            T::AnonymousNominal(identity) => Shape::Leaf(
+                crate::semantic_identity::anonymous_nominal_source_symbol(identity),
+            ),
+            T::Array { element, len } => Shape::Array {
+                element: DurableDropGlueType(element),
+                len: *len,
+            },
+            T::PtrConst(pointee) => Shape::PtrConst(DurableDropGlueType(pointee)),
+            T::PtrMut(pointee) => Shape::PtrMut(DurableDropGlueType(pointee)),
+            T::Slice { .. } | T::Module(_) | T::GenericParameter(_) => return None,
+        })
+    }
 }
 
 fn mangle_canonical_type(ty: &crate::TypeInstanceKey) -> String {
@@ -2011,6 +2018,377 @@ pub(crate) fn select_drop_glue_materialization_facts(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// One durable nominal fixture and the live pool nominal it names.
+    struct NominalFixture {
+        key: crate::NominalInstanceKey,
+        nominal: rue_air::SemanticLocalNominal<StableDefinitionKey, ModuleId>,
+    }
+
+    fn named_nominal_fixture(
+        module: &ModuleId,
+        kind: StableDefinitionKind,
+        name: &str,
+        lang_item: Option<rue_air::LangItem>,
+    ) -> NominalFixture {
+        let definition = StableDefinitionKey::for_test(
+            module.clone(),
+            rue_air::StableDefinitionNamespace::Type,
+            kind,
+            Arc::<str>::from(name),
+            None,
+        );
+        NominalFixture {
+            key: crate::NominalInstanceKey::Named(definition),
+            nominal: rue_air::SemanticLocalNominal {
+                key: crate::NominalInstanceKey::Named(StableDefinitionKey::for_test(
+                    module.clone(),
+                    rue_air::StableDefinitionNamespace::Type,
+                    kind,
+                    Arc::<str>::from(name),
+                    None,
+                )),
+                module_path: Arc::from(module.logical_path()),
+                name: Arc::from(name),
+                kind: match kind {
+                    StableDefinitionKind::Enum => rue_air::SemanticImportNominalKind::Enum,
+                    _ => rue_air::SemanticImportNominalKind::Struct,
+                },
+                is_public: true,
+                lang_item,
+                shape: match kind {
+                    StableDefinitionKind::Enum => rue_air::SemanticLocalNominalShape::Enum {
+                        variants: Arc::from([]),
+                        is_non_exhaustive: false,
+                    },
+                    _ => rue_air::SemanticLocalNominalShape::Struct {
+                        fields: Arc::from([]),
+                        is_copy: false,
+                        is_linear: false,
+                        declared_linear: false,
+                        destructor: None,
+                    },
+                },
+            },
+        }
+    }
+
+    /// Live symbol spelling has one owner per family, so the same type spells
+    /// the same fragment whichever vocabulary reaches it: `rue-air`'s live type
+    /// pool during sema and codegen, and this crate's durable adapter when the
+    /// rooted projection names a callable.
+    ///
+    /// The two sides join for real — `durable_cfg` keys a body's symbol
+    /// mappings on both, and drop glue defined under one spelling is called
+    /// under the other — so a fixture that disagrees here is a link-time miss
+    /// or a `CfgDomainFailure::Shape`, not a cosmetic difference.
+    #[test]
+    fn every_durable_type_spells_the_live_pool_drop_glue_fragment() {
+        let user = ModuleId::from_validated_canonical("pkg/main.rue");
+        let strbuf_module = ModuleId::from_trusted_validated_canonical("\0rue-std/strbuf.rue");
+
+        let record = named_nominal_fixture(&user, StableDefinitionKind::Struct, "Record", None);
+        // A canonical standard-library nominal: exempt through the lang-item
+        // registry on both sides, never through a name table.
+        let strbuf = named_nominal_fixture(
+            &strbuf_module,
+            StableDefinitionKind::Struct,
+            "StrBuf",
+            Some(rue_air::LangItem::StrBuf),
+        );
+        let choice = named_nominal_fixture(&user, StableDefinitionKind::Enum, "Choice", None);
+        // A user enum that happens to carry a reserved built-in enum name is
+        // the exemption both sides have to agree about.
+        let arch = named_nominal_fixture(&user, StableDefinitionKind::Enum, "Arch", None);
+
+        let anonymous_key = crate::AnonymousNominalKey {
+            kind: crate::AnonymousNominalKind::Struct,
+            producer: crate::semantic_identity::StableProducerId::Definition(
+                StableDefinitionKey::for_test(
+                    user.clone(),
+                    rue_air::StableDefinitionNamespace::Value,
+                    StableDefinitionKind::Function,
+                    Arc::<str>::from("Wrap"),
+                    None,
+                ),
+            ),
+            anchor: crate::semantic_identity::StructuralAnchor::new(vec![
+                crate::semantic_identity::StructuralPathSegment::AnonymousType(0),
+            ]),
+        };
+        let anonymous = NominalFixture {
+            key: crate::NominalInstanceKey::Anonymous(Node::new(anonymous_key.clone())),
+            nominal: rue_air::SemanticLocalNominal {
+                key: crate::NominalInstanceKey::Anonymous(Node::new(anonymous_key.clone())),
+                module_path: Arc::from(user.logical_path()),
+                name: Arc::from(crate::semantic_identity::anonymous_nominal_source_symbol(
+                    &anonymous_key,
+                )),
+                kind: rue_air::SemanticImportNominalKind::Struct,
+                is_public: false,
+                lang_item: None,
+                shape: rue_air::SemanticLocalNominalShape::Struct {
+                    fields: Arc::from([]),
+                    is_copy: false,
+                    is_linear: false,
+                    declared_linear: false,
+                    destructor: None,
+                },
+            },
+        };
+        let builtin = NominalFixture {
+            key: crate::NominalInstanceKey::Builtin {
+                kind: crate::AnonymousNominalKind::Struct,
+                name: Arc::from("String"),
+            },
+            nominal: rue_air::SemanticLocalNominal {
+                key: crate::NominalInstanceKey::Builtin {
+                    kind: crate::AnonymousNominalKind::Struct,
+                    name: Arc::from("String"),
+                },
+                module_path: Arc::from("<builtin>"),
+                name: Arc::from("String"),
+                kind: rue_air::SemanticImportNominalKind::Struct,
+                is_public: true,
+                lang_item: None,
+                shape: rue_air::SemanticLocalNominalShape::Struct {
+                    fields: Arc::from([]),
+                    is_copy: false,
+                    is_linear: false,
+                    declared_linear: false,
+                    destructor: None,
+                },
+            },
+        };
+
+        let fixtures = [&record, &strbuf, &choice, &arch, &anonymous, &builtin];
+        let epoch = rue_air::SemanticImportEpoch::new_local_in_space(
+            fixtures
+                .iter()
+                .map(|fixture| fixture.nominal.clone())
+                .collect(),
+            Vec::new(),
+            vec![user.clone(), strbuf_module.clone()],
+            rue_rir::SharedSymbolSpace::private(),
+        )
+        .expect("the fixture nominals form a valid body-local epoch");
+
+        // Recover each fixture's live type, then build the composite shapes
+        // from it with the pool's own interning so both vocabularies describe
+        // the same types.
+        let pool = epoch.type_pool();
+        let live = |fixture: &NominalFixture| -> rue_air::Type {
+            let name = fixture.nominal.name.as_ref();
+            match fixture.nominal.kind {
+                rue_air::SemanticImportNominalKind::Struct => pool
+                    .all_struct_ids()
+                    .into_iter()
+                    .find(|id| &*pool.struct_def(*id).name == name)
+                    .map(rue_air::Type::new_struct),
+                rue_air::SemanticImportNominalKind::Enum => pool
+                    .all_enum_ids()
+                    .into_iter()
+                    .find(|id| &*pool.enum_def(*id).name == name)
+                    .map(rue_air::Type::new_enum),
+            }
+            .unwrap_or_else(|| panic!("epoch registered no live nominal for {name}"))
+        };
+
+        let mut cases: Vec<(crate::TypeInstanceKey, rue_air::Type)> = vec![
+            (crate::TypeInstanceKey::I8, rue_air::Type::I8),
+            (crate::TypeInstanceKey::I16, rue_air::Type::I16),
+            (crate::TypeInstanceKey::I32, rue_air::Type::I32),
+            (crate::TypeInstanceKey::I64, rue_air::Type::I64),
+            (crate::TypeInstanceKey::U8, rue_air::Type::U8),
+            (crate::TypeInstanceKey::U16, rue_air::Type::U16),
+            (crate::TypeInstanceKey::U32, rue_air::Type::U32),
+            (crate::TypeInstanceKey::U64, rue_air::Type::U64),
+            (crate::TypeInstanceKey::Bool, rue_air::Type::BOOL),
+            (crate::TypeInstanceKey::Unit, rue_air::Type::UNIT),
+            (crate::TypeInstanceKey::Never, rue_air::Type::NEVER),
+            (
+                crate::TypeInstanceKey::ComptimeType,
+                rue_air::Type::COMPTIME_TYPE,
+            ),
+            (crate::TypeInstanceKey::F32, rue_air::Type::F32),
+            (crate::TypeInstanceKey::F64, rue_air::Type::F64),
+            (
+                crate::TypeInstanceKey::ComptimeFloat,
+                rue_air::Type::COMPTIME_FLOAT,
+            ),
+        ];
+        for fixture in fixtures {
+            let ty = live(fixture);
+            let key = crate::TypeInstanceKey::Nominal(fixture.key.clone());
+            cases.push((key.clone(), ty));
+            // Arrays and pointers exercise the recursion and every separator
+            // the fragment grammar spells.
+            let array = pool.intern_array_from_type(ty, 3);
+            cases.push((
+                crate::TypeInstanceKey::Array {
+                    element: Node::new(key.clone()),
+                    len: 3,
+                },
+                rue_air::Type::new_array(array),
+            ));
+            cases.push((
+                crate::TypeInstanceKey::Array {
+                    element: Node::new(crate::TypeInstanceKey::Array {
+                        element: Node::new(key.clone()),
+                        len: 3,
+                    }),
+                    len: 2,
+                },
+                rue_air::Type::new_array(
+                    pool.intern_array_from_type(rue_air::Type::new_array(array), 2),
+                ),
+            ));
+            cases.push((
+                crate::TypeInstanceKey::PtrConst(Node::new(key.clone())),
+                rue_air::Type::new_ptr_const(pool.intern_ptr_const_from_type(ty)),
+            ));
+            cases.push((
+                crate::TypeInstanceKey::PtrMut(Node::new(key)),
+                rue_air::Type::new_ptr_mut(pool.intern_ptr_mut_from_type(ty)),
+            ));
+        }
+
+        let frozen = pool.clone().freeze();
+        for (key, ty) in &cases {
+            let durable = drop_glue_type_name(key)
+                .unwrap_or_else(|| panic!("no durable drop-glue fragment for {key:?}"));
+            assert_eq!(
+                durable,
+                rue_air::drop_glue_names::type_name(*ty, &frozen),
+                "durable and live spellings disagree for {key:?}"
+            );
+            assert_eq!(
+                rooted_callable_symbol(&FunctionInstanceKey::DropGlue(Node::new(key.clone())))
+                    .as_ref(),
+                rue_air::drop_glue_names::drop_glue_symbol(&durable),
+                "the rooted drop-glue symbol is not the live one for {key:?}"
+            );
+        }
+
+        // The named nominals carry the qualification decision itself.
+        assert_eq!(
+            drop_glue_type_name(&crate::TypeInstanceKey::Nominal(record.key.clone())).as_deref(),
+            Some("Record$pkg_2fmain_2erue")
+        );
+        assert_eq!(
+            drop_glue_type_name(&crate::TypeInstanceKey::Nominal(strbuf.key.clone())).as_deref(),
+            Some("StrBuf")
+        );
+        assert_eq!(
+            drop_glue_type_name(&crate::TypeInstanceKey::Nominal(choice.key.clone())).as_deref(),
+            Some("Choice$pkg_2fmain_2erue")
+        );
+        assert_eq!(
+            drop_glue_type_name(&crate::TypeInstanceKey::Nominal(arch.key.clone())).as_deref(),
+            Some("Arch")
+        );
+
+        // A type that never owns glue has no live glue symbol in either
+        // vocabulary: the live pool has no such type at all, and the durable
+        // side answers `None` rather than inventing a spelling.
+        for unspellable in [
+            crate::TypeInstanceKey::Module(user.clone()),
+            crate::TypeInstanceKey::GenericParameter(0),
+            crate::TypeInstanceKey::Slice {
+                element: Node::new(crate::TypeInstanceKey::U8),
+                name: Arc::from("Slice"),
+            },
+        ] {
+            assert_eq!(drop_glue_type_name(&unspellable), None);
+        }
+    }
+
+    /// A member callable is spelled by the one renderer whichever side names
+    /// it, including the separator that carries the receiver.
+    #[test]
+    fn member_callables_spell_through_one_renderer() {
+        let module = ModuleId::from_validated_canonical("pkg/main.rue");
+        let owner = ("Record", StableDefinitionKind::Struct);
+        let member = |kind, name: &str| {
+            StableDefinitionKey::for_test(
+                module.clone(),
+                rue_air::StableDefinitionNamespace::Value,
+                kind,
+                Arc::<str>::from(name),
+                Some((owner.1, Arc::<str>::from(owner.0))),
+            )
+        };
+        let owner_symbol = "Record$pkg_2fmain_2erue";
+        for (kind, name, expected) in [
+            (
+                StableDefinitionKind::Method,
+                "get",
+                rue_air::live_symbols::member_callable_name(owner_symbol, "get", true),
+            ),
+            (
+                StableDefinitionKind::AssociatedFunction,
+                "make",
+                rue_air::live_symbols::member_callable_name(owner_symbol, "make", false),
+            ),
+            (
+                StableDefinitionKind::Destructor,
+                "__drop",
+                rue_air::live_symbols::member_callable_name(owner_symbol, "__drop", true),
+            ),
+        ] {
+            assert_eq!(
+                live_callable_symbol(&FunctionInstanceKey::Definition(member(kind, name)))
+                    .as_deref(),
+                Some(expected.as_str())
+            );
+        }
+
+        // An anonymous nominal's members take the same separators: the
+        // receiver decides, not which vocabulary reached the member.
+        let anonymous = crate::AnonymousNominalKey {
+            kind: crate::AnonymousNominalKind::Struct,
+            producer: crate::semantic_identity::StableProducerId::Definition(
+                StableDefinitionKey::for_test(
+                    module.clone(),
+                    rue_air::StableDefinitionNamespace::Value,
+                    StableDefinitionKind::Function,
+                    Arc::<str>::from("Wrap"),
+                    None,
+                ),
+            ),
+            anchor: crate::semantic_identity::StructuralAnchor::new(vec![
+                crate::semantic_identity::StructuralPathSegment::AnonymousType(0),
+            ]),
+        };
+        let anonymous_owner = crate::semantic_identity::anonymous_nominal_source_symbol(&anonymous);
+        for (kind, name, has_self) in [
+            (crate::AnonymousMemberKind::Method, "get", true),
+            (
+                crate::AnonymousMemberKind::AssociatedFunction,
+                "make",
+                false,
+            ),
+            (crate::AnonymousMemberKind::Destructor, "__drop", true),
+        ] {
+            let identity = FunctionInstanceKey::AnonymousMember {
+                owner: Node::new(crate::TypeInstanceKey::Nominal(
+                    crate::NominalInstanceKey::Anonymous(Node::new(anonymous.clone())),
+                )),
+                member: crate::AnonymousMemberKey {
+                    kind,
+                    name: Arc::from(name),
+                },
+            };
+            assert_eq!(
+                live_callable_symbol(&identity),
+                Some(rue_air::live_symbols::member_callable_name(
+                    &anonymous_owner,
+                    name,
+                    has_self
+                ))
+            );
+        }
+    }
 
     fn facts_with_modules(modules: Vec<ModuleId>) -> LocalMaterializationFacts {
         LocalMaterializationFacts {

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -304,43 +304,64 @@ pub(crate) fn anonymous_member_source_symbol_in(
     let TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(owner)) = owner.as_ref() else {
         return None;
     };
-    Some(format!(
-        "{}.{}",
-        anonymous_nominal_source_symbol_in(plan, owner),
-        member.name
+    // The member kind is the receiver: an anonymous nominal's associated
+    // function is spelled with `::` exactly as a named nominal's is, because
+    // the separator comes from the one renderer rather than from which
+    // vocabulary reached it.
+    Some(rue_air::live_symbols::member_callable_name(
+        &anonymous_nominal_source_symbol_in(plan, owner),
+        &member.name,
+        member.kind != AnonymousMemberKind::AssociatedFunction,
     ))
 }
 
-/// Spell a named nominal through the same unconditional module qualification
-/// used by AIR's type pool. Canonical language-item and reserved builtin types
-/// retain their bare ABI names.
+/// Spell a named nominal through `rue_air::live_symbols`, the one owner of
+/// live nominal spelling, so a durable identity and the AIR type pool cannot
+/// disagree about whether a nominal is module-qualified.
+///
+/// Only a type definition has a nominal symbol; every other definition kind
+/// answers `None` and its caller names it some other way.
 pub(crate) fn named_nominal_source_symbol(identity: &StableDefinitionKey) -> Option<String> {
-    match identity.kind() {
+    matches!(
+        identity.kind(),
+        crate::StableDefinitionKind::Struct | crate::StableDefinitionKind::Enum
+    )
+    .then(|| named_nominal_symbol(identity.kind(), identity.name(), identity.module()))
+}
+
+/// Spell the nominal a member callable belongs to.
+///
+/// The owner of a method, associated function, or destructor is always a type,
+/// so this is the same spelling as [`named_nominal_source_symbol`] without the
+/// kind test that key already answered.
+pub(crate) fn named_type_source_symbol(owner: &StableNamedTypeKey) -> String {
+    named_nominal_symbol(owner.kind(), owner.name(), owner.module())
+}
+
+/// The one place a durable identity decides whether its nominal is exempt from
+/// module qualification.
+///
+/// Both exemptions are registry membership, never a name table of this crate's
+/// own: a canonical standard-library nominal is recognized by the lang-item
+/// registry after its module crossed the trusted provenance boundary, and a
+/// reserved built-in enum by the builtin universe.
+fn named_nominal_symbol(
+    kind: crate::StableDefinitionKind,
+    name: &str,
+    module: &ModuleId,
+) -> String {
+    let keeps_bare_symbol = match kind {
         crate::StableDefinitionKind::Struct => {
-            if identity.module().is_trusted_standard_library()
-                && rue_air::LangItem::from_standard_library_nominal(
-                    identity.module().logical_path(),
-                    identity.name(),
-                )
-                .is_some()
-            {
-                return Some(identity.name().to_owned());
-            }
+            module.is_trusted_standard_library()
+                && rue_air::LangItem::from_standard_library_nominal(module.logical_path(), name)
+                    .is_some()
         }
-        crate::StableDefinitionKind::Enum => {
-            if rue_builtins::is_reserved_enum_name(identity.name()) {
-                return Some(identity.name().to_owned());
-            }
-        }
-        _ => return None,
-    }
-    Some(format!(
-        "{}${}",
-        identity.name(),
-        rue_air::mangle_symbol_component(&rue_air::normalize_module_path(
-            identity.module().logical_path()
-        ))
-    ))
+        crate::StableDefinitionKind::Enum => rue_air::live_symbols::enum_keeps_bare_symbol(name),
+        _ => false,
+    };
+    rue_air::live_symbols::named_nominal_symbol(name, keeps_bare_symbol, || {
+        rue_air::live_symbols::module_symbol_component(module.logical_path())
+    })
 }
 
 /// Relocate one durable semantic type into the type-instance vocabulary.

--- a/scripts/validate-type-architecture.py
+++ b/scripts/validate-type-architecture.py
@@ -101,6 +101,7 @@ PUBLIC_TYPE_DECLARATION_ALLOWLIST = {
     ("rue-air", "semantic_type_resolution.rs", "ComptimeStructuredTypeJob"): "consuming structured-type resolver continuation",
     ("rue-air", "semantic_type_resolution.rs", "ComptimeStructuredTypePoll"): "structured-type resolver protocol state",
     ("rue-air", "semantic_identity.rs", "TypeInstanceKey"): "canonical cross-boundary type identity",
+    ("rue-air", "drop_glue_names.rs", "DropGlueTypeShape"): "drop-glue fragment grammar node over a vocabulary's own leaves, not a live type identity",
     ("rue-air", "sema/comptime/intrinsics.rs", "ComptimeTypeIntrinsic"): "finite comptime operation classification, not a live type identity",
     ("rue-air", "sema/comptime/model.rs", "ComptimeMethodType"): "engine-resolved anonymous-method type descriptor, not a live type identity",
     ("rue-air", "sema/comptime/structured_type.rs", "ComptimeStructuredTypeResolution"): "engine structured-type suspension protocol state",


### PR DESCRIPTION
Part of RUE-1972

## Why

The live symbol spelling that `--emit air` and `--emit cfg` print, that `durable_cfg` keys its symbol mappings on, and that drop glue and member callables are looked up by was re-derived in several places with independently maintained rules: three owners for nominal qualification, two for drop-glue names, four spellings for member callables, and two for specializations. Parity was held only by tests, so a lang item or exemption registered in one place and not another would have produced `CfgDomainFailure::Shape`, a `__rue_drop_*` lookup miss, or wrong glue bound for same-named types.

## What

Three of the four families now have one owner in rue-air. The fourth is deliberately left split, with the reason documented in code; see below.

- **Nominal qualification.** New `rue-air/src/live_symbols.rs` owns `named_nominal_symbol` (the `$` join, with the module component derived lazily so exempt nominals do not pay for it), `module_symbol_component`, and `enum_keeps_bare_symbol`. The intern pool and the compiler both call it, supplying only their own exemption facts. `named_type_live_symbol`, `symbol_type_name`, and the engine's private `method_symbol` are deleted. The issue's "two exemption tables" turned out to be two predicates over the same `rue_builtins::BUILTIN_ENUMS` array; `enum_keeps_bare_symbol` delegates to `BuiltinUniverse::builtin_enum_name` rather than deleting it, because rue-air's own api_inventory guard confines builtin-enum membership to `builtin_universe`.
- **Drop-glue live name.** `drop_glue_names.rs` spells the fragment grammar once (`DropGlueTypeShape`, `drop_glue_type_fragment`, `drop_glue_symbol`), driven from the live pool and from durable `TypeInstanceKey`s via the RUE-1978 conversion pair. Each vocabulary contributes only its own leaves; the durable side's `None` for slice, module, and generic parameter is pre-existing behavior, preserved.
- **Member callables.** One renderer, `live_symbols::member_callable_name`; `member_callable_name_for_owner` is removed. It is promoted to the host trait as `body_member_callable_name` and `try_member_callable_symbol`, so the `OrdinaryBodyEngine` call sites in `calls.rs`, `ownership.rs`, `aggregates.rs`, `builtin_ops.rs`, and `intrinsics.rs` reach the derived-spelling memo instead of re-rendering and re-interning. The four production `{owner}.__drop` spellings route through it too. One deliberate behavior change: `anonymous_member_source_symbol_in` ignored the member kind, so an anonymous nominal's associated function spelled `__anon_struct_X.make` on the compiler side while sema spelled `__anon_struct_X::make`; it now takes the separator from the kind. Verified with a repro (`--emit air` shows `::make`; the program still links and runs).
- **Specialization: left split.** rue-air's `mangle_specialized_name` is id-based over live pool handles inside one body analysis; the compiler's `mangle_canonical_type` is content-based over `TypeInstanceKey` for rooted callables. Both `--emit air` and `--emit cfg` print the compiler's content-based name, nothing pins the id-based one, and a call site reaches its callee through the stable identity `durable_cfg` records beside the live name, not by string match. Unifying downward is impossible (the rooted path has no type pool) and unifying upward would make sema's within-analysis key content-addressed, which is a design change: `semantic_identity.rs` forbids live handles in durable identities and ADR-0076 makes handle values scheduling-dependent. The `Specialization` arm documents this in place.

Guards: `live_symbol_spelling_has_one_owner_per_family` (rue-air) and `live_symbol_spelling_is_adapted_from_rue_air_not_re_derived` (rue-compiler) in the api_inventory tests.

## Verification

- Acceptance test `every_durable_type_spells_the_live_pool_drop_glue_fragment` builds a body-local `SemanticImportEpoch` from nominal fixtures (named struct, lang-item `StrBuf`, user enum, a user enum named `Arch`, anonymous struct, builtin nominal) and spells 15 scalars plus each nominal, its array, nested array, and both pointer kinds through both vocabularies, asserting equality, that the rooted `__rue_drop_*` symbol is the live one, and that slice, module, and generic parameter have no glue spelling. `member_callables_spell_through_one_renderer` covers named and anonymous method, associated function, and destructor.
- `scripts/rue unit air` (888), `scripts/rue unit compiler` (1227, 59 ignored), `scripts/rue unit codegen` (890): all pass.
- `scripts/rue quick`: Pass 36, Fail 0, re-run after rebasing onto current trunk.
- `scripts/rue ui emit` (9), `ui drop` (42), `ui anon` (13); `scripts/rue cli drop` (149), `cli generic` (86), `cli emit` (47), `cli specialization` (14); `scripts/rue spec drop` (61): all pass.
- `scripts/rue fmt` clean; rue-air, rue-compiler, and rue-codegen clippy gates pass.

No CLI or spec corpus cases changed, so the oracle-diff target was not needed.