### PR TITLE
RUE-2045: resolve a bare crate token to a same-package secondary test target

### DIFF
--- a/scripts/rue
+++ b/scripts/rue
@@ -153,6 +153,37 @@ case "$cmd" in
                 break
             fi
         done
+        # No package is spelled like the token: it may still be the *target*
+        # name of a second rue_crate/rue_binary living inside some other
+        # package's BUCK file (RUE-2045), e.g. crates/rue declares both `rue`
+        # and `rue-driver`. Scan every BUCK file's macro bodies for an exact
+        # `name = "<token>",` line; a unique hit resolves straight to that
+        # package with the target defaulted below, same as a package match.
+        if [[ -z "$pkg" && -z "$unit_target" ]]; then
+            target_matches=()
+            for buck_file in crates/*/BUCK; do
+                [[ -f "$buck_file" ]] || continue
+                if [[ "$(awk -v tok="$crate" '
+                        /^(rue_crate|rue_binary)\(/ { in_macro = 1; next }
+                        in_macro && /^\)/ { in_macro = 0 }
+                        in_macro {
+                            line = $0
+                            sub(/^[ \t]+/, "", line)
+                            sub(/[ \t]+$/, "", line)
+                            if (line == "name = \"" tok "\",") { print "1"; exit }
+                        }
+                    ' "$buck_file")" == "1" ]]; then
+                    target_matches+=("$(basename "$(dirname "$buck_file")")")
+                fi
+            done
+            if [[ ${#target_matches[@]} -eq 1 ]]; then
+                pkg="${target_matches[0]}"
+                unit_target="$crate-test"
+            elif [[ ${#target_matches[@]} -gt 1 ]]; then
+                echo "scripts/rue unit: target '$crate' is ambiguous across packages: ${target_matches[*]} (use <package>:$crate-test)" >&2
+                exit 2
+            fi
+        fi
         # An unknown crate produces a clear message naming every package that
         # was probed, instead of a raw buck2 target-not-found dump.
         if [[ -z "$pkg" ]]; then

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -825,7 +825,20 @@ make_rue_unit_sandbox() {
   cp "$SRC_ROOT/scripts/rue" "$sb/scripts/rue"; chmod +x "$sb/scripts/rue"
   # crates/rue is the package whose own name needs no prefix; keeping it in the
   # sandbox pins that the exact spelling wins over crates/rue-rue (RUE-2040).
-  printf '# stub\n' >"$sb/crates/rue/BUCK"
+  # It also declares a second rue_crate target, rue-driver, spelled the way
+  # crates/rue/BUCK really does (RUE-2045): the wrapper resolves a *package*
+  # name, not a target name, so this is a package with no package of its own.
+  cat >"$sb/crates/rue/BUCK" <<'EOF'
+rue_binary(
+    name = "rue",
+    crate_root = "src/main.rs",
+)
+
+rue_crate(
+    name = "rue-driver",
+    crate_root = "src/lib.rs",
+)
+EOF
   printf '# stub\n' >"$sb/crates/rue-parser/BUCK"
   printf '# stub\n' >"$sb/crates/rue-compiler/BUCK"
   cat >"$sb/buck2" <<'EOF'
@@ -886,6 +899,17 @@ test_rue_unit_maps_crate_and_forwards_args() {
       FAKE_LIST_OUT='rue_driver::tests::case: test' \
       ./scripts/rue unit rue:rue-driver-test ) >/dev/null 2>&1 || rc=$?
   check "scripts/rue unit: crate:target form reaches a second target in that package" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'run //crates/rue:rue-driver-test --' "$sb/buck.log" && echo 0 || echo 1)"
+
+  # RUE-2045: the bare crate name a Rust developer actually knows — no package
+  # of its own, no explicit :target — resolves by scanning every BUCK file's
+  # rue_crate/rue_binary bodies for that exact name, not just by guessing a
+  # package. `crate-driver` (no `crates/rue-driver`) must not shadow this.
+  : >"$sb/buck.log"; rc=0
+  ( cd "$sb" && BUCK_LOG="$sb/buck.log" \
+      FAKE_LIST_OUT='rue_driver::tests::case: test' \
+      ./scripts/rue unit rue-driver ) >/dev/null 2>&1 || rc=$?
+  check "scripts/rue unit: a target with no package of its own resolves by name" \
     "$([ "$rc" -eq 0 ] && grep -Fxq 'run //crates/rue:rue-driver-test --' "$sb/buck.log" && echo 0 || echo 1)"
   rm -rf "$sb"
 }


### PR DESCRIPTION
`scripts/rue unit` resolved a token to a *package* and defaulted the target to `<package>-test`, so a second `rue_crate`/`rue_binary` living inside another package's BUCK file (e.g. `crates/rue` declares both `rue` and `rue-driver`) had no direct spelling: `scripts/rue unit rue-driver` failed with "unknown crate" even though `rue-driver` is exactly the crate name a Rust developer would reach for. The only working form was the explicit `rue:rue-driver-test`.

When package resolution fails and no explicit `:target` was given, scan every `crates/*/BUCK` file's `rue_crate`/`rue_binary` bodies for an exact `name = "<token>",` line. A unique hit resolves to that package with the target defaulted to `<token>-test`, same as an ordinary package match; more than one hit is reported as ambiguous rather than guessed at.

Verified against the real repo: `scripts/rue unit rue-driver` now runs 72 tests against `//crates/rue:rue-driver-test`; every existing resolution form (prefix-less, `rue-`-prefixed, explicit `crate:target`, the no-prefix `rue` package) is unchanged; an unknown crate still errors clearly. Added sandbox coverage in `scripts/test-wrapper-scripts.sh`; full wrapper-script suite (178 checks) green.

Fixes RUE-2045