### PR TITLE
Carry an array repeat as one element and a count

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -2062,7 +2062,7 @@ impl Air {
                         }
                     }
                 }
-                AirInstData::ArrayInit { elements } => {
+                AirInstData::ArrayInit { elements, shape } => {
                     validate_type(inst.ty).map_err(|reason| {
                         fail(Some(index), format!("invalid array identity: {reason}"))
                     })?;
@@ -2070,6 +2070,12 @@ impl Air {
                         return Err(fail(
                             Some(index),
                             "array initialization result is not an array type".into(),
+                        ));
+                    }
+                    if matches!(shape, ArrayInitShape::Repeat) && elements.len() != 1 {
+                        return Err(fail(
+                            Some(index),
+                            "array repeat carries exactly one element reference".into(),
                         ));
                     }
                     for &raw in self
@@ -2550,11 +2556,32 @@ impl Air {
         ty: Type,
         span: Span,
     ) -> Result<AirRef, AirBuildError> {
+        self.add_array_init_shaped(elements, ArrayInitShape::Elementwise, ty, span)
+    }
+
+    /// Build the repeat form of an array construction: one element reference
+    /// standing for every element of `ty` (RUE-2069).
+    pub(crate) fn add_array_repeat(
+        &mut self,
+        value: AirRef,
+        ty: Type,
+        span: Span,
+    ) -> Result<AirRef, AirBuildError> {
+        self.add_array_init_shaped(&[value], ArrayInitShape::Repeat, ty, span)
+    }
+
+    fn add_array_init_shaped(
+        &mut self,
+        elements: &[AirRef],
+        shape: ArrayInitShape,
+        ty: Type,
+        span: Span,
+    ) -> Result<AirRef, AirBuildError> {
         self.preflight_refs("array elements", elements.iter().copied())?;
         self.reserve_instruction("array elements")?;
         let elements = self.add_array_elements(elements)?;
         Ok(self.push_inst(AirInst {
-            data: AirInstData::ArrayInit { elements },
+            data: AirInstData::ArrayInit { elements, shape },
             ty,
             span,
         }))
@@ -2613,6 +2640,16 @@ impl Air {
     #[inline]
     pub fn is_borrow_slot(&self, slot: u32) -> bool {
         self.borrow_slots.contains(&slot)
+    }
+
+    /// Every recorded borrow slot, in the order they were recorded (see
+    /// `borrow_slots`). Consumers that need the whole set read it here rather
+    /// than asking [`Self::is_borrow_slot`] about each slot of the frame: a
+    /// single array local can own a hundred million slots, while this list
+    /// holds one entry per borrowing binder (RUE-2069).
+    #[inline]
+    pub(crate) fn borrow_slots(&self) -> &[u32] {
+        &self.borrow_slots
     }
 
     /// Add an instruction and return its reference.
@@ -3453,6 +3490,22 @@ pub struct AirInst {
     pub span: Span,
 }
 
+/// How an array-construction payload describes the array's elements.
+///
+/// A repeat literal (`[value; count]`) names one value and a count, and that
+/// count is the array type's own length. Keeping the shape symbolic through
+/// AIR, the CFG and code generation is what lets a large repeat cost the same
+/// as a small one: an elementwise payload is proportional to the array's
+/// length in every representation that carries it (RUE-2069).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArrayInitShape {
+    /// One payload entry per element, in index order.
+    Elementwise,
+    /// One payload entry repeated for every element of the array. The element
+    /// count is the length of the instruction's array type.
+    Repeat,
+}
+
 /// AIR instruction data - fully typed operations.
 #[derive(Debug)]
 pub enum AirInstData {
@@ -3678,11 +3731,14 @@ pub enum AirInstData {
     },
 
     // Array operations
-    /// Create a new array with initialized elements.
+    /// Create a new array value.
     /// The array type is stored in `AirInst.ty` as `Type::new_array(...)`.
     ArrayInit {
-        /// Start index into extra array for element refs
+        /// Start index into extra array for element refs. A
+        /// [`ArrayInitShape::Repeat`] payload holds exactly one ref.
         elements: AirArrayElements,
+        /// How the payload describes the array's elements.
+        shape: ArrayInitShape,
     },
 
     // Place operations
@@ -4024,7 +4080,10 @@ impl Air {
                     }
                     writeln!(f, "]")?;
                 }
-                AirInstData::ArrayInit { elements } => {
+                AirInstData::ArrayInit {
+                    elements,
+                    shape: ArrayInitShape::Elementwise,
+                } => {
                     write!(f, "array_init [")?;
                     for (i, elem) in self.get_array_elements(elements).enumerate() {
                         if i > 0 {
@@ -4033,6 +4092,18 @@ impl Air {
                         write!(f, "{}", elem)?;
                     }
                     writeln!(f, "]")?;
+                }
+                AirInstData::ArrayInit {
+                    elements,
+                    shape: ArrayInitShape::Repeat,
+                } => {
+                    // The repeat count is the array type's length, which this
+                    // printer has no type pool to resolve.
+                    let value = self
+                        .get_array_elements(elements)
+                        .next()
+                        .expect("an array repeat carries its repeated value");
+                    writeln!(f, "array_repeat [{}]", value)?;
                 }
                 AirInstData::PlaceRead { place } => {
                     write!(f, "place_read ")?;

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -67,7 +67,7 @@ pub use inst::{
     AirEnumPayload, AirInst, AirInstData, AirIntrinsicArgs, AirMatchArms, AirParamMode, AirPattern,
     AirPayloadError, AirPayloadStorageStats, AirPlace, AirPlaceBase, AirPlaceRef, AirProjection,
     AirRef, AirSourceOrder, AirStructFields, AirTypeArgs, AirValidationContext, AirValidationError,
-    AirValidationErrorKind, MAX_AIR_INSTRUCTIONS_PER_BODY, ValidatedAir,
+    AirValidationErrorKind, ArrayInitShape, MAX_AIR_INSTRUCTIONS_PER_BODY, ValidatedAir,
 };
 pub use integer_semantics::IntegerType;
 pub use intern_pool::{

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -1996,10 +1996,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// 2. requires the element type to be `Copy` — a repeat materializes
     ///    `count` copies of one value, which is only sound for Copy elements
     ///    (matching Rust's `[v; N]: Copy`);
-    /// 3. evaluates `value` exactly once and desugars to an `ArrayInit` whose
-    ///    `count` elements all reference that single evaluated value, so the
-    ///    existing per-element store lowering fills every slot on both
-    ///    backends with no codegen changes.
+    /// 3. evaluates `value` exactly once (spec 7.1:39) and builds the repeat
+    ///    form of `ArrayInit`: one element reference plus the array type's
+    ///    length, which the CFG carries unchanged and both backends lower to
+    ///    a fill (RUE-2069).
     fn analyze_array_repeat(
         &mut self,
         air: &mut Air,
@@ -2073,17 +2073,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // cannot hold — either on their own (it is one slot looser) or once
         // earlier locals have spent part of the budget. Such a repeat is
         // rejected by the binding's or temporary's `reserve_frame_slots`, but
-        // only after this expansion has already built one element reference
-        // per element: `[0; 268435455]` cost about 8 s and 2 GB to produce a
-        // diagnostic that depends on nothing but the layout (RUE-2059). Ask
-        // the frame budget first so rejecting an unrepresentable repeat is
-        // O(1); accepted repeats are unaffected, since a region that fits here
-        // still fits when the owning storage reserves it.
+        // only after the whole initializer has been analyzed, and the answer
+        // depends on nothing but the layout (RUE-2059). Ask the frame budget
+        // here so an unrepresentable repeat is diagnosed at the literal
+        // itself; accepted repeats are unaffected, since a region that fits
+        // here still fits when the owning storage reserves it.
         self.require_frame_slots_fit(ctx.next_slot, array_slots, span)?;
 
-        // Desugar to ArrayInit: `length` elements, each the single value.
-        let elem_refs = vec![value_result.air_ref; length as usize];
-        let air_ref = air.add_array_init(&elem_refs, array_type, span)?;
+        // Keep the repeat symbolic: one element reference plus the array
+        // type's own length. Expanding it here made every later
+        // representation — the AIR body, the CFG, and one machine store per
+        // element — proportional to the count, so a valid `[0; 100000000]`
+        // could not be compiled at all (RUE-2069).
+        let air_ref = air.add_array_repeat(value_result.air_ref, array_type, span)?;
 
         // The value expression is evaluated exactly once even when the length
         // is 0 (spec 7.1:39). With no element referencing it the evaluation

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -708,20 +708,26 @@ mod tests {
             "the non-consuming frame probe asks the reserving path, not a second budget rule"
         );
 
-        // RUE-2059: an array-repeat literal expands one element reference per
-        // element, so the frame budget must be asked before that expansion,
-        // not after. Rejecting `[0; 268435455]` otherwise costs seconds and
-        // gigabytes for a diagnostic decided entirely by the layout.
+        // RUE-2059: a repeat's rejection is decided entirely by its layout, so
+        // the frame budget is asked before the rest of the literal is built,
+        // not after. RUE-2069: what follows is the symbolic repeat form — one
+        // element reference and the array type's length — and never a payload
+        // with one entry per element, so a huge accepted repeat costs no more
+        // than a small one.
         let repeat = method_item(AGGREGATES_SOURCE, "analyze_array_repeat");
         let probe_at = repeat
             .find("self.require_frame_slots_fit(")
             .expect("the repeat path asks the frame budget");
-        let expand_at = repeat
-            .find("vec![value_result.air_ref;")
-            .expect("the repeat path expands one element reference per element");
+        let build_at = repeat
+            .find("air.add_array_repeat(value_result.air_ref,")
+            .expect("the repeat path builds the symbolic repeat form");
         assert!(
-            probe_at < expand_at,
-            "the frame-budget check must precede the per-element payload expansion"
+            probe_at < build_at,
+            "the frame-budget check must precede the array construction"
+        );
+        assert!(
+            !repeat.contains("vec![value_result.air_ref;"),
+            "the repeat path must not expand one element reference per element"
         );
 
         let checked = method_item(engine_owner, "checked_abi_slot_count");

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -442,12 +442,13 @@ pub(crate) fn export_body<H: SemanticBodyExportHost>(
                     .collect::<Result<Vec<_>, _>>()?
                     .into(),
             },
-            AirInstData::ArrayInit { elements } => SemanticBodyInstData::ArrayInit {
+            AirInstData::ArrayInit { elements, shape } => SemanticBodyInstData::ArrayInit {
                 elements: body
                     .get_array_elements(elements)
                     .map(|v| r(v, current))
                     .collect::<Result<Vec<_>, _>>()?
                     .into(),
+                shape: *shape,
             },
             AirInstData::PlaceRead { place: value } => SemanticBodyInstData::PlaceRead {
                 place: place(*value)?,
@@ -516,9 +517,17 @@ pub(crate) fn export_body<H: SemanticBodyExportHost>(
         .iter()
         .map(|(slot, ty)| Ok((*slot, host.export_body_type(*ty)?)))
         .collect::<Result<Vec<_>, F>>()?;
-    let borrow_slots = (0..analyzed.num_locals)
-        .filter(|slot| body.is_borrow_slot(*slot))
+    // Read the recorded set rather than asking about each slot of the frame:
+    // one array local can own a hundred million slots (RUE-2069). Sorted so
+    // the exported body stays canonical whatever order the binders were
+    // recorded in.
+    let mut borrow_slots = body
+        .borrow_slots()
+        .iter()
+        .copied()
+        .filter(|slot| *slot < analyzed.num_locals)
         .collect::<Vec<_>>();
+    borrow_slots.sort_unstable();
     // The recorded references were captured when method resolution selected
     // each winner. Order the payload by content-canonical render so equal
     // recorded sets serialize identically regardless of session-local ids.

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -347,6 +347,9 @@ pub enum SemanticBodyInstData<K, M> {
     },
     ArrayInit {
         elements: Arc<[SemanticBodyRef]>,
+        /// Elementwise, or the repeat form whose single element stands for
+        /// every element of the array type (RUE-2069).
+        shape: crate::ArrayInitShape,
     },
     PlaceRead {
         place: SemanticBodyPlaceRef,
@@ -704,8 +707,9 @@ impl<K, M> SemanticBodyInstData<K, M> {
                 fields: fields.clone(),
                 source_order: source_order.clone(),
             },
-            D::ArrayInit { elements } => D::ArrayInit {
+            D::ArrayInit { elements, shape } => D::ArrayInit {
                 elements: elements.clone(),
+                shape: *shape,
             },
             D::PlaceRead { place } => D::PlaceRead { place: *place },
             D::PlaceWrite { place, value } => D::PlaceWrite {
@@ -914,7 +918,7 @@ impl<K, M> SemanticBodyInstData<K, M> {
                     inst(visitor, *field);
                 }
             }
-            D::ArrayInit { elements } => {
+            D::ArrayInit { elements, .. } => {
                 for element in elements.iter() {
                     inst(visitor, *element);
                 }
@@ -1346,6 +1350,7 @@ mod schema_tests {
             },
             D::ArrayInit {
                 elements: vec![1, 2].into(),
+                shape: crate::ArrayInitShape::Elementwise,
             },
             D::PlaceRead { place: 4 },
             D::PlaceWrite { place: 4, value: 1 },

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -1109,9 +1109,21 @@ where
                     air.add_struct_init(struct_id(struct_key)?, &fields, source_order, ty, span)?;
                     continue;
                 }
-                SemanticBodyInstData::ArrayInit { elements } => {
+                SemanticBodyInstData::ArrayInit { elements, shape } => {
                     let elements = refs(elements, current)?;
-                    air.add_array_init(&elements, ty, span)?;
+                    match shape {
+                        crate::ArrayInitShape::Elementwise => {
+                            air.add_array_init(&elements, ty, span)?;
+                        }
+                        // The repeat form names exactly one element (RUE-2069);
+                        // any other payload is a malformed imported body.
+                        crate::ArrayInitShape::Repeat => {
+                            let [value] = elements[..] else {
+                                return Err(F::InvalidInstructionReference);
+                            };
+                            air.add_array_repeat(value, ty, span)?;
+                        }
+                    }
                     continue;
                 }
                 SemanticBodyInstData::PlaceRead { place } => {

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2608,7 +2608,11 @@ impl<'a> CfgBuilder<'a> {
                 }
             }
 
-            AirInstData::ArrayInit { elements } => {
+            // The payload is carried across as it stands: the repeat shape's
+            // single element stands for every element of the array type, and
+            // code generation fills the region from it (RUE-2069).
+            AirInstData::ArrayInit { elements, shape } => {
+                let shape = *shape;
                 let mut element_vals = Vec::new();
                 for elem in self.air.get_array_elements(elements) {
                     let Some(val) = self.lower_value(elem) else {
@@ -2619,7 +2623,7 @@ impl<'a> CfgBuilder<'a> {
                 // Store elements in extra array
                 let elements_result = self.cfg.push_array_elements(element_vals);
                 let elements = self.payload_or(elements_result, CfgArrayElements::EMPTY, span);
-                let value = self.emit(CfgInstData::ArrayInit { elements }, ty, span);
+                let value = self.emit(CfgInstData::ArrayInit { elements, shape }, ty, span);
                 self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -1368,7 +1368,7 @@ fn translate_data(
                 fields: dst.push_struct_fields(fields)?,
             }
         }
-        ArrayInit { elements } => {
+        ArrayInit { elements, shape } => {
             let elements: Vec<CfgValue> = callee
                 .array_elements(elements)
                 .iter()
@@ -1376,6 +1376,7 @@ fn translate_data(
                 .collect();
             ArrayInit {
                 elements: dst.push_array_elements(elements)?,
+                shape: *shape,
             }
         }
         EnumVariant {

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -34,7 +34,7 @@ const _: () = assert!(std::mem::size_of::<CfgInstData>() <= 32);
 
 use ahash::AHashSet;
 use lasso::{Key, Spur, ThreadedRodeo};
-use rue_air::{EnumId, ParamSlotModes, StructId, Type};
+use rue_air::{ArrayInitShape, EnumId, ParamSlotModes, StructId, Type};
 use rue_span::Span;
 
 use crate::payload::{
@@ -221,8 +221,9 @@ impl CfgInstData {
                 struct_id: *struct_id,
                 fields: fields.duplicate(),
             },
-            Self::ArrayInit { elements } => Self::ArrayInit {
+            Self::ArrayInit { elements, shape } => Self::ArrayInit {
                 elements: elements.duplicate(),
+                shape: *shape,
             },
             Self::EnumVariant {
                 enum_id,
@@ -556,11 +557,15 @@ pub enum CfgInstData {
         fields: CfgStructFields,
     },
     // Array operations
-    /// Array initialization. Element values use the array-element family.
+    /// Array construction. Element values use the array-element family.
     /// The array type is stored in `CfgInst.ty`.
     ArrayInit {
-        /// Start index into Cfg's extra array
+        /// Start index into Cfg's extra array. The repeat shape stores
+        /// exactly one element, standing for every element of the array.
         elements: CfgArrayElements,
+        /// Elementwise, or the repeat form of `[value; count]` whose count is
+        /// the array type's own length (RUE-2069).
+        shape: ArrayInitShape,
     },
     // Enum operations
     /// Create an enum variant value: the discriminant plus (for tuple
@@ -1309,10 +1314,11 @@ impl Cfg {
                         .push_struct_fields(self.struct_fields(fields).iter().copied())
                         .map_err(CfgRemapError::Edit)?,
                 },
-                ArrayInit { elements } => ArrayInit {
+                ArrayInit { elements, shape } => ArrayInit {
                     elements: cfg
                         .push_array_elements(self.array_elements(elements).iter().copied())
                         .map_err(CfgRemapError::Edit)?,
+                    shape: *shape,
                 },
                 EnumVariant {
                     enum_id,
@@ -1850,10 +1856,28 @@ impl Cfg {
         }
     }
 
+    /// The array-element payload of an `ArrayInit`, as stored: one entry per
+    /// element for the elementwise shape, and the single repeated value for
+    /// the repeat shape. A consumer that needs one entry per element asks
+    /// [`Self::array_init_repeat`] first and expands the repeat itself
+    /// (RUE-2069).
     pub fn get_array_elements<'a>(&'a self, data: &CfgInstData) -> &'a [CfgValue] {
         match data {
-            CfgInstData::ArrayInit { elements } => self.array_elements(elements),
+            CfgInstData::ArrayInit { elements, .. } => self.array_elements(elements),
             _ => panic!("get_array_elements called on non-ArrayInit instruction"),
+        }
+    }
+
+    /// The repeated value of an array construction in the repeat shape, whose
+    /// count is the instruction's own array-type length; `None` for the
+    /// elementwise shape and for every other instruction (RUE-2069).
+    pub fn array_init_repeat(&self, data: &CfgInstData) -> Option<CfgValue> {
+        match data {
+            CfgInstData::ArrayInit {
+                elements,
+                shape: ArrayInitShape::Repeat,
+            } => Some(self.array_elements(elements)[0]),
+            _ => None,
         }
     }
 
@@ -1984,26 +2008,35 @@ impl Cfg {
         Ok(())
     }
 
-    /// Replace an array initializer's elements atomically.
+    /// Replace an array initializer's elements atomically. The payload keeps
+    /// the instruction's shape, so a repeat still names exactly one element.
     pub fn replace_array_elements(
         &mut self,
         value: CfgValue,
         values: impl IntoIterator<Item = CfgValue>,
     ) -> Result<(), CfgEditError> {
         const OP: &str = "array elements";
-        if !matches!(
-            self.values.get(value.0 as usize).map(|inst| &inst.data),
-            Some(CfgInstData::ArrayInit { .. })
-        ) {
+        let shape = match self.values.get(value.0 as usize).map(|inst| &inst.data) {
+            Some(CfgInstData::ArrayInit { shape, .. }) => *shape,
+            _ => {
+                return Err(Self::invalid_edit(
+                    OP,
+                    "target is not an ArrayInit instruction",
+                ));
+            }
+        };
+        let staged = Self::stage_edit(OP, values)?;
+        if matches!(shape, ArrayInitShape::Repeat) && staged.len() != 1 {
             return Err(Self::invalid_edit(
                 OP,
-                "target is not an ArrayInit instruction",
+                "an array repeat carries exactly one element",
             ));
         }
-        let staged = Self::stage_edit(OP, values)?;
         self.validate_value_refs(OP, staged.iter(), |value| *value)?;
         let elements = payload::push_array_elements(&mut self.extra, staged)?;
-        let CfgInstData::ArrayInit { elements: stored } = &mut self.values[value.0 as usize].data
+        let CfgInstData::ArrayInit {
+            elements: stored, ..
+        } = &mut self.values[value.0 as usize].data
         else {
             return Err(Self::invalid_edit(OP, "target changed during replacement"));
         };
@@ -2412,11 +2445,34 @@ impl Cfg {
         ))
     }
 
-    /// Append an array initializer owned by this CFG.
+    /// Append an elementwise array initializer owned by this CFG.
     pub fn append_array_init(
         &mut self,
         block: BlockId,
         elements: impl IntoIterator<Item = CfgValue>,
+        ty: Type,
+        span: Span,
+    ) -> Result<CfgValue, CfgEditError> {
+        self.append_array_init_shaped(block, elements, ArrayInitShape::Elementwise, ty, span)
+    }
+
+    /// Append the repeat form `[value; count]`, whose count is `ty`'s own
+    /// array length (RUE-2069).
+    pub fn append_array_repeat(
+        &mut self,
+        block: BlockId,
+        value: CfgValue,
+        ty: Type,
+        span: Span,
+    ) -> Result<CfgValue, CfgEditError> {
+        self.append_array_init_shaped(block, [value], ArrayInitShape::Repeat, ty, span)
+    }
+
+    fn append_array_init_shaped(
+        &mut self,
+        block: BlockId,
+        elements: impl IntoIterator<Item = CfgValue>,
+        shape: ArrayInitShape,
         ty: Type,
         span: Span,
     ) -> Result<CfgValue, CfgEditError> {
@@ -2428,7 +2484,7 @@ impl Cfg {
         Ok(self.add_inst_to_block(
             block,
             CfgInst {
-                data: CfgInstData::ArrayInit { elements },
+                data: CfgInstData::ArrayInit { elements, shape },
                 ty,
                 span,
             },
@@ -3002,7 +3058,7 @@ impl Cfg {
                             .map(&map),
                     )?;
                 }
-                ArrayInit { elements } => {
+                ArrayInit { elements, .. } => {
                     before_payload(payload::CfgArrayElements::FAMILY)?;
                     *elements = payload::push_array_elements(
                         &mut self.extra,
@@ -3471,7 +3527,10 @@ impl Cfg {
                 }
                 write!(f, "}}")
             }
-            CfgInstData::ArrayInit { elements } => {
+            CfgInstData::ArrayInit {
+                elements,
+                shape: ArrayInitShape::Elementwise,
+            } => {
                 write!(f, "array_init [")?;
                 for (i, elem) in self.array_elements(elements).iter().enumerate() {
                     if i > 0 {
@@ -3480,6 +3539,14 @@ impl Cfg {
                     write!(f, "{}", elem)?;
                 }
                 write!(f, "]")
+            }
+            CfgInstData::ArrayInit {
+                elements,
+                shape: ArrayInitShape::Repeat,
+            } => {
+                // The repeat count is the array type's length; this printer
+                // has no type pool to resolve it.
+                write!(f, "array_repeat [{}]", self.array_elements(elements)[0])
             }
             CfgInstData::EnumVariant {
                 enum_id,

--- a/crates/rue-cfg/src/inst/payload_metrics.rs
+++ b/crates/rue-cfg/src/inst/payload_metrics.rs
@@ -25,7 +25,7 @@ impl Cfg {
                 CfgInstData::StructInit { fields, .. } => {
                     account(1, fields.extent(), std::mem::size_of::<CfgValue>())
                 }
-                CfgInstData::ArrayInit { elements } => {
+                CfgInstData::ArrayInit { elements, .. } => {
                     account(2, elements.extent(), std::mem::size_of::<CfgValue>())
                 }
                 CfgInstData::EnumVariant { payload, .. } => {

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -560,7 +560,7 @@ fn capture_operands(cfg: &Cfg, data: &CfgInstData) -> SourceOperands {
         CfgInstData::AccessorCall { args, .. } => operands.call_args = cfg.call_args(args).to_vec(),
         CfgInstData::Intrinsic { .. } => operands.values = cfg.get_intrinsic_args(data).to_vec(),
         CfgInstData::StructInit { .. } => operands.values = cfg.get_struct_fields(data).to_vec(),
-        CfgInstData::ArrayInit { elements } => {
+        CfgInstData::ArrayInit { elements, .. } => {
             operands.values = cfg.array_elements(elements).to_vec();
         }
         CfgInstData::EnumVariant { payload, .. } => {
@@ -838,8 +838,9 @@ fn remap_data(
             struct_id: *struct_id,
             fields: cfg.push_struct_fields(operands.values.iter().map(|v| m(*v)))?,
         },
-        CfgInstData::ArrayInit { .. } => CfgInstData::ArrayInit {
+        CfgInstData::ArrayInit { shape, .. } => CfgInstData::ArrayInit {
             elements: cfg.push_array_elements(operands.values.iter().map(|v| m(*v)))?,
+            shape: *shape,
         },
         CfgInstData::EnumVariant {
             enum_id,

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -329,7 +329,7 @@ impl Cfg {
             CfgInstData::StructInit { fields, .. } => {
                 out.extend_from_slice(self.struct_fields(fields))
             }
-            CfgInstData::ArrayInit { elements } => {
+            CfgInstData::ArrayInit { elements, .. } => {
                 out.extend_from_slice(self.array_elements(elements))
             }
             CfgInstData::EnumVariant { payload, .. } => {
@@ -1508,7 +1508,7 @@ impl<'a> Verifier<'a> {
                             .checked_struct_fields(fields)
                             .map_err(|error| self.payload_error(location, error))?;
                     }
-                    CfgInstData::ArrayInit { elements } => {
+                    CfgInstData::ArrayInit { elements, .. } => {
                         self.cfg
                             .checked_array_elements(elements)
                             .map_err(|error| self.payload_error(location, error))?;
@@ -2179,7 +2179,7 @@ impl<'a> Verifier<'a> {
                     f(operand, "struct field");
                 }
             }
-            CfgInstData::ArrayInit { elements } => {
+            CfgInstData::ArrayInit { elements, .. } => {
                 for &operand in self.cfg.array_elements(elements) {
                     f(operand, "array element");
                 }
@@ -4795,6 +4795,7 @@ mod tests {
             CfgInst {
                 data: CfgInstData::ArrayInit {
                     elements: crate::payload::CfgArrayElements::malformed(u32::MAX, 2),
+                    shape: rue_air::ArrayInitShape::Elementwise,
                 },
                 ty: Type::I32,
                 span: Span::new(0, 0),

--- a/crates/rue-cli-tests/cases/array_repeat.toml
+++ b/crates/rue-cli-tests/cases/array_repeat.toml
@@ -217,3 +217,246 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0903", "type annotation required for empty array"]
+
+# --- filled repeats (RUE-2069) -----------------------------------------------
+#
+# A repeat is carried symbolically — one evaluated element plus the array
+# type's own length — from semantic analysis through the CFG into both
+# backends, which fill the region with a counted loop above
+# `value_plan::REPEAT_FILL_MIN_SLOTS` and keep the unrolled store per slot
+# below it. Every case below fills a region well above that threshold and pins
+# the CONTENTS, because a fill that walks the wrong direction, drops the last
+# element, or mis-strides a multi-slot element still produces a program that
+# runs. Each is pinned on both backends: the loop is built from each backend's
+# own instructions.
+
+[[case]]
+name = "x86_64_linux_filled_repeats_write_every_element"
+description = "Above the fill threshold, a non-zero scalar, a multi-slot Copy struct, a nested repeat and a zero fill each write every element on x86-64 (RUE-2069)."
+files = [{ path = "main.rue", source = """
+@copy
+struct Pair { a: i32, b: i64 }
+
+fn main() -> i32 {
+    let xs: [i32; 100] = [5; 100];
+    let mut sum: i32 = 0;
+    for x in xs {
+        sum = sum + x;
+    }
+    @dbg(sum);
+
+    let ps: [Pair; 40] = [Pair { a: 3, b: 4 }; 40];
+    let mut acc: i64 = 0;
+    for p in ps {
+        acc = acc + p.b;
+    }
+    @dbg(acc);
+    @dbg(ps[0].a + ps[39].a);
+
+    let zs: [[i32; 8]; 8] = [[9; 8]; 8];
+    @dbg(zs[0][0] + zs[7][7]);
+
+    let ws: [[i32; 64]; 4] = [[6; 64]; 4];
+    @dbg(ws[0][0] + ws[3][63] + ws[2][17]);
+
+    let big: [i64; 4096] = [0; 4096];
+    @dbg(big[0] + big[4095]);
+    0
+}
+""" }]
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = """
+500
+160
+6
+18
+18
+0
+"""
+
+[[case]]
+name = "aarch64_linux_filled_repeats_write_every_element"
+description = "The same filled repeats on AArch64, whose fill loop is built from its own instructions (RUE-2069)."
+files = [{ path = "main.rue", source = """
+@copy
+struct Pair { a: i32, b: i64 }
+
+fn main() -> i32 {
+    let xs: [i32; 100] = [5; 100];
+    let mut sum: i32 = 0;
+    for x in xs {
+        sum = sum + x;
+    }
+    @dbg(sum);
+
+    let ps: [Pair; 40] = [Pair { a: 3, b: 4 }; 40];
+    let mut acc: i64 = 0;
+    for p in ps {
+        acc = acc + p.b;
+    }
+    @dbg(acc);
+    @dbg(ps[0].a + ps[39].a);
+
+    let zs: [[i32; 8]; 8] = [[9; 8]; 8];
+    @dbg(zs[0][0] + zs[7][7]);
+
+    let ws: [[i32; 64]; 4] = [[6; 64]; 4];
+    @dbg(ws[0][0] + ws[3][63] + ws[2][17]);
+
+    let big: [i64; 4096] = [0; 4096];
+    @dbg(big[0] + big[4095]);
+    0
+}
+""" }]
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = """
+500
+160
+6
+18
+18
+0
+"""
+
+[[case]]
+name = "x86_64_linux_filled_repeat_evaluates_its_value_once"
+description = "A filled repeat evaluates the repeated value exactly once (spec 7.1:39) though the fill writes it 64 times, as a binding's initializer and as an assignment, on x86-64 (RUE-2069)."
+files = [{ path = "main.rue", source = """
+fn bump(inout counter: i32) -> i32 {
+    counter = counter + 1;
+    7
+}
+
+fn main() -> i32 {
+    let mut calls: i32 = 0;
+    let ys: [i32; 64] = [bump(inout calls); 64];
+    @dbg(calls);
+    @dbg(ys[0] + ys[63]);
+    let mut assigned: [i32; 64] = [0; 64];
+    assigned = [bump(inout calls); 64];
+    @dbg(calls);
+    @dbg(assigned[0] + assigned[63]);
+    0
+}
+""" }]
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = """
+1
+14
+2
+14
+"""
+
+[[case]]
+name = "aarch64_linux_filled_repeat_evaluates_its_value_once"
+description = "The same evaluation-once contract through the AArch64 fill (RUE-2069)."
+files = [{ path = "main.rue", source = """
+fn bump(inout counter: i32) -> i32 {
+    counter = counter + 1;
+    7
+}
+
+fn main() -> i32 {
+    let mut calls: i32 = 0;
+    let ys: [i32; 64] = [bump(inout calls); 64];
+    @dbg(calls);
+    @dbg(ys[0] + ys[63]);
+    let mut assigned: [i32; 64] = [0; 64];
+    assigned = [bump(inout calls); 64];
+    @dbg(calls);
+    @dbg(assigned[0] + assigned[63]);
+    0
+}
+""" }]
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = """
+1
+14
+2
+14
+"""
+
+# A hundred million elements is a valid local inside the frame budget, and it
+# used to be uncompilable: the repeat expanded to one element reference per
+# element in AIR and one machine store per element after it, which was 13 GB of
+# compiler memory and seven bytes of code per element (RUE-2069). The emitted
+# MIR is the whole proof — a counted loop naming the count as its trip count,
+# with no store at a per-element frame offset — and stopping at `--emit mir`
+# keeps the case off an 800 MB stack frame at run time.
+
+[[case]]
+name = "x86_64_linux_hundred_million_element_repeat_is_one_fill"
+description = "A hundred-million-element repeat emits x86-64's counted fill loop, not a store per element (RUE-2069)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let xs: [i8; 100000000] = [0; 100000000];
+    @dbg(xs[0]);
+    0
+}
+""" }]
+args = ["--target", "x86-64-linux", "--emit", "mir", "main.rue"]
+compile_only = true
+# Vreg numbers are not the contract; the shape is: the count appears as a
+# loop trip count, the element is stored through a cursor register, and no
+# store names a per-element frame offset.
+compile_stdout_contains = ["100000000", "jnz .L", "mov [v"]
+compile_stdout_not_contains = ["mov [rbp-"]
+
+[[case]]
+name = "aarch64_linux_hundred_million_element_repeat_is_one_fill"
+description = "The same repeat emits AArch64's counted fill loop (RUE-2069)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let xs: [i8; 100000000] = [0; 100000000];
+    @dbg(xs[0]);
+    0
+}
+""" }]
+args = ["--target", "aarch64-linux", "--emit", "mir", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["#100000000", "cbnz v", ", [v"]
+compile_stdout_not_contains = ["str v0, [fp"]
+
+# The fill is the whole point only if the ARTIFACT stops growing too: the
+# expanded form emitted seven bytes of machine code per element on x86-64, so
+# `[0; 100000000]` linked to roughly 700 MB. `max_executable_bytes` measures
+# the produced executable, which `--emit mir` above cannot. The program is
+# never run: its frame is 800 MB.
+
+[[case]]
+name = "x86_64_linux_hundred_million_element_repeat_object_stays_small"
+description = "A hundred-million-element repeat links to a small x86-64 executable: emitted code does not scale with the count (RUE-2069)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let xs: [i8; 100000000] = [0; 100000000];
+    @dbg(xs[0]);
+    0
+}
+""" }]
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+compile_only = true
+max_executable_bytes = 1048576
+
+[[case]]
+name = "aarch64_linux_hundred_million_element_repeat_object_stays_small"
+description = "The same repeat links to a small AArch64 executable (RUE-2069)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let xs: [i8; 100000000] = [0; 100000000];
+    @dbg(xs[0]);
+    0
+}
+""" }]
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+compile_only = true
+max_executable_bytes = 1048576

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -134,6 +134,9 @@
 //! - `no_symbol_table = true`: assert the produced executable carries no
 //!   symbol table entries, pinning that default internal-linker output is
 //!   unsymbolized (the documented motivation for the profiling workflow)
+//! - `max_executable_bytes`: upper bound on the produced executable's size in
+//!   bytes. For cases whose point is that emitted code does NOT scale with a
+//!   compile-time constant in the source (RUE-2069).
 //!
 //! # Execution modes
 //!
@@ -2001,6 +2004,7 @@ fn case_runs_prebuilt_program(case: &Case) -> bool {
         ffi_answer_archive: false,
         json_diagnostics: false,
         no_symbol_table: false,
+        max_executable_bytes: None,
         requires_system_linker: false,
         // Compile-time assertions, checked below: a staged case must make none.
         error_contains,
@@ -2354,6 +2358,22 @@ fn run_case(
         .map_err(|error| TestFailure::assertion(error.to_string()))?;
     if let Some(target) = executable_target {
         validate_executable(&program, target)?;
+    }
+
+    // Artifact-size bound (RUE-2069): the point of some cases is that emitted
+    // code does not grow with a count written in the source, which only a
+    // measurement of the produced artifact can pin.
+    if let Some(limit) = case.max_executable_bytes {
+        let size = std::fs::metadata(&program)
+            .map_err(|error| {
+                TestFailure::assertion(format!("cannot size {}: {error}", program.display()))
+            })?
+            .len();
+        if size > limit {
+            return Err(TestFailure::assertion(format!(
+                "executable is {size} bytes, over the case's {limit}-byte bound"
+            )));
+        }
     }
 
     // Symbol-table expectations (RUE-1173). The format is the case's declared
@@ -3542,6 +3562,15 @@ fn is_canonical_known_bug_marker(marker: &str) -> bool {
         && bytes[1..].iter().all(u8::is_ascii_digit)
 }
 
+/// `max_executable_bytes` measures a produced executable, so it cannot
+/// accompany `compile_fail` (RUE-2069). Returns the load-time error, if any.
+fn invalid_executable_size_bound(case: &Case) -> Option<&'static str> {
+    (case.compile_fail && case.max_executable_bytes.is_some()).then_some(
+        "`max_executable_bytes` inspects a produced executable and is \
+         incompatible with `compile_fail`",
+    )
+}
+
 /// Symbol-table expectations require a produced executable, so they cannot
 /// accompany `compile_fail`, and asserting an empty table contradicts
 /// asserting its contents (RUE-1173). Returns the load-time error, if any.
@@ -3657,6 +3686,15 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                         std::process::exit(1);
                     }
                     if let Some(reason) = invalid_symbol_expectations(case) {
+                        eprintln!(
+                            "error: {}: case '{}': {}",
+                            path.display(),
+                            case.name,
+                            reason
+                        );
+                        std::process::exit(1);
+                    }
+                    if let Some(reason) = invalid_executable_size_bound(case) {
                         eprintln!(
                             "error: {}: case '{}': {}",
                             path.display(),
@@ -5382,7 +5420,7 @@ mod tests {
         // the compiler's environment, or asserts something about a compile the
         // staged path never runs. ADR-0070 keeps every one of these cases
         // compile-in-harness.
-        let overrides: [(&str, fn(&mut Case)); 17] = [
+        let overrides: [(&str, fn(&mut Case)); 18] = [
             // The one differential_opt calculator case: four compiles by
             // design, at opt levels the runner drives.
             ("differential_opt", |case| case.differential_opt = true),
@@ -5406,6 +5444,9 @@ mod tests {
             ("ffi_answer_archive", |case| case.ffi_answer_archive = true),
             ("json_diagnostics", |case| case.json_diagnostics = true),
             ("no_symbol_table", |case| case.no_symbol_table = true),
+            ("max_executable_bytes", |case| {
+                case.max_executable_bytes = Some(1 << 20)
+            }),
             ("requires_system_linker", |case| {
                 case.requires_system_linker = true
             }),
@@ -5733,6 +5774,31 @@ mod tests {
             ..Default::default()
         };
         assert!(invalid_symbol_expectations(&unsymbolized).is_none());
+    }
+
+    /// An artifact-size bound measures a produced executable, so a case that
+    /// expects no executable cannot carry one (RUE-2069).
+    #[test]
+    fn executable_size_bound_requires_a_produced_executable() {
+        let with_compile_fail = Case {
+            compile_fail: true,
+            max_executable_bytes: Some(1 << 20),
+            ..Default::default()
+        };
+        assert!(invalid_executable_size_bound(&with_compile_fail).is_some());
+
+        let bounded = Case {
+            compile_only: true,
+            max_executable_bytes: Some(1 << 20),
+            ..Default::default()
+        };
+        assert!(invalid_executable_size_bound(&bounded).is_none());
+
+        let unbounded = Case {
+            compile_fail: true,
+            ..Default::default()
+        };
+        assert!(invalid_executable_size_bound(&unbounded).is_none());
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -174,6 +174,9 @@ pub struct CfgLower<'a> {
     fn_name: &'a str,
     /// Maps StructInit CFG values to their field vregs
     struct_slot_vregs: AHashMap<CfgValue, Vec<VReg>>,
+    /// Array repeats deferred to a fill, keyed by their `ArrayInit` value
+    /// (RUE-2069). See `value_plan::ValueLowerAdapter::array_repeat_fills`.
+    array_repeat_fills: AHashMap<CfgValue, crate::value_plan::ArrayRepeatFill>,
     /// Maps by-reference parameter indices to their pointer vregs.
     /// For by-ref params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
@@ -389,6 +392,7 @@ impl<'a> CfgLower<'a> {
             block_param_vregs: AHashMap::with_capacity(estimated_block_params),
             fn_name: cfg.fn_name(),
             struct_slot_vregs: AHashMap::with_capacity(estimated_struct_inits),
+            array_repeat_fills: AHashMap::new(),
             by_ref_param_ptrs: AHashMap::with_capacity(estimated_by_ref_params),
             param_reg_vregs: AHashMap::new(),
         }
@@ -1787,6 +1791,31 @@ impl<'a> CfgLower<'a> {
                     float_width,
                     &leaf_types,
                 );
+                return ValueResult::SideEffect;
+            }
+            // A deferred repeat emits no element stores of its own: the value
+            // is one evaluated element plus a count until the store that
+            // consumes it fills the region (RUE-2069). Its primary is the
+            // same never-read placeholder an `ArrayInit` produces, kept
+            // defined so register allocation sees an ordinary value.
+            ResidualValuePlan::ArrayRepeat => {
+                let dst = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::MovImm {
+                    dst: Operand::Virtual(dst),
+                    imm: 0,
+                });
+                dst
+            }
+            ResidualValuePlan::ArrayFill { destination, fill } => {
+                match destination {
+                    crate::value_plan::StoreDestination::FrameSlot(slot) => {
+                        crate::agg_slots::fill_frame_region(self, &fill, slot);
+                    }
+                    crate::value_plan::StoreDestination::ByRefParam(param_slot) => {
+                        let ptr = self.ensure_by_ref_param_ptr(param_slot);
+                        crate::agg_slots::fill_through_ptr(self, &fill, ptr);
+                    }
+                }
                 return ValueResult::SideEffect;
             }
             ResidualValuePlan::StructInit { fields, .. }
@@ -4024,6 +4053,11 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
             self.struct_slot_vregs.insert(value, result.slots);
         }
     }
+    fn array_repeat_fills(
+        &mut self,
+    ) -> &mut AHashMap<CfgValue, crate::value_plan::ArrayRepeatFill> {
+        &mut self.array_repeat_fills
+    }
 }
 
 impl CfgLower<'_> {
@@ -4693,7 +4727,7 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             width,
         });
     }
-    fn alloc_marshal_label(&mut self) -> LabelId {
+    fn alloc_lowering_label(&mut self) -> LabelId {
         self.mir.alloc_label()
     }
     fn emit_marshal_branch_if_tag_ne(&mut self, tag: VReg, discriminant: u64, label: LabelId) {
@@ -4703,8 +4737,31 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn emit_marshal_jump(&mut self, label: LabelId) {
         self.mir.push(Aarch64Inst::B { label });
     }
-    fn emit_marshal_label(&mut self, label: LabelId) {
+    fn emit_lowering_label(&mut self, label: LabelId) {
         self.mir.push(Aarch64Inst::Label { id: label });
+    }
+    fn emit_fill_counter(&mut self, count: u64) -> VReg {
+        let dst = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(dst),
+            imm: i64::try_from(count).expect("an array fill's count fits a signed immediate"),
+        });
+        dst
+    }
+    fn emit_fill_advance(&mut self, dst: VReg, delta: i64) {
+        // The emitter splits an immediate wider than ADD's 12-bit field, so a
+        // multi-slot element's stride needs no separate materialization here.
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(dst),
+            imm: i32::try_from(delta).expect("an array fill's step fits a 32-bit immediate"),
+        });
+    }
+    fn emit_fill_branch_if_nonzero(&mut self, counter: VReg, label: LabelId) {
+        self.mir.push(Aarch64Inst::Cbnz {
+            src: Operand::Virtual(counter),
+            label,
+        });
     }
 }
 
@@ -5335,6 +5392,12 @@ mod tests {
                 .unwrap()
         }
 
+        fn array_repeat(&mut self, value: CfgValue, ty: Type) -> CfgValue {
+            self.cfg
+                .append_array_repeat(self.current, value, ty, span())
+                .unwrap()
+        }
+
         fn enum_variant(
             &mut self,
             enum_id: EnumId,
@@ -5571,6 +5634,123 @@ mod tests {
     /// frame value lowers on AArch64 in lockstep with x86-64: array `[]`
     /// indexing strides by the *slot* stride (`abi_slot_count(element) *
     /// SLOT_BYTES`) against the slot-shaped frame storage (RUE-975).
+    /// RUE-2069: an array repeat is lowered as a fill whose instruction count
+    /// does not depend on how many elements it writes, while a repeat below
+    /// the threshold keeps the unrolled store-per-slot form it always had.
+    #[test]
+    fn array_repeat_fill_cost_is_independent_of_the_element_count() {
+        fn lower_repeat(count: u64) -> Aarch64Mir {
+            let interner = ThreadedRodeo::new();
+            let pool = TypeInternPool::new();
+            let array_ty = Type::new_array(pool.intern_array_from_type(Type::I32, count));
+            let pool = pool.freeze();
+            let mut fixture = FixtureCfg::new(
+                Type::I32,
+                count as u32,
+                "main",
+                ParamSlotModes::new(vec![], vec![]),
+                vec![],
+                &pool,
+                &interner,
+            );
+            fixture.live(0, array_ty);
+            let seven = fixture.konst(7, Type::I32);
+            let array = fixture.array_repeat(seven, array_ty);
+            fixture.alloc(0, array);
+            fixture.dead(0, array_ty);
+            let zero = fixture.konst(0, Type::I32);
+            fixture.ret(Some(zero));
+            fixture.lower().expect("an array repeat must lower")
+        }
+
+        // Two counts three orders of magnitude apart produce the same
+        // machine code: the fill is a loop over a region, not a store per
+        // element.
+        let small_fill = lower_repeat(1_024);
+        let large_fill = lower_repeat(1_000_000);
+        assert_eq!(small_fill.inst_count(), large_fill.inst_count());
+        // Only the region's base offset and the loop's trip count differ.
+        let opcodes = |mir: &Aarch64Mir| -> Vec<String> {
+            mir.instructions()
+                .iter()
+                .map(|inst| {
+                    inst.to_string()
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or_default()
+                        .to_string()
+                })
+                .collect()
+        };
+        assert_eq!(opcodes(&small_fill), opcodes(&large_fill));
+
+        // Below the threshold the elementwise form stays: one store per slot,
+        // so the count is visible in the instruction total.
+        let unrolled_four = lower_repeat(4);
+        let unrolled_eight = lower_repeat(8);
+        assert_eq!(
+            unrolled_eight.inst_count() - unrolled_four.inst_count(),
+            4,
+            "an unrolled repeat emits one store per element"
+        );
+        assert!(
+            unrolled_four.inst_count() < large_fill.inst_count(),
+            "the fill's fixed cost is what the threshold trades against"
+        );
+    }
+
+    /// A repeat of a repeat is one fill over the whole region, not the inner
+    /// repeat unrolled into the outer loop's body: growing the inner count
+    /// leaves the emitted code unchanged (RUE-2069).
+    #[test]
+    fn a_nested_array_repeat_is_one_fill() {
+        fn lower_nested(inner_count: u64, outer_count: u64) -> Aarch64Mir {
+            let interner = ThreadedRodeo::new();
+            let pool = TypeInternPool::new();
+            let inner_ty = Type::new_array(pool.intern_array_from_type(Type::I32, inner_count));
+            let outer_ty = Type::new_array(pool.intern_array_from_type(inner_ty, outer_count));
+            let pool = pool.freeze();
+            let mut fixture = FixtureCfg::new(
+                Type::I32,
+                (inner_count * outer_count) as u32,
+                "main",
+                ParamSlotModes::new(vec![], vec![]),
+                vec![],
+                &pool,
+                &interner,
+            );
+            fixture.live(0, outer_ty);
+            let seven = fixture.konst(7, Type::I32);
+            let inner = fixture.array_repeat(seven, inner_ty);
+            let outer = fixture.array_repeat(inner, outer_ty);
+            fixture.alloc(0, outer);
+            fixture.dead(0, outer_ty);
+            let zero = fixture.konst(0, Type::I32);
+            fixture.ret(Some(zero));
+            fixture.lower().expect("a nested array repeat must lower")
+        }
+
+        let opcodes = |mir: &Aarch64Mir| -> Vec<String> {
+            mir.instructions()
+                .iter()
+                .map(|inst| {
+                    inst.to_string()
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or_default()
+                        .to_string()
+                })
+                .collect()
+        };
+        // The inner repeat is itself over the fill threshold, so without
+        // flattening it would contribute one store per inner element to the
+        // outer loop's body.
+        let small_inner = lower_nested(64, 4);
+        let large_inner = lower_nested(1_024, 4);
+        assert_eq!(small_inner.inst_count(), large_inner.inst_count());
+        assert_eq!(opcodes(&small_inner), opcodes(&large_inner));
+    }
+
     #[test]
     fn aggregate_layout_allows_frame_array_slot_stride_indexing() {
         // `let a: [i32; 3] = [1, 2, 3]; let i: u64 = 1; a[i]`

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -33,7 +33,9 @@ use crate::vreg::VReg;
 /// Implementations are thin: `emit_load_slot` is a single frame-relative load
 /// instruction (`mov dst, [rbp+offset]` / `ldr dst, [fp, #offset]`); the rest
 /// expose existing lowerer state.
-pub(crate) trait SlotBackend: BoundsCheckBackend {
+pub(crate) trait SlotBackend:
+    BoundsCheckBackend + crate::value_plan::ValueLowerAdapter
+{
     /// The shared lowering context (CFG, type pool, slot counts).
     fn ctx(&self) -> &CfgLowerContext<'_>;
 
@@ -145,8 +147,10 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
     /// and AAPCS64 does not (ADR-0084).
     fn emit_sret_pointer_echo(&mut self);
 
-    /// Allocate a fresh label for a tag-dispatch marshalling edge (RUE-1037).
-    fn alloc_marshal_label(&mut self) -> crate::vreg::LabelId;
+    /// Allocate a fresh label for a branch this module emits inside a block:
+    /// a tag-dispatch marshalling edge (RUE-1037) or an array fill's loop
+    /// (RUE-2069).
+    fn alloc_lowering_label(&mut self) -> crate::vreg::LabelId;
 
     /// Compare the discriminant in `tag` against `discriminant` and branch to
     /// `label` when they are NOT equal (RUE-1037): the fall-through path runs the
@@ -162,8 +166,20 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
     /// variant's arm for the dispatch's merge point.
     fn emit_marshal_jump(&mut self, label: crate::vreg::LabelId);
 
-    /// Bind `label` at the current position (RUE-1037).
-    fn emit_marshal_label(&mut self, label: crate::vreg::LabelId);
+    /// Bind `label` at the current position (RUE-1037, RUE-2069).
+    fn emit_lowering_label(&mut self, label: crate::vreg::LabelId);
+
+    /// A fresh vreg holding an array fill's remaining-element count
+    /// (RUE-2069).
+    fn emit_fill_counter(&mut self, count: u64) -> VReg;
+
+    /// Advance an array fill's cursor or counter by `delta`, in place
+    /// (RUE-2069).
+    fn emit_fill_advance(&mut self, dst: VReg, delta: i64);
+
+    /// Branch back to `label` while an array fill's counter is not zero
+    /// (RUE-2069).
+    fn emit_fill_branch_if_nonzero(&mut self, counter: VReg, label: crate::vreg::LabelId);
 }
 
 /// Zero the padding byte `ranges` of a compact memory image reached through
@@ -347,7 +363,29 @@ pub(crate) fn get_or_compute_field_vregs<B: SlotBackend>(
         return None;
     }
     b.get_vreg(value);
-    b.slot_cache().get(&value).cloned()
+    if let Some(vregs) = b.slot_cache().get(&value).cloned() {
+        return Some(vregs);
+    }
+    expand_array_repeat(b, value)
+}
+
+/// The elementwise slot vector of a deferred array repeat (RUE-2069).
+///
+/// A repeat large enough to fill has no slot vector of its own: the store
+/// that consumes it writes the region from one element. Every other consumer
+/// — a by-value argument, an aggregate field, a return — needs one vreg per
+/// slot, which is the element's own slots repeated, since each element is a
+/// copy of the same evaluated value. The expansion is cached like any other
+/// producer's, so it happens at most once per value.
+fn expand_array_repeat<B: SlotBackend>(b: &mut B, value: CfgValue) -> Option<Vec<VReg>> {
+    let fill = b.array_repeat_fills().get(&value).cloned()?;
+    let total = usize::try_from(fill.total_slots()).ok()?;
+    let mut slots = Vec::with_capacity(total);
+    for _ in 0..fill.count {
+        slots.extend_from_slice(&fill.element_slots);
+    }
+    b.slot_cache().insert(value, slots.clone());
+    Some(slots)
 }
 
 /// Materialize and return the complete representation of a multi-slot
@@ -424,6 +462,63 @@ pub(crate) fn preallocate_block_param_slots<B: SlotBackend>(
         );
     }
     b.slot_cache().insert(param_value, slot_vregs);
+}
+
+/// Write `fill.count` copies of one already-evaluated element into the frame
+/// region beginning at `base_slot` (RUE-2069).
+///
+/// The region is the same one [`store_slots`] writes and follows the same
+/// ADR-0040 direction rule: logical slot 0 sits at the region's LOWEST
+/// address, which is its highest-numbered frame slot. Taking that address once
+/// and walking upward is what makes the whole sequence independent of the
+/// element count.
+pub(crate) fn fill_frame_region<B: SlotBackend>(
+    b: &mut B,
+    fill: &crate::value_plan::ArrayRepeatFill,
+    base_slot: u32,
+) {
+    let total_slots =
+        u32::try_from(fill.total_slots()).expect("a filled region fits the frame's slot numbering");
+    let low_slot = base_slot + total_slots.saturating_sub(1);
+    let base = b.alloc_vreg();
+    b.emit_slot_addr(base, low_slot);
+    fill_through_ptr(b, fill, base);
+}
+
+/// [`fill_frame_region`] through a pointer to the region's low end: element
+/// `e`'s slot `j` lands at `ptr + (e*element_slots + j)*8`, the ascending
+/// layout every aggregate has behind a pointer (ADR-0040).
+pub(crate) fn fill_through_ptr<B: SlotBackend>(
+    b: &mut B,
+    fill: &crate::value_plan::ArrayRepeatFill,
+    ptr: VReg,
+) {
+    assert!(
+        !fill.element_slots.is_empty(),
+        "an array fill writes at least one slot per element"
+    );
+    assert_eq!(
+        fill.element_slots.len(),
+        fill.element_leaf_types.len(),
+        "an array fill types every element slot"
+    );
+    if fill.count == 0 {
+        return;
+    }
+    let element_bytes = i64::try_from(fill.element_slots.len() as u64 * SLOT_BYTES)
+        .expect("an element's byte width fits the frame");
+
+    // The cursor is this loop's own: `ptr` may be a by-reference parameter's
+    // pointer, which the rest of the function still reads.
+    let cursor = b.alloc_vreg();
+    b.emit_reg_move(cursor, ptr);
+    let remaining = b.emit_fill_counter(u64::from(fill.count));
+    let top = b.alloc_lowering_label();
+    b.emit_lowering_label(top);
+    store_slots_through_ptr_typed(b, &fill.element_slots, cursor, 0, &fill.element_leaf_types);
+    b.emit_fill_advance(cursor, element_bytes);
+    b.emit_fill_advance(remaining, -1);
+    b.emit_fill_branch_if_nonzero(remaining, top);
 }
 
 /// Store a whole aggregate value's `vals` (one vreg per logical slot, slot 0
@@ -612,15 +707,15 @@ fn store_image_segs<B: SlotBackend>(
                 let tag = vals[region.tag_slot as usize];
                 // The discriminant is a common leaf across every variant.
                 b.emit_narrow_store_through_ptr(tag, ptr, region.tag_offset, region.tag_access);
-                let end = b.alloc_marshal_label();
+                let end = b.alloc_lowering_label();
                 for arm in &region.arms {
-                    let next = b.alloc_marshal_label();
+                    let next = b.alloc_lowering_label();
                     b.emit_marshal_branch_if_tag_ne(tag, arm.discriminant, next);
                     store_image_segs(b, vals, ptr, &arm.segs, true);
                     b.emit_marshal_jump(end);
-                    b.emit_marshal_label(next);
+                    b.emit_lowering_label(next);
                 }
-                b.emit_marshal_label(end);
+                b.emit_lowering_label(end);
             }
         }
     }
@@ -723,15 +818,15 @@ fn load_image_segs<B: SlotBackend>(
                         b.emit_set_zero(result[slot as usize]);
                     }
                 }
-                let end = b.alloc_marshal_label();
+                let end = b.alloc_lowering_label();
                 for arm in &region.arms {
-                    let next = b.alloc_marshal_label();
+                    let next = b.alloc_lowering_label();
                     b.emit_marshal_branch_if_tag_ne(tag, arm.discriminant, next);
                     load_image_segs(b, ptr, result, float_widths, &arm.segs, true);
                     b.emit_marshal_jump(end);
-                    b.emit_marshal_label(next);
+                    b.emit_lowering_label(next);
                 }
-                b.emit_marshal_label(end);
+                b.emit_lowering_label(end);
             }
         }
     }

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -209,10 +209,11 @@ fn format_cfg_inst_data_impl(
                 .collect();
             format!("struct_init #{struct_id:?} {{{}}}", fields.join(", "))
         }
-        CfgInstData::ArrayInit { .. } => {
+        CfgInstData::ArrayInit { shape, .. } => match shape {
             // Note: Can't show elements without Cfg access
-            "array_init [...]".to_string()
-        }
+            rue_air::ArrayInitShape::Elementwise => "array_init [...]".to_string(),
+            rue_air::ArrayInitShape::Repeat => "array_repeat [...]".to_string(),
+        },
         CfgInstData::EnumVariant {
             enum_id,
             variant_index,

--- a/crates/rue-codegen/src/local_storage.rs
+++ b/crates/rue-codegen/src/local_storage.rs
@@ -164,11 +164,23 @@ struct SharingViolation {
     second: usize,
 }
 
+/// CFG local slot -> emitted frame local slot.
+///
+/// The identity numbering is held as a rule rather than a table: it is the
+/// common case, it is what every slot outside a table already falls back to,
+/// and one array local can own a hundred million slots, which is a
+/// hundred-million-entry table to say "each slot keeps its own number"
+/// (RUE-2069).
+#[derive(Debug, Clone)]
+enum LocalSlotMap {
+    Identity,
+    Shared(Vec<u32>),
+}
+
 /// The per-function local frame-slot assignment.
 #[derive(Debug, Clone)]
 pub(crate) struct LocalSlotPlan {
-    /// CFG local slot -> emitted frame local slot.
-    map: Vec<u32>,
+    map: LocalSlotMap,
     /// Frame local slots the assignment occupies.
     frame_local_slots: u32,
 }
@@ -179,7 +191,7 @@ impl LocalSlotPlan {
     /// a sharing decision, and the baseline the planned path shrinks from.
     pub(crate) fn identity(num_locals: u32) -> Self {
         Self {
-            map: (0..num_locals).collect(),
+            map: LocalSlotMap::Identity,
             frame_local_slots: num_locals,
         }
     }
@@ -205,7 +217,10 @@ impl LocalSlotPlan {
     /// number, exactly as the pre-RUE-768 identity layout gave it, and the
     /// canonical ZST place address it yields (RUE-605) still names zero bytes.
     pub(crate) fn frame_slot(&self, slot: u32) -> u32 {
-        self.map.get(slot as usize).copied().unwrap_or(slot)
+        match &self.map {
+            LocalSlotMap::Identity => slot,
+            LocalSlotMap::Shared(map) => map.get(slot as usize).copied().unwrap_or(slot),
+        }
     }
 
     /// Frame local slots the plan occupies (also the base of the emitted
@@ -217,7 +232,10 @@ impl LocalSlotPlan {
     /// Whether any two entities were merged onto shared cells.
     #[cfg(test)]
     pub(crate) fn shares_any_slot(&self) -> bool {
-        self.frame_local_slots < self.map.len() as u32
+        match &self.map {
+            LocalSlotMap::Identity => false,
+            LocalSlotMap::Shared(map) => self.frame_local_slots < map.len() as u32,
+        }
     }
 
     /// The CFG local slots assigned to each emitted frame local cell, indexed
@@ -229,8 +247,14 @@ impl LocalSlotPlan {
     /// cell, and a report that cannot say so cannot be used to review the
     /// decision or pin it against regression.
     pub(crate) fn cfg_slots_by_frame_slot(&self) -> Vec<Vec<u32>> {
+        let map = match &self.map {
+            LocalSlotMap::Identity => {
+                return (0..self.frame_local_slots).map(|slot| vec![slot]).collect();
+            }
+            LocalSlotMap::Shared(map) => map,
+        };
         let mut owners = vec![Vec::new(); self.frame_local_slots as usize];
-        for (cfg_slot, &frame_slot) in self.map.iter().enumerate() {
+        for (cfg_slot, &frame_slot) in map.iter().enumerate() {
             // A ZST local can sit one past the local area and is not mapped;
             // it owns no cell, so it names none here either.
             if let Some(cell) = owners.get_mut(frame_slot as usize) {
@@ -302,7 +326,7 @@ impl LocalSlotPlan {
             return None;
         }
         Some(Self {
-            map,
+            map: LocalSlotMap::Shared(map),
             frame_local_slots,
         })
     }
@@ -756,7 +780,7 @@ mod tests {
         // Owners come back in CFG order within a cell, which is what makes the
         // rendered name stable across runs.
         let merged = LocalSlotPlan {
-            map: vec![0, 1, 0],
+            map: LocalSlotMap::Shared(vec![0, 1, 0]),
             frame_local_slots: 2,
         };
         assert_eq!(merged.cfg_slots_by_frame_slot(), vec![vec![0, 2], vec![1]]);
@@ -766,7 +790,7 @@ mod tests {
         // to a cell. It must not be attributed to a cell it does not occupy,
         // and must not index out of bounds.
         let with_zst = LocalSlotPlan {
-            map: vec![0, 1],
+            map: LocalSlotMap::Shared(vec![0, 1]),
             frame_local_slots: 1,
         };
         assert_eq!(with_zst.cfg_slots_by_frame_slot(), vec![vec![0]]);

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -6,12 +6,9 @@
 //! Struct, enum, array, and pointer definitions are resolved through the
 //! canonical `FrozenTypeInternPool` (ADR-0024).
 
-use ahash::AHashMap;
 use lasso::ThreadedRodeo;
 use rue_air::{ArrayTypeId, EnumId, FrozenTypeInternPool, StructId, TypeKind};
-use rue_cfg::{Cfg, CfgInstData, CfgValue, Type, ValidatedCfg};
-
-use crate::vreg::VReg;
+use rue_cfg::{Cfg, CfgInstData, CfgValue, Type};
 
 /// Extract the ArrayTypeId from a Type::Array.
 /// Returns None if the type is not an array type.
@@ -167,9 +164,19 @@ fn push_leaf_types(type_pool: &FrozenTypeInternPool, ty: Type, out: &mut Vec<Typ
             }
         }
         TypeKind::Array(array_id) => {
+            // Walk the element once and repeat its leaves: an array of a
+            // zero-slot element contributes nothing however long it is, so
+            // this is where a `[(); 100000000]` local stops costing a hundred
+            // million walks of the same type (RUE-2069).
             let (element_type, length) = type_pool.array_def(array_id);
+            let mut element_leaves = Vec::new();
+            push_leaf_types(type_pool, element_type, &mut element_leaves);
+            if element_leaves.is_empty() {
+                return;
+            }
+            out.reserve((element_leaves.len() as u64 * length) as usize);
             for _ in 0..length {
-                push_leaf_types(type_pool, element_type, out);
+                out.extend_from_slice(&element_leaves);
             }
         }
         TypeKind::Enum(enum_id) => {
@@ -192,6 +199,34 @@ fn push_leaf_types(type_pool: &FrozenTypeInternPool, ty: Type, out: &mut Vec<Typ
             out.extend(std::iter::repeat_n(Type::I64, payload_slots));
         }
         _ => out.push(ty),
+    }
+}
+
+/// The leaf type behind logical slot 0 of `ty` — the first entry
+/// [`aggregate_leaf_types`] would produce — without materializing the whole
+/// leaf vector. `None` when the type has no slots.
+///
+/// Every value plan needs this one leaf to give the primary vreg its register
+/// class, and building the full vector for it made planning proportional to
+/// the value's slot count: one local of a hundred million elements cost a
+/// hundred-million-entry vector per value plan that mentioned it (RUE-2069).
+pub fn primary_leaf_type(type_pool: &FrozenTypeInternPool, ty: Type) -> Option<Type> {
+    match ty.kind() {
+        TypeKind::Unit | TypeKind::Never => None,
+        TypeKind::Struct(struct_id) => type_pool
+            .struct_def(struct_id)
+            .fields
+            .iter()
+            .find_map(|field| primary_leaf_type(type_pool, field.ty)),
+        TypeKind::Array(array_id) => {
+            let (element_type, length) = type_pool.array_def(array_id);
+            (length > 0)
+                .then(|| primary_leaf_type(type_pool, element_type))
+                .flatten()
+        }
+        // Slot 0 of an enum is its discriminant, whatever the payload holds.
+        TypeKind::Enum(_) => Some(Type::I32),
+        _ => Some(ty),
     }
 }
 
@@ -1224,131 +1259,11 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
     Ok(())
 }
 
-/// Recursively collect all scalar vregs from an array value.
-///
-/// For nested arrays, this flattens them to a list of scalar vregs.
-/// This is used during code generation to handle array arguments that need
-/// to be passed in registers or stored to memory slot by slot.
-///
-/// # Arguments
-/// * `cfg` - The control flow graph containing the instructions
-/// * `struct_slot_vregs` - Cache mapping CFG values to their slot vregs
-/// * `value` - The CFG value to collect vregs from
-/// * `get_vreg` - Closure to get/allocate a vreg for a given CFG value
-pub fn collect_array_scalar_vregs(
-    cfg: &ValidatedCfg,
-    struct_slot_vregs: &AHashMap<CfgValue, Vec<VReg>>,
-    value: CfgValue,
-    get_vreg: &mut impl FnMut(CfgValue) -> VReg,
-) -> Vec<VReg> {
-    let inst = cfg.get_inst(value);
-    match &inst.data {
-        CfgInstData::ArrayInit { .. } => {
-            let elements = cfg.get_array_elements(&inst.data);
-            let mut result = Vec::new();
-            // Collect elements in logical order (element 0 first), matching
-            // The slot cache is uniform ascending order and
-            // the ascending physical layout is produced at store time (ADR-0040
-            // / RUE-311).
-            for elem in elements.iter() {
-                let elem_inst = cfg.get_inst(*elem);
-                if elem_inst.ty.is_array() {
-                    // Recursively collect from nested array
-                    result.extend(collect_array_scalar_vregs(
-                        cfg,
-                        struct_slot_vregs,
-                        *elem,
-                        get_vreg,
-                    ));
-                } else if elem_inst.ty.is_struct() {
-                    // Recursively collect from struct element (includes builtin String)
-                    result.extend(collect_struct_scalar_vregs(
-                        cfg,
-                        struct_slot_vregs,
-                        *elem,
-                        get_vreg,
-                    ));
-                } else {
-                    // Scalar element - get its vreg
-                    result.push(get_vreg(*elem));
-                }
-            }
-            result
-        }
-        _ => {
-            // For non-ArrayInit sources, try struct_slot_vregs cache
-            if let Some(vregs) = struct_slot_vregs.get(&value).cloned() {
-                vregs
-            } else {
-                vec![get_vreg(value)]
-            }
-        }
-    }
-}
-
 // The drop-glue array symbol name comes from the single authority in
 // `rue_air::drop_glue_names`, shared with compiler glue synthesis and the other
 // backend, so the external ABI cannot drift (RUE-796). Re-exported for the
 // existing `crate::types::array_drop_glue_name` call sites.
 pub use rue_air::drop_glue_names::array_drop_glue_name;
-
-/// Recursively collect all scalar vregs from a struct value.
-///
-/// This flattens any array fields to their scalar elements.
-/// This is used during code generation to handle struct arguments that need
-/// to be passed in registers or stored to memory slot by slot.
-///
-/// # Arguments
-/// * `cfg` - The control flow graph containing the instructions
-/// * `struct_slot_vregs` - Cache mapping CFG values to their slot vregs
-/// * `value` - The CFG value to collect vregs from
-/// * `get_vreg` - Closure to get/allocate a vreg for a given CFG value
-pub fn collect_struct_scalar_vregs(
-    cfg: &ValidatedCfg,
-    struct_slot_vregs: &AHashMap<CfgValue, Vec<VReg>>,
-    value: CfgValue,
-    get_vreg: &mut impl FnMut(CfgValue) -> VReg,
-) -> Vec<VReg> {
-    let inst = cfg.get_inst(value);
-    match &inst.data {
-        CfgInstData::StructInit { .. } => {
-            let fields = cfg.get_struct_fields(&inst.data);
-            let mut result = Vec::new();
-            for field in fields {
-                let field_inst = cfg.get_inst(*field);
-                if field_inst.ty.is_array() {
-                    // Recursively collect from array field
-                    result.extend(collect_array_scalar_vregs(
-                        cfg,
-                        struct_slot_vregs,
-                        *field,
-                        get_vreg,
-                    ));
-                } else if field_inst.ty.is_struct() {
-                    // Recursively collect from nested struct field (includes builtin String)
-                    result.extend(collect_struct_scalar_vregs(
-                        cfg,
-                        struct_slot_vregs,
-                        *field,
-                        get_vreg,
-                    ));
-                } else {
-                    // Scalar field - get its vreg
-                    result.push(get_vreg(*field));
-                }
-            }
-            result
-        }
-        _ => {
-            // For non-StructInit sources, try struct_slot_vregs cache
-            if let Some(vregs) = struct_slot_vregs.get(&value).cloned() {
-                vregs
-            } else {
-                vec![get_vreg(value)]
-            }
-        }
-    }
-}
 
 #[cfg(test)]
 mod layout_authority_tests {
@@ -1444,6 +1359,73 @@ mod layout_authority_tests {
                 }
                 assert!(type_slot_count(pool, ty) >= field_offsets.len() as u32);
             }
+        }
+    }
+
+    /// The slot-0 leaf shortcut answers exactly what the full leaf vector's
+    /// first entry does, for every shape in the fixture pool. Value planning
+    /// reads the register class of the primary vreg from it, and a whole leaf
+    /// vector is proportional to the value's slot count (RUE-2069).
+    #[test]
+    fn primary_leaf_type_matches_the_full_leaf_vector() {
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let (pair_id, _) = pool.register_struct(
+            interner.get_or_intern("Pair"),
+            StructDef {
+                name: "Pair".into(),
+                fields: vec![
+                    StructField {
+                        name: "a".to_string(),
+                        ty: Type::F64,
+                    },
+                    StructField {
+                        name: "b".to_string(),
+                        ty: Type::I32,
+                    },
+                ],
+                is_copy: true,
+                is_linear: false,
+                declared_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let pairs_id = pool.intern_array_from_type(Type::new_struct(pair_id), 4);
+        pool.register_struct(
+            interner.get_or_intern("Wrapper"),
+            StructDef {
+                name: "Wrapper".into(),
+                fields: vec![
+                    StructField {
+                        name: "unit".to_string(),
+                        ty: Type::UNIT,
+                    },
+                    StructField {
+                        name: "pairs".to_string(),
+                        ty: Type::new_array(pairs_id),
+                    },
+                ],
+                is_copy: true,
+                is_linear: false,
+                declared_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        pool.intern_array_from_type(Type::UNIT, 3);
+        let pool = &pool.freeze();
+
+        for ty in pool.all_types() {
+            assert_eq!(
+                super::primary_leaf_type(pool, ty),
+                super::aggregate_leaf_types(pool, ty).first().copied(),
+                "slot-0 leaf disagrees for {ty:?}"
+            );
         }
     }
 }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -10,6 +10,7 @@
 //! materialization requires updating the exhaustive match below, so an
 //! architecture cannot quietly invent a different scalar/aggregate policy.
 
+use ahash::AHashMap;
 use lasso::Spur;
 use rue_air::IntrinsicOperation;
 use rue_air::{EnumId, IntegerType, StructId, TypeKind};
@@ -140,6 +141,19 @@ pub enum ResidualValuePlan {
     ArrayInit {
         elements: Vec<(MaterializedValue, ValueShape)>,
     },
+    /// An array repeat whose region is filled rather than materialized
+    /// (RUE-2069). The repeated value has already been evaluated into
+    /// [`ArrayRepeatFill::element_slots`]; this instruction itself produces
+    /// only the placeholder primary every `ArrayInit` produces, and the fill
+    /// is emitted where the array is stored.
+    ArrayRepeat,
+    /// Fill a storage region with `count` copies of one already-materialized
+    /// element (RUE-2069). This replaces the `Alloc` or `Store` that would
+    /// otherwise write one slot per element.
+    ArrayFill {
+        destination: StoreDestination,
+        fill: ArrayRepeatFill,
+    },
     EnumVariant {
         enum_id: EnumId,
         variant_index: u32,
@@ -214,6 +228,44 @@ pub enum StoreDestination {
     FrameSlot(u32),
     ByRefParam(u32),
 }
+
+/// An array repeat `[value; count]` held as one evaluated element plus a
+/// count, ready to be written into a storage region as a fill (RUE-2069).
+///
+/// The elementwise representation of a repeat is one vreg and one machine
+/// store per element, so a large repeat could not be compiled at all: a
+/// hundred-million-element zeroed local needed 13 GB and seven bytes of
+/// machine code per element. The repeated value is Copy by construction
+/// (E0905), which is what lets every element share one materialization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArrayRepeatFill {
+    /// One vreg per slot of the repeated element, in ascending logical order.
+    /// Never empty: a zero-slot element writes nothing and is not deferred.
+    pub element_slots: Vec<VReg>,
+    /// The leaf type behind each element slot, so a float slot is stored at
+    /// its own width from its own register class.
+    pub element_leaf_types: Vec<Type>,
+    /// How many copies of the element the array holds.
+    pub count: u32,
+}
+
+impl ArrayRepeatFill {
+    /// Total slots the filled region spans.
+    pub fn total_slots(&self) -> u64 {
+        self.element_slots.len() as u64 * u64::from(self.count)
+    }
+}
+
+/// Smallest region, in slots, that a repeat fills with a counted loop instead
+/// of one store per slot (RUE-2069).
+///
+/// Below this the unrolled stores are both smaller and faster than the loop's
+/// fixed cost — a region pointer, a counter, a compare and a branch, plus the
+/// per-iteration pointer bump — so a repeat that small keeps exactly the code
+/// it had before the fill existed. Above it the unrolled form grows without
+/// bound (seven bytes of machine code per element on x86-64) while the loop
+/// stays the same handful of instructions whatever the count.
+pub const REPEAT_FILL_MIN_SLOTS: u64 = 32;
 
 /// One already-decided cleanup call: a destructor or a drop-glue body handed
 /// its owner as ONE by-value argument of the owner's type.
@@ -618,6 +670,18 @@ pub trait ValueLowerAdapter:
     fn emit_checked_arithmetic(&mut self, plan: ArithmeticPlan) -> ValueResult;
     fn emit_trap(&mut self, plan: TrapPlan) -> ValueResult;
     fn cache_value(&mut self, value: CfgValue, result: MaterializedValue);
+    /// The lowerer's deferred array-repeat fills, keyed by the `ArrayInit`
+    /// value that produced them (RUE-2069).
+    ///
+    /// A deferred repeat has no slot vector: it caches only its placeholder
+    /// primary, and its region is written by whichever `Alloc` or `Store`
+    /// consumes it. An entry stays after a fill, because the same repeat can
+    /// initialize more than one local and because any other consumer — a
+    /// by-value argument, a return, a projected write — still needs the
+    /// elementwise expansion
+    /// [`agg_slots::require_aggregate_slots`](crate::agg_slots::require_aggregate_slots)
+    /// builds from it.
+    fn array_repeat_fills(&mut self) -> &mut AHashMap<CfgValue, ArrayRepeatFill>;
 }
 
 /// The representation required by a value consumer.
@@ -708,6 +772,9 @@ pub fn float_width(ty: Type) -> Option<FloatWidth> {
 /// a plan that reaches a value through its primary vreg does so only when that
 /// vreg is the whole value, and every other slot takes its own class from
 /// `leaf_types` through the typed slot walk.
+///
+/// [`crate::types::primary_leaf_type`] answers the same question from the type
+/// alone, for callers that have no leaf vector in hand.
 pub fn primary_slot_float_width(leaf_types: &[Type]) -> Option<FloatWidth> {
     leaf_types.first().copied().and_then(float_width)
 }
@@ -861,6 +928,8 @@ pub enum ValueKind {
     Intrinsic,
     StructInit,
     ArrayInit,
+    ArrayRepeat,
+    ArrayFill,
     EnumVariant,
     EnumPayloadGet,
     IntegerCast,
@@ -948,10 +1017,8 @@ impl ValuePlan {
             } else {
                 MaterializationRequirement::Primary
             },
-            primary_float_width: primary_slot_float_width(&crate::types::aggregate_leaf_types(
-                ctx.type_pool,
-                ty,
-            )),
+            primary_float_width: crate::types::primary_leaf_type(ctx.type_pool, ty)
+                .and_then(float_width),
             integer_width: value_width,
             source_integer_width: match &inst.data {
                 CfgInstData::IntCast { from_ty, .. } => integer_width(*from_ty),
@@ -1310,6 +1377,11 @@ enum ResidualInput {
         struct_id: StructId,
     },
     ArrayInit,
+    /// An array repeat large enough to fill rather than expand (RUE-2069).
+    ArrayRepeat {
+        element: CfgValue,
+        count: u32,
+    },
     EnumVariant {
         enum_id: EnumId,
         variant_index: u32,
@@ -1348,6 +1420,41 @@ fn result_narrowing(ctx: &CfgLowerContext<'_>, value: CfgValue) -> IntegerExtens
     narrowing_extension(integer_width(ty).unwrap_or_else(|| {
         panic!("narrowed operation on non-integer type: {ty:?}");
     }))
+}
+
+/// The logical elements of an array construction, one per element of the
+/// array type. A repeat that is materialized elementwise — below
+/// [`REPEAT_FILL_MIN_SLOTS`], or consumed somewhere a fill cannot serve —
+/// expands here, which is exactly the representation the elementwise shape
+/// carries (RUE-2069).
+fn array_init_elements(ctx: &CfgLowerContext<'_>, value: CfgValue) -> Vec<CfgValue> {
+    let inst = ctx.cfg.get_inst(value);
+    match ctx.cfg.array_init_repeat(&inst.data) {
+        // A zero-slot element stores nothing whatever the count, and the
+        // entries a store skips are exactly the ones this list exists to
+        // name. One entry still materializes the repeated value, which spec
+        // 7.1:39 requires evaluated exactly once, so the emitted code is the
+        // same and the list does not grow with the count. A zero-LENGTH array
+        // is a different case and keeps its empty list below: its element
+        // does have slots, and a representation carrying one would not match
+        // the array's own slot count.
+        Some(element) if ctx.type_slot_count(ctx.cfg.get_inst(element).ty) == 0 => {
+            vec![element]
+        }
+        Some(element) => vec![element; ctx.array_length(inst.ty) as usize],
+        None => ctx.cfg.get_array_elements(&inst.data).to_vec(),
+    }
+}
+
+/// The element count of an array repeat whose region is worth filling with a
+/// counted loop instead of one store per slot (RUE-2069).
+fn deferred_repeat_count(ctx: &CfgLowerContext<'_>, value: CfgValue) -> Option<u32> {
+    let inst = ctx.cfg.get_inst(value);
+    let element = ctx.cfg.array_init_repeat(&inst.data)?;
+    let element_slots = u64::from(ctx.type_slot_count(ctx.cfg.get_inst(element).ty));
+    let count = u32::try_from(ctx.array_length(inst.ty)).ok()?;
+    let total = element_slots.checked_mul(u64::from(count))?;
+    (element_slots > 0 && total >= REPEAT_FILL_MIN_SLOTS).then_some(count)
 }
 
 fn residual_plan<A: ValueLowerAdapter>(
@@ -1414,6 +1521,15 @@ fn residual_plan<A: ValueLowerAdapter>(
         // slot numbering assumes every parameter is homed, while the emitted
         // frame compacts register-only parameters away (RUE-1170).
         ResidualInput::Alloc { slot, init } => {
+            // A deferred repeat writes its region here rather than handing
+            // over one vreg per slot; asking for its leaf types first would
+            // already be proportional to the array's length (RUE-2069).
+            if let Some(fill) = adapter.array_repeat_fills().get(&init).cloned() {
+                return ResidualValuePlan::ArrayFill {
+                    destination: StoreDestination::FrameSlot(ctx.frame_slot(slot)),
+                    fill,
+                };
+            }
             let leaf_types =
                 crate::types::aggregate_leaf_types(ctx.type_pool, ctx.cfg.get_inst(init).ty);
             ResidualValuePlan::Alloc {
@@ -1434,6 +1550,12 @@ fn residual_plan<A: ValueLowerAdapter>(
             }
         }
         ResidualInput::Store { slot, value } => {
+            if let Some(fill) = adapter.array_repeat_fills().get(&value).cloned() {
+                return ResidualValuePlan::ArrayFill {
+                    destination: store_destination(ctx, slot),
+                    fill,
+                };
+            }
             let leaf_types =
                 crate::types::aggregate_leaf_types(ctx.type_pool, ctx.cfg.get_inst(value).ty);
             ResidualValuePlan::Store {
@@ -1471,11 +1593,8 @@ fn residual_plan<A: ValueLowerAdapter>(
                 .collect(),
         },
         ResidualInput::ArrayInit => ResidualValuePlan::ArrayInit {
-            elements: ctx
-                .cfg
-                .get_array_elements(&ctx.cfg.get_inst(value).data)
-                .iter()
-                .copied()
+            elements: array_init_elements(ctx, value)
+                .into_iter()
                 .map(|element| {
                     (
                         operand(ctx, adapter, element),
@@ -1484,6 +1603,60 @@ fn residual_plan<A: ValueLowerAdapter>(
                 })
                 .collect(),
         },
+        // Evaluate the repeated value once and hand it to whichever store
+        // consumes the array; this instruction leaves only the placeholder
+        // primary an `ArrayInit` produces (RUE-2069).
+        ResidualInput::ArrayRepeat { element, count } => {
+            // A repeat whose element is itself a filled repeat is one fill.
+            // The inner element tiles the inner array, so it tiles the outer
+            // region too and the two counts multiply. Falling through instead
+            // would expand the inner repeat into the outer loop's body — one
+            // store per inner element — so `[[0; 100000]; 100]` emitted a
+            // hundred thousand stores for a region one loop fills.
+            if let Some(inner) = adapter.array_repeat_fills().get(&element).cloned()
+                && let Some(count) = inner.count.checked_mul(count)
+            {
+                assert_eq!(
+                    inner.element_slots.len() as u64 * u64::from(count),
+                    u64::from(ctx.type_slot_count(ctx.cfg.get_inst(value).ty)),
+                    "a nested array repeat's elements tile its array's slots"
+                );
+                adapter
+                    .array_repeat_fills()
+                    .insert(value, ArrayRepeatFill { count, ..inner });
+                return ResidualValuePlan::ArrayRepeat;
+            }
+            let element_leaf_types =
+                crate::types::aggregate_leaf_types(ctx.type_pool, ctx.cfg.get_inst(element).ty);
+            let materialized = operand(ctx, adapter, element);
+            let element_slots = if materialized.slots.is_empty() {
+                vec![materialized.primary]
+            } else {
+                materialized.slots
+            };
+            assert_eq!(
+                element_slots.len(),
+                element_leaf_types.len(),
+                "a repeated element's slot vector covers its leaves"
+            );
+            // The region a fill writes is the array's own, so the element's
+            // slots must tile it exactly: a mismatch would write past the
+            // array or leave its tail untouched.
+            assert_eq!(
+                element_slots.len() as u64 * u64::from(count),
+                u64::from(ctx.type_slot_count(ctx.cfg.get_inst(value).ty)),
+                "an array repeat's elements tile its array's slots"
+            );
+            adapter.array_repeat_fills().insert(
+                value,
+                ArrayRepeatFill {
+                    element_slots,
+                    element_leaf_types,
+                    count,
+                },
+            );
+            ResidualValuePlan::ArrayRepeat
+        }
         ResidualInput::EnumVariant {
             enum_id,
             variant_index,
@@ -1630,6 +1803,8 @@ fn residual_kind(plan: &ResidualValuePlan) -> ValueKind {
         ResidualValuePlan::ParamStore { .. } => ValueKind::ParameterStore,
         ResidualValuePlan::StructInit { .. } => ValueKind::StructInit,
         ResidualValuePlan::ArrayInit { .. } => ValueKind::ArrayInit,
+        ResidualValuePlan::ArrayRepeat => ValueKind::ArrayRepeat,
+        ResidualValuePlan::ArrayFill { .. } => ValueKind::ArrayFill,
         ResidualValuePlan::EnumVariant { .. } => ValueKind::EnumVariant,
         ResidualValuePlan::EnumPayloadGet { .. } => ValueKind::EnumPayloadGet,
         ResidualValuePlan::IntCast { .. } => ValueKind::IntegerCast,
@@ -2115,9 +2290,16 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                 struct_id: *struct_id
             })
         }
-        CfgInstData::ArrayInit { .. } => {
-            lower_residual!(ResidualInput::ArrayInit)
-        }
+        CfgInstData::ArrayInit { .. } => match deferred_repeat_count(ctx, value) {
+            Some(count) => {
+                let element = ctx
+                    .cfg
+                    .array_init_repeat(&inst.data)
+                    .expect("a deferred repeat carries its repeated value");
+                lower_residual!(ResidualInput::ArrayRepeat { element, count })
+            }
+            None => lower_residual!(ResidualInput::ArrayInit),
+        },
         CfgInstData::EnumVariant {
             enum_id,
             variant_index,

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -190,6 +190,9 @@ pub struct CfgLower<'a> {
     fn_name: &'a str,
     /// Maps StructInit CFG values to their field vregs
     struct_slot_vregs: AHashMap<CfgValue, Vec<VReg>>,
+    /// Array repeats deferred to a fill, keyed by their `ArrayInit` value
+    /// (RUE-2069). See `value_plan::ValueLowerAdapter::array_repeat_fills`.
+    array_repeat_fills: AHashMap<CfgValue, crate::value_plan::ArrayRepeatFill>,
     /// Maps by-reference parameter indices to their pointer vregs.
     /// For by-ref params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
@@ -395,6 +398,7 @@ impl<'a> CfgLower<'a> {
             next_label: 0,
             fn_name: cfg.fn_name(),
             struct_slot_vregs: AHashMap::with_capacity(estimated_struct_inits),
+            array_repeat_fills: AHashMap::new(),
             by_ref_param_ptrs: AHashMap::with_capacity(estimated_by_ref_params),
             param_reg_vregs: AHashMap::new(),
         }
@@ -2106,6 +2110,31 @@ impl<'a> CfgLower<'a> {
                     float_width,
                     &leaf_types,
                 );
+                return ValueResult::SideEffect;
+            }
+            // A deferred repeat emits no element stores of its own: the value
+            // is one evaluated element plus a count until the store that
+            // consumes it fills the region (RUE-2069). Its primary is the
+            // same never-read placeholder an `ArrayInit` produces, kept
+            // defined so register allocation sees an ordinary value.
+            ResidualValuePlan::ArrayRepeat => {
+                let dst = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRI32 {
+                    dst: Operand::Virtual(dst),
+                    imm: 0,
+                });
+                dst
+            }
+            ResidualValuePlan::ArrayFill { destination, fill } => {
+                match destination {
+                    crate::value_plan::StoreDestination::FrameSlot(slot) => {
+                        crate::agg_slots::fill_frame_region(self, &fill, slot);
+                    }
+                    crate::value_plan::StoreDestination::ByRefParam(param_slot) => {
+                        let ptr = self.ensure_by_ref_param_ptr(param_slot);
+                        crate::agg_slots::fill_through_ptr(self, &fill, ptr);
+                    }
+                }
                 return ValueResult::SideEffect;
             }
             ResidualValuePlan::StructInit { fields, .. }
@@ -4075,6 +4104,11 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
             self.struct_slot_vregs.insert(value, result.slots);
         }
     }
+    fn array_repeat_fills(
+        &mut self,
+    ) -> &mut AHashMap<CfgValue, crate::value_plan::ArrayRepeatFill> {
+        &mut self.array_repeat_fills
+    }
 }
 
 /// Return the immediate form usable for a full-width enum-tag comparison.
@@ -4666,7 +4700,7 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             width,
         });
     }
-    fn alloc_marshal_label(&mut self) -> LabelId {
+    fn alloc_lowering_label(&mut self) -> LabelId {
         self.new_label()
     }
     fn emit_marshal_branch_if_tag_ne(&mut self, tag: VReg, discriminant: u64, label: LabelId) {
@@ -4676,8 +4710,29 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn emit_marshal_jump(&mut self, label: LabelId) {
         self.mir.push(X86Inst::Jmp { label });
     }
-    fn emit_marshal_label(&mut self, label: LabelId) {
+    fn emit_lowering_label(&mut self, label: LabelId) {
         self.mir.push(X86Inst::Label { id: label });
+    }
+    fn emit_fill_counter(&mut self, count: u64) -> VReg {
+        let dst = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(dst),
+            imm: i64::try_from(count).expect("an array fill's count fits a signed immediate"),
+        });
+        dst
+    }
+    fn emit_fill_advance(&mut self, dst: VReg, delta: i64) {
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Virtual(dst),
+            imm: i32::try_from(delta).expect("an array fill's step fits a 32-bit immediate"),
+        });
+    }
+    fn emit_fill_branch_if_nonzero(&mut self, counter: VReg, label: LabelId) {
+        self.mir.push(X86Inst::Cmp64RI {
+            src: Operand::Virtual(counter),
+            imm: 0,
+        });
+        self.mir.push(X86Inst::Jnz { label });
     }
 }
 
@@ -5359,6 +5414,12 @@ mod tests {
                 .unwrap()
         }
 
+        fn array_repeat(&mut self, value: CfgValue, ty: Type) -> CfgValue {
+            self.cfg
+                .append_array_repeat(self.current, value, ty, span())
+                .unwrap()
+        }
+
         fn enum_variant(
             &mut self,
             enum_id: EnumId,
@@ -5496,6 +5557,123 @@ mod tests {
     /// (`abi_slot_count(element) * SLOT_BYTES`) because the frame stores every
     /// element slot-shaped (RUE-975), so element addressing is physically correct
     /// even when the compact element size diverges from the slot stride.
+    /// RUE-2069: an array repeat is lowered as a fill whose instruction count
+    /// does not depend on how many elements it writes, while a repeat below
+    /// the threshold keeps the unrolled store-per-slot form it always had.
+    #[test]
+    fn array_repeat_fill_cost_is_independent_of_the_element_count() {
+        fn lower_repeat(count: u64) -> X86Mir {
+            let interner = ThreadedRodeo::new();
+            let pool = TypeInternPool::new();
+            let array_ty = Type::new_array(pool.intern_array_from_type(Type::I32, count));
+            let pool = pool.freeze();
+            let mut fixture = FixtureCfg::new(
+                Type::I32,
+                count as u32,
+                "main",
+                ParamSlotModes::new(vec![], vec![]),
+                vec![],
+                &pool,
+                &interner,
+            );
+            fixture.live(0, array_ty);
+            let seven = fixture.konst(7, Type::I32);
+            let array = fixture.array_repeat(seven, array_ty);
+            fixture.alloc(0, array);
+            fixture.dead(0, array_ty);
+            let zero = fixture.konst(0, Type::I32);
+            fixture.ret(Some(zero));
+            fixture.lower().expect("an array repeat must lower")
+        }
+
+        // Two counts three orders of magnitude apart produce the same
+        // machine code: the fill is a loop over a region, not a store per
+        // element.
+        let small_fill = lower_repeat(1_024);
+        let large_fill = lower_repeat(1_000_000);
+        assert_eq!(small_fill.inst_count(), large_fill.inst_count());
+        // Only the region's base offset and the loop's trip count differ.
+        let opcodes = |mir: &X86Mir| -> Vec<String> {
+            mir.instructions()
+                .iter()
+                .map(|inst| {
+                    inst.to_string()
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or_default()
+                        .to_string()
+                })
+                .collect()
+        };
+        assert_eq!(opcodes(&small_fill), opcodes(&large_fill));
+
+        // Below the threshold the elementwise form stays: one store per slot,
+        // so the count is visible in the instruction total.
+        let unrolled_four = lower_repeat(4);
+        let unrolled_eight = lower_repeat(8);
+        assert_eq!(
+            unrolled_eight.inst_count() - unrolled_four.inst_count(),
+            4,
+            "an unrolled repeat emits one store per element"
+        );
+        assert!(
+            unrolled_four.inst_count() < large_fill.inst_count(),
+            "the fill's fixed cost is what the threshold trades against"
+        );
+    }
+
+    /// A repeat of a repeat is one fill over the whole region, not the inner
+    /// repeat unrolled into the outer loop's body: growing the inner count
+    /// leaves the emitted code unchanged (RUE-2069).
+    #[test]
+    fn a_nested_array_repeat_is_one_fill() {
+        fn lower_nested(inner_count: u64, outer_count: u64) -> X86Mir {
+            let interner = ThreadedRodeo::new();
+            let pool = TypeInternPool::new();
+            let inner_ty = Type::new_array(pool.intern_array_from_type(Type::I32, inner_count));
+            let outer_ty = Type::new_array(pool.intern_array_from_type(inner_ty, outer_count));
+            let pool = pool.freeze();
+            let mut fixture = FixtureCfg::new(
+                Type::I32,
+                (inner_count * outer_count) as u32,
+                "main",
+                ParamSlotModes::new(vec![], vec![]),
+                vec![],
+                &pool,
+                &interner,
+            );
+            fixture.live(0, outer_ty);
+            let seven = fixture.konst(7, Type::I32);
+            let inner = fixture.array_repeat(seven, inner_ty);
+            let outer = fixture.array_repeat(inner, outer_ty);
+            fixture.alloc(0, outer);
+            fixture.dead(0, outer_ty);
+            let zero = fixture.konst(0, Type::I32);
+            fixture.ret(Some(zero));
+            fixture.lower().expect("a nested array repeat must lower")
+        }
+
+        let opcodes = |mir: &X86Mir| -> Vec<String> {
+            mir.instructions()
+                .iter()
+                .map(|inst| {
+                    inst.to_string()
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or_default()
+                        .to_string()
+                })
+                .collect()
+        };
+        // The inner repeat is itself over the fill threshold, so without
+        // flattening it would contribute one store per inner element to the
+        // outer loop's body.
+        let small_inner = lower_nested(64, 4);
+        let large_inner = lower_nested(1_024, 4);
+        assert_eq!(small_inner.inst_count(), large_inner.inst_count());
+        assert_eq!(opcodes(&small_inner), opcodes(&large_inner));
+    }
+
     #[test]
     fn aggregate_layout_allows_frame_array_slot_stride_indexing() {
         // `let a: [i32; 3] = [1, 2, 3]; let i: u64 = 1; a[i]`

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -823,7 +823,7 @@ impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::SemanticB
                 .retained_charge()
                 .saturating_add(fields.retained_charge())
                 .saturating_add(source_order.retained_charge()),
-            Self::ArrayInit { elements } => elements.retained_charge(),
+            Self::ArrayInit { elements, .. } => elements.retained_charge(),
             Self::EnumVariant {
                 enum_key, payload, ..
             } => enum_key

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1363,6 +1363,7 @@ fn unsupported_corpus_field(case: &Case) -> Option<IneligibleReason> {
         json_diagnostic_order: _,
         symbols_contain: _,
         no_symbol_table: _,
+        max_executable_bytes: _,
         // The CLI suite re-runs the case at every `-O` level; the differential
         // already executes each eligible case at O1, O2, and O3 against the
         // same pinned stdout and exit code, so this asks for nothing extra.
@@ -2185,6 +2186,7 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
         let mut case = base.clone();
         case.differential_opt = true;
         case.no_symbol_table = true;
+        case.max_executable_bytes = Some(1 << 20);
         case.json_diagnostics = true;
         case.compile_stderr_not_contains = vec!["DEBUG:".to_string()];
         assert_eq!(unsupported_corpus_field(&case), None);

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -456,6 +456,9 @@ pub enum ContractViolationKind {
     NonIntegerOperationType,
     UnsupportedDebugType,
     UnsplicedAccessor,
+    /// An array construction whose result type is not an array, or a repeat
+    /// whose count the host cannot represent (RUE-2069).
+    ArrayConstructionShape,
 }
 
 /// The closed, machine-readable cause of an oracle execution failure.
@@ -3947,10 +3950,34 @@ impl<'a> Interp<'a> {
                 let fields = cfg.get_struct_fields(&inst.data).to_vec();
                 Value::Aggregate(self.eval_all(cfg, frame, &fields)?)
             }
-            CfgInstData::ArrayInit { .. } => {
-                let elems = cfg.get_array_elements(&inst.data).to_vec();
-                Value::Aggregate(self.eval_all(cfg, frame, &elems)?)
-            }
+            // A repeat names its element once and takes its count from the
+            // array type, exactly as the CFG carries it (RUE-2069). The
+            // element is evaluated once and copied, which is what the fill
+            // both backends emit does.
+            CfgInstData::ArrayInit { .. } => match cfg.array_init_repeat(&inst.data) {
+                Some(element) => {
+                    let count = inst
+                        .ty
+                        .as_array()
+                        .and_then(|id| self.type_pool().try_array_def(id))
+                        .map(|(_, count)| count)
+                        .and_then(|count| usize::try_from(count).ok())
+                        .ok_or_else(|| {
+                            unsupported(
+                                UnsupportedKind::ContractViolation(
+                                    ContractViolationKind::ArrayConstructionShape,
+                                ),
+                                format!("array repeat with result type {:?}", inst.ty),
+                            )
+                        })?;
+                    let value = self.eval(cfg, frame, element)?;
+                    Value::Aggregate(vec![value; count])
+                }
+                None => {
+                    let elems = cfg.get_array_elements(&inst.data).to_vec();
+                    Value::Aggregate(self.eval_all(cfg, frame, &elems)?)
+                }
+            },
             // A discriminant-only variant is its tag (an `Int`); a payload-
             // carrying variant is an `Aggregate` whose element 0 is the tag and
             // the rest are the payload fields, in declaration order (RUE-285).

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -1217,6 +1217,21 @@ fn main() -> i32 {
 exit_code = 12
 
 [[case]]
+name = "array_repeat_evaluates_value_once_for_a_filled_count"
+spec = ["7.1:39"]
+description = "A count large enough that code generation fills the region with a loop rather than one store per element still evaluates the value exactly once: one line of output, not one per element (RUE-2069)"
+source = """
+fn produce() -> i32 { @dbg(42); 7 }
+fn main() -> i32 {
+    let a: [i32; 100] = [produce(); 100];
+    a[0] + a[99]
+}
+"""
+expected_stdout = """42
+"""
+exit_code = 14
+
+[[case]]
 name = "array_repeat_zero_count_evaluates_value_side_effect"
 spec = ["7.1:39"]
 description = "The repeat value expression is evaluated exactly once even when the count is 0 (RUE-531: it was dropped entirely)"

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -404,6 +404,16 @@ pub struct Case {
     /// Incompatible with `compile_fail` and `symbols_contain`.
     #[serde(default)]
     pub no_symbol_table: bool,
+    /// Upper bound, in bytes, on the produced executable's size.
+    ///
+    /// A case whose point is that emitted machine code does not grow with a
+    /// count written in the source needs the artifact measured, not merely
+    /// produced: `[0; 100000000]` once emitted seven bytes of code per element
+    /// (RUE-2069), which is a correct program and a 700 MB executable.
+    /// Inspects a produced executable, so it is incompatible with
+    /// `compile_fail`.
+    #[serde(default)]
+    pub max_executable_bytes: Option<u64>,
     /// Exact expected exit status of the DRIVER invocation itself, for a
     /// subcommand that neither compiles-and-runs nor fails to compile.
     ///

--- a/crates/rue-ui-tests/cases/diagnostics/function_frame_too_large.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/function_frame_too_large.toml
@@ -13,9 +13,13 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-# This deliberately huge frame can contend with the other premerge corpus
-# actions on shared Linux runners. Keep the timeout a hang detector rather than
-# a load-sensitive latency gate.
+# The first array fits the frame budget on its own, so it is analyzed before
+# the second one blows the budget. That analysis used to expand the repeat into
+# 134 million element references — ~7s and ~1.6GB for a diagnostic decided by
+# the layout — and now carries the repeat symbolically, costing tens of
+# milliseconds (RUE-2069). The timeout stays a hang detector with orders of
+# magnitude of headroom rather than a load-sensitive latency gate: this suite
+# contends with the other premerge corpus actions on shared Linux runners.
 timeout_ms = 30000
 error_contains = ["[E0907]", "function stack frame or outgoing call area", "2147483632"]
 


### PR DESCRIPTION
## Summary

`[value; count]` desugared to an `ArrayInit` naming one element reference per element, and that expansion survived into the CFG and both backends, where every element became its own store. `[0; 10000000]` took 70 s, 2.0 GB and produced a 70 MB executable; `[0; 100000000]` could not be compiled at all. The cost was paid even to reject a repeat: the `cumulative_locals_exceed_frame_budget` UI case spent ~7 s building an array the layout alone rejects.

- AIR's `ArrayInit` now carries an `ArrayInitShape`: `Elementwise` (the old payload) or `Repeat` (exactly one element reference, count read from the array type). The shape threads through packed validation, the printer, durable body export/import, the CFG builder, inline, unroll, verify, payload metrics, `retained_charge`, and the oracle interpreter (evaluates the element once and copies it). The repeated value is Copy by construction (E0905), so one materialization serves every element.
- Codegen defers a repeat spanning at least `REPEAT_FILL_MIN_SLOTS` (32) slots: the value is materialized once and the `Alloc`/`Store` that consumes the array writes the region with a counted loop over a cursor (`ResidualValuePlan::ArrayFill`, `agg_slots::fill_frame_region` / `fill_through_ptr`), in the same ADR-0040 low-end-ascending direction `store_slots` uses, at each element slot's own leaf width. A repeat of a repeat multiplies the counts into one loop. Below the threshold, or wherever a fill cannot serve (by-value argument, return, aggregate field, projected read), the elementwise slot vector is expanded from the same element, so small repeats keep byte-identical code.
- Both backends build the loop from instructions they already have (x86-64: `MovRI64`/`AddRI`/`Cmp64RI`/`Jnz`; AArch64: `MovImm`/`AddImm`/`Cbnz`), so no new MIR instruction is introduced. The two `SlotBackend` label primitives named for enum marshalling now serve the fill too and are renamed `alloc_lowering_label` / `emit_lowering_label`.
- Two structures proportional to slot count rather than shape are gone: `LocalSlotPlan` holds `Identity` as a rule instead of a `0..n` table, and the borrow-slot export reads the recorded set instead of asking about every frame slot. `types::primary_leaf_type` answers the slot-0 leaf question without materializing a leaf vector.
- New CLI harness field `max_executable_bytes` (in the shared `rue_test_runner::cli_corpus` schema) so a case can bound the produced artifact; rejected at load time alongside `compile_fail`.

## Measurements

`fn main() -> i32 { let xs: [i8; N] = [0; N]; @dbg(xs[0]); 0 }`, x86-64-linux, internal linker:

| N | before | after |
|---|---|---|
| 1,000,000 | 6.67 s, 266 MB RSS, 7.0 MB executable | 0.09 s, 50 MB, 24 KB |
| 10,000,000 | 70.4 s, 1.98 GB RSS, 70 MB executable | 0.05 s, 50 MB, 24 KB |
| 100,000,000 | aborted at 6.3 GB RSS (allocation failure) | 0.05 s, 50 MB, 24 KB |

`cumulative_locals_exceed_frame_budget`: 7.16 s / 1.6 GB → 0.02 s / 38 MB.

## Tests

- `rue-cli-tests/cases/array_repeat.toml`: filled repeats writing every element (non-zero scalar, multi-slot `@copy` struct, nested repeats below and above the threshold, zero fill), evaluation-once through an `inout` side effect, the 100M repeat linked and size-bounded, and `--emit mir` cases pinning the loop shape; each pinned on x86-64 and AArch64.
- Backend unit tests on both architectures: `array_repeat_fill_cost_is_independent_of_the_element_count` and `a_nested_array_repeat_is_one_fill`.
- Spec case under 7.1:39 (evaluated exactly once at a filled count); no spec prose change needed.

Not done, by choice: a dedicated zeroing sequence for all-zero constants (`rep stosq` would be a new asymmetric MIR instruction with no AArch64 counterpart), and repeating a non-repeat array value (`let a = [0; 64]; let b = [a; 4];`) still expands elementwise since the operand is a place read.

## Validation

`scripts/rue fmt`, `quick` (36/36), `unit codegen` (905), `cfg` (428), `air` (879), `test-runner` (144), `oracle-diff` (108), `cli array_repeat abi aggregate_abi_matrix drop enum` (360), `ui` (425), `spec` (2878), and the oracle-diff, spec-traceability, planted-miscompile-isolation and debug-assert gates, all passing on the rebased tree. The agent's full `premerge` on the pre-rebase tree passed except the two environmental CLI cases.

Closes RUE-2069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_