### PR TITLE
The C-ABI matrix derives argument positions from both rosters

### DIFF
--- a/crates/rue-c-abi-matrix/BUCK
+++ b/crates/rue-c-abi-matrix/BUCK
@@ -8,6 +8,12 @@ load("//:test_defs.bzl", "rue_sh_test")
 # generator itself (grid completeness, position derivation, name uniqueness,
 # literal ranges), so the macro's generated `rue-c-abi-matrix-test` target is
 # kept: those assertions need no compiler and no C toolchain.
+#
+# `rue-air` is a test-only dependency: the position-coverage assertion asks
+# `lower_c_signature` — the one classifier the compiler places by — where each
+# shape lands at each generated position, so the coverage property is checked
+# against the real placement rules rather than against a second copy of them.
+# The generator itself needs only the psABI description in `rue-target`.
 rue_binary(
     name = "rue-c-abi-matrix",
     deps = [
@@ -15,6 +21,9 @@ rue_binary(
         "//crates/rue-test-runner:rue-test-runner",
         "//third-party:libtest2-mimic",
         "//third-party:tempfile",
+    ],
+    test_deps = [
+        "//crates/rue-air:rue-air",
     ],
 )
 

--- a/crates/rue-c-abi-matrix/src/grid.rs
+++ b/crates/rue-c-abi-matrix/src/grid.rs
@@ -31,11 +31,43 @@
 //! odd-multiplier checksum stays exact arithmetic and a rounding difference
 //! never masks a placement bug.
 //!
+//! # Positions
+//!
+//! An argument cell's parameter list is a run of filler arguments of one
+//! register bank with the shape somewhere inside it and one filler of the
+//! *other* bank at the end. [`positions_for`] sizes the run from that bank's
+//! roster — [`CConventionSpec::gp_argument_registers`] or
+//! [`CConventionSpec::fp_argument_registers`] — and places the shape at the
+//! first register, the last register, the first stack slot, or a deeper stack
+//! slot of it. Integer fillers move an integer shape past the general-purpose
+//! roster; float fillers move a float shape past the floating-point one, which
+//! is the only way a stacked float scalar, a stacked homogeneous
+//! floating-point aggregate, or a stacked split-bank composite becomes a cell
+//! at all.
+//!
+//! Both rosters reach every shape. A shape with a float leaf gets the whole
+//! floating-point run; every shape also gets the position where the
+//! floating-point roster is spent and the general-purpose one is not, the
+//! mirror of the general-purpose first-stack position. Between the two, a
+//! float scalar is proven still in a floating-point register when the integer
+//! roster is exhausted, and an integer argument still in a general-purpose
+//! register when the floating-point roster is. The trailing cross-bank filler
+//! carries that proof past the shape as well, which is what pins SysV's rule
+//! that an aggregate forced to memory leaves the other bank's registers to the
+//! arguments after it. Every filler is checksummed like every leaf, so a
+//! filler that lands in the wrong register or at the wrong stack offset is a
+//! failing cell rather than a silent one.
+//!
+//! Floating-point runs alternate `f64` and `f32`, so a stacked run holds
+//! adjacent four-byte arguments: the placement Apple's natural-size packing
+//! and the eight-byte stack slot of the other two rows disagree about.
+//!
 //! # Extending the table
 //!
 //! Adding a leaf type is a table edit: one [`Leaf`] variant with its two type
 //! spellings and its conversion rules, and one [`SHAPES`] row per new shape.
-//! Nothing else in this module knows the leaf inventory.
+//! Nothing else in this module knows the leaf inventory, and a shape that
+//! carries a float leaf earns the floating-point positions by carrying it.
 
 use rue_target::CConventionSpec;
 
@@ -741,12 +773,32 @@ impl Direction {
     }
 }
 
+/// Which register roster a position's filler run spends.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Bank {
+    /// Integer fillers, spending [`CConventionSpec::gp_argument_registers`].
+    Gp,
+    /// Floating-point fillers, spending
+    /// [`CConventionSpec::fp_argument_registers`].
+    Fp,
+}
+
 /// Where the shape sits in the crossing.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Position {
-    /// The shape occupies argument `index`; every other argument is an `i64`
-    /// filler.
-    Argument { key: &'static str, index: usize },
+    /// The shape occupies argument `index` of an `arity`-slot list. Every other
+    /// slot is a filler: `bank`'s own type up to the last slot, which always
+    /// carries the other bank's.
+    Argument {
+        /// The position's name, which is also part of the cell's seed.
+        key: &'static str,
+        /// The roster the filler run spends.
+        bank: Bank,
+        /// The shape's slot in the argument list.
+        index: usize,
+        /// How many arguments the list has.
+        arity: usize,
+    },
     /// The shape is the result type.
     Return,
 }
@@ -758,47 +810,92 @@ impl Position {
             Position::Return => "return",
         }
     }
-}
 
-/// The argument positions for one convention, plus the arity every argument
-/// cell uses. Positions are named by what they exercise, and their indices come
-/// from the convention's own register budget rather than a hard-coded number.
-pub struct Positions {
-    pub arity: usize,
-    pub positions: Vec<Position>,
-}
-
-pub fn positions_for(spec: &CConventionSpec) -> Positions {
-    let registers = spec.gp_argument_registers as usize;
-    assert!(
-        registers >= 2,
-        "a C convention with fewer than two argument registers has no distinct positions"
-    );
-    // Four slots past the register budget, so `deep_stack` is genuinely deep and
-    // every cell — whatever its position — also stacks arguments.
-    let arity = registers + 4;
-    Positions {
-        arity,
-        positions: vec![
-            Position::Argument {
-                key: "arg0",
-                index: 0,
-            },
-            Position::Argument {
-                key: "last_reg",
-                index: registers - 1,
-            },
-            Position::Argument {
-                key: "first_stack",
-                index: registers,
-            },
-            Position::Argument {
-                key: "deep_stack",
-                index: registers + 3,
-            },
-            Position::Return,
-        ],
+    /// How many arguments an argument cell at this position passes.
+    pub fn arity(self) -> usize {
+        match self {
+            Position::Argument { arity, .. } => arity,
+            Position::Return => 0,
+        }
     }
+
+    /// The leaf type of the filler in `slot`.
+    ///
+    /// Every slot but the last carries the position's own bank, so the run
+    /// spends exactly that roster and nothing else. The last slot carries the
+    /// other bank's, which is what proves that the roster the shape did not
+    /// exhaust still hands out registers to the arguments after it.
+    ///
+    /// A floating-point run alternates the two widths, so a run long enough to
+    /// stack holds adjacent four-byte arguments — the one placement Apple's
+    /// natural-size packing and the eight-byte stack slot of the other two rows
+    /// disagree about.
+    pub fn filler_leaf(self, slot: usize) -> Leaf {
+        let Position::Argument { bank, arity, .. } = self else {
+            panic!("only an argument position has filler slots");
+        };
+        assert!(
+            slot < arity,
+            "filler slot {slot} is past the {arity}-argument list"
+        );
+        if slot + 1 == arity {
+            return match bank {
+                Bank::Gp => Leaf::F64,
+                Bank::Fp => Leaf::I64,
+            };
+        }
+        match bank {
+            Bank::Gp => Leaf::I64,
+            Bank::Fp if slot % 2 == 0 => Leaf::F64,
+            Bank::Fp => Leaf::F32,
+        }
+    }
+}
+
+/// The positions one shape crosses at under `spec`: its argument positions in
+/// both banks, then the result.
+///
+/// Indices come from the convention's own rosters rather than a hard-coded
+/// number, so a convention with a different register budget moves them without
+/// a source edit. A run is three registers longer than its roster, so every
+/// cell also stacks arguments whatever the shape's own placement is, and the
+/// deep-stack position is genuinely deep.
+pub fn positions_for(spec: &CConventionSpec, shape: &Shape) -> Vec<Position> {
+    let gp = spec.gp_argument_registers as usize;
+    let fp = spec.fp_argument_registers as usize;
+    assert!(
+        gp >= 2 && fp >= 2,
+        "a C convention with fewer than two argument registers in a bank has no distinct \
+         positions in it"
+    );
+    // The run, the shape's own slot, and the trailing cross-bank filler.
+    let gp_arity = gp + 5;
+    let fp_arity = fp + 5;
+    let argument = |key, bank, index, arity| Position::Argument {
+        key,
+        bank,
+        index,
+        arity,
+    };
+    let float_leaves = shape.ty.leaves().iter().any(|(_, leaf)| leaf.is_float());
+    let mut positions = vec![
+        argument("arg0", Bank::Gp, 0, gp_arity),
+        argument("gp_last_reg", Bank::Gp, gp - 1, gp_arity),
+        argument("gp_first_stack", Bank::Gp, gp, gp_arity),
+        argument("gp_deep_stack", Bank::Gp, gp + 3, gp_arity),
+    ];
+    if float_leaves {
+        positions.push(argument("fp_last_reg", Bank::Fp, fp - 1, fp_arity));
+    }
+    // Every shape reaches a spent floating-point roster, float-leaved or not: it
+    // is where an integer argument proves it still takes a general-purpose
+    // register, the mirror of what `gp_first_stack` proves about a float one.
+    positions.push(argument("fp_first_stack", Bank::Fp, fp, fp_arity));
+    if float_leaves {
+        positions.push(argument("fp_deep_stack", Bank::Fp, fp + 3, fp_arity));
+    }
+    positions.push(Position::Return);
+    positions
 }
 
 /// What one line of the program's stdout proves, for a mismatch report.
@@ -1089,7 +1186,6 @@ struct CellPlan {
 fn plan_cell(
     shape: &'static Shape,
     position: Position,
-    arity: usize,
     direction: Direction,
     abi: &str,
 ) -> CellPlan {
@@ -1104,8 +1200,10 @@ fn plan_cell(
     let leaves = shape.ty.leaves();
 
     let (fillers, shape_values, multipliers) = match position {
-        Position::Argument { index, .. } => {
-            let mut fillers: Vec<Value> = (0..arity).map(|_| rng.value(Leaf::I64)).collect();
+        Position::Argument { index, arity, .. } => {
+            let mut fillers: Vec<Value> = (0..arity)
+                .map(|slot| rng.value(position.filler_leaf(slot)))
+                .collect();
             // The shape occupies this slot; its filler value is never emitted.
             fillers[index] = Value::Int(0);
             let shape_values: Vec<Value> =
@@ -1155,7 +1253,7 @@ fn plan_cell(
                         mix(leaf_value, *leaf, &mut checksum);
                     }
                 } else {
-                    mix(value, Leaf::I64, &mut checksum);
+                    mix(value, position.filler_leaf(slot), &mut checksum);
                 }
             }
         }
@@ -1178,14 +1276,15 @@ fn plan_cell(
     }
 }
 
-/// Parameter list for an argument cell, as `(name, type)` pairs.
-fn argument_parameters(plan: &CellPlan, arity: usize, index: usize) -> Vec<(String, Ty)> {
-    (0..arity)
+/// Parameter list for an argument cell, as `(name, type)` pairs: the shape in
+/// its own slot and the position's fillers everywhere else.
+fn argument_parameters(plan: &CellPlan, index: usize) -> Vec<(String, Ty)> {
+    (0..plan.position.arity())
         .map(|slot| {
             let ty = if slot == index {
                 plan.shape.ty
             } else {
-                Ty::Leaf(Leaf::I64)
+                Ty::Leaf(plan.position.filler_leaf(slot))
             };
             (format!("a{slot}"), ty)
         })
@@ -1269,7 +1368,6 @@ fn rue_return_builder(plan: &CellPlan, abi: &str) -> String {
 /// Generate the paired sources and expected output for one direction and one
 /// ABI spelling.
 pub fn generate(direction: Direction, abi: &str, spec: &CConventionSpec) -> Program {
-    let layout = positions_for(spec);
     let mut structs: Vec<&'static StructDef> = Vec::new();
     for shape in SHAPES {
         shape.ty.structs(&mut structs);
@@ -1278,12 +1376,11 @@ pub fn generate(direction: Direction, abi: &str, spec: &CConventionSpec) -> Prog
     let plans: Vec<CellPlan> = SHAPES
         .iter()
         .flat_map(|shape| {
-            layout
-                .positions
-                .iter()
-                .map(move |position| (shape, *position))
+            positions_for(spec, shape)
+                .into_iter()
+                .map(move |position| (shape, position))
         })
-        .map(|(shape, position)| plan_cell(shape, position, layout.arity, direction, abi))
+        .map(|(shape, position)| plan_cell(shape, position, direction, abi))
         .collect();
 
     let mut c_body = String::new();
@@ -1295,8 +1392,8 @@ pub fn generate(direction: Direction, abi: &str, spec: &CConventionSpec) -> Prog
         let leaves = plan.shape.ty.leaves();
         match (direction, plan.position) {
             // --- Rue calls C with the shape in one argument slot -------------
-            (Direction::Import, Position::Argument { index, .. }) => {
-                let parameters = argument_parameters(plan, layout.arity, index);
+            (Direction::Import, Position::Argument { index, arity, .. }) => {
+                let parameters = argument_parameters(plan, index);
                 let c_params: Vec<String> = parameters
                     .iter()
                     .map(|(name, ty)| format!("{} {name}", ty.c_type()))
@@ -1319,7 +1416,7 @@ pub fn generate(direction: Direction, abi: &str, spec: &CConventionSpec) -> Prog
                     } else {
                         c_body.push_str(&c_mix(
                             &format!("a{slot}"),
-                            Leaf::I64,
+                            plan.position.filler_leaf(slot),
                             *multiplier.next().expect("a multiplier per filler"),
                         ));
                     }
@@ -1338,7 +1435,7 @@ pub fn generate(direction: Direction, abi: &str, spec: &CConventionSpec) -> Prog
 
                 rue_body.push_str(&format!("fn call_{}() -> u64 {{\n", plan.name));
                 rue_body.push_str(&rue_argument_value(plan));
-                let arguments: Vec<String> = (0..layout.arity)
+                let arguments: Vec<String> = (0..arity)
                     .map(|slot| {
                         if slot == index {
                             "v".to_string()
@@ -1378,8 +1475,8 @@ pub fn generate(direction: Direction, abi: &str, spec: &CConventionSpec) -> Prog
             }
 
             // --- C calls a Rue export with the shape in one argument slot ----
-            (Direction::Export, Position::Argument { index, .. }) => {
-                let parameters = argument_parameters(plan, layout.arity, index);
+            (Direction::Export, Position::Argument { index, arity, .. }) => {
+                let parameters = argument_parameters(plan, index);
                 let rue_params: Vec<String> = parameters
                     .iter()
                     .map(|(name, ty)| format!("{name}: {}", ty.rue_type()))
@@ -1406,7 +1503,7 @@ pub fn generate(direction: Direction, abi: &str, spec: &CConventionSpec) -> Prog
                         rue_body.push_str(&rue_mix(
                             step,
                             &format!("a{slot}"),
-                            Leaf::I64,
+                            plan.position.filler_leaf(slot),
                             *multiplier.next().expect("a multiplier per filler"),
                         ));
                         step += 1;
@@ -1430,12 +1527,12 @@ pub fn generate(direction: Direction, abi: &str, spec: &CConventionSpec) -> Prog
                     &leaves,
                     &plan.shape_values,
                 ));
-                let arguments: Vec<String> = (0..layout.arity)
+                let arguments: Vec<String> = (0..arity)
                     .map(|slot| {
                         if slot == index {
                             "v".to_string()
                         } else {
-                            plan.fillers[slot].c_literal(Leaf::I64)
+                            plan.fillers[slot].c_literal(plan.position.filler_leaf(slot))
                         }
                     })
                     .collect();

--- a/crates/rue-c-abi-matrix/src/main.rs
+++ b/crates/rue-c-abi-matrix/src/main.rs
@@ -281,27 +281,197 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::grid::{
-        Direction, Leaf, PROBE_BYTES, Position, SHAPES, Ty, Value, generate, positions_for,
+        Bank, Direction, Leaf, PROBE_BYTES, Position, SHAPES, Shape, Ty, Value, generate,
+        positions_for,
     };
-    use rue_target::{CConventionSpec, CallingConvention, Target};
+    use rue_air::{
+        AggregateLeaves, ArgConvention, ArgLocation, CAbiLeaf, CAbiLeafKind, CAbiScalarKind,
+        CAbiTypeFacts, PointerLocation, lower_c_signature,
+    };
+    use rue_target::{CConventionSpec, CRegisterClass, CallingConvention, Target};
 
     fn spec() -> CConventionSpec {
         CallingConvention::X86_64SysV.c_spec()
     }
 
+    /// Every C row the grid is generated for. The host runs one of them; the
+    /// generator's own answers are checkable for all three from any host.
+    const ROWS: [CallingConvention; 3] = [
+        CallingConvention::X86_64SysV,
+        CallingConvention::Aarch64Aapcs,
+        CallingConvention::Aarch64AapcsDarwin,
+    ];
+
+    /// Every shape's argument positions under `spec`, as one flat list.
+    fn argument_positions(spec: &CConventionSpec) -> Vec<(&'static Shape, Position)> {
+        SHAPES
+            .iter()
+            .flat_map(|shape| {
+                positions_for(spec, shape)
+                    .into_iter()
+                    .map(move |position| (shape, position))
+            })
+            .filter(|(_, position)| matches!(position, Position::Argument { .. }))
+            .collect()
+    }
+
+    /// The width of one leaf in the C layout both generated sources declare.
+    fn leaf_bytes(leaf: Leaf) -> u64 {
+        match leaf {
+            Leaf::I8 | Leaf::U8 | Leaf::Bool => 1,
+            Leaf::I16 | Leaf::U16 => 2,
+            Leaf::I32 | Leaf::U32 | Leaf::F32 => 4,
+            Leaf::I64 | Leaf::U64 | Leaf::F64 | Leaf::Ptr => 8,
+        }
+    }
+
+    /// A shape's alignment: its leaf's own, or its widest field's.
+    fn align_of(ty: Ty) -> u64 {
+        match ty {
+            Ty::Leaf(leaf) | Ty::Array(leaf, _) => leaf_bytes(leaf),
+            Ty::Struct(def) => def
+                .fields
+                .iter()
+                .map(|field| align_of(field.ty))
+                .max()
+                .expect("every grid struct has at least one field"),
+        }
+    }
+
+    /// A shape's `sizeof`: fields at their own alignments in declaration order,
+    /// the whole padded to the shape's alignment.
+    fn size_of(ty: Ty) -> u64 {
+        match ty {
+            Ty::Leaf(leaf) => leaf_bytes(leaf),
+            Ty::Array(leaf, len) => leaf_bytes(leaf) * len as u64,
+            Ty::Struct(_) => {
+                let align = align_of(ty);
+                let mut end = 0;
+                collect_leaves(ty, 0, &mut end, &mut Vec::new());
+                end.div_ceil(align) * align
+            }
+        }
+    }
+
+    /// Append every scalar leaf of `ty` at its byte offset from `base`, leaving
+    /// the byte after the last one in `end`.
+    fn collect_leaves(ty: Ty, base: u64, end: &mut u64, out: &mut Vec<CAbiLeaf>) {
+        match ty {
+            Ty::Leaf(leaf) => {
+                let width = leaf_bytes(leaf);
+                out.push(CAbiLeaf {
+                    offset: base,
+                    width,
+                    kind: match leaf {
+                        Leaf::F32 => CAbiLeafKind::F32,
+                        Leaf::F64 => CAbiLeafKind::F64,
+                        _ => CAbiLeafKind::Integer,
+                    },
+                });
+                *end = base + width;
+            }
+            Ty::Array(leaf, len) => {
+                for index in 0..len as u64 {
+                    collect_leaves(Ty::Leaf(leaf), base + index * leaf_bytes(leaf), end, out);
+                }
+            }
+            Ty::Struct(def) => {
+                let mut offset = base;
+                for field in def.fields {
+                    let align = align_of(field.ty);
+                    offset = offset.div_ceil(align) * align;
+                    collect_leaves(field.ty, offset, end, out);
+                    offset = *end;
+                }
+                *end = offset;
+            }
+        }
+    }
+
+    /// The classifier's view of one shape or filler type.
+    fn facts(ty: Ty) -> CAbiTypeFacts {
+        if let Ty::Leaf(leaf) = ty {
+            let kind = match leaf {
+                Leaf::I8 => CAbiScalarKind::I8,
+                Leaf::I16 => CAbiScalarKind::I16,
+                Leaf::I32 => CAbiScalarKind::I32,
+                Leaf::U8 => CAbiScalarKind::U8,
+                Leaf::U16 => CAbiScalarKind::U16,
+                Leaf::U32 => CAbiScalarKind::U32,
+                Leaf::Bool => CAbiScalarKind::Bool,
+                Leaf::F32 => CAbiScalarKind::F32,
+                Leaf::F64 => CAbiScalarKind::F64,
+                Leaf::I64 | Leaf::U64 | Leaf::Ptr => CAbiScalarKind::RegisterWidth,
+            };
+            return CAbiTypeFacts::Scalar {
+                kind,
+                class: kind.register_class(),
+            };
+        }
+        let size = size_of(ty);
+        let mut leaves = Vec::new();
+        collect_leaves(ty, 0, &mut 0, &mut leaves);
+        CAbiTypeFacts::Aggregate {
+            size,
+            align: align_of(ty),
+            leaves: AggregateLeaves::from_leaves(size, leaves),
+        }
+    }
+
+    /// Where `shape` lands when a cell passes it at `position`, according to the
+    /// one classifier the compiler places by.
+    fn placement(
+        convention: CallingConvention,
+        shape: &Shape,
+        position: Position,
+    ) -> Option<ArgLocation> {
+        let Position::Argument { index, arity, .. } = position else {
+            return None;
+        };
+        let parameters: Vec<(CAbiTypeFacts, ArgConvention)> = (0..arity)
+            .map(|slot| {
+                let ty = if slot == index {
+                    shape.ty
+                } else {
+                    Ty::Leaf(position.filler_leaf(slot))
+                };
+                (facts(ty), ArgConvention::ByValue)
+            })
+            .collect();
+        // Every argument cell answers the `u64` checksum, so no row's hidden
+        // indirect-result pointer shifts the argument registers.
+        let lowered = lower_c_signature(convention, &parameters, facts(Ty::Leaf(Leaf::U64)));
+        Some(lowered.arguments()[index].location)
+    }
+
+    /// Whether a placement reaches the callee without the outgoing argument
+    /// area: in registers, or as a by-reference copy whose pointer is in one.
+    fn in_registers(location: ArgLocation) -> bool {
+        match location {
+            ArgLocation::Registers { .. } => true,
+            ArgLocation::Indirect { pointer, .. } => {
+                matches!(pointer, PointerLocation::Register { .. })
+            }
+            ArgLocation::Stack { .. } | ArgLocation::Omitted => false,
+        }
+    }
+
     #[test]
     fn every_shape_reaches_every_position_in_both_directions() {
-        let layout = positions_for(&spec());
+        let cells: usize = SHAPES
+            .iter()
+            .map(|shape| positions_for(&spec(), shape).len())
+            .sum();
         for direction in [Direction::Import, Direction::Export] {
             let program = generate(direction, "C", &spec());
             assert_eq!(
                 program.cells.len(),
-                SHAPES.len() * layout.positions.len(),
-                "the grid must be the full shape x position product"
+                cells,
+                "the grid must be every shape's whole position set"
             );
             assert_eq!(program.cells.len(), program.expected.len());
             for shape in SHAPES {
-                for position in &layout.positions {
+                for position in positions_for(&spec(), shape) {
                     assert!(
                         program
                             .cells
@@ -317,26 +487,140 @@ mod tests {
     }
 
     #[test]
-    fn positions_come_from_the_conventions_register_budget() {
-        for convention in [
-            CallingConvention::X86_64SysV,
-            CallingConvention::Aarch64Aapcs,
-            CallingConvention::Aarch64AapcsDarwin,
-        ] {
-            let registers = convention.c_spec().gp_argument_registers as usize;
-            let layout = positions_for(&convention.c_spec());
-            let indices: Vec<usize> = layout
-                .positions
-                .iter()
-                .filter_map(|position| match position {
-                    Position::Argument { index, .. } => Some(*index),
-                    Position::Return => None,
-                })
-                .collect();
-            assert_eq!(indices, vec![0, registers - 1, registers, registers + 3]);
-            assert!(
-                layout.arity > registers,
-                "every cell must also stack arguments"
+    fn positions_come_from_both_register_rosters() {
+        for convention in ROWS {
+            let spec = convention.c_spec();
+            let gp = spec.gp_argument_registers as usize;
+            let fp = spec.fp_argument_registers as usize;
+            for shape in SHAPES {
+                let float_leaved = shape
+                    .ty
+                    .leaves()
+                    .iter()
+                    .any(|(_, leaf)| matches!(leaf, Leaf::F32 | Leaf::F64));
+                let places: Vec<(&'static str, Bank, usize, usize)> = positions_for(&spec, shape)
+                    .into_iter()
+                    .filter_map(|position| match position {
+                        Position::Argument {
+                            key,
+                            bank,
+                            index,
+                            arity,
+                        } => Some((key, bank, index, arity)),
+                        Position::Return => None,
+                    })
+                    .collect();
+                let mut expected = vec![
+                    ("arg0", Bank::Gp, 0, gp + 5),
+                    ("gp_last_reg", Bank::Gp, gp - 1, gp + 5),
+                    ("gp_first_stack", Bank::Gp, gp, gp + 5),
+                    ("gp_deep_stack", Bank::Gp, gp + 3, gp + 5),
+                ];
+                if float_leaved {
+                    expected.push(("fp_last_reg", Bank::Fp, fp - 1, fp + 5));
+                }
+                expected.push(("fp_first_stack", Bank::Fp, fp, fp + 5));
+                if float_leaved {
+                    expected.push(("fp_deep_stack", Bank::Fp, fp + 3, fp + 5));
+                }
+                assert_eq!(places, expected, "positions for {}", shape.key);
+            }
+        }
+    }
+
+    #[test]
+    fn a_filler_run_spends_its_own_roster_and_ends_in_the_other() {
+        for convention in ROWS {
+            let spec = convention.c_spec();
+            for (shape, position) in argument_positions(&spec) {
+                let Position::Argument {
+                    key, bank, arity, ..
+                } = position
+                else {
+                    unreachable!("argument_positions keeps only argument positions");
+                };
+                let own = match bank {
+                    Bank::Gp => CRegisterClass::Gp,
+                    Bank::Fp => CRegisterClass::Fp,
+                };
+                let class = |slot: usize| match position.filler_leaf(slot) {
+                    Leaf::F32 | Leaf::F64 => CRegisterClass::Fp,
+                    _ => CRegisterClass::Gp,
+                };
+                assert!(
+                    (0..arity - 1).all(|slot| class(slot) == own),
+                    "{}/{key}: every filler before the last must be the position's own bank",
+                    shape.key
+                );
+                assert_ne!(
+                    class(arity - 1),
+                    own,
+                    "{}/{key}: the last filler must be the other bank's",
+                    shape.key
+                );
+                // The run reaches three registers past its roster, and the list
+                // adds the shape's own slot and the cross-bank filler on top, so
+                // every cell stacks arguments whatever the shape's placement is.
+                assert_eq!(
+                    arity,
+                    spec.argument_registers(own) as usize + 5,
+                    "{}/{key}: the run must overflow its roster",
+                    shape.key
+                );
+            }
+        }
+    }
+
+    /// The coverage property the position set exists for: every shape is
+    /// stacked somewhere, and every shape that can travel in registers at all
+    /// does so somewhere. Both answers come from `lower_c_signature`, the one
+    /// classifier the compiler places by, rather than from reading the table.
+    #[test]
+    fn every_shape_is_stacked_and_registered_where_the_classifier_allows() {
+        for convention in ROWS {
+            let spec = convention.c_spec();
+            let mut cells = 0usize;
+            for shape in SHAPES {
+                let positions = positions_for(&spec, shape);
+                cells += positions.len();
+                let placements: Vec<(Position, ArgLocation)> = positions
+                    .iter()
+                    .filter_map(|position| {
+                        placement(convention, shape, *position)
+                            .map(|location| (*position, location))
+                    })
+                    .collect();
+                assert!(
+                    placements
+                        .iter()
+                        .any(|(_, location)| !in_registers(*location)),
+                    "{}: no position of the {} row puts it on the stack",
+                    shape.key,
+                    convention.name()
+                );
+                // A shape travels in registers somewhere exactly when it does at
+                // the one position where neither roster is spent; anything else
+                // is a shape the row always passes through memory.
+                let ever_registers = placements
+                    .iter()
+                    .any(|(_, location)| in_registers(*location));
+                let registers_with_empty_rosters = placements
+                    .iter()
+                    .find(|(position, _)| position.key() == "arg0")
+                    .map(|(_, location)| in_registers(*location))
+                    .expect("every shape has the arg0 position");
+                assert_eq!(
+                    ever_registers,
+                    registers_with_empty_rosters,
+                    "{}: the {} row's register placement must be reachable from the position set",
+                    shape.key,
+                    convention.name()
+                );
+            }
+            println!(
+                "{}: {cells} cells per generated program over {} shapes",
+                convention.name(),
+                SHAPES.len()
             );
         }
     }

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -466,7 +466,8 @@ the Rue side with the real driver, links the two with `--linker cc
 --link-archive`, runs the executable, and compares its stdout with checksums the
 generator computed from the same table it emitted both sources from.
 
-The grid is shape x position x direction x ABI spelling:
+The grid is every shape's own position set, crossed with direction and ABI
+spelling:
 
 - **Shapes** (31): `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `bool`,
   `f32`, `f64`, `ptr const u8`, and twenty `@repr(c)` structs chosen for the
@@ -482,11 +483,35 @@ The grid is shape x position x direction x ABI spelling:
   A float leaf carries a whole number, exactly representable in binary32 and
   binary64 alike, so the odd-multiplier checksum stays exact integer
   arithmetic.
-- **Positions** (5): argument 0, the convention's last argument register, the
-  first stack slot, a deep stack slot, and the result type. The indices come
-  from `CConventionSpec::gp_argument_registers`, so a convention with a
-  different register budget moves them without a source edit. Every other
-  argument is an `i64` filler, and every cell also stacks arguments.
+- **Positions** (6 or 8, per shape): argument 0, the last register, the first
+  stack slot and a deeper stack slot of the *general-purpose* roster; the
+  *floating-point* roster's first stack slot; its last register and a deeper
+  stack slot too when the shape has a float leaf; and the result type. Indices
+  come from `CConventionSpec::gp_argument_registers` and
+  `fp_argument_registers`, so a convention with a different register budget
+  moves them without a source edit.
+
+  An argument cell's other slots are fillers of one bank — integers for a
+  general-purpose position, alternating `f64` and `f32` for a floating-point
+  one — long enough to run three registers past that roster, so every cell also
+  stacks arguments. The last slot is always a filler of the *other* bank. That
+  is what makes a stacked float a cell at all: a float scalar, a homogeneous
+  floating-point aggregate, and a split-bank composite only reach the outgoing
+  argument area once the floating-point roster is spent, which an integer
+  filler run never does. It is also what pins the two rosters' independence in
+  both directions — a float scalar is still in a floating-point register when
+  the integer roster is exhausted, an integer argument still in a
+  general-purpose register when the floating-point one is, and SysV's rule that
+  an aggregate forced to memory leaves the other bank's registers to the
+  arguments after it. Fillers are checksummed exactly like the shape's own
+  leaves, so a misplaced filler fails a cell rather than passing silently.
+
+  `//crates/rue-c-abi-matrix:rue-c-abi-matrix-test` holds the coverage property
+  structurally: for every shape and every one of the three rows it asks
+  `lower_c_signature` — the classifier the compiler itself places by — where the
+  shape lands at each generated position, and asserts that some position stacks
+  it and that some position keeps it in registers whenever the row places it in
+  registers at all.
 - **Directions** (2): import (Rue calls generated C) and export (a generated C
   driver calls a `pub extern` Rue function).
 - **ABI spellings** (2): `"C"` and the host row's own name, so the alias and the
@@ -502,13 +527,13 @@ also round-trip a seed: the callee answers a deliberately different value when
 the seed did not arrive intact, so a broken argument crossing cannot hide behind
 a correct result.
 
-That is 400 cells in four generated programs — one per direction and spelling —
-which compile, link, and run in about five seconds. The generated C is
-freestanding on every row: no headers, no libc, fixed-width typedefs spelled
-from the target's data model with `_Static_assert`s holding them, and no
-platform conditionals. Linking goes through `cc` because the objects `cc`
-produces carry relocation and section kinds the internal linker's static subset
-does not promise to handle.
+That is 208 cells per program and 832 across the four generated programs — one
+per direction and spelling — which compile, link, and run in about thirteen
+seconds. The generated C is freestanding on every row: no headers, no libc,
+fixed-width typedefs spelled from the target's data model with
+`_Static_assert`s holding them, and no platform conditionals. Linking goes
+through `cc` because the objects `cc` produces carry relocation and section
+kinds the internal linker's static subset does not promise to handle.
 
 The target is host-only by construction and carries the `rue_platform_native`
 label, so the native lanes run it: SysV AMD64 on linux-x64, AAPCS64 on
@@ -517,13 +542,17 @@ linux-arm64, and the Apple arm64 row on macos-arm64. A host with no `cc` and
 `./buck2 test //crates/rue-c-abi-matrix:c-abi-matrix-test`; `scripts/rue
 premerge` includes it, and `scripts/rue quick` deliberately does not.
 
-One gap the grid does *not* close is the open Apple amendment above. Every
-filler is an `i64`, so a stacked composite is followed by an 8-byte-aligned
-argument that re-aligns the outgoing area, and the difference between Apple's
-natural-size footprint and the whole-eightbyte one Rue emits is absorbed rather
-than observed. Distinguishing them needs a filler narrower than a slot next to a
-stacked composite, which is worth adding with the byte-granular marshaling that
-would make it pass.
+The alternating float run puts a four-byte argument next to a stacked one, so
+Apple's natural-size footprint for a stacked `f32` and the eight-byte slot the
+other two rows give it are different offsets for the arguments that follow, and
+the Apple lane executes the difference. The open Apple amendment above is the
+half that remains: a stacked *composite* claims whole eightbytes on every row
+here, and every general-purpose filler is an `i64`, so a stacked composite is
+still followed by an 8-byte-aligned argument that absorbs the difference between
+Apple's natural-size footprint and the whole-eightbyte image Rue emits.
+Observing that one needs a filler narrower than a slot beside a stacked
+composite, which is worth adding with the byte-granular marshaling that would
+make it pass.
 
 Backend tests additionally enforce that the typed runtime manifest stays within
 each backend's implemented register-only subset and that its boundary resolves


### PR DESCRIPTION
Follow-up to [#3002](https://github.com/rue-language/rue/pull/3002) (RUE-1059): the generated C-boundary conformance matrix now places every shape past the floating-point argument roster as well as the general-purpose one, so stacked float scalars, stacked HFAs and stacked split-bank aggregates are cells.

## The position model

`positions_for(spec, shape)` replaces the roster-agnostic `positions_for(spec)`. Each `Position::Argument` carries `{ key, bank, index, arity }` with a new `Bank { Gp, Fp }`. An argument cell's parameter list is a run of fillers of one bank, three registers longer than that bank's roster, with the shape at a chosen slot inside it and one filler of the other bank last:

- filler per slot: `Gp` run is `i64` with a trailing `f64`; `Fp` run alternates `f64`/`f32` with a trailing `i64`;
- every shape gets `arg0`, `gp_last_reg`, `gp_first_stack`, `gp_deep_stack`, `fp_first_stack` and `return`; a shape with a float leaf also gets `fp_last_reg` and `fp_deep_stack`.

The alternating float run makes Apple's natural-size packing observable (a stacked `f32` shape is followed by a stacked `f32` filler, so the Apple row's four-byte footprint and the eight-byte slot of AAPCS64 and SysV put every later argument at different offsets). The trailing cross-bank filler pins SysV's rule that an aggregate forced to memory still leaves the other bank's registers to later arguments. Every filler is checksummed like a shape leaf.

Cells the classifier confirms now exist include: `f32` at `fp_first_stack` as a 4-byte slot on Apple arm64 and an 8-byte slot on AAPCS64 and SysV; `{f64,f64}` and `{f32;4}` at `fp_last_reg` stacked whole on AAPCS64 (C.3, FP roster exhausted); `{i64,f64}` to memory on SysV when either bank is spent but in integer registers on AAPCS64 with the FP roster spent; `{f64,f64,f64}` still in FP registers with the GP roster exhausted.

## Cell counts

| row | before | after |
|---|---|---|
| x86-64-sysv | 155 | 208 |
| aarch64-aapcs | 155 | 208 |
| aarch64-aapcs-darwin | 155 | 208 |

Four programs on the host: 620 → 832 cells, all passing against the host `cc` on x86-64 Linux.

## Coverage test

`every_shape_is_stacked_and_registered_where_the_classifier_allows` asks `lower_c_signature` where each shape lands at each generated position on all three rows and asserts that some position stacks it and that it reaches registers from the position set exactly when it does so with both rosters empty (so an always-memory shape is not falsely required to). Two further tests pin the model itself. `rue-air` is a test-only dependency of the matrix crate for this.

## Compiler

No compiler change was needed: the widened matrix found no mismatching cell, so the stacked-float path landed in #3002 already handles these placements. The AArch64 rows are compiled here and executed on the native CI hosts.

## Docs

`grid.rs` gains a Positions module-doc section; `docs/notes/ffi-abi-conformance-audit.md` records the position model, the cell counts and the runtime, and narrows the open Apple-amendment gap to stacked composites only.

Closes RUE-2077

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_