### PR TITLE
The `?` failure arm hands its error payload to the constructor

### DIFF
--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -2230,7 +2230,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             span,
         });
 
-        // Failure arm: build the early `return`.
+        // Failure arm: build the early `return`. Only a genuine side effect
+        // belongs in the block's statement list: a block statement's own result
+        // is a temporary the block drops at the end of the statement (RUE-65,
+        // RUE-66), so naming a value there that the return expression still
+        // consumes would drop it and then hand the dropped value to the
+        // constructor (RUE-2051).
         let (fail_stmt, fail_ret_value) = match fail_err_ty {
             None => {
                 // Option `None`: drop the scrutinee (nullary variant, no-op glue)
@@ -2242,7 +2247,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 });
                 let none_ctor =
                     air.add_enum_variant(ret_enum_id, ret_fail_idx, &[], return_type, span)?;
-                (drop_scrutinee, none_ctor)
+                (Some(drop_scrutinee), none_ctor)
             }
             Some(err_ty) => {
                 // Result `Err(e)`: move the error payload out of the scrutinee
@@ -2259,7 +2264,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 });
                 let err_ctor =
                     air.add_enum_variant(ret_enum_id, ret_fail_idx, &[err_val], return_type, span)?;
-                (err_val, err_ctor)
+                // `err_val` is the constructor's operand, not a statement: the
+                // `Err` it builds owns the payload and carries it out of the
+                // function.
+                (None, err_ctor)
             }
         };
         let ret = air.add_inst(AirInst {
@@ -2267,7 +2275,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: Type::NEVER,
             span,
         });
-        let fail_body = air.add_block(&[fail_stmt], ret, Type::NEVER, span)?;
+        let fail_body = air.add_block(fail_stmt.as_slice(), ret, Type::NEVER, span)?;
 
         // Encode the two arms and emit the dispatching match. Its value type is
         // the success payload (the failure arm diverges).

--- a/crates/rue-cli-tests/cases/try_operator.toml
+++ b/crates/rue-cli-tests/cases/try_operator.toml
@@ -1,10 +1,11 @@
-# `?` accepts only exact specializations of the trusted std Option
-# (std.option.Option). User-defined Some/None lookalikes are ordinary enums with
-# no `?` behavior. This is exercised by pure `?` on std Option (no intrinsics).
+# `?` accepts only exact specializations of the trusted std producers
+# (std.option.Option, std.result.Result). User-defined Some/None lookalikes are
+# ordinary enums with no `?` behavior. This is exercised by pure `?` on those
+# two std types (no intrinsics).
 [section]
 id = "cli.try_operator"
-name = "The `?` (try) operator on Option"
-description = "End-to-end runtime behavior of `?`: unwrap Some, short-circuit None, propagate a StrBuf payload, and the two static errors (E0503/E0504). RUE-6, ADR-0038."
+name = "The `?` (try) operator"
+description = "End-to-end runtime behavior of `?`: unwrap Some, short-circuit None, propagate a StrBuf payload, propagate a droppable Result error exactly once, and the two static errors (E0503/E0504). RUE-6, ADR-0038."
 
 # The `?` operator unwraps Some and short-circuits None, driven from real stdin
 # through the compiled binary. `pick` returns Some for a positive count and None
@@ -127,3 +128,102 @@ fn main() -> i32 { f(); 0 }
 args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0504", "applied to an `Option`"]
+
+# `?` on a `Result` whose error type has drop glue, in an ordinary function
+# (RUE-2051). The failure arm moves the error payload out of the operand and
+# into the `Err` of the enclosing function's return type; that constructor owns
+# it from there. The payload used to be named as a statement of the failure
+# arm's block as well, so an error type with drop glue was dropped at the `?`
+# site and then handed to the constructor already dropped, which the CFG
+# verifier rejected.
+[[case]]
+name = "try_result_droppable_error_payload"
+description = "`?` on Result(i64, StrBuf) in an ordinary function: the Ok path yields 3, the Err path carries the StrBuf out."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+  { path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const R = std.result.Result(i64, StrBuf);
+
+fn parse(n: i64) -> R {
+    if n < 0 { R.Err("negative") } else { R.Ok(n) }
+}
+
+fn compute(a: i64, b: i64) -> R {
+    let x = parse(a)?;
+    R.Ok(x + b)
+}
+
+fn report(a: i64) {
+    match compute(a, 2) {
+        R.Ok(v) => println("ok " + @to_string(v)),
+        R.Err(e) => println("err " + e),
+    }
+}
+
+fn main() -> i32 {
+    report(0 - 1);
+    match compute(1, 2) {
+        R.Ok(v) => @intCast(v),
+        R.Err(_) => 1,
+    }
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+stdout = """
+err negative
+"""
+exit_code = 3
+
+# The propagated error payload is dropped exactly once. `Failure`'s destructor
+# prints its code, so the drop count and its position in the output are both
+# pinned: the Ok run prints nothing, and the Err run prints exactly one `5`,
+# when the caller's binding for the propagated payload leaves scope.
+[[case]]
+name = "try_result_error_payload_drops_once"
+description = "A `?`-propagated error payload with a destructor runs it exactly once, at its final owner."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+  { path = "main.rue", source = """
+const std = @import("std");
+
+struct Failure { code: i32 }
+
+drop fn Failure(self) {
+    @dbg(self.code);
+}
+
+const R = std.result.Result(i64, Failure);
+
+fn parse(n: i64) -> R {
+    if n < 0 { R.Err(Failure { code: 5 }) } else { R.Ok(n) }
+}
+
+fn compute(a: i64, b: i64) -> R {
+    let x = parse(a)?;
+    R.Ok(x + b)
+}
+
+fn run(a: i64) -> i32 {
+    match compute(a, 2) {
+        R.Ok(v) => @intCast(v),
+        R.Err(_e) => 0 - 1,
+    }
+}
+
+fn main() -> i32 {
+    @dbg(run(1));
+    @dbg(run(0 - 1));
+    0
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+stdout = """
+3
+5
+-1
+"""
+exit_code = 0

--- a/crates/rue-spec/cases/expressions/try.toml
+++ b/crates/rue-spec/cases/expressions/try.toml
@@ -433,3 +433,110 @@ fn main() -> i32 {
 """
 real_std = true
 exit_code = 42
+
+# =============================================================================
+# `?` on a `Result` whose error type owns a destructor, in an ORDINARY function
+# (not a test body). The failure arm moves the error payload out of the operand
+# and hands it to the `Err` of the enclosing function's own return type
+# (4.15:4); that constructor is the payload's new owner, so the payload is
+# neither dropped at the `?` site nor dropped twice (3.9:2). Before RUE-2051 the
+# error payload was named as a statement of the failure arm's block as well as
+# an operand of that constructor, so a payload with drop glue was dropped at the
+# `?` site and then handed to the constructor already dropped.
+# =============================================================================
+
+[[case]]
+# The success path of a `Result(i64, StrBuf)` `?`: the droppable error type
+# plays no part, and `?` evaluates to the `Ok` payload.
+name = "try_result_ok_path_with_droppable_error_type"
+spec = ["4.15:1", "4.15:3", "4.15:4", "4.15:5"]
+description = "`?` on `Result(i64, StrBuf)` in an ordinary function unwraps `Ok` and continues; the droppable error type is untouched."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const R = std.result.Result(i64, StrBuf);
+fn parse(n: i64) -> R {
+    if n < 0 { R.Err("negative") } else { R.Ok(n) }
+}
+fn compute(a: i64, b: i64) -> R {
+    let x = parse(a)?;
+    R.Ok(x + b)
+}
+fn main() -> i32 {
+    match compute(1, 2) {
+        R.Ok(v) => @intCast(v),
+        R.Err(_) => 1,
+    }
+}
+"""
+real_std = true
+exit_code = 3
+
+[[case]]
+# The failure path of the same `?`: the `StrBuf` error payload moves out of the
+# operand and into the enclosing function's `Err`, which carries it to the
+# caller intact.
+name = "try_result_err_path_propagates_droppable_payload"
+spec = ["4.15:3", "4.15:4"]
+description = "The `?` failure arm moves a `StrBuf` error payload into the enclosing function's `Err` and early-returns it to the caller."
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const R = std.result.Result(i64, StrBuf);
+fn parse(n: i64) -> R {
+    if n < 0 { R.Err("negative") } else { R.Ok(n) }
+}
+fn compute(a: i64, b: i64) -> R {
+    let x = parse(a)?;
+    R.Ok(x + b)
+}
+fn main() -> i32 {
+    match compute(0 - 1, 2) {
+        R.Ok(v) => @intCast(v),
+        R.Err(e) => {
+            println(e);
+            9
+        },
+    }
+}
+"""
+real_std = true
+expected_stdout = "negative\n"
+exit_code = 9
+
+[[case]]
+# An error type with a destructor counts the drops. The propagated payload is
+# dropped exactly once, where the caller's binding for it goes out of scope; the
+# success path constructs no error and drops nothing.
+name = "try_result_err_payload_drops_exactly_once"
+spec = ["4.15:4", "3.9:2"]
+description = "A `?`-propagated error payload whose type has a destructor is dropped exactly once, at its final owner."
+source = """
+const std = @import("std");
+struct Failure { code: i32 }
+drop fn Failure(self) {
+    @dbg(self.code);
+}
+const R = std.result.Result(i64, Failure);
+fn parse(n: i64) -> R {
+    if n < 0 { R.Err(Failure { code: 5 }) } else { R.Ok(n) }
+}
+fn compute(a: i64, b: i64) -> R {
+    let x = parse(a)?;
+    R.Ok(x + b)
+}
+fn run(a: i64) -> i32 {
+    match compute(a, 2) {
+        R.Ok(v) => @intCast(v),
+        R.Err(_e) => 0 - 1,
+    }
+}
+fn main() -> i32 {
+    @dbg(run(1));
+    @dbg(run(0 - 1));
+    0
+}
+"""
+real_std = true
+expected_stdout = "3\n5\n-1\n"
+exit_code = 0

--- a/docs/process/tutorial.md
+++ b/docs/process/tutorial.md
@@ -129,8 +129,6 @@ when the limitation is lifted and update the chapter that mentions it.
 - A qualified enum path cannot appear inside another variant's payload
   pattern (`R.Err(E.A(x))` does not parse, RUE-2053); the examples use a
   nested `match`.
-- `?` inside a function returning `Result(T, StrBuf)` hits an internal
-  compiler error (RUE-2051); the examples use enum error types.
 - An immutable `let` binding is accepted as an `inout` argument to a free
   function (RUE-2054); the ownership chapter says the caller "declares" the
   binding `let mut` rather than "must" until that is enforced.


### PR DESCRIPTION
A single `?` in an ordinary function returning `Result(T, E)` where `E` has drop glue (for example `StrBuf`) crashed the compiler with E9000 `enum payload ... was already dropped on a reaching path` (RUE-2051).

## Root cause

`build_try_desugar` in `crates/rue-air/src/sema/control_flow.rs` builds the `?` failure arm as an AIR block. For the `Option` form the block's single statement is a genuine side effect, the scrutinee's `Drop`. For the `Result` form the code symmetrically put `err_val`, the `EnumPayloadGet` that moves the `Err` payload out of the scrutinee, in the statement list, while the block's value expression `Ret(Err(err_val))` also consumes it. CFG lowering treats a statement's own result as a temporary the statement owns and emits a `Drop` for it when its type needs drop glue, so a droppable payload was dropped at the `?` site and then handed to the `Err` constructor already dropped. Error types without drop glue never emitted that drop, and test bodies use a different desugar, which is why those shapes kept working.

## What changes

- The failure arm's statement is now optional: the scrutinee `Drop` for the `Option` form, nothing for the `Result` form, whose `err_val` reaches lowering solely as the `Err` constructor's operand. No codegen change.
- Spec cases in `crates/rue-spec/cases/expressions/try.toml`: the `Ok` path with a droppable error type, the `Err` path propagating a droppable payload, and a destructor-counting error type asserting exactly one drop, citing 4.15:1, 4.15:3, 4.15:4, 4.15:5 and 3.9:2.
- CLI cases in `crates/rue-cli-tests/cases/try_operator.toml`: the reported program (exit 3) and the destructor-counting program pinning one drop.
- `docs/process/tutorial.md`: the RUE-2051 entry is removed from the tutorial's known-limitations list.

## Validation

`scripts/rue premerge` passes locally apart from the two sandbox-environmental CLI cases (`remove_dir_all_permission_denied_is_not_partial_success`, `tcp_ipv6_loopback_round_trip`); oracle-diff and spec-traceability pass.

Closes RUE-2051

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_