### PR TITLE
RUE-1968: one value-domain policy for both comptime hosts

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -1646,6 +1646,10 @@ fn comptime_instdata_evaluation_has_one_production_authority() {
             "sema/comptime/value_domain_tests",
             include_str!("sema/comptime/value_domain_tests.rs"),
         ),
+        (
+            "sema/comptime/value_policy",
+            include_str!("sema/comptime/value_policy.rs"),
+        ),
         ("sema/comptime_eval", include_str!("sema/comptime_eval.rs")),
         (
             "sema/consistency_tests",
@@ -2248,14 +2252,35 @@ fn comptime_match_patterns_have_one_decoder_and_a_semantic_host_boundary() {
     );
 
     let host = comptime_host_contract(comptime);
+    // RUE-1968: the host contract offers only the enum-variant path domain.
+    // Wildcard, boolean, and integer patterns are decided once, by the engine,
+    // for every host -- a host that could answer them again is how the two
+    // hosts drifted apart in the first place.
+    assert!(
+        !host.contains("fn match_pattern("),
+        "scalar pattern matching must not return to the host contract"
+    );
     let match_hook = host
-        .split("fn match_pattern(")
+        .split("fn match_path_pattern(")
         .nth(1)
         .and_then(|source| source.split("fn match_no_selected_arm(").next())
         .expect("bounded ComptimeHost match hook");
     assert!(match_hook.contains("ComptimeMatchPattern<Self::Name>"));
     assert!(!match_hook.contains("ProgramKey"));
     assert!(!match_hook.contains("RirPatternView"));
+
+    let policy = comptime
+        .split("pub fn comptime_scalar_pattern_decision")
+        .nth(1)
+        .and_then(|source| source.split("\n}\n").next())
+        .expect("one shared scalar pattern policy");
+    for scalar in [
+        "ComptimeMatchPattern::Wildcard",
+        "ComptimeMatchPattern::Bool(expected)",
+        "ComptimeMatchPattern::Integer(expected)",
+    ] {
+        assert!(policy.contains(scalar), "shared policy misses {scalar}");
+    }
 
     let engine_match = comptime
         .rsplit("InstData::Match { scrutinee, arms } => {")
@@ -2265,10 +2290,14 @@ fn comptime_match_patterns_have_one_decoder_and_a_semantic_host_boundary() {
     let decode = engine_match
         .find("self.decode_match_pattern")
         .expect("engine decodes reached patterns");
-    let host_match = engine_match
-        .find("self.host.match_pattern")
-        .expect("engine offers semantic patterns to host");
-    assert!(decode < host_match, "decode must precede the host hook");
+    let decide = engine_match
+        .find("self.match_pattern")
+        .expect("engine decides reached patterns");
+    assert!(decode < decide, "decode must precede the decision");
+    assert!(
+        !engine_match.contains("self.host.match_pattern"),
+        "the engine must not hand a scalar pattern back to the host"
+    );
     assert!(engine_match.contains("for (pattern, body) in arms.iter()"));
     assert!(!engine_match.contains("RirPatternView::"));
 }
@@ -2768,7 +2797,12 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
         .nth(1)
         .and_then(|source| source.split("\n    fn ").next())
         .expect("ordinary match terminal hook");
-    assert!(ordinary_match.contains("ComptimeOutcome::RuntimeDependent"));
+    // RUE-1968: a comptime-known match that selects no arm is a
+    // non-exhaustive pattern set (4.14:19, 4.7:9). Both hosts report it, and
+    // both spell it with the one shared reason, so `const` position and
+    // `comptime {}` position cannot drift apart again.
+    assert!(ordinary_match.contains("COMPTIME_MATCH_NO_SELECTED_ARM"));
+    assert!(!ordinary_match.contains("ComptimeOutcome::RuntimeDependent"));
     let macro_start = production
         .find("macro_rules! host_value")
         .expect("canonical host-value funnel");
@@ -3990,6 +4024,10 @@ fn sema_diagnostics_use_the_friendly_type_display_authority() {
         (
             "sema/comptime/value_domain_tests",
             include_str!("sema/comptime/value_domain_tests.rs"),
+        ),
+        (
+            "sema/comptime/value_policy",
+            include_str!("sema/comptime/value_policy.rs"),
         ),
         ("sema/comptime_eval", include_str!("sema/comptime_eval.rs")),
         ("sema/context", include_str!("sema/context.rs")),

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -139,8 +139,11 @@ pub use sema::{
     comptime_depth_over_limit, next_comptime_depth, occupying_body_parameter_types,
 };
 pub use sema::{
-    ComptimeDiagnosticSite, ComptimeIntegerOperation, ComptimeMatchPattern,
-    ComptimeSemanticRejection, ComptimeUnaryOperation, decode_comptime_match_pattern,
+    COMPTIME_MATCH_NO_SELECTED_ARM, ComptimeDiagnosticSite, ComptimeIntegerOperation,
+    ComptimeMatchPattern, ComptimePatternDecision, ComptimeSemanticRejection,
+    ComptimeUnaryOperation, comptime_arithmetic_operation_name,
+    comptime_arithmetic_overflow_reason, comptime_scalar_pattern_decision,
+    comptime_untyped_integer_result, decode_comptime_match_pattern,
 };
 pub use semantic_body::{
     SEMANTIC_BODY_INST_KINDS, SemanticAnonymousBodyExport, SemanticBody, SemanticBodyAnchor,

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -29,6 +29,7 @@ mod model;
 mod registry;
 mod sites;
 mod structured_type;
+mod value_policy;
 
 pub use frames::*;
 pub use intrinsics::*;
@@ -36,6 +37,7 @@ pub use model::*;
 pub use registry::*;
 pub use sites::*;
 pub use structured_type::*;
+pub use value_policy::*;
 
 #[cfg(test)]
 mod value_domain_tests;
@@ -57,6 +59,7 @@ pub(crate) const COMPTIME_PRODUCTION_SOURCE: &str = concat!(
     include_str!("comptime/sites.rs"),
     include_str!("comptime/frames.rs"),
     include_str!("comptime/structured_type.rs"),
+    include_str!("comptime/value_policy.rs"),
     include_str!("comptime.rs"),
 );
 
@@ -70,6 +73,7 @@ pub(crate) const COMPTIME_SOURCE: &str = concat!(
     include_str!("comptime/sites.rs"),
     include_str!("comptime/frames.rs"),
     include_str!("comptime/structured_type.rs"),
+    include_str!("comptime/value_policy.rs"),
     include_str!("comptime.rs"),
     "\n#[cfg(test)]\nmod value_domain_tests {\n",
     include_str!("comptime/value_domain_tests.rs"),
@@ -411,14 +415,25 @@ pub trait ComptimeValueAlgebra: ComptimeDomain {
         name: Self::Name,
         span: Span,
     ) -> ComptimeHostResult<ComptimeNamedValueResolution<Self::Value>, Self::Failure>;
-    fn match_pattern(
+    /// Decide an enum-variant path pattern against an already-reduced
+    /// scrutinee. Wildcard, boolean, and integer patterns are decided once
+    /// for every host by `comptime_scalar_pattern_decision` (RUE-1968); a
+    /// path pattern is the one form whose meaning depends on which
+    /// enum-shaped values a domain can represent, and the default domain
+    /// represents none of them.
+    fn match_path_pattern(
         &self,
-        pattern: &ComptimeMatchPattern<Self::Name>,
-        value: &Self::Value,
-    ) -> Option<bool>;
-    /// Resolve the terminal policy when every reached match arm declined.
-    /// Ordinary body evaluation remains runtime-dependent; durable hosts may
-    /// preserve a declaration-time failure through this semantic hook.
+        _pattern: &ComptimeMatchPattern<Self::Name>,
+        _value: &Self::Value,
+    ) -> Option<bool> {
+        None
+    }
+    /// Report a comptime-known `match` whose reached arms all declined.
+    /// Selection happens over an exhaustive pattern set (4.14:19, 4.7:9), so
+    /// arriving here means the set was not exhaustive: an error in `const`
+    /// position and in `comptime {}` position alike. Hosts differ only in how
+    /// they carry the failure, and both spell it
+    /// `COMPTIME_MATCH_NO_SELECTED_ARM`.
     fn match_no_selected_arm(
         &self,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
@@ -867,6 +882,21 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         })
     }
 
+    /// Decide one decoded arm pattern against a reduced scrutinee. The scalar
+    /// domain is the engine's own (RUE-1968) so both hosts cannot answer it
+    /// differently; only an enum-variant path reaches the host.
+    fn match_pattern(
+        &self,
+        pattern: &ComptimeMatchPattern<H::Name>,
+        value: &H::Value,
+    ) -> Option<bool> {
+        match comptime_scalar_pattern_decision(pattern, value) {
+            ComptimePatternDecision::Decided(matched) => Some(matched),
+            ComptimePatternDecision::Undecidable => None,
+            ComptimePatternDecision::HostPath => self.host.match_path_pattern(pattern, value),
+        }
+    }
+
     fn classify_array_length_binding(
         env: &ComptimeEnv<'_, H::Value, H::Type, H::Name, H::File, H::CanonicalIdentity>,
         name: &H::Name,
@@ -1313,7 +1343,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                     .enumerate()
                     .find_map(|(index, (pattern, _))| {
                         let pattern = self.decode_match_pattern(&self.program_key(), &pattern);
-                        match self.host.match_pattern(&pattern, &value) {
+                        match self.match_pattern(&pattern, &value) {
                             Some(true) => Some(ComptimeOutcome::Known(ComptimeSelection::Match {
                                 arm: index,
                             })),
@@ -2921,16 +2951,18 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
 
             // Comptime-known `match`: evaluate the scrutinee, select the first
             // arm whose pattern matches, and reduce to that arm's body value
-            // (spec 4.14:19, RUE-262). An enum-variant (`Path`) pattern isn't
-            // representable in the host's value domain, and a non-constant scrutinee is
-            // not decidable here — both make the `match` non-evaluable.
+            // (spec 4.14:19, RUE-262). Scalar patterns are decided here for
+            // every host; an enum-variant (`Path`) pattern is left to the
+            // host's value domain, which may not represent enum values at
+            // all, and a non-constant scrutinee is not decidable either —
+            // both make the `match` non-evaluable.
             InstData::Match { scrutinee, arms } => {
                 let scrutinee = *scrutinee;
                 let scrut = outcome_value!(self.eval(scrutinee, env));
                 let arms = self.program_rir().match_arms(arms).to_vec();
                 for (pattern, body) in arms.iter() {
                     let semantic_pattern = self.decode_match_pattern(&self.program_key(), pattern);
-                    match self.host.match_pattern(&semantic_pattern, &scrut) {
+                    match self.match_pattern(&semantic_pattern, &scrut) {
                         Some(true) => return self.eval(*body, env),
                         Some(false) => continue,
                         // Undecidable pattern (e.g. an enum-variant `Path`

--- a/crates/rue-air/src/sema/comptime/value_domain_tests.rs
+++ b/crates/rue-air/src/sema/comptime/value_domain_tests.rs
@@ -224,11 +224,18 @@ fn engine_decodes_match_patterns_lazily_per_active_program() {
 }
 
 #[test]
-fn match_without_a_selected_arm_uses_the_host_terminal_policy() {
-    let make_program = || {
+fn scalar_patterns_are_engine_decided_and_only_paths_reach_the_host() {
+    // RUE-1968: wildcard/bool/integer patterns are decided by the shared
+    // value policy inside the engine, so no host can answer them a second
+    // way. Only an enum-variant path reaches `match_path_pattern`, and the
+    // terminal `match_no_selected_arm` hook stays the host's.
+    let interner = lasso::ThreadedRodeo::new();
+    let type_name = interner.get_or_intern("Color");
+    let variant = interner.get_or_intern("Red");
+    let make_program = |scrutinee_data: InstData, pattern: rue_rir::RirPattern| {
         let mut editor = RirEditor::new();
         let scrutinee = editor.add_inst(Inst {
-            data: InstData::BoolConst(false),
+            data: scrutinee_data,
             span: Span::new(0, 1),
         });
         let body = editor.add_inst(Inst {
@@ -236,18 +243,28 @@ fn match_without_a_selected_arm_uses_the_host_terminal_policy() {
             span: Span::new(1, 2),
         });
         let root = editor
-            .add_match(
-                scrutinee,
-                &[(rue_rir::RirPattern::Bool(true, Span::new(0, 1)), body)],
-                Span::new(0, 2),
-            )
+            .add_match(scrutinee, &[(pattern, body)], Span::new(0, 2))
             .unwrap();
         (editor.finish(), root)
     };
-    let (program0, root0) = make_program();
-    let (program1, root1) = make_program();
+    let bool_pattern = || rue_rir::RirPattern::Bool(true, Span::new(0, 1));
+    let path_pattern = || rue_rir::RirPattern::Path {
+        module: None,
+        ctor_head: None,
+        type_name,
+        variant,
+        elements: Vec::new(),
+        span: Span::new(0, 1),
+    };
+    // Program 0 and 1: a bool pattern the engine decides against `false`.
+    let (program0, root0) = make_program(InstData::BoolConst(false), bool_pattern());
+    let (program1, root1) = make_program(InstData::BoolConst(false), bool_pattern());
+    // Program 2: an integer scrutinee under a bool pattern is undecidable.
+    let (program2, root2) = make_program(InstData::IntConst(7), bool_pattern());
+    // Program 3: an enum-variant path, the one form the host answers.
+    let (program3, root3) = make_program(InstData::BoolConst(false), path_pattern());
     let mut host = FakeHost {
-        programs: vec![program0, program1],
+        programs: vec![program0, program1, program2, program3],
         type_symbol: SymbolHandle::new(lasso::ThreadedRodeo::new().get_or_intern("T")),
         constant: None,
         dependencies: Vec::new(),
@@ -259,10 +276,13 @@ fn match_without_a_selected_arm_uses_the_host_terminal_policy() {
         float_evaluations: Cell::new(0),
     };
     let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
-    MATCH_PATTERN_MATCHES.with(|matches| matches.set(true));
-    MATCH_PATTERN_FORCE_FALSE.with(|force| force.set(true));
+
+    // The engine decides `Bool(true)` against `false` without consulting the
+    // host, and the declined arm set reaches the host's terminal policy.
+    MATCH_PATTERN_MATCHES.with(|matches| matches.set(false));
     MATCH_NO_SELECTED_FAILURE.with(|failure| failure.set(true));
     MATCH_NO_SELECTED_SITES.with(|sites| sites.borrow_mut().clear());
+    MATCH_PATTERN_EVENTS.with(|events| events.borrow_mut().clear());
     assert!(matches!(
         ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(0, root0), &mut env),
         ComptimeOutcome::HostFailure(FAKE_FAILURE)
@@ -274,6 +294,12 @@ fn match_without_a_selected_arm_uses_the_host_terminal_policy() {
     MATCH_NO_SELECTED_SITES.with(|sites| {
         assert_eq!(sites.borrow().as_slice(), &[(0, 0, 2), (1, 0, 2)]);
     });
+    MATCH_PATTERN_EVENTS.with(|events| {
+        assert!(
+            events.borrow().is_empty(),
+            "a scalar pattern must not reach the host"
+        );
+    });
 
     MATCH_NO_SELECTED_FAILURE.with(|failure| failure.set(false));
     assert!(matches!(
@@ -281,15 +307,40 @@ fn match_without_a_selected_arm_uses_the_host_terminal_policy() {
         ComptimeOutcome::RuntimeDependent
     ));
 
+    // A scrutinee outside the pattern's scalar domain is undecidable, so the
+    // terminal policy is never reached.
     MATCH_NO_SELECTED_FAILURE.with(|failure| failure.set(true));
     MATCH_NO_SELECTED_SITES.with(|sites| sites.borrow_mut().clear());
-    MATCH_PATTERN_MATCHES.with(|matches| matches.set(false));
     assert!(matches!(
-        ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(0, root0), &mut env),
+        ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(2, root2), &mut env),
         ComptimeOutcome::RuntimeDependent
     ));
     MATCH_NO_SELECTED_SITES.with(|sites| assert!(sites.borrow().is_empty()));
 
+    // A path pattern is the host's to answer: declining it undecidably keeps
+    // the whole match runtime-dependent.
+    assert!(matches!(
+        ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(3, root3), &mut env),
+        ComptimeOutcome::RuntimeDependent
+    ));
+    MATCH_NO_SELECTED_SITES.with(|sites| assert!(sites.borrow().is_empty()));
+
+    // ... and answering it selects the arm.
+    MATCH_PATTERN_MATCHES.with(|matches| matches.set(true));
+    MATCH_PATTERN_FORCE_FALSE.with(|force| force.set(false));
+    assert!(matches!(
+        ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(3, root3), &mut env),
+        ComptimeOutcome::Known(FakeValue::Unit)
+    ));
+    MATCH_PATTERN_EVENTS.with(|events| {
+        assert_eq!(events.borrow().len(), 1);
+        assert!(matches!(
+            events.borrow()[0],
+            ComptimeMatchPattern::Path { .. }
+        ));
+    });
+
+    MATCH_PATTERN_EVENTS.with(|events| events.borrow_mut().clear());
     MATCH_PATTERN_FORCE_FALSE.with(|force| force.set(false));
     MATCH_PATTERN_MATCHES.with(|matches| matches.set(false));
     MATCH_NO_SELECTED_FAILURE.with(|failure| failure.set(false));
@@ -1464,7 +1515,7 @@ impl ComptimeValueAlgebra for FakeHost {
             None => ComptimeNamedValueResolution::Missing,
         })
     }
-    fn match_pattern(
+    fn match_path_pattern(
         &self,
         pattern: &ComptimeMatchPattern<Self::Name>,
         _value: &Self::Value,

--- a/crates/rue-air/src/sema/comptime/value_policy.rs
+++ b/crates/rue-air/src/sema/comptime/value_policy.rs
@@ -1,0 +1,119 @@
+//! The one value-domain policy every `ComptimeHost` obeys (RUE-1968).
+//!
+//! Two hosts implement [`ComptimeHost`](super::ComptimeHost): ordinary body
+//! evaluation in sema (`const` initializers reached from a body, `comptime {}`
+//! blocks, comptime parameters) and durable declaration-time evaluation in
+//! `rue-compiler`. They answer different questions about *their own* value
+//! representations -- that is what the host boundary is for -- but the
+//! questions below are not about a representation. They are language
+//! decisions, and while each host answered them in its own copy the copies
+//! drifted: the same fragment reported one diagnostic in `const` position and
+//! a different one in `comptime {}` position.
+//!
+//! Every decision that depends only on already-reduced values belongs here, so
+//! that a host cannot answer it a second way. Hosts still own how a decision
+//! is *reported*, because a declaration-time failure and a body diagnostic are
+//! carried by different error types.
+
+use super::{ComptimeMatchPattern, ComptimeValue};
+use crate::integer_semantics::CheckedIntegerResult;
+
+/// The reason text for a comptime-known `match` whose reached arms all
+/// declined. By 4.14:19 the arm is selected from an exhaustive pattern set
+/// (4.7:9), so reaching this point means the pattern set was not exhaustive --
+/// an error in `const` position and in `comptime {}` position alike.
+pub const COMPTIME_MATCH_NO_SELECTED_ARM: &str = "comptime match has no selected arm";
+
+/// What one decoded arm pattern decides about an already-reduced scrutinee.
+///
+/// The scalar half of the decision is the same in every value domain and is
+/// made by [`comptime_scalar_pattern_decision`]. Only [`Self::HostPath`] is
+/// deferred, because an enum-variant path is the one pattern whose meaning
+/// depends on which values a host's domain can represent at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComptimePatternDecision {
+    /// The pattern definitely matches, or definitely does not.
+    Decided(bool),
+    /// The scrutinee does not inhabit the pattern's scalar domain, so this
+    /// `match` is not decidable at compile time here.
+    Undecidable,
+    /// An enum-variant path pattern: the host's value domain decides.
+    HostPath,
+}
+
+/// Decide a decoded arm pattern against a reduced scrutinee (spec 4.14:19).
+///
+/// A wildcard always matches. A boolean or integer pattern matches when the
+/// scrutinee carries that scalar and the values are equal; a scrutinee of any
+/// other kind makes the `match` undecidable rather than a definite non-match,
+/// because a value the pattern cannot be compared against carries no evidence
+/// either way.
+pub fn comptime_scalar_pattern_decision<N, V: ComptimeValue>(
+    pattern: &ComptimeMatchPattern<N>,
+    value: &V,
+) -> ComptimePatternDecision {
+    match pattern {
+        ComptimeMatchPattern::Wildcard => ComptimePatternDecision::Decided(true),
+        ComptimeMatchPattern::Bool(expected) => value
+            .as_boolean()
+            .map_or(ComptimePatternDecision::Undecidable, |actual| {
+                ComptimePatternDecision::Decided(actual == *expected)
+            }),
+        ComptimeMatchPattern::Integer(expected) => value
+            .as_integer()
+            .map_or(ComptimePatternDecision::Undecidable, |actual| {
+                ComptimePatternDecision::Decided(actual == *expected)
+            }),
+        ComptimeMatchPattern::Path { .. } => ComptimePatternDecision::HostPath,
+    }
+}
+
+/// The one spelling of an arithmetic operation in comptime diagnostics.
+///
+/// The engine names operations by their source operator, plus `negation` for
+/// unary minus, which has no distinct operator spelling of its own.
+pub fn comptime_arithmetic_operation_name(operation: &str) -> &str {
+    match operation {
+        "+" => "addition",
+        "-" => "subtraction",
+        "*" => "multiplication",
+        "/" => "division",
+        "%" => "remainder",
+        "<<" => "left shift",
+        ">>" => "right shift",
+        other => other,
+    }
+}
+
+/// The one reason text for an integer operation whose result does not fit its
+/// type (spec 4.14:4: the operation would trap at run time, so evaluating it
+/// at compile time is an error).
+pub fn comptime_arithmetic_overflow_reason(
+    operation: &str,
+    type_name: &str,
+    result: CheckedIntegerResult,
+) -> String {
+    let operation = comptime_arithmetic_operation_name(operation);
+    let detail = result.raw().map_or_else(
+        || format!("the result does not fit in {type_name}"),
+        |value| format!("the result {value} does not fit in {type_name}"),
+    );
+    format!(
+        "integer overflow evaluating {operation} at type {type_name}: {detail} \
+         (this operation would panic at runtime)"
+    )
+}
+
+/// The value of an integer operation the host could not give a semantic type.
+///
+/// An untyped result is not a language value: nothing has told the evaluator
+/// which type's arithmetic to check, so there is no width at which to report
+/// an overflow. Results inside the `i64` window are still exact and usable
+/// (array lengths and comptime arguments are folded from them); anything wider
+/// is simply not evaluable, and the expression stays runtime-dependent instead
+/// of acquiring an invented width.
+pub fn comptime_untyped_integer_result(result: CheckedIntegerResult) -> Option<i128> {
+    result
+        .raw()
+        .filter(|value| *value >= i128::from(i64::MIN) && *value <= i128::from(i64::MAX))
+}

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -56,15 +56,16 @@ use rue_span::{FileId, Span};
 
 use super::aggregate_resolution::decode_module_spine;
 use super::comptime::{
-    ComptimeAnonymousKind, ComptimeArgMode, ComptimeArrayLengthBinding, ComptimeCallAdmission,
-    ComptimeCallArgument, ComptimeCallKey, ComptimeCallPreparation, ComptimeCallProtocol,
-    ComptimeDiagnosticSite, ComptimeDomain, ComptimeEngine, ComptimeEnv as GenericComptimeEnv,
-    ComptimeFile, ComptimeFrame, ComptimeHost, ComptimeHostError, ComptimeHostResult,
-    ComptimeIdentity, ComptimeInterrupts, ComptimeMatchPattern, ComptimeMethodDescriptor,
-    ComptimeName, ComptimeNamedValueResolution, ComptimeOutcome, ComptimeProgramFacts,
-    ComptimeRejections, ComptimeSelection, ComptimeSemanticRejection,
+    COMPTIME_MATCH_NO_SELECTED_ARM, ComptimeAnonymousKind, ComptimeArgMode,
+    ComptimeArrayLengthBinding, ComptimeCallAdmission, ComptimeCallArgument, ComptimeCallKey,
+    ComptimeCallPreparation, ComptimeCallProtocol, ComptimeDiagnosticSite, ComptimeDomain,
+    ComptimeEngine, ComptimeEnv as GenericComptimeEnv, ComptimeFile, ComptimeFrame, ComptimeHost,
+    ComptimeHostError, ComptimeHostResult, ComptimeIdentity, ComptimeInterrupts,
+    ComptimeMethodDescriptor, ComptimeName, ComptimeNamedValueResolution, ComptimeOutcome,
+    ComptimeProgramFacts, ComptimeRejections, ComptimeSelection, ComptimeSemanticRejection,
     ComptimeStructuredTypeResolution, ComptimeStructuredTypes, ComptimeTrap, ComptimeType,
-    ComptimeTypeAlgebra, ComptimeValueAlgebra,
+    ComptimeTypeAlgebra, ComptimeValueAlgebra, comptime_arithmetic_overflow_reason,
+    comptime_untyped_integer_result,
 };
 use super::context::{AnalysisContext, CheckedConstIndexCandidate, ConstValue};
 use super::info::FunctionCallInfo;
@@ -350,30 +351,6 @@ impl<'a>
             defining_file: Some(ctx.current_file_id),
             expected_result: None,
         }
-    }
-}
-
-/// Decide whether a compile-time-known scrutinee value matches a match arm's
-/// pattern (RUE-262). Returns:
-/// - `Some(true)` / `Some(false)` — the pattern definitely does / does not match;
-/// - `None` — the match can't be decided at compile time here (an enum-variant
-///   `Path` pattern, or a scrutinee whose kind the pattern can't compare
-///   against), so the caller treats the whole `match` as non-evaluable.
-pub(crate) fn const_pattern_matches(
-    pattern: &ComptimeMatchPattern<impl ComptimeName>,
-    scrut: ConstValue,
-) -> Option<bool> {
-    match pattern {
-        ComptimeMatchPattern::Wildcard => Some(true),
-        ComptimeMatchPattern::Bool(b) => match scrut {
-            ConstValue::Bool(sb) => Some(sb == *b),
-            _ => None,
-        },
-        ComptimeMatchPattern::Integer(pattern) => match scrut {
-            ConstValue::Integer(n) => Some(n == *pattern),
-            _ => None,
-        },
-        ComptimeMatchPattern::Path { .. } => None,
     }
 }
 
@@ -867,10 +844,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// Finish an arithmetic operation using the kernel's typed result and its
     /// available raw mathematical result for diagnostics.
     ///
-    /// - Typed: out-of-range results are a hard error (the operation would
-    ///   panic at runtime, spec 8.1 / 4.14:4).
-    /// - Untyped fallback: results outside the `i64` range make the
-    ///   expression non-evaluable (legacy checked-i64 semantics).
+    /// Both the overflow wording and the untyped-result rule come from the
+    /// shared value policy (RUE-1968), so the same fragment reads the same in
+    /// `const` position and in `comptime {}` position; this host only decides
+    /// how to carry the failure.
     fn finish_arith(
         &self,
         result: CheckedIntegerResult,
@@ -878,31 +855,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         op: &str,
         span: Span,
     ) -> CompileResult<Option<ConstValue>> {
-        match ty {
-            Some(ty) => match result.checked() {
-                Some(v) => Ok(Some(ConstValue::Integer(v))),
-                _ => {
-                    let ty_name = self.format_type_name(ty);
-                    let detail = match result.raw() {
-                        Some(v) => format!("the result {} does not fit in {}", v, ty_name),
-                        None => format!("the result does not fit in {}", ty_name),
-                    };
-                    Err(comptime_panic_err(
-                        format!(
-                            "integer overflow evaluating `{}` at type {}: {} \
-                             (this operation would panic at runtime)",
-                            op, ty_name, detail
-                        ),
-                        span,
-                    ))
-                }
-            },
-            None => match result.raw() {
-                Some(v) if v >= i128::from(i64::MIN) && v <= i128::from(i64::MAX) => {
-                    Ok(Some(ConstValue::Integer(v)))
-                }
-                _ => Ok(None),
-            },
+        let Some(ty) = ty else {
+            return Ok(comptime_untyped_integer_result(result).map(ConstValue::Integer));
+        };
+        match result.checked() {
+            Some(value) => Ok(Some(ConstValue::Integer(value))),
+            None => Err(comptime_panic_err(
+                comptime_arithmetic_overflow_reason(op, &self.format_type_name(ty), result),
+                span,
+            )),
         }
     }
 
@@ -2665,18 +2626,17 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeValueAlgebra for OrdinaryBodyEngin
             None => ComptimeNamedValueResolution::RuntimeDependent,
         })
     }
-    fn match_pattern(
-        &self,
-        pattern: &ComptimeMatchPattern<Spur>,
-        value: &ConstValue,
-    ) -> Option<bool> {
-        const_pattern_matches(pattern, value.clone())
-    }
+    // The ordinary body value domain has no enum-shaped value, so every
+    // path pattern stays undecidable here; the engine decides the scalar
+    // patterns for both hosts (RUE-1968).
     fn match_no_selected_arm(
         &self,
-        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeOutcome<Self::Value, Self::Failure> {
-        ComptimeOutcome::RuntimeDependent
+        ComptimeOutcome::HostFailure(comptime_panic_err(
+            COMPTIME_MATCH_NO_SELECTED_ARM.to_owned(),
+            site.span(),
+        ))
     }
     fn evaluate_binary_rhs_after_rejection(&self) -> bool {
         false
@@ -2688,17 +2648,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeValueAlgebra for OrdinaryBodyEngin
         op: &str,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<Option<ConstValue>, Self::Failure> {
-        // The engine uses a distinct semantic token for unary negation so
-        // durable hosts can preserve its operation-specific wording. The
-        // ordinary body diagnostic remains the historical `-` spelling.
-        OrdinaryBodyEngine::finish_arith(
-            self,
-            result,
-            ty,
-            if op == "negation" { "-" } else { op },
-            site.span(),
-        )
-        .map_err(Into::into)
+        OrdinaryBodyEngine::finish_arith(self, result, ty, op, site.span()).map_err(Into::into)
     }
 
     fn resolve_float_const(
@@ -3038,10 +2988,17 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
 
 #[cfg(test)]
 mod binding_tests {
+    use super::super::comptime::{
+        ComptimeMatchPattern, ComptimePatternDecision, comptime_scalar_pattern_decision,
+    };
     use super::*;
 
     #[test]
-    fn ordinary_pattern_policy_keeps_unknown_paths_undecidable() {
+    fn ordinary_values_answer_the_shared_pattern_policy() {
+        // The ordinary body domain owns no pattern decision of its own
+        // (RUE-1968): the shared policy reads its values through
+        // `ComptimeValue`, and an enum-variant path is left to the host,
+        // which has no enum-shaped value to answer with.
         let interner = lasso::ThreadedRodeo::<lasso::Spur>::new();
         let type_name = interner.get_or_intern("Os");
         let variant = interner.get_or_intern("Macos");
@@ -3053,27 +3010,37 @@ mod binding_tests {
             binding_count: 0,
         };
         assert_eq!(
-            const_pattern_matches(
+            comptime_scalar_pattern_decision(
                 &ComptimeMatchPattern::<lasso::Spur>::Wildcard,
-                ConstValue::Unit
+                &ConstValue::Unit
             ),
-            Some(true)
+            ComptimePatternDecision::Decided(true)
         );
         assert_eq!(
-            const_pattern_matches(
+            comptime_scalar_pattern_decision(
                 &ComptimeMatchPattern::<lasso::Spur>::Integer(-3),
-                ConstValue::Integer(-3)
+                &ConstValue::Integer(-3)
             ),
-            Some(true)
+            ComptimePatternDecision::Decided(true)
         );
         assert_eq!(
-            const_pattern_matches(
-                &ComptimeMatchPattern::<lasso::Spur>::Bool(true),
-                ConstValue::Integer(1)
+            comptime_scalar_pattern_decision(
+                &ComptimeMatchPattern::<lasso::Spur>::Integer(-3),
+                &ConstValue::Integer(3)
             ),
-            None
+            ComptimePatternDecision::Decided(false)
         );
-        assert_eq!(const_pattern_matches(&target, ConstValue::Unit), None);
+        assert_eq!(
+            comptime_scalar_pattern_decision(
+                &ComptimeMatchPattern::<lasso::Spur>::Bool(true),
+                &ConstValue::Integer(1)
+            ),
+            ComptimePatternDecision::Undecidable
+        );
+        assert_eq!(
+            comptime_scalar_pattern_decision(&target, &ConstValue::Unit),
+            ComptimePatternDecision::HostPath
+        );
     }
 
     #[test]

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -65,6 +65,13 @@ pub use binding_manifest::{
 // stays private; only the guard source crosses this boundary.
 pub(crate) use aggregate_resolution::{decode_module_spine, select_module_nominal};
 pub use comptime::ComptimeMethodReceiverPolicy;
+pub use comptime::{
+    COMPTIME_MATCH_NO_SELECTED_ARM, ComptimeDiagnosticSite, ComptimeFloatWidth,
+    ComptimeMatchPattern, ComptimePatternDecision, ComptimeSemanticRejection,
+    ComptimeUnaryOperation, comptime_arithmetic_operation_name,
+    comptime_arithmetic_overflow_reason, comptime_scalar_pattern_decision,
+    comptime_untyped_integer_result, decode_comptime_match_pattern,
+};
 #[cfg(test)]
 pub(crate) use comptime::{COMPTIME_PRODUCTION_SOURCE, COMPTIME_SOURCE};
 pub use comptime::{
@@ -82,10 +89,6 @@ pub use comptime::{
     ComptimeTargetIntrinsic, ComptimeTrap, ComptimeType, ComptimeTypeAlgebra,
     ComptimeTypeIntrinsic, ComptimeValue, ComptimeValueAlgebra, MAX_COMPTIME_CALL_DEPTH,
     comptime_depth_over_limit, next_comptime_depth,
-};
-pub use comptime::{
-    ComptimeDiagnosticSite, ComptimeFloatWidth, ComptimeMatchPattern, ComptimeSemanticRejection,
-    ComptimeUnaryOperation, decode_comptime_match_pattern,
 };
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;

--- a/crates/rue-cli-tests/cases/const_init.toml
+++ b/crates/rue-cli-tests/cases/const_init.toml
@@ -169,7 +169,9 @@ fn main() -> i32 { 0 }
 compile_fail = true
 error_contains = ["E0800", "out of range", "u8"]
 
-# A negative value can't adopt an unsigned annotation.
+# A negative value can't adopt an unsigned annotation. Unary `-` on an
+# unsigned type is the stronger rule (4.2:14) and fires first, exactly as it
+# does in a function body (RUE-1968).
 [[case]]
 name = "negative_value_unsigned_annotation_rejected"
 files = [{ path = "main.rue", source = """
@@ -178,7 +180,7 @@ const N: u8 = -5;
 fn main() -> i32 { 0 }
 """ }]
 compile_fail = true
-error_contains = ["value -5 is out of range for type u8"]
+error_contains = ["E0801", "cannot apply unary operator `-` to type 'u8'"]
 
 # Forward reference within a file: declaration order does not matter.
 [[case]]

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -8428,7 +8428,7 @@ fn durable_const_integer_semantics_use_the_shared_kernel() {
     for required in [
         "finish_arith",
         "DurableComptimeScalarPolicy::checked_integer_result",
-        "durable_arithmetic_operation_name",
+        "rue_air::comptime_arithmetic_overflow_reason",
         "checked_neg_literal_report_i128",
     ] {
         assert!(
@@ -8991,13 +8991,26 @@ fn durable_comptime_responsibilities_have_exact_module_owners() {
 #[test]
 fn match_patterns_have_one_air_decoder_and_one_durable_kernel() {
     let durable = DURABLE_COMPTIME_SOURCE;
+    // RUE-1968: the durable kernel decides the enum-variant path domain only.
+    // Wildcard, boolean, and integer patterns are decided for every host by
+    // the shared AIR policy, so a second scalar copy must not reappear here.
     assert_eq!(
         durable
-            .matches("pub(crate) fn durable_match_pattern_matches")
+            .matches("pub(crate) fn durable_target_path_pattern_matches")
             .count(),
         1
     );
     assert!(durable.contains("ComptimeMatchPattern::Path"));
+    for scalar in [
+        "ComptimeMatchPattern::Wildcard",
+        "ComptimeMatchPattern::Integer(pattern)",
+        "ComptimeMatchPattern::Bool(pattern)",
+    ] {
+        assert!(
+            !durable.contains(scalar),
+            "durable host re-decided a scalar pattern: {scalar}"
+        );
+    }
     for rejection in [
         "ConditionNotBoolean",
         "ArithmeticOperandNotInteger",

--- a/crates/rue-compiler/src/durable_comptime/diagnostics.rs
+++ b/crates/rue-compiler/src/durable_comptime/diagnostics.rs
@@ -151,12 +151,11 @@ impl DurableComptimeFailure {
         ))
     }
 
-    /// The exact durable terminal used when a comptime match reaches no
-    /// selected arm. This remains a resolution failure, matching the
-    /// established declaration-time behavior.
-    /// evaluator's existing `comptime match has no selected arm` policy.
+    /// The durable terminal for a comptime match that reaches no selected
+    /// arm. It remains a resolution failure, and its wording is the one the
+    /// shared value policy gives both hosts (RUE-1968).
     pub(crate) fn comptime_match_no_selected_arm() -> Self {
-        Self::resolution("comptime match has no selected arm")
+        Self::resolution(rue_air::COMPTIME_MATCH_NO_SELECTED_ARM)
     }
 
     /// Map the AIR-owned semantic rejection vocabulary to the exact durable
@@ -288,15 +287,27 @@ impl DurableComptimeFailure {
         ))
     }
 
-    pub(crate) fn integer_literal_overflow(type_name: &str, value: i128) -> Self {
-        Self::comptime_failure(format!(
-            "integer overflow evaluating constant at type {type_name}: value {value} is out of range for type {type_name}; {value} does not fit in {type_name} (this operation would panic at runtime)"
+    /// An integer magnitude outside the range of the type an operation is
+    /// evaluated at. This is the out-of-range literal fact (E0800), the same
+    /// one the body type checker reports for the same source text (RUE-1968).
+    pub(crate) fn literal_out_of_range(type_name: &str, value: i128) -> Self {
+        Self::failure(SemanticNucleusFailure::Diagnostic(
+            rue_error::ErrorKind::LiteralOutOfRange {
+                value,
+                ty: type_name.to_owned(),
+            },
         ))
     }
 
-    pub(crate) fn arithmetic_overflow(type_name: &str, operation: &str, detail: &str) -> Self {
-        Self::comptime_failure(format!(
-            "integer overflow evaluating {operation} at type {type_name}: {detail} (this operation would panic at runtime)"
+    /// Declaration-time arithmetic overflow, worded by the one shared
+    /// value policy so `const` and `comptime {}` positions agree (RUE-1968).
+    pub(crate) fn arithmetic_overflow(
+        type_name: &str,
+        operation: &str,
+        result: rue_air::integer_semantics::CheckedIntegerResult,
+    ) -> Self {
+        Self::comptime_failure(rue_air::comptime_arithmetic_overflow_reason(
+            operation, type_name, result,
         ))
     }
 
@@ -665,24 +676,6 @@ pub(super) fn durable_host_error_outcome<T>(
     }
 }
 
-/// AIR supplies compact operator tokens; durable diagnostics use the
-/// operation names from established declaration-time semantics. Unary negation is
-/// passed as its own token by the canonical engine so it cannot be confused
-/// with subtraction.
-pub(super) fn durable_arithmetic_operation_name(operation: &str) -> &str {
-    match operation {
-        "+" => "addition",
-        "-" => "subtraction",
-        "*" => "multiplication",
-        "/" => "division",
-        "%" => "remainder",
-        "<<" => "left shift",
-        ">>" => "right shift",
-        "negation" => "negation",
-        other => other,
-    }
-}
-
 #[cfg(test)]
 mod terminal_adapter_tests {
     use super::*;
@@ -787,16 +780,12 @@ mod terminal_adapter_tests {
                 ),
             ),
             (
-                DurableComptimeFailure::integer_literal_overflow("i8", 128),
-                "integer overflow evaluating constant at type i8: value 128 is out of range for type i8; 128 does not fit in i8 (this operation would panic at runtime)".to_owned(),
-            ),
-            (
                 DurableComptimeFailure::arithmetic_overflow(
                     "i8",
-                    "addition",
-                    "value 128 is out of range for type i8; 128 does not fit in i8",
+                    "+",
+                    rue_air::integer_semantics::CheckedIntegerResult::from_raw(Some(128)),
                 ),
-                "integer overflow evaluating addition at type i8: value 128 is out of range for type i8; 128 does not fit in i8 (this operation would panic at runtime)".to_owned(),
+                "integer overflow evaluating addition at type i8: the result 128 does not fit in i8 (this operation would panic at runtime)".to_owned(),
             ),
         ];
         for (failure, expected) in cases {

--- a/crates/rue-compiler/src/durable_comptime/host.rs
+++ b/crates/rue-compiler/src/durable_comptime/host.rs
@@ -770,12 +770,12 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeValueAlgebra
         Ok(rue_air::ComptimeNamedValueResolution::Known(value))
     }
 
-    fn match_pattern(
+    fn match_path_pattern(
         &self,
         pattern: &rue_air::ComptimeMatchPattern<Self::Name>,
         value: &Self::Value,
     ) -> Option<bool> {
-        Some(durable_match_pattern_matches(pattern, value))
+        Some(durable_target_path_pattern_matches(pattern, value))
     }
 
     fn match_no_selected_arm(
@@ -829,12 +829,8 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeValueAlgebra
         _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> rue_air::ComptimeHostResult<Option<Self::Value>, Self::Failure> {
         let ty = ty.unwrap_or(DurableComptimeType(DurableType::I32));
-        let value = DurableComptimeScalarPolicy::checked_integer_result(
-            ty.as_ref(),
-            result,
-            durable_arithmetic_operation_name(op),
-        )
-        .map_err(durable_host_error)?;
+        let value = DurableComptimeScalarPolicy::checked_integer_result(ty.as_ref(), result, op)
+            .map_err(durable_host_error)?;
         Ok(Some(EvaluatedSemanticConst::integer_typed(value, Some(ty))))
     }
 
@@ -1726,16 +1722,6 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeRejections
             &self.diagnostic_site(site),
             rue_error::ErrorKind::CannotNegate(DurableComptimeScalarPolicy::type_name(ty.as_ref())),
         )
-    }
-
-    fn reject_unsigned_negation(
-        &self,
-        _ty: &Self::Type,
-        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
-    ) -> Option<Self::Failure> {
-        // Declaration-time evaluation reports the checked integer overflow
-        // from `finish_arith`, rather than AIR's ordinary CannotNegate policy.
-        None
     }
 
     fn label_ctor_instantiation_site(

--- a/crates/rue-compiler/src/durable_comptime/projection.rs
+++ b/crates/rue-compiler/src/durable_comptime/projection.rs
@@ -466,6 +466,12 @@ impl DurableComptimeScalarPolicy {
         Self::integer_operation_type(expected, operand, None)
     }
 
+    /// An untyped integer operand only carries a magnitude; the operation's
+    /// type is what decides whether that magnitude denotes a value at all.
+    /// A magnitude outside it is the out-of-range literal (E0800, 3.1:17,
+    /// 6.5:5) the body type checker reports for the same source text -- not a
+    /// trapping operation -- so `const` and `comptime {}` positions agree on
+    /// both the code and the wording (RUE-1968).
     pub(crate) fn require_integer_fits(
         ty: &DurableType,
         value: i128,
@@ -474,29 +480,24 @@ impl DurableComptimeScalarPolicy {
         if durable_const_fits_type(&integer, ty) {
             return Ok(());
         }
-        Err(DurableComptimeFailure::integer_literal_overflow(
+        Err(DurableComptimeFailure::literal_out_of_range(
             &durable_type_diagnostic_name(ty),
             value,
         ))
     }
 
+    /// The overflow text comes from the shared value policy (RUE-1968), so a
+    /// `const` initializer and a `comptime {}` block report one wording.
     pub(crate) fn checked_integer_result(
         ty: &DurableType,
         result: rue_air::integer_semantics::CheckedIntegerResult,
         operation: &str,
     ) -> Result<i128, DurableComptimeFailure> {
         let Some(value) = result.checked() else {
-            let type_name = durable_type_diagnostic_name(ty);
-            let detail = result.raw().map_or_else(
-                || format!("the result does not fit in {type_name}"),
-                |value| {
-                    format!(
-                        "value {value} is out of range for type {type_name}; {value} does not fit in {type_name}"
-                    )
-                },
-            );
             return Err(DurableComptimeFailure::arithmetic_overflow(
-                &type_name, operation, &detail,
+                &durable_type_diagnostic_name(ty),
+                operation,
+                result,
             ));
         };
         Ok(value)
@@ -681,39 +682,31 @@ pub(crate) fn durable_named_array_length_integer(
     })
 }
 
-/// Match semantics shared by the durable evaluator and the AIR host.
+/// The durable half of the shared match policy (RUE-1968): the enum-variant
+/// path domain, which is the one pattern form the AIR engine cannot decide
+/// from `ComptimeValue` alone. Every scalar pattern is decided for both hosts
+/// by `rue_air::comptime_scalar_pattern_decision`.
+///
 /// Durable values deliberately remain narrower than the language's runtime
 /// enum algebra: only an exact, unqualified, binding-free target descriptor
-/// path is decidable here.
-pub(crate) fn durable_match_pattern_matches<N: AsRef<str>>(
+/// path is matchable here, and every other path is a definite non-match.
+pub(crate) fn durable_target_path_pattern_matches<N: AsRef<str>>(
     pattern: &ComptimeMatchPattern<N>,
     value: &EvaluatedSemanticConst,
 ) -> bool {
-    match pattern {
-        ComptimeMatchPattern::Wildcard => true,
-        ComptimeMatchPattern::Integer(pattern) => matches!(
-            value,
-            EvaluatedSemanticConst::Value(value)
-                if matches!(value.value, DurableConstValue::Integer(actual) if actual == *pattern)
-        ),
-        ComptimeMatchPattern::Bool(pattern) => matches!(
-            value,
-            EvaluatedSemanticConst::Value(value)
-                if matches!(value.value, DurableConstValue::Bool(actual) if actual == *pattern)
-        ),
-        ComptimeMatchPattern::Path {
-            module_qualified: false,
-            ctor_qualified: false,
-            type_name,
-            variant,
-            binding_count: 0,
-        } => matches!(
-            value,
-            EvaluatedSemanticConst::TargetEnum(target)
-                if type_name.as_ref() == target.type_name && variant.as_ref() == target.variant
-        ),
-        ComptimeMatchPattern::Path { .. } => false,
-    }
+    matches!(
+        (pattern, value),
+        (
+            ComptimeMatchPattern::Path {
+                module_qualified: false,
+                ctor_qualified: false,
+                type_name,
+                variant,
+                binding_count: 0,
+            },
+            EvaluatedSemanticConst::TargetEnum(target),
+        ) if type_name.as_ref() == target.type_name && variant.as_ref() == target.variant
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1075,8 +1068,8 @@ mod tests {
             DurableComptimeScalarPolicy::require_integer_fits(&T::U8, 256),
             Err(DurableComptimeFailure::Failure(value))
                 if matches!(*value, SemanticNucleusFailure::Diagnostic(
-                    rue_error::ErrorKind::ComptimeEvaluationFailed { ref reason }
-                ) if reason.contains("does not fit in u8"))
+                    rue_error::ErrorKind::LiteralOutOfRange { value: 256, ref ty }
+                ) if ty == "u8")
         ));
         let integer = rue_air::integer_semantics::IntegerType::new(8, true).unwrap();
         assert_eq!(
@@ -1369,7 +1362,10 @@ mod tests {
     }
 
     #[test]
-    fn durable_match_kernel_preserves_scalar_and_target_pattern_policy() {
+    fn durable_path_kernel_preserves_target_pattern_policy() {
+        // Scalar patterns are decided once for both hosts by the shared AIR
+        // policy (RUE-1968); the durable kernel keeps only the target
+        // descriptor path domain, which no other host can answer.
         let integer = value(DurableConstValue::Integer(-7), Some(DurableType::I16));
         let boolean = value(DurableConstValue::Bool(true), Some(DurableType::Bool));
         let target = EvaluatedSemanticConst::TargetEnum(TargetEnumValue {
@@ -1386,31 +1382,7 @@ mod tests {
             }
         };
 
-        assert!(durable_match_pattern_matches(
-            &ComptimeMatchPattern::<Arc<str>>::Wildcard,
-            &EvaluatedSemanticConst::Module(ModuleId::from_logical_path("m").unwrap()),
-        ));
-        assert!(durable_match_pattern_matches(
-            &ComptimeMatchPattern::<Arc<str>>::Integer(-7),
-            &integer,
-        ));
-        assert!(!durable_match_pattern_matches(
-            &ComptimeMatchPattern::<Arc<str>>::Integer(7),
-            &integer,
-        ));
-        assert!(durable_match_pattern_matches(
-            &ComptimeMatchPattern::<Arc<str>>::Bool(true),
-            &boolean,
-        ));
-        assert!(!durable_match_pattern_matches(
-            &ComptimeMatchPattern::<Arc<str>>::Bool(false),
-            &integer,
-        ));
-        assert!(!durable_match_pattern_matches(
-            &ComptimeMatchPattern::<Arc<str>>::Integer(-7),
-            &boolean,
-        ));
-        assert!(durable_match_pattern_matches(
+        assert!(durable_target_path_pattern_matches(
             &path(false, false, "Os", "Macos", 0),
             &target,
         ));
@@ -1421,7 +1393,46 @@ mod tests {
             path(false, true, "Os", "Macos", 0),
             path(false, false, "Os", "Macos", 1),
         ] {
-            assert!(!durable_match_pattern_matches(&pattern, &target));
+            assert!(!durable_target_path_pattern_matches(&pattern, &target));
         }
+        // A path pattern is never satisfied by a durable scalar value.
+        for scrutinee in [&integer, &boolean] {
+            assert!(!durable_target_path_pattern_matches(
+                &path(false, false, "Os", "Macos", 0),
+                scrutinee,
+            ));
+        }
+
+        // The shared scalar policy answers from the durable value domain.
+        assert_eq!(
+            rue_air::comptime_scalar_pattern_decision(
+                &ComptimeMatchPattern::<Arc<str>>::Integer(-7),
+                &integer,
+            ),
+            rue_air::ComptimePatternDecision::Decided(true)
+        );
+        assert_eq!(
+            rue_air::comptime_scalar_pattern_decision(
+                &ComptimeMatchPattern::<Arc<str>>::Bool(true),
+                &boolean,
+            ),
+            rue_air::ComptimePatternDecision::Decided(true)
+        );
+        assert_eq!(
+            rue_air::comptime_scalar_pattern_decision(
+                &ComptimeMatchPattern::<Arc<str>>::Wildcard,
+                &EvaluatedSemanticConst::Module(ModuleId::from_logical_path("m").unwrap()),
+            ),
+            rue_air::ComptimePatternDecision::Decided(true)
+        );
+        // A scalar pattern against a value of another kind carries no
+        // evidence either way, in every value domain.
+        assert_eq!(
+            rue_air::comptime_scalar_pattern_decision(
+                &ComptimeMatchPattern::<Arc<str>>::Integer(-7),
+                &boolean,
+            ),
+            rue_air::ComptimePatternDecision::Undecidable
+        );
     }
 }

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -3476,3 +3476,66 @@ pub const strs = @import("strs.rue");
 pub const res = @import("res.rue");
 """, "strs.rue" = "pub struct Str { n: i32 }", "res.rue" = "pub fn Res(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }" }
 exit_code = 42
+
+# =============================================================================
+# One comptime-evaluable judgement, whichever position asks for it (RUE-1968)
+#
+# A `const` initializer must be comptime-evaluable by exactly the set that
+# governs a comptime block (6.5:2 refers to 4.14:26-29), so a fragment that
+# fails in one position must fail the same way in the other. Each case here is
+# the `comptime {}` half of a pair; the `const` half lives beside it in
+# items/constants.toml, and the diagnostics themselves are pinned in the
+# `diagnostics.comptime-position-agreement` UI section.
+# =============================================================================
+
+[[case]]
+name = "comptime_match_without_a_selected_arm_is_rejected"
+spec = ["4.14:19", "4.14:4"]
+description = "A comptime match selects from an exhaustive pattern set; when no reached arm matches, the block is rejected exactly as the same fragment is in const position"
+source = """
+fn main() -> i32 {
+    let x: i32 = comptime { match 3 { 1 => 10, 2 => 20 } };
+    x
+}
+"""
+compile_fail = true
+error_contains = ["E1200", "comptime match has no selected arm"]
+
+[[case]]
+name = "comptime_match_selects_the_first_matching_arm"
+spec = ["4.14:19"]
+description = "The first arm whose pattern matches supplies the block's value"
+source = """
+fn main() -> i32 {
+    comptime { match 2 { 1 => 10, 2 => 42, _ => 0 } }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_unsigned_negation_is_a_legality_error"
+spec = ["4.2:14", "4.14:2"]
+description = "Unary `-` on an unsigned type is rejected as not negatable, not reported as an overflow, in comptime position as in const position (RUE-1968)"
+source = """
+fn main() -> i32 {
+    let k: u32 = comptime { -1 };
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0801", "cannot apply unary operator `-` to type 'u32'"]
+
+[[case]]
+name = "comptime_overflow_names_the_operation_and_the_result"
+spec = ["4.14:4"]
+description = "The overflow diagnostic names the operation and the result that does not fit, identically to the same fragment in const position (RUE-1968)"
+source = """
+fn main() -> i32 {
+    let k: i32 = comptime { 2000000 * 2000 };
+    k
+}
+"""
+compile_fail = true
+error_contains = [
+    "integer overflow evaluating multiplication at type i32: the result 4000000000 does not fit in i32",
+]

--- a/crates/rue-spec/cases/items/constants.toml
+++ b/crates/rue-spec/cases/items/constants.toml
@@ -183,15 +183,15 @@ error_contains = "out of range"
 
 [[case]]
 name = "negative_value_out_of_unsigned_range"
-spec = ["6.5:5"]
-description = "A negative value cannot adopt an unsigned annotation"
+spec = ["6.5:5", "4.2:14"]
+description = "A negative value cannot adopt an unsigned annotation. The negation legality rule (4.2:14) is the stronger one and fires first, in const position exactly as in a function body (RUE-1968)"
 source = """
 const N: u8 = -5;
 
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = "out of range"
+error_contains = ["E0801", "cannot apply unary operator `-` to type 'u8'"]
 
 [[case]]
 name = "non_integer_annotation_must_match"
@@ -427,3 +427,56 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["comptime"]
+
+# =============================================================================
+# The const half of the comptime-position pairs (6.5:2, 6.5:12) — RUE-1968
+#
+# 6.5:2 defines a constant initializer as comptime-evaluable by the very set
+# that governs a `comptime` block, so the two positions must judge one fragment
+# alike. The comptime half of each pair lives in expressions/comptime.toml.
+# =============================================================================
+
+[[case]]
+name = "const_match_without_a_selected_arm_is_rejected"
+spec = ["6.5:2"]
+description = "A const initializer whose comptime match selects no arm is rejected exactly as the same fragment is inside a comptime block (RUE-1968)"
+source = """
+const X: i32 = match 3 { 1 => 10, 2 => 20 };
+fn main() -> i32 { X }
+"""
+compile_fail = true
+error_contains = ["E1200", "comptime match has no selected arm"]
+
+[[case]]
+name = "const_match_selects_the_first_matching_arm"
+spec = ["6.5:2"]
+description = "A comptime match in const position selects the first arm whose pattern matches"
+source = """
+const X: i32 = match 2 { 1 => 10, 2 => 42, _ => 0 };
+fn main() -> i32 { X }
+"""
+exit_code = 42
+
+[[case]]
+name = "const_unsigned_negation_is_a_legality_error"
+spec = ["6.5:2"]
+description = "Unary `-` on an unsigned type is rejected as not negatable (4.2:14) in const position too, rather than as an initializer overflow (RUE-1968)"
+source = """
+const K: u32 = -1;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0801", "cannot apply unary operator `-` to type 'u32'"]
+
+[[case]]
+name = "const_overflow_names_the_operation_and_the_result"
+spec = ["6.5:12"]
+description = "The initializer overflow diagnostic names the operation and the result that does not fit, identically to the same fragment inside a comptime block (RUE-1968)"
+source = """
+const K: i32 = 2000000 * 2000;
+fn main() -> i32 { K }
+"""
+compile_fail = true
+error_contains = [
+    "integer overflow evaluating multiplication at type i32: the result 4000000000 does not fit in i32",
+]

--- a/crates/rue-ui-tests/cases/diagnostics/comptime_position_agreement.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/comptime_position_agreement.toml
@@ -1,0 +1,201 @@
+[section]
+id = "diagnostics.comptime-position-agreement"
+name = "Comptime diagnostics agree in const and comptime position"
+description = """
+A const initializer is comptime-evaluable by exactly the set that governs a
+comptime block (6.5:2, 4.14:26-29), so the same fragment must be judged the
+same way in either position. Two ComptimeHosts implement that judgement --
+ordinary body evaluation and durable declaration-time evaluation -- and each
+case below pairs the two positions on one fragment so the hosts cannot drift
+apart again (RUE-1968).
+"""
+
+# =============================================================================
+# A comptime-known match that selects no arm (4.14:19)
+# =============================================================================
+
+[[case]]
+name = "match_no_selected_arm_in_const_position"
+source = """
+const X: i32 = match 3 { 1 => 10, 2 => 20 };
+
+fn main() -> i32 { X }
+"""
+compile_fail = true
+error_contains = [
+    "E1200",
+    "comptime match has no selected arm",
+]
+
+[[case]]
+name = "match_no_selected_arm_in_comptime_position"
+source = """
+fn main() -> i32 {
+    let x: i32 = comptime { match 3 { 1 => 10, 2 => 20 } };
+    x
+}
+"""
+compile_fail = true
+error_contains = [
+    "E1200",
+    "comptime match has no selected arm",
+]
+
+# =============================================================================
+# Arithmetic overflow wording (4.14:4, 6.5:12)
+# =============================================================================
+
+[[case]]
+name = "multiplication_overflow_in_const_position"
+source = """
+const K: i32 = 2000000 * 2000;
+
+fn main() -> i32 { K }
+"""
+compile_fail = true
+error_contains = [
+    "E1200",
+    "integer overflow evaluating multiplication at type i32: the result 4000000000 does not fit in i32",
+    "this operation would panic at runtime",
+]
+
+[[case]]
+name = "multiplication_overflow_in_comptime_position"
+source = """
+fn main() -> i32 {
+    let k: i32 = comptime { 2000000 * 2000 };
+    k
+}
+"""
+compile_fail = true
+error_contains = [
+    "E1200",
+    "integer overflow evaluating multiplication at type i32: the result 4000000000 does not fit in i32",
+    "this operation would panic at runtime",
+]
+
+[[case]]
+name = "u8_intermediate_overflow_in_const_position"
+source = """
+const K: u8 = 200 + 100 - 100;
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E1200",
+    "integer overflow evaluating addition at type u8: the result 300 does not fit in u8",
+]
+
+[[case]]
+name = "u8_intermediate_overflow_in_comptime_position"
+source = """
+fn main() -> i32 {
+    let k: u8 = comptime { 200 + 100 - 100 };
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E1200",
+    "integer overflow evaluating addition at type u8: the result 300 does not fit in u8",
+]
+
+# =============================================================================
+# An out-of-range operand magnitude is the literal fact, not a trap (3.1:17)
+# =============================================================================
+
+[[case]]
+name = "out_of_range_operand_in_const_position"
+source = """
+const K: i32 = 0 - 3000000000;
+
+fn main() -> i32 { K }
+"""
+compile_fail = true
+error_contains = [
+    "E0800",
+    "literal value 3000000000 is out of range for type 'i32'",
+]
+
+[[case]]
+name = "out_of_range_operand_in_comptime_position"
+source = """
+fn main() -> i32 {
+    let k: i32 = comptime { 0 - 3000000000 };
+    k
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0800",
+    "literal value 3000000000 is out of range for type 'i32'",
+]
+
+# =============================================================================
+# Unsigned negation is a legality error, not an overflow (4.2:14)
+# =============================================================================
+
+[[case]]
+name = "unsigned_negation_in_const_position"
+source = """
+const K: u32 = -1;
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E0801",
+    "cannot apply unary operator `-` to type 'u32'",
+]
+
+[[case]]
+name = "unsigned_negation_in_comptime_position"
+source = """
+fn main() -> i32 {
+    let k: u32 = comptime { -1 };
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0801",
+    "cannot apply unary operator `-` to type 'u32'",
+]
+
+[[case]]
+name = "unsigned_negation_of_a_constant_in_const_position"
+source = """
+const A: u32 = 1;
+const K: u32 = -A;
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E0801",
+    "cannot apply unary operator `-` to type 'u32'",
+]
+
+# =============================================================================
+# Agreement is not only about failures: the same fragment reduces alike
+# =============================================================================
+
+[[case]]
+name = "signed_minimum_negation_in_const_position"
+source = """
+const K: i8 = -128;
+
+fn main() -> i32 { @intCast(K) + 170 }
+"""
+exit_code = 42
+
+[[case]]
+name = "signed_minimum_negation_in_comptime_position"
+source = """
+fn main() -> i32 {
+    let k: i8 = comptime { -128 };
+    @intCast(k) + 170
+}
+"""
+exit_code = 42


### PR DESCRIPTION
Fixes RUE-1968

A constant initializer is comptime-evaluable by exactly the set that governs a `comptime {}` block (6.5:2, 4.14:26-29), so the same fragment must be judged the same way in either position. The two `ComptimeHost` implementations (ordinary body evaluation in sema, durable declaration-time evaluation in rue-compiler) each answered the shared value-domain questions in their own copy, and the copies had drifted.

## Changes

- New `sema/comptime/value_policy.rs` owns every decision that depends only on already-reduced values, and both hosts get them from there: scalar pattern matching (`comptime_scalar_pattern_decision`), the arithmetic-overflow reason and operation spelling, the window an untyped integer result is evaluable in, and the no-selected-arm reason.
- The `ComptimeHost` contract's `match_pattern` is replaced by a narrower `match_path_pattern` (default `None`); the engine decides wildcard, boolean, and integer patterns itself. `const_pattern_matches` is deleted and the durable kernel is narrowed to `durable_target_path_pattern_matches`. `durable_arithmetic_operation_name` and `integer_literal_overflow` are gone. Host-method count is unchanged.

## Behavior changes (each makes the two positions agree)

- A comptime-known `match` that selects no arm is reported in both positions (4.14:19, 4.7:9). `comptime { match 3 { 1 => 10, 2 => 20 } }` previously said "cannot be known at compile time".
- Unary `-` on an unsigned type is rejected as E0801 in `const` position too (4.2:14); the durable host had opted out via `reject_unsigned_negation` and reported an overflow instead.
- An integer operand whose magnitude does not fit the evaluation type is E0800 (3.1:17) in `const` position, matching the body type checker, rather than a trapping operation.
- The overflow message names the operation in words in both positions and states the result once.
- The `const N: u8 = -5;` CLI case moves from the range rule to the negation rule.

## Divergences examined but not changed

- `Color.Red` in a `const` vs `comptime {}` block: both positions reject; only the wording differs ("member access on a non-module const value" vs "cannot be known at compile time"). That is the documented rejection seam (a body may fall back to run time, a constant may not), not a value-domain decision. Improving the generic wording inside a mandatory `comptime {}` block is worth its own issue.
- Untyped-operand width: the durable host defaults to i32, the ordinary host leaves the operation untyped in the i64 window. No longer observable in the repros (the operand-fits check yields the same E0800 in both), but still two fallbacks.
- `const X: i32 = match 3 { 1 => 10, 2 => 20 };` ideally reports E0600 non-exhaustive; const initializers are not exhaustiveness-checked today, so this unifies on the E1200 both hosts can produce.

## Tests

- New `rue-ui-tests/cases/diagnostics/comptime_position_agreement.toml` with 13 paired cases asserting the identical diagnostic in both positions.
- Spec cases added under 4.14:19, 4.14:4, 4.2:14 (expressions/comptime.toml) and 6.5:2, 6.5:12 (items/constants.toml).

## Verification

- `rue-air-test` 877 passed; `rue-compiler-test` 1231 passed; clippy, fmt, debug-assert gates for both crates, `error-explanation-examples-test`, `rue-compiler-public-api-test`, `//:type-architecture-inventory-validation`, `oracle-diff-test`: all pass.
- `scripts/rue spec` 2874 passed; `scripts/rue ui` 425 passed; `scripts/rue cli` passes apart from the two known environmental cases (uid 0 permission test, IPv6 loopback).
- `scripts/rue quick` after rebase on trunk: Pass 36, Fail 0.
