### PR TITLE
Cleanup entry points take their owner as one typed aggregate

### DIFF
--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1888,6 +1888,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 local_atoms,
                 num_locals,
                 num_param_slots,
+                cleanup_owner: None,
                 param_modes,
                 allow_unreachable_code,
             },
@@ -2042,6 +2043,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 local_atoms,
                 num_locals,
                 num_param_slots,
+                // A destructor's parameter list is its owner, taken by value;
+                // the body may never mention `self`, so the type travels here.
+                cleanup_owner: is_destructor.then_some(struct_type),
                 param_modes,
                 allow_unreachable_code: false,
             },
@@ -2125,6 +2129,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 local_atoms,
                 num_locals,
                 num_param_slots,
+                // A destructor's parameter list is its owner, taken by value;
+                // the body may never mention `self`, so the type travels here.
+                cleanup_owner: Some(struct_type),
                 param_modes,
                 allow_unreachable_code: false,
             },

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -246,11 +246,10 @@ pub struct SourceParamAbi {
     pub slot_count: u32,
     /// The parameter's source type, or `None` when the parameter is one
     /// register-width slot the convention needs no type for: a by-reference
-    /// pointer, whose pointee the convention never consults; a leaf of a
-    /// cleanup callee's flattened parameter list; or a slot no `Param`
-    /// instruction or drop entry names. A typeless descriptor always has
-    /// `slot_count == 1`, so every parameter is one value the convention places
-    /// as a whole.
+    /// pointer, whose pointee the convention never consults; or a slot no
+    /// `Param` instruction or drop entry names. A typeless descriptor always
+    /// has `slot_count == 1`, so every parameter is one value the convention
+    /// places as a whole.
     ///
     /// Where the parameter's incoming value travels is not recorded here: code
     /// generation recomputes it from this type through the one placement
@@ -404,6 +403,15 @@ pub struct AnalyzedFunction {
     /// For scalar types (i32, bool), each parameter uses 1 slot.
     /// For struct types, each field uses 1 slot (flattened ABI).
     pub num_param_slots: u32,
+    /// For a cleanup callable — a destructor or a drop-glue body — the type of
+    /// the owner it takes as its single by-value parameter. `None` for every
+    /// other callable, whose parameters the AIR names one by one.
+    ///
+    /// A cleanup body's own AIR cannot always name it: a destructor that never
+    /// mentions `self` records no parameter type at all, and glue reads its
+    /// owner's leaves at field types. The owner travels beside
+    /// `num_param_slots`, which is that owner's ABI slot count.
+    pub cleanup_owner: Option<crate::Type>,
     /// Physical by-reference and logical writability modes for every ABI slot.
     /// Length matches `num_param_slots`; flattened parameters repeat their
     /// source parameter's mode for each occupied slot.
@@ -419,19 +427,6 @@ pub enum AnalyzedCallableKind {
     Accessor,
     Destructor,
     DropGlue,
-}
-
-impl AnalyzedCallableKind {
-    /// Whether this callable's parameter list is the flattened decomposition of
-    /// one owner value rather than a list of source parameters.
-    ///
-    /// A destructor and a drop glue body address their owner's leaves by slot
-    /// index — the synthesized glue reads a field, an element, or a variant
-    /// payload straight out of a parameter slot — so each slot is its own
-    /// register-width parameter on both sides of the call.
-    pub fn has_flattened_leaf_parameters(self) -> bool {
-        matches!(self, Self::Destructor | Self::DropGlue)
-    }
 }
 
 /// Value-only workload counters for demand-driven body dispatch.

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -567,6 +567,10 @@ pub(crate) fn export_body<H: SemanticBodyExportHost>(
             borrow_slots: Arc::from(borrow_slots),
             num_locals: analyzed.num_locals,
             num_param_slots: analyzed.num_param_slots,
+            cleanup_owner: analyzed
+                .cleanup_owner
+                .map(|ty| host.export_body_type(ty))
+                .transpose()?,
             param_by_ref: Arc::from(analyzed.param_modes.by_ref()),
             param_writable: Arc::from(analyzed.param_modes.writable()),
             allow_unreachable_code: analyzed.allow_unreachable_code,

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -997,6 +997,14 @@ pub struct SemanticBody<K, M> {
     pub borrow_slots: Arc<[u32]>,
     pub num_locals: u32,
     pub num_param_slots: u32,
+    /// For a cleanup callee — a destructor or a drop-glue body — the owner type
+    /// its single by-value parameter is; `None` for every other body, whose
+    /// parameters the instructions and drop entries name one by one.
+    ///
+    /// `num_param_slots` is this owner's ABI slot count, and the two travel
+    /// together so a fresh analysis and an imported body describe the same
+    /// parameter list.
+    pub cleanup_owner: Option<SemanticImportType<K, M>>,
     pub param_by_ref: Arc<[bool]>,
     pub param_writable: Arc<[bool]>,
     pub allow_unreachable_code: bool,
@@ -1101,6 +1109,11 @@ impl<K, M> SemanticBody<K, M> {
             borrow_slots: self.borrow_slots.clone(),
             num_locals: self.num_locals,
             num_param_slots: self.num_param_slots,
+            cleanup_owner: self
+                .cleanup_owner
+                .as_ref()
+                .map(|ty| ty.try_map_identities(key, module))
+                .transpose()?,
             param_by_ref: self.param_by_ref.clone(),
             param_writable: self.param_writable.clone(),
             allow_unreachable_code: self.allow_unreachable_code,

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -583,6 +583,9 @@ pub struct SemanticLocalMaterialization<K, M> {
     pub local_atoms: Vec<crate::LocalAtomRecord<K, M>>,
     pub num_locals: u32,
     pub num_param_slots: u32,
+    /// For a cleanup callee — a destructor or a drop-glue body — the live owner
+    /// type its single by-value parameter is. `None` for every other body.
+    pub cleanup_owner: Option<crate::Type>,
     pub param_modes: crate::ParamSlotModes,
     pub allow_unreachable_code: bool,
     pub type_pool: crate::FrozenTypeInternPool,
@@ -1695,6 +1698,12 @@ where
                 })
             },
         )?;
+        let cleanup_owner = body
+            .cleanup_owner
+            .as_ref()
+            .map(|ty| self.import_type_local(ty))
+            .transpose()
+            .map_err(SemanticBodyImportFailure::Semantic)?;
         let materialized_types = additional_types
             .iter()
             .map(|stable| {
@@ -1736,6 +1745,7 @@ where
             local_atoms,
             num_locals,
             num_param_slots,
+            cleanup_owner,
             param_modes,
             allow_unreachable_code,
             type_pool: self.type_pool.freeze(),
@@ -3209,6 +3219,7 @@ mod tests {
             borrow_slots: Arc::new([]),
             num_locals: 0,
             num_param_slots: 0,
+            cleanup_owner: None,
             param_by_ref: Arc::new([]),
             param_writable: Arc::new([]),
             allow_unreachable_code: false,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -512,6 +512,7 @@ where
             local_atoms,
             num_locals,
             num_param_slots,
+            cleanup_owner: None,
             param_modes,
             allow_unreachable_code: base_info.allow_unreachable_code,
         },

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -733,6 +733,10 @@ pub struct CfgBuilder<'a> {
     implicit_destructor_types: AHashSet<Type>,
     anonymous_destructor_dependency_incomplete: bool,
     callable_kind: AnalyzedCallableKind,
+    /// For a cleanup callee — a destructor or a drop-glue body — the owner type
+    /// its whole parameter list is: one by-value parameter of that type
+    /// (RUE-2074). `None` for every other body, whose parameters the AIR names.
+    cleanup_owner: Option<Type>,
     /// For an accessor body, the AIR values on the spine from `Ret` down to
     /// the `PlaceRead` that lowered the trailing `yield`.
     ///
@@ -792,6 +796,13 @@ fn accessor_yield_spine(
 /// a fresh analysis and a durable/imported body, since both rebuild from the
 /// same AIR.
 ///
+/// A cleanup callee — a destructor or a drop-glue body — is the one shape whose
+/// parameter the AIR cannot always name: a destructor that never mentions
+/// `self` records no parameter type, and glue reads its owner's leaves at their
+/// field types. Its owner therefore travels beside `num_param_slots` and is the
+/// whole parameter list: one by-value parameter of the owner's type, classified
+/// and placed exactly as a user function taking that type by value (RUE-2074).
+///
 /// The descriptor says *what* each parameter is, never where it arrives: code
 /// generation asks `rue_air::lower_native_signature` where the incoming value
 /// travels, so the callee's prologue and its callers read one placement
@@ -802,14 +813,32 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
     let num_params = builder.cfg.num_params();
     let by_ref: Vec<bool> = builder.cfg.param_modes().to_vec();
 
-    // A cleanup callee — a destructor or a drop glue body — addresses its
-    // owner's decomposition one slot at a time (RUE-998 / RUE-311), so its
-    // parameter list *is* those leaves: one register-width parameter per slot,
-    // which is exactly what its caller `CallPlan::from_slot_values` hands over.
-    // These synthetic symbols are compiler-reserved (`__rue_drop_*` glue,
-    // `<Type>.__drop` destructors), the same identity code generation already
-    // resolves them by.
-    let flattened_leaf_parameters = builder.callable_kind.has_flattened_leaf_parameters();
+    assert_eq!(
+        builder.cleanup_owner.is_some(),
+        matches!(
+            builder.callable_kind,
+            AnalyzedCallableKind::Destructor | AnalyzedCallableKind::DropGlue
+        ),
+        "a cleanup callee carries its owner type and nothing else does; without \
+         it the callee would rebuild a parameter list its callers do not hand \
+         over"
+    );
+    if let Some(owner) = builder.cleanup_owner {
+        let slot_count = type_pool.abi_slot_count(owner);
+        assert_eq!(
+            slot_count, num_params,
+            "a cleanup callee's parameter list is its owner: the owner's ABI \
+             slot count must be the body's parameter slot count"
+        );
+        if slot_count == 0 {
+            return Vec::new();
+        }
+        return vec![SourceParamAbi {
+            start_slot: 0,
+            slot_count,
+            ty: Some(owner),
+        }];
+    }
 
     // Slot -> source type. A parameter's own extent is what groups the slots,
     // so every by-value parameter needs one: the drop schedule and the body's
@@ -838,7 +867,7 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
         // so the split leaves every later parameter's placement unchanged. A
         // typeless descriptor therefore always spans exactly one slot, which is
         // what lets code generation place every parameter as a single value.
-        let (slot_count, ty) = match (is_by_ref || flattened_leaf_parameters, ty_at.get(&slot)) {
+        let (slot_count, ty) = match (is_by_ref, ty_at.get(&slot)) {
             (false, Some(&ty)) => (type_pool.abi_slot_count(ty).max(1), Some(ty)),
             _ => (1, None),
         };
@@ -921,6 +950,7 @@ impl<'a> CfgBuilder<'a> {
         interner: &'a ThreadedRodeo,
         allow_unreachable_code: bool,
         callable_kind: AnalyzedCallableKind,
+        cleanup_owner: Option<Type>,
     ) -> CfgOutput {
         Self::build_with_symbol_resolver(
             air,
@@ -932,6 +962,7 @@ impl<'a> CfgBuilder<'a> {
             interner,
             allow_unreachable_code,
             callable_kind,
+            cleanup_owner,
             |name| Some(interner.get_or_intern(name)),
         )
     }
@@ -946,6 +977,7 @@ impl<'a> CfgBuilder<'a> {
         _interner: &'a ThreadedRodeo,
         allow_unreachable_code: bool,
         callable_kind: AnalyzedCallableKind,
+        cleanup_owner: Option<Type>,
         source_symbol_resolver: impl Fn(&str) -> Option<Spur> + 'a,
     ) -> CfgOutput {
         let mut builder = CfgBuilder {
@@ -986,6 +1018,7 @@ impl<'a> CfgBuilder<'a> {
             implicit_destructor_types: AHashSet::new(),
             anonymous_destructor_dependency_incomplete: false,
             callable_kind,
+            cleanup_owner,
             accessor_yield_spine: AHashSet::new(),
         };
 
@@ -4737,6 +4770,7 @@ mod tests {
             interner,
             false,
             AnalyzedCallableKind::Ordinary,
+            None,
         )
         .cfg
         .unwrap()
@@ -4923,6 +4957,7 @@ mod tests {
                 borrow_slots: Arc::new([]),
                 num_locals: self.num_locals,
                 num_param_slots: self.num_param_slots,
+                cleanup_owner: None,
                 param_by_ref: self.param_by_ref.into(),
                 param_writable: self.param_writable.into(),
                 allow_unreachable_code: false,
@@ -4947,6 +4982,7 @@ mod tests {
                 &materialized.interner,
                 materialized.allow_unreachable_code,
                 materialized.callable_kind,
+                materialized.cleanup_owner,
             )
             .cfg
             .unwrap()
@@ -6858,6 +6894,7 @@ mod tests {
                 interner,
                 false,
                 AnalyzedCallableKind::Ordinary,
+                None,
             )
             .cfg
             .unwrap()
@@ -7855,6 +7892,7 @@ mod tests {
                 &interner,
                 false,
                 AnalyzedCallableKind::Ordinary,
+                None,
             )
             .cfg
             .unwrap();
@@ -7933,6 +7971,7 @@ mod tests {
             &interner,
             false,
             AnalyzedCallableKind::Ordinary,
+            None,
         );
 
         assert!(

--- a/crates/rue-cli-tests/cases/cleanup_entry_point_abi.toml
+++ b/crates/rue-cli-tests/cases/cleanup_entry_point_abi.toml
@@ -1,0 +1,454 @@
+# Cleanup entry points take their owner as one typed aggregate (RUE-2074).
+#
+# A destructor (`<Type>.__drop`) and a synthesized drop-glue body
+# (`__rue_drop_*`) are ordinary by-value functions of their owner's type: the
+# convention places and marshals the owner exactly as it places a user function
+# taking that type by value (ADR-0084), and the glue reads its owner's leaves at
+# slots of the owner's canonical flattened layout.
+#
+# The failure mode this file guards is direction: a frame-resident aggregate
+# ascends in address with its logical slots while frame slot numbers descend
+# (ADR-0040), so a cleanup body that addressed its owner from the wrong end
+# would still see plausible-looking values — the fields would be permuted, not
+# absent. Every case therefore drops a value whose parts are pairwise
+# distinguishable by both VALUE and TYPE (a `i32`/`i64`/`f64`/nested-struct
+# mixture), and each destructor prints what it actually saw.
+#
+# Each scenario runs on both rows, since the two conventions place the same
+# owner differently; the aarch64 half is executed only on a native aarch64 host.
+
+[section]
+id = "cli.cleanup_entry_point_abi"
+name = "Cleanup entry points receive their owner as one by-value aggregate"
+description = "A destructor and drop glue see every field of their owner, in order, on both backends (RUE-2074)."
+
+# =============================================================================
+# A struct owner: a user destructor reads every field of `self`, then the glue
+# hands the droppable field to that field's own destructor.
+# =============================================================================
+
+[[case]]
+name = "x86_64_struct_owner_reaches_its_destructor_and_glue_whole"
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Inner { a: i64, b: i32 }
+
+drop fn Inner(self) {
+    @dbg(1000);
+    @dbg(self.a);
+    @dbg(self.b);
+}
+
+struct Rec { tag: i32, big: i64, f: f64, inner: Inner }
+
+drop fn Rec(self) {
+    @dbg(2000);
+    @dbg(self.tag);
+    @dbg(self.big);
+    @dbg(self.f);
+    @dbg(self.inner.a);
+    @dbg(self.inner.b);
+}
+
+fn main() -> i32 {
+    let r = Rec { tag: 7, big: 123456789, f: 2.5, inner: Inner { a: 42, b: 9 } };
+    @dbg(r.tag);
+    0
+}
+""" }]
+stdout = """
+7
+2000
+7
+123456789
+2.5
+42
+9
+1000
+42
+9
+"""
+
+[[case]]
+name = "aarch64_struct_owner_reaches_its_destructor_and_glue_whole"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Inner { a: i64, b: i32 }
+
+drop fn Inner(self) {
+    @dbg(1000);
+    @dbg(self.a);
+    @dbg(self.b);
+}
+
+struct Rec { tag: i32, big: i64, f: f64, inner: Inner }
+
+drop fn Rec(self) {
+    @dbg(2000);
+    @dbg(self.tag);
+    @dbg(self.big);
+    @dbg(self.f);
+    @dbg(self.inner.a);
+    @dbg(self.inner.b);
+}
+
+fn main() -> i32 {
+    let r = Rec { tag: 7, big: 123456789, f: 2.5, inner: Inner { a: 42, b: 9 } };
+    @dbg(r.tag);
+    0
+}
+""" }]
+stdout = """
+7
+2000
+7
+123456789
+2.5
+42
+9
+1000
+42
+9
+"""
+
+# =============================================================================
+# A struct owner over sixteen bytes, which AAPCS64 rule C.12 crosses BY
+# REFERENCE through a caller-owned copy while SysV stacks it. The destructor and
+# the glue are two cleanup calls on one value, so each must get its own copy that
+# stays live until its own call returns.
+# =============================================================================
+
+[[case]]
+name = "x86_64_wide_struct_owner_crosses_to_both_cleanup_calls"
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Inner { a: i64, b: i32 }
+
+drop fn Inner(self) {
+    @dbg(1000);
+    @dbg(self.a);
+    @dbg(self.b);
+}
+
+struct Wide { p: i64, q: i64, r: i64, inner: Inner }
+
+drop fn Wide(self) {
+    @dbg(2000);
+    @dbg(self.p);
+    @dbg(self.q);
+    @dbg(self.r);
+    @dbg(self.inner.a);
+    @dbg(self.inner.b);
+}
+
+fn main() -> i32 {
+    let w = Wide { p: 1, q: 2, r: 3, inner: Inner { a: 42, b: 9 } };
+    @dbg(w.p);
+    0
+}
+""" }]
+stdout = """
+1
+2000
+1
+2
+3
+42
+9
+1000
+42
+9
+"""
+
+[[case]]
+name = "aarch64_wide_struct_owner_crosses_to_both_cleanup_calls"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Inner { a: i64, b: i32 }
+
+drop fn Inner(self) {
+    @dbg(1000);
+    @dbg(self.a);
+    @dbg(self.b);
+}
+
+struct Wide { p: i64, q: i64, r: i64, inner: Inner }
+
+drop fn Wide(self) {
+    @dbg(2000);
+    @dbg(self.p);
+    @dbg(self.q);
+    @dbg(self.r);
+    @dbg(self.inner.a);
+    @dbg(self.inner.b);
+}
+
+fn main() -> i32 {
+    let w = Wide { p: 1, q: 2, r: 3, inner: Inner { a: 42, b: 9 } };
+    @dbg(w.p);
+    0
+}
+""" }]
+stdout = """
+1
+2000
+1
+2
+3
+42
+9
+1000
+42
+9
+"""
+
+# =============================================================================
+# An array owner whose elements are themselves multi-slot: array glue drops
+# element 0 first, and each element arrives with its own two fields paired.
+# =============================================================================
+
+[[case]]
+name = "x86_64_array_owner_drops_multi_slot_elements_in_index_order"
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Inner { a: i64, b: i32 }
+
+drop fn Inner(self) {
+    @dbg(1000);
+    @dbg(self.a);
+    @dbg(self.b);
+}
+
+fn main() -> i32 {
+    let row = [
+        Inner { a: 10, b: 11 },
+        Inner { a: 20, b: 21 },
+        Inner { a: 30, b: 31 },
+    ];
+    @dbg(row[1].b);
+    0
+}
+""" }]
+stdout = """
+21
+1000
+10
+11
+1000
+20
+21
+1000
+30
+31
+"""
+
+[[case]]
+name = "aarch64_array_owner_drops_multi_slot_elements_in_index_order"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Inner { a: i64, b: i32 }
+
+drop fn Inner(self) {
+    @dbg(1000);
+    @dbg(self.a);
+    @dbg(self.b);
+}
+
+fn main() -> i32 {
+    let row = [
+        Inner { a: 10, b: 11 },
+        Inner { a: 20, b: 21 },
+        Inner { a: 30, b: 31 },
+    ];
+    @dbg(row[1].b);
+    0
+}
+""" }]
+stdout = """
+21
+1000
+10
+11
+1000
+20
+21
+1000
+30
+31
+"""
+
+# =============================================================================
+# An enum owner with two payload variants of different shapes. Enum glue reads
+# the discriminant at the owner's canonical slot 0 and each variant's payload
+# from the union overlaying slots 1.., so it must select the ACTIVE variant's
+# fields — a `Flt` whose only leaf is a float and a two-slot `Inner` — and leave
+# the other variant's overlapping payload alone. Locals drop LIFO.
+# =============================================================================
+
+[[case]]
+name = "x86_64_enum_owner_drops_the_active_variant_payload"
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Inner { a: i64, b: i32 }
+
+drop fn Inner(self) {
+    @dbg(1000);
+    @dbg(self.a);
+    @dbg(self.b);
+}
+
+struct Flt { v: f64 }
+
+drop fn Flt(self) {
+    @dbg(3000);
+    @dbg(self.v);
+}
+
+enum Shape {
+    Small(Inner),
+    Big(i32, Flt, Inner),
+    Nothing,
+}
+
+fn main() -> i32 {
+    let _s = Shape.Small(Inner { a: 51, b: 52 });
+    let _b = Shape.Big(11, Flt { v: 4.5 }, Inner { a: 61, b: 62 });
+    let _n = Shape.Nothing;
+    @dbg(900);
+    0
+}
+""" }]
+stdout = """
+900
+3000
+4.5
+1000
+61
+62
+1000
+51
+52
+"""
+
+[[case]]
+name = "aarch64_enum_owner_drops_the_active_variant_payload"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Inner { a: i64, b: i32 }
+
+drop fn Inner(self) {
+    @dbg(1000);
+    @dbg(self.a);
+    @dbg(self.b);
+}
+
+struct Flt { v: f64 }
+
+drop fn Flt(self) {
+    @dbg(3000);
+    @dbg(self.v);
+}
+
+enum Shape {
+    Small(Inner),
+    Big(i32, Flt, Inner),
+    Nothing,
+}
+
+fn main() -> i32 {
+    let _s = Shape.Small(Inner { a: 51, b: 52 });
+    let _b = Shape.Big(11, Flt { v: 4.5 }, Inner { a: 61, b: 62 });
+    let _n = Shape.Nothing;
+    @dbg(900);
+    0
+}
+""" }]
+stdout = """
+900
+3000
+4.5
+1000
+61
+62
+1000
+51
+52
+"""
+
+# =============================================================================
+# A frame-homed parameter whose single slot carries a FLOAT leaf under a struct
+# wrapper. The slot's register class follows its leaf (RUE-2001), so reading the
+# wrapper must load it in the floating-point class — the same rule the cleanup
+# path now depends on when it hands a float-leaf field to that field's own
+# destructor.
+# =============================================================================
+
+[[case]]
+name = "x86_64_homed_float_wrapper_parameter_reads_in_the_float_class"
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Q { f: f64 }
+
+fn peek(borrow q: Q) -> f64 { q.f }
+
+fn id(q: Q) -> Q {
+    @dbg(peek(borrow q));
+    q
+}
+
+fn main() -> i32 {
+    let a = Q { f: 2.5 };
+    let b = id(a);
+    @dbg(b.f);
+    0
+}
+""" }]
+stdout = """
+2.5
+2.5
+"""
+
+[[case]]
+name = "aarch64_homed_float_wrapper_parameter_reads_in_the_float_class"
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+struct Q { f: f64 }
+
+fn peek(borrow q: Q) -> f64 { q.f }
+
+fn id(q: Q) -> Q {
+    @dbg(peek(borrow q));
+    q
+}
+
+fn main() -> i32 {
+    let a = Q { f: 2.5 };
+    let b = id(a);
+    @dbg(b.f);
+    0
+}
+""" }]
+stdout = """
+2.5
+2.5
+"""

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -671,23 +671,6 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Emit a target-local cleanup call using the normalized slot vector.
-    fn emit_slot_call(&mut self, arg_vregs: &[VReg], symbol: &str) {
-        let plan = crate::call_plan::CallPlan::from_slot_values(
-            crate::call_plan::CallTarget::rue(symbol),
-            arg_vregs,
-            rue_target::ConventionSpec::native(self.target),
-            self.target.c_calling_convention(),
-        );
-        let _ = self.lower_call_plan(plan);
-    }
-
-    /// Call `symbol` passing `arg_vregs` as flattened by-value slot arguments
-    /// per the standard convention: the first slots in ARG_REGS, the rest
-    /// stored to a 16-byte-aligned stack area released after the call — the
-    /// same shape as generic `Call` lowering. Drop and drop-glue calls use this
-    /// path so every slot beyond the eight register arguments is passed on the
-    /// stack (RUE-193).
     fn block_label(&self, block_id: BlockId) -> LabelId {
         Aarch64Mir::block_label(block_id.as_u32())
     }
@@ -1062,7 +1045,17 @@ impl<'a> CfgLower<'a> {
         actions: Vec<crate::value_plan::DropAction>,
     ) -> crate::value_plan::ValueResult {
         for action in actions {
-            self.emit_slot_call(&action.slots, &action.symbol);
+            // One cleanup call at a time: building the plan emits the
+            // argument's marshaling, and a caller-owned indirect copy must stay
+            // live until the call it belongs to has returned.
+            let plan = crate::call_plan::CallPlan::from_inputs(
+                crate::call_plan::CallTarget::rue(action.symbol),
+                crate::call_plan::ReturnPlan::ZeroSized,
+                std::slice::from_ref(&action.argument),
+                std::slice::from_ref(&action.native),
+                self,
+            );
+            let _ = self.lower_call_plan(plan);
         }
 
         let primary = self.mir.alloc_vreg();
@@ -2037,7 +2030,13 @@ impl<'a> CfgLower<'a> {
         ty: Type,
         policy: crate::value_plan::ValuePlan,
     ) -> (VReg, Vec<VReg>) {
-        let float_width = crate::value_plan::float_width(ty);
+        // A slot's register class follows its LEAF, not the type wrapped around
+        // it (RUE-2001): a `struct Q { f: f64 }` and a bare `f64` hold the same
+        // thing in the same one slot, so reading the width off the parameter's
+        // own type would load a float-carrying wrapper with an integer load into
+        // a general-purpose register and hand it to a float-typed consumer.
+        let leaf_types = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty);
+        let float_width = crate::value_plan::primary_slot_float_width(&leaf_types);
         let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
             crate::reg_class::RegClass::Fp
         } else {
@@ -2082,7 +2081,6 @@ impl<'a> CfgLower<'a> {
                 });
             }
         } else if count > 1 {
-            let leaf_types = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty);
             let slots: Vec<_> = (0..count)
                 .map(|slot| {
                     let width = crate::value_plan::float_width(leaf_types[slot as usize]);
@@ -2091,7 +2089,7 @@ impl<'a> CfgLower<'a> {
                     } else {
                         crate::reg_class::RegClass::Gp
                     });
-                    let frame_slot = self.ctx.param_frame_slot(index) + count - 1 - slot;
+                    let frame_slot = self.ctx.param_value_low_slot(index, count) - slot;
                     if let Some(width) = width {
                         <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
                             self, v, frame_slot, width,
@@ -2115,14 +2113,16 @@ impl<'a> CfgLower<'a> {
             <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
                 self,
                 dst,
-                self.ctx.param_frame_slot(index),
+                self.ctx.param_value_low_slot(index, 1),
                 width,
             );
         } else {
             self.mir.push(Aarch64Inst::Ldr {
                 dst: Operand::Virtual(dst),
                 base: Reg::Fp,
-                offset: self.ctx.local_offset(self.ctx.param_frame_slot(index)),
+                offset: self
+                    .ctx
+                    .local_offset(self.ctx.param_value_low_slot(index, 1)),
             });
         }
         (dst, Vec::new())

--- a/crates/rue-codegen/src/byref_args.rs
+++ b/crates/rue-codegen/src/byref_args.rs
@@ -45,9 +45,12 @@ pub(crate) fn lower_byref_arg_addr<B: PlaceLowerBackend + ?Sized>(
                 b.emit_reg_move(addr_vreg, ptr_vreg);
             } else {
                 // Addressing a by-value parameter requires its frame home;
-                // the storage plan homes every such parameter (RUE-1170).
-                let frame_slot = b.ctx().param_frame_slot(*slot);
-                b.emit_frame_addr(addr_vreg, frame_slot + low_shift);
+                // the storage plan homes every such parameter (RUE-1170). The
+                // address wanted is the value's low end, which for a slot
+                // inside a wider parameter is a projection into that
+                // parameter's frame image.
+                let low_slot = b.ctx().param_value_low_slot(*slot, low_shift + 1);
+                b.emit_frame_addr(addr_vreg, low_slot);
             }
             addr_vreg
         }

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -804,8 +804,9 @@ fn place_argument<M: CallMaterializer>(
     (UserArgMode::Value, values, classes, locations)
 }
 
-/// One already-materialized leaf of a cleanup callee's flattened parameter
-/// list: a register-width general-purpose scalar.
+/// A value the convention needs no type for: one register-width
+/// general-purpose scalar. A by-reference parameter's incoming pointer, and a
+/// by-value parameter slot whose type the AIR never named.
 pub(crate) const fn register_width_leaf() -> NativeArg {
     NativeArg::Scalar {
         kind: rue_air::CAbiScalarKind::RegisterWidth,
@@ -990,57 +991,6 @@ impl CallPlan {
             stack_slot_count,
             stack_bytes: signature.stack_bytes(),
             caller_indirect_bytes,
-        }
-    }
-
-    /// Build the same normalized shape for a cleanup call — a destructor or a
-    /// drop glue body — whose slots have already been materialized by the
-    /// canonical aggregate leaves.
-    ///
-    /// A cleanup callee's parameters *are* those leaves: the synthesized body
-    /// addresses an owner's decomposition one slot at a time, so its signature
-    /// is one register-width scalar per leaf. That signature goes through the
-    /// same lowering every other call uses, and the callee's own parameter plan
-    /// reads the same per-slot descriptors, so the two ends cannot disagree.
-    pub fn from_slot_values(
-        target: CallTarget,
-        slots: &[VReg],
-        native_convention: ConventionSpec,
-        c_convention: CallingConvention,
-    ) -> Self {
-        let parameters = vec![(register_width_leaf().facts(), ArgConvention::ByValue); slots.len()];
-        let signature = lower_native_signature(native_convention, &parameters, LoweredReturn::Void);
-        let abi_classes = vec![AbiSlotClass::Gp; slots.len()];
-        let abi_locations = signature
-            .arguments()
-            .iter()
-            .map(|argument| scalar_location(argument.location))
-            .collect::<Vec<_>>();
-        let stack_slot_count = abi_locations
-            .iter()
-            .filter(|location| matches!(location, AbiSlotLocation::Stack { .. }))
-            .count();
-        Self {
-            callee_convention: callee_pairing(&target, native_convention, c_convention)
-                .convention(),
-            target,
-            hidden_sret: None,
-            user_args: vec![UserArgPlan {
-                mode: UserArgMode::Value,
-                slots: slots.to_vec(),
-            }],
-            abi_slots: slots.to_vec(),
-            abi_classes,
-            abi_locations,
-            return_plan: ReturnPlan::ZeroSized,
-            return_registers: None,
-            compact_return_image: None,
-            compact_return_dispatch: None,
-            result: None,
-            result_float_width: None,
-            stack_slot_count,
-            stack_bytes: signature.stack_bytes(),
-            caller_indirect_bytes: 0,
         }
     }
 }
@@ -1245,60 +1195,6 @@ mod tests {
             )
             .is_err()
         );
-    }
-
-    #[test]
-    fn slot_call_plan_counts_aligned_stack_slots() {
-        let slots: Vec<_> = (0..9).map(VReg::new).collect();
-        let plan = CallPlan::from_slot_values(
-            CallTarget::rue("drop"),
-            &slots,
-            ConventionSpec::native(rue_target::Target::X86_64Linux),
-            CallingConvention::X86_64SysV,
-        );
-
-        assert_eq!(plan.abi_slots, slots);
-        assert_eq!(plan.stack_slot_count, 3);
-        assert_eq!(plan.stack_bytes, 32);
-        assert_eq!(plan.return_plan, ReturnPlan::ZeroSized);
-    }
-
-    #[test]
-    fn every_row_places_a_cleanup_leaf_in_a_whole_ascending_eightbyte() {
-        // A cleanup callee (a destructor, a drop glue body) takes an
-        // aggregate's leaves as one register-width parameter per
-        // leaf, each carrying a canonically 64-bit-extended value, so a leaf the
-        // roster cannot hold claims one whole eightbyte from its convention's
-        // argument area — under Apple's natural-size packing as much as under
-        // the eight-byte slot rows, because eight bytes is a register-width
-        // value's natural size.
-        let slots: Vec<_> = (0..10).map(VReg::new).collect();
-        for target in rue_target::Target::all() {
-            let plan = CallPlan::from_slot_values(
-                CallTarget::rue("drop"),
-                &slots,
-                ConventionSpec::native(*target),
-                target.c_calling_convention(),
-            );
-            let registers =
-                usize::try_from(ConventionSpec::native(*target).spec().gp_argument_registers)
-                    .expect("a roster size fits usize");
-            let stacked = &plan.abi_locations[registers..];
-            assert_eq!(
-                stacked,
-                (0..stacked.len())
-                    .map(AbiSlotLocation::stack_slot)
-                    .collect::<Vec<_>>(),
-                "{target:?}: cleanup leaves stack in whole ascending eightbytes"
-            );
-            assert_eq!(
-                &plan.abi_locations[..registers],
-                (0..registers)
-                    .map(AbiSlotLocation::GpReg)
-                    .collect::<Vec<_>>(),
-                "{target:?}: cleanup leaves take the roster in order"
-            );
-        }
     }
 
     #[test]

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -547,4 +547,43 @@ impl<'a> CfgLowerContext<'a> {
         };
         self.frame_local_slots() + area_slot
     }
+
+    /// The emitted frame slot holding logical slot 0 — the low end in address —
+    /// of the `slot_count`-slot value that begins at parameter ABI slot `index`.
+    ///
+    /// A homed parameter is one contiguous frame image laid out ascending in
+    /// address with its logical slots while frame slot numbers descend
+    /// (ADR-0040), so the parameter's own slot 0 is its *last* frame slot and
+    /// slot `k` is one slot back from slot `k - 1`. A `Param { index }` naming a
+    /// slot inside a wider parameter — the leaf a cleanup body reads out of its
+    /// owner (RUE-2074) — is therefore a projection into that image, addressed
+    /// exactly as a place projection at the same slot offset would be, not a
+    /// parameter of its own.
+    ///
+    /// With no grouped descriptors (a synthetic CFG) every slot is its own
+    /// homed parameter, which is the same answer for `index` naming a whole
+    /// parameter.
+    pub fn param_value_low_slot(&self, index: u32, slot_count: u32) -> u32 {
+        let group = self
+            .cfg
+            .source_param_abi()
+            .iter()
+            .find(|descriptor| {
+                descriptor.start_slot <= index
+                    && index < descriptor.start_slot + descriptor.slot_count
+            })
+            .map(|descriptor| (descriptor.start_slot, descriptor.slot_count));
+        match group {
+            Some((start_slot, group_slots)) => {
+                let offset = index - start_slot;
+                assert!(
+                    offset + slot_count <= group_slots,
+                    "a {slot_count}-slot value at offset {offset} runs past the \
+                     {group_slots}-slot parameter that starts at slot {start_slot}"
+                );
+                self.param_frame_slot(start_slot) + group_slots - 1 - offset
+            }
+            None => self.param_frame_slot(index) + slot_count.saturating_sub(1),
+        }
+    }
 }

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -726,6 +726,7 @@ mod tests {
             &interner,
             false,
             rue_air::AnalyzedCallableKind::Ordinary,
+            None,
         );
         (cfg_output.cfg.unwrap(), type_pool, interner)
     }
@@ -761,6 +762,7 @@ mod tests {
             &interner,
             false,
             rue_air::AnalyzedCallableKind::Ordinary,
+            None,
         );
         (cfg_output.cfg.unwrap(), type_pool, interner)
     }
@@ -796,6 +798,7 @@ mod tests {
             &interner,
             false,
             rue_air::AnalyzedCallableKind::Ordinary,
+            None,
         );
         (cfg_output.cfg.unwrap(), type_pool, interner)
     }

--- a/crates/rue-codegen/src/param_storage.rs
+++ b/crates/rue-codegen/src/param_storage.rs
@@ -135,12 +135,11 @@ fn incoming_return(pairing: ConventionSpec, has_sret: bool) -> LoweredReturn {
 /// The native description of one source parameter.
 ///
 /// A by-reference parameter is one pointer whatever it points at. A by-value
-/// parameter with no recovered type is one register-width slot — a leaf of a
-/// cleanup callee's flattened parameter list (a destructor or drop glue body,
-/// whose caller `CallPlan::from_slot_values` hands over one leaf per
-/// parameter), or a slot of a synthetic CFG without descriptors. The CFG
-/// derivation guarantees such a descriptor spans exactly one slot, which is
-/// what makes every parameter a single value the convention places as a whole.
+/// parameter with no recovered type is one register-width slot — the `str` view
+/// an unread `borrow str` parameter arrives as, or a slot of a synthetic CFG
+/// without descriptors. The CFG derivation guarantees such a descriptor spans
+/// exactly one slot, which is what makes every parameter a single value the
+/// convention places as a whole.
 fn parameter_native(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
@@ -526,9 +525,10 @@ struct ParamReferenceScan {
 /// A reference rooted at a parameter's first ABI slot can span the
 /// parameter's whole type — a multi-slot `Param` read, a place access, or a
 /// by-value `ParamStore` addresses `[index, index + slot_count)` as one
-/// contiguous frame region. A cleanup callee (a destructor or drop glue body)
-/// describes those same slots as *separate* single-slot parameters, so every
-/// mark covers the referenced type's full slot span, not just the base slot.
+/// contiguous frame region. The descriptors need not agree: a body whose
+/// parameter type was never recovered describes those same slots as *separate*
+/// single-slot parameters, so every mark covers the referenced type's full slot
+/// span, not just the base slot.
 fn scan_param_references(cfg: &Cfg, type_pool: &FrozenTypeInternPool) -> ParamReferenceScan {
     let num_params = cfg.num_params() as usize;
     let num_locals = cfg.num_locals();
@@ -994,7 +994,7 @@ mod tests {
         );
     }
 
-    /// A cleanup callee (a destructor, a drop glue body) describes one source
+    /// A body whose parameter type the AIR never named describes one source
     /// aggregate as SEPARATE single-slot parameters. A place or multi-slot
     /// `Param` reference rooted at the first slot addresses the whole
     /// contiguous region, so the scan must home the full type span —
@@ -1031,8 +1031,8 @@ mod tests {
         let pool = type_pool.freeze();
 
         let mut cfg = Cfg::new(Type::UNIT, 0, 2, "split".into(), vec![false, false]);
-        // Two single-slot descriptors for one two-slot source value: the
-        // shape a cleanup callee's flattened parameter list has.
+        // Two single-slot descriptors for one two-slot source value: the shape
+        // a parameter list with no recovered types has.
         cfg.set_source_param_abi(scalar_descriptors(2));
         let entry = cfg.new_block();
         cfg.entry = entry;

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -958,6 +958,7 @@ mod tests {
             &fixture.interner,
             false,
             rue_air::AnalyzedCallableKind::Ordinary,
+            None,
         );
         output.cfg.expect("test CFG must build")
     }

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -817,6 +817,7 @@ mod tests {
             &interner,
             false,
             rue_air::AnalyzedCallableKind::Ordinary,
+            None,
         );
         (cfg_output.cfg.unwrap(), type_pool, interner)
     }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -196,13 +196,26 @@ pub enum StoreDestination {
     ByRefParam(u32),
 }
 
-/// One already-decided cleanup call. The shared planner chooses the symbol,
-/// action order, and logical ABI slot order; adapters only marshal these slots
-/// using their target call convention.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// One already-decided cleanup call: a destructor or a drop-glue body handed
+/// its owner as ONE by-value argument of the owner's type.
+///
+/// A cleanup entry point is an ordinary one-argument Rue function, so the
+/// shared planner decides only the symbol, the action order, and the argument's
+/// classification; the adapter then places and marshals it through the same
+/// [`CallPlan::from_inputs`](crate::call_plan::CallPlan::from_inputs) path
+/// every other call uses (ADR-0084, RUE-2074). The plan is built by the adapter
+/// rather than here because building it emits the argument's marshaling, which
+/// must sit immediately before its own call: a caller-owned indirect copy lives
+/// on the stack until the call it belongs to returns.
+#[derive(Debug, Clone)]
 pub struct DropAction {
+    /// The cleanup entry point's machine symbol.
     pub symbol: String,
-    pub slots: Vec<VReg>,
+    /// The owner value and the type the convention classifies it by.
+    pub argument: crate::call_plan::CallArgInput,
+    /// That type's native description: the facts it is classified by and the
+    /// marshaling that reaches its placement.
+    pub native: crate::native_abi::NativeArg,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1049,92 +1062,68 @@ fn place_from_value<A: ValueLowerAdapter>(
     })
 }
 
+/// The cleanup calls one `Drop` runs, in spec-3.9 order: the type's own
+/// destructor, then the glue that drops its parts.
+///
+/// Each callee takes the dropped value as one by-value parameter of its own
+/// type, so every action names the same argument and differs only in symbol.
 fn drop_plan<A: ValueLowerAdapter>(
     ctx: &CfgLowerContext<'_>,
     adapter: &mut A,
     value: CfgValue,
 ) -> Vec<DropAction> {
-    let result = operand(ctx, adapter, value);
-    let shape = ValuePlan::for_value(ctx, value).shape;
-    let mut slots = if shape.slot_count() == 0 {
-        Vec::new()
-    } else if result.slots.is_empty() {
-        vec![result.primary]
-    } else {
-        result.slots
-    };
     let dropped_ty = ctx.cfg.get_inst(value).ty;
-    let mut actions = Vec::new();
+    let mut symbols = Vec::new();
 
     match dropped_ty.kind() {
         TypeKind::Struct(struct_id) => {
             let struct_def = ctx.type_pool.struct_def(struct_id);
-            if struct_def.is_builtin {
-                if let Some(destructor) = &struct_def.destructor {
-                    actions.push(DropAction {
-                        symbol: adapter.resolve_named_symbol(destructor),
-                        slots,
-                    });
-                }
-            } else {
-                if let Some(destructor) = &struct_def.destructor {
-                    let mut destructor_slots = slots.clone();
-                    destructor_slots.reverse();
-                    actions.push(DropAction {
-                        symbol: adapter.resolve_named_symbol(destructor),
-                        slots: destructor_slots,
-                    });
-                }
-                let mut glue_slots = slots;
-                let mut offset = 0usize;
-                for field in &struct_def.fields {
-                    let count = ctx.type_slot_count(field.ty) as usize;
-                    if count > 1 && offset + count <= glue_slots.len() {
-                        glue_slots[offset..offset + count].reverse();
-                    }
-                    offset += count;
-                }
-                actions.push(DropAction {
-                    symbol: adapter.resolve_named_symbol(
-                        &rue_air::drop_glue_names::struct_drop_glue_name(struct_id, ctx.type_pool),
-                    ),
-                    slots: glue_slots,
-                });
+            if let Some(destructor) = &struct_def.destructor {
+                symbols.push(adapter.resolve_named_symbol(destructor));
+            }
+            // A builtin type's destructor is its entire cleanup; a user struct
+            // then runs the glue that drops its fields.
+            if !struct_def.is_builtin {
+                symbols.push(adapter.resolve_named_symbol(
+                    &rue_air::drop_glue_names::struct_drop_glue_name(struct_id, ctx.type_pool),
+                ));
             }
         }
         TypeKind::Array(array_id) => {
-            let element_slots = ctx.array_element_slot_count(dropped_ty) as usize;
-            if element_slots > 1 {
-                for chunk in slots.chunks_mut(element_slots) {
-                    chunk.reverse();
-                }
-            }
-            actions.push(DropAction {
-                symbol: adapter.resolve_named_symbol(
-                    &rue_air::drop_glue_names::array_drop_glue_name(array_id, ctx.type_pool),
-                ),
-                slots,
-            });
+            symbols.push(adapter.resolve_named_symbol(
+                &rue_air::drop_glue_names::array_drop_glue_name(array_id, ctx.type_pool),
+            ));
         }
         TypeKind::Enum(enum_id) => {
-            // Enum drop glue's parameter list is the enum's leaves, one
-            // register-width parameter each, which is what
-            // `CallPlan::from_slot_values` hands over. A frame-resident aggregate ascends
-            // in address with its logical slots while frame slot numbers descend
-            // (ADR-0040), so handing the leaves over in reverse is what lands
-            // them in the glue's own parameter area in logical order (RUE-998).
-            slots.reverse();
-            actions.push(DropAction {
-                symbol: adapter.resolve_named_symbol(
-                    &rue_air::drop_glue_names::enum_drop_glue_name(enum_id, ctx.type_pool),
-                ),
-                slots,
-            });
+            symbols.push(adapter.resolve_named_symbol(
+                &rue_air::drop_glue_names::enum_drop_glue_name(enum_id, ctx.type_pool),
+            ));
         }
         _ => unreachable!("Drop instruction reached codegen for unexpected type: {dropped_ty:?}"),
     }
 
-    actions
+    let aggregate = ctx.is_multislot_aggregate(dropped_ty);
+    let argument = crate::call_plan::CallArgInput::Value {
+        value,
+        ty: dropped_ty,
+        slot_count: ctx.type_slot_count(dropped_ty),
+        is_multislot_aggregate: aggregate,
+        slot_types: if aggregate {
+            crate::types::aggregate_leaf_types(ctx.type_pool, dropped_ty)
+        } else {
+            vec![dropped_ty]
+        },
+    };
+    let native =
+        crate::native_abi::native_arg(ctx.type_pool, dropped_ty, rue_air::ArgConvention::ByValue);
+    symbols
+        .into_iter()
+        .map(|symbol| DropAction {
+            symbol,
+            argument: argument.clone(),
+            native: native.clone(),
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -3465,8 +3454,11 @@ mod tests {
         );
     }
 
+    /// A cleanup entry point takes its owner as ONE by-value argument of the
+    /// owner's type, on both adapters (RUE-2074): the action names the callee
+    /// and the whole dropped value, never a per-leaf slot vector.
     #[test]
-    fn builtin_aggregate_drop_preserves_legacy_slots_on_both_adapters() {
+    fn builtin_aggregate_drop_hands_its_owner_over_as_one_by_value_argument() {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::new();
         let name = interner.get_or_intern("DropAggregate");
@@ -3529,7 +3521,7 @@ mod tests {
         assert_eq!(x86_value.slots.len(), 3);
         assert_eq!(x86_actions.len(), 1);
         assert_eq!(x86_actions[0].symbol, "DropAggregate::__drop");
-        assert_eq!(x86_actions[0].slots, x86_value.slots);
+        assert_owner_argument(&x86_actions[0], value, aggregate_ty);
 
         let arm_ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
         let mut arm = Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux);
@@ -3538,7 +3530,30 @@ mod tests {
         assert_eq!(arm_value.slots.len(), 3);
         assert_eq!(arm_actions.len(), 1);
         assert_eq!(arm_actions[0].symbol, "DropAggregate::__drop");
-        assert_eq!(arm_actions[0].slots, arm_value.slots);
+        assert_owner_argument(&arm_actions[0], value, aggregate_ty);
+    }
+
+    /// One cleanup action carries the dropped value itself, classified by its
+    /// own type, and nothing else.
+    fn assert_owner_argument(action: &super::DropAction, owner: CfgValue, owner_ty: Type) {
+        let crate::call_plan::CallArgInput::Value {
+            value,
+            ty,
+            slot_count,
+            is_multislot_aggregate,
+            ..
+        } = &action.argument
+        else {
+            panic!("a cleanup argument is always by value");
+        };
+        assert_eq!(*value, owner);
+        assert_eq!(*ty, owner_ty);
+        assert_eq!(*slot_count, 3);
+        assert!(is_multislot_aggregate);
+        assert!(matches!(
+            action.native,
+            crate::native_abi::NativeArg::Aggregate { .. }
+        ));
     }
 
     /// A float leaf reached through an aggregate is compared the way a

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -686,23 +686,6 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Emit a target-local cleanup call using the normalized slot vector.
-    fn emit_slot_call(&mut self, arg_vregs: &[VReg], symbol: &str) {
-        let plan = crate::call_plan::CallPlan::from_slot_values(
-            crate::call_plan::CallTarget::rue(symbol),
-            arg_vregs,
-            rue_target::ConventionSpec::native(X86_64_TARGET),
-            x86_64_target_c_convention(),
-        );
-        let _ = self.lower_call_plan(plan);
-    }
-
-    /// Call `symbol` passing `arg_vregs` as flattened by-value slot arguments
-    /// per the standard convention: the first slots in ARG_REGS, the rest
-    /// pushed on the stack (16-byte aligned, cleaned up after the call) —
-    /// the same shape as generic `Call` lowering. Drop and drop-glue calls use
-    /// this path so every slot beyond the six register arguments is passed on
-    /// the stack (RUE-193).
     fn emit_div_core(&mut self, is_64: bool, is_signed: bool, rhs_vreg: VReg) {
         if is_signed {
             // Sign-extend (R/E)AX into (R/E)DX.
@@ -1262,7 +1245,17 @@ impl<'a> CfgLower<'a> {
         actions: Vec<crate::value_plan::DropAction>,
     ) -> crate::value_plan::ValueResult {
         for action in actions {
-            self.emit_slot_call(&action.slots, &action.symbol);
+            // One cleanup call at a time: building the plan emits the
+            // argument's marshaling, and a caller-owned indirect copy must stay
+            // live until the call it belongs to has returned.
+            let plan = crate::call_plan::CallPlan::from_inputs(
+                crate::call_plan::CallTarget::rue(action.symbol),
+                crate::call_plan::ReturnPlan::ZeroSized,
+                std::slice::from_ref(&action.argument),
+                std::slice::from_ref(&action.native),
+                self,
+            );
+            let _ = self.lower_call_plan(plan);
         }
 
         let primary = self.mir.alloc_vreg();
@@ -2372,7 +2365,13 @@ impl<'a> CfgLower<'a> {
         ty: Type,
         policy: crate::value_plan::ValuePlan,
     ) -> (VReg, Vec<VReg>) {
-        let float_width = crate::value_plan::float_width(ty);
+        // A slot's register class follows its LEAF, not the type wrapped around
+        // it (RUE-2001): a `struct Q { f: f64 }` and a bare `f64` hold the same
+        // thing in the same one slot, so reading the width off the parameter's
+        // own type would load a float-carrying wrapper with an integer load into
+        // a general-purpose register and hand it to a float-typed consumer.
+        let leaf_types = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty);
+        let float_width = crate::value_plan::primary_slot_float_width(&leaf_types);
         let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
             crate::reg_class::RegClass::Fp
         } else {
@@ -2418,7 +2417,6 @@ impl<'a> CfgLower<'a> {
                 });
             }
         } else if count > 1 {
-            let leaf_types = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty);
             let slots: Vec<_> = (0..count)
                 .map(|slot| {
                     let width = crate::value_plan::float_width(leaf_types[slot as usize]);
@@ -2427,7 +2425,7 @@ impl<'a> CfgLower<'a> {
                     } else {
                         crate::reg_class::RegClass::Gp
                     });
-                    let frame_slot = self.ctx.param_frame_slot(index) + count - 1 - slot;
+                    let frame_slot = self.ctx.param_value_low_slot(index, count) - slot;
                     if let Some(width) = width {
                         <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
                             self, v, frame_slot, width,
@@ -2452,14 +2450,16 @@ impl<'a> CfgLower<'a> {
             <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
                 self,
                 dst,
-                self.ctx.param_frame_slot(index),
+                self.ctx.param_value_low_slot(index, 1),
                 width,
             );
         } else {
             self.mir.push(X86Inst::MovRM {
                 dst: Operand::Virtual(dst),
                 base: Reg::Rbp,
-                offset: self.ctx.local_offset(self.ctx.param_frame_slot(index)),
+                offset: self
+                    .ctx
+                    .local_offset(self.ctx.param_value_low_slot(index, 1)),
             });
         }
         (dst, Vec::new())

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1709,6 +1709,7 @@ fn build_cfg(
         &materialized.interner,
         materialized.allow_unreachable_code,
         materialized.callable_kind,
+        materialized.cleanup_owner,
         |name| materialized.interner.get(name),
     );
     let cfg_builder_ns = elapsed_ns(builder_started);

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -13,12 +13,18 @@
 //! ```
 //!
 //! We generate a function `__rue_drop_Container` that:
-//! 1. Receives the struct's flattened fields as parameters
+//! 1. Receives the owner as one by-value parameter of the owner's type, placed
+//!    exactly as a user function taking `Container` by value would place it
 //! 2. Drops each field that needs dropping (in declaration order)
 //!
 //! For arrays like `[String; 3]`, we generate a function `__rue_drop_array_String_3` that:
-//! 1. Receives all element slots as parameters (flattened)
+//! 1. Receives the array as that same single by-value parameter
 //! 2. Drops each element in index order (element 0 first, then 1, etc.)
+//!
+//! A glue body reads its owner's leaves with `Param { index }`, where `index` is
+//! a slot of the owner's canonical flattened layout — field 0 first, element 0
+//! first, an enum's discriminant at slot 0 with the payload union overlaying
+//! slots 1.. (RUE-2074).
 
 #[cfg(test)]
 use ahash::AHashMap;
@@ -113,12 +119,11 @@ pub(crate) fn synthesize_canonical_drop_glue(
             } else {
                 Ty::U64
             };
-            let disc = add(
-                SemanticBodyInstData::Param {
-                    index: num_param_slots.saturating_sub(1),
-                },
-                disc_ty.clone(),
-            );
+            // The owner arrives as one by-value parameter of its own type, so a
+            // `Param { index }` names slot `index` of the enum's canonical
+            // flattened layout: the discriminant is logical slot 0 and the
+            // union payload overlays slots 1.. (RUE-2074).
+            let disc = add(SemanticBodyInstData::Param { index: 0 }, disc_ty.clone());
             let unit = add(SemanticBodyInstData::UnitConst, Ty::Unit);
             let mut arms = Vec::new();
             for (variant_index, variant) in variants.iter().enumerate() {
@@ -132,10 +137,7 @@ pub(crate) fn synthesize_canonical_drop_glue(
                     if field.drop {
                         let ty = crate::semantic_identity::semantic_type_from_instance(&field.ty);
                         let param = add(
-                            SemanticBodyInstData::Param {
-                                index: num_param_slots
-                                    .saturating_sub(field_slot.saturating_add(width)),
-                            },
+                            SemanticBodyInstData::Param { index: field_slot },
                             ty.clone(),
                         );
                         drops.push(add(SemanticBodyInstData::Drop { value: param }, ty));
@@ -192,6 +194,10 @@ pub(crate) fn synthesize_canonical_drop_glue(
         borrow_slots: Arc::new([]),
         num_locals: 0,
         num_param_slots,
+        // The glue's whole parameter list is its owner, taken by value; the
+        // body reads the owner's leaves at their own field types, so the owner
+        // itself is named only here (RUE-2074).
+        cleanup_owner: Some(crate::semantic_identity::semantic_type_from_instance(owner)),
         param_by_ref: vec![false; num_param_slots as usize].into(),
         param_writable: vec![false; num_param_slots as usize].into(),
         allow_unreachable_code: false,
@@ -384,6 +390,7 @@ fn create_struct_drop_glue_function(
         local_atoms: Vec::new(),
         num_locals: 0,
         num_param_slots,
+        cleanup_owner: Some(Type::new_struct(struct_id)),
         param_modes: ParamSlotModes::new(param_modes.clone(), vec![false; param_modes.len()]),
         allow_unreachable_code: false,
     })
@@ -441,12 +448,10 @@ fn create_array_drop_glue_function(
     // For each element, emit a Drop instruction, in ASCENDING index order
     // (element 0 dropped first — the language-visible order the oracle checks).
     //
-    // The flattened parameter slots are in LOGICAL order (ADR-0040 / RUE-311):
-    // element 0 occupies the first element-chunk, element N-1 the last. So
-    // iterate chunks front-to-back to drop in ascending index order. Each chunk
-    // is read back as one aggregate `Param`, which the codegen `Drop` lowering
-    // hands over in the reversed by-value ABI order, so the drop caller reverses
-    // each element's own slots to compensate (see the array `Drop` handler).
+    // A `Param { index }` names slot `index` of the owner's canonical flattened
+    // layout, so element 0 occupies the first element-chunk and element N-1 the
+    // last: iterating chunks front-to-back drops in ascending index order, and
+    // each chunk is read back whole as one aggregate `Param`.
     // Type::Struct handles both user-defined structs and builtin String.
     for phys_chunk in 0..length {
         let current_param_slot = phys_chunk as u32 * element_slot_count;
@@ -507,6 +512,7 @@ fn create_array_drop_glue_function(
         local_atoms: Vec::new(),
         num_locals: 0,
         num_param_slots,
+        cleanup_owner: Some(Type::new_array(array_id)),
         param_modes: ParamSlotModes::new(param_modes.clone(), vec![false; param_modes.len()]),
         allow_unreachable_code: false,
     })
@@ -514,14 +520,13 @@ fn create_array_drop_glue_function(
 
 /// Create a drop glue function for a payload-carrying enum type (RUE-221).
 ///
-/// The function receives the enum's flattened slots as one ordinary Rue
-/// by-value argument. The ABI reverses that complete slot vector: the final
-/// parameter slot is the discriminant and the preceding slots are the reversed
-/// payload union. It switches on the discriminant and, for the active variant,
-/// drops each droppable payload field in declaration order. Variants whose
-/// payload needs no drop (and discriminant-only variants) fall through to a
-/// no-op wildcard default arm, so exactly the active variant's payload is
-/// dropped.
+/// The function receives the enum as one ordinary Rue by-value argument of the
+/// enum's own type, whose canonical flattened layout puts the discriminant at
+/// slot 0 and overlays the payload union on slots 1.. It switches on the
+/// discriminant and, for the active variant, drops each droppable payload field
+/// in declaration order. Variants whose payload needs no drop (and
+/// discriminant-only variants) fall through to a no-op wildcard default arm, so
+/// exactly the active variant's payload is dropped.
 #[cfg(test)]
 fn create_enum_drop_glue_function(
     enum_id: EnumId,
@@ -564,10 +569,11 @@ fn create_enum_drop_glue_function(
     // Total ABI slots: discriminant (slot 0) + payload area (largest variant).
     let num_param_slots = type_pool.abi_slot_count(Type::new_enum(enum_id));
 
-    // A whole enum is one multi-slot by-value argument, so its ABI slot vector
-    // is reversed. The logical slot-0 discriminant is therefore last.
+    // The owner arrives as one by-value parameter of its own type, so a `Param`
+    // names a slot of the enum's canonical flattened layout: the discriminant
+    // is logical slot 0 (RUE-2074).
     let disc_ty = enum_def.discriminant_type();
-    let disc_param = air.add_param(num_param_slots - 1, disc_ty, span);
+    let disc_param = air.add_param(0, disc_ty, span);
 
     // A single shared unit value for every arm body and the outer block.
     let unit_const = air.add_unit(span);
@@ -602,12 +608,9 @@ fn create_enum_drop_glue_function(
             let field_slots = type_pool.abi_slot_count(field_ty);
             let should_drop = planned_fields[field_index].drop;
             if should_drop {
-                // The logical half-open range [field_slot, field_slot +
-                // field_slots) becomes the reversed ABI range beginning here.
-                // Reading an aggregate Param reverses that range once more,
-                // reconstructing the field in logical order (RUE-998).
-                let abi_field_slot = num_param_slots - (field_slot + field_slots);
-                let param_ref = air.add_param(abi_field_slot, field_ty, span);
+                // The payload overlays the union at logical slot 1, so field j
+                // begins at the canonical slot the running total names.
+                let param_ref = air.add_param(field_slot, field_ty, span);
                 let drop_ref = air.add_drop(param_ref, span);
                 drop_stmts.push(drop_ref);
             }
@@ -658,6 +661,7 @@ fn create_enum_drop_glue_function(
         local_atoms: Vec::new(),
         num_locals: 0,
         num_param_slots,
+        cleanup_owner: Some(Type::new_enum(enum_id)),
         param_modes: ParamSlotModes::new(param_modes.clone(), vec![false; param_modes.len()]),
         allow_unreachable_code: false,
     })
@@ -706,6 +710,14 @@ mod tests {
         let body = synthesize_canonical_drop_glue(&owner, &facts, &slots).unwrap();
         assert_eq!(body.num_param_slots, 6);
         assert_eq!(body.param_by_ref.as_ref(), &[false; 6]);
+        // The glue's whole parameter list is its owner, taken by value; the
+        // owner reaches the CFG's parameter layout only through this field.
+        assert_eq!(
+            body.cleanup_owner,
+            Some(crate::semantic_identity::semantic_type_from_instance(
+                &owner
+            ))
+        );
         let params = body
             .instructions
             .iter()
@@ -1052,7 +1064,11 @@ mod tests {
         .unwrap();
         assert_eq!(outer.num_param_slots, type_pool.abi_slot_count(outer_ty));
         assert_eq!(outer.num_param_slots, 27);
+        // Canonical flattened order: a field begins at the running total of the
+        // widths of the fields declared before it, zero-sized fields included at
+        // width zero. The last four fields are the droppable ones.
         assert_eq!(param_indices(&outer), [19, 20, 22, 24]);
+        assert_eq!(outer.cleanup_owner, Some(outer_ty));
 
         let array_facts = test_facts(crate::type_queries::DropGluePlan::Array {
             element: test_type_identity(drop_ty, &type_pool),
@@ -1071,7 +1087,9 @@ mod tests {
             array.num_param_slots,
             type_pool.abi_slot_count(drop_array_ty)
         );
+        // Element `i` of a 2-slot-per-element array begins at slot `i * width`.
         assert_eq!(param_indices(&array), [0, 1]);
+        assert_eq!(array.cleanup_owner, Some(drop_array_ty));
 
         let enum_facts = test_facts(crate::type_queries::DropGluePlan::Enum {
             variants: type_pool
@@ -1105,7 +1123,13 @@ mod tests {
             enum_glue.num_param_slots,
             type_pool.abi_slot_count(drop_enum_ty)
         );
-        assert_eq!(param_indices(&enum_glue), [2, 1, 0, 0]);
+        // An enum's canonical layout puts the discriminant at slot 0 and
+        // overlays the payload union on slots 1.. — so the discriminant `Param`
+        // comes first, then variant 0's two droppable fields at slots 1 and 2,
+        // then variant 1's single droppable field, which follows an `i32` and so
+        // also lands at slot 2.
+        assert_eq!(param_indices(&enum_glue), [0, 1, 2, 2]);
+        assert_eq!(enum_glue.cleanup_owner, Some(drop_enum_ty));
     }
 
     #[test]

--- a/crates/rue-compiler/src/error_printer.rs
+++ b/crates/rue-compiler/src/error_printer.rs
@@ -665,6 +665,7 @@ pub(crate) fn synthesize_error_printer(
         },
         num_locals: slot::PAYLOAD.saturating_add(payload_slots),
         num_param_slots,
+        cleanup_owner: None,
         param_by_ref: vec![false; num_param_slots as usize].into(),
         param_writable: vec![false; num_param_slots as usize].into(),
         allow_unreachable_code: false,

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -1921,6 +1921,14 @@ pub(crate) fn select_materialization_facts(
         require_type(ty);
         selection.semantic_type(ty);
     }
+    // A cleanup callee's whole parameter list is its owner, which the body's
+    // own instructions need never mention — a destructor that ignores `self`,
+    // glue that reads only its owner's leaves — so the owner is required here
+    // to reach the CFG's parameter layout (RUE-2074).
+    if let Some(owner) = body.cleanup_owner.as_ref() {
+        require_type(owner);
+        selection.semantic_type(owner);
+    }
     for reference in body.method_references.iter() {
         selection.nominal(&reference.receiver);
     }
@@ -2006,6 +2014,7 @@ pub(crate) fn select_drop_glue_materialization_facts(
         borrow_slots: Arc::new([]),
         num_locals: 0,
         num_param_slots: 0,
+        cleanup_owner: None,
         param_by_ref: Arc::new([]),
         param_writable: Arc::new([]),
         allow_unreachable_code: false,
@@ -2532,6 +2541,7 @@ mod tests {
             borrow_slots: Arc::new([]),
             num_locals: 0,
             num_param_slots: 0,
+            cleanup_owner: None,
             param_by_ref: Arc::new([]),
             param_writable: Arc::new([]),
             allow_unreachable_code: false,

--- a/crates/rue-compiler/src/test_dispatcher.rs
+++ b/crates/rue-compiler/src/test_dispatcher.rs
@@ -324,6 +324,7 @@ pub(crate) fn synthesize_test_dispatcher(table: &[Option<crate::FunctionInstance
         borrow_slots: Arc::new([]),
         num_locals: LOCAL_SLOTS,
         num_param_slots: 0,
+        cleanup_owner: None,
         param_by_ref: Arc::new([]),
         param_writable: Arc::new([]),
         allow_unreachable_code: false,

--- a/docs/designs/0084-native-calling-convention.md
+++ b/docs/designs/0084-native-calling-convention.md
@@ -383,13 +383,10 @@ moves in the same change as the convention it models, never in a follow-up.
   (`runtime_call_plan::manifest_signature`) and the backends read placements out
   of it; the registers-only guard is now a manifest property test. `AbiSlotClass`
   is a codegen-internal register-bank-and-width selector with one owner
-  (`rue-codegen`'s `abi_slot_class`). One thing the phase did not do: a cleanup
-  entry point still crosses as one register-width scalar per leaf rather than as
-  its owner's aggregate image, because the synthesized drop-glue body addresses
-  its owner's leaves as individual parameter slots. Giving it a single aggregate
-  parameter means re-authoring the glue AIR and its frame-image indexing, which
-  is a separate slice; what retired here is the *convention* branch, not the
-  flattened glue signature.
+  (`rue-codegen`'s `abi_slot_class`). RUE-2074 then closed the last exception:
+  a cleanup entry point — a destructor or a synthesized drop-glue body — takes
+  its owner as one by-value parameter of the owner's type, classified and placed
+  by this same walk.
 
 ## Consequences
 

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -145,22 +145,28 @@ is the one predicate that chooses between the two, consulted from both ends.
 
 ### Cleanup entry points
 
-A destructor and a drop glue body address their owner's decomposition one slot
-at a time: the synthesized glue reads a field, an array element, or a variant
-payload straight out of a parameter slot, and the destructor's `self` spans the
-whole run. Their *signature* is therefore one register-width scalar per leaf,
-and the convention places that signature exactly as it places any other list of
-register-width scalars — the roster in order, then the row's own argument-area
-packing. There is no cleanup arm in the classifier: `CallPlan::from_slot_values`
-at the caller and `ParamStoragePlan` at the callee both present one
-register-width value per leaf to `lower_native_signature`, and the CFG's own
-parameter descriptors say the same thing, one slot each.
+A cleanup callee — a destructor (`<Type>.__drop`) or a synthesized drop-glue
+body (`__rue_drop_*`) — is an ordinary by-value function of its owner's type. It
+takes **one** parameter, the owner, classified and placed exactly as a user
+function taking that type by value: the same `lower_native_signature` answer
+against the same `CAbiTypeFacts`, through the same compact image when the
+owner's leaves are not its eightbytes, and by reference when the row's composite
+rule says so. There is no cleanup arm anywhere in the classifier or in the
+caller: a `Drop` builds the ordinary one-argument `CallPlan`, and the callee's
+`ParamStoragePlan` reads the single typed descriptor the CFG derived from the
+owner type its body carries.
+
+Inside a glue body a leaf is reached as `Param { index }` naming slot `index` of
+the owner's *canonical* flattened layout — field 0 first, element 0 first, an
+enum's discriminant at slot 0 with the payload union overlaying slots 1.. — which
+addresses the owner's homed frame image exactly as a place projection at the same
+slot offset does. No slot vector is reversed on either side.
 
 Every by-value parameter the CFG describes with a type is placed by that type
 (`SourceParamAbi::ty`); a descriptor with no type is exactly one register-width
-slot — a by-reference pointer, a cleanup leaf, or a slot no instruction names —
-which is asserted where code generation reads it. Nothing reaches placement as a
-run of untyped slots.
+slot — a by-reference pointer, the `str` view an unread `borrow str` parameter
+arrives as, or a slot no instruction names — which is asserted where code
+generation reads it. Nothing reaches placement as a run of untyped slots.
 
 ### Returns
 


### PR DESCRIPTION
Follow-up to ADR-0084 phase 3 ([#2992](https://github.com/rue-language/rue/pull/2992)): a destructor or synthesized drop-glue body now takes its owner as one by-value parameter of the owner's type, classified and placed exactly as a user function taking that type by value would be. The last leaf-per-slot crossing is gone.

## What changes

- **Owner type reaches the callee.** `SemanticBody` gains `cleanup_owner`, set by `synthesize_canonical_drop_glue` and by the destructor sites in the ordinary engine, exported and mapped like the rest of the body, materialized to a live `Type` and handed to the CFG builder. `derive_source_param_abi` emits one `SourceParamAbi { start_slot: 0, slot_count: abi_slot_count(owner), ty: Some(owner) }` for a cleanup callee and asserts the owner is present exactly when the callable kind is `Destructor | DropGlue`, with a slot count equal to the body's parameter slots.
- **Canonical slot order in the glue.** `Param { index }` names slot `index` of the owner's canonical flattened layout: struct fields at their running offsets, array elements at `i * element_width`, the enum discriminant at slot 0 with the payload union overlaying slots 1 onward. The reversed discriminant and payload indices are gone; the synthesizer tests pin the new indices.
- **Projection into the homed image.** `CfgLowerContext::param_value_low_slot(index, slot_count)` resolves a `Param` naming a slot inside a wider parameter as a projection into that parameter's homed frame image, the same arithmetic a place projection at that slot offset uses. Both backends' `lower_param_value` and `byref_args` go through it.
- **Caller side.** `DropAction` carries the dropped value as one `CallArgInput` plus its `NativeArg`; `drop_plan` only picks symbols and order. Each backend builds a `CallPlan::from_inputs` per action and lowers it immediately, so an AAPCS64 by-reference copy of a >16-byte owner is reserved and released around its own call. `CallPlan::from_slot_values` and both `emit_slot_call` helpers are deleted, along with every per-field, per-element and whole-value slot reversal.
- **Flag retired.** `AnalyzedCallableKind::has_flattened_leaf_parameters` and its branch in the CFG builder are deleted. The `ty: None` one-slot descriptor arm stays only for the unread `borrow str` view, which still produces it; its cleanup wording is gone.

## Pre-existing bug fixed on both backends

A frame-homed parameter whose single slot carries a float leaf under a wrapper (`struct Q { f: f64 }`) was allocated and loaded in the GP class because `lower_param_value` read the float width off the parameter's type rather than its leaf. It ICEd on trunk with `FloatMov ... left: Gp right: Fp` for a program that borrows such a parameter. The cleanup path now depends on the rule (an enum glue hands a float-leaf payload to that field's destructor in the FP bank), so it is fixed via `primary_slot_float_width(aggregate_leaf_types(...))`, with a target-pinned CLI case per backend.

## Tests

New `crates/rue-cli-tests/cases/cleanup_entry_point_abi.toml`, five scenarios on both rows: a struct owner with distinguishable `i32`/`i64`/`f64`/nested fields; a >16-byte owner (AAPCS64 by-reference, SysV stacked) dropped by both a destructor and glue; an array of multi-slot elements; an enum with a float-leaf variant and a two-slot variant; and the float-wrapper regression. `--emit abi` on the enum program shows the placement variety on AArch64: the float variant's destructor in `v0`, the two-slot variant's in `x0`/`x1`, the glue indirect through `x0`.

The oracle needed no change: it already calls a destructor with one by-value argument of the owner type and recurses structurally instead of calling glue.

## Docs

The "Cleanup entry points" section of `docs/notes/ffi-abi-conformance-audit.md` describes a cleanup callee as an ordinary by-value function of its owner's type, and ADR-0084's phase-3 status paragraph records that this closed the one item phase 3 left.

## Validation

`scripts/rue premerge` passes locally apart from the two sandbox-environmental CLI cases (`remove_dir_all_permission_denied_is_not_partial_success`, `tcp_ipv6_loopback_round_trip`); the C-ABI matrix, oracle-diff, planted-miscompile, spec-traceability and debug-assert targets pass. No planted-miscompile preimage moved.

Closes RUE-2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_