### PR TITLE
Require a mutable binding for an inout argument

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -6574,6 +6574,43 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         false
     }
 
+    /// Reject an `inout` argument whose place is rooted at an immutable local
+    /// binding (spec 6.1:43, RUE-2054).
+    ///
+    /// An `inout` argument is a write to the caller's place, so it carries the
+    /// same mut-binding requirement an assignment to that place carries, and
+    /// reports the same diagnostic (E0203, 5.2:3). `let`, `for`, and `match`
+    /// bindings all reach this through `ctx.locals`, and locals shadow
+    /// parameters (RUE-278), so a `let mut` rebinding a parameter name is the
+    /// binding that later uses see.
+    ///
+    /// Roots that are not locals are governed elsewhere and are deliberately
+    /// left alone here: a name that binds nothing is a non-lvalue (E0425), a
+    /// `borrow` parameter is E0428 (6.1:24, checked just above this), and a
+    /// by-value parameter names the callee's own copy, which 6.1:18 and the
+    /// RUE-2042 parameter-slot contract let the callee pass `inout`.
+    fn reject_immutable_inout_arg_root(
+        &self,
+        root: Spur,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<()> {
+        let Some(local) = ctx.locals.get(&root) else {
+            return Ok(());
+        };
+        if local.is_mut {
+            return Ok(());
+        }
+        let name = self.body_interner().resolve(&root).to_string();
+        let help = format!(
+            "an `inout` argument writes to the caller's place; make the binding mutable: \
+             `let mut {name} = ...`"
+        );
+        Err(CompileError::new(ErrorKind::AssignToImmutable(name), span)
+            .with_label("variable declared as immutable here", local.span)
+            .with_help(help))
+    }
+
     /// Reject a mutation of a collection that an enclosing `for` loop is
     /// iterating (spec 4.8:26, RUE-233). A `for` over a named variable holds a
     /// scoped shared borrow of it for the loop's duration, so mutating that
@@ -7562,6 +7599,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         },
                         self.body_rir_ref().get(arg.value).span,
                     ));
+                }
+                // An `inout` argument writes to the caller's place, so its
+                // root must be a mutable binding — the same requirement an
+                // assignment to that place and an `inout self` receiver carry
+                // (spec 6.1:43, RUE-2054).
+                if arg.is_inout() {
+                    self.reject_immutable_inout_arg_root(
+                        root,
+                        self.body_rir_ref().get(arg.value).span,
+                        ctx,
+                    )?;
                 }
                 Some(root)
             } else {

--- a/crates/rue-cli-tests/cases/constprop.toml
+++ b/crates/rue-cli-tests/cases/constprop.toml
@@ -134,7 +134,7 @@ fn bump(inout v: i32) {
     v = v + 1;
 }
 fn main() -> i32 {
-    let a: i32 = 41;
+    let mut a: i32 = 41;
     bump(inout a);
     a
 }

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -573,6 +573,75 @@ exit_code = 0
 # =============================================================================
 
 [[case]]
+name = "inout_arg_requires_mut_binding"
+spec = ["6.1:43"]
+description = "An inout argument writes to the caller's place, so an immutable `let` binding is rejected"
+source = """
+fn bump(inout x: i32) {
+    x = x + 1;
+}
+fn main() -> i32 {
+    let v = 1;
+    bump(inout v);
+    v
+}
+"""
+compile_fail = true
+error_contains = "E0203"
+
+[[case]]
+name = "inout_arg_mut_binding_accepted"
+spec = ["6.1:43"]
+description = "A `let mut` binding satisfies the inout argument's mutability requirement"
+source = """
+fn bump(inout x: i32) {
+    x = x + 1;
+}
+fn main() -> i32 {
+    let mut v = 41;
+    bump(inout v);
+    v
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_arg_field_of_immutable_binding_rejected"
+spec = ["6.1:43"]
+description = "A projection is mutable only when its root binding is, so a field of a `let` binding is rejected"
+source = """
+struct S { a: i32 }
+fn bump(inout x: i32) {
+    x = x + 1;
+}
+fn main() -> i32 {
+    let s = S { a: 1 };
+    bump(inout s.a);
+    s.a
+}
+"""
+compile_fail = true
+error_contains = "E0203"
+
+[[case]]
+name = "inout_self_receiver_shares_mut_binding_rule"
+spec = ["6.1:43", "6.4:26"]
+description = "An `inout self` receiver carries the same requirement and reports the same diagnostic"
+source = """
+struct C {
+    v: i32,
+    fn bump(inout self) { self.v = self.v + 1; }
+}
+fn main() -> i32 {
+    let c = C { v: 1 };
+    c.bump();
+    c.v
+}
+"""
+compile_fail = true
+error_contains = "E0203"
+
+[[case]]
 name = "inout_requires_lvalue"
 spec = ["6.1:17"]
 description = "Inout argument must be an lvalue (not a literal)"

--- a/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
@@ -73,3 +73,59 @@ error_contains = [
     "[E0427]",
     "borrow argument must be a variable, field, or array element",
 ]
+
+[[case]]
+name = "inout_argument_requires_a_mutable_binding"
+description = "An `inout` argument writes to the caller's place, so an immutable `let` binding is rejected with the same E0203 an assignment to it would give, plus an inout-specific help (RUE-2054, spec 6.1:43)."
+source = """
+fn bump(inout x: i32) { x = x + 1; }
+
+fn main() -> i32 {
+    let v = 1;
+    bump(inout v);
+    v
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0203]",
+    "cannot assign to immutable variable 'v'",
+    "variable declared as immutable here",
+    "an `inout` argument writes to the caller's place; make the binding mutable: `let mut v = ...`",
+]
+
+[[case]]
+name = "inout_argument_of_a_for_pattern_binding_is_rejected"
+description = "A `for` pattern binding is immutable like a `let`, so it is rejected on the same rule (RUE-2054, spec 6.1:43)."
+source = """
+fn bump(inout x: i32) { x = x + 1; }
+
+fn main() -> i32 {
+    let a = [1, 2, 3];
+    for x in a {
+        bump(inout x);
+    }
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0203]",
+    "cannot assign to immutable variable 'x'",
+    "an `inout` argument writes to the caller's place; make the binding mutable: `let mut x = ...`",
+]
+
+[[case]]
+name = "inout_argument_of_a_by_value_parameter_is_accepted"
+description = "A by-value parameter names the callee's own copy of the argument, which it may pass `inout`; the post-call read observes the write (spec 6.1:18, RUE-2042)."
+source = """
+fn bump(inout x: i32) { x = x + 1; }
+
+fn takes(n: i32) -> i32 {
+    bump(inout n);
+    n
+}
+
+fn main() -> i32 { takes(41) }
+"""
+exit_code = 42

--- a/docs/process/tutorial.md
+++ b/docs/process/tutorial.md
@@ -129,7 +129,4 @@ when the limitation is lifted and update the chapter that mentions it.
 - A qualified enum path cannot appear inside another variant's payload
   pattern (`R.Err(E.A(x))` does not parse, RUE-2053); the examples use a
   nested `match`.
-- An immutable `let` binding is accepted as an `inout` argument to a free
-  function (RUE-2054); the ownership chapter says the caller "declares" the
-  binding `let mut` rather than "must" until that is enforced.
 - `for` does not iterate `ArrayBuf`; the examples index over `len()`.

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -69,6 +69,17 @@ At the call site, an argument passed to an `inout` parameter **MUST** be marked 
 
 An argument to an `inout` parameter **MUST** be an lvalue (a variable, field access, or array index expression).
 
+{{ rule(id="6.1:43", cat="legality-rule") }}
+
+An `inout` argument writes to the caller's place, so that place **MUST** be
+mutable. A place rooted at a local binding **MUST** be rooted at a `let mut`
+binding; a projection of one (`s.field`, `a[i]`) is mutable exactly when its
+root binding is. An immutable local binding — a `let` binding, or a `for` or
+`match` pattern binding — is rejected with the diagnostic an assignment to that
+place would produce (E0203, 5.2:3). A place rooted at an `inout` parameter is
+mutable (6.1:14); one rooted at a `borrow` parameter is rejected under 6.1:24.
+The requirement is the same one an `inout self` receiver carries (6.4:26).
+
 {{ rule(id="6.1:18", cat="dynamic-semantics") }}
 
 When a function is called with an `inout` argument:

--- a/website/content/tutorial/08-ownership.md
+++ b/website/content/tutorial/08-ownership.md
@@ -197,8 +197,9 @@ error: [E0432]: argument to borrow parameter must use 'borrow' keyword
 ## `inout`: lend for writing
 
 An `inout` parameter gives the function write access to the caller's value.
-The caller declares the binding `let mut`, and again the keyword appears on
-both sides:
+The caller must declare the binding `let mut` — an `inout` argument writes to
+the caller's place, so an immutable binding is rejected — and again the keyword
+appears on both sides:
 
 ```rue run
 const std = @import("std");


### PR DESCRIPTION
An immutable `let` binding was accepted as an `inout` argument to a free function (the program compiled and mutated the binding), while the same through an `inout self` method was rejected with E0203 (RUE-2054).

## What changes

- **Sema.** `reject_immutable_inout_arg_root` in `crates/rue-air/src/sema/analysis/ownership.rs`, called from the by-ref argument chokepoint every call's `inout` operands pass through (free functions, module members, associated functions, method arguments), right after the existing `borrow`-parameter rejection. It emits E0203 `AssignToImmutable`, the same code and kind the receiver and assignment paths use, with the declaration span labelled and a help line suggesting `let mut`. A projection (`inout s.a`, `inout a[0]`) is checked at its root binding; `for` and `match` bindings are immutable roots too; `let mut`, `inout` parameters and shadowing locals stay accepted; the `borrow`-parameter and constant cases keep their existing diagnostics.
- **Spec.** New legality rule 6.1:43 in `docs/spec/src/06-items/01-functions.md`: the place named by an `inout` argument must be mutable, a projection is mutable exactly when its root is, an `inout` parameter root is mutable, a `borrow` root is 6.1:24, and this is the same requirement 6.4:26 puts on an `inout self` receiver. Four spec cases in `items/functions.toml` cite it.
- **UI tests.** Three cases in `diagnostics/call-argument-modes.toml`: the free-function rejection with the exact message and help, a `for`-binding rejection, and the accepted by-value-parameter case that documents the carve-out below.
- **Corpus.** One program had to change: `constprop.toml`'s `inout_arg_not_mispropagated_O1` now declares its binding `let mut`; its intent (no constant folding across an `inout` call) is unchanged. Nothing in `std/` or `examples/` passed an immutable local `inout`.
- **Tutorial.** The ownership chapter now says the caller must declare the binding `let mut`; the entry is removed from the tutorial's known-limitations list.

## Deliberate carve-out

A by-value parameter passed `inout` (`fn f(v: i64) { bump(inout v); v }`) stays accepted. Spec 6.1:32 calls such a parameter immutable, but the RUE-2042 change merged on 2026-09-05 pins that shape as legal with CLI cases across optimisation levels, so rejecting it would reverse a day-old decision inside a bug fix. The rule, the code comment and a UI case name the carve-out; the spec-versus-compiler question is filed as RUE-2079 for a ruling.

## Validation

`scripts/rue premerge` passes locally apart from the two sandbox-environmental CLI cases (`remove_dir_all_permission_denied_is_not_partial_success`, `tcp_ipv6_loopback_round_trip`); oracle-diff and spec-traceability pass.

Closes RUE-2054

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_