### PR TITLE
RUE-2086: keep a zero-sized local's slot from aliasing its neighbour's value

### DIFF
--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -66,6 +66,26 @@
 //! A `Load` that is itself a by-ref call argument is never forwarded under
 //! either rule: the by-ref lowering requires that argument to remain a place.
 //!
+//! ## Slot identity is not value identity: the well-typedness guard
+//!
+//! A slot index does not identify a single typed storage location. A
+//! zero-sized local reserves *no* frame slots, so its slot index is the same
+//! index the next local receives, and the two unrelated locals then share one
+//! `$n` in every slot-keyed table here (RUE-2086). Forwarding the value most
+//! recently stored to `$n` into a `Load $n` that belongs to the *other* local
+//! substitutes a value of the wrong type, and downstream consumers that read
+//! an operand's type or materialized slot count off the CFG then plan the
+//! wrong machine code — `@ptr_write` through a `ptr mut ()` emitted a real
+//! eight-byte store because a `ptr mut` value had been forwarded into its
+//! `()`-typed value operand.
+//!
+//! Neither rule forwards across a type change: a substitution is recorded only
+//! when the stored value's type equals the `Load`'s own result type. That keeps
+//! the pass's output well-typed by construction — the same invariant sema
+//! established and every later consumer assumes — and it costs nothing on a
+//! slot that really does hold one type, which is every slot a non-zero-sized
+//! local owns.
+//!
 //! ## Applying substitutions and cleanup
 //!
 //! Both rules record `subst[load] = value`; all substitutions apply in one
@@ -103,6 +123,10 @@ pub struct Stats {
     /// Dominator trees computed by this pass. The tree is built only when at
     /// least one distinct cross-block Rule 1 pair needs proof.
     pub dominator_computations: u64,
+    /// Loads a rule had a candidate value for but declined to forward because
+    /// the stored value's type differs from the load's (RUE-2086 — a slot
+    /// shared between a zero-sized local and the local that reuses its index).
+    pub loads_declined_type_mismatch: u64,
 }
 
 /// Run value forwarding. Call at `-O2`/`-O3` after simplification and before
@@ -198,12 +222,20 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
                     if cfg.is_ownership_boundary_value(value) {
                         continue;
                     }
+                    let load_ty = cfg.get_inst(value).ty;
                     if let Some(SlotWrites::One {
                         value: write_value,
                         block: write_block,
                     }) = slot_class.get(slot as usize).copied()
                     {
-                        // Rule 1: global single-write forwarding.
+                        // Rule 1: global single-write forwarding. The one
+                        // write may belong to a different local that shares
+                        // this slot index with a zero-sized one (RUE-2086);
+                        // a type change is how that shows up.
+                        if cfg.get_inst(write_value).ty != load_ty {
+                            stats.loads_declined_type_mismatch += 1;
+                            continue;
+                        }
                         subst[value.as_u32() as usize] = Some(write_value);
                         stats.loads_forwarded_single_write += 1;
                         if write_block != block_id {
@@ -212,6 +244,15 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
                     } else if !cfg.is_address_taken(slot) {
                         // Rule 2: block-local forwarding for multi-write slots.
                         if let Some(&Some(stored)) = last_store.get(slot as usize) {
+                            // A zero-sized local shares its slot index with the
+                            // local that reuses it, so the tracked store may
+                            // belong to a different location entirely
+                            // (RUE-2086). Only a same-typed value is this
+                            // load's.
+                            if cfg.get_inst(stored).ty != load_ty {
+                                stats.loads_declined_type_mismatch += 1;
+                                continue;
+                            }
                             subst[value.as_u32() as usize] = Some(stored);
                             stats.loads_forwarded_block_local += 1;
                         }
@@ -899,6 +940,134 @@ mod tests {
         assert!(matches!(
             cfg.get_block(live).terminator,
             Terminator::Return { value: Some(v) } if v == init
+        ));
+    }
+
+    /// RUE-2086: a zero-sized local reserves no frame slots, so its slot index
+    /// is the one the next local receives and the two share `$0`. The
+    /// block-local table then holds the *pointer* the second local stored when
+    /// the first local's `()`-typed load is reached, and forwarding it made
+    /// `@ptr_write` store eight bytes through a zero-sized sentinel address.
+    #[test]
+    fn test_block_local_declines_forward_across_a_type_change() {
+        // `let e: () = (); let pm: ptr mut () = @raw_mut(..); @ptr_write(pm, e)`
+        // — both locals are slot 0, so the `()` load must not see the pointer.
+        let mut cfg = make_cfg(1);
+        let unit = push(&mut cfg, CfgInstData::Const(0), Type::UNIT);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: unit,
+            },
+            Type::UNIT,
+        );
+        let pointer = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I64);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: pointer,
+            },
+            Type::UNIT,
+        );
+        let pointer_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I64);
+        let unit_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::UNIT);
+        let sum = push(
+            &mut cfg,
+            CfgInstData::Add(pointer_load, unit_load),
+            Type::I64,
+        );
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
+
+        let stats = run(&mut cfg).unwrap();
+        // The same-typed load still forwards; the `()` load does not.
+        assert_eq!(stats.loads_forwarded_block_local, 1);
+        assert_eq!(stats.loads_declined_type_mismatch, 1);
+        assert!(
+            matches!(cfg.get_inst(sum).data, CfgInstData::Add(x, y) if x == pointer && y == unit_load)
+        );
+        assert!(matches!(
+            cfg.get_inst(unit_load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    /// The same guard on Rule 1: one whole-slot write is still not this load's
+    /// write when a zero-sized local shares the slot index (RUE-2086).
+    #[test]
+    fn test_single_write_declines_forward_across_a_type_change() {
+        let mut cfg = make_cfg(1);
+        let init = push(&mut cfg, CfgInstData::Const(7), Type::I64);
+        push(&mut cfg, CfgInstData::Alloc { slot: 0, init }, Type::UNIT);
+        let unit_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::UNIT);
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Return {
+                value: Some(unit_load),
+            },
+        );
+
+        let stats = run(&mut cfg).unwrap();
+        assert_eq!(stats.loads_forwarded_single_write, 0);
+        assert_eq!(stats.loads_declined_type_mismatch, 1);
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == unit_load
+        ));
+    }
+    /// The other direction of the same aliasing, which no CLI case can cover:
+    /// the `()` is stored *last* and a sized load of the shared slot follows.
+    ///
+    /// Reaching this from source needs the zero-sized local to be re-assigned
+    /// after the sized one is initialized (`let mut e: () = (); let y: i64 = 5;
+    /// e = ();`), because slot indices only ever advance, so the zero-sized
+    /// local's `Alloc` always comes first. That shape is miscompiled the other
+    /// way round — the `()` reaches a sized consumer and makes its materialized
+    /// slot count zero, so a store or an argument disappears rather than
+    /// appearing. It is pinned here rather than in `rue-cli-tests` because the
+    /// differential oracle mismodels the source shape itself: its own local
+    /// store is keyed by slot index too, so the re-assigned `()` overwrites the
+    /// sized neighbour and it reports the wrong answer for a correctly compiled
+    /// program.
+    #[test]
+    fn test_block_local_declines_forwarding_a_zero_sized_store_to_a_sized_load() {
+        let mut cfg = make_cfg(1);
+        let sized = push(&mut cfg, CfgInstData::Const(5), Type::I64);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: sized,
+            },
+            Type::UNIT,
+        );
+        // The zero-sized local's re-assignment lands on the same slot.
+        let unit = push(&mut cfg, CfgInstData::Const(0), Type::UNIT);
+        push(
+            &mut cfg,
+            CfgInstData::Store {
+                slot: 0,
+                value: unit,
+            },
+            Type::UNIT,
+        );
+        let sized_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I64);
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Return {
+                value: Some(sized_load),
+            },
+        );
+
+        let stats = run(&mut cfg).unwrap();
+        assert_eq!(stats.loads_forwarded_block_local, 0);
+        assert_eq!(stats.loads_declined_type_mismatch, 1);
+        // The sized read stays a load; forwarding the `()` would have made the
+        // consumer see a value with no ABI slots.
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == sized_load
         ));
     }
 }

--- a/crates/rue-cli-tests/cases/zero_sized_place_address.toml
+++ b/crates/rue-cli-tests/cases/zero_sized_place_address.toml
@@ -181,3 +181,96 @@ compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:"]
 # #<n>`; the bracketed `[fp, #...]` of an ordinary slot load or store does not
 # match this substring.
 compile_stdout_not_contains = [", fp, #"]
+
+# --- Writing through the address, not just forming it (RUE-2086) ------------
+# The address is only half the story: `@ptr_write` through a `ptr mut ()` must
+# move no bytes. Codegen decided that from the *materialized* value operand's
+# slot count, and the optimizer could make that operand a real one-slot value.
+# A zero-sized local reserves no frame slots, so its slot index is the index the
+# next local receives; `let e: () = ()` and `let pm: ptr mut ()` share `$1`.
+# Value forwarding (`-O2`) then handed `pm`'s pointer to `e`'s `()`-typed load
+# and the write stored eight bytes through the zero-sized sentinel address —
+# `-O0`/`-O1` printed 42, `-O2` faulted. Two independent guards now close it:
+# forwarding never crosses a type change, and the write consults the pointer's
+# declared pointee. `differential_opt` is what pins the levels against each
+# other.
+#
+# Every case below reaches the bug through a zero-sized *address*, so each is
+# also closed by the `@ptr_write` guard alone, and the differential oracle
+# classifies `@raw` of a zero-sized place as an unmodeled gap before executing
+# anything. `cli.zero_sized_slot_sharing` carries the other direction — a `()`
+# forwarded into a sized consumer — which pins the forwarder's type guard on its
+# own and is oracle-gated.
+[[case]]
+name = "trailing_zero_sized_field_write_moves_no_bytes"
+description = "RUE-2086 repro: writing `()` through `@raw_mut(tail.unit)` leaves the sized sibling alone at every optimization level."
+files = [{ path = "main.rue", source = """
+struct Tail { value: i64, unit: () }
+fn main() -> i32 {
+    let mut tail = Tail { value: 42, unit: () };
+    let e: () = ();
+    let pm: ptr mut () = checked { @raw_mut(tail.unit) };
+    checked { @ptr_write(pm, e) };
+    @dbg(tail.value);
+    0
+}
+""" }]
+stdout = "42\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "all_zst_root_write_moves_no_bytes"
+description = "The all-ZST-root variant of the same write: the whole local is zero-sized, so it shares its slot index with everything that follows."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut u: () = ();
+    let value: i64 = 42;
+    let e: () = ();
+    let pm: ptr mut () = checked { @raw_mut(u) };
+    checked { @ptr_write(pm, e) };
+    @dbg(value);
+    0
+}
+""" }]
+stdout = "42\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "zero_sized_read_through_shared_slot_stays_correct"
+description = "The read-only counterpart: `@ptr_read` of a `ptr const ()` whose local shares a slot with a sized one produces `()` and disturbs nothing."
+files = [{ path = "main.rue", source = """
+struct Tail { value: i64, unit: () }
+fn main() -> i32 {
+    let tail = Tail { value: 42, unit: () };
+    let pc: ptr const () = checked { @raw(tail.unit) };
+    let read: () = checked { @ptr_read(pc) };
+    let _kept: () = read;
+    @dbg(tail.value);
+    0
+}
+""" }]
+stdout = "42\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "sized_write_through_shared_slot_still_stores"
+description = "The over-tightening guard: a sized pointee sharing its slot arrangement with a zero-sized local still performs its store."
+files = [{ path = "main.rue", source = """
+struct Tail { value: i64, unit: () }
+fn main() -> i32 {
+    let mut tail = Tail { value: 42, unit: () };
+    let e: () = ();
+    let unit_ptr: ptr mut () = checked { @raw_mut(tail.unit) };
+    let value_ptr: ptr mut i64 = checked { @raw_mut(tail.value) };
+    checked { @ptr_write(unit_ptr, e) };
+    checked { @ptr_write(value_ptr, 7) };
+    @dbg(tail.value);
+    0
+}
+""" }]
+stdout = "7\n"
+exit_code = 0
+differential_opt = true

--- a/crates/rue-cli-tests/cases/zero_sized_slot_sharing.toml
+++ b/crates/rue-cli-tests/cases/zero_sized_slot_sharing.toml
@@ -1,0 +1,103 @@
+# A zero-sized local shares its frame slot index with the local that reuses it
+# (RUE-2086), and what consumes the wrongly forwarded value is not limited to
+# `@ptr_write`.
+#
+# `reserve_frame_slots` advances the frame watermark by `abi_slot_count(ty)`, so
+# a zero-sized local reserves nothing and the next local receives the same `$n`.
+# Value forwarding's tables are keyed by that index alone, so at `-O2` it handed
+# one local's stored value to the other local's `Load`. The resulting CFG is
+# ill-typed, and every consumer that reads an operand's type or its materialized
+# slot count then plans the wrong machine code.
+#
+# `cli.zero_sized_place_address` covers the `@ptr_write` consumer the issue
+# reported. Those cases are all reached through `@raw`/`@raw_mut` of a
+# zero-sized place, which has two consequences: each is also closed by the
+# `@ptr_write` guard on its own, and the differential oracle classifies them as
+# an unmodeled gap before executing anything, so oracle-diff can neither
+# confirm nor refute the bug through them.
+#
+# The cases here are the ones that pin the forwarder's type guard by itself.
+# None of them is a pointer operation, so the `@ptr_write` guard is provably
+# inert for all three and only the forwarder fix makes them pass. None forms a
+# zero-sized address either, so the oracle models them and runs them for real:
+# before the fix it reports them as disagreements between its own evaluation and
+# the compiled program.
+#
+# The consumer here is the ordinary call ABI, which counts a `()` argument as
+# zero slots. Forwarding the sized neighbour's value into that argument gave it
+# a slot and shifted every argument after it into the wrong register.
+#
+# `differential_opt` compiles and runs each at `-O0`/`-O1`/`-O2`/`-O3` and
+# requires one answer across all four, which is the shape of this bug: the
+# unoptimized levels were always right.
+
+[section]
+id = "cli.zero_sized_slot_sharing"
+name = "Zero-sized locals sharing a frame slot"
+description = "A zero-sized local's slot index is reused by the next local; a value must never be forwarded between the two, whatever consumes the result (RUE-2086)."
+
+[[case]]
+name = "zero_sized_call_argument_does_not_shift_later_arguments"
+description = "RUE-2086: a `()` argument sharing its slot with a sized local must keep its zero-slot ABI, or the arguments after it are placed in the wrong registers."
+files = [{ path = "main.rue", source = """
+fn take(u: (), v: i64) -> i64 { v }
+fn main() -> i32 {
+    let e: () = ();
+    let y: i64 = 5;
+    let r: i64 = take(e, 9);
+    @dbg(r);
+    @dbg(y);
+    0
+}
+""" }]
+stdout = "9\n5\n"
+exit_code = 0
+differential_opt = true
+
+# Inlining splices the callee's body and reoptimizes it, so the shared slot is
+# reached through a second path into the same pass.
+[[case]]
+name = "zero_sized_call_argument_survives_inlining"
+description = "RUE-2086: the shared-slot argument shape stays correct when the enclosing function is inlined and reoptimized."
+files = [{ path = "main.rue", source = """
+fn take(u: (), v: i64) -> i64 { v }
+fn inner(v: i64) -> i64 {
+    let e: () = ();
+    let y: i64 = v;
+    let r: i64 = take(e, 9);
+    r + y
+}
+fn main() -> i32 {
+    @dbg(inner(5));
+    @dbg(inner(6));
+    0
+}
+""" }]
+stdout = "14\n15\n"
+exit_code = 0
+differential_opt = true
+
+# `-O3` unrolls the loop and specializes the induction variable's slot, which
+# puts a differently typed store ahead of the `()` load. This one is correct at
+# `-O2` and wrong only at `-O3`, which is why the level sweep matters.
+[[case]]
+name = "zero_sized_call_argument_survives_unrolling"
+description = "RUE-2086: the shared-slot argument shape stays correct through `-O3` loop unrolling, which specializes slots in the unrolled body."
+files = [{ path = "main.rue", source = """
+fn take(u: (), v: i64) -> i64 { v }
+fn main() -> i32 {
+    let mut i: i64 = 0;
+    let e: () = ();
+    let mut acc: i64 = 0;
+    while i < 3 {
+        let y: i64 = i + 100;
+        acc = acc + take(e, y);
+        i = i + 1;
+    }
+    @dbg(acc);
+    0
+}
+""" }]
+stdout = "303\n"
+exit_code = 0
+differential_opt = true

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2505,7 +2505,16 @@ impl<'a> CfgLower<'a> {
             | rue_air::IntrinsicOperation::PtrWriteUnaligned => {
                 let ptr = plan.args[0].primary;
                 let value = &plan.args[1];
-                if let Some(map) = &plan.physical_slots {
+                if plan.zero_sized_pointee_write || value.slot_count == 0 {
+                    // Nothing to store. The declared pointee's width is the
+                    // authority: a `ptr mut ()` write moves no bytes however
+                    // the value operand materialized, which is what keeps a
+                    // differently typed value forwarded into that operand from
+                    // becoming a store through the zero-sized sentinel address
+                    // (RUE-2086). The materialized slot count still answers for
+                    // a diverging operand, so the two only ever agree to store
+                    // nothing.
+                } else if let Some(map) = &plan.physical_slots {
                     // A compact enum value: truncate each internal slot to its
                     // physical width at its compact byte offset (RUE-1000). The
                     // pointee's padding is zeroed first (ADR-0052 ruling 5).
@@ -2531,8 +2540,6 @@ impl<'a> CfgLower<'a> {
                         value.slots.clone()
                     };
                     crate::agg_slots::store_dispatch_image(self, &vals, ptr, image);
-                } else if value.slot_count == 0 {
-                    // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
                     let leaf_types =
                         crate::types::aggregate_leaf_types(self.ctx.type_pool, plan.args[1].ty);
@@ -7558,6 +7565,92 @@ mod tests {
                 .iter()
                 .any(|inst| matches!(inst, Aarch64Inst::MovImm { imm: 0, .. })),
             "a scalar zero constant is read as a value and must be materialized: {:?}",
+            mir.instructions()
+        );
+    }
+
+    /// RUE-2086 guard: `@ptr_write` through a `ptr mut ()` moves no bytes,
+    /// decided by the pointer's declared pointee rather than by whatever the
+    /// value operand materialized into.
+    ///
+    /// A zero-sized local reserves no frame slots, so its slot index is the
+    /// index the next local receives and the two unrelated locals share one
+    /// `$n`. Value forwarding once handed the pointer stored in that shared
+    /// slot to the `()`-typed load of the other local, and this arm — reading
+    /// the materialized operand's slot count — emitted a real eight-byte store
+    /// through the zero-sized sentinel address. The ill-typed operand is
+    /// reproduced verbatim here so the arm is pinned independently of the
+    /// optimizer that produced it.
+    #[test]
+    fn zero_sized_pointee_write_emits_no_store() {
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let unit_ptr_ty = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::UNIT));
+        let pool = pool.freeze();
+        let mut fixture = FixtureCfg::new(
+            Type::I32,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let address = fixture.konst(1, unit_ptr_ty);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[address, address],
+            Type::UNIT,
+        );
+        let zero = fixture.konst(0, Type::I32);
+        fixture.ret(Some(zero));
+        let mir = fixture.lower_with_plan();
+        assert!(
+            !mir.instructions().iter().any(|inst| matches!(
+                inst,
+                Aarch64Inst::StrIndexed { .. }
+                    | Aarch64Inst::NarrowStoreIndexed { .. }
+                    | Aarch64Inst::FloatStore { .. }
+            )),
+            "a zero-sized pointee write must store nothing: {:?}",
+            mir.instructions()
+        );
+    }
+
+    /// The companion to the guard above: a sized pointee still stores. The
+    /// declared-pointee test must not silence an ordinary `@ptr_write`.
+    #[test]
+    fn sized_pointee_write_still_stores() {
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let i64_ptr_ty = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::I64));
+        let pool = pool.freeze();
+        let mut fixture = FixtureCfg::new(
+            Type::I32,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let address = fixture.konst(8, i64_ptr_ty);
+        let payload = fixture.konst(42, Type::I64);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[address, payload],
+            Type::UNIT,
+        );
+        let zero = fixture.konst(0, Type::I32);
+        fixture.ret(Some(zero));
+        let mir = fixture.lower_with_plan();
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::StrIndexed { .. })),
+            "a sized pointee write must still store: {:?}",
             mir.instructions()
         );
     }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -570,6 +570,19 @@ pub struct IntrinsicPlan {
     /// initialized. Empty for every other operation, a padding-free pointee, and
     /// gate-off, so no zeroing is emitted there.
     pub image_padding: Vec<rue_air::layout::PaddingRange>,
+    /// For a `@ptr_write`/`@ptr_write_unaligned`, whether the pointer operand's
+    /// *declared* pointee is zero-sized. `false` for every other operation and
+    /// whenever the pointer operand is not a `ptr mut` (a diverging operand).
+    ///
+    /// A write through `ptr mut ()` moves no bytes, and that is a property of
+    /// the pointer's type alone. The materialized value operand cannot be
+    /// trusted to say so: an optimizer defect that substitutes a differently
+    /// typed value into the value operand turns the operand's slot count into
+    /// a store through a zero-sized type's sentinel address (RUE-2086). The
+    /// backends refuse the store when either this flag or the materialized
+    /// slot count says there are no bytes, so the two answers only ever
+    /// subtract stores, never add one.
+    pub zero_sized_pointee_write: bool,
 }
 
 /// Place with every dynamic index already materialized. The plan contains no
@@ -2228,6 +2241,19 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         .compact_image_padding_ranges(access.pointee_ty),
                     _ => Vec::new(),
                 };
+                // The declared pointee, read off the pointer operand's type,
+                // is the authority on whether a write moves any bytes
+                // (RUE-2086).
+                let zero_sized_pointee_write = matches!(
+                    operation,
+                    IntrinsicOperation::PtrWrite | IntrinsicOperation::PtrWriteUnaligned
+                ) && args
+                    .first()
+                    .and_then(|arg| match ctx.cfg.get_inst(*arg).ty.kind() {
+                        TypeKind::PtrMut(id) => Some(ctx.type_pool.ptr_mut_def(id)),
+                        _ => None,
+                    })
+                    .is_some_and(|pointee| ctx.type_slot_count(pointee) == 0);
                 let result = adapter.emit_intrinsic(IntrinsicPlan {
                     operation,
                     runtime_call,
@@ -2241,6 +2267,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     physical_slots,
                     dispatch_image,
                     image_padding,
+                    zero_sized_pointee_write,
                 });
                 cache_result(adapter, value, result);
                 Some(ValueKind::Intrinsic)

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3112,7 +3112,16 @@ impl<'a> CfgLower<'a> {
             | rue_air::IntrinsicOperation::PtrWriteUnaligned => {
                 let ptr = plan.args[0].primary;
                 let value = &plan.args[1];
-                if let Some(map) = &plan.physical_slots {
+                if plan.zero_sized_pointee_write || value.slot_count == 0 {
+                    // Nothing to store. The declared pointee's width is the
+                    // authority: a `ptr mut ()` write moves no bytes however
+                    // the value operand materialized, which is what keeps a
+                    // differently typed value forwarded into that operand from
+                    // becoming a store through the zero-sized sentinel address
+                    // (RUE-2086). The materialized slot count still answers for
+                    // a diverging operand, so the two only ever agree to store
+                    // nothing.
+                } else if let Some(map) = &plan.physical_slots {
                     // A compact enum value: truncate each internal slot to its
                     // physical width at its compact byte offset (RUE-1000). The
                     // pointee's padding is zeroed first (ADR-0052 ruling 5).
@@ -3138,8 +3147,6 @@ impl<'a> CfgLower<'a> {
                         value.slots.clone()
                     };
                     crate::agg_slots::store_dispatch_image(self, &vals, ptr, image);
-                } else if value.slot_count == 0 {
-                    // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
                     let leaf_types =
                         crate::types::aggregate_leaf_types(self.ctx.type_pool, plan.args[1].ty);
@@ -7724,6 +7731,92 @@ mod tests {
                 .iter()
                 .any(|inst| matches!(inst, X86Inst::MovRI32 { imm: 0, .. })),
             "a scalar zero constant is read as a value and must be materialized: {:?}",
+            mir.instructions()
+        );
+    }
+
+    /// RUE-2086 guard: `@ptr_write` through a `ptr mut ()` moves no bytes,
+    /// decided by the pointer's declared pointee rather than by whatever the
+    /// value operand materialized into.
+    ///
+    /// A zero-sized local reserves no frame slots, so its slot index is the
+    /// index the next local receives and the two unrelated locals share one
+    /// `$n`. Value forwarding once handed the pointer stored in that shared
+    /// slot to the `()`-typed load of the other local, and this arm — reading
+    /// the materialized operand's slot count — emitted a real eight-byte store
+    /// through the zero-sized sentinel address. The ill-typed operand is
+    /// reproduced verbatim here so the arm is pinned independently of the
+    /// optimizer that produced it.
+    #[test]
+    fn zero_sized_pointee_write_emits_no_store() {
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let unit_ptr_ty = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::UNIT));
+        let pool = pool.freeze();
+        let mut fixture = FixtureCfg::new(
+            Type::I32,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let address = fixture.konst(1, unit_ptr_ty);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[address, address],
+            Type::UNIT,
+        );
+        let zero = fixture.konst(0, Type::I32);
+        fixture.ret(Some(zero));
+        let mir = fixture.lower_with_plan();
+        assert!(
+            !mir.instructions().iter().any(|inst| matches!(
+                inst,
+                X86Inst::MovMRIndexed { .. }
+                    | X86Inst::NarrowStoreIndexed { .. }
+                    | X86Inst::FloatStore { .. }
+            )),
+            "a zero-sized pointee write must store nothing: {:?}",
+            mir.instructions()
+        );
+    }
+
+    /// The companion to the guard above: a sized pointee still stores. The
+    /// declared-pointee test must not silence an ordinary `@ptr_write`.
+    #[test]
+    fn sized_pointee_write_still_stores() {
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let i64_ptr_ty = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::I64));
+        let pool = pool.freeze();
+        let mut fixture = FixtureCfg::new(
+            Type::I32,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let address = fixture.konst(8, i64_ptr_ty);
+        let payload = fixture.konst(42, Type::I64);
+        fixture.intrinsic(
+            rue_air::IntrinsicOperation::PtrWrite,
+            "ptr_write",
+            &[address, payload],
+            Type::UNIT,
+        );
+        let zero = fixture.konst(0, Type::I32);
+        fixture.ret(Some(zero));
+        let mir = fixture.lower_with_plan();
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::MovMRIndexed { .. })),
+            "a sized pointee write must still store: {:?}",
             mir.instructions()
         );
     }

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -533,7 +533,19 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.zero_sized_place_address",
+        "all_zst_root_write_moves_no_bytes",
+        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
+        &[],
+    ),
+    Entry::new(
+        "cli.zero_sized_place_address",
         "indexed_zero_sized_field_address_in_bounds",
+        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
+        &[],
+    ),
+    Entry::new(
+        "cli.zero_sized_place_address",
+        "sized_write_through_shared_slot_still_stores",
         intrinsic(UnsupportedIntrinsicKind::PointerWrite),
         &[],
     ),
@@ -546,6 +558,18 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.zero_sized_place_address",
         "trailing_zero_sized_field_address_keeps_neighbour_intact",
+        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
+        &[],
+    ),
+    Entry::new(
+        "cli.zero_sized_place_address",
+        "trailing_zero_sized_field_write_moves_no_bytes",
+        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
+        &[],
+    ),
+    Entry::new(
+        "cli.zero_sized_place_address",
+        "zero_sized_read_through_shared_slot_stays_correct",
         intrinsic(UnsupportedIntrinsicKind::PointerWrite),
         &[],
     ),


### PR DESCRIPTION
Fixes RUE-2086

A zero-sized local reserves no frame slots, so its slot index is the index the
next local receives and two unrelated locals share one `$n`. Value forwarding's
tables are keyed by that index alone, so at `-O2` it handed one local's stored
value to the other local's `Load`, producing an ill-typed CFG.

The issue reported this through `@ptr_write`: a `ptr mut ()` forwarded into the
`()`-typed value operand made the operand's materialized slot count non-zero, so
the backends emitted an eight-byte store through the zero-sized canonical
address. `-O0` and `-O1` printed the struct's sized field, `-O2` faulted, on both
backends.

## The fix

**Value forwarding no longer substitutes across a type change.** A slot index is
not a typed storage location; only a value whose type matches the load's can be
that load's value. This keeps the pass's output well-typed by construction,
which is the invariant every later consumer already assumes, and it closes the
hazard for all of them rather than for one call site. It costs nothing on a slot
a non-zero-sized local owns: instrumenting the guard over all 1391 programs
under `examples/` at `-O2` and `-O3` produced zero declines.

**`@ptr_write` also stops trusting the materialized operand** for the question
the pointer's own type answers. The plan carries whether the declared pointee is
zero-sized, and both backends skip the store when either that or the operand's
slot count says there are no bytes to move. The disjunction is deliberate: it
can only remove a store, never add one, and a diverging value operand keeps its
current handling. Each fix closes the reported repro independently.

## Coverage

`@ptr_write` is only the consumer this was reported through. The ordinary call
ABI counts a `()` argument as zero slots, so the same forward gave such an
argument a slot and shifted every argument after it into the wrong register. The
new `cli.zero_sized_slot_sharing` section covers that consumer through a plain
call, an inlined one, and an unrolled loop. Those cases involve no pointer, so
they rest on the forwarding rule rather than on the `@ptr_write` guard, and —
unlike a case reached through `@raw` of a zero-sized place — the differential
oracle models them and reports the pre-fix compiler as disagreeing with it.

Also: four `differential_opt` cases for the reported shape and its read and
all-zero-sized-root variants, two forwarder unit tests per direction, and two
codegen unit tests per backend.

Specification §9.2 (9.2:6b) already requires a write to transfer exactly
`@size_of(T)` physical bytes and to leave every byte outside that range
unchanged; at `T = ()` that is no bytes. This restores conformance rather than
changing it.
