### PR TITLE
One path-head parser for patterns and struct literals

### DIFF
--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -1500,23 +1500,6 @@ fn expr_record(
                 expr_record(owner, &index.index),
             ],
         ),
-        Expr::Path(path) => syntax_record(
-            "path",
-            span,
-            Some(
-                format!(
-                    "{}::{}",
-                    owner.resolve_raw_symbol(path.type_name.name),
-                    owner.resolve_raw_symbol(path.variant.name)
-                )
-                .into(),
-            ),
-            None,
-            path.base
-                .iter()
-                .map(|base| expr_record(owner, base))
-                .collect(),
-        ),
         Expr::SelfExpr(_) => syntax_record("self", span, None, None, Vec::new()),
         Expr::Comptime(block) => syntax_record(
             "comptime",

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -2400,11 +2400,6 @@ impl<'a> ParsedBodyProjectionCollector<'a> {
                 self.visit_expr(&value.base)?;
                 self.visit_expr(&value.index)?;
             }
-            Expr::Path(value) => {
-                if let Some(base) = &value.base {
-                    self.visit_expr(base)?;
-                }
-            }
             Expr::Comptime(value) => self.visit_expr(&value.expr)?,
             Expr::Checked(value) => self.visit_expr(&value.expr)?,
         }

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -229,10 +229,6 @@ fn expr_charge(expr: &ast::Expr) -> u64 {
             .saturating_add(value.repeat.as_ref().map_or(0, array_length_charge)),
         Expr::Index(value) => boxed_charge(&value.base, expr_charge)
             .saturating_add(boxed_charge(&value.index, expr_charge)),
-        Expr::Path(value) => value
-            .base
-            .as_ref()
-            .map_or(0, |base| boxed_charge(base, expr_charge)),
         Expr::Comptime(value) => boxed_charge(&value.expr, expr_charge),
         Expr::Checked(value) => boxed_charge(&value.expr, expr_charge),
         Expr::TypeLit(value) => type_charge(&value.type_expr),

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -668,22 +668,6 @@ impl Shapes<'_> {
                 "_".into(),
                 "_".into(),
             ),
-            Expr::Path(v) => {
-                let base = v.base.as_ref().map_or_else(
-                    || self.ident(),
-                    |e| {
-                        node(
-                            "field",
-                            "",
-                            self.expr(e),
-                            "_".into(),
-                            "_".into(),
-                            "_".into(),
-                        )
-                    },
-                );
-                node("field", "", base, "_".into(), "_".into(), "_".into())
-            }
             Expr::Comptime(v) => node(
                 "comptime",
                 "",

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -843,8 +843,6 @@ pub enum Expr {
     ArrayLit(ArrayLitExpr),
     /// Array indexing (e.g., `arr[0]`)
     Index(IndexExpr),
-    /// Path expression (e.g., `Color::Red`)
-    Path(PathExpr),
     /// Self expression (e.g., `self` in method bodies)
     SelfExpr(SelfExpr),
     /// Comptime block expression (e.g., `comptime { 1 + 2 }`)
@@ -1257,18 +1255,6 @@ pub struct IndexExpr {
     pub span: Span,
 }
 
-/// A path expression (e.g., `Color::Red` or `module.Color::Red` for enum variant).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PathExpr {
-    /// Optional module/namespace prefix (e.g., `utils` in `utils.Color::Red`)
-    pub base: Option<Box<Expr>>,
-    /// The type name (e.g., `Color`)
-    pub type_name: Ident,
-    /// The variant name (e.g., `Red`)
-    pub variant: Ident,
-    pub span: Span,
-}
-
 /// A statement (does not produce a value).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Statement {
@@ -1547,7 +1533,6 @@ impl Expr {
             Expr::IntrinsicCall(intrinsic) => intrinsic.span,
             Expr::ArrayLit(array_lit) => array_lit.span,
             Expr::Index(index_expr) => index_expr.span,
-            Expr::Path(path_expr) => path_expr.span,
             Expr::SelfExpr(self_expr) => self_expr.span,
             Expr::Comptime(comptime_expr) => comptime_expr.span,
             Expr::Checked(checked_expr) => checked_expr.span,
@@ -1649,7 +1634,6 @@ impl Expr {
             })),
             Expr::ArrayLit(literal) => out.extend(literal.elements.iter()),
             Expr::Index(index) => out.extend([index.base.as_ref(), index.index.as_ref()]),
-            Expr::Path(path) => out.extend(path.base.as_deref()),
             Expr::Comptime(expr) => out.push(&expr.expr),
             Expr::Checked(expr) => out.push(&expr.expr),
         }
@@ -2050,14 +2034,6 @@ fn rebind_expr(expr: &mut Expr, file_id: FileId) {
             rebind_expr(&mut index.base, file_id);
             rebind_expr(&mut index.index, file_id);
             rebind_span(&mut index.span, file_id);
-        }
-        Expr::Path(path) => {
-            if let Some(base) = &mut path.base {
-                rebind_expr(base, file_id);
-            }
-            rebind_ident(&mut path.type_name, file_id);
-            rebind_ident(&mut path.variant, file_id);
-            rebind_span(&mut path.span, file_id);
         }
         Expr::SelfExpr(self_expr) => rebind_span(&mut self_expr.span, file_id),
         Expr::Comptime(block) => {
@@ -2500,12 +2476,6 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
             writeln!(f, "Index:")?;
             fmt_expr(f, &index.index, level + 2)
         }
-        Expr::Path(path) => writeln!(
-            f,
-            "Path sym:{}::sym:{}",
-            path.type_name.name.into_usize(),
-            path.variant.name.into_usize()
-        ),
         Expr::SelfExpr(_) => {
             writeln!(f, "SelfExpr")
         }

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -59,7 +59,6 @@ pub use ast::{
     Param,
     ParamMode,
     ParenExpr,
-    PathExpr,
     PathPattern,
     Pattern,
     PatternElement,

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -118,13 +118,7 @@ impl Parser {
                     let fields = self.field_inits()?;
                     let span = self.span_from(start);
                     name.span = span;
-                    Ok(Expr::StructLit(StructLitExpr {
-                        base: None,
-                        name,
-                        ctor_args: None,
-                        fields,
-                        span,
-                    }))
+                    Ok(PathHead::local(name, None).into_struct_lit(fields, span))
                 } else {
                     Ok(Expr::Ident(name))
                 }
@@ -247,13 +241,10 @@ impl Parser {
             let args = self.call_args()?;
             if self.at(TokenKind::LBrace) && self.looks_like_fields() {
                 let fields = self.field_inits()?;
-                Ok(Expr::StructLit(StructLitExpr {
-                    base: None,
-                    name,
-                    ctor_args: Some(args),
-                    fields,
-                    span: self.span_from(start),
-                }))
+                Ok(
+                    PathHead::local(name, Some(args))
+                        .into_struct_lit(fields, self.span_from(start)),
+                )
             } else {
                 Ok(Expr::Call(CallExpr {
                     name,
@@ -263,16 +254,89 @@ impl Parser {
             }
         } else if self.at(TokenKind::LBrace) && self.looks_like_fields() {
             let fields = self.field_inits()?;
-            Ok(Expr::StructLit(StructLitExpr {
-                base: None,
-                name,
-                ctor_args: None,
-                fields,
-                span: self.span_from(start),
-            }))
+            Ok(PathHead::local(name, None).into_struct_lit(fields, self.span_from(start)))
         } else {
             Ok(Expr::Ident(name))
         }
+    }
+
+    /// Parse a path head and the `.` IDENT that closes it: the
+    /// `pattern_head "." IDENT` prefix of an enum-variant pattern (spec 4.7:2).
+    ///
+    /// This is the grammar's one path-head parser, and it lives beside the
+    /// expression path machinery it mirrors. It walks the forms `ident_expr`
+    /// and `postfix` accept — a name, an inline type-constructor call on it
+    /// (`Result(i32, i32)`, RUE-596), and `.`-separated module segments
+    /// (`std.result.Result`, RUE-947) — and folds the leading segments into the
+    /// same [`Expr::Field`] chain `postfix` builds, so the head a pattern
+    /// carries and the head a struct literal carries are one [`PathHead`]. The
+    /// trailing name is returned separately: only the caller knows whether it
+    /// is an enum variant or a field.
+    ///
+    /// A `(...)` group attached to a segment is the constructor call, not a
+    /// payload list, whenever a `.` follows it. The first segment needs no such
+    /// lookahead: no variant has been named yet, so a group there can only be a
+    /// constructor call, and consuming it reports a missing `.` at the token
+    /// that actually ends the head rather than at the group.
+    pub(super) fn path_head(&mut self) -> PResult<(PathHead, Ident)> {
+        let mut head = PathHead::local(self.ident()?, None);
+        if self.at(TokenKind::LParen) {
+            head.ctor_args = Some(self.call_args()?);
+        }
+        loop {
+            self.expect(TokenKind::Dot)?;
+            let name = self.ident()?;
+            let ctor_args = if self.at(TokenKind::LParen) && self.ctor_group_precedes_dot() {
+                Some(self.call_args()?)
+            } else {
+                None
+            };
+            if ctor_args.is_none() && !self.at(TokenKind::Dot) {
+                return Ok((head, name));
+            }
+            // `name` continues the path, so the segment before it was a module
+            // segment. Constructor arguments attach to the last segment of the
+            // head only; anything earlier is rejected rather than silently
+            // moved onto the type name.
+            if head.ctor_args.is_some() {
+                self.error(
+                    "type-constructor arguments in a pattern must follow the final type path \
+                     segment",
+                );
+                return Err(());
+            }
+            head = PathHead {
+                base: Some(Box::new(head.into_qualifier())),
+                name,
+                ctor_args,
+            };
+        }
+    }
+
+    /// With the cursor at a `(`, scan to the matching `)` and report whether
+    /// the token immediately after it is a `.`. This distinguishes an inline
+    /// type-constructor call on a path head (`Result(i32, i32).Ok`, the group
+    /// precedes a dot) from a variant's payload bindings (`Ok(v)`, the group is
+    /// terminal) during a single left-to-right pass (RUE-947).
+    fn ctor_group_precedes_dot(&self) -> bool {
+        debug_assert!(self.at(TokenKind::LParen));
+        let mut cursor = self.cursor;
+        let mut depth = 0usize;
+        while let Some(token) = self.tokens.get(cursor) {
+            match token.kind {
+                TokenKind::LParen => depth += 1,
+                TokenKind::RParen => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return self.tokens.get(cursor + 1).map(|t| t.kind) == Some(TokenKind::Dot);
+                    }
+                }
+                TokenKind::Eof => return false,
+                _ => {}
+            }
+            cursor += 1;
+        }
+        false
     }
 
     /// Reject a trailing-dot float literal (`5.`) before it is mistaken for a
@@ -342,13 +406,8 @@ impl Parser {
                         if self.at(TokenKind::LBrace) && self.looks_like_fields() {
                             let fields = self.field_inits()?;
                             let span = base.span().extend_to(self.previous_end());
-                            base = Expr::StructLit(StructLitExpr {
-                                base: Some(Box::new(base)),
-                                name: field,
-                                ctor_args: Some(args),
-                                fields,
-                                span,
-                            });
+                            base = PathHead::qualified(base, field, Some(args))
+                                .into_struct_lit(fields, span);
                         } else {
                             let span = base.span().extend_to(self.previous_end());
                             base = Expr::MethodCall(MethodCallExpr {
@@ -361,13 +420,7 @@ impl Parser {
                     } else if self.at(TokenKind::LBrace) && self.looks_like_fields() {
                         let fields = self.field_inits()?;
                         let span = base.span().extend_to(self.previous_end());
-                        base = Expr::StructLit(StructLitExpr {
-                            base: Some(Box::new(base)),
-                            name: field,
-                            ctor_args: None,
-                            fields,
-                            span,
-                        });
+                        base = PathHead::qualified(base, field, None).into_struct_lit(fields, span);
                     } else {
                         let span = base.span().extend_to(field.span.end);
                         base = Expr::Field(FieldExpr {
@@ -679,6 +732,72 @@ impl Parser {
             }
         }
         false
+    }
+}
+
+/// The head shared by a struct literal and an enum-variant pattern: an
+/// optional module prefix, the type name, and the inline type-constructor call
+/// attached to that name (spec 4.7:2 `pattern_head`; RUE-596, RUE-947,
+/// RUE-951).
+///
+/// The prefix is the `.`-separated module segments already folded into the
+/// [`Expr::Field`] chain the module-qualified lowering reads, so a head parsed
+/// for a pattern and a head parsed for a struct literal are indistinguishable
+/// downstream.
+pub(super) struct PathHead {
+    pub(super) base: Option<Box<Expr>>,
+    pub(super) name: Ident,
+    pub(super) ctor_args: Option<Vec<CallArg>>,
+}
+
+impl PathHead {
+    /// A head with no module prefix (`Color`, `Result(i32, i32)`).
+    fn local(name: Ident, ctor_args: Option<Vec<CallArg>>) -> Self {
+        Self {
+            base: None,
+            name,
+            ctor_args,
+        }
+    }
+
+    /// A head with a module prefix (`std.result.Result`).
+    pub(super) fn qualified(base: Expr, name: Ident, ctor_args: Option<Vec<CallArg>>) -> Self {
+        Self {
+            base: Some(Box::new(base)),
+            name,
+            ctor_args,
+        }
+    }
+
+    /// Fold a completed head back into the field chain a module prefix is
+    /// spelled as, once a further segment proves it was one (`std.result` in
+    /// `std.result.Result.Ok`).
+    /// A constructor call ends a head, so `path_head` rejects a further
+    /// segment before it gets here and there is never a call to carry over.
+    fn into_qualifier(self) -> Expr {
+        match self.base {
+            Some(base) => {
+                let span = base.span().extend_to(self.name.span.end);
+                Expr::Field(FieldExpr {
+                    base,
+                    field: self.name,
+                    span,
+                })
+            }
+            None => Expr::Ident(self.name),
+        }
+    }
+
+    /// A struct literal is a path head followed by its field list
+    /// (`P { .. }`, `P(args) { .. }`, `m.P(args) { .. }`).
+    fn into_struct_lit(self, fields: Vec<FieldInit>, span: Span) -> Expr {
+        Expr::StructLit(StructLitExpr {
+            base: self.base,
+            name: self.name,
+            ctor_args: self.ctor_args,
+            fields,
+            span,
+        })
     }
 }
 

--- a/crates/rue-parser/src/parser/statements.rs
+++ b/crates/rue-parser/src/parser/statements.rs
@@ -203,87 +203,17 @@ impl Parser {
         }
     }
 
-    /// With the cursor at a `(`, scan to the matching `)` and report whether the
-    /// token immediately after it is a `.`. This distinguishes an inline
-    /// type-constructor call on a pattern head (`Result(i32, i32).Ok`, the group
-    /// precedes a dot) from a variant's payload bindings (`Ok(v)`, the group is
-    /// terminal) during a single left-to-right pass (RUE-947).
-    fn paren_group_precedes_dot(&self) -> bool {
-        debug_assert!(self.at(TokenKind::LParen));
-        let mut cursor = self.cursor;
-        let mut depth = 0usize;
-        while let Some(token) = self.tokens.get(cursor) {
-            match token.kind {
-                TokenKind::LParen => depth += 1,
-                TokenKind::RParen => {
-                    depth -= 1;
-                    if depth == 0 {
-                        return self.tokens.get(cursor + 1).map(|t| t.kind) == Some(TokenKind::Dot);
-                    }
-                }
-                TokenKind::Eof => return false,
-                _ => {}
-            }
-            cursor += 1;
-        }
-        false
-    }
-
+    /// One enum-variant pattern: `path_pattern = pattern_head "." IDENT
+    /// [ "(" pattern_elements ")" ]` (spec 4.7:2).
+    ///
+    /// The head is parsed by [`Parser::path_head`], the grammar's one
+    /// path-head parser, so a pattern head is built from the same forms and
+    /// carried in the same shape as an expression's struct-literal head. What is left here is
+    /// the classification the pattern grammar adds on top: the trailing name is
+    /// the variant, and a terminal `(...)` is its payload list of patterns
+    /// rather than the call arguments an expression would parse there.
     fn path_pattern(&mut self, start: u32) -> PResult<Pattern> {
-        let first = self.ident()?;
-        // The inline type-constructor call (RUE-596) attaches to the `type_name`
-        // segment — the last one before the variant. For a local head that is
-        // the first ident (`Result(i32, i32).Ok(v)`); for a module-qualified
-        // head it is a later segment (`std.result.Result(i32, i32).Ok(v)`,
-        // RUE-947). A `(...)` group is the ctor call only when it precedes a
-        // dot; a terminal `(...)` is the variant's payload bindings.
-        let mut ctor_args = None;
-        if self.at(TokenKind::LParen) {
-            ctor_args = Some(self.call_args()?);
-        }
-        self.expect(TokenKind::Dot)?;
-        let mut segments = vec![self.ident()?];
-        // Exactly one identifier — the variant — may follow constructor
-        // arguments. Reject a group attached to an earlier module segment
-        // instead of silently moving it onto the final type-name segment.
-        let mut segments_after_ctor = ctor_args.as_ref().map(|_| 1usize);
-        if ctor_args.is_none() && self.at(TokenKind::LParen) && self.paren_group_precedes_dot() {
-            ctor_args = Some(self.call_args()?);
-            segments_after_ctor = Some(0);
-        }
-        while self.eat(TokenKind::Dot) {
-            segments.push(self.ident()?);
-            if let Some(count) = &mut segments_after_ctor {
-                *count += 1;
-            }
-            if ctor_args.is_none() && self.at(TokenKind::LParen) && self.paren_group_precedes_dot()
-            {
-                ctor_args = Some(self.call_args()?);
-                segments_after_ctor = Some(0);
-            }
-        }
-        if matches!(segments_after_ctor, Some(count) if count != 1) {
-            self.error(
-                "type-constructor arguments in a pattern must follow the final type path segment",
-            );
-            return Err(());
-        }
-        let variant = segments.pop().unwrap();
-        let (type_name, base) = if segments.is_empty() {
-            (first, None)
-        } else {
-            let type_name = segments.pop().unwrap();
-            let mut expr = Expr::Ident(first);
-            for field in segments {
-                let span = expr.span().extend_to(field.span.end);
-                expr = Expr::Field(FieldExpr {
-                    base: Box::new(expr),
-                    field,
-                    span,
-                });
-            }
-            (type_name, Some(Box::new(expr)))
-        };
+        let (head, variant) = self.path_head()?;
         let mut elements = Vec::new();
         if self.eat(TokenKind::LParen) {
             if self.at(TokenKind::RParen) {
@@ -302,9 +232,9 @@ impl Parser {
             self.expect(TokenKind::RParen)?;
         }
         Ok(Pattern::Path(PathPattern {
-            base,
-            type_name,
-            ctor_args,
+            base: head.base,
+            type_name: head.name,
+            ctor_args: head.ctor_args,
             variant,
             elements,
             span: self.span_from(start),
@@ -678,6 +608,60 @@ mod tests {
         assert!(!parses("fn f() { let x = 1 x }"));
     }
 
+    fn parse_errors(source: &str) -> Vec<String> {
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        match Parser::new(tokens, interner).parse() {
+            Ok(_) => Vec::new(),
+            Err(errors) => errors.iter().map(|error| error.to_string()).collect(),
+        }
+    }
+
+    /// The pattern of the first arm of the `match` that is `f`'s body.
+    fn first_arm_pattern(source: &str) -> PathPattern {
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        let (ast, _) = Parser::new(tokens, interner).parse().unwrap();
+        let Item::Function(function) = &ast.items[0] else {
+            panic!("expected a function item");
+        };
+        let Expr::Block(body) = &function.body else {
+            panic!("expected a block body");
+        };
+        let Expr::Match(match_expr) = &*body.expr else {
+            panic!("expected a match expression, got {:?}", body.expr);
+        };
+        match &match_expr.arms[0].pattern {
+            Pattern::Path(path) => path.clone(),
+            other => panic!("expected a path pattern, got {other:?}"),
+        }
+    }
+
+    /// The `.`-separated identifiers a pattern head's module base is spelled
+    /// as, innermost first, resolved through the interner.
+    fn base_segments(pattern: &PathPattern, interner: &lasso::ThreadedRodeo) -> Vec<String> {
+        let mut segments = Vec::new();
+        let mut cursor = pattern.base.as_deref();
+        while let Some(expr) = cursor {
+            match expr {
+                Expr::Field(field) => {
+                    segments.push(interner.resolve(&field.field.name).to_owned());
+                    cursor = Some(&field.base);
+                }
+                Expr::Ident(ident) => {
+                    segments.push(interner.resolve(&ident.name).to_owned());
+                    cursor = None;
+                }
+                other => panic!("a pattern head base is a field chain, got {other:?}"),
+            }
+        }
+        segments.reverse();
+        segments
+    }
+
+    fn interner_of(source: &str) -> lasso::ThreadedRodeo {
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        Parser::new(tokens, interner).parse().unwrap().1
+    }
+
     #[test]
     fn pattern_constructor_arguments_follow_the_final_type_segment() {
         assert!(parses(
@@ -689,5 +673,94 @@ mod tests {
         assert!(!parses(
             "fn f(x: i32) -> i32 { match x { std(i32).result.Result.Ok(v) => v } }"
         ));
+    }
+
+    /// A module-qualified head carries its module segments as the same field
+    /// chain an expression path builds, with and without payload bindings.
+    #[test]
+    fn module_qualified_variant_pattern_carries_a_field_chain_base() {
+        for (source, bindings) in [
+            ("fn f(x: i32) -> i32 { match x { a.b.E.A => 0 } }", 0),
+            ("fn f(x: i32) -> i32 { match x { a.b.E.A(v) => v } }", 1),
+        ] {
+            let interner = interner_of(source);
+            let pattern = first_arm_pattern(source);
+            assert_eq!(base_segments(&pattern, &interner), ["a", "b"], "{source}");
+            assert_eq!(interner.resolve(&pattern.type_name.name), "E", "{source}");
+            assert_eq!(interner.resolve(&pattern.variant.name), "A", "{source}");
+            assert!(pattern.ctor_args.is_none(), "{source}");
+            assert_eq!(pattern.elements.len(), bindings, "{source}");
+        }
+    }
+
+    /// A generic-call head attaches its arguments to the final type segment,
+    /// leaving the module segments before it as the base.
+    #[test]
+    fn generic_call_head_attaches_to_the_final_type_segment() {
+        let source = "fn f(x: i32) -> i32 { match x { m.Generic(i32, u8).Variant(v) => v } }";
+        let interner = interner_of(source);
+        let pattern = first_arm_pattern(source);
+        assert_eq!(base_segments(&pattern, &interner), ["m"]);
+        assert_eq!(interner.resolve(&pattern.type_name.name), "Generic");
+        assert_eq!(interner.resolve(&pattern.variant.name), "Variant");
+        assert_eq!(pattern.ctor_args.as_ref().map(Vec::len), Some(2));
+        assert_eq!(pattern.elements.len(), 1);
+    }
+
+    /// A payload position parses with the same head parser, so every head form
+    /// nests (RUE-2053).
+    #[test]
+    fn nested_variant_patterns_accept_every_head_form() {
+        for source in [
+            "fn f(x: i32) -> i32 { match x { E.A(F.B) => 0 } }",
+            "fn f(x: i32) -> i32 { match x { E.A(F.B(v)) => v } }",
+            "fn f(x: i32) -> i32 { match x { E.A(m.F.B(v), _) => v } }",
+            "fn f(x: i32) -> i32 { match x { E.A(Result(i32, u8).Ok(v)) => v } }",
+            "fn f(x: i32) -> i32 { match x { E.A(F.B(G.C(v))) => v } }",
+        ] {
+            assert!(parses(source), "{source}");
+        }
+        let source = "fn f(x: i32) -> i32 { match x { E.A(m.F.B(v), _) => v } }";
+        let interner = interner_of(source);
+        let pattern = first_arm_pattern(source);
+        let PatternElement::Nested(nested) = &pattern.elements[0] else {
+            panic!("expected a nested pattern");
+        };
+        assert_eq!(base_segments(nested, &interner), ["m"]);
+        assert_eq!(interner.resolve(&nested.type_name.name), "F");
+        assert_eq!(interner.resolve(&nested.variant.name), "B");
+        assert!(matches!(pattern.elements[1], PatternElement::Binding(_)));
+    }
+
+    /// The pattern grammar is narrower than the expression path grammar: a
+    /// parenthesized head or `Self` reaches sema in expression position but is
+    /// not a `pattern_head` (spec 4.7:2), and the head parser does not widen it.
+    #[test]
+    fn non_pattern_heads_are_still_rejected_as_patterns() {
+        for source in [
+            "fn f(x: i32) -> i32 { match x { (Color).Red => 0 } }",
+            "fn f(x: i32) -> i32 { match x { Self.Red => 0 } }",
+            "fn f(x: i32) -> i32 { match x { (Color.Red) => 0 } }",
+        ] {
+            assert_eq!(
+                parse_errors(source).first().map(String::as_str),
+                Some("expected pattern"),
+                "{source}"
+            );
+        }
+    }
+
+    /// A head with no variant reports the missing `.` at the token that ends
+    /// the head, not at the group the head consumed on the way there.
+    #[test]
+    fn a_head_without_a_variant_reports_the_missing_dot() {
+        assert_eq!(
+            parse_errors("fn f(x: i32) -> i32 { match x { Some(v) => v } }").first(),
+            Some(&"expected '.', found '=>'".to_owned())
+        );
+        assert_eq!(
+            parse_errors("fn f(x: i32) -> i32 { match x { Color => 0 } }").first(),
+            Some(&"expected '.', found '=>'".to_owned())
+        );
     }
 }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -343,11 +343,6 @@ impl Validator<'_> {
                 self.check_expr(&i.base);
                 self.check_expr(&i.index);
             }
-            Expr::Path(p) => {
-                if let Some(base) = &p.base {
-                    self.check_expr(base);
-                }
-            }
             Expr::Comptime(c) => self.check_expr(&c.expr),
             Expr::Checked(c) => self.check_expr(&c.expr),
             Expr::TypeLit(t) => self.check_type_expr(&t.type_expr),

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -951,6 +951,41 @@ impl<'a> AstGen<'a> {
         }
     }
 
+    /// Lower the inline type-constructor call of a path head (RUE-596): the
+    /// `F(args)` of `F(args) { .. }` and of `F(args).Variant(..)`.
+    ///
+    /// The constructor becomes its own instruction, which sema reduces to the
+    /// type at comptime. A module-qualified head (`std.tuple.Pair(i64, i32)`,
+    /// RUE-951; `std.result.Result(i32, i32)`, RUE-947) reaches the constructor
+    /// through its module base, so it lowers to a method call on that base; a
+    /// bare call would fail to resolve the name in local scope. Struct-literal
+    /// heads and pattern heads are the same syntax (the parser gives them one
+    /// shape), so they get one lowering.
+    fn gen_ctor_head(
+        &mut self,
+        module: Option<InstRef>,
+        name: Spur,
+        args: &[CallArg],
+        span: rue_span::Span,
+    ) -> InstRef {
+        let arg_refs: Vec<_> = args
+            .iter()
+            .enumerate()
+            .map(|(index, arg)| {
+                self.with_structural_segment(
+                    crate::RirStructuralPathSegment::Operand(index as u32 + 1),
+                    |this| this.convert_call_arg(arg),
+                )
+            })
+            .collect();
+        let name = self.symbol(name);
+        match module {
+            Some(base) => self.rir.add_method_call(base, name, &arg_refs, span),
+            None => self.rir.add_call(name, &arg_refs, span),
+        }
+        .record_failure(&mut self.payload_error)
+    }
+
     fn gen_function(&mut self, func: &Function) -> InstRef {
         self.with_producer_root(&func.body, |this| this.gen_function_body(func))
     }
@@ -1352,33 +1387,8 @@ impl<'a> AstGen<'a> {
                     self.gen_expr_at(crate::RirStructuralPathSegment::Operand(0), base_expr)
                 });
 
-                // Inline type-constructor struct-literal head `F(args) { ... }`
-                // (RUE-596): generate the constructor call `F(args)` as its own
-                // instruction; sema reduces it to the struct type at comptime. When
-                // the head is module-qualified (`std.tuple.Pair(i64, i32) { ... }`,
-                // RUE-951) the constructor is reached through the module base, so
-                // emit a method call on it exactly as the pattern ctor head does
-                // (RUE-947); a bare call would fail to resolve `Pair` locally.
                 let ctor_head = struct_lit.ctor_args.as_ref().map(|args| {
-                    let arg_refs: Vec<_> = args
-                        .iter()
-                        .enumerate()
-                        .map(|(index, arg)| {
-                            self.with_structural_segment(
-                                crate::RirStructuralPathSegment::Operand(index as u32 + 1),
-                                |this| this.convert_call_arg(arg),
-                            )
-                        })
-                        .collect();
-                    let name = self.symbol(struct_lit.name.name);
-                    match module {
-                        Some(base) => {
-                            self.rir
-                                .add_method_call(base, name, &arg_refs, struct_lit.span)
-                        }
-                        None => self.rir.add_call(name, &arg_refs, struct_lit.span),
-                    }
-                    .record_failure(&mut self.payload_error)
+                    self.gen_ctor_head(module, struct_lit.name.name, args, struct_lit.span)
                 });
 
                 let fields: Vec<_> = struct_lit
@@ -1556,21 +1566,6 @@ impl<'a> AstGen<'a> {
                 self.rir.add_inst(Inst {
                     data: InstData::IndexGet { base, index },
                     span: index_expr.span,
-                })
-            }
-            Expr::Path(path_expr) => {
-                // Generate module reference if this is a qualified path
-                let module = path_expr.base.as_ref().map(|base_expr| {
-                    self.gen_expr_at(crate::RirStructuralPathSegment::Operand(0), base_expr)
-                });
-
-                self.rir.add_inst(Inst {
-                    data: InstData::EnumVariant {
-                        module,
-                        type_name: self.symbol(path_expr.type_name.name),
-                        variant: self.symbol(path_expr.variant.name),
-                    },
-                    span: path_expr.span,
                 })
             }
             Expr::MethodCall(method_call) => {
@@ -1783,69 +1778,43 @@ impl<'a> AstGen<'a> {
     /// slot, numbered after the head's module operand and constructor
     /// arguments so the two can never collide.
     fn gen_path_pattern(&mut self, path: &rue_parser::PathPattern) -> RirPattern {
-        {
-            {
-                // If there's a base expression (module reference), generate it first
-                let module = path.base.as_ref().map(|base| {
-                    self.gen_expr_at(crate::RirStructuralPathSegment::Operand(0), base)
-                });
-                // Inline type-constructor pattern head `F(args).Variant(..)`
-                // (RUE-596): generate the constructor call `F(args)` as its own
-                // instruction; sema reduces it to the enum type at comptime. When
-                // the head is module-qualified (`std.result.Result(i32, i32).Ok`,
-                // RUE-947) the constructor is reached through the module base, so
-                // emit a method call on it exactly as the construction head does;
-                // a bare call would fail to resolve `Result` in local scope.
-                let ctor_head = path.ctor_args.as_ref().map(|args| {
-                    let arg_refs: Vec<_> = args
-                        .iter()
-                        .enumerate()
-                        .map(|(index, arg)| {
-                            self.with_structural_segment(
-                                crate::RirStructuralPathSegment::Operand(index as u32 + 1),
-                                |this| this.convert_call_arg(arg),
-                            )
-                        })
-                        .collect();
-                    let name = self.symbol(path.type_name.name);
-                    match module {
-                        Some(base) => self.rir.add_method_call(base, name, &arg_refs, path.span),
-                        None => self.rir.add_call(name, &arg_refs, path.span),
-                    }
-                    .record_failure(&mut self.payload_error)
-                });
-                // Payload positions of a tuple-variant pattern (RUE-221): a
-                // binder, or a nested variant pattern (RUE-2053).
-                let ctor_arity = path.ctor_args.as_ref().map_or(0, |args| args.len());
-                let elements: Vec<RirPatternElement> = path
-                    .elements
-                    .iter()
-                    .enumerate()
-                    .map(|(position, element)| match element {
-                        rue_parser::PatternElement::Binding(name) => {
-                            RirPatternElement::Binding(self.symbol(name.name))
-                        }
-                        rue_parser::PatternElement::Nested(nested) => {
-                            let segment = crate::RirStructuralPathSegment::Operand(
-                                (1 + ctor_arity + position) as u32,
-                            );
-                            RirPatternElement::Nested(
-                                self.with_structural_segment(segment, |this| {
-                                    this.gen_path_pattern(nested)
-                                }),
-                            )
-                        }
-                    })
-                    .collect();
-                RirPattern::Path {
-                    module,
-                    ctor_head,
-                    type_name: self.symbol(path.type_name.name),
-                    variant: self.symbol(path.variant.name),
-                    elements,
-                    span: path.span,
+        // The module reference the head is qualified by, if any.
+        let module = path
+            .base
+            .as_ref()
+            .map(|base| self.gen_expr_at(crate::RirStructuralPathSegment::Operand(0), base));
+        let ctor_head = path
+            .ctor_args
+            .as_ref()
+            .map(|args| self.gen_ctor_head(module, path.type_name.name, args, path.span));
+        // Payload positions of a tuple-variant pattern (RUE-221): a
+        // binder, or a nested variant pattern (RUE-2053).
+        let ctor_arity = path.ctor_args.as_ref().map_or(0, |args| args.len());
+        let elements: Vec<RirPatternElement> = path
+            .elements
+            .iter()
+            .enumerate()
+            .map(|(position, element)| match element {
+                rue_parser::PatternElement::Binding(name) => {
+                    RirPatternElement::Binding(self.symbol(name.name))
                 }
-            }
+                rue_parser::PatternElement::Nested(nested) => {
+                    let segment = crate::RirStructuralPathSegment::Operand(
+                        (1 + ctor_arity + position) as u32,
+                    );
+                    RirPatternElement::Nested(
+                        self.with_structural_segment(segment, |this| this.gen_path_pattern(nested)),
+                    )
+                }
+            })
+            .collect();
+        RirPattern::Path {
+            module,
+            ctor_head,
+            type_name: self.symbol(path.type_name.name),
+            variant: self.symbol(path.variant.name),
+            elements,
+            span: path.span,
         }
     }
 
@@ -2945,13 +2914,6 @@ impl SiteWalker {
             Expr::MethodCall(method_call) => {
                 self.operand(0, |this| this.walk_expr(&method_call.receiver));
                 self.walk_call_args(&method_call.args, 1);
-            }
-            Expr::Path(path) => {
-                // A path expression carries only an optional module base; inline
-                // type-constructor heads are a pattern-only form (`walk_pattern`).
-                if let Some(base) = &path.base {
-                    self.operand(0, |this| this.walk_expr(base));
-                }
             }
             Expr::IntrinsicCall(intrinsic) => {
                 // `gen_expr` enumerates every argument to keep operand indices

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -96,8 +96,8 @@ ALLOWANCES = {
         "oracle harness ABI, representation-vector, and typed-view bookkeeping"
         " checks, not compiler correctness gates",
     ),
+    "crates/rue-parser/src/parser/expressions.rs": Allowance(1, "redundant parser entry precondition"),
     "crates/rue-parser/src/parser/shared.rs": Allowance(2, "redundant parser entry preconditions"),
-    "crates/rue-parser/src/parser/statements.rs": Allowance(1, "redundant parser entry precondition"),
     "crates/rue-rir/src/inst/payload.rs": Allowance(
         1, "redundant RIR variable-width encoding check"
     ),


### PR DESCRIPTION
## Summary

The pattern grammar carried a second, hand-rolled path parser: `path_pattern` walked its own `IDENT (.IDENT)* [ctor(args)] .IDENT` chain, scanned paren groups with its own lookahead, and rebuilt the module prefix as an `Expr::Field` chain by hand, all of which the expression path forms in `ident_expr` and `postfix` already do.

- `Parser::path_head` in the expression module now parses that head once. It returns a `PathHead` (module prefix already folded into the `Expr::Field` chain `postfix` builds, the type name, and the inline type-constructor call attached to it) plus the trailing name the caller classifies. `path_pattern` is that classification only: the trailing name is the variant, and a terminal `(...)` is its payload list of `pattern_element`s rather than call arguments. The three struct-literal heads (`P { .. }`, `m.P(args) { .. }`, `Self { .. }`) build their literal through `PathHead::into_struct_lit`, so a pattern head and a struct-literal head are one representation. The paren lookahead lives once, as `ctor_group_precedes_dot`.
- The accepted pattern grammar does not move and stays inside the spec's `pattern_head` (4.7:2): `(Color).Red`, `Self.Red` and `(Color.Red)` in pattern position are still "expected pattern"; constructor arguments must still follow the final type path segment; a head with no variant still reports the missing `.` at the token that ends the head (the first segment takes its `(...)` group unconditionally, which is what keeps `Some(v) => v` reporting at the `=>`, pinning the `diagnostics/parser_recovery` golden).
- `Expr::Path` / `PathExpr` are deleted with every dead consumer arm (parser AST span/children/rebind/printer, `validate.rs`, RIR astgen and its anonymous-site walk, the compiler's artifact view, parsed-module visitor and retained-charge accounting, the frontend-diff shape mapping) and the `rue_parser::PathExpr` re-export. Seven crates had dead arms, not eight: the `Expr::Path` matches in `rue-air/src/api_inventory.rs` are `syn::Expr::Path` over Rust source. No API inventory or shape-identity value changed.
- astgen's copy-pasted inline type-constructor lowering is now one `gen_ctor_head`, called from both the struct-literal and pattern arms.
- The parser's one reviewed debug assertion moved with the paren lookahead from `statements.rs` to `expressions.rs`, so the debug-assertion ledger key moves; the count is unchanged.

Not done: RIR `InstData::EnumVariant` now has no producer at all. It was already unreachable (its only astgen producer was the dead `Expr::Path` arm), so nothing regressed, but removing it ripples through packed encoding, validation, printer, comptime, inference, aggregates and analysis and is a separate change.

## Tests

Parser unit tests pin the module-qualified head with and without bindings, the generic-call head, the RUE-2053 nested-variant shapes, the rejected heads (`non_pattern_heads_are_still_rejected_as_patterns`), and the missing-dot diagnostic (`a_head_without_a_variant_reports_the_missing_dot`). No goldens moved.

## Validation

`scripts/rue fmt`, `quick` (36/36), `unit parser` (84), `unit rir` (151), `unit compiler` (1233), `ui` (437), `spec` (2885), `cli enum match nested_variant_patterns modules` (360), and the frontend-diff, oracle-diff, debug-assert-ledger, debug-assert-policy-tool, spec-traceability and planted-miscompile-isolation gates, all passing on the rebased tree. The agent's full `cli` (2731 passed, the two environmental cases) and `premerge` (Pass 219, Fail 0) on the pre-rebase tree passed.

Closes RUE-1988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_