### PR TITLE
RUE-1989: give each type-name spelling one decoder and one renderer

### DIFF
--- a/crates/rue-air/src/declaration_validation.rs
+++ b/crates/rue-air/src/declaration_validation.rs
@@ -36,6 +36,17 @@ pub fn reserved_function_name(name: &str) -> Option<ErrorKind> {
     })
 }
 
+/// Reject a struct or enum declaration whose name is reserved for a
+/// compiler-provided nominal (spec 6.0:3, E0404).
+///
+/// The reserved set has one owner, [`crate::types::is_reserved_type_name`],
+/// beside the rest of the built-in type-name spellings.
+pub fn reserved_type_name(name: &str) -> Option<ErrorKind> {
+    crate::types::is_reserved_type_name(name).then(|| ErrorKind::ReservedTypeName {
+        type_name: name.to_owned(),
+    })
+}
+
 pub fn duplicate_constant(name: &str) -> ErrorKind {
     ErrorKind::DuplicateConstant {
         name: name.to_owned(),

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -788,9 +788,7 @@ impl<'a> ConstraintGenerator<'a> {
         if let InferType::Concrete(t) = ty
             && let Some(id) = t.as_struct()
         {
-            let name: &str = &self.type_pool.struct_def(id).name;
-            return crate::types::is_string_view_struct_name(name)
-                || crate::types::is_slice_struct_name(name);
+            return self.type_pool.text_view_kind(id).is_some();
         }
         false
     }
@@ -813,11 +811,9 @@ impl<'a> ConstraintGenerator<'a> {
     /// StrBuf is not in this family: it is a source-defined struct whose
     /// declared `len` ordinary method lookup already resolves.
     fn is_view_len_call(&self, receiver: StructId, method: Spur, arg_count: usize) -> bool {
-        let name: &str = &self.type_pool.struct_def(receiver).name;
         arg_count == 0
             && self.interner.resolve(&method) == "len"
-            && (crate::types::is_slice_struct_name(name)
-                || crate::types::is_string_view_struct_name(name))
+            && self.type_pool.text_view_kind(receiver).is_some()
     }
 
     /// The string-literal analogue of [`Self::is_view_len_call`]: a zero-arg
@@ -844,7 +840,10 @@ impl<'a> ConstraintGenerator<'a> {
         let Some(id) = t.as_struct() else {
             return false;
         };
-        crate::types::is_string_view_struct_name(&self.type_pool.struct_def(id).name)
+        matches!(
+            self.type_pool.text_view_kind(id),
+            Some(crate::types::TextViewKind::Str | crate::types::TextViewKind::StrFixed(_))
+        )
     }
 
     /// The pointee of a pointer operand whose type is *already* concrete at
@@ -1008,7 +1007,7 @@ impl<'a> ConstraintGenerator<'a> {
         let id = ty.as_struct()?;
         // `str`/`Str(N)` share the view representation but index as bytes;
         // `is_string_indexable_type` answers those before this is consulted.
-        if !crate::types::is_slice_struct_name(&self.type_pool.struct_def(id).name) {
+        if self.type_pool.text_view_kind(id) != Some(crate::types::TextViewKind::Slice) {
             return None;
         }
         match self.type_pool.struct_def(id).fields.first()?.ty.kind() {
@@ -4497,9 +4496,9 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     fn string_literal_default_is_str(&self) -> bool {
-        self.string_literal_default
-            .as_struct()
-            .is_some_and(|id| &*self.type_pool.struct_def(id).name == "str")
+        self.string_literal_default.as_struct().is_some_and(|id| {
+            self.type_pool.text_view_kind(id) == Some(crate::types::TextViewKind::Str)
+        })
     }
 
     fn call_args_continue(&self, args: &rue_rir::RirCallArgsRange) -> bool {

--- a/crates/rue-air/src/inference/types.rs
+++ b/crates/rue-air/src/inference/types.rs
@@ -115,7 +115,7 @@ impl InferType {
             InferType::Var(id) => id.to_string(),
             InferType::IntLiteral => "{integer}".to_string(),
             InferType::Array { element, length } => {
-                format!("[{}; {}]", element.name_with_pool(pool), length)
+                crate::types::array_type_name(&element.name_with_pool(pool), *length)
             }
         }
     }

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -2487,7 +2487,9 @@ impl TypeInternPoolInner {
                 .unwrap_or_else(|| format!("<enum#{}>", id.0)),
             Some(TypeKind::Array(id)) => self
                 .try_array_def(id)
-                .map(|(element, len)| format!("[{}; {}]", self.safe_type_name(element), len))
+                .map(|(element, len)| {
+                    crate::types::array_type_name(&self.safe_type_name(element), len)
+                })
                 .unwrap_or_else(|| format!("<array#{}>", id.0)),
             Some(TypeKind::PtrConst(id)) => match self.try_entry(id.pool_index() as usize) {
                 Some(TypeData::PtrConst { pointee }) => {
@@ -3527,6 +3529,17 @@ impl TypeInternPool {
         Arc::make_mut(&mut inner.lang_item_structs).insert(lang_item, struct_id);
     }
 
+    /// Which compiler-generated text view a nominal is, if any (RUE-1989).
+    ///
+    /// The one pool-level answer to "is this `str`, `Str(N)`, or `[T]`?". It
+    /// checks the builtin bit as well as the canonical spelling, so a
+    /// source-defined nominal cannot counterfeit a view, and every phase that
+    /// routes text and slice values asks here rather than comparing the struct
+    /// name itself.
+    pub fn text_view_kind(&self, struct_id: StructId) -> Option<crate::types::TextViewKind> {
+        crate::types::text_view_struct_kind(self.try_struct_def(struct_id)?.as_ref())
+    }
+
     /// Whether a nominal is the canonical trusted standard-library StrBuf.
     pub fn is_strbuf(&self, struct_id: StructId) -> bool {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
@@ -4059,6 +4072,11 @@ impl FrozenTypeInternPool {
 
     pub fn try_struct_def(&self, id: StructId) -> Option<&StructDefEntry> {
         self.inner.try_struct_def(id)
+    }
+
+    /// Backend-facing counterpart to [`TypeInternPool::text_view_kind`].
+    pub fn text_view_kind(&self, struct_id: StructId) -> Option<crate::types::TextViewKind> {
+        crate::types::text_view_struct_kind(self.try_struct_def(struct_id)?)
     }
 
     /// Borrow a completed nominal enum definition without locking or cloning.

--- a/crates/rue-air/src/intrinsic.rs
+++ b/crates/rue-air/src/intrinsic.rs
@@ -111,6 +111,15 @@ pub trait RuntimeAirTypePool {
     fn ptr_mut_def(&self, id: crate::PtrMutTypeId) -> Type;
 }
 
+/// Whether a pool text-view classification is one of the two-word string
+/// views: `str` or `Str(N)`. A `[T]` slice is a view too, but it is not text.
+fn is_text_view(kind: Option<crate::TextViewKind>) -> bool {
+    matches!(
+        kind,
+        Some(crate::TextViewKind::Str | crate::TextViewKind::StrFixed(_))
+    )
+}
+
 /// Convert an AIR value type to the compact type vocabulary used by the
 /// runtime-call manifest.  This is shared by durable import and CFG so the
 /// manifest remains the sole authority for runtime intrinsic call shapes.
@@ -139,11 +148,10 @@ fn runtime_air_type_in_pool(pool: &TypeInternPool, ty: Type) -> Option<RuntimeAi
     if ty.is_unsigned() {
         return Some(RuntimeAirType::UnsignedInteger);
     }
-    if let TypeKind::Struct(struct_id) = ty.kind() {
-        let name: &str = &pool.struct_def(struct_id).name;
-        if pool.is_strbuf(struct_id) || crate::is_string_view_struct_name(name) {
-            return Some(RuntimeAirType::Text);
-        }
+    if let TypeKind::Struct(struct_id) = ty.kind()
+        && (pool.is_strbuf(struct_id) || is_text_view(pool.text_view_kind(struct_id)))
+    {
+        return Some(RuntimeAirType::Text);
     }
     if let Some(ptr) = ty.as_ptr_const()
         && pool.ptr_const_def(ptr) == Type::U8
@@ -261,11 +269,10 @@ impl RuntimeAirTypePool for FrozenTypeInternPool {
         if ty.is_unsigned() {
             return Some(RuntimeAirType::UnsignedInteger);
         }
-        if let TypeKind::Struct(struct_id) = ty.kind() {
-            let name: &str = &self.struct_def(struct_id).name;
-            if self.is_strbuf(struct_id) || crate::is_string_view_struct_name(name) {
-                return Some(RuntimeAirType::Text);
-            }
+        if let TypeKind::Struct(struct_id) = ty.kind()
+            && (self.is_strbuf(struct_id) || is_text_view(self.text_view_kind(struct_id)))
+        {
+            return Some(RuntimeAirType::Text);
         }
         if let Some(ptr) = ty.as_ptr_const()
             && self.ptr_const_def(ptr) == Type::U8

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -187,8 +187,9 @@ pub use semantic_type_resolution::{
 };
 pub use types::{
     ArrayLen, ArrayTypeId, EnumDef, EnumId, LangItem, ModuleDef, ModuleId, PtrConstTypeId,
-    PtrMutTypeId, StructDef, StructField, StructId, Type, TypeKind, fixed_string_capacity,
-    is_slice_struct_name, is_string_view_struct_name,
+    PtrMutTypeId, StructDef, StructField, StructId, TextViewKind, Type, TypeKind, array_type_name,
+    fixed_string_capacity, fixed_string_name, is_slice_struct_name, is_string_view_struct_name,
+    slice_struct_name, text_view_name_kind,
 };
 
 /// Sentinel value used to encode parameter slots in AIR instructions.

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -676,7 +676,7 @@ where
     /// Mint (or return) one generated fixed-capacity string and publish its
     /// name in the same generated-nominal overlay used by slice views.
     pub fn register_generated_fixed_string(&self, capacity: u64) -> Option<StructId> {
-        let name = format!("Str({capacity})");
+        let name = crate::types::fixed_string_name(capacity);
         let symbol = self.identity.pool().intern_name(&name).ok()?;
         let id = self
             .identity

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -1126,7 +1126,7 @@ where
         &mut self,
         capacity: u64,
     ) -> Result<Type, IdentityMintError> {
-        let name: Arc<str> = Arc::from(format!("Str({capacity})").as_str());
+        let name: Arc<str> = Arc::from(crate::types::fixed_string_name(capacity).as_str());
         let symbol = self
             .intern_name(&name)
             .map_err(IdentityMintError::Interner)?;
@@ -3935,7 +3935,7 @@ mod tests {
             TypeKind::Enum(id) => pool.enum_def(id).name.to_string(),
             TypeKind::Array(id) => {
                 let (element, len) = pool.array_def(id);
-                format!("[{}; {}]", render(pool, element), len)
+                crate::types::array_type_name(&render(pool, element), len)
             }
             TypeKind::PtrConst(id) => format!("ptr const {}", render(pool, pool.ptr_const_def(id))),
             TypeKind::PtrMut(id) => format!("ptr mut {}", render(pool, pool.ptr_mut_def(id))),

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -496,6 +496,7 @@ mod tests {
 
         let typeck_impls = impl_items(TYPECK_SOURCE);
         let classification_methods = [
+            "text_view_kind",
             "is_str_struct",
             "is_str_fixed_struct",
             "str_fixed_capacity",
@@ -1713,12 +1714,21 @@ mod tests {
                 include_str!("semantic_body_export.rs"),
             ),
             ("typeck.rs", TYPECK_SOURCE),
+            ("body_endpoint.rs", include_str!("body_endpoint.rs")),
+            (
+                "provider_body_host.rs",
+                include_str!("provider_body_host.rs"),
+            ),
         ];
         for (name, source) in consumers {
+            // Decoding and rendering are one policy: a consumer that spells
+            // `Str(N)` by hand drifts from the decoder just as surely as one
+            // that parses it by hand (RUE-1989).
             for peer in [
                 ".strip_prefix(\"Str(\")",
                 ".starts_with(\"Str(\")",
                 ".starts_with('[')",
+                "format!(\"Str(",
             ] {
                 assert!(
                     !source.contains(peer),
@@ -1730,6 +1740,11 @@ mod tests {
             "pub fn fixed_string_capacity(",
             "pub fn is_slice_struct_name(",
             "pub fn is_string_view_struct_name(",
+            "pub fn fixed_string_name(",
+            "pub fn slice_struct_name(",
+            "pub fn array_type_name(",
+            "pub fn text_view_name_kind(",
+            "pub fn is_reserved_type_name(",
         ] {
             assert_eq!(
                 TYPES_SOURCE.matches(helper).count(),

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -845,7 +845,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             InferType::Var(id) => id.to_string(),
             InferType::IntLiteral => "{integer}".to_string(),
             InferType::Array { element, length } => {
-                format!("[{}; {length}]", self.format_infer_type_name(element))
+                crate::types::array_type_name(&self.format_infer_type_name(element), *length)
             }
         }
     }
@@ -1745,13 +1745,10 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         let crate::types::TypeKind::Struct(struct_id) = ty.kind() else {
             return None;
         };
+        self.body_type_pool().text_view_kind(struct_id)?;
         let def = self.body_type_pool().struct_def(struct_id);
-        if crate::types::is_slice_struct_name(&def.name)
-            || crate::types::is_string_view_struct_name(&def.name)
-        {
-            if let crate::types::TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
-                return Some(self.body_type_pool().ptr_const_def(ptr_id));
-            }
+        if let crate::types::TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
+            return Some(self.body_type_pool().ptr_const_def(ptr_id));
         }
         None
     }

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -4004,18 +4004,16 @@ where
     }
 
     fn type_syntax_make_fixed_str(&mut self, capacity: u64, span: Span) -> CompileResult<Type> {
+        let spelling = crate::types::fixed_string_name(capacity);
         let id = self
             .endpoint
             .register_generated_fixed_string(capacity)
             .ok_or_else(|| {
-                CompileError::new(
-                    rue_error::ErrorKind::UnknownType(format!("Str({capacity})")),
-                    span,
-                )
+                CompileError::new(rue_error::ErrorKind::UnknownType(spelling.clone()), span)
             })?;
         let name = self
             .interner
-            .get(format!("Str({capacity})"))
+            .get(&spelling)
             .expect("generated Str name must be admitted before publication");
         self.generated_structs.insert(name, id);
         Ok(Type::new_struct(id))
@@ -4232,7 +4230,7 @@ where
                 self.friendly_durable_anonymous_display(identity)?
             }
             T::Array { element, len } => {
-                format!("[{}; {len}]", self.friendly_durable_type_display(element)?)
+                crate::types::array_type_name(&self.friendly_durable_type_display(element)?, *len)
             }
             T::Slice { element, name } => {
                 let _ = element;
@@ -4326,7 +4324,7 @@ where
                 .type_pool
                 .try_array_def(id)
                 .map(|(element, length)| {
-                    format!("[{}; {}]", self.friendly_type_display(element), length)
+                    crate::types::array_type_name(&self.friendly_type_display(element), length)
                 })
                 .unwrap_or_else(|| ty.safe_name_with_pool(Some(&self.type_pool))),
             Some(TypeKind::PtrConst(id)) => format!(

--- a/crates/rue-air/src/sema/provider_strings_ownership_tests.rs
+++ b/crates/rue-air/src/sema/provider_strings_ownership_tests.rs
@@ -34,7 +34,7 @@ fn str_view() -> FixtureType {
 /// boundary.
 fn fixed_str(capacity: u32) -> FixtureType {
     SemanticImportType::BuiltinNominal {
-        name: Arc::from(format!("Str({capacity})")),
+        name: Arc::from(crate::types::fixed_string_name(capacity.into())),
         kind: SemanticImportNominalKind::Struct,
     }
 }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -29,7 +29,7 @@ pub(crate) const MAX_TYPE_SIZE_BYTES: u64 = i32::MAX as u64;
 /// policy in spec C.1:2.
 pub(crate) const MAX_TYPE_SLOTS: u64 = MAX_TYPE_SIZE_BYTES / 8;
 use crate::sema::ConstValue;
-use crate::types::{ArrayLen, Type, TypeKind};
+use crate::types::{ArrayLen, TextViewKind, Type, TypeKind};
 
 /// The narrow semantic surface consumed by the canonical type-syntax
 /// evaluator.  This deliberately owns neither a declaration epoch nor a body
@@ -993,16 +993,21 @@ pub(super) fn semantic_type_syntax_compile_error(
 }
 
 impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
-    /// Is `ty` the synthetic `str` struct (ADR-0043 Phase 3, RUE-324)? Detected
-    /// by the struct name being exactly `str`. Used to route string literals and
-    /// slice-style `.len()`/index operations through the fat-pointer paths while
-    /// keeping `str` first-class (exempt from the slice second-class rule).
+    /// Which compiler-generated text view `ty` is, if it is one (RUE-1989).
+    ///
+    /// The pool owns the classification — the builtin bit together with the
+    /// canonical spelling — so the engine's string predicates below are thin
+    /// readings of one answer rather than independent name comparisons.
+    pub(crate) fn text_view_kind(&self, ty: Type) -> Option<crate::types::TextViewKind> {
+        self.body_type_pool().text_view_kind(ty.as_struct()?)
+    }
+
+    /// Is `ty` the synthetic `str` struct (ADR-0043 Phase 3, RUE-324)? Used to
+    /// route string literals and slice-style `.len()`/index operations through
+    /// the fat-pointer paths while keeping `str` first-class (exempt from the
+    /// slice second-class rule).
     pub(crate) fn is_str_struct(&self, ty: Type) -> bool {
-        if let TypeKind::Struct(struct_id) = ty.kind() {
-            &*self.body_type_pool().struct_def(struct_id).name == "str"
-        } else {
-            false
-        }
+        matches!(self.text_view_kind(ty), Some(TextViewKind::Str))
     }
 
     /// Is `ty` a fixed-capacity string `Str(N)` (ADR-0043 Phase 5, RUE-326)?
@@ -1013,13 +1018,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     }
 
     /// If `ty` is a fixed-capacity string `Str(N)`, return its capacity `N`
-    /// (ADR-0043 Phase 5, RUE-326); otherwise `None`. The builtin bit and
-    /// canonical spelling are checked by one shared classifier.
+    /// (ADR-0043 Phase 5, RUE-326); otherwise `None`.
     pub(crate) fn str_fixed_capacity(&self, ty: Type) -> Option<u64> {
-        if let TypeKind::Struct(struct_id) = ty.kind() {
-            crate::types::fixed_string_struct_capacity(&self.body_type_pool().struct_def(struct_id))
-        } else {
-            None
+        match self.text_view_kind(ty)? {
+            TextViewKind::StrFixed(capacity) => Some(capacity),
+            TextViewKind::Str | TextViewKind::Slice => None,
         }
     }
 
@@ -1030,7 +1033,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// treat them identically. The capacity-fits legality rule is the only place
     /// `Str(N)` diverges from `str`.
     pub(crate) fn is_str_like(&self, ty: Type) -> bool {
-        self.is_str_struct(ty) || self.is_str_fixed_struct(ty)
+        matches!(
+            self.text_view_kind(ty),
+            Some(TextViewKind::Str | TextViewKind::StrFixed(_))
+        )
     }
 }
 

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -262,6 +262,43 @@ macro_rules! define_semantic_import_const_schema {
 semantic_import_const_schema!(define_semantic_import_const_schema);
 
 impl<K, M> SemanticImportType<K, M> {
+    /// Resolve a primitive type-syntax name in the durable type algebra.
+    ///
+    /// The name table itself belongs to [`crate::Type::from_primitive_name`];
+    /// this is its one projection into the durable algebra, so a durable
+    /// resolver never carries a second spelling table that could accept
+    /// `usize` in one position and reject it in another (RUE-1989). A name that
+    /// resolves to a type the durable algebra has no primitive variant for is
+    /// `None`, exactly as a non-primitive name is.
+    #[must_use]
+    pub fn from_primitive_name(name: &str) -> Option<Self> {
+        use crate::TypeKind as K;
+        Some(match crate::Type::from_primitive_name(name)?.try_kind()? {
+            K::I8 => Self::I8,
+            K::I16 => Self::I16,
+            K::I32 => Self::I32,
+            K::I64 => Self::I64,
+            K::U8 => Self::U8,
+            K::U16 => Self::U16,
+            K::U32 => Self::U32,
+            K::U64 => Self::U64,
+            K::Bool => Self::Bool,
+            K::Unit => Self::Unit,
+            K::Never => Self::Never,
+            K::ComptimeType => Self::ComptimeType,
+            K::F32 => Self::F32,
+            K::F64 => Self::F64,
+            K::ComptimeFloat => Self::ComptimeFloat,
+            K::Struct(_)
+            | K::Enum(_)
+            | K::Array(_)
+            | K::PtrConst(_)
+            | K::PtrMut(_)
+            | K::Module(_)
+            | K::Error => return None,
+        })
+    }
+
     /// Fold this value in post-order through the canonical schema visitor.
     pub fn try_fold<T, E>(
         &self,
@@ -2479,7 +2516,7 @@ mod tests {
             ),
             TypeKind::Array(id) => {
                 let (element, len) = epoch.type_pool().array_def(id);
-                format!("[{element}; {len}]", element = projection(epoch, element))
+                crate::types::array_type_name(&projection(epoch, element), len)
             }
             TypeKind::Module(id) => {
                 format!("module {}", epoch.module_registry().get_def(id).file_path)

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -30,9 +30,10 @@ pub fn fixed_string_capacity(name: &str) -> Option<u64> {
 /// source-defined struct must not counterfeit `Str(N)`. Keep the builtin bit
 /// check beside the canonical spelling parser so semantic consumers agree.
 pub(crate) fn fixed_string_struct_capacity(def: &StructDef) -> Option<u64> {
-    def.is_builtin
-        .then(|| fixed_string_capacity(&def.name))
-        .flatten()
+    match text_view_struct_kind(def) {
+        Some(TextViewKind::StrFixed(capacity)) => Some(capacity),
+        _ => None,
+    }
 }
 
 /// Whether `name` is the canonical spelling of a synthetic slice struct.
@@ -40,9 +41,103 @@ pub fn is_slice_struct_name(name: &str) -> bool {
     name.starts_with('[') && name.ends_with(']') && !name.contains(';')
 }
 
+/// The canonical name of the core `str` view.
+pub(crate) const CORE_STR_NAME: &str = "str";
+
 /// Whether `name` is a two-word string-view nominal (`str` or `Str(N)`).
 pub fn is_string_view_struct_name(name: &str) -> bool {
-    name == "str" || fixed_string_capacity(name).is_some()
+    matches!(
+        text_view_name_kind(name),
+        Some(TextViewKind::Str | TextViewKind::StrFixed(_))
+    )
+}
+
+/// Which compiler-generated two-word view a nominal is.
+///
+/// `str`, `Str(N)`, and `[T]` share one `{ptr, len}` representation and one
+/// family of spelling rules, so the phases that route them — literal
+/// materialization, `.len()`, indexing, by-value passing, second-class
+/// checks — classify through this one enum rather than comparing struct names
+/// themselves (RUE-1989).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TextViewKind {
+    /// The core `str` view over borrowed UTF-8 bytes.
+    Str,
+    /// A fixed-capacity string `Str(N)` carrying its capacity.
+    StrFixed(u64),
+    /// A slice view `[T]`.
+    Slice,
+}
+
+/// Whether `name` is a type-name spelling reserved for a compiler-provided
+/// nominal, so a user declaration may not take it (spec 6.0:3).
+///
+/// The core `str` view is the one such spelling: it is injected into the type
+/// pool as a builtin nominal rather than declared in source, so a user
+/// `struct str` or `enum str` would have to share a name with a nominal that
+/// already exists in every module's scope. `Str(N)` and `[T]` are generated
+/// spellings too, but no declaration syntax can write them, and `StrBuf` is an
+/// ordinary source declaration in `std` that a user type may freely shadow.
+#[must_use]
+pub fn is_reserved_type_name(name: &str) -> bool {
+    name == CORE_STR_NAME
+}
+
+/// Classify a canonical generated view spelling, ignoring provenance.
+///
+/// Callers that hold a struct definition must use [`text_view_struct_kind`]
+/// instead: the spelling alone does not prove the nominal is compiler-made.
+pub fn text_view_name_kind(name: &str) -> Option<TextViewKind> {
+    if name == CORE_STR_NAME {
+        Some(TextViewKind::Str)
+    } else if let Some(capacity) = fixed_string_capacity(name) {
+        Some(TextViewKind::StrFixed(capacity))
+    } else if is_slice_struct_name(name) {
+        Some(TextViewKind::Slice)
+    } else {
+        None
+    }
+}
+
+/// Classify a struct definition as a compiler-generated text view.
+///
+/// The builtin bit is part of the classification: a source-defined nominal
+/// must not counterfeit a view, whatever it is spelled.
+pub(crate) fn text_view_struct_kind(def: &StructDef) -> Option<TextViewKind> {
+    def.is_builtin
+        .then(|| text_view_name_kind(&def.name))
+        .flatten()
+}
+
+/// Render the canonical synthetic name of the fixed-capacity string `Str(N)`.
+///
+/// The exact inverse of [`fixed_string_capacity`]: a phase that mints, names,
+/// or reports a fixed string spells it here rather than formatting `Str(N)`
+/// itself, so the decoder and every producer cannot drift (RUE-1989).
+#[must_use]
+pub fn fixed_string_name(capacity: u64) -> String {
+    format!("Str({capacity})")
+}
+
+/// Render the canonical synthetic name of the slice view over `element`.
+///
+/// The inverse of [`is_slice_struct_name`]. The slice nominal's name IS its
+/// source spelling, so a producer that has only the element spelling builds the
+/// name here rather than bracketing it by hand.
+#[must_use]
+pub fn slice_struct_name(element: &str) -> String {
+    format!("[{element}]")
+}
+
+/// Render the canonical spelling of the array type `[T; N]`.
+///
+/// Array types are structural rather than nominal, so this is a presentation
+/// spelling rather than an identity: diagnostics, type-name displays, and
+/// durable projections all render an array through this one renderer so the
+/// separator and bracket placement cannot drift between them.
+#[must_use]
+pub fn array_type_name(element: &str, len: u64) -> String {
+    format!("[{element}; {len}]")
 }
 
 /// A unique identifier for a struct definition.
@@ -1141,6 +1236,26 @@ mod tests {
         assert!(!is_string_view_struct_name("Str(042)"));
     }
 
+    #[test]
+    fn synthetic_name_renderers_invert_their_decoders() {
+        for capacity in [0, 1, 42, u64::MAX] {
+            let name = fixed_string_name(capacity);
+            assert_eq!(fixed_string_capacity(&name), Some(capacity), "{name}");
+            assert!(is_string_view_struct_name(&name), "{name}");
+        }
+
+        // The slice classifier reads the outer brackets and the absence of an
+        // array separator, so it round-trips a slice of any element spelling
+        // that is not itself an array.
+        for element in ["u8", "i32", "[u8]", "ptr const u8"] {
+            let name = slice_struct_name(element);
+            assert!(is_slice_struct_name(&name), "{name}");
+        }
+
+        assert_eq!(array_type_name("u8", 4), "[u8; 4]");
+        assert!(!is_slice_struct_name(&array_type_name("u8", 4)));
+    }
+
     // ========== Type ID tests ==========
 
     #[test]
@@ -1369,6 +1484,30 @@ mod tests {
         assert_eq!(Type::from_primitive_name("type"), Some(Type::COMPTIME_TYPE));
         assert_eq!(Type::from_primitive_name("f32"), Some(Type::F32));
         assert_eq!(Type::from_primitive_name("f64"), Some(Type::F64));
+    }
+
+    /// The float spellings the lexer publishes and the ones the type table
+    /// resolves are the same set (RUE-1989).
+    ///
+    /// `rue-lexer::FLOAT_TYPE_NAMES` is the one list, read by the parser
+    /// positions that must recognize a float type name lexically. rue-air does
+    /// not depend on the lexer at build time, so the agreement is asserted
+    /// here rather than shared through a call.
+    #[test]
+    fn the_lexer_float_type_names_are_exactly_the_resolvable_float_primitives() {
+        for spelling in rue_lexer::FLOAT_TYPE_NAMES {
+            let resolved = Type::from_primitive_name(spelling).expect("a float type name resolves");
+            assert!(resolved.is_float(), "{spelling} resolved to {resolved:?}");
+        }
+
+        let resolvable_floats = [
+            "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "usize", "isize", "bool", "()",
+            "!", "type", "f32", "f64",
+        ]
+        .into_iter()
+        .filter(|name| Type::from_primitive_name(name).is_some_and(|resolved| resolved.is_float()))
+        .collect::<Vec<_>>();
+        assert_eq!(resolvable_floats, rue_lexer::FLOAT_TYPE_NAMES);
     }
 
     #[test]

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -4795,7 +4795,12 @@ mod tests {
                 is_linear: false,
                 declared_linear: false,
                 destructor: destructor.map(Into::into),
-                is_builtin: false,
+                // A generated view spelling is a compiler-provided nominal in
+                // production, and the pool's text-view classification reads
+                // that bit as well as the name (RUE-1989); a fixture whose
+                // `str` were registered as source-defined would not classify
+                // as text.
+                is_builtin: rue_air::text_view_name_kind(name).is_some(),
                 is_pub: false,
                 file_id: FileId::DEFAULT,
             },

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -1754,9 +1754,12 @@ impl<'a> Verifier<'a> {
         ) else {
             return false;
         };
-        let is_fixed_str = rue_air::fixed_string_capacity(&source_def.name).is_some();
+        let is_fixed_str = matches!(
+            pool.text_view_kind(source_id),
+            Some(rue_air::TextViewKind::StrFixed(_))
+        );
         is_fixed_str
-            && &*result_def.name == "str"
+            && pool.text_view_kind(result_id) == Some(rue_air::TextViewKind::Str)
             && source_def.fields.len() == result_def.fields.len()
             && source_def
                 .fields

--- a/crates/rue-cli-tests/cases/module_const_type_namespace.toml
+++ b/crates/rue-cli-tests/cases/module_const_type_namespace.toml
@@ -190,14 +190,14 @@ compile_fail = true
 error_contains = ["E0423", "field access on non-struct type 'type'"]
 
 [[case]]
-name = "user_enum_blocks_opposite_kind_builtin_struct_literal"
-description = "RUE-1966 symmetric wrong-kind control: a same-named user enum blocks fallback to builtin str as a struct-literal head."
+name = "user_enum_cannot_take_the_builtin_str_spelling"
+description = "RUE-1966 symmetric wrong-kind control, tightened by RUE-1989: the only builtin struct spelling a user declaration could shadow is `str`, and that name is now reserved, so the declaration is refused before any struct-literal head resolves."
 files = [{ path = "main.rue", source = """
 enum str { Value }
 fn main() -> i32 { let _ = str { x: 1 }; 0 }
 """ }]
 compile_fail = true
-error_contains = ["E0204", "unknown type 'str'"]
+error_contains = ["E0404", "cannot define type `str`"]
 
 [[case]]
 name = "primitive_spelling_blocks_same_named_user_struct_literal"

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -453,8 +453,11 @@ impl<'a> CfgLowerContext<'a> {
     pub fn is_string_like_for_equality(&self, ty: Type) -> bool {
         match ty.kind() {
             TypeKind::Struct(struct_id) => {
-                let struct_def = self.type_pool.struct_def(struct_id);
-                self.is_strbuf(ty) || rue_air::is_string_view_struct_name(&struct_def.name)
+                self.is_strbuf(ty)
+                    || matches!(
+                        self.type_pool.text_view_kind(struct_id),
+                        Some(rue_air::TextViewKind::Str | rue_air::TextViewKind::StrFixed(_))
+                    )
             }
             _ => false,
         }

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1977,7 +1977,7 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
     (753, 3_150_885_663_910_159_936),
     (2_598, 10_270_973_964_375_394_836),
     (11653, 15_769_724_788_918_086_723),
-    (106_643, 1_879_126_869_505_685_683),
+    (108_305, 456_066_266_069_628_992),
     (3_254, 11_949_940_325_034_004_149),
     (5_552, 14_658_861_127_087_730_967),
     (872, 14_092_162_116_261_787_003),
@@ -5993,8 +5993,18 @@ fn compiler_uses_air_synthetic_type_identity_policy() {
             include_str!("local_semantic_materialization.rs"),
         ),
         ("revisioned_query_database.rs", REVISIONED_DATABASE_SOURCE),
+        (
+            "provider_body.rs",
+            include_str!("revisioned_query_database/body/provider_body.rs"),
+        ),
     ] {
-        for peer in [".strip_prefix(\"Str(\")", ".starts_with(\"Str(\")"] {
+        // Decoders and renderers alike: the `Str(N)` spelling is read and
+        // written only through rue-air's owner pair (RUE-1989).
+        for peer in [
+            ".strip_prefix(\"Str(\")",
+            ".starts_with(\"Str(\")",
+            "format!(\"Str(",
+        ] {
             assert!(
                 !source.contains(peer),
                 "{name} regained handwritten synthetic-type identity policy: {peer}"

--- a/crates/rue-compiler/src/durable_comptime/projection.rs
+++ b/crates/rue-compiler/src/durable_comptime/projection.rs
@@ -212,7 +212,7 @@ fn durable_type_diagnostic_name_kernel(ty: &DurableType) -> String {
             }
         },
         T::Array { element, len } => {
-            format!("[{}; {len}]", durable_type_diagnostic_name(element))
+            rue_air::array_type_name(&durable_type_diagnostic_name(element), *len)
         }
         T::Slice { name, .. } => name.to_string(),
         T::PtrConst(pointee) => {

--- a/crates/rue-compiler/src/error_printer.rs
+++ b/crates/rue-compiler/src/error_printer.rs
@@ -295,7 +295,7 @@ fn leaf_render(ty: &crate::TypeInstanceKey, types: &impl ErrorPrinterTypes) -> L
 fn byte_view(ty: &crate::TypeInstanceKey, types: &impl ErrorPrinterTypes) -> Option<ByteView> {
     if let crate::TypeInstanceKey::BuiltinNominal { kind, name } = ty
         && *kind == rue_air::AnonymousNominalKind::Struct
-        && (name.as_ref() == "str" || rue_air::fixed_string_capacity(name).is_some())
+        && rue_air::is_string_view_struct_name(name)
     {
         let nominal = crate::NominalInstanceKey::Builtin {
             kind: rue_air::AnonymousNominalKind::Struct,

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -1645,30 +1645,14 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
         QueryAbort,
         crate::semantic_query_nucleus::SemanticNucleusFailure,
     > {
-        use crate::durable_semantics::DurableType as T;
-        Ok(Some(match name {
-            "i8" => T::I8,
-            "i16" => T::I16,
-            "i32" => T::I32,
-            "i64" => T::I64,
-            "isize" => T::I64,
-            "u8" => T::U8,
-            "u16" => T::U16,
-            "u32" => T::U32,
-            "u64" => T::U64,
-            "usize" => T::U64,
-            "bool" => T::Bool,
-            "()" => T::Unit,
-            "!" => T::Never,
-            "type" => T::ComptimeType,
-            "f32" => T::F32,
-            "f64" => T::F64,
-            // `comptime_float` is absent for the same reason `comptime_int`
-            // is: a comptime-only type is inferred, never named (spec 3.12:3).
-            // This table mirrors `rue_air::Type::from_primitive_name` and must
-            // keep mirroring it (RUE-1076).
-            _ => return Ok(None),
-        }))
+        // The primitive-name table has one owner in rue-air. `comptime_float`
+        // is absent from it for the same reason `comptime_int` is: a
+        // comptime-only type is inferred, never named (spec 3.12:3), so this
+        // resolver answers `None` for it without repeating the reason
+        // (RUE-1076, RUE-1989).
+        Ok(crate::durable_semantics::DurableType::from_primitive_name(
+            name,
+        ))
     }
 
     fn builtin_type(
@@ -1941,7 +1925,7 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
         );
         Ok(Some(
             crate::durable_semantics::DurableType::BuiltinNominal {
-                name: Arc::from(format!("Str({capacity})")),
+                name: Arc::from(rue_air::fixed_string_name(capacity)),
                 kind: rue_air::SemanticImportNominalKind::Struct,
             },
         ))

--- a/crates/rue-compiler/src/revisioned_query_database/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/provider.rs
@@ -3116,32 +3116,16 @@ pub(super) fn provider_definition_category(
     }
 }
 
-/// The durable type for a primitive type-syntax name, mirroring
-/// `rue_air::Type::from_primitive_name` in the durable algebra.
+/// The durable type for a primitive type-syntax name.
+///
+/// The spelling table has one owner — `rue_air::Type::from_primitive_name`,
+/// projected into the durable algebra by `DurableType::from_primitive_name`.
+/// In particular there is no `comptime_float`: a comptime-only type is
+/// inferred, never named (spec 3.12:3), exactly as `comptime_int` is not
+/// nameable.
 #[cfg(test)]
 pub(super) fn primitive_durable_type(name: &str) -> Option<crate::DurableType> {
-    use crate::DurableType as T;
-    Some(match name {
-        "i8" => T::I8,
-        "i16" => T::I16,
-        "i32" => T::I32,
-        "i64" => T::I64,
-        "u8" => T::U8,
-        "u16" => T::U16,
-        "u32" => T::U32,
-        "u64" => T::U64,
-        "usize" => T::U64,
-        "isize" => T::I64,
-        "bool" => T::Bool,
-        "()" => T::Unit,
-        "!" => T::Never,
-        "type" => T::ComptimeType,
-        "f32" => T::F32,
-        "f64" => T::F64,
-        // No `comptime_float`: a comptime-only type is inferred, never named
-        // (spec 3.12:3), exactly as `comptime_int` is not nameable.
-        _ => return None,
-    })
+    crate::DurableType::from_primitive_name(name)
 }
 
 #[cfg(test)]

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
@@ -235,6 +235,27 @@ $runtime
                                                 ))
                                                 .with_terminal_kind(QueryTerminalKind::Failure));
                                             }
+                                            // A user nominal may not take a
+                                            // type-name spelling the compiler
+                                            // injects (spec 6.0:3). The check
+                                            // rides beside the reserved
+                                            // function names so both refusals
+                                            // are raised at declaration
+                                            // registration, before any
+                                            // reference resolves against the
+                                            // shadowed builtin (RUE-1989).
+                                            if matches!(
+                                                query.declaration.category,
+                                                crate::declaration_candidate::DeclarationCandidateCategory::Struct
+                                                    | crate::declaration_candidate::DeclarationCandidateCategory::Enum
+                                            ) && let Some(kind) = rue_air::declaration_validation::reserved_type_name(
+                                                &query.declaration.name,
+                                            ) {
+                                                return Ok(QueryOutput::success(Value::Failure(
+                                                    Failure::Diagnostic(kind),
+                                                ))
+                                                .with_terminal_kind(QueryTerminalKind::Failure));
+                                            }
                                             let mut substitutions = BTreeMap::new();
                                             if let Some(owner) = &query.declaration.owner {
                                                 let owner_candidate = crate::declaration_candidate::DeclarationCandidateKey {

--- a/crates/rue-compiler/src/revisioned_query_database/test_support.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/test_support.rs
@@ -360,7 +360,7 @@ pub(crate) fn endpoint_display(pool: &rue_air::TypeInternPool, ty: rue_air::Type
         TypeKind::Enum(id) => pool.enum_def(id).name.to_string(),
         TypeKind::Array(id) => {
             let (element, len) = pool.array_def(id);
-            format!("[{}; {}]", endpoint_display(pool, element), len)
+            rue_air::array_type_name(&endpoint_display(pool, element), len)
         }
         TypeKind::PtrConst(id) => {
             format!(

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -885,14 +885,16 @@ define_error_codes! {
         ],
         references: [ErrorCodeReference { title: "Copy struct field requirement", path: "docs/spec/src/03-types/08-move-semantics.md", rule: Some("3.8:18") }],
     };
-    /// Retained compatibility metadata for compilers that reserved built-in
-    /// nominal spellings. Current Rue reserves no type names (spec 6.0:3), so
-    /// production compilation does not emit this code.
+    /// A user struct or enum took a type-name spelling the compiler injects.
+    /// `str` is the one reserved spelling (spec 6.0:3).
     RESERVED_TYPE_NAME = 404 => {
-        explanation: "This code is retained for compatibility with older Rue compilers that rejected a user-defined type whose name was reserved for a built-in nominal. Current Rue reserves no type-name spellings and does not emit E0404.",
-        likely_cause: "If E0404 appears in stored output or from an older compiler, that compiler was enforcing a historical built-in type-name reservation. With a current compiler, user-defined type names participate in ordinary lexical and module lookup.",
-        examples: [ErrorCodeExample { title: "Built-in spellings are ordinary type names", source: "struct StrBuf { value: i32 }\nfn main() -> i32 {\n    StrBuf { value: 42 }.value\n}", outcome: ErrorCodeExampleOutcome::Compiles }],
-        references: [ErrorCodeReference { title: "Ordinary type-name lookup", path: "docs/spec/src/06-items/_index.md", rule: Some("6.0:3") }],
+        explanation: "A user-defined struct or enum has a name reserved for a compiler-provided type. Rue reserves exactly one type-name spelling: `str`, the built-in view over borrowed UTF-8 bytes. It is injected into every module's scope rather than declared in source, so a user declaration cannot take its name. Every other type name — `StrBuf` among them, an ordinary declaration in `std` — participates in ordinary lexical and module lookup and may be reused freely.",
+        likely_cause: "A struct or enum was named `str`. Rename it; a name such as `Str`, `StrView`, or a domain name distinct from the built-in view is available.",
+        examples: [
+            ErrorCodeExample { title: "Define a type named str", source: "struct str { value: i32 }\nfn main() -> i32 { 0 }", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Other built-in spellings are ordinary type names", source: "struct StrBuf { value: i32 }\nfn main() -> i32 {\n    StrBuf { value: 42 }.value\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [ErrorCodeReference { title: "Reserved type names", path: "docs/spec/src/06-items/_index.md", rule: Some("6.0:3") }],
     };
     DUPLICATE_TYPE_DEFINITION = 405 => {
         explanation: "A module defines more than one struct or enum with the same type name.",

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -151,6 +151,25 @@ pub fn is_keyword(word: &str) -> bool {
     KEYWORDS.contains(&word)
 }
 
+/// Every floating-point type name a program may write, ordered by spelling.
+///
+/// These are deliberately absent from [`KEYWORDS`]: `f32` and `f64` are
+/// ordinary identifiers naming builtin types (spec 3.12:2), so they do not
+/// steal value-position names, and the token table classifies them as
+/// `Ident`. `comptime_float` is absent for a different reason — it is the
+/// inferred type of a float literal and no program may name it (spec 3.12:3),
+/// exactly as `comptime_int` is unnameable.
+///
+/// This is the one list; the parser positions that must recognize a float type
+/// name lexically read it rather than repeating the spellings, and rue-air's
+/// `Type::from_primitive_name` is tested against it (RUE-1989).
+pub const FLOAT_TYPE_NAMES: &[&str] = &["f32", "f64"];
+
+/// Whether `word` is one of the [`FLOAT_TYPE_NAMES`].
+pub fn is_float_type_name(word: &str) -> bool {
+    FLOAT_TYPE_NAMES.contains(&word)
+}
+
 /// Token kinds in the Rue language.
 ///
 /// This enum is `Copy` since all variants contain only small, copyable data:
@@ -611,6 +630,29 @@ impl std::fmt::Display for TokenKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn float_type_names_are_sorted_unique_identifiers() {
+        let mut sorted = FLOAT_TYPE_NAMES.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted, FLOAT_TYPE_NAMES.to_vec());
+
+        for spelling in FLOAT_TYPE_NAMES {
+            assert!(
+                !is_keyword(spelling),
+                "{spelling} names a builtin type without reserving the identifier"
+            );
+            assert!(is_float_type_name(spelling));
+            let (tokens, _) = Lexer::new(spelling)
+                .tokenize()
+                .unwrap_or_else(|error| panic!("float type {spelling} failed to lex: {error}"));
+            assert!(matches!(tokens[0].kind, TokenKind::Ident(_)));
+        }
+
+        // Unnameable comptime-only types are not float type names (spec 3.12:3).
+        assert!(!is_float_type_name("comptime_float"));
+    }
 
     #[test]
     fn keywords_are_sorted_and_unique() {

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1399,13 +1399,16 @@ impl<'a> Interp<'a> {
     }
 
     fn is_bare_str_type(&self, ty: Type) -> bool {
-        ty.as_struct()
-            .is_some_and(|struct_id| &*self.type_pool().struct_def(struct_id).name == "str")
+        ty.as_struct().is_some_and(|struct_id| {
+            self.type_pool().text_view_kind(struct_id) == Some(rue_air::TextViewKind::Str)
+        })
     }
 
     fn is_str_like_struct(&self, struct_id: rue_air::StructId) -> bool {
-        let name: &str = &self.type_pool().struct_def(struct_id).name;
-        rue_air::is_string_view_struct_name(name)
+        matches!(
+            self.type_pool().text_view_kind(struct_id),
+            Some(rue_air::TextViewKind::Str | rue_air::TextViewKind::StrFixed(_))
+        )
     }
 
     fn text_struct_slots(&self, struct_id: rue_air::StructId) -> Option<usize> {
@@ -2004,7 +2007,8 @@ impl<'a> Interp<'a> {
                     return false;
                 };
                 let def = self.type_pool().struct_def(*struct_id);
-                let is_slice = rue_air::is_slice_struct_name(&def.name);
+                let is_slice = self.type_pool().text_view_kind(*struct_id)
+                    == Some(rue_air::TextViewKind::Slice);
                 if !is_slice
                     || def.fields.len() != 2
                     || def.fields[0].ty != pointer_ty

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -494,7 +494,9 @@ impl Parser {
             _ => false,
         });
         let float_type_initializer = match self.kind() {
-            TokenKind::Ident(symbol) => matches!(self.interner.resolve(&symbol), "f32" | "f64"),
+            TokenKind::Ident(symbol) => {
+                rue_lexer::is_float_type_name(self.interner.resolve(&symbol))
+            }
             _ => false,
         };
         let init = if type_annotated && float_type_initializer {

--- a/crates/rue-parser/src/parser/types.rs
+++ b/crates/rue-parser/src/parser/types.rs
@@ -122,7 +122,9 @@ impl Parser {
             // a type the implementation infers and no program may name (spec
             // 3.12:3), so it stays an ordinary identifier and is reported like
             // any other unknown name, exactly as `comptime_int` is (RUE-1076).
-            TokenKind::Ident(symbol) if matches!(self.interner.resolve(&symbol), "f32" | "f64") => {
+            TokenKind::Ident(symbol)
+                if rue_lexer::is_float_type_name(self.interner.resolve(&symbol)) =>
+            {
                 symbol
             }
             _ => return None,

--- a/crates/rue-spec/cases/items/general.toml
+++ b/crates/rue-spec/cases/items/general.toml
@@ -29,6 +29,43 @@ fn main() -> i32 { match StrBuf.Full { StrBuf.Empty => 0, StrBuf.Full => 8 } }
 exit_code = 8
 
 # =============================================================================
+# Reserved Type Name (RUE-1989)
+# =============================================================================
+
+[[case]]
+name = "struct_named_str_is_reserved"
+spec = ["6.0:3"]
+description = "`str` names the built-in text view and may not be redefined as a struct"
+source = """
+struct str { value: i32 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0404", "cannot define type `str`"]
+
+[[case]]
+name = "enum_named_str_is_reserved"
+spec = ["6.0:3"]
+description = "The reservation covers enum declarations too"
+source = """
+enum str { Empty, Full }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0404", "cannot define type `str`"]
+
+[[case]]
+name = "str_lookalike_type_names_are_ordinary"
+spec = ["6.0:3"]
+description = "Only the exact `str` spelling is reserved"
+source = """
+struct Str { value: i32 }
+enum strs { Empty, Full }
+fn main() -> i32 { Str { value: 9 }.value }
+"""
+exit_code = 9
+
+# =============================================================================
 # Type Name Uniqueness - Duplicate Definitions
 # =============================================================================
 

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -48,13 +48,16 @@ User-defined type names (structs and enums) **MUST** be unique within their defi
 
 {{ rule(id="6.0:3", cat="legality-rule") }}
 
-User-defined type names are resolved by ordinary lexical and module lookup. The language currently reserves no type-name spellings; in particular, `StrBuf` is an ordinary standard-library declaration and may also name an unrelated user type.
+User-defined type names are resolved by ordinary lexical and module lookup. The language reserves exactly one type-name spelling: `str`, the built-in view over borrowed UTF-8 bytes (3.7), which the implementation provides in every module's scope rather than declaring in source. A struct or enum declaration named `str` produces a compile-time error. No other spelling is reserved; in particular, `StrBuf` is an ordinary standard-library declaration and may also name an unrelated user type.
 
 {{ rule(id="6.0:4", cat="example") }}
 
 ```rue
 // OK: this is an ordinary user nominal, unrelated to std.strbuf.StrBuf.
 struct StrBuf { data: i32 }
+
+// Error: `str` names the built-in text view and may not be redefined.
+struct str { data: i32 }  // compile error: reserved type name
 ```
 
 {{ rule(id="6.0:5", cat="legality-rule") }}


### PR DESCRIPTION
Fixes RUE-1989

Type-name spellings were parsed and printed in several independent places, so a producer could drift from the classifier that reads it back.

## Changes

- `rue_air::types` now owns both directions of every generated spelling: `fixed_string_name` beside the `Str(N)` decoder, `slice_struct_name` beside the slice classifier, and `array_type_name` for `[T; N]`. The body identity pool, body endpoint, provider body host, durable provider, and the type-name displays in rue-air and rue-compiler call the renderers instead of formatting by hand. The existing consistency guards that forbade a handwritten `Str(` decoder now forbid a handwritten renderer too.
- `TextViewKind` and `TypeInternPool::text_view_kind` (plus the `FrozenTypeInternPool` counterpart) replace the scattered comparisons of a struct name against `str`, `Str(N)`, and `[T]` in inference, the ordinary engine, intrinsic classification, CFG verification, codegen, and the oracle. The pool checks the builtin bit as well as the spelling, so a source-defined nominal cannot counterfeit a view.
- The durable algebra no longer keeps its own primitive-name table: `SemanticImportType::from_primitive_name` projects `Type::from_primitive_name`, and both compiler-side tables delegate to it.
- The float type names live once in `rue_lexer::FLOAT_TYPE_NAMES` beside the keyword table; both parser positions that recognized `f32`/`f64` inline read it, and a rue-air test asserts the list agrees with the primitive table.
- `str` becomes a reserved type name. It is injected into every module's scope as a builtin nominal, so a user `struct str` used to shadow it half-way and reach CFG verification as an internal compiler error (E9000). It is now refused at declaration registration with E0404, the code already retained for this rejection. Spec 6.0:3 records the reservation (it previously stated no spelling was reserved), with new spec cases under it.

## Notes for review

- The `str` reservation is a normative spec change; the issue asked for it and E0404 was already reserved for it, but it deserves an explicit look.
- A `const str: type = ...` alias is still accepted (it resolves cleanly, no ICE). Rejecting it needs the parsed annotation at the check point to avoid refusing a value const of that name, so it is left for a follow-up if wanted.
- The `rue-error` "does not fit in `Str(N)`" message still spells the name inline because rue-air depends on rue-error.

## Verification

- rue-air / rue-parser / rue-lexer / rue-compiler / rue-error / rue-cfg / rue-oracle / rue-codegen test, clippy, debug-assert, and fmt gates plus `//:type-architecture-inventory-validation`: all pass.
- `//:spec-tests`, `//:spec-traceability`, `//:compiler-spec-machine-index`, `//:ui-tests`, oracle-diff targets: pass.
- `//:cli-tests`: 2696 passed; the 2 failures are the known environmental cases (uid 0 permission test, IPv6 loopback).
- `scripts/rue quick` after rebase on trunk: Pass 36, Fail 0.
