### PR TITLE
RUE-1987: one CLI-corpus schema and one host-platform table

### DIFF
--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -26,7 +26,13 @@
 //!
 //! # Case format
 //!
-//! Cases live in `crates/rue-cli-tests/cases/*.toml`:
+//! Cases live in `crates/rue-cli-tests/cases/*.toml`. The schema itself —
+//! `TestFile`, `Section`, `Case`, and the fixture and contract types below —
+//! is owned by [`rue_test_runner::cli_corpus`], because `rue-oracle-diff`
+//! re-reads these same files and must see the identical field set; it denies
+//! unknown fields, so an authored field no reader knows is a load error rather
+//! than a silently skipped semantic (RUE-1987). What a field *means* when a
+//! case runs, and which combinations of fields are legal, stay here.
 //!
 //! ```toml
 //! [section]
@@ -185,13 +191,18 @@ use std::time::{Duration, Instant};
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_target::{Arch, Target};
+use rue_test_runner::cli_corpus::{
+    AutomaticExampleContract, Case, CliCaseTier, ExecutionClass, ExecutionContractDeclaration,
+    HangTimeoutProfile, Section, TestFile, TimeoutProfile, WatchEdit, WatchScenario,
+    WatchScenarioKind, unknown_known_bug_on_platforms, unknown_only_on_platforms,
+};
 use rue_test_runner::{
     ExpectedFailureOutcome, KNOWN_TARGETS, PlatformCaseSelection, ShardSelector, TestFailure,
     TestNameOrigin, TestResult, classify_expected_failure, compiler_command,
     configure_process_group, find_dir, find_rue_binary, ice_message, kill_process_group,
     run_with_timeout, validate_nonempty_case_corpus, validate_unique_test_names,
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use sharding::CliShardPlan;
 
@@ -1138,58 +1149,6 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
     },
 ];
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct TestFile {
-    section: Section,
-    /// Named execution contracts contributed by this file. Keeping these in
-    /// the same declarative corpus as cases lets automatic examples and TOML
-    /// cases share one scheduling and timeout policy.
-    #[serde(default, rename = "contract")]
-    contracts: HashMap<String, ExecutionContractDeclaration>,
-    /// The one declarative authority for correctness hang guards. Contracts
-    /// select a named profile instead of inventing raw deadlines.
-    #[serde(default, rename = "timeout_profile")]
-    timeout_profiles: HashMap<TimeoutProfile, HangTimeoutProfile>,
-    /// Parsed here so unknown policy fields fail closed. The CI wrapper owns
-    /// the whole-suite derivation from these values.
-    #[serde(default)]
-    timeout_policy: Option<TimeoutPolicy>,
-    /// Contracts and tiers for recursively discovered examples, keyed by the
-    /// path that also determines their `cli.examples::...` test name.
-    #[serde(default)]
-    automatic_example: Vec<AutomaticExampleContract>,
-    #[serde(default, rename = "case")]
-    cases: Vec<Case>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct Section {
-    id: String,
-    #[allow(dead_code)]
-    name: String,
-    #[allow(dead_code)]
-    #[serde(default)]
-    description: Option<String>,
-    /// Default execution contract for every case in this section. Individual
-    /// cases may override it when only one scenario is heavyweight.
-    #[serde(default)]
-    contract: Option<String>,
-    /// Logical execution tier for this section's explicit cases. Automatic
-    /// examples declare their tier independently.
-    #[serde(default)]
-    tier: CliCaseTier,
-}
-
-#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-enum CliCaseTier {
-    #[default]
-    Premerge,
-    Slow,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CliCaseTierSelection {
     All,
@@ -1226,45 +1185,6 @@ impl CliCaseTierSelection {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-enum ExecutionClass {
-    Ordinary,
-    Heavyweight,
-}
-
-#[derive(Debug, Clone, Copy, Deserialize, Hash, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-enum TimeoutProfile {
-    Ordinary,
-    Slow,
-    Stress,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct HangTimeoutProfile {
-    compile_hang_timeout_ms: u64,
-    runtime_hang_timeout_ms: u64,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct TimeoutPolicy {
-    expected_cost_multiplier_percent: u64,
-    fixed_headroom_ms: u64,
-    minimum_shard_timeout_ms: u64,
-    minimum_monolith_timeout_ms: u64,
-    minimum_slow_suite_timeout_ms: u64,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ExecutionContractDeclaration {
-    class: ExecutionClass,
-    timeout_profile: TimeoutProfile,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ExecutionContract {
     class: ExecutionClass,
@@ -1286,15 +1206,6 @@ impl ExecutionContract {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct AutomaticExampleContract {
-    path: String,
-    contract: String,
-    #[serde(default)]
-    tier: CliCaseTier,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AutomaticExampleMetadata {
     contract: ExecutionContract,
@@ -1307,303 +1218,6 @@ struct LoadedCorpus {
     contracts: HashMap<String, ExecutionContractDeclaration>,
     timeout_profiles: HashMap<TimeoutProfile, HangTimeoutProfile>,
     automatic_examples: Vec<AutomaticExampleContract>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct SourceFile {
-    path: String,
-    source: String,
-}
-
-/// A symbolic link staged in the temp directory before the case runs.
-///
-/// `target` is written verbatim and is deliberately not validated or resolved:
-/// a dangling link, a self-referential link, and a link whose target the
-/// compiled program creates at run time are all legitimate fixtures for
-/// filesystem-facing cases.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct SymlinkFixture {
-    link: String,
-    target: String,
-}
-
-/// A regular hard link staged after the source files. Hard-link support is a
-/// filesystem capability of the test host, so failure is reported rather than
-/// silently turning a regression case into an ordinary-file control.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct HardLinkFixture {
-    link: String,
-    target: String,
-}
-
-/// Imperative end-to-end watch scenario. These cases use the watch protocol
-/// seam in `rue` to synchronize edits and then terminate the watch process;
-/// ordinary CLI cases remain declarative and use the normal compile/run path.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct WatchScenario {
-    kind: WatchScenarioKind,
-    /// Optional diagnostic format passed to the real watch process. JSON
-    /// scenarios additionally assert that every non-empty stderr line is a
-    /// non-empty diagnostic array.
-    #[serde(default)]
-    error_format: Option<String>,
-    #[serde(default)]
-    source_path: Option<String>,
-    #[serde(default)]
-    compile_delay_ms: Option<u64>,
-    /// Widen the gap between the watcher's change monitor stopping and its
-    /// trailing input check, so an edit can be made to land inside it on
-    /// purpose. That window is where RUE-1783 lived: a change discovered there
-    /// was acted on but never announced on the protocol.
-    #[serde(default)]
-    boundary_delay_ms: Option<u64>,
-    /// Hold retained re-observation inside its first physical-read boundary,
-    /// so an edit deterministically supersedes in-progress discovery.
-    #[serde(default)]
-    reobserve_delay_ms: Option<u64>,
-    /// Hold the watcher between re-observation and reached-toolchain
-    /// acquisition, so an edit can deterministically land while acquisition is
-    /// reading demanded modules or re-closing (RUE-1863).
-    #[serde(default)]
-    acquire_delay_ms: Option<u64>,
-    edits: Vec<WatchEdit>,
-    /// Substrings the watch process's stderr must contain. The milestone
-    /// protocol says which boundary a cycle reached; this pins what the cycle
-    /// told the user when it got there.
-    #[serde(default)]
-    stderr_contains: Vec<String>,
-    /// The exit status the published program has at each publication the
-    /// scenario waits for. An `initial_failure` scenario publishes only once,
-    /// so it declares one; every other kind declares two.
-    expected_exit_codes: Vec<i32>,
-}
-
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-enum WatchScenarioKind {
-    Edit,
-    Cancel,
-    Delete,
-    SymlinkRetarget,
-    SupersedeReobserve,
-    SupersedeAcquire,
-    /// The FIRST cycle fails, so the watcher publishes nothing before the
-    /// edit repairs the program. Every other kind opens with a publication,
-    /// which is exactly what a first-cycle failure cannot produce.
-    InitialFailure,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct WatchEdit {
-    path: String,
-    #[serde(default)]
-    source: Option<String>,
-    #[serde(default)]
-    delete: bool,
-    #[serde(default)]
-    symlink_target: Option<String>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct Case {
-    name: String,
-    /// Human-readable explanation of what this case pins and why. Not used by
-    /// the harness; it exists so case files can document intent inline.
-    #[allow(dead_code)]
-    #[serde(default)]
-    description: Option<String>,
-    /// Named execution contract. Overrides the section default.
-    #[serde(default)]
-    contract: Option<String>,
-    /// Files written to the temp directory before invoking the compiler.
-    #[serde(default)]
-    files: Vec<SourceFile>,
-    /// Symbolic links staged in the temp directory alongside `files`. A `files`
-    /// entry can only produce a regular file, so this is what lets a case pin
-    /// symlink behavior.
-    #[serde(default)]
-    symlinks: Vec<SymlinkFixture>,
-    /// Hard links staged in the temp directory alongside `files`.
-    #[serde(default)]
-    hard_links: Vec<HardLinkFixture>,
-    /// Run only when distinct path spellings differing by case resolve to one
-    /// file. Hosts without that filesystem capability report an explicit
-    /// ignored result rather than dropping the regression.
-    #[serde(default)]
-    requires_case_insensitive_fs: bool,
-    /// Repo-root-relative source file to compile directly instead of copying
-    /// inline source into the temp directory. Use this when a CLI case should
-    /// pin a checked-in example/program rather than duplicating its source.
-    #[serde(default)]
-    source_path: Option<String>,
-    /// Compiler arguments, relative to the temp dir (default: first file + `-o prog`).
-    #[serde(default)]
-    args: Option<Vec<String>>,
-    /// Synthesize a tiny C-free static archive exporting `answer() -> 42` as
-    /// pure machine code for the case's target, and substitute its path for the
-    /// `${FFI_ARCHIVE}` token in `args` (ADR-0064 C FFI P1 proof program). The
-    /// archive is produced with the compiler's own object machinery
-    /// (`rue_linker::ObjectBuilder`), mirroring how the runtime archive is
-    /// linked in — no C toolchain is required.
-    #[serde(default)]
-    ffi_answer_archive: bool,
-    /// Name of the executable the compiler is expected to produce.
-    #[serde(default)]
-    output: Option<String>,
-    /// A synchronized, imperative `--watch` integration scenario.
-    #[serde(default)]
-    watch: Option<WatchScenario>,
-    /// Extra environment variables for the compiler invocation.
-    #[serde(default)]
-    env: HashMap<String, String>,
-    /// Command-line arguments passed to the COMPILED PROGRAM when it runs
-    /// (RUE-935). These become `argv[1..]`; `argv[0]` is the program path the
-    /// harness invokes. Distinct from `args`, which are the compiler's flags.
-    #[serde(default)]
-    program_args: Vec<String>,
-    /// Extra environment variables for the COMPILED PROGRAM's run (RUE-935),
-    /// layered on top of the inherited environment. Distinct from `env`, which
-    /// applies to the compiler invocation.
-    #[serde(default)]
-    program_env: HashMap<String, String>,
-    /// Piped to the compiled program's stdin.
-    #[serde(default)]
-    stdin: Option<String>,
-    /// Expect compilation to fail.
-    #[serde(default)]
-    compile_fail: bool,
-    /// Substrings expected in the compiler's stderr when compilation fails.
-    #[serde(default)]
-    error_contains: Vec<String>,
-    /// Compile but don't run the produced binary.
-    #[serde(default)]
-    compile_only: bool,
-    /// Target whose executable structure must be validated after compilation.
-    #[serde(default)]
-    executable_target: Option<String>,
-    /// Run a structurally validated executable only when it is native to this
-    /// host. This lets one case cover every host-target compile pair without
-    /// attempting to execute foreign machine code.
-    #[serde(default)]
-    execute_if_native: bool,
-    /// Substrings expected in the compiler's stdout (e.g. `--emit` output).
-    #[serde(default)]
-    compile_stdout_contains: Vec<String>,
-    /// Substrings that must NOT appear in the compiler's stdout.
-    #[serde(default)]
-    compile_stdout_not_contains: Vec<String>,
-    /// Substrings that MUST appear in the compiler's stderr, regardless of
-    /// whether compilation succeeds or fails. Use for warnings that must
-    /// survive a successful compile (e.g. under `--emit`).
-    #[serde(default)]
-    compile_stderr_contains: Vec<String>,
-    /// Substrings that must NOT appear in the compiler's stderr, regardless of
-    /// whether compilation succeeds or fails. Use to guard against debug spew
-    /// or leaked internal diagnostics (e.g. raw `DEBUG:` eprintln lines).
-    #[serde(default)]
-    compile_stderr_not_contains: Vec<String>,
-    /// Validate the compiler's stderr as the `--error-format json` surface
-    /// (RUE-436): EVERY non-empty stderr line must parse as a JSON array of
-    /// diagnostic objects, and every object must carry the full documented
-    /// schema (see `docs/process/diagnostics.md`). Substring assertions cannot
-    /// catch malformed JSON, a dropped field, or a renamed key — this can, and
-    /// it fails the case when they happen. Under `--error-format json` stderr
-    /// carries diagnostics only (the `Compiled ... -> ...` banner is stdout),
-    /// so the "every line" rule is exact rather than a filter.
-    #[serde(default)]
-    json_diagnostics: bool,
-    /// Exact, ordered digest of the diagnostics `json_diagnostics` parsed, as
-    /// `"<severity> <code> <file>:<line>:<column>"` per diagnostic, flattened
-    /// across every stderr line in emission order. An absent field renders as
-    /// `-`: warnings are uncoded (`"warning - main.rue:2:5"`) and a diagnostic
-    /// with no span has no locator (`"error E1403 -"`). This pins diagnostic
-    /// ORDER, not merely presence: a case that lists the same diagnostics in a
-    /// different order fails. Requires `json_diagnostics`.
-    #[serde(default)]
-    json_diagnostic_order: Vec<String>,
-    /// Exact expected program stdout.
-    #[serde(default)]
-    stdout: Option<String>,
-    /// Substrings expected in the program's stdout.
-    #[serde(default)]
-    stdout_contains: Vec<String>,
-    /// Substrings expected in the program's stderr (runtime panics).
-    #[serde(default)]
-    runtime_error_contains: Vec<String>,
-    /// Expected program exit code (default 0).
-    #[serde(default)]
-    exit_code: Option<i32>,
-    /// Expected failure: reference to the Linear issue tracking the bug.
-    #[serde(default)]
-    known_bug: Option<String>,
-    /// Platforms the known_bug applies to (e.g. ["x86-64-linux"]). Empty
-    /// means all platforms. On other platforms the case runs as a normal
-    /// test. Useful for ABI bugs that manifest differently per target.
-    #[serde(default)]
-    known_bug_on: Vec<String>,
-    /// Platforms this case runs on (e.g. ["x86-64-linux"]); elsewhere it is
-    /// reported as ignored. Empty means all platforms. Use when the expected
-    /// behavior itself depends on the host (e.g. `--target X` is a
-    /// cross-compile on some hosts and a native compile on others).
-    #[serde(default)]
-    only_on: Vec<String>,
-    /// Skip this case entirely.
-    #[serde(default)]
-    skip: bool,
-    /// Opt-level differential test (RUE-236): compile+run this case once per
-    /// optimization level (`-O0`, `-O1`, `-O2`, `-O3`) and assert IDENTICAL
-    /// exit code AND stdout across all levels. A divergence fails the case,
-    /// naming the level that differs. This catches optimizer passes that break
-    /// semantics — the analogue, at the *program's* opt level, of the
-    /// release-mode CI job (RUE-45) that catches `cfg(debug_assertions)`
-    /// divergence in the *compiler*. `-O2`/`-O3` alias `-O1` today, so results
-    /// match now; the net is set so a future divergence is caught.
-    ///
-    /// Marked cases must be plain compile-and-run cases: `compile_fail`,
-    /// `compile_only`, and an explicit `-O` in `args` are rejected (the runner
-    /// drives the opt level itself). Give the case exact `stdout` and
-    /// `exit_code` so each level is also checked against the known-good result,
-    /// not merely against the other levels.
-    #[serde(default)]
-    differential_opt: bool,
-    /// Report the case as ignored when no system `cc` driver is on `PATH`.
-    /// For cases exercising the `--linker cc` symbolized profiling build
-    /// (RUE-1173): every supported CI host provides `cc`, but a minimal local
-    /// environment without a C toolchain should skip rather than fail.
-    #[serde(default)]
-    requires_system_linker: bool,
-    /// Substrings that must each match at least one defined symbol name in
-    /// the produced executable's symbol table (ELF `.symtab` / Mach-O
-    /// `LC_SYMTAB`). Verifies the symbolized profiling build keeps function
-    /// symbols (RUE-1173). Incompatible with `compile_fail`.
-    #[serde(default)]
-    symbols_contain: Vec<String>,
-    /// Assert the produced executable carries no symbol table entries. Pins
-    /// that default internal-linker output is unsymbolized — the documented
-    /// motivation for the `--linker cc` profiling workflow (RUE-1173).
-    /// Incompatible with `compile_fail` and `symbols_contain`.
-    #[serde(default)]
-    no_symbol_table: bool,
-    /// Exact expected exit status of the DRIVER invocation itself, for a
-    /// subcommand that neither compiles-and-runs nor fails to compile.
-    ///
-    /// `rue test` (ADR-0083) is the case this exists for: its exit status is a
-    /// documented four-way contract (0 passed / 1 failures / 2 runner error /
-    /// 3 empty selection) that agents branch on, and `compile_fail`'s
-    /// "nonzero" cannot tell 1 from 3. Setting it also declares that the
-    /// invocation produces no executable to run, so the case ends after the
-    /// compiler's own stdout, stderr, and status are checked — assert the
-    /// driver's output with `compile_stdout_contains` and
-    /// `compile_stderr_contains`. Incompatible with `compile_fail`, whose
-    /// contract is exactly the weaker one this replaces.
-    #[serde(default)]
-    driver_exit_code: Option<i32>,
 }
 
 /// What running one case produced: the compiled program's exit code and
@@ -3945,22 +3559,6 @@ fn invalid_symbol_expectations(case: &Case) -> Option<&'static str> {
     None
 }
 
-fn unknown_only_on_targets(case: &Case) -> Vec<&str> {
-    case.only_on
-        .iter()
-        .map(String::as_str)
-        .filter(|platform| !KNOWN_TARGETS.contains(platform))
-        .collect()
-}
-
-fn unknown_known_bug_on_targets(case: &Case) -> Vec<&str> {
-    case.known_bug_on
-        .iter()
-        .map(String::as_str)
-        .filter(|platform| !KNOWN_TARGETS.contains(platform))
-        .collect()
-}
-
 fn load_cases(cases_dir: &Path) -> LoadedCorpus {
     let toml_files = rue_test_runner::discover_files(cases_dir, "toml").unwrap_or_else(|error| {
         eprintln!(
@@ -4067,7 +3665,7 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                         );
                         std::process::exit(1);
                     }
-                    let unknown_platforms = unknown_only_on_targets(case);
+                    let unknown_platforms = unknown_only_on_platforms(case);
                     if !unknown_platforms.is_empty() {
                         eprintln!(
                             "error: {}: case '{}' has unknown only_on platform(s): {} (known: {})",
@@ -4078,7 +3676,7 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                         );
                         std::process::exit(1);
                     }
-                    let unknown_known_bug_platforms = unknown_known_bug_on_targets(case);
+                    let unknown_known_bug_platforms = unknown_known_bug_on_platforms(case);
                     if !unknown_known_bug_platforms.is_empty() {
                         eprintln!(
                             "error: {}: case '{}' has unknown known_bug_on platform(s): {} (known: {})",
@@ -4764,7 +4362,39 @@ fn emit_shard_loads(
         .map_err(|error| format!("cannot serialize shard loads: {error}"))
 }
 
+/// Report the harness's own view of the host platform and, with it, the
+/// vocabulary its corpus may name.
+///
+/// The shell gates around this harness (`scripts/test-cli-known-bug-markers.sh`,
+/// `scripts/test-harness-duplicate-names.sh`) write `only_on` / `known_bug_on`
+/// fixtures scoped to "this host" and "some other valid platform". They used to
+/// re-derive both from their own `uname` ladders, which could disagree with the
+/// harness they were driving — exactly the drift these gates exist to catch. A
+/// Buck `env` value is static and cannot detect a host, so the harness answers
+/// the question instead, and the scripts ask it.
+fn host_facts(query: &str) -> Option<String> {
+    match query {
+        "--print-host-target" => Some(rue_test_runner::get_host_target().to_string()),
+        "--print-known-targets" => Some(KNOWN_TARGETS.join("\n")),
+        _ => None,
+    }
+}
+
 fn main() {
+    // Answer host-platform queries before anything else: these run with no
+    // corpus, no compiler, and no libtest2 arguments.
+    let mut args = std::env::args().skip(1);
+    if let Some(first) = args.next()
+        && let Some(answer) = host_facts(&first)
+    {
+        if args.next().is_some() {
+            eprintln!("error: {first} takes no further arguments");
+            std::process::exit(2);
+        }
+        println!("{answer}");
+        return;
+    }
+
     // An optional `INDEX/COUNT` spec selects one cost-balanced slice of the
     // corpus so CI can fan the work across parallel runners. Unset (the
     // default, and every local/filtered run) means the whole corpus.
@@ -4964,6 +4594,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_test_runner::cli_corpus::SourceFile;
 
     #[cfg(unix)]
     fn fake_compiler(script: &str) -> (tempfile::TempDir, PathBuf) {
@@ -5861,7 +5492,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(unknown_only_on_targets(&case), vec!["x86_64-linux"]);
+        assert_eq!(unknown_only_on_platforms(&case), vec!["x86_64-linux"]);
     }
 
     #[test]
@@ -5872,7 +5503,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(unknown_known_bug_on_targets(&case), vec!["x86_64-linux"]);
+        assert_eq!(unknown_known_bug_on_platforms(&case), vec!["x86_64-linux"]);
     }
 
     #[test]
@@ -5906,7 +5537,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(unknown_only_on_targets(&case).is_empty());
+        assert!(unknown_only_on_platforms(&case).is_empty());
     }
 
     #[test]
@@ -5920,7 +5551,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(unknown_known_bug_on_targets(&case).is_empty());
+        assert!(unknown_known_bug_on_platforms(&case).is_empty());
     }
 
     #[test]

--- a/crates/rue-cli-tests/src/sharding.rs
+++ b/crates/rue-cli-tests/src/sharding.rs
@@ -1,3 +1,4 @@
+use rue_target::HostPlatform;
 use rue_test_runner::ShardSelector;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -232,14 +233,30 @@ pub fn shard_loads_report(
     })
 }
 
-fn host_platform() -> &'static str {
-    match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("macos", "aarch64") => "macos",
-        ("linux", "aarch64") => "linux-arm64",
-        ("linux", "x86_64") => "linux-x64",
-        _ => "other",
+/// The weights-file bucket for a host platform.
+///
+/// `shard-weights.json` and `scripts/generate-cli-shard-weights.py` key their
+/// overlays by CI-runner vocabulary (`linux-x64`), not by Rue target names
+/// (`x86-64-linux`), so this is a translation of the canonical host — not a
+/// second detection of it. A host Rue does not name, or one the weights file
+/// does not model, falls back to `other`, which carries no overlay and leaves
+/// every case on the common baseline.
+fn weights_platform(host: HostPlatform) -> &'static str {
+    match host {
+        HostPlatform::AARCH64_MACOS => "macos",
+        HostPlatform::AARCH64_LINUX => "linux-arm64",
+        HostPlatform::X86_64_LINUX => "linux-x64",
+        _ => UNMODELED_PLATFORM,
     }
 }
+
+/// The weights bucket for the host this harness is running on.
+fn host_platform() -> &'static str {
+    HostPlatform::current().map_or(UNMODELED_PLATFORM, weights_platform)
+}
+
+/// The bucket for a host `shard-weights.json` carries no overlay for.
+const UNMODELED_PLATFORM: &str = "other";
 
 #[cfg(test)]
 mod tests {
@@ -249,6 +266,26 @@ mod tests {
         ShardSelector::parse(Some(&format!("{index}/{count}")))
             .unwrap()
             .unwrap()
+    }
+
+    #[test]
+    fn every_named_host_maps_to_a_weights_bucket() {
+        assert_eq!(weights_platform(HostPlatform::X86_64_LINUX), "linux-x64");
+        assert_eq!(weights_platform(HostPlatform::AARCH64_LINUX), "linux-arm64");
+        assert_eq!(weights_platform(HostPlatform::AARCH64_MACOS), "macos");
+        // Intel macOS is a host Rue's harnesses recognize but the weights file
+        // does not model; it must land on the unmodeled bucket rather than
+        // borrowing another host's measured costs.
+        assert_eq!(
+            weights_platform(HostPlatform::X86_64_MACOS),
+            UNMODELED_PLATFORM
+        );
+    }
+
+    #[test]
+    fn the_running_host_uses_its_own_bucket() {
+        let expected = HostPlatform::current().map_or(UNMODELED_PLATFORM, weights_platform);
+        assert_eq!(host_platform(), expected);
     }
 
     #[test]

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -1029,15 +1029,19 @@ fn rust_shape(source: &str) -> Result<String, String> {
     Ok(rust_outputs(source)?.shape)
 }
 
+/// Every `.rue` file under `root`, discovered the way every other Rue harness
+/// discovers a corpus.
+///
+/// [`rue_test_runner::discover_files`] is the canonical recursive walk: it
+/// sorts each directory's entries, resolves symlinks explicitly, and refuses to
+/// revisit a directory, so a symlink cycle in the corpus is a bounded error
+/// rather than a hang. Both callers here fold the result into a `BTreeSet` or
+/// sort it, so the extra ordering guarantee costs nothing and the shared walk
+/// replaces a second, weaker one (RUE-1987).
 fn collect_rue_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
-    for entry in fs::read_dir(root).map_err(|e| format!("read {}: {e}", root.display()))? {
-        let path = entry.map_err(|e| e.to_string())?.path();
-        if path.is_dir() {
-            collect_rue_files(&path, files)?;
-        } else if path.extension().is_some_and(|e| e == "rue") {
-            files.push(path);
-        }
-    }
+    let discovered = rue_test_runner::discover_files(root, "rue")
+        .map_err(|error| format!("read {}: {error}", root.display()))?;
+    files.extend(discovered);
     Ok(())
 }
 

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -23,8 +23,11 @@ rue_binary(
     deps = [
         "//crates/rue-oracle:rue-oracle",
         "//crates/rue-compiler:rue-compiler",
-        # rue-test-runner parses + template-expands the rue-spec corpus exactly
-        # as the spec suite does, so the `spec` mode's templating can't drift.
+        # rue-test-runner owns both corpus schemas this harness reads: it
+        # parses + template-expands the rue-spec corpus exactly as the spec
+        # suite does, and `cli_corpus` is the one CLI case schema the
+        # rue-cli-tests harness also deserializes (RUE-1987), so neither the
+        # spec templating nor the CLI field set can drift between them.
         "//crates/rue-test-runner:rue-test-runner",
         "//crates/rue-error:rue-error",
         # The harness classifies a refused query-runtime worker thread as a host

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -34,6 +34,14 @@
 //!   against native binaries compiled at O0, O1, O2, and O3. See [`fuzz`]. A `dump <seed>`
 //!   subcommand prints a generated program for inspection.
 //!
+//! Both corpus modes read their cases through `rue_test_runner`'s schemas —
+//! `cli_corpus` for rue-cli-tests, the spec runner's own types for rue-spec —
+//! so the case format cannot drift between a suite and this differential. The
+//! CLI schema denies unknown fields, and every case field this harness cannot
+//! reproduce is named as an explicit ineligibility rather than ignored, so a
+//! new corpus field cannot silently change what rue-cli-tests runs while the
+//! differential keeps reporting agreement (RUE-1987).
+//!
 //! Every mode exits non-zero if an eligible program is rejected by the front
 //! end, interpretation hits a resource limit or compiler/oracle contract
 //! violation, or the oracle disagrees with expected behavior. Only typed
@@ -60,8 +68,14 @@ use rue_oracle::{
     ModelGapKind, Outcome, RunSourceError, TrapKind, run_session_with_cfg_differential,
     run_source_with_cfg_differential,
 };
-use serde::Deserialize;
-use std::collections::{BTreeMap, HashMap};
+// The rue-cli-tests corpus schema is owned by `rue_test_runner::cli_corpus`.
+// The differential reads the same authored files as the CLI suite, so it reads
+// them through the same `deny_unknown_fields` types: a field this harness
+// cannot honour is then a decision it makes explicitly (see
+// `unsupported_corpus_field`) instead of a semantic it silently dropped
+// (RUE-1987).
+use rue_test_runner::cli_corpus::{self, Case, TestFile, TimeoutProfile};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -70,88 +84,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[derive(Deserialize)]
-struct TestFile {
-    section: Section,
-    #[serde(default, rename = "timeout_profile")]
-    timeout_profiles: HashMap<String, HangTimeoutProfile>,
-    #[serde(default, rename = "case")]
-    cases: Vec<Case>,
-}
-
-/// The stable identity-bearing subset of a rue-cli-tests section. The
-/// differential schema remains permissive about every field it does not use.
-#[derive(Deserialize)]
-struct Section {
-    id: String,
-    #[serde(default)]
-    contract: Option<String>,
-}
-
-#[derive(Clone, Copy, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct HangTimeoutProfile {
-    compile_hang_timeout_ms: u64,
-    runtime_hang_timeout_ms: u64,
-}
-
 #[derive(Clone, Copy)]
 struct CliExecutionTimeouts {
     compile: Duration,
     runtime: Duration,
-}
-
-/// A permissive subset of the rue-cli-tests case schema — only the fields the
-/// oracle can act on. Unknown fields (spec references, compiler diagnostics,
-/// …) are ignored.
-#[derive(Deserialize)]
-struct Case {
-    name: String,
-    #[serde(default)]
-    contract: Option<String>,
-    #[serde(default)]
-    files: Vec<SourceFile>,
-    #[serde(default)]
-    source_path: Option<String>,
-    #[serde(default)]
-    args: Option<Vec<String>>,
-    #[serde(default)]
-    stdin: Option<String>,
-    #[serde(default)]
-    env: HashMap<String, String>,
-    #[serde(default)]
-    program_args: Vec<String>,
-    #[serde(default)]
-    program_env: HashMap<String, String>,
-    #[serde(default)]
-    compile_fail: bool,
-    #[serde(default)]
-    compile_only: bool,
-    #[serde(default)]
-    watch: Option<serde::de::IgnoredAny>,
-    #[serde(default)]
-    stdout: Option<String>,
-    #[serde(default)]
-    stdout_contains: Vec<String>,
-    #[serde(default)]
-    runtime_error_contains: Vec<String>,
-    #[serde(default)]
-    exit_code: Option<i32>,
-    #[serde(default)]
-    known_bug: Option<String>,
-    #[serde(default)]
-    known_bug_on: Vec<String>,
-    #[serde(default)]
-    only_on: Vec<String>,
-    #[serde(default)]
-    skip: bool,
-}
-
-#[derive(Deserialize)]
-struct SourceFile {
-    #[allow(dead_code)]
-    path: String,
-    source: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -189,6 +125,10 @@ enum IneligibleReason {
     CompileOnly,
     ApplicableKnownBug,
     WatchOrchestration,
+    DriverInvocation,
+    StagedFixtures,
+    HostCapability,
+    ForeignArchive,
     StandardInput,
     CompilerEnvironment,
     RuntimeArguments,
@@ -215,6 +155,10 @@ impl fmt::Display for IneligibleReason {
             Self::CompileOnly => f.write_str("compile-only case"),
             Self::ApplicableKnownBug => f.write_str("applicable known bug"),
             Self::WatchOrchestration => f.write_str("watch orchestration"),
+            Self::DriverInvocation => f.write_str("driver-only invocation"),
+            Self::StagedFixtures => f.write_str("staged filesystem fixtures"),
+            Self::HostCapability => f.write_str("required host capability"),
+            Self::ForeignArchive => f.write_str("synthesized foreign archive"),
             Self::StandardInput => f.write_str("standard input required"),
             Self::CompilerEnvironment => f.write_str("compiler environment"),
             Self::RuntimeArguments => f.write_str("runtime command-line arguments"),
@@ -653,7 +597,11 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
 fn cli_execution_timeouts(files: &[(&PathBuf, TestFile)]) -> Result<CliExecutionTimeouts, String> {
     let mut profiles = files
         .iter()
-        .filter_map(|(_, file)| file.timeout_profiles.get("ordinary").copied())
+        .filter_map(|(_, file)| {
+            file.timeout_profiles
+                .get(&TimeoutProfile::Ordinary)
+                .copied()
+        })
         .collect::<Vec<_>>();
     if profiles.is_empty() {
         // A partial focused run may not include execution_contracts.toml in
@@ -667,7 +615,7 @@ fn cli_execution_timeouts(files: &[(&PathBuf, TestFile)]) -> Result<CliExecution
         let authority = load_cli_test_file(&path).map_err(|error| {
             format!("cannot load authoritative CLI execution contracts: {error}")
         })?;
-        if let Some(profile) = authority.timeout_profiles.get("ordinary") {
+        if let Some(profile) = authority.timeout_profiles.get(&TimeoutProfile::Ordinary) {
             profiles.push(*profile);
         }
     }
@@ -1361,6 +1309,108 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
     check_case_with_native(path, case, None, None)
 }
 
+/// The differential's explicit projection of the shared corpus schema: the
+/// first authored field this harness cannot honour, if any.
+///
+/// The CLI corpus is authored for the CLI suite, and a case field can change
+/// what running that case *means* — a staged symlink the compile resolves, a
+/// synthesized archive an argument points at, a subcommand that produces no
+/// program at all. Before the schema was shared this harness deserialized a
+/// permissive subset and dropped every such field on the floor, so it reported
+/// agreement on semantics it had never applied (RUE-1987).
+///
+/// The destructuring below is exhaustive on purpose. Adding a field to
+/// [`rue_test_runner::cli_corpus::Case`] stops compiling here until this
+/// harness says whether it can honour it, which is the property the shared
+/// `deny_unknown_fields` schema exists to give.
+fn unsupported_corpus_field(case: &Case) -> Option<IneligibleReason> {
+    let Case {
+        // Handled by `check_case_with_native` itself, in the CLI runner's own
+        // wrapper order, so they classify with their established reasons.
+        name: _,
+        contract: _,
+        files: _,
+        source_path: _,
+        args: _,
+        watch: _,
+        env: _,
+        program_args: _,
+        program_env: _,
+        stdin: _,
+        compile_fail: _,
+        compile_only: _,
+        known_bug: _,
+        known_bug_on: _,
+        only_on: _,
+        skip: _,
+        runtime_error_contains: _,
+        exit_code: _,
+        stdout: _,
+        stdout_contains: _,
+
+        // Documentation and CLI-side assertions layered on a run whose
+        // *semantics* the oracle does model. The CLI suite owns checking them;
+        // ignoring them here narrows what this harness verifies without
+        // changing what the program is expected to do.
+        description: _,
+        output: _,
+        error_contains: _,
+        compile_stdout_contains: _,
+        compile_stdout_not_contains: _,
+        compile_stderr_contains: _,
+        compile_stderr_not_contains: _,
+        json_diagnostics: _,
+        json_diagnostic_order: _,
+        symbols_contain: _,
+        no_symbol_table: _,
+        // The CLI suite re-runs the case at every `-O` level; the differential
+        // already executes each eligible case at O1, O2, and O3 against the
+        // same pinned stdout and exit code, so this asks for nothing extra.
+        differential_opt: _,
+
+        // Fields that change what the case does, which this harness cannot
+        // reproduce.
+        symlinks,
+        hard_links,
+        requires_case_insensitive_fs,
+        ffi_answer_archive,
+        executable_target,
+        execute_if_native,
+        requires_system_linker,
+        driver_exit_code,
+    } = case;
+
+    // `driver_exit_code` declares a driver subcommand that never produces a
+    // program: there is no execution for the oracle to agree with.
+    if driver_exit_code.is_some() {
+        return Some(IneligibleReason::DriverInvocation);
+    }
+    // Links are staged into the compile's working directory before the case
+    // runs, and the in-process oracle has no such directory. A dangling or
+    // aliasing link is frequently the whole point of the case.
+    if !symlinks.is_empty() || !hard_links.is_empty() {
+        return Some(IneligibleReason::StagedFixtures);
+    }
+    // Capability-scoped cases are reported as ignored by the CLI suite on a
+    // host that lacks the capability. Running them here regardless would judge
+    // them under conditions their author excluded.
+    if *requires_case_insensitive_fs || *requires_system_linker {
+        return Some(IneligibleReason::HostCapability);
+    }
+    // The `${FFI_ARCHIVE}` token resolves to a machine-code archive built for a
+    // concrete target and linked into the program; the oracle links nothing.
+    if *ffi_answer_archive {
+        return Some(IneligibleReason::ForeignArchive);
+    }
+    // An explicit executable target makes the case's contract target-specific,
+    // the same way a spec case's `target` does. The oracle has no target
+    // context to reproduce it with.
+    if executable_target.is_some() || *execute_if_native {
+        return Some(IneligibleReason::TargetPinned);
+    }
+    None
+}
+
 fn check_case_with_native(
     path: &Path,
     case: &Case,
@@ -1400,6 +1450,9 @@ fn check_case_with_native(
     // can compare. The CLI harness owns this orchestration contract.
     if case.watch.is_some() {
         return CaseOutcome::Ineligible(IneligibleReason::WatchOrchestration);
+    }
+    if let Some(reason) = unsupported_corpus_field(case) {
+        return CaseOutcome::Ineligible(reason);
     }
     if case.stdin.is_some() {
         return CaseOutcome::Ineligible(IneligibleReason::StandardInput);
@@ -1715,21 +1768,27 @@ fn load_cli_test_file(path: &Path) -> Result<TestFile, String> {
 
     let mut platform_failures = Vec::new();
     for case in &file.cases {
-        let mut unknown: Vec<&str> = case
-            .only_on
-            .iter()
-            .map(String::as_str)
-            .filter(|platform| !rue_test_runner::KNOWN_TARGETS.contains(platform))
-            .collect();
-        unknown.sort_unstable();
-        unknown.dedup();
-        if !unknown.is_empty() {
-            platform_failures.push(format!(
-                "case {:?} has unknown only_on platform(s): {} (known: {})",
-                case.name,
-                unknown.join(", "),
-                rue_test_runner::KNOWN_TARGETS.join(", ")
-            ));
+        // The same validator the CLI suite runs, on the same schema: an
+        // unknown platform name can never equal a host, so a case carrying one
+        // would be skipped everywhere while still counting as corpus coverage.
+        for (axis, unknown) in [
+            ("only_on", cli_corpus::unknown_only_on_platforms(case)),
+            (
+                "known_bug_on",
+                cli_corpus::unknown_known_bug_on_platforms(case),
+            ),
+        ] {
+            let mut unknown = unknown;
+            unknown.sort_unstable();
+            unknown.dedup();
+            if !unknown.is_empty() {
+                platform_failures.push(format!(
+                    "case {:?} has unknown {axis} platform(s): {} (known: {})",
+                    case.name,
+                    unknown.join(", "),
+                    rue_test_runner::KNOWN_TARGETS.join(", ")
+                ));
+            }
         }
     }
     platform_failures.sort();
@@ -1771,6 +1830,9 @@ fn discover_toml(dirs: &[PathBuf]) -> (Vec<PathBuf>, Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_test_runner::cli_corpus::{
+        HardLinkFixture, SourceFile, SymlinkFixture, WatchScenario, WatchScenarioKind,
+    };
 
     #[test]
     fn nested_grid_row_and_arraybuf_accessors_agree_at_cfg_boundaries() {
@@ -1815,28 +1877,30 @@ mod tests {
     fn corpus_case(source: &str, compile_fail: bool) -> Case {
         Case {
             name: "classification probe".to_string(),
-            contract: None,
             files: vec![SourceFile {
                 path: "probe.rue".to_string(),
                 source: source.to_string(),
             }],
-            source_path: None,
-            args: None,
-            stdin: None,
-            env: HashMap::new(),
-            program_args: Vec::new(),
-            program_env: HashMap::new(),
             compile_fail,
-            compile_only: false,
-            watch: None,
-            stdout: None,
-            stdout_contains: Vec::new(),
-            runtime_error_contains: Vec::new(),
             exit_code: Some(0),
-            known_bug: None,
-            known_bug_on: Vec::new(),
-            only_on: Vec::new(),
-            skip: false,
+            ..Case::default()
+        }
+    }
+
+    /// The smallest watch scenario the shared schema accepts. Its content is
+    /// irrelevant here: the differential refuses every watch case on sight.
+    fn watch_scenario() -> WatchScenario {
+        WatchScenario {
+            kind: WatchScenarioKind::Edit,
+            error_format: None,
+            source_path: None,
+            compile_delay_ms: None,
+            boundary_delay_ms: None,
+            reobserve_delay_ms: None,
+            acquire_delay_ms: None,
+            edits: Vec::new(),
+            stderr_contains: Vec::new(),
+            expected_exit_codes: Vec::new(),
         }
     }
 
@@ -1854,6 +1918,7 @@ mod tests {
             r#"
             [section]
             id = "cli.execution_contracts"
+            name = "Execution contracts"
 
             [timeout_profile.ordinary]
             compile_hang_timeout_ms = 180000
@@ -1906,6 +1971,7 @@ mod tests {
                 r#"
 [section]
 id = "cli.fixture"
+name = "Fixture"
 
 [[case]]
 name = "{name}"
@@ -1986,6 +2052,7 @@ files = [{{ path = "probe.rue", source = "not Rue" }}]
             r#"
 [section]
 id = "cli.invalid_platform"
+name = "Invalid platform"
 
 [[case]]
 name = "misspelled platform"
@@ -2009,6 +2076,118 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
             corpus_mode(vec![temp.path().to_string_lossy().into_owned()]),
             ExitCode::FAILURE
         );
+    }
+
+    #[test]
+    fn unknown_known_bug_on_is_a_fatal_load_error() {
+        let temp = tempfile::tempdir().expect("create temporary cases root");
+        let invalid = temp.path().join("invalid-xfail-platform.toml");
+        std::fs::write(
+            &invalid,
+            r#"
+[section]
+id = "cli.invalid_xfail_platform"
+name = "Invalid xfail platform"
+
+[[case]]
+name = "misspelled xfail platform"
+known_bug = "RUE-1"
+known_bug_on = ["x86_64-linux"]
+files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
+"#,
+        )
+        .expect("write invalid known_bug_on fixture");
+
+        let failure = load_cli_test_file(&invalid)
+            .err()
+            .expect("an unknown known_bug_on platform must not load");
+        assert!(failure.contains("unknown known_bug_on platform(s): x86_64-linux"));
+        assert_eq!(
+            corpus_mode(vec![temp.path().to_string_lossy().into_owned()]),
+            ExitCode::FAILURE
+        );
+    }
+
+    #[test]
+    fn an_unknown_case_field_is_a_fatal_load_error() {
+        let temp = tempfile::tempdir().expect("create temporary cases root");
+        let invalid = temp.path().join("invented-field.toml");
+        std::fs::write(
+            &invalid,
+            r#"
+[section]
+id = "cli.invented_field"
+name = "Invented field"
+
+[[case]]
+name = "invented"
+invented_field = true
+files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
+"#,
+        )
+        .expect("write invented-field fixture");
+
+        // The whole point of sharing the CLI schema: a field this harness does
+        // not know cannot be a semantic it silently skipped (RUE-1987).
+        let failure = load_cli_test_file(&invalid)
+            .err()
+            .expect("an unknown case field must not load");
+        assert!(failure.contains("could not parse"), "{failure}");
+        assert!(failure.contains("invented_field"), "{failure}");
+    }
+
+    #[test]
+    fn corpus_fields_the_differential_cannot_honour_are_named_not_ignored() {
+        let base = corpus_case("fn main() -> i32 { 0 }", false);
+        assert_eq!(unsupported_corpus_field(&base), None);
+
+        let mut case = base.clone();
+        case.driver_exit_code = Some(3);
+        assert_eq!(
+            unsupported_corpus_field(&case),
+            Some(IneligibleReason::DriverInvocation)
+        );
+
+        let mut case = base.clone();
+        case.hard_links = vec![HardLinkFixture {
+            link: "alias.rue".to_string(),
+            target: "probe.rue".to_string(),
+        }];
+        assert_eq!(
+            unsupported_corpus_field(&case),
+            Some(IneligibleReason::StagedFixtures)
+        );
+
+        let mut case = base.clone();
+        case.requires_case_insensitive_fs = true;
+        assert_eq!(
+            unsupported_corpus_field(&case),
+            Some(IneligibleReason::HostCapability)
+        );
+
+        let mut case = base.clone();
+        case.ffi_answer_archive = true;
+        assert_eq!(
+            unsupported_corpus_field(&case),
+            Some(IneligibleReason::ForeignArchive)
+        );
+
+        let mut case = base.clone();
+        case.execute_if_native = true;
+        assert_eq!(
+            unsupported_corpus_field(&case),
+            Some(IneligibleReason::TargetPinned)
+        );
+
+        // Assertions the CLI suite layers on a run the oracle *does* model stay
+        // eligible: they narrow what this harness checks, not what the program
+        // is expected to do.
+        let mut case = base.clone();
+        case.differential_opt = true;
+        case.no_symbol_table = true;
+        case.json_diagnostics = true;
+        case.compile_stderr_not_contains = vec!["DEBUG:".to_string()];
+        assert_eq!(unsupported_corpus_field(&case), None);
     }
 
     #[test]
@@ -2099,9 +2278,11 @@ files = [{ path = "probe.rue", source = "not Rue" }]
             CaseOutcome::Agree
         ));
 
-        // Keep parity with rue-cli-tests: only `only_on` is validated. An
-        // unknown known_bug_on value does not match this host, so the case
-        // runs normally and can fail loudly instead of being silently xfailed.
+        // An unknown known_bug_on value does not match this host, so a case
+        // carrying one runs normally and can fail loudly rather than being
+        // silently xfailed. `load_cli_test_file` rejects it before that can
+        // happen (see `unknown_known_bug_on_is_a_fatal_load_error`); the
+        // classifier's own behavior is the safe one either way.
         case.known_bug_on = vec!["not-a-real-target".to_string()];
         assert!(matches!(
             check_case(Path::new("known-bug.toml"), &case),
@@ -2236,9 +2417,27 @@ files = [{ path = "probe.rue", source = "not Rue" }]
         case.compile_only = false;
         assert_cli_ineligible(&case, IneligibleReason::ApplicableKnownBug);
         case.known_bug = None;
-        case.watch = Some(serde::de::IgnoredAny);
+        case.watch = Some(watch_scenario());
         assert_cli_ineligible(&case, IneligibleReason::WatchOrchestration);
         case.watch = None;
+        case.driver_exit_code = Some(3);
+        assert_cli_ineligible(&case, IneligibleReason::DriverInvocation);
+        case.driver_exit_code = None;
+        case.symlinks = vec![SymlinkFixture {
+            link: "alias.rue".to_string(),
+            target: "probe.rue".to_string(),
+        }];
+        assert_cli_ineligible(&case, IneligibleReason::StagedFixtures);
+        case.symlinks.clear();
+        case.requires_system_linker = true;
+        assert_cli_ineligible(&case, IneligibleReason::HostCapability);
+        case.requires_system_linker = false;
+        case.ffi_answer_archive = true;
+        assert_cli_ineligible(&case, IneligibleReason::ForeignArchive);
+        case.ffi_answer_archive = false;
+        case.executable_target = Some("x86-64-linux".to_string());
+        assert_cli_ineligible(&case, IneligibleReason::TargetPinned);
+        case.executable_target = None;
         assert_cli_ineligible(&case, IneligibleReason::StandardInput);
         case.stdin = None;
         assert_cli_ineligible(&case, IneligibleReason::CompilerEnvironment);

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -36,31 +36,13 @@ impl Target {
     /// that case explicitly instead of silently compiling for some other
     /// platform.
     pub fn host() -> Option<Self> {
-        if cfg!(all(target_arch = "x86_64", target_os = "linux")) {
-            Some(Target::X86_64Linux)
-        } else if cfg!(all(target_arch = "aarch64", target_os = "linux")) {
-            Some(Target::Aarch64Linux)
-        } else if cfg!(all(target_arch = "aarch64", target_os = "macos")) {
-            Some(Target::Aarch64Macos)
-        } else {
-            None
-        }
+        HostPlatform::current().and_then(HostPlatform::compiler_target)
     }
 
     /// Returns a best-effort name for the host this compiler binary was built
     /// for, including unsupported hosts. Used in diagnostics.
     pub fn host_description() -> &'static str {
-        if cfg!(all(target_arch = "x86_64", target_os = "linux")) {
-            "x86-64-linux"
-        } else if cfg!(all(target_arch = "aarch64", target_os = "linux")) {
-            "aarch64-linux"
-        } else if cfg!(all(target_arch = "aarch64", target_os = "macos")) {
-            "aarch64-macos"
-        } else if cfg!(all(target_arch = "x86_64", target_os = "macos")) {
-            "x86-64-macos"
-        } else {
-            "unsupported host"
-        }
+        HostPlatform::current().map_or(UNSUPPORTED_HOST_DESCRIPTION, HostPlatform::name)
     }
 
     /// Returns the architecture component of this target.
@@ -187,6 +169,123 @@ impl Target {
 }
 
 impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// What `host_description` reports for a host no [`HostPlatform`] names.
+const UNSUPPORTED_HOST_DESCRIPTION: &str = "unsupported host";
+
+/// A host Rue's tooling recognizes, and the compilation target (if any) that
+/// host can build for natively.
+///
+/// The two halves are deliberately separate. A host can be *known* to the
+/// harnesses — nameable in a case's `only_on` / `known_bug_on` list, resolvable
+/// to a shard-weight bucket — without Rue having a compiler target for it;
+/// Intel macOS is exactly that host. Keeping the pair in one value is what
+/// stops a harness from classifying a host as supported that the compiler
+/// itself rejects, and makes adding a platform a single edit here rather than a
+/// `cfg!` ladder re-derived in every consumer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HostPlatform {
+    name: &'static str,
+    compiler_target: Option<Target>,
+}
+
+impl HostPlatform {
+    /// x86-64 Linux.
+    pub const X86_64_LINUX: Self = Self {
+        name: "x86-64-linux",
+        compiler_target: Some(Target::X86_64Linux),
+    };
+    /// AArch64 Linux.
+    pub const AARCH64_LINUX: Self = Self {
+        name: "aarch64-linux",
+        compiler_target: Some(Target::Aarch64Linux),
+    };
+    /// Apple Silicon macOS.
+    pub const AARCH64_MACOS: Self = Self {
+        name: "aarch64-macos",
+        compiler_target: Some(Target::Aarch64Macos),
+    };
+    /// Intel macOS. Rue's harnesses run there, but the compiler has no
+    /// x86-64 macOS target, so this host carries no [`Target`].
+    pub const X86_64_MACOS: Self = Self {
+        name: "x86-64-macos",
+        compiler_target: None,
+    };
+
+    /// Every host platform Rue's tooling recognizes.
+    pub const ALL: &'static [Self] = &[
+        Self::X86_64_LINUX,
+        Self::AARCH64_LINUX,
+        Self::AARCH64_MACOS,
+        Self::X86_64_MACOS,
+    ];
+
+    /// The names of [`HostPlatform::ALL`], in the same order.
+    ///
+    /// Consumers that validate authored platform names (a case file's
+    /// `only_on` list) need the names as a `const` slice, which cannot be
+    /// derived from `ALL` in a constant expression; a unit test holds the two
+    /// in agreement.
+    pub const ALL_NAMES: &'static [&'static str] = &[
+        Self::X86_64_LINUX.name(),
+        Self::AARCH64_LINUX.name(),
+        Self::AARCH64_MACOS.name(),
+        Self::X86_64_MACOS.name(),
+    ];
+
+    /// The host this binary was built for, or `None` when it is a platform Rue
+    /// does not recognize at all.
+    ///
+    /// This is the one `cfg!` ladder over host architecture and OS in the
+    /// repository; everything else that needs a host name or a native target
+    /// goes through it.
+    pub fn current() -> Option<Self> {
+        if cfg!(all(target_arch = "x86_64", target_os = "linux")) {
+            Some(Self::X86_64_LINUX)
+        } else if cfg!(all(target_arch = "aarch64", target_os = "linux")) {
+            Some(Self::AARCH64_LINUX)
+        } else if cfg!(all(target_arch = "aarch64", target_os = "macos")) {
+            Some(Self::AARCH64_MACOS)
+        } else if cfg!(all(target_arch = "x86_64", target_os = "macos")) {
+            Some(Self::X86_64_MACOS)
+        } else {
+            None
+        }
+    }
+
+    /// Look a host platform up by its canonical Rue name.
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|platform| platform.name() == name)
+    }
+
+    /// The canonical Rue spelling of this host, e.g. `x86-64-linux`.
+    pub const fn name(self) -> &'static str {
+        self.name
+    }
+
+    /// The compilation target this host builds for natively, or `None` when
+    /// Rue has no target for it.
+    pub const fn compiler_target(self) -> Option<Target> {
+        self.compiler_target
+    }
+
+    /// The architecture component of this host's name (`x86-64-linux` ->
+    /// `x86-64`).
+    pub fn architecture(self) -> &'static str {
+        self.name
+            .rsplit_once('-')
+            .map_or(self.name, |(arch, _os)| arch)
+    }
+}
+
+impl fmt::Display for HostPlatform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.name())
     }
@@ -447,6 +546,61 @@ mod tests {
                 "Round-trip failed for {}: displayed as '{}', parsed back as {:?}",
                 target, displayed, parsed
             );
+        }
+    }
+
+    #[test]
+    fn host_platform_names_match_the_platform_table() {
+        let derived: Vec<&str> = HostPlatform::ALL
+            .iter()
+            .copied()
+            .map(HostPlatform::name)
+            .collect();
+        assert_eq!(derived, HostPlatform::ALL_NAMES);
+    }
+
+    #[test]
+    fn host_platform_names_are_unique_and_lookupable() {
+        for platform in HostPlatform::ALL {
+            assert_eq!(HostPlatform::from_name(platform.name()), Some(*platform));
+        }
+        assert_eq!(HostPlatform::from_name("x86_64-linux"), None);
+    }
+
+    #[test]
+    fn every_compilation_target_is_some_host_platform_native_target() {
+        for target in Target::all() {
+            assert!(
+                HostPlatform::ALL
+                    .iter()
+                    .any(|platform| platform.compiler_target() == Some(*target)),
+                "no host platform builds {target} natively"
+            );
+            assert!(
+                HostPlatform::from_name(target.name())
+                    .is_some_and(|platform| platform.compiler_target() == Some(*target)),
+                "{target} must name the host platform that builds it"
+            );
+        }
+    }
+
+    #[test]
+    fn host_platform_architecture_drops_the_os_component() {
+        assert_eq!(HostPlatform::X86_64_LINUX.architecture(), "x86-64");
+        assert_eq!(HostPlatform::AARCH64_MACOS.architecture(), "aarch64");
+    }
+
+    #[test]
+    fn host_target_and_description_agree_with_the_current_host_platform() {
+        match HostPlatform::current() {
+            Some(platform) => {
+                assert_eq!(Target::host_description(), platform.name());
+                assert_eq!(Target::host(), platform.compiler_target());
+            }
+            None => {
+                assert_eq!(Target::host_description(), UNSUPPORTED_HOST_DESCRIPTION);
+                assert_eq!(Target::host(), None);
+            }
         }
     }
 }

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -1,0 +1,533 @@
+//! The CLI-corpus TOML schema and its platform validation.
+//!
+//! `crates/rue-cli-tests/cases/*.toml` is the authoritative declarative corpus
+//! for the CLI integration suite, and more than one harness reads it: the CLI
+//! suite runs the cases, and `rue-oracle-diff` re-reads the same files to check
+//! the reference interpreter against them. When each harness declared its own
+//! `Deserialize` view of the format, the differential's view was a permissive
+//! subset that ignored unknown fields — so a case could grow a field that
+//! changes what the CLI suite does (staged symlinks, a `--watch` scenario, a
+//! driver-only exit contract) while the differential kept "agreeing" about
+//! semantics it had never applied.
+//!
+//! This module is the single schema. It carries `deny_unknown_fields`
+//! throughout, so an authored field this type does not know is a load error
+//! rather than a silent omission, and every consumer projects the subset it can
+//! honour *explicitly* — naming the fields it refuses instead of dropping them
+//! on the floor.
+//!
+//! The schema is deliberately data only. Which field combinations are legal,
+//! and what running a case means, stay with the CLI harness that owns those
+//! semantics; what lives here is the shape of the file and the platform
+//! vocabulary (`only_on` / `known_bug_on`) that every reader must agree on.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+use crate::KNOWN_TARGETS;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TestFile {
+    pub section: Section,
+    /// Named execution contracts contributed by this file. Keeping these in
+    /// the same declarative corpus as cases lets automatic examples and TOML
+    /// cases share one scheduling and timeout policy.
+    #[serde(default, rename = "contract")]
+    pub contracts: HashMap<String, ExecutionContractDeclaration>,
+    /// The one declarative authority for correctness hang guards. Contracts
+    /// select a named profile instead of inventing raw deadlines.
+    #[serde(default, rename = "timeout_profile")]
+    pub timeout_profiles: HashMap<TimeoutProfile, HangTimeoutProfile>,
+    /// Parsed here so unknown policy fields fail closed. The CI wrapper owns
+    /// the whole-suite derivation from these values.
+    #[serde(default)]
+    pub timeout_policy: Option<TimeoutPolicy>,
+    /// Contracts and tiers for recursively discovered examples, keyed by the
+    /// path that also determines their `cli.examples::...` test name.
+    #[serde(default)]
+    pub automatic_example: Vec<AutomaticExampleContract>,
+    #[serde(default, rename = "case")]
+    pub cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Section {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Default execution contract for every case in this section. Individual
+    /// cases may override it when only one scenario is heavyweight.
+    #[serde(default)]
+    pub contract: Option<String>,
+    /// Logical execution tier for this section's explicit cases. Automatic
+    /// examples declare their tier independently.
+    #[serde(default)]
+    pub tier: CliCaseTier,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CliCaseTier {
+    #[default]
+    Premerge,
+    Slow,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionClass {
+    Ordinary,
+    Heavyweight,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Hash, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TimeoutProfile {
+    Ordinary,
+    Slow,
+    Stress,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct HangTimeoutProfile {
+    pub compile_hang_timeout_ms: u64,
+    pub runtime_hang_timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TimeoutPolicy {
+    pub expected_cost_multiplier_percent: u64,
+    pub fixed_headroom_ms: u64,
+    pub minimum_shard_timeout_ms: u64,
+    pub minimum_monolith_timeout_ms: u64,
+    pub minimum_slow_suite_timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutionContractDeclaration {
+    pub class: ExecutionClass,
+    pub timeout_profile: TimeoutProfile,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AutomaticExampleContract {
+    pub path: String,
+    pub contract: String,
+    #[serde(default)]
+    pub tier: CliCaseTier,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceFile {
+    pub path: String,
+    pub source: String,
+}
+
+/// A symbolic link staged in the temp directory before the case runs.
+///
+/// `target` is written verbatim and is deliberately not validated or resolved:
+/// a dangling link, a self-referential link, and a link whose target the
+/// compiled program creates at run time are all legitimate fixtures for
+/// filesystem-facing cases.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SymlinkFixture {
+    pub link: String,
+    pub target: String,
+}
+
+/// A regular hard link staged after the source files. Hard-link support is a
+/// filesystem capability of the test host, so failure is reported rather than
+/// silently turning a regression case into an ordinary-file control.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct HardLinkFixture {
+    pub link: String,
+    pub target: String,
+}
+
+/// Imperative end-to-end watch scenario. These cases use the watch protocol
+/// seam in `rue` to synchronize edits and then terminate the watch process;
+/// ordinary CLI cases remain declarative and use the normal compile/run path.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WatchScenario {
+    pub kind: WatchScenarioKind,
+    /// Optional diagnostic format passed to the real watch process. JSON
+    /// scenarios additionally assert that every non-empty stderr line is a
+    /// non-empty diagnostic array.
+    #[serde(default)]
+    pub error_format: Option<String>,
+    #[serde(default)]
+    pub source_path: Option<String>,
+    #[serde(default)]
+    pub compile_delay_ms: Option<u64>,
+    /// Widen the gap between the watcher's change monitor stopping and its
+    /// trailing input check, so an edit can be made to land inside it on
+    /// purpose. That window is where RUE-1783 lived: a change discovered there
+    /// was acted on but never announced on the protocol.
+    #[serde(default)]
+    pub boundary_delay_ms: Option<u64>,
+    /// Hold retained re-observation inside its first physical-read boundary,
+    /// so an edit deterministically supersedes in-progress discovery.
+    #[serde(default)]
+    pub reobserve_delay_ms: Option<u64>,
+    /// Hold the watcher between re-observation and reached-toolchain
+    /// acquisition, so an edit can deterministically land while acquisition is
+    /// reading demanded modules or re-closing (RUE-1863).
+    #[serde(default)]
+    pub acquire_delay_ms: Option<u64>,
+    pub edits: Vec<WatchEdit>,
+    /// Substrings the watch process's stderr must contain. The milestone
+    /// protocol says which boundary a cycle reached; this pins what the cycle
+    /// told the user when it got there.
+    #[serde(default)]
+    pub stderr_contains: Vec<String>,
+    /// The exit status the published program has at each publication the
+    /// scenario waits for. An `initial_failure` scenario publishes only once,
+    /// so it declares one; every other kind declares two.
+    pub expected_exit_codes: Vec<i32>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WatchScenarioKind {
+    Edit,
+    Cancel,
+    Delete,
+    SymlinkRetarget,
+    SupersedeReobserve,
+    SupersedeAcquire,
+    /// The FIRST cycle fails, so the watcher publishes nothing before the
+    /// edit repairs the program. Every other kind opens with a publication,
+    /// which is exactly what a first-cycle failure cannot produce.
+    InitialFailure,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WatchEdit {
+    pub path: String,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub delete: bool,
+    #[serde(default)]
+    pub symlink_target: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Case {
+    pub name: String,
+    /// Human-readable explanation of what this case pins and why. Not used by
+    /// the harness; it exists so case files can document intent inline.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Named execution contract. Overrides the section default.
+    #[serde(default)]
+    pub contract: Option<String>,
+    /// Files written to the temp directory before invoking the compiler.
+    #[serde(default)]
+    pub files: Vec<SourceFile>,
+    /// Symbolic links staged in the temp directory alongside `files`. A `files`
+    /// entry can only produce a regular file, so this is what lets a case pin
+    /// symlink behavior.
+    #[serde(default)]
+    pub symlinks: Vec<SymlinkFixture>,
+    /// Hard links staged in the temp directory alongside `files`.
+    #[serde(default)]
+    pub hard_links: Vec<HardLinkFixture>,
+    /// Run only when distinct path spellings differing by case resolve to one
+    /// file. Hosts without that filesystem capability report an explicit
+    /// ignored result rather than dropping the regression.
+    #[serde(default)]
+    pub requires_case_insensitive_fs: bool,
+    /// Repo-root-relative source file to compile directly instead of copying
+    /// inline source into the temp directory. Use this when a CLI case should
+    /// pin a checked-in example/program rather than duplicating its source.
+    #[serde(default)]
+    pub source_path: Option<String>,
+    /// Compiler arguments, relative to the temp dir (default: first file + `-o prog`).
+    #[serde(default)]
+    pub args: Option<Vec<String>>,
+    /// Synthesize a tiny C-free static archive exporting `answer() -> 42` as
+    /// pure machine code for the case's target, and substitute its path for the
+    /// `${FFI_ARCHIVE}` token in `args` (ADR-0064 C FFI P1 proof program). The
+    /// archive is produced with the compiler's own object machinery
+    /// (`rue_linker::ObjectBuilder`), mirroring how the runtime archive is
+    /// linked in — no C toolchain is required.
+    #[serde(default)]
+    pub ffi_answer_archive: bool,
+    /// Name of the executable the compiler is expected to produce.
+    #[serde(default)]
+    pub output: Option<String>,
+    /// A synchronized, imperative `--watch` integration scenario.
+    #[serde(default)]
+    pub watch: Option<WatchScenario>,
+    /// Extra environment variables for the compiler invocation.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Command-line arguments passed to the COMPILED PROGRAM when it runs
+    /// (RUE-935). These become `argv[1..]`; `argv[0]` is the program path the
+    /// harness invokes. Distinct from `args`, which are the compiler's flags.
+    #[serde(default)]
+    pub program_args: Vec<String>,
+    /// Extra environment variables for the COMPILED PROGRAM's run (RUE-935),
+    /// layered on top of the inherited environment. Distinct from `env`, which
+    /// applies to the compiler invocation.
+    #[serde(default)]
+    pub program_env: HashMap<String, String>,
+    /// Piped to the compiled program's stdin.
+    #[serde(default)]
+    pub stdin: Option<String>,
+    /// Expect compilation to fail.
+    #[serde(default)]
+    pub compile_fail: bool,
+    /// Substrings expected in the compiler's stderr when compilation fails.
+    #[serde(default)]
+    pub error_contains: Vec<String>,
+    /// Compile but don't run the produced binary.
+    #[serde(default)]
+    pub compile_only: bool,
+    /// Target whose executable structure must be validated after compilation.
+    #[serde(default)]
+    pub executable_target: Option<String>,
+    /// Run a structurally validated executable only when it is native to this
+    /// host. This lets one case cover every host-target compile pair without
+    /// attempting to execute foreign machine code.
+    #[serde(default)]
+    pub execute_if_native: bool,
+    /// Substrings expected in the compiler's stdout (e.g. `--emit` output).
+    #[serde(default)]
+    pub compile_stdout_contains: Vec<String>,
+    /// Substrings that must NOT appear in the compiler's stdout.
+    #[serde(default)]
+    pub compile_stdout_not_contains: Vec<String>,
+    /// Substrings that MUST appear in the compiler's stderr, regardless of
+    /// whether compilation succeeds or fails. Use for warnings that must
+    /// survive a successful compile (e.g. under `--emit`).
+    #[serde(default)]
+    pub compile_stderr_contains: Vec<String>,
+    /// Substrings that must NOT appear in the compiler's stderr, regardless of
+    /// whether compilation succeeds or fails. Use to guard against debug spew
+    /// or leaked internal diagnostics (e.g. raw `DEBUG:` eprintln lines).
+    #[serde(default)]
+    pub compile_stderr_not_contains: Vec<String>,
+    /// Validate the compiler's stderr as the `--error-format json` surface
+    /// (RUE-436): EVERY non-empty stderr line must parse as a JSON array of
+    /// diagnostic objects, and every object must carry the full documented
+    /// schema (see `docs/process/diagnostics.md`). Substring assertions cannot
+    /// catch malformed JSON, a dropped field, or a renamed key — this can, and
+    /// it fails the case when they happen. Under `--error-format json` stderr
+    /// carries diagnostics only (the `Compiled ... -> ...` banner is stdout),
+    /// so the "every line" rule is exact rather than a filter.
+    #[serde(default)]
+    pub json_diagnostics: bool,
+    /// Exact, ordered digest of the diagnostics `json_diagnostics` parsed, as
+    /// `"<severity> <code> <file>:<line>:<column>"` per diagnostic, flattened
+    /// across every stderr line in emission order. An absent field renders as
+    /// `-`: warnings are uncoded (`"warning - main.rue:2:5"`) and a diagnostic
+    /// with no span has no locator (`"error E1403 -"`). This pins diagnostic
+    /// ORDER, not merely presence: a case that lists the same diagnostics in a
+    /// different order fails. Requires `json_diagnostics`.
+    #[serde(default)]
+    pub json_diagnostic_order: Vec<String>,
+    /// Exact expected program stdout.
+    #[serde(default)]
+    pub stdout: Option<String>,
+    /// Substrings expected in the program's stdout.
+    #[serde(default)]
+    pub stdout_contains: Vec<String>,
+    /// Substrings expected in the program's stderr (runtime panics).
+    #[serde(default)]
+    pub runtime_error_contains: Vec<String>,
+    /// Expected program exit code (default 0).
+    #[serde(default)]
+    pub exit_code: Option<i32>,
+    /// Expected failure: reference to the Linear issue tracking the bug.
+    #[serde(default)]
+    pub known_bug: Option<String>,
+    /// Platforms the known_bug applies to (e.g. ["x86-64-linux"]). Empty
+    /// means all platforms. On other platforms the case runs as a normal
+    /// test. Useful for ABI bugs that manifest differently per target.
+    #[serde(default)]
+    pub known_bug_on: Vec<String>,
+    /// Platforms this case runs on (e.g. ["x86-64-linux"]); elsewhere it is
+    /// reported as ignored. Empty means all platforms. Use when the expected
+    /// behavior itself depends on the host (e.g. `--target X` is a
+    /// cross-compile on some hosts and a native compile on others).
+    #[serde(default)]
+    pub only_on: Vec<String>,
+    /// Skip this case entirely.
+    #[serde(default)]
+    pub skip: bool,
+    /// Opt-level differential test (RUE-236): compile+run this case once per
+    /// optimization level (`-O0`, `-O1`, `-O2`, `-O3`) and assert IDENTICAL
+    /// exit code AND stdout across all levels. A divergence fails the case,
+    /// naming the level that differs. This catches optimizer passes that break
+    /// semantics — the analogue, at the *program's* opt level, of the
+    /// release-mode CI job (RUE-45) that catches `cfg(debug_assertions)`
+    /// divergence in the *compiler*. `-O2`/`-O3` alias `-O1` today, so results
+    /// match now; the net is set so a future divergence is caught.
+    ///
+    /// Marked cases must be plain compile-and-run cases: `compile_fail`,
+    /// `compile_only`, and an explicit `-O` in `args` are rejected (the runner
+    /// drives the opt level itself). Give the case exact `stdout` and
+    /// `exit_code` so each level is also checked against the known-good result,
+    /// not merely against the other levels.
+    #[serde(default)]
+    pub differential_opt: bool,
+    /// Report the case as ignored when no system `cc` driver is on `PATH`.
+    /// For cases exercising the `--linker cc` symbolized profiling build
+    /// (RUE-1173): every supported CI host provides `cc`, but a minimal local
+    /// environment without a C toolchain should skip rather than fail.
+    #[serde(default)]
+    pub requires_system_linker: bool,
+    /// Substrings that must each match at least one defined symbol name in
+    /// the produced executable's symbol table (ELF `.symtab` / Mach-O
+    /// `LC_SYMTAB`). Verifies the symbolized profiling build keeps function
+    /// symbols (RUE-1173). Incompatible with `compile_fail`.
+    #[serde(default)]
+    pub symbols_contain: Vec<String>,
+    /// Assert the produced executable carries no symbol table entries. Pins
+    /// that default internal-linker output is unsymbolized — the documented
+    /// motivation for the `--linker cc` profiling workflow (RUE-1173).
+    /// Incompatible with `compile_fail` and `symbols_contain`.
+    #[serde(default)]
+    pub no_symbol_table: bool,
+    /// Exact expected exit status of the DRIVER invocation itself, for a
+    /// subcommand that neither compiles-and-runs nor fails to compile.
+    ///
+    /// `rue test` (ADR-0083) is the case this exists for: its exit status is a
+    /// documented four-way contract (0 passed / 1 failures / 2 runner error /
+    /// 3 empty selection) that agents branch on, and `compile_fail`'s
+    /// "nonzero" cannot tell 1 from 3. Setting it also declares that the
+    /// invocation produces no executable to run, so the case ends after the
+    /// compiler's own stdout, stderr, and status are checked — assert the
+    /// driver's output with `compile_stdout_contains` and
+    /// `compile_stderr_contains`. Incompatible with `compile_fail`, whose
+    /// contract is exactly the weaker one this replaces.
+    #[serde(default)]
+    pub driver_exit_code: Option<i32>,
+}
+/// The `only_on` platform names in `case` that are not [`KNOWN_TARGETS`].
+///
+/// An unknown name can never equal the host, so the case would be skipped on
+/// EVERY platform — silently, while still counting as corpus coverage. Both
+/// readers of this corpus reject at load time on the same answer.
+pub fn unknown_only_on_platforms(case: &Case) -> Vec<&str> {
+    unknown_platforms(&case.only_on)
+}
+
+/// The `known_bug_on` platform names in `case` that are not [`KNOWN_TARGETS`].
+///
+/// A typo here is the mirror-image failure of an unknown `only_on`: the xfail
+/// scope matches no host, so the case runs as an ordinary test everywhere and
+/// the marker silently stops meaning anything.
+pub fn unknown_known_bug_on_platforms(case: &Case) -> Vec<&str> {
+    unknown_platforms(&case.known_bug_on)
+}
+
+fn unknown_platforms(platforms: &[String]) -> Vec<&str> {
+    platforms
+        .iter()
+        .map(String::as_str)
+        .filter(|platform| !KNOWN_TARGETS.contains(platform))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn case_with(only_on: &[&str], known_bug_on: &[&str]) -> Case {
+        Case {
+            name: "probe".to_string(),
+            only_on: only_on.iter().map(|s| (*s).to_string()).collect(),
+            known_bug_on: known_bug_on.iter().map(|s| (*s).to_string()).collect(),
+            ..Case::default()
+        }
+    }
+
+    #[test]
+    fn known_platform_names_are_accepted_on_both_axes() {
+        for platform in KNOWN_TARGETS {
+            let case = case_with(&[platform], &[platform]);
+            assert!(unknown_only_on_platforms(&case).is_empty());
+            assert!(unknown_known_bug_on_platforms(&case).is_empty());
+        }
+    }
+
+    #[test]
+    fn misspelled_platform_names_are_reported_per_axis() {
+        let case = case_with(&["x86_64-linux"], &["darwin"]);
+        assert_eq!(unknown_only_on_platforms(&case), vec!["x86_64-linux"]);
+        assert_eq!(unknown_known_bug_on_platforms(&case), vec!["darwin"]);
+    }
+
+    #[test]
+    fn an_unknown_field_is_a_load_error_rather_than_a_silent_omission() {
+        let error = toml::from_str::<TestFile>(
+            r#"
+[section]
+id = "cli.probe"
+name = "Probe"
+
+[[case]]
+name = "probe"
+invented_field = true
+"#,
+        )
+        .expect_err("an unknown case field must not parse");
+        assert!(error.to_string().contains("invented_field"), "{error}");
+    }
+
+    #[test]
+    fn the_schema_parses_a_representative_case_file() {
+        let file: TestFile = toml::from_str(
+            r#"
+[timeout_profile.ordinary]
+compile_hang_timeout_ms = 1000
+runtime_hang_timeout_ms = 1000
+
+[contract.heavyweight]
+class = "heavyweight"
+timeout_profile = "ordinary"
+
+[section]
+id = "cli.probe"
+name = "Probe"
+tier = "slow"
+
+[[case]]
+name = "probe"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }" }]
+exit_code = 0
+"#,
+        )
+        .expect("parse representative corpus file");
+        assert_eq!(file.section.id, "cli.probe");
+        assert_eq!(file.section.tier, CliCaseTier::Slow);
+        assert_eq!(
+            file.timeout_profiles[&TimeoutProfile::Ordinary],
+            HangTimeoutProfile {
+                compile_hang_timeout_ms: 1000,
+                runtime_hang_timeout_ms: 1000,
+            }
+        );
+        assert_eq!(
+            file.contracts["heavyweight"].class,
+            ExecutionClass::Heavyweight
+        );
+        assert_eq!(file.cases.len(), 1);
+    }
+}

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -3,11 +3,12 @@
 //! This crate provides common functionality for running compiler tests,
 //! including test case parsing, execution, and output comparison.
 
+pub mod cli_corpus;
 pub mod pipe_drain;
 pub mod supervise;
 
 use rue_error::{PreviewFeature, error_code_metadata};
-use rue_target::Target;
+use rue_target::HostPlatform;
 use serde::{Deserialize, Deserializer};
 use supervise::{CaptureStream, Outcome, OverflowPolicy, Supervisor};
 
@@ -582,46 +583,26 @@ pub fn classify_expected_failure(result: TestResult) -> ExpectedFailureOutcome {
 ///
 /// Returns strings like "x86-64-linux", "aarch64-linux", "aarch64-macos".
 pub fn get_host_target() -> &'static str {
-    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    {
-        Target::X86_64Linux.name()
-    }
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-    {
-        Target::Aarch64Linux.name()
-    }
-    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-    {
-        Target::Aarch64Macos.name()
-    }
-    #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
-    {
-        "x86-64-macos"
-    }
-    #[cfg(not(any(
-        all(target_arch = "x86_64", target_os = "linux"),
-        all(target_arch = "aarch64", target_os = "linux"),
-        all(target_arch = "aarch64", target_os = "macos"),
-        all(target_arch = "x86_64", target_os = "macos"),
-    )))]
-    {
-        "unknown"
-    }
+    HostPlatform::current().map_or(UNKNOWN_HOST_TARGET, HostPlatform::name)
 }
 
-/// Every platform name `only_on`/`known_bug_on` may legally name — the same
-/// set [`get_host_target`] can return. Case files are validated against this
-/// list at load time: a typo'd platform name would otherwise make the case
-/// silently run NOWHERE while still counting as spec coverage (the RUE-132
+/// What [`get_host_target`] reports on a host [`HostPlatform`] does not name.
+/// It is deliberately absent from [`KNOWN_TARGETS`], so a case scoped to any
+/// real platform is skipped there rather than silently matching.
+pub const UNKNOWN_HOST_TARGET: &str = "unknown";
+
+/// Every platform name `only_on`/`known_bug_on` may legally name — the names of
+/// [`HostPlatform::ALL`], which is also the set [`get_host_target`] can return
+/// on a recognized host. Case files are validated against this list at load
+/// time: a typo'd platform name would otherwise make the case silently run
+/// NOWHERE while still counting as spec coverage (the RUE-132
 /// skipped-test-counts-as-coverage class, via the platform axis).
-pub const KNOWN_TARGETS: &[&str] = &[
-    Target::X86_64Linux.name(),
-    Target::Aarch64Linux.name(),
-    Target::Aarch64Macos.name(),
-    // Host-only: Rue can run tests on Intel macOS, but does not currently have
-    // an x86-64 macOS compiler target.
-    "x86-64-macos",
-];
+///
+/// A name here says the harness knows the host, not that Rue can compile for
+/// it: `x86-64-macos` is a host platform with no compiler target
+/// ([`HostPlatform::compiler_target`] is `None`), which is why the two facts
+/// are one value rather than two lists.
+pub const KNOWN_TARGETS: &[&str] = HostPlatform::ALL_NAMES;
 
 /// Select which declarative platform cases a test harness registers.
 ///
@@ -682,11 +663,8 @@ pub const CI_EXECUTED_TARGETS: &[&str] = &["x86-64-linux", "aarch64-linux", "aar
 ///
 /// Returns `None` for a name that is not a known platform; callers reach this
 /// only after [`validate_only_on_targets`] has accepted the name.
-pub fn target_architecture(target: &str) -> Option<&str> {
-    if !KNOWN_TARGETS.contains(&target) {
-        return None;
-    }
-    target.rsplit_once('-').map(|(arch, _os)| arch)
+pub fn target_architecture(target: &str) -> Option<&'static str> {
+    HostPlatform::from_name(target).map(HostPlatform::architecture)
 }
 
 /// Whether a case scoped by `only_on` executes on at least one platform that
@@ -3379,6 +3357,7 @@ pub fn find_rue_binary() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_target::Target;
     use std::time::Instant;
 
     const VALID_TEST_FILE: &str = r#"
@@ -5332,6 +5311,32 @@ exit_code = 42
                 "compiler target {target} has no required CI lane executing its cases"
             );
         }
+    }
+
+    #[test]
+    fn every_ci_executed_platform_can_build_for_itself() {
+        // A required CI lane compiles and RUNS programs for its host, which is
+        // only possible where the host platform carries a compiler target.
+        // `x86-64-macos` is the counterexample the platform table exists to
+        // keep straight: a known host with no Rue target, and so not a lane.
+        for target in CI_EXECUTED_TARGETS {
+            let platform = HostPlatform::from_name(target)
+                .unwrap_or_else(|| panic!("CI-executed platform {target} is not a host platform"));
+            assert!(
+                platform.compiler_target().is_some(),
+                "CI lane {target} executes native programs, but Rue has no compiler target for it"
+            );
+        }
+    }
+
+    #[test]
+    fn the_host_target_name_is_known_or_explicitly_unknown() {
+        let host = get_host_target();
+        assert_eq!(
+            KNOWN_TARGETS.contains(&host),
+            host != UNKNOWN_HOST_TARGET,
+            "the host name must be a known platform, or the explicit unknown marker"
+        );
     }
 
     #[test]

--- a/scripts/test-cli-known-bug-markers.sh
+++ b/scripts/test-cli-known-bug-markers.sh
@@ -15,27 +15,30 @@ set -eu
 work_dir="$(mktemp -d "${TMPDIR:-/tmp}/rue-known-bug-marker.XXXXXX")"
 trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
 
-host_target() {
-    case "$(uname -s):$(uname -m)" in
-        Linux:x86_64) printf '%s\n' 'x86-64-linux' ;;
-        Linux:aarch64|Linux:arm64) printf '%s\n' 'aarch64-linux' ;;
-        Darwin:x86_64) printf '%s\n' 'x86-64-macos' ;;
-        Darwin:arm64|Darwin:aarch64) printf '%s\n' 'aarch64-macos' ;;
-        *)
-            echo "unsupported host: $(uname -s) $(uname -m)" >&2
-            exit 1
-            ;;
-    esac
-}
+# The host platform and the platform vocabulary both come from the harness
+# under test, which reads them from rue-target's one host table. A `uname`
+# ladder here would be a second, independently-drifting answer to the question
+# this gate exists to check (RUE-1987). RUE_HOST_TARGET / RUE_KNOWN_TARGETS
+# override it for a caller that already knows.
+host="${RUE_HOST_TARGET:-$("$RUE_CLI_HARNESS" --print-host-target)}"
+known_targets="${RUE_KNOWN_TARGETS:-$("$RUE_CLI_HARNESS" --print-known-targets)}"
+if [ -z "$host" ] || [ -z "$known_targets" ]; then
+    echo "could not resolve the host platform from $RUE_CLI_HARNESS;" \
+        "set RUE_HOST_TARGET and RUE_KNOWN_TARGETS to override" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$known_targets" | grep -F -x -q -e "$host"; then
+    echo "harness host '$host' is not one of its own known targets" >&2
+    exit 1
+fi
 
-foreign_target() {
-    case "$(host_target)" in
-        x86-64-linux) printf '%s\n' 'aarch64-linux' ;;
-        aarch64-linux) printf '%s\n' 'x86-64-linux' ;;
-        x86-64-macos) printf '%s\n' 'aarch64-macos' ;;
-        aarch64-macos) printf '%s\n' 'x86-64-macos' ;;
-    esac
-}
+# Any valid platform that is not this host: a known_bug_on scope that must NOT
+# absorb a failure here.
+foreign="$(printf '%s\n' "$known_targets" | grep -F -v -x -e "$host" | head -n 1)"
+if [ -z "$foreign" ]; then
+    echo "the harness knows only one platform; cannot build a foreign scope" >&2
+    exit 1
+fi
 
 write_case() {
     marker="$1"
@@ -136,7 +139,7 @@ check_known_bug_on_rejected() {
 }
 
 check_host_scoped_xfail() {
-    write_failure_case "$(host_target)"
+    write_failure_case "$host"
     output="$({
         RUE_CLI_CASES="$work_dir" \
         RUE_CLI_CASE_TIER=premerge \
@@ -146,7 +149,7 @@ check_host_scoped_xfail() {
 }
 
 check_foreign_scoped_xfail_does_not_apply() {
-    write_failure_case "$(foreign_target)"
+    write_failure_case "$foreign"
     set +e
     output="$({
         RUE_CLI_CASES="$work_dir" \

--- a/scripts/test-harness-duplicate-names.sh
+++ b/scripts/test-harness-duplicate-names.sh
@@ -12,26 +12,30 @@ set -eu
 : "${RUE_CLI_HARNESS:?RUE_CLI_HARNESS must point to the CLI harness}"
 : "${RUE_BINARY:?RUE_BINARY must point to the Rue compiler}"
 
-host_target() {
-    case "$(uname -s):$(uname -m)" in
-        Linux:x86_64) printf '%s\n' 'x86-64-linux' ;;
-        Linux:aarch64|Linux:arm64) printf '%s\n' 'aarch64-linux' ;;
-        Darwin:x86_64) printf '%s\n' 'x86-64-macos' ;;
-        Darwin:arm64|Darwin:aarch64) printf '%s\n' 'aarch64-macos' ;;
-        *)
-            echo "unsupported host for duplicate-harness regression: $(uname -s) $(uname -m)" >&2
-            exit 1
-            ;;
-    esac
-}
-
-host="$(host_target)"
-case "$host" in
-    x86-64-linux) foreign='aarch64-linux' ;;
-    aarch64-linux) foreign='x86-64-linux' ;;
-    x86-64-macos) foreign='aarch64-linux' ;;
-    aarch64-macos) foreign='x86-64-linux' ;;
-esac
+# The host platform and the platform vocabulary come from the harness under
+# test, which reads them from rue-target's one host table; a `uname` ladder here
+# would be a second answer that can disagree with the harness this gate drives
+# (RUE-1987). RUE_HOST_TARGET / RUE_KNOWN_TARGETS override it for a caller that
+# already knows.
+host="${RUE_HOST_TARGET:-$("$RUE_CLI_HARNESS" --print-host-target)}"
+known_targets="${RUE_KNOWN_TARGETS:-$("$RUE_CLI_HARNESS" --print-known-targets)}"
+if [ -z "$host" ] || [ -z "$known_targets" ]; then
+    echo "could not resolve the host platform for the duplicate-harness" \
+        "regression from $RUE_CLI_HARNESS; set RUE_HOST_TARGET and" \
+        "RUE_KNOWN_TARGETS to override" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$known_targets" | grep -F -x -q -e "$host"; then
+    echo "harness host '$host' is not one of its own known targets" >&2
+    exit 1
+fi
+# Any valid platform other than this host, so the duplicate is filtered out
+# here and validation must still reject it.
+foreign="$(printf '%s\n' "$known_targets" | grep -F -v -x -e "$host" | head -n 1)"
+if [ -z "$foreign" ]; then
+    echo "the harness knows only one platform; cannot build a foreign scope" >&2
+    exit 1
+fi
 
 work_dir="$(mktemp -d "${TMPDIR:-/tmp}/rue-duplicate-harness.XXXXXX")"
 trap 'rm -rf "$work_dir"' EXIT HUP INT TERM


### PR DESCRIPTION
Fixes RUE-1987

The rue-cli-tests case format was declared three times (rue-cli-tests, rue-test-runner's spec corpus, and a permissive subset in rue-oracle-diff that ignored unknown fields), and the host-platform naming ladder was written five times.

## Changes

- **Corpus schema.** New `rue_test_runner::cli_corpus` owns `TestFile`/`Section`/`Case` plus the fixture, contract, timeout, and watch types, all keeping `deny_unknown_fields`, and the two platform validators. rue-cli-tests imports them; the semantic load-time rules (differential_opt pinning, compile_fail assertions, symbol expectations) stay in rue-cli-tests, which owns what a field means. rue-oracle-diff deletes its own `TestFile`/`Case`/`Section`/`SourceFile`/`HangTimeoutProfile` and reads the shared types, then projects them in `unsupported_corpus_field`, which destructures `Case` exhaustively so a new schema field stops it compiling until the differential decides. New ineligibility reasons: `DriverInvocation`, `StagedFixtures`, `HostCapability`, `ForeignArchive` (plus `TargetPinned`). oracle-diff now also validates `known_bug_on` names.
- **Host platform.** `rue_target::HostPlatform { name, compiler_target: Option<Target> }` with `ALL`, `ALL_NAMES`, `current()`, `from_name()`, and `architecture()` holds the repo's only host `cfg!` ladder. `Target::host`, `Target::host_description`, `get_host_target`, `KNOWN_TARGETS`, `target_architecture`, and the sharding weights bucket derive from it. `x86-64-macos` is structurally "known host, no compiler target" rather than a string special-cased twice; a test asserts every CI-executed platform has a compiler target.
- **Shell scripts.** Both `uname` ladders and the hand-written foreign-target tables are gone. The CLI harness gains `--print-host-target` / `--print-known-targets`; the scripts read `RUE_HOST_TARGET` / `RUE_KNOWN_TARGETS` if set and otherwise ask the harness, failing clearly if neither resolves. A static Buck `env` cannot detect a host and `rue_sh_test` has no wrapper to inject one, so asking the harness keeps the value coming from the one Rust table.
- **frontend-diff.** `collect_rue_files` delegates to `rue_test_runner::discover_files(root, "rue")`; both callers already sorted or set-folded the result.

No BUCK dependency edges needed adding (the consumers already depend on rue-test-runner, which depends on rue-target); only the stale comment in `crates/rue-oracle-diff/BUCK` changed.

## Notes for review

- The issue named `source_manifest`, `watch`, and contract-scoped `env` as silently ignored by oracle-diff. `source_manifest` is not a CLI-corpus field (it exists only in rue-bench), and `watch`/`env` were already classified. The actually silently-ignored fields were `symlinks`, `hard_links`, `requires_case_insensitive_fs`, `ffi_answer_archive`, `executable_target`, `execute_if_native`, `requires_system_linker`, and `driver_exit_code`; they are now named ineligibility reasons. No currently eligible case declares any of them, so classification is unchanged today.
- oracle-diff's inline TOML test fixtures now need `section.name`, as the CLI suite always did; three fixtures gained it. Real corpus files were unaffected.
- The case-shape validators (`differential_opt_missing_pin`, `compile_fail_missing_assertion`, ...) stay in rue-cli-tests; moving them would make oracle-diff reject its own minimal fixtures. Possible follow-up.

## Verification

- `//:cli-tests`: 2696 passed; the 2 failures are the known environmental cases (uid 0 permission test, IPv6 loopback).
- `oracle-diff-test`, `oracle-diff-spec-test`, `//:test-harness-duplicate-names`, `//:cli-known-bug-marker-validation`, `//:frontend-diff-test`, `//:ci-gate-validation`, `//:ci-gate-validator-tool-tests`, `//:cli-timeout-policy-validation`, `//:cli-shard-weights-validation`: pass.
- Unit tests for rue-test-runner, rue-target, rue-cli-tests, rue-frontend-diff, rue-oracle-diff: all pass. Clippy, fmt, and debug-assert gates for the five crates plus `//:type-architecture-inventory-validation`: pass.
- `scripts/rue quick` after rebase on trunk: Pass 36, Fail 0.
