### PR TITLE
Floats cross the C boundary

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -122,7 +122,9 @@ pub fn is_slot_identical_layout<P: crate::FfiTypePool + ?Sized>(type_pool: &P, t
         | TypeKind::ComptimeType
         | TypeKind::ComptimeFloat
         | TypeKind::Module(_) => true,
-        // Phase 4 deliberately has no float ABI lowering yet.
+        // A float leaf is read and written by a floating-point access at its
+        // own width, never as an opaque slot, so it is not slot-identical even
+        // where its footprint is eight bytes.
         TypeKind::F32 | TypeKind::F64 => false,
         // Narrow scalars: one/two/four bytes under the compact layout.
         TypeKind::I8
@@ -184,9 +186,10 @@ impl CAbiScalarKind {
     /// compile-time-only type). The stable query plane makes the same
     /// projection from its own type keys.
     ///
-    /// The float classes are part of the projection because the native
-    /// convention places floats by these same rules (ADR-0084); the C boundary
-    /// rejects them earlier, in `c_passable_by_value`.
+    /// The float classes are part of the projection because both conventions
+    /// place a float by one rule: the native row by ADR-0084, and the C row
+    /// because `f32` and `f64` are FFI-safe scalars naming C `float` and
+    /// `double` (ADR-0064 P5).
     pub fn for_live_type(ty: Type) -> Option<Self> {
         Some(match ty.kind() {
             TypeKind::I8 => Self::I8,
@@ -302,12 +305,14 @@ impl ScalarAbiExtension {
 /// The narrow-integer extension every C row asks for, and who owes it.
 ///
 /// Every supported scalar (`c_passable_by_value`: the full integer set, `bool`,
-/// pointers) occupies exactly one general-purpose register, and Rue's internal
-/// invariant keeps a narrow value canonically 64-bit-extended in its vreg
-/// (signed sign-extended, unsigned and `bool` zero-extended). That is a
-/// *stronger* guarantee than any row asks of an argument, so **argument passing
-/// needs no boundary instruction** on any of them — including Apple's row,
-/// which makes the caller extend an argument narrower than 32 bits.
+/// pointers, and the two floating-point widths) occupies exactly one register
+/// of its own bank, and Rue's internal invariant keeps a narrow *integer*
+/// canonically 64-bit-extended in its vreg (signed sign-extended, unsigned and
+/// `bool` zero-extended). That is a *stronger* guarantee than any row asks of
+/// an argument, so **argument passing needs no boundary instruction** on any of
+/// them — including Apple's row, which makes the caller extend an argument
+/// narrower than 32 bits. A float fills its own register and is extended in
+/// neither direction.
 ///
 /// The one direction that does need an instruction is the **return**: SysV
 /// AMD64 leaves the bits above a narrow result unspecified, and AAPCS64 defines

--- a/crates/rue-air/src/ffi_predicates.rs
+++ b/crates/rue-air/src/ffi_predicates.rs
@@ -11,9 +11,9 @@
 //! 2. [`c_ffi_safe`] — the structural hard-error policy: linear,
 //!    destructor-bearing, and ownership-bearing fields are forbidden across the
 //!    boundary. Pointee layouts are *not* required, so opaque pointers pass.
-//! 3. [`c_passable_by_value`] — the by-value classifier seam. In P1.5 it
-//!    delegates to the P1 register-only restriction (`i64`/`u64`/pointers); it is
-//!    the seam P2/P3 fill with eightbyte classification and register packing.
+//! 3. [`c_passable_by_value`] — the by-value classifier seam: the scalars and
+//!    C-classifiable aggregates [`lower_c_signature`](crate::lower_c_signature)
+//!    places, by eightbyte classification and register packing.
 //!
 //! Every failure carries the failing [`FfiPredicate`], the offending field
 //! *path*, and a structured [`FfiRejectReason`] rather than a bare `bool` — the
@@ -68,8 +68,8 @@ pub enum FfiRejectReason {
     /// A type with no C representation at all (unit, never, module, comptime,
     /// slice-shaped, …).
     UnsupportedType,
-    /// A type that is not in the by-value set the current phase (P2) implements
-    /// — the [`c_passable_by_value`] seam P3 widens to aggregates.
+    /// A type with no by-value form at a C parameter or result position: a
+    /// fixed-size array, which C decays to a pointer.
     NotRegisterPassable,
 }
 
@@ -95,8 +95,9 @@ impl FfiRejectReason {
             }
             FfiRejectReason::UnsupportedType => "this type has no C representation in v0",
             FfiRejectReason::NotRegisterPassable => {
-                "this type is not yet passable by value across a C boundary (only \
-                 integer and pointer scalars are; aggregates await a later FFI phase)"
+                "this type has no by-value C parameter form (C decays an array \
+                 argument to a pointer; pass a pointer or wrap the value in a \
+                 `@repr(c)` struct)"
             }
         }
     }
@@ -166,7 +167,8 @@ pub trait FfiTypePool {
 }
 
 /// Whether a scalar type kind is a C-compatible scalar (integer widths, `bool`,
-/// or a raw pointer). The `std.c` transparent aliases resolve to these.
+/// the two binary floating-point widths, or a raw pointer). The `std.c`
+/// transparent aliases resolve to these.
 fn is_c_scalar(kind: TypeKind) -> bool {
     matches!(
         kind,
@@ -179,6 +181,8 @@ fn is_c_scalar(kind: TypeKind) -> bool {
             | TypeKind::U32
             | TypeKind::U64
             | TypeKind::Bool
+            | TypeKind::F32
+            | TypeKind::F64
             | TypeKind::PtrConst(_)
             | TypeKind::PtrMut(_)
     )
@@ -308,22 +312,24 @@ fn check_c_ffi_safe<P: FfiTypePool>(
     }
 }
 
-/// Predicate 3: can `ty` cross a C boundary *by value* in the current phase?
+/// Predicate 3: can `ty` cross a C boundary *by value*?
 ///
 /// This is the classifier seam, kept in lock-step with
 /// [`lower_c_signature`](crate::lower_c_signature), the one function that places
-/// each crossing. The admitted set is the **full integer scalar set** — every
-/// signed and unsigned integer width, `bool` as the 1-byte `_Bool`, and raw
-/// pointers, the scalars the placement assigns to a single integer register with
-/// a defined narrow-integer extension
-/// ([`ScalarAbiExtension`](crate::call_abi::ScalarAbiExtension)) — plus
+/// each crossing. The admitted set is the **full scalar set** — every signed and
+/// unsigned integer width, `bool` as the 1-byte `_Bool`, raw pointers, and the
+/// two binary floating-point widths (`f32` as C `float`, `f64` as C `double`) —
+/// each of which the placement assigns to a single register of its own bank,
+/// with a defined narrow-integer extension
+/// ([`ScalarAbiExtension`](crate::call_abi::ScalarAbiExtension)) for the narrow
+/// integers and none for a float, which fills its register. Added to that are
 /// **C-classifiable aggregates**: a struct marked `@repr(c)` that satisfies
 /// [`has_c_layout`] and [`c_ffi_safe`] (i.e. is [`repr_c_marker_eligible`]) is
 /// passable by value. The placement assigns an aggregate eightbyte-wise — ≤16
-/// bytes packs into one or two registers in C field order; larger goes to memory
-/// by the convention's own rule. In the integer-only core every eightbyte
-/// classifies INTEGER; a field type that would classify SSE cannot exist until
-/// RUE-714 adds floats (P5).
+/// bytes packs into one or two registers in C field order, each in the bank its
+/// own leaves classify it into, and AAPCS64 additionally carries a homogeneous
+/// floating-point aggregate one member per register; larger goes to memory by
+/// the convention's own rule.
 ///
 /// Fixed arrays stay rejected here (`NotRegisterPassable`) — C decays an array
 /// parameter to a pointer, so a by-value array is not a boundary type; it is
@@ -340,6 +346,8 @@ pub fn c_passable_by_value<P: FfiTypePool>(pool: &P, ty: Type) -> Result<(), Ffi
         | TypeKind::I64
         | TypeKind::U64
         | TypeKind::Bool
+        | TypeKind::F32
+        | TypeKind::F64
         | TypeKind::PtrConst(_)
         | TypeKind::PtrMut(_) => Ok(()),
         // A C-classifiable aggregate is passable by value iff it is a marked and
@@ -440,12 +448,21 @@ mod tests {
     #[test]
     fn scalars_and_pointers_have_c_layout_and_are_safe_and_passable() {
         let pool = MockPool::default();
-        for ty in [Type::I64, Type::U64, Type::I32, Type::U8, Type::BOOL, ptr()] {
+        for ty in [
+            Type::I64,
+            Type::U64,
+            Type::I32,
+            Type::U8,
+            Type::BOOL,
+            Type::F32,
+            Type::F64,
+            ptr(),
+        ] {
             assert!(has_c_layout(&pool, ty), "{ty:?} should have C layout");
             assert!(c_ffi_safe(&pool, ty).is_ok(), "{ty:?} should be FFI-safe");
         }
-        // P2 (RUE-1056) widens by-value passing to the full integer scalar set
-        // plus `bool` and pointers.
+        // The by-value scalar set is every integer width, `bool` as the 1-byte
+        // `_Bool`, both floating-point widths (P5, RUE-1059), and pointers.
         for ty in [
             Type::I8,
             Type::U8,
@@ -456,11 +473,13 @@ mod tests {
             Type::I64,
             Type::U64,
             Type::BOOL,
+            Type::F32,
+            Type::F64,
             ptr(),
         ] {
             assert!(
                 c_passable_by_value(&pool, ty).is_ok(),
-                "{ty:?} should be passable by value in P2"
+                "{ty:?} should be passable by value"
             );
         }
         // P3 (RUE-1057): an eligible `@repr(c)` aggregate is now passable by

--- a/crates/rue-air/src/lowered_signature.rs
+++ b/crates/rue-air/src/lowered_signature.rs
@@ -42,13 +42,13 @@
 //!
 //! ## Floats
 //!
-//! Classification is complete over floating-point values: an eightbyte whose
-//! every leaf is a float classifies [`EightbyteClass::Sse`] and travels in
-//! [`CRegisterClass::Fp`], and AAPCS64's homogeneous floating-point aggregates
-//! travel in consecutive floating-point registers. No *C* signature reaches
-//! that surface, because the C boundary rejects `f32`/`f64`
-//! (`c_passable_by_value`); the native convention is what has floats to place,
-//! and it places them by these same rules.
+//! Classification is complete over floating-point values, and both conventions
+//! reach it: an eightbyte whose every leaf is a float classifies
+//! [`EightbyteClass::Sse`] and travels in [`CRegisterClass::Fp`], and AAPCS64's
+//! homogeneous floating-point aggregates travel in consecutive floating-point
+//! registers, one per *member* rather than one per eightbyte. `f32` and `f64`
+//! are FFI-safe scalars naming C `float` and `double` (ADR-0064 P5), so a C
+//! signature places them by these rules exactly as a native one does.
 
 use rue_target::{
     AggregateClassificationRule, CConventionSpec, CRegisterClass, CallingConvention,
@@ -69,8 +69,8 @@ pub enum CAbiTypeFacts {
     Scalar {
         /// The scalar's width-and-signedness class.
         kind: CAbiScalarKind,
-        /// The register bank the scalar travels in. `Gp` for every scalar the
-        /// C boundary currently admits.
+        /// The register bank the scalar travels in: `Fp` for `f32` and `f64`,
+        /// `Gp` for every integer, `bool`, and pointer.
         class: CRegisterClass,
     },
     /// An aggregate (struct, array, or enum) of `size` bytes at `align`
@@ -372,10 +372,12 @@ const fn eightbyte_mask(size: u64) -> u64 {
 /// The register class of one eightbyte of an aggregate.
 ///
 /// SysV AMD64 section 3.2.3 classifies each eightbyte of an aggregate and
-/// assigns it a register of the matching bank; AAPCS64's composite rule reaches
-/// the same answer for the integer-only surface. Every eightbyte of every
-/// currently admissible type is [`Integer`](Self::Integer): a field that would
-/// classify [`Sse`](Self::Sse) is a float, which the boundary rejects.
+/// assigns it a register of the matching bank: an eightbyte whose every leaf is
+/// a float is [`Sse`](Self::Sse) and everything else is
+/// [`Integer`](Self::Integer). AAPCS64 never classifies per eightbyte — a
+/// composite that is not a homogeneous floating-point aggregate travels in
+/// integer registers whatever its fields are (section 6.8.2 rules C.13 and
+/// C.14) — so this classification is read only under the SysV rule.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EightbyteClass {
     /// The eightbyte travels in a general-purpose integer register.

--- a/crates/rue-c-abi-matrix/src/grid.rs
+++ b/crates/rue-c-abi-matrix/src/grid.rs
@@ -26,12 +26,16 @@
 //! deliberately different ("poisoned") value when the seed did not arrive
 //! intact, so a broken argument crossing cannot hide behind a correct result.
 //!
+//! Floating-point leaves carry values that are exactly representable in both
+//! widths — small integers — and contribute the integer they convert to, so the
+//! odd-multiplier checksum stays exact arithmetic and a rounding difference
+//! never masks a placement bug.
+//!
 //! # Extending the table
 //!
-//! Floats are still rejected at Rue's C boundary. Adding them later is a table
-//! edit: one [`Leaf`] variant with its two type spellings and its conversion
-//! rules, and one [`SHAPES`] row per new shape. Nothing else in this module
-//! knows the leaf inventory.
+//! Adding a leaf type is a table edit: one [`Leaf`] variant with its two type
+//! spellings and its conversion rules, and one [`SHAPES`] row per new shape.
+//! Nothing else in this module knows the leaf inventory.
 
 use rue_target::CConventionSpec;
 
@@ -53,6 +57,10 @@ pub enum Leaf {
     I64,
     U64,
     Bool,
+    /// `f32` in Rue, `float` in C.
+    F32,
+    /// `f64` in Rue, `double` in C.
+    F64,
     /// `ptr const u8` in Rue, `const rue_u8 *` in C.
     Ptr,
 }
@@ -69,6 +77,8 @@ impl Leaf {
             Leaf::I64 => "i64",
             Leaf::U64 => "u64",
             Leaf::Bool => "bool",
+            Leaf::F32 => "f32",
+            Leaf::F64 => "f64",
             Leaf::Ptr => "ptr const u8",
         }
     }
@@ -87,6 +97,8 @@ impl Leaf {
             Leaf::I64 => "rue_i64",
             Leaf::U64 => "rue_u64",
             Leaf::Bool => "rue_bool",
+            Leaf::F32 => "rue_f32",
+            Leaf::F64 => "rue_f64",
             Leaf::Ptr => "const rue_u8 *",
         }
     }
@@ -97,8 +109,14 @@ impl Leaf {
             Leaf::I16 | Leaf::U16 => Some(16),
             Leaf::I32 | Leaf::U32 => Some(32),
             Leaf::I64 | Leaf::U64 => Some(64),
-            Leaf::Bool | Leaf::Ptr => None,
+            Leaf::Bool | Leaf::F32 | Leaf::F64 | Leaf::Ptr => None,
         }
+    }
+
+    /// Whether the leaf lives in the floating-point file, which is what makes
+    /// it worth a row here: its placement bank differs from every other leaf's.
+    fn is_float(self) -> bool {
+        matches!(self, Leaf::F32 | Leaf::F64)
     }
 
     fn is_signed(self) -> bool {
@@ -112,6 +130,9 @@ impl Leaf {
             Leaf::I64 => "L",
             Leaf::U64 => "UL",
             Leaf::U8 | Leaf::U16 | Leaf::U32 => "U",
+            // An unsuffixed C floating literal is a `double`; the `f` suffix is
+            // what keeps a `float` field's initializer its own type.
+            Leaf::F32 => "f",
             _ => "",
         }
     }
@@ -122,6 +143,12 @@ impl Leaf {
 pub enum Value {
     Int(i128),
     Bool(bool),
+    /// A floating-point value, held as the integer it equals. Every float in
+    /// the grid is a small whole number, so it is exactly representable in both
+    /// binary32 and binary64 and converts back to this integer with no
+    /// rounding — which is what lets the checksum stay exact integer arithmetic
+    /// on both sides of the boundary.
+    Float(i64),
     /// An index into [`PROBE_BYTES`]; the pointer itself is `&c_probe_bytes[i]`.
     Ptr(u8),
 }
@@ -140,6 +167,9 @@ impl Value {
                 }
             }
             Value::Bool(b) => u64::from(b),
+            // Both sides convert the float to a signed 64-bit integer before
+            // mixing it, which is exact for a whole number in range.
+            Value::Float(v) => v as u64,
             Value::Ptr(index) => u64::from(PROBE_BYTES[usize::from(index)]),
         }
     }
@@ -149,6 +179,7 @@ impl Value {
             Value::Int(v) => v.to_string(),
             Value::Bool(true) => "true".to_string(),
             Value::Bool(false) => "false".to_string(),
+            Value::Float(v) => format!("{v}.0"),
             Value::Ptr(index) => index.to_string(),
         }
     }
@@ -157,6 +188,7 @@ impl Value {
         match self {
             Value::Int(v) => format!("{v}{}", leaf.c_literal_suffix()),
             Value::Bool(b) => (if b { "1" } else { "0" }).to_string(),
+            Value::Float(v) => format!("{v}.0{}", leaf.c_literal_suffix()),
             Value::Ptr(index) => format!("&c_probe_bytes[{index}]"),
         }
     }
@@ -169,6 +201,8 @@ impl Value {
             Value::Int(0) => Value::Int(1),
             Value::Int(_) => Value::Int(0),
             Value::Bool(b) => Value::Bool(!b),
+            Value::Float(0) => Value::Float(1),
+            Value::Float(_) => Value::Float(0),
             Value::Ptr(index) => Value::Ptr((index + 1) % 8),
         }
     }
@@ -404,11 +438,164 @@ static ABI_ARRAY: StructDef = StructDef {
     ],
 };
 
+// --- Floating-point shapes (ADR-0064 P5) ------------------------------------
+//
+// Chosen to land on every boundary the two rows' floating-point rules have.
+// SysV AMD64 classifies each eightbyte by its own leaves, so `{f32, f32}` is
+// one SSE eightbyte and `{f32, f32, f32, f32}` is two; AAPCS64 instead asks
+// whether the whole aggregate is a homogeneous floating-point aggregate and
+// spends one register per *member*, so those two shapes take one and four
+// `v`-registers there. `{i64, f64}` and `{f64, i64}` split the banks in either
+// order under SysV and are ordinary integer composites under AAPCS64;
+// `{i32, f32}` packs into a single INTEGER eightbyte under SysV and is not an
+// HFA either way. `{f64, f64, f64}` is an HFA of three members and MEMORY
+// under SysV. `{f64; 5}` is over both limits — too large for SysV's register
+// budget, and not an HFA of at most four members, so AAPCS64 passes it by
+// reference. `{i32, f32, i32}` puts a float in the middle of integers, where
+// its eightbyte is INTEGER-classified by the leaves around it.
+
+static ABI_F32_F32: StructDef = StructDef {
+    name: "AbiF32F32",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::F32),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::F32),
+        },
+    ],
+};
+
+static ABI_F32_X4: StructDef = StructDef {
+    name: "AbiF32X4",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::F32),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::F32),
+        },
+        Field {
+            name: "f2",
+            ty: Ty::Leaf(Leaf::F32),
+        },
+        Field {
+            name: "f3",
+            ty: Ty::Leaf(Leaf::F32),
+        },
+    ],
+};
+
+static ABI_F64_F64: StructDef = StructDef {
+    name: "AbiF64F64",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::F64),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::F64),
+        },
+    ],
+};
+
+static ABI_F64_X3: StructDef = StructDef {
+    name: "AbiF64X3",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::F64),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::F64),
+        },
+        Field {
+            name: "f2",
+            ty: Ty::Leaf(Leaf::F64),
+        },
+    ],
+};
+
+static ABI_F64_X5: StructDef = StructDef {
+    name: "AbiF64X5",
+    fields: &[Field {
+        name: "f0",
+        ty: Ty::Array(Leaf::F64, 5),
+    }],
+};
+
+static ABI_I64_F64: StructDef = StructDef {
+    name: "AbiI64F64",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::F64),
+        },
+    ],
+};
+
+static ABI_F64_I64: StructDef = StructDef {
+    name: "AbiF64I64",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::F64),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::I64),
+        },
+    ],
+};
+
+static ABI_I32_F32: StructDef = StructDef {
+    name: "AbiI32F32",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::I32),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::F32),
+        },
+    ],
+};
+
+static ABI_I32_F32_I32: StructDef = StructDef {
+    name: "AbiI32F32I32",
+    fields: &[
+        Field {
+            name: "f0",
+            ty: Ty::Leaf(Leaf::I32),
+        },
+        Field {
+            name: "f1",
+            ty: Ty::Leaf(Leaf::F32),
+        },
+        Field {
+            name: "f2",
+            ty: Ty::Leaf(Leaf::I32),
+        },
+    ],
+};
+
 /// The shape rows. Scalars first, then `@repr(c)` structs chosen to land on the
 /// classification boundaries both current psABI rows care about: one and two
 /// bytes, two fields sharing one eightbyte, a padded 16, an exact 16, a 17-byte
 /// footprint padded to 24, an exact 24 (past the two-register budget on both
-/// rows), a leading narrow field, a nested struct, and an array field.
+/// rows), a leading narrow field, a nested struct, and an array field — then
+/// the floating-point rows above.
 pub static SHAPES: &[Shape] = &[
     Shape {
         key: "i8",
@@ -489,6 +676,50 @@ pub static SHAPES: &[Shape] = &[
     Shape {
         key: "s_array",
         ty: Ty::Struct(&ABI_ARRAY),
+    },
+    Shape {
+        key: "f32",
+        ty: Ty::Leaf(Leaf::F32),
+    },
+    Shape {
+        key: "f64",
+        ty: Ty::Leaf(Leaf::F64),
+    },
+    Shape {
+        key: "s_f32f32",
+        ty: Ty::Struct(&ABI_F32_F32),
+    },
+    Shape {
+        key: "s_f32x4",
+        ty: Ty::Struct(&ABI_F32_X4),
+    },
+    Shape {
+        key: "s_f64f64",
+        ty: Ty::Struct(&ABI_F64_F64),
+    },
+    Shape {
+        key: "s_f64x3",
+        ty: Ty::Struct(&ABI_F64_X3),
+    },
+    Shape {
+        key: "s_f64x5",
+        ty: Ty::Struct(&ABI_F64_X5),
+    },
+    Shape {
+        key: "s_i64f64",
+        ty: Ty::Struct(&ABI_I64_F64),
+    },
+    Shape {
+        key: "s_f64i64",
+        ty: Ty::Struct(&ABI_F64_I64),
+    },
+    Shape {
+        key: "s_i32f32",
+        ty: Ty::Struct(&ABI_I32_F32),
+    },
+    Shape {
+        key: "s_i32f32i32",
+        ty: Ty::Struct(&ABI_I32_F32_I32),
     },
 ];
 
@@ -633,6 +864,11 @@ impl Rng {
         match leaf {
             Leaf::Bool => Value::Bool(self.next() & 1 == 1),
             Leaf::Ptr => Value::Ptr((self.next() % PROBE_BYTES.len() as u64) as u8),
+            // A whole number in +/-1,000,000: exactly representable in binary32
+            // (every integer below 2^24 is) and therefore in binary64 too, so
+            // neither width rounds it and both sides convert it back to the
+            // same integer.
+            Leaf::F32 | Leaf::F64 => Value::Float((self.next() % 2_000_001) as i64 - 1_000_000),
             _ => {
                 let width = leaf
                     .integer_width()
@@ -676,12 +912,16 @@ fn c_prelude() -> String {
     out.push_str("typedef unsigned int rue_u32;\n");
     out.push_str("typedef long rue_i64;\n");
     out.push_str("typedef unsigned long rue_u64;\n");
-    out.push_str("typedef _Bool rue_bool;\n\n");
+    out.push_str("typedef _Bool rue_bool;\n");
+    out.push_str("typedef float rue_f32;\n");
+    out.push_str("typedef double rue_f64;\n\n");
     out.push_str("_Static_assert(sizeof(rue_i8) == 1, \"signed char must be 8-bit\");\n");
     out.push_str("_Static_assert(sizeof(rue_i16) == 2, \"short must be 16-bit\");\n");
     out.push_str("_Static_assert(sizeof(rue_i32) == 4, \"int must be 32-bit\");\n");
     out.push_str("_Static_assert(sizeof(rue_i64) == 8, \"long must be 64-bit under LP64\");\n");
-    out.push_str("_Static_assert(sizeof(void *) == 8, \"pointers must be 64-bit\");\n\n");
+    out.push_str("_Static_assert(sizeof(void *) == 8, \"pointers must be 64-bit\");\n");
+    out.push_str("_Static_assert(sizeof(rue_f32) == 4, \"float must be binary32\");\n");
+    out.push_str("_Static_assert(sizeof(rue_f64) == 8, \"double must be binary64\");\n\n");
     out.push_str(&format!(
         "static const rue_u8 c_probe_bytes[{}] = {{ {probe} }};\n\n",
         PROBE_BYTES.len()
@@ -738,7 +978,10 @@ fn c_mix(expr: &str, leaf: Leaf, multiplier: u64) -> String {
     let widened = match leaf {
         Leaf::Ptr => format!("(rue_u64)(*({expr}))"),
         Leaf::Bool => format!("(rue_u64)(({expr}) ? 1 : 0)"),
-        _ if leaf.is_signed() => format!("(rue_u64)(rue_i64)({expr})"),
+        // Both go through `rue_i64`: a signed integer so the cast to `rue_u64`
+        // sees the sign extension, and a float because converting it to a
+        // signed 64-bit integer is exact for the whole numbers the grid uses.
+        _ if leaf.is_float() || leaf.is_signed() => format!("(rue_u64)(rue_i64)({expr})"),
         _ => format!("(rue_u64)({expr})"),
     };
     format!("    acc += {widened} * {multiplier}UL;\n")
@@ -760,6 +1003,10 @@ fn rue_mix(index: usize, expr: &str, leaf: Leaf, multiplier: u64) -> String {
             out.push_str(&format!(
                 "    let x{index}: u64 = if {expr} {{ 1 }} else {{ 0 }};\n"
             ));
+        }
+        Leaf::F32 | Leaf::F64 => {
+            out.push_str(&format!("    let t{index}: i64 = @float_to_int({expr});\n"));
+            out.push_str(&format!("    let x{index}: u64 = @bitCast(t{index});\n"));
         }
         Leaf::I64 => {
             out.push_str(&format!("    let x{index}: u64 = @bitCast({expr});\n"));

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -1372,3 +1372,221 @@ fn main() -> i32 {
   { path = "a.rue", source = """pub fn main() -> i32 { 7 }""" },
 ]
 exit_code = 7
+
+# --- P5: floating point and the FP calling convention (ADR-0064 P5) ---------
+#
+# Floats are FFI-safe scalars (spec 9.3:1e): `f32` is C `float` and `f64` is C
+# `double`, and both cross in the row's floating-point register file. The
+# archive's `ffi_fadd` / `ffi_fmul32` members are leaves that read their
+# arguments out of `xmm0`/`xmm1` (SysV) or `d0`/`d1` and `s0`/`s1` (AAPCS64)
+# and answer in the first of them, so a wrong bank or a wrong move width
+# produces a different number rather than a link error. Every value here is a
+# whole number in both binary32 and binary64, so the printed integer is exact.
+
+[[case]]
+name = "x86_64_linux_float_import_returns_exact_result"
+description = "An `extern \"C\"` import taking two `f64`s and one taking two `f32`s cross in the SSE registers and return exact results on x86-64."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_fadd(a: f64, b: f64) -> f64;
+    fn ffi_fmul32(a: f32, b: f32) -> f32;
+}
+
+fn main() -> i32 {
+    let sum = checked { ffi_fadd(1.5, 2.25) };
+    let product = checked { ffi_fmul32(3.0, 5.0) };
+    @dbg(@float_to_int(sum * 4.0));
+    @dbg(@float_to_int(@float_cast(product)));
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "15\n15\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_float_import_returns_exact_result"
+description = "The same float imports cross in `d0`/`d1` and `s0`/`s1` under AAPCS64 and return the same exact results."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_fadd(a: f64, b: f64) -> f64;
+    fn ffi_fmul32(a: f32, b: f32) -> f32;
+}
+
+fn main() -> i32 {
+    let sum = checked { ffi_fadd(1.5, 2.25) };
+    let product = checked { ffi_fmul32(3.0, 5.0) };
+    @dbg(@float_to_int(sum * 4.0));
+    @dbg(@float_to_int(@float_cast(product)));
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "15\n15\n"
+exit_code = 0
+
+[[case]]
+name = "x86_64_linux_float_export_called_from_c"
+description = "A separately compiled C caller invokes `pub extern \"C\" fn` exports taking and returning `f64` and `f32`; both reduce to aliases of their native bodies, since the two rows place a float identically."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_call_float_exports() -> i64;
+}
+
+pub extern "C" fn rue_fadd_export(a: f64, b: f64) -> f64 { a + b }
+pub extern "C" fn rue_f32_export(a: f32, b: f32) -> f32 { a * b }
+
+fn main() -> i32 {
+    @dbg(checked { ffi_call_float_exports() });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "315\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_float_export_called_from_c"
+description = "The same C caller reaches the same float exports through `d0`/`d1` and `s0`/`s1` under AAPCS64."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_call_float_exports() -> i64;
+}
+
+pub extern "C" fn rue_fadd_export(a: f64, b: f64) -> f64 { a + b }
+pub extern "C" fn rue_f32_export(a: f32, b: f32) -> f32 { a * b }
+
+fn main() -> i32 {
+    @dbg(checked { ffi_call_float_exports() });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "315\n"
+exit_code = 0
+
+# A float-carrying `@repr(c)` aggregate crosses by value in every direction the
+# classifier can place one. The shapes here are the ones whose two rows differ:
+# `{f64, f64}` is two SSE eightbytes under SysV and a homogeneous
+# floating-point aggregate of two members under AAPCS64; `{f32; 4}` is two SSE
+# eightbytes of packed pairs under SysV and four `s`-register members under
+# AAPCS64; `{i64, f64}` splits the banks under SysV and is an ordinary integer
+# composite under AAPCS64; the 40-byte one is MEMORY under SysV and
+# by-reference under AAPCS64. Execution across the whole grid at every argument
+# and result position is `//crates/rue-c-abi-matrix:c-abi-matrix-test`; what
+# these two pin is that each row's classifier reaches machine code at all.
+
+[[case]]
+name = "float_aggregates_cross_by_value_under_sysv"
+description = "HFA, packed-pair, split-bank, and oversized float `@repr(c)` aggregates are accepted in both directions of a foreign signature and reach machine code on the x86-64 row."
+files = [{ path = "main.rue", source = """
+@repr(c) struct Pair { x: f64, y: f64 }
+@repr(c) struct Quad { a: f32, b: f32, c: f32, d: f32 }
+@repr(c) struct Split { tag: i64, value: f64 }
+@repr(c) struct Wide { values: [f64; 5] }
+
+extern "C" {
+    fn c_pair(p: Pair) -> Pair;
+    fn c_quad(q: Quad) -> Quad;
+    fn c_split(s: Split) -> Split;
+    fn c_wide(w: Wide) -> Wide;
+}
+
+pub extern "C" fn rue_pair(p: Pair) -> Pair { p }
+pub extern "C" fn rue_quad(q: Quad) -> Quad { q }
+pub extern "C" fn rue_split(s: Split) -> Split { s }
+pub extern "C" fn rue_wide(w: Wide) -> Wide { w }
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["--preview", "c_ffi", "--target", "x86-64-linux", "--emit", "asm", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (x86-64-linux) ==="]
+
+[[case]]
+name = "float_aggregates_cross_by_value_under_aapcs64"
+description = "The same aggregates reach machine code under AAPCS64, where the two HFAs travel one member per `v`-register and the 40-byte one goes by reference."
+files = [{ path = "main.rue", source = """
+@repr(c) struct Pair { x: f64, y: f64 }
+@repr(c) struct Quad { a: f32, b: f32, c: f32, d: f32 }
+@repr(c) struct Split { tag: i64, value: f64 }
+@repr(c) struct Wide { values: [f64; 5] }
+
+extern "C" {
+    fn c_pair(p: Pair) -> Pair;
+    fn c_quad(q: Quad) -> Quad;
+    fn c_split(s: Split) -> Split;
+    fn c_wide(w: Wide) -> Wide;
+}
+
+pub extern "C" fn rue_pair(p: Pair) -> Pair { p }
+pub extern "C" fn rue_quad(q: Quad) -> Quad { q }
+pub extern "C" fn rue_split(s: Split) -> Split { s }
+pub extern "C" fn rue_wide(w: Wide) -> Wide { w }
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["--preview", "c_ffi", "--target", "aarch64-linux", "--emit", "asm", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-linux) ==="]
+
+# An `f32` argument past the floating-point register budget is stacked, and the
+# footprint it takes there is the one row-level difference a float has: AAPCS64
+# gives it the low four bytes of a whole eight-byte slot, while Apple's arm64
+# amendment packs the outgoing argument area at natural size and gives it four
+# bytes outright. Both rows are built here; neither is executed, because this
+# suite has no Apple host and the archive carries no ten-argument leaf.
+
+[[case]]
+name = "aarch64_macos_stacked_f32_packs_at_natural_size"
+description = "A ninth and tenth `f32` argument are past the eight `v`-register budget and are stacked; Apple's arm64 row packs each at its own four-byte width."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_stack_f32(
+        a: f32, b: f32, c: f32, d: f32, e: f32,
+        f: f32, g: f32, h: f32, i: f32, j: f32,
+    ) -> f32;
+}
+
+fn main() -> i32 {
+    let value = checked { ffi_stack_f32(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0) };
+    @dbg(@float_to_int(@float_cast(value)));
+    0
+}
+""" }]
+args = ["--preview", "c_ffi", "--target", "aarch64-macos", "--emit", "asm", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-macos) ==="]
+
+[[case]]
+name = "aarch64_linux_stacked_f32_takes_a_whole_slot"
+description = "The same signature under AAPCS64 proper, where a stacked `f32` occupies the low four bytes of a whole eight-byte slot."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_stack_f32(
+        a: f32, b: f32, c: f32, d: f32, e: f32,
+        f: f32, g: f32, h: f32, i: f32, j: f32,
+    ) -> f32;
+}
+
+fn main() -> i32 {
+    let value = checked { ffi_stack_f32(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0) };
+    @dbg(@float_to_int(@float_cast(value)));
+    0
+}
+""" }]
+args = ["--preview", "c_ffi", "--target", "aarch64-linux", "--emit", "asm", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-linux) ==="]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -397,11 +397,39 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
             0x00, 0x91, 0x01, 0x09, 0x00, 0xF9, 0xC0, 0x03, 0x5F, 0xD6,
         ],
     };
+    // --- P5 floating-point leaves (ADR-0064 P5, RUE-1059) --------------------
+    //
+    // The float half of the boundary, in the same hand-assembled leaf form as
+    // every member above: a `double` and a `float` arriving in the row's
+    // floating-point argument registers and leaving in its first floating-point
+    // result register, with no integer register touched at all. Both are the
+    // shape the ADR's proof program names — a `double`-taking probe called from
+    // Rue with an exact result — reduced to a leaf so no C toolchain or libm is
+    // needed to link one.
+    //
+    // ffi_fadd(double a, double b) -> a + b.
+    let fadd: Vec<u8> = match target.arch() {
+        // addsd xmm0, xmm1 ; ret
+        Arch::X86_64 => vec![0xF2, 0x0F, 0x58, 0xC1, 0xC3],
+        // fadd d0, d0, d1 ; ret
+        Arch::Aarch64 => vec![0x00, 0x28, 0x61, 0x1E, 0xC0, 0x03, 0x5F, 0xD6],
+    };
+    // ffi_fmul32(float a, float b) -> a * b. An `f32` argument occupies the low
+    // half of its register on both rows, so a leaf that reads it at 32 bits is
+    // exactly the check that the caller placed it there.
+    let fmul32: Vec<u8> = match target.arch() {
+        // mulss xmm0, xmm1 ; ret
+        Arch::X86_64 => vec![0xF3, 0x0F, 0x59, 0xC1, 0xC3],
+        // fmul s0, s0, s1 ; ret
+        Arch::Aarch64 => vec![0x00, 0x08, 0x21, 0x1E, 0xC0, 0x03, 0x5F, 0xD6],
+    };
     for (symbol, code) in [
         ("ffi_pair_combine", pair_combine),
         ("ffi_triple_tail", triple_tail),
         ("ffi_make_pair", make_pair),
         ("ffi_fill_triple", fill_triple),
+        ("ffi_fadd", fadd),
+        ("ffi_fmul32", fmul32),
     ] {
         objects.push((
             format!("{symbol}.o"),
@@ -653,6 +681,46 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
             vec![(32, "rue_five_shift")],
         ),
     };
+    // The float half of the export direction (ADR-0064 P5, RUE-1059): a C
+    // caller that hands two `double`s and two `float`s to Rue exports and reads
+    // both results back out of the row's floating-point result register.
+    //
+    //   long ffi_call_float_exports(void) {
+    //       long a = (long)rue_fadd_export(1.0, 2.0);   // 3
+    //       long b = (long)rue_f32_export(3.0f, 5.0f);  // 15
+    //       return a * 100 + b;                         // 315
+    //   }
+    //
+    // Hand-assembled rather than compiled, because a C compiler materializes
+    // each floating-point constant from `.rodata` and this archive's members
+    // carry none: the immediates are built in a general-purpose register and
+    // moved whole into the floating-point file instead.
+    let (float_exports_code, float_exports_relocs): (Vec<u8>, Vec<(u64, &str)>) = match target
+        .arch()
+    {
+        Arch::X86_64 => (
+            vec![
+                0x48, 0x83, 0xEC, 0x18, 0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F,
+                0x66, 0x48, 0x0F, 0x6E, 0xC0, 0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x40, 0x66, 0x48, 0x0F, 0x6E, 0xC8, 0xE8, 0x00, 0x00, 0x00, 0x00, 0xF2, 0x48, 0x0F,
+                0x2C, 0xC0, 0x48, 0x89, 0x04, 0x24, 0xB8, 0x00, 0x00, 0x40, 0x40, 0x66, 0x0F, 0x6E,
+                0xC0, 0xB8, 0x00, 0x00, 0xA0, 0x40, 0x66, 0x0F, 0x6E, 0xC8, 0xE8, 0x00, 0x00, 0x00,
+                0x00, 0xF3, 0x48, 0x0F, 0x2C, 0xC0, 0x48, 0x8B, 0x14, 0x24, 0x48, 0x6B, 0xD2, 0x64,
+                0x48, 0x01, 0xD0, 0x48, 0x83, 0xC4, 0x18, 0xC3,
+            ],
+            vec![(35, "rue_fadd_export"), (67, "rue_f32_export")],
+        ),
+        Arch::Aarch64 => (
+            vec![
+                0xFD, 0x7B, 0xBE, 0xA9, 0xFD, 0x03, 0x00, 0x91, 0x00, 0x10, 0x6E, 0x1E, 0x01, 0x10,
+                0x60, 0x1E, 0x00, 0x00, 0x00, 0x94, 0x00, 0x00, 0x78, 0x9E, 0xE0, 0x0B, 0x00, 0xF9,
+                0x00, 0x10, 0x21, 0x1E, 0x01, 0x90, 0x22, 0x1E, 0x00, 0x00, 0x00, 0x94, 0x00, 0x00,
+                0x38, 0x9E, 0xE1, 0x0B, 0x40, 0xF9, 0x82, 0x0C, 0x80, 0xD2, 0x20, 0x00, 0x02, 0x9B,
+                0xFD, 0x7B, 0xC2, 0xA8, 0xC0, 0x03, 0x5F, 0xD6,
+            ],
+            vec![(16, "rue_fadd_export"), (36, "rue_f32_export")],
+        ),
+    };
     let mut caller_objects: Vec<(String, Vec<u8>)> = Vec::new();
     for (symbol, code, relocs) in [
         ("ffi_call_exports", call_exports_code, call_exports_relocs),
@@ -664,6 +732,11 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
         ),
         ("ffi_call_wide_return", wide_return_code, wide_return_relocs),
         ("ffi_sret_echo_ok", sret_echo_code, sret_echo_relocs),
+        (
+            "ffi_call_float_exports",
+            float_exports_code,
+            float_exports_relocs,
+        ),
     ] {
         let mut builder = rue_linker::ObjectBuilder::new(target, symbol).code(code);
         for (offset, target_symbol) in relocs {

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -43,20 +43,15 @@ pub(super) const FP_ARG_REGS: [Reg; 8] = [
     Reg::V7,
 ];
 
-/// The physical register a foreign call's classified register piece names.
-///
-/// A foreign argument is marshaled through its compact memory image, whose
-/// pieces are whole eightbytes in general-purpose vregs, so a floating-point
-/// piece has no value to move: the C boundary rejects `f32`/`f64`
-/// (`c_passable_by_value`), which is what keeps every piece integer-classed.
-fn foreign_argument_register(class: rue_target::CRegisterClass, index: u32) -> Reg {
-    assert_eq!(
-        class,
-        rue_target::CRegisterClass::Gp,
-        "a foreign argument crosses through its eightbyte image in the \
-         general-purpose bank"
-    );
-    ARG_REGS[index as usize]
+/// The physical register a foreign call's classified register piece names:
+/// AAPCS64's `x0`-`x7` for a general-purpose piece and `v0`-`v7` for a
+/// floating-point one, which carries a float scalar and each member of a
+/// homogeneous floating-point aggregate (section 6.8.2 rule C.3).
+fn foreign_argument_register(class: crate::abi_slot_class::AbiSlotClass, index: u32) -> Reg {
+    match class.bank() {
+        rue_target::CRegisterClass::Gp => ARG_REGS[index as usize],
+        rue_target::CRegisterClass::Fp => FP_ARG_REGS[index as usize],
+    }
 }
 
 /// The native convention's result registers (ADR-0084). AAPCS64 defines only
@@ -4237,6 +4232,20 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         self.image_arg_eightbytes(value, image)
     }
 
+    fn foreign_aggregate_leaves(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.require_aggregate_slots(value)
+    }
+
+    fn foreign_eightbyte_as_float(&mut self, bits: VReg, width: FloatWidth) -> VReg {
+        let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+        self.mir.push(Aarch64Inst::BitsToFloat {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(bits),
+            width,
+        });
+        dst
+    }
+
     fn foreign_byref_copy(
         &mut self,
         value: CfgValue,
@@ -4282,6 +4291,26 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
             let offset = checked_displacement_bytes(u64::from(store.offset))
                 .expect("foreign stack slot offset must fit displacement");
             let src = Operand::Virtual(store.value);
+            // A value the placement carries in the floating-point file is
+            // stored from there, and it commits exactly its own width: Apple's
+            // amendment gives a stacked `f32` a four-byte footprint, and
+            // AAPCS64 proper gives it the low four bytes of an eight-byte slot
+            // whose remaining bytes no callee is entitled to read (section
+            // 6.8.2 rule C.15).
+            if let crate::abi_slot_class::AbiSlotClass::Fp(width) = store.class {
+                assert!(
+                    u32::from(width.bytes()) <= store.bytes,
+                    "a stacked floating-point argument fits the footprint the \
+                     convention gave it"
+                );
+                self.mir.push(Aarch64Inst::FloatStore {
+                    base: Reg::Sp,
+                    offset,
+                    src,
+                    width,
+                });
+                continue;
+            }
             match store.bytes {
                 8 => self.mir.push(Aarch64Inst::Str {
                     src,
@@ -4305,11 +4334,20 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         &mut self,
         register_args: &[crate::foreign_call::ForeignRegisterArg],
     ) {
+        // Every argument register of both banks is reserved from allocation, so
+        // no source vreg can already be sitting in one and each value moves
+        // straight into the register the classification named.
         for arg in register_args {
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Physical(foreign_argument_register(arg.class, arg.index)),
-                src: Operand::Virtual(arg.value),
-            });
+            let dst = Operand::Physical(foreign_argument_register(arg.class, arg.index));
+            let src = Operand::Virtual(arg.value);
+            match arg.class {
+                crate::abi_slot_class::AbiSlotClass::Gp => {
+                    self.mir.push(Aarch64Inst::MovRR { dst, src })
+                }
+                crate::abi_slot_class::AbiSlotClass::Fp(width) => {
+                    self.mir.push(Aarch64Inst::FloatMov { dst, src, width })
+                }
+            }
         }
     }
 
@@ -4354,19 +4392,73 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         });
     }
 
-    fn foreign_scalar_result(&mut self, primary: VReg, ext: rue_air::ScalarAbiExtension) {
-        self.mir.push(Aarch64Inst::MovRR {
-            dst: Operand::Virtual(primary),
-            src: Operand::Physical(Reg::X0),
-        });
-        self.emit_c_return_extension(primary, ext);
+    fn foreign_scalar_result(
+        &mut self,
+        primary: VReg,
+        class: crate::abi_slot_class::AbiSlotClass,
+        ext: rue_air::ScalarAbiExtension,
+    ) {
+        match class {
+            crate::abi_slot_class::AbiSlotClass::Gp => {
+                self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Virtual(primary),
+                    src: Operand::Physical(Reg::X0),
+                });
+                self.emit_c_return_extension(primary, ext);
+            }
+            // A float fills its result register; nothing is extended into or
+            // out of `v0`.
+            crate::abi_slot_class::AbiSlotClass::Fp(width) => {
+                self.mir.push(Aarch64Inst::FloatMov {
+                    dst: Operand::Virtual(primary),
+                    src: Operand::Physical(Reg::V0),
+                    width,
+                })
+            }
+        }
     }
 
     fn foreign_register_result(
         &mut self,
         _primary: VReg,
         image: &crate::foreign_call::AggregateImage,
+        pieces: rue_air::RegisterPieces,
+        marshal: &crate::native_abi::NativeArgMarshal,
     ) -> Vec<VReg> {
+        use crate::abi_slot_class::AbiSlotClass;
+        // Every result register the classification named, read back in the file
+        // it came home in. C's own result rosters are a prefix of the native
+        // ones (ADR-0084), so a piece's roster index addresses both.
+        let read =
+            |lower: &mut Self, piece: rue_air::RegisterPiece, class: AbiSlotClass| match class {
+                AbiSlotClass::Gp => {
+                    let v = lower.mir.alloc_vreg();
+                    lower.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(v),
+                        src: Operand::Physical(RET_REGS[piece.index as usize]),
+                    });
+                    v
+                }
+                AbiSlotClass::Fp(width) => {
+                    let v = lower.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                    lower.mir.push(Aarch64Inst::FloatMov {
+                        dst: Operand::Virtual(v),
+                        src: Operand::Physical(FP_RET_REGS[piece.index as usize]),
+                        width,
+                    });
+                    v
+                }
+            };
+        if let crate::native_abi::NativeArgMarshal::Direct { classes } = marshal {
+            // The result registers hold the value's own leaves — an HFA's
+            // members most visibly; nothing is read out of memory.
+            return pieces
+                .as_slice()
+                .iter()
+                .zip(classes)
+                .map(|(piece, class)| read(self, *piece, *class))
+                .collect();
+        }
         self.mir.push(Aarch64Inst::SubImm {
             dst: Operand::Physical(Reg::Sp),
             src: Operand::Physical(Reg::Sp),
@@ -4378,14 +4470,25 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
             dst: Operand::Virtual(buf),
             src: Operand::Physical(Reg::Sp),
         });
-        let mut eb_vals = Vec::with_capacity(image.eightbytes() as usize);
-        for index in 0..image.eightbytes() as usize {
-            let v = self.mir.alloc_vreg();
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Virtual(v),
-                src: Operand::Physical(RET_REGS[index]),
+        let mut eb_vals = Vec::with_capacity(pieces.len() as usize);
+        for (index, piece) in pieces.as_slice().iter().enumerate() {
+            let class = marshal.class(index, piece.class);
+            let value = read(self, *piece, class);
+            // A marshaled eightbyte is a bit pattern, not a number, so one the
+            // row returned in the floating-point file moves back into a
+            // general-purpose vreg for the image store.
+            eb_vals.push(match class {
+                AbiSlotClass::Gp => value,
+                AbiSlotClass::Fp(width) => {
+                    let bits = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::FloatToBits {
+                        dst: Operand::Virtual(bits),
+                        src: Operand::Virtual(value),
+                        width,
+                    });
+                    bits
+                }
             });
-            eb_vals.push(v);
         }
         crate::agg_slots::store_slots_through_ptr(self, &eb_vals, buf, 0);
         let native = crate::agg_slots::load_enum_slots_through_ptr(self, buf, &image.map);
@@ -4414,11 +4517,24 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         native
     }
 
-    fn foreign_move_primary(&mut self, primary: VReg, slot: VReg) {
-        self.mir.push(Aarch64Inst::MovRR {
-            dst: Operand::Virtual(primary),
-            src: Operand::Virtual(slot),
-        });
+    fn foreign_move_primary(
+        &mut self,
+        primary: VReg,
+        slot: VReg,
+        class: crate::abi_slot_class::AbiSlotClass,
+    ) {
+        // The primary vreg mirrors logical slot 0, so the move that syncs it is
+        // the one for that slot's own file.
+        let dst = Operand::Virtual(primary);
+        let src = Operand::Virtual(slot);
+        match class {
+            crate::abi_slot_class::AbiSlotClass::Gp => {
+                self.mir.push(Aarch64Inst::MovRR { dst, src })
+            }
+            crate::abi_slot_class::AbiSlotClass::Fp(width) => {
+                self.mir.push(Aarch64Inst::FloatMov { dst, src, width })
+            }
+        }
     }
 }
 

--- a/crates/rue-codegen/src/abi_report.rs
+++ b/crates/rue-codegen/src/abi_report.rs
@@ -172,12 +172,11 @@ impl AbiParameterMode {
 pub enum CPlacement {
     /// No register, no stack byte, no pointer.
     Omitted,
-    /// `count` consecutive registers of `class` from roster index `first`.
-    Registers {
-        class: CRegisterClass,
-        first: u32,
-        count: u32,
-    },
+    /// One register per piece, in ascending memory order. An argument can span
+    /// both banks — SysV AMD64 passes `{i64, f64}` in one integer register and
+    /// one SSE register — so the pieces are named individually and a run of
+    /// one bank is recognized when it prints.
+    Registers { pieces: RegisterPieces },
     /// By value in the outgoing argument area.
     Stack { offset: u32, size: u32, align: u32 },
     /// By pointer to a caller-owned copy.
@@ -205,13 +204,7 @@ impl From<ArgLocation> for CPlacement {
     fn from(location: ArgLocation) -> Self {
         match location {
             ArgLocation::Omitted => Self::Omitted,
-            ArgLocation::Registers { pieces } => Self::Registers {
-                class: pieces.uniform_class().expect(
-                    "a C argument's registers are one bank while the boundary rejects floats",
-                ),
-                first: pieces.first_index().unwrap_or(0),
-                count: pieces.len(),
-            },
+            ArgLocation::Registers { pieces } => Self::Registers { pieces },
             ArgLocation::Stack {
                 offset,
                 size,
@@ -820,18 +813,27 @@ fn sret_pointer_text(registers: TargetRegisters, register: SretRegisterKind) -> 
     }
 }
 
-/// The result registers a value comes back in, named one per eightbyte. A run
-/// of one bank reads as a run; a result split across banks names each piece,
-/// because there is no single roster to run over.
-fn result_register_text(
+/// The `(bank, roster index)` pairs the rendering reads.
+fn piece_pairs(pieces: RegisterPieces) -> Vec<(CRegisterClass, u32)> {
+    pieces
+        .as_slice()
+        .iter()
+        .map(|piece| (piece.class, piece.index))
+        .collect()
+}
+
+/// The registers a value travels in, named one per piece. A run of one bank
+/// reads as a run; a value split across banks names each piece, because there
+/// is no single roster to run over.
+fn register_pieces_text(
     registers: TargetRegisters,
+    role: RegisterRole,
     pieces: &[(CRegisterClass, u32)],
     noun: &str,
 ) -> String {
-    let noun = format!("{noun} register");
     match pieces {
         [] => "no value".to_owned(),
-        [(class, index)] => register_run(registers, RegisterRole::Result, *class, *index, 1, &noun),
+        [(class, index)] => register_run(registers, role, *class, *index, 1, noun),
         many if many.iter().all(|(class, _)| *class == many[0].0)
             && many
                 .iter()
@@ -840,19 +842,36 @@ fn result_register_text(
         {
             register_run(
                 registers,
-                RegisterRole::Result,
+                role,
                 many[0].0,
                 many[0].1,
                 many.len() as u32,
-                &noun,
+                noun,
             )
         }
         many => many
             .iter()
-            .map(|(class, index)| registers.result(*class, *index).to_owned())
+            .map(|(class, index)| match role {
+                RegisterRole::Argument => registers.argument(*class, *index).to_owned(),
+                RegisterRole::Result => registers.result(*class, *index).to_owned(),
+            })
             .collect::<Vec<_>>()
             .join(", "),
     }
+}
+
+/// [`register_pieces_text`] for a result, whose noun carries the role.
+fn result_register_text(
+    registers: TargetRegisters,
+    pieces: &[(CRegisterClass, u32)],
+    noun: &str,
+) -> String {
+    register_pieces_text(
+        registers,
+        RegisterRole::Result,
+        pieces,
+        &format!("{noun} register"),
+    )
 }
 
 /// Where an indirectly-passed argument's own pointer lives, with the
@@ -910,16 +929,10 @@ fn placement_text(registers: TargetRegisters, placement: &AbiPlacement) -> (Stri
 fn c_placement_text(registers: TargetRegisters, placement: CPlacement) -> String {
     match placement {
         CPlacement::Omitted => "omitted (zero-sized)".to_owned(),
-        CPlacement::Registers {
-            class,
-            first,
-            count,
-        } => register_run(
+        CPlacement::Registers { pieces } => register_pieces_text(
             registers,
             RegisterRole::Argument,
-            class,
-            first,
-            count,
+            &piece_pairs(pieces),
             "register",
         ),
         CPlacement::Stack {
@@ -1203,9 +1216,7 @@ mod tests {
         let (line, continuation) = native_placement_text(
             registers,
             &NativePlacement::Argument(CPlacement::Registers {
-                class: CRegisterClass::Gp,
-                first: 0,
-                count: 2,
+                pieces: RegisterPieces::consecutive(CRegisterClass::Gp, 0, 2),
             }),
         );
         assert_eq!(line, "gp registers 0-1 (rdi, rsi)");

--- a/crates/rue-codegen/src/export_thunk.rs
+++ b/crates/rue-codegen/src/export_thunk.rs
@@ -79,34 +79,100 @@ use rue_air::ScalarAbiExtension;
 use crate::{EmittedRelocation, MachineCode};
 
 /// One flattened leaf of a value's compact memory image: where one native ABI
-/// slot lives in the C image, and how wide it is there.
+/// slot lives in the C image, how wide it is there, and which register file it
+/// travels in.
 ///
-/// Loading a leaf into a native slot extends it to Rue's canonical 64-bit form;
-/// storing a native slot back into the image truncates it to `width`.
+/// Loading an integer leaf into a native slot extends it to Rue's canonical
+/// 64-bit form; storing a native slot back into the image truncates it to
+/// `width`. A floating-point leaf has no extension in either direction — it
+/// fills its register — so `float` selects the floating-point load and store of
+/// exactly `width` bytes instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ImageLeaf {
     /// Byte offset of the leaf within the compact image.
     pub byte_offset: u32,
     /// Physical width in bytes: 1, 2, 4, or 8.
     pub width: u32,
-    /// Whether a load sign-extends (`true`) or zero-extends (`false`).
+    /// Whether a load sign-extends (`true`) or zero-extends (`false`). Never
+    /// set for a floating-point leaf.
     pub signed: bool,
+    /// Whether the leaf lives in the floating-point file.
+    pub float: bool,
+}
+
+/// The marshaling rule's view of a flattened leaf run.
+fn leaf_classes(leaves: &[ImageLeaf]) -> Vec<crate::native_abi::ImageLeafClass> {
+    leaves.iter().map(ImageLeaf::class).collect()
+}
+
+impl ImageLeaf {
+    /// The pair the shared marshaling rule reads: where the leaf starts, and
+    /// the file its own vreg lives in.
+    fn class(&self) -> crate::native_abi::ImageLeafClass {
+        (
+            i32::try_from(self.byte_offset).unwrap_or(i32::MAX),
+            if self.float {
+                crate::abi_slot_class::AbiSlotClass::Fp(if self.width == 4 {
+                    crate::value_plan::FloatWidth::F32
+                } else {
+                    crate::value_plan::FloatWidth::F64
+                })
+            } else {
+                crate::abi_slot_class::AbiSlotClass::Gp
+            },
+        )
+    }
+
+    /// One whole eightbyte of an image at `index`, the shape a packed value's
+    /// register piece carries.
+    const fn eightbyte(index: u32) -> Self {
+        Self {
+            byte_offset: index * 8,
+            width: 8,
+            signed: false,
+            float: false,
+        }
+    }
+
+    /// Whether a C caller leaves bits of this leaf's register undefined that
+    /// Rue's canonical 64-bit form defines. A float fills its own register, so
+    /// only a narrow *integer* owes the entry a re-extension.
+    const fn needs_reextension(&self) -> bool {
+        !self.float && self.width < 8
+    }
 }
 
 /// How the native body reads one parameter apart.
 ///
 /// *Where* the parameter travels is the native lowering's answer, the same one
-/// the callee's own parameter plan reads; this is the other half — whether the
-/// value's leaves are its eightbytes, and where each leaf sits in the compact
-/// image either way.
+/// the callee's own parameter plan reads; this is the other half — where each
+/// leaf sits in the compact image, and therefore, against a placement, whether
+/// the leaves themselves cross or the image's eightbytes do.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NativeParameter {
     /// The value's flattened leaves, in ascending image order.
     pub leaves: Vec<ImageLeaf>,
-    /// Whether each leaf starts its own eightbyte, so the leaves themselves
-    /// cross in Rue's canonical 64-bit form rather than the image's eightbytes
-    /// crossing whole (`crate::native_abi::NativeImage::direct_leaves`).
-    pub leaves_are_eightbytes: bool,
+    /// How many eightbytes the compact image spans.
+    pub eightbytes: u32,
+}
+
+impl NativeParameter {
+    /// How the value reaches `location`: as its own leaf vregs, or as the
+    /// eightbytes of its image. The export asks the shared rule
+    /// (`crate::native_abi::aggregate_marshal`) the import and the native call
+    /// ask, so the three cannot disagree about a crossing.
+    fn marshal(&self, location: ArgLocation) -> crate::native_abi::NativeArgMarshal {
+        crate::native_abi::aggregate_marshal(&leaf_classes(&self.leaves), self.eightbytes, location)
+    }
+
+    /// Whether the value's own leaves cross at `location`, rather than the
+    /// eightbytes of its image.
+    fn crosses_by_leaf(&self, location: ArgLocation) -> bool {
+        matches!(
+            self.marshal(location),
+            crate::native_abi::NativeArgMarshal::Direct { .. }
+        )
+    }
 }
 
 /// How the native body returns.
@@ -161,9 +227,8 @@ pub struct ExportSignature {
     /// Whether the result is an aggregate rather than a scalar, which decides
     /// whether a register return names leaves or a single canonical value.
     result_is_aggregate: bool,
-    /// Whether the native convention hands the result's leaves over as
-    /// themselves rather than packing them into the image's eightbytes.
-    return_leaves_are_eightbytes: bool,
+    /// How many eightbytes the result's compact image spans.
+    return_eightbytes: u32,
     return_leaves: Vec<ImageLeaf>,
     return_padding: Vec<PaddingRange>,
     /// The result's byte size, which is how much of the C caller's storage an
@@ -192,7 +257,7 @@ impl ExportSignature {
                 c: rue_air::c_abi_type_facts(type_pool, ty),
                 native: NativeParameter {
                     leaves: image_leaves(type_pool, ty),
-                    leaves_are_eightbytes: native_leaves_are_eightbytes(type_pool, ty),
+                    eightbytes: image_eightbytes(type_pool, ty),
                 },
             })
             .collect();
@@ -201,12 +266,36 @@ impl ExportSignature {
             parameters,
             result: rue_air::c_abi_type_facts(type_pool, return_type),
             result_is_aggregate: crate::types::is_multislot_aggregate(type_pool, return_type),
-            return_leaves_are_eightbytes: native_leaves_are_eightbytes(type_pool, return_type),
+            return_eightbytes: image_eightbytes(type_pool, return_type),
             return_leaves: image_leaves(type_pool, return_type),
             return_padding: type_pool.compact_image_padding_ranges(return_type),
             return_bytes: u32::try_from(type_pool.layout(return_type).size)
                 .expect("an export result size fits u32"),
         }
+    }
+
+    /// Whether the result comes back one homogeneous floating-point *member*
+    /// per register, rather than one eightbyte or one leaf.
+    fn return_is_float_members(&self, pieces: rue_air::RegisterPieces) -> bool {
+        pieces.uniform_class() == Some(CRegisterClass::Fp)
+            && matches!(
+                crate::native_abi::image_float_members(&leaf_classes(&self.return_leaves)),
+                Some((_, members)) if members == pieces.len()
+            )
+    }
+
+    /// Whether the result's own leaves come back in the registers `pieces`
+    /// names, rather than the eightbytes of its image — the shared marshaling
+    /// rule, read in the result direction.
+    fn return_crosses_by_leaf(&self, pieces: rue_air::RegisterPieces) -> bool {
+        matches!(
+            crate::native_abi::aggregate_marshal(
+                &leaf_classes(&self.return_leaves),
+                self.return_eightbytes,
+                ArgLocation::Registers { pieces },
+            ),
+            crate::native_abi::NativeArgMarshal::Direct { .. }
+        )
     }
 
     /// The lowered C signature a caller of this export writes and this thunk
@@ -233,7 +322,7 @@ impl ExportSignature {
             LoweredReturn::Registers { pieces, .. } => {
                 if !self.result_is_aggregate {
                     NativeReturn::Scalar
-                } else if self.return_leaves_are_eightbytes {
+                } else if self.return_crosses_by_leaf(pieces) {
                     NativeReturn::Registers {
                         leaves: self.return_leaves.clone(),
                     }
@@ -311,8 +400,14 @@ impl ExportSignature {
             let crosses_by_leaf = matches!(
                 c_argument.location,
                 ArgLocation::Registers { .. } | ArgLocation::Stack { .. }
-            ) && parameter.native.leaves_are_eightbytes;
-            if crosses_by_leaf && parameter.native.leaves.iter().any(|leaf| leaf.width < 8) {
+            ) && parameter.native.crosses_by_leaf(c_argument.location);
+            if crosses_by_leaf
+                && parameter
+                    .native
+                    .leaves
+                    .iter()
+                    .any(ImageLeaf::needs_reextension)
+            {
                 return CEntry::Thunk(ThunkReason::NarrowParameter { parameter: index });
             }
         }
@@ -346,15 +441,21 @@ impl ExportSignature {
                     NativeReturn::Scalar => false,
                     // The image's eightbytes *are* the C image's eightbytes.
                     NativeReturn::Eightbytes { .. } => false,
-                    // One register per leaf is the C image only when every leaf
-                    // fills its own eightbyte, leaving no padding byte for the
-                    // thunk to zero and no narrow slot to place inside a wider
-                    // one (ADR-0052 ruling 5).
+                    // A homogeneous floating-point aggregate comes back one
+                    // *member* per register under both rows (AAPCS64 rule
+                    // C.3), so the native body already left exactly what a C
+                    // caller reads — members leave no padding and fill their
+                    // registers by construction. Otherwise one register per
+                    // leaf is the C image only when every leaf fills its own
+                    // eightbyte, leaving no padding byte for the thunk to zero
+                    // and no narrow slot to place inside a wider one (ADR-0052
+                    // ruling 5).
                     NativeReturn::Registers { leaves } => {
-                        !self.return_padding.is_empty()
-                            || leaves.iter().enumerate().any(|(index, leaf)| {
-                                leaf.width != 8 || leaf.byte_offset != (index as u32) * 8
-                            })
+                        !self.return_is_float_members(native)
+                            && (!self.return_padding.is_empty()
+                                || leaves.iter().enumerate().any(|(index, leaf)| {
+                                    leaf.width != 8 || leaf.byte_offset != (index as u32) * 8
+                                }))
                     }
                     NativeReturn::Void | NativeReturn::Sret => true,
                 }
@@ -444,33 +545,38 @@ fn image_leaves(type_pool: &FrozenTypeInternPool, ty: Type) -> Vec<ImageLeaf> {
         )
         .into_iter()
         .map(|slot| {
-            assert!(
-                slot.float_width.is_none(),
-                "the C boundary still rejects floats, so no export leaf is float-classed"
+            // An enum payload's union slot is a general-purpose bit carrier
+            // even where a variant puts a float there, so the file follows the
+            // same rule every other direction of a crossing uses.
+            let float = matches!(
+                crate::native_abi::leaf_slot_class(&slot),
+                crate::abi_slot_class::AbiSlotClass::Fp(_)
             );
             ImageLeaf {
                 byte_offset: u32::try_from(slot.byte_offset)
                     .expect("a compact image offset is non-negative and fits u32"),
                 width: slot.access.map_or(8, |access| u32::from(access.width)),
                 signed: slot.access.is_some_and(|access| access.signed),
+                float,
             }
         })
         .collect()
 }
 
-/// Whether the native convention hands `ty`'s leaves over as themselves rather
-/// than packing them into the image's eightbytes.
-///
-/// This is the one predicate both ends of a native crossing consult
-/// (`crate::native_abi::NativeImage::direct_leaves`); a scalar is trivially its
-/// own eightbyte. Every export type is C-passable, so every leaf is
-/// general-purpose and the bank agreement the predicate also checks is
-/// automatic.
-fn native_leaves_are_eightbytes(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
-    match crate::native_abi::native_by_value_arg(type_pool, ty) {
-        crate::native_abi::NativeArg::Aggregate { image } => image.direct_leaves().is_some(),
-        _ => true,
+/// The width one floating-point piece moves at: its leaf's own width when the
+/// leaves cross, and a whole eightbyte lane otherwise.
+fn float_piece_width(leaf: ImageLeaf) -> crate::value_plan::FloatWidth {
+    if leaf.float && leaf.width == 4 {
+        crate::value_plan::FloatWidth::F32
+    } else {
+        crate::value_plan::FloatWidth::F64
     }
+}
+
+/// How many eightbytes `ty`'s compact image spans — the count of register
+/// pieces a placement that packs it names.
+fn image_eightbytes(type_pool: &FrozenTypeInternPool, ty: Type) -> u32 {
+    u32::try_from(type_pool.layout(ty).size.div_ceil(8)).expect("an export image fits u32")
 }
 
 /// Build the machine code for a Rue-to-C export thunk.
@@ -518,14 +624,38 @@ enum NativeSlotSource {
     Leaf { parameter: usize, leaf: usize },
     /// Eightbyte `index` of parameter `parameter`'s compact image, whole.
     Eightbyte { parameter: usize, index: usize },
+    /// A value the C caller left in one incoming argument register, spilled to
+    /// `offset` in the thunk frame. `leaf` names the width and signedness it is
+    /// read back at; its `byte_offset` is zero, because the register holds that
+    /// value and nothing else.
+    ///
+    /// This is how a register-placed parameter's pieces are reached, rather
+    /// than through a contiguous image: a value whose eightbytes travel in
+    /// different banks — `{i64, f64}` on SysV AMD64 — has no contiguous
+    /// register image to read, but every piece still sits alone in the
+    /// register the classification named for it.
+    SavedRegister { save_offset: u32, leaf: ImageLeaf },
 }
 
 /// Where the native convention puts one of those values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NativeSlotDestination {
-    /// Native argument register `index` of the general-purpose roster. Every
-    /// export type is C-passable, so no value reaches the floating-point one.
+    /// Native argument register `index` of the general-purpose roster.
     Register { index: u32 },
+    /// Native argument register `index` of the floating-point roster, loaded
+    /// at `width`.
+    ///
+    /// Reached only when the C row *stacked* the value and the native row
+    /// register-places it, which the wider native return bank can do by
+    /// leaving a general-purpose register the C row spent on a hidden
+    /// indirect-result pointer. A value the C row itself put in a
+    /// floating-point register is already in the register the native row wants
+    /// — both rows place the floating-point roster identically (ADR-0084) —
+    /// and the thunk leaves it alone.
+    FpRegister {
+        index: u32,
+        width: crate::value_plan::FloatWidth,
+    },
     /// The target row's dedicated indirect-result register, outside the
     /// argument roster (AAPCS64 `x8`, section 6.9).
     SretRegister,
@@ -569,6 +699,11 @@ struct ThunkPlan {
     slots: Vec<(NativeSlotSource, NativeSlotDestination)>,
     /// The return value's leaves, when the native body returns in registers.
     return_leaves: Vec<ImageLeaf>,
+    /// How many eightbytes the result's compact image spans.
+    return_eightbytes: u32,
+    /// The result registers the *native* body left its value in, when it
+    /// returns in registers.
+    native_return_pieces: rue_air::RegisterPieces,
     return_padding: Vec<PaddingRange>,
     /// Frame offset each native value is assembled at: a staging cell for a
     /// register-passed one, its own position in the outgoing native argument
@@ -576,7 +711,7 @@ struct ThunkPlan {
     slot_offsets: Vec<u32>,
     /// `(native argument register, staging cell)` for every register-passed
     /// value, in placement order.
-    register_loads: Vec<(Option<u32>, u32)>,
+    register_loads: Vec<(RegisterLoad, u32)>,
     /// Frame offset of the incoming C argument register save block.
     save_base: u32,
     /// Frame offset holding the C caller's indirect-result pointer, when the C
@@ -587,6 +722,20 @@ struct ThunkPlan {
     /// return is indirect (through [`Self::c_sret_offset`]).
     return_image: Option<ReturnImage>,
     frame_bytes: u32,
+}
+
+/// Which register one staging cell is loaded into before the native call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegisterLoad {
+    /// Native argument register `index` of the general-purpose roster.
+    Gp { index: u32 },
+    /// Native argument register `index` of the floating-point roster.
+    Fp {
+        index: u32,
+        width: crate::value_plan::FloatWidth,
+    },
+    /// The native convention's dedicated indirect-result register.
+    Sret,
 }
 
 /// Where the C image of an aggregate return is assembled.
@@ -658,8 +807,13 @@ impl ThunkPlan {
             .enumerate()
         {
             let value_leaves = &description.native.leaves;
+            let c_location = c.arguments()[parameter].location;
+            // Which shape the value presents where the *C caller* left it,
+            // which is the shape the thunk reads: its own leaves, or the whole
+            // eightbytes of its image.
+            let by_leaf = description.native.crosses_by_leaf(c_location);
             let source = |index: usize| {
-                if description.native.leaves_are_eightbytes {
+                if by_leaf {
                     NativeSlotSource::Leaf {
                         parameter,
                         leaf: index,
@@ -668,18 +822,68 @@ impl ThunkPlan {
                     NativeSlotSource::Eightbyte { parameter, index }
                 }
             };
+            // The piece's own value, read back at its own width: one leaf when
+            // the leaves cross, one whole eightbyte otherwise.
+            let piece_leaf = |index: usize| {
+                if by_leaf {
+                    ImageLeaf {
+                        byte_offset: 0,
+                        ..value_leaves[index]
+                    }
+                } else {
+                    ImageLeaf::eightbyte(0)
+                }
+            };
             match placement.location {
                 ArgLocation::Omitted => {}
                 ArgLocation::Registers { pieces } => {
-                    assert_eq!(
-                        pieces.uniform_class(),
-                        Some(CRegisterClass::Gp),
-                        "an export argument still crosses only in general-purpose registers"
-                    );
                     for (index, piece) in pieces.as_slice().iter().enumerate() {
+                        let destination = match piece.class {
+                            CRegisterClass::Gp => {
+                                NativeSlotDestination::Register { index: piece.index }
+                            }
+                            CRegisterClass::Fp => NativeSlotDestination::FpRegister {
+                                index: piece.index,
+                                width: float_piece_width(piece_leaf(index)),
+                            },
+                        };
+                        let ArgLocation::Registers { pieces: c_pieces } = c_location else {
+                            // The C row stacked what the native row registers:
+                            // the wider native return bank can leave a
+                            // general-purpose register free that the C row
+                            // spent on a hidden indirect-result pointer. The
+                            // value is read out of the C caller's own argument
+                            // area.
+                            slots.push((source(index), destination));
+                            continue;
+                        };
+                        let c_piece = c_pieces.as_slice()[index];
+                        // Both rows spend the floating-point roster
+                        // identically — only the hidden indirect-result
+                        // pointer can shift a placement, and it takes a
+                        // general-purpose register (ADR-0084) — so a
+                        // floating-point piece is already in the register the
+                        // native body reads it from and the thunk leaves it
+                        // alone.
+                        if piece.class == CRegisterClass::Fp {
+                            assert_eq!(
+                                (c_piece.class, c_piece.index),
+                                (piece.class, piece.index),
+                                "the two rows place the floating-point argument roster alike"
+                            );
+                            continue;
+                        }
+                        // A general-purpose piece occupies its incoming
+                        // register alone, so it is read back out of that
+                        // register's own save cell rather than through an
+                        // image — a `{i64, f64}` has no contiguous register
+                        // image to read.
                         slots.push((
-                            source(index),
-                            NativeSlotDestination::Register { index: piece.index },
+                            NativeSlotSource::SavedRegister {
+                                save_offset: c_piece.index * 8,
+                                leaf: piece_leaf(index),
+                            },
+                            destination,
                         ));
                     }
                 }
@@ -716,7 +920,11 @@ impl ThunkPlan {
         let register_slots = slots
             .iter()
             .filter(|(_, destination)| {
-                matches!(destination, NativeSlotDestination::Register { .. })
+                matches!(
+                    destination,
+                    NativeSlotDestination::Register { .. }
+                        | NativeSlotDestination::FpRegister { .. }
+                )
             })
             .count() as u32;
         // The outgoing native argument area sits at the base of the frame, so
@@ -803,19 +1011,14 @@ impl ThunkPlan {
             .iter()
             .zip(c.arguments())
             .map(|(_, argument)| match argument.location {
-                ArgLocation::Registers { pieces } => {
-                    // The register save block holds the general-purpose roster,
-                    // and a register-passed value's eightbytes are contiguous in
-                    // it, so its image needs no repacking. Nothing reaches the
-                    // floating-point roster while the C boundary rejects floats.
-                    assert_eq!(
-                        pieces.uniform_class(),
-                        Some(CRegisterClass::Gp),
-                        "an export argument still crosses only in general-purpose registers"
-                    );
-                    ImageBase::Frame {
-                        offset: save_base + pieces.first_index().unwrap_or(0) * 8,
-                    }
+                // A register-placed value is never read through an image: each
+                // of its pieces sits alone in the register the classification
+                // named, and is reached through that register's own save cell
+                // ([`NativeSlotSource::SavedRegister`]). The base is set to the
+                // save block so a debug print of the plan names something
+                // meaningful; nothing reads it.
+                ArgLocation::Registers { .. } | ArgLocation::Omitted => {
+                    ImageBase::Frame { offset: save_base }
                 }
                 ArgLocation::Stack { offset, .. } => ImageBase::Incoming { offset },
                 ArgLocation::Indirect { pointer, .. } => match pointer {
@@ -827,8 +1030,6 @@ impl ThunkPlan {
                     // which the incoming area addresses directly.
                     PointerLocation::Stack { offset } => ImageBase::Incoming { offset },
                 },
-                // A zero-sized argument has no image; its base is never read.
-                ArgLocation::Omitted => ImageBase::Frame { offset: save_base },
             })
             .collect::<Vec<_>>();
 
@@ -839,21 +1040,21 @@ impl ThunkPlan {
         let mut slot_offsets = Vec::with_capacity(slots.len());
         let mut register_loads = Vec::new();
         for (_, destination) in &slots {
-            match *destination {
-                NativeSlotDestination::Register { index } => {
-                    let offset = stage_base + staged * 8;
-                    staged += 1;
-                    register_loads.push((Some(index), offset));
-                    slot_offsets.push(offset);
+            let load = match *destination {
+                NativeSlotDestination::Register { index } => RegisterLoad::Gp { index },
+                NativeSlotDestination::FpRegister { index, width } => {
+                    RegisterLoad::Fp { index, width }
                 }
-                NativeSlotDestination::SretRegister => {
-                    let offset = stage_base + staged * 8;
-                    staged += 1;
-                    register_loads.push((None, offset));
+                NativeSlotDestination::SretRegister => RegisterLoad::Sret,
+                NativeSlotDestination::Stack { offset } => {
                     slot_offsets.push(offset);
+                    continue;
                 }
-                NativeSlotDestination::Stack { offset } => slot_offsets.push(offset),
-            }
+            };
+            let offset = stage_base + staged * 8;
+            staged += 1;
+            register_loads.push((load, offset));
+            slot_offsets.push(offset);
         }
 
         Self {
@@ -863,6 +1064,12 @@ impl ThunkPlan {
             leaves,
             slots,
             return_leaves: signature.return_leaves.clone(),
+            return_eightbytes: signature.return_eightbytes,
+            native_return_pieces: lower_native_return(
+                ConventionSpec::native(target),
+                signature.result,
+            )
+            .register_pieces(),
             return_padding: signature.return_padding.clone(),
             slot_offsets,
             register_loads,
@@ -948,21 +1155,30 @@ impl ThunkPlan {
                     // whole and the callee reads the leaves back out of it.
                     self.set_base(emitter, parameter);
                     emitter.load_leaf(
-                        ImageLeaf {
-                            byte_offset: (index as u32) * 8,
-                            width: 8,
-                            signed: false,
-                        },
+                        ImageLeaf::eightbyte(
+                            u32::try_from(index).expect("an eightbyte index fits"),
+                        ),
                         destination,
                     );
+                }
+                NativeSlotSource::SavedRegister { save_offset, leaf } => {
+                    // The value occupies its incoming register alone, so its
+                    // save cell *is* its image. Reading it as an integer at its
+                    // own width restores the canonical extension Rue's scalar
+                    // invariant relies on and no C caller promises.
+                    emitter.base_from_frame(save_base + save_offset);
+                    emitter.load_leaf(leaf, destination);
                 }
             }
         }
 
         for (register, offset) in &self.register_loads {
-            match register {
-                Some(index) => emitter.load_argument_register(*index, *offset),
-                None => emitter.load_sret_register(*offset),
+            match *register {
+                RegisterLoad::Gp { index } => emitter.load_argument_register(index, *offset),
+                RegisterLoad::Fp { index, width } => {
+                    emitter.load_fp_argument_register(index, *offset, width)
+                }
+                RegisterLoad::Sret => emitter.load_sret_register(*offset),
             }
         }
         emitter.call(native_symbol);
@@ -979,6 +1195,53 @@ impl ThunkPlan {
             }
             ImageBase::Incoming { offset } => emitter.base_from_incoming(offset),
             ImageBase::SavedPointer { offset } => emitter.base_from_saved_pointer(offset),
+        }
+    }
+
+    /// The file, move width, and image position of result-register piece
+    /// `index` of an aggregate result placed in `pieces` — the shared
+    /// marshaling rule read in the result direction.
+    fn result_piece(
+        &self,
+        pieces: rue_air::RegisterPieces,
+        index: usize,
+    ) -> (crate::abi_slot_class::AbiSlotClass, u32) {
+        let marshal = crate::native_abi::aggregate_marshal(
+            &leaf_classes(&self.return_leaves),
+            self.return_eightbytes,
+            ArgLocation::Registers { pieces },
+        );
+        let class = marshal.class(index, pieces.as_slice()[index].class);
+        let offset = match marshal {
+            // A register holds one of the value's own leaves — an HFA's
+            // member most visibly, which sits at its own member stride.
+            crate::native_abi::NativeArgMarshal::Direct { .. } => {
+                self.return_leaves[index].byte_offset
+            }
+            crate::native_abi::NativeArgMarshal::Image { .. } => {
+                u32::try_from(index).expect("a result index fits u32") * 8
+            }
+        };
+        (class, offset)
+    }
+
+    /// Write native result register `index` into the C image at `leaf`, from
+    /// the file the native row returned it in.
+    fn store_native_result_piece<E: ThunkEmitter>(
+        &self,
+        emitter: &mut E,
+        index: usize,
+        leaf: ImageLeaf,
+    ) {
+        let piece = self.native_return_pieces.as_slice()[index];
+        let (class, _) = self.result_piece(self.native_return_pieces, index);
+        match class {
+            crate::abi_slot_class::AbiSlotClass::Gp => {
+                emitter.store_return_register(piece.index, leaf)
+            }
+            crate::abi_slot_class::AbiSlotClass::Fp(width) => {
+                emitter.store_fp_return_register(piece.index, leaf.byte_offset, width)
+            }
         }
     }
 
@@ -1014,13 +1277,10 @@ impl ThunkPlan {
             // Stage the whole eightbytes, then hand the C caller exactly the
             // bytes its storage holds.
             for index in 0..*count {
-                emitter.store_return_register(
-                    index,
-                    ImageLeaf {
-                        byte_offset: index * 8,
-                        width: 8,
-                        signed: false,
-                    },
+                self.store_native_result_piece(
+                    emitter,
+                    index as usize,
+                    ImageLeaf::eightbyte(index),
                 );
             }
             emitter.base_from_saved_pointer(pointer_offset);
@@ -1036,23 +1296,24 @@ impl ThunkPlan {
                 let end = u32::try_from(range.end).expect("a padding offset fits u32");
                 emitter.zero_image_bytes(start, end - start);
             }
-            for (index, leaf) in self.return_leaves.iter().enumerate() {
-                emitter.store_return_register(
-                    u32::try_from(index).expect("a return slot index fits u32"),
-                    *leaf,
-                );
+            for index in 0..self.return_leaves.len() {
+                self.store_native_result_piece(emitter, index, self.return_leaves[index]);
             }
         }
 
         match self.c.ret() {
             LoweredReturn::Registers { pieces, .. } => {
-                assert_eq!(
-                    pieces.uniform_class(),
-                    Some(CRegisterClass::Gp),
-                    "the C boundary still returns only general-purpose values"
-                );
-                for index in 0..pieces.len() {
-                    emitter.load_result_register(index, index * 8);
+                for index in 0..pieces.len() as usize {
+                    let piece = pieces.as_slice()[index];
+                    let (class, offset) = self.result_piece(pieces, index);
+                    match class {
+                        crate::abi_slot_class::AbiSlotClass::Gp => {
+                            emitter.load_result_register(piece.index, offset)
+                        }
+                        crate::abi_slot_class::AbiSlotClass::Fp(width) => {
+                            emitter.load_fp_result_register(piece.index, offset, width)
+                        }
+                    }
                 }
             }
             LoweredReturn::Sret { echoed, .. } => {
@@ -1108,6 +1369,14 @@ trait ThunkEmitter {
     fn store_base(&mut self, destination: u32);
     /// Native argument register `index` := frame + `offset`.
     fn load_argument_register(&mut self, index: u32, offset: u32);
+    /// Native floating-point argument register `index` := the `width` bytes at
+    /// frame + `offset`.
+    fn load_fp_argument_register(
+        &mut self,
+        index: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+    );
     /// The native convention's dedicated indirect-result register := frame +
     /// `offset`.
     fn load_sret_register(&mut self, offset: u32);
@@ -1116,10 +1385,26 @@ trait ThunkEmitter {
     /// base + `leaf.byte_offset` := the low `leaf.width` bytes of native return
     /// register `index`.
     fn store_return_register(&mut self, index: u32, leaf: ImageLeaf);
+    /// base + `offset` := the low `width` bytes of native floating-point return
+    /// register `index`.
+    fn store_fp_return_register(
+        &mut self,
+        index: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+    );
     /// Zero `len` bytes at base + `offset`.
     fn zero_image_bytes(&mut self, offset: u32, len: u32);
     /// C result register `index` := the eight bytes at base + `offset`.
     fn load_result_register(&mut self, index: u32, offset: u32);
+    /// C floating-point result register `index` := the `width` bytes at base +
+    /// `offset`.
+    fn load_fp_result_register(
+        &mut self,
+        index: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+    );
     /// The primary C result register := the pointer stored at frame + `offset`.
     fn echo_sret_pointer(&mut self, offset: u32);
     /// base + 0 .. base + `byte_count` := frame + `source_offset` .. , copied in
@@ -1222,6 +1507,25 @@ impl X86Emitter {
     fn load_frame(&mut self, reg: u8, offset: u32) {
         self.mem(&[0x8B], reg, X86_RSP, Self::frame_disp(offset), true, false);
     }
+
+    /// `movss`/`movsd` between `xmm` and `[base + disp]`; `store` picks the
+    /// direction. The mandatory SSE prefix precedes any REX byte, which is
+    /// what [`Self::mem`] emits next.
+    fn sse_mem(
+        &mut self,
+        xmm: u8,
+        base: u8,
+        disp: i32,
+        width: crate::value_plan::FloatWidth,
+        store: bool,
+    ) {
+        self.code.push(match width {
+            crate::value_plan::FloatWidth::F32 => 0xF3,
+            crate::value_plan::FloatWidth::F64 => 0xF2,
+        });
+        let opcode = if store { 0x11 } else { 0x10 };
+        self.mem(&[0x0F, opcode], xmm, base, disp, false, false);
+    }
 }
 
 impl ThunkEmitter for X86Emitter {
@@ -1318,6 +1622,16 @@ impl ThunkEmitter for X86Emitter {
         self.load_frame(X86_ARG_REGS[index as usize], offset);
     }
 
+    fn load_fp_argument_register(
+        &mut self,
+        index: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        let disp = Self::frame_disp(offset);
+        self.sse_mem(index as u8, X86_RSP, disp, width, false);
+    }
+
     fn load_sret_register(&mut self, _offset: u32) {
         unreachable!("SysV AMD64 has no dedicated indirect-result register");
     }
@@ -1345,6 +1659,16 @@ impl ThunkEmitter for X86Emitter {
             1 => self.mem(&[0x88], reg, X86_BASE, disp, false, true),
             width => unreachable!("a compact image leaf is 1, 2, 4, or 8 bytes, not {width}"),
         }
+    }
+
+    fn store_fp_return_register(
+        &mut self,
+        index: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        let disp = Self::frame_disp(offset);
+        self.sse_mem(index as u8, X86_BASE, disp, width, true);
     }
 
     fn zero_image_bytes(&mut self, offset: u32, len: u32) {
@@ -1381,6 +1705,16 @@ impl ThunkEmitter for X86Emitter {
             true,
             false,
         );
+    }
+
+    fn load_fp_result_register(
+        &mut self,
+        index: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        let disp = Self::frame_disp(offset);
+        self.sse_mem(index as u8, X86_BASE, disp, width, false);
     }
 
     fn echo_sret_pointer(&mut self, offset: u32) {
@@ -1500,6 +1834,25 @@ impl Aarch64Emitter {
         self.access(0xF940_0000, 8, rt, base, offset);
     }
 
+    /// `ldr`/`str` of an `s`- or `d`-register at `base + offset` (the
+    /// SIMD&FP scaled-immediate forms); `store` picks the direction.
+    fn fp_access(
+        &mut self,
+        rt: u32,
+        base: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+        store: bool,
+    ) {
+        let (opcode, size) = match (width, store) {
+            (crate::value_plan::FloatWidth::F32, false) => (0xBD40_0000, 4),
+            (crate::value_plan::FloatWidth::F32, true) => (0xBD00_0000, 4),
+            (crate::value_plan::FloatWidth::F64, false) => (0xFD40_0000, 8),
+            (crate::value_plan::FloatWidth::F64, true) => (0xFD00_0000, 8),
+        };
+        self.access(opcode, size, rt, base, offset);
+    }
+
     /// The incoming argument area begins just past the frame record the
     /// prologue pushed.
     fn incoming_base(&mut self, offset: u32) -> u32 {
@@ -1581,6 +1934,15 @@ impl ThunkEmitter for Aarch64Emitter {
         self.load64(index, A64_SP, offset);
     }
 
+    fn load_fp_argument_register(
+        &mut self,
+        index: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        self.fp_access(index, A64_SP, offset, width, false);
+    }
+
     fn load_sret_register(&mut self, offset: u32) {
         self.load64(A64_SRET, A64_SP, offset);
     }
@@ -1603,6 +1965,15 @@ impl ThunkEmitter for Aarch64Emitter {
         self.access(opcode, leaf.width, index, A64_BASE, leaf.byte_offset);
     }
 
+    fn store_fp_return_register(
+        &mut self,
+        index: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        self.fp_access(index, A64_BASE, offset, width, true);
+    }
+
     fn zero_image_bytes(&mut self, offset: u32, len: u32) {
         for (position, width) in zero_runs(offset, len) {
             let opcode = match width {
@@ -1617,6 +1988,15 @@ impl ThunkEmitter for Aarch64Emitter {
 
     fn load_result_register(&mut self, index: u32, offset: u32) {
         self.load64(index, A64_BASE, offset);
+    }
+
+    fn load_fp_result_register(
+        &mut self,
+        index: u32,
+        offset: u32,
+        width: crate::value_plan::FloatWidth,
+    ) {
+        self.fp_access(index, A64_BASE, offset, width, false);
     }
 
     fn echo_sret_pointer(&mut self, _offset: u32) {
@@ -1672,6 +2052,7 @@ mod tests {
             byte_offset: 0,
             width,
             signed,
+            float: false,
         }
     }
 
@@ -1684,7 +2065,7 @@ mod tests {
             c: scalar_facts(kind),
             native: NativeParameter {
                 leaves: vec![scalar_leaf(width, signed)],
-                leaves_are_eightbytes: true,
+                eightbytes: 1,
             },
         }
     }
@@ -1713,7 +2094,7 @@ mod tests {
             parameters,
             result: CAbiTypeFacts::ZeroSized,
             result_is_aggregate: false,
-            return_leaves_are_eightbytes: true,
+            return_eightbytes: 1,
             return_bytes: 0,
             return_leaves: Vec::new(),
             return_padding: Vec::new(),
@@ -1729,16 +2110,19 @@ mod tests {
                 byte_offset: 0,
                 width: 8,
                 signed: false,
+                float: false,
             },
             ImageLeaf {
                 byte_offset: 8,
                 width: 8,
                 signed: false,
+                float: false,
             },
             ImageLeaf {
                 byte_offset: 16,
                 width: 8,
                 signed: false,
+                float: false,
             },
         ];
         ExportSignature {
@@ -1747,12 +2131,12 @@ mod tests {
                 c: CAbiTypeFacts::integer_aggregate(24, 8),
                 native: NativeParameter {
                     leaves: leaves.clone(),
-                    leaves_are_eightbytes: true,
+                    eightbytes: 1,
                 },
             }],
             result: CAbiTypeFacts::integer_aggregate(24, 8),
             result_is_aggregate: true,
-            return_leaves_are_eightbytes: true,
+            return_eightbytes: 1,
             return_bytes: 24,
             return_leaves: leaves,
             return_padding: Vec::new(),
@@ -1768,11 +2152,13 @@ mod tests {
                 byte_offset: 0,
                 width: 4,
                 signed: true,
+                float: false,
             },
             ImageLeaf {
                 byte_offset: 4,
                 width: 4,
                 signed: true,
+                float: false,
             },
         ];
         ExportSignature {
@@ -1781,12 +2167,12 @@ mod tests {
                 c: CAbiTypeFacts::integer_aggregate(8, 4),
                 native: NativeParameter {
                     leaves: leaves.clone(),
-                    leaves_are_eightbytes: false,
+                    eightbytes: 1,
                 },
             }],
             result: CAbiTypeFacts::integer_aggregate(8, 4),
             result_is_aggregate: true,
-            return_leaves_are_eightbytes: false,
+            return_eightbytes: 1,
             return_bytes: 8,
             return_leaves: leaves,
             return_padding: Vec::new(),
@@ -1841,13 +2227,13 @@ mod tests {
                         c: scalar_facts(kind),
                         native: NativeParameter {
                             leaves: vec![scalar_leaf(kind.natural_bytes(), false)],
-                            leaves_are_eightbytes: true,
+                            eightbytes: 1,
                         },
                     })
                     .collect(),
                 result,
                 result_is_aggregate: false,
-                return_leaves_are_eightbytes: true,
+                return_eightbytes: 1,
                 return_bytes: 8,
                 return_leaves: vec![scalar_leaf(2, true)],
                 return_padding: Vec::new(),
@@ -2057,12 +2443,13 @@ mod tests {
                     .iter()
                     .map(|(source, _)| *source)
                     .collect::<Vec<_>>(),
-                vec![NativeSlotSource::Eightbyte {
-                    parameter: 0,
-                    index: 0
+                vec![NativeSlotSource::SavedRegister {
+                    save_offset: 0,
+                    leaf: ImageLeaf::eightbyte(0),
                 }],
                 "no hidden return pointer crosses, so the packed pair takes the \
-                 first argument register"
+                 first argument register, and its one eightbyte is read out of \
+                 that register's own save cell"
             );
             // The eightbyte the native body returned is the eightbyte C wants.
             assert_eq!(plan.return_image, None);
@@ -2081,6 +2468,7 @@ mod tests {
                 byte_offset: index * 4,
                 width: 4,
                 signed: true,
+                float: false,
             })
             .collect();
         ExportSignature {
@@ -2088,7 +2476,7 @@ mod tests {
             parameters: Vec::new(),
             result: CAbiTypeFacts::integer_aggregate(20, 4),
             result_is_aggregate: true,
-            return_leaves_are_eightbytes: false,
+            return_eightbytes: 1,
             return_bytes: 20,
             return_leaves: leaves,
             return_padding: Vec::new(),
@@ -2244,6 +2632,7 @@ mod tests {
                 byte_offset: 0,
                 width,
                 signed,
+                float: false,
             }];
             let signature = ExportSignature {
                 convention: CallingConvention::X86_64SysV,
@@ -2251,12 +2640,12 @@ mod tests {
                     c: CAbiTypeFacts::integer_aggregate(width.into(), width.into()),
                     native: NativeParameter {
                         leaves: leaves.clone(),
-                        leaves_are_eightbytes: true,
+                        eightbytes: 1,
                     },
                 }],
                 result: CAbiTypeFacts::integer_aggregate(width.into(), width.into()),
                 result_is_aggregate: true,
-                return_leaves_are_eightbytes: true,
+                return_eightbytes: 1,
                 return_bytes: width.into(),
                 return_leaves: leaves,
                 return_padding: vec![PaddingRange {
@@ -2285,6 +2674,7 @@ mod tests {
                 byte_offset: index * 8,
                 width: 8,
                 signed: false,
+                float: false,
             })
             .collect()
     }
@@ -2297,7 +2687,7 @@ mod tests {
             parameters,
             result: CAbiTypeFacts::integer_aggregate(u64::from(bytes), 8),
             result_is_aggregate: true,
-            return_leaves_are_eightbytes: true,
+            return_eightbytes: 1,
             return_bytes: bytes,
             return_leaves: word_leaves(bytes / 8),
             return_padding: Vec::new(),
@@ -2316,7 +2706,7 @@ mod tests {
             parameters,
             result: scalar_facts(kind),
             result_is_aggregate: false,
-            return_leaves_are_eightbytes: true,
+            return_eightbytes: 1,
             return_bytes: width,
             return_leaves: vec![scalar_leaf(width, signed)],
             return_padding: Vec::new(),
@@ -2410,7 +2800,7 @@ mod tests {
             c: CAbiTypeFacts::integer_aggregate(16, 8),
             native: NativeParameter {
                 leaves: word_leaves(2),
-                leaves_are_eightbytes: true,
+                eightbytes: 1,
             },
         };
         for (target, entry) in entries(&word_aggregate_result(vec![sixteen], 16)) {
@@ -2465,18 +2855,20 @@ mod tests {
             parameters: Vec::new(),
             result: CAbiTypeFacts::integer_aggregate(16, 8),
             result_is_aggregate: true,
-            return_leaves_are_eightbytes: true,
+            return_eightbytes: 1,
             return_bytes: 16,
             return_leaves: vec![
                 ImageLeaf {
                     byte_offset: 0,
                     width: 4,
                     signed: true,
+                    float: false,
                 },
                 ImageLeaf {
                     byte_offset: 8,
                     width: 8,
                     signed: false,
+                    float: false,
                 },
             ],
             return_padding: vec![PaddingRange { start: 4, end: 8 }],
@@ -2514,9 +2906,12 @@ mod tests {
             for &target in Target::all() {
                 let signature = on(target, &signature);
                 let plan = ThunkPlan::new(target, &signature);
-                let identity = plan.slots.iter().all(|(source, _)| {
-                    !matches!(source, NativeSlotSource::Leaf { parameter, leaf }
-                        if plan.leaves[*parameter][*leaf].width < 8)
+                let identity = plan.slots.iter().all(|(source, _)| match source {
+                    NativeSlotSource::Leaf { parameter, leaf } => {
+                        !plan.leaves[*parameter][*leaf].needs_reextension()
+                    }
+                    NativeSlotSource::SavedRegister { leaf, .. } => !leaf.needs_reextension(),
+                    _ => true,
                 }) && !plan.adapts_result();
                 assert_eq!(
                     identity,

--- a/crates/rue-codegen/src/foreign_call.rs
+++ b/crates/rue-codegen/src/foreign_call.rs
@@ -24,11 +24,13 @@ use rue_air::{
     LoweredSignature, PointerLocation, ScalarAbiExtension, Type, lower_c_signature,
 };
 use rue_cfg::{Cfg, CfgCallArg, CfgValue};
-use rue_target::{CRegisterClass, CallingConvention};
+use rue_target::CallingConvention;
 
+use crate::abi_slot_class::AbiSlotClass;
 use crate::frame_layout::{
     FrameBudgetExceeded, checked_aligned_region_bytes, checked_call_area_from_stack_bytes,
 };
+use crate::native_abi::{NativeArgMarshal, aggregate_marshal};
 use crate::types::{self, PhysicalEnumSlot};
 use crate::vreg::VReg;
 
@@ -94,6 +96,30 @@ impl AggregateImage {
             leaves: self.leaves,
         }
     }
+
+    /// How this image reaches `location`: as the value's own leaf vregs, or as
+    /// the eightbytes of a staged buffer. The C boundary asks the very question
+    /// a native crossing asks, of the same function, so an import and a native
+    /// call of one shape marshal it identically (ADR-0084).
+    pub(crate) fn marshal(&self, location: ArgLocation) -> NativeArgMarshal {
+        aggregate_marshal(&self.leaf_classes(), self.eightbytes(), location)
+    }
+
+    /// The marshaling rule's view of this image's leaves.
+    fn leaf_classes(&self) -> Vec<crate::native_abi::ImageLeafClass> {
+        self.map
+            .iter()
+            .map(|leaf| (leaf.byte_offset, crate::native_abi::leaf_slot_class(leaf)))
+            .collect()
+    }
+
+    /// The file the aggregate's first native leaf lives in, which is the file
+    /// the value's primary vreg is synced from.
+    pub(crate) fn first_leaf_class(&self) -> AbiSlotClass {
+        self.map
+            .first()
+            .map_or(AbiSlotClass::Gp, crate::native_abi::leaf_slot_class)
+    }
 }
 
 /// One value crossing into a foreign call. *Where* it crosses is the lowered
@@ -143,6 +169,28 @@ impl ForeignArg {
     fn packs_as_scalar(&self) -> bool {
         matches!(self, Self::Scalar { .. })
     }
+
+    /// How this argument reaches `location`: which register file and move width
+    /// each piece uses, and whether the pieces are the value's own leaf vregs.
+    fn marshal(&self, location: ArgLocation) -> NativeArgMarshal {
+        match self {
+            Self::Scalar { kind, .. } => NativeArgMarshal::Direct {
+                classes: vec![scalar_slot_class(*kind)],
+            },
+            Self::Aggregate { image, .. } => image.marshal(location),
+        }
+    }
+}
+
+/// The register file and move width one C scalar travels in: a float rides the
+/// floating-point file at its own width, every integer, `bool`, and pointer the
+/// general-purpose one.
+fn scalar_slot_class(kind: CAbiScalarKind) -> AbiSlotClass {
+    match kind {
+        CAbiScalarKind::F32 => AbiSlotClass::Fp(crate::value_plan::FloatWidth::F32),
+        CAbiScalarKind::F64 => AbiSlotClass::Fp(crate::value_plan::FloatWidth::F64),
+        _ => AbiSlotClass::Gp,
+    }
 }
 
 /// How a foreign call's return value crosses. *Where* it crosses — result
@@ -181,6 +229,10 @@ pub struct ForeignCallInputs {
     symbol: String,
     args: Vec<ForeignArg>,
     ret: ForeignReturn,
+    /// The result's own classification facts, which name the file a scalar
+    /// result comes back in — `xmm0`/`v0` for a float, the integer result
+    /// register otherwise.
+    return_facts: CAbiTypeFacts,
     signature: LoweredSignature,
 }
 
@@ -205,7 +257,17 @@ impl ForeignCallInputs {
             symbol,
             args,
             ret,
+            return_facts,
             signature,
+        }
+    }
+
+    /// The register file a scalar result comes back in, and the width of the
+    /// move that takes it out.
+    fn return_class(&self) -> AbiSlotClass {
+        match self.return_facts {
+            CAbiTypeFacts::Scalar { kind, .. } => scalar_slot_class(kind),
+            CAbiTypeFacts::Aggregate { .. } | CAbiTypeFacts::ZeroSized => AbiSlotClass::Gp,
         }
     }
 
@@ -236,11 +298,17 @@ impl ForeignCallInputs {
 ///
 /// `offset` is always a multiple of `bytes`, which is what makes every store
 /// encodable in AArch64's scaled `imm12` addressing mode.
+///
+/// `class` is the file the stored vreg lives in: a stacked `f32`/`f64` argument
+/// and an HFA member hold their value in the floating-point file, so the store
+/// is a floating-point one. An eightbyte read out of a staged image is an
+/// integer-shaped lane whatever it carries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ForeignStackStore {
     pub(crate) value: VReg,
     pub(crate) offset: u32,
     pub(crate) bytes: u32,
+    pub(crate) class: AbiSlotClass,
 }
 
 /// The complete outgoing argument area: what to store where, and how many bytes
@@ -291,16 +359,16 @@ impl ForeignCallPlan {
     /// The stores one stacked argument makes: its eightbyte (or narrower)
     /// pieces at ascending offsets from the argument's own packed offset.
     fn stack_stores(&self, arg_index: usize, values: &[VReg]) -> Vec<ForeignStackStore> {
-        let ArgLocation::Stack { offset, size, .. } =
-            self.signature().arguments()[arg_index].location
-        else {
+        let location = self.signature().arguments()[arg_index].location;
+        let ArgLocation::Stack { offset, size, .. } = location else {
             panic!("stack stores are only emitted for a stacked argument");
         };
-        let bytes = if self.inputs.args[arg_index].packs_as_scalar() {
-            size
-        } else {
-            8
-        };
+        let arg = &self.inputs.args[arg_index];
+        let bytes = if arg.packs_as_scalar() { size } else { 8 };
+        // A stacked aggregate crosses as the whole eightbytes of its staged
+        // image, which are integer-shaped lanes; only a stacked *scalar* keeps
+        // its own file, and a stacked `f32`/`f64` is stored from there.
+        let marshal = arg.marshal(location);
         values
             .iter()
             .enumerate()
@@ -309,6 +377,7 @@ impl ForeignCallPlan {
                 offset: offset
                     + u32::try_from(piece * 8).expect("foreign stack offset must fit u32"),
                 bytes,
+                class: marshal.class(piece, marshal.stacked_bank(piece)),
             })
             .collect()
     }
@@ -355,8 +424,10 @@ impl ForeignCallPlan {
 /// pair to a physical register rather than counting the values it has seen.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ForeignRegisterArg {
-    /// The register bank.
-    pub(crate) class: CRegisterClass,
+    /// The register file the value travels in, and the width of the move that
+    /// puts it there — an `f32` and an `f64` share the floating-point bank but
+    /// not the instruction.
+    pub(crate) class: AbiSlotClass,
     /// Roster index within that bank's argument registers.
     pub(crate) index: u32,
     /// The vreg holding the value.
@@ -379,6 +450,18 @@ pub(crate) trait ForeignCallLoweringBackend {
         value: CfgValue,
         image: &AggregateImage,
     ) -> Vec<VReg>;
+    /// The aggregate's own leaf vregs, in ascending image order, each already
+    /// in the file its leaf lives in. Taken when the placement crosses the
+    /// value leaf by leaf rather than through its staged eightbytes.
+    fn foreign_aggregate_leaves(&mut self, value: CfgValue) -> Vec<VReg>;
+    /// Move one eightbyte read out of a staged image into the floating-point
+    /// file. The lane is a bit pattern rather than a number, so the whole
+    /// eightbyte crosses even where the leaves inside it are `f32`s.
+    fn foreign_eightbyte_as_float(
+        &mut self,
+        bits: VReg,
+        width: crate::value_plan::FloatWidth,
+    ) -> VReg;
     fn foreign_byref_copy(&mut self, value: CfgValue, image: &AggregateImage) -> VReg;
     /// Reserve the outgoing argument area and commit every store in it. The
     /// area's size and each store's offset and width are the convention's
@@ -395,15 +478,33 @@ pub(crate) trait ForeignCallLoweringBackend {
     fn foreign_cleanup_stack(&mut self, stack: &ForeignStackArea);
     fn foreign_cleanup_byref(&mut self, byref_bytes: u32);
     fn foreign_zero_result(&mut self, primary: VReg);
-    fn foreign_scalar_result(&mut self, primary: VReg, ext: ScalarAbiExtension);
-    fn foreign_register_result(&mut self, primary: VReg, image: &AggregateImage) -> Vec<VReg>;
+    /// Take the scalar result out of the primary result register of `class`'s
+    /// bank and re-extend it (a C callee leaves a narrow integer's high bits
+    /// unspecified; a float fills its register and needs nothing).
+    fn foreign_scalar_result(
+        &mut self,
+        primary: VReg,
+        class: AbiSlotClass,
+        ext: ScalarAbiExtension,
+    );
+    /// Reconstruct a register-returned aggregate's native leaves. `pieces`
+    /// names the result register each piece came back in and `marshal` whether
+    /// those registers hold the value's own leaves or its staged eightbytes.
+    fn foreign_register_result(
+        &mut self,
+        primary: VReg,
+        image: &AggregateImage,
+        pieces: rue_air::RegisterPieces,
+        marshal: &NativeArgMarshal,
+    ) -> Vec<VReg>;
     fn foreign_sret_result(
         &mut self,
         primary: VReg,
         image: &AggregateImage,
         sret_ptr: VReg,
     ) -> Vec<VReg>;
-    fn foreign_move_primary(&mut self, primary: VReg, slot: VReg);
+    /// Sync the primary vreg with logical slot 0, whose file `class` names.
+    fn foreign_move_primary(&mut self, primary: VReg, slot: VReg, class: AbiSlotClass);
 }
 
 /// Lower one foreign call through the single shared event sequence. Concrete
@@ -449,7 +550,7 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
         // it takes the first general-purpose argument register and the
         // classification already shifted every user argument past it.
         register_args.push(ForeignRegisterArg {
-            class: CRegisterClass::Gp,
+            class: AbiSlotClass::Gp,
             index: 0,
             value: sret_ptr.expect("SysV sret placement requires storage"),
         });
@@ -460,16 +561,40 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
         .zip(plan.signature().arguments())
         .enumerate()
     {
-        let values = match (arg, argument.location) {
+        // How the value reaches the placement: its own leaf vregs when every
+        // piece the row named is one leaf in that leaf's own file — a scalar,
+        // a value whose leaves start their own eightbytes, an HFA the row
+        // carries member-wise — and the staged image's eightbytes otherwise.
+        let marshal = arg.marshal(argument.location);
+        let mut values = match (arg, argument.location) {
             (_, ArgLocation::Omitted) => continue,
             (ForeignArg::Scalar { value, .. }, _) => vec![backend.foreign_get_vreg(*value)],
             (ForeignArg::Aggregate { value, image }, ArgLocation::Indirect { .. }) => {
                 vec![backend.foreign_byref_copy(*value, image)]
             }
+            (ForeignArg::Aggregate { value, .. }, _)
+                if matches!(marshal, NativeArgMarshal::Direct { .. }) =>
+            {
+                backend.foreign_aggregate_leaves(*value)
+            }
             (ForeignArg::Aggregate { value, image }, _) => {
                 backend.foreign_image_arg_eightbytes(*value, image)
             }
         };
+        // An eightbyte read out of a staged image comes back integer-shaped;
+        // one the classification put in the floating-point bank takes its bits
+        // there as a whole lane.
+        if let (NativeArgMarshal::Image { .. }, ArgLocation::Registers { pieces }) =
+            (&marshal, argument.location)
+        {
+            for (index, value) in values.iter_mut().enumerate() {
+                if let AbiSlotClass::Fp(width) =
+                    marshal.class(index, pieces.as_slice()[index].class)
+                {
+                    *value = backend.foreign_eightbyte_as_float(*value, width);
+                }
+            }
+        }
         match argument.location {
             ArgLocation::Registers { pieces } => {
                 assert_eq!(
@@ -477,9 +602,9 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
                     values.len(),
                     "one value per register the classification named"
                 );
-                register_args.extend(pieces.as_slice().iter().zip(&values).map(
-                    |(piece, value)| ForeignRegisterArg {
-                        class: piece.class,
+                register_args.extend(pieces.as_slice().iter().zip(&values).enumerate().map(
+                    |(index, (piece, value))| ForeignRegisterArg {
+                        class: marshal.class(index, piece.class),
                         index: piece.index,
                         value: *value,
                     },
@@ -489,11 +614,18 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
                 pointer: PointerLocation::Register { index },
                 ..
             } => register_args.push(ForeignRegisterArg {
-                class: CRegisterClass::Gp,
+                class: AbiSlotClass::Gp,
                 index,
                 value: values[0],
             }),
-            ArgLocation::Stack { .. } => stack.stores.extend(plan.stack_stores(arg_index, &values)),
+            ArgLocation::Stack { .. } => {
+                assert_eq!(
+                    marshal.eightbyte_count(),
+                    values.len(),
+                    "one value per piece the classification stacked"
+                );
+                stack.stores.extend(plan.stack_stores(arg_index, &values));
+            }
             ArgLocation::Indirect {
                 pointer: PointerLocation::Stack { offset },
                 ..
@@ -501,6 +633,7 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
                 value: values[0],
                 offset,
                 bytes: 8,
+                class: AbiSlotClass::Gp,
             }),
             ArgLocation::Omitted => unreachable!("an omitted argument was skipped above"),
         }
@@ -526,11 +659,33 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
             Vec::new()
         }
         (ForeignReturn::Scalar, LoweredReturn::Registers { extension, .. }) => {
-            backend.foreign_scalar_result(primary, extension);
+            backend.foreign_scalar_result(primary, inputs.return_class(), extension);
             Vec::new()
         }
-        (ForeignReturn::Aggregate { image }, LoweredReturn::Registers { .. }) => {
-            backend.foreign_register_result(primary, image)
+        (ForeignReturn::Aggregate { image }, LoweredReturn::Registers { pieces, .. }) => {
+            // A returned aggregate is reconstructed through its image, which
+            // reads every leaf at its own width: a C callee leaves the bits
+            // above a narrow leaf unspecified, so the leaf's own vreg cannot
+            // simply be the result register. The one shape that has no image
+            // eightbytes to read is a homogeneous floating-point aggregate the
+            // row returned one *member* per register, whose members fill their
+            // registers and are the value's own leaves.
+            let marshal = if pieces.len() == image.eightbytes() {
+                NativeArgMarshal::Image {
+                    eightbytes: image.eightbytes(),
+                }
+            } else {
+                let marshal = image.marshal(ArgLocation::Registers { pieces });
+                assert!(
+                    matches!(&marshal, NativeArgMarshal::Direct { classes }
+                        if classes.len() == pieces.len() as usize),
+                    "a result whose register count is not its image's eightbyte \
+                     count comes back one homogeneous floating-point member per \
+                     register"
+                );
+                marshal
+            };
+            backend.foreign_register_result(primary, image, pieces, &marshal)
         }
         (ForeignReturn::Aggregate { image }, LoweredReturn::Sret { .. }) => backend
             .foreign_sret_result(
@@ -543,7 +698,11 @@ pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
         }
     };
     if let Some(&slot) = slots.first() {
-        backend.foreign_move_primary(primary, slot);
+        let class = match &inputs.ret {
+            ForeignReturn::Aggregate { image } => image.first_leaf_class(),
+            ForeignReturn::Scalar | ForeignReturn::ZeroSized => AbiSlotClass::Gp,
+        };
+        backend.foreign_move_primary(primary, slot, class);
     }
     crate::value_plan::MaterializedValue { primary, slots }
 }
@@ -1001,6 +1160,20 @@ mod tests {
             (0..image.eightbytes()).map(|_| self.vreg()).collect()
         }
 
+        fn foreign_aggregate_leaves(&mut self, _value: CfgValue) -> Vec<VReg> {
+            self.record("leaves");
+            vec![self.vreg()]
+        }
+
+        fn foreign_eightbyte_as_float(
+            &mut self,
+            _bits: VReg,
+            width: crate::value_plan::FloatWidth,
+        ) -> VReg {
+            self.record(format!("lane_to_float:{width:?}"));
+            self.vreg()
+        }
+
         fn foreign_byref_copy(&mut self, _value: CfgValue, image: &AggregateImage) -> VReg {
             self.record(format!("byref:{}", image.storage_bytes));
             self.vreg()
@@ -1043,11 +1216,22 @@ mod tests {
             self.record("zero_result");
         }
 
-        fn foreign_scalar_result(&mut self, _primary: VReg, _ext: ScalarAbiExtension) {
+        fn foreign_scalar_result(
+            &mut self,
+            _primary: VReg,
+            _class: AbiSlotClass,
+            _ext: ScalarAbiExtension,
+        ) {
             self.record("scalar_result");
         }
 
-        fn foreign_register_result(&mut self, _primary: VReg, image: &AggregateImage) -> Vec<VReg> {
+        fn foreign_register_result(
+            &mut self,
+            _primary: VReg,
+            image: &AggregateImage,
+            _pieces: rue_air::RegisterPieces,
+            _marshal: &NativeArgMarshal,
+        ) -> Vec<VReg> {
             self.record(format!("register_result:{}", image.eightbytes()));
             vec![self.vreg()]
         }
@@ -1062,7 +1246,7 @@ mod tests {
             vec![self.vreg()]
         }
 
-        fn foreign_move_primary(&mut self, _primary: VReg, _slot: VReg) {
+        fn foreign_move_primary(&mut self, _primary: VReg, _slot: VReg, _class: AbiSlotClass) {
             self.record("move_primary");
         }
     }

--- a/crates/rue-codegen/src/native_abi.rs
+++ b/crates/rue-codegen/src/native_abi.rs
@@ -85,6 +85,34 @@ impl NativeImage {
         }
     }
 
+    /// The value's members when it is a homogeneous floating-point aggregate:
+    /// the width every member shares and how many there are.
+    ///
+    /// AAPCS64 rule C.3 spends one floating-point register per HFA *member*,
+    /// not one per eightbyte, so a `{f32, f32, f32, f32}` crosses in four
+    /// `s`-registers spanning two eightbytes. Recognizing that shape is what
+    /// lets [`NativeArg::marshal`] hand each member's own leaf vreg to its own
+    /// register instead of packing the image; `{f64, f64}`, whose members
+    /// already start their own eightbytes, reaches the same answer through
+    /// [`Self::direct_leaves`].
+    ///
+    /// A tag-dispatched image has no members, nor does a map whose leaves are
+    /// not all floats of one width laid end to end, nor one whose float leaf is
+    /// an enum payload's general-purpose bit carrier.
+    pub fn homogeneous_float_members(&self) -> Option<(FloatWidth, u32)> {
+        image_float_members(&self.leaf_classes()?)
+    }
+
+    /// The marshaling rule's view of this image's leaves, or `None` for a
+    /// tag-dispatched image, whose leaves move with the active variant and so
+    /// are always read out of memory.
+    pub fn leaf_classes(&self) -> Option<Vec<ImageLeafClass>> {
+        let NativeImageKind::Map { map, .. } = &self.kind else {
+            return None;
+        };
+        Some(map.iter().map(leaf_class).collect())
+    }
+
     /// The bank and width each leaf's own vreg travels in when the leaves *are*
     /// the eightbytes, or `None` when the image must be marshaled.
     ///
@@ -95,25 +123,117 @@ impl NativeImage {
     /// are padding, which no reader of the image looks at.) A tag-dispatched
     /// image is never direct: its leaves move with the active variant.
     pub fn direct_leaves(&self) -> Option<Vec<AbiSlotClass>> {
-        let NativeImageKind::Map { map, .. } = &self.kind else {
-            return None;
-        };
-        let direct = map
-            .iter()
-            .enumerate()
-            .all(|(index, leaf)| leaf.byte_offset == i32::try_from(index * 8).unwrap_or(i32::MAX));
-        if !direct {
-            return None;
-        }
-        Some(map.iter().map(leaf_slot_class).collect())
+        image_direct_leaves(&self.leaf_classes()?)
     }
+}
+
+/// The one fact the marshaling rule reads about each leaf of a compact image:
+/// the byte it starts at, and the register file its own vreg lives in.
+///
+/// Every crossing projects its own leaf description onto this pair — a native
+/// call and a foreign call from the image's slot map, an export from its
+/// flattened [`crate::export_thunk::ImageLeaf`]s — so all three consult one
+/// marshaling rule rather than three lookalikes.
+pub type ImageLeafClass = (i32, AbiSlotClass);
+
+/// The pair one compact-image slot presents to the marshaling rule.
+fn leaf_class(leaf: &PhysicalEnumSlot) -> ImageLeafClass {
+    (leaf.byte_offset, leaf_slot_class(leaf))
+}
+
+/// The value's members when it is a homogeneous floating-point aggregate: the
+/// width every member shares and how many there are, or `None` when the leaves
+/// are not all floats of one width laid end to end.
+///
+/// Both crossings ask this one question so an import, an export, and a native
+/// call cannot disagree about whether an aggregate travels member-wise.
+pub fn image_float_members(leaves: &[ImageLeafClass]) -> Option<(FloatWidth, u32)> {
+    let AbiSlotClass::Fp(width) = leaves.first()?.1 else {
+        return None;
+    };
+    let stride = i32::from(width.bytes());
+    leaves
+        .iter()
+        .enumerate()
+        .all(|(index, (offset, class))| {
+            *class == AbiSlotClass::Fp(width)
+                && *offset == i32::try_from(index).unwrap_or(i32::MAX) * stride
+        })
+        .then(|| (width, u32::try_from(leaves.len()).unwrap_or(u32::MAX)))
+}
+
+/// The file each leaf's own vreg travels in when the leaves *are* the
+/// eightbytes — leaf *i* starts at byte `8 * i` — and `None` otherwise.
+pub fn image_direct_leaves(leaves: &[ImageLeafClass]) -> Option<Vec<AbiSlotClass>> {
+    leaves
+        .iter()
+        .enumerate()
+        .all(|(index, (offset, _))| *offset == i32::try_from(index * 8).unwrap_or(i32::MAX))
+        .then(|| leaves.iter().map(|(_, class)| *class).collect())
+}
+
+/// How an aggregate with these image `leaves` presents itself to `location`:
+/// as its own leaf vregs, or as the eightbytes of a staged image.
+///
+/// This is the whole marshaling decision, made once for every crossing —
+/// a native call's argument and result, a foreign call's, and an export's.
+/// Three shapes reach [`NativeArgMarshal::Direct`]: a homogeneous
+/// floating-point aggregate the row placed member-wise (AAPCS64 rule C.3), a
+/// value whose leaves already start their own eightbytes, and — through those
+/// two — every one-leaf value. Anything else, and anything whose leaf banks
+/// disagree with the banks the placement named, is packed through the image.
+pub fn aggregate_marshal(
+    leaves: &[ImageLeafClass],
+    eightbytes: u32,
+    location: ArgLocation,
+) -> NativeArgMarshal {
+    let packed = NativeArgMarshal::Image { eightbytes };
+    // A value with no leaves has nothing to hand over leaf by leaf; whatever
+    // bytes it occupies cross as its image.
+    if leaves.is_empty() {
+        return packed;
+    }
+    // A homogeneous floating-point aggregate placed in floating-point registers
+    // crosses one *member* per register (AAPCS64 rule C.3). Its members are
+    // exactly its leaves, so every leaf vreg travels whole and nothing is
+    // packed; the placement's register count is what says the row read the
+    // aggregate by member rather than by eightbyte.
+    if let ArgLocation::Registers { pieces } = location
+        && pieces.uniform_class() == Some(CRegisterClass::Fp)
+        && let Some((width, members)) = image_float_members(leaves)
+        && members == pieces.len()
+    {
+        return NativeArgMarshal::Direct {
+            classes: vec![AbiSlotClass::Fp(width); members as usize],
+        };
+    }
+    let Some(classes) = image_direct_leaves(leaves) else {
+        return packed;
+    };
+    // An aggregate whose leaves start their own eightbytes still marshals
+    // through its image when the convention puts an eightbyte in a bank its
+    // leaf does not live in — AAPCS64 passes a composite in integer registers
+    // whatever its members are (section 6.8.2 rules C.13 and C.14), and an
+    // enum's union payload is a general-purpose bit carrier even where every
+    // variant puts a float there.
+    if let ArgLocation::Registers { pieces } = location {
+        let banks_agree = classes.len() == pieces.len() as usize
+            && classes
+                .iter()
+                .zip(pieces.as_slice())
+                .all(|(class, piece)| class.bank() == piece.class);
+        if !banks_agree {
+            return packed;
+        }
+    }
+    NativeArgMarshal::Direct { classes }
 }
 
 /// The bank one image leaf's own vreg belongs to: an enum's union payload is a
 /// general-purpose bit carrier whatever its variants hold, a float leaf rides
 /// in the floating-point file at its own width, everything else is
 /// general-purpose.
-fn leaf_slot_class(leaf: &PhysicalEnumSlot) -> AbiSlotClass {
+pub fn leaf_slot_class(leaf: &PhysicalEnumSlot) -> AbiSlotClass {
     match leaf.float_width {
         Some(width) if !leaf.bit_carrier => AbiSlotClass::Fp(width),
         _ => AbiSlotClass::Gp,
@@ -175,33 +295,25 @@ impl NativeArg {
     /// The bank and move width of each eightbyte the value presents to
     /// `location`, and whether they are the value's own leaf vregs.
     ///
-    /// A value's leaves are its eightbytes only if they also travel in the
-    /// banks the placement named: an aggregate whose leaves start their own
-    /// eightbytes still marshals through its image when the convention puts an
-    /// eightbyte in a bank its leaf does not live in — AAPCS64 passes a
-    /// composite in integer registers whatever its members are (section 6.8.2
-    /// rules C.13 and C.14), and an enum's union payload is a general-purpose
-    /// bit carrier even where every variant puts a float there.
+    /// An aggregate's answer is [`aggregate_marshal`]'s, the one home of that
+    /// decision; a scalar is trivially its own single piece and a zero-sized
+    /// value presents none.
     pub fn marshal(&self, location: ArgLocation) -> NativeArgMarshal {
-        let marshal = self.eightbyte_classes();
-        let (NativeArgMarshal::Direct { classes }, ArgLocation::Registers { pieces }) =
-            (&marshal, location)
-        else {
-            return marshal;
-        };
-        let banks_agree = classes.len() == pieces.len() as usize
-            && classes
-                .iter()
-                .zip(pieces.as_slice())
-                .all(|(class, piece)| class.bank() == piece.class);
-        if banks_agree {
-            return marshal;
-        }
         match self {
-            Self::Aggregate { image } => NativeArgMarshal::Image {
-                eightbytes: image.eightbytes(),
+            Self::Omitted => NativeArgMarshal::Direct {
+                classes: Vec::new(),
             },
-            _ => marshal,
+            Self::Scalar { class, .. } => NativeArgMarshal::Direct {
+                classes: vec![*class],
+            },
+            Self::Aggregate { image } => match image.leaf_classes() {
+                Some(leaves) => aggregate_marshal(&leaves, image.eightbytes(), location),
+                // A tag-dispatched image's leaves move with the active variant,
+                // so its eightbytes are always read out of memory.
+                None => NativeArgMarshal::Image {
+                    eightbytes: image.eightbytes(),
+                },
+            },
         }
     }
 
@@ -214,28 +326,6 @@ impl NativeArg {
     /// construction (ADR-0084).
     pub fn marshal_in_registers(&self, pieces: rue_air::RegisterPieces) -> NativeArgMarshal {
         self.marshal(ArgLocation::Registers { pieces })
-    }
-
-    /// The banks the value's own leaf vregs live in, before the placement is
-    /// consulted.
-    fn eightbyte_classes(&self) -> NativeArgMarshal {
-        match self {
-            Self::Omitted => NativeArgMarshal::Direct {
-                classes: Vec::new(),
-            },
-            Self::Scalar { class, .. } => NativeArgMarshal::Direct {
-                classes: vec![*class],
-            },
-            Self::Aggregate { image } => match image.direct_leaves() {
-                Some(classes) => NativeArgMarshal::Direct { classes },
-                // A marshaled eightbyte is a 64-bit lane of the image, so an
-                // SSE-classified one moves as a whole double even when the
-                // leaves inside it are `f32`s.
-                None => NativeArgMarshal::Image {
-                    eightbytes: image.eightbytes(),
-                },
-            },
-        }
     }
 }
 

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -532,6 +532,18 @@ pub enum FloatWidth {
     F64,
 }
 
+impl FloatWidth {
+    /// The value's footprint in memory: four bytes for binary32, eight for
+    /// binary64 (ADR-0065). This is the stride an aggregate's float members sit
+    /// at and the width a load or store of one commits.
+    pub const fn bytes(self) -> u8 {
+        match self {
+            Self::F32 => 4,
+            Self::F64 => 8,
+        }
+    }
+}
+
 pub fn float_width(ty: Type) -> Option<FloatWidth> {
     match ty.kind() {
         TypeKind::F32 => Some(FloatWidth::F32),
@@ -1772,7 +1784,13 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         call_args,
                         convention,
                     );
-                    let result_vreg = adapter.reserve_typed_value_result(float_width(inst.ty));
+                    // The result vreg mirrors the return's logical slot 0, so
+                    // its class follows that slot's LEAF, exactly as a native
+                    // call's does: a `@repr(c)` aggregate whose first field is
+                    // a float lands in an FP vreg.
+                    let result_vreg = adapter.reserve_typed_value_result(primary_slot_float_width(
+                        &crate::types::aggregate_leaf_types(ctx.type_pool, inst.ty),
+                    ));
                     adapter.emit_foreign_call(foreign_inputs, result_vreg)
                 } else {
                     // The result vreg mirrors the return's logical slot 0, so its

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -69,20 +69,15 @@ pub(super) const FP_ARG_REGS: [Reg; 8] = [
     Reg::Xmm7,
 ];
 
-/// The physical register a foreign call's classified register piece names.
-///
-/// A foreign argument is marshaled through its compact memory image, whose
-/// pieces are whole eightbytes in general-purpose vregs, so an SSE-classed
-/// piece has no value to move: the C boundary rejects `f32`/`f64`
-/// (`c_passable_by_value`), which is what keeps every piece integer-classed.
-fn foreign_argument_register(class: rue_target::CRegisterClass, index: u32) -> Reg {
-    assert_eq!(
-        class,
-        rue_target::CRegisterClass::Gp,
-        "a foreign argument crosses through its eightbyte image in the \
-         general-purpose bank"
-    );
-    ARG_REGS[index as usize]
+/// The physical register a foreign call's classified register piece names:
+/// SysV AMD64's integer argument roster for a general-purpose piece and its
+/// SSE roster for a floating-point one, which carries a float scalar and every
+/// SSE-classified eightbyte of an aggregate (section 3.2.3).
+fn foreign_argument_register(class: crate::abi_slot_class::AbiSlotClass, index: u32) -> Reg {
+    match class.bank() {
+        rue_target::CRegisterClass::Gp => ARG_REGS[index as usize],
+        rue_target::CRegisterClass::Fp => FP_ARG_REGS[index as usize],
+    }
 }
 
 /// The native convention's result registers (ADR-0084). SysV AMD64 defines
@@ -4298,6 +4293,20 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         self.image_arg_eightbytes(value, image)
     }
 
+    fn foreign_aggregate_leaves(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.require_aggregate_slots(value)
+    }
+
+    fn foreign_eightbyte_as_float(&mut self, bits: VReg, width: FloatWidth) -> VReg {
+        let dst = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+        self.mir.push(X86Inst::BitsToFloat {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(bits),
+            width,
+        });
+        dst
+    }
+
     fn foreign_byref_copy(
         &mut self,
         _value: CfgValue,
@@ -4335,10 +4344,7 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
             });
         }
         for store in stack.stores.iter().rev() {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Physical(Reg::Rax),
-                src: Operand::Virtual(store.value),
-            });
+            self.stage_foreign_value_in_rax(store.value, store.class);
             self.mir.push(X86Inst::Push {
                 src: Operand::Physical(Reg::Rax),
             });
@@ -4351,20 +4357,33 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
     ) {
         // Staging every value on the stack first and popping it into its
         // register afterwards keeps one argument's move from clobbering
-        // another's source, whatever order the classification named.
+        // another's source, whatever order the classification named. A
+        // floating-point value stages as its bit pattern and is moved back into
+        // the SSE file at its own width on the way out, so the two banks share
+        // one staging sequence.
         for arg in register_args.iter().rev() {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Physical(Reg::Rax),
-                src: Operand::Virtual(arg.value),
-            });
+            self.stage_foreign_value_in_rax(arg.value, arg.class);
             self.mir.push(X86Inst::Push {
                 src: Operand::Physical(Reg::Rax),
             });
         }
         for arg in register_args {
-            self.mir.push(X86Inst::Pop {
-                dst: Operand::Physical(foreign_argument_register(arg.class, arg.index)),
-            });
+            let register = foreign_argument_register(arg.class, arg.index);
+            match arg.class {
+                crate::abi_slot_class::AbiSlotClass::Gp => self.mir.push(X86Inst::Pop {
+                    dst: Operand::Physical(register),
+                }),
+                crate::abi_slot_class::AbiSlotClass::Fp(width) => {
+                    self.mir.push(X86Inst::Pop {
+                        dst: Operand::Physical(Reg::Rax),
+                    });
+                    self.mir.push(X86Inst::BitsToFloat {
+                        dst: Operand::Physical(register),
+                        src: Operand::Physical(Reg::Rax),
+                        width,
+                    });
+                }
+            }
         }
     }
 
@@ -4396,19 +4415,71 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         });
     }
 
-    fn foreign_scalar_result(&mut self, primary: VReg, ext: rue_air::ScalarAbiExtension) {
-        self.mir.push(X86Inst::MovRR {
-            dst: Operand::Virtual(primary),
-            src: Operand::Physical(Reg::Rax),
-        });
-        self.emit_c_return_extension(primary, ext);
+    fn foreign_scalar_result(
+        &mut self,
+        primary: VReg,
+        class: crate::abi_slot_class::AbiSlotClass,
+        ext: rue_air::ScalarAbiExtension,
+    ) {
+        match class {
+            crate::abi_slot_class::AbiSlotClass::Gp => {
+                self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(primary),
+                    src: Operand::Physical(Reg::Rax),
+                });
+                self.emit_c_return_extension(primary, ext);
+            }
+            // A float fills its result register; nothing is extended into or
+            // out of `xmm0`.
+            crate::abi_slot_class::AbiSlotClass::Fp(width) => self.mir.push(X86Inst::FloatMov {
+                dst: Operand::Virtual(primary),
+                src: Operand::Physical(Reg::Xmm0),
+                width,
+            }),
+        }
     }
 
     fn foreign_register_result(
         &mut self,
         _primary: VReg,
         image: &crate::foreign_call::AggregateImage,
+        pieces: rue_air::RegisterPieces,
+        marshal: &crate::native_abi::NativeArgMarshal,
     ) -> Vec<VReg> {
+        use crate::abi_slot_class::AbiSlotClass;
+        // Every result register the classification named, read back in the file
+        // it came home in. C's own result rosters are a prefix of the native
+        // ones (ADR-0084), so a piece's roster index addresses both.
+        let read =
+            |lower: &mut Self, piece: rue_air::RegisterPiece, class: AbiSlotClass| match class {
+                AbiSlotClass::Gp => {
+                    let v = lower.mir.alloc_vreg();
+                    lower.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(v),
+                        src: Operand::Physical(RET_REGS[piece.index as usize]),
+                    });
+                    v
+                }
+                AbiSlotClass::Fp(width) => {
+                    let v = lower.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
+                    lower.mir.push(X86Inst::FloatMov {
+                        dst: Operand::Virtual(v),
+                        src: Operand::Physical(FP_RET_REGS[piece.index as usize]),
+                        width,
+                    });
+                    v
+                }
+            };
+        if let crate::native_abi::NativeArgMarshal::Direct { classes } = marshal {
+            // The result registers hold the value's own leaves; nothing is
+            // read out of memory.
+            return pieces
+                .as_slice()
+                .iter()
+                .zip(classes)
+                .map(|(piece, class)| read(self, *piece, *class))
+                .collect();
+        }
         self.mir.push(X86Inst::AddRI {
             dst: Operand::Physical(Reg::Rsp),
             imm: -checked_displacement_bytes(u64::from(image.storage_bytes))
@@ -4419,14 +4490,25 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
             dst: Operand::Virtual(buf),
             src: Operand::Physical(Reg::Rsp),
         });
-        let mut eb_vals = Vec::with_capacity(image.eightbytes() as usize);
-        for index in 0..image.eightbytes() as usize {
-            let v = self.mir.alloc_vreg();
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(v),
-                src: Operand::Physical(RET_REGS[index]),
+        let mut eb_vals = Vec::with_capacity(pieces.len() as usize);
+        for (index, piece) in pieces.as_slice().iter().enumerate() {
+            let class = marshal.class(index, piece.class);
+            let value = read(self, *piece, class);
+            // A marshaled eightbyte is a bit pattern, not a number, so an
+            // SSE-classified one moves back into a general-purpose vreg for
+            // the image store.
+            eb_vals.push(match class {
+                AbiSlotClass::Gp => value,
+                AbiSlotClass::Fp(width) => {
+                    let bits = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::FloatToBits {
+                        dst: Operand::Virtual(bits),
+                        src: Operand::Virtual(value),
+                        width,
+                    });
+                    bits
+                }
             });
-            eb_vals.push(v);
         }
         crate::agg_slots::store_slots_through_ptr(self, &eb_vals, buf, 0);
         let native = crate::agg_slots::load_enum_slots_through_ptr(self, buf, &image.map);
@@ -4453,11 +4535,48 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
         native
     }
 
-    fn foreign_move_primary(&mut self, primary: VReg, slot: VReg) {
-        self.mir.push(X86Inst::MovRR {
-            dst: Operand::Virtual(primary),
-            src: Operand::Virtual(slot),
-        });
+    fn foreign_move_primary(
+        &mut self,
+        primary: VReg,
+        slot: VReg,
+        class: crate::abi_slot_class::AbiSlotClass,
+    ) {
+        // The primary vreg mirrors logical slot 0, so the move that syncs it is
+        // the one for that slot's own file.
+        match class {
+            crate::abi_slot_class::AbiSlotClass::Gp => self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(primary),
+                src: Operand::Virtual(slot),
+            }),
+            crate::abi_slot_class::AbiSlotClass::Fp(width) => self.mir.push(X86Inst::FloatMov {
+                dst: Operand::Virtual(primary),
+                src: Operand::Virtual(slot),
+                width,
+            }),
+        }
+    }
+}
+
+impl CfgLower<'_> {
+    /// Stage one outgoing foreign value in `rax` so it can be pushed. A
+    /// floating-point value stages as its bit pattern, moved at its own width
+    /// so an `f32` carries exactly its four bytes.
+    fn stage_foreign_value_in_rax(
+        &mut self,
+        value: VReg,
+        class: crate::abi_slot_class::AbiSlotClass,
+    ) {
+        match class {
+            crate::abi_slot_class::AbiSlotClass::Gp => self.mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Virtual(value),
+            }),
+            crate::abi_slot_class::AbiSlotClass::Fp(width) => self.mir.push(X86Inst::FloatToBits {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Virtual(value),
+                width,
+            }),
+        }
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -242,6 +242,8 @@ impl SemanticNucleusTypeProvider<'_> {
             | T::U32
             | T::U64
             | T::Bool
+            | T::F32
+            | T::F64
             | T::PtrConst(_)
             | T::PtrMut(_) => Ok(None),
             T::Array { element, .. } => self.ffi_shape_failure(element, path),
@@ -296,8 +298,6 @@ impl SemanticNucleusTypeProvider<'_> {
             | T::Unit
             | T::Never
             | T::ComptimeType
-            | T::F32
-            | T::F64
             | T::ComptimeFloat
             | T::BuiltinNominal { .. }
             | T::Module(_)
@@ -2692,6 +2692,8 @@ pub(in crate::revisioned_query_database) fn resolve_parsed_semantic_signature(
                                 | T::U32
                                 | T::U64
                                 | T::Bool
+                                | T::F32
+                                | T::F64
                                 | T::PtrConst(_)
                                 | T::PtrMut(_)
                         ) {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -3801,17 +3801,16 @@ pub enum ErrorKind {
         what: String,
     },
 
-    /// A type appeared in an `extern "C"` signature that the current FFI phase
-    /// cannot classify. C FFI P3 (ADR-0064, RUE-1057) supports every integer and
-    /// pointer scalar (`i8`/`u8`/`i16`/`u16`/`i32`/`u32`/`i64`/`u64`, `bool` as
-    /// `_Bool`, and raw pointers) *and* C-classifiable `@repr(c)` aggregates.
-    /// What remains rejected here: a Rue enum (not FFI-safe in v0), and — until
-    /// RUE-714 adds the type (P5) — floating-point.
+    /// A type appeared in an `extern "C"` signature that the C boundary cannot
+    /// classify. C FFI (ADR-0064) supports every integer and pointer scalar
+    /// (`i8`/`u8`/`i16`/`u16`/`i32`/`u32`/`i64`/`u64`, `bool` as `_Bool`, and
+    /// raw pointers), the two floating-point widths (`f32` as C `float`, `f64`
+    /// as C `double`), *and* C-classifiable `@repr(c)` aggregates. What remains
+    /// rejected here is a Rue enum, which is not FFI-safe in v0.
     #[error(
         "type `{ty}` is not supported in an `extern \"C\"` signature: \
-         C FFI (ADR-0064) supports integer and pointer scalars and \
-         C-classifiable `@repr(c)` aggregates — enums are not FFI-safe and \
-         floating-point awaits RUE-714"
+         C FFI (ADR-0064) supports integer, floating-point and pointer scalars \
+         and C-classifiable `@repr(c)` aggregates — enums are not FFI-safe"
     )]
     ExternSignatureTypeUnsupported {
         /// The rejected type, as rendered for the user.

--- a/crates/rue-spec/cases/runtime/foreign-boundary.toml
+++ b/crates/rue-spec/cases/runtime/foreign-boundary.toml
@@ -166,6 +166,89 @@ compile_fail = true
 error_contains = ["unsupported extern ABI", "rue"]
 
 # =============================================================================
+# FFI-safe types (9.3:1e, 9.3:1f, 9.3:1g)
+#
+# The admitted set is the C-compatible scalars — every integer width, `bool`,
+# both floating-point widths, and raw pointers — plus `@repr(c)` structs built
+# from them. Everything else is rejected rather than approximated.
+# =============================================================================
+
+[[case]]
+name = "foreign_float_scalars_are_ffi_safe"
+spec = ["9.3:1e", "9.3:1f"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "`f32` and `f64` are FFI-safe scalars: they name C `float` and `double` and are accepted in both directions of a foreign signature"
+source = """
+extern "C" {
+    fn c_scale(x: f64, factor: f32) -> f64;
+}
+
+pub extern "C" fn rue_widen(x: f32) -> f64 { @float_cast(x) }
+
+fn main() -> i32 { 0 }
+"""
+compile_only = true
+
+[[case]]
+name = "foreign_float_bearing_repr_c_aggregate_is_ffi_safe"
+spec = ["9.3:1e", "9.3:1f"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "A `@repr(c)` struct whose fields are floating-point, and one mixing a float with an integer, cross by value like any other C-classifiable aggregate"
+source = """
+@repr(c)
+struct Vec2 { x: f64, y: f64 }
+
+@repr(c)
+struct Tagged { tag: i64, value: f64 }
+
+extern "C" {
+    fn c_len2(v: Vec2) -> f64;
+    fn c_tag(t: Tagged) -> Tagged;
+}
+
+pub extern "C" fn rue_flip(v: Vec2) -> Vec2 { Vec2 { x: v.y, y: v.x } }
+
+fn main() -> i32 { 0 }
+"""
+compile_only = true
+
+[[case]]
+name = "foreign_enum_parameter_is_not_ffi_safe"
+spec = ["9.3:1e"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "A Rue enum is a tagged sum type with no C counterpart and is rejected in a foreign signature rather than given one"
+source = """
+enum Mode { Fast, Slow }
+
+extern "C" {
+    fn run(mode: Mode) -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E1101", "enums are not FFI-safe"]
+
+[[case]]
+name = "foreign_array_parameter_is_not_ffi_safe"
+spec = ["9.3:1e"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "A fixed-size array is eligible only as a `@repr(c)` struct field: C decays an array argument to a pointer, so it is not a boundary type of its own"
+source = """
+extern "C" {
+    fn sum(values: [f64; 4]) -> f64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E1103", "decays arrays to pointers"]
+
+# =============================================================================
 # Foreign redeclaration (9.3:5, RUE-1218)
 # =============================================================================
 

--- a/crates/rue-target/src/calling_convention.rs
+++ b/crates/rue-target/src/calling_convention.rs
@@ -179,8 +179,7 @@ pub struct CConventionSpec {
     /// stack area begins (6 on SysV AMD64, 8 on AAPCS64).
     pub gp_argument_registers: u32,
     /// How many floating-point registers carry arguments (8 on every current
-    /// row). Unreached while the C boundary rejects floats; carried so the
-    /// float slice extends this table rather than rewriting it.
+    /// row): `xmm0`-`xmm7` on SysV AMD64, `v0`-`v7` on AAPCS64.
     pub fp_argument_registers: u32,
     /// How many general-purpose registers carry a result (`rax:rdx` on SysV
     /// AMD64, `x0:x1` on AAPCS64).

--- a/docs/designs/0064-c-ffi.md
+++ b/docs/designs/0064-c-ffi.md
@@ -299,6 +299,20 @@ macOS). All land behind `c_ffi` until the whole surface is proven.
 | **P6** | Variadic rejecting diagnostic (or full support as a separate decision) + `StrBuf`↔`char*` helpers with an explicit NUL/ownership contract. | P2 | A variadic `extern` decl emits the rejecting diagnostic (UI test); a `StrBuf` passed to a C `strlen`-shape function. |
 | **P7** | Dynamic linking against `libc.so` (stretch): `PT_INTERP`, dynamic symtab, PLT/GOT synthesis. Likely its own ADR. | P1 | A dynamically linked executable calls a `libc.so` symbol at runtime. |
 
+**Status: P5 delivered (RUE-1059).** `f32` and `f64` are FFI-safe scalars
+naming C `float` and `double` (spec 9.3:1e), and a `@repr(c)` aggregate whose
+fields are floating-point crosses by value under both rows: SysV AMD64's
+per-eightbyte SSE classification, and AAPCS64's homogeneous-floating-point-
+aggregate rule, which spends one register per *member* rather than per
+eightbyte. The reject-don't-guess staging discipline P1.5 restated for floats is
+therefore retired — no SSE-classified field is a hard error any more — and what
+remains rejected in a foreign signature is a Rue enum and a by-value array
+(§ 9.3:1e). Because ADR-0084 gives the native row the target's own C argument
+placement, a float export usually reduces to an alias of its native body rather
+than a thunk. The conformance grid
+(`//crates/rue-c-abi-matrix:c-abi-matrix-test`) carries the float shapes at
+every argument and result position in both directions.
+
 ## Amendment 1 (2026-07-19): C representation guarantees (RUE-742)
 
 This section folds the RUE-742 design ruling into the accepted ADR. RUE-742 was

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -85,7 +85,7 @@ supported representation.
 | Property | Native Rue: x86-64 Linux | Native Rue: AArch64 Linux/macOS | Current target-C runtime subset |
 | --- | --- | --- | --- |
 | Integer/pointer argument registers | `rdi`, `rsi`, `rdx`, `rcx`, `r8`, `r9` | `x0`-`x7` | Same target registers |
-| Floating-point argument registers | `xmm0`-`xmm7` | `v0`-`v7` | Not reached; the C boundary rejects floats |
+| Floating-point argument registers | `xmm0`-`xmm7` | `v0`-`v7` | The same registers |
 | Argument placement | SysV eightbyte classification | AAPCS64 composite rules, with Apple's amendments on the Darwin row | The same rows |
 | Stack arguments | The row's own argument-area packing | The row's own argument-area packing | Not implemented; every current helper fits registers |
 | Scalar result | `rax` | `x0` | `rax` or `x0`/`w0` |
@@ -297,6 +297,14 @@ usually the same place:
   extension, in ascending memory order.
 - A value whose leaves pack together crosses as the image's eightbytes, loaded
   whole.
+- A value the row placed in *floating-point* registers is already in the
+  register the native body reads it from, and the thunk leaves it alone: the two
+  rows spend the floating-point roster identically, because the only placement
+  the wider native return bank can shift is a general-purpose one — the hidden
+  indirect-result pointer's. A general-purpose piece is read back out of its own
+  incoming register's save cell rather than through a contiguous image, which is
+  what lets a value whose eightbytes travel in different banks — `{i64, f64}` on
+  SysV AMD64 — reach the body at all.
 - When both directions are indirect, the C caller's indirect-result storage *is*
   the native body's storage, so the result is never copied; SysV's `rax` echo is
   then a reload of the saved pointer. When the native body returns its leaves in
@@ -460,12 +468,20 @@ generator computed from the same table it emitted both sources from.
 
 The grid is shape x position x direction x ABI spelling:
 
-- **Shapes** (20): `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `bool`,
-  `ptr const u8`, and ten `@repr(c)` structs chosen for the classification
-  boundaries — `{u8}`, `{u8,u8}`, `{i32,i32}`, `{i64,u8}`, `{i64,i64}`,
-  `{i64,i64,u8}`, `{i64,i64,i64}`, `{u8,i64}`, a nested `{{i32,i32},i64}`, and
-  `{[u8;4],i32}`. Floats are still rejected at the boundary; the table is shaped
-  so adding them is a table edit.
+- **Shapes** (31): `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `bool`,
+  `f32`, `f64`, `ptr const u8`, and twenty `@repr(c)` structs chosen for the
+  classification boundaries — `{u8}`, `{u8,u8}`, `{i32,i32}`, `{i64,u8}`,
+  `{i64,i64}`, `{i64,i64,u8}`, `{i64,i64,i64}`, `{u8,i64}`, a nested
+  `{{i32,i32},i64}`, and `{[u8;4],i32}` on the integer side, and `{f32,f32}`,
+  `{f32,f32,f32,f32}`, `{f64,f64}`, `{f64,f64,f64}`, `{[f64;5]}`, `{i64,f64}`,
+  `{f64,i64}`, `{i32,f32}`, and `{i32,f32,i32}` on the floating-point side.
+  Those last rows are the ones the two psABI rows disagree about most: an HFA
+  crosses member-wise under AAPCS64 and eightbyte-wise under SysV, a split-bank
+  pair spends one register of each bank under SysV and two integer registers
+  under AAPCS64, and `{[f64;5]}` is over both rows' limits in different ways.
+  A float leaf carries a whole number, exactly representable in binary32 and
+  binary64 alike, so the odd-multiplier checksum stays exact integer
+  arithmetic.
 - **Positions** (5): argument 0, the convention's last argument register, the
   first stack slot, a deep stack slot, and the result type. The indices come
   from `CConventionSpec::gp_argument_registers`, so a convention with a
@@ -541,7 +557,8 @@ signature and its executing cases. What remains open:
 - Apple's byte-exact placement of a stacked composite argument, which needs
   byte-granular marshaling rather than the whole-eightbyte image stores the
   current path emits;
-- floating-point/vector arguments and results, which the boundary still rejects;
+- vector arguments and results, which have no Rue type to cross as (scalar
+  floating point crosses; see the floating-point rows of the matrix above);
 - variadic calls, or an explicit diagnostic rejecting them; and
 - pointer provenance, mutability, and lifetime rules.
 

--- a/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
+++ b/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
@@ -70,6 +70,42 @@ denote the same convention and place values identically; the difference is what
 the declaration *says*, which is why the mismatched case is a rejection rather
 than a substitution.
 
+## FFI-safe types
+
+{{ rule(id="9.3:1e", cat="legality-rule") }}
+
+Every parameter and result type of a foreign declaration or export **MUST** be
+FFI-safe. The FFI-safe types are the **C-compatible scalars** — the signed and
+unsigned integer types `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`;
+`bool`, which crosses as C `_Bool` with its one-byte 0/1 representation; the
+floating-point types `f32` and `f64`, which cross as C `float` and `double`; and
+the raw pointer types `ptr const T` and `ptr mut T`, which cross as C pointers —
+together with a struct marked `@repr(c)` that is itself FFI-eligible (§ 2.5:36).
+A type that is none of these is ill-formed in a foreign signature and **MUST** be
+rejected at compile time; in particular an enum, which is a tagged sum type with
+no C counterpart, is not FFI-safe, and a fixed-size array is eligible only as a
+`@repr(c)` struct *field*, never as a parameter or result of its own, because C
+decays an array argument to a pointer.
+
+{{ rule(id="9.3:1f", cat="normative") }}
+
+A value of an FFI-safe type crosses the boundary where the named calling
+convention places it, and its representation on each side is the other's:
+`f32` and `f64` are IEEE-754 binary32 and binary64 (§ 3.12), which is what C
+`float` and `double` are on every target Rue supports, so a float crosses in the
+convention's floating-point register file with no conversion, and a `@repr(c)`
+struct crosses as the C object its layout guarantee (§ 2.5:33) makes it —
+including one whose fields are floating-point, which the platform psABI may
+classify into floating-point registers rather than integer ones.
+
+{{ rule(id="9.3:1g", cat="informative") }}
+
+The FFI-safe set is deliberately the set whose representation is *known* rather
+than the set that could be given one: C has no representation for a Rue enum,
+and Rue has none for C `long double`, so neither crosses and neither is
+approximated. The same reject-don't-guess discipline is why a nested aggregate
+must carry its own `@repr(c)` marker (§ 2.5:36) instead of inheriting one.
+
 ## Abort at the boundary
 
 {{ rule(id="9.3:2", cat="dynamic-semantics") }}

--- a/std/c.rue
+++ b/std/c.rue
@@ -100,6 +100,26 @@ pub const c_ssize_t = i64;
 pub const c_ptrdiff_t = i64;
 
 // ---------------------------------------------------------------------------
+// Floating point
+// ---------------------------------------------------------------------------
+//
+// C `float` and `double` are IEEE-754 binary32 and binary64 on every supported
+// target, which is exactly what Rue's `f32` and `f64` are (ADR-0065), and both
+// are FFI-safe scalars at the C boundary (spec 9.3:1e). Write `f32` and `f64`
+// directly in an `extern "C"` signature; there is no `c_float`/`c_double`
+// alias here.
+//
+// A transparent alias is a file-level `const` whose initializer names a type,
+// and only the type keywords (`i8`-`u64`, `bool`, `type`) are nameable in
+// value position today; `f32`/`f64` lex as ordinary identifiers, so
+// `const c_double = f64;` does not compile (RUE-2076). The aliases arrive
+// with that fix.
+//
+// `long double` has no Rue counterpart either — it is 80-bit x87 on x86-64 and
+// binary128 on AArch64 — so nothing names it, rather than something naming it
+// wrongly.
+
+// ---------------------------------------------------------------------------
 // Boolean
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
ADR-0064 phase P5 (RUE-1059): `f32` and `f64` are FFI-safe scalars, and float-carrying `@repr(c)` aggregates cross by the platform psABI, on both backends and all three rows. The classifier already placed floats for the native row since ADR-0084; this change lifts the "reject-don't-guess" hard error at the `extern "C"` boundary and makes the import, export, matrix, spec and docs paths carry them.

## What changes

- **Predicates.** `is_c_scalar` and `c_passable_by_value` in `rue_air::ffi_predicates` admit `F32`/`F64`; the durable-plane twin in `provider_body.rs` and the extern-signature scalar check agree. `NotRegisterPassable` now means only "a by-value array" and says so. E1101's message lists floats among the supported scalars.
- **Import side.** `ForeignRegisterArg` and `ForeignStackStore` carry an `AbiSlotClass` (bank and move width). x86-64 selects `ARG_REGS`/`FP_ARG_REGS` by bank and stages an FP value as its bit pattern at its own width; AArch64 moves register args directly (`FloatMov`) and stores stacked FP values at the leaf's width. An `f32` commits exactly four bytes on every row (Apple natural-size packing, AAPCS64 low half of an eight-byte slot). A returned aggregate always reads back through its image at each leaf's width, except an HFA the row returned member-wise.
- **One marshaling rule.** `native_abi::aggregate_marshal` now recognizes the AAPCS64 HFA member shape (one FP register per member) and is the single rule for native calls, foreign calls and exports, each projecting its own leaf description onto it. This also fixes a pre-existing native-convention ICE: `struct P { a: f32, b: f32 }` by value on `aarch64-linux` tripped `one eightbyte per result register the classification named`.
- **Export side.** A float parameter is already in the register the native body reads it from, so the thunk leaves it alone (asserted). `ImageLeaf` gains `float`, so an `f32` no longer forces a re-extension thunk; a GP piece is read from its own incoming register's save cell, which `{i64, f64}` needs. Four FP emitter leaves per backend (`movss`/`movsd` with the mandatory prefix before REX on x86-64; scaled SIMD&FP `ldr`/`str` `s`/`d` forms on AArch64). Float scalar exports, `{f64,f64}`, `{f32;4}` and `{i64,f64}` in and out all reduce to aliases on both rows; a thunk remains only for a narrow integer parameter alongside a float or a result only the native bank holds.
- **`--emit abi`.** `CPlacement::Registers` carries `RegisterPieces`, so a split-bank argument prints per piece (`rdi, xmm0`) instead of panicking on `uniform_class`.
- **Also fixed:** the foreign-call result vreg was reserved from the aggregate's own type rather than its first leaf, so a `@repr(c)` aggregate whose first field is a float got a GP primary.

## Conformance matrix

`Leaf::{F32, F64}` with exact whole-number values (below 2^24, so binary32 and binary64 agree and the odd-multiplier checksum stays exact), and eleven new shapes: `f32`, `f64`, `{f32,f32}`, `{f32;4}` (HFA-4), `{f64,f64}` (HFA-2), `{f64,f64,f64}` (HFA-3), `{[f64;5]}`, `{i64,f64}`, `{f64,i64}`, `{i32,f32}`, `{i32,f32,i32}`. 20 → 31 shapes, 100 → 155 cells per program, all passing against the host `cc`. The matrix caught one bug in the change itself (a one-field `@repr(c)` struct returned from C read straight from `rax` without the narrow load), which is what drove the read-through-the-image rule.

## Spec and docs

- New 9.3:1e (legality rule: the FFI-safe set, enumerated), 9.3:1f (normative: representation and placement, including float-carrying aggregates) and 9.3:1g (informative: reject-don't-guess) in the foreign-boundary chapter; four spec cases cite them.
- ADR-0064 gets a P5 delivery status line; the audit note's FP roster row, shape inventory and export marshaling bullets are updated; `std/c.rue` documents why `f32`/`f64` are written directly (RUE-2076).

## Tests

Eight new `c_ffi.toml` cases (58 → 66): `f64` and `f32` imports with exact results and a C caller invoking `f64`/`f32` Rue exports, executed on x86-64 and `execute_if_native` on aarch64-linux, via three hand-assembled archive members (`ffi_fadd`, `ffi_fmul32`, `ffi_call_float_exports`); build-only cases for the float aggregate shapes on both rows and stacked `f32` on `aarch64-macos` and `aarch64-linux`. Unit tests in air, codegen and the matrix crate.

## Not in this change

- `std.c.c_float` / `c_double`: blocked by a language gap where `f32`/`f64` cannot be named in value position (RUE-2076).
- The ADR's literal libm `pow` probe: the driver has no way to pass `-lm` and static `libm.a` needs symbols the runtime archive lacks (RUE-2078, under the linking surface RUE-744).
- Stacked float scalars as matrix cells: the grid keys positions off the GP roster only (RUE-2077).
- AArch64 and macOS execution is CI-only from the development host; the new AArch64 FP load/store encodings are the highest-value thing for the native arm64 jobs to exercise.

## Validation

`scripts/rue premerge` passes locally apart from the two sandbox-environmental CLI cases (`remove_dir_all_permission_denied_is_not_partial_success`, `tcp_ipv6_loopback_round_trip`); the C-ABI matrix, oracle-diff, planted-miscompile, spec-traceability and debug-assert targets pass. No planted-miscompile preimage moved.

Closes RUE-1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_