### PR TITLE
One comptime depth diagnostic, and cycles say cycle

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -3266,6 +3266,69 @@ fn comptime_depth_has_one_canonical_authority() {
     );
 }
 
+/// The depth sentence and the cycle sentence each exist once in this crate,
+/// and the host contract cannot spell a limit of its own (RUE-1975).
+///
+/// Six copies of the depth sentence used to be spread across two crates, and
+/// two of them sat on a query-cycle arm, so the same program was described as
+/// depth exhaustion or as a cycle depending on which counter reached it first.
+/// The wording is now a constructor; a host that formats its own sentence, or
+/// a `depth_exceeded` hook that takes a limit it could disagree about, is the
+/// shape that regression takes.
+#[test]
+fn comptime_depth_and_cycle_wording_have_one_spelling_each() {
+    let comptime = crate::sema::COMPTIME_PRODUCTION_SOURCE;
+    let ordinary = include_str!("sema/comptime_eval.rs");
+    assert_eq!(
+        comptime
+            .matches("exceeded the maximum nesting depth")
+            .count(),
+        1,
+        "the depth sentence must be spelled once, in its constructor"
+    );
+    assert_eq!(
+        comptime.matches("depends on its own result").count(),
+        1,
+        "the cycle sentence must be spelled once, in its constructor"
+    );
+    assert!(
+        comptime.contains("pub fn comptime_depth_exceeded_reason")
+            && comptime.contains("pub fn comptime_call_cycle_reason"),
+        "both wordings must be published as constructors"
+    );
+    // The host-generic evaluator may not name a concrete diagnostic kind, so
+    // the pairing of each wording with its `ErrorKind` lives one layer out.
+    let specialize = include_str!("specialize.rs");
+    assert!(
+        specialize.contains("pub fn comptime_depth_exceeded_diagnostic")
+            && specialize.contains("pub fn comptime_call_cycle_diagnostic")
+            && specialize.contains("crate::sema::comptime_depth_exceeded_reason(name)")
+            && specialize.contains("crate::sema::comptime_call_cycle_reason(name)"),
+        "each diagnostic must pair its kind with the shared wording"
+    );
+    assert_eq!(
+        specialize
+            .matches("exceeded the maximum nesting depth")
+            .count(),
+        0,
+        "the diagnostic layer must not restate the depth sentence"
+    );
+    assert!(
+        !ordinary.contains("exceeded the maximum nesting depth")
+            && ordinary.contains("comptime_depth_exceeded_diagnostic"),
+        "the ordinary host must consume the constructor, not restate it"
+    );
+    let hook = comptime
+        .split("fn depth_exceeded(")
+        .nth(1)
+        .and_then(|source| source.split(") -> Self::Failure").next())
+        .expect("depth hook signature");
+    assert!(
+        !hook.contains("depth: usize"),
+        "a host cannot be handed a limit it could report instead of the enforced one"
+    );
+}
+
 #[test]
 fn type_syntax_dependency_admission_indexes_only_the_large_case() {
     let typeck = include_str!("sema/typeck.rs");

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -136,7 +136,8 @@ pub use sema::{
     SemanticProducedAnonymousNominal, SemanticProducedAnonymousNominalShape, SourceParamAbi,
     analyze_provider_anonymous_body, analyze_provider_ordinary_body,
     analyze_provider_specialized_body, body_parameter_types, by_reference_parameter_pointee_types,
-    comptime_depth_over_limit, next_comptime_depth, occupying_body_parameter_types,
+    comptime_call_cycle_reason, comptime_depth_exceeded_reason, comptime_depth_over_limit,
+    next_comptime_depth, occupying_body_parameter_types,
 };
 pub use sema::{
     COMPTIME_MATCH_NO_SELECTED_ARM, ComptimeDiagnosticSite, ComptimeIntegerOperation,
@@ -145,6 +146,8 @@ pub use sema::{
     comptime_arithmetic_overflow_reason, comptime_scalar_pattern_decision,
     comptime_untyped_integer_result, decode_comptime_match_pattern,
 };
+// The two comptime-recursion diagnostics: one limit, one wording each, chosen
+// where a concrete diagnostic kind may be named (RUE-1975).
 pub use semantic_body::{
     SEMANTIC_BODY_INST_KINDS, SemanticAnonymousBodyExport, SemanticBody, SemanticBodyAnchor,
     SemanticBodyCallArg, SemanticBodyCandidate, SemanticBodyCandidateInstallWork,
@@ -188,6 +191,7 @@ pub use semantic_type_resolution::{
     SemanticVisibilityDomainCache, resolve_semantic_module_path, resolve_semantic_module_path_from,
     resolve_structured_semantic_type_syntax, resolve_structured_semantic_type_syntax_with,
 };
+pub use specialize::{comptime_call_cycle_diagnostic, comptime_depth_exceeded_diagnostic};
 pub use types::{
     ArrayLen, ArrayTypeId, EnumDef, EnumId, LangItem, ModuleDef, ModuleId, PtrConstTypeId,
     PtrMutTypeId, StructDef, StructField, StructId, TextViewKind, Type, TypeKind, array_type_name,

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -133,6 +133,36 @@ pub const fn comptime_depth_over_limit(depth: usize) -> bool {
     depth > MAX_COMPTIME_CALL_DEPTH
 }
 
+/// The one wording for a comptime call that ran past
+/// [`MAX_COMPTIME_CALL_DEPTH`] (spec 4.14:18).
+///
+/// Three independent mechanisms can be the first to observe the same overrun:
+/// the engine's own frame stack, the query boundary that re-enters a child
+/// comptime-call query, and the body scheduler's specialization frontier. They
+/// bound different quantities but enforce one language rule, so which one trips
+/// first is an implementation detail of the path a program takes. Spelling the
+/// sentence here keeps that detail invisible: the same program cannot be
+/// described two ways depending on whether it was reached from a `const`
+/// initializer, a `comptime` block, or an ordinary body.
+pub fn comptime_depth_exceeded_reason(name: &str) -> String {
+    format!(
+        "specialization of '{name}' exceeded the maximum nesting depth ({MAX_COMPTIME_CALL_DEPTH}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?"
+    )
+}
+
+/// The one wording for a comptime call that is required to evaluate itself
+/// (spec 4.14:18a).
+///
+/// A call whose reduction demands the very same call with the very same
+/// compile-time arguments is a cycle, not an overrun: no depth budget, however
+/// large, would let it finish, and reporting a nesting depth invites the
+/// reader to look for a runaway argument that is not there.
+pub fn comptime_call_cycle_reason(name: &str) -> String {
+    format!(
+        "specialization of '{name}' depends on its own result: reducing this call with these compile-time arguments requires that same call, so the recursion has no base case to start from"
+    )
+}
+
 /// Both operands of a binary arithmetic or ordering operation, classified by
 /// the value domain they were reduced to.
 enum ArithOperands<V> {
@@ -774,10 +804,13 @@ pub trait ComptimeRejections: ComptimeDomain {
         what: &str,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<(), Self::Failure>;
+    /// Report the depth overrun this host's failure type spells. The limit is
+    /// not a parameter: hosts word it with
+    /// [`comptime_depth_exceeded_reason`] rather than a number of their own,
+    /// so no host can name a boundary the engine did not enforce.
     fn depth_exceeded(
         &self,
         name: &Self::Name,
-        depth: usize,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure;
     /// Report an integer constant that is not representable in `ty`. `value`
@@ -1543,11 +1576,10 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             .count();
         if frame.name.is_some() && comptime_depth_over_limit(entered_depth) {
             let site = ComptimeDiagnosticSite::new(frame.program.clone(), frame.function_span);
-            return ComptimeOutcome::HostFailure(self.host.depth_exceeded(
-                frame.name.as_ref().expect("named frame"),
-                MAX_COMPTIME_CALL_DEPTH,
-                &site,
-            ));
+            return ComptimeOutcome::HostFailure(
+                self.host
+                    .depth_exceeded(frame.name.as_ref().expect("named frame"), &site),
+            );
         }
         if let Some(name) = frame.name.clone() {
             let canonical_identity = if let Some(identity) = frame.call_identity.clone() {

--- a/crates/rue-air/src/sema/comptime/value_domain_tests.rs
+++ b/crates/rue-air/src/sema/comptime/value_domain_tests.rs
@@ -2146,7 +2146,6 @@ impl ComptimeRejections for FakeHost {
     fn depth_exceeded(
         &self,
         _name: &Self::Name,
-        _depth: usize,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure {
         DIAGNOSTIC_SITES.with(|sites| {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2941,20 +2941,12 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeRejections for OrdinaryBodyEngine<
     fn depth_exceeded(
         &self,
         name: &Spur,
-        depth: usize,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure {
         CompileError::new(
-            ErrorKind::ComptimeEvaluationFailed {
-                reason: format!(
-                    "specialization of '{}' exceeded the maximum nesting depth ({}); \
-                     is a comptime-recursive function missing a compile-time-known \
-                     base case, or a generic function recursively instantiating \
-                     itself with new types?",
-                    self.body_interner().resolve(name),
-                    depth
-                ),
-            },
+            crate::specialize::comptime_depth_exceeded_diagnostic(
+                self.body_interner().resolve(name),
+            ),
             site.span(),
         )
     }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -88,7 +88,8 @@ pub use comptime::{
     ComptimeStructuredTypeResolution, ComptimeStructuredTypeSuspension, ComptimeStructuredTypes,
     ComptimeTargetIntrinsic, ComptimeTrap, ComptimeType, ComptimeTypeAlgebra,
     ComptimeTypeIntrinsic, ComptimeValue, ComptimeValueAlgebra, MAX_COMPTIME_CALL_DEPTH,
-    comptime_depth_over_limit, next_comptime_depth,
+    comptime_call_cycle_reason, comptime_depth_exceeded_reason, comptime_depth_over_limit,
+    next_comptime_depth,
 };
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;

--- a/crates/rue-air/src/sema/provider_fixture_tests.rs
+++ b/crates/rue-air/src/sema/provider_fixture_tests.rs
@@ -604,7 +604,7 @@ fn provider_local_memo_hit_still_obeys_depth_before_lookup() {
     assert!(matches!(
         &error.kind,
         ErrorKind::ComptimeEvaluationFailed { reason }
-            if reason == "specialization of 'recur' exceeded the maximum nesting depth (64); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?"
+            if *reason == crate::sema::comptime_depth_exceeded_reason("recur")
     ));
     assert_eq!(error_source_slice(source, &error), source);
 }
@@ -627,7 +627,7 @@ fn provider_specialized_body_failed_reduction_is_not_cached_and_retries() {
     assert!(matches!(
         &first_error.kind,
         ErrorKind::ComptimeEvaluationFailed { reason }
-            if reason == "specialization of 'looping' exceeded the maximum nesting depth (64); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?"
+            if *reason == crate::sema::comptime_depth_exceeded_reason("looping")
     ));
     assert_eq!(error_source_slice(source, &first_error), source);
     assert_eq!(first_stats.publications, 0);

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -43,9 +43,40 @@ use crate::sema::{
 };
 
 // The canonical budget is owned by the comptime frame engine and re-exported
-// here for callers that already import the sema surface.
+// here for callers that already import the sema surface. The compiler query
+// scheduler consumes it while tracking the causal depth of its specialization
+// worklist.
 pub use crate::sema::MAX_COMPTIME_CALL_DEPTH;
 use crate::types::{StructId, Type};
+
+/// The diagnostic for a comptime call that ran past
+/// [`MAX_COMPTIME_CALL_DEPTH`] (spec 4.14:18).
+///
+/// The engine's frame stack, the query boundary that re-enters a child
+/// comptime-call query, and the body scheduler's specialization frontier each
+/// bound a different quantity against this one limit, and which of them trips
+/// first depends only on the position a program is written in. They therefore
+/// report it with one constructor, so the same program cannot be described two
+/// ways (RUE-1975). The host-generic evaluator owns the wording; the kind is
+/// chosen here, where naming a concrete diagnostic type is allowed.
+pub fn comptime_depth_exceeded_diagnostic(name: &str) -> ErrorKind {
+    ErrorKind::ComptimeEvaluationFailed {
+        reason: crate::sema::comptime_depth_exceeded_reason(name),
+    }
+}
+
+/// The diagnostic for a comptime call whose reduction requires that same call
+/// (spec 4.14:18a).
+///
+/// This is what the query graph reports as a cycle. It is not a depth overrun
+/// and must not borrow that wording: no larger budget would admit the program,
+/// so naming a nesting depth would send the reader looking for a runaway
+/// argument that is not there (RUE-1975).
+pub fn comptime_call_cycle_diagnostic(name: &str) -> ErrorKind {
+    ErrorKind::ComptimeEvaluationFailed {
+        reason: crate::sema::comptime_call_cycle_reason(name),
+    }
+}
 
 /// A key for a specialized function:
 /// (base_function_name, type_arguments, value_arguments).
@@ -68,9 +99,6 @@ struct SpecializationInfo {
     call_site_span: Span,
 }
 
-/// Canonical maximum nesting depth for a comptime call. The compiler query
-/// scheduler re-exports this value while tracking the causal depth of its
-/// specialization worklist.
 fn collect_specializations(
     air: &Air,
     interner: &ThreadedRodeo,

--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -897,3 +897,22 @@ files = [{ path = "main.rue", source = "fn main() {}\n" }]
 args = ["explain", "E0201", "main.rue"]
 compile_fail = true
 error_contains = ["requires exactly one error code", "Usage: rue explain <E####>"]
+
+# RUE-1975: E1200 covers two recursion failures that read alike and are not
+# alike -- a specialization that ran past the nesting depth, and a call that
+# needs its own result. The explanation has to keep them apart, so it cites
+# both rules.
+[[case]]
+name = "comptime_code_explains_both_recursion_failures"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E1200"]
+compile_only = true
+compile_stdout_contains = [
+  "E1200: Comptime evaluation failed",
+  "Recurse with no compile-time-known base case:",
+  "Require a comptime call's own result:",
+  "docs/spec/src/04-expressions/14-comptime.md (spec rule 4.14:18)",
+  "docs/spec/src/04-expressions/14-comptime.md (spec rule 4.14:18a)",
+]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]

--- a/crates/rue-cli-tests/cases/comptime_const_position_parity.toml
+++ b/crates/rue-cli-tests/cases/comptime_const_position_parity.toml
@@ -169,3 +169,68 @@ fn main() -> i32 { 0 }
 """ }]
 compile_fail = true
 compile_stderr_contains = ["E1200", "must be a type"]
+
+# RUE-1975: three different counters can be the first to notice one overrun --
+# the engine's frame stack, the query boundary that re-enters a child comptime
+# call, and the body scheduler's specialization frontier. Which one trips
+# depends on the position a program is written in, so each of them used to
+# carry its own copy of the sentence and the copies could drift apart. These
+# cases pin the whole sentence, not a prefix, on each reachable path: the
+# reported text must not tell the reader which mechanism noticed.
+[[case]]
+name = "depth_sentence_is_whole_and_identical_on_the_scheduler_path"
+description = "An ordinary body call overruns on the scheduler's specialization frontier and prints the shared sentence in full."
+files = [{ path = "main.rue", source = """
+fn deep(comptime n: i64) -> i64 { if n <= 0 { 0 } else { 1 + deep(n - 1) } }
+fn main() -> i32 { let x: i64 = deep(65); @dbg(x); 0 }
+""" }]
+compile_fail = true
+error_contains = [
+    "E1200",
+    "specialization of 'deep' exceeded the maximum nesting depth (64); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
+]
+
+[[case]]
+name = "depth_sentence_is_whole_and_identical_on_the_durable_const_path"
+description = "A declaration-time const overruns inside the durable engine and prints the same sentence, naming the same function and the same limit."
+files = [{ path = "main.rue", source = """
+fn deep(comptime n: i64) -> i64 { comptime { if n == 0 { 0 } else { deep(n - 1) + 1 } } }
+const X: i64 = deep(65);
+fn main() -> i32 { @dbg(X); 0 }
+""" }]
+compile_fail = true
+error_contains = [
+    "E1200",
+    "specialization of 'deep' exceeded the maximum nesting depth (64); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
+]
+
+[[case]]
+name = "depth_sentence_is_whole_and_identical_on_the_block_path"
+description = "A `comptime {}` block overruns on the same durable engine and prints the same sentence."
+files = [{ path = "main.rue", source = """
+fn deep(comptime n: i64) -> i64 { if n <= 0 { 0 } else { 1 + deep(n - 1) } }
+fn main() -> i32 { let x: i64 = comptime { deep(65) }; @dbg(x); 0 }
+""" }]
+compile_fail = true
+error_contains = [
+    "E1200",
+    "specialization of 'deep' exceeded the maximum nesting depth (64); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
+]
+
+# The companion to the three depth cases: a call that depends on its own result
+# is a different failure and must read as one. No depth budget would admit it,
+# so borrowing the depth sentence here sends the reader looking for a runaway
+# argument that this program does not have.
+[[case]]
+name = "a_self_dependent_call_is_not_reported_as_a_depth_overrun"
+description = "A comptime call whose reduction requires that same call reports the cycle (4.14:18a), never the depth sentence."
+files = [{ path = "main.rue", source = """
+fn same(comptime n: u64) -> u64 { comptime { same(n) } }
+fn main() -> i32 { @dbg(same(0)); 0 }
+""" }]
+compile_fail = true
+error_contains = [
+    "E1200",
+    "specialization of 'same' depends on its own result: reducing this call with these compile-time arguments requires that same call, so the recursion has no base case to start from",
+]
+compile_stderr_not_contains = ["exceeded the maximum nesting depth"]

--- a/crates/rue-cli-tests/cases/comptime_self_call_typing.toml
+++ b/crates/rue-cli-tests/cases/comptime_self_call_typing.toml
@@ -688,8 +688,8 @@ compile_fail = true
 error_contains = ["E1200", "exceeded the maximum nesting depth"]
 
 [[case]]
-name = "control_same_argument_self_recursion_reaches_depth_diagnostic"
-description = "A self call with an unchanging argument revisits one canonical query key. That is a genuine cycle, and it must surface as the nesting-depth diagnostic, not as a query-cycle ICE."
+name = "control_same_argument_self_recursion_reports_the_cycle"
+description = "A self call with an unchanging argument revisits one canonical query key. That is a genuine cycle: it must surface as self-dependence, not as a query-cycle ICE and not as the nesting-depth diagnostic, which would describe a runaway argument this program does not have (RUE-1975)."
 files = [{ path = "main.rue", source = """
 fn f(comptime n: u64) -> u64 {
     comptime { f(n) }
@@ -701,4 +701,5 @@ fn main() -> i32 {
 }
 """ }]
 compile_fail = true
-error_contains = ["E1200", "exceeded the maximum nesting depth"]
+error_contains = ["E1200", "depends on its own result"]
+compile_stderr_not_contains = ["exceeded the maximum nesting depth"]

--- a/crates/rue-cli-tests/cases/comptime_type_recursion_depth.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_recursion_depth.toml
@@ -45,11 +45,17 @@ fn main() -> i32 {
 }
 """ }]
 
+# RUE-1975: `Bad()` takes no arguments, so its reduction demands the one query
+# key it is already reducing. That is self-dependence, not an overrun: the
+# depth budget is never consulted and no larger budget would admit the program.
+# The diagnostic used to borrow the depth sentence anyway and send the reader
+# looking for a runaway argument that does not exist.
 [[case]]
-name = "no_arg_type_recursion_is_e1200"
-description = "`fn Bad() -> type { Bad() }` → clean E1200 (was SIGABRT 134)."
+name = "no_arg_type_recursion_is_a_cycle_not_a_depth_overrun"
+description = "`fn Bad() -> type { Bad() }` → clean E1200 naming the self-dependence (was SIGABRT 134, then the depth sentence)."
 compile_fail = true
-error_contains = ["E1200", "exceeded the maximum nesting depth"]
+error_contains = ["E1200", "depends on its own result"]
+compile_stderr_not_contains = ["exceeded the maximum nesting depth"]
 files = [{ path = "main.rue", source = """
 fn Bad() -> type { Bad() }
 fn main() -> i32 { Bad(); 0 }

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1995,7 +1995,7 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
     (3_611, 15_282_171_189_445_768_455),
     (4_802, 13_585_732_442_571_114_436),
     (2_906, 14_218_343_244_686_701_314),
-    (52_774, 6_578_628_352_398_612_154),
+    (51_769, 14_289_453_487_945_239_920),
     (8_851, 7_734_652_166_175_953_446),
     (14_038, 8_977_560_222_769_304_814),
     (380, 6_623_933_847_739_557_204),
@@ -8456,11 +8456,57 @@ fn comptime_depth_consumers_use_the_air_authority() {
     assert!(
         database.contains("comptime_specialization_depth")
             && database.contains("rue_air::comptime_depth_over_limit")
-            && database.contains("rue_air::MAX_COMPTIME_CALL_DEPTH")
             && database.contains("ComptimeFrame::callable_body")
             && database.contains("!rue_air::comptime_depth_over_limit")
             && !database.contains("<= rue_air::MAX_COMPTIME_CALL_DEPTH"),
         "durable query scheduling must use the canonical AIR depth authority"
+    );
+}
+
+/// No consumer in this crate restates the depth sentence, and the two
+/// query-cycle arms say cycle rather than depth (RUE-1975).
+///
+/// The scheduler frontier, the query-boundary ticket, and the durable host all
+/// enforce one limit on quantities they each measure differently; the wording
+/// is AIR's so which of them notices first stays invisible. The cycle arms are
+/// the pointed case: `nucleus_result` returning `Cycle` means the query graph
+/// re-entered this exact call, which no depth budget would have saved.
+#[test]
+fn comptime_depth_and_cycle_wording_come_from_air() {
+    for (name, source) in [
+        ("revisioned_query_database", REVISIONED_DATABASE_SOURCE),
+        (
+            "durable_comptime/diagnostics",
+            DURABLE_COMPTIME_DIAGNOSTICS_SOURCE,
+        ),
+        ("durable_comptime/host", DURABLE_COMPTIME_HOST_SOURCE),
+    ] {
+        assert!(
+            !source.contains("exceeded the maximum nesting depth"),
+            "{name} restates the depth sentence instead of consuming rue_air's"
+        );
+    }
+    let database = REVISIONED_DATABASE_SOURCE;
+    assert_eq!(
+        database
+            .matches("rue_air::comptime_call_cycle_diagnostic(definition.name())")
+            .count(),
+        2,
+        "both query-cycle arms must report a cycle, not a depth overrun"
+    );
+    assert_eq!(
+        database
+            .matches("rue_air::comptime_depth_exceeded_diagnostic(")
+            .count(),
+        2,
+        "both scheduler depth arms must report the shared depth sentence"
+    );
+    assert!(
+        DURABLE_COMPTIME_DIAGNOSTICS_SOURCE
+            .contains("rue_air::comptime_depth_exceeded_diagnostic(name)")
+            && DURABLE_COMPTIME_HOST_SOURCE
+                .contains("DurableComptimeFailure::maximum_depth(name.as_str())"),
+        "the durable terminal must forward the name and nothing else"
     );
 }
 

--- a/crates/rue-compiler/src/durable_comptime/diagnostics.rs
+++ b/crates/rue-compiler/src/durable_comptime/diagnostics.rs
@@ -281,9 +281,12 @@ impl DurableComptimeFailure {
         }
     }
 
-    pub(crate) fn maximum_depth(name: &str, maximum: usize) -> Self {
-        Self::comptime_failure(format!(
-            "specialization of '{name}' exceeded the maximum nesting depth ({maximum}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?"
+    /// The depth-overrun terminal, worded by the one AIR authority so the
+    /// durable engine and the query boundary that re-enters it cannot describe
+    /// the same overrun differently (RUE-1975).
+    pub(crate) fn maximum_depth(name: &str) -> Self {
+        Self::failure(SemanticNucleusFailure::Diagnostic(
+            rue_air::comptime_depth_exceeded_diagnostic(name),
         ))
     }
 
@@ -770,14 +773,8 @@ mod terminal_adapter_tests {
     fn named_diagnostic_constructors_preserve_exact_legacy_text() {
         let cases = [
             (
-                DurableComptimeFailure::maximum_depth(
-                    "count",
-                    rue_air::specialize::MAX_COMPTIME_CALL_DEPTH,
-                ),
-                format!(
-                    "specialization of 'count' exceeded the maximum nesting depth ({}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
-                    rue_air::specialize::MAX_COMPTIME_CALL_DEPTH,
-                ),
+                DurableComptimeFailure::maximum_depth("count"),
+                rue_air::comptime_depth_exceeded_reason("count"),
             ),
             (
                 DurableComptimeFailure::arithmetic_overflow(

--- a/crates/rue-compiler/src/durable_comptime/host.rs
+++ b/crates/rue-compiler/src/durable_comptime/host.rs
@@ -1692,10 +1692,9 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeRejections
     fn depth_exceeded(
         &self,
         name: &Self::Name,
-        depth: usize,
         _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure {
-        durable_host_failure(DurableComptimeFailure::maximum_depth(name.as_str(), depth))
+        durable_host_failure(DurableComptimeFailure::maximum_depth(name.as_str()))
     }
 
     fn literal_out_of_range(

--- a/crates/rue-compiler/src/revisioned_query_database/body/closure_nucleus.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/closure_nucleus.rs
@@ -490,6 +490,12 @@ pub(in crate::revisioned_query_database) fn schedule_body_instance<V>(
 /// its first application. The scheduler records the root at depth zero and
 /// increments for every specialization edge, so the first specialization is
 /// scheduler-depth one but comptime-depth zero.
+///
+/// The conversion exists so the scheduler measures the quantity 4.14:18 bounds
+/// rather than a second budget of its own: past this point the frontier is
+/// counted in comptime call depth, checked against
+/// [`rue_air::comptime_depth_over_limit`], and reported with
+/// [`rue_air::comptime_depth_exceeded_diagnostic`] (RUE-1975).
 #[inline]
 pub(in crate::revisioned_query_database) fn comptime_specialization_depth(
     scheduler_depth: usize,

--- a/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
@@ -1011,7 +1011,15 @@ impl Drop for TestSemanticComptimeArrayLengthOverrideGuard {
 /// Query-stack ticket for a durable comptime call.
 ///
 /// The query boundary owns this ticket so cancellation and unwinding restore
-/// the caller's depth; the limit and diagnostic authority remain in AIR.
+/// the caller's depth; the limit and the diagnostic remain AIR's (RUE-1975).
+///
+/// This is not a second copy of the engine's frame bound. A `ComptimeCall`
+/// query runs its own engine, whose frame stack starts empty, so nesting that
+/// crosses the query boundary — a type-syntax comptime call reduced while
+/// another comptime call is already being reduced — is invisible to every
+/// engine involved. Without this ticket that nesting would recurse on the host
+/// stack with nothing counting it. One limit, one sentence, two places it can
+/// be observed.
 pub(in crate::revisioned_query_database) struct SemanticComptimeCallDepthGuard(usize);
 
 impl SemanticComptimeCallDepthGuard {
@@ -1024,12 +1032,7 @@ impl SemanticComptimeCallDepthGuard {
             // frame, so the first active query is propagated call depth one.
             let propagated_depth = rue_air::next_comptime_depth(current);
             if rue_air::comptime_depth_over_limit(propagated_depth) {
-                return Err(
-                    crate::durable_comptime::DurableComptimeFailure::maximum_depth(
-                        name,
-                        rue_air::MAX_COMPTIME_CALL_DEPTH,
-                    ),
-                );
+                return Err(crate::durable_comptime::DurableComptimeFailure::maximum_depth(name));
             }
             depth.set(current + 1);
             Ok(Self(current))

--- a/crates/rue-compiler/src/revisioned_query_database/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/provider.rs
@@ -1192,16 +1192,15 @@ impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
         let value = match self.provider.nucleus_result(query) {
             Ok(Some(value)) => value,
             Ok(None) => return rue_air::DurableComptimeCallOutcome::NotReduced,
+            // A cycle is not an overrun. The query graph re-entered this exact
+            // comptime call with these exact arguments, so no depth budget
+            // would let it finish; reporting a nesting depth would send the
+            // reader looking for a runaway argument that is not there
+            // (RUE-1975).
             Err(QueryAbort::Cycle(_)) => {
                 return rue_air::DurableComptimeCallOutcome::Diagnostic(
                     rue_air::DurableComptimeDiagnostic {
-                        kind: rue_error::ErrorKind::ComptimeEvaluationFailed {
-                            reason: format!(
-                                "specialization of '{}' exceeded the maximum nesting depth ({}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
-                                definition.name(),
-                                rue_air::MAX_COMPTIME_CALL_DEPTH,
-                            ),
-                        },
+                        kind: rue_air::comptime_call_cycle_diagnostic(definition.name()),
                         span: None,
                     },
                 );
@@ -1246,18 +1245,15 @@ impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
                     rue_air::DurableComptimeDiagnostic { kind, span },
                 );
             }
+            // The same cycle, observed as a recorded nucleus failure rather
+            // than an abort. It is the arm a self-dependent comptime call such
+            // as `fn Bad() -> type { Bad() }` actually reaches (RUE-1975).
             crate::semantic_query_nucleus::SemanticNucleusValue::Failure(
                 crate::semantic_query_nucleus::SemanticNucleusFailure::Cycle(_),
             ) => {
                 return rue_air::DurableComptimeCallOutcome::Diagnostic(
                     rue_air::DurableComptimeDiagnostic {
-                        kind: rue_error::ErrorKind::ComptimeEvaluationFailed {
-                            reason: format!(
-                                "specialization of '{}' exceeded the maximum nesting depth ({}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
-                                definition.name(),
-                                rue_air::MAX_COMPTIME_CALL_DEPTH,
-                            ),
-                        },
+                        kind: rue_air::comptime_call_cycle_diagnostic(definition.name()),
                         span: None,
                     },
                 );

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_reachability.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_reachability.rs
@@ -382,12 +382,7 @@ $runtime
                                     instance.as_ref().clone(),
                                     crate::CompileErrors::from(
                                         crate::CompileError::without_span(
-                                            rue_error::ErrorKind::ComptimeEvaluationFailed {
-                                                reason: format!(
-                                                    "specialization of '{name}' exceeded the maximum nesting depth ({}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
-                                                    rue_air::MAX_COMPTIME_CALL_DEPTH
-                                                ),
-                                            },
+                                            rue_air::comptime_depth_exceeded_diagnostic(&name),
                                         ),
                                     ),
                                 );
@@ -427,12 +422,7 @@ $runtime
                                 instance.as_ref().clone(),
                                 crate::CompileErrors::from(
                                     crate::CompileError::without_span(
-                                        rue_error::ErrorKind::ComptimeEvaluationFailed {
-                                            reason: format!(
-                                                "specialization of '{name}' exceeded the maximum nesting depth ({}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
-                                                rue_air::MAX_COMPTIME_CALL_DEPTH
-                                            ),
-                                        },
+                                        rue_air::comptime_depth_exceeded_diagnostic(name),
                                     ),
                                 ),
                             );

--- a/crates/rue-compiler/src/revisioned_query_database/tests/retention_cancellation.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/retention_cancellation.rs
@@ -13,10 +13,21 @@ fn semantic_comptime_call_depth_guard_restores_after_every_exit() {
     }
     SEMANTIC_COMPTIME_CALL_DEPTH
         .with(|depth| assert_eq!(depth.get(), rue_air::MAX_COMPTIME_CALL_DEPTH));
-    assert!(
-        SemanticComptimeCallDepthGuard::enter("count").is_err(),
-        "the exact next depth must be rejected"
-    );
+    // The query boundary reports the overrun the engine's frame stack cannot
+    // see, so it must report it in the engine's own words (RUE-1975).
+    let rejected = SemanticComptimeCallDepthGuard::enter("count")
+        .err()
+        .expect("the exact next depth must be rejected");
+    let crate::durable_comptime::DurableComptimeFailure::Failure(failure) = rejected else {
+        panic!("a depth overrun is a domain failure, not an abort");
+    };
+    let crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+        rue_error::ErrorKind::ComptimeEvaluationFailed { reason },
+    ) = *failure
+    else {
+        panic!("a depth overrun is the comptime-evaluation diagnostic");
+    };
+    assert_eq!(reason, rue_air::comptime_depth_exceeded_reason("count"));
     while guards.pop().is_some() {}
     SEMANTIC_COMPTIME_CALL_DEPTH.with(|depth| assert_eq!(depth.get(), 0));
 

--- a/crates/rue-compiler/tests/error_explanation_examples.rs
+++ b/crates/rue-compiler/tests/error_explanation_examples.rs
@@ -49,6 +49,7 @@ fn compiler_owned_explanation_examples_have_the_declared_outcome() {
                     | 900..=908
                     | 950
                     | 1000
+                    | 1200
             )
     }) {
         let explanation = error_code_explanation(metadata.code)

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -2235,7 +2235,18 @@ define_error_codes! {
     // ========================================================================
     // Comptime errors (E1200-E1299)
     // ========================================================================
-    COMPTIME_EVALUATION_FAILED = 1200;
+    COMPTIME_EVALUATION_FAILED = 1200 => {
+        explanation: "Compile-time evaluation could not produce a value for a position that requires one. The `reason` names the specific failure: an operation whose result is not compile-time known, an arithmetic fact that would trap at runtime, and -- the two recursion cases -- a specialization that ran past the maximum nesting depth, or a comptime call whose reduction requires that same call. The two recursion cases are distinct. A depth overrun means each round produced a new specialization and the chain never reached a base case, so a smaller argument or a reachable base case fixes it. Self-dependence means the call needs its own result with the same compile-time arguments, which no depth budget would satisfy.",
+        likely_cause: "A comptime-recursive function is missing a compile-time-known base case, a generic function reinstantiates itself with a new type every round, or a comptime call is written so that reducing it demands its own result. Give the recursion a base case the compiler can see, or break the self-dependence.",
+        examples: [
+            ErrorCodeExample { title: "Recurse with no compile-time-known base case", source: "fn runaway(comptime n: i32) -> i32 {\n    runaway(n + 1)\n}\nfn main() -> i32 { runaway(0) }", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Require a comptime call's own result", source: "fn Bad() -> type { Bad() }\nfn main() -> i32 {\n    Bad();\n    0\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+        ],
+        references: [
+            ErrorCodeReference { title: "Specialization has a maximum nesting depth", path: "docs/spec/src/04-expressions/14-comptime.md", rule: Some("4.14:18") },
+            ErrorCodeReference { title: "A comptime call may not depend on its own result", path: "docs/spec/src/04-expressions/14-comptime.md", rule: Some("4.14:18a") },
+        ],
+    };
     COMPTIME_ARG_NOT_CONST = 1201;
 
     // ========================================================================

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2291,6 +2291,38 @@ compile_fail = true
 error_contains = "exceeded the maximum"
 
 [[case]]
+name = "comptime_call_that_depends_on_itself_is_a_cycle"
+spec = ["4.14:18a"]
+description = "A comptime call whose reduction requires that same call is diagnosed as self-dependence, not as an overrun of the 4.14:18 nesting depth"
+source = """
+fn Bad() -> type {
+    Bad()
+}
+fn main() -> i32 {
+    Bad();
+    0
+}
+"""
+compile_fail = true
+error_contains = "depends on its own result"
+
+[[case]]
+name = "comptime_call_cycle_is_not_reported_as_depth_exhaustion"
+spec = ["4.14:18a"]
+description = "The self-dependent call reports the cycle rather than the depth sentence, so a reader is not sent looking for a runaway argument that does not exist"
+source = """
+fn f(comptime n: u64) -> u64 {
+    comptime { f(n) }
+}
+fn main() -> i32 {
+    f(0);
+    0
+}
+"""
+compile_fail = true
+error_contains = "depends on its own result"
+
+[[case]]
 name = "comptime_match_selects_arm_recursion"
 spec = ["4.14:19"]
 description = "A match on a comptime-known scrutinee selects its arm at compile time, letting comptime recursion written with match terminate (RUE-191)"

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -186,6 +186,16 @@ fn runaway(comptime n: i32) -> i32 {
 }
 ```
 
+{{ rule(id="4.14:18a", cat="legality-rule") }}
+
+It is a compile-time error when reducing a comptime call requires the result of that same call with the same compile-time arguments, directly or through other comptime calls. Such a call has no base case at any depth, so an implementation **MUST** diagnose the self-dependence itself rather than report it as an overrun of the 4.14:18 nesting depth: no larger depth would admit the program.
+
+```rue
+fn Bad() -> type {
+    Bad()  // ERROR: reducing Bad() requires Bad()
+}
+```
+
 {{ rule(id="4.14:19", cat="normative") }}
 
 Within a specialized function body, a `match` expression whose scrutinee can be evaluated at compile time likewise selects its arm at compile time: only the body of the first arm whose pattern matches the comptime value is analyzed and compiled. Comptime recursion may therefore equivalently be written with `match`. The pattern set itself must still be exhaustive (4.7:9) — exhaustiveness is a property of the patterns, which are checked even though unselected arm bodies are not.


### PR DESCRIPTION
## Summary

The comptime nesting-depth limit is enforced in three places that each measure a different quantity (the evaluator's frame stack, the query boundary that re-enters a child comptime-call query, and the body scheduler's specialization frontier), and its "exceeded the maximum nesting depth (N)" sentence was spelled six times. Two of those copies sat on query-cycle arms in the durable provider, so `fn Bad() -> type { Bad() }` and a self call with an unchanging argument were reported as a depth overrun when no depth budget could ever let them finish.

- `rue_air::sema::comptime` owns `comptime_depth_exceeded_reason(name)` and `comptime_call_cycle_reason(name)`; `rue_air::specialize` pairs each with its `ErrorKind` as `comptime_depth_exceeded_diagnostic` / `comptime_call_cycle_diagnostic`. All five production consumers use them; both `provider.rs` cycle arms (`QueryAbort::Cycle` and `SemanticNucleusFailure::Cycle`) now report self-dependence.
- The `ComptimeRejections::depth_exceeded` host hook lost its `depth` parameter, so no host can report a boundary the engine did not enforce.
- The query-boundary ticket (`SEMANTIC_COMPTIME_CALL_DEPTH`) stays: a `ComptimeCall` query runs its own evaluator whose frame stack starts empty, so nesting across the query boundary is invisible to every evaluator involved. It is a second observation point of one limit, not a second limit, and now uses the shared wording. The scheduler bound is the same policy and goes through the same constructor.
- Spec: new legality rule 4.14:18a (a comptime call may not require its own result with the same compile-time arguments; implementations must diagnose the self-dependence rather than a depth overrun), with two spec cases citing it.
- `--explain E1200` had no text; it now keeps the two recursion failures apart, cites 4.14:18 and 4.14:18a, and is checked by the explanation-example harness plus a `cli_explain` case.
- Guard tests in rue-air and rue-compiler assert each sentence is spelled once, that no rue-compiler source restates it, and that both cycle arms use the cycle constructor. One registration shape-identity checksum in the compiler inventory (`compiler.body-reachability`) changed with the edited registration.

## Tests

- `comptime_const_position_parity.toml`: four new cases pinning the whole sentence on the scheduler, durable-const, and block paths plus the cycle companion.
- `comptime_self_call_typing.toml` / `comptime_type_recursion_depth.toml`: the two self-dependent cases now expect the cycle wording and assert the depth sentence is absent.
- `retention_cancellation.rs` asserts the guard's text equals the shared constructor's.

## Validation

`scripts/rue fmt`, `quick` (36/36), `unit air` (880), `unit compiler` (1232), `unit error` (127), `cli comptime_const_position_parity comptime_self_call_typing comptime_type_recursion_depth cli_explain` (35), `ui` (425), `spec` (2880), and the spec-traceability, oracle-diff, error-explanation-examples and planted-miscompile-isolation gates, all passing on the rebased tree. The agent's full `cli` (2721 passed) and `premerge` on the pre-rebase tree passed except the two environmental CLI cases.

Closes RUE-1975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_