### PR TITLE
Decide integer cast and post-operation policy once

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -456,26 +456,7 @@ impl<'a> CfgLower<'a> {
                             dst: Operand::Virtual(extended),
                             src: Operand::Virtual(value),
                         });
-                        let dst = Operand::Virtual(extended);
-                        let src = Operand::Virtual(extended);
-                        self.mir.push(match extension {
-                            crate::value_plan::IntegerExtension::Sign8 => {
-                                Aarch64Inst::Sxtb { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::Zero8 => {
-                                Aarch64Inst::Uxtb { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::Sign16 => {
-                                Aarch64Inst::Sxth { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::Zero16 => {
-                                Aarch64Inst::Uxth { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::Sign32 => {
-                                Aarch64Inst::Sxtw { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::None => unreachable!(),
-                        });
+                        self.emit_extension(extended, extended, extension);
                         Some(extended)
                     }
                 }
@@ -756,6 +737,7 @@ impl<'a> CfgLower<'a> {
         let overflow_call = plan.overflow_call;
         let div_by_zero_call = plan.div_by_zero_call;
         let wrap = plan.wrap;
+        let post_op = plan.post_op;
         let vreg = match plan.operation {
             ArithmeticOperation::FloatAdd { lhs, rhs, width }
             | ArithmeticOperation::FloatSub { lhs, rhs, width }
@@ -802,11 +784,7 @@ impl<'a> CfgLower<'a> {
                         src2: Operand::Virtual(rhs),
                     }
                 });
-                if wrap {
-                    self.emit_wrap_narrow_subword(width, vreg);
-                } else {
-                    self.emit_overflow_check_add(width, vreg, overflow_call.clone());
-                }
+                self.emit_post_op_add(post_op, vreg, overflow_call.clone());
                 vreg
             }
             ArithmeticOperation::Sub { lhs, rhs, width } => {
@@ -824,11 +802,7 @@ impl<'a> CfgLower<'a> {
                         src2: Operand::Virtual(rhs),
                     }
                 });
-                if wrap {
-                    self.emit_wrap_narrow_subword(width, vreg);
-                } else {
-                    self.emit_overflow_check_sub(width, vreg, overflow_call.clone());
-                }
+                self.emit_post_op_sub(post_op, vreg, overflow_call.clone());
                 vreg
             }
             ArithmeticOperation::Mul {
@@ -848,7 +822,7 @@ impl<'a> CfgLower<'a> {
                         src1: Operand::Virtual(lhs),
                         src2: Operand::Virtual(rhs),
                     });
-                    self.emit_wrap_narrow_mul(width, vreg);
+                    self.emit_wrap_narrow_mul(post_op, width, vreg);
                 } else if let Some((src, amount)) = shift.filter(|_| width.bits >= 32) {
                     self.mir.push(if width.bits == 64 {
                         Aarch64Inst::LslImm {
@@ -910,7 +884,14 @@ impl<'a> CfgLower<'a> {
                     let _ = self.lower_runtime_call(overflow_call.clone());
                     self.mir.push(Aarch64Inst::Label { id: ok });
                 } else {
-                    self.emit_overflow_check_mul(width, vreg, lhs, rhs, overflow_call.clone());
+                    self.emit_overflow_check_mul(
+                        post_op,
+                        width,
+                        vreg,
+                        lhs,
+                        rhs,
+                        overflow_call.clone(),
+                    );
                 }
                 vreg
             }
@@ -1025,7 +1006,7 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(value),
                     }
                 });
-                self.emit_overflow_check_neg(width, vreg, overflow_call.clone());
+                self.emit_post_op_neg(post_op, vreg, overflow_call.clone());
                 vreg
             }
         };
@@ -1448,7 +1429,7 @@ impl<'a> CfgLower<'a> {
                 });
                 dst
             }
-            ResidualValuePlan::BitNot { value } => {
+            ResidualValuePlan::BitNot { value, narrow } => {
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(if width.is_some_and(|w| w.bits == 64) {
                     Aarch64Inst::MvnRR {
@@ -1461,7 +1442,7 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(value),
                     }
                 });
-                self.emit_subword_narrow(dst, ty);
+                self.emit_extension(dst, dst, narrow);
                 dst
             }
             ResidualValuePlan::Bitwise { op, lhs, rhs } => {
@@ -1490,6 +1471,7 @@ impl<'a> CfgLower<'a> {
                 lhs,
                 rhs,
                 constant,
+                narrow,
             } => {
                 let dst = self.mir.alloc_vreg();
                 let is64 = width.is_some_and(|w| w.bits == 64);
@@ -1567,7 +1549,7 @@ impl<'a> CfgLower<'a> {
                         },
                     });
                 }
-                self.emit_subword_narrow(dst, ty);
+                self.emit_extension(dst, dst, narrow);
                 dst
             }
             ResidualValuePlan::Comparison {
@@ -1980,6 +1962,8 @@ impl<'a> CfgLower<'a> {
             ResidualValuePlan::IntCast {
                 value,
                 from_width,
+                check,
+                widen,
                 trap_call,
             } => {
                 let dst = self.mir.alloc_vreg();
@@ -1987,17 +1971,8 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(dst),
                     src: Operand::Virtual(value),
                 });
-                let to_width = width.unwrap();
-                self.emit_int_cast_check(value, from_width, to_width, trap_call);
-                if from_width.signed && to_width.bits > from_width.bits {
-                    let src = Operand::Virtual(value);
-                    let dst = Operand::Virtual(dst);
-                    self.mir.push(match from_width.bits {
-                        8 => Aarch64Inst::Sxtb { dst, src },
-                        16 => Aarch64Inst::Sxth { dst, src },
-                        _ => Aarch64Inst::Sxtw { dst, src },
-                    });
-                }
+                self.emit_int_cast_check(value, from_width, check, trap_call);
+                self.emit_extension(dst, value, widen);
                 dst
             }
             ResidualValuePlan::Drop { actions } => {
@@ -2577,26 +2552,7 @@ impl<'a> CfgLower<'a> {
                             dst: Operand::Virtual(extended),
                             src: Operand::Virtual(offset),
                         });
-                        let dst = Operand::Virtual(extended);
-                        let src = Operand::Virtual(extended);
-                        match extension {
-                            crate::value_plan::IntegerExtension::Sign8 => {
-                                self.mir.push(Aarch64Inst::Sxtb { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::Zero8 => {
-                                self.mir.push(Aarch64Inst::Uxtb { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::Sign16 => {
-                                self.mir.push(Aarch64Inst::Sxth { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::Zero16 => {
-                                self.mir.push(Aarch64Inst::Uxth { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::Sign32 => {
-                                self.mir.push(Aarch64Inst::Sxtw { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::None => unreachable!(),
-                        }
+                        self.emit_extension(extended, extended, extension);
                         extended
                     }
                 };
@@ -2920,60 +2876,52 @@ impl<'a> CfgLower<'a> {
         crate::value_plan::MaterializedValue { primary, slots }
     }
 
-    /// Lower a CFG value (instruction).
-    /// Try to extract a power-of-two shift amount from a constant value.
+    /// Branch to `ok_label` when a sub-word result the machine computed at
+    /// W-register width is back inside its declared range.
     ///
-    /// Returns `Some(shift_amount)` if the value is a constant that is a power of 2
-    /// greater than 1, otherwise returns `None`.
-    ///
-    /// Used for strength reduction: `x * 2^n` can be lowered to `x << n`.
-    fn emit_subword_range_check(
+    /// Both comparisons run at 32-bit width. The sub-word arithmetic was
+    /// emitted as a 32-bit (W-register) op that zeroes bits 32-63, so a 64-bit
+    /// compare against the sign-extended byte/word would mismatch a
+    /// legitimately-negative in-range result and falsely trap (RUE-28 sub,
+    /// RUE-60 neg). Which test a width needs is decided by
+    /// [`crate::value_plan::post_op_policy`], not here.
+    fn emit_sub_word_check(
         &mut self,
-        width: crate::value_plan::IntegerWidth,
+        check: crate::value_plan::SubWordCheck,
         result_vreg: VReg,
         ok_label: LabelId,
     ) {
-        match (width.bits, width.signed) {
-            (8, false) => {
-                // Result must be <= 255
-                self.mir.push(Aarch64Inst::CmpImm {
-                    src: Operand::Virtual(result_vreg),
-                    imm: 255,
-                });
+        use crate::value_plan::SubWordCheck;
+        match check {
+            SubWordCheck::UpperBound { max } => {
+                // A byte bound fits the compare's 12-bit immediate; a wider
+                // bound is materialized first.
+                match i32::try_from(max).ok().filter(|bound| *bound < 4096) {
+                    Some(bound) => self.mir.push(Aarch64Inst::CmpImm {
+                        src: Operand::Virtual(result_vreg),
+                        imm: bound,
+                    }),
+                    None => {
+                        let max_vreg = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::MovImm {
+                            dst: Operand::Virtual(max_vreg),
+                            imm: i64::try_from(max).expect("sub-word upper bound"),
+                        });
+                        self.mir.push(Aarch64Inst::CmpRR {
+                            src1: Operand::Virtual(result_vreg),
+                            src2: Operand::Virtual(max_vreg),
+                        });
+                    }
+                }
                 // Branch if below or same (unsigned <=)
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Ls,
                     label: ok_label,
                 });
             }
-            (16, false) => {
-                // Result must be <= 65535
-                let max_vreg = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Virtual(max_vreg),
-                    imm: 65535,
-                });
-                self.mir.push(Aarch64Inst::CmpRR {
-                    src1: Operand::Virtual(result_vreg),
-                    src2: Operand::Virtual(max_vreg),
-                });
-                self.mir.push(Aarch64Inst::BCond {
-                    cond: Cond::Ls,
-                    label: ok_label,
-                });
-            }
-            (8, true) => {
-                // Sign-extend to 64-bit and compare with original
+            SubWordCheck::SignExtended { extension } => {
                 let sext_vreg = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::Sxtb {
-                    dst: Operand::Virtual(sext_vreg),
-                    src: Operand::Virtual(result_vreg),
-                });
-                // Compare at 32-bit width. The sub-word arithmetic was emitted
-                // as a 32-bit (W-register) op that zeroes bits 32-63, so a 64-bit
-                // compare against the sign-extended byte/word would mismatch a
-                // legitimately-negative in-range result and falsely trap
-                // (RUE-28 sub, RUE-60 neg). The low 32 bits must match.
+                self.emit_extension(sext_vreg, result_vreg, extension);
                 self.mir.push(Aarch64Inst::CmpRR {
                     src1: Operand::Virtual(result_vreg),
                     src2: Operand::Virtual(sext_vreg),
@@ -2982,61 +2930,63 @@ impl<'a> CfgLower<'a> {
                     cond: Cond::Eq,
                     label: ok_label,
                 });
-            }
-            (16, true) => {
-                // Sign-extend to 64-bit and compare with original
-                let sext_vreg = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::Sxth {
-                    dst: Operand::Virtual(sext_vreg),
-                    src: Operand::Virtual(result_vreg),
-                });
-                // Compare at 32-bit width. The sub-word arithmetic was emitted
-                // as a 32-bit (W-register) op that zeroes bits 32-63, so a 64-bit
-                // compare against the sign-extended byte/word would mismatch a
-                // legitimately-negative in-range result and falsely trap
-                // (RUE-28 sub, RUE-60 neg). The low 32 bits must match.
-                self.mir.push(Aarch64Inst::CmpRR {
-                    src1: Operand::Virtual(result_vreg),
-                    src2: Operand::Virtual(sext_vreg),
-                });
-                self.mir.push(Aarch64Inst::BCond {
-                    cond: Cond::Eq,
-                    label: ok_label,
-                });
-            }
-            _ => {
-                // Not a sub-word type, do nothing
             }
         }
     }
 
-    fn emit_overflow_check_add(
+    /// Emit the arms of [`crate::value_plan::PostOpPolicy`] that raise no trap:
+    /// the re-narrowing a wrapping result needs, and the empty policy. Returns
+    /// whether the policy was one of them, so the per-operation emitters below
+    /// allocate an ok-label only when a trap can actually be taken.
+    fn emit_untrapped_post_op(
         &mut self,
-        width: crate::value_plan::IntegerWidth,
+        policy: crate::value_plan::PostOpPolicy,
+        result_vreg: VReg,
+    ) -> bool {
+        use crate::value_plan::PostOpPolicy;
+        match policy {
+            PostOpPolicy::Narrow(extension) => {
+                self.emit_extension(result_vreg, result_vreg, extension);
+                true
+            }
+            PostOpPolicy::None => true,
+            PostOpPolicy::OverflowFlags { .. } | PostOpPolicy::RangeCheck(_) => false,
+        }
+    }
+
+    /// Emit the trap guarding a checked ADD.
+    ///
+    /// `ADDS` at a machine width leaves the overflow in the flags; a sub-word
+    /// result is tested against its range instead. Which of the two applies is
+    /// the shared plan's decision, not this backend's.
+    fn emit_post_op_add(
+        &mut self,
+        policy: crate::value_plan::PostOpPolicy,
         result_vreg: VReg,
         trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
+        use crate::value_plan::PostOpPolicy;
+        if self.emit_untrapped_post_op(policy, result_vreg) {
+            return;
+        }
         let ok_label = self.mir.alloc_label();
 
-        match (width.bits, width.signed) {
-            // 32-bit and 64-bit unsigned: C=1 means overflow (carry out)
-            // Branch to ok if C=0 (no overflow)
-            (32 | 64, false) => {
+        match policy {
+            // Unsigned: C=1 means overflow (carry out), so ok when C=0.
+            PostOpPolicy::OverflowFlags { signed: false } => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Lo, // Lo = C=0 (no carry)
                     label: ok_label,
                 });
             }
-            // 32-bit and 64-bit signed: V flag indicates overflow
-            (32 | 64, true) => {
+            // Signed: the V flag indicates overflow.
+            PostOpPolicy::OverflowFlags { signed: true } => {
                 self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
-            // Sub-word types: check if result fits in type's range
-            (8 | 16, _) => {
-                self.emit_subword_range_check(width, result_vreg, ok_label);
+            PostOpPolicy::RangeCheck(check) => {
+                self.emit_sub_word_check(check, result_vreg, ok_label);
             }
-            // Other types don't have arithmetic
-            _ => return,
+            PostOpPolicy::None | PostOpPolicy::Narrow(_) => return,
         }
 
         // Overflow occurred - call panic handler
@@ -3044,62 +2994,71 @@ impl<'a> CfgLower<'a> {
         self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
-    /// Emit overflow check for SUB based on the type.
+    /// Emit the trap guarding a checked SUB.
     ///
-    /// For ARM64 SUBS:
-    /// - Signed: V flag indicates overflow
-    /// - Unsigned: C=0 means borrow (underflow), C=1 means no borrow
-    fn emit_overflow_check_sub(
+    /// For `SUBS`, C=0 means borrow (underflow) and the V flag indicates a
+    /// signed overflow; a sub-word result is tested against its range instead.
+    fn emit_post_op_sub(
         &mut self,
-        width: crate::value_plan::IntegerWidth,
+        policy: crate::value_plan::PostOpPolicy,
         result_vreg: VReg,
         trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
+        use crate::value_plan::PostOpPolicy;
+        if self.emit_untrapped_post_op(policy, result_vreg) {
+            return;
+        }
         let ok_label = self.mir.alloc_label();
 
-        match (width.bits, width.signed) {
-            // 32-bit and 64-bit unsigned: C=0 means borrow (underflow)
-            // Branch to ok if C=1 (no underflow)
-            (32 | 64, false) => {
+        match policy {
+            // Unsigned: C=0 means borrow (underflow), so ok when C=1.
+            PostOpPolicy::OverflowFlags { signed: false } => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Hs, // Hs = C=1 (no borrow)
                     label: ok_label,
                 });
             }
-            // 32-bit and 64-bit signed: V flag indicates overflow
-            (32 | 64, true) => {
+            // Signed: the V flag indicates overflow.
+            PostOpPolicy::OverflowFlags { signed: true } => {
                 self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
-            // Sub-word types: check if result fits in type's range
-            (8 | 16, _) => {
-                self.emit_subword_range_check(width, result_vreg, ok_label);
+            PostOpPolicy::RangeCheck(check) => {
+                self.emit_sub_word_check(check, result_vreg, ok_label);
             }
-            // Other types don't have arithmetic
-            _ => return,
+            PostOpPolicy::None | PostOpPolicy::Narrow(_) => return,
         }
 
         let _ = self.lower_runtime_call(trap_call.clone());
         self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
-    /// Emit overflow check for MUL based on the type.
+    /// Emit the trap guarding a checked MUL.
     ///
-    /// For multiplication, we need different approaches for signed vs unsigned:
-    /// - Signed: Use SMULL (64-bit result), compare with sign-extended 32-bit
-    /// - Unsigned: Use UMULL (64-bit result), check if high bits are non-zero
+    /// A machine-width product is probed with a widening multiply — SMULL/UMULL
+    /// for 32 bits, SMULH/UMULH for 64 — while a sub-word product is computed
+    /// plainly and then tested against its range. The shared plan says which of
+    /// the two this width takes; the widening-multiply selection below is this
+    /// backend's own instruction choice.
     fn emit_overflow_check_mul(
         &mut self,
+        policy: crate::value_plan::PostOpPolicy,
         width: crate::value_plan::IntegerWidth,
         result_vreg: VReg,
         lhs_vreg: VReg,
         rhs_vreg: VReg,
         trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
+        use crate::value_plan::PostOpPolicy;
         let ok_label = self.mir.alloc_label();
 
-        match (width.bits, width.signed) {
+        let check = match policy {
+            PostOpPolicy::OverflowFlags { .. } => None,
+            PostOpPolicy::RangeCheck(check) => Some(check),
+            PostOpPolicy::None | PostOpPolicy::Narrow(_) => return,
+        };
+        match (check, width.bits, width.signed) {
             // 32-bit signed: SMULL gives 64-bit result
-            (32, true) => {
+            (None, 32, true) => {
                 let smull_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::SmullRR {
                     dst: Operand::Virtual(smull_vreg),
@@ -3128,7 +3087,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // 32-bit unsigned: UMULL gives 64-bit result
-            (32, false) => {
+            (None, 32, false) => {
                 let umull_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::UmullRR {
                     dst: Operand::Virtual(umull_vreg),
@@ -3153,7 +3112,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // 64-bit signed: Use SMULH for high bits
-            (64, true) => {
+            (None, 64, true) => {
                 // Do the multiply first
                 self.mir.push(Aarch64Inst::MulRR {
                     dst: Operand::Virtual(result_vreg),
@@ -3185,7 +3144,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // 64-bit unsigned: Use UMULH for high bits
-            (64, false) => {
+            (None, 64, false) => {
                 // Do the multiply first
                 self.mir.push(Aarch64Inst::MulRR {
                     dst: Operand::Virtual(result_vreg),
@@ -3205,17 +3164,16 @@ impl<'a> CfgLower<'a> {
                     label: ok_label,
                 });
             }
-            // Sub-word types: do the multiply, then check range
-            (8 | 16, _) => {
-                // For sub-word, just do the multiply and check range
+            // A sub-word product: multiply plainly, then check the range.
+            (Some(check), _, _) => {
                 self.mir.push(Aarch64Inst::MulRR {
                     dst: Operand::Virtual(result_vreg),
                     src1: Operand::Virtual(lhs_vreg),
                     src2: Operand::Virtual(rhs_vreg),
                 });
-                self.emit_subword_range_check(width, result_vreg, ok_label);
+                self.emit_sub_word_check(check, result_vreg, ok_label);
             }
-            _ => return,
+            (None, bits, _) => panic!("checked multiply at non-machine width {bits}"),
         }
 
         let _ = self.lower_runtime_call(trap_call.clone());
@@ -3291,45 +3249,49 @@ impl<'a> CfgLower<'a> {
         self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
-    /// Emit overflow check for NEG based on the type.
+    /// Emit the trap guarding a checked NEG.
     ///
-    /// For NEGS (0 - x):
-    /// - Signed: V flag indicates overflow (when negating MIN_VALUE)
-    /// - Unsigned: Any non-zero value causes overflow (since 0 - x wraps)
-    fn emit_overflow_check_neg(
+    /// For `NEGS` (0 - x) at a machine width the V flag indicates a signed
+    /// overflow (negating MIN) and C=0 marks any non-zero unsigned operand; a
+    /// sub-word result is tested against its range instead.
+    fn emit_post_op_neg(
         &mut self,
-        width: crate::value_plan::IntegerWidth,
+        policy: crate::value_plan::PostOpPolicy,
         result_vreg: VReg,
         trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
+        use crate::value_plan::{PostOpPolicy, SubWordCheck};
+        if self.emit_untrapped_post_op(policy, result_vreg) {
+            return;
+        }
         let ok_label = self.mir.alloc_label();
 
-        match (width.bits, width.signed) {
+        match policy {
             // Unsigned: NEGS sets C=0 for non-zero operands (which is overflow)
             // Branch to ok if C=1 (meaning operand was 0, no overflow)
-            (32 | 64, false) => {
+            PostOpPolicy::OverflowFlags { signed: false } => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Hs, // Hs = C=1
                     label: ok_label,
                 });
             }
             // Signed: V flag indicates overflow
-            (32 | 64, true) => {
+            PostOpPolicy::OverflowFlags { signed: true } => {
                 self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
-            // Sub-word unsigned types: only 0 is valid (negating to 0)
-            (8 | 16, false) => {
-                // Result must be 0 for no overflow
+            // A sub-word unsigned negation leaves 0 - x at W-register width, far
+            // above the type's maximum for every non-zero operand, so the
+            // plan's upper bound is tested here as "the result is zero".
+            PostOpPolicy::RangeCheck(SubWordCheck::UpperBound { .. }) => {
                 self.mir.push(Aarch64Inst::Cbz {
                     src: Operand::Virtual(result_vreg),
                     label: ok_label,
                 });
             }
-            // Sub-word signed types: check if result fits in type's range
-            (8 | 16, true) => {
-                self.emit_subword_range_check(width, result_vreg, ok_label);
+            PostOpPolicy::RangeCheck(check) => {
+                self.emit_sub_word_check(check, result_vreg, ok_label);
             }
-            _ => return,
+            PostOpPolicy::None | PostOpPolicy::Narrow(_) => return,
         }
 
         let _ = self.lower_runtime_call(trap_call.clone());
@@ -3354,115 +3316,80 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Emit an aborting call to `__rue_panic(ptr, len)` for `@panic("msg")` and
-    /// `@assert(cond, "msg")` (RUE-319). `msg_val` is the CFG value of the
-    /// message `String`; its fat pointer supplies the `ptr`/`len` arguments
-    /// (X0/X1). Never returns at runtime.
+    /// Emit the range check an `@intCast` needs before its result is used.
+    ///
+    /// Which bounds a cast is checked against is decided once, for both
+    /// targets, by [`crate::value_plan::int_cast_check_plan`]; this emits the
+    /// compare, the branch, and the trap call for the arm it is handed
+    /// (RUE-1982). What stays here is target work: the comparison width — a
+    /// 64-bit source must not be compared at 32 bits, or 2^32 would pass an i32
+    /// range check and silently truncate (RUE-31) — and the sign extension
+    /// below, which a W-register's zero-extension forces before a `>= 0` test.
     fn emit_int_cast_check(
         &mut self,
         src_vreg: VReg,
         from_width: crate::value_plan::IntegerWidth,
-        to_width: crate::value_plan::IntegerWidth,
+        check: crate::value_plan::IntCastCheckPlan,
         trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
-        let from_signed = from_width.signed;
-        let to_signed = to_width.signed;
-        let from_bits = from_width.bits;
-        let to_bits = to_width.bits;
+        use crate::value_plan::IntCastCheckPlan;
 
-        // If casting to a larger or equal-sized type with compatible signedness,
-        // and source is unsigned or both are signed, no check needed
-        if to_bits >= from_bits {
-            // Widening or same-size cast
-            if from_signed == to_signed {
-                // Same signedness, widening - always safe
-                return;
-            }
-            if !from_signed && to_signed && to_bits > from_bits {
-                // Unsigned to larger signed - always safe
-                return;
-            }
-            // Signed to same-size unsigned needs check (negative values fail)
-            // Unsigned to same-size signed needs check (large values fail)
+        if check == IntCastCheckPlan::None {
+            return;
         }
-
+        let from_bits = from_width.bits;
         let ok_label = self.mir.alloc_label();
 
-        // Calculate the min and max values for the target type
-        let (min_val, max_val) = crate::value_plan::integer_range(to_width);
+        match check {
+            IntCastCheckPlan::None => unreachable!("handled above"),
+            IntCastCheckPlan::Range { min, max } => {
+                // Signed source, signed target: below MIN, then above MAX.
+                let min_vreg = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::MovImm {
+                    dst: Operand::Virtual(min_vreg),
+                    imm: min,
+                });
+                self.push_cmp_rr(src_vreg, min_vreg, from_bits);
+                self.mir.push(Aarch64Inst::BCond {
+                    cond: Cond::Ge,
+                    label: ok_label,
+                });
 
-        if from_signed {
-            // Source is signed - need to check both min and max
-            if to_signed {
-                // Signed to signed: check MIN <= value <= MAX
-                if to_bits < from_bits || (to_bits == from_bits && min_val != i64::MIN) {
-                    // Check lower bound
-                    let min_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Virtual(min_vreg),
-                        imm: min_val,
-                    });
-                    // A 64-bit source needs a 64-bit compare: the 32-bit CmpRR
-                    // only sees the low half, so e.g. 2^32 would pass an i32
-                    // range check and silently truncate (RUE-31).
-                    self.push_cmp_rr(src_vreg, min_vreg, from_bits);
-                    // For signed comparison, branch if greater or equal
-                    self.mir.push(Aarch64Inst::BCond {
-                        cond: Cond::Ge,
-                        label: ok_label,
-                    });
+                // Below min - panic
+                let _ = self.lower_runtime_call(trap_call.clone());
+                self.mir.push(Aarch64Inst::Label { id: ok_label });
 
-                    // Below min - panic
-                    let _ = self.lower_runtime_call(trap_call.clone());
-                    self.mir.push(Aarch64Inst::Label { id: ok_label });
+                let ok_label2 = self.mir.alloc_label();
+                let max_vreg = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::MovImm {
+                    dst: Operand::Virtual(max_vreg),
+                    imm: max,
+                });
+                self.push_cmp_rr(src_vreg, max_vreg, from_bits);
+                self.mir.push(Aarch64Inst::BCond {
+                    cond: Cond::Le,
+                    label: ok_label2,
+                });
 
-                    let ok_label2 = self.mir.alloc_label();
-                    // Check upper bound
-                    let max_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Virtual(max_vreg),
-                        imm: max_val,
-                    });
-                    self.push_cmp_rr(src_vreg, max_vreg, from_bits);
-                    // For signed comparison, branch if less or equal
-                    self.mir.push(Aarch64Inst::BCond {
-                        cond: Cond::Le,
-                        label: ok_label2,
-                    });
-
-                    // Above max - panic
-                    let _ = self.lower_runtime_call(trap_call.clone());
-                    self.mir.push(Aarch64Inst::Label { id: ok_label2 });
-                }
-            } else {
-                // Signed to unsigned: value must be >= 0 and <= max
-                // Check for negative
+                // Above max - panic
+                let _ = self.lower_runtime_call(trap_call.clone());
+                self.mir.push(Aarch64Inst::Label { id: ok_label2 });
+            }
+            IntCastCheckPlan::NonNegative { then_max } => {
+                // Signed source, unsigned target: negative first, then the
+                // upper bound when the target cannot hold every non-negative
+                // source value.
                 //
-                // For sub-64-bit types, we need to sign-extend first because
-                // ARM64 32-bit operations zero-extend to 64 bits, which would
-                // make -1 appear as a large positive number in 64-bit compare.
+                // A sub-64-bit source is sign-extended first: ARM64 32-bit
+                // operations zero-extend to 64 bits, which would make -1 look
+                // like a large positive value to the compare below.
                 let compare_vreg = if from_bits < 64 {
                     let sext_vreg = self.mir.alloc_vreg();
-                    match from_bits {
-                        8 => {
-                            self.mir.push(Aarch64Inst::Sxtb {
-                                dst: Operand::Virtual(sext_vreg),
-                                src: Operand::Virtual(src_vreg),
-                            });
-                        }
-                        16 => {
-                            self.mir.push(Aarch64Inst::Sxth {
-                                dst: Operand::Virtual(sext_vreg),
-                                src: Operand::Virtual(src_vreg),
-                            });
-                        }
-                        _ => {
-                            self.mir.push(Aarch64Inst::Sxtw {
-                                dst: Operand::Virtual(sext_vreg),
-                                src: Operand::Virtual(src_vreg),
-                            });
-                        }
-                    }
+                    self.emit_extension(
+                        sext_vreg,
+                        src_vreg,
+                        crate::value_plan::width_extension(from_width),
+                    );
                     sext_vreg
                 } else {
                     src_vreg
@@ -3481,16 +3408,15 @@ impl<'a> CfgLower<'a> {
                 let _ = self.lower_runtime_call(trap_call.clone());
                 self.mir.push(Aarch64Inst::Label { id: ok_label });
 
-                // Also check upper bound if narrowing
-                if to_bits < from_bits {
+                if let Some(max) = then_max {
                     let ok_label2 = self.mir.alloc_label();
                     let max_vreg = self.mir.alloc_vreg();
                     self.mir.push(Aarch64Inst::MovImm {
                         dst: Operand::Virtual(max_vreg),
-                        imm: max_val,
+                        imm: max,
                     });
                     self.push_cmp_rr(src_vreg, max_vreg, from_bits);
-                    // Unsigned comparison for upper bound check
+                    // Unsigned comparison for the upper bound
                     self.mir.push(Aarch64Inst::BCond {
                         cond: Cond::Ls, // Ls = unsigned less or same
                         label: ok_label2,
@@ -3501,18 +3427,14 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(Aarch64Inst::Label { id: ok_label2 });
                 }
             }
-        } else {
-            // Source is unsigned
-            if to_signed {
-                // Unsigned to signed: value must fit in positive range of target
-                // Check that value <= signed max
+            IntCastCheckPlan::Max(max) => {
+                // Unsigned source: one upper bound, compared as unsigned.
                 let max_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovImm {
                     dst: Operand::Virtual(max_vreg),
-                    imm: max_val,
+                    imm: max,
                 });
                 self.push_cmp_rr(src_vreg, max_vreg, from_bits);
-                // Unsigned comparison (Ls = below or same)
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Ls,
                     label: ok_label,
@@ -3521,81 +3443,63 @@ impl<'a> CfgLower<'a> {
                 // Above max - panic
                 let _ = self.lower_runtime_call(trap_call.clone());
                 self.mir.push(Aarch64Inst::Label { id: ok_label });
+            }
+        }
+    }
+
+    /// Emit the one instruction a shared [`IntegerExtension`] names, or nothing
+    /// for [`IntegerExtension::None`].
+    ///
+    /// This is the backend's only integer-extension primitive: re-narrowing a
+    /// wrapping or sub-word result, widening a signed cast, and extending a
+    /// call argument or pointer offset all name the extension in the shared
+    /// plan and reach the machine through here (RUE-1982).
+    ///
+    /// [`IntegerExtension`]: crate::value_plan::IntegerExtension
+    /// [`IntegerExtension::None`]: crate::value_plan::IntegerExtension::None
+    fn emit_extension(
+        &mut self,
+        dst: VReg,
+        src: VReg,
+        extension: crate::value_plan::IntegerExtension,
+    ) {
+        use crate::value_plan::IntegerExtension;
+        let dst = Operand::Virtual(dst);
+        let src = Operand::Virtual(src);
+        self.mir.push(match extension {
+            IntegerExtension::None => return,
+            IntegerExtension::Sign8 => Aarch64Inst::Sxtb { dst, src },
+            IntegerExtension::Zero8 => Aarch64Inst::Uxtb { dst, src },
+            IntegerExtension::Sign16 => Aarch64Inst::Sxth { dst, src },
+            IntegerExtension::Zero16 => Aarch64Inst::Uxth { dst, src },
+            IntegerExtension::Sign32 => Aarch64Inst::Sxtw { dst, src },
+        });
+    }
+
+    /// Re-narrow a wrapping multiply result to its declared width (RUE-647).
+    ///
+    /// `MUL` is a 64-bit operation whose upper bits carry the high half of the
+    /// product, unlike the flag-setting 32-bit `Adds`/`Subs` a wrapping add or
+    /// subtract leaves an already-zeroed upper half behind. That is a fact about
+    /// this instruction, so the 32-bit repair lives here; every other width
+    /// takes the extension the shared plan decided.
+    fn emit_wrap_narrow_mul(
+        &mut self,
+        policy: crate::value_plan::PostOpPolicy,
+        width: crate::value_plan::IntegerWidth,
+        vreg: VReg,
+    ) {
+        let crate::value_plan::PostOpPolicy::Narrow(extension) = policy else {
+            panic!("a wrapping multiply must carry a narrowing policy: {policy:?}");
+        };
+        if width.bits == 32 {
+            let dst = Operand::Virtual(vreg);
+            let src = Operand::Virtual(vreg);
+            if width.signed {
+                self.mir.push(Aarch64Inst::Sxtw { dst, src });
             } else {
-                // Unsigned to unsigned: narrowing check
-                if to_bits < from_bits {
-                    let max_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Virtual(max_vreg),
-                        imm: max_val,
-                    });
-                    self.push_cmp_rr(src_vreg, max_vreg, from_bits);
-                    self.mir.push(Aarch64Inst::BCond {
-                        cond: Cond::Ls,
-                        label: ok_label,
-                    });
-
-                    // Above max - panic
-                    let _ = self.lower_runtime_call(trap_call.clone());
-                    self.mir.push(Aarch64Inst::Label { id: ok_label });
-                }
-            }
-        }
-    }
-
-    /// Get the min and max values for an integer type.
-    /// Materialize the shift count masked to the operand's bit width into a
-    /// fresh vreg (so a sub-word variable count >= the width wraps per spec).
-    /// For 32/64-bit operands the hardware mask already matches.
-    fn emit_subword_narrow(&mut self, vreg: VReg, ty: Type) {
-        let dst = Operand::Virtual(vreg);
-        let src = Operand::Virtual(vreg);
-        match crate::value_plan::type_bits(ty) {
-            8 if crate::value_plan::type_is_signed(ty) => {
-                self.mir.push(Aarch64Inst::Sxtb { dst, src })
-            }
-            8 => self.mir.push(Aarch64Inst::Uxtb { dst, src }),
-            16 if crate::value_plan::type_is_signed(ty) => {
-                self.mir.push(Aarch64Inst::Sxth { dst, src })
-            }
-            16 => self.mir.push(Aarch64Inst::Uxth { dst, src }),
-            _ => {}
-        }
-    }
-
-    /// Re-narrow a sub-word wrapping `Add`/`Sub` result to its declared width
-    /// (RUE-647). The flag-setting `Adds`/`Subs` are 32-bit ops that zero bits
-    /// 32..63, so 32- and 64-bit results are already canonical; only 8/16-bit
-    /// results need the low byte/halfword re-extended to match the canonical
-    /// sign/zero extension of an in-range value.
-    fn emit_wrap_narrow_subword(&mut self, width: crate::value_plan::IntegerWidth, vreg: VReg) {
-        let dst = Operand::Virtual(vreg);
-        let src = Operand::Virtual(vreg);
-        match (width.bits, width.signed) {
-            (8, true) => self.mir.push(Aarch64Inst::Sxtb { dst, src }),
-            (8, false) => self.mir.push(Aarch64Inst::Uxtb { dst, src }),
-            (16, true) => self.mir.push(Aarch64Inst::Sxth { dst, src }),
-            (16, false) => self.mir.push(Aarch64Inst::Uxth { dst, src }),
-            _ => {}
-        }
-    }
-
-    /// Truncate a wrapping multiply result to its declared width (RUE-647).
-    /// `MUL` is a 64-bit op whose upper bits carry the high half of the product,
-    /// so every sub-64-bit width must be re-narrowed: 8/16-bit sign/zero-extend
-    /// the low byte/halfword; a 32-bit signed result sign-extends the low word,
-    /// and a 32-bit unsigned result zeroes the upper word (`lsl #32; lsr #32`)
-    /// so a later `u32 -> u64` widening sees the correct zero-extended value.
-    fn emit_wrap_narrow_mul(&mut self, width: crate::value_plan::IntegerWidth, vreg: VReg) {
-        let dst = Operand::Virtual(vreg);
-        let src = Operand::Virtual(vreg);
-        match (width.bits, width.signed) {
-            (8, true) => self.mir.push(Aarch64Inst::Sxtb { dst, src }),
-            (8, false) => self.mir.push(Aarch64Inst::Uxtb { dst, src }),
-            (16, true) => self.mir.push(Aarch64Inst::Sxth { dst, src }),
-            (16, false) => self.mir.push(Aarch64Inst::Uxth { dst, src }),
-            (32, true) => self.mir.push(Aarch64Inst::Sxtw { dst, src }),
-            (32, false) => {
+                // Zero the upper word so a later `u32 -> u64` widening sees the
+                // zero-extended value.
                 self.mir.push(Aarch64Inst::LslImm { dst, src, imm: 32 });
                 self.mir.push(Aarch64Inst::Lsr64Imm {
                     dst,
@@ -3603,8 +3507,9 @@ impl<'a> CfgLower<'a> {
                     imm: 32,
                 });
             }
-            _ => {}
+            return;
         }
+        self.emit_extension(vreg, vreg, extension);
     }
 
     /// Emit a comparison instruction.

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -211,6 +211,84 @@ fn value_planning_uses_the_air_integer_semantics_kernel() {
 }
 
 #[test]
+fn integer_cast_and_arithmetic_post_op_policy_live_only_in_the_value_plan() {
+    // A cast's range check and an arithmetic result's overflow/re-narrowing
+    // rule are language semantics, not target encodings. Each backend used to
+    // re-derive them from `(bits, signed)` — AArch64 in three copies — so a
+    // width fixed in one table and missed in another silently gave the two
+    // targets different arithmetic (RUE-31, RUE-647, RUE-1982).
+    let value_plan = include_str!("value_plan.rs");
+    for owner in [
+        "pub enum IntCastCheckPlan",
+        "pub fn int_cast_check_plan(",
+        "pub enum PostOpPolicy",
+        "pub enum SubWordCheck",
+        "pub fn post_op_policy(",
+        "pub fn width_extension(",
+        "pub fn narrowing_extension(",
+    ] {
+        assert!(
+            value_plan.contains(owner),
+            "integer policy owner lost {owner}"
+        );
+    }
+    // The plan asks AIR whether a value is representable rather than comparing
+    // bit counts, so the cast the backends compile is the cast semantic
+    // analysis and constant folding accept.
+    assert!(value_plan.contains("target.fits_i128(source.min_i128())"));
+
+    for (name, source) in [
+        ("x86_64/cfg_lower", include_str!("x86_64/cfg_lower.rs")),
+        ("aarch64/cfg_lower", include_str!("aarch64/cfg_lower.rs")),
+    ] {
+        let production = source
+            .split("\n#[cfg(test)]\nmod ")
+            .next()
+            .expect("codegen production prefix");
+        for removed in [
+            "fn emit_subword_narrow(",
+            "fn emit_wrap_narrow(",
+            "fn emit_wrap_narrow_subword(",
+            "fn emit_subword_range_check(",
+            "fn emit_overflow_check(",
+            "fn emit_overflow_check_add(",
+            "fn emit_overflow_check_sub(",
+            "fn emit_overflow_check_neg(",
+        ] {
+            assert!(
+                !production.contains(removed),
+                "backend {name} regained a per-target integer policy table: {removed}"
+            );
+        }
+        for forbidden in [
+            "type_bits",
+            "type_is_signed",
+            "from_signed",
+            "to_signed",
+            "to_width",
+            "65535",
+        ] {
+            assert!(
+                !production.contains(forbidden),
+                "backend {name} re-derives integer policy from the width: {forbidden}"
+            );
+        }
+        // One extension primitive per backend, and it is the only place an
+        // extension instruction is selected from the shared enum.
+        assert_eq!(
+            production.matches("fn emit_extension(").count(),
+            1,
+            "backend {name} must expose exactly one integer-extension primitive"
+        );
+        assert_eq!(
+            production.matches("IntegerExtension::Sign16").count(),
+            1,
+            "backend {name} selects an extension instruction outside emit_extension"
+        );
+    }
+}
+
+#[test]
 fn codegen_consults_air_for_aggregate_and_switch_compare_policy() {
     // The call planner and the value materializer must classify aggregates
     // identically, or a call passes a value in a shape the other side never

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -92,12 +92,20 @@ pub enum ResidualValuePlan {
         lhs: VReg,
         rhs: VReg,
         constant: Option<u64>,
+        /// The re-narrowing the result needs, decided by
+        /// [`narrowing_extension`]: a shift is emitted at the machine's width,
+        /// so a sub-word result's high bits are not the canonical extension of
+        /// its low bits until this is applied (RUE-29).
+        narrow: IntegerExtension,
     },
     Not {
         value: VReg,
     },
     BitNot {
         value: VReg,
+        /// The re-narrowing the result needs; see
+        /// [`ResidualValuePlan::Shift::narrow`].
+        narrow: IntegerExtension,
     },
     Alloc {
         slot: u32,
@@ -156,7 +164,18 @@ pub enum ResidualValuePlan {
     },
     IntCast {
         value: VReg,
+        /// The source width, which decides the width the bound comparisons run
+        /// at: a 64-bit source must not be compared at 32 bits (RUE-31).
         from_width: IntegerWidth,
+        /// The bounds this cast traps outside of, decided once from the source
+        /// and target integer semantics (RUE-1982). A backend emits the
+        /// compare/branch/trap sequence of the arm it is given; it never
+        /// re-derives which bounds a `(from, to)` pair needs.
+        check: IntCastCheckPlan,
+        /// The extension the result needs after the check, so a widening signed
+        /// cast carries the source's sign rather than its zero padding
+        /// (RUE-88). [`IntegerExtension::None`] for every other cast.
+        widen: IntegerExtension,
         trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     },
     Drop {
@@ -225,9 +244,121 @@ pub struct ArithmeticPlan {
     pub div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan,
     /// When `true`, this is a wrapping `Add`/`Sub`/`Mul` (`@wrapping_*`,
     /// RUE-647): the backend emits the plain ALU op with NO overflow-check
-    /// branch, truncating sub-64-bit results to the declared width so the
-    /// two's-complement wrap is observable. Never set for `Div`/`Mod`/`Neg`.
+    /// branch. This selects the OPERATION; what follows it is
+    /// [`Self::post_op`]. Never set for `Div`/`Mod`/`Neg`.
     pub wrap: bool,
+    /// What follows the machine operation: an overflow trap read from the
+    /// target's flags, a sub-word range test, or the re-narrowing a wrapping
+    /// result needs (RUE-1982). Decided once by [`post_op_policy`]; a backend
+    /// emits the arm it is given and never re-derives it from the width.
+    pub post_op: PostOpPolicy,
+}
+
+impl ArithmeticPlan {
+    /// Build the plan for one arithmetic operation. The runtime entries and the
+    /// post-operation policy follow from the operation itself, so no caller
+    /// chooses them.
+    pub fn new(operation: ArithmeticOperation, wrap: bool) -> Self {
+        Self {
+            operation,
+            overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                RuntimeHelperId::Overflow,
+            ),
+            div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                RuntimeHelperId::DivByZero,
+            ),
+            wrap,
+            post_op: post_op_policy(operation, wrap),
+        }
+    }
+}
+
+/// What an integer arithmetic result needs after the machine operation has run.
+///
+/// Both backends compute a sub-64-bit result at a wider machine width, so the
+/// language-level question — is this result in its declared range, and does a
+/// wrapping result still have to be re-narrowed — has one answer per operation
+/// and width. That answer is decided here; a backend supplies the instructions
+/// for the arm it receives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostOpPolicy {
+    /// Nothing follows the operation: floating-point arithmetic, and division
+    /// and remainder, whose guards run before it.
+    None,
+    /// The result fills a whole machine width, so the target's own overflow
+    /// detection for that width decides the trap.
+    OverflowFlags { signed: bool },
+    /// The result is narrower than the width the machine computed it at: it is
+    /// in range exactly when this test says so, and traps otherwise.
+    RangeCheck(SubWordCheck),
+    /// A wrapping operation (`@wrapping_*`): never traps, but the result is
+    /// re-narrowed to its declared width so the two's-complement wrap is
+    /// observable (RUE-647).
+    Narrow(IntegerExtension),
+}
+
+/// How a sub-word result computed at a wider machine width is tested against
+/// its declared range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubWordCheck {
+    /// An unsigned width: the result is in range exactly when it is at most
+    /// `max`.
+    UpperBound { max: u64 },
+    /// A signed width: the result is in range exactly when re-extending its low
+    /// bits reproduces it.
+    SignExtended { extension: IntegerExtension },
+}
+
+/// Decide what follows an arithmetic operation of this shape.
+///
+/// Whether a result traps, and on what test, is language semantics, so it is
+/// decided here for both targets: a width answered by one backend's table and
+/// missed by another's would give the same program target-dependent overflow
+/// behavior (RUE-647, RUE-1982).
+pub fn post_op_policy(operation: ArithmeticOperation, wrap: bool) -> PostOpPolicy {
+    let width = match operation {
+        ArithmeticOperation::Add { width, .. }
+        | ArithmeticOperation::Sub { width, .. }
+        | ArithmeticOperation::Mul { width, .. }
+        | ArithmeticOperation::Neg { width, .. } => width,
+        // A divide's guards (zero divisor, MIN / -1) precede the operation, and
+        // float arithmetic neither traps nor re-narrows.
+        ArithmeticOperation::Div { .. }
+        | ArithmeticOperation::Mod { .. }
+        | ArithmeticOperation::FloatAdd { .. }
+        | ArithmeticOperation::FloatSub { .. }
+        | ArithmeticOperation::FloatMul { .. }
+        | ArithmeticOperation::FloatDiv { .. }
+        | ArithmeticOperation::FloatNeg { .. } => return PostOpPolicy::None,
+    };
+    if wrap {
+        return PostOpPolicy::Narrow(narrowing_extension(width));
+    }
+    match width.bits {
+        8 | 16 if width.signed => PostOpPolicy::RangeCheck(SubWordCheck::SignExtended {
+            extension: narrowing_extension(width),
+        }),
+        8 | 16 => PostOpPolicy::RangeCheck(SubWordCheck::UpperBound {
+            max: integer_type(width).max_i128() as u64,
+        }),
+        _ => PostOpPolicy::OverflowFlags {
+            signed: width.signed,
+        },
+    }
+}
+
+/// Select the re-narrowing a result of this width needs when the machine
+/// computed it at a wider width.
+///
+/// Only 8- and 16-bit results differ from the machine form both backends
+/// compute sub-64-bit arithmetic at, so this is [`width_extension`] with the
+/// 32-bit case dropped: a 32-bit ALU result is already canonical, while a
+/// 32-bit signed VALUE reaching a 64-bit leaf still needs the extension.
+pub fn narrowing_extension(width: IntegerWidth) -> IntegerExtension {
+    match width.bits {
+        8 | 16 => width_extension(width),
+        _ => IntegerExtension::None,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1210,6 +1341,15 @@ enum ResidualInput {
     },
 }
 
+/// The re-narrowing a value's own result width needs after an operation both
+/// backends emit at the machine's width.
+fn result_narrowing(ctx: &CfgLowerContext<'_>, value: CfgValue) -> IntegerExtension {
+    let ty = ctx.cfg.get_inst(value).ty;
+    narrowing_extension(integer_width(ty).unwrap_or_else(|| {
+        panic!("narrowed operation on non-integer type: {ty:?}");
+    }))
+}
+
 fn residual_plan<A: ValueLowerAdapter>(
     ctx: &CfgLowerContext<'_>,
     adapter: &mut A,
@@ -1251,6 +1391,7 @@ fn residual_plan<A: ValueLowerAdapter>(
                 CfgInstData::Const(value) => Some(value),
                 _ => None,
             },
+            narrow: result_narrowing(ctx, value),
         },
         ResidualInput::Shr(lhs, rhs) => ResidualValuePlan::Shift {
             op: ShiftOp::Right,
@@ -1260,12 +1401,14 @@ fn residual_plan<A: ValueLowerAdapter>(
                 CfgInstData::Const(value) => Some(value),
                 _ => None,
             },
+            narrow: result_narrowing(ctx, value),
         },
         ResidualInput::Not(value) => ResidualValuePlan::Not {
             value: operand(ctx, adapter, value).primary,
         },
-        ResidualInput::BitNot(value) => ResidualValuePlan::BitNot {
-            value: operand(ctx, adapter, value).primary,
+        ResidualInput::BitNot(source) => ResidualValuePlan::BitNot {
+            value: operand(ctx, adapter, source).primary,
+            narrow: result_narrowing(ctx, value),
         },
         // Slot-addressed plans carry emitted-frame slot numbers: the CFG's
         // slot numbering assumes every parameter is homed, while the emitted
@@ -1394,13 +1537,30 @@ fn residual_plan<A: ValueLowerAdapter>(
                 ),
             }
         }
-        ResidualInput::IntCast { value, from_ty } => ResidualValuePlan::IntCast {
-            value: operand(ctx, adapter, value).primary,
-            from_width: integer_width(from_ty).expect("integer cast source width"),
-            trap_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                RuntimeHelperId::IntcastOverflow,
-            ),
-        },
+        ResidualInput::IntCast {
+            value: source,
+            from_ty,
+        } => {
+            let from_width = integer_width(from_ty).expect("integer cast source width");
+            let to_width =
+                integer_width(ctx.cfg.get_inst(value).ty).expect("integer cast target width");
+            ResidualValuePlan::IntCast {
+                value: operand(ctx, adapter, source).primary,
+                from_width,
+                check: int_cast_check_plan(from_width, to_width),
+                // A narrowing or same-width cast keeps the source's canonical
+                // form; only a widening signed source must re-extend, and the
+                // extension is the source width's, not the target's.
+                widen: if from_width.signed && to_width.bits > from_width.bits {
+                    integer_extension(from_ty)
+                } else {
+                    IntegerExtension::None
+                },
+                trap_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::IntcastOverflow,
+                ),
+            }
+        }
         ResidualInput::Drop { value } => ResidualValuePlan::Drop {
             actions: drop_plan(ctx, adapter, value),
         },
@@ -1518,16 +1678,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     width: policy.integer_width.expect("add width"),
                 }
             };
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation,
-                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::Overflow,
-                ),
-                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::DivByZero,
-                ),
-                wrap: false,
-            });
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(operation, false));
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
         }
@@ -1543,16 +1694,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     width: policy.integer_width.expect("sub width"),
                 }
             };
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation,
-                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::Overflow,
-                ),
-                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::DivByZero,
-                ),
-                wrap: false,
-            });
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(operation, false));
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
         }
@@ -1560,20 +1702,14 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             let lhs_result = operand(ctx, adapter, *lhs);
             let rhs_result = operand(ctx, adapter, *rhs);
             if let Some(width) = float_width(inst.ty) {
-                let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                    operation: ArithmeticOperation::FloatMul {
+                let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(
+                    ArithmeticOperation::FloatMul {
                         lhs: lhs_result.primary,
                         rhs: rhs_result.primary,
                         width,
                     },
-                    overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                        RuntimeHelperId::Overflow,
-                    ),
-                    div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                        RuntimeHelperId::DivByZero,
-                    ),
-                    wrap: false,
-                });
+                    false,
+                ));
                 cache_result(adapter, value, result);
                 return Some(ValueKind::BinaryArithmetic);
             }
@@ -1587,21 +1723,15 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             } else {
                 None
             };
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation: ArithmeticOperation::Mul {
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(
+                ArithmeticOperation::Mul {
                     lhs: lhs_result.primary,
                     rhs: rhs_result.primary,
                     width,
                     shift,
                 },
-                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::Overflow,
-                ),
-                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::DivByZero,
-                ),
-                wrap: false,
-            });
+                false,
+            ));
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
         }
@@ -1609,16 +1739,10 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             let width = policy.integer_width.expect("wrapping_add width");
             let lhs = operand(ctx, adapter, *lhs).primary;
             let rhs = operand(ctx, adapter, *rhs).primary;
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation: ArithmeticOperation::Add { lhs, rhs, width },
-                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::Overflow,
-                ),
-                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::DivByZero,
-                ),
-                wrap: true,
-            });
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(
+                ArithmeticOperation::Add { lhs, rhs, width },
+                true,
+            ));
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
         }
@@ -1626,16 +1750,10 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             let width = policy.integer_width.expect("wrapping_sub width");
             let lhs = operand(ctx, adapter, *lhs).primary;
             let rhs = operand(ctx, adapter, *rhs).primary;
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation: ArithmeticOperation::Sub { lhs, rhs, width },
-                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::Overflow,
-                ),
-                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::DivByZero,
-                ),
-                wrap: true,
-            });
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(
+                ArithmeticOperation::Sub { lhs, rhs, width },
+                true,
+            ));
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
         }
@@ -1647,21 +1765,15 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             // bits are identical for signed and unsigned two's-complement, so
             // no power-of-two strength reduction and no widening overflow probe
             // (RUE-647). `shift: None` forces the plain-multiply path.
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation: ArithmeticOperation::Mul {
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(
+                ArithmeticOperation::Mul {
                     lhs,
                     rhs,
                     width,
                     shift: None,
                 },
-                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::Overflow,
-                ),
-                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::DivByZero,
-                ),
-                wrap: true,
-            });
+                true,
+            ));
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
         }
@@ -1677,16 +1789,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     width: policy.integer_width.expect("div width"),
                 }
             };
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation,
-                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::Overflow,
-                ),
-                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::DivByZero,
-                ),
-                wrap: false,
-            });
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(operation, false));
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
         }
@@ -1694,16 +1797,10 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             let width = policy.integer_width.expect("mod width");
             let lhs = operand(ctx, adapter, *lhs).primary;
             let rhs = operand(ctx, adapter, *rhs).primary;
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation: ArithmeticOperation::Mod { lhs, rhs, width },
-                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::Overflow,
-                ),
-                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::DivByZero,
-                ),
-                wrap: false,
-            });
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(
+                ArithmeticOperation::Mod { lhs, rhs, width },
+                false,
+            ));
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
         }
@@ -1720,16 +1817,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     width: policy.integer_width.expect("neg width"),
                 }
             };
-            let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
-                operation,
-                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::Overflow,
-                ),
-                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
-                    RuntimeHelperId::DivByZero,
-                ),
-                wrap: false,
-            });
+            let result = adapter.emit_checked_arithmetic(ArithmeticPlan::new(operation, false));
             cache_result(adapter, value, result);
             Some(ValueKind::UnaryArithmetic)
         }
@@ -2367,29 +2455,24 @@ pub fn type_is_signed(ty: Type) -> bool {
 /// Select the extension needed before an integer becomes a 64-bit pointer
 /// offset. Values already represented at full width need no instruction.
 pub fn integer_extension(ty: Type) -> IntegerExtension {
-    match integer_width(ty) {
-        None => IntegerExtension::None,
-        Some(IntegerWidth {
-            bits: 8,
-            signed: true,
-        }) => IntegerExtension::Sign8,
-        Some(IntegerWidth {
-            bits: 8,
-            signed: false,
-        }) => IntegerExtension::Zero8,
-        Some(IntegerWidth {
-            bits: 16,
-            signed: true,
-        }) => IntegerExtension::Sign16,
-        Some(IntegerWidth {
-            bits: 16,
-            signed: false,
-        }) => IntegerExtension::Zero16,
-        Some(IntegerWidth {
-            bits: 32,
-            signed: true,
-        }) => IntegerExtension::Sign32,
-        Some(_) => IntegerExtension::None,
+    integer_width(ty).map_or(IntegerExtension::None, width_extension)
+}
+
+/// The instruction-free description of the canonical 64-bit form of a value of
+/// this width: what a register holding only the low bits must be extended by to
+/// reach it. Every extension either backend emits is named here, so a width is
+/// described once whether it is reached through a [`Type`] or an
+/// [`IntegerWidth`] (RUE-1982).
+pub fn width_extension(width: IntegerWidth) -> IntegerExtension {
+    match width.bits {
+        8 if width.signed => IntegerExtension::Sign8,
+        8 => IntegerExtension::Zero8,
+        16 if width.signed => IntegerExtension::Sign16,
+        16 => IntegerExtension::Zero16,
+        // An unsigned 32-bit value is canonical once bits 32-63 are zero, which
+        // every 32-bit machine operation already leaves them.
+        32 if width.signed => IntegerExtension::Sign32,
+        _ => IntegerExtension::None,
     }
 }
 
@@ -2438,15 +2521,72 @@ pub fn type_range(ty: Type) -> (i64, i64) {
 }
 
 /// Return the representable range selected by a shared integer-width plan.
+///
+/// The upper bound is clamped to `i64::MAX` so it fits the immediate both
+/// backends materialize it into. Only `u64` is clamped, and no check ever
+/// compares against a `u64` upper bound: every value of every source type is
+/// representable in `u64` except a negative one, which the non-negative test
+/// already rejects.
 pub fn integer_range(width: IntegerWidth) -> (i64, i64) {
-    let integer = u8::try_from(width.bits)
-        .ok()
-        .and_then(|bits| IntegerType::new(bits, width.signed))
-        .expect("invalid integer width");
+    let integer = integer_type(width);
     (
         integer.min_i128() as i64,
         integer.max_i128().min(i128::from(i64::MAX)) as i64,
     )
+}
+
+/// The AIR integer kernel behind a shared width plan. Widths reach codegen from
+/// [`IntegerType`] itself, so an unsupported one is a malformed plan.
+fn integer_type(width: IntegerWidth) -> IntegerType {
+    u8::try_from(width.bits)
+        .ok()
+        .and_then(|bits| IntegerType::new(bits, width.signed))
+        .expect("invalid integer width")
+}
+
+/// The bounds an `@intCast` traps outside of.
+///
+/// These are the four shapes the `(source signedness, target signedness)`
+/// quadrants need once the always-representable pairs are removed: a signed
+/// target needs both bounds, an unsigned target needs a non-negative test and
+/// then an upper bound only when it cannot hold every non-negative source
+/// value, and an unsigned source needs an upper bound alone. Both backends
+/// consume this decision and choose only the comparison width and the branch
+/// encoding (RUE-1982).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntCastCheckPlan {
+    /// Every value of the source type is representable in the target type.
+    None,
+    /// Signed source, signed target: trap below `min`, then trap above `max`,
+    /// both as signed comparisons.
+    Range { min: i64, max: i64 },
+    /// Signed source, unsigned target: trap when the source is negative, then
+    /// trap above `then_max` as an unsigned comparison when the target cannot
+    /// hold every non-negative source value.
+    NonNegative { then_max: Option<i64> },
+    /// Unsigned source: trap above `max` as an unsigned comparison.
+    Max(i64),
+}
+
+/// Decide the range check an `@intCast` from `from` to `to` needs.
+///
+/// Representability is asked of the AIR integer kernel rather than re-derived
+/// from bit counts and signedness, so the cast the backends compile is the cast
+/// constant folding and semantic analysis accept.
+pub fn int_cast_check_plan(from: IntegerWidth, to: IntegerWidth) -> IntCastCheckPlan {
+    let source = integer_type(from);
+    let target = integer_type(to);
+    if target.fits_i128(source.min_i128()) && target.fits_i128(source.max_i128()) {
+        return IntCastCheckPlan::None;
+    }
+    let (min, max) = integer_range(to);
+    match (from.signed, to.signed) {
+        (true, true) => IntCastCheckPlan::Range { min, max },
+        (true, false) => IntCastCheckPlan::NonNegative {
+            then_max: (target.max_i128() < source.max_i128()).then_some(max),
+        },
+        (false, _) => IntCastCheckPlan::Max(max),
+    }
 }
 
 /// Return the by-reference parameter slots that must be preloaded before the
@@ -2487,6 +2627,219 @@ pub fn assert_slot_policy(plan: ValuePlan, actual: usize) {
         plan.assert_complete_slots(actual);
     } else if actual > 1 {
         panic!("scalar value plan unexpectedly has {actual} materialized slots");
+    }
+}
+
+#[cfg(test)]
+mod integer_policy_tests {
+    use super::*;
+
+    const WIDTHS: [IntegerWidth; 8] = [
+        IntegerWidth {
+            bits: 8,
+            signed: true,
+        },
+        IntegerWidth {
+            bits: 16,
+            signed: true,
+        },
+        IntegerWidth {
+            bits: 32,
+            signed: true,
+        },
+        IntegerWidth {
+            bits: 64,
+            signed: true,
+        },
+        IntegerWidth {
+            bits: 8,
+            signed: false,
+        },
+        IntegerWidth {
+            bits: 16,
+            signed: false,
+        },
+        IntegerWidth {
+            bits: 32,
+            signed: false,
+        },
+        IntegerWidth {
+            bits: 64,
+            signed: false,
+        },
+    ];
+
+    /// Every value a backend could be handed at a boundary of any integer type.
+    fn probe_values() -> Vec<i128> {
+        let mut values = vec![0, -1, 1];
+        for width in WIDTHS {
+            let integer = integer_type(width);
+            for value in [
+                integer.min_i128() - 1,
+                integer.min_i128(),
+                integer.min_i128() + 1,
+                integer.max_i128() - 1,
+                integer.max_i128(),
+                integer.max_i128() + 1,
+            ] {
+                values.push(value);
+            }
+        }
+        values.sort_unstable();
+        values.dedup();
+        values
+    }
+
+    /// Whether the emitted arms of a check plan trap on `value`. Both backends
+    /// emit exactly these comparisons; the upper bounds are compared as
+    /// unsigned, but every bound and every value reaching one is non-negative,
+    /// so one signed comparison models both.
+    fn traps(plan: IntCastCheckPlan, value: i128) -> bool {
+        match plan {
+            IntCastCheckPlan::None => false,
+            IntCastCheckPlan::Range { min, max } => {
+                value < i128::from(min) || value > i128::from(max)
+            }
+            IntCastCheckPlan::NonNegative { then_max } => {
+                value < 0 || then_max.is_some_and(|max| value > i128::from(max))
+            }
+            IntCastCheckPlan::Max(max) => value > i128::from(max),
+        }
+    }
+
+    #[test]
+    fn every_integer_cast_pair_traps_exactly_on_the_unrepresentable() {
+        let values = probe_values();
+        for from in WIDTHS {
+            for to in WIDTHS {
+                let source = integer_type(from);
+                let target = integer_type(to);
+                let plan = int_cast_check_plan(from, to);
+                for &value in &values {
+                    if !source.fits_i128(value) {
+                        continue;
+                    }
+                    assert_eq!(
+                        traps(plan, value),
+                        !target.fits_i128(value),
+                        "cast {from:?} -> {to:?} of {value} disagrees with {plan:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_cast_plan_carries_no_bound_a_comparison_cannot_hold() {
+        for from in WIDTHS {
+            for to in WIDTHS {
+                let bounds = match int_cast_check_plan(from, to) {
+                    IntCastCheckPlan::None => vec![],
+                    IntCastCheckPlan::Range { min, max } => vec![min, max],
+                    IntCastCheckPlan::NonNegative { then_max } => then_max.into_iter().collect(),
+                    IntCastCheckPlan::Max(max) => vec![max],
+                };
+                for bound in bounds {
+                    assert!(
+                        integer_type(to).fits_i128(i128::from(bound)),
+                        "cast {from:?} -> {to:?} names a bound outside the target"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn every_arithmetic_shape_has_one_post_operation_policy() {
+        for width in WIDTHS {
+            let lhs = VReg::new(0);
+            let rhs = VReg::new(1);
+            let checked = [
+                ArithmeticOperation::Add { lhs, rhs, width },
+                ArithmeticOperation::Sub { lhs, rhs, width },
+                ArithmeticOperation::Mul {
+                    lhs,
+                    rhs,
+                    width,
+                    shift: None,
+                },
+                ArithmeticOperation::Neg { value: lhs, width },
+            ];
+            for operation in checked {
+                match post_op_policy(operation, false) {
+                    PostOpPolicy::OverflowFlags { signed } => {
+                        assert!(width.bits >= 32, "{width:?} is not a machine width");
+                        assert_eq!(signed, width.signed);
+                    }
+                    PostOpPolicy::RangeCheck(SubWordCheck::UpperBound { max }) => {
+                        assert!(width.bits < 32 && !width.signed);
+                        assert_eq!(i128::from(max), integer_type(width).max_i128());
+                    }
+                    PostOpPolicy::RangeCheck(SubWordCheck::SignExtended { extension }) => {
+                        assert!(width.bits < 32 && width.signed);
+                        assert_eq!(extension, width_extension(width));
+                    }
+                    other => panic!("checked {width:?} arithmetic planned {other:?}"),
+                }
+            }
+
+            let wrapping = [
+                ArithmeticOperation::Add { lhs, rhs, width },
+                ArithmeticOperation::Sub { lhs, rhs, width },
+                ArithmeticOperation::Mul {
+                    lhs,
+                    rhs,
+                    width,
+                    shift: None,
+                },
+            ];
+            for operation in wrapping {
+                assert_eq!(
+                    post_op_policy(operation, true),
+                    PostOpPolicy::Narrow(narrowing_extension(width)),
+                    "wrapping {width:?} arithmetic must only re-narrow"
+                );
+            }
+
+            for operation in [
+                ArithmeticOperation::Div { lhs, rhs, width },
+                ArithmeticOperation::Mod { lhs, rhs, width },
+            ] {
+                assert_eq!(post_op_policy(operation, false), PostOpPolicy::None);
+            }
+        }
+    }
+
+    #[test]
+    fn narrowing_is_the_width_extension_of_a_sub_word_result() {
+        for width in WIDTHS {
+            let narrowing = narrowing_extension(width);
+            if width.bits < 32 {
+                assert_eq!(narrowing, width_extension(width));
+                assert_ne!(narrowing, IntegerExtension::None);
+            } else {
+                // A 32- or 64-bit result of an operation at its own width is
+                // already canonical, so nothing follows it.
+                assert_eq!(narrowing, IntegerExtension::None);
+            }
+        }
+    }
+
+    #[test]
+    fn one_extension_table_answers_both_the_type_and_the_width() {
+        for (ty, width) in [
+            (Type::I8, WIDTHS[0]),
+            (Type::I16, WIDTHS[1]),
+            (Type::I32, WIDTHS[2]),
+            (Type::I64, WIDTHS[3]),
+            (Type::U8, WIDTHS[4]),
+            (Type::U16, WIDTHS[5]),
+            (Type::U32, WIDTHS[6]),
+            (Type::U64, WIDTHS[7]),
+        ] {
+            assert_eq!(integer_extension(ty), width_extension(width));
+            assert_eq!(integer_width(ty), Some(width));
+        }
     }
 }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -461,26 +461,7 @@ impl<'a> CfgLower<'a> {
                             dst: Operand::Virtual(extended),
                             src: Operand::Virtual(value),
                         });
-                        let dst = Operand::Virtual(extended);
-                        let src = Operand::Virtual(extended);
-                        self.mir.push(match extension {
-                            crate::value_plan::IntegerExtension::Sign8 => {
-                                X86Inst::Movsx8To64 { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::Zero8 => {
-                                X86Inst::Movzx8To64 { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::Sign16 => {
-                                X86Inst::Movsx16To64 { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::Zero16 => {
-                                X86Inst::Movzx16To64 { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::Sign32 => {
-                                X86Inst::Movsx32To64 { dst, src }
-                            }
-                            crate::value_plan::IntegerExtension::None => unreachable!(),
-                        });
+                        self.emit_extension(extended, extended, extension);
                         Some(extended)
                     }
                 }
@@ -771,42 +752,33 @@ impl<'a> CfgLower<'a> {
         self.mir.push(X86Inst::Label { id: ok_label });
     }
 
-    /// Materialize the shift count masked to the operand's bit width into a
-    /// fresh vreg, so a sub-word variable count >= the width wraps per spec
-    /// (the x86 CL shift only masks by 31/63). For 32/64-bit operands the
-    /// hardware mask already matches, so the count is returned unmasked.
-    fn emit_subword_narrow(&mut self, vreg: VReg, ty: Type) {
-        let dst = Operand::Virtual(vreg);
-        let src = Operand::Virtual(vreg);
-        match crate::value_plan::type_bits(ty) {
-            8 if crate::value_plan::type_is_signed(ty) => {
-                self.mir.push(X86Inst::Movsx8To64 { dst, src })
-            }
-            8 => self.mir.push(X86Inst::Movzx8To64 { dst, src }),
-            16 if crate::value_plan::type_is_signed(ty) => {
-                self.mir.push(X86Inst::Movsx16To64 { dst, src })
-            }
-            16 => self.mir.push(X86Inst::Movzx16To64 { dst, src }),
-            _ => {}
-        }
-    }
-
-    /// Truncate a wrapping-arithmetic result to its declared width so the
-    /// two's-complement wrap is observable (RUE-647). A sub-word wrapping
-    /// `Add`/`Sub`/`Mul` is emitted as a 32-bit ALU op whose out-of-range bits
-    /// (bits N..31) do not match the canonical sign/zero extension of the low
-    /// N bits; re-extending fixes them. The 32-bit ops already zero bits 32..63,
-    /// so 32- and 64-bit results need no narrowing.
-    fn emit_wrap_narrow(&mut self, width: crate::value_plan::IntegerWidth, vreg: VReg) {
-        let dst = Operand::Virtual(vreg);
-        let src = Operand::Virtual(vreg);
-        match (width.bits, width.signed) {
-            (8, true) => self.mir.push(X86Inst::Movsx8To64 { dst, src }),
-            (8, false) => self.mir.push(X86Inst::Movzx8To64 { dst, src }),
-            (16, true) => self.mir.push(X86Inst::Movsx16To64 { dst, src }),
-            (16, false) => self.mir.push(X86Inst::Movzx16To64 { dst, src }),
-            _ => {}
-        }
+    /// Emit the one instruction a shared [`IntegerExtension`] names, or nothing
+    /// for [`IntegerExtension::None`].
+    ///
+    /// This is the backend's only integer-extension primitive: re-narrowing a
+    /// wrapping or sub-word result, widening a signed cast, and extending a
+    /// call argument or pointer offset all name the extension in the shared
+    /// plan and reach the machine through here (RUE-1982).
+    ///
+    /// [`IntegerExtension`]: crate::value_plan::IntegerExtension
+    /// [`IntegerExtension::None`]: crate::value_plan::IntegerExtension::None
+    fn emit_extension(
+        &mut self,
+        dst: VReg,
+        src: VReg,
+        extension: crate::value_plan::IntegerExtension,
+    ) {
+        use crate::value_plan::IntegerExtension;
+        let dst = Operand::Virtual(dst);
+        let src = Operand::Virtual(src);
+        self.mir.push(match extension {
+            IntegerExtension::None => return,
+            IntegerExtension::Sign8 => X86Inst::Movsx8To64 { dst, src },
+            IntegerExtension::Zero8 => X86Inst::Movzx8To64 { dst, src },
+            IntegerExtension::Sign16 => X86Inst::Movsx16To64 { dst, src },
+            IntegerExtension::Zero16 => X86Inst::Movzx16To64 { dst, src },
+            IntegerExtension::Sign32 => X86Inst::Movsx32To64 { dst, src },
+        });
     }
 
     /// Allocate a new inline label ID.
@@ -938,6 +910,7 @@ impl<'a> CfgLower<'a> {
         let overflow_call = plan.overflow_call;
         let div_by_zero_call = plan.div_by_zero_call;
         let wrap = plan.wrap;
+        let post_op = plan.post_op;
         let vreg = match plan.operation {
             ArithmeticOperation::FloatAdd { lhs, rhs, width }
             | ArithmeticOperation::FloatSub { lhs, rhs, width }
@@ -990,11 +963,7 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(rhs),
                     }
                 });
-                if wrap {
-                    self.emit_wrap_narrow(width, vreg);
-                } else {
-                    self.emit_overflow_check(width, vreg, overflow_call.clone());
-                }
+                self.emit_post_op(post_op, vreg, overflow_call.clone());
                 vreg
             }
             ArithmeticOperation::Sub { lhs, rhs, width } => {
@@ -1014,11 +983,7 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(rhs),
                     }
                 });
-                if wrap {
-                    self.emit_wrap_narrow(width, vreg);
-                } else {
-                    self.emit_overflow_check(width, vreg, overflow_call.clone());
-                }
+                self.emit_post_op(post_op, vreg, overflow_call.clone());
                 vreg
             }
             ArithmeticOperation::Mul {
@@ -1049,7 +1014,7 @@ impl<'a> CfgLower<'a> {
                             src: Operand::Virtual(rhs),
                         }
                     });
-                    self.emit_wrap_narrow(width, vreg);
+                    self.emit_post_op(post_op, vreg, overflow_call.clone());
                 } else if let Some((src, amount)) = shift.filter(|_| width.bits >= 32) {
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Virtual(vreg),
@@ -1127,7 +1092,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Physical(Reg::Rax),
                     });
-                    self.emit_overflow_check(width, vreg, overflow_call.clone());
+                    self.emit_post_op(post_op, vreg, overflow_call.clone());
                 } else {
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Virtual(vreg),
@@ -1144,7 +1109,7 @@ impl<'a> CfgLower<'a> {
                             src: Operand::Virtual(rhs),
                         }
                     });
-                    self.emit_overflow_check(width, vreg, overflow_call.clone());
+                    self.emit_post_op(post_op, vreg, overflow_call.clone());
                 }
                 vreg
             }
@@ -1225,7 +1190,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                     }
                 });
-                self.emit_overflow_check(width, vreg, overflow_call.clone());
+                self.emit_post_op(post_op, vreg, overflow_call.clone());
                 vreg
             }
         };
@@ -1770,7 +1735,7 @@ impl<'a> CfgLower<'a> {
                 });
                 dst
             }
-            ResidualValuePlan::BitNot { value } => {
+            ResidualValuePlan::BitNot { value, narrow } => {
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Virtual(dst),
@@ -1785,7 +1750,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(dst),
                     }
                 });
-                self.emit_subword_narrow(dst, ty);
+                self.emit_extension(dst, dst, narrow);
                 dst
             }
             ResidualValuePlan::Bitwise { op, lhs, rhs } => {
@@ -1828,6 +1793,7 @@ impl<'a> CfgLower<'a> {
                 lhs,
                 rhs,
                 constant,
+                narrow,
             } => {
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRR {
@@ -1902,7 +1868,7 @@ impl<'a> CfgLower<'a> {
                         },
                     );
                 }
-                self.emit_subword_narrow(dst, ty);
+                self.emit_extension(dst, dst, narrow);
                 dst
             }
             ResidualValuePlan::Comparison {
@@ -2315,6 +2281,8 @@ impl<'a> CfgLower<'a> {
             ResidualValuePlan::IntCast {
                 value,
                 from_width,
+                check,
+                widen,
                 trap_call,
             } => {
                 let dst = self.mir.alloc_vreg();
@@ -2322,17 +2290,8 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(dst),
                     src: Operand::Virtual(value),
                 });
-                let to_width = width.unwrap();
-                self.emit_int_cast_check(value, from_width, to_width, trap_call);
-                if from_width.signed && to_width.bits > from_width.bits {
-                    let src = Operand::Virtual(value);
-                    let dst = Operand::Virtual(dst);
-                    self.mir.push(match from_width.bits {
-                        8 => X86Inst::Movsx8To64 { dst, src },
-                        16 => X86Inst::Movsx16To64 { dst, src },
-                        _ => X86Inst::Movsx32To64 { dst, src },
-                    });
-                }
+                self.emit_int_cast_check(value, from_width, check, trap_call);
+                self.emit_extension(dst, value, widen);
                 dst
             }
             ResidualValuePlan::Drop { actions } => {
@@ -3201,26 +3160,7 @@ impl<'a> CfgLower<'a> {
                             dst: Operand::Virtual(extended),
                             src: Operand::Virtual(offset),
                         });
-                        let dst = Operand::Virtual(extended);
-                        let src = Operand::Virtual(extended);
-                        match extension {
-                            crate::value_plan::IntegerExtension::Sign8 => {
-                                self.mir.push(X86Inst::Movsx8To64 { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::Zero8 => {
-                                self.mir.push(X86Inst::Movzx8To64 { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::Sign16 => {
-                                self.mir.push(X86Inst::Movsx16To64 { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::Zero16 => {
-                                self.mir.push(X86Inst::Movzx16To64 { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::Sign32 => {
-                                self.mir.push(X86Inst::Movsx32To64 { dst, src })
-                            }
-                            crate::value_plan::IntegerExtension::None => unreachable!(),
-                        }
+                        self.emit_extension(extended, extended, extension);
                         extended
                     }
                 };
@@ -3499,302 +3439,222 @@ impl<'a> CfgLower<'a> {
         crate::value_plan::MaterializedValue { primary, slots }
     }
 
-    /// Lower a CFG value (instruction).
-    /// Try to extract a power-of-two shift amount from a constant value.
-    ///
-    /// Returns `Some(shift_amount)` if the value is a constant that is a power of 2
-    /// greater than 1, otherwise returns `None`.
-    ///
-    /// Used for strength reduction: `x * 2^n` can be lowered to `x << n`.
-    fn emit_overflow_check(
+    /// Emit what the shared plan says follows an integer arithmetic operation:
+    /// the re-narrowing of a wrapping result, or the trap guarding a checked
+    /// one (RUE-1982). Which of those a `(width, operation)` needs is decided by
+    /// [`crate::value_plan::post_op_policy`], not here.
+    fn emit_post_op(
         &mut self,
-        width: crate::value_plan::IntegerWidth,
+        policy: crate::value_plan::PostOpPolicy,
         result_vreg: VReg,
         trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
-        let ok_label = self.new_label();
+        use crate::value_plan::PostOpPolicy;
 
-        match (width.bits, width.signed) {
-            // 32-bit and 64-bit unsigned: check carry flag
-            (32 | 64, false) => {
-                self.mir.push(X86Inst::Jae { label: ok_label });
-            }
-            // 32-bit and 64-bit signed: check overflow flag
-            (32 | 64, true) => {
-                self.mir.push(X86Inst::Jno { label: ok_label });
-            }
-            // Sub-word unsigned types: check if result fits in range [0, max]
-            (8, false) => {
-                // Result must be <= 255
-                self.mir.push(X86Inst::CmpRI {
-                    src: Operand::Virtual(result_vreg),
-                    imm: 255,
-                });
-                // Jump if below or equal (unsigned)
-                self.mir.push(X86Inst::Jbe { label: ok_label });
-            }
-            (16, false) => {
-                // Result must be <= 65535
-                let max_vreg = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRI32 {
-                    dst: Operand::Virtual(max_vreg),
-                    imm: 65535,
-                });
-                self.mir.push(X86Inst::CmpRR {
-                    src1: Operand::Virtual(result_vreg),
-                    src2: Operand::Virtual(max_vreg),
-                });
-                // Jump if below or equal (unsigned)
-                self.mir.push(X86Inst::Jbe { label: ok_label });
-            }
-            // Sub-word signed types: check if result fits in range [min, max]
-            (8, true) => {
-                // For i8: result must be in [-128, 127]
-                // Sign-extend to 64-bit and compare with original
-                // If they differ, overflow occurred
-                let sext_vreg = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::Movsx8To64 {
-                    dst: Operand::Virtual(sext_vreg),
-                    src: Operand::Virtual(result_vreg),
-                });
-                // Compare at 32-bit width. The sub-word arithmetic was emitted
-                // as a 32-bit op that zero-extends bits 32-63, so result_vreg's
-                // valid data is only in its low 32 bits. A 64-bit compare against
-                // the sign-extended byte/word (1s in bits 32-63 for a negative
-                // value) would mismatch a legitimately-negative in-range result
-                // and falsely trap (RUE-28 sub, RUE-60 neg). The low 32 bits —
-                // sign-extended byte/word vs the 32-bit result — must match.
-                self.mir.push(X86Inst::CmpRR {
-                    src1: Operand::Virtual(result_vreg),
-                    src2: Operand::Virtual(sext_vreg),
-                });
-                self.mir.push(X86Inst::Jz { label: ok_label });
-            }
-            (16, true) => {
-                // For i16: result must be in [-32768, 32767]
-                // Sign-extend to 64-bit and compare with original
-                let sext_vreg = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::Movsx16To64 {
-                    dst: Operand::Virtual(sext_vreg),
-                    src: Operand::Virtual(result_vreg),
-                });
-                // Compare at 32-bit width. The sub-word arithmetic was emitted
-                // as a 32-bit op that zero-extends bits 32-63, so result_vreg's
-                // valid data is only in its low 32 bits. A 64-bit compare against
-                // the sign-extended byte/word (1s in bits 32-63 for a negative
-                // value) would mismatch a legitimately-negative in-range result
-                // and falsely trap (RUE-28 sub, RUE-60 neg). The low 32 bits —
-                // sign-extended byte/word vs the 32-bit result — must match.
-                self.mir.push(X86Inst::CmpRR {
-                    src1: Operand::Virtual(result_vreg),
-                    src2: Operand::Virtual(sext_vreg),
-                });
-                self.mir.push(X86Inst::Jz { label: ok_label });
-            }
-            // Other types (bool, unit, struct, etc.) don't have arithmetic
-            _ => {
-                // No overflow check needed
+        match policy {
+            // A wrapping result never traps, so no ok-label is needed.
+            PostOpPolicy::Narrow(extension) => {
+                self.emit_extension(result_vreg, result_vreg, extension);
                 return;
             }
+            PostOpPolicy::None => return,
+            PostOpPolicy::OverflowFlags { .. } | PostOpPolicy::RangeCheck(_) => {}
         }
 
-        // Overflow occurred - call panic handler
+        let ok_label = self.new_label();
+        match policy {
+            // The ALU op the plan's width selected already set the flags: CF for
+            // an unsigned carry or borrow, OF for a signed overflow.
+            PostOpPolicy::OverflowFlags { signed: false } => {
+                self.mir.push(X86Inst::Jae { label: ok_label });
+            }
+            PostOpPolicy::OverflowFlags { signed: true } => {
+                self.mir.push(X86Inst::Jno { label: ok_label });
+            }
+            PostOpPolicy::RangeCheck(check) => {
+                self.emit_sub_word_check(check, result_vreg, ok_label);
+            }
+            PostOpPolicy::None | PostOpPolicy::Narrow(_) => unreachable!("handled above"),
+        }
+
+        // Out of range - call panic handler
         let _ = self.lower_runtime_call(trap_call.clone());
         self.mir.push(X86Inst::Label { id: ok_label });
     }
 
-    /// Emit an aborting call to `__rue_panic(ptr, len)` for `@panic("msg")` and
-    /// `@assert(cond, "msg")` (RUE-319). `msg_val` is the CFG value of the
-    /// message `String`; its fat pointer supplies the `ptr`/`len` arguments.
-    /// Never returns at runtime.
+    /// Branch to `ok_label` when a sub-word result the machine computed at
+    /// 32-bit width is back inside its declared range.
+    ///
+    /// Both comparisons run at 32-bit width. The sub-word arithmetic was
+    /// emitted as a 32-bit op that zero-extends bits 32-63, so `result_vreg`'s
+    /// valid data is only in its low 32 bits; a 64-bit compare against the
+    /// sign-extended byte/word (1s in bits 32-63 for a negative value) would
+    /// mismatch a legitimately-negative in-range result and falsely trap
+    /// (RUE-28 sub, RUE-60 neg).
+    fn emit_sub_word_check(
+        &mut self,
+        check: crate::value_plan::SubWordCheck,
+        result_vreg: VReg,
+        ok_label: LabelId,
+    ) {
+        use crate::value_plan::SubWordCheck;
+        match check {
+            SubWordCheck::UpperBound { max } => {
+                // A byte bound rides in the compare's immediate; a wider bound
+                // is materialized, as the AArch64 compare's 12-bit immediate
+                // requires, so one plan arm keeps one shape on both targets.
+                match u8::try_from(max) {
+                    Ok(bound) => self.mir.push(X86Inst::CmpRI {
+                        src: Operand::Virtual(result_vreg),
+                        imm: i32::from(bound),
+                    }),
+                    Err(_) => {
+                        let max_vreg = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::MovRI32 {
+                            dst: Operand::Virtual(max_vreg),
+                            imm: i32::try_from(max).expect("sub-word upper bound"),
+                        });
+                        self.mir.push(X86Inst::CmpRR {
+                            src1: Operand::Virtual(result_vreg),
+                            src2: Operand::Virtual(max_vreg),
+                        });
+                    }
+                }
+                // Jump if below or equal (unsigned)
+                self.mir.push(X86Inst::Jbe { label: ok_label });
+            }
+            SubWordCheck::SignExtended { extension } => {
+                let sext_vreg = self.mir.alloc_vreg();
+                self.emit_extension(sext_vreg, result_vreg, extension);
+                self.mir.push(X86Inst::CmpRR {
+                    src1: Operand::Virtual(result_vreg),
+                    src2: Operand::Virtual(sext_vreg),
+                });
+                self.mir.push(X86Inst::Jz { label: ok_label });
+            }
+        }
+    }
+
+    /// Emit the range check an `@intCast` needs before its result is used.
+    ///
+    /// Which bounds a cast is checked against is decided once, for both
+    /// targets, by [`crate::value_plan::int_cast_check_plan`]; this emits the
+    /// compare, the branch, and the trap call for the arm it is handed
+    /// (RUE-1982). Only the comparison width is chosen here: a 64-bit source
+    /// must be compared at 64 bits, or a value above 2^32 would pass an i32
+    /// range check and silently truncate (RUE-31).
     fn emit_int_cast_check(
         &mut self,
         src_vreg: VReg,
         from_width: crate::value_plan::IntegerWidth,
-        to_width: crate::value_plan::IntegerWidth,
+        check: crate::value_plan::IntCastCheckPlan,
         trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
-        let from_signed = from_width.signed;
-        let to_signed = to_width.signed;
-        let from_bits = from_width.bits;
-        let to_bits = to_width.bits;
+        use crate::value_plan::IntCastCheckPlan;
 
-        // If casting to a larger or equal-sized type with compatible signedness,
-        // and source is unsigned or both are signed, no check needed
-        if to_bits >= from_bits {
-            // Widening or same-size cast
-            if from_signed == to_signed {
-                // Same signedness, widening - always safe
-                return;
-            }
-            if !from_signed && to_signed && to_bits > from_bits {
-                // Unsigned to larger signed - always safe
-                return;
-            }
-            // Signed to same-size unsigned needs check (negative values fail)
-            // Unsigned to same-size signed needs check (large values fail)
+        if check == IntCastCheckPlan::None {
+            return;
         }
-
+        let wide = from_width.bits > 32;
         let ok_label = self.new_label();
 
-        // Calculate the min and max values for the target type
-        let (min_val, max_val) = crate::value_plan::integer_range(to_width);
+        match check {
+            IntCastCheckPlan::None => unreachable!("handled above"),
+            IntCastCheckPlan::Range { min, max } => {
+                // Signed source, signed target: below MIN, then above MAX.
+                let min_vreg = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRI64 {
+                    dst: Operand::Virtual(min_vreg),
+                    imm: min,
+                });
+                self.push_cmp_rr(src_vreg, min_vreg, wide);
+                self.mir.push(X86Inst::Jge { label: ok_label });
 
-        if from_signed {
-            // Source is signed - need to check both min and max
-            if to_signed {
-                // Signed to signed: check MIN <= value <= MAX
-                if to_bits < from_bits || (to_bits == from_bits && min_val != i64::MIN) {
-                    // Check lower bound
-                    let min_vreg = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::MovRI64 {
-                        dst: Operand::Virtual(min_vreg),
-                        imm: min_val,
-                    });
-                    if from_bits > 32 {
-                        self.mir.push(X86Inst::Cmp64RR {
-                            src1: Operand::Virtual(src_vreg),
-                            src2: Operand::Virtual(min_vreg),
-                        });
-                    } else {
-                        self.mir.push(X86Inst::CmpRR {
-                            src1: Operand::Virtual(src_vreg),
-                            src2: Operand::Virtual(min_vreg),
-                        });
-                    }
-                    // For signed comparison, use Jge (jump if greater or equal to min)
-                    self.mir.push(X86Inst::Jge { label: ok_label });
+                // Below min - panic
+                let _ = self.lower_runtime_call(trap_call.clone());
+                self.mir.push(X86Inst::Label { id: ok_label });
 
-                    // Below min - panic
-                    let _ = self.lower_runtime_call(trap_call.clone());
-                    self.mir.push(X86Inst::Label { id: ok_label });
+                let ok_label2 = self.new_label();
+                let max_vreg = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRI64 {
+                    dst: Operand::Virtual(max_vreg),
+                    imm: max,
+                });
+                self.push_cmp_rr(src_vreg, max_vreg, wide);
+                self.mir.push(X86Inst::Jle { label: ok_label2 });
 
-                    let ok_label2 = self.new_label();
-                    // Check upper bound
-                    let max_vreg = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::MovRI64 {
-                        dst: Operand::Virtual(max_vreg),
-                        imm: max_val,
-                    });
-                    if from_bits > 32 {
-                        self.mir.push(X86Inst::Cmp64RR {
-                            src1: Operand::Virtual(src_vreg),
-                            src2: Operand::Virtual(max_vreg),
-                        });
-                    } else {
-                        self.mir.push(X86Inst::CmpRR {
-                            src1: Operand::Virtual(src_vreg),
-                            src2: Operand::Virtual(max_vreg),
-                        });
-                    }
-                    self.mir.push(X86Inst::Jle { label: ok_label2 });
-
-                    // Above max - panic
-                    let _ = self.lower_runtime_call(trap_call.clone());
-                    self.mir.push(X86Inst::Label { id: ok_label2 });
-                }
-            } else {
-                // Signed to unsigned: value must be >= 0 and <= max
-                // Check for negative
-                if from_bits > 32 {
-                    self.mir.push(X86Inst::Cmp64RI {
+                // Above max - panic
+                let _ = self.lower_runtime_call(trap_call.clone());
+                self.mir.push(X86Inst::Label { id: ok_label2 });
+            }
+            IntCastCheckPlan::NonNegative { then_max } => {
+                // Signed source, unsigned target: negative first, then the
+                // upper bound when the target cannot hold every non-negative
+                // source value.
+                self.mir.push(if wide {
+                    X86Inst::Cmp64RI {
                         src: Operand::Virtual(src_vreg),
                         imm: 0,
-                    });
+                    }
                 } else {
-                    self.mir.push(X86Inst::CmpRI {
+                    X86Inst::CmpRI {
                         src: Operand::Virtual(src_vreg),
                         imm: 0,
-                    });
-                }
+                    }
+                });
                 self.mir.push(X86Inst::Jge { label: ok_label });
 
                 // Negative - panic
                 let _ = self.lower_runtime_call(trap_call.clone());
                 self.mir.push(X86Inst::Label { id: ok_label });
 
-                // Also check upper bound if narrowing
-                if to_bits < from_bits {
+                if let Some(max) = then_max {
                     let ok_label2 = self.new_label();
                     let max_vreg = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::MovRI64 {
                         dst: Operand::Virtual(max_vreg),
-                        imm: max_val,
+                        imm: max,
                     });
-                    if from_bits > 32 {
-                        self.mir.push(X86Inst::Cmp64RR {
-                            src1: Operand::Virtual(src_vreg),
-                            src2: Operand::Virtual(max_vreg),
-                        });
-                        // Unsigned comparison for upper bound check
-                        self.mir.push(X86Inst::Jbe { label: ok_label2 });
-                    } else {
-                        self.mir.push(X86Inst::CmpRR {
-                            src1: Operand::Virtual(src_vreg),
-                            src2: Operand::Virtual(max_vreg),
-                        });
-                        self.mir.push(X86Inst::Jbe { label: ok_label2 });
-                    }
+                    self.push_cmp_rr(src_vreg, max_vreg, wide);
+                    // Unsigned comparison for the upper bound
+                    self.mir.push(X86Inst::Jbe { label: ok_label2 });
 
                     // Above max - panic
                     let _ = self.lower_runtime_call(trap_call.clone());
                     self.mir.push(X86Inst::Label { id: ok_label2 });
                 }
             }
-        } else {
-            // Source is unsigned
-            if to_signed {
-                // Unsigned to signed: value must fit in positive range of target
-                // Check that value <= signed max
+            IntCastCheckPlan::Max(max) => {
+                // Unsigned source: one upper bound, compared as unsigned.
                 let max_vreg = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRI64 {
                     dst: Operand::Virtual(max_vreg),
-                    imm: max_val,
+                    imm: max,
                 });
-                if from_bits > 32 {
-                    self.mir.push(X86Inst::Cmp64RR {
-                        src1: Operand::Virtual(src_vreg),
-                        src2: Operand::Virtual(max_vreg),
-                    });
-                } else {
-                    self.mir.push(X86Inst::CmpRR {
-                        src1: Operand::Virtual(src_vreg),
-                        src2: Operand::Virtual(max_vreg),
-                    });
-                }
-                // Unsigned comparison
+                self.push_cmp_rr(src_vreg, max_vreg, wide);
                 self.mir.push(X86Inst::Jbe { label: ok_label });
 
                 // Above max - panic
                 let _ = self.lower_runtime_call(trap_call.clone());
                 self.mir.push(X86Inst::Label { id: ok_label });
-            } else {
-                // Unsigned to unsigned: narrowing check
-                if to_bits < from_bits {
-                    let max_vreg = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::MovRI64 {
-                        dst: Operand::Virtual(max_vreg),
-                        imm: max_val,
-                    });
-                    if from_bits > 32 {
-                        self.mir.push(X86Inst::Cmp64RR {
-                            src1: Operand::Virtual(src_vreg),
-                            src2: Operand::Virtual(max_vreg),
-                        });
-                    } else {
-                        self.mir.push(X86Inst::CmpRR {
-                            src1: Operand::Virtual(src_vreg),
-                            src2: Operand::Virtual(max_vreg),
-                        });
-                    }
-                    self.mir.push(X86Inst::Jbe { label: ok_label });
-
-                    // Above max - panic
-                    let _ = self.lower_runtime_call(trap_call.clone());
-                    self.mir.push(X86Inst::Label { id: ok_label });
-                }
             }
         }
+    }
+
+    /// Push a register-register compare at the width of the compared value:
+    /// `Cmp64RR` for a 64-bit source, `CmpRR` otherwise.
+    fn push_cmp_rr(&mut self, src1: VReg, src2: VReg, wide: bool) {
+        self.mir.push(if wide {
+            X86Inst::Cmp64RR {
+                src1: Operand::Virtual(src1),
+                src2: Operand::Virtual(src2),
+            }
+        } else {
+            X86Inst::CmpRR {
+                src1: Operand::Virtual(src1),
+                src2: Operand::Virtual(src2),
+            }
+        });
     }
 
     /// Emit a comparison instruction.


### PR DESCRIPTION
Part of the RUE-1962 duplicate-functionality audit (RUE-1982): the integer-cast range-check decision tree and the sub-word overflow and re-narrowing width tables were re-derived in each backend (three times within AArch64). They are now decided once on the value plan, and the backends are emitters.

## Plan types (`crates/rue-codegen/src/value_plan.rs`)

- `IntCastCheckPlan { None | Range { min, max } | NonNegative { then_max } | Max(i64) }`, built by `int_cast_check_plan(from, to)` from `rue_air::integer_semantics::IntegerType::fits_i128` on the source's endpoints rather than bit-count comparisons; carried on `ResidualValuePlan::IntCast` with the `widen` extension a widening signed cast takes.
- `PostOpPolicy { None | OverflowFlags { signed } | RangeCheck(SubWordCheck) | Narrow(IntegerExtension) }` with `SubWordCheck { UpperBound { max } | SignExtended { extension } }`, built by `post_op_policy(operation, wrap)` and carried on `ArithmeticPlan::post_op`; `ArithmeticPlan::new` is the only constructor.
- `width_extension(IntegerWidth)` is the one extension table (`integer_extension(Type)` delegates to it); `narrowing_extension` is that table minus the 32-bit case for results computed at a wider width.

## What the backends emit

Each backend keeps one `emit_extension(dst, src, IntegerExtension)` primitive and emits `compare + branch + trap` per plan arm. The only target decisions left are the comparison width, AArch64's sign extension of a sub-64-bit source before the `>= 0` test (now named through `width_extension`), AArch64's per-operation flag reading (`B.lo`/`B.hs`/`Bvc`, `Cbz` for the sub-word unsigned negate arm), and the 32-bit repair after a 64-bit `MUL`, which stays a backend-local branch inside `emit_wrap_narrow_mul`.

Deleted: x86-64 `emit_overflow_check`'s width table, `emit_subword_narrow`, `emit_wrap_narrow`; AArch64 `emit_subword_range_check`, `emit_overflow_check_{add,sub,neg}`, `emit_subword_narrow`, `emit_wrap_narrow_subword`, the table inside `emit_wrap_narrow_mul`; the inline extension matches in both backends' call-argument and pointer-offset paths; and the `from_signed`/`to_signed`/`to_bits` re-derivation at the head of both cast checks.

## Guards and tests

Five cross-target unit tests enumerate every `(from, to)` cast pair and every `(bits, signed)` arithmetic shape against the plan, and an api-inventory guard asserts the owners live in `value_plan.rs`, that none of the deleted function names return in either backend, that no width re-derivation (`type_bits`, `type_is_signed`, `65535`, and so on) appears in either backend's production prefix, and that each backend has exactly one `emit_extension`.

## Byte identity

All 24 executables identical before and after: `examples/lattice/main.rue` and a generated probe covering all 64 `@intCast` pairs among the eight integer widths, every arithmetic, bitwise and shift operator, `@wrapping_*`, negation and constant-multiply strength reduction at every width, at `-O0`..`-O3` on x86-64-linux, aarch64-linux and aarch64-macos. The trunk baseline was re-recorded from a clean checkout and reproduced the earlier record byte for byte.

## Validation

`scripts/rue premerge` passes locally apart from the two sandbox-environmental CLI cases (`remove_dir_all_permission_denied_is_not_partial_success`, `tcp_ipv6_loopback_round_trip`); oracle-diff, the planted-miscompile validation and the codegen debug-assert gate pass. No planted-miscompile preimage moved.

Closes RUE-1982

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_