### PR TITLE
RUE-2085: skip execution of the x86-64-linux nested_variant_patterns cases on non-native hosts

### DIFF
--- a/crates/rue-cli-tests/cases/nested_variant_patterns.toml
+++ b/crates/rue-cli-tests/cases/nested_variant_patterns.toml
@@ -35,6 +35,7 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
 executable_target = "x86-64-linux"
+execute_if_native = true
 exit_code = 1
 
 [[case]]
@@ -101,6 +102,7 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
 executable_target = "x86-64-linux"
+execute_if_native = true
 exit_code = 97
 
 [[case]]
@@ -170,6 +172,7 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
 executable_target = "x86-64-linux"
+execute_if_native = true
 stdout = """
 7
 -1
@@ -237,6 +240,7 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
 executable_target = "x86-64-linux"
+execute_if_native = true
 stdout = """
 7
 -1
@@ -312,6 +316,7 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
 executable_target = "x86-64-linux"
+execute_if_native = true
 exit_code = 44
 
 [[case]]


### PR DESCRIPTION
The five `x86_64_linux_*` cases in `nested_variant_patterns.toml` set `executable_target = "x86-64-linux"` but omitted `execute_if_native = true`, unlike their `aarch64_linux_*` siblings in the same file. Without it, the harness unconditionally executes the produced binary, so on a non-x86-64 host it runs a foreign-arch ELF and fails with "cannot execute binary file" (exit 126) instead of skipping, as every other cross-target case in this file already does.

Verified locally on aarch64-macos: all 10 cases in the file now pass (previously the 5 x86_64_linux_* cases failed with exit 126).

Fixes RUE-2085