### PR TITLE
One owner for a generic call's comptime arguments

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2058,6 +2058,7 @@ impl<'a> ConstraintGenerator<'a> {
                 let alias_target = self.const_function_alias((span.file_id, *name));
                 let function_key =
                     alias_target.or_else(|| self.function_by_file((span.file_id, *name)));
+                let arg_range = args;
                 let args = self.rir.call_args(args);
                 let mut arg_diverged = false;
                 // `print(s)` / `println(s)` builtin free functions (RUE-1):
@@ -2086,162 +2087,13 @@ impl<'a> ConstraintGenerator<'a> {
                     // type value), the constraint is skipped and the check happens in
                     // semantic analysis instead (RUE-73, RUE-99).
                     if func.is_generic {
-                        // Process all arguments once, collecting their inferred types
-                        let mut arg_infos = Vec::with_capacity(args.len());
-                        for arg in args.iter() {
-                            if self.was_canceled() {
-                                break;
-                            }
-                            let info =
-                                self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
-                            arg_diverged |= !info.continues;
-                            arg_infos.push(info);
-                            if self.was_canceled() {
-                                break;
-                            }
-                        }
-
-                        // Build the type substitution map from comptime type arguments
-                        let mut type_subst: AHashMap<lasso::Spur, Type> = AHashMap::new();
-                        // Comptime VALUE arguments (`comptime N: i32`) captured
-                        // as their integer constant, so a return/param type
-                        // sized by one — an array length `[i32; N]` — resolves
-                        // at this call (RUE-252).
-                        let mut value_subst: AHashMap<lasso::Spur, i128> = AHashMap::new();
-                        for (i, arg) in args.iter().enumerate() {
-                            if self.was_canceled() {
-                                break;
-                            }
-                            if i >= func.param_comptime.len()
-                                || !func.param_comptime[i]
-                                || i >= func.param_names.len()
-                            {
-                                continue;
-                            }
-                            if func.param_comptime_type.get(i) == Some(&true) {
-                                if let Some(ConstValue::Type(concrete_ty)) =
-                                    self.comptime_argument_value(arg.value)
-                                {
-                                    type_subst.insert(func.param_names[i], concrete_ty);
-                                } else if let Some(concrete_ty) =
-                                    self.extract_type_argument(arg.value, ctx)
-                                {
-                                    type_subst.insert(func.param_names[i], concrete_ty);
-                                }
-                            } else if let Some(ConstValue::Integer(v)) =
-                                self.comptime_argument_value(arg.value)
-                            {
-                                value_subst.insert(func.param_names[i], v);
-                            }
-                        }
-
-                        // Constrain each runtime argument to its parameter type, with
-                        // type parameters substituted. Comptime type parameters (the
-                        // `T: type` arguments themselves) are validated in sema.
-                        for (i, arg_info) in arg_infos.iter().enumerate() {
-                            if self.was_canceled() {
-                                break;
-                            }
-                            if i >= func.param_types.len() || i >= func.param_comptime.len() {
-                                break;
-                            }
-                            let declared = &func.param_types[i];
-                            if self.staged_comptime_selectors
-                                && self
-                                    .comptime_argument_values
-                                    .is_none_or(|values| values.is_empty())
-                                && *declared == InferType::Concrete(Type::COMPTIME_TYPE)
-                            {
-                                continue;
-                            }
-                            if func.param_comptime_type.get(i) == Some(&true) {
-                                // Comptime TYPE parameter - the argument is a type value
-                                continue;
-                            }
-                            let expected = if *declared == InferType::Concrete(Type::COMPTIME_TYPE)
-                            {
-                                // Generic parameter like `x: T`, or a composite
-                                // mentioning a type parameter like `a: [T; 3]`
-                                // (RUE-172) - substitute T
-                                match func.param_type_syntax.get(i).and_then(|syntax| {
-                                    syntax.as_ref().and_then(|syntax| {
-                                        self.infer_structured_type_hint(
-                                            syntax,
-                                            &type_subst,
-                                            &value_subst,
-                                            span.file_id,
-                                        )
-                                    })
-                                }) {
-                                    Some(ty) => ty,
-                                    // Unknown type parameter - checked in sema
-                                    None => continue,
-                                }
-                            } else {
-                                declared.clone()
-                            };
-                            // Slice parameters coerce from an array argument
-                            // (ADR-0043, RUE-322); see the non-generic path.
-                            if self.is_slice_struct_type(expected.clone()) {
-                                continue;
-                            }
-                            self.add_constraint(Constraint::equal(
-                                arg_info.ty.clone(),
-                                expected,
-                                arg_info.span,
-                            ));
-                        }
-
-                        // Compute the actual return type by substituting type
-                        // parameters - bare (`-> T`) or inside a composite
-                        // (`-> [T; 3]`, RUE-172).
-                        let return_type = if func.return_type
-                            == InferType::Concrete(Type::COMPTIME_TYPE)
-                        {
-                            match self.substituted_generic_return_type(
-                                &func,
-                                &type_subst,
-                                &value_subst,
-                                span.file_id,
-                            ) {
-                                Some(ty) => ty,
-                                None => {
-                                    // The declared return type is a
-                                    // type-function application to a type
-                                    // parameter (`-> Option(T)`; RUE-272).
-                                    // The constraint generator can't reduce
-                                    // a `-> type` constructor body, so it
-                                    // can't name the monomorphized
-                                    // struct/enum here — sema computes the
-                                    // true type in the analyze pass. Use a
-                                    // fresh inference variable (pinned by
-                                    // the call's use site) rather than the
-                                    // `COMPTIME_TYPE` placeholder, which
-                                    // would spuriously unify against the real
-                                    // result type and reject the program
-                                    // (E0206). A literal `-> type`
-                                    // constructor call is NOT a type-call in
-                                    // this sense and still yields
-                                    // `COMPTIME_TYPE`.
-                                    let is_type_call =
-                                        func.return_type_syntax.as_ref().is_some_and(|syntax| {
-                                            matches!(
-                                                syntax.arena.node(syntax.root),
-                                                Some(RirTypeSyntaxNode::TypeCall { .. })
-                                            )
-                                        });
-                                    if self.staged_comptime_selectors || is_type_call {
-                                        InferType::Var(self.fresh_var())
-                                    } else {
-                                        func.return_type.clone()
-                                    }
-                                }
-                            }
-                        } else {
-                            func.return_type.clone()
-                        };
-
-                        return_type
+                        self.generate_generic_call(
+                            &func,
+                            arg_range,
+                            span.file_id,
+                            &mut arg_diverged,
+                            ctx,
+                        )
                     } else if args.len() != func.param_types.len() {
                         // Check argument count matches parameter count.
                         // Semantic analysis will emit a proper error; we just need to avoid
@@ -3914,172 +3766,64 @@ impl<'a> ConstraintGenerator<'a> {
                                 .and_then(|file_id| self.function_by_file((file_id, *method)))
                         });
                         if let Some(func) = function_key.and_then(|key| self.func_sig(key)) {
-                            // Populated by the generic branch below and read by
-                            // the return-type substitution after it.
-                            let mut type_subst: AHashMap<lasso::Spur, Type> = AHashMap::new();
-                            let mut value_subst: AHashMap<lasso::Spur, i128> = AHashMap::new();
-                            if !func.is_generic && call_args.len() == func.param_types.len() {
-                                // Constrain each argument against its declared
-                                // parameter type (same as a direct Call).
-                                for (arg, param_ty) in call_args.iter().zip(func.param_types.iter())
-                                {
-                                    let arg_info = self.generate_sequenced_operand(
-                                        arg.value,
-                                        ctx,
-                                        !arg_diverged,
-                                    );
-                                    arg_diverged |= !arg_info.continues;
-                                    if self.was_canceled() {
-                                        break;
-                                    }
-                                    // Slice and `borrow str` parameters coerce
-                                    // from a `borrow` argument; skip strict
-                                    // equality and let sema materialize the
-                                    // fat-pointer view (ADR-0043, RUE-322,
-                                    // RUE-559) — same as the direct-Call path.
-                                    if self.is_slice_struct_type(param_ty.clone()) {
-                                        continue;
-                                    }
-                                    self.add_constraint(Constraint::contextual(
-                                        arg_info.ty,
-                                        param_ty.clone(),
-                                        arg_info.span,
-                                    ));
-                                }
-                            } else if func.is_generic {
-                                // Generic module-member callee (RUE-693): mirror
-                                // the direct-Call generic path. Build the type
-                                // substitution from the comptime type arguments,
-                                // then constrain each runtime argument to its
-                                // *substituted* parameter type. Without this, a
-                                // literal argument to `h.min(i64, 3, 7)` stayed
-                                // unconstrained across the module boundary and
-                                // defaulted to i32, clashing with the instantiated
-                                // i64 parameter (the non-generic path above already
-                                // constrains, and same-file generic Calls do too).
-                                let mut arg_infos = Vec::with_capacity(call_args.len());
-                                for arg in call_args.iter() {
-                                    let info = self.generate_sequenced_operand(
-                                        arg.value,
-                                        ctx,
-                                        !arg_diverged,
-                                    );
-                                    arg_diverged |= !info.continues;
-                                    arg_infos.push(info);
-                                    if self.was_canceled() {
-                                        break;
-                                    }
-                                }
-                                for (i, arg) in call_args.iter().enumerate() {
-                                    if self.was_canceled() {
-                                        break;
-                                    }
-                                    if i >= func.param_comptime.len()
-                                        || !func.param_comptime[i]
-                                        || i >= func.param_names.len()
-                                    {
-                                        continue;
-                                    }
-                                    if func.param_comptime_type.get(i) == Some(&true) {
-                                        if let Some(concrete_ty) =
-                                            self.extract_type_argument(arg.value, ctx)
-                                        {
-                                            type_subst.insert(func.param_names[i], concrete_ty);
-                                        }
-                                    } else if let Some(ConstValue::Integer(v)) =
-                                        self.comptime_argument_value(arg.value)
-                                    {
-                                        value_subst.insert(func.param_names[i], v);
-                                    }
-                                }
-                                for (i, arg_info) in arg_infos.iter().enumerate() {
-                                    if self.was_canceled() {
-                                        break;
-                                    }
-                                    if i >= func.param_types.len() || i >= func.param_comptime.len()
-                                    {
-                                        break;
-                                    }
-                                    if func.param_comptime_type.get(i) == Some(&true) {
-                                        continue;
-                                    }
-                                    let declared = &func.param_types[i];
-                                    if self.staged_comptime_selectors
-                                        && value_subst.is_empty()
-                                        && *declared == InferType::Concrete(Type::COMPTIME_TYPE)
-                                    {
-                                        continue;
-                                    }
-                                    let expected =
-                                        if *declared == InferType::Concrete(Type::COMPTIME_TYPE) {
-                                            match func.param_type_syntax.get(i).and_then(|syntax| {
-                                                syntax.as_ref().and_then(|syntax| {
-                                                    self.infer_structured_type_hint(
-                                                        syntax,
-                                                        &type_subst,
-                                                        &value_subst,
-                                                        span.file_id,
-                                                    )
-                                                })
-                                            }) {
-                                                Some(ty) => ty,
-                                                None => continue,
-                                            }
-                                        } else {
-                                            declared.clone()
-                                        };
-                                    if self.is_slice_struct_type(expected.clone()) {
-                                        continue;
-                                    }
-                                    self.add_constraint(Constraint::equal(
-                                        arg_info.ty.clone(),
-                                        expected,
-                                        arg_info.span,
-                                    ));
-                                }
-                            } else {
-                                // Arity mismatch: just process the arguments;
-                                // sema checks the rest.
-                                for arg in call_args.iter() {
-                                    let info = self.generate_sequenced_operand(
-                                        arg.value,
-                                        ctx,
-                                        !arg_diverged,
-                                    );
-                                    arg_diverged |= !info.continues;
-                                    if self.was_canceled() {
-                                        break;
-                                    }
-                                }
-                            }
-                            if func.return_type == InferType::Concrete(Type::COMPTIME_TYPE) {
-                                // `-> T` resolves from this call's type
-                                // arguments on the same canonical route as the
-                                // direct-Call path. A bare fresh variable let
-                                // the use site decide instead: in
-                                // `h.sq(f32, v) == 6.25` the literal defaulted
-                                // to `f64` and unified with the unconstrained
-                                // result, while sema specialized the call to
-                                // `f32` — a mismatch that only surfaced as an
-                                // AIR verification ICE. Float type names are
-                                // ordinary identifiers rather than lexer
-                                // keywords (ADR-0065), so `f32` arrives here as
-                                // a `VarRef` and is resolved by
-                                // `extract_type_argument`'s primitive lookup
-                                // above.
-                                //
-                                // A return type that still can't be reduced
-                                // here (a type-function application such as
-                                // `-> Option(T)`) keeps the fresh variable;
-                                // sema specialization determines it.
-                                self.substituted_generic_return_type(
+                            if func.is_generic {
+                                // Generic module-member callee (RUE-693): the
+                                // same owner the direct-`Call` path uses, so a
+                                // module boundary cannot change which comptime
+                                // arguments are captured or whether `-> T` is
+                                // substituted.
+                                self.generate_generic_call(
                                     &func,
-                                    &type_subst,
-                                    &value_subst,
+                                    args,
                                     span.file_id,
+                                    &mut arg_diverged,
+                                    ctx,
                                 )
-                                .unwrap_or_else(|| InferType::Var(self.fresh_var()))
                             } else {
+                                if call_args.len() == func.param_types.len() {
+                                    // Constrain each argument against its declared
+                                    // parameter type (same as a direct Call).
+                                    for (arg, param_ty) in
+                                        call_args.iter().zip(func.param_types.iter())
+                                    {
+                                        let arg_info = self.generate_sequenced_operand(
+                                            arg.value,
+                                            ctx,
+                                            !arg_diverged,
+                                        );
+                                        arg_diverged |= !arg_info.continues;
+                                        if self.was_canceled() {
+                                            break;
+                                        }
+                                        // Slice and `borrow str` parameters coerce
+                                        // from a `borrow` argument; skip strict
+                                        // equality and let sema materialize the
+                                        // fat-pointer view (ADR-0043, RUE-322,
+                                        // RUE-559) — same as the direct-Call path.
+                                        if self.is_slice_struct_type(param_ty.clone()) {
+                                            continue;
+                                        }
+                                        self.add_constraint(Constraint::contextual(
+                                            arg_info.ty,
+                                            param_ty.clone(),
+                                            arg_info.span,
+                                        ));
+                                    }
+                                } else {
+                                    // Arity mismatch: just process the arguments;
+                                    // sema checks the rest.
+                                    for arg in call_args.iter() {
+                                        let info = self.generate_sequenced_operand(
+                                            arg.value,
+                                            ctx,
+                                            !arg_diverged,
+                                        );
+                                        arg_diverged |= !info.continues;
+                                        if self.was_canceled() {
+                                            break;
+                                        }
+                                    }
+                                }
                                 func.return_type.clone()
                             }
                         } else {
@@ -4589,6 +4333,14 @@ impl<'a> ConstraintGenerator<'a> {
     /// Returns `None` — with the arguments NOT yet visited — when `function`
     /// is not a variant/associated function of `ty`; the caller processes the
     /// arguments and lets sema diagnose.
+    ///
+    /// A callee reached this way is never generic, so it has no comptime
+    /// argument for [`Self::generate_generic_call`] to capture: semantic
+    /// analysis specializes free-function calls only, and an associated
+    /// function declared with a `comptime` parameter is monomorphized nowhere
+    /// in the pipeline. `ty` itself is already the monomorphized type, so its
+    /// members' declared parameter and return types carry the substitution the
+    /// generic owner would otherwise apply.
     fn generate_call_on_reduced_type(
         &mut self,
         ty: Type,
@@ -4960,47 +4712,179 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
-    /// Resolve a call argument used as a comptime type value (e.g. the `i32` in
-    /// `identity(i32, 42)`) to a concrete type, if it can be determined during
-    /// constraint generation.
+    /// Generate constraints for a call whose callee has comptime parameters —
+    /// one owner for both call shapes that resolve a generic function
+    /// signature, the direct `f(..)` and the module member `m.f(..)`, so a
+    /// module boundary cannot change which comptime arguments are captured,
+    /// which parameter types they are substituted into, or whether a `-> T`
+    /// return is resolved.
     ///
-    /// Handles type literals (`i32`, `bool`, ...), named struct/enum types
-    /// (user-declared as well as built-in), and forwarded type parameters (a
-    /// reference to `T` inside a specialized generic body, resolved via
-    /// `self.type_subst`). Returns `None` for type values that are only known
-    /// to semantic analysis (e.g. a local variable bound to an anonymous struct
-    /// type) - those are type-checked in sema instead.
+    /// The captured facts come from semantic analysis: `argument_values` holds
+    /// each comptime argument as the canonical comptime engine evaluated it
+    /// (`collect_generic_argument_facts`), so an argument spelled as a computed
+    /// type (`Id(u64)`), a `const` alias, a `let`-bound alias, or a plain type
+    /// name all arrive here as the same `ConstValue`. Constraint generation
+    /// answers only the two forms that need no evaluation at all — see
+    /// [`Self::extract_type_argument`].
+    ///
+    /// `arg_diverged` is threaded so the caller keeps the call's own
+    /// reachability accounting.
+    fn generate_generic_call(
+        &mut self,
+        func: &FunctionSig,
+        args: &rue_rir::RirCallArgsRange,
+        file_id: FileId,
+        arg_diverged: &mut bool,
+        ctx: &mut ConstraintContext,
+    ) -> InferType {
+        let args = self.rir.call_args(args);
+        // Process all arguments once, collecting their inferred types.
+        let mut arg_infos = Vec::with_capacity(args.len());
+        for arg in args.iter() {
+            if self.was_canceled() {
+                break;
+            }
+            let info = self.generate_sequenced_operand(arg.value, ctx, !*arg_diverged);
+            *arg_diverged |= !info.continues;
+            arg_infos.push(info);
+            if self.was_canceled() {
+                break;
+            }
+        }
+
+        // Comptime TYPE arguments give the type substitution; comptime VALUE
+        // arguments (`comptime N: i32`) give the value substitution, so a
+        // parameter or return type sized by one — an array length `[i32; N]` —
+        // resolves at this call (RUE-252).
+        let mut type_subst: AHashMap<lasso::Spur, Type> = AHashMap::new();
+        let mut value_subst: AHashMap<lasso::Spur, i128> = AHashMap::new();
+        for (i, arg) in args.iter().enumerate() {
+            if self.was_canceled() {
+                break;
+            }
+            if i >= func.param_comptime.len()
+                || !func.param_comptime[i]
+                || i >= func.param_names.len()
+            {
+                continue;
+            }
+            if func.param_comptime_type.get(i) == Some(&true) {
+                if let Some(ConstValue::Type(concrete_ty)) = self.comptime_argument_value(arg.value)
+                {
+                    type_subst.insert(func.param_names[i], concrete_ty);
+                } else if let Some(concrete_ty) = self.extract_type_argument(arg.value, ctx) {
+                    type_subst.insert(func.param_names[i], concrete_ty);
+                }
+            } else if let Some(ConstValue::Integer(v)) = self.comptime_argument_value(arg.value) {
+                value_subst.insert(func.param_names[i], v);
+            }
+        }
+
+        // A staged probe pass runs before the canonical argument facts exist.
+        // Substituting from the necessarily incomplete map there would pin a
+        // parameter to the wrong type, so leave those parameters to the final
+        // pass, which has the facts.
+        let facts_pending = self.staged_comptime_selectors
+            && self
+                .comptime_argument_values
+                .is_none_or(|values| values.is_empty());
+
+        // Constrain each runtime argument to its parameter type, with type
+        // parameters substituted. Comptime type parameters (the `T: type`
+        // arguments themselves) are validated in sema.
+        for (i, arg_info) in arg_infos.iter().enumerate() {
+            if self.was_canceled() {
+                break;
+            }
+            if i >= func.param_types.len() || i >= func.param_comptime.len() {
+                break;
+            }
+            if func.param_comptime_type.get(i) == Some(&true) {
+                // Comptime TYPE parameter - the argument is a type value.
+                continue;
+            }
+            let declared = &func.param_types[i];
+            let expected = if *declared == InferType::Concrete(Type::COMPTIME_TYPE) {
+                if facts_pending {
+                    continue;
+                }
+                // Generic parameter like `x: T`, or a composite mentioning a
+                // type parameter like `a: [T; 3]` (RUE-172) - substitute T.
+                match func.param_type_syntax.get(i).and_then(|syntax| {
+                    syntax.as_ref().and_then(|syntax| {
+                        self.infer_structured_type_hint(syntax, &type_subst, &value_subst, file_id)
+                    })
+                }) {
+                    Some(ty) => ty,
+                    // Unknown type parameter - checked in sema.
+                    None => continue,
+                }
+            } else {
+                declared.clone()
+            };
+            // Slice parameters coerce from an array argument (ADR-0043,
+            // RUE-322); see the non-generic path.
+            if self.is_slice_struct_type(expected.clone()) {
+                continue;
+            }
+            self.add_constraint(Constraint::equal(
+                arg_info.ty.clone(),
+                expected,
+                arg_info.span,
+            ));
+        }
+
+        // Compute the actual return type by substituting type parameters —
+        // bare (`-> T`) or inside a composite (`-> [T; 3]`, RUE-172).
+        if func.return_type == InferType::Concrete(Type::COMPTIME_TYPE) {
+            // A return type that cannot be reduced here — an unresolved type
+            // parameter, or a type-function application such as `-> Option(T)`
+            // whose monomorphized struct/enum only sema can name — becomes a
+            // fresh variable pinned by the call's use site. The `COMPTIME_TYPE`
+            // placeholder would instead unify against the real result type and
+            // reject the program (E0206), and a bare fresh variable with no
+            // substitution attempt would let the use site decide a type sema
+            // never agreed to (`h.sq(f32, v) == 6.25` defaulted the literal to
+            // `f64` against an `f32` specialization, an AIR verification ICE).
+            self.substituted_generic_return_type(func, &type_subst, &value_subst, file_id)
+                .unwrap_or_else(|| InferType::Var(self.fresh_var()))
+        } else {
+            func.return_type.clone()
+        }
+    }
+
+    /// Name-resolve a comptime type argument that needs no evaluation: a
+    /// written type literal (the `i32` in `identity(i32, 42)`), and a name that
+    /// the canonical unqualified-nominal selector binds to a type — a type
+    /// parameter forwarded from the enclosing specialization, a `let`-bound
+    /// comptime alias sema pre-resolved for this walk, a file-level `const`
+    /// alias, a primitive, a declared or built-in struct/enum.
+    ///
+    /// This is a fallback, never a peer: [`Self::generate_generic_call`] asks
+    /// [`Self::comptime_argument_value`] first, so an argument the comptime
+    /// engine evaluated (a computed type such as `Id(u64)`, or any of the
+    /// spellings above) is taken from that one evaluation. `None` means the
+    /// argument is a form only semantic analysis can reduce, and the parameter
+    /// and return constraints that would depend on it are left to it.
     fn extract_type_argument(&self, arg: InstRef, ctx: &ConstraintContext) -> Option<Type> {
         let file_id = self.rir.get(arg).span.file_id;
         match &self.rir.get(arg).data {
             InstData::TypeConst { type_name } => {
-                match self.infer_rir_type_hint(*type_name, self.rir.get(arg).span.file_id) {
+                match self.infer_rir_type_hint(*type_name, file_id) {
                     Some(InferType::Concrete(ty)) => Some(ty),
                     _ => None,
                 }
             }
-            // A struct/enum name or forwarded type parameter used as a value
-            // parses as a variable reference, not a type literal.
+            // A struct/enum name, an alias, or a forwarded type parameter used
+            // as a value parses as a variable reference, not a type literal.
+            //
+            // A local or parameter shadows any same-named struct/enum. A local
+            // *not* bound to a comptime type value (a runtime value) has no
+            // concrete type here. Preserve that error through dependent
+            // substitutions so inference does not manufacture a downstream
+            // mismatch; sema reports the canonical comptime known-value
+            // diagnostic at the argument itself.
             InstData::VarRef { name, .. } => {
-                // A local bound to a type value (`let X = i32; identity(X, 42)`
-                // or `let P = Pair(i32); f(P, ..)`) resolves to that bound type
-                // via the in-scope comptime-alias view — the same map
-                // generic-enum construction/matching consults (`enum_type_for`).
-                // Without this the type argument was left unresolved, so the
-                // call's return type defaulted to the literal `type` and
-                // mismatched the substituted element type (spurious E0206,
-                // RUE-281). The literal form (`identity(i32, 42)`) already
-                // worked via the `TypeConst` arm; this makes an aliased type
-                // behave identically.
-                // A local or parameter shadows any same-named struct/enum. A
-                // local *not* bound to a comptime type value (a runtime value)
-                // has no concrete type here. Preserve that error through
-                // dependent substitutions so inference does not manufacture a
-                // downstream mismatch; sema reports the canonical comptime
-                // known-value diagnostic at the argument itself.
-                // Forwarded type parameters (`T` inside a specialized generic
-                // body) are not in scope as runtime params/locals and resolve
-                // via `self.type_subst` above.
                 let lexical_shadowed = ctx.locals.contains_key(name) || ctx.contains_param(*name);
                 self.unqualified_nominal_type_with_substitution(
                     *name,
@@ -5017,12 +4901,10 @@ impl<'a> ConstraintGenerator<'a> {
     /// callee's declared return-type syntax — a bare `-> T`, or a composite
     /// mentioning a type parameter such as `-> [T; 3]` (RUE-172).
     ///
-    /// This is the one route both call shapes take: the same-module
-    /// `InstData::Call` path and the module-qualified `module.f(...)` path,
-    /// which previously left `-> T` as a bare inference variable. `None` means
-    /// the declared return type cannot be reduced during constraint generation
-    /// (an unresolved type parameter, or a type-function application like
-    /// `-> Option(T)`); each caller keeps its own fallback for that case.
+    /// `None` means the declared return type cannot be reduced during
+    /// constraint generation (an unresolved type parameter, or a type-function
+    /// application like `-> Option(T)`); [`Self::generate_generic_call`], its
+    /// one caller, falls back to a fresh inference variable.
     fn substituted_generic_return_type(
         &self,
         func: &FunctionSig,

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -464,27 +464,27 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
             let inst = self.body_rir_ref().get(inst_ref);
             let found = match &inst.data {
-                rue_rir::InstData::Call { name, args }
-                | rue_rir::InstData::MethodCall {
-                    method: name, args, ..
-                } => {
-                    let function_key = self
-                        .resolve_function_name_local(*name, inst.span.file_id)
-                        .unwrap_or(*name);
-                    self.function_info(function_key).is_some_and(|function| {
-                        if !function.is_generic {
-                            false
-                        } else {
+                rue_rir::InstData::Call { args, .. }
+                | rue_rir::InstData::MethodCall { args, .. } => {
+                    self.generic_callee_key(&inst.data, inst.span, None)
+                        .and_then(|key| self.function_info(key))
+                        .is_some_and(|function| {
+                            if !function.is_generic {
+                                return false;
+                            }
+                            // Every comptime argument is a fact site, type
+                            // arguments included: inference substitutes the
+                            // captured type into the callee's parameter and
+                            // return types, and the canonical evaluation this
+                            // pre-pass produces is where that type comes from,
+                            // whatever the argument's spelling (RUE-1967).
                             let param_data = self.body_param_data(function.params);
-                            let param_is_type = self.comptime_type_param_flags(&function);
                             self.body_rir_ref().call_args(args).iter().enumerate().any(
                                 |(index, _)| {
                                     param_data.comptime().get(index).copied().unwrap_or(false)
-                                        && !param_is_type.get(index).copied().unwrap_or(false)
                                 },
                             )
-                        }
-                    })
+                        })
                 }
                 _ => false,
             };
@@ -1246,51 +1246,24 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                 bindings: bindings.clone(),
                             });
                         }
-                        rue_rir::InstData::Call { name, args } => {
-                            let call_span = inst_span;
-                            let function_key = self
-                                .resolve_function_name_local(*name, call_span.file_id)
-                                .unwrap_or(*name);
-                            let call_args = self.body_rir_ref().call_args(args).to_vec();
-                            canonical_evaluations = canonical_evaluations.saturating_add(
-                                self.collect_generic_argument_facts(
-                                    function_key,
-                                    &call_args,
-                                    call_span,
-                                    resolved_types,
-                                    type_subst,
-                                    value_subst,
-                                    &bindings,
-                                    &mut argument_values,
-                                ),
-                            );
-                        }
-                        rue_rir::InstData::MethodCall {
-                            receiver,
-                            method,
-                            args,
-                        } => {
-                            if let Some(module) =
-                                resolved_types.get(receiver).and_then(Type::as_module)
+                        rue_rir::InstData::Call { args, .. }
+                        | rue_rir::InstData::MethodCall { args, .. } => {
+                            if let Some(function_key) =
+                                self.generic_callee_key(&inst_data, inst_span, Some(resolved_types))
                             {
-                                let module_file = self.module_def(module).file_id;
-                                if let Some(function_key) =
-                                    self.resolve_function_name_local(*method, module_file)
-                                {
-                                    let call_args = self.body_rir_ref().call_args(args).to_vec();
-                                    canonical_evaluations = canonical_evaluations.saturating_add(
-                                        self.collect_generic_argument_facts(
-                                            function_key,
-                                            &call_args,
-                                            inst_span,
-                                            resolved_types,
-                                            type_subst,
-                                            value_subst,
-                                            &bindings,
-                                            &mut argument_values,
-                                        ),
-                                    );
-                                }
+                                let call_args = self.body_rir_ref().call_args(args).to_vec();
+                                canonical_evaluations = canonical_evaluations.saturating_add(
+                                    self.collect_generic_argument_facts(
+                                        function_key,
+                                        &call_args,
+                                        inst_span,
+                                        resolved_types,
+                                        type_subst,
+                                        value_subst,
+                                        &bindings,
+                                        &mut argument_values,
+                                    ),
+                                );
                             }
                         }
                         _ => {}
@@ -1352,6 +1325,68 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             scope_nodes,
             scope_materializations,
         ))
+    }
+
+    /// The callee key one call instruction would specialize, for the two call
+    /// shapes that can name a generic function: a direct `f(..)` and a module
+    /// member `m.f(..)`.
+    ///
+    /// The staged pre-pass gate and the fact collector must agree on this. When
+    /// they did not, a module-member generic call was not recognized as a fact
+    /// site, the pre-pass never ran for it, and inference fell back to whatever
+    /// spellings it could name-resolve itself — so the same call took its
+    /// comptime arguments from a different source than a direct call did
+    /// (RUE-1967).
+    ///
+    /// `resolved_types` is the collector's inferred-type map, which resolves
+    /// any receiver expression. The gate runs before those types exist and
+    /// passes `None`; a receiver naming a module binding in this file is still
+    /// resolvable from the declaration state alone, and a receiver that is not
+    /// (a re-export chain) simply leaves the body on the single-pass route it
+    /// was on before.
+    fn generic_callee_key(
+        &self,
+        inst_data: &rue_rir::InstData,
+        span: Span,
+        resolved_types: Option<&AHashMap<InstRef, Type>>,
+    ) -> Option<Spur> {
+        match inst_data {
+            rue_rir::InstData::Call { name, .. } => Some(
+                self.resolve_function_name_local(*name, span.file_id)
+                    .unwrap_or(*name),
+            ),
+            rue_rir::InstData::MethodCall {
+                receiver, method, ..
+            } => {
+                let module =
+                    self.method_receiver_module(*receiver, span.file_id, resolved_types)?;
+                let module_file = self.module_def(module).file_id;
+                self.resolve_function_name_local(*method, module_file)
+            }
+            _ => None,
+        }
+    }
+
+    /// The module a method-call receiver names, from the inferred receiver type
+    /// when one is available and otherwise from the file's module bindings.
+    fn method_receiver_module(
+        &self,
+        receiver: InstRef,
+        file_id: FileId,
+        resolved_types: Option<&AHashMap<InstRef, Type>>,
+    ) -> Option<crate::types::ModuleId> {
+        if let Some(module) = resolved_types
+            .and_then(|types| types.get(&receiver))
+            .and_then(Type::as_module)
+        {
+            return Some(module);
+        }
+        let rue_rir::InstData::VarRef { name, .. } = self.body_rir_ref().get(receiver).data else {
+            return None;
+        };
+        self.call_facts()
+            .call_module_binding(file_id, name)
+            .and_then(|binding| binding.ty.as_module())
     }
 
     fn collect_generic_argument_facts(

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -1706,6 +1706,80 @@ mod tests {
         );
     }
 
+    /// One owner generates every call to a generic callee, and its comptime
+    /// arguments come from the canonical semantic evaluation. When the capture
+    /// was written once per call shape, the same call was accepted through one
+    /// shape and rejected through another (RUE-1967).
+    #[test]
+    fn generic_call_generation_has_one_owner() {
+        assert_eq!(
+            GENERATE_SOURCE.matches("fn generate_generic_call(").count(),
+            1,
+            "generic-call constraint generation must have exactly one owner"
+        );
+        let owner = source_item(GENERATE_SOURCE, "fn generate_generic_call(");
+        // The captured facts are the canonical evaluation's, with a
+        // name-resolution fallback for the spellings that need no evaluation.
+        assert_eq!(owner.matches("self.comptime_argument_value(").count(), 2);
+        assert_eq!(owner.matches("self.extract_type_argument(").count(), 1);
+        // Parameter substitution and return substitution both live here, so no
+        // call shape can have one without the other.
+        assert!(owner.contains("self.infer_structured_type_hint("));
+        assert!(owner.contains("self.substituted_generic_return_type("));
+
+        // Only the owner reads a generic callee's comptime arguments.
+        for probe in [
+            "self.comptime_argument_value(",
+            "self.extract_type_argument(",
+            "self.substituted_generic_return_type(",
+        ] {
+            assert_eq!(
+                GENERATE_SOURCE.matches(probe).count(),
+                owner.matches(probe).count(),
+                "{probe} is used outside the single generic-call owner"
+            );
+        }
+
+        // Every call shape that can name a generic callee reaches the owner.
+        assert_eq!(
+            GENERATE_SOURCE
+                .matches("self.generate_generic_call(")
+                .count(),
+            2,
+            "the direct-Call and module-member paths are the two call shapes \
+             that resolve a generic function signature"
+        );
+        for shape in ["InstData::Call { name, args }", "ty.is_module()"] {
+            assert!(
+                GENERATE_SOURCE.contains(shape),
+                "call shape {shape} moved; recheck that it still reaches \
+                 generate_generic_call"
+            );
+        }
+
+        // Sema decides which calls get canonically evaluated comptime
+        // arguments; the staged-pass gate and the fact collector must resolve
+        // the callee the same way or a call shape silently loses its facts.
+        assert_eq!(
+            TYPE_INFERENCE_SOURCE
+                .matches("fn generic_callee_key(")
+                .count(),
+            1
+        );
+        for consumer in ["fn has_comptime_fact_sites(", "fn collect_comptime_facts("] {
+            assert!(
+                source_item(TYPE_INFERENCE_SOURCE, consumer).contains("self.generic_callee_key("),
+                "{consumer} regained its own generic-callee resolution"
+            );
+        }
+        // A comptime type argument is a fact site exactly as a value argument
+        // is: the gate must not filter type parameters back out.
+        assert!(
+            !source_item(TYPE_INFERENCE_SOURCE, "fn has_comptime_fact_sites(")
+                .contains("param_is_type")
+        );
+    }
+
     #[test]
     fn synthetic_type_names_have_one_identity_policy() {
         let consumers = [

--- a/crates/rue-cli-tests/cases/comptime_type_argument_shapes.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_argument_shapes.toml
@@ -1,0 +1,193 @@
+# Comptime type arguments are captured the same way whatever the call's shape
+# (RUE-1967, spec 4.14:5a).
+#
+# Capturing a generic callee's comptime type argument and substituting it into
+# the callee's parameter and return types was written once per call shape, and
+# the copies disagreed: the same `first(U, 3000000000, 4)` was accepted through
+# one shape and rejected through another, either as E0800 ("literal 3000000000
+# out of range for i32", the argument left unconstrained and defaulted) or as
+# E0206 ("expected u64, found type", the unsubstituted `-> T` unified against
+# the real result). One owner now generates every generic call, and the captured
+# arguments are the ones the canonical comptime evaluation produced, so a
+# computed type argument (`Id(u64)`) reaches inference exactly as a written one
+# does.
+#
+# `u64` with a value above the `i32` range is what makes a lost capture
+# observable: the run prints the value, so a defaulted or truncated parameter
+# cannot pass silently.
+
+[section]
+id = "cli.comptime_type_argument_shapes"
+name = "Comptime type arguments across call shapes"
+description = "A generic callee's comptime type argument binds the same type through every call shape and spelling."
+
+[[case]]
+name = "direct_call_const_alias_of_a_primitive"
+description = "A file-level const alias of a primitive as the comptime type argument of a same-file callee."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn Id(comptime T: type) -> type { T }
+
+const U = Id(u64);
+
+fn first(comptime T: type, a: T, b: T) -> T { a }
+
+fn main() -> i32 {
+    let x = first(U, 3000000000, 4);
+    @dbg(x);
+    0
+}
+""" },
+]
+exit_code = 0
+stdout = "3000000000\n"
+
+[[case]]
+name = "direct_call_type_constructor_application"
+description = "The type-constructor call written at the argument position: only the canonical comptime evaluation can reduce it."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn Id(comptime T: type) -> type { T }
+
+fn first(comptime T: type, a: T, b: T) -> T { a }
+
+fn main() -> i32 {
+    let x = first(Id(u64), 3000000000, 4);
+    @dbg(x);
+    0
+}
+""" },
+]
+exit_code = 0
+stdout = "3000000000\n"
+
+[[case]]
+name = "module_member_call_const_alias_and_application"
+description = "The module-qualified shape binds the same type from both spellings."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "pick.rue", source = """
+pub fn first(comptime T: type, a: T, b: T) -> T { a }
+""" },
+  { path = "main.rue", source = """
+const m = @import("pick.rue");
+
+fn Id(comptime T: type) -> type { T }
+
+const U = Id(u64);
+
+fn main() -> i32 {
+    let x = m.first(U, 3000000000, 4);
+    let y = m.first(Id(u64), 3000000000, 4);
+    @dbg(x);
+    @dbg(y);
+    0
+}
+""" },
+]
+exit_code = 0
+stdout = "3000000000\n3000000000\n"
+
+[[case]]
+name = "type_qualified_assoc_fn_call_through_a_const_alias"
+description = "A const alias of a primitive reaches an associated function of a type built from it."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn Id(comptime T: type) -> type { T }
+
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+
+        fn keep(a: T) -> T { a }
+    }
+}
+
+const U = Id(u64);
+const B = Box(U);
+
+fn main() -> i32 {
+    let x = B.keep(3000000000);
+    @dbg(x);
+    0
+}
+""" },
+]
+exit_code = 0
+stdout = "3000000000\n"
+
+[[case]]
+name = "type_qualified_assoc_fn_call_on_an_inline_constructor_head"
+description = "The same associated function reached through an inline type-constructor head."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn Id(comptime T: type) -> type { T }
+
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+
+        fn keep(a: T) -> T { a }
+    }
+}
+
+const U = Id(u64);
+
+fn main() -> i32 {
+    let x = Box(U).keep(3000000000);
+    @dbg(x);
+    0
+}
+""" },
+]
+exit_code = 0
+stdout = "3000000000\n"
+
+[[case]]
+name = "let_bound_alias_and_bare_primitive_agree_with_the_const_alias"
+description = "The body-local `let` alias and the bare primitive bind the same type as the const alias does."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn Id(comptime T: type) -> type { T }
+
+fn first(comptime T: type, a: T, b: T) -> T { a }
+
+fn main() -> i32 {
+    let U = Id(u64);
+    let x = first(U, 3000000000, 4);
+    let y = first(u64, 3000000000, 4);
+    @dbg(x);
+    @dbg(y);
+    0
+}
+""" },
+]
+exit_code = 0
+stdout = "3000000000\n3000000000\n"
+
+[[case]]
+name = "generic_return_substitution_survives_the_module_boundary"
+description = "A `-> T` return resolves at a module-qualified call, so a sibling literal takes the substituted width instead of defaulting."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "pick.rue", source = """
+pub fn first(comptime T: type, a: T, b: T) -> T { a }
+""" },
+  { path = "main.rue", source = """
+const m = @import("pick.rue");
+
+fn Id(comptime T: type) -> type { T }
+
+const U = Id(u64);
+
+fn main() -> i32 {
+    if m.first(U, 3000000000, 4) == 3000000000 { 0 } else { 1 }
+}
+""" },
+]
+exit_code = 0

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -656,24 +656,24 @@ compile_fail = true
 error_contains = ["E0425", "inout argument must be"]
 [[case]]
 name = "invalid_comptime_type_argument_reports_diagnostic"
-description = "A rejected comptime type argument is a deterministic user error, not an incomplete body query."
+description = "A rejected comptime type argument is a deterministic user error, not an incomplete body query. The comptime engine names the rejected argument; an unresolved `-> T` no longer stands in as the literal `type`, whose downstream mismatch used to arrive first (RUE-1967)."
 files = [{ path = "main.rue", source = """
 fn id(comptime T: type, value: T) -> T { value }
 fn main() -> i32 { id(32, 42) }
 """ }]
 compile_fail = true
-error_contains = ["E0206", "type mismatch"]
+error_contains = ["E1200", "comptime type parameter must be a type literal"]
 compile_stderr_not_contains = ["internal compiler error", "did not publish a terminal"]
 
 [[case]]
 name = "unknown_comptime_type_argument_reports_diagnostic"
-description = "An unknown type passed to a comptime type parameter does not abort body-query publication."
+description = "An unknown type passed to a comptime type parameter does not abort body-query publication, and is reported at the argument rather than as a mismatch at the call's result (RUE-1967)."
 files = [{ path = "main.rue", source = """
 fn id(comptime T: type, value: T) -> T { value }
 fn main() -> i32 { id(i34, 42) }
 """ }]
 compile_fail = true
-error_contains = ["E0206", "type mismatch"]
+error_contains = ["E1201", "requires a compile-time known value"]
 compile_stderr_not_contains = ["internal compiler error", "did not publish a terminal"]
 
 [[case]]

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -3571,3 +3571,91 @@ compile_fail = true
 error_contains = [
     "integer overflow evaluating multiplication at type i32: the result 4000000000 does not fit in i32",
 ]
+
+# =============================================================================
+# Comptime type arguments (4.14:5a)
+#
+# The bound type comes from evaluating the argument, so it does not depend on
+# how the argument is spelled or on the form of the call. `u64` is chosen
+# because a value above the `i32` range makes a lost binding observable: an
+# argument left unconstrained defaults to `i32` and the literal no longer fits.
+# =============================================================================
+
+[[case]]
+name = "comptime_type_argument_const_alias_of_a_primitive"
+spec = ["4.14:5a", "4.14:22"]
+description = "A file-level const alias of a primitive binds the type parameter exactly as the primitive's own spelling does"
+source = """
+fn Id(comptime T: type) -> type { T }
+fn first(comptime T: type, a: T, b: T) -> T { a }
+
+const U = Id(u64);
+
+fn main() -> i32 {
+    let x = first(U, 3000000000, 4);
+    if x == 3000000000 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_type_argument_type_constructor_call"
+spec = ["4.14:5a", "4.14:22"]
+description = "A type-constructor call written at the argument position binds the type parameter to the type it reduces to"
+source = """
+fn Id(comptime T: type) -> type { T }
+fn first(comptime T: type, a: T, b: T) -> T { a }
+
+fn main() -> i32 {
+    let x = first(Id(u64), 3000000000, 4);
+    if x == 3000000000 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_type_argument_module_qualified_call"
+spec = ["4.14:5a"]
+description = "A module-qualified call binds the type parameter from the same argument an unqualified call does"
+source = """
+const m = @import("pick.rue");
+
+fn Id(comptime T: type) -> type { T }
+
+const U = Id(u64);
+
+fn main() -> i32 {
+    let x = m.first(U, 3000000000, 4);
+    let y = m.first(Id(u64), 3000000000, 4);
+    if x == y { 42 } else { 1 }
+}
+"""
+aux_files = { "pick.rue" = """
+pub fn first(comptime T: type, a: T, b: T) -> T { a }
+""" }
+exit_code = 42
+
+[[case]]
+name = "comptime_type_argument_type_qualified_call"
+spec = ["4.14:5a", "4.14:22"]
+description = "A const alias of a primitive reaches an associated function of a type built from it, through a type-qualified call"
+source = """
+fn Id(comptime T: type) -> type { T }
+
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+
+        fn keep(a: T) -> T { a }
+    }
+}
+
+const U = Id(u64);
+const B = Box(U);
+
+fn main() -> i32 {
+    let x = B.keep(3000000000);
+    if x == 3000000000 { 42 } else { 1 }
+}
+"""
+exit_code = 42

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -120,6 +120,31 @@ fn main() -> i32 {
 
 When a function has a `comptime T: type` parameter, occurrences of `T` in parameter types and return types are substituted with the concrete type at each call site.
 
+{{ rule(id="4.14:5a", cat="normative") }}
+
+The argument supplied for a `comptime T: type` parameter is any
+comptime-evaluable expression whose value is a type, and `T` is bound to the
+type that expression evaluates to. A type literal, a `let` or `const` binding of
+a type value (rule 4.14:22), a type parameter of the enclosing specialization,
+and a type-constructor call written at the argument position are all such
+expressions, and equal type values bind `T` equally however they are spelled.
+The form of the call does not change that binding either: an unqualified call
+and a module-qualified call (`m.f(…)`) substitute the same type into the
+parameter and return types of rules 4.14:5 and 4.14:16.
+
+```rue
+fn Id(comptime T: type) -> type { T }
+fn first(comptime T: type, a: T, b: T) -> T { a }
+
+const U = Id(u64);
+
+fn main() -> i32 {
+    let aliased = first(U, 3000000000, 4);        // T = u64 through a const alias
+    let applied = first(Id(u64), 3000000000, 4);  // ... and through the call itself
+    if aliased == applied { 0 } else { 1 }
+}
+```
+
 {{ rule(id="4.14:16", cat="normative") }}
 
 A type parameter may appear anywhere within a composite parameter or return type — as an array element type (`[T; N]`), a pointer pointee (`ptr const T`, `ptr mut T`), or a nesting of these (`[[T; 2]; 3]`) — and is substituted recursively at each call site, in both parameter and return position.


### PR DESCRIPTION
## Summary

Capturing a generic callee's comptime type and value arguments, and substituting them into the callee's parameter and return types, was written once per call shape in HM constraint generation, and the copies disagreed. The direct `f(..)` path consulted the canonically evaluated argument and then substituted the return type; the module-member `m.f(..)` path only name-resolved the argument and never substituted a `-> T` return; the two guarded the staged probe pass differently. So `first(Id(u64), 3000000000, 4)` was rejected as E0800 (argument left unconstrained and defaulted to `i32`) through one shape and as E0206 (unsubstituted `-> T` unified against the real result) through another.

- `ConstraintGenerator::generate_generic_call` in `inference/generate.rs` is the single owner: argument generation, `type_subst`/`value_subst` capture, substituted-parameter constraints, and the substituted return type. Both call shapes that resolve a generic function signature call it; nothing else reads `comptime_argument_value`, `extract_type_argument`, or `substituted_generic_return_type`.
- Two sema-side defects fed the split. The staged pre-pass gate `has_comptime_fact_sites` counted only comptime *value* parameters, so a callee whose comptime parameters are all types never got a canonical evaluation; and it resolved a module-member callee in the caller's file while `collect_generic_argument_facts` resolved it in the module's, so `m.f(..)` was not a fact site either way. Both now resolve the callee through one `generic_callee_key` (+ `method_receiver_module`), and a comptime type argument is a fact site exactly as a value argument is. A computed type argument (`Id(u64)`) therefore reaches inference through the same evaluation a written type name does.
- `extract_type_argument` stays strictly as the fallback for spellings that need no evaluation (a body-local `let U = Id(u64)` alias, which sema's fact walk cannot see), consulted only after the canonical fact; filed as RUE-2093.
- An unresolvable `-> T` now always becomes a fresh inference variable (the module-member path's behaviour) instead of the literal `type` placeholder.
- Guard test `sema::consistency_tests::generic_call_generation_has_one_owner`: exactly one `generate_generic_call`, exactly two call sites, the three fact-reading helpers used nowhere else, one `generic_callee_key` used by both sema consumers, and the gate free of the `param_is_type` exclusion.
- Spec 4.14 gains 4.14:5a: a comptime type argument binds the type its expression evaluates to whatever the spelling, and an unqualified and a module-qualified call substitute the same type. (The rule is worded for those two shapes only: generic associated functions are not specialized anywhere in the pipeline today, so a type-qualified generic call cannot exist; filed as RUE-2092.)

## Golden changes

Two cases in `ice_regressions.toml`, a consequence of the fresh-variable fallback: `id(32, 42)` now reports E1200 "comptime type parameter must be a type literal" and `id(i34, 42)` E1201 "requires a compile-time known value" at the rejected argument, where the placeholder previously produced an E0206 mismatch at the call's result first. Both remain clean diagnostics with no internal compiler error, which is what those cases pin.

## Tests

- `crates/rue-cli-tests/cases/comptime_type_argument_shapes.toml` (new): seven executing cases (direct, module-member, inline `Id(u64)`, const alias into a type constructor and out through an associated function) pinning stdout `3000000000`.
- `crates/rue-spec/cases/expressions/comptime.toml`: four cases citing 4.14:5a (+ 4.14:22).

## Validation

`scripts/rue fmt`, `quick` (36/36), `unit air` (887), `ui` (437), `spec` (2889), `cli comptime_type_argument_shapes ice_regressions comptime examples` (381), and the spec-traceability, oracle-diff and planted-miscompile-isolation gates, all passing on the rebased tree. The agent's full `cli` (2743 passed, the two environmental cases) and `premerge` on the pre-rebase tree passed. Compile time on the two largest examples is unchanged within noise (rill 5.77 s → 5.63 s, mosaic 9.40 s → 9.19 s user).

Closes RUE-1967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_