### PR TITLE
RUE-2023: run the test cycle on the retained watch host

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -1471,7 +1471,14 @@ driver_exit_code = 2
 compile_stderr_contains = ["`rue test` cannot be combined with -o/--output"]
 
 [[case]]
-name = "test_mode_refuses_watch_and_the_timing_surfaces"
+name = "test_mode_refuses_the_timing_surfaces"
+description = """
+`--benchmark-json` and `--time-passes` both write into stdout, which is the
+event stream's. `--watch` is NOT among these: a watcher and a run share the
+process's lifetime rather than compete for it, and running each cycle on one
+retained compiler is what removes the per-run recompile (RUE-2023). It is
+covered by `cli.watch_test`.
+"""
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
@@ -1479,9 +1486,47 @@ fn main() -> i32 {
 }
 """ },
 ]
-args = ["test", "main.rue", "--watch"]
+args = ["test", "main.rue", "--benchmark-json"]
 driver_exit_code = 2
-compile_stderr_contains = ["`rue test` cannot be combined with --watch"]
+compile_stderr_contains = ["`rue test` cannot be combined with --benchmark-json"]
+
+[[case]]
+name = "test_mode_watch_refuses_a_listing"
+description = """
+A listing is an inventory of one revision and a watcher has no one revision, so
+it is the single test-mode flag `--watch` excludes (RUE-2023). The status is the
+runner-error `2`, like every other refused `rue test` invocation.
+"""
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = ["test", "main.rue", "--watch", "--list"]
+driver_exit_code = 2
+compile_stderr_contains = ["`rue test --watch` cannot be combined with --list"]
+
+[[case]]
+name = "test_mode_watch_still_refuses_the_output_modes"
+description = """
+`--watch` combines with every test-mode flag, but the modes compile mode already
+refuses with it stay refused — and in test mode they report the runner-error
+status rather than compile mode's argument status.
+"""
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = ["test", "main.rue", "--watch", "--emit", "air"]
+driver_exit_code = 2
+compile_stderr_contains = [
+    "--watch cannot be combined with --emit, --benchmark-json, or --time-passes",
+]
 
 [[case]]
 name = "a_test_only_flag_outside_test_mode_is_refused_by_name"

--- a/crates/rue-cli-tests/cases/watch_test.toml
+++ b/crates/rue-cli-tests/cases/watch_test.toml
@@ -1,0 +1,327 @@
+[section]
+id = "cli.watch_test"
+name = "The rue test watch loop"
+description = """
+RUE-2023: `rue test <root> --watch` runs one test cycle per accepted source
+revision on ONE retained compiler, so an iteration pays for what the edit
+changed rather than for a whole fresh compile.
+
+These cases drive the real binary through the same milestone protocol
+`cli.watch` uses, so every step waits for the cycle it is about to assert on
+rather than sleeping. What they pin is the surface a consumer sees: one
+`run_started`/`run_finished` pair per cycle with the cycle number in the head
+event, `run_canceled` in place of `run_finished` for a cycle an edit abandoned,
+a failed cycle that publishes no events and keeps watching, and the exit status
+the watcher reports when it is finally asked to stop — which is the only exit
+status a watcher produces at all.
+
+The schema is docs/process/test-events.md; `cli.rue_test` pins the one-shot
+stream, and these pin what `--watch` adds to it.
+"""
+
+[[case]]
+name = "an_edited_test_body_changes_only_that_tests_verdict"
+description = """
+The cycle is the whole suite, not a guess at what the edit reached: both tests
+run again, and only the edited one's verdict moves. Changed-only re-execution is
+deliberately not this (test-events.md, `--watch`).
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 { 0 }
+""" },
+    { path = "tests.rue", source = """
+test "doubles" {
+    @assert(2 * 2 == 4);
+}
+
+test "adds" {
+    @assert(1 + 1 == 2);
+}
+""" },
+]
+
+[case.watch_test]
+kind = "edit"
+expected_exit = 1
+stdout_contains = [
+    # Cycle 1: the head event carries its number, and both tests pass.
+    '"cycle":1,"event":"run_started","jobs":1,"opt_level":"0","plan":{"selected":2,"total":2},"root":"main.rue","schema":"1.0","seed":1',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":2',
+    # Cycle 2: a second pair, numbered, over the same two tests.
+    '"cycle":2,"event":"run_started"',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":1,"passed":1',
+    # And the failure is the edited test's own assertion, at its own site.
+    '"failure":{"exit_code":101,"kind":"assert","location":{"column":5,"file":"tests.rue","line":2}',
+    '"id":"tests.rue::doubles"',
+]
+stdout_not_contains = [
+    # `adds` was not touched, so nothing ever failed at its assertion's site.
+    '"file":"tests.rue","line":6',
+    '"cycle":3',
+]
+
+[[case.watch_test.edits]]
+path = "tests.rue"
+source = """
+test "doubles" {
+    @assert(2 * 2 == 5);
+}
+
+test "adds" {
+    @assert(1 + 1 == 2);
+}
+"""
+
+[[case]]
+name = "an_edited_helper_reruns_the_tests_that_reach_it"
+description = """
+The edit is in a module no test declares: the cycle re-observes the closure, the
+retained compiler re-analyzes what the change reached, and the test that calls
+the helper reports a new verdict. The test that does not call it is unaffected.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 { 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn double(x: i32) -> i32 { x * 2 }
+""" },
+    { path = "tests.rue", source = """
+const helper = @import("helper.rue");
+
+test "doubles through the helper" {
+    @assert(helper.double(2) == 4);
+}
+
+test "adds without it" {
+    @assert(1 + 1 == 2);
+}
+""" },
+]
+
+[case.watch_test]
+kind = "edit"
+expected_exit = 1
+stdout_contains = [
+    '"cycle":1,"event":"run_started"',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":2',
+    '"cycle":2,"event":"run_started","jobs":1,"opt_level":"0","plan":{"selected":2,"total":2}',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":1,"passed":1',
+    '"id":"tests.rue::doubles through the helper"',
+]
+stdout_not_contains = ['"cycle":3']
+
+[[case.watch_test.edits]]
+path = "helper.rue"
+source = """
+pub fn double(x: i32) -> i32 { x * 3 }
+"""
+
+[[case]]
+name = "a_broken_closure_fails_the_cycle_and_the_loop_keeps_watching"
+description = """
+An `@import` that no longer resolves is outside every test closure, so the cycle
+publishes NO events — not even a `run_started` for a run that never began — and
+says so on stderr with the compiler's own diagnostic plus a status line. The
+loop keeps watching, and the repairing edit produces an ordinary cycle. The
+previous cycle's verdicts are not reprinted (test-events.md, `--watch`).
+
+The cycle number is the loop's, not the stream's: the failed cycle consumed 2,
+so the repaired one is 3 and the stream skips a number. That is the point of
+publishing it — a gap says a revision produced no run.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 { 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn double(x: i32) -> i32 { x * 2 }
+""" },
+    { path = "tests.rue", source = """
+const helper = @import("helper.rue");
+
+test "doubles through the helper" {
+    @assert(helper.double(2) == 4);
+}
+""" },
+]
+
+[case.watch_test]
+kind = "compile_error"
+expected_exit = 0
+stdout_contains = [
+    '"cycle":1,"event":"run_started"',
+    '"cycle":3,"event":"run_started"',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":1',
+]
+stdout_not_contains = [
+    # Cycle 2 is the failed one: no head event, no verdicts, no summary.
+    '"cycle":2',
+    '"event":"run_canceled"',
+]
+stderr_contains = [
+    "E0704",
+    "cannot find module 'helper.rue'",
+    "Watch cycle failed after",
+    "no summary for this revision",
+]
+
+[[case.watch_test.edits]]
+path = "helper.rue"
+delete = true
+
+[[case.watch_test.edits]]
+path = "helper.rue"
+source = """
+pub fn double(x: i32) -> i32 { x * 2 }
+"""
+
+[[case]]
+name = "an_edit_during_the_run_cancels_the_cycle"
+description = """
+The edit lands while a test is running. Its process group is killed, the cycle
+ends with `run_canceled` rather than a `run_finished` whose counts would
+describe neither the verdicts it published nor the test it killed, and the
+`test_started` it had already published stays unfinished. The next cycle is
+ordinary.
+
+The spinning test's budget is short so a missed kill still ends the case rather
+than the suite's hang guard; the cancellation is what the case asserts, and it
+lands long before that budget expires.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 { 0 }
+""" },
+    { path = "tests.rue", source = """
+test "spins" {
+    let mut i: i32 = 0;
+    while i >= 0 {
+        if i > 0 {
+            i = i - 1;
+        }
+    }
+}
+""" },
+]
+
+[case.watch_test]
+kind = "cancel"
+timeout_ms = 8000
+expected_exit = 0
+stdout_contains = [
+    '"cycle":1,"event":"run_started","jobs":1,"opt_level":"0","plan":{"selected":1,"total":1}',
+    '{"event":"test_started","id":"tests.rue::spins"}',
+    '{"cycle":1,"event":"run_canceled","reported":0,"selected":1,',
+    '"cycle":2,"event":"run_started"',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":1',
+]
+stdout_not_contains = [
+    # The killed test produced no verdict, and the abandoned cycle no summary.
+    '"id":"tests.rue::spins","repro"',
+    '"verdict":"crash"',
+    '"verdict":"timeout"',
+]
+stderr_contains = ["Watch cycle canceled after"]
+
+[[case.watch_test.edits]]
+path = "tests.rue"
+source = """
+test "settles" {
+    @assert(1 + 1 == 2);
+}
+"""
+
+[[case]]
+name = "an_empty_selection_keeps_its_own_exit_status"
+description = """
+`3` is a distinct outcome rather than a vacuous success because an empty
+selection is how a typo becomes false evidence, and a watcher stopped after such
+a cycle owes an agent that distinction exactly as a one-shot run does. Only the
+runner-error `2` is withheld from the watch exit status, because that is the one
+answer that would claim no cycle ever completed.
+
+The cycle itself is complete and ordinary: `run_started` with an empty plan,
+`run_finished` with zero counts, and the reason on stderr.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 { 0 }
+""" },
+    { path = "tests.rue", source = """
+test "doubles" {
+    @assert(2 * 2 == 4);
+}
+""" },
+]
+
+[case.watch_test]
+kind = "edit"
+args = ["--filter", "nothing matches this"]
+expected_exit = 3
+stdout_contains = [
+    '"cycle":1,"event":"run_started","jobs":1,"opt_level":"0","plan":{"selected":0,"total":1}',
+    '"cycle":2,"event":"run_started","jobs":1,"opt_level":"0","plan":{"selected":0,"total":1}',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":0',
+]
+stderr_contains = ["error: no tests matched the selection"]
+
+[[case.watch_test.edits]]
+path = "tests.rue"
+source = """
+test "doubles" {
+    @assert(2 * 2 == 5);
+}
+"""
+
+[[case]]
+name = "human_format_prints_a_summary_per_cycle_and_says_it_is_watching"
+description = """
+Passes stay silent and failures print whole, exactly as a one-shot run reports
+them; what `--watch` adds for a person is one summary per cycle and the
+`watching…` line that says the loop is idle again. The line is stderr's, like
+every other status the loop writes, because stdout is the event stream in the
+other format and the two must not disagree about which stream carries what.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 { 0 }
+""" },
+    { path = "tests.rue", source = """
+test "doubles" {
+    @assert(2 * 2 == 4);
+}
+""" },
+]
+
+[case.watch_test]
+kind = "edit"
+format = "human"
+expected_exit = 1
+stdout_contains = [
+    "1 passed (",
+    "FAIL tests.rue::doubles",
+    "0 passed, 1 failed (",
+]
+stderr_contains = ["watching…"]
+
+[[case.watch_test.edits]]
+path = "tests.rue"
+source = """
+test "doubles" {
+    @assert(2 * 2 == 5);
+}
+"""

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -197,13 +197,15 @@ use rue_target::{Arch, Target};
 use rue_test_runner::cli_corpus::{
     AutomaticExampleContract, Case, CliCaseTier, ExecutionClass, ExecutionContractDeclaration,
     HangTimeoutProfile, Section, TestFile, TimeoutProfile, WatchEdit, WatchScenario,
-    WatchScenarioKind, unknown_known_bug_on_platforms, unknown_only_on_platforms,
+    WatchScenarioKind, WatchTestScenario, WatchTestScenarioKind, unknown_known_bug_on_platforms,
+    unknown_only_on_platforms,
 };
 use rue_test_runner::{
     ExpectedFailureOutcome, KNOWN_TARGETS, PlatformCaseSelection, ShardSelector, TestFailure,
     TestNameOrigin, TestResult, classify_expected_failure, compiler_command,
-    configure_process_group, find_dir, find_rue_binary, ice_message, kill_process_group,
-    run_with_timeout, validate_nonempty_case_corpus, validate_unique_test_names,
+    configure_process_group, find_dir, find_rue_binary, ice_message, interrupt_process_group,
+    kill_process_group, run_with_timeout, validate_nonempty_case_corpus,
+    validate_unique_test_names,
 };
 use serde::Serialize;
 
@@ -1992,6 +1994,7 @@ fn case_runs_prebuilt_program(case: &Case) -> bool {
         args: None,
         output: None,
         watch: None,
+        watch_test: None,
         env,
         executable_target: None,
         compile_fail: false,
@@ -2922,6 +2925,207 @@ fn run_watch_case(
     })
 }
 
+/// Drive a real `rue test --watch` process through the milestone protocol,
+/// editing its sources between cycles, and assert on the event stream it
+/// publishes (RUE-2023).
+///
+/// It never runs a produced program: a test watcher publishes no executable, so
+/// what it owes a consumer is the stream and the exit status it reports when it
+/// is asked to stop. Both are checked here.
+fn run_watch_test_case(
+    case: &Case,
+    scenario: &WatchTestScenario,
+    contract: &ExecutionContract,
+    rue_binary: &Path,
+    real_std: &Path,
+) -> TestResult {
+    let required_edits = match scenario.kind {
+        WatchTestScenarioKind::Edit | WatchTestScenarioKind::Cancel => 1,
+        WatchTestScenarioKind::CompileError => 2,
+    };
+    if scenario.edits.len() != required_edits {
+        return Err(TestFailure::assertion(format!(
+            "a {:?} watch-test scenario requires exactly {required_edits} edit(s)",
+            scenario.kind
+        )));
+    }
+
+    let temp_dir = tempfile::tempdir().map_err(|error| {
+        TestFailure::fatal(format!("failed to create watch-test temp dir: {error}"))
+    })?;
+    let dir = temp_dir.path();
+    for file in &case.files {
+        let path = dir.join(&file.path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                TestFailure::fatal(format!(
+                    "failed to create watch-test fixture directory: {error}"
+                ))
+            })?;
+        }
+        std::fs::write(&path, &file.source).map_err(|error| {
+            TestFailure::fatal(format!(
+                "failed to write watch-test fixture {}: {error}",
+                file.path
+            ))
+        })?;
+    }
+
+    let source = case
+        .files
+        .first()
+        .map(|file| file.path.as_str())
+        .ok_or_else(|| TestFailure::assertion("watch-test scenario has no root source"))?;
+    let protocol = dir.join("watch.protocol");
+    let mut compiler_args = vec![
+        "test".to_owned(),
+        source.to_owned(),
+        "--watch".to_owned(),
+        // The event stream promises the content of each line, not an order
+        // across concurrent tests, so a case that asserts on it runs one test
+        // at a time. The seed is explicit for the same reason it is in
+        // `cli.rue_test`: a pinned plan is a comparable one.
+        "-j1".to_owned(),
+        "--seed".to_owned(),
+        "1".to_owned(),
+        "--format".to_owned(),
+        scenario.format.clone().unwrap_or_else(|| "json".to_owned()),
+    ];
+    if let Some(timeout) = scenario.timeout_ms {
+        compiler_args.push("--timeout-ms".to_owned());
+        compiler_args.push(timeout.to_string());
+    }
+    compiler_args.extend(scenario.args.iter().cloned());
+
+    let mut command = case_compiler_command(rue_binary, &compiler_args, dir, &case.env, real_std);
+    command
+        .env("RUE_WATCH_TEST_PROTOCOL", &protocol)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    configure_process_group(&mut command);
+    let mut child = command.spawn().map_err(|error| {
+        TestFailure::fatal(format!("failed to spawn watch-test process: {error}"))
+    })?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TestFailure::fatal("watch-test process stdout pipe was unavailable"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| TestFailure::fatal("watch-test process stderr pipe was unavailable"))?;
+    let stdout = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let _ = std::io::BufReader::new(stdout).read_to_end(&mut bytes);
+        bytes
+    });
+    let stderr = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let _ = std::io::BufReader::new(stderr).read_to_end(&mut bytes);
+        bytes
+    });
+
+    let deadline = Instant::now() + contract.runtime_timeout().min(Duration::from_secs(60));
+    let mut interrupted = None;
+    let result = (|| -> Result<(), String> {
+        wait_for_watch_event(&mut child, &protocol, "ready", 1, deadline)?;
+        match scenario.kind {
+            WatchTestScenarioKind::Edit => {
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 1, deadline)?;
+                write_watch_edit(dir, &scenario.edits[0])?;
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 2, deadline)?;
+            }
+            WatchTestScenarioKind::CompileError => {
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 1, deadline)?;
+                write_watch_edit(dir, &scenario.edits[0])?;
+                wait_for_watch_event(&mut child, &protocol, "compile-error", 1, deadline)?;
+                // A failed cycle publishes no events at all: the head event is
+                // owed only to a run that began (test-events.md, "Streams").
+                if watch_event_count(&protocol, "run-started") != 1 {
+                    return Err(format!(
+                        "a failed watch cycle opened a run: {:?}",
+                        watch_events(&protocol)
+                    ));
+                }
+                write_watch_edit(dir, &scenario.edits[1])?;
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 2, deadline)?;
+            }
+            WatchTestScenarioKind::Cancel => {
+                // Wait for a test process to actually exist before editing:
+                // the point of the case is the kill landing on a live group.
+                wait_for_watch_event(&mut child, &protocol, "test-spawned", 1, deadline)?;
+                write_watch_edit(dir, &scenario.edits[0])?;
+                wait_for_watch_event(&mut child, &protocol, "run-canceled", 1, deadline)?;
+                // The abandoned cycle published no `run_finished`, so the one
+                // this waits for is the NEXT cycle's.
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 1, deadline)?;
+            }
+        }
+        // A watcher produces an exit status only when it is asked to stop, and
+        // that status is the last completed cycle's (ADR-0083 §2).
+        interrupt_process_group(&mut child);
+        let status = wait_for_watch_exit(&mut child, deadline)?;
+        interrupted = Some(status);
+        Ok(())
+    })();
+
+    let (status, stdout_bytes, stderr_bytes) = finish_watch_child(child, stdout, stderr, true);
+    let result = result.and_then(|()| {
+        let exit = interrupted
+            .and_then(|status| status.code())
+            .ok_or_else(|| "watch-test process did not exit with a status".to_string())?;
+        if exit != scenario.expected_exit {
+            return Err(format!(
+                "watch-test exit mismatch: expected {}, actual {exit}",
+                scenario.expected_exit
+            ));
+        }
+        let out = String::from_utf8_lossy(&stdout_bytes);
+        for expected in &scenario.stdout_contains {
+            if !out.contains(expected.as_str()) {
+                return Err(format!("watch-test stdout did not contain {expected:?}"));
+            }
+        }
+        for unexpected in &scenario.stdout_not_contains {
+            if out.contains(unexpected.as_str()) {
+                return Err(format!("watch-test stdout contained {unexpected:?}"));
+            }
+        }
+        let err = String::from_utf8_lossy(&stderr_bytes);
+        for expected in &scenario.stderr_contains {
+            if !err.contains(expected.as_str()) {
+                return Err(format!("watch-test stderr did not contain {expected:?}"));
+            }
+        }
+        Ok(())
+    });
+    result.map_err(|error| {
+        TestFailure::assertion(format!(
+            "{error}\nwatch-test process status: {status:?}\nwatch-test protocol: {:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            watch_events(&protocol),
+            String::from_utf8_lossy(&stdout_bytes),
+            String::from_utf8_lossy(&stderr_bytes),
+        ))
+    })
+}
+
+/// Wait for an interrupted watcher to exit, without consuming the suite's hang
+/// guard if it never does.
+fn wait_for_watch_exit(
+    child: &mut std::process::Child,
+    deadline: Instant,
+) -> Result<std::process::ExitStatus, String> {
+    while Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(error) => return Err(format!("failed waiting for watch-test process: {error}")),
+        }
+    }
+    Err("timed out waiting for the interrupted watch-test process to exit".to_string())
+}
+
 /// Run the case's program from its temp directory and check every runtime
 /// expectation.
 ///
@@ -3144,6 +3348,8 @@ fn run_case_wrapper(
 
     let result = if let Some(scenario) = &case.watch {
         run_watch_case(case, scenario, contract, rue_binary, real_std)
+    } else if let Some(scenario) = &case.watch_test {
+        run_watch_test_case(case, scenario, contract, rue_binary, real_std)
     } else if case.differential_opt {
         run_case_differential(case, contract, rue_binary, real_std, repo_root)
     } else {

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -57,6 +57,7 @@ use import_discovery_owner::ImportDiscoveryOwner;
 pub use metrics::*;
 use program_artifacts::no_published_program;
 pub use rooted_artifacts::*;
+pub(crate) use rooted_projections::{TestClosureAnalysis, TestClosureAnalysisOutcome};
 #[cfg(test)]
 use rooted_projections::{stable_function_definition_root, stable_producer_definition_root};
 

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -2495,12 +2495,42 @@ impl CompilerSession {
         &mut self,
         options: &CompileOptions,
     ) -> Result<TestClosureAnalysis, CompileErrors> {
-        let attempt = self
-            .rooted_body_graph_attempt(options, rue_query::CancellationToken::new())
-            .map_err(|control| semantic_control_errors("rooted test closure analysis", control))?;
+        match self.cancellable_test_closure_analysis(options, rue_query::CancellationToken::new()) {
+            TestClosureAnalysisOutcome::Analyzed(analysis) => Ok(analysis),
+            TestClosureAnalysisOutcome::Errors(errors) => Err(errors),
+            // The token this passed can never be canceled: nobody else holds it.
+            TestClosureAnalysisOutcome::Canceled => {
+                unreachable!("an uncancelled test analysis cannot report cancellation")
+            }
+        }
+    }
+
+    /// [`Self::rooted_test_closure_analysis`] under a caller's cancellation
+    /// token, for the retained watch host's test cycle (RUE-2023).
+    ///
+    /// Cancellation is an outcome rather than an error because it is not a
+    /// fact about the program: the source revision this analyzed has been
+    /// replaced, so its diagnostics describe bytes the user no longer has.
+    pub(crate) fn cancellable_test_closure_analysis(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: rue_query::CancellationToken,
+    ) -> TestClosureAnalysisOutcome {
+        let attempt = match self.rooted_body_graph_attempt(options, cancellation) {
+            Ok(attempt) => attempt,
+            Err(SemanticRequestControl::Abort(rue_query::QueryAbort::Canceled)) => {
+                return TestClosureAnalysisOutcome::Canceled;
+            }
+            Err(control) => {
+                return TestClosureAnalysisOutcome::Errors(semantic_control_errors(
+                    "rooted test closure analysis",
+                    control,
+                ));
+            }
+        };
         let rejection = match attempt {
             RootedBodyGraphAttempt::Graph(graph) => {
-                return Ok(TestClosureAnalysis {
+                return TestClosureAnalysisOutcome::Analyzed(TestClosureAnalysis {
                     inventory: Arc::clone(&graph.test_inventory),
                     failed: Vec::new(),
                     diagnostics: CompileErrors::default(),
@@ -2509,7 +2539,7 @@ impl CompilerSession {
             RootedBodyGraphAttempt::Rejected(rejection) => rejection,
         };
         if rejection.global {
-            return Err(rejection.into_errors());
+            return TestClosureAnalysisOutcome::Errors(rejection.into_errors());
         }
         let per_body = rejection.per_body();
         let edges = rejection.call_edges();
@@ -2549,7 +2579,7 @@ impl CompilerSession {
                 // to attribute, not one nobody owns: the closure was built from
                 // the test roots, so every body in it is reachable from one.
                 // Reporting the whole run is the honest answer.
-                return Err(rejection.into_errors());
+                return TestClosureAnalysisOutcome::Errors(rejection.into_errors());
             }
             for ordinal in reaching {
                 failed_tests
@@ -2573,7 +2603,7 @@ impl CompilerSession {
                 errors: errors.into(),
             })
             .collect();
-        Ok(TestClosureAnalysis {
+        TestClosureAnalysisOutcome::Analyzed(TestClosureAnalysis {
             inventory: Arc::clone(&rejection.test_inventory),
             // The union, once each: a helper several tests reach fails each of
             // them, and stderr must still show its diagnostic one time.
@@ -3500,6 +3530,18 @@ pub(crate) struct TestClosureAnalysis {
     /// reach it. This is what stderr publishes; the copies attached to each
     /// failed test are the attribution convenience (ADR-0083 §3).
     pub(crate) diagnostics: CompileErrors,
+}
+
+/// What a cancellable test-closure analysis answered (RUE-2023).
+pub(crate) enum TestClosureAnalysisOutcome {
+    Analyzed(TestClosureAnalysis),
+    /// The request failed outside every test closure, so the whole request
+    /// fails. Per-test failures are inside [`TestClosureAnalysis::failed`]
+    /// instead; they are verdicts, not a failed request.
+    Errors(CompileErrors),
+    /// A newer source revision arrived. Nothing is reported: the diagnostics
+    /// this would have carried describe source that no longer exists.
+    Canceled,
 }
 
 /// Render a semantic control answer on the uncancellable error surface.

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -840,30 +840,10 @@ pub fn test_image_in_compile_scope(
 ) -> crate::MultiErrorResult<TestImage> {
     require_test_root_selection(options)?;
     let analysis = session.rooted_test_closure_analysis(options)?;
-    let inventory = TestInventory {
-        entries: analysis
-            .inventory
-            .iter()
-            .map(|test| test.entry.clone())
-            .collect(),
-    };
-    let compile_failures = analysis
-        .failed
-        .iter()
-        .map(|failure| TestCompileFailure {
-            entry: failure.test.entry.clone(),
-            errors: failure.errors.clone(),
-        })
-        .collect::<Vec<_>>();
-    let excluded: std::sync::Arc<[crate::FunctionInstanceKey]> = analysis
-        .failed
-        .iter()
-        .map(|failure| failure.test.identity.clone())
-        .collect::<Vec<_>>()
-        .into();
+    let assembled = assemble_test_image(&analysis);
     // The second request analyzes a smaller root set, so it can fail where the
     // first did not.
-    let output = match session.with_excluded_test_roots(excluded, |session| {
+    let output = match session.with_excluded_test_roots(assembled.excluded, |session| {
         session.executable_in_compile_scope(options)
     }) {
         Ok(output) => output,
@@ -871,8 +851,8 @@ pub fn test_image_in_compile_scope(
     };
     Ok(TestImage {
         output,
-        inventory,
-        compile_failures,
+        inventory: assembled.inventory,
+        compile_failures: assembled.compile_failures,
         failure_diagnostics: analysis.diagnostics,
     })
 }
@@ -897,6 +877,108 @@ pub(crate) fn carrying_first_pass(
         }
     }
     errors
+}
+
+/// Host-facing outcome of a cancellable retained test-image build (RUE-2023).
+///
+/// The counterpart of [`CancellableCompileOutcome`] for `RootSelection::Tests`,
+/// so a retained watch host can build one test image per accepted source
+/// revision and abandon the one an edit overtook.
+pub enum CancellableTestImageOutcome {
+    Completed(Box<TestImage>),
+    Errors(crate::CompileErrors),
+    Canceled,
+}
+
+/// [`test_image_in_compile_scope`] with cooperative cancellation (RUE-2023).
+///
+/// Both halves of the request observe the token: the closure analysis that
+/// decides which tests the image can hold, and the second, narrowed request
+/// that links it. A cycle the watcher canceled reports neither diagnostics nor
+/// an image, because both describe a revision the user has already replaced.
+pub fn cancellable_test_image_in_compile_scope(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+    cancellation: CompilationCancellation,
+) -> CancellableTestImageOutcome {
+    if let Err(errors) = require_test_root_selection(options) {
+        return CancellableTestImageOutcome::Errors(errors);
+    }
+    let analysis =
+        match session.cancellable_test_closure_analysis(options, cancellation.token.clone()) {
+            crate::session::TestClosureAnalysisOutcome::Analyzed(analysis) => analysis,
+            crate::session::TestClosureAnalysisOutcome::Errors(errors) => {
+                return CancellableTestImageOutcome::Errors(errors);
+            }
+            crate::session::TestClosureAnalysisOutcome::Canceled => {
+                return CancellableTestImageOutcome::Canceled;
+            }
+        };
+    let assembled = assemble_test_image(&analysis);
+    let snapshot = match session.committed_snapshot_for_executable() {
+        Ok(snapshot) => snapshot,
+        Err(errors) => return CancellableTestImageOutcome::Errors(errors),
+    };
+    // The second request analyzes a smaller root set, so it can fail where the
+    // first did not.
+    let output = session.with_excluded_test_roots(assembled.excluded, |session| {
+        crate::queries::compile_with_session_with_cancellation(
+            session,
+            &snapshot,
+            options,
+            cancellation.token,
+        )
+    });
+    match output {
+        Ok(output) => CancellableTestImageOutcome::Completed(Box::new(TestImage {
+            output,
+            inventory: assembled.inventory,
+            compile_failures: assembled.compile_failures,
+            failure_diagnostics: analysis.diagnostics,
+        })),
+        Err(crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)) => {
+            CancellableTestImageOutcome::Canceled
+        }
+        Err(control) => CancellableTestImageOutcome::Errors(carrying_first_pass(
+            analysis.diagnostics,
+            crate::session::pipeline_control_errors("cancellable test image", control),
+        )),
+    }
+}
+
+/// The inventory, the per-test failures, and the exclusion set one analysis
+/// decides, shared by the cancellable and uncancellable image requests so the
+/// two can never disagree about which tests an image holds.
+struct AssembledTestImage {
+    inventory: TestInventory,
+    compile_failures: Vec<TestCompileFailure>,
+    excluded: std::sync::Arc<[crate::FunctionInstanceKey]>,
+}
+
+fn assemble_test_image(analysis: &crate::session::TestClosureAnalysis) -> AssembledTestImage {
+    AssembledTestImage {
+        inventory: TestInventory {
+            entries: analysis
+                .inventory
+                .iter()
+                .map(|test| test.entry.clone())
+                .collect(),
+        },
+        compile_failures: analysis
+            .failed
+            .iter()
+            .map(|failure| TestCompileFailure {
+                entry: failure.test.entry.clone(),
+                errors: failure.errors.clone(),
+            })
+            .collect(),
+        excluded: analysis
+            .failed
+            .iter()
+            .map(|failure| failure.test.identity.clone())
+            .collect::<Vec<_>>()
+            .into(),
+    }
 }
 
 fn require_test_root_selection(options: &crate::CompileOptions) -> crate::MultiErrorResult<()> {

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1333,6 +1333,7 @@ fn unsupported_corpus_field(case: &Case) -> Option<IneligibleReason> {
         source_path: _,
         args: _,
         watch: _,
+        watch_test: _,
         env: _,
         program_args: _,
         program_env: _,
@@ -1448,8 +1449,11 @@ fn check_case_with_native(
     }
     // A watch case is an imperative sequence of filesystem edits and driver
     // publications, not one concrete source execution the in-process oracle
-    // can compare. The CLI harness owns this orchestration contract.
-    if case.watch.is_some() {
+    // can compare. The CLI harness owns this orchestration contract. A
+    // `watch_test` case is the same thing for `rue test --watch`, and doubly
+    // so: what it asserts on is an event stream across several revisions, and
+    // the sources it starts with are only the first of them (RUE-2023).
+    if case.watch.is_some() || case.watch_test.is_some() {
         return CaseOutcome::Ineligible(IneligibleReason::WatchOrchestration);
     }
     if let Some(reason) = unsupported_corpus_field(case) {
@@ -1833,6 +1837,7 @@ mod tests {
     use super::*;
     use rue_test_runner::cli_corpus::{
         HardLinkFixture, SourceFile, SymlinkFixture, WatchScenario, WatchScenarioKind,
+        WatchTestScenario, WatchTestScenarioKind,
     };
 
     #[test]
@@ -1902,6 +1907,20 @@ mod tests {
             edits: Vec::new(),
             stderr_contains: Vec::new(),
             expected_exit_codes: Vec::new(),
+        }
+    }
+
+    fn watch_test_scenario() -> WatchTestScenario {
+        WatchTestScenario {
+            kind: WatchTestScenarioKind::Edit,
+            format: None,
+            timeout_ms: None,
+            args: Vec::new(),
+            edits: Vec::new(),
+            stdout_contains: Vec::new(),
+            stdout_not_contains: Vec::new(),
+            stderr_contains: Vec::new(),
+            expected_exit: 0,
         }
     }
 
@@ -2422,6 +2441,12 @@ files = [{ path = "probe.rue", source = "not Rue" }]
         case.watch = Some(watch_scenario());
         assert_cli_ineligible(&case, IneligibleReason::WatchOrchestration);
         case.watch = None;
+        // `rue test --watch` is the same orchestration contract: several source
+        // revisions, an event stream rather than one program's output, and a
+        // starting fixture set that is only the first of them (RUE-2023).
+        case.watch_test = Some(watch_test_scenario());
+        assert_cli_ineligible(&case, IneligibleReason::WatchOrchestration);
+        case.watch_test = None;
         case.driver_exit_code = Some(3);
         assert_cli_ineligible(&case, IneligibleReason::DriverInvocation);
         case.driver_exit_code = None;

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -212,6 +212,55 @@ pub enum WatchScenarioKind {
     InitialFailure,
 }
 
+/// A synchronized end-to-end `rue test --watch` scenario (RUE-2023).
+///
+/// The sibling of [`WatchScenario`] for the test-mode watcher. It drives the
+/// same milestone protocol, so a case waits for the cycle it is about to assert
+/// on instead of sleeping, and it asserts on the event stream the watcher
+/// publishes rather than on a produced executable — a test watcher publishes
+/// none.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WatchTestScenario {
+    pub kind: WatchTestScenarioKind,
+    /// `--format` for the run. Defaults to `json`, because the event stream is
+    /// the surface these cases exist to pin.
+    #[serde(default)]
+    pub format: Option<String>,
+    /// `--timeout-ms` for the run, when a case needs one that is not the
+    /// default (a deliberately spinning test wants a short leash).
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+    /// Extra compiler arguments, appended after the standard ones.
+    #[serde(default)]
+    pub args: Vec<String>,
+    pub edits: Vec<WatchEdit>,
+    /// Substrings the whole of stdout must contain, and must not.
+    #[serde(default)]
+    pub stdout_contains: Vec<String>,
+    #[serde(default)]
+    pub stdout_not_contains: Vec<String>,
+    #[serde(default)]
+    pub stderr_contains: Vec<String>,
+    /// The status the watcher exits with when the case interrupts it: the last
+    /// COMPLETED cycle's, which is the only exit status a watcher produces.
+    pub expected_exit: i32,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WatchTestScenarioKind {
+    /// One edit, one further cycle. The case's `stdout_contains` says what the
+    /// second cycle's verdicts must be.
+    Edit,
+    /// Break the closure, observe the failed cycle, repair it, observe the
+    /// next completed one.
+    CompileError,
+    /// Edit while a test is running: the cycle is abandoned with
+    /// `run_canceled` and the next one completes.
+    Cancel,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WatchEdit {
@@ -273,6 +322,9 @@ pub struct Case {
     /// A synchronized, imperative `--watch` integration scenario.
     #[serde(default)]
     pub watch: Option<WatchScenario>,
+    /// A synchronized, imperative `rue test --watch` integration scenario.
+    #[serde(default)]
+    pub watch_test: Option<WatchTestScenario>,
     /// Extra environment variables for the compiler invocation.
     #[serde(default)]
     pub env: HashMap<String, String>,

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -2654,6 +2654,28 @@ pub fn configure_process_group(cmd: &mut Command) {
 #[cfg(not(unix))]
 pub fn configure_process_group(_cmd: &mut Command) {}
 
+/// Ask a child's whole process group to stop, the way a terminal's Ctrl-C
+/// would, and leave it to exit on its own terms.
+///
+/// The counterpart of [`kill_process_group`] for a child whose REACTION to
+/// being interrupted is the thing under test — `rue test --watch` reports the
+/// last completed cycle's status on SIGINT rather than dying of the signal, and
+/// a SIGKILL would prove nothing about that.
+#[cfg(unix)]
+pub fn interrupt_process_group(child: &mut std::process::Child) {
+    let pid = child.id() as i32;
+    // SAFETY: a negative pid names the group led by `pid`, which
+    // `configure_process_group` made this child the leader of.
+    unsafe {
+        libc::kill(-pid, libc::SIGINT);
+    }
+}
+
+#[cfg(not(unix))]
+pub fn interrupt_process_group(child: &mut std::process::Child) {
+    let _ = child.kill();
+}
+
 /// Kill the timed-out child and everything in its process group, then reap it.
 #[cfg(unix)]
 pub fn kill_process_group(child: &mut std::process::Child) {

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 use std::time::Instant;
 
-use rue_compiler::unstable::{CancellableCompileOutcome, CompilationCancellation, OneShotMetrics};
+use rue_compiler::unstable::{
+    CancellableCompileOutcome, CancellableTestImageOutcome, CompilationCancellation,
+    OneShotMetrics, TestCompileFailure, TestImage, TestInventory,
+};
 use rue_compiler::{CompileOptions, CompileWarning, LinkerMode};
 use rue_driver::{FilesystemCompilerHost, WatchInput};
 
@@ -315,5 +318,159 @@ fn linker_name(linker: &LinkerMode) -> &str {
     match linker {
         LinkerMode::Internal => "internal",
         LinkerMode::System(command) => command,
+    }
+}
+
+/// What a published test image hands the runner (ADR-0083 §3).
+///
+/// The linked bytes are already at the cycle's image path; what the run still
+/// needs is the inventory that assigned the dispatch ordinals and the tests the
+/// image could not hold.
+pub(crate) struct PublishedTestImage {
+    pub(crate) inventory: TestInventory,
+    pub(crate) compile_failures: Vec<TestCompileFailure>,
+}
+
+/// One test-image cycle, the test-mode twin of [`CycleRequest`].
+///
+/// Same steps in the same order as [`drive_cycle`] — discovery gate,
+/// destination preflight, compile, publish, warnings — over the request's test
+/// root set instead of its executable one, so `rue test` and `rue test --watch`
+/// reach the image through one orchestration rather than two (RUE-2023). What
+/// a watch cycle adds around it stays in `watch`, exactly as it does for the
+/// executable cycle; what a test cycle adds *after* it — the run — is
+/// `test_mode`'s.
+pub(crate) struct TestCycleRequest<'a, 'diagnostics> {
+    pub(crate) host: &'a mut FilesystemCompilerHost,
+    pub(crate) options: &'a CompileOptions,
+    pub(crate) diagnostics: &'a DiagnosticOutput<'diagnostics>,
+    /// Where the linked image is staged. Always inside the run's own private
+    /// directory, never a path the user named: `rue test` refuses `-o` for
+    /// exactly this reason, so no cycle here can publish over a user artifact.
+    pub(crate) image_path: &'a Path,
+    pub(crate) observation: CycleObservation<'a>,
+}
+
+/// The outcome of a test-image cycle, on the same terms as [`CycleReport`].
+pub(crate) enum TestCycleReport {
+    /// The image reached the cycle's image path and can be run.
+    Published(Box<PublishedTestImage>),
+    /// The request was rejected outside every test closure, or the image could
+    /// not be staged. Diagnostics are already on the diagnostic stream.
+    Failed,
+    /// A newer source revision arrived before the image could be published.
+    Superseded(Supersession),
+    /// The image build was canceled without a newer revision being observed.
+    Canceled,
+}
+
+pub(crate) fn drive_test_cycle(request: TestCycleRequest<'_, '_>) -> TestCycleReport {
+    let TestCycleRequest {
+        host,
+        options,
+        diagnostics,
+        image_path,
+        observation,
+    } = request;
+
+    // The same gate the executable cycle opens with, and for the same reason:
+    // an unresolved `@import` is the user's problem and is reported as itself
+    // rather than as whatever the staging preflight would have said (RUE-810).
+    if let Some(errors) = host.discovery_refusal() {
+        diagnostics.print_errors(&errors);
+        return TestCycleReport::Failed;
+    }
+
+    let destination = match preflight(image_path, host, &observation) {
+        Ok(destination) => destination,
+        Err(error) => {
+            diagnostics.print_error(&error.into_compile_error());
+            return TestCycleReport::Failed;
+        }
+    };
+
+    let image = match observation {
+        CycleObservation::OneShot => match host.test_image_in_compile_scope(options) {
+            Ok(image) => image,
+            Err(errors) => {
+                diagnostics.print_errors(&errors);
+                return TestCycleReport::Failed;
+            }
+        },
+        CycleObservation::Watch {
+            ref cancellation,
+            superseded,
+            ..
+        } => {
+            let outcome =
+                host.cancellable_test_image_in_compile_scope(options, cancellation.clone());
+            // A superseded cycle describes an image the user's source no longer
+            // asks for. Check before reporting, so a transient error already
+            // fixed on disk never reaches the terminal.
+            if superseded() {
+                return TestCycleReport::Superseded(Supersession::BeforePublication);
+            }
+            match outcome {
+                CancellableTestImageOutcome::Completed(image) => *image,
+                CancellableTestImageOutcome::Errors(errors) => {
+                    diagnostics.print_errors(&errors);
+                    return TestCycleReport::Failed;
+                }
+                CancellableTestImageOutcome::Canceled => return TestCycleReport::Canceled,
+            }
+        }
+    };
+
+    let TestImage {
+        output,
+        inventory,
+        compile_failures,
+        failure_diagnostics,
+    } = image;
+    let metrics = output.unstable_metrics();
+    let linked = LinkedExecutable {
+        target: options.target,
+        warnings: output.warnings,
+        metrics,
+        linked_bytes: output.elf,
+        destination,
+        observation: match observation {
+            CycleObservation::OneShot => PublicationObservation::OneShot,
+            CycleObservation::Watch { inputs, .. } => PublicationObservation::Watch(inputs),
+        },
+    };
+    let publication = {
+        let _span = tracing::info_span!("output_write", driver_phase = true).entered();
+        linked.publish()
+    };
+    // Warnings and the closure's own analysis failures live outside the
+    // publication result so a failed publication cannot discard them, exactly
+    // as the executable cycle treats its warnings.
+    //
+    // stderr is the authoritative diagnostic stream and carries the failures
+    // exactly as a whole-request failure would have: once, in the run's own
+    // `--error-format`, before any event. The copies inside the `compile_error`
+    // events are the attribution (ADR-0083 §3). They are published here rather
+    // than by the run, and so whatever the selection turns out to be, because
+    // the closure that produced them is the WHOLE closure: a filter narrows the
+    // run set, never the analysis root set, and a filtered run that silently
+    // swallowed a broken test file would be the papercut the
+    // unimported-test-file warning exists to prevent.
+    diagnostics.print_warnings(&publication.warnings);
+    if !failure_diagnostics.is_empty() {
+        diagnostics.print_errors(&failure_diagnostics);
+    }
+    match publication.result {
+        Ok(_) => TestCycleReport::Published(Box::new(PublishedTestImage {
+            inventory,
+            compile_failures,
+        })),
+        Err(PublishError::InputsChanged) => {
+            TestCycleReport::Superseded(Supersession::AtPublication)
+        }
+        Err(error) => {
+            diagnostics.print_error(&error.into_compile_error());
+            TestCycleReport::Failed
+        }
     }
 }

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -2,9 +2,10 @@ use std::path::Path;
 
 use rue_compiler::unstable::TestCandidateInventory;
 use rue_compiler::unstable::{
-    CancellableCompileOutcome, CodegenReady, CompilationCancellation, ObjectsReady,
-    PresentationOutput, PresentationRequest, TestImage, TestListing, UnimportedTestFile,
-    cancellable_executable_in_compile_scope, codegen_ready, executable_in_compile_scope,
+    CancellableCompileOutcome, CancellableTestImageOutcome, CodegenReady, CompilationCancellation,
+    ObjectsReady, PresentationOutput, PresentationRequest, TestImage, TestListing,
+    UnimportedTestFile, cancellable_executable_in_compile_scope,
+    cancellable_test_image_in_compile_scope, codegen_ready, executable_in_compile_scope,
     objects_ready, runnable_ready, test_image_in_compile_scope, test_inventory,
     unimported_test_files,
 };
@@ -231,6 +232,24 @@ impl FilesystemCompilerHost {
     ) -> MultiErrorResult<TestImage> {
         self.closed_discovery()?;
         test_image_in_compile_scope(&mut self.state.session, options)
+    }
+
+    /// Link the test image like [`Self::test_image_in_compile_scope`], under a
+    /// caller's cancellation token (RUE-2023).
+    ///
+    /// This is what makes a `rue test --watch` cycle abandonable: an edit
+    /// landing while the image is being analyzed or linked cancels it, and the
+    /// cycle reports nothing rather than diagnostics about source the user has
+    /// already replaced.
+    pub fn cancellable_test_image_in_compile_scope(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: CompilationCancellation,
+    ) -> CancellableTestImageOutcome {
+        if let Err(errors) = self.closed_discovery() {
+            return CancellableTestImageOutcome::Errors(errors);
+        }
+        cancellable_test_image_in_compile_scope(&mut self.state.session, options, cancellation)
     }
 
     /// Report the declared candidates the compiled closure does not contain

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -292,10 +292,16 @@ Commands:
   --test-candidates <path>
                        Report declared test files nothing imports
   Test mode reuses --target, -O<n>, --preview, --jobs, --source-manifest,
-  --link-archive, --error-format, and the logging options. There --jobs bounds
-  concurrent test processes only; compilation uses auto-detected parallelism.
-  It cannot be combined with --emit, --watch, --benchmark-json, --time-passes,
-  or -o.
+  --link-archive, --error-format, --watch, and the logging options. There
+  --jobs bounds concurrent test processes only; compilation uses auto-detected
+  parallelism. It cannot be combined with --emit, --benchmark-json,
+  --time-passes, or -o; --watch additionally excludes --list.
+  With --watch, one test cycle runs per accepted source revision on one
+  retained compiler, so a cycle pays for what the edit changed rather than for
+  a whole recompile. Each cycle publishes its own run_started/run_finished
+  pair; an edit landing mid-run kills the tests and ends the cycle with
+  run_canceled. The exit status is produced only on SIGINT/SIGTERM and is the
+  last COMPLETED cycle's: 0 all passed, 1 otherwise, 2 if none completed.
   Exit codes: 0 all passed, 1 failures, 2 compilation or runner error,
   3 empty selection.
   A root module actually named `test` is spelled `./test`.
@@ -340,6 +346,7 @@ Options:
   --time-passes        Show timing for each compilation pass
   --benchmark-json     Output timing as JSON (for benchmarking)
   --watch              Recompile when the accepted source closure changes
+                       With `rue test`, re-run the tests instead
   --version            Show version information
   --help               Show this help message",
         targets = Target::all_names(),
@@ -990,10 +997,13 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
 ///
 /// Test mode joins the same validation path `--watch` uses (ADR-0083 §2). Each
 /// refusal is a real conflict over one resource rather than a taste: `--emit`
-/// and `--benchmark-json` own stdout, which is the event stream's; `--watch`
-/// owns the process's lifetime, which the run does; `-o` names an executable
-/// destination a test run never publishes to; and `--time-passes` writes an
-/// unstructured timing report into the same stream.
+/// and `--benchmark-json` own stdout, which is the event stream's; `-o` names
+/// an executable destination a test run never publishes to; and
+/// `--time-passes` writes an unstructured timing report into the same stream.
+/// `--watch` is not among them: a watcher and a run share the process's
+/// lifetime rather than compete for it, and running the cycle on the retained
+/// host is what removes the per-run recompile (RUE-2023). Only `--list` is
+/// refused with it, because a listing is an inventory of one revision.
 ///
 /// The reverse direction matters just as much: a test-only flag in compile
 /// mode is refused by name. Silently ignoring `rue --filter x main.rue` would
@@ -1007,10 +1017,14 @@ fn validate_mode_combinations(options: &Options) -> Result<(), String> {
         }
         return Ok(());
     }
+    if options.watch && options.test.list {
+        // A listing is an inventory of one revision, and a watcher has no one
+        // revision. There is no useful "watch the listing" behavior to define
+        // and every other test-mode flag combines with `--watch` (RUE-2023).
+        return Err("Error: `rue test --watch` cannot be combined with --list".to_owned());
+    }
     let conflict = if !options.emit_stages.is_empty() {
         Some("--emit")
-    } else if options.watch {
-        Some("--watch")
     } else if options.benchmark_json {
         Some("--benchmark-json")
     } else if options.time_passes {
@@ -2454,7 +2468,9 @@ fn main() {
     }
     if let Err(message) = validate_watch_modes(&options) {
         eprintln!("{message}");
-        std::process::exit(1);
+        // A refused `rue test --watch` combination is still "the run did not
+        // happen", which is the status an agent branches on (ADR-0083 §2).
+        std::process::exit(driver_failure_exit_code(&options.mode));
     }
     // A `rue test` invocation that cannot run reports the runner-error status
     // rather than the compile-mode argument status, so an agent branching on
@@ -2574,12 +2590,34 @@ fn main() {
     }
 
     if options.watch {
+        // Both watch modes drive the same loop over the same retained host;
+        // only the cycle body differs (RUE-2023). Test mode's per-cycle
+        // configuration is assembled here, where the parsed options still
+        // exist, because the loop never returns.
+        let mode = match options.mode {
+            DriverMode::Test => watch::WatchMode::Test(Box::new(watch::TestWatch {
+                repro_flags: test_repro_flags(&options),
+                repro_env: test_repro_env(captured_std_root.as_deref()),
+                jobs: test_mode_jobs(options.jobs),
+                target: options.target,
+                opt_level: options.opt_level,
+                test_candidates_path: options.test_candidates_path.clone(),
+                // Derived once for the process: consecutive cycles then
+                // shuffle the same way, and a difference between two of them
+                // is attributable to the edit rather than to the order.
+                seed: options.test.seed.unwrap_or_else(test_mode::fresh_seed),
+                options: options.test.clone(),
+            })),
+            DriverMode::Compile => watch::WatchMode::Executable {
+                output_path: options.output_path,
+            },
+        };
         watch::run(watch::WatchRequest {
             host: compiler_host,
             compile_options,
             source_path: options.source_path,
-            output_path: options.output_path,
             error_format: options.error_format,
+            mode,
         });
     }
 
@@ -3550,7 +3588,6 @@ mod tests {
     fn test_mode_refuses_every_incompatible_flag() {
         let conflicts: &[(&[&str], &str)] = &[
             (&["test", "main.rue", "--emit", "ast"], "--emit"),
-            (&["test", "main.rue", "--watch"], "--watch"),
             (
                 &["test", "main.rue", "--benchmark-json"],
                 "--benchmark-json",
@@ -3558,6 +3595,10 @@ mod tests {
             (&["test", "main.rue", "--time-passes"], "--time-passes"),
             (&["test", "main.rue", "-o", "prog"], "-o/--output"),
             (&["test", "main.rue", "--output", "prog"], "-o/--output"),
+            // `--watch` is not one of them, but a listing is: an inventory is
+            // an inventory of one revision, and a watcher has no one revision
+            // (RUE-2023).
+            (&["test", "main.rue", "--watch", "--list"], "--list"),
         ];
         for (args, flag) in conflicts {
             let options = unwrap_options(parse_args_from(args));
@@ -3565,6 +3606,33 @@ mod tests {
                 .expect_err(&format!("{flag} must conflict with `rue test`"));
             assert!(error.contains(flag), "{error}");
         }
+    }
+
+    /// `rue test --watch` is the whole point of RUE-2023: one retained
+    /// compiler running one cycle per accepted source revision, rather than a
+    /// combination the driver refuses.
+    #[test]
+    fn test_mode_accepts_watch_with_every_other_test_flag() {
+        let options = unwrap_options(parse_args_from(&[
+            "test",
+            "main.rue",
+            "--watch",
+            "--filter",
+            "x",
+            "--format",
+            "json",
+            "--timeout-ms",
+            "10",
+            "--shard",
+            "1/2",
+            "--seed",
+            "1",
+            "-j2",
+        ]));
+        assert!(options.watch);
+        assert_eq!(options.mode, DriverMode::Test);
+        assert!(validate_mode_combinations(&options).is_ok());
+        assert!(validate_watch_modes(&options).is_ok());
     }
 
     /// The reverse direction: a test-only flag outside test mode is refused by

--- a/crates/rue/src/test_mode/events.rs
+++ b/crates/rue/src/test_mode/events.rs
@@ -287,6 +287,11 @@ pub(crate) enum Event {
         shard: Option<String>,
         selected: usize,
         total: usize,
+        /// The 1-based watch cycle this run is, so a consumer tailing one
+        /// `rue test --watch` process can group the events of each cycle.
+        /// **Absent** outside `--watch`, where a process runs exactly once
+        /// and there is nothing to group (RUE-2023).
+        cycle: Option<u64>,
     },
     TestStarted {
         id: String,
@@ -302,6 +307,23 @@ pub(crate) enum Event {
         wall_ms: u64,
         unimported_test_files: Option<Vec<UnimportedFile>>,
         test_candidates: CandidateSource,
+    },
+    /// A watch cycle abandoned mid-run: an edit landed while tests were
+    /// executing, the runner killed their process groups, and the cycle is
+    /// over (RUE-2023).
+    ///
+    /// It replaces this cycle's `run_finished`, never accompanies one: the
+    /// verdicts already published stand, the tests still running produced
+    /// none, and a `run_finished` whose counts described neither would be a
+    /// lie. A cycle canceled before its image existed emits nothing at all,
+    /// because no `run_started` opened it.
+    RunCanceled {
+        cycle: u64,
+        /// Verdicts this cycle published before the edit landed.
+        reported: usize,
+        /// Tests the plan selected.
+        selected: usize,
+        wall_ms: u64,
     },
     /// A `--list --format json` inventory record. The listing stream carries
     /// no `run_started`, so this record carries the schema version itself —
@@ -351,6 +373,7 @@ impl Event {
                 shard,
                 selected,
                 total,
+                cycle,
             } => {
                 object.insert("event".to_owned(), Value::String("run_started".to_owned()));
                 object.insert(
@@ -362,6 +385,12 @@ impl Event {
                 object.insert("opt_level".to_owned(), Value::String(opt_level.clone()));
                 object.insert("seed".to_owned(), Value::from(*seed));
                 object.insert("jobs".to_owned(), Value::from(*jobs));
+                // Absent rather than zero outside `--watch`: a consumer that
+                // finds the key knows it is reading one cycle of a retained
+                // watch host, the way `shard` says the run was partitioned.
+                if let Some(cycle) = cycle {
+                    object.insert("cycle".to_owned(), Value::from(*cycle));
+                }
                 if let Some(shard) = shard {
                     object.insert("shard".to_owned(), Value::String(shard.clone()));
                 }
@@ -473,6 +502,18 @@ impl Event {
                     Value::String(test_candidates.as_str().to_owned()),
                 );
             }
+            Self::RunCanceled {
+                cycle,
+                reported,
+                selected,
+                wall_ms,
+            } => {
+                object.insert("event".to_owned(), Value::String("run_canceled".to_owned()));
+                object.insert("cycle".to_owned(), Value::from(*cycle));
+                object.insert("reported".to_owned(), Value::from(*reported));
+                object.insert("selected".to_owned(), Value::from(*selected));
+                object.insert("wall_ms".to_owned(), Value::from(*wall_ms));
+            }
             Self::Test {
                 id,
                 module,
@@ -516,6 +557,7 @@ mod tests {
             shard: Some("1/2".to_owned()),
             selected: 3,
             total: 8,
+            cycle: None,
         }
         .to_ndjson();
         assert_eq!(
@@ -537,9 +579,51 @@ mod tests {
             shard: None,
             selected: 1,
             total: 1,
+            cycle: None,
         }
         .to_ndjson();
         assert!(!line.contains("shard"), "{line}");
+        assert!(!line.contains("cycle"), "{line}");
+    }
+
+    /// The watch cycle number is additive: it appears only for a `--watch`
+    /// cycle, and lands in alphabetical order like every other key (RUE-2023).
+    #[test]
+    fn a_watch_cycle_publishes_its_number_in_the_head_event() {
+        let line = Event::RunStarted {
+            root: "m.rue".to_owned(),
+            target: "x86-64-linux".to_owned(),
+            opt_level: "1".to_owned(),
+            seed: 1,
+            jobs: 1,
+            shard: None,
+            selected: 1,
+            total: 1,
+            cycle: Some(3),
+        }
+        .to_ndjson();
+        assert!(
+            line.contains("\"cycle\":3,\"event\":\"run_started\""),
+            "{line}"
+        );
+    }
+
+    /// A canceled cycle publishes what it managed rather than a `run_finished`
+    /// whose counts would describe neither the verdicts it published nor the
+    /// tests it killed (RUE-2023).
+    #[test]
+    fn a_canceled_cycle_names_itself_and_what_it_reported() {
+        let line = Event::RunCanceled {
+            cycle: 2,
+            reported: 3,
+            selected: 9,
+            wall_ms: 41,
+        }
+        .to_ndjson();
+        assert_eq!(
+            line,
+            "{\"cycle\":2,\"event\":\"run_canceled\",\"reported\":3,\"selected\":9,\"wall_ms\":41}"
+        );
     }
 
     #[test]

--- a/crates/rue/src/test_mode/exec.rs
+++ b/crates/rue/src/test_mode/exec.rs
@@ -82,6 +82,10 @@ pub(crate) struct Dispatch<'a> {
     pub(crate) seed: u64,
     pub(crate) timeout: Duration,
     pub(crate) stream_budget: usize,
+    /// A watch cycle's run cancellation, so a child that starts in the instant
+    /// the cycle is abandoned is killed by the observer that registers it
+    /// rather than running to its own timeout (RUE-2023).
+    pub(crate) cancellation: Option<&'a RunCancellation>,
 }
 
 /// Render a selector exactly as the dispatcher parses it: sixteen lowercase
@@ -98,8 +102,17 @@ pub(crate) fn selector(ordinal: u32) -> String {
 /// cases in a parallel suite — would otherwise name the same scratch
 /// directories, and one run's fresh-directory setup would delete the other
 /// run's working directory out from under a live test.
-pub(crate) fn run_root(seed: u64) -> PathBuf {
-    std::env::temp_dir().join(format!("rue-test-{seed}-{}", std::process::id()))
+/// `cycle` is `Some` under `rue test --watch`, where one process runs many
+/// times: without it, cycle N+1 would delete the scratch directory a failing
+/// test in cycle N deliberately retained (RUE-2023). A one-shot run passes
+/// `None` and keeps the name it always had.
+pub(crate) fn run_root(seed: u64, cycle: Option<u64>) -> PathBuf {
+    let pid = std::process::id();
+    let name = match cycle {
+        Some(cycle) => format!("rue-test-{seed}-{pid}-c{cycle}"),
+        None => format!("rue-test-{seed}-{pid}"),
+    };
+    std::env::temp_dir().join(name)
 }
 
 /// The scratch directory one test runs in.
@@ -214,8 +227,47 @@ fn unregister_group(slot: usize, pgid: i32) {
 /// This is what the handler runs, and the tests exercise the same body over a
 /// registry of their own — the only way to observe it without signalling the
 /// test binary itself.
-fn kill_registered_groups() {
+pub(crate) fn kill_registered_groups() {
     kill_groups_in(&LIVE_GROUPS);
+}
+
+/// The authority that ends a watch cycle's execution phase (RUE-2023).
+///
+/// A `rue test --watch` cycle is abandonable at every point, including while
+/// tests are running: an edit kills the live process groups and the cycle
+/// publishes `run_canceled` rather than verdicts about source the user has
+/// already replaced. The flag and the kill are one operation because a worker
+/// between two tests must be stopped by the flag while the test already
+/// running must be stopped by the signal.
+///
+/// A one-shot run holds none of these: nothing outside the run can end it, and
+/// a terminal's Ctrl-C is [`install_signal_forwarding`]'s.
+#[derive(Clone, Default)]
+pub(crate) struct RunCancellation {
+    canceled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl RunCancellation {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stop the run: publish the flag, then kill every live group.
+    ///
+    /// That order is what makes the two halves cover each other. A worker
+    /// about to spawn observes the flag and never spawns; a worker that
+    /// spawned before the flag was published has already registered its group
+    /// and the sweep reaches it; and a worker that registered *between* the
+    /// flag and the sweep re-reads the flag from `LiveGroup::spawned` and kills
+    /// its own child. `SeqCst` on both sides is what leaves no fourth case.
+    pub(crate) fn cancel(&self) {
+        self.canceled.store(true, Ordering::SeqCst);
+        kill_registered_groups();
+    }
+
+    pub(crate) fn is_canceled(&self) -> bool {
+        self.canceled.load(Ordering::SeqCst)
+    }
 }
 
 /// The registry operations, over the array rather than the static, so a test
@@ -300,6 +352,64 @@ pub(crate) fn install_signal_forwarding() {
     });
 }
 
+/// The status a watch-mode interrupt exits with (ADR-0083 §2, RUE-2023).
+///
+/// `rue test --watch` produces an exit code only when it is asked to stop, and
+/// that code is the last completed cycle's: `0` all passed, `1` otherwise, and
+/// `2` while no cycle has completed at all. Held here, next to the handler that
+/// reads it, because a signal handler may not take a lock.
+static WATCH_EXIT_STATUS: AtomicI32 = AtomicI32::new(super::TestExitCode::RunnerError as i32);
+
+/// Publish the status a later interrupt should exit with.
+pub(crate) fn set_watch_exit_status(exit: super::TestExitCode) {
+    WATCH_EXIT_STATUS.store(exit.code(), Ordering::SeqCst);
+}
+
+/// The handler `rue test --watch` installs for SIGINT and SIGTERM.
+///
+/// A watch process has no natural end, so being asked to stop IS its result:
+/// it kills the tests and reports the last completed cycle's status rather
+/// than dying of the signal the way a one-shot run does. `_exit` is used
+/// because it is async-signal-safe and because every event is already
+/// flushed as it is written.
+extern "C" fn exit_with_last_cycle_status(_signal: i32) {
+    kill_registered_groups();
+    // SAFETY: `_exit` is async-signal-safe and does not return.
+    unsafe {
+        libc::_exit(WATCH_EXIT_STATUS.load(Ordering::SeqCst));
+    }
+}
+
+static WATCH_SIGNAL_EXIT: OnceLock<()> = OnceLock::new();
+
+/// Take responsibility for the tests, and for the process's exit status, in
+/// watch mode.
+///
+/// The counterpart of [`install_signal_forwarding`], installed instead of it:
+/// the two disagree about what a stopped runner should look like, and only one
+/// disposition can be in force. A signal already ignored when we started stays
+/// ignored, for the same reason it does there.
+pub(crate) fn install_watch_signal_exit() {
+    WATCH_SIGNAL_EXIT.get_or_init(|| {
+        for signal in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
+            // SAFETY: `sigaction` on a catchable signal with a valid handler.
+            unsafe {
+                let mut previous: libc::sigaction = std::mem::zeroed();
+                if libc::sigaction(signal, std::ptr::null(), &mut previous) == 0
+                    && previous.sa_sigaction == libc::SIG_IGN
+                {
+                    continue;
+                }
+                let mut action: libc::sigaction = std::mem::zeroed();
+                action.sa_sigaction = exit_with_last_cycle_status as libc::sighandler_t;
+                libc::sigemptyset(&mut action.sa_mask);
+                action.sa_flags = libc::SA_RESTART;
+                libc::sigaction(signal, &action, std::ptr::null_mut());
+            }
+        }
+    });
+}
+
 /// Run one test to a verdict.
 ///
 /// Errors are runner errors — the image could not be executed at all — and are
@@ -338,6 +448,7 @@ pub(crate) fn run_one(dispatch: Dispatch<'_>) -> io::Result<Execution> {
     let mut live = LiveGroup {
         channel_write: Some(channel_write),
         slot: None,
+        cancellation: dispatch.cancellation,
     };
     let run = Supervisor::new(command, dispatch.timeout)
         .stream_budget(dispatch.stream_budget)
@@ -413,12 +524,13 @@ pub(crate) fn run_one(dispatch: Dispatch<'_>) -> io::Result<Execution> {
 /// Both halves exist only while the child does: the parent's copy of the
 /// channel's write end, which must be released the moment the child owns its
 /// own, and the registry slot the signal handler walks.
-struct LiveGroup {
+struct LiveGroup<'a> {
     channel_write: Option<OwnedFd>,
     slot: Option<usize>,
+    cancellation: Option<&'a RunCancellation>,
 }
 
-impl GroupObserver for LiveGroup {
+impl GroupObserver for LiveGroup<'_> {
     fn spawned(&mut self, pgid: i32) {
         // While the parent's write end is open, the channel's reader can never
         // see end of stream.
@@ -426,6 +538,17 @@ impl GroupObserver for LiveGroup {
         // Published before anything can block, so a signal arriving during the
         // drain still finds this test.
         self.slot = register_group(pgid);
+        // A watch cycle canceled while this child was being spawned would
+        // otherwise have swept the registry before this entry joined it, and
+        // the child would run to its own timeout with nobody waiting for its
+        // verdict (RUE-2023).
+        if self.cancellation.is_some_and(RunCancellation::is_canceled) {
+            // SAFETY: a negative pid names the group led by `pgid`; an
+            // already-empty group fails harmlessly.
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
     }
 
     fn reaped(&mut self, pgid: i32) {
@@ -580,7 +703,7 @@ mod tests {
     /// from the event stream alone.
     #[test]
     fn a_scratch_directory_is_named_from_the_seed_and_ordinal() {
-        let root = run_root(417);
+        let root = run_root(417, None);
         let path = scratch_path(&root, 417, 3);
         assert_eq!(
             path.file_name().unwrap().to_str().unwrap(),
@@ -594,7 +717,7 @@ mod tests {
     /// directory. The run root is what keeps them disjoint.
     #[test]
     fn a_run_root_is_private_to_its_process() {
-        let root = run_root(417);
+        let root = run_root(417, None);
         assert_eq!(root.parent().unwrap(), std::env::temp_dir());
         assert!(
             root.file_name()
@@ -604,6 +727,43 @@ mod tests {
                 .ends_with(&format!("-{}", std::process::id())),
             "{root:?}"
         );
+    }
+
+    /// A watch process runs the same seed many times, so its run root also
+    /// names the cycle: without that, cycle N+1 would delete the scratch
+    /// directory a failing test in cycle N deliberately retained (RUE-2023).
+    #[test]
+    fn a_watch_cycle_gets_a_run_root_of_its_own() {
+        let first = run_root(417, Some(1));
+        let second = run_root(417, Some(2));
+        assert_ne!(first, second);
+        assert_ne!(first, run_root(417, None));
+        assert!(
+            first
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .ends_with("-c1"),
+            "{first:?}"
+        );
+        // A retained scratch directory is still tied to the run by seed and
+        // ordinal; only the root that holds it moved.
+        assert_eq!(
+            scratch_path(&first, 417, 3).file_name(),
+            scratch_path(&second, 417, 3).file_name()
+        );
+    }
+
+    /// Cancellation is published before the sweep, so a worker that reads the
+    /// flag at any point after `cancel` returns never spawns.
+    #[test]
+    fn a_canceled_run_reports_itself_to_every_worker() {
+        let cancellation = RunCancellation::new();
+        assert!(!cancellation.is_canceled());
+        let clone = cancellation.clone();
+        cancellation.cancel();
+        assert!(clone.is_canceled(), "cancellation is shared, not copied");
     }
 
     /// The channel's budget is separate from the streams' so a test that floods

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -25,7 +25,7 @@ pub(crate) mod selection;
 pub(crate) mod verdict;
 
 use std::io::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
@@ -42,6 +42,13 @@ use events::{
 use exec::{DEFAULT_STREAM_BUDGET, Dispatch};
 use selection::Shard;
 use verdict::{FailureKind, Verdict};
+
+// What the watch loop drives a test cycle with. Test mode owns the run; the
+// loop owns the process's lifetime, the change monitor, and the signals
+// (RUE-2023).
+pub(crate) use exec::{
+    RunCancellation, install_watch_signal_exit, reserve_channel_descriptor, set_watch_exit_status,
+};
 
 /// The default per-test wall-clock budget, matching `rue-test-runner`'s
 /// (ADR-0083 §3).
@@ -150,7 +157,7 @@ pub(crate) struct TestRequest<'a, 'diagnostics> {
 /// library exposes without a dependency. The value is published in
 /// `run_started` and repeated in every repro argv, so a shuffle that surfaced a
 /// bug is re-runnable.
-fn fresh_seed() -> u64 {
+pub(crate) fn fresh_seed() -> u64 {
     use std::hash::{BuildHasher, Hasher};
     std::collections::hash_map::RandomState::new()
         .build_hasher()
@@ -239,23 +246,134 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
         return list(host, &compile_options, &options, diagnostics, &reporter);
     }
 
+    match run_cycle(CycleRequest {
+        host,
+        compile_options: &compile_options,
+        options: &options,
+        diagnostics,
+        root: &root,
+        repro_flags: &repro_flags,
+        repro_env: &repro_env,
+        jobs,
+        target,
+        opt_level,
+        candidates: candidates.as_ref(),
+        seed,
+        cycle: None,
+        cancellation: None,
+        observation: crate::compile::CycleObservation::OneShot,
+    }) {
+        CycleOutcome::Finished(exit) => exit,
+        // A one-shot cycle observes nothing that could supersede it and holds
+        // no cancellation anyone else can trip; those outcomes belong to the
+        // watch loop alone (RUE-2023).
+        CycleOutcome::Canceled | CycleOutcome::Superseded(_) => TestExitCode::RunnerError,
+    }
+}
+
+/// Everything one test cycle needs.
+///
+/// One-shot mode drives exactly one of these; `rue test --watch` drives one per
+/// accepted source revision on the retained host, which is what removes the
+/// per-run recompile (RUE-2023). Everything that differs between the two is a
+/// field here — the cycle number, the run cancellation, and how the image is
+/// observed — so there is one cycle body rather than a batch one and a watch
+/// one that drift.
+pub(crate) struct CycleRequest<'a, 'diagnostics> {
+    pub(crate) host: &'a mut FilesystemCompilerHost,
+    pub(crate) compile_options: &'a CompileOptions,
+    pub(crate) options: &'a TestOptions,
+    pub(crate) diagnostics: &'a crate::DiagnosticOutput<'diagnostics>,
+    pub(crate) root: &'a str,
+    pub(crate) repro_flags: &'a [String],
+    pub(crate) repro_env: &'a [(String, String)],
+    pub(crate) jobs: usize,
+    pub(crate) target: Target,
+    pub(crate) opt_level: OptLevel,
+    /// Re-acquired per cycle under `--watch`: `--test-candidates` names files
+    /// on disk, and the answer to "what does this target own" changes with the
+    /// same edits everything else here does.
+    pub(crate) candidates: Option<&'a TestCandidateInventory>,
+    /// Fixed for the life of the process unless `--seed` was given, so
+    /// consecutive cycles shuffle the same way and a difference between two of
+    /// them is attributable to the edit rather than to the order.
+    pub(crate) seed: u64,
+    /// The 1-based watch cycle number, or `None` for a one-shot run.
+    pub(crate) cycle: Option<u64>,
+    /// The watch loop's authority to end this cycle's execution phase.
+    pub(crate) cancellation: Option<&'a exec::RunCancellation>,
+    pub(crate) observation: crate::compile::CycleObservation<'a>,
+}
+
+/// How a cycle ended.
+pub(crate) enum CycleOutcome {
+    /// The cycle published `run_finished` (or failed before any event could be
+    /// published) and this is the status a one-shot run would exit with.
+    Finished(TestExitCode),
+    /// The cycle was abandoned. If it had reached the run, `run_canceled` says
+    /// so on the event stream; if it was still building the image, nothing was
+    /// published at all, because no `run_started` had opened the cycle.
+    Canceled,
+    /// A newer source revision arrived before the image could be published.
+    Superseded(crate::compile::Supersession),
+}
+
+/// Build the image for one revision and run the plan over it.
+pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
+    let CycleRequest {
+        host,
+        compile_options,
+        options,
+        diagnostics,
+        root,
+        repro_flags,
+        repro_env,
+        jobs,
+        target,
+        opt_level,
+        candidates,
+        seed,
+        cycle,
+        cancellation,
+        observation,
+    } = request;
+
+    // One private directory per cycle, so a failing test's retained scratch
+    // directory from cycle N survives cycle N+1 (RUE-2023).
+    let run_root = exec::run_root(seed, cycle);
+    if let Err(error) = std::fs::create_dir_all(&run_root) {
+        eprintln!("error: could not create the test run directory: {error}");
+        return CycleOutcome::Finished(TestExitCode::RunnerError);
+    }
+    let image_path = run_root.join("rue-test-image");
+
     // Nothing is published before the image exists: a compile failure outside
     // every test closure is diagnostics on stderr and exit 2, with an empty
     // event stream. A failure INSIDE one is not that failure — the image still
-    // exists, built from the tests that did analyze (ADR-0083 §3).
-    let image = match host.test_image_in_compile_scope(&compile_options) {
-        Ok(image) => image,
-        Err(errors) => {
-            diagnostics.print_errors(&errors);
-            return TestExitCode::RunnerError;
+    // exists, built from the tests that did analyze (ADR-0083 §3). The cycle
+    // that decides all of that is `compile`'s, shared with the executable
+    // build and with executable watch (RUE-1969, RUE-2023).
+    let image = match crate::compile::drive_test_cycle(crate::compile::TestCycleRequest {
+        host: &mut *host,
+        options: compile_options,
+        diagnostics,
+        image_path: &image_path,
+        observation,
+    }) {
+        crate::compile::TestCycleReport::Published(image) => *image,
+        crate::compile::TestCycleReport::Failed => {
+            discard_run_root(&image_path, &run_root);
+            return CycleOutcome::Finished(TestExitCode::RunnerError);
+        }
+        crate::compile::TestCycleReport::Canceled => {
+            discard_run_root(&image_path, &run_root);
+            return CycleOutcome::Canceled;
+        }
+        crate::compile::TestCycleReport::Superseded(boundary) => {
+            discard_run_root(&image_path, &run_root);
+            return CycleOutcome::Superseded(boundary);
         }
     };
-    let rue_compiler::unstable::TestImage {
-        output: image,
-        inventory,
-        compile_failures,
-        failure_diagnostics,
-    } = image;
     // Built here rather than above because the closure is only published once
     // the image is: nothing before this point could answer how many modules the
     // program has.
@@ -265,26 +383,19 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
             multi_module_closure: host.published_user_module_count() > 1,
         },
     );
-    diagnostics.print_warnings(&image.warnings);
-    // stderr is the authoritative diagnostic stream and carries these exactly
-    // as a whole-run failure would have: once, in the run's own
-    // `--error-format`, before any event. The copies inside the events are the
-    // attribution (ADR-0083 §3). They are printed whatever the selection is,
-    // because the closure that produced them is the whole closure: a filter
-    // narrows the run set, never the analysis root set, and a filtered run that
-    // silently swallowed a broken test file would be the papercut the
-    // unimported-test-file warning exists to prevent.
-    if !failure_diagnostics.is_empty() {
-        diagnostics.print_errors(&failure_diagnostics);
-    }
-    let compile_errors = CompileErrorVerdicts::new(&compile_failures, diagnostics);
+    let compile_errors = CompileErrorVerdicts::new(&image.compile_failures, diagnostics);
 
-    let total = inventory.entries.len();
-    let plan = selection::plan(&inventory.entries, &options.filters, options.shard, seed);
+    let total = image.inventory.entries.len();
+    let plan = selection::plan(
+        &image.inventory.entries,
+        &options.filters,
+        options.shard,
+        seed,
+    );
     let started = Instant::now();
 
     reporter.emit(&Event::RunStarted {
-        root: root.clone(),
+        root: root.to_owned(),
         target: target.to_string(),
         opt_level: opt_level_digit(opt_level),
         seed,
@@ -292,12 +403,15 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
         shard: options.shard.map(|shard| shard.to_string()),
         selected: plan.len(),
         total,
+        cycle,
     });
+    watch_milestone("run-started");
 
     if plan.is_empty() {
-        let unimported = report_unimported(host, candidates.as_ref(), diagnostics);
+        discard_run_root(&image_path, &run_root);
+        let unimported = report_unimported(host, candidates, diagnostics);
         let Ok(unimported) = unimported else {
-            return TestExitCode::RunnerError;
+            return CycleOutcome::Finished(TestExitCode::RunnerError);
         };
         // Said before the terminal event, so a reader of an interleaved
         // terminal sees the reason ahead of the vacuous "0 passed" summary.
@@ -310,25 +424,17 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
             compile_error: 0,
             wall_ms: elapsed_ms(started),
             unimported_test_files: unimported,
-            test_candidates: candidate_source(candidates.as_ref()),
+            test_candidates: candidate_source(candidates),
         });
-        return TestExitCode::EmptySelection;
+        watch_milestone("run-finished");
+        return CycleOutcome::Finished(TestExitCode::EmptySelection);
     }
-
-    let run_root = exec::run_root(seed);
-    let image_path = match publish_image(&image.elf, target, &run_root) {
-        Ok(path) => path,
-        Err(message) => {
-            eprintln!("{message}");
-            return TestExitCode::RunnerError;
-        }
-    };
 
     // A repro is pasted into some other shell, from some other directory, so it
     // names the compiler and the root by absolute path rather than by whatever
     // spelling this invocation happened to use (RUE-2020).
     let repro_program = repro_program();
-    let repro_root = absolute_spelling(Path::new(&root));
+    let repro_root = absolute_spelling(Path::new(root));
 
     let outcome = execute_plan(ExecutionRequest {
         plan: &plan,
@@ -340,23 +446,40 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
         jobs,
         repro_program: &repro_program,
         repro_root: &repro_root,
-        repro_flags: &repro_flags,
-        repro_env: &repro_env,
+        repro_flags,
+        repro_env,
         reporter: &reporter,
+        cancellation,
     });
     // The image is the runner's own artifact and is never retained; the run
     // root goes with it unless a failing test left a scratch directory behind,
     // in which case the non-recursive removal fails and the evidence survives.
-    let _ = std::fs::remove_file(&image_path);
-    let _ = std::fs::remove_dir(&run_root);
+    discard_run_root(&image_path, &run_root);
+
+    // An edit that landed mid-run killed the tests that were still going, so
+    // the counts describe neither the whole plan nor the verdicts that would
+    // have followed. The cycle says it was abandoned and says how far it got;
+    // it does not publish a `run_finished` (RUE-2023).
+    if outcome.canceled {
+        reporter.emit(&Event::RunCanceled {
+            // A run is only cancellable through a watch cycle's own
+            // cancellation, and a watch cycle always has a number.
+            cycle: cycle.unwrap_or(0),
+            reported: outcome.reported(),
+            selected: plan.len(),
+            wall_ms: elapsed_ms(started),
+        });
+        watch_milestone("run-canceled");
+        return CycleOutcome::Canceled;
+    }
 
     if let Some(error) = outcome.runner_error {
         eprintln!("error: {error}");
-        return TestExitCode::RunnerError;
+        return CycleOutcome::Finished(TestExitCode::RunnerError);
     }
 
-    let Ok(unimported) = report_unimported(host, candidates.as_ref(), diagnostics) else {
-        return TestExitCode::RunnerError;
+    let Ok(unimported) = report_unimported(host, candidates, diagnostics) else {
+        return CycleOutcome::Finished(TestExitCode::RunnerError);
     };
     reporter.emit(&Event::RunFinished {
         passed: outcome.passed,
@@ -366,17 +489,40 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
         compile_error: outcome.compile_error,
         wall_ms: elapsed_ms(started),
         unimported_test_files: unimported,
-        test_candidates: candidate_source(candidates.as_ref()),
+        test_candidates: candidate_source(candidates),
     });
+    watch_milestone("run-finished");
 
     // A `compile_error` test is a failed test, not a failed run: exit 1 with
     // the other tests' verdicts, never the 2 that says nothing ran
     // (ADR-0083 §3).
-    if outcome.failed + outcome.timeout + outcome.crash + outcome.compile_error > 0 {
-        TestExitCode::Failures
-    } else {
-        TestExitCode::AllPassed
-    }
+    CycleOutcome::Finished(
+        if outcome.failed + outcome.timeout + outcome.crash + outcome.compile_error > 0 {
+            TestExitCode::Failures
+        } else {
+            TestExitCode::AllPassed
+        },
+    )
+}
+
+/// Remove the cycle's image and, if nothing retained a scratch directory
+/// inside it, the run root itself.
+///
+/// The removal is deliberately non-recursive: a failing test's scratch
+/// directory is evidence, and the directory that holds it survives with it
+/// (ADR-0083 §5.4).
+fn discard_run_root(image_path: &Path, run_root: &Path) {
+    let _ = std::fs::remove_file(image_path);
+    let _ = std::fs::remove_dir(run_root);
+}
+
+/// Report a run milestone on the watch loop's test protocol.
+///
+/// Dormant unless `RUE_WATCH_TEST_PROTOCOL` names a file, exactly like every
+/// other milestone: this is the seam that lets a watch-mode CLI case wait for
+/// a cycle's run to start, finish, or be abandoned instead of sleeping.
+fn watch_milestone(event: &str) {
+    crate::watch::test_event(event);
 }
 
 /// The `compile_error` verdicts a run publishes, keyed by ordinal.
@@ -564,40 +710,6 @@ fn list(
     TestExitCode::AllPassed
 }
 
-/// Write the linked image where it can be executed.
-///
-/// This goes through the driver's ordinary publication path rather than a bare
-/// `fs::write`, because publication is where target-specific finalization
-/// happens — notably ad-hoc Mach-O signing, without which the image would not
-/// run at all on Apple silicon.
-fn publish_image(
-    elf: &[u8],
-    target: Target,
-    run_root: &std::path::Path,
-) -> Result<PathBuf, String> {
-    std::fs::create_dir_all(run_root)
-        .map_err(|error| format!("error: could not create the test run directory: {error}"))?;
-    let path = run_root.join("rue-test-image");
-    let destination = crate::output::preflight_destination(&path, std::iter::empty())
-        .map_err(|error| publish_failure("stage", error))?;
-    crate::output::publish_executable(crate::output::PublishRequest {
-        destination,
-        bytes: elf,
-        target,
-    })
-    .map_err(|error| publish_failure("publish", error))?;
-    Ok(path)
-}
-
-/// A staging failure, rendered through the same message a publication failure
-/// carries on the compile path.
-fn publish_failure(verb: &str, error: crate::output::PublishError) -> String {
-    format!(
-        "error: could not {verb} the test image: {}",
-        error.into_compile_error().kind
-    )
-}
-
 struct ExecutionRequest<'a> {
     plan: &'a [TestInventoryEntry],
     /// The verdicts the compiler already decided, by ordinal. A plan entry
@@ -614,6 +726,9 @@ struct ExecutionRequest<'a> {
     repro_flags: &'a [String],
     repro_env: &'a [(String, String)],
     reporter: &'a Reporter,
+    /// A watch cycle's authority to abandon this run. `None` for a one-shot
+    /// run, which nothing outside itself can end (RUE-2023).
+    cancellation: Option<&'a exec::RunCancellation>,
 }
 
 #[derive(Default)]
@@ -624,6 +739,17 @@ struct ExecutionOutcome {
     crash: usize,
     compile_error: usize,
     runner_error: Option<String>,
+    /// An edit landed while the plan was running, so the run stopped short of
+    /// it (RUE-2023).
+    canceled: bool,
+}
+
+impl ExecutionOutcome {
+    /// Verdicts this run actually published, which is what a canceled cycle
+    /// reports in place of counts by class.
+    fn reported(&self) -> usize {
+        self.passed + self.failed + self.timeout + self.crash + self.compile_error
+    }
 }
 
 /// Run the plan across a bounded pool of workers.
@@ -664,6 +790,11 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
                     {
                         return;
                     }
+                    // Read before anything is published, so an abandoned cycle
+                    // never opens a `test_started` it can only leave dangling.
+                    if canceled(request.cancellation) {
+                        return;
+                    }
                     request.reporter.emit(&Event::TestStarted {
                         id: entry.id.clone(),
                     });
@@ -685,6 +816,7 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
                         ));
                         continue;
                     }
+                    crate::watch::test_event("test-spawned");
                     let execution = exec::run_one(Dispatch {
                         image: request.image,
                         run_root: request.run_root,
@@ -692,7 +824,30 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
                         seed: request.seed,
                         timeout: request.timeout,
                         stream_budget: DEFAULT_STREAM_BUDGET,
+                        cancellation: request.cancellation,
                     });
+                    // The cancellation killed this test's process group, so
+                    // whatever it reported is an artifact of the kill rather
+                    // than a verdict about the program. The `test_started`
+                    // above stands unfinished, and `run_canceled` is what
+                    // tells a consumer why (RUE-2023).
+                    if canceled(request.cancellation) {
+                        // This one directory goes with the verdict that was
+                        // never published. Retention is for evidence a reader
+                        // was pointed at (ADR-0083 §5.4), and no event names
+                        // this path; the abort-only runtime left nothing in it
+                        // to inspect either, because the process was SIGKILLed.
+                        // Only this ordinal's directory: a sibling test's
+                        // retained scratch in the same run root belongs to a
+                        // verdict that WAS published, which is why the run root
+                        // itself is still removed non-recursively.
+                        let _ = std::fs::remove_dir_all(exec::scratch_path(
+                            request.run_root,
+                            request.seed,
+                            entry.ordinal,
+                        ));
+                        return;
+                    }
                     let execution = match execution {
                         Ok(execution) => execution,
                         Err(error) => {
@@ -743,7 +898,13 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
         runner_error: runner_error
             .into_inner()
             .unwrap_or_else(|error| error.into_inner()),
+        canceled: canceled(request.cancellation),
     }
+}
+
+/// Whether a watch cycle has abandoned the run this worker is serving.
+fn canceled(cancellation: Option<&exec::RunCancellation>) -> bool {
+    cancellation.is_some_and(exec::RunCancellation::is_canceled)
 }
 
 /// Turn one finished process into its `test_finished` event.

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -68,7 +68,28 @@ pub(crate) fn render(event: &Event) -> Option<String> {
             compile_error: *compile_error,
             wall_ms: *wall_ms,
         })),
+        Event::RunCanceled {
+            reported,
+            selected,
+            wall_ms,
+            // The cycle number is for a consumer grouping a tailed stream; a
+            // person reading a terminal is already inside the cycle.
+            cycle: _,
+        } => Some(canceled(*reported, *selected, *wall_ms)),
     }
+}
+
+/// `canceled after 3 of 9 tests (0.4s); a newer source revision is available`.
+///
+/// The two counts are the honest report a `run_finished` could not make: the
+/// verdicts this cycle published, and the plan it was working through when the
+/// edit landed (RUE-2023).
+fn canceled(reported: usize, selected: usize, wall_ms: u64) -> String {
+    format!(
+        "canceled after {reported} of {selected} test{} ({}); a newer source revision is available",
+        if selected == 1 { "" } else { "s" },
+        seconds(wall_ms)
+    )
 }
 
 /// The runner's own notice for this event, or `None` when a run is owed none.
@@ -564,9 +585,36 @@ mod tests {
                 shard: None,
                 selected: 1,
                 total: 1,
+                cycle: None,
             })
             .is_none()
         );
+    }
+
+    /// A canceled cycle is the one thing a watch consumer must not read as a
+    /// silent end, so it prints in place of the summary it replaces
+    /// (RUE-2023).
+    #[test]
+    fn a_canceled_cycle_reports_what_it_managed() {
+        let rendered = super::render(&Event::RunCanceled {
+            cycle: 2,
+            reported: 3,
+            selected: 9,
+            wall_ms: 400,
+        })
+        .expect("a canceled cycle is never silent");
+        assert_eq!(
+            rendered,
+            "canceled after 3 of 9 tests (0.4s); a newer source revision is available"
+        );
+        let single = super::render(&Event::RunCanceled {
+            cycle: 1,
+            reported: 0,
+            selected: 1,
+            wall_ms: 0,
+        })
+        .expect("a canceled cycle is never silent");
+        assert!(single.contains("0 of 1 test ("), "{single}");
     }
 
     #[test]

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -7,17 +7,19 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use rue_compiler::CompileOptions;
 use rue_compiler::unstable::{CompilationCancellation, SourceInfo};
+use rue_compiler::{CompileOptions, OptLevel};
 #[cfg(test)]
 use rue_driver::watch_inputs_changed_with_reader;
 use rue_driver::{
     FilesystemCompilerHost, SourceLoadError, WatchFingerprint, WatchInput, watch_inputs_changed,
 };
+use rue_target::Target;
 
 use crate::compile::{
     Announcement, CycleObservation, CycleReport, CycleRequest, Supersession, drive_cycle,
 };
+use crate::test_mode;
 use crate::{DiagnosticOutput, ErrorFormat, render_source_load_error};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -35,14 +37,21 @@ const TEST_COMPILE_DELAY_ENV: &str = "RUE_WATCH_TEST_COMPILE_DELAY_MS";
 const TEST_ACQUIRE_DELAY_ENV: &str = "RUE_WATCH_TEST_ACQUIRE_DELAY_MS";
 const TEST_BOUNDARY_DELAY_ENV: &str = "RUE_WATCH_TEST_BOUNDARY_DELAY_MS";
 
-fn test_event(event: &str) {
+pub(crate) fn test_event(event: &str) {
     let Some(path) = std::env::var_os(TEST_PROTOCOL_ENV) else {
         return;
     };
     let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
         return;
     };
-    let _ = writeln!(file, "{event}");
+    // One `write(2)`, not two. `writeln!` on an unbuffered `File` issues the
+    // payload and the newline separately, and two writers can interleave
+    // between them: `test-spawned` is emitted from the run's worker threads
+    // rather than from this loop, so under `--jobs N` that produced
+    // concatenated lines and a harness undercount. A single append-mode write
+    // of this size is atomic (RUE-2023).
+    let line = format!("{event}\n");
+    let _ = file.write_all(line.as_bytes());
     let _ = file.flush();
 }
 
@@ -111,8 +120,73 @@ pub(crate) struct WatchRequest {
     pub(crate) host: FilesystemCompilerHost,
     pub(crate) compile_options: CompileOptions,
     pub(crate) source_path: String,
-    pub(crate) output_path: String,
     pub(crate) error_format: ErrorFormat,
+    pub(crate) mode: WatchMode,
+}
+
+/// What one accepted source revision produces.
+///
+/// The loop itself — the change monitor, re-observation, acquisition,
+/// cancellation, debouncing, and the cycle boundary — is the same either way;
+/// only the cycle body differs, which is what lets `rue test --watch` reuse the
+/// retained host instead of paying a fresh process and a full compile per run
+/// (RUE-2023).
+pub(crate) enum WatchMode {
+    /// Publish the user's executable at this path.
+    Executable { output_path: String },
+    /// Build the request's test image and run its tests.
+    Test(Box<TestWatch>),
+}
+
+/// The test-mode configuration a watch cycle repeats verbatim.
+pub(crate) struct TestWatch {
+    pub(crate) options: test_mode::TestOptions,
+    pub(crate) repro_flags: Vec<String>,
+    pub(crate) repro_env: Vec<(String, String)>,
+    pub(crate) jobs: usize,
+    pub(crate) target: Target,
+    pub(crate) opt_level: OptLevel,
+    /// `--test-candidates`, re-read per cycle: the declared list and the files
+    /// it names are both ordinary disk state, and a cycle reports what is on
+    /// disk now.
+    pub(crate) test_candidates_path: Option<String>,
+    /// Derived once for the whole process unless `--seed` was given, so
+    /// consecutive cycles shuffle the same way and a difference between two of
+    /// them is attributable to the edit rather than to the order.
+    pub(crate) seed: u64,
+}
+
+/// Everything one cycle is canceled through.
+///
+/// A compile is canceled cooperatively inside the query graph; a run is
+/// canceled by killing the process groups it is supervising. One edit ends
+/// both, so the change monitor holds both and the two can never disagree about
+/// whether this cycle is still wanted (RUE-2023).
+#[derive(Clone)]
+struct CycleCancellation {
+    compilation: CompilationCancellation,
+    run: Option<test_mode::RunCancellation>,
+}
+
+impl CycleCancellation {
+    fn cancel(&self) {
+        self.compilation.cancel();
+        if let Some(run) = &self.run {
+            run.cancel();
+        }
+    }
+}
+
+/// What one cycle did, in the vocabulary the loop's boundary logic needs.
+enum CycleStatus {
+    /// The cycle produced its artifact: an executable at the output path, or a
+    /// completed test run.
+    Completed,
+    /// The cycle was rejected. Its diagnostics are already out and the loop
+    /// keeps watching.
+    Failed,
+    Superseded(Supersession),
+    Canceled,
 }
 
 struct ChangeMonitor {
@@ -137,7 +211,7 @@ struct WatchSymlinkObservation {
 }
 
 impl ChangeMonitor {
-    fn start(inputs: Vec<WatchInput>, cancellation: CompilationCancellation) -> Self {
+    fn start(inputs: Vec<WatchInput>, cancellation: CycleCancellation) -> Self {
         let stop = Arc::new(AtomicBool::new(false));
         let changed = Arc::new(AtomicBool::new(false));
         let thread_stop = stop.clone();
@@ -215,9 +289,37 @@ impl ChangeMonitor {
     }
 }
 
-pub(crate) fn run(mut request: WatchRequest) -> ! {
+pub(crate) fn run(request: WatchRequest) -> ! {
+    let WatchRequest {
+        mut host,
+        compile_options,
+        source_path,
+        error_format,
+        mut mode,
+    } = request;
     let mut needs_reobserve = false;
-    println!("Watching {} for changes", request.source_path);
+    let mut cycle: u64 = 0;
+
+    if let WatchMode::Test(_) = &mode {
+        // Once for the process, before anything can spawn: descriptor 3 is
+        // pinned shut so no pipe the standard library opens for its own
+        // bookkeeping can be allocated there and then destroyed by a child's
+        // `dup2` onto the failure channel (`exec::reserve_channel_descriptor`).
+        // Per cycle would be pointless — the reservation is idempotent and
+        // never released — and per spawn would be a race.
+        test_mode::reserve_channel_descriptor();
+        // A watch process has no natural end, so being asked to stop IS its
+        // result: it reports the last completed cycle's status rather than
+        // dying of the signal a one-shot run dies of (ADR-0083 §2).
+        test_mode::install_watch_signal_exit();
+    }
+
+    match &mode {
+        // stdout is the event stream in test mode, so the loop's own voice
+        // goes where every other runner notice goes.
+        WatchMode::Test(_) => eprintln!("Watching {source_path} for changes"),
+        WatchMode::Executable { .. } => println!("Watching {source_path} for changes"),
+    }
     test_event("ready");
 
     loop {
@@ -229,30 +331,29 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
             // instead of waiting for compilation proper to notice it
             // (RUE-1830, RUE-1863). One monitor spans both so the window has
             // no unobserved seam between them.
-            let stale_inputs = request.host.watch_inputs();
+            let stale_inputs = host.watch_inputs();
             let cancellation = CompilationCancellation::new();
             let (monitor, observation_baseline) =
                 ChangeMonitor::start_reobservation(stale_inputs.clone(), cancellation.clone());
             let superseded = || cancellation.is_canceled();
             test_event("reobserve-started");
             let mut phase = ObservationPhase::Reobserve;
-            let mut observed = request.host.reobserve_superseding(&superseded);
+            let mut observed = host.reobserve_superseding(&superseded);
             if observed.is_ok() {
                 test_event("reobserve-ok");
                 phase = ObservationPhase::Acquire;
                 test_acquire_delay();
-                observed = request.host.acquire_reached_toolchain_modules_superseding(
-                    &request.compile_options,
-                    &superseded,
-                );
+                observed = host
+                    .acquire_reached_toolchain_modules_superseding(&compile_options, &superseded);
             }
             let monitor_changed = monitor.finish();
             let changed =
                 monitor_changed || current_observations(&stale_inputs) != observation_baseline;
             if changed || matches!(&observed, Err(SourceLoadError::Superseded)) {
                 test_event(phase.superseded_event());
-                print_watch_status(
-                    request.error_format,
+                print_cycle_status(
+                    &mode,
+                    error_format,
                     format!(
                         "Watch re-observation superseded after {} ms; a newer source revision is available",
                         cycle_started.elapsed().as_millis()
@@ -271,12 +372,14 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
                 }
                 Err(error) => {
                     test_event(phase.error_event());
-                    print_source_load_error(error, request.error_format);
-                    print_watch_status(
-                        request.error_format,
+                    print_source_load_error(error, error_format);
+                    print_cycle_status(
+                        &mode,
+                        error_format,
                         format!(
-                            "Watch cycle failed after {} ms; keeping the last successful executable",
-                            cycle_started.elapsed().as_millis()
+                            "Watch cycle failed after {} ms; {}",
+                            cycle_started.elapsed().as_millis(),
+                            failure_consequence(&mode)
                         ),
                     );
                     thread::sleep(FAILED_REOBSERVE_RETRY);
@@ -285,39 +388,77 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
             }
         }
 
-        let inputs = request.host.watch_inputs();
-        let source_snapshot = request.host.source_snapshot().clone();
+        let inputs = host.watch_inputs();
+        let source_snapshot = host.source_snapshot().clone();
         let source_infos = source_snapshot
             .files()
             .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
             .collect();
-        let diagnostics = DiagnosticOutput::new(request.error_format, source_infos);
+        let diagnostics = DiagnosticOutput::new(error_format, source_infos);
 
         let cancellation = CompilationCancellation::new();
-        let monitor = ChangeMonitor::start(inputs.clone(), cancellation.clone());
+        // A test cycle stays abandonable past its compile: one edit cancels
+        // whichever half of the cycle it lands in, so the monitor carries the
+        // authority to kill this cycle's running tests alongside the one that
+        // cancels its compilation (RUE-2023). An executable cycle has no
+        // execution phase and so carries none.
+        let run_cancellation =
+            matches!(mode, WatchMode::Test(_)).then(test_mode::RunCancellation::new);
+        let monitor = ChangeMonitor::start(
+            inputs.clone(),
+            CycleCancellation {
+                compilation: cancellation.clone(),
+                run: run_cancellation.clone(),
+            },
+        );
         test_event("compile-started");
         test_compile_delay();
         // A cycle is superseded once the monitor has seen an edit, or once a
         // fresh read of the closure disagrees with what this cycle observed.
         let superseded = || monitor.changed() || inputs_changed(&inputs);
-        let report = drive_cycle(CycleRequest {
-            host: &mut request.host,
-            options: &request.compile_options,
-            diagnostics: &diagnostics,
-            source_path: &request.source_path,
-            output_path: &request.output_path,
-            observation: CycleObservation::Watch {
-                inputs: inputs.clone(),
-                cancellation,
-                superseded: &superseded,
-            },
-            announcement: Announcement::Cycle(cycle_started),
-        });
+        let observation = CycleObservation::Watch {
+            inputs: inputs.clone(),
+            cancellation,
+            superseded: &superseded,
+        };
+        let status = match &mut mode {
+            WatchMode::Executable { output_path } => executable_status(drive_cycle(CycleRequest {
+                host: &mut host,
+                options: &compile_options,
+                diagnostics: &diagnostics,
+                source_path: &source_path,
+                output_path,
+                observation,
+                announcement: Announcement::Cycle(cycle_started),
+            })),
+            WatchMode::Test(config) => {
+                cycle += 1;
+                test_status(test_watch_cycle(TestWatchCycle {
+                    host: &mut host,
+                    compile_options: &compile_options,
+                    config,
+                    diagnostics: &diagnostics,
+                    source_path: &source_path,
+                    cycle,
+                    cancellation: run_cancellation
+                        .as_ref()
+                        .expect("a test cycle always holds a run cancellation"),
+                    observation,
+                }))
+            }
+        };
 
         let mut publication_changed = false;
-        match report {
-            CycleReport::Published(_) => test_event("published"),
-            CycleReport::Superseded(boundary) => {
+        match status {
+            CycleStatus::Completed => {
+                // The milestone names the artifact reaching disk, which both
+                // modes do: an executable at the output path, a test image in
+                // the cycle's own run directory. A test cycle's run milestones
+                // are `test_mode`'s and were emitted inside it.
+                test_event("published");
+                announce_watching(&mode);
+            }
+            CycleStatus::Superseded(boundary) => {
                 // The compile monitor and the publication guard both refuse to
                 // publish a stale revision; the milestone says which of them
                 // caught it, and only the publication guard's answer feeds the
@@ -327,33 +468,40 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
                     Supersession::AtPublication => "canceled-at-publication",
                     Supersession::BeforePublication => "canceled-before-publication",
                 });
-                print_watch_status(
-                    request.error_format,
+                print_cycle_status(
+                    &mode,
+                    error_format,
                     format!(
                         "Watch cycle canceled after {} ms; a newer source revision is available",
                         cycle_started.elapsed().as_millis()
                     ),
                 );
             }
-            CycleReport::Canceled => {
+            CycleStatus::Canceled => {
                 test_event("canceled");
-                print_watch_status(
-                    request.error_format,
+                print_cycle_status(
+                    &mode,
+                    error_format,
                     format!(
                         "Watch cycle canceled after {} ms",
                         cycle_started.elapsed().as_millis()
                     ),
                 );
             }
-            CycleReport::Failed => {
+            CycleStatus::Failed => {
                 test_event("compile-error");
-                print_watch_status(
-                    request.error_format,
+                print_cycle_status(
+                    &mode,
+                    error_format,
                     format!(
-                        "Watch cycle failed after {} ms; keeping the last successful executable",
-                        cycle_started.elapsed().as_millis()
+                        "Watch cycle failed after {} ms; {}",
+                        cycle_started.elapsed().as_millis(),
+                        failure_consequence(&mode)
                     ),
                 );
+                // A failed cycle ends the same way a completed one does: the
+                // loop goes back to waiting, and a person is told so.
+                announce_watching(&mode);
             }
         }
 
@@ -379,6 +527,143 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
     }
 }
 
+/// What a failed cycle leaves the user with, which is the one thing the two
+/// modes' status lines disagree about.
+///
+/// An executable watch keeps the last executable it published on disk. A test
+/// watch published nothing to keep: this revision reached no `run_finished`,
+/// and whatever the last completed cycle reported is still on the stream above
+/// rather than reprinted here.
+///
+/// "No summary" rather than "no tests ran", because the one failure that can
+/// reach here after the image existed — a test the runner could not execute at
+/// all — did run some. What is true of every failed cycle is that it published
+/// no summary.
+fn failure_consequence(mode: &WatchMode) -> &'static str {
+    match mode {
+        WatchMode::Executable { .. } => "keeping the last successful executable",
+        WatchMode::Test(_) => "no summary for this revision",
+    }
+}
+
+/// Say the loop is idle again after a cycle a person watched go by.
+///
+/// Said after a cycle that ENDED — completed or failed — and not after one a
+/// newer revision superseded or canceled, because that loop is not idle: the
+/// next cycle starts immediately.
+///
+/// Human format only: `--format json` delimits its cycles with `run_finished`
+/// and `run_canceled`, and a consumer of that stream is owed no prose.
+fn announce_watching(mode: &WatchMode) {
+    if let WatchMode::Test(config) = mode
+        && config.options.format == test_mode::OutputFormat::Human
+    {
+        eprintln!("watching…");
+    }
+}
+
+fn executable_status(report: CycleReport) -> CycleStatus {
+    match report {
+        CycleReport::Published(_) => CycleStatus::Completed,
+        CycleReport::Failed => CycleStatus::Failed,
+        CycleReport::Superseded(boundary) => CycleStatus::Superseded(boundary),
+        CycleReport::Canceled => CycleStatus::Canceled,
+    }
+}
+
+/// Fold a test cycle's outcome into the loop's vocabulary, and publish the
+/// status a later interrupt exits with.
+///
+/// `rue test --watch` produces an exit code only when it is asked to stop, and
+/// that code is the last cycle that actually COMPLETED reporting itself: a
+/// cycle that could not build its image, or that an edit abandoned, leaves the
+/// previous answer standing rather than overwriting it with "the run did not
+/// happen" (ADR-0083 §2, RUE-2023).
+///
+/// A completed cycle's own status carries through unchanged, `EmptySelection`
+/// included. "Your filter matched nothing" and "tests failed" are the different
+/// mistakes ADR-0083 §2 gives `3` its own code for, and a watcher stopped after
+/// such a cycle owes an agent that distinction exactly as a one-shot run does.
+fn test_status(outcome: test_mode::CycleOutcome) -> CycleStatus {
+    match outcome {
+        // Not a completed cycle: the image failed, or the runner did. This is
+        // the one status that must not reach the atomic — it would claim the
+        // last completed cycle never happened.
+        test_mode::CycleOutcome::Finished(test_mode::TestExitCode::RunnerError) => {
+            CycleStatus::Failed
+        }
+        test_mode::CycleOutcome::Finished(exit) => {
+            test_mode::set_watch_exit_status(exit);
+            CycleStatus::Completed
+        }
+        test_mode::CycleOutcome::Canceled => CycleStatus::Canceled,
+        test_mode::CycleOutcome::Superseded(boundary) => CycleStatus::Superseded(boundary),
+    }
+}
+
+/// One `rue test --watch` cycle: the declared candidate list as it stands now,
+/// then the ordinary test cycle over this revision's image.
+struct TestWatchCycle<'a, 'diagnostics> {
+    host: &'a mut FilesystemCompilerHost,
+    compile_options: &'a CompileOptions,
+    config: &'a TestWatch,
+    diagnostics: &'a DiagnosticOutput<'diagnostics>,
+    source_path: &'a str,
+    cycle: u64,
+    cancellation: &'a test_mode::RunCancellation,
+    observation: CycleObservation<'a>,
+}
+
+fn test_watch_cycle(request: TestWatchCycle<'_, '_>) -> test_mode::CycleOutcome {
+    let TestWatchCycle {
+        host,
+        compile_options,
+        config,
+        diagnostics,
+        source_path,
+        cycle,
+        cancellation,
+        observation,
+    } = request;
+    // Re-read per cycle: the list is disk state and so are the files it names,
+    // so a candidate added, removed, or newly broken since the last cycle is
+    // reported by this one. The warning it produces is printed by the cycle
+    // itself, once, in each cycle whose report is non-empty (RUE-2023).
+    let candidates = match &config.test_candidates_path {
+        Some(path) => match rue_driver::load_declared_candidates(path) {
+            Ok(declared) => match host.acquire_test_candidates(&declared) {
+                Ok(inventory) => Some(inventory),
+                Err(errors) => {
+                    diagnostics.print_errors(&errors);
+                    return test_mode::CycleOutcome::Finished(test_mode::TestExitCode::RunnerError);
+                }
+            },
+            Err(message) => {
+                eprintln!("{message}");
+                return test_mode::CycleOutcome::Finished(test_mode::TestExitCode::RunnerError);
+            }
+        },
+        None => None,
+    };
+    test_mode::run_cycle(test_mode::CycleRequest {
+        host,
+        compile_options,
+        options: &config.options,
+        diagnostics,
+        root: source_path,
+        repro_flags: &config.repro_flags,
+        repro_env: &config.repro_env,
+        jobs: config.jobs,
+        target: config.target,
+        opt_level: config.opt_level,
+        candidates: candidates.as_ref(),
+        seed: config.seed,
+        cycle: Some(cycle),
+        cancellation: Some(cancellation),
+        observation,
+    })
+}
+
 fn print_source_load_error(error: SourceLoadError, error_format: ErrorFormat) {
     eprintln!("{}", render_source_load_error(error, error_format));
 }
@@ -390,6 +675,23 @@ fn print_watch_status(error_format: ErrorFormat, message: impl std::fmt::Display
     match error_format {
         ErrorFormat::Text => eprintln!("{message}"),
         ErrorFormat::Json => println!("{message}"),
+    }
+}
+
+/// Cycle status, on the stream this mode can spare.
+///
+/// An executable watch keeps the placement above. A test watch cannot: stdout
+/// is the event stream there, and `--format json` promises a consumer that
+/// every line of it parses. Its status goes to stderr in both formats, which is
+/// where `rue test`'s other notices already go (test-events.md, "Streams").
+fn print_cycle_status(
+    mode: &WatchMode,
+    error_format: ErrorFormat,
+    message: impl std::fmt::Display,
+) {
+    match mode {
+        WatchMode::Test(_) => eprintln!("{message}"),
+        WatchMode::Executable { .. } => print_watch_status(error_format, message),
     }
 }
 

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -958,9 +958,12 @@ them — recorded in the follow-up issues (§6), not here.
 The four deferred ADRs of §6 (RUE-1621 through RUE-1624), then: structured
 assertion intrinsics beyond Phase 2.5's comparison family; capability
 declarations in types and at trait boundaries (flagged from the capability
-work); JUnit and CTRF adapters; test-aware `--watch` (rerun exactly the
-dirtied selection on save — needs the deferred selection work plus the
-existing watch loop).
+work); JUnit and CTRF adapters; changed-only re-execution under `--watch`
+(rerun exactly the dirtied selection on save, rather than the whole suite —
+needs the deferred verdict cache of §6, and is unsound for any test that
+touches the filesystem or the network). `rue test --watch` itself shipped in
+RUE-2023: one retained compiler runs one whole test cycle per accepted source
+revision, which is the part that needed only the existing watch loop.
 
 ## References
 

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -258,6 +258,7 @@ The head event, and the only one carrying the schema version for a run.
 | `seed` | integer | The run's shuffle seed (see `--seed`). |
 | `jobs` | integer | Concurrent test processes, which is all `--jobs` bounds in test mode; compilation uses auto-detected parallelism. |
 | `shard` | string | `"K/N"`. **Absent** when `--shard` was not given. |
+| `cycle` | integer | The 1-based watch cycle this run is. **Absent** outside `--watch`. Under `--watch` the cycle it opens ends with `run_finished` or `run_canceled`, and a later `run_started` closes it either way. |
 | `plan` | object | `{"selected": integer, "total": integer}` — tests selected, and tests in the closure. |
 
 ### `test_started`
@@ -460,6 +461,30 @@ DIRECTORY — the compiler's project root — and its build-side producer is the
 `rue_test` rule (`rue_rules.bzl`, ADR-0083's boundary), which writes it from
 the target's declared `srcs` and fails the target when this array is non-empty,
 since `rue test` itself reports the orphan and still exits `0`.
+
+### `run_canceled`
+
+A `--watch` cycle abandoned while its tests were running. **Only `rue test
+--watch` produces this event**; a one-shot run has nothing that could end it.
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `event` | `"run_canceled"` | |
+| `cycle` | integer | The cycle this ends, matching its `run_started.cycle`. |
+| `reported` | integer | Verdicts this cycle published before the edit landed. |
+| `selected` | integer | Tests the cycle's plan held. |
+| `wall_ms` | integer | Wall time from `run_started` to the cancellation. |
+
+It **replaces** this cycle's `run_finished` and never accompanies one. The
+`test_finished` events already published stand; the tests still running were
+killed with their process groups and produced none, so the cycle's last
+`test_started` has no `test_finished` and a `run_finished` whose counts
+described neither would be a lie. Under `--format human` the same event reads
+`canceled after 3 of 9 tests (0.4s); a newer source revision is available`.
+
+A cycle canceled *before* its image existed emits nothing at all, because no
+`run_started` had opened it — the same rule as any other compile failure, in
+[Streams](#streams). The status line on stderr is what reports those.
 
 ### `test` (listing records)
 
@@ -756,7 +781,10 @@ Directories live under a per-run directory named for the seed and the runner's
 process id, and are themselves named `rue-test-<seed>-<ordinal>`. The run
 directory is what keeps two runs that share an explicit `--seed` — a repro next
 to the run that produced it, or two suites in parallel — from deleting each
-other's live working directories.
+other's live working directories. Under `--watch` the run directory also carries
+the cycle: `rue-test-<seed>-<pid>-c<cycle>`. One process runs the same seed many
+times there, and without the cycle in the name the next cycle's fresh-directory
+setup would delete the evidence a failing test in this one deliberately kept.
 
 **Retention is the user's to undo.** The run directory and every scratch
 directory it holds sit under the OS temp directory. A retained one is evidence,
@@ -781,6 +809,60 @@ containment. ADR-0083 §3 scopes that clause to verified-hermetic tests, which
 the deferred capability ADR introduces; the MVP verifies nothing and claims it
 for no test.
 
+## `--watch`
+
+`rue test <root> --watch` keeps **one** compiler for the life of the process and
+runs one test cycle per accepted source revision, so a cycle pays for what the
+edit changed rather than for a whole recompile. It combines with every test-mode
+flag except `--list` — a listing is an inventory of one revision, and a watcher
+has no one revision — and keeps compile mode's own exclusions (`--emit`,
+`--benchmark-json`, `--time-passes`, `-o`).
+
+- **One cycle is one run.** Each publishes its own `run_started` /
+  `run_finished` pair, and `run_started.cycle` numbers them from 1 so a consumer
+  tailing the process can group what lies between. The number counts CYCLES, not
+  runs, so the stream can skip one: a cycle that failed to build its image
+  published no events at all, and the gap is what says so.
+- **A new `run_started` closes whatever was open.** A cycle ends with
+  `run_finished` **or** [`run_canceled`](#run_canceled) — and, for the one
+  failure that can reach the stream after `run_started`, with neither: a runner
+  error (the image could not be executed at all) ends the cycle with no
+  terminator, exactly as it does for a one-shot run. A consumer tailing the
+  stream must therefore treat the next `run_started` as closing the previous
+  cycle rather than waiting for a terminator it may never be owed.
+- **The seed is fixed for the process** unless `--seed` was given. Consecutive
+  cycles therefore shuffle identically, and a difference between two of them is
+  attributable to the edit rather than to the order.
+- **`--test-candidates` is re-read each cycle**, list and named files both, so
+  the unimported-test-file warning describes what is on disk now. It is printed
+  once per cycle whose report is non-empty. Neither the list nor the files it
+  names are watch inputs — they are not sources of the program — so editing one
+  alone wakes nothing; the new report arrives with the next cycle a source edit
+  triggers.
+- **An edit cancels the cycle it lands in.** During compilation nothing is
+  published, exactly as a compile failure publishes nothing. During execution
+  the running tests' process groups are killed and the cycle ends with
+  [`run_canceled`](#run_canceled) instead of `run_finished`.
+- **A compile failure keeps the loop watching.** Its diagnostics go to stderr as
+  always, followed by a status line (`Watch cycle failed after N ms; no summary
+  for this revision`), and the previous cycle's verdicts are not reprinted. Every status line
+  the loop writes goes to stderr in both formats — stdout belongs to the event
+  stream — which is where the runner's other notices already go.
+- **The exit status is produced only on SIGINT or SIGTERM**, and is the last
+  cycle that COMPLETED reporting itself on the ordinary
+  [exit-code table](#exit-codes): `0` if it passed, `1` if it failed, `3` if it
+  selected nothing — and `2` while no cycle has completed at all. A cycle that failed to build its image or that an
+  edit abandoned leaves the previous answer standing, because it answered
+  nothing itself. The live tests are killed before the process exits, as they
+  are for a one-shot run; unlike a one-shot run the watcher exits with that
+  status rather than dying of the signal, because being asked to stop is the
+  only end a watcher has.
+
+Changed-only re-execution — re-running just the tests whose reached set
+intersects the edit — is deliberately not part of this. It is unsound for any
+test that touches the filesystem or the network, and belongs to the deferred
+verdict cache (ADR-0083 §6), which is opt-in and knows what it is claiming.
+
 ## Versioning
 
 This schema follows ADR-0061 §6. The version is `1.0`, published in the head
@@ -803,6 +885,14 @@ event of a run and in each `--list --format json` record.
   and optional, and `repro` still holds what it always did — the argv that
   reproduces this one test — in a spelling that resolves from more places than
   the old one, not a different kind of value.
+- `run_started.cycle` and the `run_canceled` event arrived the same way
+  (RUE-2023), as an optional field and a new event kind. The version stays
+  `1.0`: nothing a `1.0` consumer already read changed, and a consumer that
+  reads only one-shot runs never sees either. A consumer that tails a
+  `rue test --watch` process must handle `run_canceled` as a cycle terminator
+  alongside `run_finished`, which is exactly the "ignore unknown event kinds"
+  rule doing its job — an old consumer waits for a `run_finished` that this
+  cycle owes it no more, and reads the next `run_started` instead.
 - The comparison operands were briefly named `expected`/`actual` and were
   renamed to `left`/`right` in place, still at `1.0` (RUE-1954): the rename
   landed before any consumer outside this repository existed, so it is the one


### PR DESCRIPTION
Closes RUE-2023

`rue test <root> --watch` keeps one `FilesystemCompilerHost` for the life of the process and runs one test cycle per accepted source revision, so an iteration pays for what the edit changed rather than for a whole fresh compile.

Measured on a copy of `examples/gazette` (aarch64-macos), edit → `run_finished`, including the loop's 75 ms debounce:

| | fresh process | watch cycle |
| --- | --- | --- |
| one test (`--filter slugifies`) | 1.26 s | **0.63 s** |
| whole 35-test suite (`-j1`) | 1.80 s | 1.20 s |

## The loop is the one that already existed

`watch::run` gains a `WatchMode`, and the only thing that differs per mode is the cycle body — the change monitor, re-observation, toolchain acquisition, supersession, debouncing, and the cycle boundary are unchanged and shared.

The cycle body itself is `compile`'s. `drive_test_cycle` is the test-root twin of `drive_cycle` (RUE-1969), with the same discovery gate, destination preflight, cancellable compile, publication guard, and warning order. One-shot `rue test` now reaches its image through it too, so `test_mode::publish_image` is gone and there is **one** image-publication path rather than the two that existed before.

## Cancellation reaches the run

`cancellable_test_image_in_compile_scope` gives the image request the token the executable request already had (both phases observe it — the closure analysis and the narrowed second link). A new `RunCancellation` kills the live test process groups when an edit lands mid-run: the flag is published before the registry sweep, and a child that registers between the two kills itself from the `GroupObserver` hook that registers it, so no child can be spawned into an abandoned cycle and run to its own timeout.

Such a cycle publishes `run_canceled` instead of `run_finished` — the verdicts it already emitted stand, the killed tests produced none, and counts describing neither would be a lie. The killed test's own scratch directory goes with the verdict that was never published, while a sibling's retained evidence stays. A cycle canceled *before* its image existed publishes nothing at all, because no `run_started` had opened it.

## Schema (additive, stays 1.0)

- `run_started` gains an optional `cycle`, absent outside `--watch`.
- `run_canceled` is a new event kind.

The number counts cycles rather than runs, so the stream skips one when a cycle fails to build its image; a consumer treats a new `run_started` as closing whatever was open, which it already had to — a runner error after `run_started` ends a one-shot run with no terminator either. `docs/process/test-events.md` documents all of it, including a new `--watch` section.

## Also

- `--watch` combines with every test-mode flag except `--list`, and keeps the existing `--emit` / `--benchmark-json` / `--time-passes` / `-o` exclusions, now reporting the runner-error status for them.
- The seed is fixed per process unless `--seed` was given, so consecutive cycles shuffle identically and a difference between two of them is attributable to the edit.
- `--test-candidates` is re-read each cycle, list and named files both.
- The run root carries the cycle number (`rue-test-<seed>-<pid>-c<N>`) so a failing test's retained scratch directory survives the next cycle.
- The exit status is produced only on SIGINT/SIGTERM and is the last **completed** cycle's own status (`0` passed, `1` failed, `3` selected nothing), `2` while none has completed.
- The milestone protocol writer emits one `write(2)` per line: `test-spawned` is the first milestone written from the run's worker threads, and two writes interleaved under `--jobs N`.
- `rue-oracle-diff` classifies a `watch_test` case as watch orchestration alongside `watch` — it is an event stream across several revisions, and the fixture set it starts with is only the first of them.

## Verification

`scripts/rue quick` (36 targets); `unit` for `rue`, `compiler`, `rue-cli-tests`, `rue-test-runner`, `rue-oracle-diff`; `scripts/rue cli` for `watch` (16, incl. 6 new `cli.watch_test`), `rue_test`, `test_`, `trap`, `panic`, `test_candidates`, `output_mode`, `diagnostic`, `examples_gazette`, `basics`. A focused `rue-oracle-diff` run over `watch_test.toml` reports all six cases `watch orchestration`.

Hand-verified against real packages across cycles: edit-a-test-body, edit-a-helper, both compile-error shapes (per-test `compile_error` verdict vs. whole-cycle failure), mid-run cancellation at `-j1` and `-j3`, candidate re-read, retained-evidence-vs-cancel-litter, and the full exit-status matrix.