### PR TITLE
RUE-1971: parse directives and warning names into one typed table

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -12,6 +12,7 @@ use super::*;
 use crate::inst::AirPlaceRef;
 use crate::scope::ScopedContext;
 use ahash::AHashMap;
+use rue_rir::WarningName;
 
 /// The position into which a value is being placed when the ADR-0043 two-types
 /// string model (RUE-386) requires a *first-class* `str`: a bare `str`
@@ -2123,7 +2124,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Check if @allow(unused_variable) directive is present
         let directives = self.body_rir_ref().directives(directives);
-        let allow_unused = self.has_allow_directive(directives.iter(), "unused_variable");
+        let allow_unused = self.has_allow_directive(directives.iter(), WarningName::UnusedVariable);
 
         // Allocate slots
         let num_slots = self.require_layout_slots(var_type, span)?;
@@ -5386,21 +5387,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     pub(crate) fn has_allow_directive<'r>(
         &self,
         directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
-        warning_name: &str,
+        warning: WarningName,
     ) -> bool {
-        let allow_sym = self.body_interner().get("allow");
-        let warning_sym = self.body_interner().get(warning_name);
-
-        for directive in directives {
-            if Some(directive.name) == allow_sym {
-                for arg in &directive.args {
-                    if Some(*arg) == warning_sym {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+        rue_rir::directives_allow(self.body_interner(), directives, warning)
     }
 
     /// Check for unused local variables in the current scope (before popping it).

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use ahash::AHashMap;
 use lasso::Spur;
-use rue_rir::InstRef;
+use rue_rir::{InstRef, WarningName};
 use rue_span::FileId;
 
 use super::anon_structs::IssuedAnonymousNominalKey;
@@ -744,17 +744,12 @@ where
         else {
             return None;
         };
-        let allow = |warning_name: &str| {
-            let allow_sym = self.rir.rir_interner().get("allow");
-            let warning_sym = self.rir.rir_interner().get(warning_name);
-            self.rir
-                .rir()
-                .directives(directives)
-                .iter()
-                .any(|directive| {
-                    Some(directive.name) == allow_sym
-                        && directive.args.iter().any(|arg| Some(*arg) == warning_sym)
-                })
+        let allow = |warning| {
+            rue_rir::directives_allow(
+                self.rir.rir_interner(),
+                self.rir.rir().directives(directives).iter(),
+                warning,
+            )
         };
         self.identity
             .pool_mut()?
@@ -768,9 +763,9 @@ where
                     returns_type: false,
                     is_extern: false,
                     is_c_export: false,
-                    allow_unused_function: allow("unused_function"),
-                    allow_unused_variable: allow("unused_variable"),
-                    allow_unreachable_code: allow("unreachable_code"),
+                    allow_unused_function: allow(WarningName::UnusedFunction),
+                    allow_unused_variable: allow(WarningName::UnusedVariable),
+                    allow_unreachable_code: allow(WarningName::UnreachableCode),
                     file_id: inst.span.file_id,
                 },
             )
@@ -1074,17 +1069,12 @@ where
         else {
             return None;
         };
-        let allow = |warning_name: &str| {
-            let allow_sym = self.rir.rir_interner().get("allow");
-            let warning_sym = self.rir.rir_interner().get(warning_name);
-            self.rir
-                .rir()
-                .directives(directives)
-                .iter()
-                .any(|directive| {
-                    Some(directive.name) == allow_sym
-                        && directive.args.iter().any(|arg| Some(*arg) == warning_sym)
-                })
+        let allow = |warning| {
+            rue_rir::directives_allow(
+                self.rir.rir_interner(),
+                self.rir.rir().directives(directives).iter(),
+                warning,
+            )
         };
         self.identity
             .pool_mut()?
@@ -1109,9 +1099,9 @@ where
                         .is_some_and(|symbol| self.rir.rir_interner().resolve(symbol) == "type"),
                     is_extern: *is_extern,
                     is_c_export: *is_c_export,
-                    allow_unused_function: allow("unused_function"),
-                    allow_unused_variable: allow("unused_variable"),
-                    allow_unreachable_code: allow("unreachable_code"),
+                    allow_unused_function: allow(WarningName::UnusedFunction),
+                    allow_unused_variable: allow(WarningName::UnusedVariable),
+                    allow_unreachable_code: allow(WarningName::UnreachableCode),
                     file_id: inst.span.file_id,
                 },
             )

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -3225,6 +3225,7 @@ mod tests {
     use super::*;
     use crate::Node;
     use crate::semantic_identity::{AnonymousNominalKind, CanonicalArguments, StableProducerId};
+    use rue_rir::WarningName;
 
     type Key = u32;
     type Module = Arc<str>;
@@ -6466,15 +6467,10 @@ mod tests {
     /// the same read `binding_manifest.rs` performs when filling the handle.
     fn rir_has_allow<'r>(
         interner: &ThreadedRodeo,
-        mut directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
-        warning_name: &str,
+        directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
+        warning: WarningName,
     ) -> bool {
-        let allow_sym = interner.get("allow");
-        let warning_sym = interner.get(warning_name);
-        directives.any(|directive| {
-            Some(directive.name) == allow_sym
-                && directive.args.iter().any(|arg| Some(*arg) == warning_sym)
-        })
+        rue_rir::directives_allow(interner, directives, warning)
     }
 
     /// True when the return syntax names exactly `name`.
@@ -6523,9 +6519,21 @@ mod tests {
             returns_type: rir_type_named(rir, interner, *return_type, "type"),
             is_extern: *is_extern,
             is_c_export: *is_c_export,
-            allow_unused_function: rir_has_allow(interner, dirs.iter(), "unused_function"),
-            allow_unused_variable: rir_has_allow(interner, dirs.iter(), "unused_variable"),
-            allow_unreachable_code: rir_has_allow(interner, dirs.iter(), "unreachable_code"),
+            allow_unused_function: rir_has_allow(
+                interner,
+                dirs.iter(),
+                WarningName::UnusedFunction,
+            ),
+            allow_unused_variable: rir_has_allow(
+                interner,
+                dirs.iter(),
+                WarningName::UnusedVariable,
+            ),
+            allow_unreachable_code: rir_has_allow(
+                interner,
+                dirs.iter(),
+                WarningName::UnreachableCode,
+            ),
             file_id: inst.span.file_id,
         }
     }

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -19,7 +19,7 @@ use std::cell::RefCell;
 use std::hash::Hash;
 
 use lasso::Spur;
-use rue_rir::{InstData, InstRef};
+use rue_rir::{InstData, InstRef, WarningName};
 use rue_span::FileId;
 
 use super::body_identity::{
@@ -402,9 +402,9 @@ where
                 .is_some_and(|symbol| self.rir.rir_interner().resolve(symbol) == "type"),
             is_extern: *is_extern,
             is_c_export: *is_c_export,
-            allow_unused_function: self.has_allow(dirs.iter(), "unused_function"),
-            allow_unused_variable: self.has_allow(dirs.iter(), "unused_variable"),
-            allow_unreachable_code: self.has_allow(dirs.iter(), "unreachable_code"),
+            allow_unused_function: self.has_allow(dirs.iter(), WarningName::UnusedFunction),
+            allow_unused_variable: self.has_allow(dirs.iter(), WarningName::UnusedVariable),
+            allow_unreachable_code: self.has_allow(dirs.iter(), WarningName::UnreachableCode),
             file_id: inst.span.file_id,
         })
     }
@@ -435,14 +435,9 @@ where
     /// interner (the driver holds no analyzer state).
     fn has_allow<'r>(
         &self,
-        mut directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
-        warning_name: &str,
+        directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
+        warning: WarningName,
     ) -> bool {
-        let allow_sym = self.rir.rir_interner().get("allow");
-        let warning_sym = self.rir.rir_interner().get(warning_name);
-        directives.any(|directive| {
-            Some(directive.name) == allow_sym
-                && directive.args.iter().any(|arg| Some(*arg) == warning_sym)
-        })
+        rue_rir::directives_allow(self.rir.rir_interner(), directives, warning)
     }
 }

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -15,7 +15,7 @@ use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeatures};
 use rue_rir::{
     InstData, InstRef, Rir, RirParam, RirParamMode, RirTypeSyntaxBuilder, RirTypeSyntaxRef,
-    SymbolHandle,
+    SymbolHandle, WarningName,
 };
 use rue_span::{FileId, Span};
 use rue_target::Target;
@@ -5947,23 +5947,15 @@ where
                 };
                 let (return_type, body, directives) = (*return_type, *body, directives.clone());
                 let body_span = host.rir.rir().get(body).span;
-                let allow = |warning_name: &str| {
-                    let allow_symbol = host.rir.rir_interner().get("allow");
-                    let warning_symbol = host.rir.rir_interner().get(warning_name);
-                    host.rir
-                        .rir()
-                        .directives(&directives)
-                        .iter()
-                        .any(|directive| {
-                            Some(directive.name) == allow_symbol
-                                && directive
-                                    .args
-                                    .iter()
-                                    .any(|arg| Some(*arg) == warning_symbol)
-                        })
+                let allow = |warning| {
+                    rue_rir::directives_allow(
+                        host.rir.rir_interner(),
+                        host.rir.rir().directives(&directives).iter(),
+                        warning,
+                    )
                 };
-                let allow_unused_variable = allow("unused_variable");
-                let allow_unreachable_code = allow("unreachable_code");
+                let allow_unused_variable = allow(WarningName::UnusedVariable);
+                let allow_unreachable_code = allow(WarningName::UnreachableCode);
                 let return_type = host.resolve_body_type(return_type, declaration_span)?;
                 host.endpoint
                     .finalize_containment_metadata()

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -693,14 +693,14 @@ fn directive_records<'a>(
         let children = directive
             .args
             .iter()
-            .map(|arg| match arg {
-                rue_parser::DirectiveArg::Ident(ident) => syntax_record(
+            .map(|arg| {
+                syntax_record(
                     "directive_argument",
-                    ident.span,
-                    Some(resolved_ident(owner, *ident)),
+                    arg.ident.span,
+                    Some(resolved_ident(owner, arg.ident)),
                     None,
                     Vec::new(),
-                ),
+                )
             })
             .collect();
         syntax_record(

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -1811,7 +1811,9 @@ mod tests {
     fn canonical_merge_interning_exhaustion_is_a_resource_diagnostic() {
         // The bound is injected into the session-owned revision symbol space,
         // so canonical materialization and its worker queries observe it
-        // without process- or thread-local mutation.
+        // without process- or thread-local mutation. The limit is chosen just
+        // below what merging these two files needs, so it tracks the number of
+        // symbols the frontend interns for them.
         let snapshot = snapshot(
             &[
                 (1, "/first.rue", "first.rue", "fn first() {}"),
@@ -1819,7 +1821,7 @@ mod tests {
             ],
             1,
         );
-        let mut session = crate::CompilerSession::with_interner_limit(20);
+        let mut session = crate::CompilerSession::with_interner_limit(17);
         session.update(&snapshot).into_result().unwrap();
         let errors = session.canonical_rir().unwrap_err();
         assert!(

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -524,19 +524,15 @@ pub(crate) fn project_semantic_signature(
             Ok(ParsedSemanticSignature::Struct {
                 syntax: syntax.finish(),
                 fields: fields.into(),
-                is_copy: structure
+                is_copy: rue_parser::ast::has_directive(
+                    &structure.directives,
+                    rue_parser::DirectiveName::Copy,
+                ),
+                is_linear: structure.is_linear,
+                is_repr_c: structure
                     .directives
                     .iter()
-                    .any(|directive| resolve(directive.name.name) == "copy"),
-                is_linear: structure.is_linear,
-                is_repr_c: structure.directives.iter().any(|directive| {
-                    resolve(directive.name.name) == "repr"
-                        && directive.args.iter().any(|argument| match argument {
-                            rue_parser::ast::DirectiveArg::Ident(argument) => {
-                                resolve(argument.name) == "c"
-                            }
-                        })
-                }),
+                    .any(|directive| directive.repr_arg() == Some(rue_parser::ReprArg::C)),
             })
         }
         ParsedDeclarationAstRef::Enum(value) => {
@@ -572,21 +568,21 @@ pub(crate) fn project_semantic_signature(
                 syntax: syntax.finish(),
                 variants: variants.into(),
                 payloads: payloads.into(),
-                is_non_exhaustive: value
-                    .directives
-                    .iter()
-                    .any(|directive| resolve(directive.name.name) == "non_exhaustive"),
+                is_non_exhaustive: rue_parser::ast::has_directive(
+                    &value.directives,
+                    rue_parser::DirectiveName::NonExhaustive,
+                ),
                 is_public: value.visibility == rue_parser::ast::Visibility::Public,
-                non_exhaustive_range: value
-                    .directives
-                    .iter()
-                    .find(|directive| resolve(directive.name.name) == "non_exhaustive")
-                    .and_then(|directive| {
-                        Some((
-                            directive.span.start.checked_sub(value.span.start)?,
-                            directive.span.end.checked_sub(value.span.start)?,
-                        ))
-                    }),
+                non_exhaustive_range: rue_parser::ast::find_directive(
+                    &value.directives,
+                    rue_parser::DirectiveName::NonExhaustive,
+                )
+                .and_then(|directive| {
+                    Some((
+                        directive.span.start.checked_sub(value.span.start)?,
+                        directive.span.end.checked_sub(value.span.start)?,
+                    ))
+                }),
             })
         }
         // A test's signature is fixed by the grammar: no parameters, no

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -2840,14 +2840,10 @@ fn rooted_unused_function_warnings(
         let Some(function) = functions.get(&locator.declaration_span).copied() else {
             continue;
         };
-        let allows_unused = function.directives.iter().any(|directive| {
-            module.resolve_raw_symbol(directive.name.name) == "allow"
-                && directive.args.iter().any(|argument| match argument {
-                    rue_parser::ast::DirectiveArg::Ident(argument) => {
-                        module.resolve_raw_symbol(argument.name) == "unused_function"
-                    }
-                })
-        });
+        let allows_unused = rue_parser::ast::directives_allow(
+            &function.directives,
+            rue_parser::WarningName::UnusedFunction,
+        );
         if allows_unused {
             continue;
         }
@@ -3152,11 +3148,11 @@ fn semantic_nucleus_failure_diagnostics(
             rue_parser::ast::Item::Struct(structure)
                 if module.resolve_raw_symbol(structure.name.name) == type_name =>
             {
-                structure
-                    .directives
-                    .iter()
-                    .find(|directive| module.resolve_raw_symbol(directive.name.name) == "copy")
-                    .map(|directive| directive.span)
+                rue_parser::ast::find_directive(
+                    &structure.directives,
+                    rue_parser::DirectiveName::Copy,
+                )
+                .map(|directive| directive.span)
             }
             _ => None,
         });

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -84,9 +84,7 @@ impl Shapes<'_> {
             node(
                 "directive",
                 "",
-                list(d.args.iter().map(|arg| match arg {
-                    DirectiveArg::Ident(_) => self.ident(),
-                })),
+                list(d.args.iter().map(|_| self.ident())),
                 "_".into(),
                 "_".into(),
                 "_".into(),

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -26,6 +26,7 @@
 
 use std::fmt;
 
+use crate::directives::{DirectiveArgValue, DirectiveName, ReprArg, WarningName};
 use lasso::{Key, Spur};
 use rue_span::{FileId, Span};
 use smallvec::SmallVec;
@@ -62,17 +63,66 @@ impl Ast {
 pub struct Directive {
     /// The directive name (without the @)
     pub name: Ident,
+    /// `name` classified against the directive vocabulary
+    /// ([`crate::directives`]), or `None` for a name the language does not
+    /// define. The parser classifies once so no consumer re-spells a directive
+    /// name; post-parse validation reports the `None` case.
+    pub kind: Option<DirectiveName>,
     /// Arguments to the directive
     pub args: Vec<DirectiveArg>,
     /// Span covering the entire directive
     pub span: Span,
 }
 
-/// An argument to a directive.
+impl Directive {
+    /// True when this is `@allow(<warning>)`.
+    pub fn allows(&self, warning: WarningName) -> bool {
+        self.kind == Some(DirectiveName::Allow)
+            && self
+                .args
+                .iter()
+                .any(|arg| arg.value == DirectiveArgValue::Warning(warning))
+    }
+
+    /// The representation this `@repr(<argument>)` guarantees, when the
+    /// directive is a well-formed `@repr`.
+    pub fn repr_arg(&self) -> Option<ReprArg> {
+        if self.kind != Some(DirectiveName::Repr) {
+            return None;
+        }
+        self.args.iter().find_map(|arg| match arg.value {
+            DirectiveArgValue::Repr(repr) => Some(repr),
+            DirectiveArgValue::Warning(_) | DirectiveArgValue::Unrecognized => None,
+        })
+    }
+}
+
+/// An argument to a directive: the source identifier and its classification
+/// against the owning directive's argument vocabulary.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DirectiveArg {
-    /// An identifier argument (e.g., `unused_variable` in `@allow(unused_variable)`)
-    Ident(Ident),
+pub struct DirectiveArg {
+    /// The identifier as written (e.g., `unused_variable` in
+    /// `@allow(unused_variable)`)
+    pub ident: Ident,
+    /// What the identifier denotes for the owning directive.
+    pub value: DirectiveArgValue,
+}
+
+/// The first directive in `directives` with the given name.
+pub fn find_directive(directives: &[Directive], name: DirectiveName) -> Option<&Directive> {
+    directives
+        .iter()
+        .find(|directive| directive.kind == Some(name))
+}
+
+/// True when `directives` carries the given directive.
+pub fn has_directive(directives: &[Directive], name: DirectiveName) -> bool {
+    find_directive(directives, name).is_some()
+}
+
+/// True when `directives` carries `@allow(<warning>)`.
+pub fn directives_allow(directives: &[Directive], warning: WarningName) -> bool {
+    directives.iter().any(|directive| directive.allows(warning))
 }
 
 /// A top-level item in a source file.
@@ -1584,9 +1634,7 @@ fn rebind_directives(directives: &mut Directives, file_id: FileId) {
     for directive in directives {
         rebind_ident(&mut directive.name, file_id);
         for argument in &mut directive.args {
-            match argument {
-                DirectiveArg::Ident(ident) => rebind_ident(ident, file_id),
-            }
+            rebind_ident(&mut argument.ident, file_id);
         }
         rebind_span(&mut directive.span, file_id);
     }

--- a/crates/rue-parser/src/directives.rs
+++ b/crates/rue-parser/src/directives.rs
@@ -1,0 +1,377 @@
+//! The directive vocabulary: the names Rue defines for `@`-directives, the
+//! arguments each accepts, and the sites each is honored at (spec 2.5).
+//!
+//! This module is the single owner of directive spellings. The parser
+//! classifies every `@name(args)` against it once, while building the AST, and
+//! records the result in [`crate::ast::Directive::kind`] and
+//! [`crate::ast::DirectiveArg::value`]. Post-parse validation, RIR lowering,
+//! semantic analysis and the compiler session read that typed value instead of
+//! re-spelling the name, so a directive or warning name appears as a string
+//! exactly once in the compiler.
+//!
+//! Adding a name is one entry in the [`vocabulary!`] list below. The site and
+//! arity tables are exhaustive matches over the enum, so the new entry does not
+//! compile until it declares where it is accepted, where it is honored, and how
+//! many arguments it takes.
+
+use std::fmt;
+
+/// Declares one closed vocabulary: the variants, their source spellings, the
+/// full list and the spelling lookup are generated from a single table, so no
+/// half of the mapping can drift from another.
+macro_rules! vocabulary {
+    (
+        $(#[$enum_meta:meta])*
+        $name:ident {
+            $( $(#[$variant_meta:meta])* $variant:ident = $spelling:literal, )+
+        }
+    ) => {
+        $(#[$enum_meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum $name {
+            $( $(#[$variant_meta])* $variant, )+
+        }
+
+        impl $name {
+            /// Every spelling the language defines, in specification order.
+            pub const ALL: &'static [Self] = &[ $( Self::$variant, )+ ];
+
+            /// The source spelling of this name.
+            pub const fn as_str(self) -> &'static str {
+                match self {
+                    $( Self::$variant => $spelling, )+
+                }
+            }
+
+            /// The name a source spelling denotes, or `None` when the language
+            /// defines no such name.
+            pub fn from_source(text: &str) -> Option<Self> {
+                match text {
+                    $( $spelling => Some(Self::$variant), )+
+                    _ => None,
+                }
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+    };
+}
+
+vocabulary! {
+    /// A directive name: the builtin that modifies the item or statement it
+    /// precedes (spec 2.5:8).
+    DirectiveName {
+        /// `@allow(<warning>, ...)` suppresses warnings (spec 2.5:11).
+        Allow = "allow",
+        /// `@copy` marks a struct a Copy type (spec 2.5:27).
+        Copy = "copy",
+        /// `@repr(<argument>)` is the representation guarantee marker
+        /// (spec 2.5:33, ADR-0064 Amendment 1).
+        Repr = "repr",
+        /// `@non_exhaustive` opts a public enum into the source compatibility
+        /// contract for matches in importing modules.
+        NonExhaustive = "non_exhaustive",
+    }
+}
+
+vocabulary! {
+    /// A warning name `@allow` accepts (spec 2.5:13).
+    WarningName {
+        /// A binding is declared but never used.
+        UnusedVariable = "unused_variable",
+        /// A function is declared but never called.
+        UnusedFunction = "unused_function",
+        /// Code that cannot be reached.
+        UnreachableCode = "unreachable_code",
+    }
+}
+
+vocabulary! {
+    /// A representation argument `@repr` accepts (spec 2.5:34).
+    ReprArg {
+        /// The selected target's default C data model.
+        C = "c",
+    }
+}
+
+/// The syntactic construct a directive is attached to.
+///
+/// A `test "name" { .. }` declaration (ADR-0083 §1) accepts exactly the
+/// directives a function accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DirectiveSite {
+    Function,
+    Struct,
+    Enum,
+    Method,
+    Const,
+    Let,
+    Test,
+}
+
+impl DirectiveSite {
+    /// The plural noun a diagnostic names this site with.
+    pub const fn description(self) -> &'static str {
+        match self {
+            DirectiveSite::Function => "functions",
+            DirectiveSite::Struct => "structs",
+            DirectiveSite::Enum => "enums",
+            DirectiveSite::Method => "methods",
+            DirectiveSite::Const => "const declarations",
+            DirectiveSite::Let => "let statements",
+            DirectiveSite::Test => "test declarations",
+        }
+    }
+}
+
+/// How many arguments a directive takes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectiveArity {
+    /// No arguments; any argument is an arity error.
+    None,
+    /// Exactly one argument drawn from the directive's argument vocabulary.
+    ExactlyOne,
+    /// Any number of arguments, each drawn from the directive's vocabulary.
+    Any,
+}
+
+/// A directive argument classified against the vocabulary its directive
+/// accepts.
+///
+/// `Unrecognized` covers a spelling outside that vocabulary, an argument on a
+/// directive that takes none, and every argument of an unknown directive.
+/// Post-parse validation reports each of those.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectiveArgValue {
+    Warning(WarningName),
+    Repr(ReprArg),
+    Unrecognized,
+}
+
+impl DirectiveName {
+    /// The sites this directive may be attached to (spec 2.5). Attaching it
+    /// anywhere else is a compile-time error.
+    pub const fn allowed_sites(self) -> &'static [DirectiveSite] {
+        match self {
+            // `@allow` scopes to a body (spec 2.5:17, 2.5:19, 2.5:21) or to a
+            // single binding (spec 2.5:15).
+            DirectiveName::Allow => &[
+                DirectiveSite::Function,
+                DirectiveSite::Method,
+                DirectiveSite::Test,
+                DirectiveSite::Let,
+            ],
+            // spec 2.5:28
+            DirectiveName::Copy => &[DirectiveSite::Struct],
+            // spec 2.5:34
+            DirectiveName::Repr => &[DirectiveSite::Struct],
+            DirectiveName::NonExhaustive => &[DirectiveSite::Enum],
+        }
+    }
+
+    /// The number of arguments this directive takes (spec 2.5).
+    pub const fn arity(self) -> DirectiveArity {
+        match self {
+            // spec 2.5:12 and 2.5:23: one or more warning names.
+            DirectiveName::Allow => DirectiveArity::Any,
+            // spec 2.5:29
+            DirectiveName::Copy => DirectiveArity::None,
+            // spec 2.5:34: parameterized, exactly one representation argument.
+            DirectiveName::Repr => DirectiveArity::ExactlyOne,
+            DirectiveName::NonExhaustive => DirectiveArity::None,
+        }
+    }
+
+    /// True when this directive may be attached to `site`.
+    pub fn accepts_site(self, site: DirectiveSite) -> bool {
+        self.allowed_sites().contains(&site)
+    }
+
+    /// Classify one argument identifier against this directive's argument
+    /// vocabulary.
+    pub fn classify_arg(self, text: &str) -> DirectiveArgValue {
+        match self {
+            DirectiveName::Allow => WarningName::from_source(text)
+                .map_or(DirectiveArgValue::Unrecognized, DirectiveArgValue::Warning),
+            DirectiveName::Repr => ReprArg::from_source(text)
+                .map_or(DirectiveArgValue::Unrecognized, DirectiveArgValue::Repr),
+            DirectiveName::Copy | DirectiveName::NonExhaustive => DirectiveArgValue::Unrecognized,
+        }
+    }
+}
+
+impl WarningName {
+    /// The sites at which `@allow(<this warning>)` changes what the compiler
+    /// reports (spec 2.5:15, 2.5:17, 2.5:19, 2.5:21, 2.5:40).
+    ///
+    /// A warning named at a site outside this set would be accepted and then
+    /// ignored — the failure mode directive validation exists to prevent — so
+    /// it is a compile-time error instead.
+    pub const fn allowed_sites(self) -> &'static [DirectiveSite] {
+        match self {
+            // Honored for one binding (spec 2.5:15) and for every binding in a
+            // body (spec 2.5:17).
+            WarningName::UnusedVariable => &[
+                DirectiveSite::Function,
+                DirectiveSite::Method,
+                DirectiveSite::Test,
+                DirectiveSite::Let,
+            ],
+            // The warning is about a declaration, so only a declaration can
+            // allow it (spec 2.5:19).
+            WarningName::UnusedFunction => &[
+                DirectiveSite::Function,
+                DirectiveSite::Method,
+                DirectiveSite::Test,
+            ],
+            // Reachability is a property of a body, not of one binding
+            // (spec 2.5:21).
+            WarningName::UnreachableCode => &[
+                DirectiveSite::Function,
+                DirectiveSite::Method,
+                DirectiveSite::Test,
+            ],
+        }
+    }
+
+    /// True when `@allow(<this warning>)` is honored at `site`.
+    pub fn honored_at(self, site: DirectiveSite) -> bool {
+        self.allowed_sites().contains(&site)
+    }
+}
+
+/// `@allow, @copy, @repr, and @non_exhaustive` — the directive vocabulary as a
+/// diagnostic list.
+pub fn directive_name_list() -> String {
+    oxford_list(
+        &DirectiveName::ALL
+            .iter()
+            .map(|name| format!("@{name}"))
+            .collect::<Vec<_>>(),
+    )
+}
+
+/// `unused_variable, unused_function, unreachable_code` — the warning
+/// vocabulary as a diagnostic list.
+pub fn warning_name_list() -> String {
+    joined(WarningName::ALL.iter().map(|name| name.as_str()))
+}
+
+/// `c` — the `@repr` argument vocabulary as a diagnostic list.
+pub fn repr_arg_list() -> String {
+    joined(ReprArg::ALL.iter().map(|arg| arg.as_str()))
+}
+
+/// `functions, methods, and test declarations` — a site set as a diagnostic
+/// list.
+pub fn site_list(sites: &[DirectiveSite]) -> String {
+    oxford_list(
+        &sites
+            .iter()
+            .map(|site| site.description().to_string())
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn joined<'a>(items: impl Iterator<Item = &'a str>) -> String {
+    items.collect::<Vec<_>>().join(", ")
+}
+
+/// Join with commas and a trailing `and`, the phrasing the placement and
+/// unknown-name diagnostics read with.
+fn oxford_list(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [only] => only.clone(),
+        [first, second] => format!("{first} and {second}"),
+        [rest @ .., last] => format!("{}, and {last}", rest.join(", ")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_spelling_round_trips() {
+        for name in DirectiveName::ALL {
+            assert_eq!(DirectiveName::from_source(name.as_str()), Some(*name));
+        }
+        for name in WarningName::ALL {
+            assert_eq!(WarningName::from_source(name.as_str()), Some(*name));
+        }
+        for arg in ReprArg::ALL {
+            assert_eq!(ReprArg::from_source(arg.as_str()), Some(*arg));
+        }
+    }
+
+    #[test]
+    fn unknown_spellings_classify_as_none() {
+        assert_eq!(DirectiveName::from_source("alllow"), None);
+        assert_eq!(WarningName::from_source("unused_variabl"), None);
+        assert_eq!(ReprArg::from_source("packed"), None);
+    }
+
+    #[test]
+    fn diagnostic_lists_read_as_prose() {
+        assert_eq!(
+            directive_name_list(),
+            "@allow, @copy, @repr, and @non_exhaustive"
+        );
+        assert_eq!(
+            warning_name_list(),
+            "unused_variable, unused_function, unreachable_code"
+        );
+        assert_eq!(repr_arg_list(), "c");
+        assert_eq!(site_list(&[DirectiveSite::Struct]), "structs");
+        assert_eq!(
+            site_list(WarningName::UnreachableCode.allowed_sites()),
+            "functions, methods, and test declarations"
+        );
+    }
+
+    #[test]
+    fn a_warning_is_honored_only_where_its_directive_is_accepted() {
+        for warning in WarningName::ALL {
+            for site in warning.allowed_sites() {
+                assert!(
+                    DirectiveName::Allow.accepts_site(*site),
+                    "{warning} is honored at a site @allow may not be attached to"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn only_unused_variable_is_honored_on_a_let() {
+        let honored: Vec<_> = WarningName::ALL
+            .iter()
+            .filter(|warning| warning.honored_at(DirectiveSite::Let))
+            .collect();
+        assert_eq!(honored, vec![&WarningName::UnusedVariable]);
+    }
+
+    #[test]
+    fn argument_vocabularies_follow_the_directive() {
+        assert_eq!(
+            DirectiveName::Allow.classify_arg("unreachable_code"),
+            DirectiveArgValue::Warning(WarningName::UnreachableCode)
+        );
+        assert_eq!(
+            DirectiveName::Repr.classify_arg("c"),
+            DirectiveArgValue::Repr(ReprArg::C)
+        );
+        assert_eq!(
+            DirectiveName::Repr.classify_arg("unreachable_code"),
+            DirectiveArgValue::Unrecognized
+        );
+        assert_eq!(
+            DirectiveName::Copy.classify_arg("c"),
+            DirectiveArgValue::Unrecognized
+        );
+    }
+}

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -1,12 +1,11 @@
 //! Parser and AST for the Rue programming language.
 
 pub mod ast;
+pub mod directives;
 pub mod intrinsics;
 mod parser;
 mod parser_policy;
 mod validate;
-
-pub use validate::KNOWN_DIRECTIVES;
 
 /// Maximum number of detailed parser diagnostics retained for one source file.
 /// If more unique grammar-recovery or post-parse validation diagnostics are
@@ -16,6 +15,10 @@ pub use validate::KNOWN_DIRECTIVES;
 /// The budget is local to each [`Parser`] invocation. The preceding lexer phase
 /// uses its own independent per-file diagnostic budget.
 pub const PARSER_DIAGNOSTIC_BUDGET: usize = 100;
+
+pub use directives::{
+    DirectiveArgValue, DirectiveArity, DirectiveName, DirectiveSite, ReprArg, WarningName,
+};
 
 pub use ast::{
     ArgMode,

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -3,6 +3,7 @@
 //! Cohesive grammar domains live in the sibling modules under `parser/`.
 
 use crate::ast::*;
+use crate::directives::{DirectiveArgValue, DirectiveName};
 use crate::parser_policy::{condition, diagnostics, nesting, recovery};
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileErrors, ErrorKind, MultiErrorResult};
@@ -48,9 +49,6 @@ struct PrimitiveTypeSpurs {
     underscore: Spur,
     drop_kw: Spur,
     drop_marker: Spur,
-    allow_directive: Spur,
-    copy_directive: Spur,
-    repr_directive: Spur,
 }
 
 impl PrimitiveTypeSpurs {
@@ -84,9 +82,6 @@ impl PrimitiveTypeSpurs {
             test_kw: intern("test")?,
             drop_kw: intern("drop")?,
             drop_marker: intern("__drop")?,
-            allow_directive: intern("allow")?,
-            copy_directive: intern("copy")?,
-            repr_directive: intern("repr")?,
             underscore: intern("_")?,
         })
     }
@@ -110,9 +105,6 @@ impl PrimitiveTypeSpurs {
             test_kw: symbol,
             drop_kw: symbol,
             drop_marker: symbol,
-            allow_directive: symbol,
-            copy_directive: symbol,
-            repr_directive: symbol,
             underscore: symbol,
         }
     }
@@ -705,7 +697,14 @@ mod tests {
         }
         assert_eq!(
             modules(include_str!("lib.rs")),
-            ["ast", "intrinsics", "parser", "parser_policy", "validate"]
+            [
+                "ast",
+                "directives",
+                "intrinsics",
+                "parser",
+                "parser_policy",
+                "validate"
+            ]
         );
         assert_eq!(
             modules(include_str!("parser.rs")),
@@ -824,16 +823,23 @@ mod tests {
 
     #[test]
     fn multiple_directives_before_let_parse_as_one_statement() {
+        // Each directive keeps its own argument list, and a run of directives
+        // attaches to the one construct that follows. The warning names are
+        // chosen for the site that honors them (spec 2.5:40); the grammar fact
+        // under test is the grouping, not the vocabulary.
         let (ast, _) = parse_source(
-            "fn main() -> i32 { \
-             @allow(unused_variable, unreachable_code) \
-             @allow(unused_function) \
+            "@allow(unused_variable, unreachable_code) \
+             fn main() -> i32 { \
+             @allow(unused_variable) \
+             @allow(unused_variable) \
              let x = 1; x }",
         )
         .unwrap();
         let Item::Function(function) = &ast.items[0] else {
             panic!("expected function");
         };
+        assert_eq!(function.directives.len(), 1);
+        assert_eq!(function.directives[0].args.len(), 2);
         let Expr::Block(body) = &function.body else {
             panic!("expected block body");
         };
@@ -841,7 +847,7 @@ mod tests {
             panic!("expected directed let statement");
         };
         assert_eq!(statement.directives().len(), 2);
-        assert_eq!(statement.directives()[0].args.len(), 2);
+        assert_eq!(statement.directives()[0].args.len(), 1);
         assert_eq!(statement.directives()[1].args.len(), 1);
     }
 

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -8,15 +8,25 @@ impl Parser {
         while self.at(TokenKind::At) {
             let start = self.bump().span.start;
             let name = self.ident()?;
+            // Classify against the directive vocabulary once, here, so every
+            // later consumer reads a typed value instead of re-spelling the
+            // name (`crate::directives`). An unknown name stays `None` and is
+            // reported by post-parse validation.
+            let kind = DirectiveName::from_source(self.interner.resolve(&name.name));
             let mut args = Vec::new();
             if self.eat(TokenKind::LParen) {
                 args = self.comma_separated(TokenKind::RParen, |parser| {
-                    parser.ident().map(DirectiveArg::Ident)
+                    let ident = parser.ident()?;
+                    let value = kind.map_or(DirectiveArgValue::Unrecognized, |kind| {
+                        kind.classify_arg(parser.interner.resolve(&ident.name))
+                    });
+                    Ok(DirectiveArg { ident, value })
                 })?;
                 self.expect(TokenKind::RParen)?;
             }
             out.push(Directive {
                 name,
+                kind,
                 args,
                 span: self.span_from(start),
             });

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -596,10 +596,11 @@ impl Parser {
             }
         }
         self.expect(TokenKind::RParen)?;
-        if name.name == self.syms.allow_directive
-            || name.name == self.syms.copy_directive
-            || name.name == self.syms.repr_directive
-        {
+        // Every directive name is rejected here, driven by the same
+        // vocabulary the validator uses (`crate::directives`), so a directive
+        // written in expression position reports its placement rather than
+        // reaching sema as an unknown intrinsic.
+        if DirectiveName::from_source(self.interner.resolve(&name.name)).is_some() {
             self.error_at("directive must precede a statement", self.span_from(start));
             return Err(());
         }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -8,44 +8,23 @@
 //! accepted and ignored, turning typos like `@alllow(...)` into no-ops.
 //! Unknown directives are now a compile error naming the directive. (RUE-133)
 //!
+//! Every name and site rule this module enforces comes from
+//! [`crate::directives`], the vocabulary the parser already classified each
+//! directive against; nothing here re-spells a directive or warning name.
+//!
 //! Note this covers *directive* position only (before items and `let`
 //! statements). Expression-position `@name(...)` intrinsics (`@dbg`,
 //! `@syscall`, `@intCast`, ...) are validated by sema, which already rejects
 //! unknown intrinsics.
 
 use crate::ast::{Ast, Directive, Expr, IntrinsicArg, Item, Method, Statement, TypeExpr};
+use crate::directives::{
+    DirectiveArgValue, DirectiveArity, DirectiveName, DirectiveSite, ReprArg, directive_name_list,
+    repr_arg_list, site_list, warning_name_list,
+};
 use crate::parser_policy::diagnostics::ParserDiagnostics;
 use lasso::ThreadedRodeo;
 use rue_error::{CompileError, ErrorKind};
-
-/// Directive names the compiler understands.
-///
-/// This is the single source of truth for *directive* (item/statement
-/// position) names; keep it in sync with the consumers in sema:
-/// - `allow`  — suppresses lints, e.g. `@allow(unused_variable)` on `let`
-///   (see `has_allow_directive` in rue-air)
-/// - `copy`   — marks a struct as a copy type (see `has_copy_directive`)
-/// - `repr`   — the C representation guarantee marker `@repr(c)` on a struct
-///   (ADR-0064 Amendment 1; see `has_repr_c_directive` in rue-air)
-/// - `non_exhaustive` — opts a public enum into the source/API compatibility
-///   contract for matches in importing modules.
-pub const KNOWN_DIRECTIVES: &[&str] = &["allow", "copy", "repr", "non_exhaustive"];
-
-/// Representation arguments accepted by `@repr(...)`.
-///
-/// Only `c` is accepted in v0 (ADR-0064 Amendment 1). The parameterized grammar
-/// stays open for future `@repr(packed)` / `@repr(align(n))`; parsing validates
-/// the argument so `@repr(packed)` fails loudly with the accepted set named,
-/// rather than being silently ignored.
-pub const KNOWN_REPR_ARGS: &[&str] = &["c"];
-
-/// Warning names accepted by `@allow(...)`.
-///
-/// Parsing validates spelling so typos like `@allow(unused_variabl)` fail
-/// loudly; sema consumes these names when emitting and suppressing warnings
-/// (RUE-356).
-pub const KNOWN_WARNING_NAMES: &[&str] =
-    &["unused_variable", "unused_function", "unreachable_code"];
 
 /// Walk the AST and report directive-validation diagnostics through the same
 /// bounded per-file policy as grammar recovery.
@@ -65,154 +44,129 @@ struct Validator<'a> {
     errors: ParserDiagnostics,
 }
 
-#[derive(Clone, Copy)]
-enum DirectiveSite {
-    Function,
-    Struct,
-    Enum,
-    Method,
-    Const,
-    Let,
-    /// A `test "name" { .. }` declaration (ADR-0083 §1). Accepts exactly the
-    /// directives a function accepts.
-    Test,
-}
-
-impl DirectiveSite {
-    fn description(self) -> &'static str {
-        match self {
-            DirectiveSite::Function => "functions",
-            DirectiveSite::Struct => "structs",
-            DirectiveSite::Enum => "enums",
-            DirectiveSite::Method => "methods",
-            DirectiveSite::Const => "const declarations",
-            DirectiveSite::Let => "let statements",
-            DirectiveSite::Test => "test declarations",
-        }
-    }
-}
-
 impl Validator<'_> {
     fn check_directives(&mut self, directives: &[Directive], site: DirectiveSite) {
         for directive in directives {
-            let name = self.interner.resolve(&directive.name.name);
-            if !KNOWN_DIRECTIVES.contains(&name) {
+            let Some(kind) = directive.kind else {
                 self.errors.push(CompileError::new(
                     ErrorKind::ParseError(format!(
-                        "unknown directive '@{}'; known directives are @allow, @copy, @repr, and @non_exhaustive",
-                        name
+                        "unknown directive '@{}'; known directives are {}",
+                        self.interner.resolve(&directive.name.name),
+                        directive_name_list()
                     )),
                     directive.span,
                 ));
                 continue;
+            };
+
+            let placed = kind.accepts_site(site);
+            if !placed {
+                self.errors.push(CompileError::new(
+                    ErrorKind::ParseError(format!(
+                        "@{kind} can only be applied to {}, not {}",
+                        site_list(kind.allowed_sites()),
+                        site.description()
+                    )),
+                    directive.span,
+                ));
             }
 
-            match name {
-                "non_exhaustive" => {
-                    if !matches!(site, DirectiveSite::Enum) {
-                        self.errors.push(CompileError::new(
-                            ErrorKind::ParseError(format!(
-                                "@non_exhaustive can only be applied to enums, not {}",
-                                site.description()
-                            )),
-                            directive.span,
-                        ));
-                    } else if !directive.args.is_empty() {
-                        self.errors.push(CompileError::new(
-                            ErrorKind::ParseError("@non_exhaustive takes no arguments".to_string()),
-                            directive.span,
-                        ));
-                    }
-                }
-                "copy" => {
-                    if !matches!(site, DirectiveSite::Struct) {
-                        self.errors.push(CompileError::new(
-                            ErrorKind::ParseError(format!(
-                                "@copy can only be applied to structs, not {}",
-                                site.description()
-                            )),
-                            directive.span,
-                        ));
-                    } else if !directive.args.is_empty() {
-                        // Arity is per-directive: @copy takes no arguments
-                        // (spec 2.5), while @allow legitimately takes lint names.
-                        self.errors.push(CompileError::new(
-                            ErrorKind::ParseError("@copy takes no arguments".to_string()),
-                            directive.span,
-                        ));
-                    }
-                }
-                "repr" => {
-                    // `@repr(c)` is the C representation guarantee marker
-                    // (ADR-0064 Amendment 1). It applies only to structs, and
-                    // is parameterized: exactly one argument, `c` in v0. Unknown
-                    // arguments (e.g. `@repr(packed)`) fail loudly here naming
-                    // the accepted set, leaving the grammar open for future
-                    // packed/align representations.
-                    if !matches!(site, DirectiveSite::Struct) {
-                        self.errors.push(CompileError::new(
-                            ErrorKind::ParseError(format!(
-                                "@repr can only be applied to structs, not {}",
-                                site.description()
-                            )),
-                            directive.span,
-                        ));
-                    } else if directive.args.len() != 1 {
-                        self.errors.push(CompileError::new(
-                            ErrorKind::ParseError(format!(
-                                "@repr takes exactly one representation argument; \
-                                 accepted arguments are {}",
-                                KNOWN_REPR_ARGS.join(", ")
-                            )),
-                            directive.span,
-                        ));
-                    } else {
-                        let crate::ast::DirectiveArg::Ident(ident) = &directive.args[0];
-                        let arg = self.interner.resolve(&ident.name);
-                        if !KNOWN_REPR_ARGS.contains(&arg) {
+            // Arity and argument vocabulary are per-directive: `@copy` takes no
+            // arguments (spec 2.5:29) while `@allow` legitimately takes warning
+            // names (spec 2.5:12). A misplaced directive reports its placement
+            // only; its arguments are not the user's next problem.
+            if placed && self.check_arity(directive, kind) {
+                self.check_args(directive, kind, site);
+            }
+        }
+    }
+
+    /// Report a wrong argument count, and answer whether the count is right.
+    /// A wrong count already names what the directive accepts, so the
+    /// arguments themselves are not reported a second time.
+    fn check_arity(&mut self, directive: &Directive, kind: DirectiveName) -> bool {
+        match kind.arity() {
+            DirectiveArity::None if !directive.args.is_empty() => {
+                self.errors.push(CompileError::new(
+                    ErrorKind::ParseError(format!("@{kind} takes no arguments")),
+                    directive.span,
+                ));
+                false
+            }
+            DirectiveArity::ExactlyOne if directive.args.len() != 1 => {
+                self.errors.push(CompileError::new(
+                    ErrorKind::ParseError(format!(
+                        "@{kind} takes exactly one representation argument; \
+                         accepted arguments are {}",
+                        repr_arg_list()
+                    )),
+                    directive.span,
+                ));
+                false
+            }
+            DirectiveArity::None | DirectiveArity::ExactlyOne | DirectiveArity::Any => true,
+        }
+    }
+
+    /// Check each argument against the vocabulary its directive accepts, and —
+    /// for `@allow` — against the sites at which the named warning is actually
+    /// honored. A warning allowed at a site that never consults it would be
+    /// accepted and ignored, which is the failure this validator exists to
+    /// prevent (spec 2.5:40).
+    fn check_args(&mut self, directive: &Directive, kind: DirectiveName, site: DirectiveSite) {
+        match kind {
+            DirectiveName::Allow => {
+                for arg in &directive.args {
+                    match arg.value {
+                        DirectiveArgValue::Warning(warning) if warning.honored_at(site) => {}
+                        DirectiveArgValue::Warning(warning) => {
                             self.errors.push(CompileError::new(
                                 ErrorKind::ParseError(format!(
-                                    "unknown @repr argument '{arg}'; accepted arguments are {}",
-                                    KNOWN_REPR_ARGS.join(", ")
+                                    "@allow({warning}) is not honored on {}; \
+                                     {warning} can be allowed on {}",
+                                    site.description(),
+                                    site_list(warning.allowed_sites())
                                 )),
-                                ident.span,
+                                arg.ident.span,
+                            ));
+                        }
+                        DirectiveArgValue::Repr(_) | DirectiveArgValue::Unrecognized => {
+                            self.errors.push(CompileError::new(
+                                ErrorKind::ParseError(format!(
+                                    "unrecognized warning name '{}' in @allow; \
+                                     known warnings are {}",
+                                    self.interner.resolve(&arg.ident.name),
+                                    warning_name_list()
+                                )),
+                                arg.ident.span,
                             ));
                         }
                     }
                 }
-                "allow" => {
-                    if !matches!(
-                        site,
-                        DirectiveSite::Function
-                            | DirectiveSite::Method
-                            | DirectiveSite::Test
-                            | DirectiveSite::Let
-                    ) {
-                        self.errors.push(CompileError::new(
-                            ErrorKind::ParseError(format!(
-                                "@allow can only be applied to functions, methods, test declarations, or let statements, not {}",
-                                site.description()
-                            )),
-                            directive.span,
-                        ));
-                    }
-
-                    for arg in &directive.args {
-                        let crate::ast::DirectiveArg::Ident(ident) = arg;
-                        let warning = self.interner.resolve(&ident.name);
-                        if !KNOWN_WARNING_NAMES.contains(&warning) {
+            }
+            DirectiveName::Repr => {
+                // The parameterized grammar stays open for future
+                // `@repr(packed)` / `@repr(align(n))`: an unknown argument
+                // fails loudly here naming the accepted set rather than being
+                // silently ignored (ADR-0064 Amendment 1).
+                for arg in &directive.args {
+                    match arg.value {
+                        DirectiveArgValue::Repr(ReprArg::C) => {}
+                        DirectiveArgValue::Warning(_) | DirectiveArgValue::Unrecognized => {
                             self.errors.push(CompileError::new(
                                 ErrorKind::ParseError(format!(
-                                    "unrecognized warning name '{warning}' in @allow; known warnings are {}",
-                                    KNOWN_WARNING_NAMES.join(", ")
+                                    "unknown @repr argument '{}'; accepted arguments are {}",
+                                    self.interner.resolve(&arg.ident.name),
+                                    repr_arg_list()
                                 )),
-                                ident.span,
+                                arg.ident.span,
                             ));
                         }
                     }
                 }
-                _ => unreachable!("known directive list and validator are out of sync"),
             }
+            // Arity already rejected any argument these carry.
+            DirectiveName::Copy | DirectiveName::NonExhaustive => {}
         }
     }
 
@@ -231,9 +185,8 @@ impl Validator<'_> {
             Item::Enum(e) => {
                 self.check_directives(&e.directives, DirectiveSite::Enum);
                 if e.visibility != crate::ast::Visibility::Public
-                    && let Some(directive) = e.directives.iter().find(|directive| {
-                        self.interner.resolve(&directive.name.name) == "non_exhaustive"
-                    })
+                    && let Some(directive) =
+                        crate::ast::find_directive(&e.directives, DirectiveName::NonExhaustive)
                 {
                     self.errors.push(CompileError::new(
                         ErrorKind::ParseError(

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -23,8 +23,8 @@ use rue_parser::ast::{ConstDecl, DropFn, ExternBlock, ExternFn, TestDecl};
 use rue_parser::intrinsics::{OFFSET_OF_INTRINSIC, TYPE_INTRINSICS};
 use rue_parser::{
     ArgMode, ArrayLength, AssignStatement, AssignTarget, BinaryOp, CallArg, CompoundOp, Directive,
-    DirectiveArg, EnumDecl, Expr, Function, IntrinsicArg, Item, LetPattern, Method, ParamMode,
-    Pattern, Statement, StructDecl, TypeExpr, UnaryOp, ast::Visibility,
+    EnumDecl, Expr, Function, IntrinsicArg, Item, LetPattern, Method, ParamMode, Pattern,
+    Statement, StructDecl, TypeExpr, UnaryOp, ast::Visibility,
 };
 
 use crate::inst::{
@@ -774,9 +774,10 @@ impl<'a> AstGen<'a> {
         self.rir
             .add_enum_decl(
                 enum_decl.visibility == Visibility::Public,
-                enum_decl.directives.iter().any(|directive| {
-                    self.interner.resolve(&directive.name.name) == "non_exhaustive"
-                }),
+                rue_parser::ast::has_directive(
+                    &enum_decl.directives,
+                    rue_parser::DirectiveName::NonExhaustive,
+                ),
                 name,
                 &variants,
                 &payload_types,
@@ -912,9 +913,7 @@ impl<'a> AstGen<'a> {
                 args: d
                     .args
                     .iter()
-                    .map(|arg| match arg {
-                        DirectiveArg::Ident(ident) => self.symbol(ident.name),
-                    })
+                    .map(|arg| self.symbol(arg.ident.name))
                     .collect(),
                 span: d.span,
             })

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -6,10 +6,11 @@
 use std::fmt;
 use std::marker::PhantomData;
 
-use lasso::{Key, Spur};
+use lasso::{Key, Spur, ThreadedRodeo};
 use rue_span::{FileId, Span};
 
 use crate::type_syntax::{RirTypeSyntaxArena, RirTypeSyntaxBuilder, RirTypeSyntaxRef};
+use rue_parser::{DirectiveName, WarningName};
 
 mod payload;
 mod printer;

--- a/crates/rue-rir/src/inst/payload.rs
+++ b/crates/rue-rir/src/inst/payload.rs
@@ -518,6 +518,37 @@ impl RirDirectiveView<'_> {
             span: self.span,
         }
     }
+
+    /// Classify this directive against the directive vocabulary
+    /// (`rue_parser::directives`), the single owner of directive spellings.
+    ///
+    /// The RIR stores directive names and arguments as interned symbols, so
+    /// classification needs the interner that owns them; the vocabulary itself
+    /// is never restated here.
+    pub fn kind(&self, interner: &ThreadedRodeo) -> Option<DirectiveName> {
+        DirectiveName::from_source(interner.resolve(&self.name))
+    }
+
+    /// True when this directive is `@allow(<warning>)`.
+    pub fn allows(&self, interner: &ThreadedRodeo, warning: WarningName) -> bool {
+        self.kind(interner) == Some(DirectiveName::Allow)
+            && self
+                .args
+                .iter()
+                .any(|arg| WarningName::from_source(interner.resolve(&arg)) == Some(warning))
+    }
+}
+
+/// True when a declaration's directives carry `@allow(<warning>)`.
+///
+/// Every consumer that honors a warning suppression asks this one question, so
+/// the "directives contain `@allow(name)`" walk exists once.
+pub fn directives_allow<'r>(
+    interner: &ThreadedRodeo,
+    mut directives: impl Iterator<Item = RirDirectiveView<'r>>,
+    warning: WarningName,
+) -> bool {
+    directives.any(|directive| directive.allows(interner, warning))
 }
 
 /// Extra data marker types for type-safe storage in the extra array.

--- a/crates/rue-rir/src/inst/schema.rs
+++ b/crates/rue-rir/src/inst/schema.rs
@@ -28,12 +28,17 @@ impl PayloadFallback for InstRef {
     }
 }
 
-/// A directive in the RIR (e.g., @allow(unused_variable))
+/// A directive in the RIR (e.g., @allow(unused_variable)).
+///
+/// Names and arguments are stored as interned symbols, like every other name
+/// in the RIR. Consumers classify them with [`RirDirectiveView::kind`] and
+/// [`crate::directives_allow`], which read the one directive vocabulary
+/// (`rue_parser::directives`) rather than restating any spelling.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RirDirective {
-    /// Directive name (e.g., "allow")
+    /// Directive name, interned (e.g., `allow`)
     pub name: Spur,
-    /// Arguments (e.g., ["unused_variable"])
+    /// Arguments, interned (e.g., `unused_variable`)
     pub args: Vec<Spur>,
     /// Span covering the directive
     pub span: Span,

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -46,8 +46,9 @@ pub use inst::{
     RirPatternView, RirPayloadBuildError, RirPayloadError, RirPayloadStorageStats, RirPrinter,
     RirSpanField, RirSpanRemapError, RirSpanSlot, RirSpanTraversalError, RirStructFieldsRange,
     RirStructMethodsRange, RirStructuralAnchor, RirStructuralPathSegment, RirValidationContext,
-    ValidatedRir,
+    ValidatedRir, directives_allow,
 };
+pub use rue_parser::{DirectiveName, ReprArg, WarningName};
 pub use symbol::{SharedSymbolSpace, SymbolHandle, SymbolSpaceGenerations};
 pub use type_syntax::{
     RirTypeSyntaxAppendError, RirTypeSyntaxArena, RirTypeSyntaxBuildError, RirTypeSyntaxBuilder,

--- a/crates/rue-rir/src/type_syntax.rs
+++ b/crates/rue-rir/src/type_syntax.rs
@@ -11,7 +11,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use ahash::AHashMap;
-use rue_parser::ast::{ArrayLength, DirectiveArg, ParamMode, TypeExpr};
+use rue_parser::ast::{ArrayLength, ParamMode, TypeExpr};
 
 /// Dense index of one structured type-syntax node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -807,8 +807,7 @@ impl<S: Clone + Eq + Hash> RirTypeSyntaxBuilder<S> {
                                 .map_err(|_| RirTypeSyntaxBuildError::TooMuchPayload)?,
                         );
                         for argument in &directive.args {
-                            let DirectiveArg::Ident(argument) = argument;
-                            let argument = self.symbol(resolve(argument.name))?;
+                            let argument = self.symbol(resolve(argument.ident.name))?;
                             method_words.push(argument.as_u32());
                         }
                     }

--- a/crates/rue-spec/cases/lexical/builtins.toml
+++ b/crates/rue-spec/cases/lexical/builtins.toml
@@ -189,11 +189,57 @@ exit_code = 0
 no_warnings = true
 
 [[case]]
-name = "allow_multiple_warnings"
-spec = ["2.5:23"]
+name = "allow_unreachable_code_on_let_rejected"
+spec = ["2.5:40"]
 source = """
 fn main() -> i32 {
-    @allow(unused_variable, unreachable_code)
+    return 0;
+    @allow(unreachable_code)
+    let x = 42;
+    x
+}
+"""
+compile_fail = true
+error_contains = "@allow(unreachable_code) is not honored on let statements"
+
+[[case]]
+name = "allow_unused_function_on_let_rejected"
+spec = ["2.5:40"]
+source = """
+fn main() -> i32 {
+    @allow(unused_function)
+    let x = 42;
+    x
+}
+"""
+compile_fail = true
+error_contains = "@allow(unused_function) is not honored on let statements"
+
+[[case]]
+name = "allow_unused_variable_on_let_still_honored"
+spec = ["2.5:40"]
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+    let x = 42;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_multiple_warnings"
+spec = ["2.5:23"]
+description = """
+Both names are listed on the function, the site that honors each of them
+(spec 2.5:40); `unreachable_code` on the `let` names a warning that site never
+consults.
+"""
+source = """
+@allow(unused_variable, unreachable_code)
+fn main() -> i32 {
+    return 0;
     let x = 42;
     0
 }

--- a/crates/rue-ui-tests/cases/diagnostics/directives.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/directives.toml
@@ -2,11 +2,12 @@
 #
 # Unknown @-directives in item/statement position used to be silently
 # accepted and ignored, so a typo like `@alllow(...)` was a no-op. They are
-# now a compile error naming the directive. The known set lives in
-# rue-parser's `validate::KNOWN_DIRECTIVES` (allow, copy, repr, non_exhaustive); the cases
-# below pin both the rejection and that every known directive still works.
-# (Expression-position intrinsics like @dbg/@intCast and the fused @import
-# token are separate mechanisms and unaffected.)
+# now a compile error naming the directive. The vocabulary — directive names,
+# argument names, and the sites each is accepted and honored at — lives in
+# rue-parser's `directives` module (allow, copy, repr, non_exhaustive); the
+# cases below pin both the rejection and that every known directive still
+# works. (Expression-position intrinsics like @dbg/@intCast and the fused
+# @import token are separate mechanisms and unaffected.)
 #
 # This file also covers parameter-modifier validation: `comptime comptime T`
 # used to be silently accepted via a vestigial is_comptime/ParamMode duality.
@@ -127,6 +128,86 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["@copy takes no arguments"]
+
+[[case]]
+name = "allow_unreachable_code_on_let_rejected"
+description = """
+RUE-1971: the validator accepted @allow(<any known warning>) on a let while
+sema honored only unused_variable there, so @allow(unreachable_code) on a let
+was accepted and the warning still fired. A warning may only be named at a
+site that honors it (spec 2.5:40).
+"""
+source = """
+fn main() -> i32 {
+    return 0;
+    @allow(unreachable_code)
+    let x = 42;
+    x
+}
+"""
+compile_fail = true
+error_contains = [
+    "@allow(unreachable_code) is not honored on let statements",
+    "unreachable_code can be allowed on functions, methods, and test declarations",
+]
+
+[[case]]
+name = "allow_unreachable_code_on_function_still_suppresses"
+description = "The same directive on the enclosing function is honored (spec 2.5:21)."
+source = """
+@allow(unreachable_code)
+fn main() -> i32 {
+    return 0;
+    let x = 42;
+    x
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_unused_function_on_let_rejected"
+source = """
+fn main() -> i32 {
+    @allow(unused_function)
+    let x = 42;
+    x
+}
+"""
+compile_fail = true
+error_contains = ["@allow(unused_function) is not honored on let statements"]
+
+[[case]]
+name = "allow_on_struct_rejected"
+description = "@allow is a body/binding directive; a struct is not one of its sites."
+source = """
+@allow(unused_variable)
+struct P { x: i32 }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "@allow can only be applied to functions, methods, test declarations, and let statements",
+    "not structs",
+]
+
+[[case]]
+name = "non_exhaustive_in_expression_position_rejected"
+description = """
+RUE-1971: the parser's expression-position rejection is driven by the same
+directive table as the validator, so every directive name — not just
+allow/copy/repr — reports its placement instead of reaching sema's unknown
+intrinsic path.
+"""
+source = """
+fn main() -> i32 {
+    let x = @non_exhaustive(1);
+    x
+}
+"""
+compile_fail = true
+error_contains = ["directive must precede a statement"]
 
 [[case]]
 name = "known_directive_copy_still_works"

--- a/crates/rue-ui-tests/cases/warnings/unused.toml
+++ b/crates/rue-ui-tests/cases/warnings/unused.toml
@@ -657,10 +657,18 @@ expected_warning_count = 1
 
 [[case]]
 name = "allow_unused_variable_multiple_args"
+description = """
+A multi-name @allow is honored where every name it lists is honored: on the
+function both bindings and reachability are suppressed. On a let, only
+unused_variable is honored, so listing unreachable_code there is an error
+(spec 2.5:40, RUE-1971) — covered in diagnostics/directives.toml.
+"""
 source = """
+@allow(unused_variable, unreachable_code)
 fn main() -> i32 {
-    @allow(unused_variable, unreachable_code)
     let x = 42;
+    return 0;
+    let y = 1;
     0
 }
 """

--- a/docs/spec/src/02-lexical-structure/05-builtins.md
+++ b/docs/spec/src/02-lexical-structure/05-builtins.md
@@ -159,6 +159,22 @@ fn example() -> i32 {
 }
 ```
 
+### Warning Names and Sites
+
+{{ rule(id="2.5:40", cat="legality-rule") }}
+
+A warning name in `@allow` **MUST** be one the annotated site honors. `unused_variable` may be named on a function, method, or test declaration (2.5:17) and on a let statement (2.5:15); every other warning name describes a property of a whole body and may be named only on a function, method, or test declaration (2.5:19, 2.5:21). Naming a warning on a site that does not honor it is a compile-time error, so a directive is never accepted and then silently ignored.
+
+{{ rule(id="2.5:41") }}
+
+```rue
+fn main() -> i32 {
+    @allow(unreachable_code)   // error: not honored on let statements
+    let x = 42;
+    x
+}
+```
+
 ### Multiple Warnings
 
 {{ rule(id="2.5:23", cat="normative") }}


### PR DESCRIPTION
Fixes RUE-1971

## Why

Directive names, warning names, and the "where is this directive honored" policy lived as string tables in six places, and they had drifted. Two user-visible results:

| Program | Before | After |
|---|---|---|
| `@allow(unreachable_code)` before a `let` | accepted, warning still emitted | `error: [E0102]: @allow(unreachable_code) is not honored on let statements; unreachable_code can be allowed on functions, methods, and test declarations` |
| `@non_exhaustive(1)` in expression position | `error: [E0700]: unknown intrinsic '@non_exhaustive'` (fell through to sema) | `error: [E0102]: directive must precede a statement`, same as the other directives |

The function-level `@allow(unreachable_code)` still suppresses the warning.

## What

- New `crates/rue-parser/src/directives.rs` is the single owner: `DirectiveName`, `WarningName`, and `ReprArg` are generated from one `vocabulary!` list, with `DirectiveSite`, `DirectiveArity`, `DirectiveArgValue`, and exhaustive `allowed_sites()`, `arity()`, and `classify_arg()` tables. Adding a name does not compile until every table says where it is accepted, where it is honored, and how many arguments it takes.
- The parser classifies each `@name(args)` once while building the AST (`Directive::kind`, `DirectiveArg::value`); `validate.rs` is rewritten with no string table; the expression-position rejection is table-driven, so `non_exhaustive` is covered and three parser syms are deleted.
- `rue-rir` carries the typed view (`RirDirectiveView::kind`/`allows`, one `directives_allow` helper); the RIR payload's packed layout is unchanged.
- The five rue-air sema sites (`call_resolution`, `ownership`, `body_identity`, `provider_body_host`, `body_endpoint` twice) all call `rue_rir::directives_allow(.., WarningName::X)`. rue-compiler (`semantic_query_nucleus`, `rooted_projections`, `artifact_views`) and `rue-frontend-diff` match on the enum. Two of the issue's rue-compiler sites turned out to be test assertions about interner contents; the real `unused_function` read was elsewhere in `rooted_projections.rs` and is covered.

**`let` policy: reject.** Spec 2.5:15 defines `@allow(unused_variable)` before a let; 2.5:19 and 2.5:21 define `unused_function` and `unreachable_code` only before a function definition, and sema honors only `unused_variable` at a `let`. The spec was silent on naming the other warnings at a `let`, so this takes the conservative reading and adds spec 2.5:40 (legality rule) and 2.5:41 (example) stating it, with three spec cases citing 2.5:40. Overruling is one change to `WarningName::allowed_sites()`. Two pre-existing cases that encoded the old behavior (`lexical.builtins::allow_multiple_warnings`, `warnings.unused::allow_unused_variable_multiple_args`) move their directives to the function site.

Diagnostics reuse the existing directive-placement code E0102; no new code and no JSON field change.

Not fixed, worth a spec-side follow-up: spec 2.5:13 lists `unreachable_pattern` as a recognized warning, but the compiler has never accepted or implemented it. Adding it to the table would recreate accepted-and-ignored, so it is left out.

## Verification

| Command | Result |
|---|---|
| `scripts/rue unit parser` / `rir` | 79 / 151 passed (two parser inventory tests updated) |
| `//crates/rue-air:rue-air-test`, `//crates/rue-compiler:rue-compiler-test` | pass (1227; one interning-exhaustion limit adjusted since the parser no longer interns three always-on directive symbols) |
| `scripts/rue quick` | pass, re-run after rebasing onto current trunk |
| `scripts/rue spec 2.5`, `//:spec-tests` | 24 / all pass |
| `//:ui-tests` (`directive`, `allow`, `warning`) | pass |
| `//:cli-tests` | 2658 passed; the 2 failures are environmental to the build container (uid 0 defeats `remove_dir_all_permission_denied_is_not_partial_success`; no IPv6 for `tcp_ipv6_loopback_round_trip`) |
| `//crates/rue-oracle-diff:oracle-diff-test` | pass |
| `//:type-architecture-inventory-validation`, `//:payload-ownership-inventory-validation`, debug-assert checks for parser/rir/air/compiler | pass |
| `scripts/rue fmt`; clippy gates for parser, rir, air, compiler, frontend-diff | clean |