### PR TITLE
Read a `for` loop's iterable through a borrow

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -835,8 +835,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     // These three intrinsics are synthesized ONLY by the `for`-loop desugaring
     // in AstGen (`gen_for`); they are the type-dependent leaves of the
     // desugaring, resolved here once the collection's type is known. Reading
-    // the collection is a scoped borrow (ADR-0037): the move state is snapshot
-    // and restored so iterating does not consume the source.
+    // the collection is a scoped borrow (ADR-0037, spec 4.8:26): it is analyzed
+    // under a by-ref root so iterating neither consumes the source nor moves
+    // out of a `borrow`/`inout` parameter.
     // ========================================================================
 
     /// [`rue_rir::InternalIntrinsic::IterLen`] computes the loop bound
@@ -998,10 +999,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(AnalysisResult::new(call_ref, ret_ty))
     }
 
-    /// Analyze a for-loop's collection operand as a scoped borrow: the value is
-    /// read but its move state is restored afterward, so referencing it each
-    /// iteration (for the bound, the element, and the advance) does not consume
-    /// the source and it remains usable after the loop.
+    /// Analyze a for-loop's collection operand as a scoped borrow (spec
+    /// 4.8:26): referencing it each iteration (for the bound, the element, and
+    /// the advance) reads through a loan instead of consuming the source, so
+    /// the collection is neither moved nor dropped by the loop and remains
+    /// usable afterward.
+    ///
+    /// The read is analyzed under `byref_arg_root`, exactly as a `borrow` call
+    /// argument is: that is what makes a `borrow` or `inout` parameter
+    /// iterable, since moving out of either is rejected outright and no
+    /// after-the-fact move-state restore can undo that diagnostic (RUE-2052).
+    /// The snapshot/restore around it stays as the belt-and-braces guarantee
+    /// that no move state survives the operand, whatever place shape the
+    /// desugar hands in.
     pub(super) fn analyze_borrowed_collection(
         &mut self,
         air: &mut Air,
@@ -1010,7 +1020,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> CompileResult<AnalysisResult> {
         let root = self.extract_root_variable(coll);
         let move_before = self.snapshot_move_state(root, ctx);
-        let coll_result = self.analyze_inst(air, coll, ctx)?;
+        let coll_result = self.analyze_with_borrow_root(air, coll, root, ctx)?;
         self.restore_move_state_and_cancel(air, coll_result.air_ref, move_before, ctx);
         Ok(coll_result)
     }

--- a/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
+++ b/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
@@ -1,6 +1,6 @@
 # A `for` loop is a shared borrow of the collection for the loop's duration
-# (spec 4.8:26, RUE-233/RUE-257/RUE-259 — one root: the loop desugared to a
-# move-out instead of the shared borrow the spec mandates). Three faces:
+# (spec 4.8:26, RUE-233/RUE-257/RUE-259/RUE-2052 — one root: the loop desugared
+# to a move-out instead of the shared borrow the spec mandates). Four faces:
 #
 #  * RUE-233: mutating the iterated place — element (`a[i]=`), whole variable
 #    (`a=`), or field — inside the body is E0428 (`MutateBorrowedValue`), like
@@ -11,13 +11,16 @@
 #  * RUE-259: a NON-Copy element type is bound by shared borrow, not moved out
 #    of the collection — the loop compiles (used to be E0904), the array drops
 #    each element exactly once, and moving the binder out is rejected.
+#  * RUE-2052: because the loop only reads the collection through that borrow,
+#    the iterable need not be owned by the iterating function — a `borrow` or
+#    `inout` parameter is iterable (used to be E0429).
 #
 # Iterating a different collection, and read-only iteration, still compile.
 
 [section]
 id = "cli.for_loop_iter_borrow"
 name = "For-loop iterable borrow-check"
-description = "A `for` loop is a shared borrow: non-Copy elements iterate without moving, per-element destructors run once, mutating the collection mid-loop is E0428 (RUE-233/257/259)."
+description = "A `for` loop is a shared borrow: non-Copy elements iterate without moving, borrowed iterables are accepted, per-element destructors run once, mutating the collection mid-loop is E0428 (RUE-233/257/259/2052)."
 
 [[case]]
 name = "mutate_iterated_element_is_e0428"
@@ -239,3 +242,153 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 9
+
+# --- RUE-2052: the iterable may itself be borrowed ---------------------------
+# Iteration reads the collection through a loan, so the iterating function does
+# not have to own it: a `borrow` or `inout` parameter is iterable, and no move
+# is recorded against a local either. The reported program is target-pinned like
+# cli.abi_conformance: every host compiles and links both backends, and the
+# matching native host executes it.
+
+[[case]]
+name = "x86_64_linux_for_over_borrow_strbuf_parameter"
+description = "RUE-2052: `for b in s` over a `borrow StrBuf` parameter compiles and counts 2 spaces on x86-64 (was E0429)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn count_spaces(borrow s: StrBuf) -> u64 {
+    let mut n: u64 = 0;
+    for b in s {
+        if b == 32 { n += 1; }
+    }
+    n
+}
+
+fn main() -> i32 {
+    let s: StrBuf = "a b c";
+    @intCast(count_spaces(borrow s))
+}
+""" }]
+exit_code = 2
+
+[[case]]
+name = "aarch64_linux_for_over_borrow_strbuf_parameter"
+description = "RUE-2052: the same borrowed-iterable program compiles, links, and (on a native host) counts 2 spaces on AArch64."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn count_spaces(borrow s: StrBuf) -> u64 {
+    let mut n: u64 = 0;
+    for b in s {
+        if b == 32 { n += 1; }
+    }
+    n
+}
+
+fn main() -> i32 {
+    let s: StrBuf = "a b c";
+    @intCast(count_spaces(borrow s))
+}
+""" }]
+exit_code = 2
+
+[[case]]
+name = "for_over_inout_strbuf_parameter_is_a_read"
+description = "RUE-2052: iterating an `inout StrBuf` parameter is a shared read, not a write — the parameter stays mutable afterward (2 spaces + 6 bytes = 8)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn count_then_push(inout s: StrBuf) -> u64 {
+    let mut n: u64 = 0;
+    for b in s {
+        if b == 32 { n += 1; }
+    }
+    s.push(33);
+    n
+}
+
+fn main() -> i32 {
+    let mut s: StrBuf = "a b c";
+    let n = count_then_push(inout s);
+    @intCast(n + s.len())
+}
+""" }]
+exit_code = 8
+
+[[case]]
+name = "for_over_borrow_array_of_non_copy_elements"
+description = "RUE-2052: a `borrow [StrBuf; 2]` parameter iterates without moving out of the loan (2 + 3 bytes, plus 2 read back from the caller's array = 7)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn total_len(borrow a: [StrBuf; 2]) -> u64 {
+    let mut t: u64 = 0;
+    for s in a {
+        t += s.len();
+    }
+    t
+}
+
+fn main() -> i32 {
+    let a: [StrBuf; 2] = ["ab", "cde"];
+    let n = total_len(borrow a);
+    @intCast(n + a[0].len())
+}
+""" }]
+exit_code = 7
+
+[[case]]
+name = "for_over_local_strbuf_leaves_it_usable"
+description = "RUE-2052 (the other side): a local StrBuf iterated by a `for` is borrowed, not moved, so `s.len()` after the loop is fine (2 + 5 = 7)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let s: StrBuf = "a b c";
+    let mut n: u64 = 0;
+    for b in s {
+        if b == 32 { n += 1; }
+    }
+    @intCast(n + s.len())
+}
+""" }]
+exit_code = 7
+
+[[case]]
+name = "for_over_temporary_iterable_drops_it_once_after_the_loop"
+description = "RUE-2052 control: a by-value temporary iterable is still owned by the loop's hidden binding and dropped exactly once, after the loop."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Res { tag: i32 }
+drop fn Res(self) { @dbg(self.tag); }
+fn make() -> [Res; 2] { [Res { tag: 7 }, Res { tag: 8 }] }
+fn main() -> i32 {
+    let mut total = 0;
+    for r in make() {
+        total = total + r.tag;
+    }
+    @dbg(99);
+    total
+}
+""" }]
+stdout = "7\n8\n99\n"
+exit_code = 15

--- a/crates/rue-spec/cases/expressions/for.toml
+++ b/crates/rue-spec/cases/expressions/for.toml
@@ -362,3 +362,158 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "array or a StrBuf"
+
+# =============================================================================
+# By-reference iterables (RUE-2052)
+#
+# Iteration is a shared read (4.8:26), so the iterable never has to be owned by
+# the iterating function: a `borrow` or an `inout` parameter is read through its
+# loan exactly as a local is.
+# =============================================================================
+
+# The reported program: a `borrow StrBuf` parameter is iterable, because reading
+# it for the bound and for each byte is a loan rather than a move out of the
+# borrow (previously rejected E0429).
+[[case]]
+name = "for_borrow_strbuf_parameter"
+spec = ["4.8:25", "4.8:26"]
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn count_spaces(borrow s: StrBuf) -> u64 {
+    let mut n: u64 = 0;
+    for b in s {
+        if b == 32 { n += 1; }
+    }
+    n
+}
+
+fn main() -> i32 {
+    let s: StrBuf = "a b c";
+    @intCast(count_spaces(borrow s))
+}
+"""
+exit_code = 2
+
+# The `.chars()` scalar view of a `borrow` parameter is the same shared read.
+[[case]]
+name = "for_chars_of_borrow_strbuf_parameter"
+spec = ["4.8:25", "4.8:26"]
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn count_chars(borrow s: StrBuf) -> u64 {
+    let mut n: u64 = 0;
+    for _c in s.chars() {
+        n += 1;
+    }
+    n
+}
+
+fn main() -> i32 {
+    let s: StrBuf = "café";
+    @intCast(count_chars(borrow s))
+}
+"""
+exit_code = 4
+
+# Reading an `inout` parameter in a `for` is a shared read, not a write: it is
+# accepted, and the parameter is still a mutable place afterward, so the
+# caller's variable sees the later mutation.
+[[case]]
+name = "for_inout_strbuf_parameter_reads"
+spec = ["4.8:26"]
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn count_then_push(inout s: StrBuf) -> u64 {
+    let mut n: u64 = 0;
+    for b in s {
+        if b == 32 { n += 1; }
+    }
+    s.push(33);
+    n
+}
+
+fn main() -> i32 {
+    let mut s: StrBuf = "a b c";
+    let n = count_then_push(inout s);
+    @intCast(n + s.len())
+}
+"""
+exit_code = 8
+
+# A local StrBuf iterated by a `for` is borrowed, not moved: it is still usable
+# after the loop.
+[[case]]
+name = "for_local_strbuf_usable_after_loop"
+spec = ["4.8:26"]
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let s: StrBuf = "a b c";
+    let mut n: u64 = 0;
+    for b in s {
+        if b == 32 { n += 1; }
+    }
+    @intCast(n + s.len())
+}
+"""
+exit_code = 7
+
+# An array with non-Copy elements passed `borrow` is iterable for the same
+# reason: the loop reads the elements through the parameter's loan and moves
+# nothing out of it.
+[[case]]
+name = "for_borrow_array_of_non_copy_elements"
+spec = ["4.8:25", "4.8:26"]
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn total_len(borrow a: [StrBuf; 2]) -> u64 {
+    let mut t: u64 = 0;
+    for s in a {
+        t += s.len();
+    }
+    t
+}
+
+fn main() -> i32 {
+    let a: [StrBuf; 2] = ["ab", "cde"];
+    let n = total_len(borrow a);
+    @intCast(n + a[0].len())
+}
+"""
+exit_code = 7
+
+# A by-value temporary iterable has no owner outside the loop, so the `for`
+# binds it once and its destructor still runs exactly once, after the loop.
+[[case]]
+name = "for_temporary_iterable_dropped_once_after_loop"
+spec = ["4.8:26"]
+source = """
+struct Res { tag: i32 }
+drop fn Res(self) { @dbg(self.tag); }
+fn make() -> [Res; 2] { [Res { tag: 7 }, Res { tag: 8 }] }
+fn main() -> i32 {
+    let mut total = 0;
+    for r in make() {
+        total = total + r.tag;
+    }
+    @dbg(99);
+    total
+}
+"""
+exit_code = 15
+expected_stdout = "7\n8\n99\n"

--- a/docs/process/tutorial.md
+++ b/docs/process/tutorial.md
@@ -124,8 +124,6 @@ when the limitation is lifted and update the chapter that mentions it.
 
 - `[T]` slice parameters accept only 64-bit element types (E0908, RUE-2055);
   the slice examples use `i64`.
-- `for` over a `borrow` `StrBuf` parameter is rejected (E0429, RUE-2052); the
-  examples iterate a clone or take the string by value.
 - A qualified enum path cannot appear inside another variant's payload
   pattern (`R.Err(E.A(x))` does not parse, RUE-2053); the examples use a
   nested `match`.

--- a/website/content/tutorial/10-strings.md
+++ b/website/content/tutorial/10-strings.md
@@ -17,7 +17,7 @@ const StrBuf = std.strbuf.StrBuf;
 
 fn shout(borrow s: StrBuf) -> StrBuf {
     let mut out = StrBuf.new();
-    for b in s.clone() {
+    for b in s {
         if b >= b'a' && b <= b'z' {
             out.push(b - (b'a' - b'A'));
         } else {
@@ -40,10 +40,10 @@ HELLO, RUE
 length: 10
 ```
 
-Two things in `shout` are explained later in this chapter. `b'a'` is a *byte
-literal*, the integer value of an ASCII character. And `shout` iterates
-`s.clone()` rather than `s` because today `for` cannot walk a borrowed
-`StrBuf` directly (RUE-2052); once that is fixed, the clone goes away.
+One thing in `shout` is explained later in this chapter: `b'a'` is a *byte
+literal*, the integer value of an ASCII character. Note that `for` walks the
+borrowed `s` directly — iteration is a shared read, so the string stays
+usable in the caller afterward.
 
 ## `str` and `StrBuf`
 
@@ -163,7 +163,7 @@ fn main() -> i32 {
     let word: StrBuf = "héllo";
     let mut bytes = 0;
     let mut chars = 0;
-    for _ in word.clone() {
+    for _ in word {
         bytes += 1;
     }
     for _ in word.chars() {


### PR DESCRIPTION
`for b in s` over a `borrow StrBuf` parameter was rejected with E0429 `cannot move out of borrowed value`, contrary to spec 4.8:26, which makes a `for` iteration a shared read of the collection (RUE-2052).

## Root cause

The `for` desugar emits `VarRef`s to the collection for the loop bound, the element read and the `.chars()` advance. Sema funnels those through `analyze_borrowed_collection`, which analysed the operand as an ordinary by-value read and then undid the move afterwards (snapshot the root's move state, analyse, restore). That only works when the read was legal to begin with: a local records a rollback-able move, but a `borrow` parameter returns E0429 immediately and an `inout` parameter its own move-out error, so a borrowed iterable never reached the restore. Iterating a local `StrBuf` and using it afterwards already worked.

## What changes

- `analyze_borrowed_collection` now analyses the operand under the by-ref root (`analyze_with_borrow_root`), the same loan a `borrow` call argument and `@dbg` use, so no move is recorded and neither parameter arm fires. The snapshot/restore stays as a guard; the comments describe the mechanism. No CFG or codegen change.
- Spec cases in `expressions/for.toml` citing 4.8:26 (and 4.8:25): the reported program (exit 2), `.chars()` over a borrowed parameter, an `inout` parameter read that stays a mutable place afterwards, a local usable after the loop, a `borrow` array of non-Copy elements, and a by-value temporary dropped exactly once after the loop.
- CLI cases in `for_loop_iter_borrow.toml` pinned on both backends for the same shapes.
- The tutorial's strings chapter iterates the borrowed parameter directly instead of a clone, and the known-limitations entry is removed.

Unchanged and verified against the previous build: a real move out of a `borrow` parameter is still E0429, mutating the collection in the loop body is still E0428, and the drop schedule for a by-value temporary iterable is untouched.

## Not in this change

Slices and `ArrayBuf` are still not `for` iterables (spec 4.8:25 lists arrays and `StrBuf` only); that is a language change, not this bug. `std/env.rue` carries a stale comment claiming `name[i]` on a borrowed `StrBuf` would move out of it, which is already untrue on trunk and is worth a small separate cleanup.

## Validation

`scripts/rue premerge` passes locally apart from the two sandbox-environmental CLI cases (`remove_dir_all_permission_denied_is_not_partial_success`, `tcp_ipv6_loopback_round_trip`); oracle-diff and spec-traceability pass.

Closes RUE-2052

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_