### PR TITLE
RUE-1976: materialize literal constants through one owner beside the integer kernel

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -1390,6 +1390,110 @@ fn integer_consumers_use_one_representation_independent_kernel() {
 }
 
 #[test]
+fn literal_materialization_has_one_owner_beside_the_integer_kernel() {
+    let types = include_str!("types.rs");
+    let owner = include_str!("sema/analyze_ops.rs");
+    let aggregates = include_str!("sema/aggregates.rs");
+    let ownership = include_str!("sema/analysis/ownership.rs");
+    let instructions = include_str!("sema/analysis/instructions.rs");
+    let pointers = include_str!("sema/analysis/pointers.rs");
+    let control_flow = include_str!("sema/control_flow.rs");
+    let comptime_adapter = include_str!("sema/comptime_eval.rs");
+
+    // One match turns a `Type` into the kernel's `IntegerType`, so every
+    // width and range decision in rue-air reaches the kernel through it and
+    // the next width the kernel learns reaches all of them at once.
+    assert!(types.contains("pub fn integer_semantics(&self) -> Option<IntegerType>"));
+    assert_eq!(types.matches("IntegerType::new(").count(), 1);
+    for (name, source) in [
+        ("the literal owner", owner),
+        ("struct initializers", aggregates),
+        ("named constant uses", ownership),
+        ("comptime block results", instructions),
+        ("pointer writes", pointers),
+        ("control flow", control_flow),
+        ("the comptime adapter", comptime_adapter),
+        (
+            "the comptime engine",
+            crate::sema::COMPTIME_PRODUCTION_SOURCE,
+        ),
+    ] {
+        assert!(
+            !source.contains("IntegerType::new("),
+            "{name} regained a private width table"
+        );
+    }
+
+    // The one place a constant becomes an AIR `Const`.
+    assert_eq!(
+        owner
+            .matches("pub(crate) fn materialize_int_const(")
+            .count(),
+        1
+    );
+    assert_eq!(
+        owner
+            .matches("pub(crate) fn materialize_float_const(")
+            .count(),
+        1
+    );
+
+    for (name, source) in [
+        ("struct initializers", aggregates),
+        ("named constant uses", ownership),
+        ("comptime block results", instructions),
+        ("pointer writes", pointers),
+    ] {
+        assert!(
+            source.contains("materialize_int_const(")
+                || source.contains("materialize_float_const("),
+            "{name} stopped materializing constants through the shared owner"
+        );
+        assert!(
+            !source.contains("ErrorKind::LiteralOutOfRange"),
+            "{name} regained a private out-of-range diagnostic"
+        );
+        assert!(
+            !source.contains("to_bits()"),
+            "{name} regained a private float-literal encoding"
+        );
+    }
+
+    // Retired range predicates: each was a second answer to "does this value
+    // fit", and `literal_fits` answered only for the positive half.
+    for retired in [
+        "fn literal_fits(",
+        "fn negated_literal_fits(",
+        "fn const_int_fits(",
+    ] {
+        for (name, source) in [
+            ("types", types),
+            ("literal owner", owner),
+            ("comptime adapter", comptime_adapter),
+        ] {
+            assert!(!source.contains(retired), "{name} regained {retired}");
+        }
+    }
+
+    // Negation of a literal is a kernel question, not a hand-written table of
+    // type minima or a wrapping trick.
+    for hand_rolled in [
+        "i8::MIN as i64",
+        "i16::MIN as i64",
+        "i32::MIN as i64",
+        "i64::MIN as u64",
+        "wrapping_neg()",
+    ] {
+        for (name, source) in [("literal owner", owner), ("control flow", control_flow)] {
+            assert!(
+                !source.contains(hand_rolled),
+                "{name} regained {hand_rolled}"
+            );
+        }
+    }
+}
+
+#[test]
 fn comptime_instdata_evaluation_has_one_production_authority() {
     let inference = include_str!("inference/generate.rs");
     let type_inference = include_str!("sema/analysis/type_inference.rs");

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -1160,29 +1160,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let field_span = self.body_rir_ref().get(field_value).span;
             let field_inst = self.body_rir_ref().get(field_value);
             let field_result = if let InstData::IntConst(value) = &field_inst.data {
-                // Integer literal - use the expected field type directly, but
-                // range-check it first because this shortcut bypasses
-                // `analyze_literal`; `S { a: 300 }` with `a: u8` must produce
-                // E0800 rather than truncate to 44. (RUE-72)
-                let encoded = if expected_field_type == Type::F32 {
-                    u64::from((*value as f32).to_bits())
-                } else if expected_field_type == Type::F64 {
-                    (*value as f64).to_bits()
-                } else if expected_field_type.literal_fits(*value) {
-                    *value
-                } else {
-                    return Err(CompileError::new(
-                        ErrorKind::LiteralOutOfRange {
-                            value: *value,
-                            ty: self.format_type_name(expected_field_type),
-                        },
-                        field_inst.span,
-                    ));
-                };
+                // Integer literal: adopt the expected field type directly, so
+                // a field type HM could not resolve (a struct reached through
+                // a comptime type variable) still types its literal. The
+                // constant itself is materialized by the shared owner, which
+                // is what keeps `S { a: 300 }` with `a: u8` an E0800 rather
+                // than a truncation to 44 (RUE-72).
+                let span = field_inst.span;
+                let data =
+                    self.materialize_int_const(i128::from(*value), expected_field_type, span)?;
                 let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::Const(encoded),
+                    data,
                     ty: expected_field_type,
-                    span: field_inst.span,
+                    span,
                 });
                 AnalysisResult::new(air_ref, expected_field_type)
             } else if self.is_str_like(expected_field_type) {

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -3,6 +3,7 @@
 //! This category is the canonical instruction dispatcher and owns assignment
 //! analysis for projected places.
 
+use super::super::analyze_ops::FloatConstSource;
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::*;
 use crate::sema::comptime::{ComptimeEngine, ComptimeMethodType, ComptimeOutcome};
@@ -265,35 +266,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
                         // Backstop range check: negative results are legal
                         // for signed targets (RUE-71); the value just has to
-                        // be representable in the target type.
-                        if !super::super::comptime_eval::const_int_fits(value, ty) {
-                            return if value >= 0 {
-                                Err(CompileError::new(
-                                    ErrorKind::LiteralOutOfRange {
-                                        value: value as u64,
-                                        ty: self.format_type_name(ty),
-                                    },
-                                    inst.span,
-                                ))
-                            } else {
-                                Err(CompileError::new(
-                                    ErrorKind::ComptimeEvaluationFailed {
-                                        reason: format!(
-                                            "value {} is out of range for type {}",
-                                            value,
-                                            self.format_type_name(ty)
-                                        ),
-                                    },
-                                    inst.span,
-                                ))
-                            };
-                        }
-
-                        // Two's-complement encoding: negative values are
-                        // sign-extended into the u64 payload, matching how
-                        // negative literals are emitted elsewhere.
+                        // be representable in the target type. The shared
+                        // owner reports a value that is not (E0800), so a
+                        // comptime block and the same value written directly
+                        // fail with one code and one message.
+                        let data = self.materialize_int_const(value, ty, inst.span)?;
                         let air_ref = air.add_inst(AirInst {
-                            data: AirInstData::Const(value as u64),
+                            data,
                             ty,
                             span: inst.span,
                         });
@@ -341,29 +320,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             inst.span,
                             "comptime floating-point value",
                         )?;
-                        let spelling = self.body_interner().resolve(&content.spur());
-                        if !ty.is_float() {
-                            return Err(CompileError::new(
-                                ErrorKind::TypeMismatch {
-                                    expected: "f32 or f64".to_owned(),
-                                    found: self.format_type_name(ty),
-                                },
-                                inst.span,
-                            ));
-                        }
                         // A computed comptime value may be `inf` or `NaN`; only a
                         // source literal is held to the finite-range rule.
-                        let bits = crate::float_value_bits(spelling, ty).ok_or_else(|| {
-                            CompileError::new(
-                                ErrorKind::TypeMismatch {
-                                    expected: format!("{} value", self.format_type_name(ty)),
-                                    found: spelling.to_owned(),
-                                },
-                                inst.span,
-                            )
-                        })?;
+                        let spelling = self.body_interner().resolve(&content.spur()).to_owned();
+                        let data = self.materialize_float_const(
+                            FloatConstSource::ComputedValue {
+                                spelling: &spelling,
+                            },
+                            ty,
+                            inst.span,
+                        )?;
                         let air_ref = air.add_inst(AirInst {
-                            data: AirInstData::Const(bits),
+                            data,
                             ty,
                             span: inst.span,
                         });

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5,6 +5,7 @@
 //! them. It extends the canonical body-analysis engine rather than
 //! introducing peer analysis state.
 
+use super::super::analyze_ops::FloatConstSource;
 use super::super::context::{LocalVar, ParamInfo};
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::super::ownership_state::{FieldPath, VariableMoveState};
@@ -2190,7 +2191,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
     ) -> CompileResult<(AirInstData, Type)> {
         Ok(match value {
-            ConstValue::Integer(v) => (AirInstData::Const(v as u64), ty),
+            ConstValue::Integer(v) => (self.materialize_int_const(v, ty, span)?, ty),
             ConstValue::Bool(b) => (AirInstData::BoolConst(b), Type::BOOL),
             ConstValue::Unit => (AirInstData::UnitConst, Type::UNIT),
             ConstValue::Function(_) => unreachable!(
@@ -2215,32 +2216,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 (AirInstData::StringConst(local_id), ty)
             }
             ConstValue::Float(content) => {
-                let spelling = self.body_interner().resolve(&content.spur());
-                if ty == Type::COMPTIME_FLOAT {
-                    return Ok((AirInstData::Const(0), ty));
-                }
-                if !ty.is_float() {
-                    return Err(CompileError::new(
-                        ErrorKind::TypeMismatch {
-                            expected: "f32 or f64".to_owned(),
-                            found: self.format_type_name(ty),
-                        },
-                        span,
-                    ));
-                }
                 // A literal's spelling was already range-checked where it was
                 // written; a computed constant may legitimately be `inf` or
-                // `NaN`, so the value parser is the permissive one.
-                let bits = crate::float_value_bits(spelling, ty).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::TypeMismatch {
-                            expected: format!("{} value", self.format_type_name(ty)),
-                            found: spelling.to_owned(),
-                        },
-                        span,
-                    )
-                })?;
-                (AirInstData::Const(bits), ty)
+                // `NaN`, so this reads the spelling as a value.
+                let spelling = self.body_interner().resolve(&content.spur()).to_owned();
+                let data = self.materialize_float_const(
+                    FloatConstSource::ComputedValue {
+                        spelling: &spelling,
+                    },
+                    ty,
+                    span,
+                )?;
+                (data, ty)
             }
         })
     }

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -185,17 +185,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let divergence_before_value = ctx.divergence_kinds;
         let value_result = match &value_inst.data {
             InstData::IntConst(value) if pointee_type.is_integer() => {
-                if !pointee_type.literal_fits(*value) {
-                    return Err(CompileError::new(
-                        ErrorKind::LiteralOutOfRange {
-                            value: *value,
-                            ty: self.format_type_name(pointee_type),
-                        },
-                        value_inst.span,
-                    ));
-                }
+                let data =
+                    self.materialize_int_const(i128::from(*value), pointee_type, value_inst.span)?;
                 let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::Const(*value),
+                    data,
                     ty: pointee_type,
                     span: value_inst.span,
                 });

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6,6 +6,14 @@
 //! - [`analyze_literal`] - Integer, boolean, string, and unit constants
 //! - [`analyze_unary_op`] - Negation, logical NOT, bitwise NOT
 //!
+//! It also owns constant materialization for the whole crate: every position
+//! that turns an integer or floating-point constant into an AIR `Const` goes
+//! through [`OrdinaryBodyEngine::materialize_int_const`] or
+//! [`OrdinaryBodyEngine::materialize_float_const`], so one range rule, one
+//! "does not fit" diagnostic, and one payload encoding stand behind literals,
+//! struct-initializer fields, pointer writes, named constant uses, and
+//! comptime-block results alike.
+//!
 //! Control-flow expressions are owned by the sibling `control_flow` module.
 //! Aggregate construction and member operations are owned by the sibling
 //! `aggregates` module. Place and ownership behavior remains canonical in
@@ -25,9 +33,20 @@ use rue_rir::{InstData, InstRef};
 
 use super::context::{AnalysisContext, AnalysisResult};
 use crate::inst::{Air, AirInst, AirInstData};
-use crate::types::{Type, TypeKind};
+use crate::types::Type;
 
 // ============================================================================
+
+/// How a floating-point constant reached materialization.
+///
+/// A literal is held to the source-literal rule — its spelling must name a
+/// finite value at the target width — while a value computed at compile time
+/// may legitimately be `inf` or `NaN`, so the two read the same spelling with
+/// different parsers.
+pub(crate) enum FloatConstSource<'a> {
+    Literal { spelling: &'a str, negated: bool },
+    ComputedValue { spelling: &'a str },
+}
 
 impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// Resolve an integer expression through canonical inference, admitting
@@ -47,6 +66,106 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         } else {
             Self::get_resolved_type(ctx, inst_ref, span, context)
         }
+    }
+
+    // ========================================================================
+    // Constant materialization: the one owner
+    // ========================================================================
+
+    /// Materialize an integer constant as the AIR `Const` payload for `ty`.
+    ///
+    /// Every position that turns an integer written in source — or computed
+    /// at compile time from integers written in source — into an AIR constant
+    /// comes through here: ordinary literals, negated literals, the
+    /// struct-initializer field shortcut, `@ptr_write` value coercion, named
+    /// constant uses, and comptime-block results. One range rule and one
+    /// "does not fit" diagnostic (E0800, spec 6.5:5) therefore stand behind
+    /// all of them, and the payload has one encoding.
+    ///
+    /// `value` is the mathematical value, so a negated literal passes the
+    /// value it denotes (`-129`), not the magnitude its operand spells.
+    pub(crate) fn materialize_int_const(
+        &self,
+        value: i128,
+        ty: Type,
+        span: rue_span::Span,
+    ) -> CompileResult<AirInstData> {
+        // An integer is admitted directly where a float is expected
+        // (ADR-0065 §3): it becomes the float nearest to it. This is literal
+        // contextualization, not a runtime integer/float conversion.
+        if ty.is_float() {
+            let bits = if ty == Type::F32 {
+                u64::from((value as f32).to_bits())
+            } else {
+                (value as f64).to_bits()
+            };
+            return Ok(AirInstData::Const(bits));
+        }
+
+        // A target with no integer range at all — an array, a struct — is one
+        // the value cannot be represented in either, so it takes the same
+        // report rather than materializing a payload the backend would then
+        // have to make sense of.
+        if !ty
+            .integer_semantics()
+            .is_some_and(|integer| integer.fits_i128(value))
+        {
+            return Err(CompileError::new(
+                ErrorKind::LiteralOutOfRange {
+                    value,
+                    ty: self.format_type_name(ty),
+                },
+                span,
+            ));
+        }
+
+        // Two's-complement encoding: a negative value is sign-extended into
+        // the u64 payload.
+        Ok(AirInstData::Const(value as u64))
+    }
+
+    /// Materialize a floating-point constant as the AIR `Const` payload for
+    /// `ty`, with the spelling read by the parser its source calls for.
+    pub(crate) fn materialize_float_const(
+        &self,
+        source: FloatConstSource<'_>,
+        ty: Type,
+        span: rue_span::Span,
+    ) -> CompileResult<AirInstData> {
+        // `comptime_float` has no runtime width to round to; its uses are
+        // resolved before lowering, so the placeholder payload is zero.
+        if ty == Type::COMPTIME_FLOAT {
+            return Ok(AirInstData::Const(0));
+        }
+        if !ty.is_float() {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: "f32 or f64".to_owned(),
+                    found: self.format_type_name(ty),
+                },
+                span,
+            ));
+        }
+        let type_name = self.format_type_name(ty);
+        let (bits, expected, found) = match source {
+            FloatConstSource::Literal { spelling, negated } => (
+                crate::finite_float_literal_bits_with_sign(spelling, ty, negated),
+                format!("finite {type_name} literal"),
+                if negated {
+                    format!("-{spelling}")
+                } else {
+                    spelling.to_owned()
+                },
+            ),
+            FloatConstSource::ComputedValue { spelling } => (
+                crate::float_value_bits(spelling, ty),
+                format!("{type_name} value"),
+                spelling.to_owned(),
+            ),
+        };
+        let bits = bits
+            .ok_or_else(|| CompileError::new(ErrorKind::TypeMismatch { expected, found }, span))?;
+        Ok(AirInstData::Const(bits))
     }
 
     // ========================================================================
@@ -75,34 +194,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let ty =
                     Self::get_resolved_type(ctx, inst_ref, inst.span, "floating-point literal")?;
                 let spelling = self.body_interner().resolve(text);
-                if ty == Type::COMPTIME_FLOAT {
-                    let air_ref = air.add_inst(AirInst {
-                        data: AirInstData::Const(0),
-                        ty,
-                        span: inst.span,
-                    });
-                    return Ok(AnalysisResult::new(air_ref, ty));
-                }
-                if !ty.is_float() {
-                    return Err(CompileError::new(
-                        ErrorKind::TypeMismatch {
-                            expected: "f32 or f64".to_string(),
-                            found: self.format_type_name(ty),
-                        },
-                        inst.span,
-                    ));
-                }
-                let bits = crate::finite_float_literal_bits(spelling, ty).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::TypeMismatch {
-                            expected: format!("finite {} literal", self.format_type_name(ty)),
-                            found: spelling.to_string(),
-                        },
-                        inst.span,
-                    )
-                })?;
+                let data = self.materialize_float_const(
+                    FloatConstSource::Literal {
+                        spelling,
+                        negated: false,
+                    },
+                    ty,
+                    inst.span,
+                )?;
                 let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::Const(bits),
+                    data,
                     ty,
                     span: inst.span,
                 });
@@ -118,36 +219,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // Normal inferred literals still take the resolved-map path.
                 let ty = Self::resolved_integer_type(ctx, inst_ref, inst.span, "integer literal")?;
 
-                // Integer literals are admitted directly in a float context
-                // (ADR-0065 §3); this is literal contextualization, not a
-                // runtime implicit integer/float conversion.
-                if ty.is_float() {
-                    let bits = if ty == Type::F32 {
-                        u64::from((*value as f32).to_bits())
-                    } else {
-                        (*value as f64).to_bits()
-                    };
-                    let air_ref = air.add_inst(AirInst {
-                        data: AirInstData::Const(bits),
-                        ty,
-                        span: inst.span,
-                    });
-                    return Ok(AnalysisResult::new(air_ref, ty));
-                }
-
-                // Check if the literal value fits in the target type's range
-                if !ty.literal_fits(*value) {
-                    return Err(CompileError::new(
-                        ErrorKind::LiteralOutOfRange {
-                            value: *value,
-                            ty: self.format_type_name(ty),
-                        },
-                        inst.span,
-                    ));
-                }
-
+                let data = self.materialize_int_const(i128::from(*value), ty, inst.span)?;
                 let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::Const(*value),
+                    data,
                     ty,
                     span: inst.span,
                 });
@@ -284,44 +358,40 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     && ty.is_float()
                 {
                     let spelling = self.body_interner().resolve(text);
-                    let bits = crate::finite_float_literal_bits_with_sign(spelling, ty, true)
-                        .ok_or_else(|| {
-                            CompileError::new(
-                                ErrorKind::TypeMismatch {
-                                    expected: format!(
-                                        "finite {} literal",
-                                        self.format_type_name(ty)
-                                    ),
-                                    found: format!("-{spelling}"),
-                                },
-                                inst.span,
-                            )
-                        })?;
+                    let data = self.materialize_float_const(
+                        FloatConstSource::Literal {
+                            spelling,
+                            negated: true,
+                        },
+                        ty,
+                        inst.span,
+                    )?;
                     let air_ref = air.add_inst(AirInst {
-                        data: AirInstData::Const(bits),
+                        data,
                         ty,
                         span: inst.span,
                     });
                     return Ok(AnalysisResult::new(air_ref, ty));
                 }
-                if let InstData::IntConst(value) = &operand_inst.data {
-                    // Check if this value, when negated, fits in the target signed type
-                    if ty.negated_literal_fits(*value) && !ty.literal_fits(*value) {
-                        // This is the MIN value case - store the MIN value directly.
-                        let neg_value = match ty.kind() {
-                            TypeKind::I8 => (i8::MIN as i64) as u64,
-                            TypeKind::I16 => (i16::MIN as i64) as u64,
-                            TypeKind::I32 => (i32::MIN as i64) as u64,
-                            TypeKind::I64 => i64::MIN as u64,
-                            _ => unreachable!(),
-                        };
-                        let air_ref = air.add_inst(AirInst {
-                            data: AirInstData::Const(neg_value),
-                            ty,
-                            span: inst.span,
-                        });
-                        return Ok(AnalysisResult::new(air_ref, ty));
-                    }
+                // A negated integer literal whose magnitude alone is out of
+                // range is one literal, not an operation on one: `-128` at
+                // `i8` denotes the type minimum even though `128` does not
+                // fit, so the operand cannot be analyzed on its own. Handing
+                // the owner the value the literal denotes admits that case
+                // and, when the denoted value does not fit either, reports
+                // `-129` rather than the magnitude the operand spells.
+                if let InstData::IntConst(magnitude) = &operand_inst.data
+                    && let Some(integer) = ty.integer_semantics()
+                    && !integer.fits_i128(i128::from(*magnitude))
+                {
+                    let data =
+                        self.materialize_int_const(-i128::from(*magnitude), ty, inst.span)?;
+                    let air_ref = air.add_inst(AirInst {
+                        data,
+                        ty,
+                        span: inst.span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, ty));
                 }
 
                 let operand_result = self.analyze_inst(air, *operand, ctx)?;

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -765,9 +765,12 @@ pub trait ComptimeRejections: ComptimeDomain {
         depth: usize,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure;
+    /// Report an integer constant that is not representable in `ty`. `value`
+    /// is the mathematical value the source denotes, so a negated literal
+    /// reports `-129` rather than the magnitude its operand spells.
     fn literal_out_of_range(
         &self,
-        value: u64,
+        value: i128,
         ty: &Self::Type,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure;
@@ -2200,7 +2203,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                         .is_some_and(|integer| integer.fits_i128(v))
                     {
                         return ComptimeOutcome::HostFailure(self.host.literal_out_of_range(
-                            *value,
+                            v,
                             ty,
                             &self.diagnostic_site(span),
                         ));
@@ -2247,13 +2250,30 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                     // The literal path uses mathematical magnitude semantics:
                     // unlike an ordinary runtime value, `128` must not first
                     // canonicalize to -128 before becoming `-128`.
-                    let result = ty
+                    let integer = ty
                         .as_ref()
-                        .and_then(|ty| self.host.type_integer_semantics(ty))
-                        .map_or_else(
-                            || CheckedIntegerResult::from_raw((magnitude as i128).checked_neg()),
-                            |integer| integer.checked_neg_literal_report_i128(magnitude as i128),
-                        );
+                        .and_then(|ty| self.host.type_integer_semantics(ty));
+                    // A negated integer literal is one literal, not an
+                    // operation on one. When the value it denotes does not
+                    // fit its signed type, that is the literal out-of-range
+                    // fact (E0800, spec 6.5:5) the body path reports for the
+                    // same source text, not a trapping operation (6.5:12).
+                    if let (Some(integer), Some(literal_ty)) = (integer, ty.as_ref())
+                        && integer.is_signed()
+                        && integer
+                            .checked_neg_literal_i128(magnitude as i128)
+                            .is_none()
+                    {
+                        return ComptimeOutcome::HostFailure(self.host.literal_out_of_range(
+                            -(magnitude as i128),
+                            literal_ty,
+                            &self.diagnostic_site(span),
+                        ));
+                    }
+                    let result = integer.map_or_else(
+                        || CheckedIntegerResult::from_raw((magnitude as i128).checked_neg()),
+                        |integer| integer.checked_neg_literal_report_i128(magnitude as i128),
+                    );
                     self.finish_arith_value(result, ty, "negation", span)
                 } else {
                     match self.eval(*operand, env) {

--- a/crates/rue-air/src/sema/comptime/value_domain_tests.rs
+++ b/crates/rue-air/src/sema/comptime/value_domain_tests.rs
@@ -2111,7 +2111,7 @@ impl ComptimeRejections for FakeHost {
     }
     fn literal_out_of_range(
         &self,
-        _value: u64,
+        _value: i128,
         _ty: &Self::Type,
         _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure {
@@ -3301,6 +3301,56 @@ fn typed_division_by_zero_is_a_structured_trap() {
 
 #[test]
 fn direct_negative_literal_uses_the_distinct_negation_operation() {
+    // `128` at a signed 8-bit type is the case that separates the two: as a
+    // literal magnitude it negates to the type minimum, while an ordinary
+    // value would canonicalize to -128 first and then fail to negate.
+    let mut editor = rue_rir::RirEditor::new();
+    let magnitude = editor.add_inst(rue_rir::Inst {
+        data: InstData::IntConst(128),
+        span: Span::new(0, 3),
+    });
+    let negative = editor.add_inst(rue_rir::Inst {
+        data: InstData::Neg { operand: magnitude },
+        span: Span::new(0, 4),
+    });
+    let interner = lasso::ThreadedRodeo::new();
+    let mut host = FakeHost {
+        programs: vec![editor.finish()],
+        type_symbol: SymbolHandle::new(interner.get_or_intern("T")),
+        constant: None,
+        dependencies: Vec::new(),
+        call_plans: AHashMap::new(),
+        recursive: None,
+        enter_count: 0,
+        finish_outcome: FakeFinishOutcome::Identity,
+        finished: Vec::new(),
+        float_evaluations: Cell::new(0),
+    };
+    let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+    FINISH_ARITH_OPERATIONS.with(|operations| operations.borrow_mut().clear());
+
+    assert!(matches!(
+        ComptimeEngine::new(&mut host).evaluate(
+            ComptimeFrame {
+                expected_result: Some(FakeType(8)),
+                ..ComptimeFrame::expression(0, negative)
+            },
+            &mut env,
+        ),
+        ComptimeOutcome::Known(FakeValue::Integer(-128))
+    ));
+    FINISH_ARITH_OPERATIONS.with(|operations| {
+        assert_eq!(operations.borrow().as_slice(), ["negation"]);
+    });
+}
+
+/// A negated literal the signed type cannot represent is the literal
+/// out-of-range fact (E0800), not a trapping arithmetic operation: it is
+/// reported through the host's literal channel and never reaches the checked
+/// arithmetic policy, so a comptime block and the same value written directly
+/// fail with one code.
+#[test]
+fn out_of_range_negative_literal_reports_through_the_literal_channel() {
     let mut editor = rue_rir::RirEditor::new();
     let magnitude = editor.add_inst(rue_rir::Inst {
         data: InstData::IntConst(129),
@@ -3334,10 +3384,10 @@ fn direct_negative_literal_uses_the_distinct_negation_operation() {
             },
             &mut env,
         ),
-        ComptimeOutcome::RuntimeDependent
+        ComptimeOutcome::HostFailure(_)
     ));
     FINISH_ARITH_OPERATIONS.with(|operations| {
-        assert_eq!(operations.borrow().as_slice(), ["negation"]);
+        assert!(operations.borrow().is_empty());
     });
 }
 

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -267,7 +267,10 @@ pub(super) fn validate_comptime_value_for_type_impl(
     if let ConstValue::Integer(integer) = value
         && expected.is_integer()
     {
-        if const_int_fits(integer, expected) {
+        if expected
+            .integer_semantics()
+            .is_some_and(|integer_type| integer_type.fits_i128(integer))
+        {
             return Ok(());
         }
         return Err(CompileError::new(
@@ -372,12 +375,6 @@ pub(crate) fn const_pattern_matches(
         },
         ComptimeMatchPattern::Path { .. } => None,
     }
-}
-
-/// Check whether `value` is representable in integer type `ty`.
-pub(crate) fn const_int_fits(value: i128, ty: Type) -> bool {
-    ty.integer_semantics()
-        .is_some_and(|integer| integer.fits_i128(value))
 }
 
 /// Build the E1200 error for a constant operation that would panic at runtime.
@@ -3013,7 +3010,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeRejections for OrdinaryBodyEngine<
     }
     fn literal_out_of_range(
         &self,
-        value: u64,
+        value: i128,
         ty: &Type,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure {

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -845,32 +845,27 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
     ) -> CompileResult<i64> {
         let ty_name = self.format_type_name(scrutinee_type);
-        if negative {
-            if scrutinee_type.is_unsigned() {
-                return Err(
-                    CompileError::new(ErrorKind::CannotNegate(ty_name), span).with_note(
-                        "unsigned values are never negative, so this pattern could never match",
-                    ),
-                );
-            }
-            if !scrutinee_type.negated_literal_fits(value) {
-                return Err(CompileError::new(
-                    ErrorKind::LiteralOutOfRange { value, ty: ty_name },
-                    span,
-                )
-                .with_note(format!("the pattern value is -{}", value)));
-            }
-            // wrapping_neg handles the i64::MIN magnitude (9223372036854775808).
-            Ok((value as i64).wrapping_neg())
-        } else {
-            if !scrutinee_type.literal_fits(value) {
-                return Err(CompileError::new(
-                    ErrorKind::LiteralOutOfRange { value, ty: ty_name },
-                    span,
-                ));
-            }
-            Ok(value as i64)
+        if negative && scrutinee_type.is_unsigned() {
+            return Err(
+                CompileError::new(ErrorKind::CannotNegate(ty_name), span).with_note(
+                    "unsigned values are never negative, so this pattern could never match",
+                ),
+            );
         }
+        let denoted = pattern_int_denoted(value, negative);
+        if !scrutinee_type
+            .integer_semantics()
+            .is_some_and(|integer| integer.fits_i128(denoted))
+        {
+            return Err(CompileError::new(
+                ErrorKind::LiteralOutOfRange {
+                    value: denoted,
+                    ty: ty_name,
+                },
+                span,
+            ));
+        }
+        Ok(denoted as i64)
     }
 
     /// Emit unreachable-pattern warnings (spec 4.7:20) for a `match` that the
@@ -1573,14 +1568,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 RirPattern::Int {
                     value, negative, ..
                 } => {
-                    // Already range-checked above; wrapping_neg handles the
-                    // i64::MIN magnitude (9223372036854775808).
-                    let n = if *negative {
-                        (*value as i64).wrapping_neg()
-                    } else {
-                        *value as i64
-                    };
-                    AirPattern::Int(n)
+                    // Already range-checked above.
+                    AirPattern::Int(pattern_int_denoted(*value, *negative) as i64)
                 }
                 RirPattern::Bool(b, _) => AirPattern::Bool(*b),
                 RirPattern::Path {
@@ -3008,6 +2997,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Ok(AnalysisResult::with_continues(air_ref, ty, !diverged))
         }
     }
+}
+
+/// The value an integer pattern denotes: the magnitude its literal spells,
+/// negated when the pattern is written with a leading `-`. The magnitude is
+/// carried unsigned so `-9223372036854775808` names `i64::MIN` without the
+/// operand itself having to be representable; the i128 arithmetic is what
+/// makes that exact rather than a wrapping trick.
+fn pattern_int_denoted(value: u64, negative: bool) -> i128 {
+    let magnitude = i128::from(value);
+    if negative { -magnitude } else { magnitude }
 }
 
 #[cfg(test)]

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -996,18 +996,6 @@ impl Type {
         )
     }
 
-    /// Check if a u64 value fits within the range of this integer type.
-    ///
-    /// For signed types, only the positive range is checked (0 to max positive).
-    /// Negation is handled separately to allow values like `-128` for i8.
-    ///
-    /// Returns `true` if the value fits, `false` otherwise.
-    /// For non-integer types, returns `false`.
-    #[must_use]
-    pub fn literal_fits(&self, value: u64) -> bool {
-        self.int_max().is_some_and(|max| i128::from(value) <= max)
-    }
-
     /// Get the bit width of this integer type (8, 16, 32, or 64).
     ///
     /// Returns `None` for non-integer types.
@@ -1044,19 +1032,6 @@ impl Type {
     #[must_use]
     pub fn int_max(&self) -> Option<i128> {
         self.integer_semantics().map(IntegerType::max_i128)
-    }
-
-    /// Check if a u64 value can be negated to fit within the range of this signed integer type.
-    ///
-    /// This is used to allow literals like `2147483648` when negated to `-2147483648` (i32::MIN).
-    /// Returns `true` if the negated value fits, `false` otherwise.
-    #[must_use]
-    pub fn negated_literal_fits(&self, value: u64) -> bool {
-        self.integer_semantics().is_some_and(|integer| {
-            integer
-                .checked_neg_literal_i128(i128::from(value))
-                .is_some()
-        })
     }
 
     /// Encode this type as a u32 for storage in extra arrays.
@@ -1445,111 +1420,6 @@ mod tests {
         assert!(!Type::BOOL.can_coerce_to(&Type::I32));
         assert!(!Type::I32.can_coerce_to(&Type::I64));
         assert!(!Type::new_struct(StructId(0)).can_coerce_to(&Type::I32));
-    }
-
-    // ========== Type::literal_fits() tests ==========
-
-    #[test]
-    fn test_literal_fits_i8() {
-        assert!(Type::I8.literal_fits(0));
-        assert!(Type::I8.literal_fits(127)); // i8::MAX
-        assert!(!Type::I8.literal_fits(128));
-    }
-
-    #[test]
-    fn test_literal_fits_i16() {
-        assert!(Type::I16.literal_fits(0));
-        assert!(Type::I16.literal_fits(32767)); // i16::MAX
-        assert!(!Type::I16.literal_fits(32768));
-    }
-
-    #[test]
-    fn test_literal_fits_i32() {
-        assert!(Type::I32.literal_fits(0));
-        assert!(Type::I32.literal_fits(2147483647)); // i32::MAX
-        assert!(!Type::I32.literal_fits(2147483648));
-    }
-
-    #[test]
-    fn test_literal_fits_i64() {
-        assert!(Type::I64.literal_fits(0));
-        assert!(Type::I64.literal_fits(9223372036854775807)); // i64::MAX
-        assert!(!Type::I64.literal_fits(9223372036854775808));
-    }
-
-    #[test]
-    fn test_literal_fits_u8() {
-        assert!(Type::U8.literal_fits(0));
-        assert!(Type::U8.literal_fits(255)); // u8::MAX
-        assert!(!Type::U8.literal_fits(256));
-    }
-
-    #[test]
-    fn test_literal_fits_u16() {
-        assert!(Type::U16.literal_fits(0));
-        assert!(Type::U16.literal_fits(65535)); // u16::MAX
-        assert!(!Type::U16.literal_fits(65536));
-    }
-
-    #[test]
-    fn test_literal_fits_u32() {
-        assert!(Type::U32.literal_fits(0));
-        assert!(Type::U32.literal_fits(4294967295)); // u32::MAX
-        assert!(!Type::U32.literal_fits(4294967296));
-    }
-
-    #[test]
-    fn test_literal_fits_u64() {
-        assert!(Type::U64.literal_fits(0));
-        assert!(Type::U64.literal_fits(u64::MAX)); // Any u64 fits
-    }
-
-    #[test]
-    fn test_literal_fits_non_integer() {
-        assert!(!Type::BOOL.literal_fits(0));
-        assert!(!Type::new_struct(StructId(0)).literal_fits(0));
-        assert!(!Type::UNIT.literal_fits(0));
-    }
-
-    // ========== Type::negated_literal_fits() tests ==========
-
-    #[test]
-    fn test_negated_literal_fits_i8() {
-        assert!(Type::I8.negated_literal_fits(128)); // -128 = i8::MIN
-        assert!(!Type::I8.negated_literal_fits(129));
-    }
-
-    #[test]
-    fn test_negated_literal_fits_i16() {
-        assert!(Type::I16.negated_literal_fits(32768)); // -32768 = i16::MIN
-        assert!(!Type::I16.negated_literal_fits(32769));
-    }
-
-    #[test]
-    fn test_negated_literal_fits_i32() {
-        assert!(Type::I32.negated_literal_fits(2147483648)); // -2147483648 = i32::MIN
-        assert!(!Type::I32.negated_literal_fits(2147483649));
-    }
-
-    #[test]
-    fn test_negated_literal_fits_i64() {
-        assert!(Type::I64.negated_literal_fits(9223372036854775808)); // i64::MIN abs
-        assert!(!Type::I64.negated_literal_fits(9223372036854775809));
-    }
-
-    #[test]
-    fn test_negated_literal_fits_unsigned() {
-        // Unsigned types don't support negated literals
-        assert!(!Type::U8.negated_literal_fits(1));
-        assert!(!Type::U16.negated_literal_fits(1));
-        assert!(!Type::U32.negated_literal_fits(1));
-        assert!(!Type::U64.negated_literal_fits(1));
-    }
-
-    #[test]
-    fn test_negated_literal_fits_non_integer() {
-        assert!(!Type::BOOL.negated_literal_fits(1));
-        assert!(!Type::new_struct(StructId(0)).negated_literal_fits(1));
     }
 
     // ========== Type Display tests ==========

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1977,7 +1977,7 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
     (753, 3_150_885_663_910_159_936),
     (2_598, 10_270_973_964_375_394_836),
     (11653, 15_769_724_788_918_086_723),
-    (109_638, 5_326_388_425_001_326_533),
+    (106_643, 1_879_126_869_505_685_683),
     (3_254, 11_949_940_325_034_004_149),
     (5_552, 14_658_861_127_087_730_967),
     (872, 14_092_162_116_261_787_003),
@@ -8352,6 +8352,46 @@ fn rue_1191_anonymous_digest_collision_authority_is_body_closure_owned() {
     assert!(
         !transaction_evaluator.contains("register_body_closure_anonymous_digest("),
         "the per-body evaluator must not call the cross-body registrar"
+    );
+}
+
+#[test]
+fn durable_integer_widths_have_one_kernel_adapter() {
+    let projection = DURABLE_COMPTIME_PROJECTION_SOURCE;
+    let nucleus =
+        include_str!("revisioned_query_database/registrations/semantic/semantic_nucleus.rs");
+    let provider_body = include_str!("revisioned_query_database/body/provider_body.rs");
+
+    // One match turns a `DurableType` into the kernel's `IntegerType`. A
+    // second table here would keep answering for eight widths after the
+    // kernel learned a ninth, and the declaration-time answer would then
+    // disagree with the body path for the same program.
+    assert!(projection.contains("pub(crate) fn durable_int_width("));
+    assert_eq!(
+        projection.matches("DurableType::I8 => (8, true),").count(),
+        1
+    );
+
+    for (name, source) in [
+        ("the semantic nucleus", nucleus),
+        ("the body provider", provider_body),
+    ] {
+        assert!(
+            source.contains("durable_int_width(") || source.contains("durable_const_fits_type("),
+            "{name} stopped asking the kernel adapter about integer widths"
+        );
+        assert!(
+            !source.contains("DurableType::I8"),
+            "{name} regained a per-width DurableType table"
+        );
+    }
+
+    // One code for "does not fit": the nucleus reports the same E0800 the
+    // body path does, whatever the value's sign.
+    assert!(nucleus.contains("ErrorKind::LiteralOutOfRange"));
+    assert!(
+        !nucleus.contains("value {value} is out of range for type"),
+        "the nucleus regained a second out-of-range channel"
     );
 }
 

--- a/crates/rue-compiler/src/durable_comptime/host.rs
+++ b/crates/rue-compiler/src/durable_comptime/host.rs
@@ -1704,7 +1704,7 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeRejections
 
     fn literal_out_of_range(
         &self,
-        value: u64,
+        value: i128,
         ty: &Self::Type,
         site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure {

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -1795,17 +1795,7 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
                         });
                 }
                 if let Some(ty) = self.deferred_value_parameters.get(name) {
-                    if matches!(
-                        ty,
-                        crate::durable_semantics::DurableType::I8
-                            | crate::durable_semantics::DurableType::I16
-                            | crate::durable_semantics::DurableType::I32
-                            | crate::durable_semantics::DurableType::I64
-                            | crate::durable_semantics::DurableType::U8
-                            | crate::durable_semantics::DurableType::U16
-                            | crate::durable_semantics::DurableType::U32
-                            | crate::durable_semantics::DurableType::U64
-                    ) {
+                    if crate::durable_comptime::durable_int_width(ty).is_some() {
                         return Ok(None);
                     }
                     return Self::provider_domain_failure(
@@ -2029,15 +2019,10 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
             return Ok(V::Type(ty.clone()));
         }
         if let Some(ty) = self.deferred_value_parameters.get(syntax) {
+            if crate::durable_comptime::durable_int_width(ty).is_some() {
+                return Ok(V::Integer(0));
+            }
             return match ty {
-                crate::durable_semantics::DurableType::I8
-                | crate::durable_semantics::DurableType::I16
-                | crate::durable_semantics::DurableType::I32
-                | crate::durable_semantics::DurableType::I64
-                | crate::durable_semantics::DurableType::U8
-                | crate::durable_semantics::DurableType::U16
-                | crate::durable_semantics::DurableType::U32
-                | crate::durable_semantics::DurableType::U64 => Ok(V::Integer(0)),
                 crate::durable_semantics::DurableType::Bool => Ok(V::Bool(false)),
                 crate::durable_semantics::DurableType::Unit => Ok(V::Unit),
                 _ => Self::provider_failure(format!(

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
@@ -813,14 +813,13 @@ $runtime
                                                                         && matches!(value, crate::durable_semantics::DurableConstValue::Float(_)))
                                                             })
                                                                 && match (&ty, &value) {
-                                                                (crate::durable_semantics::DurableType::I8, crate::durable_semantics::DurableConstValue::Integer(value)) => i8::try_from(*value).is_ok(),
-                                                                (crate::durable_semantics::DurableType::I16, crate::durable_semantics::DurableConstValue::Integer(value)) => i16::try_from(*value).is_ok(),
-                                                                (crate::durable_semantics::DurableType::I32, crate::durable_semantics::DurableConstValue::Integer(value)) => i32::try_from(*value).is_ok(),
-                                                                (crate::durable_semantics::DurableType::I64, crate::durable_semantics::DurableConstValue::Integer(value)) => i64::try_from(*value).is_ok(),
-                                                                (crate::durable_semantics::DurableType::U8, crate::durable_semantics::DurableConstValue::Integer(value)) => u8::try_from(*value).is_ok(),
-                                                                (crate::durable_semantics::DurableType::U16, crate::durable_semantics::DurableConstValue::Integer(value)) => u16::try_from(*value).is_ok(),
-                                                                (crate::durable_semantics::DurableType::U32, crate::durable_semantics::DurableConstValue::Integer(value)) => u32::try_from(*value).is_ok(),
-                                                                (crate::durable_semantics::DurableType::U64, crate::durable_semantics::DurableConstValue::Integer(value)) => u64::try_from(*value).is_ok(),
+                                                                // Integer range is the kernel's to decide:
+                                                                // a width this table spelled itself would
+                                                                // silently disagree with the body path the
+                                                                // next time the kernel learns one.
+                                                                (_, crate::durable_semantics::DurableConstValue::Integer(_)) => {
+                                                                    crate::durable_comptime::durable_const_fits_type(&value, &ty)
+                                                                }
                                                                 (crate::durable_semantics::DurableType::Bool, crate::durable_semantics::DurableConstValue::Bool(_))
                                                                 | (crate::durable_semantics::DurableType::Unit, crate::durable_semantics::DurableConstValue::Unit)
                                                                 | (crate::durable_semantics::DurableType::ComptimeFloat, crate::durable_semantics::DurableConstValue::Float(_))
@@ -857,34 +856,15 @@ $runtime
                                                                 })
                                                             } else {
                                                                 let kind = match (&ty, &value) {
-                                                                    (crate::durable_semantics::DurableType::I8
-                                                                    | crate::durable_semantics::DurableType::I16
-                                                                    | crate::durable_semantics::DurableType::I32
-                                                                    | crate::durable_semantics::DurableType::I64
-                                                                    | crate::durable_semantics::DurableType::U8
-                                                                    | crate::durable_semantics::DurableType::U16
-                                                                    | crate::durable_semantics::DurableType::U32
-                                                                    | crate::durable_semantics::DurableType::U64,
-                                                                    crate::durable_semantics::DurableConstValue::Integer(value)) if *value >= 0 => {
+                                                                    // One code for "does not fit", whatever
+                                                                    // the sign: E0800, as spec 6.5:5 states
+                                                                    // and the body path reports.
+                                                                    (_, crate::durable_semantics::DurableConstValue::Integer(value))
+                                                                        if crate::durable_comptime::durable_int_width(&ty).is_some() =>
+                                                                    {
                                                                         rue_error::ErrorKind::LiteralOutOfRange {
-                                                                            value: *value as u64,
+                                                                            value: *value,
                                                                             ty: durable_type_diagnostic_name(&ty),
-                                                                        }
-                                                                    }
-                                                                    (crate::durable_semantics::DurableType::I8
-                                                                    | crate::durable_semantics::DurableType::I16
-                                                                    | crate::durable_semantics::DurableType::I32
-                                                                    | crate::durable_semantics::DurableType::I64
-                                                                    | crate::durable_semantics::DurableType::U8
-                                                                    | crate::durable_semantics::DurableType::U16
-                                                                    | crate::durable_semantics::DurableType::U32
-                                                                    | crate::durable_semantics::DurableType::U64,
-                                                                    crate::durable_semantics::DurableConstValue::Integer(value)) => {
-                                                                        rue_error::ErrorKind::ComptimeEvaluationFailed {
-                                                                            reason: format!(
-                                                                                "value {value} is out of range for type {}",
-                                                                                durable_type_diagnostic_name(&ty),
-                                                                            ),
                                                                         }
                                                                     }
                                                                     (crate::durable_semantics::DurableType::F32

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -3713,7 +3713,7 @@ pub enum ErrorKind {
 
     // Literal errors
     #[error("literal value {value} is out of range for type '{ty}'")]
-    LiteralOutOfRange { value: u64, ty: String },
+    LiteralOutOfRange { value: i128, ty: String },
 
     // Operator errors
     #[error("cannot apply unary operator `-` to type '{0}'")]

--- a/crates/rue-spec/cases/types/integers.toml
+++ b/crates/rue-spec/cases/types/integers.toml
@@ -628,6 +628,53 @@ error_contains = "out of range"
 # would fail during lexing, not during semantic analysis range checking.
 
 # =============================================================================
+# Out-of-range literals report one fact in every position (3.1:17, 3.1:18)
+# =============================================================================
+
+[[case]]
+name = "negated_literal_below_min_is_out_of_range"
+spec = ["3.1:18"]
+description = "A negated literal is judged by the value it denotes: -129 is outside i8, so it is an out-of-range literal (E0800), not a trapping negation."
+source = """
+fn main() -> i32 {
+    let x: i8 = -129;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0800", "-129", "i8"]
+
+[[case]]
+name = "out_of_range_literal_in_{position}_reports_one_code"
+spec = ["3.1:17"]
+description = "The range rule belongs to the literal and its target type, not to the position the literal is written in, so every position reports E0800."
+source = """
+{source}
+"""
+compile_fail = true
+error_contains = ["E0800", "out of range", "i8"]
+params = [
+  { position = "an_expression", source = """fn main() -> i32 {
+    let x: i8 = 200;
+    0
+}""" },
+  { position = "a_comptime_block", source = """fn main() -> i32 {
+    let x: i8 = comptime { 200 };
+    0
+}""" },
+  { position = "a_negated_comptime_block", source = """fn main() -> i32 {
+    let x: i8 = comptime { -129 };
+    0
+}""" },
+  { position = "a_constant_initializer", source = """const BAD: i8 = 200;
+
+fn main() -> i32 { 0 }""" },
+  { position = "a_negated_constant_initializer", source = """const BAD: i8 = -129;
+
+fn main() -> i32 { 0 }""" },
+]
+
+# =============================================================================
 # Valid Edge Cases (MIN values via negation)
 # =============================================================================
 

--- a/docs/spec/src/03-types/01-integer-types.md
+++ b/docs/spec/src/03-types/01-integer-types.md
@@ -137,11 +137,11 @@ fn main() -> i32 {
 
 {{ rule(id="3.1:17", cat="legality-rule") }}
 
-A compiler **MUST** reject programs where an integer literal value exceeds the representable range of its target type.
+A compiler **MUST** reject programs where an integer literal value exceeds the representable range of its target type. The rule is a property of the literal and its target type, not of where the literal is written: an ordinary expression, a `comptime` block (4.14), a struct-initializer field, and a constant initializer (6.5:5) all reject the same literal, with the same diagnostic.
 
 {{ rule(id="3.1:18", cat="normative") }}
 
-When an integer literal is the operand of a unary negation operator, and the negated value would be representable in the target signed integer type, the expression is valid even if the literal value itself exceeds the positive range of that type. This allows the minimum value of each signed integer type to be written as a negated literal.
+When an integer literal is the operand of a unary negation operator, and the negated value would be representable in the target signed integer type, the expression is valid even if the literal value itself exceeds the positive range of that type. This allows the minimum value of each signed integer type to be written as a negated literal. A negated literal is judged by the value it denotes: when that value is outside the target type's range the program is rejected under 3.1:17, as an out-of-range literal rather than as a trapping arithmetic operation (6.5:12).
 
 {{ rule(id="3.1:19") }}
 


### PR DESCRIPTION
Fixes RUE-1976

## Why

Literal-to-AIR `Const` materialization was written four times in rue-air sema, and the same "does not fit" fact produced different codes by position. Measured on trunk:

| program | before | after |
|---|---|---|
| `let x: i8 = -129` | E0800 "literal value **129** is out of range for type 'i8'" | E0800 "literal value **-129** …" |
| `let x: i8 = comptime { -129 }` | E1200 "integer overflow evaluating `-` …" | E0800 "literal value -129 …" |
| `const A: i8 = -129` | E1200 "integer overflow evaluating negation …" | E0800 "literal value -129 …" |
| positive twins (`200`, `comptime { 200 }`, `const A: i8 = 200`, `S { a: 300 }`) | E0800 | unchanged |
| `comptime { 100 + 100 }` at i8 | E1200 | E1200 (a trap keeps its code) |
| `-128`, `i32::MIN`, `i64::MIN` written as negated literals | accepted | accepted |

The E0800/E1200 split was wider than the issue described: besides `instructions.rs` it lived in `semantic_nucleus.rs` (positive E0800, negative E1200 prose), and the user-visible repro came from the comptime engine's negation-of-literal path in `comptime.rs`. `Type::literal_fits` only checked the positive half, and `ownership::materialize_const_value` had no range check on its integer arm at all.

## What

- One `materialize_int_literal` / `materialize_float_literal` pair in `analyze_ops.rs`, routed from `analyze_literal`, the struct-init shortcut in `aggregates.rs`, `ownership::materialize_const_value`, the `InstData::Comptime` result in `instructions.rs`, plus two sites the issue missed: `analysis/pointers.rs` (`@ptr_write` literal coercion) and the pattern range check in `control_flow.rs`. The negation-of-literal MIN table and the `wrapping_neg` sites go through `IntegerType` kernel calls. `ownership`'s permissive float path is a real distinction and is kept as a `FloatConstSource::{Literal, ComputedValue}` parameter rather than flattened.
- Durable side: `semantic_nucleus.rs` calls `durable_const_fits_type` instead of its inline `i8::try_from` table; two per-width `DurableType` enumerations in `provider_body.rs` collapse onto the kernel adapter; `durable_comptime/host.rs` follows. `const_int_fits` and `durable_const_fits_type` already delegated to the kernel after RUE-1983.
- Guards in both `api_inventory.rs` files: one `match` producing `IntegerType` from `Type` in rue-air and one from `DurableType` in rue-compiler, plus a no-private-width-table check over the eight relevant sources (file-scoped, matching the rue-cfg precedent).
- `ErrorKind::LiteralOutOfRange.value` widens from `u64` to `i128` so a negative renders; the `--error-format json` schema is unchanged.
- Spec: 3.1:17 now states the rule is a property of the literal and its target type regardless of position (expression, `comptime` block, struct-initializer field, constant initializer), and 3.1:18 says a negated literal is judged by the value it denotes and rejected under 3.1:17 rather than as trapping arithmetic (6.5:12). Six new cases in `types/integers.toml` pin every position.

**Error-code decision: E0800.** The registry reserves E0800 to E0899 for literal and operator faults, spec 6.5:5 already gives E0800 to an out-of-range constant value, and 6.5:12 reserves E1200 for an initializer that would trap. Negating a literal is materialization, not arithmetic.

Not changed, deliberately: `const N: u8 = -5` still gives E1200 while `let x: u8 = -5` gives E0801, because the durable host defers unsigned negation; that is a separate divergence (RUE-1968 territory), gated out here with `integer.is_signed()`. Also historical rather than live: there is no `require_preview(Floats)` gap, since floats stabilized in ADR-0065 Phase 10.

## Verification

| Command | Result |
|---|---|
| `scripts/rue unit air` (875), `unit compiler` (1228), `unit error` (127) | pass |
| `scripts/rue quick` | pass, re-run after rebasing onto current trunk |
| `scripts/rue ui ""` (full, 404), `scripts/rue spec ""` (full, 2837) | pass |
| `scripts/rue cli ""` (full, 2696) | 2688 passed; the 2 failures are environmental to the build container (uid 0 defeats `remove_dir_all_permission_denied_is_not_partial_success`; no IPv6 loopback for `tcp_ipv6_loopback_round_trip`) |
| `//crates/rue-oracle-diff:oracle-diff-test`, `//:spec-traceability`, `//:compiler-spec-machine-index`, `//:doc-link-validation` | pass |
| `//:type-architecture-inventory-validation`; debug-assert checks and clippy gates for rue-air, rue-compiler, rue-error | pass |
| `scripts/rue fmt` | clean |