### PR TITLE
RUE-2082: pin the test channel and the payload printer to one rendering bound

### DIFF
--- a/crates/rue-compiler/src/error_printer.rs
+++ b/crates/rue-compiler/src/error_printer.rs
@@ -63,10 +63,16 @@ type Place = SemanticBodyPlace<crate::StableDefinitionKey, crate::ModuleId>;
 type Projection = SemanticBodyProjection<crate::StableDefinitionKey, crate::ModuleId>;
 
 /// Rendered-payload budget in bytes (ADR-0083 §2 capture bounds).
-pub(crate) const PAYLOAD_BUDGET: u64 = 4096;
+///
+/// This is [`rue_runtime_abi::RENDERING_BOUND`]: the runtime's test channel
+/// bounds a failure record's `message` to the same constant, so a rendering
+/// and the record carrying it agree by construction rather than by two
+/// literals staying in step by hand.
+pub(crate) const PAYLOAD_BUDGET: u64 = rue_runtime_abi::RENDERING_BOUND;
 
-/// Appended when a rendering exceeded [`PAYLOAD_BUDGET`].
-pub(crate) const TRUNCATION_MARKER: &str = " …[truncated]";
+/// Appended when a rendering exceeded [`PAYLOAD_BUDGET`], in the spelling
+/// [`rue_runtime_abi::RENDERING_TRUNCATION_MARKER`] carries for both writers.
+pub(crate) const TRUNCATION_MARKER: &str = rue_runtime_abi::RENDERING_TRUNCATION_MARKER;
 
 /// How one value renders once the walk has stopped descending.
 ///

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -3,8 +3,10 @@
 //! Canonical typed description of the Rue compiler/runtime ABI.
 //!
 //! This crate deliberately has no dependencies. It describes logical C-boundary
-//! facts; target register assignment and compiler semantic types belong to
-//! their respective owners.
+//! facts and other constants the compiler and runtime must agree on byte for
+//! byte (e.g. the shared test-channel/diagnostic rendering bound); target
+//! register assignment and compiler semantic types belong to their respective
+//! owners.
 
 use core::fmt;
 
@@ -58,6 +60,22 @@ pub enum AbiType {
 /// the low 32 bits of the adjacent `u64` bit-pattern parameter may be set.
 pub const FLOAT_WIDTH_F32: u32 = 32;
 pub const FLOAT_WIDTH_F64: u32 = 64;
+
+/// Bound in bytes on a payload rendered for a report (spec 6.7:15, ADR-0083 §2
+/// capture bounds).
+///
+/// Two writers on opposite sides of the boundary hold to this number, and a
+/// consumer that sets a channel record beside the stderr line for the same
+/// failure has to see one bound rather than two that happen to agree: the
+/// compiler's structural payload printer emits it into the rendering code it
+/// generates, and the runtime's test channel cuts a failure record's `message`
+/// to it. The runtime cannot depend on the compiler, so the number lives in
+/// the crate both of them already depend on instead of as a literal in each.
+pub const RENDERING_BOUND: u64 = 4096;
+
+/// Appended to a rendering [`RENDERING_BOUND`] cut short, in the spelling spec
+/// 6.7:15 fixes. Shared by the same two writers, for the same reason.
+pub const RENDERING_TRUNCATION_MARKER: &str = " …[truncated]";
 
 /// How a parameter crosses the C boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -2070,6 +2088,18 @@ mod tests {
                 .availability
                 .contains(RuntimeTarget::Aarch64Linux)
         );
+    }
+
+    /// The rendering bound and its marker are one normative pair (spec 6.7:15)
+    /// that the compiler's payload printer and the runtime's test channel both
+    /// read from here. Referencing one constant already makes them agree; this
+    /// pins what they agree *on*, so a change to the number or the spelling has
+    /// to be deliberate and has to reach the specification too.
+    #[test]
+    fn the_rendering_bound_and_marker_are_the_normative_pair() {
+        assert_eq!(RENDERING_BOUND, 4096);
+        assert_eq!(RENDERING_TRUNCATION_MARKER, " \u{2026}[truncated]");
+        assert_eq!(RENDERING_TRUNCATION_MARKER.len(), 15);
     }
 
     #[test]

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -119,19 +119,23 @@ const USAGE_MESSAGE: [u8; 50] = *b"rue-test: expected one 16-hex-digit test sele
 
 /// How many bytes of a record's `message` reach the channel.
 ///
-/// The same 4 KiB rendering bound the `?` payload and the comparison operands
-/// are held to (spec 6.7:15), applied here for a different reason: those are
-/// bounded so a report stays readable, and this is bounded so a report stays a
-/// report. The channel's retention budget is a quarter of a stream's and JSON
-/// escaping can expand a control byte six-fold, so a message a few tens of
-/// kilobytes long would exhaust the budget, and the runner answers an exhausted
-/// channel by killing the process group and publishing `output_overflow` — the
-/// trap's class and its exit status lost to the length of its own text.
-const MESSAGE_BOUND: usize = 4096;
+/// This is [`rue_runtime_abi::RENDERING_BOUND`] — the same 4 KiB rendering
+/// bound the `?` payload and the comparison operands are held to (spec
+/// 6.7:15), read from the one crate the compiler's printer and this writer
+/// both depend on rather than spelled again here — applied for a different
+/// reason: those are bounded so a report stays readable, and this is bounded
+/// so a report stays a report. The channel's retention budget is a quarter of
+/// a stream's and JSON escaping can expand a control byte six-fold, so a
+/// message a few tens of kilobytes long would exhaust the budget, and the
+/// runner answers an exhausted channel by killing the process group and
+/// publishing `output_overflow` — the trap's class and its exit status lost to
+/// the length of its own text.
+const MESSAGE_BOUND: usize = rue_runtime_abi::RENDERING_BOUND as usize;
 
 /// Appended to a `message` the bound cut short, in the spelling spec 6.7:15
-/// already fixes for a truncated rendering.
-const TRUNCATION_MARKER: [u8; 15] = *b" \xe2\x80\xa6[truncated]";
+/// already fixes for a truncated rendering and
+/// [`rue_runtime_abi::RENDERING_TRUNCATION_MARKER`] carries for both writers.
+const TRUNCATION_MARKER: &[u8] = rue_runtime_abi::RENDERING_TRUNCATION_MARKER.as_bytes();
 
 /// Emitter for one channel frame.
 ///
@@ -344,7 +348,7 @@ fn failure_head(
     for run in message {
         if run.len() > remaining {
             writer.escaped(&run[..remaining]);
-            writer.raw(&TRUNCATION_MARKER);
+            writer.raw(TRUNCATION_MARKER);
             break;
         }
         writer.escaped(run);

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -14,8 +14,11 @@ target rules without duplicating that contract's helper table.
   result-storage aggregates;
 - safety requirements, return behavior, and target availability;
 - separately classified entry points, compiler-built memory routines,
-  platform shims, and the retained ABI-version marker; and
-- the current lockstep ABI version.
+  platform shims, and the retained ABI-version marker;
+- the current lockstep ABI version; and
+- the rendering bound and truncation marker (`RENDERING_BOUND`,
+  `RENDERING_TRUNCATION_MARKER`) the compiler's payload printer and the
+  runtime's record writer are both held to.
 
 Compiler phases carry `RuntimeHelperId` and typed runtime-call adaptations.
 AIR and CFG do not discover runtime behavior from symbol strings. Shared call
@@ -356,13 +359,16 @@ path directly rather than calling `__rue_panic` — a second `trap:panic` frame
 after their own would be noise on a channel whose first frame is the verdict.
 
 The record writer holds every helper above to two rules the caller does not have
-to know about. A `message` reaches the channel bounded to 4096 bytes, cut to
-that bound with ` …[truncated]` appended, because the channel's retention budget
-is the runner's and a record that exhausts it costs the test its class and its
-exit status; the same message still reaches stderr whole, within stderr's own
-retention budget. And a byte that is not part of a well-formed UTF-8 sequence is
-escaped as `\u00xx` rather than written raw, because a Rue string is an
-arbitrary byte sequence and a record has to stay JSON text (RUE-2064).
+to know about. A `message` reaches the channel bounded to `RENDERING_BOUND`
+(4096) bytes, cut to that bound with `RENDERING_TRUNCATION_MARKER`
+(` …[truncated]`) appended — the same manifest pair the compiler's payload
+printer renders to, so the record and the rendering it carries cannot drift
+apart — because the channel's retention budget is the runner's and a record
+that exhausts it costs the test its class and its exit status; the same message
+still reaches stderr whole, within stderr's own retention budget. And a byte
+that is not part of a well-formed UTF-8 sequence is escaped as `\u00xx` rather
+than written raw, because a Rue string is an arbitrary byte sequence and a
+record has to stay JSON text (RUE-2064).
 [test-events.md](process/test-events.md) states both as the consumer-facing
 contract.
 


### PR DESCRIPTION
`MESSAGE_BOUND`/`TRUNCATION_MARKER` in `rue-runtime::test_channel` and `PAYLOAD_BUDGET`/`TRUNCATION_MARKER` in `rue-compiler::error_printer` were two independently-maintained literals that happened to agree (both 4096, both the same marker string). Moved the pair into `rue-runtime-abi` as `RENDERING_BOUND`/`RENDERING_TRUNCATION_MARKER` (`u64`, since this is a `no_std` target-independent manifest crate); both crates now define their existing local const names in terms of the shared one, so every call site is unchanged. Added a drift test in `rue-runtime-abi` pinning the exact value and marker spelling/length.

Pure refactor, verified with object-level equivalence: the runtime staticlib is byte-identical on x86-64-linux between base and branch, and differs only in debug-info line numbers on aarch64-macos (the added doc comment's line-number shift into `core::panic::Location` records — no code, section, or symbol changed). Both boundaries (4096 whole, 4097 truncated at 4111 bytes) verified by hand on both the runtime test-channel side and the compiler's `?`-payload printer side.

No ABI-version bump: the constants never reach the archive as a symbol, and compiler+archive are built from one revision, so a version mismatch here is unrepresentable. Docs updated in `docs/runtime-abi.md` only — `docs/process/test-events.md`'s existing sentence is a consumer-facing contract claim that's still accurate and shouldn't leak the internal Rust constant name.

Fixes RUE-2082