### PR TITLE
RUE-2065: keep a diverging arm's registers out of the prologue

### DIFF
--- a/crates/rue-cli-tests/cases/frame_slot_reuse.toml
+++ b/crates/rue-cli-tests/cases/frame_slot_reuse.toml
@@ -16,6 +16,13 @@
 #   size that reuse (or the deliberate absence of reuse) produces on BOTH
 #   backends. Without these a future change could quietly stop sharing, or
 #   start sharing something it must not, with the behavior cases still green.
+#
+# The sizes below are the locals area alone. `main` ends in `__rue_exit`, so
+# every instruction in it is one control can only leave by aborting, and
+# RUE-2065 keeps a register only such a region occupies out of the prologue —
+# a function that never returns restores nothing. What each case pins is the
+# cell plan: the count, the order, and which locals share, all of which this
+# change leaves untouched.
 
 [section]
 id = "cli.frame_slot_reuse"
@@ -129,7 +136,7 @@ fn main() -> i32 {
 args = ["--emit", "stackframe", "--target", "aarch64-linux", "main.rue"]
 compile_only = true
 # Without reuse the nine slots produced a 96-byte AArch64 frame.
-compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 48 bytes"]
 
 # --- Overlapping lifetimes NEVER share --------------------------------------
 
@@ -175,7 +182,7 @@ fn main() -> i32 {
 """ }]
 args = ["--emit", "stackframe", "--target", "x86-64-linux", "main.rue"]
 compile_only = true
-compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 80 bytes"]
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
 
 [[case]]
 name = "overlapping_lifetimes_never_share_frame_aarch64"
@@ -196,7 +203,7 @@ fn main() -> i32 {
 """ }]
 args = ["--emit", "stackframe", "--target", "aarch64-linux", "main.rue"]
 compile_only = true
-compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 96 bytes"]
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 80 bytes"]
 
 # --- Multi-slot aggregates move as units ------------------------------------
 
@@ -258,7 +265,7 @@ fn main() -> i32 {
 """ }]
 args = ["--emit", "stackframe", "--target", "x86-64-linux", "main.rue"]
 compile_only = true
-compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 32 bytes"]
 
 [[case]]
 name = "multi_slot_aggregates_share_as_whole_runs_frame_aarch64"
@@ -286,7 +293,7 @@ fn main() -> i32 {
 """ }]
 args = ["--emit", "stackframe", "--target", "aarch64-linux", "main.rue"]
 compile_only = true
-compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 48 bytes"]
 
 # --- A borrow keeps a slot alive past its last direct use -------------------
 
@@ -345,7 +352,7 @@ fn main() -> i32 {
 """ }]
 args = ["--emit", "stackframe", "--target", "x86-64-linux", "main.rue"]
 compile_only = true
-compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 48 bytes"]
 
 [[case]]
 name = "borrow_extended_lifetime_keeps_its_slot_frame_aarch64"
@@ -371,7 +378,7 @@ fn main() -> i32 {
 """ }]
 args = ["--emit", "stackframe", "--target", "aarch64-linux", "main.rue"]
 compile_only = true
-compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 80 bytes"]
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
 
 # --- Match arms: per-arm bindings share, and the value stays right ----------
 

--- a/crates/rue-cli-tests/cases/panic_guard_prologue.toml
+++ b/crates/rue-cli-tests/cases/panic_guard_prologue.toml
@@ -1,0 +1,197 @@
+# A `@panic` guard costs the passing path no prologue (RUE-2065).
+#
+# `@panic` stages its failure site with `__rue_test_failure_site` and then calls
+# the panic helper, so the arm holds the site's four operands and the message
+# across an ordinary *returning* call. Read as textual intervals, those values —
+# and every value the guarded function keeps live across the guard — cross a
+# call, which is the one thing that makes a callee-saved register the only legal
+# home. The prologue then saves a register the arm alone touches, and every
+# entry pays a store and every exit a load on the path that never panics: the
+# cost `docs/process/test-events.md` says a guarded accessor must not pay.
+#
+# Allocation now reads two divergence facts. A clobber inside a region control
+# can only leave by aborting cannot destroy a value with no use in that region,
+# and a callee-saved register only such a region occupies needs no prologue
+# save, because the function never returns to restore it. These cases pin the
+# result on both backends: the guarded accessors save no callee-saved register
+# beyond what their non-panicking shape needs, and no register the panic arm
+# alone uses reaches the prologue.
+
+[section]
+id = "cli.panic_guard_prologue"
+name = "Panic-guard prologues"
+description = "A `@panic` guard's cold arm leaves the passing path's prologue alone on both backends (RUE-2065)."
+
+[[case]]
+name = "panic_guarded_accessor_keeps_a_minimal_aarch64_prologue"
+description = "Both `@panic` spellings guard a returning accessor; the AArch64 prologue is the frame record alone and the arm's operands live in unsaved callee-saved registers."
+files = [{ path = "main.rue", source = """
+fn open(port: u16) -> u16 {
+    if port == 0 {
+        @panic("no port");
+    }
+    port
+}
+
+fn open_quiet(port: u16) -> u16 {
+    if port == 0 {
+        @panic();
+    }
+    port
+}
+
+fn main() -> i32 {
+    if open(7) == 7 && open_quiet(9) == 9 { 0 } else { 1 }
+}
+""" }]
+args = ["--emit", "asm", "--target", "aarch64-linux", "-O2", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "=== Assembly (aarch64-linux) ===",
+    """; prologue
+   0:   stp x29, x30, [sp, #-16]!
+   4:   mov x29, sp
+   8:   mov x13, x0""",
+    "bl __rue_panic_no_msg",
+    "bl __rue_panic",
+]
+# Every callee-saved save form the emitter can produce. The arm still occupies
+# x19-x21, and that is the point: the registers it uses never reach a prologue.
+compile_stdout_not_contains = [
+    "stp x19",
+    "stp x21",
+    "stp x23",
+    "stp x25",
+    "stp x27",
+    "str x19, [sp",
+    "str x21, [sp",
+    "str x23, [sp",
+    "str x25, [sp",
+    "str x27, [sp",
+]
+
+[[case]]
+name = "panic_guarded_accessor_keeps_a_minimal_x86_64_prologue"
+description = "The same program on x86-64 saves only the one callee-saved register its single allocatable caller-saved register cannot cover; none of the arm's operands reaches the prologue."
+files = [{ path = "main.rue", source = """
+fn open(port: u16) -> u16 {
+    if port == 0 {
+        @panic("no port");
+    }
+    port
+}
+
+fn open_quiet(port: u16) -> u16 {
+    if port == 0 {
+        @panic();
+    }
+    port
+}
+
+fn main() -> i32 {
+    if open(7) == 7 && open_quiet(9) == 9 { 0 } else { 1 }
+}
+""" }]
+args = ["--emit", "asm", "--target", "x86-64-linux", "-O2", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "=== Assembly (x86-64-linux) ===",
+    """; prologue
+   0:   push rbp
+   1:   mov rbp, rsp
+   4:   push rbx
+   5:   sub rsp, 8
+   c:   mov rbx, rdi""",
+    "call __rue_panic_no_msg",
+    "call __rue_panic",
+]
+# `r11` is x86-64's only allocatable caller-saved register, so `rbx` still
+# carries the parameter across the guard. The arm's own operands take
+# `r12`-`r15`, and none of those saves reaches a prologue.
+compile_stdout_not_contains = ["push r12", "push r13", "push r14", "push r15"]
+
+[[case]]
+name = "panic_guarded_accessors_still_panic_at_runtime"
+description = "The unsaved callee-saved registers in the arm do not change what a guard does when it fires: the guarded call aborts with the pinned stderr line and exit 101."
+files = [{ path = "main.rue", source = """
+fn open(port: u16) -> u16 {
+    if port == 0 {
+        @panic("no port");
+    }
+    port
+}
+
+fn main() -> i32 {
+    let good: i32 = @intCast(open(7));
+    @dbg(good);
+    let bad: i32 = @intCast(open(0));
+    @dbg(bad);
+    0
+}
+""" }]
+stdout = "7\n"
+runtime_error_contains = ["panic: no port"]
+exit_code = 101
+
+[[case]]
+name = "a_guarded_accessor_in_a_loop_returns_the_right_values"
+description = "The passing path through a `@panic` guard is exercised many times in one frame, so a register the arm clobbered without saving would show up as a wrong sum."
+files = [{ path = "main.rue", source = """
+fn checked_double(n: i64, limit: i64) -> i64 {
+    if n >= limit {
+        @panic("out of range");
+    }
+    n + n
+}
+
+fn main() -> i32 {
+    let mut total: i64 = 0;
+    let mut i: i64 = 0;
+    // `total` and `i` are both live across every guard, and the guard's arm
+    // takes callee-saved registers the prologue no longer saves.
+    while i < 1000 {
+        total = total + checked_double(i, 1000);
+        i = i + 1;
+    }
+    let shown: i32 = @intCast(total);
+    @dbg(shown);
+    0
+}
+""" }]
+stdout = "999000\n"
+exit_code = 0
+
+[[case]]
+name = "a_panic_arm_reads_a_coalesced_join_value_intact"
+description = "A value the arm itself reads after the arm's staging call keeps its clobber protection through coalescing: `k` is an `if`/`else` join, so the pair of moves that produce it is coalesced away, and the arm must still read 42 rather than the register the staging call left behind."
+files = [{ path = "main.rue", source = """
+fn f(q: i64) -> i64 {
+    // Hoisted so the guard's condition is live across the join below: that
+    // pressure is what puts the merged value in a caller-saved register, and
+    // the shape stops reproducing without it.
+    let zero: bool = q == 0;
+    // An `if`/`else` join lowers to two moves into one value, which
+    // coalescing folds into whichever half is the representative. The
+    // divergence facts have to be folded with it: the arm below reads `k`
+    // after a returning call, so `k` may not live in a register that call
+    // clobbers, and coalescing must not lose that by recording the read
+    // against the half it discards.
+    let k: i64 = if q > 5 { 41 } else { 42 };
+    if zero {
+        @dbg(77);
+        @dbg(k);
+        @panic("guard");
+    }
+    k
+}
+
+fn main() -> i32 {
+    @dbg(f(9));
+    @dbg(f(0));
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+stdout = "41\n77\n42\n"
+runtime_error_contains = ["panic: guard"]
+exit_code = 101

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -552,6 +552,8 @@ where
                 ranges: IndexMap::new(),
                 clobbers_at: Vec::new(),
                 non_returning_at: Vec::new(),
+                diverging_at: Vec::new(),
+                diverging_uses: Vec::new(),
                 vreg_classes,
             },
             collect_debug.then(|| LivenessDebugInfo {
@@ -636,20 +638,123 @@ where
         }
     });
 
-    // Step 6: Collect clobbers and the never-returning call sites (RUE-1224)
+    // Step 6: Collect clobbers and the never-returning call sites (RUE-1224),
+    // then extend the second of those to whole diverging regions (RUE-2065).
     let clobbers_at: Vec<&'static [R]> = instructions.iter().map(&get_clobbers).collect();
     let non_returning_at: Vec<bool> = instructions.iter().map(&get_non_returning).collect();
+    let diverging_at = compute_divergence(&successors, &non_returning_at);
+    let diverging_uses = collect_diverging_uses(vreg_count, &inst_uses, &diverging_at);
 
     (
         LivenessInfo {
             ranges,
             clobbers_at,
             non_returning_at,
+            diverging_at,
+            diverging_uses,
             vreg_classes,
         },
         debug,
         loop_info,
     )
+}
+
+/// Mark every instruction control can only leave by aborting the process.
+///
+/// A call the runtime ABI manifest declares `ReturnBehavior::Never` diverges by
+/// definition: it aborts, and reports no successors. Any other instruction
+/// diverges when it has successors and all of them diverge, so the whole region
+/// between the branch into a `@panic` arm and the trap call at its end is
+/// marked, not just the trap call itself.
+///
+/// The marked set is closed under successors — an instruction reachable from a
+/// diverging one cannot reach a return either — which is what makes the
+/// allocator's two divergence rules sound; see [`crate::regalloc::ClobberIndex`]
+/// and [`crate::regalloc::DivergenceIndex`] (RUE-2065).
+///
+/// This is a least fixed point, so anything unproven stays unmarked: an
+/// instruction with no successors that is not such a call (`ret`, `ud2`, `brk`)
+/// is not marked, and neither is a cycle with no exit. Every MIR control
+/// transfer is direct, so the successor table this reads is exact.
+fn compute_divergence(successors: &[SuccessorList], non_returning: &[bool]) -> Vec<bool> {
+    let num_insts = successors.len();
+    let mut diverging = vec![false; num_insts];
+    let mut worklist: Vec<usize> = non_returning
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, &never)| never.then_some(idx))
+        .collect();
+    if worklist.is_empty() {
+        return diverging;
+    }
+    for &idx in &worklist {
+        diverging[idx] = true;
+    }
+
+    // Walking to predecessors needs the reverse of the successor table. Build
+    // it in compressed form — one bound array and one flat edge array — so a
+    // function with many instructions does not pay a `Vec` per instruction.
+    let mut pred_bounds = vec![0_u32; num_insts + 1];
+    for succs in successors {
+        for &succ in succs {
+            pred_bounds[succ + 1] += 1;
+        }
+    }
+    for idx in 0..num_insts {
+        pred_bounds[idx + 1] += pred_bounds[idx];
+    }
+    let mut fill = pred_bounds.clone();
+    let mut preds = vec![0_u32; pred_bounds[num_insts] as usize];
+    for (from, succs) in successors.iter().enumerate() {
+        for &succ in succs {
+            preds[fill[succ] as usize] = from as u32;
+            fill[succ] += 1;
+        }
+    }
+
+    // An instruction joins the set once its last unmarked successor joins it,
+    // so each edge is retired at most once and the walk is linear. Duplicate
+    // successor entries appear once in each table and cancel out.
+    let mut unmarked: Vec<u32> = successors.iter().map(|succs| succs.len() as u32).collect();
+    while let Some(idx) = worklist.pop() {
+        for &pred in &preds[pred_bounds[idx] as usize..pred_bounds[idx + 1] as usize] {
+            let pred = pred as usize;
+            if diverging[pred] {
+                continue;
+            }
+            unmarked[pred] -= 1;
+            if unmarked[pred] == 0 {
+                diverging[pred] = true;
+                worklist.push(pred);
+            }
+        }
+    }
+    diverging
+}
+
+/// Which virtual registers a diverging instruction reads.
+///
+/// Every use of a vreg absent from this set is at an instruction control can
+/// still return from. Divergence is closed under successors, so no diverging
+/// instruction can then lie on a path from one of that vreg's definitions to
+/// one of its uses: reaching one would make the use diverging too (RUE-2065).
+fn collect_diverging_uses(
+    vreg_count: u32,
+    inst_uses: &[VRegList],
+    diverging: &[bool],
+) -> Vec<bool> {
+    let mut diverging_uses = vec![false; vreg_count as usize];
+    for (idx, uses) in inst_uses.iter().enumerate() {
+        if !diverging[idx] {
+            continue;
+        }
+        for &vreg in uses.iter() {
+            if let Some(slot) = diverging_uses.get_mut(vreg.index() as usize) {
+                *slot = true;
+            }
+        }
+    }
+    diverging_uses
 }
 
 /// Compute detailed liveness debug information.
@@ -1362,12 +1467,29 @@ mod tests {
     // Simple test instruction type
     #[derive(Debug, Clone)]
     enum TestInst {
-        Def { dst: u32 },
-        Use { src: u32 },
-        Move { dst: u32, src: u32 },
-        Label { id: LabelId },
-        Branch { label: LabelId },
+        Def {
+            dst: u32,
+        },
+        Use {
+            src: u32,
+        },
+        Move {
+            dst: u32,
+            src: u32,
+        },
+        Label {
+            id: LabelId,
+        },
+        Branch {
+            label: LabelId,
+        },
         Ret,
+        /// A call to a helper the runtime ABI manifest declares
+        /// `ReturnBehavior::Never`: it aborts, so it has no successors.
+        Trap,
+        /// A `brk`/`ud2`-shaped instruction: no successors either, but nothing
+        /// declares it never-returning.
+        Brk,
     }
 
     fn test_get_label(inst: &TestInst) -> Option<LabelId> {
@@ -1394,7 +1516,7 @@ mod tests {
                 }
                 succs
             }
-            TestInst::Ret => SuccessorList::new(),
+            TestInst::Ret | TestInst::Trap | TestInst::Brk => SuccessorList::new(),
             _ => {
                 let mut successors = SuccessorList::new();
                 if idx + 1 < num_insts {
@@ -1423,6 +1545,200 @@ mod tests {
 
     fn test_get_clobbers(_inst: &TestInst) -> &'static [u32] {
         &[]
+    }
+
+    fn test_get_non_returning(inst: &TestInst) -> bool {
+        matches!(inst, TestInst::Trap)
+    }
+
+    #[test]
+    fn divergence_covers_a_whole_guard_arm_and_stops_at_the_join() {
+        // The shape a `@panic`-guarded accessor lowers to: the receiver is
+        // defined before the guard, the arm stages a failure site and aborts,
+        // and the continuation reads the receiver after the join. Everything
+        // from the branch into the arm to the trap is reachable only on the
+        // path that aborts; the guard branch and the continuation are not.
+        let cont = LabelId::new(0);
+        let instructions = vec![
+            TestInst::Def { dst: 0 },
+            TestInst::Branch { label: cont },
+            TestInst::Def { dst: 1 },
+            TestInst::Use { src: 1 },
+            TestInst::Trap,
+            TestInst::Label { id: cont },
+            TestInst::Use { src: 0 },
+            TestInst::Ret,
+        ];
+        let num_insts = instructions.len();
+
+        let info: LivenessInfo<u32> = analyze(
+            &instructions,
+            2,
+            VRegClasses::all_gp(2),
+            test_get_label,
+            |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
+            test_get_uses,
+            test_get_defs,
+            test_get_clobbers,
+            test_get_non_returning,
+        );
+
+        assert_eq!(
+            info.diverging_at,
+            vec![false, false, true, true, true, false, false, false]
+        );
+        assert!(
+            !info.has_diverging_use(VReg::new(0)),
+            "the receiver is read only after the join"
+        );
+        assert!(
+            info.has_diverging_use(VReg::new(1)),
+            "the arm's staged operand is read on the aborting path"
+        );
+    }
+
+    #[test]
+    fn a_loop_with_no_exit_is_not_proven_diverging() {
+        // The analysis is a least fixed point, so a cycle that reaches no trap
+        // stays unmarked rather than marking itself.
+        let head = LabelId::new(0);
+        let instructions = vec![
+            TestInst::Label { id: head },
+            TestInst::Def { dst: 0 },
+            TestInst::Branch { label: head },
+        ];
+        let num_insts = instructions.len();
+
+        let info: LivenessInfo<u32> = analyze(
+            &instructions,
+            1,
+            VRegClasses::all_gp(1),
+            test_get_label,
+            |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
+            test_get_uses,
+            test_get_defs,
+            test_get_clobbers,
+            test_get_non_returning,
+        );
+
+        assert!(info.diverging_at.iter().all(|&diverges| !diverges));
+    }
+
+    #[test]
+    fn a_loop_whose_only_exit_is_a_trap_stays_unmarked() {
+        // The loop's one way out is the trap at 3, so control really can only
+        // leave the body by aborting — but proving that needs the greatest
+        // fixed point, and this is the least one: instruction 2 waits on its
+        // back edge, which waits on 2. Failing to mark costs the arm's
+        // registers a prologue save and nothing else, so the unprovable case
+        // stays out.
+        let head = LabelId::new(0);
+        let instructions = vec![
+            TestInst::Label { id: head },
+            TestInst::Def { dst: 0 },
+            TestInst::Branch { label: head },
+            TestInst::Trap,
+        ];
+        let num_insts = instructions.len();
+
+        let info: LivenessInfo<u32> = analyze(
+            &instructions,
+            1,
+            VRegClasses::all_gp(1),
+            test_get_label,
+            |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
+            test_get_uses,
+            test_get_defs,
+            test_get_clobbers,
+            test_get_non_returning,
+        );
+
+        assert_eq!(info.diverging_at, vec![false, false, false, true]);
+    }
+
+    #[test]
+    fn a_zero_successor_instruction_diverges_only_when_it_never_returns() {
+        // `ret`, `brk`, and `ud2` all report no successors, and "no successors"
+        // is not the seed — the seed is the manifest's `ReturnBehavior::Never`.
+        // Only the arm that ends in such a call is marked.
+        let tail = LabelId::new(0);
+        let shape = |arm: TestInst| {
+            vec![
+                TestInst::Def { dst: 0 },
+                TestInst::Branch { label: tail },
+                arm,
+                TestInst::Label { id: tail },
+                TestInst::Use { src: 0 },
+                TestInst::Ret,
+            ]
+        };
+        let analyze_shape = |instructions: Vec<TestInst>| -> Vec<bool> {
+            let num_insts = instructions.len();
+            let info: LivenessInfo<u32> = analyze(
+                &instructions,
+                1,
+                VRegClasses::all_gp(1),
+                test_get_label,
+                |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
+                test_get_uses,
+                test_get_defs,
+                test_get_clobbers,
+                test_get_non_returning,
+            );
+            info.diverging_at
+        };
+
+        assert_eq!(
+            analyze_shape(shape(TestInst::Brk)),
+            vec![false; 6],
+            "a `brk` that nothing declares never-returning is not a divergence seed"
+        );
+        assert_eq!(
+            analyze_shape(shape(TestInst::Trap)),
+            vec![false, false, true, false, false, false],
+            "the trap call is, and the `ret` at the end of the other path is not"
+        );
+    }
+
+    #[test]
+    fn only_the_diverging_arm_of_a_join_is_marked() {
+        // One arm returns a value it computes, the other aborts. Divergence
+        // stops at the branch, which can still reach the returning arm, and the
+        // guarded value read only by the returning arm keeps its clobber
+        // protection.
+        let arm = LabelId::new(0);
+        let instructions = vec![
+            TestInst::Def { dst: 0 },
+            TestInst::Branch { label: arm },
+            TestInst::Def { dst: 1 },
+            TestInst::Use { src: 0 },
+            TestInst::Ret,
+            TestInst::Label { id: arm },
+            TestInst::Def { dst: 2 },
+            TestInst::Use { src: 2 },
+            TestInst::Trap,
+        ];
+        let num_insts = instructions.len();
+
+        let info: LivenessInfo<u32> = analyze(
+            &instructions,
+            3,
+            VRegClasses::all_gp(3),
+            test_get_label,
+            |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
+            test_get_uses,
+            test_get_defs,
+            test_get_clobbers,
+            test_get_non_returning,
+        );
+
+        assert_eq!(
+            info.diverging_at,
+            vec![false, false, false, false, false, true, true, true, true]
+        );
+        assert!(!info.has_diverging_use(VReg::new(0)));
+        assert!(!info.has_diverging_use(VReg::new(1)));
+        assert!(info.has_diverging_use(VReg::new(2)));
     }
 
     fn reset_dataflow_call_count() {

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -464,6 +464,24 @@ pub struct LivenessInfo<Reg: Copy + Eq + std::hash::Hash + 'static> {
     /// no value is live after it; see [`ClobberIndex::build`] for why the
     /// distinction matters to allocation (RUE-1224).
     pub non_returning_at: Vec<bool>,
+    /// For each instruction index, whether control can only leave that
+    /// instruction by aborting the process.
+    ///
+    /// The never-returning calls above seed this, and it spreads back over
+    /// every instruction all of whose successors already carry it — the whole
+    /// `@panic` or trap arm, not just the call that ends it. Allocation reads
+    /// it twice: a clobber inside such a region cannot destroy a value with no
+    /// use in one, and a callee-saved register only such a region occupies
+    /// needs no prologue save, because the function never returns to restore it
+    /// (RUE-2065).
+    pub diverging_at: Vec<bool>,
+    /// For each virtual register, whether any diverging instruction reads it.
+    ///
+    /// Every use of a register absent from this set is at an instruction
+    /// control can still return from, so no diverging instruction sits on a
+    /// path from one of its definitions to one of its uses; see
+    /// [`ClobberIndex::is_clobbered_during`].
+    pub diverging_uses: Vec<bool>,
     /// The register class of each virtual register.
     ///
     /// Liveness carries the MIR's class table forward so that allocation and
@@ -480,6 +498,8 @@ impl<Reg: Copy + Eq + std::hash::Hash + 'static> LivenessInfo<Reg> {
             ranges: IndexMap::new(),
             clobbers_at: Vec::new(),
             non_returning_at: Vec::new(),
+            diverging_at: Vec::new(),
+            diverging_uses: Vec::new(),
             vreg_classes: VRegClasses::new(),
         }
     }
@@ -493,6 +513,8 @@ impl<Reg: Copy + Eq + std::hash::Hash + 'static> LivenessInfo<Reg> {
             ranges,
             clobbers_at: Vec::new(),
             non_returning_at: Vec::new(),
+            diverging_at: Vec::new(),
+            diverging_uses: Vec::new(),
             vreg_classes: VRegClasses::all_gp(vreg_count),
         }
     }
@@ -544,6 +566,75 @@ impl<Reg: Copy + Eq + std::hash::Hash + 'static> LivenessInfo<Reg> {
             .copied()
             .unwrap_or(false)
     }
+
+    /// Whether control can only leave the instruction at `inst_idx` by
+    /// aborting the process.
+    ///
+    /// Liveness built without this information answers `false` everywhere,
+    /// which turns both divergence rules off and keeps the pre-RUE-2065
+    /// behavior for hand-constructed test liveness.
+    pub fn diverges_at(&self, inst_idx: usize) -> bool {
+        self.diverging_at.get(inst_idx).copied().unwrap_or(false)
+    }
+
+    /// Whether any diverging instruction reads `vreg`.
+    ///
+    /// The conservative answer is `true`, and it is what liveness built without
+    /// this information gives: a value that may be read on an aborting path
+    /// must survive everything that path does to its register.
+    pub fn has_diverging_use(&self, vreg: VReg) -> bool {
+        self.diverging_uses
+            .get(vreg.index() as usize)
+            .copied()
+            .unwrap_or(true)
+    }
+
+    /// Fold every per-vreg fact of `absorbed` into `representative`, which
+    /// becomes the one vreg the coalesced pair is allocated as.
+    ///
+    /// **Invariant: every per-vreg fact this struct holds must be merged
+    /// here.** Coalescing rewrites each reference to `absorbed` as
+    /// `representative`, so afterwards the representative answers for the whole
+    /// merged value and `absorbed` is never asked again. A fact left behind is
+    /// then silently read off half a value — which is how a diverging use
+    /// recorded against a move's destination went missing, relaxed the clobber
+    /// rule for the merged interval, and handed an arm's live value a register
+    /// the arm's staging call destroys (RUE-2065).
+    ///
+    /// The facts, and what merging each one means:
+    ///
+    /// - `ranges`: the hull of both halves, since the merged value is live
+    ///   wherever either half was.
+    /// - `diverging_uses`: read at a diverging instruction if either half was.
+    /// - `vreg_classes`: identical already — [`coalesce`] refuses a
+    ///   class-crossing pair, which the assertion below restates. It is
+    ///   always-on rather than a `debug_assert!` because merging across classes
+    ///   would let one physical register stand for two values that cannot share
+    ///   one, changing emitted code; `docs/process/ci.md` gives code generation
+    ///   no debug-assert allowance.
+    pub fn merge_into(&mut self, absorbed: VReg, representative: VReg) {
+        assert_eq!(
+            self.class_of(absorbed),
+            self.class_of(representative),
+            "coalescing must refuse a class-crossing pair before merging it",
+        );
+
+        let merged = match (
+            self.range(absorbed).copied(),
+            self.range(representative).copied(),
+        ) {
+            (Some(a), Some(r)) => Some(LiveRange::new(a.start.min(r.start), a.end.max(r.end))),
+            (only, None) | (None, only) => only,
+        };
+        self.ranges[representative] = merged;
+        self.ranges[absorbed] = None;
+
+        if self.has_diverging_use(absorbed) {
+            if let Some(slot) = self.diverging_uses.get_mut(representative.index() as usize) {
+                *slot = true;
+            }
+        }
+    }
 }
 
 // ============================================================================
@@ -566,13 +657,26 @@ impl<Reg: Copy + Eq + std::hash::Hash + 'static> LivenessInfo<Reg> {
 /// instructions) once per function; each query is O(tracked) lookup plus two
 /// array reads.
 ///
-/// A never-returning call contributes no clobber event (RUE-1224). See
-/// [`ClobberIndex::build`].
+/// A never-returning call contributes no clobber event, and a diverging
+/// instruction contributes none to the second of the two counts every tracked
+/// register carries. See [`ClobberIndex::build`] (RUE-1224, RUE-2065).
 pub struct ClobberIndex<Reg> {
-    /// One entry per tracked register: the register, and prefix counts where
-    /// `counts[i]` is the number of instructions before `i` that clobber it.
-    /// The count slice has `instruction_count + 1` entries.
-    tracked: Vec<(Reg, Vec<u32>)>,
+    tracked: Vec<TrackedClobbers<Reg>>,
+}
+
+/// One tracked register's prefix counts.
+///
+/// `counts[i]` is the number of instructions before `i` that clobber the
+/// register, so a range is clobber-free exactly when the counts at its two
+/// endpoints agree. Each slice has `instruction_count + 1` entries.
+struct TrackedClobbers<Reg> {
+    reg: Reg,
+    /// Every clobber the index counts.
+    all: Vec<u32>,
+    /// The same, restricted to instructions that do not diverge. Empty when no
+    /// diverging instruction in this function clobbers anything, in which case
+    /// it would be a copy of `all` and queries read `all` instead.
+    returning_only: Vec<u32>,
 }
 
 impl<Reg: Copy + Eq> ClobberIndex<Reg> {
@@ -596,24 +700,63 @@ impl<Reg: Copy + Eq> ClobberIndex<Reg> {
     /// fire, a register holding a user value may hold anything by the time the
     /// handler runs. Nothing observes that: Rue emits no DWARF and the traps
     /// print a fixed message and exit without a backtrace (RUE-1146's audit).
+    ///
+    /// The same reasoning reaches past the trap call to every instruction in
+    /// its region. A `@panic` arm stages a failure site with an ordinary
+    /// *returning* call before aborting, and that call's clobber sits textually
+    /// inside the live range of every value the guarded function holds across
+    /// the guard — the receiver and index of a bounds-checked accessor, say.
+    /// Control reaches that clobber only on the path that aborts, so it cannot
+    /// destroy a value whose uses all lie off that path. The second count each
+    /// tracked register carries omits those clobbers, and
+    /// [`Self::is_clobbered_during`] reads it for exactly the intervals that
+    /// qualify (RUE-2065).
     pub fn build(liveness: &LivenessInfo<Reg>, tracked: &[Reg]) -> Self
     where
         Reg: std::hash::Hash,
     {
         let num_insts = liveness.clobbers_at.len();
+        // A diverging instruction that is itself a never-returning call is
+        // already uncounted, so the relaxed counts differ from the strict ones
+        // only where a returning instruction inside a diverging region clobbers
+        // something. Most functions have no such instruction and pay nothing.
+        let has_diverging_clobber = (0..num_insts).any(|idx| {
+            liveness.diverges_at(idx)
+                && !liveness.is_non_returning(idx)
+                && !liveness.clobbers_at(idx).is_empty()
+        });
         let tracked = tracked
             .iter()
             .map(|&reg| {
-                let mut counts = Vec::with_capacity(num_insts + 1);
+                let mut all = Vec::with_capacity(num_insts + 1);
+                let mut returning_only = if has_diverging_clobber {
+                    Vec::with_capacity(num_insts + 1)
+                } else {
+                    Vec::new()
+                };
                 let mut running = 0_u32;
-                counts.push(running);
+                let mut running_returning = 0_u32;
+                all.push(running);
+                if has_diverging_clobber {
+                    returning_only.push(running_returning);
+                }
                 for idx in 0..num_insts {
                     if !liveness.is_non_returning(idx) && liveness.clobbers_at(idx).contains(&reg) {
                         running += 1;
+                        if !liveness.diverges_at(idx) {
+                            running_returning += 1;
+                        }
                     }
-                    counts.push(running);
+                    all.push(running);
+                    if has_diverging_clobber {
+                        returning_only.push(running_returning);
+                    }
                 }
-                (reg, counts)
+                TrackedClobbers {
+                    reg,
+                    all,
+                    returning_only,
+                }
             })
             .collect();
         Self { tracked }
@@ -621,17 +764,88 @@ impl<Reg: Copy + Eq> ClobberIndex<Reg> {
 
     /// Whether any instruction in `range` (endpoints included) clobbers `reg`.
     ///
+    /// `ignore_diverging` asks the question of the instructions control can
+    /// reach without aborting. Pass it only for an interval with no use at a
+    /// diverging instruction, which is what makes the omitted clobbers
+    /// unreachable from any definition of that interval; see
+    /// [`LivenessInfo::has_diverging_use`].
+    ///
     /// A register the index was not built for answers `true`: the index proves
     /// the *absence* of clobbers only for the registers it tracks, and the safe
     /// answer for anything else is that the register may be destroyed.
-    pub fn is_clobbered_during(&self, reg: Reg, range: &LiveRange) -> bool {
-        let Some((_, counts)) = self.tracked.iter().find(|(tracked, _)| *tracked == reg) else {
+    pub fn is_clobbered_during(&self, reg: Reg, range: &LiveRange, ignore_diverging: bool) -> bool {
+        let Some(entry) = self.tracked.iter().find(|entry| entry.reg == reg) else {
             return true;
+        };
+        let counts = if ignore_diverging && !entry.returning_only.is_empty() {
+            &entry.returning_only
+        } else {
+            &entry.all
         };
         let last = counts.len() - 1;
         let start = range.start.min(last);
         let end = range.end.saturating_add(1).min(last);
         counts[end] > counts[start]
+    }
+}
+
+// ============================================================================
+// Divergence Index
+// ============================================================================
+
+/// Constant-time "does every instruction in this live range diverge?".
+///
+/// An interval that lives entirely inside a region control can only leave by
+/// aborting never has to be restored: the function does not return from that
+/// region, so a callee-saved register it occupies needs no prologue save and no
+/// epilogue reload. Every entry to the function pays for that save and every
+/// exit for the reload, so charging the passing path for a register only the
+/// `@panic` arm touches is exactly the cost `docs/process/test-events.md` says
+/// a guarded accessor must not pay (RUE-2065).
+///
+/// The shape mirrors [`ClobberIndex`]: a prefix count of the instructions that
+/// do *not* diverge, so a range is wholly diverging exactly when the counts at
+/// its two endpoints agree.
+pub struct DivergenceIndex {
+    /// `returning_before[i]` is the number of instructions before `i` that do
+    /// not diverge, with `instruction_count + 1` entries. Empty when no
+    /// instruction in the function diverges, which answers every query `false`.
+    returning_before: Vec<u32>,
+}
+
+impl DivergenceIndex {
+    /// Build an index over `liveness`'s divergence marks.
+    pub fn build<Reg: Copy + Eq + std::hash::Hash + 'static>(liveness: &LivenessInfo<Reg>) -> Self {
+        let num_insts = liveness.instruction_count();
+        if !liveness.diverging_at.iter().any(|&diverges| diverges) {
+            return Self {
+                returning_before: Vec::new(),
+            };
+        }
+        let mut returning_before = Vec::with_capacity(num_insts + 1);
+        let mut running = 0_u32;
+        returning_before.push(running);
+        for idx in 0..num_insts {
+            if !liveness.diverges_at(idx) {
+                running += 1;
+            }
+            returning_before.push(running);
+        }
+        Self { returning_before }
+    }
+
+    /// Whether every instruction in `range` (endpoints included) diverges.
+    ///
+    /// An empty range table answers `false`, so liveness built without
+    /// divergence information leaves the save set exactly as it was.
+    pub fn range_diverges(&self, range: &LiveRange) -> bool {
+        if self.returning_before.is_empty() {
+            return false;
+        }
+        let last = self.returning_before.len() - 1;
+        let start = range.start.min(last);
+        let end = range.end.saturating_add(1).min(last);
+        self.returning_before[end] == self.returning_before[start]
     }
 }
 
@@ -927,6 +1141,13 @@ impl CoalesceResult {
 /// that has to survive. Backends do not offer such a pair as a candidate
 /// today, and none can arise while every vreg is [`RegClass::Gp`], so this is
 /// a guard rather than a filter (RUE-1067).
+///
+/// # Merged facts
+///
+/// A merged pair is allocated as one vreg, so the representative has to answer
+/// every question for both halves. [`LivenessInfo::merge_into`] is the single
+/// place that folding happens, and it carries the invariant: every per-vreg
+/// fact liveness holds is merged there.
 pub fn coalesce<Reg: Copy + Eq + std::hash::Hash>(
     candidates: &[CoalesceCandidate],
     liveness: &mut LivenessInfo<Reg>,
@@ -997,19 +1218,15 @@ pub fn coalesce<Reg: Copy + Eq + std::hash::Hash>(
         let can_coalesce = src_range.end <= move_point && dst_range.start >= move_point;
 
         if can_coalesce {
-            // Merge the ranges: the combined range spans both
-            let merged_range = LiveRange::new(
-                src_range.start.min(dst_range.start),
-                src_range.end.max(dst_range.end),
-            );
-
             // Use src as the representative (arbitrary choice, but keeps the original value)
             parent[dst.index() as usize] = src.index();
             result.coalesce_map[dst.index() as usize] = src.index();
 
-            // Update liveness: assign merged range to src, remove dst
-            liveness.ranges[src] = Some(merged_range);
-            liveness.ranges[dst] = None;
+            // Fold dst into src: the representative inherits the hull of both
+            // ranges and every other per-vreg fact of the pair. Going through
+            // `merge_into` is what keeps a later fact from being forgotten here
+            // (RUE-2065).
+            liveness.merge_into(dst, src);
 
             // Mark the move for elimination
             result.mark_eliminated(candidate.inst_idx);
@@ -2023,12 +2240,17 @@ pub fn linear_scan_with_debug<Reg: Copy + Eq + std::hash::Hash>(
 /// occupying a sunk register denies it to a later call-crossing interval that
 /// then reaches for a fresh one. Ruling that out is [`accept_reuse_pass`]'s
 /// job, not this function's.
+///
+/// `off_diverging_paths` says this interval has no use control reaches without
+/// aborting, which is what lets the clobber question skip the diverging regions
+/// inside the range; see [`ClobberIndex::is_clobbered_during`].
 fn pick_free_register<Reg: Copy + Eq + std::hash::Hash>(
     save: SaveClasses<'_, Reg>,
     clobbers: &ClobberIndex<Reg>,
     active: &[(VReg, Reg, usize)],
     sunk: &[Reg],
     range: &LiveRange,
+    off_diverging_paths: bool,
 ) -> Option<Reg> {
     // A class can never have more active intervals than physical registers.
     // Query that small canonical list directly instead of rebuilding a hash
@@ -2044,10 +2266,9 @@ fn pick_free_register<Reg: Copy + Eq + std::hash::Hash>(
         .copied()
         .find(|&reg| sunk.contains(&reg) && !is_used(reg))
         .or_else(|| {
-            save.caller_saved
-                .iter()
-                .copied()
-                .find(|&reg| !is_used(reg) && !clobbers.is_clobbered_during(reg, range))
+            save.caller_saved.iter().copied().find(|&reg| {
+                !is_used(reg) && !clobbers.is_clobbered_during(reg, range, off_diverging_paths)
+            })
         })
         .or_else(|| save.callee_saved.iter().copied().find(|&reg| !is_used(reg)))
 }
@@ -2063,13 +2284,16 @@ fn pick_free_register<Reg: Copy + Eq + std::hash::Hash>(
 ///
 /// `save` is the class `reg` belongs to, which is also the arriving interval's:
 /// eviction only ever considers registers held by intervals of the same class.
+/// `off_diverging_paths` likewise describes the arriving interval, whose
+/// clobber question this is.
 fn register_survives_range<Reg: Copy + Eq + std::hash::Hash>(
     save: SaveClasses<'_, Reg>,
     clobbers: &ClobberIndex<Reg>,
     reg: Reg,
     range: &LiveRange,
+    off_diverging_paths: bool,
 ) -> bool {
-    save.is_callee_saved(reg) || !clobbers.is_clobbered_during(reg, range)
+    save.is_callee_saved(reg) || !clobbers.is_clobbered_during(reg, range, off_diverging_paths)
 }
 
 /// How many vregs an allocation keeps in a physical register.
@@ -2200,6 +2424,7 @@ fn active_by_class<Reg: Copy>(
 struct ScanInputs<Reg> {
     vregs_by_start: Vec<(VReg, LiveRange)>,
     clobbers: ClobberIndex<Reg>,
+    divergence: DivergenceIndex,
 }
 
 impl<Reg: Copy + Eq + std::hash::Hash> ScanInputs<Reg> {
@@ -2215,9 +2440,11 @@ impl<Reg: Copy + Eq + std::hash::Hash> ScanInputs<Reg> {
 
         let caller_saved = file.caller_saved_flattened();
         let clobbers = ClobberIndex::build(liveness, &caller_saved);
+        let divergence = DivergenceIndex::build(liveness);
         Self {
             vregs_by_start,
             clobbers,
+            divergence,
         }
     }
 }
@@ -2325,6 +2552,7 @@ fn scan_intervals<Reg: Copy + Eq + std::hash::Hash>(
     // class; the callee-saved registers survive every clobber by definition
     // (RUE-1146).
     let clobbers = &inputs.clobbers;
+    let divergence = &inputs.divergence;
 
     // Track which registers are currently in use and when they become free,
     // separately per register class.
@@ -2339,16 +2567,28 @@ fn scan_intervals<Reg: Copy + Eq + std::hash::Hash>(
         // Expire old intervals - remove registers whose vregs are no longer live
         active.retain(|&(_, _, end)| end >= range.start);
 
+        // Two divergence facts about this interval (RUE-2065): whether its uses
+        // all lie on paths that return, which frees it from the clobbers of the
+        // regions that abort, and whether it lives wholly inside such a region,
+        // which frees any callee-saved register it takes from the prologue.
+        let off_diverging_paths = !liveness.has_diverging_use(vreg);
+        let confined_to_divergence = divergence.range_diverges(&range);
+
         // Try to find a free register of this vreg's own class: a sunk compact
         // one, else caller-saved, else a fresh callee-saved one.
-        let allocated_reg = pick_free_register(save, clobbers, active, sunk, &range);
+        let allocated_reg =
+            pick_free_register(save, clobbers, active, sunk, &range, off_diverging_paths);
 
         if let Some(reg) = allocated_reg {
             // Assign this register
             allocation[vreg] = Some(Allocation::Register(reg));
             active.push((vreg, reg, range.end));
-            // Track callee-saved register usage: only these oblige the prologue
-            if save.is_callee_saved(reg) && !used_callee_saved.contains(&reg) {
+            // Track callee-saved register usage: only these oblige the prologue,
+            // and only for an interval the function can still return from.
+            if save.is_callee_saved(reg)
+                && !confined_to_divergence
+                && !used_callee_saved.contains(&reg)
+            {
                 used_callee_saved.push(reg);
             }
         } else {
@@ -2369,7 +2609,8 @@ fn scan_intervals<Reg: Copy + Eq + std::hash::Hash>(
                 // Evicting only helps if the freed register can actually hold
                 // the arriving interval; a caller-saved register clobbered
                 // during that interval cannot.
-                if !register_survives_range(save, clobbers, active_reg, &range) {
+                if !register_survives_range(save, clobbers, active_reg, &range, off_diverging_paths)
+                {
                     continue;
                 }
                 let active_loop_depth = loop_info.max_depth_in_range(range.start, end);
@@ -2591,6 +2832,7 @@ fn scan_intervals_with_remat<Reg: Copy + Eq + std::hash::Hash>(
     // class; the callee-saved registers survive every clobber by definition
     // (RUE-1146).
     let clobbers = &inputs.clobbers;
+    let divergence = &inputs.divergence;
 
     // Track which registers are currently in use and when they become free,
     // separately per register class.
@@ -2605,16 +2847,28 @@ fn scan_intervals_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         // Expire old intervals - remove registers whose vregs are no longer live
         active.retain(|&(_, _, end)| end >= range.start);
 
+        // Two divergence facts about this interval (RUE-2065): whether its uses
+        // all lie on paths that return, which frees it from the clobbers of the
+        // regions that abort, and whether it lives wholly inside such a region,
+        // which frees any callee-saved register it takes from the prologue.
+        let off_diverging_paths = !liveness.has_diverging_use(vreg);
+        let confined_to_divergence = divergence.range_diverges(&range);
+
         // Try to find a free register of this vreg's own class: a sunk compact
         // one, else caller-saved, else a fresh callee-saved one.
-        let allocated_reg = pick_free_register(save, clobbers, active, sunk, &range);
+        let allocated_reg =
+            pick_free_register(save, clobbers, active, sunk, &range, off_diverging_paths);
 
         if let Some(reg) = allocated_reg {
             // Assign this register
             allocation[vreg] = Some(Allocation::Register(reg));
             active.push((vreg, reg, range.end));
-            // Track callee-saved register usage: only these oblige the prologue
-            if save.is_callee_saved(reg) && !used_callee_saved.contains(&reg) {
+            // Track callee-saved register usage: only these oblige the prologue,
+            // and only for an interval the function can still return from.
+            if save.is_callee_saved(reg)
+                && !confined_to_divergence
+                && !used_callee_saved.contains(&reg)
+            {
                 used_callee_saved.push(reg);
             }
         } else {
@@ -2643,7 +2897,8 @@ fn scan_intervals_with_remat<Reg: Copy + Eq + std::hash::Hash>(
                 // Evicting only helps if the freed register can actually hold
                 // the arriving interval; a caller-saved register clobbered
                 // during that interval cannot.
-                if !register_survives_range(save, clobbers, active_reg, &range) {
+                if !register_survives_range(save, clobbers, active_reg, &range, off_diverging_paths)
+                {
                     continue;
                 }
                 let active_is_remat = can_remat(active_vreg).is_some();
@@ -2950,6 +3205,22 @@ mod tests {
         }
     }
 
+    /// Mark `indices` as instructions control can only leave by aborting, and
+    /// `readers` as the vregs some such instruction reads.
+    ///
+    /// Liveness derives both from the successor table; stating them directly
+    /// here keeps the allocator's rules testable without a backend MIR.
+    fn mark_diverging(info: &mut LivenessInfo<TestReg>, indices: &[usize], readers: &[u32]) {
+        info.diverging_at = vec![false; info.clobbers_at.len()];
+        for &idx in indices {
+            info.diverging_at[idx] = true;
+        }
+        info.diverging_uses = vec![false; info.ranges.len()];
+        for &vreg in readers {
+            info.diverging_uses[vreg as usize] = true;
+        }
+    }
+
     /// Liveness whose vregs carry the given classes, one per vreg index.
     ///
     /// Nothing in the compiler produces this yet — both backends mint only
@@ -2988,8 +3259,8 @@ mod tests {
         mark_non_returning(&mut liveness, &[2]);
         let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
 
-        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4)));
-        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(2, 2)));
+        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4), false));
+        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(2, 2), false));
     }
 
     #[test]
@@ -3000,10 +3271,10 @@ mod tests {
         mark_non_returning(&mut liveness, &[3]);
         let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
 
-        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4)));
-        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 1)));
+        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4), false));
+        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 1), false));
         assert!(
-            !index.is_clobbered_during(TestReg(0), &LiveRange::new(2, 4)),
+            !index.is_clobbered_during(TestReg(0), &LiveRange::new(2, 4), false),
             "a range that clears the returning call is clobber-free despite the trap"
         );
     }
@@ -3043,6 +3314,188 @@ mod tests {
             used_callee_saved.is_empty(),
             "no interval needed a callee-saved register, so the prologue saves nothing"
         );
+    }
+
+    // ========================================
+    // Divergence (RUE-2065)
+    // ========================================
+
+    #[test]
+    fn clobber_index_ignores_a_returning_call_inside_a_diverging_region() {
+        // A `@panic` arm: the guarded function's value is defined at 0 and used
+        // at 4, and the arm between them stages a failure site with an ordinary
+        // returning call at 1 before aborting at 3. Instructions 1..=3 are
+        // reachable only on the path that aborts, so the staging call's clobber
+        // cannot destroy a value with no use in the arm.
+        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], REG0_AT_1_AND_3);
+        mark_non_returning(&mut liveness, &[3]);
+        mark_diverging(&mut liveness, &[1, 2, 3], &[]);
+        let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
+
+        assert!(
+            index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4), false),
+            "the strict question still counts the returning call"
+        );
+        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4), true));
+    }
+
+    #[test]
+    fn clobber_index_keeps_a_diverging_clobber_for_a_value_the_arm_reads() {
+        // The same shape, except the value is the staged message the arm itself
+        // reads after the staging call returns. That use is on the aborting
+        // path, so the clobber is real and no relaxation applies to it.
+        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], REG0_AT_1_AND_3);
+        mark_non_returning(&mut liveness, &[3]);
+        mark_diverging(&mut liveness, &[1, 2, 3], &[0]);
+        let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
+
+        assert!(liveness.has_diverging_use(VReg::new(0)));
+        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4), false));
+    }
+
+    #[test]
+    fn divergence_index_answers_containment_and_defaults_to_false() {
+        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], REG0_AT_1_AND_3);
+        mark_non_returning(&mut liveness, &[3]);
+        mark_diverging(&mut liveness, &[1, 2, 3], &[]);
+        let index = DivergenceIndex::build(&liveness);
+
+        assert!(index.range_diverges(&LiveRange::new(1, 3)));
+        assert!(index.range_diverges(&LiveRange::new(2, 2)));
+        assert!(!index.range_diverges(&LiveRange::new(0, 3)));
+        assert!(!index.range_diverges(&LiveRange::new(3, 4)));
+
+        // Liveness that carries no divergence marks answers `false` everywhere,
+        // which leaves the save set exactly as it was before RUE-2065.
+        let plain = make_liveness_with_clobbers(vec![(0, 0, 4)], REG0_AT_1_AND_3);
+        assert!(!DivergenceIndex::build(&plain).range_diverges(&LiveRange::new(1, 3)));
+    }
+
+    #[test]
+    fn an_interval_confined_to_a_diverging_region_costs_no_prologue_save() {
+        // Two intervals compete for one caller-saved register across a clobber
+        // at 2: the first spans the whole function, the second lives only
+        // inside the diverging arm at 2..=4. Both end up in registers, but only
+        // the one the function can return from obliges the prologue.
+        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 4), (1, 2, 4)], REG9_AT_2);
+        mark_non_returning(&mut liveness, &[4]);
+        mark_diverging(&mut liveness, &[2, 3, 4], &[1]);
+        let file = RegisterFile::gp_only(SaveClasses {
+            caller_saved: &[TestReg(9)],
+            callee_saved: &[TestReg(0), TestReg(1)],
+            compact_callee_saved: &[],
+        });
+
+        let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
+            2,
+            &liveness,
+            file,
+            0,
+            false,
+            &CostModel::default(),
+            &LoopInfo::no_loops(liveness.instruction_count()),
+        );
+
+        assert_eq!(num_spills, 0);
+        assert!(matches!(
+            allocation[VReg::new(1)],
+            Some(Allocation::Register(_))
+        ));
+        assert!(
+            used_callee_saved.is_empty(),
+            "the arm's callee-saved register is clobbered only on a path that \
+             never returns, so the prologue does not save it"
+        );
+    }
+
+    #[test]
+    fn coalescing_carries_a_diverging_use_to_the_representative() {
+        // The shape an `if`/`else` join lowers to when a `@panic` arm reads the
+        // joined value: the arm's copy `mov v1, v0` at 1 is a coalesce
+        // candidate, the arm stages a failure site with a returning call at 2
+        // that clobbers a caller-saved register, and the arm reads the merged
+        // value at 3 before aborting at 4. Liveness recorded that read against
+        // v1, so unless coalescing folds the fact into the representative the
+        // clobber rule reads "no diverging use" off v0 and hands it the very
+        // register the staging call destroys.
+        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 1), (1, 1, 4)], REG9_AT_2);
+        mark_non_returning(&mut liveness, &[4]);
+        mark_diverging(&mut liveness, &[2, 3, 4], &[1]);
+
+        let candidates = vec![CoalesceCandidate {
+            inst_idx: 1,
+            dst: VReg::new(1),
+            src: VReg::new(0),
+        }];
+        let result = coalesce(&candidates, &mut liveness);
+
+        assert_eq!(result.representative(VReg::new(1)), VReg::new(0));
+        assert_eq!(liveness.range(VReg::new(0)), Some(&LiveRange::new(0, 4)));
+        assert!(liveness.range(VReg::new(1)).is_none());
+        assert!(
+            liveness.has_diverging_use(VReg::new(0)),
+            "the merged interval is read on the aborting path because its \
+             absorbed half was"
+        );
+
+        let file = RegisterFile::gp_only(SaveClasses {
+            caller_saved: &[TestReg(9)],
+            callee_saved: &[TestReg(0)],
+            compact_callee_saved: &[],
+        });
+        let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
+            2,
+            &liveness,
+            file,
+            0,
+            false,
+            &CostModel::default(),
+            &LoopInfo::no_loops(liveness.instruction_count()),
+        );
+
+        assert_eq!(num_spills, 0);
+        assert_eq!(
+            allocation[VReg::new(0)],
+            Some(Allocation::Register(TestReg(0))),
+            "the arm reads the merged value across the staging call, so the \
+             clobbered caller-saved register is not a legal home for it"
+        );
+        assert_eq!(used_callee_saved, vec![TestReg(0)]);
+    }
+
+    #[test]
+    fn a_callee_saved_register_shared_with_a_returning_interval_is_still_saved() {
+        // The same register serves a diverging interval and a returning one.
+        // The prologue must still save it: the returning interval's use is
+        // reached, and skipping the save would corrupt the caller's register.
+        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 1), (1, 3, 4)], REG9_AT_2);
+        mark_non_returning(&mut liveness, &[4]);
+        mark_diverging(&mut liveness, &[3, 4], &[1]);
+        let file = RegisterFile::gp_only(SaveClasses {
+            caller_saved: &[],
+            callee_saved: &[TestReg(0)],
+            compact_callee_saved: &[],
+        });
+
+        let (allocation, _, used_callee_saved, _) = linear_scan_impl(
+            2,
+            &liveness,
+            file,
+            0,
+            false,
+            &CostModel::default(),
+            &LoopInfo::no_loops(liveness.instruction_count()),
+        );
+
+        assert_eq!(
+            allocation[VReg::new(0)],
+            Some(Allocation::Register(TestReg(0)))
+        );
+        assert_eq!(
+            allocation[VReg::new(1)],
+            Some(Allocation::Register(TestReg(0)))
+        );
+        assert_eq!(used_callee_saved, vec![TestReg(0)]);
     }
 
     // ========================================
@@ -3193,12 +3646,12 @@ mod tests {
         let liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], REG0_AT_2);
         let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
 
-        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4)));
-        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(2, 2)));
-        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 1)));
-        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(3, 4)));
+        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4), false));
+        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(2, 2), false));
+        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 1), false));
+        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(3, 4), false));
         // An untracked register cannot be proven clobber-free.
-        assert!(index.is_clobbered_during(TestReg(1), &LiveRange::new(0, 1)));
+        assert!(index.is_clobbered_during(TestReg(1), &LiveRange::new(0, 1), false));
     }
 
     #[test]
@@ -3206,8 +3659,8 @@ mod tests {
         let liveness = make_liveness_with_clobbers(vec![(0, 0, 1)], REG0_AT_1);
         let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
 
-        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, usize::MAX)));
-        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 0)));
+        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, usize::MAX), false));
+        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 0), false));
     }
 
     #[test]

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -325,14 +325,32 @@ analysis emits as a `BoundsCheck` intrinsic, the `s[i]` check
 `__rue_str_byte_at` performs inside the runtime, and the division-by-zero,
 overflow, and `@intCast` range checks the CFG and codegen insert. The slice
 check is an AIR intrinsic and does carry a span, so what stops it is cost rather
-than reach, and both ways to spend it fall on the *passing* path: staging a site
-beside the check runs on every access, and staging it inside the failing arm
-costs a branch on the negated condition and the arm's register pressure in every
-function that indexes. Until the trap edge can carry a site the passing path
-does not pay for, those failures name the header, and their `kind` is still
-exact — `__rue_bounds_check` writes its `trap:bounds_check` record whether or
-not a site was staged, so the class comes from the channel rather than from
-matching a stderr line.
+than reach: staging a site beside the check would run on every access, and
+staging it inside a failing arm would turn a trap edge into a branch on the
+negated condition and a cold arm in every function that indexes. Until the trap
+edge can carry a site the passing path does not pay for, those failures name the
+header, and their `kind` is still exact — `__rue_bounds_check` writes its
+`trap:bounds_check` record whether or not a site was staged, so the class comes
+from the channel rather than from matching a stderr line.
+
+The policy those traps and the `@panic` arm share is that **the passing path
+pays nothing for a staged site**. Staging beside a check would break it outright
+— the staging call would run on every access — so a site is only ever staged
+inside the arm that is about to fail. What the arm costs the passing path is
+then a register-allocation question, and RUE-2065 settled it: allocation reads
+divergence, meaning the regions control can only leave by aborting. A clobber
+inside such a region cannot destroy a value with no use in one, so the receiver
+and index a guarded accessor holds across its guard can stay in caller-saved
+registers; and a callee-saved register only such a region occupies never enters
+the prologue, because the function does not return to restore it. What the arm
+*reads* still costs: a value the arm itself uses does cross the staging call,
+and takes a callee-saved register like any value that crosses a call. A `@panic`
+arm reads only the site operands it stages itself, so the guard adds a branch on
+the negated condition and a cold arm, and no prologue save the arm is
+responsible for — subject to ordinary register pressure, which on x86-64 leaves
+`open` one save because `r11` is its only allocatable caller-saved register.
+`crates/rue-cli-tests/cases/panic_guard_prologue.toml` pins that on both
+backends.
 
 `timeout` and `crash` verdicts also carry a failure record, with kind `timeout`
 and `signal` respectively.

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -347,10 +347,13 @@ staged and reports the empty location the runner answers from the test
 declaration's header: an allocation failure, the fixed-array bounds check
 codegen emits from a place projection, the slice bounds check semantic analysis
 emits as a `BoundsCheck` intrinsic, and the `s[i]` check `__rue_str_byte_at`
-performs inside the runtime. Because the panic helpers now report, the three
-terminal channel helpers take the stderr half of the panic path directly rather
-than calling `__rue_panic` — a second `trap:panic` frame after their own would
-be noise on a channel whose first frame is the verdict.
+performs inside the runtime. Staging inside the arm costs the passing path no
+prologue: codegen treats the arm as a diverging region, so neither the staging
+call's clobbers nor the registers the arm occupies reach the guarded function's
+prologue (RUE-2065; `docs/process/test-events.md`). Because the panic helpers
+now report, the three terminal channel helpers take the stderr half of the panic
+path directly rather than calling `__rue_panic` — a second `trap:panic` frame
+after their own would be noise on a channel whose first frame is the verdict.
 
 The record writer holds every helper above to two rules the caller does not have
 to know about. A `message` reaches the channel bounded to 4096 bytes, cut to


### PR DESCRIPTION
A `@panic` guard charged the passing path for its cold arm. The arm stages a
failure site with `__rue_test_failure_site` — an ordinary *returning* call —
before aborting, so read as textual intervals both the arm's own operands and
every value the guarded function holds across the guard cross a call, which is
the one thing that makes a callee-saved register their only legal home.
`open(port)` gained three x86-64 pushes and four AArch64 saves,
`ArrayBuf.get_ref`'s caller gained three, and `RawBuf.grow_to` three; every
entry paid a store and every exit a load on the path that never panics. On the
runtime benchmark suite that was a 10% regression: wordfreq 2.13s to 2.34s,
gazette_10x 2.13s to 2.40s.

## Divergence, and the two rules allocation reads from it

Liveness now marks the instructions control can only leave by aborting. The
never-returning calls the ABI manifest declares seed the set, and it spreads
back over every instruction all of whose successors carry it, so a whole
`@panic` or trap arm is marked rather than only the call that ends it. It is a
least fixed point over the same `SuccessorList`s liveness already builds, so a
cycle it cannot prove — a loop whose only exit is a trap — simply stays
unmarked, which costs a prologue save and nothing else.

Allocation reads two rules from the set:

- A clobber at a diverging instruction cannot destroy a value with no use at
  one, because reaching that clobber would make the use diverging too. The
  receiver and index a guarded accessor holds across its guard can therefore
  stay in caller-saved registers, generalizing RUE-1224 from the trap call to
  its region.
- A callee-saved register only such a region occupies never enters the
  prologue, because the function does not return to restore it. A register a
  returning interval also uses is still saved.

Prologues are now at or below their pre-RUE-2019 shape: `open` 5 pushes to 1 on
x86-64 and 5 saves to 0 on AArch64, `open_quiet` 4 to 1 and 3 to 0, and the
rawbuf/arraybuf program's total callee-saved saves 51 to 42 on AArch64 — its
pre-RUE-2019 figure exactly.

Both backends already supply the successor and never-returning facts, so the
whole change is in the shared liveness and allocation modules and lands on
x86-64 and AArch64 together.

## Coalescing has to carry the fact

Review of the first version found a miscompile in that first rule, and this PR
carries the fix. The rule is keyed by virtual register, which makes it the
coalescer's business: coalescing merges a move's destination into its source
and allocates the pair as one value, so the representative has to answer for
both halves — but the merge folded the live ranges alone.

A value produced by an `if`/`else` join and read inside the arm *after* the
staging call had its diverging use recorded against the half coalescing
discards. The rule then read "no diverging use" off the surviving half, handed
the merged interval a caller-saved register the staging call destroys, and the
arm read the helper's return value in place of its own:

```rue
fn f(q: i64) -> i64 {
    let zero: bool = q == 0;
    let k: i64 = if q > 5 { 41 } else { 42 };
    if zero {
        @dbg(77);
        @dbg(k);   // printed 0, not 42
        @panic("x");
    }
    k
}
```

Reproduced natively at `-O2` in a plain function, a `drop fn` body, and a
`rue test` body. `LivenessInfo::merge_into` is now the one place a coalesced
pair's facts are folded, and it carries the invariant that every per-vreg fact
liveness holds is merged there: the range hull, the diverging use, and the
register class the merge already refuses to cross.

## Tests

`crates/rue-cli-tests/cases/panic_guard_prologue.toml` pins the prologue of a
`@panic`-guarded accessor on both backends, re-checks that the guard still
aborts correctly and that its passing path still computes the right values, and
runs the guarded join above — a case that reads 0 instead of 42 without the
fold. Unit tests cover the marking (a guard arm, an exitless loop and a
trap-only loop that both stay unmarked, and a zero-successor `brk` that is not a
seed) and both allocation rules, including a coalesce candidate whose
destination carries the diverging use.

`//crates/rue-oracle-diff:oracle-diff-test` passes with the new corpus case.

`crates/rue-cli-tests/cases/frame_slot_reuse.toml` pinned seven frame sizes that
counted `main`'s callee-saved area. `main` ends in `__rue_exit`, so the whole of
it is a region control can only leave by aborting and the second rule empties
its save set; the locals area is what is left, and the sizes move to it. Checked
layout by layout against `--emit stackframe`: the cell plans those cases exist
to pin — the count, the order, and which locals share — are byte-identical.

## Not in this change

RUE-2065 also reports that `open_quiet` stopped being inlined into its caller.
That half is untouched here: the inliner's gate rejects any body containing a
call, and the arm still calls `__rue_test_failure_site`, so both accessors stay
out of line — with a one-register prologue instead of the five they had.
Restoring the inlining needs a separate decision about that gate.

Fixes RUE-2065
