### PR TITLE
Bound and escape the test failure channel's message

### DIFF
--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -2274,13 +2274,20 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
     /// Stage the source location the next failure record will carry.
     ///
-    /// Every producer of an ADR-0083 §5.1 report reaches this: a test body's
-    /// `?` failure arm, the assertion family, and — since RUE-2019 — `@panic`
-    /// and the slice bounds check, whose records the runtime writes from inside
-    /// the trap helper. The staged site is consumed by whatever aborts next, so
-    /// this call must be the last thing before that terminal call: anything
-    /// evaluated in between could abort on a path that stages nothing and would
-    /// then adopt this site.
+    /// Every producer of an ADR-0083 §5.1 report that names a site reaches
+    /// this: a test body's `?` failure arm, the assertion family, and — since
+    /// RUE-2019 — `@panic`, whose record the runtime writes from inside the
+    /// panic helper. The bounds checks are not among them. Each is a bare
+    /// condition with no call beside it — the slice check is a `BoundsCheck`
+    /// intrinsic, the fixed-array check is lowered below AIR, and `s[i]`'s is
+    /// inside the runtime helper itself — and staging a site for any of them
+    /// costs the passing path, so `__rue_bounds_check` states its class and
+    /// leaves the location empty.
+    ///
+    /// The staged site is consumed by whatever aborts next, so this call must
+    /// be the last thing before that terminal call: anything evaluated in
+    /// between could abort on a path that stages nothing and would then adopt
+    /// this site.
     ///
     /// A site the host cannot resolve is staged as the empty file at 0:0 rather
     /// than reported as a compile error: the ABI accepts an absent location,

--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -362,6 +362,105 @@ compile_stdout_contains = [
 ]
 
 [[case]]
+name = "a_very_long_panic_message_is_truncated_and_stays_a_trap_panic"
+description = """
+RUE-2064: the record's `message` is bounded to 4096 bytes and marked with
+` …[truncated]`, and the bound covers the whole field, so the pinned `panic: `
+prefix counts toward it. `HEAD` and `TAIL` bracket exactly 4081 filler bytes, so
+the record ending immediately after `TAIL` is what pins the cut at 4096 and not
+merely somewhere.
+
+Unbounded, this message costs the test its verdict rather than its tail: the
+channel's retention budget is a quarter of a stream's, the runner kills the
+process group when a record exhausts it, and the report that reaches the event
+stream is `output_overflow` with no kind and no exit code — which is what this
+case asserts against. Stderr keeps the whole 300008-byte message, so the bound
+is the channel's alone.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+test "gives up at length" {
+    let mut message = std.strbuf.StrBuf.from_str(borrow "HEAD");
+    let mut i: u64 = 0;
+    while i < 4081 {
+        message.push(120);
+        i = i + 1;
+    }
+    message.append_str(borrow "TAIL");
+    while i < 300000 {
+        message.push(120);
+        i = i + 1;
+    }
+    @panic(message);
+}
+""" },
+]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"trap:panic","location":{"column":5,"file":"tests.rue","line":15},"message":"panic: HEADxxxxx',
+    'xxxxxTAIL …[truncated]"}',
+    '"stderr":{"bytes_total":300016,',
+    '"verdict":"fail"',
+]
+compile_stdout_not_contains = ['output_overflow']
+
+[[case]]
+name = "a_panic_message_that_is_not_utf8_still_reports_its_class"
+description = """
+RUE-2064: a Rue string is an arbitrary byte sequence, so a `@panic` message can
+carry bytes that are not UTF-8. The writer escapes each one as `\\u00xx` rather
+than passing it through, because a channel line the runner cannot decode costs
+the test its class: the record was dropped as malformed and the verdict fell
+back to a bare `exit` with a runner note. The `c` before the two escaped bytes
+is what shows the escaping is per-byte rather than per-line.
+
+Stderr is unchanged and still carries the raw bytes, which is why it is tagged
+`base64` here while the record is ordinary text (§2).
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+test "gives up in no encoding at all" {
+    let mut message = std.strbuf.StrBuf.new();
+    message.push(99);
+    message.push(255);
+    message.push(254);
+    @panic(message);
+}
+""" },
+]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"trap:panic","location":{"column":5,"file":"tests.rue","line":8},"message":"panic: cÿþ"}',
+    # The channel line spelled those two bytes `\u00ff\u00fe`; the event
+    # stream publishes the scalars they name, so the bytes read back.
+    '"stderr":{"bytes_total":11,"data":"cGFuaWM6IGP//go=","encoding":"base64"}',
+    '"verdict":"fail"',
+]
+compile_stdout_not_contains = ["runner_note"]
+
+[[case]]
 name = "an_out_of_bounds_index_takes_its_class_from_the_channel"
 description = """
 `__rue_bounds_check` writes its own `trap:bounds_check` record, so the class is

--- a/crates/rue-runtime/src/error.rs
+++ b/crates/rue-runtime/src/error.rs
@@ -208,11 +208,14 @@ crate::define_runtime_implementation! {
     /// 3. Exits with code 101
     ///
     /// The record carries whatever site
-    /// [`crate::test_channel::__rue_test_failure_site`] staged (RUE-2019). A
-    /// slice index stages its own before it traps; the fixed-array check the
-    /// compiler emits below AIR stages none, so its record names no file and
-    /// the runner answers from the test declaration's header, exactly as it
-    /// did when the class was read off stderr.
+    /// [`crate::test_channel::__rue_test_failure_site`] staged (RUE-2019). No
+    /// route here stages one: the fixed-array check the compiler emits below
+    /// AIR, the slice check semantic analysis emits as a `BoundsCheck`
+    /// intrinsic, and the `s[i]` check inside
+    /// [`crate::string::__rue_str_byte_at`] all reach this helper with nothing
+    /// staged, so the record names no file and the runner answers from the test
+    /// declaration's header. What the record adds over the stderr line is the
+    /// class, stated by the runtime rather than matched out of prose.
     ///
     /// # ABI
     ///

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -16,8 +16,17 @@
 //!   reader terminates the process before `write` returns at all. The runner
 //!   holds its read end open until the child exits precisely for this reason.)
 //! - **No allocation, and no staging buffer.** A record is emitted as runs
-//!   borrowed straight from the caller's own bytes, so an arbitrarily long
-//!   message needs no heap and no bound on its own length.
+//!   borrowed straight from the caller's own bytes, so no part of it is ever
+//!   assembled in memory first. The only fixed-size buffer is the six bytes one
+//!   escape occupies.
+//!
+//! A record's `message` is bounded to [`MESSAGE_BOUND`] because the channel has
+//! a retention budget of its own and a record that exhausts it costs the test
+//! its verdict: the runner kills the process group and publishes
+//! `output_overflow` in place of the class and the exit status the record was
+//! carrying. Stderr, which has no such role, still prints the message whole
+//! within its own retention budget — a message large enough to exhaust that
+//! budget too still overflows there.
 //!
 //! Records reserved by §5.1 and §5.2 — `promotion` payloads and per-case
 //! `sub_result` identities — are named by the schema and produced by nothing in
@@ -108,6 +117,22 @@ const BOUNDS_CHECK_MESSAGE: [u8; 26] = *b"error: index out of bounds";
 /// The pinned malformed-selector diagnostic (ADR-0083 §3).
 const USAGE_MESSAGE: [u8; 50] = *b"rue-test: expected one 16-hex-digit test selector\n";
 
+/// How many bytes of a record's `message` reach the channel.
+///
+/// The same 4 KiB rendering bound the `?` payload and the comparison operands
+/// are held to (spec 6.7:15), applied here for a different reason: those are
+/// bounded so a report stays readable, and this is bounded so a report stays a
+/// report. The channel's retention budget is a quarter of a stream's and JSON
+/// escaping can expand a control byte six-fold, so a message a few tens of
+/// kilobytes long would exhaust the budget, and the runner answers an exhausted
+/// channel by killing the process group and publishing `output_overflow` — the
+/// trap's class and its exit status lost to the length of its own text.
+const MESSAGE_BOUND: usize = 4096;
+
+/// Appended to a `message` the bound cut short, in the spelling spec 6.7:15
+/// already fixes for a truncated rendering.
+const TRUNCATION_MARKER: [u8; 15] = *b" \xe2\x80\xa6[truncated]";
+
 /// Emitter for one channel frame.
 ///
 /// `emit` receives already-escaped bytes in order, and the frame is assembled
@@ -137,21 +162,55 @@ impl<'a> FrameWriter<'a> {
 
     /// Emit `bytes` as the body of a JSON string.
     ///
-    /// Rue strings are arbitrary byte sequences, not guaranteed UTF-8, so this
-    /// escapes exactly what JSON requires and nothing else: the quote, the
-    /// backslash, and every control byte below `0x20` as a `\u00xx` escape.
-    /// Bytes at or above `0x80` are emitted raw, which keeps a valid UTF-8
-    /// message byte-identical on the wire and leaves an invalid one to the
-    /// runner's encoding tag (§2) rather than corrupting it here.
+    /// A record has to be JSON *text*, and a Rue string is an arbitrary byte
+    /// sequence: `@panic` and `@assert(c, msg)` both take one, and so does
+    /// anything the standard library panics with. A byte that is not part of a
+    /// well-formed UTF-8 sequence therefore cannot travel raw — the whole line
+    /// would decode as malformed and the runner would drop a real `trap:panic`
+    /// to a bare `exit` with a note about an unreadable channel.
+    ///
+    /// So this escapes what JSON requires — the quote, the backslash, and every
+    /// control byte below `0x20` — and, of the bytes at or above `0x80`, only
+    /// the ones that do not form a valid sequence. Each of those becomes
+    /// `\u00xx`, which names the byte's own value and keeps the line JSON text.
+    /// The field is not byte-reversible, though: an escaped byte and a genuine
+    /// character of the same value decode to the same scalar, so a consumer
+    /// that needs the exact bytes reads the stderr capture instead. Validating
+    /// rather than escaping every high byte is what keeps an ordinary non-ASCII
+    /// message byte-identical on the wire and legible in a report.
     ///
     /// Unescaped stretches are emitted as one run, so a message that needs no
     /// escaping costs exactly one write.
     fn escaped(&mut self, bytes: &[u8]) {
         const HEX: [u8; 16] = *b"0123456789abcdef";
         let mut run_start = 0;
-        for (index, byte) in bytes.iter().enumerate() {
+        let mut index = 0;
+        while index < bytes.len() {
+            let byte = bytes[index];
+            if byte >= 0x80 {
+                // A valid sequence stays in the run whole; an invalid lead or
+                // continuation byte is escaped one byte at a time, so the next
+                // iteration re-examines the rest as a fresh sequence.
+                if let Some(width) = utf8_sequence_width(&bytes[index..]) {
+                    index += width;
+                } else {
+                    self.raw(&bytes[run_start..index]);
+                    let escape = [
+                        b'\\',
+                        b'u',
+                        b'0',
+                        b'0',
+                        HEX[usize::from(byte >> 4)],
+                        HEX[usize::from(byte & 0x0f)],
+                    ];
+                    self.raw(&escape);
+                    index += 1;
+                    run_start = index;
+                }
+                continue;
+            }
             let mut escape = [0u8; 6];
-            let escape_len = match *byte {
+            let escape_len = match byte {
                 b'"' => {
                     escape[0] = b'\\';
                     escape[1] = b'"';
@@ -178,6 +237,7 @@ impl<'a> FrameWriter<'a> {
                 self.raw(&escape[..escape_len]);
                 run_start = index + 1;
             }
+            index += 1;
         }
         self.raw(&bytes[run_start..]);
     }
@@ -206,6 +266,44 @@ impl<'a> FrameWriter<'a> {
     }
 }
 
+/// The width of the well-formed UTF-8 sequence `bytes` starts with, or `None`
+/// when it does not start with one.
+///
+/// The ranges are Unicode's own well-formed byte sequences (Table 3-7), which
+/// reject an overlong encoding, a surrogate, and a scalar above `U+10FFFF` as
+/// well as a truncated sequence — `serde_json` and every other reader applies
+/// the same table, so anything looser here would let a line through that a
+/// reader still rejects. Written out rather than delegated to
+/// `core::str::from_utf8` so the freestanding build's emitted code stays a
+/// handful of comparisons with no libcall in it.
+fn utf8_sequence_width(bytes: &[u8]) -> Option<usize> {
+    let lead = *bytes.first()?;
+    let (width, first_continuation) = match lead {
+        0x00..=0x7f => return Some(1),
+        0xc2..=0xdf => (2, 0x80..=0xbf),
+        0xe0 => (3, 0xa0..=0xbf),
+        0xe1..=0xec | 0xee..=0xef => (3, 0x80..=0xbf),
+        0xed => (3, 0x80..=0x9f),
+        0xf0 => (4, 0x90..=0xbf),
+        0xf1..=0xf3 => (4, 0x80..=0xbf),
+        0xf4 => (4, 0x80..=0x8f),
+        _ => return None,
+    };
+    if bytes.len() < width || !first_continuation.contains(&bytes[1]) {
+        return None;
+    }
+    // The lead byte's range already constrained the first continuation; the
+    // rest are unconstrained trail bytes.
+    let mut index = 2;
+    while index < width {
+        if !(0x80..=0xbf).contains(&bytes[index]) {
+            return None;
+        }
+        index += 1;
+    }
+    Some(width)
+}
+
 /// Write the terminal completion frame.
 ///
 /// The dispatcher's epilogue is the only producer: exit 0 with end of stream
@@ -219,16 +317,22 @@ fn complete_frame(emit: &mut dyn FnMut(&[u8])) {
 /// Write every field the failure shapes share, through the open location
 /// object: they differ only in what follows the column.
 ///
-/// The message arrives as two runs rather than one so a trap can report the
-/// whole of its pinned stderr line — `panic: ` and the programmer's own bytes —
-/// with no staging buffer and no bound on the message's length. Every producer
-/// whose message is one piece passes an empty prefix, which costs no write.
-#[allow(clippy::too_many_arguments)]
+/// The message arrives as a list of runs rather than one view so a producer
+/// whose text is spelled in pieces — a trap's pinned stderr line is its
+/// `panic: ` prefix and then the programmer's own bytes — can report the whole
+/// of it without joining the pieces in a buffer first. They are one JSON string
+/// on the wire and one message to every consumer.
+///
+/// The runs are bounded together to [`MESSAGE_BOUND`]: the bound belongs to the
+/// `message` field a reader sees, not to whichever producer's piece happened to
+/// be long. A run the bound falls inside is cut at that byte, so a UTF-8
+/// sequence the cut lands in the middle of reaches the record as the escapes
+/// its leftover bytes get — still JSON text, which is the property that has to
+/// hold.
 fn failure_head(
     writer: &mut FrameWriter<'_>,
     kind: &[u8],
-    message_prefix: &[u8],
-    message: &[u8],
+    message: &[&[u8]],
     file: &[u8],
     line: u32,
     column: u32,
@@ -236,8 +340,16 @@ fn failure_head(
     writer.raw(&FAILURE_HEAD);
     writer.escaped(kind);
     writer.raw(&MESSAGE_FIELD);
-    writer.escaped(message_prefix);
-    writer.escaped(message);
+    let mut remaining = MESSAGE_BOUND;
+    for run in message {
+        if run.len() > remaining {
+            writer.escaped(&run[..remaining]);
+            writer.raw(&TRUNCATION_MARKER);
+            break;
+        }
+        writer.escaped(run);
+        remaining -= run.len();
+    }
     writer.raw(&LOCATION_FIELD);
     writer.escaped(file);
     writer.raw(&LINE_FIELD);
@@ -261,7 +373,7 @@ fn failure_frame(
     payload: &[u8],
 ) {
     let mut writer = FrameWriter::new(emit);
-    failure_head(&mut writer, kind, &[], message, file, line, column);
+    failure_head(&mut writer, kind, &[message], file, line, column);
     writer.raw(&PAYLOAD_FIELD);
     writer.escaped(payload);
     writer.raw(&FRAME_TAIL);
@@ -292,8 +404,7 @@ fn comparison_frame(
     failure_head(
         &mut writer,
         kind,
-        &[],
-        comparison_message(kind),
+        &[comparison_message(kind)],
         file,
         line,
         column,
@@ -329,7 +440,7 @@ fn comparison_message(kind: &[u8]) -> &'static [u8] {
 /// `payload` would claim otherwise.
 fn assert_frame(emit: &mut dyn FnMut(&[u8]), message: &[u8], file: &[u8], line: u32, column: u32) {
     let mut writer = FrameWriter::new(emit);
-    failure_head(&mut writer, &ASSERT_KIND, &[], message, file, line, column);
+    failure_head(&mut writer, &ASSERT_KIND, &[message], file, line, column);
     writer.raw(&LOCATION_TAIL);
 }
 
@@ -337,10 +448,9 @@ fn assert_frame(emit: &mut dyn FnMut(&[u8]), message: &[u8], file: &[u8], line: 
 ///
 /// The shape is the bare assertion's: a trap has no operands to report and
 /// nothing structured for the open `payload`, so the record ends at the
-/// location object. The message arrives as two runs rather than one so
-/// `@panic(msg)` can report the whole pinned stderr line — the `panic: `
-/// prefix and the programmer's own bytes — with no staging buffer and no bound
-/// on the message's length.
+/// location object. Its message is the pinned stderr line, spelled as the two
+/// runs [`failure_head`] joins into one string: the `panic: ` prefix and the
+/// programmer's own bytes.
 fn trap_frame(
     emit: &mut dyn FnMut(&[u8]),
     kind: &[u8],
@@ -354,8 +464,7 @@ fn trap_frame(
     failure_head(
         &mut writer,
         kind,
-        message_prefix,
-        message,
+        &[message_prefix, message],
         file,
         line,
         column,
@@ -896,8 +1005,11 @@ mod tests {
         );
     }
 
+    /// A well-formed sequence travels raw and an ill-formed byte is escaped, so
+    /// a message that mixes the two stays legible where it can be and stays
+    /// JSON text where it cannot.
     #[test]
-    fn bytes_at_or_above_0x80_are_written_raw() {
+    fn valid_utf8_travels_raw_and_an_invalid_byte_is_escaped() {
         let bytes = frame_bytes(|emit| {
             failure_frame(
                 emit,
@@ -909,26 +1021,143 @@ mod tests {
                 b"",
             )
         });
-        // The message field body appears verbatim, invalid UTF-8 included.
-        let needle: &[u8] = &[
-            b'"', b'm', b'e', b's', b's', b'a', b'g', b'e', b'"', b':', b'"',
-        ];
-        let start = bytes
-            .windows(needle.len())
-            .position(|window| window == needle)
-            .unwrap()
-            + needle.len();
-        assert_eq!(&bytes[start..start + 4], &[0xe2, 0x9c, 0x93, 0xff]);
+        let rendered = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            rendered.contains("\"message\":\"\u{2713}\\u00ff\""),
+            "{rendered}"
+        );
     }
 
+    /// Every ill-formed shape Unicode's Table 3-7 rejects: a bare continuation
+    /// byte, a lead byte with no continuation after it, an overlong encoding, a
+    /// surrogate, and a scalar above `U+10FFFF`. Each contributes exactly its
+    /// own bytes as escapes, so nothing is dropped and nothing is invented.
     #[test]
-    fn a_long_message_is_emitted_in_order_across_runs() {
-        let long = std::vec![b'x'; 4_096];
+    fn every_ill_formed_sequence_is_escaped_byte_by_byte() {
+        for (input, expected) in [
+            (&[0x80u8][..], "\\u0080"),
+            (&[0xc2][..], "\\u00c2"),
+            (&[0xc2, 0x41][..], "\\u00c2A"),
+            // Overlong: `/` encoded in two bytes.
+            (&[0xc0, 0xaf][..], "\\u00c0\\u00af"),
+            // Surrogate U+D800.
+            (&[0xed, 0xa0, 0x80][..], "\\u00ed\\u00a0\\u0080"),
+            // Above U+10FFFF.
+            (
+                &[0xf4, 0x90, 0x80, 0x80][..],
+                "\\u00f4\\u0090\\u0080\\u0080",
+            ),
+            (&[0xff, 0xfe][..], "\\u00ff\\u00fe"),
+            // Truncated four-byte sequence at the end of the message.
+            (&[0xf0, 0x9f][..], "\\u00f0\\u009f"),
+        ] {
+            let bytes =
+                frame_bytes(|emit| failure_frame(emit, b"assert", input, b"a.rue", 1, 1, b""));
+            let rendered = std::str::from_utf8(&bytes).unwrap();
+            assert!(
+                rendered.contains(&std::format!("\"message\":\"{expected}\"")),
+                "{input:?}: {rendered}"
+            );
+        }
+    }
+
+    /// Every well-formed shape reaches the record byte-identical: two, three,
+    /// and four-byte sequences, and the boundary scalars of each range.
+    #[test]
+    fn every_well_formed_sequence_travels_raw() {
+        for text in [
+            "\u{80}",
+            "\u{7ff}",
+            "\u{800}",
+            "\u{d7ff}",
+            "\u{e000}",
+            "\u{ffff}",
+            "\u{10000}",
+            "\u{10ffff}",
+        ] {
+            let bytes = frame_bytes(|emit| {
+                failure_frame(emit, b"assert", text.as_bytes(), b"a.rue", 1, 1, b"")
+            });
+            let rendered = std::str::from_utf8(&bytes).unwrap();
+            assert!(
+                rendered.contains(&std::format!("\"message\":\"{text}\"")),
+                "{text:?}: {rendered}"
+            );
+        }
+    }
+
+    /// A message exactly at the bound is emitted in order across its runs and
+    /// carries no marker: the bound is the last length that fits, not the first
+    /// that truncates.
+    #[test]
+    fn a_message_at_the_bound_is_emitted_whole_across_runs() {
+        let long = std::vec![b'x'; MESSAGE_BOUND];
         let bytes = frame_bytes(|emit| failure_frame(emit, b"assert", &long, b"a.rue", 1, 1, b""));
         let rendered = std::str::from_utf8(&bytes).unwrap();
         assert!(rendered.starts_with("{\"record\":\"failure\","));
         assert!(rendered.ends_with("\"payload\":\"\"}\n"));
         assert_eq!(rendered.matches('x').count(), long.len());
+        assert!(!rendered.contains("[truncated]"), "{}", &rendered[..80]);
+    }
+
+    /// One byte past the bound is cut to it and marked. Without this the record
+    /// grows with the message, and a message a few tens of kilobytes long
+    /// exhausts the channel's retention budget — which costs the test its whole
+    /// verdict, not just the tail of its text (RUE-2064).
+    #[test]
+    fn a_message_past_the_bound_is_cut_to_it_and_marked() {
+        let long = std::vec![b'x'; MESSAGE_BOUND + 1];
+        let bytes = frame_bytes(|emit| failure_frame(emit, b"assert", &long, b"a.rue", 1, 1, b""));
+        let rendered = std::str::from_utf8(&bytes).unwrap();
+        assert_eq!(rendered.matches('x').count(), MESSAGE_BOUND);
+        assert!(
+            rendered.contains(&std::format!(
+                "x \u{2026}[truncated]\",\"location\":{{\"file\":\"a.rue\""
+            )),
+            "{}",
+            &rendered[rendered.len() - 80..]
+        );
+    }
+
+    /// The bound belongs to the `message` field, so a trap's pinned prefix
+    /// counts toward it: the field a reader sees is 4096 bytes plus the marker
+    /// however many runs the producer spelled it in.
+    #[test]
+    fn a_traps_prefix_counts_against_the_same_bound() {
+        let long = std::vec![b'x'; MESSAGE_BOUND];
+        let bytes = frame_bytes(|emit| {
+            trap_frame(emit, &TRAP_PANIC_KIND, &PANIC_PREFIX, &long, b"a.rue", 1, 1)
+        });
+        let rendered = std::str::from_utf8(&bytes).unwrap();
+        assert_eq!(
+            rendered.matches('x').count(),
+            MESSAGE_BOUND - PANIC_PREFIX.len()
+        );
+        assert!(
+            rendered.contains("\"message\":\"panic: x"),
+            "{}",
+            &rendered[..80]
+        );
+        assert!(rendered.contains(" \u{2026}[truncated]\","));
+    }
+
+    /// A cut that lands inside a UTF-8 sequence leaves that sequence's head
+    /// bytes ill-formed, and the escaper answers them the way it answers any
+    /// other ill-formed byte. The record stays JSON text, which is the property
+    /// truncation must not be able to break.
+    #[test]
+    fn a_cut_inside_a_sequence_still_yields_json_text() {
+        // 4095 filler bytes, then a three-byte sequence the bound splits after
+        // its first byte.
+        let mut long = std::vec![b'x'; MESSAGE_BOUND - 1];
+        long.extend_from_slice("\u{2713}".as_bytes());
+        let bytes = frame_bytes(|emit| failure_frame(emit, b"assert", &long, b"a.rue", 1, 1, b""));
+        let rendered = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            rendered.contains("x\\u00e2 \u{2026}[truncated]\""),
+            "{}",
+            &rendered[rendered.len() - 80..]
+        );
     }
 
     #[test]

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -119,6 +119,37 @@ without the newline. The two routes to one trap therefore agree: a runner
 reading the channel and a runner reading stderr publish the same kind and the
 same text, and the record adds only the site (RUE-2019).
 
+**The `message` field is bounded to 4096 bytes**, the same rendering bound the
+test-body `?` payload and the comparison operands use. A longer one is cut to
+that bound and the marker ` …[truncated]` is appended, in the spelling spec
+6.7:15 already fixes for a truncated rendering; the bound covers the whole
+field, so a trap's pinned `panic: ` prefix counts toward it. This is what keeps
+a long message from costing the test its verdict: the channel's retention budget
+is a quarter of a stream's and escaping can expand a control byte six-fold, so a
+message a few tens of kilobytes long would exhaust the budget, and the runner
+answers an exhausted channel by killing the process group and publishing
+`output_overflow` — losing the class and the exit status the record was carrying
+(RUE-2064). Stderr has no such role and still prints the message whole within
+its own 1 MiB retention budget, so the two routes to a trap agree except on the
+tail of a message past the bound. The bound buys the verdict back only up to
+that budget: a message long enough to exhaust stderr's own retention still
+overflows there, and is still published as `output_overflow`.
+
+**Every string field is JSON text.** A Rue string is an arbitrary byte sequence,
+so a `message`, a `payload`, or a rendered operand can carry bytes that are not
+UTF-8. The writer escapes the quote, the backslash, every control byte below
+`0x20`, and — of the bytes at or above `0x80` — only those that are not part of
+a well-formed UTF-8 sequence, each as `\u00xx` naming the byte's own value.
+Ordinary non-ASCII text therefore reaches the record byte-identical and stays
+legible, while an ill-formed byte reaches it as an escape instead of making the
+whole line undecodable, which before RUE-2064 turned a `trap:panic` into a bare
+`exit` with a runner note about an unreadable channel. The escape keeps the line
+JSON text; it is not a lossless encoding. `message` is **not byte-reversible**:
+a scalar in `U+0080`–`U+00FF` may be either an escaped raw byte or a genuine
+character of that value, and the two decode identically. A consumer that needs
+the exact original bytes reads the stderr capture instead, whose `encoding` tag
+makes it byte-faithful within its retained window (see Capture records).
+
 A `failure` record carries **at most one of** `payload` and the pair
 `left`/`right`, and a bare `@assert` carries neither: its record ends at the
 location object, because it has no operands to report and nothing structured to
@@ -158,11 +189,18 @@ Writes are best-effort by design: an image run by hand has no descriptor 3, and
 security boundary** — it prevents accidental collision with a test's own stdout,
 which is all its consumers are promised.
 
-**Producers in this version.** Every record on this channel is
-compiler-synthesized: `@assert`, `@assert_eq`, `@assert_ne`, the test-body `?`
-failure arm, and the dispatcher's `complete` epilogue. Nothing in the language
-can call `__rue_test_failure_site` or `__rue_test_fail`, so the user assertion
-library of ADR-0083 §5.1 is what the open `kind` and the reserved payload shapes
+**Producers in this version.** Records reach the channel by two routes, both
+the implementation's. Compiler-synthesized code writes them for `@assert`,
+`@assert_eq`, `@assert_ne`, the test-body `?` failure arm, and the dispatcher's
+`complete` epilogue; for `@panic` it stages only the site, and the panic helper
+that `@panic` aborts through writes the record. The runtime writes them for
+itself from inside the trap helpers, which is how a failure with no Rue call
+site at all still reports: an allocation failure reaches `__rue_panic`, an
+`s[i]` past the end reaches `__rue_bounds_check` from within
+`__rue_str_byte_at`, and a standard library guard that spells `@panic` reports
+as any other `@panic` does (RUE-2019). Nothing in the language can call
+`__rue_test_failure_site` or `__rue_test_fail`, so the user assertion library of
+ADR-0083 §5.1 is what the open `kind` and the reserved payload shapes
 are *for* rather than something that exists yet — a line naming an unknown
 `record` is recorded as malformed, which fails the test. A user-callable
 intrinsic is tracked as RUE-2027.
@@ -281,17 +319,20 @@ Which failures carry a site of their own, and which still fall back to the
 | `trap:panic` | The `@panic` intrinsic's own site, both spellings alike (RUE-2019). |
 | Every other `trap:<class>` | The `test` declaration's header. |
 
-The remaining traps are the checks the compiler emits below AIR — the
-fixed-array bounds check in the place lowering, and the division-by-zero,
-overflow, and `@intCast` range checks the CFG and codegen insert. None of them
-is an AIR call carrying a span, and the two ways to give them one both cost the
-*passing* path: staging a site beside the check runs on every access, and
-staging it inside the failing arm costs a branch on the negated condition and
-the arm's register pressure in every function that indexes. Until the trap edge
-can carry a site the passing path does not pay for, those failures name the
-header, and their `kind` is still exact — `__rue_bounds_check` writes its
-`trap:bounds_check` record whether or not a site was staged, so the class comes
-from the channel rather than from matching a stderr line.
+The remaining traps are the checks no lowering stages a site beside: the
+fixed-array bounds check in the place lowering, the slice bounds check semantic
+analysis emits as a `BoundsCheck` intrinsic, the `s[i]` check
+`__rue_str_byte_at` performs inside the runtime, and the division-by-zero,
+overflow, and `@intCast` range checks the CFG and codegen insert. The slice
+check is an AIR intrinsic and does carry a span, so what stops it is cost rather
+than reach, and both ways to spend it fall on the *passing* path: staging a site
+beside the check runs on every access, and staging it inside the failing arm
+costs a branch on the negated condition and the arm's register pressure in every
+function that indexes. Until the trap edge can carry a site the passing path
+does not pay for, those failures name the header, and their `kind` is still
+exact — `__rue_bounds_check` writes its `trap:bounds_check` record whether or
+not a site was staged, so the class comes from the channel rather than from
+matching a stderr line.
 
 `timeout` and `crash` verdicts also carry a failure record, with kind `timeout`
 and `signal` respectively.

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -286,8 +286,10 @@ diagnostic and terminate the process with the runtime-error status.
 
 Seven helpers implement the ADR-0083 §3 and §5.1 channel. Three are dispatcher
 plumbing no source spelling selects; the reporting helpers are what a test
-body's `?` and the assertion family lower to, in an ordinary executable as well
-as in a test image.
+body's `?`, the assertion family, and `@panic` lower to, in an ordinary
+executable as well as in a test image. `@panic` reaches only
+`__rue_test_failure_site` of them: its record is written by the panic helper it
+aborts through, not by a channel export (RUE-2019).
 
 - `__rue_test_normalize_process` narrows the captured argument count to one, so
   a test observes the pinned inventory rather than the selector it was
@@ -340,13 +342,26 @@ write a `trap:panic` record carrying the staged site *before* their pinned
 stderr line, and `__rue_bounds_check` writes a `trap:bounds_check` record the
 same way. Each record's message is that helper's own stderr line without the
 newline, so nothing a consumer already read changes. The site is staged by the
-`@panic` lowering alone: an allocation failure, and the fixed-array bounds
-check codegen emits from a place projection, reach these helpers with nothing
-staged and report the empty location the runner answers from the test
-declaration's header. Because the panic helpers now report, the three terminal
-channel helpers take the stderr half of the panic path directly rather than
-calling `__rue_panic` — a second `trap:panic` frame after their own would be
-noise on a channel whose first frame is the verdict.
+`@panic` lowering alone. Everything else reaches these helpers with nothing
+staged and reports the empty location the runner answers from the test
+declaration's header: an allocation failure, the fixed-array bounds check
+codegen emits from a place projection, the slice bounds check semantic analysis
+emits as a `BoundsCheck` intrinsic, and the `s[i]` check `__rue_str_byte_at`
+performs inside the runtime. Because the panic helpers now report, the three
+terminal channel helpers take the stderr half of the panic path directly rather
+than calling `__rue_panic` — a second `trap:panic` frame after their own would
+be noise on a channel whose first frame is the verdict.
+
+The record writer holds every helper above to two rules the caller does not have
+to know about. A `message` reaches the channel bounded to 4096 bytes, cut to
+that bound with ` …[truncated]` appended, because the channel's retention budget
+is the runner's and a record that exhausts it costs the test its class and its
+exit status; the same message still reaches stderr whole, within stderr's own
+retention budget. And a byte that is not part of a well-formed UTF-8 sequence is
+escaped as `\u00xx` rather than written raw, because a Rue string is an
+arbitrary byte sequence and a record has to stay JSON text (RUE-2064).
+[test-events.md](process/test-events.md) states both as the consumer-facing
+contract.
 
 The completion and failure records go to a dedicated inherited descriptor,
 number 3, one JSON object per line. Writes are best-effort: a test image run by


### PR DESCRIPTION
A record's `message` now reaches the failure channel bounded to 4096 bytes, cut
with the ` …[truncated]` marker spec 6.7:15 already fixes for a truncated
rendering. The channel's retention budget is a quarter of a stream's, so an
unbounded message exhausted it and cost the test its whole verdict rather than
its tail: the runner killed the process group and published `output_overflow`
in place of the trap's class and its exit status. `@panic("A" x 300000)`
reported `fail | output_overflow` with no exit code and now reports
`fail | trap:panic | exit_code 101` with the message cut at the bound. Stderr
has no such role and still prints the message whole within its own 1 MiB
retention budget; a message long enough to exhaust that budget too still
overflows there, and the documentation says so rather than promising the
verdict survives any length.

The writer also escapes any byte that is not part of a well-formed UTF-8
sequence as `\u00xx` instead of passing it through. A Rue string is an arbitrary
byte sequence, so a `@panic` or `@assert` message could make the whole channel
line undecodable, and a real `trap:panic` was published as a bare `exit` with a
runner note about an unreadable channel. Validating sequences rather than
escaping every high byte keeps ordinary non-ASCII text byte-identical on the
wire; `serde_json` decodes both spellings, so the runner's decoder is unchanged.
The escape keeps the line JSON text but is not a lossless encoding, and the
contract says that too: `message` is not byte-reversible, because an escaped
raw byte and a genuine character of the same value decode to the same scalar,
so a consumer that needs the exact bytes reads the byte-faithful stderr capture
instead.

The message arrives at `failure_head` as a list of runs rather than a
prefix/body pair, which puts the bound on the field a reader sees rather than on
one producer's piece, covers `@assert(cond, msg)` as well as `@panic(msg)`, and
states the "two runs, no staging buffer" rationale once. No allocation and no
staging buffer are introduced.

Four places also claimed the slice bounds check stages its own failure site. It
does not: semantic analysis emits it as a `BoundsCheck` intrinsic with no
`TestFailureSite` call beside it, so slice indexing and `__rue_str_byte_at`
report the empty location and the runner answers from the test declaration's
header, exactly as the fixed-array check does. The corrected places are
`__rue_bounds_check`'s doc, `stage_failure_site`'s doc, the trap table's
explanation in test-events.md, and the unstaged list in runtime-abi.md; the
table's conclusion was already right. The producers paragraph in test-events.md
also still said every record was compiler-synthesized, which stopped being true
when the runtime trap helpers began writing their own frames — and for `@panic`
that paragraph now says the compiler stages only the site, since the panic
helper it aborts through writes the record.

No schema change: the record and event field sets, key order, and types are
unchanged.

Fixes RUE-2064
