### PR TITLE
RUE-1979: normalize source paths once and let discovery own the std-root policy

### DIFF
--- a/crates/rue-air/src/path_norm.rs
+++ b/crates/rue-air/src/path_norm.rs
@@ -8,36 +8,61 @@
 //! `a/../std/opt.rue`. These must collapse to one key, or the file is
 //! double-registered and member access fails (E0707, RUE-317).
 //!
-//! [`normalize_module_path`] performs that collapse **lexically**: it drops `.`
-//! (current-dir) components and resolves `..` against the preceding *normal*
-//! component. It never touches the filesystem, so it does not follow symlinks;
-//! a leading `..` with nothing to cancel (or a `..` after the root) is
-//! preserved verbatim. Every module-registry / file-table key must pass through
-//! this one function so all spellings of a file agree.
+//! [`normalize_module_path`] is the one lexical normalizer behind every source
+//! spelling in the compiler and its driver: module-registry and file-table
+//! keys, the physical paths `SourceMetadata` compares for collision, the
+//! requested/canonical identity paths import discovery mints, and the driver's
+//! manifest membership keys. Because one function decides, a spelling cannot be
+//! declared by one layer and denied by another (RUE-1979).
+//!
+//! # Policy
+//!
+//! The reduction is purely lexical — it never touches the filesystem, so it
+//! never follows symlinks. `.` components are dropped and a `..` cancels the
+//! preceding *normal* component. A `..` with nothing to cancel is decided by
+//! whether the path is absolute:
+//!
+//! - **Absolute**: the root is its own parent, so an uncancelable `..` is
+//!   dropped (`/a/../..` and `/../../x` reduce to `/` and `/x`). This matches
+//!   POSIX path resolution at the root and `PathBuf::pop`, which is a no-op
+//!   there, so a normalized absolute path always stays under its own root and
+//!   the physical spelling a host observes agrees with the identity the
+//!   compiler mints for it.
+//! - **Relative**: a leading `..` is preserved verbatim (`../std/opt.rue`), as
+//!   there is no anchor to resolve it against. Callers that must refuse an
+//!   escape (a trusted std relative path, a test candidate) check for a
+//!   surviving `..` themselves; this function does not judge.
+//!
+//! The result is idempotent: normalizing a normalized path returns it
+//! unchanged.
 
 use std::path::{Component, Path, PathBuf};
 
-/// Lexically normalize a path for equivalence comparison: drop `.` components
-/// and collapse `..` against a preceding normal component. Purely lexical —
-/// never touches the filesystem (no symlink resolution).
+/// Lexically normalize a path for equivalence comparison, following the module
+/// policy above: drop `.`, cancel `..` against a preceding normal component,
+/// then drop an uncancelable `..` on an absolute path and keep one on a
+/// relative path. Purely lexical — never touches the filesystem (no symlink
+/// resolution).
 ///
 /// Examples (`/` shown for clarity; output uses the platform separator):
 /// - `./foo.rue` -> `foo.rue`
 /// - `sub/./foo.rue` -> `sub/foo.rue`
 /// - `a/../std/opt.rue` -> `std/opt.rue`
-/// - `../std/opt.rue` -> `../std/opt.rue` (leading `..` has nothing to cancel)
+/// - `../std/opt.rue` -> `../std/opt.rue` (relative: nothing to cancel)
+/// - `/../std/opt.rue` -> `/std/opt.rue` (absolute: the root is its own parent)
 pub fn normalize_module_path(path: &str) -> String {
+    let path = Path::new(path);
+    let absolute = path.is_absolute();
     let mut out: Vec<Component> = Vec::new();
-    for comp in Path::new(path).components() {
+    for comp in path.components() {
         match comp {
             Component::CurDir => {}
             Component::ParentDir => {
-                // Cancel a preceding *normal* component; otherwise (empty, a
-                // leading `..`, or a root/prefix) keep the `..` verbatim so the
-                // normalization stays purely lexical.
                 if matches!(out.last(), Some(Component::Normal(_))) {
                     out.pop();
-                } else {
+                } else if !absolute {
+                    // Relative: a leading `..` (or one behind another `..`)
+                    // has no anchor to resolve against, so it stays verbatim.
                     out.push(comp);
                 }
             }
@@ -89,10 +114,56 @@ mod tests {
     }
 
     #[test]
-    fn preserves_uncancelable_parent() {
-        // A leading `..` has no preceding normal component to cancel.
+    fn preserves_uncancelable_parent_on_relative_paths() {
+        // A leading `..` has no preceding normal component to cancel and no
+        // anchor to resolve against, so it survives.
         assert_eq!(n("../std/opt.rue"), "../std/opt.rue");
         assert_eq!(n("../../x.rue"), "../../x.rue");
+        assert_eq!(n("a/../../b"), "../b");
+    }
+
+    #[test]
+    fn drops_uncancelable_parent_on_absolute_paths() {
+        // The root is its own parent, so an absolute path can never normalize
+        // to a spelling above its own root. Discovery identities, physical
+        // collision keys and driver manifest keys all rely on this agreeing.
+        assert_eq!(n("/a/../.."), "/");
+        assert_eq!(n("/.."), "/");
+        assert_eq!(n("/../../x"), "/x");
+        assert_eq!(n("/a/b/../../../c"), "/c");
+    }
+
+    /// The complete policy table (RUE-1979): every shape the three former
+    /// normalizers disagreed on, decided once here.
+    #[test]
+    fn policy_table() {
+        let cases = [
+            // absolute: `..` cancels, and the root is its own parent
+            ("/a/../..", "/"),
+            ("/../../x", "/x"),
+            ("/a/../b", "/b"),
+            ("/a/b/../../../c", "/c"),
+            ("/..", "/"),
+            ("/", "/"),
+            // relative: an uncancelable `..` stays verbatim
+            ("../x", "../x"),
+            ("a/../../b", "../b"),
+            ("..", ".."),
+            // `.` components and separator noise vanish either way
+            ("a/./b", "a/b"),
+            ("a//b", "a/b"),
+            ("/a/./b/", "/a/b"),
+            ("/a/b/", "/a/b"),
+            ("x/", "x"),
+            ("./x", "x"),
+            // an empty identity stays empty; callers reject it by name
+            ("", ""),
+            (".", ""),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(n(input), expected, "normalizing {input:?}");
+            assert_eq!(n(expected), expected, "{input:?} normalizes idempotently");
+        }
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -40,6 +40,22 @@ error_contains = ["Error reading ", "missing.rue:"]
 compile_stderr_not_contains = ['"code":"E1500"', '"severity":"error"']
 
 [[case]]
+name = "project_root_inside_std_is_compiler_input_json"
+description = "RUE-1979: the project-root/std-root overlap policy belongs to import discovery, so the driver reports its typed compiler input error (E1400) rather than a driver source-load classification."
+files = [{ path = "sdk/project/main.rue", source = "fn main() -> i32 { 0 }" }]
+env = { RUE_STD_PATH = "sdk" }
+args = ["--error-format", "json", "sdk/project/main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E1400 -"]
+error_contains = [
+  '"code":"E1400"',
+  "is inside the configured standard-library root",
+  '"spans":[]',
+]
+compile_stderr_not_contains = ['"code":"E1500"', "E9000", "internal compiler error"]
+
+[[case]]
 name = "missing_trusted_toolchain_input_is_json"
 description = "RUE-1323: a reached fallible intrinsic with a missing trusted std module is classified as toolchain integrity, not ordinary source load or an ICE."
 files = [{ path = "main.rue", source = 'fn main() -> i32 { let _ = @parse_i64("1"); 0 }' }]

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -120,6 +120,39 @@ pub fn triple(x: i32) -> i32 {
 args = ["--source-manifest", "sources.manifest", "main.rue", "-o", "prog"]
 stdout = "42\n"
 
+# The manifest membership key and the path import discovery requests are
+# reduced by the same normalizer, so a `.`/`..` spelling of a declared file
+# still declares it.
+[[case]]
+name = "source_manifest_entry_reduces_like_a_requested_path"
+description = "RUE-1979: manifest keys and discovery requested paths share one lexical normalizer, so `./nested/../utils.rue` declares the same file as `utils.rue`."
+files = [
+    { path = "sources.manifest", source = """
+./main.rue
+./nested/../utils.rue
+""" },
+    { path = "main.rue", source = """
+const utils = @import("nested/../utils.rue");
+
+fn main() -> i32 {
+    @dbg(utils.triple(14));
+    0
+}
+""" },
+    { path = "nested/keep.rue", source = """
+pub fn keep() -> i32 {
+    0
+}
+""" },
+    { path = "utils.rue", source = """
+pub fn triple(x: i32) -> i32 {
+    x * 3
+}
+""" },
+]
+args = ["--source-manifest", "sources.manifest", "main.rue", "-o", "prog"]
+stdout = "42\n"
+
 [[case]]
 name = "source_manifest_rejects_undeclared_root"
 description = "RUE-448: the root source itself must be listed in the build-system manifest."

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -7554,9 +7554,10 @@ fn unstable_views_do_not_alias_query_engine_records() {
         reexports,
         [
             "pubusecrate::diagnostic::{ColorChoice,DiagnosticFormatter,JsonDiagnostic,JsonDiagnosticFormatter,JsonSpan,JsonSuggestion,MultiFileFormatter,MultiFileJsonFormatter,SourceInfo,};",
-            "pubusecrate::import_discovery::{AcceptedImportSource,DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportDiscoveryPlan,ImportDiscoveryRequest,ImportDiscoveryWave,ImportInputRevision,ImportObservation,ImportObservationLedger,ImportObservationStatus,};",
+            "pubusecrate::import_discovery::{AcceptedImportSource,DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportDiscoveryPlan,ImportDiscoveryRequest,ImportDiscoveryWave,ImportInputRevision,ImportObservation,ImportObservationLedger,ImportObservationStatus,requested_path_for_module,};",
             "pubusecrate::test_candidates::{TestCandidate,TestCandidateInventory,TestCandidateOutcome,UnimportedTestFile,};",
             "pubusecrate::warm_fresh_parity::ParityObservation;",
+            "pubuserue_air::normalize_module_path;",
             "pubuserue_span::Span;",
             "pubusecrate::session::{ClosedDiscoveryContinuation,RootedCfgOutput,RootedCfgUnit,RootedParkOutcome,RootedPreOptimizationCfgOutput,RootedPreOptimizationCfgUnit,TrustedSuccessorDelta,};",
         ],

--- a/crates/rue-compiler/src/dependency_envelope.rs
+++ b/crates/rue-compiler/src/dependency_envelope.rs
@@ -358,7 +358,7 @@ mod tests {
     };
 
     fn context(epoch: u64) -> ImportDiscoveryContext {
-        ImportDiscoveryContext::new(epoch, "/project", Some("/sdk"), "test-policy").unwrap()
+        ImportDiscoveryContext::new(epoch, "/project", None, Some("/sdk"), "test-policy").unwrap()
     }
 
     fn metadata() -> FileMetadataFingerprint {

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -38,22 +38,43 @@ pub struct ImportDiscoveryContext {
 }
 
 impl ImportDiscoveryContext {
+    /// Capture one discovery epoch's invocation inputs, refusing a project
+    /// root that overlaps the configured standard-library root.
+    ///
+    /// `canonical_project_root` is the host's physically resolved spelling of
+    /// the same directory, when it has one. The overlap policy is one rule
+    /// applied to both spellings, because either one landing inside the std
+    /// root would let a project source mint trusted standard-library
+    /// identities: the lexical root catches a project literally nested under
+    /// the configured toolchain, and the canonical root catches one that
+    /// reaches it through a symlink. The canonical spelling is validated and
+    /// not retained — the retained project identity is the lexical root, which
+    /// is what durable caller identities are relative to.
     pub fn new(
         epoch: u64,
         project_root: impl AsRef<str>,
+        canonical_project_root: Option<&str>,
         std_root: Option<&str>,
         read_policy_revision: impl Into<Arc<str>>,
     ) -> CompileResult<Self> {
         let project_root = normalize_absolute(project_root.as_ref())?;
+        let canonical_project_root = canonical_project_root.map(normalize_absolute).transpose()?;
         let std_root = std_root.map(normalize_absolute).transpose()?.map(Arc::from);
-        if std_root
-            .as_deref()
-            .is_some_and(|std_root| Path::new(&project_root).starts_with(std_root))
-        {
-            return Err(invalid_input(format!(
-                "project root {:?} is inside the configured standard-library root",
-                project_root
-            )));
+        if let Some(std_root) = std_root.as_deref() {
+            for root in [
+                Some(project_root.as_str()),
+                canonical_project_root.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                if Path::new(root).starts_with(std_root) {
+                    return Err(invalid_input(format!(
+                        "project root {:?} is inside the configured standard-library root",
+                        root
+                    )));
+                }
+            }
         }
         Ok(Self {
             epoch,
@@ -113,6 +134,22 @@ impl ImportDiscoveryContext {
     }
     pub fn std_root(&self) -> Option<&str> {
         self.std_root.as_deref()
+    }
+
+    /// The namespace boundary a requested path is spelled inside: the captured
+    /// std root when the path lies under it, the project root otherwise.
+    ///
+    /// This is the same lexical `strip_prefix(std_root)` classification
+    /// [`classify_module`] mints identities with, exported so a host walks a
+    /// requested spelling against exactly the boundary the compiler will
+    /// attribute it to. `classify_module` additionally refuses a relative part
+    /// that escapes the std root, because it is minting an identity; this
+    /// query only names which root a path is spelled under.
+    pub fn boundary_for_requested(&self, requested: &Path) -> &Path {
+        match self.std_root() {
+            Some(std_root) if requested.starts_with(std_root) => Path::new(std_root),
+            _ => Path::new(self.project_root()),
+        }
     }
     pub fn read_policy_revision(&self) -> &str {
         &self.read_policy_revision
@@ -1549,7 +1586,7 @@ pub(crate) fn escaping_import_candidate(
         context.project_root(),
         context.std_root(),
     );
-    let candidate = normalize_path(&groups[0][0]);
+    let candidate = normalize_module_path(&groups[0][0]);
     if Path::new(&candidate).starts_with(boundary_root) {
         Ok(None)
     } else {
@@ -1651,7 +1688,7 @@ pub(crate) fn discovery_groups_for_occurrence(
         context.project_root(),
         context.std_root(),
     );
-    let normalized_specifier = normalize_path(occurrence.specifier());
+    let normalized_specifier = normalize_module_path(occurrence.specifier());
     candidate_groups
         .into_iter()
         .enumerate()
@@ -1673,7 +1710,7 @@ pub(crate) fn discovery_groups_for_occurrence(
                         root_anchor: Arc::from(context.project_root()),
                         group: group_index,
                         position,
-                        requested_path: Arc::from(normalize_path(&candidate)),
+                        requested_path: Arc::from(normalize_module_path(&candidate)),
                         role: candidate_role(occurrence.specifier()),
                     }
                 })
@@ -3024,7 +3061,15 @@ fn discovery_candidate_groups(
     )]]
 }
 
-fn requested_path_for_module(
+/// The requested filesystem spelling discovery resolves `module` to: the
+/// captured std root joined with the trusted relative path for a standard-library
+/// module, the project root joined with the module identity otherwise.
+///
+/// This is the compiler's own derivation, exported through `unstable` so a host
+/// that must resolve a module outside the import frontier — the driver's
+/// trusted toolchain-module acquisition — asks for the path instead of
+/// re-deriving one that could disagree.
+pub fn requested_path_for_module(
     context: &ImportDiscoveryContext,
     module: &ModuleId,
 ) -> CompileResult<String> {
@@ -3035,11 +3080,11 @@ fn requested_path_for_module(
         let std_root = context
             .std_root()
             .ok_or_else(|| invalid_input("standard-library module has no captured std root"))?;
-        return Ok(normalize_path(
+        return Ok(normalize_module_path(
             &Path::new(std_root).join(relative).to_string_lossy(),
         ));
     }
-    Ok(normalize_path(
+    Ok(normalize_module_path(
         &Path::new(context.project_root())
             .join(module.as_str())
             .to_string_lossy(),
@@ -3134,28 +3179,13 @@ fn parent_dir(path: &str) -> String {
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_default()
 }
-fn normalize_path(path: &str) -> String {
-    let mut result = PathBuf::new();
-    let absolute = Path::new(path).is_absolute();
-    for component in Path::new(path).components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                let can_pop = result
-                    .components()
-                    .next_back()
-                    .is_some_and(|component| matches!(component, Component::Normal(_)));
-                if can_pop {
-                    result.pop();
-                } else if !absolute {
-                    result.push("..");
-                }
-            }
-            _ => result.push(component.as_os_str()),
-        }
-    }
-    result.to_string_lossy().into_owned()
-}
+/// An identity path in the discovery protocol's absolute spelling.
+///
+/// Discovery identities are absolute by construction: the host resolves every
+/// candidate against the project or std root before it can be observed. The
+/// reduction itself is [`normalize_module_path`]'s single policy, so a
+/// requested path, the physical spelling `SourceMetadata` keys collisions by,
+/// and the driver's manifest membership key are the same string.
 fn normalize_absolute(path: &str) -> CompileResult<String> {
     let path = Path::new(path);
     if !path.is_absolute() {
@@ -3163,7 +3193,7 @@ fn normalize_absolute(path: &str) -> CompileResult<String> {
             "discovery identity path {path:?} is not absolute"
         )));
     }
-    Ok(normalize_path(path.to_string_lossy().as_ref()))
+    Ok(normalize_module_path(path.to_string_lossy().as_ref()))
 }
 fn lexical_relative_path(base: &Path, target: &Path) -> Option<PathBuf> {
     let base: Vec<_> = base.components().collect();
@@ -3205,13 +3235,13 @@ mod tests {
     use super::*;
 
     fn context(epoch: u64) -> ImportDiscoveryContext {
-        ImportDiscoveryContext::new(epoch, "/project", Some("/sdk"), "all").unwrap()
+        ImportDiscoveryContext::new(epoch, "/project", None, Some("/sdk"), "all").unwrap()
     }
 
     #[test]
     fn project_root_inside_or_equal_to_std_root_is_rejected() {
         for (project, std_root) in [("/sdk/project", "/sdk"), ("/sdk", "/sdk")] {
-            let error = ImportDiscoveryContext::new(1, project, Some(std_root), "all")
+            let error = ImportDiscoveryContext::new(1, project, None, Some(std_root), "all")
                 .expect_err("a project rooted inside std must fail closed");
             assert!(
                 error
@@ -3222,14 +3252,62 @@ mod tests {
         // The supported layout remains valid: the captured std tree is a
         // child of the project, so project-relative and trusted identities have
         // disjoint roots.
-        ImportDiscoveryContext::new(1, "/project", Some("/project/std"), "all")
+        ImportDiscoveryContext::new(1, "/project", None, Some("/project/std"), "all")
             .expect("std nested inside the project is valid");
+    }
+
+    /// RUE-1979: one overlap rule covers both root spellings, so a project that
+    /// only reaches the toolchain physically (through a symlinked prefix) is
+    /// refused by the same typed error as a literally nested one.
+    #[test]
+    fn canonical_project_root_inside_std_root_is_rejected() {
+        let error =
+            ImportDiscoveryContext::new(1, "/project", Some("/sdk/project"), Some("/sdk"), "all")
+                .expect_err("a project physically inside std must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("\"/sdk/project\" is inside the configured standard-library root"),
+            "unexpected error: {error}"
+        );
+        ImportDiscoveryContext::new(
+            1,
+            "/project",
+            Some("/physical/project"),
+            Some("/sdk"),
+            "all",
+        )
+        .expect("a project outside std in both spellings is valid");
+    }
+
+    #[test]
+    fn boundary_for_requested_follows_the_classification_std_root() {
+        let context = context(1);
+        assert_eq!(
+            context.boundary_for_requested(Path::new("/sdk/math/float.rue")),
+            Path::new("/sdk")
+        );
+        assert_eq!(
+            context.boundary_for_requested(Path::new("/project/main.rue")),
+            Path::new("/project")
+        );
+        // A sibling directory whose name merely starts with the std root's is
+        // not inside it; `starts_with` compares whole components.
+        assert_eq!(
+            context.boundary_for_requested(Path::new("/sdk-vendor/main.rue")),
+            Path::new("/project")
+        );
+        let rootless = ImportDiscoveryContext::new(1, "/project", None, None, "all").unwrap();
+        assert_eq!(
+            rootless.boundary_for_requested(Path::new("/sdk/math/float.rue")),
+            Path::new("/project")
+        );
     }
 
     #[test]
     fn project_provenance_does_not_inherit_std_boundary_from_its_path() {
         let context =
-            ImportDiscoveryContext::new(1, "/project", Some("/project/std"), "all").unwrap();
+            ImportDiscoveryContext::new(1, "/project", None, Some("/project/std"), "all").unwrap();
         let importer = ModuleId::from_logical_path("std/main.rue").unwrap();
         // The spelling is beneath std, but the accepted module provenance is a
         // caller module. Its escape is measured against the project root.
@@ -3447,14 +3525,15 @@ mod tests {
     #[test]
     fn classify_module_keeps_project_identities_stable_across_relocation() {
         fn classify(context: &ImportDiscoveryContext, path: &Path) -> ModuleId {
-            let path = normalize_path(&path.to_string_lossy());
+            let path = normalize_module_path(&path.to_string_lossy());
             classify_module(context, &path, &path).unwrap()
         }
 
         fn identities(root: &Path) -> Vec<ModuleId> {
             let project = root.join("project");
             let context =
-                ImportDiscoveryContext::new(1, project.to_string_lossy(), None, "all").unwrap();
+                ImportDiscoveryContext::new(1, project.to_string_lossy(), None, None, "all")
+                    .unwrap();
             [
                 project.join("main.rue"),
                 // The production path normalizer resolves nested and parent-relative
@@ -3470,8 +3549,9 @@ mod tests {
         fn rejects_external_source(root: &Path) {
             let project = root.join("project");
             let context =
-                ImportDiscoveryContext::new(1, project.to_string_lossy(), None, "all").unwrap();
-            let path = normalize_path(&root.join("dep.rue").to_string_lossy());
+                ImportDiscoveryContext::new(1, project.to_string_lossy(), None, None, "all")
+                    .unwrap();
+            let path = normalize_module_path(&root.join("dep.rue").to_string_lossy());
             assert!(classify_module(&context, &path, &path).is_err());
         }
 
@@ -3502,7 +3582,7 @@ mod tests {
     #[test]
     fn classify_module_keeps_external_std_namespace_stable() {
         fn classify(context: &ImportDiscoveryContext, path: &Path) -> ModuleId {
-            let path = normalize_path(&path.to_string_lossy());
+            let path = normalize_module_path(&path.to_string_lossy());
             classify_module(context, &path, &path).unwrap()
         }
 
@@ -3510,6 +3590,7 @@ mod tests {
             let context = ImportDiscoveryContext::new(
                 1,
                 project.to_string_lossy(),
+                None,
                 Some(std_root.to_string_lossy().as_ref()),
                 "all",
             )
@@ -3555,7 +3636,7 @@ mod tests {
         } else {
             ("/rue-parity/project", "/rue-parity/toolchain/std")
         };
-        let context = ImportDiscoveryContext::new(1, project, Some(std_root), "all").unwrap();
+        let context = ImportDiscoveryContext::new(1, project, None, Some(std_root), "all").unwrap();
 
         // The attribution helper must publish exactly the identity spelling
         // classification mints for the same requested std path, including the
@@ -3578,7 +3659,7 @@ mod tests {
             trusted_logical_path_for_requested(&context, &outside.to_string_lossy()),
             None
         );
-        let rootless = ImportDiscoveryContext::new(1, project, None, "all").unwrap();
+        let rootless = ImportDiscoveryContext::new(1, project, None, None, "all").unwrap();
         let inside = Path::new(std_root).join("_std.rue");
         assert_eq!(
             trusted_logical_path_for_requested(&rootless, &inside.to_string_lossy()),
@@ -3589,7 +3670,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn classify_module_rejects_unnamed_cross_volume_source() {
-        let context = ImportDiscoveryContext::new(1, r"C:\project", None, "all").unwrap();
+        let context = ImportDiscoveryContext::new(1, r"C:\project", None, None, "all").unwrap();
         let error = classify_module(
             &context,
             r"D:\dependency\helper.rue",
@@ -3613,8 +3694,8 @@ mod tests {
 
     #[test]
     fn absolute_normalization_never_pops_above_root() {
-        assert_eq!(normalize_path("/project/../../../x"), "/x");
-        assert_eq!(normalize_path("/../../x"), "/x");
+        assert_eq!(normalize_module_path("/project/../../../x"), "/x");
+        assert_eq!(normalize_module_path("/../../x"), "/x");
         assert_eq!(normalize_absolute("/../../../x").unwrap(), "/x");
         assert!(
             AcceptedImportSource::new(
@@ -5745,8 +5826,14 @@ mod tests {
         let plan = session
             .stage_import_discovery(
                 &source,
-                crate::ImportDiscoveryContext::new(1, "/project", Some("/project/std"), "all")
-                    .unwrap(),
+                crate::ImportDiscoveryContext::new(
+                    1,
+                    "/project",
+                    None,
+                    Some("/project/std"),
+                    "all",
+                )
+                .unwrap(),
                 accepted_reads(&source),
                 ImportObservationLedger::default(),
             )

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -2908,7 +2908,7 @@ mod tests {
 
     #[test]
     fn canonical_std_strbuf_identity_survives_qualified_and_aliased_lookup() {
-        let context = ImportDiscoveryContext::new(1, "/project", Some("/sdk"), "test")
+        let context = ImportDiscoveryContext::new(1, "/project", None, Some("/sdk"), "test")
             .expect("discovery context should be valid");
         let mut assembler = DiscoverySourceAssembler::new(
             context,
@@ -3015,7 +3015,7 @@ mod tests {
 
     #[test]
     fn trusted_std_presence_does_not_create_a_bare_strbuf_prelude_name() {
-        let context = ImportDiscoveryContext::new(1, "/project", Some("/sdk"), "test")
+        let context = ImportDiscoveryContext::new(1, "/project", None, Some("/sdk"), "test")
             .expect("discovery context should be valid");
         let mut assembler = DiscoverySourceAssembler::new(
             context,
@@ -3967,7 +3967,7 @@ mod tests {
     #[test]
     #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
     fn platform_native_o3_retains_byref_call_after_view_storage_epoch_ends() {
-        let context = ImportDiscoveryContext::new(1, "/project", Some("/sdk"), "test")
+        let context = ImportDiscoveryContext::new(1, "/project", None, Some("/sdk"), "test")
             .expect("discovery context should be valid");
         let mut assembler = DiscoverySourceAssembler::new(
             context,

--- a/crates/rue-compiler/src/revisioned_query_database/tests/parse_import.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/parse_import.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn incremental_pending_requests_stop_at_conclusive_vendored_std_failure() {
-    let context = ImportDiscoveryContext::new(1, "/project", Some("/sdk"), "all").unwrap();
+    let context = ImportDiscoveryContext::new(1, "/project", None, Some("/sdk"), "all").unwrap();
     let occurrence = crate::ImportOccurrenceKey::from_directive(&crate::ImportDirective::new(
         ModuleId::from_logical_path("main.rue").unwrap(),
         0,
@@ -1452,7 +1452,7 @@ fn import_fixture(
     ImportDiscoveryContext,
 ) {
     let context =
-        ImportDiscoveryContext::new(epoch, "/project", Some("/sdk"), "test-policy").unwrap();
+        ImportDiscoveryContext::new(epoch, "/project", None, Some("/sdk"), "test-policy").unwrap();
     let assembler = DiscoverySourceAssembler::new(
         context.clone(),
         "/project/main.rue",
@@ -1535,7 +1535,7 @@ fn import_frontier_rejects_roots_outside_the_pinned_plan() {
 #[test]
 fn ordinary_and_rooted_publication_share_one_compatibility_namespace() {
     let context =
-        ImportDiscoveryContext::new(401, "/project", Some("/sdk"), "test-policy").unwrap();
+        ImportDiscoveryContext::new(401, "/project", None, Some("/sdk"), "test-policy").unwrap();
     let mut assembler = DiscoverySourceAssembler::new(
         context.clone(),
         "/project/main.rue",
@@ -2206,7 +2206,7 @@ fn resolved_declaration_import_observes_only_winning_physical_provenance() {
         )
         .unwrap();
     let green_context =
-        ImportDiscoveryContext::new(307, "/project", Some("/sdk"), "test-policy").unwrap();
+        ImportDiscoveryContext::new(307, "/project", None, Some("/sdk"), "test-policy").unwrap();
     let (green_snapshot, green_reads, green_revision, green_plan) =
         begin_database_plan(&mut database, &mut green_assembler, green_context);
     let green_revision = publish_remapped_observations(
@@ -2336,7 +2336,7 @@ fn facade_declaration_import_observes_its_provenance_leaf_only() {
         )
         .unwrap();
     let green_context =
-        ImportDiscoveryContext::new(308, "/project", Some("/sdk"), "test-policy").unwrap();
+        ImportDiscoveryContext::new(308, "/project", None, Some("/sdk"), "test-policy").unwrap();
     let (green_snapshot, green_reads, green_revision, green_plan) =
         begin_database_plan(&mut database, &mut green_assembler, green_context);
     let green_revision = publish_remapped_observations(
@@ -2713,7 +2713,8 @@ fn resolve_import_recomputes_when_only_discovery_context_changes() {
     );
 
     let second_context =
-        ImportDiscoveryContext::new(24, "/project", Some("/other-sdk"), "other-policy").unwrap();
+        ImportDiscoveryContext::new(24, "/project", None, Some("/other-sdk"), "other-policy")
+            .unwrap();
     let snapshot = assembler.snapshot().unwrap();
     let reads = assembler.accepted_read_manifest();
     let second_revision = session
@@ -3060,7 +3061,7 @@ fn successor_revisions_carry_observations_but_new_epochs_reread() {
     );
 
     let new_context =
-        ImportDiscoveryContext::new(4, "/project", Some("/sdk"), "test-policy").unwrap();
+        ImportDiscoveryContext::new(4, "/project", None, Some("/sdk"), "test-policy").unwrap();
     let new_snapshot = assembler.snapshot().unwrap();
     let new_revision = session
         .begin_import_input_request(
@@ -3110,13 +3111,15 @@ fn input_stamp_tables_follow_exact_retained_full_and_overlay_views() {
 
     let mut database = RevisionedQueryDatabase::default();
     let first_context =
-        ImportDiscoveryContext::new(10_000, "/project", Some("/sdk"), "retention-stress").unwrap();
+        ImportDiscoveryContext::new(10_000, "/project", None, Some("/sdk"), "retention-stress")
+            .unwrap();
     let mut latest_context = first_context.clone();
 
     for generation in 0..GENERATIONS {
         let context = ImportDiscoveryContext::new(
             10_000 + generation,
             "/project",
+            None,
             Some("/sdk"),
             "retention-stress",
         )

--- a/crates/rue-compiler/src/revisioned_query_database/tests/semantic_declaration.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/semantic_declaration.rs
@@ -3597,7 +3597,7 @@ fn durable_named_value_projection_preserves_real_module_binding_identity() {
     };
 
     let context =
-        ImportDiscoveryContext::new(902, "/project", Some("/sdk"), "test-policy").unwrap();
+        ImportDiscoveryContext::new(902, "/project", None, Some("/sdk"), "test-policy").unwrap();
     let mut assembler = DiscoverySourceAssembler::new(
         context.clone(),
         "/project/main.rue",
@@ -3672,7 +3672,7 @@ fn durable_module_member_projection_preserves_order_types_and_dependencies() {
     };
 
     let context =
-        ImportDiscoveryContext::new(903, "/project", Some("/sdk"), "test-policy").unwrap();
+        ImportDiscoveryContext::new(903, "/project", None, Some("/sdk"), "test-policy").unwrap();
     let mut assembler = DiscoverySourceAssembler::new(
         context.clone(),
         "/project/main.rue",

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -824,7 +824,7 @@ fn import_source(
     value: i32,
     epoch: u64,
 ) -> (SourceSnapshot, ImportDiscoveryContext, AcceptedReadManifest) {
-    let context = ImportDiscoveryContext::new(epoch, "/p", None, "scaling-import").unwrap();
+    let context = ImportDiscoveryContext::new(epoch, "/p", None, None, "scaling-import").unwrap();
     let root = Arc::new("const a = @import(\"a.rue\"); fn main() -> i32 { a.value() }".to_owned());
     let imported = Arc::new(format!("pub fn value() -> i32 {{ {value} }}"));
     let mut assembler = DiscoverySourceAssembler::new(
@@ -860,7 +860,7 @@ fn rooted_demand_locality_source(
     // The observation regime remains fixed across revisions. Only the imported
     // source leaf changes, matching a long-lived host whose read policy is
     // stable while it services successive import-input requests.
-    let context = ImportDiscoveryContext::new(1, "/p", None, "scaling-import").unwrap();
+    let context = ImportDiscoveryContext::new(1, "/p", None, None, "scaling-import").unwrap();
     let root = Arc::new(
         "const a = @import(\"a.rue\");\n\
          fn main() -> i32 { a.value() }\n"
@@ -2027,7 +2027,8 @@ impl TestRootCorpus {
     /// `main.rue` imports every module (the aggregator idiom), so the request
     /// closure is the whole corpus under either root selection.
     fn sources(&self) -> (SourceSnapshot, ImportDiscoveryContext, AcceptedReadManifest) {
-        let context = ImportDiscoveryContext::new(1, "/p", None, "rue-1919-test-roots").unwrap();
+        let context =
+            ImportDiscoveryContext::new(1, "/p", None, None, "rue-1919-test-roots").unwrap();
         let root = Arc::new(self.main_source());
         let mut assembler = DiscoverySourceAssembler::new(
             context.clone(),
@@ -2385,6 +2386,7 @@ fn rue_1919_example_sources(
     let context = ImportDiscoveryContext::new(
         1,
         project.to_str().unwrap(),
+        None,
         Some(std_root.to_str().unwrap()),
         "rue-1919-example",
     )

--- a/crates/rue-compiler/src/session/import_discovery_owner/tests.rs
+++ b/crates/rue-compiler/src/session/import_discovery_owner/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{CompileOptions, SourceMetadata};
 
 fn continuation_std_context() -> crate::ImportDiscoveryContext {
-    crate::ImportDiscoveryContext::new(1, "/project", Some("/sdk"), "test-policy").unwrap()
+    crate::ImportDiscoveryContext::new(1, "/project", None, Some("/sdk"), "test-policy").unwrap()
 }
 
 fn continuation_metadata() -> crate::FileMetadataFingerprint {

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -6537,9 +6537,14 @@ fn unreadable_and_unparsable_candidates_are_reported_and_ordered_by_path() {
 #[test]
 fn candidates_declared_under_another_read_policy_are_refused() {
     let mut session = committed_test_closure();
-    let foreign =
-        crate::ImportDiscoveryContext::new(1, "/rue-fixture", None, "a-different-source-manifest")
-            .unwrap();
+    let foreign = crate::ImportDiscoveryContext::new(
+        1,
+        "/rue-fixture",
+        None,
+        None,
+        "a-different-source-manifest",
+    )
+    .unwrap();
     let mut candidates = crate::TestCandidateInventory::new(&foreign);
     candidates
         .declare("orphan_tests.rue", present("test \"a\" { }\n"))

--- a/crates/rue-compiler/src/source_metadata.rs
+++ b/crates/rue-compiler/src/source_metadata.rs
@@ -776,6 +776,24 @@ mod tests {
         );
     }
 
+    /// RUE-1979: physical collision keys and discovery identities reduce an
+    /// absolute spelling the same way, so a root-escaping `..` cannot make one
+    /// layer see two modules where the other sees one.
+    #[test]
+    fn absolute_physical_spellings_agree_with_discovery_identities() {
+        let escaping = "/../project/main.rue";
+        assert_eq!(normalize_module_path(escaping), "/project/main.rue");
+        assert_eq!(
+            error_message(SourceMetadata::new(
+                FileId::new(1),
+                physical(&[(1, escaping), (2, "/project/main.rue")]),
+                physical(&[(1, "main.rue"), (2, "other.rue")]),
+            )),
+            "invalid compiler input: physical paths for 1 and 2 normalize to the \
+             same identity \"/project/main.rue\""
+        );
+    }
+
     #[test]
     fn rejects_empty_input() {
         assert_eq!(

--- a/crates/rue-compiler/src/test_candidates.rs
+++ b/crates/rue-compiler/src/test_candidates.rs
@@ -353,7 +353,8 @@ mod tests {
     use super::*;
 
     fn context(std_root: Option<&str>) -> ImportDiscoveryContext {
-        ImportDiscoveryContext::new(1, "/rue-fixture", std_root, "test-candidate-policy").unwrap()
+        ImportDiscoveryContext::new(1, "/rue-fixture", None, std_root, "test-candidate-policy")
+            .unwrap()
     }
 
     fn inventory(std_root: Option<&str>) -> TestCandidateInventory {
@@ -434,7 +435,7 @@ mod tests {
     fn the_read_regime_travels_with_the_candidate_key() {
         let mut open = inventory(None);
         let mut sandboxed = TestCandidateInventory::new(
-            &ImportDiscoveryContext::new(1, "/rue-fixture", None, "manifest-abc").unwrap(),
+            &ImportDiscoveryContext::new(1, "/rue-fixture", None, None, "manifest-abc").unwrap(),
         );
         open.declare("app/a.rue", present("")).unwrap();
         sandboxed.declare("app/a.rue", present("")).unwrap();

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -358,6 +358,7 @@ impl TestDiscoveryHost {
         let context = ImportDiscoveryContext::new(
             1,
             FIXTURE_PROJECT_ROOT,
+            None,
             trusted.then_some(FIXTURE_STD_ROOT),
             "test-fixture-discovery",
         )

--- a/crates/rue-compiler/src/toolchain_module_demand.rs
+++ b/crates/rue-compiler/src/toolchain_module_demand.rs
@@ -91,18 +91,12 @@ impl TrustedToolchainModuleDemand {
     /// The trusted `ModuleId` this demand resolves to once the host satisfies it.
     ///
     /// The returned identity carries the standard-library origin, so a snapshot
-    /// that contains it reports the module as trusted.
+    /// that contains it reports the module as trusted. It is also how a host
+    /// asks discovery where to read the module from: `requested_path_for_module`
+    /// resolves this identity against the captured std root, so the host never
+    /// derives a toolchain path of its own.
     pub fn trusted_module_id(&self) -> CompileResult<ModuleId> {
         ModuleId::from_trusted_standard_library_path(self.logical_path.as_ref())
-    }
-
-    /// The path fragment relative to the standard-library root (drops the
-    /// `\0rue-std/` namespace prefix), used by the host to resolve the module
-    /// against the toolchain's std path.
-    pub fn std_relative_path(&self) -> &str {
-        self.logical_path
-            .strip_prefix(crate::TRUSTED_STANDARD_LIBRARY_NAMESPACE)
-            .unwrap_or(&self.logical_path)
     }
 }
 

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -18,11 +18,20 @@ pub use crate::import_discovery::{
     AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
     ImportDemandRoots, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave,
     ImportInputRevision, ImportObservation, ImportObservationLedger, ImportObservationStatus,
+    requested_path_for_module,
 };
 pub use crate::test_candidates::{
     TestCandidate, TestCandidateInventory, TestCandidateOutcome, UnimportedTestFile,
 };
 pub use crate::warm_fresh_parity::ParityObservation;
+/// The one lexical source-path normalizer (`rue-air`'s `path_norm`).
+///
+/// Every source spelling the compiler keys an identity by passes through this
+/// function; a host that keeps its own path table — the driver's source-manifest
+/// membership set — reduces its keys with it too, so a spelling cannot be
+/// declared by one layer and denied by another (RUE-1979). It is purely
+/// lexical: anchoring a relative spelling is the host's own step.
+pub use rue_air::normalize_module_path;
 /// A diagnostic's source location, as the diagnostic types already hand it out.
 ///
 /// `CompileError::span` is public and returns one of these, so a consumer that

--- a/crates/rue-compiler/src/warm_fresh_parity.rs
+++ b/crates/rue-compiler/src/warm_fresh_parity.rs
@@ -13,7 +13,7 @@ fn close_fuzz_discovery(session: &mut CompilerSession, source: &SourceSnapshot, 
         publish_import_observation_batch, stage_import_input_request,
     };
 
-    let context = crate::ImportDiscoveryContext::new(epoch, "/p", None, "warm-session-fuzz")
+    let context = crate::ImportDiscoveryContext::new(epoch, "/p", None, None, "warm-session-fuzz")
         .expect("fuzz discovery context is valid");
     let root = source.metadata().root_file_id();
     let root_path = source

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -84,7 +84,7 @@ fn step(name: &'static str, snapshot: SourceSnapshot) -> Step {
 }
 
 fn import_step(name: &'static str, epoch: u64, value: i32) -> Step {
-    let context = ImportDiscoveryContext::new(epoch, "/p", None, "oracle").unwrap();
+    let context = ImportDiscoveryContext::new(epoch, "/p", None, None, "oracle").unwrap();
     let metadata = |length| FileMetadataFingerprint::new(length, epoch, epoch);
     let root = Arc::new("const a = @import(\"a.rue\"); fn main() -> i32 { a.value() }".to_owned());
     let imported = Arc::new(format!("pub fn value() -> i32 {{ {value} }}"));

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1002,6 +1002,7 @@ fn run_source_with_real_std(
     let context = ImportDiscoveryContext::new(
         1,
         "/oracle",
+        None,
         Some(std_root.to_string_lossy().as_ref()),
         "oracle-real-std",
     )

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -1237,9 +1237,14 @@ fn query_cfg_state_with_trusted_std(
     };
     use std::sync::Arc;
 
-    let context =
-        ImportDiscoveryContext::new(1, "/project", Some("/project/std"), "oracle-trusted-std")
-            .expect("valid discovery context");
+    let context = ImportDiscoveryContext::new(
+        1,
+        "/project",
+        None,
+        Some("/project/std"),
+        "oracle-trusted-std",
+    )
+    .expect("valid discovery context");
     let root = Arc::new(root.to_owned());
     let mut assembler = DiscoverySourceAssembler::new(
         context.clone(),

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs;
 use std::io::{Read, Write};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -31,6 +31,7 @@ use rue_compiler::unstable::{
 };
 #[cfg(test)]
 use rue_compiler::unstable::{frontend_query_invalidations, rooted_cfg};
+use rue_compiler::unstable::{normalize_module_path, requested_path_for_module};
 use rue_compiler::{
     AcceptedReadManifest, CompileErrors, CompileOptions, CompilerSession, DependencyEnvelope,
     FileId, FileMetadataFingerprint, ImportDiscoveryContext, ImportDiscoveryStatus,
@@ -310,6 +311,15 @@ impl SourceManifest {
     }
 }
 
+/// Anchor a host-supplied spelling at the current directory and reduce it with
+/// the compiler's one path normalizer.
+///
+/// Anchoring is the driver's own step: a relative command line argument or
+/// manifest entry names a file relative to the process, and every identity the
+/// compiler mints is absolute. The reduction itself is not the driver's to
+/// decide — a manifest key that collapsed `..` differently from the requested
+/// path discovery mints would deny a file the compiler considers declared
+/// (RUE-1979), so it delegates to `normalize_module_path`.
 fn normalize_lexical_path(path: &Path) -> PathBuf {
     let absolute = if path.is_absolute() {
         path.to_path_buf()
@@ -318,18 +328,7 @@ fn normalize_lexical_path(path: &Path) -> PathBuf {
             .unwrap_or_else(|_| PathBuf::from("."))
             .join(path)
     };
-    let mut normalized = PathBuf::new();
-    for component in absolute.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-            Component::RootDir | Component::Prefix(_) => normalized.push(component.as_os_str()),
-        }
-    }
-    normalized
+    PathBuf::from(normalize_module_path(&absolute.to_string_lossy()))
 }
 
 /// Capture the standard-library root in the same physical spelling every
@@ -348,22 +347,6 @@ fn normalize_lexical_path(path: &Path) -> PathBuf {
 /// diagnostics report against the path the user configured.
 fn capture_std_root(std_root: &Path) -> PathBuf {
     fs::canonicalize(std_root).unwrap_or_else(|_| normalize_lexical_path(std_root))
-}
-
-fn reject_project_root_inside_std(
-    root_canonical: &Path,
-    std_root: Option<&Path>,
-) -> Result<(), SourceLoadError> {
-    let Some(project_root) = root_canonical.parent() else {
-        return Ok(());
-    };
-    if std_root.is_some_and(|std_root| project_root.starts_with(std_root)) {
-        return Err(SourceLoadError::Message(format!(
-            "Error: project root {:?} is inside the configured standard-library root",
-            project_root
-        )));
-    }
-    Ok(())
 }
 
 #[derive(Debug)]
@@ -515,14 +498,6 @@ fn symlink_component_identity(_: &fs::Metadata) -> Option<PhysicalFileIdentity> 
     None
 }
 
-fn spelling_boundary(context: &ImportDiscoveryContext, requested: &Path) -> PathBuf {
-    context
-        .std_root()
-        .filter(|std_root| requested.starts_with(std_root))
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(context.project_root()))
-}
-
 fn accepted_source_from_read(
     entry: &rue_compiler::AcceptedReadManifestEntry,
     canonical_path: &Path,
@@ -576,7 +551,7 @@ fn reobserve_accepted_reads(
                 ))
             })?;
         let requested_path = Path::new(entry.requested_path());
-        let boundary = spelling_boundary(context, requested_path);
+        let boundary = context.boundary_for_requested(requested_path);
         if source_manifest.is_some_and(|policy| !policy.declares_path_without_probe(requested_path))
         {
             continue;
@@ -613,7 +588,7 @@ fn reobserve_accepted_reads(
                 entry.metadata_fingerprint(),
                 cached_source,
             )
-            .map(|source| source.with_symlink_route(symlink_route(requested_path, &boundary)))
+            .map(|source| source.with_symlink_route(symlink_route(requested_path, boundary)))
             .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?
         } else {
             let read = match stable_read_to_string(&canonical_path) {
@@ -625,7 +600,7 @@ fn reobserve_accepted_reads(
                 &canonical_path,
                 read,
                 canonical_unchanged.then_some(cached_source.clone()),
-                &boundary,
+                boundary,
             )?
         };
         control.checkpoint()?;
@@ -705,7 +680,7 @@ fn execute_import_request_uncancelled(
                 .map(|source| {
                     source.with_symlink_route(symlink_route(
                         candidate,
-                        &spelling_boundary(request.context(), candidate),
+                        request.context().boundary_for_requested(candidate),
                     ))
                 })
                 .expect("stable file reads satisfy accepted import invariants");
@@ -872,6 +847,20 @@ fn test_reobserve_delay(control: DiscoveryControl<'_>) -> Result<(), SourceLoadE
     control.checkpoint()
 }
 
+/// Report a compiler-owned input failure raised while the driver was capturing
+/// its discovery context.
+///
+/// The reachable case is the project-root/standard-library-root overlap policy
+/// `ImportDiscoveryContext::new` owns (RUE-1979). It is a typed compiler input
+/// error rather than a driver message, so one code and one rendering answer for
+/// it whether the context is captured by this driver or by an embedder.
+pub(crate) fn source_load_compiler_error(error: rue_error::CompileError) -> SourceLoadError {
+    SourceLoadError::Compiler {
+        snapshot: None,
+        errors: CompileErrors::from(error),
+    }
+}
+
 /// Turn a host-side contradiction into the canonical graceful ICE diagnostic.
 /// These failures are not environmental source-load/toolchain errors: they
 /// mean the compiler's own continuation protocol violated its invariant.
@@ -1006,7 +995,10 @@ impl ImportDiscoveryResult {
                 requested.clone(),
                 PathBuf::from(entry.canonical_path()),
                 fingerprint,
-                spelling_boundary(&self.resolution.context, &requested),
+                self.resolution
+                    .context
+                    .boundary_for_requested(&requested)
+                    .to_path_buf(),
                 Arc::from(entry.symlink_route().to_vec()),
             ));
         }
@@ -1264,11 +1256,11 @@ fn accepted_path_is_stable(
 ) -> bool {
     let requested = Path::new(requested_path);
     let canonical = Path::new(canonical_path);
-    let boundary = spelling_boundary(context, requested);
-    let route_before = symlink_route(requested, &boundary);
+    let boundary = context.boundary_for_requested(requested);
+    let route_before = symlink_route(requested, boundary);
     let observed_canonical = fs::canonicalize(requested).ok();
     let observed_metadata = fs::metadata(canonical).ok();
-    let route_after = symlink_route(requested, &boundary);
+    let route_after = symlink_route(requested, boundary);
     route_before.as_ref() == expected_route
         && route_after.as_ref() == expected_route
         && observed_canonical.as_deref() == Some(canonical)
@@ -1782,17 +1774,21 @@ pub(crate) fn discover_and_load_imports(
         })
     };
     // The compiler context retains the lexical project spelling for durable
-    // caller identities, but the trust boundary is physical. When a toolchain
-    // root is configured, validate that boundary before discovery can classify
-    // any source. Keep the no-std path's established context-before-root-read
-    // order so watch cycles do not change their fast publication timing.
+    // caller identities, but the trust boundary is physical, so discovery is
+    // given both spellings and applies its one overlap policy to each before it
+    // can classify any source. Resolving the root physically is what produces
+    // the second spelling, and only a configured toolchain needs it: the
+    // no-std path keeps its established context-before-root-read order so watch
+    // cycles do not change their fast publication timing.
     let root_canonical = if std_root.is_some() {
-        let root_canonical = canonicalize_root()?;
-        reject_project_root_inside_std(&root_canonical, std_root.as_deref())?;
-        Some(root_canonical)
+        Some(canonicalize_root()?)
     } else {
         None
     };
+    let canonical_root_dir = root_canonical
+        .as_deref()
+        .and_then(Path::parent)
+        .map(|directory| directory.to_string_lossy().into_owned());
     let policy_revision = source_manifest
         .as_ref()
         .map(SourceManifest::policy_revision)
@@ -1800,13 +1796,14 @@ pub(crate) fn discover_and_load_imports(
     let context = ImportDiscoveryContext::new(
         1,
         root_dir.to_string_lossy(),
+        canonical_root_dir.as_deref(),
         std_root
             .as_deref()
             .map(|path| path.to_string_lossy())
             .as_deref(),
         policy_revision,
     )
-    .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+    .map_err(source_load_compiler_error)?;
     let root_canonical = match root_canonical {
         Some(root_canonical) => root_canonical,
         None => canonicalize_root()?,
@@ -1908,10 +1905,11 @@ pub(crate) fn reload_from_filesystem(
     let context = ImportDiscoveryContext::new(
         result.resolution.context.epoch(),
         result.resolution.context.project_root(),
+        None,
         result.resolution.context.std_root(),
-        policy_revision,
+        policy_revision.clone(),
     )
-    .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+    .map_err(source_load_compiler_error)?;
     let reobserved = reobserve_accepted_reads(
         &result.source_snapshot,
         &result.read_manifest,
@@ -1931,13 +1929,22 @@ pub(crate) fn reload_from_filesystem(
             root_entry.requested_path()
         ))
     })?;
-    // The retained root may have been retargeted since the previous close. Run
-    // the same physical containment guard after reobservation, before the new
-    // assembler can classify or publish the retargeted source.
-    reject_project_root_inside_std(
-        Path::new(root.canonical_path()),
-        context.std_root().map(Path::new),
-    )?;
+    // The retained root may have been retargeted since the previous close, so
+    // its physical spelling is known only after reobservation. Recapture the
+    // context with that spelling: discovery owns the overlap policy, and the
+    // retargeted root passes it before the new assembler can classify or
+    // publish the source.
+    let context = ImportDiscoveryContext::new(
+        context.epoch(),
+        context.project_root(),
+        Path::new(root.canonical_path())
+            .parent()
+            .map(|directory| directory.to_string_lossy())
+            .as_deref(),
+        context.std_root(),
+        policy_revision,
+    )
+    .map_err(source_load_compiler_error)?;
     let mut assembler = DiscoverySourceAssembler::new_with_symlink_route(
         context.clone(),
         root.requested_path(),
@@ -2091,6 +2098,7 @@ pub(crate) fn acquire_reached_toolchain_modules_superseding(
                     control.checkpoint()?;
                     satisfy_toolchain_module_demand(
                         &mut round_assembler,
+                        &result.resolution.context,
                         result.std_root.as_deref(),
                         result.source_manifest.as_ref(),
                         demand,
@@ -2142,7 +2150,7 @@ pub(crate) fn acquire_reached_toolchain_modules_superseding(
                     Err(error) => {
                         let error = reclassify_reclose_failure(
                             error,
-                            result.std_root.as_deref(),
+                            &result.resolution.context,
                             park.demands(),
                         );
                         abort_import_input_request(&mut result.session).map_err(|errors| {
@@ -2258,7 +2266,7 @@ fn classify_trusted_transitive_failure(
 /// errors pass through unchanged.
 fn reclassify_reclose_failure(
     error: SourceLoadError,
-    std_root: Option<&Path>,
+    context: &ImportDiscoveryContext,
     demands: &[TrustedToolchainModuleDemand],
 ) -> SourceLoadError {
     match error {
@@ -2286,7 +2294,7 @@ fn reclassify_reclose_failure(
                         .map(|demand| demand.logical_path().to_owned())
                         .unwrap_or_default(),
                     demand
-                        .map(|demand| toolchain_module_path(std_root, demand))
+                        .map(|demand| toolchain_module_path(context, demand))
                         .unwrap_or_default(),
                 )
             });
@@ -2459,14 +2467,24 @@ impl From<ToolchainAcquisitionError> for SourceLoadError {
 /// deterministically distinct from a missing or malformed toolchain.
 fn satisfy_toolchain_module_demand(
     assembler: &mut DiscoverySourceAssembler,
+    context: &ImportDiscoveryContext,
     std_root: Option<&Path>,
     source_manifest: Option<&SourceManifest>,
     demand: &TrustedToolchainModuleDemand,
 ) -> Result<(), ToolchainAcquisitionError> {
-    let std_root = std_root.ok_or_else(|| ToolchainIntegrityError::StdRootUnavailable {
+    let std_root_unavailable = || ToolchainIntegrityError::StdRootUnavailable {
         logical_path: demand.logical_path().to_owned(),
-    })?;
-    let requested = normalize_lexical_path(&std_root.join(demand.std_relative_path()));
+    };
+    let std_root = std_root.ok_or_else(std_root_unavailable)?;
+    // Discovery owns "trusted module -> requested spelling". Deriving it here
+    // instead would be a second answer to that question, free to disagree with
+    // the identity the compiler mints for the module it publishes.
+    let module = demand
+        .trusted_module_id()
+        .map_err(|_| std_root_unavailable())?;
+    let requested = PathBuf::from(
+        requested_path_for_module(context, &module).map_err(|_| std_root_unavailable())?,
+    );
 
     // Manifest authority before any probe. A path the policy does not lexically
     // declare must not touch the filesystem at all, so this check precedes
@@ -2582,14 +2600,19 @@ fn satisfy_toolchain_module_demand(
     Ok(())
 }
 
+/// The path a trusted toolchain module would have been read from, for a
+/// diagnostic that must name one. Discovery answers it; a context with no
+/// captured std root has no filesystem spelling to give, so the module is named
+/// by its logical path.
 fn toolchain_module_path(
-    std_root: Option<&Path>,
+    context: &ImportDiscoveryContext,
     demand: &TrustedToolchainModuleDemand,
 ) -> PathBuf {
-    match std_root {
-        Some(root) => normalize_lexical_path(&root.join(demand.std_relative_path())),
-        None => PathBuf::from(demand.logical_path()),
-    }
+    demand
+        .trusted_module_id()
+        .and_then(|module| requested_path_for_module(context, &module))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(demand.logical_path()))
 }
 
 #[cfg(test)]
@@ -4368,12 +4391,18 @@ mod tests {
 
         let error = reload_from_filesystem(&mut result, None)
             .expect_err("a retained project retarget into std must fail closed");
-        assert!(matches!(
-            error,
-            SourceLoadError::Message(message)
-                if message.contains("project root")
-                    && message.contains("inside the configured standard-library root")
-        ));
+        // The overlap policy belongs to discovery, so the retarget is refused
+        // by the compiler's typed input error rather than a driver message.
+        let SourceLoadError::Compiler { snapshot, errors } = error else {
+            panic!("expected a typed compiler diagnostic, got {error:?}");
+        };
+        assert!(snapshot.is_none());
+        let message = errors.iter().next().expect("one refusal").to_string();
+        assert!(
+            message.contains("project root")
+                && message.contains("inside the configured standard-library root"),
+            "unexpected refusal: {message}"
+        );
     }
 
     #[cfg(unix)]

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -175,9 +175,19 @@ input errors (`E1400-E1499`) and internal compiler errors
 the normal compiler formatter, including their source spans and existing
 codes. Ordinary root/source manifest handling is not universally E1502: a root
 policy failure is ordinary source loading (E1500), while an import policy
-diagnostic with a source snapshot remains a compiler diagnostic. The one-shot
-and `--watch` source-load paths share one rendering helper, so a given
-`SourceLoadError` has identical JSON framing, code, and message in both modes.
+diagnostic with a source snapshot remains a compiler diagnostic.
+
+Policy the compiler owns keeps its compiler code even when the driver is what
+triggers it. Capturing an import-discovery context validates the project root
+against the configured standard-library root, so a project rooted inside the
+toolchain is `E1400` (invalid compiler input) with an empty `spans` array,
+rendered by the compiler formatter — the same code and message an embedder that
+captures its own context receives, rather than a driver classification the CLI
+alone would report.
+
+The one-shot and `--watch` source-load paths share one rendering helper, so a
+given `SourceLoadError` has identical JSON framing, code, and message in both
+modes.
 
 ## Testing the surface
 


### PR DESCRIPTION
Fixes RUE-1979

## Why

Three lexical path normalizers fed the same source identities with different `..`-at-root semantics, and the driver re-derived the compiler's std-root policy. Measured on trunk:

| input | `rue_air::normalize_module_path` | `import_discovery::normalize_path` | `source_loader::normalize_lexical_path` |
|---|---|---|---|
| `/a/../..` | `/..` | `/` | `/` |
| `/../../x` | `/../../x` | `/x` | `/x` |
| `../x` | `../x` | `../x` | cwd-anchored |

They differed on exactly two axes: root-escaping `..` (rue-air preserved it, the other two clamped at root) and relative-path anchoring (only the driver anchors at cwd). The divergence does not reproduce through the CLI, as the issue predicted, because the driver pre-normalizes its root; it is real at the API boundary, where an embedder handing `SourceMetadata` a `/../a.rue` physical spelling beside `/a.rue` got "distinct modules" while discovery minted one identity.

## What

- `rue_air::normalize_module_path` is the one normalizer, with the policy stated once in `path_norm.rs`: `..` cancels a preceding normal component; an uncancelable `..` is dropped on an absolute path (the root is its own parent, matching POSIX and `PathBuf::pop`) and kept verbatim on a relative path (no anchor to resolve against). The rule is derived from the path rather than a caller-supplied flag, since a flag that disagrees with the path is a new bug surface. A `policy_table` test covers every row above plus `.`, `//`, trailing slash, and empty cases. Anchoring at cwd stays the driver's step, since it is process state rather than a reduction rule. `import_discovery::normalize_path` and `source_loader::normalize_lexical_path` are wrappers or gone.
- `ImportDiscoveryContext::new` takes both the lexical and canonical roots and owns the root-inside-std overlap check as one typed `CompileError`. It renders as `error: [E1400]: invalid compiler input: project root "…" is inside the configured standard-library root` in text and as one `E1400` JSON object with empty spans; schema fields are unchanged, so `docs/process/diagnostics.md` gains a paragraph. The driver's separate `reject_project_root_inside_std` and its flattening of the compiler's typed error into a `SourceLoadError::Message` are gone. The issue's "bare string under `--error-format json`" claim was stale: the driver already rendered `Message` as a structured `E1500`; what differed was the code and the formatter.
- `spelling_boundary` calls the compiler-exported `ImportDiscoveryContext::boundary_for_requested` (a pure query; the escaping-`..` refusal stays in `classify_module`, which mints identities). The driver's two `std_root.join(demand.std_relative_path())` sites call `requested_path_for_module`, exported under `unstable`, and `TrustedToolchainModuleDemand::std_relative_path` is deleted with its only consumer.
- Around forty `ImportDiscoveryContext::new` call sites across rue-compiler, rue-oracle, and rue-oracle-diff tests gain the new canonical-root argument mechanically.
- New tests: `source_metadata::tests::absolute_physical_spellings_agree_with_discovery_identities` pins the API-boundary divergence; a `modules.toml` CLI case exercises a root-escaping `--source-manifest` entry; a `diagnostic_json.toml` case pins the `E1400` overlap rendering.

`reload_from_filesystem` builds the context twice (before reobservation with the retained roots, after with the reobserved canonical root) because the retargeted root's physical spelling only exists after reobservation; the constructor stores nothing from the canonical root, so the two contexts are equal and `regime_token`, the deps-envelope `context`, and warm-reuse identity are unchanged.

## Verification

| Command | Result |
|---|---|
| `scripts/rue unit air path_norm` | 7 passed |
| `scripts/rue unit compiler import_discovery` / `source_identity` / `source_metadata` | 77 / 17 / pass |
| `scripts/rue unit rue ""` | 353 passed |
| `scripts/rue quick` | pass, re-run after rebasing onto current trunk |
| `scripts/rue cli modules` (146), `diagnostic_json` (21), `test_candidates` (6), `watch` (9), `source_path` (1) | all pass |
| `scripts/rue ui import` | 13 passed |
| `//crates/rue-compiler:rue-compiler-test` (1229), `//crates/rue:rue-driver-test`, `//crates/rue-air:rue-air-test` | pass |
| clippy gates for rue-air, rue-compiler, rue, rue-driver; debug-assert checks for the same | pass |
| `//:type-architecture-inventory-validation`, `//crates/rue-oracle-diff:oracle-diff-test` | pass |
| `scripts/rue fmt` | clean |

No language semantics changed, so no spec cases.