### PR TITLE
Decide and report private access once

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -1493,6 +1493,204 @@ fn literal_materialization_has_one_owner_beside_the_integer_kernel() {
     }
 }
 
+/// Every production and test source in this crate, paired with its module
+/// path — the same set Buck's `src/**/*.rs` glob compiles, asserted against
+/// the generated manifest by
+/// [`comptime_instdata_evaluation_has_one_production_authority`]. Structural
+/// guards scan this so a new module cannot escape one by being new.
+const AIR_CRATE_SOURCES: &[(&str, &str)] = &[
+    ("api_inventory", include_str!("api_inventory.rs")),
+    ("builtin_universe", include_str!("builtin_universe.rs")),
+    ("call_abi", include_str!("call_abi.rs")),
+    (
+        "declaration_validation",
+        include_str!("declaration_validation.rs"),
+    ),
+    ("drop_glue", include_str!("drop_glue.rs")),
+    ("drop_glue_names", include_str!("drop_glue_names.rs")),
+    ("exact_decimal", include_str!("exact_decimal.rs")),
+    ("ffi_predicates", include_str!("ffi_predicates.rs")),
+    (
+        "inference/constraint",
+        include_str!("inference/constraint.rs"),
+    ),
+    ("inference/generate", include_str!("inference/generate.rs")),
+    ("inference/mod", include_str!("inference/mod.rs")),
+    ("inference/types", include_str!("inference/types.rs")),
+    ("inference/unify", include_str!("inference/unify.rs")),
+    ("inst", include_str!("inst.rs")),
+    (
+        "inst/payload_support",
+        include_str!("inst/payload_support.rs"),
+    ),
+    ("integer_semantics", include_str!("integer_semantics.rs")),
+    ("intern_pool", include_str!("intern_pool.rs")),
+    ("intrinsic", include_str!("intrinsic.rs")),
+    ("layout", include_str!("layout.rs")),
+    ("lib", include_str!("lib.rs")),
+    ("live_symbols", include_str!("live_symbols.rs")),
+    ("lowered_signature", include_str!("lowered_signature.rs")),
+    ("module_registry", include_str!("module_registry.rs")),
+    ("param_arena", include_str!("param_arena.rs")),
+    ("path_norm", include_str!("path_norm.rs")),
+    ("private_access", include_str!("private_access.rs")),
+    ("runtime_call", include_str!("runtime_call.rs")),
+    ("scope", include_str!("scope.rs")),
+    (
+        "sema/aggregate_resolution",
+        include_str!("sema/aggregate_resolution.rs"),
+    ),
+    ("sema/aggregates", include_str!("sema/aggregates.rs")),
+    ("sema/analysis", include_str!("sema/analysis.rs")),
+    (
+        "sema/analysis/builtin_ops",
+        include_str!("sema/analysis/builtin_ops.rs"),
+    ),
+    (
+        "sema/analysis/calls",
+        include_str!("sema/analysis/calls.rs"),
+    ),
+    (
+        "sema/analysis/instructions",
+        include_str!("sema/analysis/instructions.rs"),
+    ),
+    (
+        "sema/analysis/intrinsics",
+        include_str!("sema/analysis/intrinsics.rs"),
+    ),
+    (
+        "sema/analysis/ownership",
+        include_str!("sema/analysis/ownership.rs"),
+    ),
+    (
+        "sema/analysis/pointers",
+        include_str!("sema/analysis/pointers.rs"),
+    ),
+    (
+        "sema/analysis/type_inference",
+        include_str!("sema/analysis/type_inference.rs"),
+    ),
+    ("sema/analyze_ops", include_str!("sema/analyze_ops.rs")),
+    ("sema/anon_structs", include_str!("sema/anon_structs.rs")),
+    (
+        "sema/binding_manifest",
+        include_str!("sema/binding_manifest.rs"),
+    ),
+    ("sema/body_endpoint", include_str!("sema/body_endpoint.rs")),
+    ("sema/body_identity", include_str!("sema/body_identity.rs")),
+    (
+        "sema/call_resolution",
+        include_str!("sema/call_resolution.rs"),
+    ),
+    ("sema/comptime", include_str!("sema/comptime.rs")),
+    (
+        "sema/comptime/frames",
+        include_str!("sema/comptime/frames.rs"),
+    ),
+    (
+        "sema/comptime/intrinsics",
+        include_str!("sema/comptime/intrinsics.rs"),
+    ),
+    (
+        "sema/comptime/model",
+        include_str!("sema/comptime/model.rs"),
+    ),
+    (
+        "sema/comptime/registry",
+        include_str!("sema/comptime/registry.rs"),
+    ),
+    (
+        "sema/comptime/sites",
+        include_str!("sema/comptime/sites.rs"),
+    ),
+    (
+        "sema/comptime/structured_type",
+        include_str!("sema/comptime/structured_type.rs"),
+    ),
+    (
+        "sema/comptime/value_domain_tests",
+        include_str!("sema/comptime/value_domain_tests.rs"),
+    ),
+    (
+        "sema/comptime/value_policy",
+        include_str!("sema/comptime/value_policy.rs"),
+    ),
+    ("sema/comptime_eval", include_str!("sema/comptime_eval.rs")),
+    (
+        "sema/consistency_tests",
+        include_str!("sema/consistency_tests.rs"),
+    ),
+    ("sema/context", include_str!("sema/context.rs")),
+    ("sema/control_flow", include_str!("sema/control_flow.rs")),
+    (
+        "sema/declaration_index",
+        include_str!("sema/declaration_index.rs"),
+    ),
+    ("sema/declarations", include_str!("sema/declarations.rs")),
+    ("sema/fact_mode", include_str!("sema/fact_mode.rs")),
+    ("sema/inference_ctx", include_str!("sema/inference_ctx.rs")),
+    ("sema/info", include_str!("sema/info.rs")),
+    ("sema/known_symbols", include_str!("sema/known_symbols.rs")),
+    ("sema/mod", include_str!("sema/mod.rs")),
+    (
+        "sema/ordinary_engine",
+        include_str!("sema/ordinary_engine.rs"),
+    ),
+    ("sema/output", include_str!("sema/output.rs")),
+    (
+        "sema/ownership_state",
+        include_str!("sema/ownership_state.rs"),
+    ),
+    ("sema/provider", include_str!("sema/provider.rs")),
+    (
+        "sema/provider_accessor_tests",
+        include_str!("sema/provider_accessor_tests.rs"),
+    ),
+    (
+        "sema/provider_body_host",
+        include_str!("sema/provider_body_host.rs"),
+    ),
+    (
+        "sema/provider_fixture",
+        include_str!("sema/provider_fixture.rs"),
+    ),
+    (
+        "sema/provider_fixture_tests",
+        include_str!("sema/provider_fixture_tests.rs"),
+    ),
+    (
+        "sema/provider_module_registry",
+        include_str!("sema/provider_module_registry.rs"),
+    ),
+    (
+        "sema/provider_semantics_tests",
+        include_str!("sema/provider_semantics_tests.rs"),
+    ),
+    (
+        "sema/provider_strings_ownership_tests",
+        include_str!("sema/provider_strings_ownership_tests.rs"),
+    ),
+    (
+        "sema/semantic_body_export",
+        include_str!("sema/semantic_body_export.rs"),
+    ),
+    ("sema/tests", include_str!("sema/tests.rs")),
+    ("sema/typeck", include_str!("sema/typeck.rs")),
+    ("sema/visibility", include_str!("sema/visibility.rs")),
+    ("semantic_body", include_str!("semantic_body.rs")),
+    ("semantic_identity", include_str!("semantic_identity.rs")),
+    ("semantic_import", include_str!("semantic_import.rs")),
+    (
+        "semantic_type_resolution",
+        include_str!("semantic_type_resolution.rs"),
+    ),
+    ("specialize", include_str!("specialize.rs")),
+    ("stable_digest", include_str!("stable_digest.rs")),
+    ("type_encoding", include_str!("type_encoding.rs")),
+    ("type_properties", include_str!("type_properties.rs")),
+    ("types", include_str!("types.rs")),
+];
+
 #[test]
 fn comptime_instdata_evaluation_has_one_production_authority() {
     let inference = include_str!("inference/generate.rs");
@@ -1534,197 +1732,7 @@ fn comptime_instdata_evaluation_has_one_production_authority() {
     // modules); a future helper must not evade the guard by renaming
     // itself. The AST visitor below tracks nested modules and lexical scopes,
     // so nested matches/closures cannot hide a peer evaluator.
-    let production = [
-        ("api_inventory", include_str!("api_inventory.rs")),
-        ("builtin_universe", include_str!("builtin_universe.rs")),
-        ("call_abi", include_str!("call_abi.rs")),
-        (
-            "declaration_validation",
-            include_str!("declaration_validation.rs"),
-        ),
-        ("drop_glue", include_str!("drop_glue.rs")),
-        ("drop_glue_names", include_str!("drop_glue_names.rs")),
-        ("exact_decimal", include_str!("exact_decimal.rs")),
-        ("ffi_predicates", include_str!("ffi_predicates.rs")),
-        (
-            "inference/constraint",
-            include_str!("inference/constraint.rs"),
-        ),
-        ("inference/generate", include_str!("inference/generate.rs")),
-        ("inference/mod", include_str!("inference/mod.rs")),
-        ("inference/types", include_str!("inference/types.rs")),
-        ("inference/unify", include_str!("inference/unify.rs")),
-        ("inst", include_str!("inst.rs")),
-        (
-            "inst/payload_support",
-            include_str!("inst/payload_support.rs"),
-        ),
-        ("integer_semantics", include_str!("integer_semantics.rs")),
-        ("intern_pool", include_str!("intern_pool.rs")),
-        ("intrinsic", include_str!("intrinsic.rs")),
-        ("layout", include_str!("layout.rs")),
-        ("lib", include_str!("lib.rs")),
-        ("live_symbols", include_str!("live_symbols.rs")),
-        ("lowered_signature", include_str!("lowered_signature.rs")),
-        ("module_registry", include_str!("module_registry.rs")),
-        ("param_arena", include_str!("param_arena.rs")),
-        ("path_norm", include_str!("path_norm.rs")),
-        ("runtime_call", include_str!("runtime_call.rs")),
-        ("scope", include_str!("scope.rs")),
-        (
-            "sema/aggregate_resolution",
-            include_str!("sema/aggregate_resolution.rs"),
-        ),
-        ("sema/aggregates", include_str!("sema/aggregates.rs")),
-        ("sema/analysis", include_str!("sema/analysis.rs")),
-        (
-            "sema/analysis/builtin_ops",
-            include_str!("sema/analysis/builtin_ops.rs"),
-        ),
-        (
-            "sema/analysis/calls",
-            include_str!("sema/analysis/calls.rs"),
-        ),
-        (
-            "sema/analysis/instructions",
-            include_str!("sema/analysis/instructions.rs"),
-        ),
-        (
-            "sema/analysis/intrinsics",
-            include_str!("sema/analysis/intrinsics.rs"),
-        ),
-        (
-            "sema/analysis/ownership",
-            include_str!("sema/analysis/ownership.rs"),
-        ),
-        (
-            "sema/analysis/pointers",
-            include_str!("sema/analysis/pointers.rs"),
-        ),
-        (
-            "sema/analysis/type_inference",
-            include_str!("sema/analysis/type_inference.rs"),
-        ),
-        ("sema/analyze_ops", include_str!("sema/analyze_ops.rs")),
-        ("sema/anon_structs", include_str!("sema/anon_structs.rs")),
-        (
-            "sema/binding_manifest",
-            include_str!("sema/binding_manifest.rs"),
-        ),
-        ("sema/body_endpoint", include_str!("sema/body_endpoint.rs")),
-        ("sema/body_identity", include_str!("sema/body_identity.rs")),
-        (
-            "sema/call_resolution",
-            include_str!("sema/call_resolution.rs"),
-        ),
-        ("sema/comptime", include_str!("sema/comptime.rs")),
-        (
-            "sema/comptime/frames",
-            include_str!("sema/comptime/frames.rs"),
-        ),
-        (
-            "sema/comptime/intrinsics",
-            include_str!("sema/comptime/intrinsics.rs"),
-        ),
-        (
-            "sema/comptime/model",
-            include_str!("sema/comptime/model.rs"),
-        ),
-        (
-            "sema/comptime/registry",
-            include_str!("sema/comptime/registry.rs"),
-        ),
-        (
-            "sema/comptime/sites",
-            include_str!("sema/comptime/sites.rs"),
-        ),
-        (
-            "sema/comptime/structured_type",
-            include_str!("sema/comptime/structured_type.rs"),
-        ),
-        (
-            "sema/comptime/value_domain_tests",
-            include_str!("sema/comptime/value_domain_tests.rs"),
-        ),
-        (
-            "sema/comptime/value_policy",
-            include_str!("sema/comptime/value_policy.rs"),
-        ),
-        ("sema/comptime_eval", include_str!("sema/comptime_eval.rs")),
-        (
-            "sema/consistency_tests",
-            include_str!("sema/consistency_tests.rs"),
-        ),
-        ("sema/context", include_str!("sema/context.rs")),
-        ("sema/control_flow", include_str!("sema/control_flow.rs")),
-        (
-            "sema/declaration_index",
-            include_str!("sema/declaration_index.rs"),
-        ),
-        ("sema/declarations", include_str!("sema/declarations.rs")),
-        ("sema/fact_mode", include_str!("sema/fact_mode.rs")),
-        ("sema/inference_ctx", include_str!("sema/inference_ctx.rs")),
-        ("sema/info", include_str!("sema/info.rs")),
-        ("sema/known_symbols", include_str!("sema/known_symbols.rs")),
-        ("sema/mod", include_str!("sema/mod.rs")),
-        (
-            "sema/ordinary_engine",
-            include_str!("sema/ordinary_engine.rs"),
-        ),
-        ("sema/output", include_str!("sema/output.rs")),
-        (
-            "sema/ownership_state",
-            include_str!("sema/ownership_state.rs"),
-        ),
-        ("sema/provider", include_str!("sema/provider.rs")),
-        (
-            "sema/provider_accessor_tests",
-            include_str!("sema/provider_accessor_tests.rs"),
-        ),
-        (
-            "sema/provider_body_host",
-            include_str!("sema/provider_body_host.rs"),
-        ),
-        (
-            "sema/provider_fixture",
-            include_str!("sema/provider_fixture.rs"),
-        ),
-        (
-            "sema/provider_fixture_tests",
-            include_str!("sema/provider_fixture_tests.rs"),
-        ),
-        (
-            "sema/provider_module_registry",
-            include_str!("sema/provider_module_registry.rs"),
-        ),
-        (
-            "sema/provider_semantics_tests",
-            include_str!("sema/provider_semantics_tests.rs"),
-        ),
-        (
-            "sema/provider_strings_ownership_tests",
-            include_str!("sema/provider_strings_ownership_tests.rs"),
-        ),
-        (
-            "sema/semantic_body_export",
-            include_str!("sema/semantic_body_export.rs"),
-        ),
-        ("sema/tests", include_str!("sema/tests.rs")),
-        ("sema/typeck", include_str!("sema/typeck.rs")),
-        ("sema/visibility", include_str!("sema/visibility.rs")),
-        ("semantic_body", include_str!("semantic_body.rs")),
-        ("semantic_identity", include_str!("semantic_identity.rs")),
-        ("semantic_import", include_str!("semantic_import.rs")),
-        (
-            "semantic_type_resolution",
-            include_str!("semantic_type_resolution.rs"),
-        ),
-        ("specialize", include_str!("specialize.rs")),
-        ("stable_digest", include_str!("stable_digest.rs")),
-        ("type_encoding", include_str!("type_encoding.rs")),
-        ("type_properties", include_str!("type_properties.rs")),
-        ("types", include_str!("types.rs")),
-    ];
+    let production = AIR_CRATE_SOURCES;
     // Keep the guard's source set tied to the same canonical Buck glob used by
     // the crate. The mapped manifest is generated from that glob, so adding a
     // production module necessarily enters this exact predicate.
@@ -1752,7 +1760,7 @@ fn comptime_instdata_evaluation_has_one_production_authority() {
     // Buck inventory by semantic shape so a renamed `str` definition cannot
     // evade the guard, while generated `Str(N)` and slice fat pointers remain
     // legitimate consumers of the same shape.
-    for (module, source) in &production {
+    for (module, source) in production {
         if *module != "builtin_universe" {
             assert!(
                 !has_core_str_definition(module, source),
@@ -2847,7 +2855,7 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
     for removed in [
         "fn anonymous_struct_id(",
         "fn has_method(",
-        "fn check_unqualified_visibility(",
+        "fn check_item_visibility(",
         "fn set_anon_struct_type_subst(",
     ] {
         assert!(
@@ -3133,7 +3141,7 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
         .find("NamedConstDependencyTargetEvent::ValueConst")
         .expect("ordinary value-constant dependency observation");
     let visibility_check = ordinary_named_value
-        .find("OrdinaryBodyEngine::check_unqualified_visibility")
+        .find("OrdinaryBodyEngine::check_item_visibility")
         .expect("ordinary value-constant visibility check");
     let value_classification = ordinary_named_value
         .find("let value = match info.value")
@@ -4423,5 +4431,104 @@ fn drop_glue_semantics_have_one_air_policy_owner() {
         assert!(!source.contains("== ANON_DROP_METHOD"), "{name}");
         assert!(!source.contains("== drop_marker"), "{name}");
         assert!(!source.contains("== \"__drop\""), "{name}");
+    }
+}
+
+/// The modules of [`AIR_CRATE_SOURCES`] that build `ErrorKind::<variant>` as a
+/// struct expression, found by walking each source's AST so a reformatting,
+/// an import alias, or a nested module cannot hide a construction site.
+fn error_kind_construction_sites(variant: &str) -> Vec<&'static str> {
+    struct Sites<'a> {
+        variant: &'a str,
+        found: bool,
+    }
+
+    impl<'ast> Visit<'ast> for Sites<'_> {
+        fn visit_expr_struct(&mut self, expression: &'ast ExprStruct) {
+            self.found |= expression
+                .path
+                .segments
+                .last()
+                .is_some_and(|segment| segment.ident == self.variant);
+            visit::visit_expr_struct(self, expression);
+        }
+    }
+
+    AIR_CRATE_SOURCES
+        .iter()
+        .filter(|(_, source)| {
+            let Ok(file) = syn::parse_file(source) else {
+                return false;
+            };
+            let mut sites = Sites {
+                variant,
+                found: false,
+            };
+            sites.visit_file(&file);
+            sites.found
+        })
+        .map(|(module, _)| *module)
+        .collect()
+}
+
+/// RUE-1973: "a private item was reached through a module" is one decision
+/// reported one way.
+///
+/// Eleven inline sites used to build E0706 themselves, in two item-kind
+/// vocabularies, while the same violation in a type annotation reported E0460.
+/// The payload now has a single constructor, so a new emitter inherits the
+/// wording instead of inventing one; the E0460 payload has a single
+/// constructor too, holding that code to the type-constructor carve-out its
+/// `--explain` text describes (spec 10.3:7, 10.4:16, 10.4:18).
+#[test]
+fn private_access_has_one_decision_and_one_diagnostic() {
+    assert_eq!(
+        error_kind_construction_sites("PrivateMemberAccess"),
+        ["private_access"],
+        "E0706 must be built only by private_access::private_member_access"
+    );
+    assert_eq!(
+        error_kind_construction_sites("PrivateUnqualifiedAccessData"),
+        ["sema/typeck"],
+        "E0460 must be built only by typeck::private_type_constructor_error"
+    );
+
+    // The vocabulary is a closed table in the same module, so `item_kind`
+    // cannot be spelled ad hoc at a call site.
+    let canonical = include_str!("private_access.rs");
+    for spelling in crate::PrivateItemKind::ALL.map(crate::PrivateItemKind::spelling) {
+        assert!(
+            canonical.contains(&format!("=> \"{spelling}\"")),
+            "item-kind spelling `{spelling}` must come from the one table"
+        );
+    }
+
+    // The predicate has one definition, and the path-shaped entry point
+    // short-circuits before deriving a domain rather than repeating the math.
+    let resolution = include_str!("semantic_type_resolution.rs");
+    assert_eq!(
+        resolution.matches("pub fn is_visible_from(").count(),
+        1,
+        "the visibility predicate has one definition"
+    );
+    assert!(canonical.contains("if is_public || accessing_path == defining_path"));
+}
+
+/// One rendering of a module's name in the diagnostics that talk about it
+/// (RUE-1973). The call path used to print the file stem (`module 'lib'`)
+/// while the type-syntax path printed the import path
+/// (`module 'sub/lib.rue'`), so one missing member read as two modules.
+#[test]
+fn module_diagnostics_have_one_display_name() {
+    let registry = include_str!("module_registry.rs");
+    assert!(registry.contains("pub fn module_display_name(import_path: &str) -> &str"));
+    for (module, source) in AIR_CRATE_SOURCES {
+        if *module == "module_registry" {
+            continue;
+        }
+        assert!(
+            !source.contains(concat!(".file_", "stem()")),
+            "a module name must not be re-rendered from a path stem: {module}"
+        );
     }
 }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -30,6 +30,7 @@ pub mod lowered_signature;
 mod module_registry;
 mod param_arena;
 mod path_norm;
+mod private_access;
 mod runtime_call;
 mod scope;
 mod sema;
@@ -87,9 +88,12 @@ pub use lowered_signature::{
     MAX_LEAF_CLASSIFIED_BYTES, PointerLocation, RegisterPiece, RegisterPieces, StackedPlacement,
     lower_c_signature, lower_native_return, lower_native_signature,
 };
-pub use module_registry::ModuleRegistry;
+pub use module_registry::{ModuleRegistry, module_display_name};
 pub use param_arena::{ParamArena, ParamRange, ParamRangeData};
 pub use path_norm::{mangle_symbol_component, normalize_module_path};
+pub use private_access::{
+    PrivateItemKind, check_source_path_visibility, private_member_access, source_path_is_accessible,
+};
 pub use runtime_call::{
     OptionVariant, RuntimeAirArgument, RuntimeAirType, RuntimeCallActivation, RuntimeCallKind,
     RuntimeOperandOrigin,

--- a/crates/rue-air/src/module_registry.rs
+++ b/crates/rue-air/src/module_registry.rs
@@ -8,6 +8,22 @@ use std::sync::{PoisonError, RwLock};
 
 use crate::types::{ModuleDef, ModuleId};
 
+/// How a module is named in a diagnostic that talks about it.
+///
+/// One rendering for every emitter: the import path the source wrote, so
+/// `module 'sub/lib.rue' has no member 'x'` says which file was consulted.
+/// Rendering only the file stem loses exactly the part that distinguishes
+/// same-named files in different directories, which is the case the reader
+/// most needs to see.
+///
+/// The argument is the import path rather than a [`ModuleDef`] because the
+/// three emitters hold a module in three shapes — a registry definition, an
+/// aggregate module fact, and a durable module identity — and the import path
+/// is what they share. Pass [`ModuleDef::import_path`]; do not re-render it.
+pub fn module_display_name(import_path: &str) -> &str {
+    import_path
+}
+
 /// Thread-safe registry for modules.
 ///
 /// The registry allows concurrent lookups after canonical construction.

--- a/crates/rue-air/src/private_access.rs
+++ b/crates/rue-air/src/private_access.rs
@@ -1,0 +1,170 @@
+//! The one decision and the one diagnostic for a private item reached through
+//! a module.
+//!
+//! Privacy is directory-based (spec 10.3:3) and uniform across item kinds
+//! (10.3:7): an item is usable outside its defining directory if and only if
+//! it is `pub`. Every position that can name an item — a value, a type
+//! annotation, a function signature, a struct literal, a match-pattern head,
+//! an associated-function receiver — therefore reaches the same answer, and
+//! must report it with the same code and the same words.
+//!
+//! This module owns both halves of that report:
+//!
+//! * [`PrivateItemKind`] is the complete vocabulary a privacy diagnostic uses
+//!   to name what it rejected — one spelling per kind, written down once.
+//! * [`private_member_access`] is the only place E0706's payload is built, so
+//!   no emitter can drift into its own wording.
+//!
+//! The *predicate* stays where the caller's file identity lives:
+//! [`crate::sema`]'s `is_accessible` answers it from `FileId`s through the
+//! memoized domain facts, and [`check_source_path_visibility`] answers it for
+//! callers outside the body engine that identify files by source path. Both
+//! short-circuit before deriving a domain and both end in the constructor
+//! here.
+
+use rue_error::ErrorKind;
+
+use crate::semantic_type_resolution::{SemanticTypeFactKind, SemanticVisibilityDomain};
+
+/// How a privacy diagnostic names the kind of item it rejected.
+///
+/// This is the whole vocabulary: one variant per item kind, one spelling per
+/// variant. `Const` covers value constants, type aliases, and module bindings
+/// alike, because a module binding *is* a `const` (spec 10.4:1) and the
+/// diagnostic names the binding the source wrote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PrivateItemKind {
+    Function,
+    Struct,
+    Enum,
+    Const,
+}
+
+impl PrivateItemKind {
+    /// Every kind, in declaration order, for guards that pin the vocabulary.
+    pub const ALL: [Self; 4] = [Self::Function, Self::Struct, Self::Enum, Self::Const];
+
+    /// The one spelling for this kind. Diagnostics use the source keyword the
+    /// reader would have written, so `const` rather than "constant".
+    pub const fn spelling(self) -> &'static str {
+        match self {
+            Self::Function => "function",
+            Self::Struct => "struct",
+            Self::Enum => "enum",
+            Self::Const => "const",
+        }
+    }
+}
+
+impl From<SemanticTypeFactKind> for PrivateItemKind {
+    fn from(kind: SemanticTypeFactKind) -> Self {
+        match kind {
+            SemanticTypeFactKind::Struct => Self::Struct,
+            SemanticTypeFactKind::Enum => Self::Enum,
+            SemanticTypeFactKind::Constant => Self::Const,
+            SemanticTypeFactKind::Function => Self::Function,
+        }
+    }
+}
+
+/// Build the E0706 payload for a private item reached through a module.
+///
+/// This is the sole construction site of [`ErrorKind::PrivateMemberAccess`];
+/// `api_inventory` pins that, so a new emitter has to come through here and
+/// inherits the vocabulary above.
+pub fn private_member_access(kind: PrivateItemKind, name: &str) -> ErrorKind {
+    ErrorKind::PrivateMemberAccess {
+        item_kind: kind.spelling().to_owned(),
+        name: name.to_owned(),
+    }
+}
+
+/// Is a declaration in `defining_path` reachable from `accessing_path`?
+///
+/// The shape of the decision for callers that identify a file by its source
+/// path rather than by `FileId`. A public item and a self-reference are
+/// answered without deriving a domain at all, matching the short-circuit the
+/// body engine's `is_accessible` applies.
+pub fn source_path_is_accessible(
+    accessing_path: &str,
+    defining_path: &str,
+    is_public: bool,
+) -> bool {
+    if is_public || accessing_path == defining_path {
+        return true;
+    }
+    SemanticVisibilityDomain::from_file_path(Some(defining_path)).is_visible_from(
+        &SemanticVisibilityDomain::from_file_path(Some(accessing_path)),
+        is_public,
+    )
+}
+
+/// Decide and report in one step, for a caller holding source paths.
+pub fn check_source_path_visibility(
+    kind: PrivateItemKind,
+    name: &str,
+    accessing_path: &str,
+    defining_path: &str,
+    is_public: bool,
+) -> Result<(), ErrorKind> {
+    if source_path_is_accessible(accessing_path, defining_path, is_public) {
+        return Ok(());
+    }
+    Err(private_member_access(kind, name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The vocabulary lives in exactly one table; this pins it so a rewording
+    /// is a deliberate edit here rather than a drift at some emitter.
+    #[test]
+    fn item_kind_spellings_are_pinned() {
+        assert_eq!(
+            PrivateItemKind::ALL.map(PrivateItemKind::spelling),
+            ["function", "struct", "enum", "const"]
+        );
+    }
+
+    #[test]
+    fn every_semantic_type_fact_kind_maps_into_the_vocabulary() {
+        for (fact, expected) in [
+            (SemanticTypeFactKind::Struct, PrivateItemKind::Struct),
+            (SemanticTypeFactKind::Enum, PrivateItemKind::Enum),
+            (SemanticTypeFactKind::Constant, PrivateItemKind::Const),
+            (SemanticTypeFactKind::Function, PrivateItemKind::Function),
+        ] {
+            assert_eq!(PrivateItemKind::from(fact), expected);
+        }
+    }
+
+    #[test]
+    fn a_public_item_and_a_self_reference_skip_the_domain_derivation() {
+        assert!(source_path_is_accessible("a/main.rue", "b/lib.rue", true));
+        assert!(source_path_is_accessible("a/main.rue", "a/main.rue", false));
+    }
+
+    #[test]
+    fn a_private_item_is_reachable_only_within_its_directory() {
+        assert!(source_path_is_accessible(
+            "sub/main.rue",
+            "sub/lib.rue",
+            false
+        ));
+        assert!(!source_path_is_accessible("main.rue", "sub/lib.rue", false));
+        assert_eq!(
+            check_source_path_visibility(
+                PrivateItemKind::Const,
+                "inner",
+                "main.rue",
+                "sub/lib.rue",
+                false,
+            ),
+            Err(ErrorKind::PrivateMemberAccess {
+                item_kind: "const".to_owned(),
+                name: "inner".to_owned(),
+            })
+        );
+    }
+}

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -92,12 +92,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let payload_types = def.variant_payload(variant_index as usize).to_vec();
 
         // Visibility check, mirroring the bare-path `EnumVariant` handler
-        // (E0460, privacy is uniform across item kinds). A comptime-bound enum
+        // (E0706, privacy is uniform across item kinds). A comptime-bound enum
         // (`let O = Option(i32); O::Some(..)`) is exempt: the type value
         // arrived through a binding, not by naming the enum (privacy_exempt).
         if !privacy_exempt {
-            self.check_unqualified_visibility(
-                "enum",
+            self.check_item_visibility(
+                crate::PrivateItemKind::Enum,
                 self.body_interner().resolve(&type_name),
                 def.file_id,
                 def.is_pub,
@@ -1031,15 +1031,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let nominal = member
                 .as_struct()
                 .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
-            // Module-qualified visibility is E0706 (RUE-525), uniform with
-            // enum members and associated-function calls through a module;
-            // E0460 is the diagnostic for unqualified naming forms.
+            // Visibility is E0706 (RUE-525), uniform with enum members and
+            // associated-function calls through a module — and with every
+            // other position that can name this struct (RUE-1973).
             let def = self.body_type_pool().struct_def(nominal.id);
             self.check_module_qualified_visibility(
                 nominal.alias,
                 module_file,
                 (def.file_id, def.is_pub),
-                "struct",
+                crate::PrivateItemKind::Struct,
                 &type_name_str,
                 span,
             )?;
@@ -1069,8 +1069,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 },
                 StructLiteralHead::Named(struct_id) => {
                     let def = self.body_type_pool().struct_def(struct_id);
-                    self.check_unqualified_visibility(
-                        "struct",
+                    self.check_item_visibility(
+                        crate::PrivateItemKind::Struct,
                         &type_name_str,
                         def.file_id,
                         def.is_pub,
@@ -1279,24 +1279,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         alias: Option<&super::ConstInfo>,
         module_file: rue_span::FileId,
         declared: (rue_span::FileId, bool),
-        item_kind: &'static str,
+        item_kind: crate::PrivateItemKind,
         name: &str,
         span: Span,
     ) -> CompileResult<()> {
         let (file, is_pub, item_kind) = match alias {
-            Some(binding) => (module_file, binding.is_pub, "const"),
+            Some(binding) => (module_file, binding.is_pub, crate::PrivateItemKind::Const),
             None => (declared.0, declared.1, item_kind),
         };
-        if self.is_accessible(span.file_id, file, is_pub) {
-            return Ok(());
-        }
-        Err(CompileError::new(
-            ErrorKind::PrivateMemberAccess {
-                item_kind: item_kind.to_string(),
-                name: name.to_string(),
-            },
-            span,
-        ))
+        self.check_item_visibility(item_kind, name, file, is_pub, span)
     }
 
     /// Analyze module type member access: `module.StructName` or `module.EnumName`.
@@ -1339,15 +1330,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let struct_def = self.body_type_pool().struct_def(struct_id);
 
             // Check visibility: pub structs are visible to all, private only to same directory
-            if !self.is_accessible(span.file_id, struct_def.file_id, struct_def.is_pub) {
-                return Err(CompileError::new(
-                    ErrorKind::PrivateMemberAccess {
-                        item_kind: "struct".to_string(),
-                        name: member_name_str,
-                    },
-                    span,
-                ));
-            }
+            self.check_item_visibility(
+                crate::PrivateItemKind::Struct,
+                &member_name_str,
+                struct_def.file_id,
+                struct_def.is_pub,
+                span,
+            )?;
 
             // Return a TypeConst instruction with the struct type
             let struct_type = Type::new_struct(struct_id);
@@ -1365,15 +1354,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let enum_def = self.body_type_pool().enum_def(enum_id);
 
             // Check visibility: pub enums are visible to all, private only to same directory
-            if !self.is_accessible(span.file_id, enum_def.file_id, enum_def.is_pub) {
-                return Err(CompileError::new(
-                    ErrorKind::PrivateMemberAccess {
-                        item_kind: "enum".to_string(),
-                        name: member_name_str,
-                    },
-                    span,
-                ));
-            }
+            self.check_item_visibility(
+                crate::PrivateItemKind::Enum,
+                &member_name_str,
+                enum_def.file_id,
+                enum_def.is_pub,
+                span,
+            )?;
 
             // Return a TypeConst instruction with the enum type
             let enum_type = Type::new_enum(enum_id);
@@ -1393,15 +1380,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // tagged module-binding variant keyed by the facade's FileId (RUE-113);
         // value consts are found by defining file and member name.
         if let ModuleTypeMember::Const(const_info) = member {
-            if !self.is_accessible(span.file_id, module_fact.file, const_info.is_pub) {
-                return Err(CompileError::new(
-                    ErrorKind::PrivateMemberAccess {
-                        item_kind: "const".to_string(),
-                        name: member_name_str,
-                    },
-                    span,
-                ));
-            }
+            self.check_item_visibility(
+                crate::PrivateItemKind::Const,
+                &member_name_str,
+                module_fact.file,
+                const_info.is_pub,
+                span,
+            )?;
 
             self.record_body_named_dependency(if const_info.ty.is_module() {
                 super::NamedConstDependencyTargetEvent::ModuleBinding {
@@ -1459,11 +1444,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Member not found in the module
         Err(CompileError::new(
             ErrorKind::UnknownModuleMember {
-                module_name: std::path::Path::new(module_fact.import_path())
-                    .file_stem()
-                    .and_then(std::ffi::OsStr::to_str)
-                    .unwrap_or_else(|| module_fact.import_path())
-                    .to_string(),
+                module_name: crate::module_display_name(module_fact.import_path()).to_string(),
                 member_name: member_name_str,
             },
             span,
@@ -1695,7 +1676,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 nominal.alias,
                 module_file,
                 (enum_def.file_id, enum_def.is_pub),
-                "enum",
+                crate::PrivateItemKind::Enum,
                 self.body_interner().resolve(&type_name),
                 span,
             )?;
@@ -1707,8 +1688,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 },
                 span,
             )?;
-            // Visibility was checked above (E0706), so skip the internal
-            // unqualified (E0460) check.
+            // Visibility was checked above, so skip the construction
+            // helper's own check.
             return self
                 .analyze_enum_variant_construction(
                     air,
@@ -1735,7 +1716,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 nominal.alias,
                 module_file,
                 (struct_def.file_id, struct_def.is_pub),
-                "struct",
+                crate::PrivateItemKind::Struct,
                 self.body_interner().resolve(&type_name),
                 span,
             )?;
@@ -1796,7 +1777,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             nominal.alias,
             module_file,
             (enum_def.file_id, enum_def.is_pub),
-            "enum",
+            crate::PrivateItemKind::Enum,
             &type_name_str,
             span,
         )?;
@@ -1844,8 +1825,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // ordinary field access (which would report the opaque "field access on
         // non-struct type 'type'"). RUE-488.
         if !via_comptime {
-            self.check_unqualified_visibility(
-                "enum",
+            self.check_item_visibility(
+                crate::PrivateItemKind::Enum,
                 self.body_interner().resolve(&type_name),
                 self.body_type_pool().enum_def(enum_id).file_id,
                 self.body_type_pool().enum_def(enum_id).is_pub,
@@ -2181,17 +2162,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             ),
                             inst.span,
                         )?;
-                    // Privacy (E0460, RUE-185): constructing a variant names
-                    // the enum unqualified, so a private enum from another
-                    // directory is not constructible here — privacy is
-                    // uniform across item kinds (spec 10.3:1, 10.3:7). The
-                    // module-qualified branch above does its own check
-                    // (E0706, `resolve_enum_through_module`). A comptime-bound
-                    // enum is exempt (the type arrived through a binding).
+                    // Privacy (E0706, RUE-185): constructing a variant
+                    // names the enum, so a private enum from another directory
+                    // is not constructible here — privacy is uniform across
+                    // item kinds (spec 10.3:1, 10.3:7). The module-qualified
+                    // branch above does its own check
+                    // (`resolve_enum_through_module`). A comptime-bound enum
+                    // is exempt (the type arrived through a binding).
                     if !via_comptime {
                         let def = self.body_type_pool().enum_def(enum_id);
-                        self.check_unqualified_visibility(
-                            "enum",
+                        self.check_item_visibility(
+                            crate::PrivateItemKind::Enum,
                             self.body_interner().resolve(&*type_name),
                             def.file_id,
                             def.is_pub,

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -13,14 +13,7 @@ use crate::sema::context::DivergenceKind;
 use crate::sema::info::FunctionCallInfo;
 use ahash::AHashMap;
 
-fn module_display_name(path: &str) -> &str {
-    std::path::Path::new(path)
-        .file_stem()
-        .and_then(std::ffi::OsStr::to_str)
-        .unwrap_or(path)
-}
-
-/// Validate membership and visibility for a module-member function call.
+/// Validate membership for a module-member function call.
 ///
 /// Membership (spec 4.13:90, RUE-140): a module contains only declarations
 /// from the imported file. The callee is resolved by the receiver module's
@@ -28,12 +21,15 @@ fn module_display_name(path: &str) -> &str {
 /// Comparing by canonical FileId rather than raw path strings makes equivalent
 /// import spellings — `helper.rue` vs
 /// `./helper.rue` — resolve members identically (spec 10.2:4, RUE-240).
+///
+/// Visibility is a separate question with its own owner: the caller applies
+/// [`OrdinaryBodyEngine::check_item_visibility`] once membership holds, so a
+/// private member reports the same E0706 here as in every other position.
 fn check_module_member_access(
     module_name: &str,
     module_file_id: Option<FileId>,
     member_file_id: FileId,
     fn_name_str: &str,
-    accessible: bool,
     via_reexport: bool,
     span: Span,
 ) -> CompileResult<()> {
@@ -44,19 +40,8 @@ fn check_module_member_access(
     if !via_reexport && module_file_id != Some(member_file_id) {
         return Err(CompileError::new(
             ErrorKind::UnknownModuleMember {
-                module_name: module_display_name(module_name).to_string(),
+                module_name: module_name.to_string(),
                 member_name: fn_name_str.to_string(),
-            },
-            span,
-        ));
-    }
-
-    // Check visibility: private functions are only accessible from the same directory
-    if !accessible {
-        return Err(CompileError::new(
-            ErrorKind::PrivateMemberAccess {
-                item_kind: "function".to_string(),
-                name: fn_name_str.to_string(),
             },
             span,
         ));
@@ -300,8 +285,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             && let Some(callee) = const_info.value.as_function()
         {
             let alias_name = self.body_interner().resolve(&name).to_string();
-            self.check_unqualified_visibility(
-                "constant",
+            self.check_item_visibility(
+                crate::PrivateItemKind::Const,
                 &alias_name,
                 const_info.span.file_id,
                 const_info.is_pub,
@@ -376,18 +361,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         args_range: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
-        check_unqualified_visibility: bool,
+        check_visibility: bool,
     ) -> CompileResult<AnalysisResult> {
         let source_name = self.call_facts().call_source_function_name(name);
         let fn_name_str = self.body_interner().resolve(&source_name).to_string();
 
-        // Visibility (E0460, RUE-37/RUE-180): an unqualified call must not
-        // reach a private function defined in another directory — privacy is
-        // uniform in every multi-file compilation (spec 10.3:7). The lookup
-        // has already selected a declaration using the reference file.
-        if check_unqualified_visibility {
-            self.check_unqualified_visibility(
-                "function",
+        // Visibility (E0706, RUE-37/RUE-180): a call must not reach a
+        // private function defined in another directory — privacy is uniform
+        // in every multi-file compilation (spec 10.3:7). The lookup has
+        // already selected a declaration using the reference file.
+        if check_visibility {
+            self.check_item_visibility(
+                crate::PrivateItemKind::Function,
                 &fn_name_str,
                 fn_info.file_id,
                 fn_info.is_pub,
@@ -1384,15 +1369,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     _ => None,
                 });
             if let Some((fkey, is_pub)) = reexport {
-                if !self.is_accessible(span.file_id, mfile, is_pub) {
-                    return Err(CompileError::new(
-                        ErrorKind::PrivateMemberAccess {
-                            item_kind: "const".to_string(),
-                            name: fn_name_str.clone(),
-                        },
-                        span,
-                    ));
-                }
+                self.check_item_visibility(
+                    crate::PrivateItemKind::Const,
+                    &fn_name_str,
+                    mfile,
+                    is_pub,
+                    span,
+                )?;
                 #[cfg(test)]
                 self.record_body_named_dependency(NamedConstDependencyTargetEvent::ValueConst {
                     file: mfile.index(),
@@ -1406,7 +1389,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let function_key = function_key.ok_or_else(|| {
             CompileError::new(
                 ErrorKind::UnknownModuleMember {
-                    module_name: module_display_name(&module_def.import_path).to_string(),
+                    module_name: crate::module_display_name(&module_def.import_path).to_string(),
                     member_name: fn_name_str.clone(),
                 },
                 span,
@@ -1417,7 +1400,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .call_function_info(function_key)
             .ok_or_compile_error(
                 ErrorKind::UnknownModuleMember {
-                    module_name: module_display_name(&module_def.import_path).to_string(),
+                    module_name: crate::module_display_name(&module_def.import_path).to_string(),
                     member_name: fn_name_str.clone(),
                 },
                 span,
@@ -1429,18 +1412,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let param_data = self.body_param_data(fn_info.params);
         let param_types = param_data.types().to_vec();
         let param_modes = param_data.modes().to_vec();
-        // A re-export was already visibility-checked against its facade const.
-        let accessible =
-            via_reexport || self.is_accessible(span.file_id, fn_info.file_id, fn_info.is_pub);
         check_module_member_access(
-            &module_def.import_path,
+            crate::module_display_name(&module_def.import_path),
             module_file_id,
             fn_info.file_id,
             &fn_name_str,
-            accessible,
             via_reexport,
             span,
         )?;
+        // A re-export was already visibility-checked against its facade const;
+        // otherwise the callee's own `pub` and defining file govern, through
+        // the one privacy decision every position shares.
+        if !via_reexport {
+            self.check_item_visibility(
+                crate::PrivateItemKind::Function,
+                &fn_name_str,
+                fn_info.file_id,
+                fn_info.is_pub,
+                span,
+            )?;
+        }
 
         // Functions with comptime parameters need specialization: a plain
         // Call to the base name would reference a body that is never
@@ -1581,7 +1572,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.clone()), span)?
         };
 
-        // Privacy (E0460, RUE-330): naming a private struct to call one of its
+        // Privacy (E0706, RUE-330): naming a private struct to call one of its
         // associated functions (`Secret::make()`) across a directory boundary is
         // rejected, matching struct-literal / type-annotation references. Privacy
         // is uniform across item kinds (spec 10.3:1, 10.3:7). Builtin structs
@@ -1589,8 +1580,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // this is a no-op for them.
         if !privacy_exempt {
             let struct_def = self.body_type_pool().struct_def(struct_id);
-            self.check_unqualified_visibility(
-                "struct",
+            self.check_item_visibility(
+                crate::PrivateItemKind::Struct,
                 &type_name_str,
                 struct_def.file_id,
                 struct_def.is_pub,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -2577,8 +2577,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if let Some(const_info) = const_info {
             // Apply the uniform privacy rule even though ordinary unqualified
             // lookup resolves in the reference file (spec 10.3:1, 10.3:7).
-            self.check_unqualified_visibility(
-                "constant",
+            self.check_item_visibility(
+                crate::PrivateItemKind::Const,
                 &name_str,
                 const_info.span.file_id,
                 const_info.is_pub,
@@ -2636,7 +2636,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // The name IS a known type, but a private one from another
             // directory (RUE-183): report the privacy error rather than
             // falling through to a misleading "undefined variable".
-            Err(e) if matches!(e.kind, ErrorKind::PrivateUnqualifiedAccess(_)) => {
+            Err(e) if matches!(e.kind, ErrorKind::PrivateMemberAccess { .. }) => {
                 return Err(e);
             }
             // Any other resolution failure: not a type name, keep falling

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1044,8 +1044,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Visibility: a non-`pub` member accessed through a module object is not
         // usable from another directory (spec 10.3:7).
         let member_name = self.body_interner().resolve(&method).to_string();
-        self.check_unqualified_visibility(
-            "function",
+        self.check_item_visibility(
+            crate::PrivateItemKind::Function,
             &member_name,
             fn_info.file_id,
             fn_info.is_pub,
@@ -2605,9 +2605,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeValueAlgebra for OrdinaryBodyEngin
             file: defining_file.index(),
             name: name_text.clone(),
         });
-        OrdinaryBodyEngine::check_unqualified_visibility(
+        OrdinaryBodyEngine::check_item_visibility(
             self,
-            "constant",
+            crate::PrivateItemKind::Const,
             &name_text,
             defining_file,
             info.is_pub,

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -2487,7 +2487,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// RUE-6). Returns `(enum_id, privacy_handled)`: `privacy_handled` is true
     /// when visibility has already been enforced (module path) or does not apply
     /// (a comptime-bound type arrived through a binding, not by naming the
-    /// enum), so a caller runs the unqualified E0460 check only when it is
+    /// enum), so a caller runs the E0706 visibility check only when it is
     /// false. `None` means the unqualified name is not an enum — the caller
     /// supplies the not-found diagnostic it wants (a user error at the legality
     /// check, an internal error during lowering).
@@ -2567,16 +2567,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::UnknownEnumType(self.body_interner().resolve(&*type_name).to_string()),
                 pattern_span,
             )?;
-        // Privacy (E0460, RUE-185): a match pattern names the enum
-        // unqualified, so a private enum from another directory cannot be
-        // matched on — privacy is uniform across item kinds (spec 10.3:1,
-        // 10.3:7). Skipped when the name arrived through a module (E0706
-        // already enforced) or a comptime binding (exempt); both are reported
-        // as `privacy_handled`.
+        // Privacy (E0706, RUE-185): a match pattern names the enum, so a
+        // private enum from another directory cannot be matched on — privacy
+        // is uniform across item kinds and positions (spec 10.3:1, 10.3:7).
+        // Skipped when the name arrived through a module (already enforced on
+        // the way in) or a comptime binding (exempt); both are reported as
+        // `privacy_handled`.
         if !privacy_handled {
             let def = self.body_type_pool().enum_def(enum_id);
-            self.check_unqualified_visibility(
-                "enum",
+            self.check_item_visibility(
+                crate::PrivateItemKind::Enum,
                 self.body_interner().resolve(&*type_name),
                 def.file_id,
                 def.is_pub,

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1620,9 +1620,19 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             is_pub,
         )
     }
-    pub(crate) fn check_unqualified_visibility(
+    /// The one "a private item was reached" decision and report (E0706).
+    ///
+    /// Privacy is uniform across item kinds and across the positions that can
+    /// name an item (spec 10.3:7, 10.4:18), so every position funnels through
+    /// this: the memoized [`Self::is_accessible`] predicate decides, and
+    /// [`rue_air::private_member_access`](crate::private_member_access) writes
+    /// the diagnostic in the one item-kind vocabulary. Callers differ only in
+    /// which declaration's `pub` and defining file govern the access — a
+    /// declaration's own for a plain reference, the binding's when the name
+    /// arrived through a `const` alias (RUE-1956).
+    pub(crate) fn check_item_visibility(
         &self,
-        item_kind: &str,
+        item_kind: crate::PrivateItemKind,
         name: &str,
         defining_file_id: FileId,
         is_pub: bool,
@@ -1631,24 +1641,10 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         if self.is_accessible(span.file_id, defining_file_id, is_pub) {
             return Ok(());
         }
-        let defining_file = self
-            .aggregate_facts()
-            .aggregate_file_path(defining_file_id)
-            .unwrap_or("<unknown>")
-            .to_string();
         Err(CompileError::new(
-            ErrorKind::PrivateUnqualifiedAccess(Box::new(
-                rue_error::PrivateUnqualifiedAccessData {
-                    item_kind: item_kind.to_string(),
-                    name: name.to_string(),
-                    defining_file,
-                },
-            )),
+            crate::private_member_access(item_kind, name),
             span,
-        )
-        .with_help(format!(
-            "`{name}` is not marked `pub`; private items are only visible within their defining directory"
-        )))
+        ))
     }
     pub(crate) fn call_facts(&self) -> &H {
         self.storage

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -3861,7 +3861,7 @@ where
     fn type_syntax_module_display_name(&self, module: ModuleId) -> Arc<str> {
         self.calls
             .module_def(module)
-            .map(|definition| Arc::from(definition.import_path.as_str()))
+            .map(|definition| Arc::from(crate::module_display_name(&definition.import_path)))
             .unwrap_or_else(|| Arc::from("<unknown module>"))
     }
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -802,12 +802,10 @@ fn module_path_compile_error(
         // struct literal, or used as an associated-function receiver (spec
         // 10.3:7, 10.4:18). E0460 stays reserved for its one carve-out,
         // applying a private comptime type constructor in type position
-        // (10.4:16), which arrives through `PrivateItem`, not here (RUE-1964).
+        // (10.4:16), which arrives through `PrivateTypeConstructor`, not here
+        // (RUE-1964, RUE-1973).
         crate::SemanticModulePathFailure::PrivateMember { member, .. } => CompileError::new(
-            ErrorKind::PrivateMemberAccess {
-                item_kind: "const".to_string(),
-                name: member.to_string(),
-            },
+            crate::private_member_access(crate::PrivateItemKind::Const, &member),
             span,
         ),
     }
@@ -833,24 +831,30 @@ pub(super) fn module_path_resolution_compile_error(
     }
 }
 
-fn private_qualified_item_error(
-    item_kind: &str,
-    member: &str,
+/// E0460: privacy's one carve-out, applying a private comptime type
+/// constructor in a type position (spec 10.3:7, 10.4:16).
+///
+/// Every other private access — including a private *named* type reached by
+/// the same type syntax — is the uniform E0706 built by
+/// [`crate::private_member_access`]. Keeping this constructor to the
+/// application form is what makes E0460's `--explain` text true.
+fn private_type_constructor_error(
+    constructor: &str,
     defining_file: &str,
     span: Span,
 ) -> CompileError {
     CompileError::new(
         ErrorKind::PrivateUnqualifiedAccess(Box::new(
             rue_error::PrivateUnqualifiedAccessData {
-                item_kind: item_kind.to_string(),
-                name: member.to_string(),
+                item_kind: crate::PrivateItemKind::Function.spelling().to_string(),
+                name: constructor.to_string(),
                 defining_file: defining_file.to_string(),
             },
         )),
         span,
     )
     .with_help(format!(
-        "`{member}` is not marked `pub`; private items are only visible within their defining directory"
+        "`{constructor}` is not marked `pub`; private items are only visible within their defining directory"
     ))
 }
 
@@ -891,12 +895,15 @@ pub(super) fn semantic_type_syntax_compile_error(
             },
             span,
         ),
-        E::Semantic(F::PrivateItem {
-            kind,
+        E::Semantic(F::PrivateItem { kind, name, .. }) => CompileError::new(
+            crate::private_member_access(crate::PrivateItemKind::from(kind), &name),
+            span,
+        ),
+        E::Semantic(F::PrivateTypeConstructor {
             name,
             defining_file,
             ..
-        }) => private_qualified_item_error(kind.diagnostic_name(), &name, &defining_file, span),
+        }) => private_type_constructor_error(&name, &defining_file, span),
         E::Semantic(F::AmbiguousItem { name, .. }) => CompileError::new(
             ErrorKind::InternalError(format!(
                 "type resolution produced an ambiguous item for '{}'",

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -56,7 +56,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             nominal.alias,
             module_file,
             (enum_def.file_id, enum_def.is_pub),
-            "enum",
+            crate::PrivateItemKind::Enum,
             &type_name_str,
             span,
         )?;

--- a/crates/rue-air/src/semantic_type_resolution.rs
+++ b/crates/rue-air/src/semantic_type_resolution.rs
@@ -165,17 +165,6 @@ pub enum SemanticProviderError<E, F> {
     Failure(F),
 }
 
-impl SemanticTypeFactKind {
-    pub fn diagnostic_name(self) -> &'static str {
-        match self {
-            Self::Struct => "struct",
-            Self::Enum => "enum",
-            Self::Constant => "constant",
-            Self::Function => "function",
-        }
-    }
-}
-
 pub trait SemanticModulePathProvider<S, M, A> {
     type Abort;
     type Failure;
@@ -614,8 +603,22 @@ pub enum SemanticTypeSyntaxFailure<A, N> {
         module_site: A,
         member: Arc<str>,
     },
+    /// A named item reached by type syntax was private from the referencing
+    /// file: the ordinary uniform privacy violation, reported as E0706 like
+    /// the same item named in any other position (spec 10.3:7, 10.4:18).
     PrivateItem {
         kind: SemanticTypeFactKind,
+        name: Arc<str>,
+        site: A,
+        defining_file: Arc<str>,
+    },
+    /// A private comptime type constructor was *applied* in a type position.
+    /// This is privacy's one carve-out (10.4:16): the visibility of the
+    /// applied constructor is checked at the application site and reported as
+    /// E0460, naming the constructor and its defining file. It is kept apart
+    /// from [`Self::PrivateItem`] so the carve-out cannot silently widen back
+    /// over ordinary named lookup.
+    PrivateTypeConstructor {
         name: Arc<str>,
         site: A,
         defining_file: Arc<str>,
@@ -924,8 +927,7 @@ where
             .defining_domain
             .is_visible_from(&accessing, head.is_public)
         {
-            return Err(E::Semantic(F::PrivateItem {
-                kind: SemanticTypeFactKind::Function,
+            return Err(E::Semantic(F::PrivateTypeConstructor {
                 name: Arc::from(name),
                 site: head.site,
                 defining_file: head.defining_file,
@@ -3937,10 +3939,9 @@ mod tests {
                 )
                 | (
                     FailureCase::PrivateConstructor,
-                    SemanticResolutionError::Semantic(SemanticTypeSyntaxFailure::PrivateItem {
-                        site,
-                        ..
-                    }),
+                    SemanticResolutionError::Semantic(
+                        SemanticTypeSyntaxFailure::PrivateTypeConstructor { site, .. },
+                    ),
                 ) => assert_eq!(Some(site), expected_site),
                 _ => panic!("unexpected failure shape for table case"),
             }

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1254,7 +1254,7 @@ pub fn sneaky() -> i32 {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0707", "module `utils` has no member `sneaky`"]
+error_contains = ["E0707", "module `utils.rue` has no member `sneaky`"]
 
 [[case]]
 name = "module_member_call_same_file_control"
@@ -2516,8 +2516,11 @@ pub fn f() -> i32 { 42 }
 compile_fail = true
 error_contains = ["E0706", "const `c` is private"]
 
-# An unknown member at the SECOND level names the inner module (`math`),
-# not the outer one (`std`) — the chain resolved member-by-member.
+# An unknown member at the SECOND level names the inner module
+# (`std/math.rue`), not the outer one (`std`) — the chain resolved
+# member-by-member. The module is named by its import path, the one rendering
+# every E0707 emitter shares (RUE-1973), so a same-named file in another
+# directory is distinguishable.
 [[case]]
 name = "nested_member_unknown_names_inner_module"
 files = [
@@ -2538,7 +2541,7 @@ pub fn abs(x: i32) -> i32 {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0707", "module `math` has no member `nosuch`"]
+error_contains = ["E0707", "module `std/math.rue` has no member `nosuch`"]
 
 # ---------------------------------------------------------------------------
 # RUE-239: top-level duplicate-name detection spans ALL item kinds

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -9467,3 +9467,32 @@ fn durable_drop_glue_policy_has_one_kernel_projection_and_one_query_consumer() {
         assert!(!source.contains("struct_method_names:"), "{name}");
     }
 }
+
+/// RUE-1973: the query database consumes AIR's privacy decision rather than
+/// keeping its own.
+///
+/// `candidate` used to derive both visibility domains from source paths and
+/// build E0706 with a `Debug`-derived item kind, so a name looked up through
+/// the query graph could disagree with the same name looked up by the body
+/// engine — and it skipped the short-circuit that answers a public item or a
+/// self-reference without touching a domain at all.
+#[test]
+fn private_access_decisions_come_from_the_shared_authority() {
+    for (module, source) in REVISIONED_DATABASE_PHASES
+        .iter()
+        .chain(REVISIONED_DATABASE_REGISTRATION_MODULES)
+    {
+        assert!(
+            !source.contains("ErrorKind::PrivateMemberAccess {"),
+            "E0706 must be built by rue_air::private_member_access: {module}"
+        );
+        assert!(
+            !source.contains("format!(\"{kind:?}\").to_lowercase()"),
+            "a privacy item kind must come from rue_air::PrivateItemKind: {module}"
+        );
+    }
+    let provider_body = include_str!("revisioned_query_database/body/provider_body.rs");
+    assert!(provider_body.contains("rue_air::check_source_path_visibility("));
+    assert!(provider_body.contains("rue_air::private_member_access("));
+    assert!(!provider_body.contains("defining.is_visible_from(&accessing"));
+}

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -35,6 +35,24 @@ pub enum DefinitionKind {
     Test,
 }
 
+impl DefinitionKind {
+    /// How a privacy diagnostic names a definition of this kind.
+    ///
+    /// The mapping is a projection onto AIR's one privacy vocabulary rather
+    /// than a second spelling table: a `Debug` rendering of this enum would
+    /// invent "destructor" and "test" wordings that no other emitter uses, and
+    /// neither names a member a reference can reach — both are callables
+    /// governed by the same rule as a function.
+    pub(crate) fn private_item_kind(self) -> rue_air::PrivateItemKind {
+        match self {
+            Self::Function | Self::Destructor | Self::Test => rue_air::PrivateItemKind::Function,
+            Self::Struct => rue_air::PrivateItemKind::Struct,
+            Self::Enum => rue_air::PrivateItemKind::Enum,
+            Self::Const => rue_air::PrivateItemKind::Const,
+        }
+    }
+}
+
 /// The name-resolution namespace containing a parsed definition candidate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DefinitionNamespace {

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -914,19 +914,19 @@ impl SemanticNucleusTypeProvider<'_> {
                 "ambiguous declaration `{name}` in module {module}"
             ));
         }
-        let defining = rue_air::SemanticVisibilityDomain::from_file_path(Some(module.as_str()));
-        let accessing = rue_air::SemanticVisibilityDomain::from_file_path(Some(
-            accessing_source.module().as_str(),
-        ));
+        // Privacy is one decision with one diagnostic (RUE-1973): AIR owns
+        // both, including the short-circuit that answers a public item or a
+        // self-reference without deriving a visibility domain at all.
         let is_public = entry.visibility == Some(rue_parser::ast::Visibility::Public);
-        if !defining.is_visible_from(&accessing, is_public) {
+        if let Err(diagnostic) = rue_air::check_source_path_visibility(
+            kind.private_item_kind(),
+            name,
+            accessing_source.module().as_str(),
+            module.as_str(),
+            is_public,
+        ) {
             return Self::provider_domain_failure(
-                crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                    rue_error::ErrorKind::PrivateMemberAccess {
-                        item_kind: format!("{kind:?}").to_lowercase(),
-                        name: name.to_owned(),
-                    },
-                ),
+                crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(diagnostic),
             );
         }
         let categories: &[crate::declaration_candidate::DeclarationCandidateCategory] = match kind {
@@ -2308,8 +2308,19 @@ pub(in crate::revisioned_query_database) fn semantic_type_query_failure(
                         ),
                     )
                 }
-                F::PrivateItem {
-                    kind,
+                // A private *named* item reached by type syntax is the uniform
+                // module-member privacy violation E0706 (spec 10.3:7,
+                // 10.4:18), the same code and words every other position
+                // reports for it.
+                F::PrivateItem { kind, name, .. } => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                        rue_air::private_member_access(rue_air::PrivateItemKind::from(kind), &name),
+                    ),
+                ),
+                // Privacy's one carve-out: applying a private comptime type
+                // constructor in a type position is E0460 (10.4:16), which
+                // names the constructor and its defining file.
+                F::PrivateTypeConstructor {
                     name,
                     defining_file,
                     ..
@@ -2317,7 +2328,7 @@ pub(in crate::revisioned_query_database) fn semantic_type_query_failure(
                     crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
                         ErrorKind::PrivateUnqualifiedAccess(Box::new(
                             rue_error::PrivateUnqualifiedAccessData {
-                                item_kind: kind.diagnostic_name().to_owned(),
+                                item_kind: rue_air::PrivateItemKind::Function.spelling().to_owned(),
                                 name: name.to_string(),
                                 defining_file: defining_file.to_string(),
                             },

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1261,7 +1261,7 @@ define_error_codes! {
     };
     // 458-459 are reserved by in-flight work.
     PRIVATE_UNQUALIFIED_ACCESS = 460 => {
-        explanation: "A comptime type constructor reached through a module binding was applied in a type annotation from outside its defining directory, but the constructor is private. Type-position application performs the same visibility check as other cross-module access; the historical metadata name `PRIVATE_UNQUALIFIED_ACCESS` does not make unqualified lookup or ordinary private member access part of E0460.",
+        explanation: "A comptime type constructor reached through a module binding was applied in a type annotation from outside its defining directory, but the constructor is private. Applying a constructor is the one privacy violation with its own code: it is checked at the application site and names the constructor and its defining file. Every other private access — naming a private `fn`, `const`, `struct`, or `enum` through a module, in any position, and reaching one through a private module binding on the way — is E0706. The metadata name `PRIVATE_UNQUALIFIED_ACCESS` is historical and describes nothing E0460 reports.",
         likely_cause: "A type annotation names a module-qualified function returning `type`, such as `lib.Secret(i32)`, but that function lacks `pub` and the referencing file is in another directory. Mark the constructor `pub` when it is part of the module's interface, or keep the use within the constructor's defining directory.",
         examples: [
             ErrorCodeExample { title: "Apply a private type constructor across directories", source: "// --- main.rue\nconst lib = @import(\"sub/lib.rue\");\nfn main() -> i32 {\n    let value: lib.Secret(i32) = lib.make();\n    value.item\n}\n// --- sub/lib.rue\nfn Secret(comptime T: type) -> type { struct { item: T } }\npub fn make() -> Secret(i32) {\n    let S = Secret(i32);\n    S { item: 42 }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
@@ -1810,7 +1810,7 @@ define_error_codes! {
         references: [ErrorCodeReference { title: "Standard-library resolution", path: "docs/spec/src/10-modules/02-import-resolution.md", rule: Some("10.2:6") }],
     };
     PRIVATE_MEMBER_ACCESS = 706 => {
-        explanation: "A module-qualified access crossed a directory boundary to a private member. The top-level item, or the enclosing type for an enum variant or associated function, was not declared `pub`. Rue privacy is directory-based: private members remain usable by files in their defining directory but are hidden from importers in other directories.",
+        explanation: "An access crossed a directory boundary to a private item. The top-level item, or the enclosing type for an enum variant or associated function, was not declared `pub`. Rue privacy is directory-based: private items remain usable by files in their defining directory but are hidden from importers in other directories. One code covers every position that can name the item — a value, a type annotation, a function signature, a struct literal, a match-pattern head, an associated-function receiver — and every kind of item, named with the keyword the source would have written: `function`, `struct`, `enum`, `const`. A module binding is a `const`, so crossing a private one on the way to a public item behind it reports this same code against the binding.",
         likely_cause: "A function, constant, type, enum, or module re-export needed by an external importer is missing `pub`; an associated function or variant belongs to a private enclosing type; or the caller was moved outside the defining directory.",
         examples: [
             ErrorCodeExample { title: "Access a private function across directories", source: "// --- main.rue\nconst lib = @import(\"sub/lib.rue\");\nfn main() -> i32 { lib.secret() }\n// --- sub/lib.rue\nfn secret() -> i32 { 42 }", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
@@ -3067,7 +3067,9 @@ fn format_array_length_mismatch(expected: u64, found: u64) -> String {
 /// exceed it).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrivateUnqualifiedAccessData {
-    /// The kind of item ("function", "struct", "enum", "constant").
+    /// The kind of item, in the one privacy vocabulary
+    /// (`rue_air::PrivateItemKind`). E0460 reports only the type-constructor
+    /// carve-out, so in practice this is always "function".
     pub item_kind: String,
     /// The item's name as written at the reference site.
     pub name: String,

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -559,6 +559,113 @@ struct Secret {
 compile_fail = true
 error_contains = ["E0706", "struct `Secret` is private"]
 
+# =============================================================================
+# A private item reached through a module in a TYPE position (RUE-1973).
+#
+# 10.4:18 makes privacy uniform across positions, and it names the type
+# annotation explicitly. Before the fix the annotation and signature spellings
+# reported E0460 — the code 10.4:18 reserves for applying a private comptime
+# type constructor — with a second item-kind vocabulary, so the same private
+# struct read as `struct 'Secret' is private` in one position and
+# `constant 'Secret' is private` in another.
+
+[[case]]
+name = "qualified_private_struct_type_annotation_rejected"
+spec = ["10.4:18", "10.3:7"]
+description = "A private struct named in a module-qualified type annotation is E0706, the same code and wording the struct literal and associated-function spellings report (RUE-1973)"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let s: lib.Secret = lib.open();
+    s.n
+}
+"""
+aux_files = { "sub/lib.rue" = """
+struct Secret { n: i32, }
+pub fn open() -> i32 { let s = Secret { n: 1 }; s.n }
+""" }
+compile_fail = true
+error_contains = ["E0706", "struct `Secret` is private"]
+
+[[case]]
+name = "qualified_private_struct_signature_rejected"
+spec = ["10.4:18", "10.3:7"]
+description = "The same private struct named in a function signature is the same E0706; a declaration's type is resolved before any body, and privacy does not depend on which resolver ran (RUE-1973)"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn take(s: lib.Secret) -> i32 { s.n }
+
+fn main() -> i32 { 0 }
+"""
+aux_files = { "sub/lib.rue" = """
+struct Secret { n: i32, }
+pub fn open() -> i32 { let s = Secret { n: 1 }; s.n }
+""" }
+compile_fail = true
+error_contains = ["E0706", "struct `Secret` is private"]
+
+[[case]]
+name = "qualified_private_enum_type_annotation_rejected"
+spec = ["10.4:18", "10.3:7"]
+description = "A private enum named in a module-qualified type annotation is E0706 naming the enum (RUE-1973)"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let h: lib.Hidden = lib.first();
+    0
+}
+"""
+aux_files = { "sub/lib.rue" = """
+enum Hidden { A, B, }
+pub fn first() -> i32 { match Hidden.A { Hidden.A => 0, Hidden.B => 1, } }
+""" }
+compile_fail = true
+error_contains = ["E0706", "enum `Hidden` is private"]
+
+[[case]]
+name = "private_type_constructor_application_is_the_one_carve_out"
+spec = ["10.4:16", "10.3:7"]
+description = "Applying a private comptime type constructor in a type position is the one privacy violation with its own code, E0460, naming the constructor and its defining file (10.3:7)"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let value: lib.Wrap(i32) = lib.make();
+    value.item
+}
+"""
+aux_files = { "sub/lib.rue" = """
+fn Wrap(comptime T: type) -> type { struct { item: T } }
+pub fn make() -> Wrap(i32) {
+    let W = Wrap(i32);
+    W { item: 42 }
+}
+""" }
+compile_fail = true
+error_contains = ["E0460", "function `Wrap` is private"]
+
+[[case]]
+name = "pub_qualified_type_positions_allowed"
+spec = ["10.4:18", "10.4:17"]
+description = "The positive twin: once the items are pub, the annotation and signature spellings compile and run"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn take(s: lib.Secret) -> i32 { s.n }
+
+fn main() -> i32 {
+    let s: lib.Secret = lib.Secret { n: 21 };
+    take(s) + 21
+}
+"""
+aux_files = { "sub/lib.rue" = """
+pub struct Secret { n: i32, }
+""" }
+exit_code = 42
+
 [[case]]
 name = "cross_dir_pub_assoc_fn_allowed"
 spec = ["10.4:19", "10.4:17"]

--- a/crates/rue-ui-tests/cases/diagnostics/private_member_access.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/private_member_access.toml
@@ -1,0 +1,277 @@
+[section]
+id = "diagnostics.private_member_access"
+name = "Private item reached through a module"
+description = """
+One decision, one code, one vocabulary (RUE-1973). Reaching a private item
+through a module binding is E0706 in every position that can name it, and the
+item kind is spelled with the keyword the source would have written. E0460
+keeps exactly one form: applying a private comptime type constructor in a type
+position. These cases pin the diagnostic surface; the language rule itself is
+covered by the modules spec suite.
+"""
+
+# ---------------------------------------------------------------------------
+# The six positions that can name a private item defined by another module.
+# Each asserts the SAME code and the SAME wording for the SAME declaration.
+
+[[case]]
+name = "private_struct_in_let_annotation"
+description = "A private struct named in a `let` type annotation. This position used to report E0460, the type-constructor carve-out, for a plain named type."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let s: lib.Secret = lib.open();
+    s.n
+}
+"""
+aux_files = { "sub/lib.rue" = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 5 } }
+}
+pub fn open() -> i32 { Secret.make().n }
+""" }
+compile_fail = true
+expected_error_code = "E0706"
+error_contains = ["struct `Secret` is private"]
+
+[[case]]
+name = "private_struct_in_fn_signature"
+description = "The same struct in a parameter type. The signature is resolved by the query graph, which used to build the diagnostic from its own copy of the domain math."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn take(s: lib.Secret) -> i32 { s.n }
+
+fn main() -> i32 { 0 }
+"""
+aux_files = { "sub/lib.rue" = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 5 } }
+}
+pub fn open() -> i32 { Secret.make().n }
+""" }
+compile_fail = true
+expected_error_code = "E0706"
+error_contains = ["struct `Secret` is private"]
+
+[[case]]
+name = "private_struct_in_qualified_struct_literal"
+description = "The same struct as the head of a module-qualified struct literal."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let s = lib.Secret { n: 3 };
+    s.n
+}
+"""
+aux_files = { "sub/lib.rue" = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 5 } }
+}
+pub fn open() -> i32 { Secret.make().n }
+""" }
+compile_fail = true
+expected_error_code = "E0706"
+error_contains = ["struct `Secret` is private"]
+
+[[case]]
+name = "private_struct_as_associated_fn_receiver"
+description = "The same struct as the receiver of a module-qualified associated-function call: an associated function's visibility follows its enclosing type."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let s = lib.Secret.make();
+    s.n
+}
+"""
+aux_files = { "sub/lib.rue" = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 5 } }
+}
+pub fn open() -> i32 { Secret.make().n }
+""" }
+compile_fail = true
+expected_error_code = "E0706"
+error_contains = ["struct `Secret` is private"]
+
+[[case]]
+name = "private_enum_in_match_pattern_head"
+description = "A private enum named in a match-pattern head."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let n = lib.open();
+    match n {
+        0 => 0,
+        _ => {
+            let h = lib.Hidden.A;
+            1
+        }
+    }
+}
+"""
+aux_files = { "sub/lib.rue" = """
+enum Hidden { A, B, }
+pub fn open() -> i32 { match Hidden.A { Hidden.A => 0, Hidden.B => 1, } }
+""" }
+compile_fail = true
+expected_error_code = "E0706"
+error_contains = ["enum `Hidden` is private"]
+
+[[case]]
+name = "private_const_read_as_a_value"
+description = "A private constant read as a value. `const`, not \"constant\": one spelling per item kind across every emitter."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    lib.LIMIT
+}
+"""
+aux_files = { "sub/lib.rue" = """
+const LIMIT: i32 = 17;
+pub fn open() -> i32 { LIMIT }
+""" }
+compile_fail = true
+expected_error_code = "E0706"
+error_contains = ["const `LIMIT` is private"]
+
+# ---------------------------------------------------------------------------
+# The vocabulary: the remaining item kind, and the negative that pins the
+# spelling rather than merely the code.
+
+[[case]]
+name = "private_function_call_names_the_function_kind"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    lib.helper()
+}
+"""
+aux_files = { "sub/lib.rue" = """
+fn helper() -> i32 { 3 }
+pub fn open() -> i32 { helper() }
+""" }
+compile_fail = true
+expected_error_code = "E0706"
+error_contains = ["function `helper` is private"]
+
+[[case]]
+name = "a_private_const_is_never_spelled_constant"
+description = "The two vocabularies used to disagree: the type-annotation path said \"constant\" while every other path said \"const\"."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let e: lib.inner.E = lib.make();
+    0
+}
+"""
+aux_files = { "sub/lib.rue" = """
+const inner = @import("deep/inner.rue");
+pub fn make() -> inner.E { inner.E.A }
+""", "sub/deep/inner.rue" = """
+pub enum E { A, B, }
+""" }
+compile_fail = true
+expected_error_code = "E0706"
+error_contains = ["const `inner` is private"]
+
+# ---------------------------------------------------------------------------
+# E0460 keeps exactly what its `--explain` text claims.
+
+[[case]]
+name = "applying_a_private_type_constructor_stays_e0460"
+description = "Privacy's one carve-out: a private comptime type constructor applied in a type position, reported against the constructor and its defining file."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let value: lib.Wrap(i32) = lib.make();
+    value.item
+}
+"""
+aux_files = { "sub/lib.rue" = """
+fn Wrap(comptime T: type) -> type { struct { item: T } }
+pub fn make() -> Wrap(i32) {
+    let W = Wrap(i32);
+    W { item: 42 }
+}
+""" }
+compile_fail = true
+expected_error_code = "E0460"
+error_contains = ["function `Wrap` is private (defined in `sub/lib.rue`)"]
+
+# ---------------------------------------------------------------------------
+# Controls: the same spellings compile once the items are exported.
+
+[[case]]
+name = "exported_items_compile_in_every_position"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn take(s: lib.Secret) -> i32 { s.n }
+
+fn main() -> i32 {
+    let s: lib.Secret = lib.Secret.make();
+    let t = lib.Secret { n: 1 };
+    let h = lib.Hidden.A;
+    let seen = match h {
+        lib.Hidden.A => 0,
+        lib.Hidden.B => 1,
+    };
+    take(s) + t.n + lib.helper() + lib.LIMIT + seen
+}
+"""
+aux_files = { "sub/lib.rue" = """
+pub struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 5 } }
+}
+pub enum Hidden { A, B, }
+pub const LIMIT: i32 = 17;
+pub fn helper() -> i32 { 3 }
+""" }
+exit_code = 26
+
+# ---------------------------------------------------------------------------
+# One rendering of a module's name: the import path, not the file stem.
+
+[[case]]
+name = "unknown_member_names_the_module_by_import_path"
+description = "Both E0707 emitters — the call path and the type-syntax path — render the module the same way, so a same-named file in another directory is distinguishable."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    lib.nope()
+}
+"""
+aux_files = { "sub/lib.rue" = "pub fn real() -> i32 { 1 }\n" }
+compile_fail = true
+expected_error_code = "E0707"
+error_contains = ["module `sub/lib.rue` has no member `nope`"]
+
+[[case]]
+name = "unknown_type_member_names_the_module_by_import_path"
+source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let x: lib.Nope = 0;
+    0
+}
+"""
+aux_files = { "sub/lib.rue" = "pub fn real() -> i32 { 1 }\n" }
+compile_fail = true
+expected_error_code = "E0707"
+error_contains = ["module `sub/lib.rue` has no member `Nope`"]


### PR DESCRIPTION
## Summary

Reaching a private item through a module was decided in one place but reported in eleven, so the same violation read differently depending on which position named the item. `let s: lib.Secret = ..` reported E0460 "struct `Secret` is private (defined in `sub/lib.rue`)" while `lib.Secret { .. }`, `lib.Secret.make()`, and `fn take(s: lib.Secret)` reported E0706 "struct `Secret` is private"; a private constant was a `const` to most emitters and a "constant" to the type-syntax one. E0460's own `--explain` text already said the code belongs to a single carve-out (applying a private comptime type constructor in a type position) and its emitters did not agree with it.

- New `rue_air::private_access` owns both halves of the report: `PrivateItemKind` is the whole item-kind vocabulary (`function`, `struct`, `enum`, `const`; one spelling per kind in one table), and `private_member_access` is the only constructor of E0706's payload. `OrdinaryBodyEngine::check_item_visibility` joins it to the memoized `is_accessible` predicate; every former inline site (the qualified nominal checks in `aggregates`, the module member call and re-export paths in `analysis::calls`, the unqualified naming forms, `visibility`, and `typeck`'s module-path failure) goes through it.
- `SemanticTypeSyntaxFailure` grows `PrivateTypeConstructor`, so the E0460 carve-out is a distinct failure that cannot silently widen back over ordinary named lookup. A private *named* type reached by type syntax is the ordinary E0706 in both the body engine and the query database. The `PRIVATE_UNQUALIFIED_ACCESS` code name is unchanged (consumer-visible); its explanation now says the name is historical.
- The query database no longer keeps its own copy of the domain math: `candidate` derived both visibility domains from source paths and built E0706 with a `Debug`-derived item kind; it now calls `rue_air::check_source_path_visibility`, which short-circuits a public item and a self-reference before deriving a domain, and maps `DefinitionKind` onto the shared vocabulary.
- E0707 gains one module-name renderer, `module_registry::module_display_name`, rendering the import path for all three emitters (the call path printed the file stem, the type-syntax path the import path, and a third stem renderer in `aggregates.rs` was not in the issue).
- Guards: `api_inventory` asserts by AST walk that E0706 is constructed in exactly one module of the crate and E0460 in exactly one, that the spellings come from the single table, and that no source re-renders a module name from a path stem; the compiler's inventory asserts its phases build neither the payload nor an item kind of their own and that `candidate` no longer derives domains.

## Golden changes

- `crates/rue-cli-tests/cases/modules.toml`: two E0707 expectations move from the file stem to the import path ("module `utils`" → "module `utils.rue`", "module `math`" → "module `std/math.rue`"), which is what distinguishes same-named files in different directories.
- The annotation position loses the "(defined in `<path>`)" tail and the help note it carried as E0460; the module it was reached through is at the error span.

## Tests

- `crates/rue-ui-tests/cases/diagnostics/private_member_access.toml` (new): all six positions from the issue at the same code and wording, the `const` spelling, the E0460 carve-out, and the single E0707 rendering.
- `crates/rue-spec/cases/modules/bindings.toml`: five cases citing 10.4:18 / 10.3:7 / 10.4:16 / 10.4:17 covering the positions that diverged, a private enum in an annotation, the carve-out, and a positive twin. No spec prose change was needed; the implementation was behind the spec.

Not done: the failure→`CompileError` mapping is still duplicated between `sema/typeck.rs` and `provider_body.rs` (both now map `PrivateItem`/`PrivateTypeConstructor`); that duplication predates this issue and covers ~30 unrelated variants.

## Validation

`scripts/rue fmt`, `quick` (36/36), `unit air` (886), `unit compiler` (1233), `unit error` (127), `cli modules explain` (235), `ui` (437), `spec` (2885), and the spec-traceability, oracle-diff, error-explanation-examples and planted-miscompile-isolation gates, all passing on the rebased tree (on top of RUE-1975). The agent's full `cli` (2704/2706, the two environmental cases) and `premerge` on the pre-rebase tree passed.

Closes RUE-1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_