### PR TITLE
One CFG lowering driver for both backends

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -105,6 +105,33 @@ fn gp_result_index(pieces: rue_air::RegisterPieces) -> usize {
 /// register — so the two directions name one register file.
 pub(super) const FP_RET_REGS: [Reg; 8] = FP_ARG_REGS;
 
+/// This target's answer to [`crate::call_plan::ScratchOverlap`], read off the
+/// rosters above rather than asserted: the reload scratch registers `x9` and
+/// `v16` sit outside the `x0`-`x7` and `v0`-`v7` result banks, so no spill
+/// reload can land in a result register and a register return writes its
+/// result registers forward.
+pub(super) const RETURN_SCRATCH_OVERLAP: crate::call_plan::ScratchOverlap = {
+    let aliases = roster_contains(&RET_REGS, super::mir::SCRATCH_VALUE)
+        || roster_contains(&FP_RET_REGS, super::mir::SCRATCH_FP_VALUE);
+    if aliases {
+        crate::call_plan::ScratchOverlap::AliasesResultRegister
+    } else {
+        crate::call_plan::ScratchOverlap::Disjoint
+    }
+};
+
+/// Whether `roster` names `reg`.
+const fn roster_contains(roster: &[Reg], reg: Reg) -> bool {
+    let mut index = 0;
+    while index < roster.len() {
+        if roster[index] as u8 == reg as u8 {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
 // Call sequences and the prologue name these registers physically, and liveness
 // models neither those physical definitions nor their uses. So they must be off
 // limits to the allocator, not merely unlikely to collide (RUE-1146).
@@ -568,87 +595,8 @@ impl<'a> CfgLower<'a> {
         });
     }
 
-    /// Recursively collect all scalar vregs from a struct value.
     fn ensure_by_ref_param_ptr(&mut self, param_slot: u32) -> VReg {
-        if let Some(ptr_vreg) = self.by_ref_param_ptrs.get(&param_slot).copied() {
-            return ptr_vreg;
-        }
-
-        // Load the pointer from the param's frame home. A register-only
-        // by-ref pointer (RUE-1170) never reaches this load: the entry
-        // preamble copies it out of its argument register into the cache
-        // before any block is lowered, so the memoized hit above serves it.
-        // Stack-passed pointers stay homed by the prologue, so this load is
-        // uniform regardless of param count.
-        let ptr_vreg = self.mir.alloc_vreg();
-        let slot = self.ctx.param_frame_slot(param_slot);
-        let offset = self.ctx.local_offset(slot);
-        self.mir.push(Aarch64Inst::Ldr {
-            dst: Operand::Virtual(ptr_vreg),
-            base: Reg::Fp,
-            offset,
-        });
-
-        // Cache it for future use
-        self.by_ref_param_ptrs.insert(param_slot, ptr_vreg);
-        ptr_vreg
-    }
-
-    /// Copy every register-only parameter (RUE-1170) out of its incoming
-    /// argument register into a virtual register, before CFG control flow
-    /// begins: the argument registers are caller-saved, so the copies must
-    /// precede every call and dominate every use (including loop back-edges
-    /// into the entry block). A register-only by-ref pointer seeds the
-    /// by-ref cache directly.
-    fn materialize_register_params(&mut self) {
-        for (param_slot, class, location) in self.ctx.param_entry_copies() {
-            let (vreg, copy) = match (class, location) {
-                (
-                    crate::abi_slot_class::AbiSlotClass::Gp,
-                    crate::call_plan::AbiSlotLocation::GpReg(class_index),
-                ) => {
-                    let vreg = self.mir.alloc_vreg();
-                    (
-                        vreg,
-                        Aarch64Inst::MovRR {
-                            dst: Operand::Virtual(vreg),
-                            src: Operand::Physical(ARG_REGS[class_index]),
-                        },
-                    )
-                }
-                (
-                    crate::abi_slot_class::AbiSlotClass::Fp(width),
-                    crate::call_plan::AbiSlotLocation::FpReg(class_index),
-                ) => {
-                    let vreg = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
-                    (
-                        vreg,
-                        Aarch64Inst::FloatMov {
-                            dst: Operand::Virtual(vreg),
-                            src: Operand::Physical(FP_ARG_REGS[class_index]),
-                            width,
-                        },
-                    )
-                }
-                _ => unreachable!("register-only parameter class and ABI bank must agree"),
-            };
-            self.mir.push(copy);
-            if self.ctx.cfg.is_param_by_ref(param_slot) {
-                self.by_ref_param_ptrs.insert(param_slot, vreg);
-            } else {
-                self.param_reg_vregs.insert(param_slot, vreg);
-            }
-        }
-    }
-
-    /// Materialize every by-reference parameter pointer before CFG control
-    /// flow begins, so the function-wide cache only contains definitions that
-    /// dominate every block which may reuse them.
-    fn preload_by_ref_param_ptrs(&mut self) {
-        self.materialize_register_params();
-        for param_slot in crate::value_plan::by_ref_param_slots(&self.ctx) {
-            self.ensure_by_ref_param_ptr(param_slot);
-        }
+        crate::cfg_lower::ensure_by_ref_param_ptr(self, param_slot)
     }
 
     fn block_label(&self, block_id: BlockId) -> LabelId {
@@ -1024,21 +972,7 @@ impl<'a> CfgLower<'a> {
         &mut self,
         actions: Vec<crate::value_plan::DropAction>,
     ) -> crate::value_plan::ValueResult {
-        for action in actions {
-            // One cleanup call at a time: building the plan emits the
-            // argument's marshaling, and a caller-owned indirect copy must stay
-            // live until the call it belongs to has returned.
-            let plan = crate::call_plan::CallPlan::from_inputs(
-                crate::call_plan::CallTarget::rue(action.symbol),
-                crate::call_plan::ReturnPlan::ZeroSized,
-                std::slice::from_ref(&action.argument),
-                std::slice::from_ref(&action.native),
-                self,
-            );
-            let _ = self.lower_call_plan(plan);
-        }
-
-        crate::value_plan::ValueResult::SideEffect
+        crate::cfg_lower::lower_drop_plan(self, actions)
     }
 
     fn lower_call_plan(
@@ -1257,38 +1191,10 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Extend a foreign scalar return (in `vreg`) to its canonical 64-bit form
-    /// per the target-C classifier (ADR-0064 P2). The narrow value occupies the
-    /// low bits of `x0` with unspecified high bits; this restores the sign/zero
-    /// extension Rue's scalar invariant relies on.
+    /// per the target-C classifier (ADR-0064 P2), through this backend's one
+    /// extension primitive.
     fn emit_c_return_extension(&mut self, vreg: VReg, ext: rue_air::ScalarAbiExtension) {
-        use rue_air::ScalarAbiExtension;
-        let dst = Operand::Virtual(vreg);
-        let src = Operand::Virtual(vreg);
-        match ext {
-            ScalarAbiExtension::None => {}
-            ScalarAbiExtension::Signed { from_bits: 8 } => {
-                self.mir.push(Aarch64Inst::Sxtb { dst, src })
-            }
-            ScalarAbiExtension::Signed { from_bits: 16 } => {
-                self.mir.push(Aarch64Inst::Sxth { dst, src })
-            }
-            ScalarAbiExtension::Signed { from_bits: 32 } => {
-                self.mir.push(Aarch64Inst::Sxtw { dst, src })
-            }
-            ScalarAbiExtension::Unsigned { from_bits: 8 } => {
-                self.mir.push(Aarch64Inst::Uxtb { dst, src })
-            }
-            ScalarAbiExtension::Unsigned { from_bits: 16 } => {
-                self.mir.push(Aarch64Inst::Uxth { dst, src })
-            }
-            ScalarAbiExtension::Unsigned { from_bits: 32 } => {
-                self.mir.push(Aarch64Inst::Uxtw { dst, src });
-            }
-            ScalarAbiExtension::Signed { from_bits }
-            | ScalarAbiExtension::Unsigned { from_bits } => {
-                panic!("unexpected target-C scalar extension width {from_bits}")
-            }
-        }
+        self.emit_extension(vreg, vreg, crate::cfg_lower::c_return_extension(ext));
     }
 
     /// Write the aggregate `value`'s leaves into the compact image at
@@ -2036,99 +1942,7 @@ impl<'a> CfgLower<'a> {
         ty: Type,
         policy: crate::value_plan::ValuePlan,
     ) -> (VReg, Vec<VReg>) {
-        // A slot's register class follows its LEAF, not the type wrapped around
-        // it (RUE-2001): a `struct Q { f: f64 }` and a bare `f64` hold the same
-        // thing in the same one slot, so reading the width off the parameter's
-        // own type would load a float-carrying wrapper with an integer load into
-        // a general-purpose register and hand it to a float-typed consumer.
-        let leaf_types = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty);
-        let float_width = crate::value_plan::primary_slot_float_width(&leaf_types);
-        let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
-            crate::reg_class::RegClass::Fp
-        } else {
-            crate::reg_class::RegClass::Gp
-        });
-        let count = policy.shape.slot_count();
-        if count == 0 {
-            // No slot to load: `dst` stays the never-read placeholder.
-            return (dst, Vec::new());
-        }
-        if let crate::value_plan::StoragePolicy::ParameterSlot { by_ref: true, .. } = policy.storage
-        {
-            let ptr = self.ensure_by_ref_param_ptr(index);
-            if count > 1 {
-                let slots: Vec<_> = (0..count)
-                    .map(|slot| {
-                        let v = self.mir.alloc_vreg();
-                        self.mir.push(Aarch64Inst::LdrIndexedOffset {
-                            dst: Operand::Virtual(v),
-                            base: ptr,
-                            offset: (slot * 8) as i32,
-                        });
-                        v
-                    })
-                    .collect();
-                return (slots[0], slots);
-            }
-            if let Some(width) = float_width {
-                <Self as crate::place_lower::PlaceLowerBackend>::emit_load_ptr_base(
-                    self,
-                    dst,
-                    ptr,
-                    Some(width),
-                );
-            } else {
-                self.mir.push(Aarch64Inst::LdrIndexed {
-                    dst: Operand::Virtual(dst),
-                    base: ptr,
-                });
-            }
-        } else if count > 1 {
-            let slots: Vec<_> = (0..count)
-                .map(|slot| {
-                    let width = crate::value_plan::float_width(leaf_types[slot as usize]);
-                    let v = self.mir.alloc_vreg_in(if width.is_some() {
-                        crate::reg_class::RegClass::Fp
-                    } else {
-                        crate::reg_class::RegClass::Gp
-                    });
-                    let frame_slot = self.ctx.param_value_low_slot(index, count) - slot;
-                    if let Some(width) = width {
-                        <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
-                            self, v, frame_slot, width,
-                        );
-                    } else {
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(v),
-                            base: Reg::Fp,
-                            offset: self.ctx.local_offset(frame_slot),
-                        });
-                    }
-                    v
-                })
-                .collect();
-            return (slots[0], slots);
-        } else if let Some(&vreg) = self.param_reg_vregs.get(&index) {
-            // Register-only scalar (RUE-1170): the entry preamble copied the
-            // argument register into one read-only vreg shared by every read.
-            return (vreg, Vec::new());
-        } else if let Some(width) = float_width {
-            <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
-                self,
-                dst,
-                self.ctx.param_value_low_slot(index, 1),
-                width,
-            );
-        } else {
-            self.mir.push(Aarch64Inst::Ldr {
-                dst: Operand::Virtual(dst),
-                base: Reg::Fp,
-                offset: self
-                    .ctx
-                    .local_offset(self.ctx.param_value_low_slot(index, 1)),
-            });
-        }
-        (dst, Vec::new())
+        crate::cfg_lower::lower_param_value(self, index, ty, policy)
     }
 
     fn lower_scalar_comparison(
@@ -3502,6 +3316,7 @@ impl<'a> CfgLower<'a> {
             IntegerExtension::Sign16 => Aarch64Inst::Sxth { dst, src },
             IntegerExtension::Zero16 => Aarch64Inst::Uxth { dst, src },
             IntegerExtension::Sign32 => Aarch64Inst::Sxtw { dst, src },
+            IntegerExtension::Zero32 => Aarch64Inst::Uxtw { dst, src },
         });
     }
 
@@ -3541,174 +3356,8 @@ impl<'a> CfgLower<'a> {
         self.emit_extension(vreg, vreg, extension);
     }
 
-    /// Emit a comparison instruction.
     fn emit_terminator_plan(&mut self, plan: crate::terminator_plan::TerminatorPlan) {
-        use crate::terminator_plan::{ReturnMode, ReturnValuePlan, TerminatorPlan};
-
-        match plan {
-            TerminatorPlan::Goto { edge } => {
-                self.emit_edge_moves(&edge);
-                if !edge.fallthrough {
-                    self.mir.push(Aarch64Inst::B {
-                        label: self.block_label(edge.target),
-                    });
-                }
-            }
-            TerminatorPlan::Branch {
-                condition,
-                then_edge,
-                else_edge,
-            } => {
-                if then_edge.fallthrough {
-                    let then_setup_label = self.mir.alloc_label();
-                    self.mir.push(Aarch64Inst::Cbnz {
-                        src: Operand::Virtual(condition),
-                        label: then_setup_label,
-                    });
-                    self.emit_edge_moves(&else_edge);
-                    if !else_edge.fallthrough {
-                        self.mir.push(Aarch64Inst::B {
-                            label: self.block_label(else_edge.target),
-                        });
-                    }
-                    self.mir.push(Aarch64Inst::Label {
-                        id: then_setup_label,
-                    });
-                    self.emit_edge_moves(&then_edge);
-                } else {
-                    let else_setup_label = self.mir.alloc_label();
-                    self.mir.push(Aarch64Inst::Cbz {
-                        src: Operand::Virtual(condition),
-                        label: else_setup_label,
-                    });
-                    self.emit_edge_moves(&then_edge);
-                    if !then_edge.fallthrough {
-                        self.mir.push(Aarch64Inst::B {
-                            label: self.block_label(then_edge.target),
-                        });
-                    }
-                    self.mir.push(Aarch64Inst::Label {
-                        id: else_setup_label,
-                    });
-                    self.emit_edge_moves(&else_edge);
-                    if !else_edge.fallthrough {
-                        self.mir.push(Aarch64Inst::B {
-                            label: self.block_label(else_edge.target),
-                        });
-                    }
-                }
-            }
-            TerminatorPlan::Switch {
-                scrutinee,
-                width,
-                cases,
-                default,
-            } => {
-                for case in cases {
-                    let case_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Virtual(case_vreg),
-                        imm: case.value,
-                    });
-                    if width.bits == 64 {
-                        self.mir.push(Aarch64Inst::Cmp64RR {
-                            src1: Operand::Virtual(scrutinee),
-                            src2: Operand::Virtual(case_vreg),
-                        });
-                    } else {
-                        self.mir.push(Aarch64Inst::CmpRR {
-                            src1: Operand::Virtual(scrutinee),
-                            src2: Operand::Virtual(case_vreg),
-                        });
-                    }
-                    self.mir.push(Aarch64Inst::BCond {
-                        cond: Cond::Eq,
-                        label: self.block_label(case.target),
-                    });
-                }
-                self.mir.push(Aarch64Inst::B {
-                    label: self.block_label(default),
-                });
-            }
-            TerminatorPlan::Return { mode } => match mode {
-                ReturnMode::Exit { call } => {
-                    let _ = self.lower_runtime_call(call);
-                }
-                ReturnMode::Function { value } => match value {
-                    ReturnValuePlan::ZeroSized => self.mir.push(Aarch64Inst::Ret),
-                    ReturnValuePlan::Scalar { value, float_width } => {
-                        self.mir.push(
-                            if self.mir.vreg_class(value) == crate::reg_class::RegClass::Fp {
-                                Aarch64Inst::FloatMov {
-                                    dst: Operand::Physical(Reg::V0),
-                                    src: Operand::Virtual(value),
-                                    width: float_width.expect("FP return width"),
-                                }
-                            } else {
-                                Aarch64Inst::MovRR {
-                                    dst: Operand::Physical(Reg::X0),
-                                    src: Operand::Virtual(value),
-                                }
-                            },
-                        );
-                        self.mir.push(Aarch64Inst::Ret);
-                    }
-                    ReturnValuePlan::Aggregate {
-                        slots,
-                        return_plan,
-                        registers,
-                    } => {
-                        if let crate::call_plan::ReturnPlan::Sret { echoed, .. } = return_plan {
-                            let return_ty = self.ctx.cfg.return_type();
-                            match crate::types::aggregate_physical_slot_map(
-                                self.ctx.type_pool,
-                                return_ty,
-                            ) {
-                                Some(map) => {
-                                    // The sret image is written compact; its padding
-                                    // is zeroed first (ADR-0052 ruling 5).
-                                    let padding =
-                                        self.ctx.type_pool.compact_image_padding_ranges(return_ty);
-                                    crate::agg_slots::store_slots_to_sret_compact(
-                                        self, &slots, &map, &padding,
-                                    )
-                                }
-                                None => match crate::types::aggregate_dispatch_image(
-                                    self.ctx.type_pool,
-                                    return_ty,
-                                ) {
-                                    // Heterogeneous compact aggregate return (RUE-1037):
-                                    // write the sret image with a per-variant tag dispatch.
-                                    Some(image) => crate::agg_slots::store_dispatch_image_to_sret(
-                                        self, &slots, &image,
-                                    ),
-                                    None => crate::agg_slots::store_slots_to_sret(self, &slots),
-                                },
-                            }
-                            // AAPCS64's dedicated `x8` is not echoed; the field
-                            // is read rather than assumed so the two rows stay
-                            // one rule.
-                            if echoed {
-                                crate::agg_slots::SlotBackend::emit_sret_pointer_echo(self);
-                            }
-                        } else {
-                            match registers.as_ref() {
-                                Some(registers) => self.write_return_registers(registers, &slots),
-                                // A zero-sized aggregate names no result
-                                // register because it has no bytes to carry.
-                                None => assert!(
-                                    slots.is_empty(),
-                                    "only a zero-sized aggregate return names no \
-                                     result register"
-                                ),
-                            }
-                        }
-                        self.mir.push(Aarch64Inst::Ret);
-                    }
-                },
-            },
-            TerminatorPlan::Unreachable => self.mir.push(Aarch64Inst::Brk),
-        }
+        crate::cfg_lower::emit_terminator_plan(self, plan)
     }
 
     /// Read one register-returned value's eightbytes out of the result
@@ -3764,6 +3413,11 @@ impl<'a> CfgLower<'a> {
     /// its register; otherwise the leaves are marshaled through the value's
     /// compact image first, and a floating-point piece then carries an image
     /// lane whose bits move whole.
+    ///
+    /// The moves run in the order
+    /// [`ReturnRegisters::write_order`](crate::call_plan::ReturnRegisters::write_order)
+    /// gives for this target's [`RETURN_SCRATCH_OVERLAP`], which is a
+    /// correctness property of a multi-eightbyte return, not a preference.
     fn write_return_registers(
         &mut self,
         registers: &crate::call_plan::ReturnRegisters,
@@ -3779,7 +3433,8 @@ impl<'a> CfgLower<'a> {
             eightbytes.len(),
             "a register return names a result register for every eightbyte"
         );
-        for (reg, value) in registers.regs.iter().zip(&eightbytes) {
+        for position in registers.write_order(RETURN_SCRATCH_OVERLAP) {
+            let (reg, value) = (&registers.regs[position], &eightbytes[position]);
             match *reg {
                 crate::call_plan::ReturnSlotReg::Gp(index) => self.mir.push(Aarch64Inst::MovRR {
                     dst: Operand::Physical(RET_REGS[index]),
@@ -3807,37 +3462,8 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    fn emit_edge_moves(&mut self, edge: &crate::terminator_plan::EdgePlan) {
-        for movement in &edge.moves {
-            self.mir.push(if let Some(width) = movement.float_width {
-                Aarch64Inst::FloatMov {
-                    dst: Operand::Virtual(movement.destination),
-                    src: Operand::Virtual(movement.source),
-                    width,
-                }
-            } else {
-                Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(movement.destination),
-                    src: Operand::Virtual(movement.source),
-                }
-            });
-        }
-    }
-
-    /// Get the vreg for a CFG value.
     fn get_vreg(&mut self, value: CfgValue) -> VReg {
-        if let Some(&vreg) = self.value_map.get(&value) {
-            return vreg;
-        }
-
-        // Not yet lowered - lower it now
-        let ctx = self.ctx;
-        crate::value_plan::lower_value(&ctx, self, value);
-
-        self.value_map
-            .get(&value)
-            .copied()
-            .expect("value should have been lowered")
+        crate::cfg_lower::get_vreg(self, value)
     }
 }
 
@@ -3863,19 +3489,7 @@ impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
         value: CfgValue,
         plan: crate::value_plan::ValuePlan,
     ) -> crate::value_plan::MaterializedValue {
-        let primary = self.block_param_vregs[&(target, param_index)];
-        let slots = if plan.shape.requires_complete_slots() {
-            let slots = self
-                .struct_slot_vregs
-                .get(&value)
-                .cloned()
-                .expect("aggregate block parameter slots should be preallocated");
-            plan.assert_complete_slots(slots.len());
-            slots
-        } else {
-            Vec::new()
-        };
-        crate::value_plan::MaterializedValue { primary, slots }
+        crate::cfg_lower::materialize_block_param(self, target, param_index, value, plan)
     }
 
     fn emit_block_label(&mut self, block: BlockId) {
@@ -3891,39 +3505,11 @@ impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
 
 impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
     fn preload_by_ref_params(&mut self) {
-        self.preload_by_ref_param_ptrs();
-        // Read each by-value aggregate parameter whose leaves are not its
-        // eightbytes back out of the compact image the prologue laid down, so
-        // field projection and whole-value reads see the correct decomposition
-        // (ADR-0084).
-        for (base_slot, image_slot_offset, through_pointer, image) in
-            crate::value_plan::param_image_unmarshals(&self.ctx)
-        {
-            crate::agg_slots::unmarshal_param_image(
-                self,
-                base_slot,
-                image_slot_offset,
-                through_pointer,
-                &image,
-            );
-        }
+        crate::cfg_lower::preload_by_ref_params(self)
     }
 
     fn prepare_block_param(&mut self, block: BlockId, index: u32, value: CfgValue, ty: Type) {
-        let primary_ty = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty)
-            .first()
-            .copied()
-            .unwrap_or(ty);
-        let vreg =
-            self.mir
-                .alloc_vreg_in(if crate::value_plan::float_width(primary_ty).is_some() {
-                    crate::reg_class::RegClass::Fp
-                } else {
-                    crate::reg_class::RegClass::Gp
-                });
-        self.block_param_vregs.insert((block, index), vreg);
-        self.value_map.insert(value, vreg);
-        crate::agg_slots::preallocate_block_param_slots(self, value, ty, vreg);
+        crate::cfg_lower::prepare_block_param(self, block, index, value, ty)
     }
 
     fn value_description(&self, value: CfgValue) -> String {
@@ -4467,6 +4053,149 @@ impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
                 self.mir.push(Aarch64Inst::FloatMov { dst, src, width })
             }
         }
+    }
+}
+
+impl<'a> crate::cfg_lower::LoweringDriverBackend<'a> for CfgLower<'a> {
+    fn lowering_context(&self) -> crate::cfg_lower::CfgLowerContext<'a> {
+        self.ctx
+    }
+
+    fn value_map(&mut self) -> &mut AHashMap<CfgValue, VReg> {
+        &mut self.value_map
+    }
+
+    fn block_param_vregs(&mut self) -> &mut AHashMap<(BlockId, u32), VReg> {
+        &mut self.block_param_vregs
+    }
+
+    fn by_ref_param_ptrs(&mut self) -> &mut AHashMap<u32, VReg> {
+        &mut self.by_ref_param_ptrs
+    }
+
+    fn param_reg_vregs(&mut self) -> &mut AHashMap<u32, VReg> {
+        &mut self.param_reg_vregs
+    }
+
+    fn emit_float_reg_move(&mut self, dst: VReg, src: VReg, width: FloatWidth) {
+        self.mir.push(Aarch64Inst::FloatMov {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(src),
+            width,
+        });
+    }
+
+    fn emit_gp_arg_register_copy(&mut self, dst: VReg, index: usize) {
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(dst),
+            src: Operand::Physical(ARG_REGS[index]),
+        });
+    }
+
+    fn emit_fp_arg_register_copy(&mut self, dst: VReg, index: usize, width: FloatWidth) {
+        self.mir.push(Aarch64Inst::FloatMov {
+            dst: Operand::Virtual(dst),
+            src: Operand::Physical(FP_ARG_REGS[index]),
+            width,
+        });
+    }
+
+    fn lower_call_plan(
+        &mut self,
+        plan: crate::call_plan::CallPlan,
+    ) -> crate::value_plan::MaterializedValue {
+        CfgLower::lower_call_plan(self, plan)
+    }
+
+    fn emit_jump_to_block(&mut self, target: BlockId) {
+        let label = self.block_label(target);
+        self.mir.push(Aarch64Inst::B { label });
+    }
+
+    fn emit_branch_if_nonzero(&mut self, condition: VReg, label: LabelId) {
+        self.mir.push(Aarch64Inst::Cbnz {
+            src: Operand::Virtual(condition),
+            label,
+        });
+    }
+
+    fn emit_branch_if_zero(&mut self, condition: VReg, label: LabelId) {
+        self.mir.push(Aarch64Inst::Cbz {
+            src: Operand::Virtual(condition),
+            label,
+        });
+    }
+
+    fn emit_switch_case_compare(
+        &mut self,
+        scrutinee: VReg,
+        value: i64,
+        width: crate::value_plan::IntegerWidth,
+    ) {
+        let case_vreg = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(case_vreg),
+            imm: value,
+        });
+        if width.bits == 64 {
+            self.mir.push(Aarch64Inst::Cmp64RR {
+                src1: Operand::Virtual(scrutinee),
+                src2: Operand::Virtual(case_vreg),
+            });
+        } else {
+            self.mir.push(Aarch64Inst::CmpRR {
+                src1: Operand::Virtual(scrutinee),
+                src2: Operand::Virtual(case_vreg),
+            });
+        }
+    }
+
+    fn emit_branch_if_equal(&mut self, target: BlockId) {
+        let label = self.block_label(target);
+        self.mir.push(Aarch64Inst::BCond {
+            cond: Cond::Eq,
+            label,
+        });
+    }
+
+    fn emit_scalar_return_move(&mut self, value: VReg, float_width: Option<FloatWidth>) {
+        self.mir.push(
+            if self.mir.vreg_class(value) == crate::reg_class::RegClass::Fp {
+                Aarch64Inst::FloatMov {
+                    dst: Operand::Physical(Reg::V0),
+                    src: Operand::Virtual(value),
+                    width: float_width.expect("FP return width"),
+                }
+            } else {
+                Aarch64Inst::MovRR {
+                    dst: Operand::Physical(Reg::X0),
+                    src: Operand::Virtual(value),
+                }
+            },
+        );
+    }
+
+    fn emit_return(&mut self) {
+        self.mir.push(Aarch64Inst::Ret);
+    }
+
+    fn emit_unreachable(&mut self) {
+        self.mir.push(Aarch64Inst::Brk);
+    }
+
+    fn write_return_registers(
+        &mut self,
+        registers: &crate::call_plan::ReturnRegisters,
+        slots: &[VReg],
+    ) {
+        CfgLower::write_return_registers(self, registers, slots)
+    }
+
+    fn lower_runtime_call(
+        &mut self,
+        plan: crate::runtime_call_plan::RuntimeCallPlan,
+    ) -> crate::value_plan::MaterializedValue {
+        CfgLower::lower_runtime_call(self, plan)
     }
 }
 
@@ -5093,16 +4822,21 @@ mod tests {
     #[test]
     fn zero32_consumers_use_canonical_uxtw_not_shift_pair() {
         let source = include_str!("cfg_lower.rs");
-        let foreign = source
-            .split("ScalarAbiExtension::Unsigned { from_bits: 32 } => {")
+        // The canonical zero-extension is selected once, in this
+        // backend's single extension primitive; the foreign `unsigned int`
+        // return reaches it through `cfg_lower::c_return_extension`.
+        let widen = source
+            .split("IntegerExtension::Zero32 =>")
             .nth(1)
-            .expect("foreign u32 return extension must remain present")
-            .split("ScalarAbiExtension::Signed { from_bits }")
+            .expect("the canonical 32-bit zero-extension arm must remain present")
+            .split('\n')
             .next()
-            .expect("foreign extension match arm must have a following arm");
-        assert!(foreign.contains("Aarch64Inst::Uxtw"));
-        assert!(!foreign.contains("Aarch64Inst::LslImm"));
-        assert!(!foreign.contains("Aarch64Inst::Lsr64Imm"));
+            .expect("an extension arm is one line");
+        assert!(widen.contains("Aarch64Inst::Uxtw"));
+        assert!(!widen.contains("ShlRI"));
+        assert!(!widen.contains("ShrRI"));
+        assert!(!widen.contains("Lsl"));
+        assert!(!widen.contains("Lsr"));
         let bitcast = source
             .split("BitCastForm::Zero32 => {")
             .nth(1)
@@ -6881,6 +6615,94 @@ mod tests {
                 }
             )
         }));
+    }
+
+    /// A return filling this target's whole general-purpose result bank: eight
+    /// eightbytes, one per result register.
+    fn eight_eightbyte_register_return(
+        pool: &FrozenTypeInternPool,
+        interner: &ThreadedRodeo,
+        eight_id: StructId,
+    ) -> ValidatedCfg {
+        let eight_ty = Type::new_struct(eight_id);
+        let mut fixture = FixtureCfg::new(
+            eight_ty,
+            0,
+            "eight",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            pool,
+            interner,
+        );
+        let base = fixture.konst(7, Type::I64);
+        let fields: Vec<_> = (1..=8)
+            .map(|value| {
+                let literal = fixture.konst(value, Type::I64);
+                fixture.value(CfgInstData::BitXor(base, literal), Type::I64)
+            })
+            .collect();
+        let value = fixture.struct_init(eight_id, &fields, eight_ty);
+        fixture.ret(Some(value));
+        fixture.cfg.finish(pool).expect("test CFG must verify")
+    }
+
+    fn eight_i64_fields() -> [(&'static str, Type); 8] {
+        [
+            ("a", Type::I64),
+            ("b", Type::I64),
+            ("c", Type::I64),
+            ("d", Type::I64),
+            ("e", Type::I64),
+            ("f", Type::I64),
+            ("g", Type::I64),
+            ("h", Type::I64),
+        ]
+    }
+
+    #[test]
+    fn a_multi_eightbyte_return_writes_its_result_registers_forward() {
+        // The reload scratch registers `x9` and `v16` are outside the `x0`-`x7`
+        // and `v0`-`v7` result banks, so no spill reload can land on a result
+        // register and this backend's `RETURN_SCRATCH_OVERLAP` leaves the
+        // return's moves in ascending eightbyte order. The order itself is the
+        // shared decision in `call_plan::return_register_write_order`; only the
+        // predicate is this target's.
+        assert_eq!(
+            RETURN_SCRATCH_OVERLAP,
+            crate::call_plan::ScratchOverlap::Disjoint
+        );
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let eight_id = register_struct(&pool, &interner, "Eight", &eight_i64_fields());
+        let pool = pool.freeze();
+        let cfg = eight_eightbyte_register_return(&pool, &interner, eight_id);
+        let mir = CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
+            .lower()
+            .expect("eight-eightbyte return must lower");
+        let written: Vec<_> = mir
+            .instructions()
+            .iter()
+            .filter_map(|inst| match inst {
+                Aarch64Inst::MovRR {
+                    dst: Operand::Physical(dst),
+                    src: Operand::Virtual(_),
+                } if RET_REGS.contains(dst) => Some(*dst),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            written,
+            vec![
+                Reg::X0,
+                Reg::X1,
+                Reg::X2,
+                Reg::X3,
+                Reg::X4,
+                Reg::X5,
+                Reg::X6,
+                Reg::X7
+            ]
+        );
     }
 
     #[test]

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -26,6 +26,7 @@ use rue_cfg::CfgValue;
 
 use crate::allocation::BoundsCheckBackend;
 use crate::cfg_lower::CfgLowerContext;
+use crate::frame_layout::slot_byte_offset;
 use crate::vreg::VReg;
 
 /// The per-backend leaf operations the shared slot logic needs.
@@ -593,11 +594,7 @@ pub(crate) fn store_slots_through_ptr<B: SlotBackend>(
     static_byte_offset: i32,
 ) {
     for (i, val) in vals.iter().enumerate() {
-        b.emit_store_through_ptr(
-            *val,
-            ptr,
-            static_byte_offset + (i as i32) * SLOT_BYTES as i32,
-        );
+        b.emit_store_through_ptr(*val, ptr, static_byte_offset + slot_byte_offset(i));
     }
 }
 
@@ -616,7 +613,7 @@ pub(crate) fn store_slots_through_ptr_typed<B: SlotBackend>(
 ) {
     assert_eq!(vals.len(), leaf_types.len());
     for (i, (val, ty)) in vals.iter().zip(leaf_types).enumerate() {
-        let byte_offset = static_byte_offset + (i as i32) * SLOT_BYTES as i32;
+        let byte_offset = static_byte_offset + slot_byte_offset(i);
         match crate::value_plan::float_width(*ty) {
             Some(width) => b.emit_float_store_through_ptr(*val, ptr, byte_offset, width),
             None => b.emit_store_through_ptr(*val, ptr, byte_offset),
@@ -636,7 +633,7 @@ pub(crate) fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
     let sret_slot = b.ctx().sret_ptr_slot();
     b.emit_load_slot(ptr, sret_slot);
     for (i, val) in vals.iter().enumerate() {
-        b.emit_store_through_ptr(*val, ptr, (i as i32) * SLOT_BYTES as i32);
+        b.emit_store_through_ptr(*val, ptr, slot_byte_offset(i));
     }
 }
 
@@ -943,7 +940,7 @@ pub(crate) fn load_slots_through_ptr_typed<B: SlotBackend>(
         .iter()
         .enumerate()
         .map(|(k, ty)| {
-            let byte_offset = (k as i32) * SLOT_BYTES as i32;
+            let byte_offset = slot_byte_offset(k);
             match crate::value_plan::float_width(*ty) {
                 Some(width) => {
                     let vreg = b.alloc_float_vreg();
@@ -997,7 +994,7 @@ fn load_through_ptr<B: SlotBackend>(b: &mut B, addr_vreg: VReg, count: u32) -> V
     let mut vregs = Vec::with_capacity(count as usize);
     for k in 0..count {
         let vreg = b.alloc_vreg();
-        b.emit_load_through_ptr(vreg, addr_vreg, (k as i32) * SLOT_BYTES as i32);
+        b.emit_load_through_ptr(vreg, addr_vreg, slot_byte_offset(k as usize));
         vregs.push(vreg);
     }
     vregs

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -289,6 +289,105 @@ fn integer_cast_and_arithmetic_post_op_policy_live_only_in_the_value_plan() {
 }
 
 #[test]
+fn target_independent_lowering_drivers_live_only_in_the_shared_cfg_lowering() {
+    // The drivers over the shared plans — the terminator emitter, the parameter
+    // reader, the entry preamble, the block-parameter helpers, the edge moves,
+    // and the drop plan — decide *what* a lowering does; only the instruction
+    // spelling is per target. They were hand-mirrored between the two backends
+    // until RUE-1981, and a driver written twice is a driver that can differ
+    // twice: that is how a multi-slot register return came to be written in one
+    // order on x86-64 and the opposite order on AArch64 with nothing stating
+    // why.
+    let shared = include_str!("cfg_lower.rs");
+    let drivers = [
+        "emit_terminator_plan",
+        "lower_param_value",
+        "materialize_register_params",
+        "preload_by_ref_param_ptrs",
+        "preload_by_ref_params",
+        "ensure_by_ref_param_ptr",
+        "emit_edge_moves",
+        "lower_drop_plan",
+        "get_vreg",
+        "materialize_block_param",
+        "prepare_block_param",
+    ];
+    for driver in drivers {
+        assert!(
+            shared.contains(&format!("pub(crate) fn {driver}")),
+            "the shared CFG lowering lost the {driver} driver"
+        );
+    }
+
+    for (name, source) in [
+        ("x86_64/cfg_lower", include_str!("x86_64/cfg_lower.rs")),
+        ("aarch64/cfg_lower", include_str!("aarch64/cfg_lower.rs")),
+    ] {
+        let production = source
+            .split("\n#[cfg(test)]\nmod ")
+            .next()
+            .expect("codegen production prefix");
+        // Every driver a backend still names is reached through the shared
+        // module, never re-implemented beside it.
+        for driver in [
+            "emit_terminator_plan",
+            "lower_param_value",
+            "ensure_by_ref_param_ptr",
+            "lower_drop_plan",
+            "get_vreg",
+            "materialize_block_param",
+            "preload_by_ref_params",
+            "prepare_block_param",
+        ] {
+            assert_eq!(
+                production
+                    .matches(&format!("crate::cfg_lower::{driver}("))
+                    .count(),
+                1,
+                "backend {name} must reach the shared {driver} driver exactly once"
+            );
+        }
+        // The entry preamble and the edge moves have no backend spelling at
+        // all: the shared driver reaches the machine through the leaves.
+        for internal in [
+            "fn materialize_register_params(",
+            "fn preload_by_ref_param_ptrs(",
+            "fn emit_edge_moves(",
+        ] {
+            assert!(
+                !production.contains(internal),
+                "backend {name} regained a hand-mirrored {internal}"
+            );
+        }
+        // Inline labels come from the MIR's own allocator on both targets, so
+        // the two label namespaces cannot drift apart (RUE-1981).
+        assert!(
+            !production.contains("next_label"),
+            "backend {name} keeps a second inline-label counter beside the MIR's"
+        );
+        assert!(
+            production.contains("alloc_label()"),
+            "backend {name} must allocate inline labels through its MIR"
+        );
+        // The multi-eightbyte return order is a shared decision read from a
+        // per-target predicate, not a hand-placed `.rev()`.
+        assert!(
+            production.contains("RETURN_SCRATCH_OVERLAP"),
+            "backend {name} must name its scratch/result-register overlap"
+        );
+        assert!(
+            production.contains("registers.write_order(RETURN_SCRATCH_OVERLAP)"),
+            "backend {name} must spend its result registers in the shared order"
+        );
+    }
+
+    // The order itself, and the reason it exists, live with the return plan.
+    let call_plan = include_str!("call_plan.rs");
+    assert!(call_plan.contains("pub fn return_register_write_order("));
+    assert!(call_plan.contains("pub enum ScratchOverlap"));
+}
+
+#[test]
 fn codegen_consults_air_for_aggregate_and_switch_compare_policy() {
     // The call planner and the value materializer must classify aggregates
     // identically, or a call passes a value in a shape the other side never

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -241,6 +241,66 @@ impl ReturnRegisters {
     pub fn eightbytes(&self) -> usize {
         self.regs.len()
     }
+
+    /// The eightbyte positions of this return, in the order a callee must move
+    /// them into their result registers.
+    ///
+    /// See [`return_register_write_order`] for why the order is a correctness
+    /// property rather than a preference.
+    pub fn write_order(&self, scratch: ScratchOverlap) -> impl Iterator<Item = usize> + use<> {
+        return_register_write_order(self.eightbytes(), scratch)
+    }
+}
+
+/// Whether a target's register-allocation reload scratch is itself one of the
+/// result registers a return writes.
+///
+/// Every result register is reserved from allocation, so no *source* of a
+/// return move can be sitting in one — with a single exception. When a source
+/// vreg is spilled, register allocation rewrites the move to reload it through
+/// the target's fixed scratch register first, and on a target whose scratch
+/// register is one of the result registers that reload lands in a result
+/// register. SysV AMD64 is such a target twice over: `rax` is both
+/// `SCRATCH_VALUE` and `RET_REGS[0]`, and `xmm0` is both `SCRATCH_FP_VALUE` and
+/// `FP_RET_REGS[0]`. AAPCS64 is not: `x9` and `v16` sit outside `x0`-`x7` and
+/// `v0`-`v7`.
+///
+/// Backends derive this from their own rosters and scratch constants rather
+/// than asserting it, so moving a scratch role onto a result register — or a
+/// result roster onto a scratch register — changes the emission order with it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScratchOverlap {
+    /// No scratch register is a result register; the return writes forward.
+    Disjoint,
+    /// A scratch register is also a result register; the return writes in
+    /// reverse.
+    AliasesResultRegister,
+}
+
+/// The eightbyte positions of a register return, in the order the callee must
+/// move them into their result registers.
+///
+/// With [`ScratchOverlap::AliasesResultRegister`] the moves run from the last
+/// eightbyte down to the first, so that any spill reload staged through the
+/// aliasing scratch register happens *before* the move that writes that
+/// register its final result value. Writing forward would instead let a later
+/// eightbyte's reload overwrite an earlier eightbyte's already-delivered
+/// result — silently corrupting eightbyte 0 of a multi-slot return whenever a
+/// later slot happens to be spilled.
+///
+/// With [`ScratchOverlap::Disjoint`] no reload can touch a result register, so
+/// the natural forward order stands.
+///
+/// The same hazard, in the other direction, orders a call's floating-point
+/// argument registers on x86-64 (`lower_foreign_call`).
+pub fn return_register_write_order(
+    eightbytes: usize,
+    scratch: ScratchOverlap,
+) -> impl Iterator<Item = usize> + use<> {
+    (0..eightbytes).map(move |position| match scratch {
+        ScratchOverlap::Disjoint => position,
+        ScratchOverlap::AliasesResultRegister => eightbytes - 1 - position,
+    })
 }
 
 /// The result registers a register-returned value of type `ty` occupies under
@@ -1133,6 +1193,41 @@ mod tests {
                 }
             })
             .collect()
+    }
+
+    #[test]
+    fn a_return_writes_its_result_registers_forward_when_no_scratch_aliases_one() {
+        // AAPCS64's shape: `x9`/`v16` are outside the result banks, so nothing
+        // a spill reload stages can land on an already-written result register
+        // and the natural ascending order stands.
+        let order: Vec<usize> = return_register_write_order(4, ScratchOverlap::Disjoint).collect();
+        assert_eq!(order, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn a_return_writes_its_result_registers_in_reverse_when_a_scratch_aliases_one() {
+        // SysV AMD64's shape: `rax` is both the reload scratch and result
+        // register 0, so eightbyte 0 must be written last — after every later
+        // eightbyte's possible reload through it.
+        let order: Vec<usize> =
+            return_register_write_order(4, ScratchOverlap::AliasesResultRegister).collect();
+        assert_eq!(order, vec![3, 2, 1, 0]);
+    }
+
+    #[test]
+    fn a_single_eightbyte_return_has_one_write_under_either_scratch_overlap() {
+        for scratch in [
+            ScratchOverlap::Disjoint,
+            ScratchOverlap::AliasesResultRegister,
+        ] {
+            let order: Vec<usize> = return_register_write_order(1, scratch).collect();
+            assert_eq!(order, vec![0], "{scratch:?}");
+            assert_eq!(
+                return_register_write_order(0, scratch).count(),
+                0,
+                "{scratch:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -1,21 +1,27 @@
-//! Shared types and utilities for CFG lowering across backends.
-//!
-//! This module contains types and helper functions used by both x86_64 and aarch64
-//! backends when lowering CFG to machine IR.
+//! Target-independent CFG lowering: context, drivers, and debug reporting.
 //!
 //! ## Architecture
 //!
-//! The CFG lowering is split into two parts:
+//! CFG lowering is split three ways:
 //!
-//! 1. **Shared context** ([`CfgLowerContext`]): Holds common data and implements
-//!    architecture-independent helper methods like type queries and chain tracing.
+//! 1. **Shared context** ([`CfgLowerContext`]): the CFG, the type pool, and the
+//!    frame-slot translation every addressed access passes through.
 //!
-//! 2. **Backend-specific lowering** (per-backend `CfgLower`): Each backend embeds
-//!    a `CfgLowerContext` and implements instruction-specific lowering that produces
-//!    its MIR type.
+//! 2. **Shared drivers** ([`LoweringDriverBackend`] and the functions below):
+//!    the parts that decide *what* a lowering does — how a terminator's edges
+//!    are ordered, where a parameter is read from, what the entry preamble
+//!    copies, which cleanup calls a drop plan makes. These read the shared
+//!    plans (`terminator_plan`, `value_plan`, `call_plan`) and reach the
+//!    machine through per-target leaves.
 //!
-//! This design eliminates significant code duplication while keeping the
-//! instruction-specific logic where it belongs.
+//! 3. **Backend-specific lowering** (per-backend `CfgLower`): the instruction
+//!    spellings, the register-class-specific sequences, and the arms that are
+//!    genuinely one target's (`@syscall`, division and overflow sequences).
+//!
+//! A driver written once cannot drift between the two backends. A driver
+//! written twice can, silently: the multi-eightbyte return order did exactly
+//! that, and the reason for it now travels with the plan rather than with one
+//! backend's comment (see [`crate::call_plan::return_register_write_order`]).
 
 use std::fmt;
 
@@ -24,6 +30,7 @@ use rue_air::{FrozenTypeInternPool, StructId, TypeKind};
 use rue_cfg::{BlockId, Cfg, CfgValue, Type};
 
 use crate::types;
+use crate::vreg::{LabelId, VReg};
 
 /// A single lowering decision: maps one CFG instruction to its MIR expansion.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -589,5 +596,576 @@ impl<'a> CfgLowerContext<'a> {
             }
             None => self.param_frame_slot(index) + slot_count.saturating_sub(1),
         }
+    }
+}
+
+/// The canonical-form extension a foreign scalar return needs (ADR-0064 P2).
+///
+/// The narrow value occupies the low bits of the target row's result register
+/// with unspecified high bits, so unlike a Rue-internal 32-bit unsigned value —
+/// which every 32-bit machine operation already leaves canonical — a foreign
+/// `unsigned int` return has to be zero-extended explicitly. Each backend
+/// spells the named extension through its one extension primitive.
+pub(crate) fn c_return_extension(
+    ext: rue_air::ScalarAbiExtension,
+) -> crate::value_plan::IntegerExtension {
+    use crate::value_plan::IntegerExtension;
+    use rue_air::ScalarAbiExtension;
+    match ext {
+        ScalarAbiExtension::None => IntegerExtension::None,
+        ScalarAbiExtension::Signed { from_bits: 8 } => IntegerExtension::Sign8,
+        ScalarAbiExtension::Signed { from_bits: 16 } => IntegerExtension::Sign16,
+        ScalarAbiExtension::Signed { from_bits: 32 } => IntegerExtension::Sign32,
+        ScalarAbiExtension::Unsigned { from_bits: 8 } => IntegerExtension::Zero8,
+        ScalarAbiExtension::Unsigned { from_bits: 16 } => IntegerExtension::Zero16,
+        ScalarAbiExtension::Unsigned { from_bits: 32 } => IntegerExtension::Zero32,
+        ScalarAbiExtension::Signed { from_bits } | ScalarAbiExtension::Unsigned { from_bits } => {
+            panic!("unexpected target-C scalar extension width {from_bits}")
+        }
+    }
+}
+
+// ============================================================================
+// Target-independent lowering drivers
+// ============================================================================
+
+/// The lowerer state and per-target instruction leaves the drivers below reach.
+///
+/// The drivers are the parts of CFG lowering that decide *what* happens rather
+/// than how it is spelled — cache a value's vreg, copy each register-only
+/// parameter out of its argument register, emit one move per edge slot, run a
+/// drop plan's cleanup calls. They were hand-mirrored between the two backends
+/// for as long as there were two of them; they live here once, and each
+/// backend's method delegates. Only operations whose spelling *is* an
+/// instruction, and the lowerer's own caches, are trait items.
+///
+/// The lifetime parameter carries the lowering context's own borrow of the CFG
+/// and type pool, which outlives any borrow of the lowerer, so a driver can
+/// hold the context while it emits.
+pub(crate) trait LoweringDriverBackend<'a>: crate::place_lower::PlaceLowerBackend {
+    /// The shared lowering context, by value.
+    fn lowering_context(&self) -> CfgLowerContext<'a>;
+
+    /// The primary vreg cache: one entry per lowered CFG value.
+    fn value_map(&mut self) -> &mut ahash::AHashMap<CfgValue, VReg>;
+
+    /// The vreg carrying each block parameter, by `(block, parameter index)`.
+    fn block_param_vregs(&mut self) -> &mut ahash::AHashMap<(BlockId, u32), VReg>;
+
+    /// The received by-reference parameter pointers, by parameter ABI slot.
+    fn by_ref_param_ptrs(&mut self) -> &mut ahash::AHashMap<u32, VReg>;
+
+    /// The vregs holding register-only parameters (RUE-1170), by ABI slot.
+    fn param_reg_vregs(&mut self) -> &mut ahash::AHashMap<u32, VReg>;
+
+    /// Emit a floating-point register-to-register move at `width`.
+    fn emit_float_reg_move(&mut self, dst: VReg, src: VReg, width: crate::value_plan::FloatWidth);
+
+    /// Copy incoming general-purpose argument register `index` into `dst`.
+    fn emit_gp_arg_register_copy(&mut self, dst: VReg, index: usize);
+
+    /// Copy incoming floating-point argument register `index` into `dst`.
+    fn emit_fp_arg_register_copy(
+        &mut self,
+        dst: VReg,
+        index: usize,
+        width: crate::value_plan::FloatWidth,
+    );
+
+    /// Lower one planned call and materialize its result.
+    fn lower_call_plan(
+        &mut self,
+        plan: crate::call_plan::CallPlan,
+    ) -> crate::value_plan::MaterializedValue;
+
+    /// Jump to `target`'s block label.
+    fn emit_jump_to_block(&mut self, target: BlockId);
+
+    /// Branch to `label` when `condition` is nonzero, comparing against zero
+    /// first on a target whose branches read a flags register.
+    fn emit_branch_if_nonzero(&mut self, condition: VReg, label: LabelId);
+
+    /// Branch to `label` when `condition` is zero, comparing against zero
+    /// first on a target whose branches read a flags register.
+    fn emit_branch_if_zero(&mut self, condition: VReg, label: LabelId);
+
+    /// Compare `scrutinee` against one switch case value at `width`.
+    fn emit_switch_case_compare(
+        &mut self,
+        scrutinee: VReg,
+        value: i64,
+        width: crate::value_plan::IntegerWidth,
+    );
+
+    /// Branch to `target`'s block label when the last comparison was equal.
+    fn emit_branch_if_equal(&mut self, target: BlockId);
+
+    /// Move a scalar return value into the result register of its own bank.
+    fn emit_scalar_return_move(
+        &mut self,
+        value: VReg,
+        float_width: Option<crate::value_plan::FloatWidth>,
+    );
+
+    /// Return from the function.
+    fn emit_return(&mut self);
+
+    /// Trap: control reached a terminator the CFG proved unreachable.
+    fn emit_unreachable(&mut self);
+
+    /// Write one register-returned value into the result registers the shared
+    /// lowering named for it, in
+    /// [`ReturnRegisters::write_order`](crate::call_plan::ReturnRegisters::write_order).
+    fn write_return_registers(
+        &mut self,
+        registers: &crate::call_plan::ReturnRegisters,
+        slots: &[VReg],
+    );
+
+    /// Lower one planned runtime-helper call.
+    fn lower_runtime_call(
+        &mut self,
+        plan: crate::runtime_call_plan::RuntimeCallPlan,
+    ) -> crate::value_plan::MaterializedValue;
+}
+
+/// The vreg carrying `value`, lowering the value first if it has not been
+/// reached yet.
+pub(crate) fn get_vreg<'a, B: LoweringDriverBackend<'a>>(b: &mut B, value: CfgValue) -> VReg {
+    if let Some(&vreg) = b.value_map().get(&value) {
+        return vreg;
+    }
+
+    // Not yet lowered - lower it now
+    let ctx = b.lowering_context();
+    crate::value_plan::lower_value(&ctx, b, value);
+
+    b.value_map()
+        .get(&value)
+        .copied()
+        .expect("value should have been lowered")
+}
+
+/// The vregs a CFG edge's argument arrives in, which
+/// [`prepare_block_param`] reserved before any block was lowered.
+pub(crate) fn materialize_block_param<'a, B: LoweringDriverBackend<'a>>(
+    b: &mut B,
+    target: BlockId,
+    param_index: u32,
+    value: CfgValue,
+    plan: crate::value_plan::ValuePlan,
+) -> crate::value_plan::MaterializedValue {
+    let primary = b.block_param_vregs()[&(target, param_index)];
+    let slots = if plan.shape.requires_complete_slots() {
+        let slots = b
+            .slot_cache()
+            .get(&value)
+            .cloned()
+            .expect("aggregate block parameter slots should be preallocated");
+        plan.assert_complete_slots(slots.len());
+        slots
+    } else {
+        Vec::new()
+    };
+    crate::value_plan::MaterializedValue { primary, slots }
+}
+
+/// Reserve the vregs one block parameter arrives in, in the register class its
+/// leaf names, before any block is lowered.
+pub(crate) fn prepare_block_param<'a, B: LoweringDriverBackend<'a>>(
+    b: &mut B,
+    block: BlockId,
+    index: u32,
+    value: CfgValue,
+    ty: Type,
+) {
+    let primary_ty = crate::types::aggregate_leaf_types(b.ctx().type_pool, ty)
+        .first()
+        .copied()
+        .unwrap_or(ty);
+    let vreg = if crate::value_plan::float_width(primary_ty).is_some() {
+        b.alloc_float_vreg()
+    } else {
+        b.alloc_vreg()
+    };
+    b.block_param_vregs().insert((block, index), vreg);
+    b.value_map().insert(value, vreg);
+    crate::agg_slots::preallocate_block_param_slots(b, value, ty, vreg);
+}
+
+/// The whole entry preamble: register-only parameter copies, by-reference
+/// parameter pointers, and the by-value aggregate parameters read back out of
+/// their compact images.
+pub(crate) fn preload_by_ref_params<'a, B: LoweringDriverBackend<'a>>(b: &mut B) {
+    preload_by_ref_param_ptrs(b);
+    // Read each by-value aggregate parameter whose leaves are not its
+    // eightbytes back out of the compact image the prologue laid down, so
+    // field projection and whole-value reads see the correct decomposition
+    // (ADR-0084).
+    let unmarshals = crate::value_plan::param_image_unmarshals(b.ctx());
+    for (base_slot, image_slot_offset, through_pointer, image) in unmarshals {
+        crate::agg_slots::unmarshal_param_image(
+            b,
+            base_slot,
+            image_slot_offset,
+            through_pointer,
+            &image,
+        );
+    }
+}
+
+/// Materialize every by-reference parameter pointer before CFG control flow
+/// begins, so the function-wide cache only contains definitions that dominate
+/// every block which may reuse them.
+pub(crate) fn preload_by_ref_param_ptrs<'a, B: LoweringDriverBackend<'a>>(b: &mut B) {
+    materialize_register_params(b);
+    let by_ref = crate::value_plan::by_ref_param_slots(b.ctx());
+    for param_slot in by_ref {
+        ensure_by_ref_param_ptr(b, param_slot);
+    }
+}
+
+/// Copy every register-only parameter (RUE-1170) out of its incoming argument
+/// register into a virtual register, before CFG control flow begins: the
+/// argument registers are caller-saved, so the copies must precede every call
+/// and dominate every use (including loop back-edges into the entry block). A
+/// register-only by-ref pointer seeds the by-ref cache directly.
+pub(crate) fn materialize_register_params<'a, B: LoweringDriverBackend<'a>>(b: &mut B) {
+    let entry_copies = b.ctx().param_entry_copies();
+    for (param_slot, class, location) in entry_copies {
+        let vreg = match (class, location) {
+            (
+                crate::abi_slot_class::AbiSlotClass::Gp,
+                crate::call_plan::AbiSlotLocation::GpReg(class_index),
+            ) => {
+                let vreg = b.alloc_vreg();
+                b.emit_gp_arg_register_copy(vreg, class_index);
+                vreg
+            }
+            (
+                crate::abi_slot_class::AbiSlotClass::Fp(width),
+                crate::call_plan::AbiSlotLocation::FpReg(class_index),
+            ) => {
+                let vreg = b.alloc_float_vreg();
+                b.emit_fp_arg_register_copy(vreg, class_index, width);
+                vreg
+            }
+            _ => unreachable!("register-only parameter class and ABI bank must agree"),
+        };
+        if b.ctx().cfg.is_param_by_ref(param_slot) {
+            b.by_ref_param_ptrs().insert(param_slot, vreg);
+        } else {
+            b.param_reg_vregs().insert(param_slot, vreg);
+        }
+    }
+}
+
+/// The pointer a by-reference parameter was received through, loaded from its
+/// frame home on first use and cached for the rest of the function.
+pub(crate) fn ensure_by_ref_param_ptr<'a, B: LoweringDriverBackend<'a>>(
+    b: &mut B,
+    param_slot: u32,
+) -> VReg {
+    if let Some(ptr_vreg) = b.by_ref_param_ptrs().get(&param_slot).copied() {
+        return ptr_vreg;
+    }
+
+    // Load the pointer from the param's frame home. A register-only
+    // by-ref pointer (RUE-1170) never reaches this load: the entry
+    // preamble copies it out of its argument register into the cache
+    // before any block is lowered, so the memoized hit above serves it.
+    // Stack-passed pointers stay homed by the prologue, so this load is
+    // uniform regardless of param count.
+    let ptr_vreg = b.alloc_vreg();
+    let slot = b.ctx().param_frame_slot(param_slot);
+    b.emit_load_slot(ptr_vreg, slot);
+
+    // Cache it for future use
+    b.by_ref_param_ptrs().insert(param_slot, ptr_vreg);
+    ptr_vreg
+}
+
+/// Emit one move per logical slot an edge carries into its target's block
+/// parameters.
+pub(crate) fn emit_edge_moves<'a, B: LoweringDriverBackend<'a>>(
+    b: &mut B,
+    edge: &crate::terminator_plan::EdgePlan,
+) {
+    for movement in &edge.moves {
+        match movement.float_width {
+            Some(width) => b.emit_float_reg_move(movement.destination, movement.source, width),
+            None => b.emit_reg_move(movement.destination, movement.source),
+        }
+    }
+}
+
+/// The vregs one `Param` value's slots arrive in.
+///
+/// A parameter reaches its reader in one of four shapes: through the pointer a
+/// by-reference parameter was received as, out of the frame image a homed
+/// parameter occupies, straight from the vreg the entry preamble copied a
+/// register-only parameter into (RUE-1170), or — for a zero-slot value — not
+/// at all.
+pub(crate) fn lower_param_value<'a, B: LoweringDriverBackend<'a>>(
+    b: &mut B,
+    index: u32,
+    ty: Type,
+    policy: crate::value_plan::ValuePlan,
+) -> (VReg, Vec<VReg>) {
+    // A slot's register class follows its LEAF, not the type wrapped around
+    // it (RUE-2001): a `struct Q { f: f64 }` and a bare `f64` hold the same
+    // thing in the same one slot, so reading the width off the parameter's
+    // own type would load a float-carrying wrapper with an integer load into
+    // a general-purpose register and hand it to a float-typed consumer.
+    let leaf_types = crate::types::aggregate_leaf_types(b.ctx().type_pool, ty);
+    let float_width = crate::value_plan::primary_slot_float_width(&leaf_types);
+    let dst = if float_width.is_some() {
+        b.alloc_float_vreg()
+    } else {
+        b.alloc_vreg()
+    };
+    let count = policy.shape.slot_count();
+    if count == 0 {
+        // No slot to load: `dst` stays the never-read placeholder.
+        return (dst, Vec::new());
+    }
+    if let crate::value_plan::StoragePolicy::ParameterSlot { by_ref: true, .. } = policy.storage {
+        let ptr = ensure_by_ref_param_ptr(b, index);
+        if count > 1 {
+            let slots: Vec<_> = (0..count)
+                .map(|slot| {
+                    let v = b.alloc_vreg();
+                    b.emit_load_through_ptr(
+                        v,
+                        ptr,
+                        crate::frame_layout::slot_byte_offset(slot as usize),
+                    );
+                    v
+                })
+                .collect();
+            return (slots[0], slots);
+        }
+        b.emit_load_ptr_base(dst, ptr, float_width);
+    } else if count > 1 {
+        let slots: Vec<_> = (0..count)
+            .map(|slot| {
+                let width = crate::value_plan::float_width(leaf_types[slot as usize]);
+                let v = if width.is_some() {
+                    b.alloc_float_vreg()
+                } else {
+                    b.alloc_vreg()
+                };
+                let frame_slot = b.ctx().param_value_low_slot(index, count) - slot;
+                match width {
+                    Some(width) => b.emit_float_load_slot(v, frame_slot, width),
+                    None => b.emit_load_slot(v, frame_slot),
+                }
+                v
+            })
+            .collect();
+        return (slots[0], slots);
+    } else if let Some(&vreg) = b.param_reg_vregs().get(&index) {
+        // Register-only scalar (RUE-1170): the entry preamble copied the
+        // argument register into one read-only vreg shared by every read.
+        return (vreg, Vec::new());
+    } else {
+        let frame_slot = b.ctx().param_value_low_slot(index, 1);
+        match float_width {
+            Some(width) => b.emit_float_load_slot(dst, frame_slot, width),
+            None => b.emit_load_slot(dst, frame_slot),
+        }
+    }
+    (dst, Vec::new())
+}
+
+/// Emit one block terminator from its target-neutral plan.
+///
+/// Every branch topology decision — which edge falls through, which one gets
+/// the setup label, which comparison the switch spends — is made here, once;
+/// the backends supply only the instruction spelling for each step.
+pub(crate) fn emit_terminator_plan<'a, B: LoweringDriverBackend<'a>>(
+    b: &mut B,
+    plan: crate::terminator_plan::TerminatorPlan,
+) {
+    use crate::terminator_plan::{ReturnMode, ReturnValuePlan, TerminatorPlan};
+
+    match plan {
+        TerminatorPlan::Goto { edge } => {
+            emit_edge_moves(b, &edge);
+            if !edge.fallthrough {
+                b.emit_jump_to_block(edge.target);
+            }
+        }
+        TerminatorPlan::Branch {
+            condition,
+            then_edge,
+            else_edge,
+        } => {
+            // The edge that falls through is emitted last, so the branch is
+            // spelled against the other one and the fall-through edge's moves
+            // land immediately before its target block.
+            if then_edge.fallthrough {
+                let then_setup_label = b.alloc_lowering_label();
+                b.emit_branch_if_nonzero(condition, then_setup_label);
+                emit_edge_moves(b, &else_edge);
+                if !else_edge.fallthrough {
+                    b.emit_jump_to_block(else_edge.target);
+                }
+                b.emit_lowering_label(then_setup_label);
+                emit_edge_moves(b, &then_edge);
+            } else {
+                let else_setup_label = b.alloc_lowering_label();
+                b.emit_branch_if_zero(condition, else_setup_label);
+                emit_edge_moves(b, &then_edge);
+                if !then_edge.fallthrough {
+                    b.emit_jump_to_block(then_edge.target);
+                }
+                b.emit_lowering_label(else_setup_label);
+                emit_edge_moves(b, &else_edge);
+                if !else_edge.fallthrough {
+                    b.emit_jump_to_block(else_edge.target);
+                }
+            }
+        }
+        TerminatorPlan::Switch {
+            scrutinee,
+            width,
+            cases,
+            default,
+        } => {
+            for case in cases {
+                b.emit_switch_case_compare(scrutinee, case.value, width);
+                b.emit_branch_if_equal(case.target);
+            }
+            b.emit_jump_to_block(default);
+        }
+        TerminatorPlan::Return { mode } => match mode {
+            ReturnMode::Exit { call } => {
+                let _ = b.lower_runtime_call(call);
+            }
+            ReturnMode::Function { value } => match value {
+                ReturnValuePlan::ZeroSized => b.emit_return(),
+                ReturnValuePlan::Scalar { value, float_width } => {
+                    b.emit_scalar_return_move(value, float_width);
+                    b.emit_return();
+                }
+                ReturnValuePlan::Aggregate {
+                    slots,
+                    return_plan,
+                    registers,
+                } => {
+                    if let crate::call_plan::ReturnPlan::Sret { echoed, .. } = return_plan {
+                        let return_ty = b.ctx().cfg.return_type();
+                        let slot_map =
+                            crate::types::aggregate_physical_slot_map(b.ctx().type_pool, return_ty);
+                        match slot_map {
+                            Some(map) => {
+                                // The sret image is written compact; its padding
+                                // is zeroed first (ADR-0052 ruling 5).
+                                let padding =
+                                    b.ctx().type_pool.compact_image_padding_ranges(return_ty);
+                                crate::agg_slots::store_slots_to_sret_compact(
+                                    b, &slots, &map, &padding,
+                                )
+                            }
+                            None => {
+                                let dispatch = crate::types::aggregate_dispatch_image(
+                                    b.ctx().type_pool,
+                                    return_ty,
+                                );
+                                match dispatch {
+                                    // Heterogeneous compact aggregate return (RUE-1037):
+                                    // write the sret image with a per-variant tag dispatch.
+                                    Some(image) => crate::agg_slots::store_dispatch_image_to_sret(
+                                        b, &slots, &image,
+                                    ),
+                                    None => crate::agg_slots::store_slots_to_sret(b, &slots),
+                                }
+                            }
+                        }
+                        // SysV AMD64 requires the callee to leave the
+                        // indirect-result pointer in `rax` on return; AAPCS64's
+                        // dedicated `x8` is not echoed. The row's own field is
+                        // read rather than assumed, so the two stay one rule.
+                        if echoed {
+                            crate::agg_slots::SlotBackend::emit_sret_pointer_echo(b);
+                        }
+                    } else {
+                        match registers.as_ref() {
+                            Some(registers) => b.write_return_registers(registers, &slots),
+                            // A zero-sized aggregate names no result
+                            // register because it has no bytes to carry.
+                            None => assert!(
+                                slots.is_empty(),
+                                "only a zero-sized aggregate return names no \
+                                 result register"
+                            ),
+                        }
+                    }
+                    b.emit_return();
+                }
+            },
+        },
+        TerminatorPlan::Unreachable => b.emit_unreachable(),
+    }
+}
+
+/// Emit a drop plan's cleanup calls.
+pub(crate) fn lower_drop_plan<'a, B: LoweringDriverBackend<'a>>(
+    b: &mut B,
+    actions: Vec<crate::value_plan::DropAction>,
+) -> crate::value_plan::ValueResult {
+    for action in actions {
+        // One cleanup call at a time: building the plan emits the
+        // argument's marshaling, and a caller-owned indirect copy must stay
+        // live until the call it belongs to has returned.
+        let plan = crate::call_plan::CallPlan::from_inputs(
+            crate::call_plan::CallTarget::rue(action.symbol),
+            crate::call_plan::ReturnPlan::ZeroSized,
+            std::slice::from_ref(&action.argument),
+            std::slice::from_ref(&action.native),
+            b,
+        );
+        let _ = b.lower_call_plan(plan);
+    }
+
+    crate::value_plan::ValueResult::SideEffect
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value_plan::IntegerExtension;
+    use rue_air::ScalarAbiExtension;
+
+    #[test]
+    fn a_foreign_narrow_return_names_the_extension_its_signedness_asks_for() {
+        assert_eq!(
+            c_return_extension(ScalarAbiExtension::None),
+            IntegerExtension::None
+        );
+        for (bits, signed, expected) in [
+            (8, true, IntegerExtension::Sign8),
+            (16, true, IntegerExtension::Sign16),
+            (32, true, IntegerExtension::Sign32),
+            (8, false, IntegerExtension::Zero8),
+            (16, false, IntegerExtension::Zero16),
+            // A foreign `unsigned int` leaves bits 32-63 unspecified, unlike
+            // every Rue-internal 32-bit result, so this one is explicit.
+            (32, false, IntegerExtension::Zero32),
+        ] {
+            let ext = if signed {
+                ScalarAbiExtension::Signed { from_bits: bits }
+            } else {
+                ScalarAbiExtension::Unsigned { from_bits: bits }
+            };
+            assert_eq!(c_return_extension(ext), expected, "{ext:?}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "unexpected target-C scalar extension width")]
+    fn a_foreign_return_of_an_unclassified_width_is_rejected() {
+        c_return_extension(ScalarAbiExtension::Unsigned { from_bits: 7 });
     }
 }

--- a/crates/rue-codegen/src/frame_layout.rs
+++ b/crates/rue-codegen/src/frame_layout.rs
@@ -87,6 +87,19 @@ pub fn checked_cell_byte_offset(cell_index: u64) -> Result<i32, FrameBudgetExcee
     .map_err(|_| FrameBudgetExceeded)
 }
 
+/// Byte offset of logical slot `slot` within an ascending slot-shaped image,
+/// frame region, or pointee.
+///
+/// This is [`checked_cell_byte_offset`] under the name the slot-by-slot walks
+/// use, so aggregate memory traffic reads its stride from the one layout
+/// authority instead of re-deriving `* SLOT_BYTES` at each access site. A slot
+/// index that overruns the displacement budget is a planning bug rather than a
+/// program input, so it is reported as a panic-backed ICE.
+#[inline]
+pub fn slot_byte_offset(slot: usize) -> i32 {
+    checked_cell_byte_offset(slot as u64).expect("a slot's byte offset must fit displacement")
+}
+
 /// Convert a byte count used as a machine displacement or immediate without
 /// allowing a narrowing conversion to wrap.
 #[inline]

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -13,6 +13,7 @@
 
 use crate::agg_slots::{self, SlotBackend};
 use crate::allocation::{self, ScalePlan};
+use crate::frame_layout::slot_byte_offset;
 use crate::vreg::VReg;
 use rue_air::Type;
 
@@ -181,7 +182,7 @@ fn resolved_access<B: PlaceLowerBackend + ?Sized>(
         ),
         crate::value_plan::PlaceBasePlan::Param { slot, by_ref: true } => {
             let ptr = b.ensure_by_ref_param_ptr(slot);
-            let byte_offset = offsets.static_slot_offset as i32 * allocation::SLOT_BYTES as i32;
+            let byte_offset = slot_byte_offset(offsets.static_slot_offset as usize);
             if let Some(dynamic) = dynamic_offset {
                 let addr = b.alloc_vreg();
                 b.emit_reg_move(addr, ptr);
@@ -206,7 +207,7 @@ fn resolved_access<B: PlaceLowerBackend + ?Sized>(
             )
         }
         crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
-            let byte_offset = offsets.static_slot_offset as i32 * allocation::SLOT_BYTES as i32;
+            let byte_offset = slot_byte_offset(offsets.static_slot_offset as usize);
             if let Some(dynamic) = dynamic_offset {
                 let addr = b.alloc_vreg();
                 b.emit_reg_move(addr, ptr);
@@ -438,7 +439,7 @@ fn lower_place_addr_plan_with_bounds<B: PlaceLowerBackend + ?Sized>(
         crate::value_plan::PlaceBasePlan::Param { slot, by_ref: true } => {
             let ptr = b.ensure_by_ref_param_ptr(slot);
             b.emit_reg_move(dst, ptr);
-            let byte_offset = offsets.static_slot_offset as i32 * allocation::SLOT_BYTES as i32;
+            let byte_offset = slot_byte_offset(offsets.static_slot_offset as usize);
             if byte_offset != 0 {
                 b.emit_addr_add_imm(dst, byte_offset);
             }
@@ -461,7 +462,7 @@ fn lower_place_addr_plan_with_bounds<B: PlaceLowerBackend + ?Sized>(
         }
         crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
             b.emit_reg_move(dst, ptr);
-            let byte_offset = offsets.static_slot_offset as i32 * allocation::SLOT_BYTES as i32;
+            let byte_offset = slot_byte_offset(offsets.static_slot_offset as usize);
             if byte_offset != 0 {
                 b.emit_addr_add_imm(dst, byte_offset);
             }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -905,6 +905,12 @@ pub enum IntegerExtension {
     Sign16,
     Zero16,
     Sign32,
+    /// Zero the high 32 bits. No Rue-internal width asks for this — an
+    /// unsigned 32-bit value is already canonical, because every 32-bit
+    /// machine operation leaves bits 32-63 zero (see [`width_extension`]) —
+    /// but a foreign callee returning `unsigned int` leaves them unspecified,
+    /// so the `extern "C"` return path names it explicitly (ADR-0064 P2).
+    Zero32,
 }
 
 /// The language operation whose target adapter must emit instructions.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2,28 +2,6 @@
 //!
 //! This module converts CFG (explicit control flow graph) to X86Mir
 //! (x86-64 instructions with virtual registers).
-//!
-//! # Label Namespace Separation
-//!
-//! During lowering, we need to generate labels for two distinct purposes:
-//!
-//! 1. **Block labels** - Each CFG basic block gets a label for control flow
-//!    (jumps, branches, etc.). These are derived deterministically from block IDs.
-//!
-//! 2. **Inline labels** - Generated during instruction lowering for things like
-//!    overflow checks, bounds checks, division-by-zero checks, and conditional
-//!    branches within a single CFG instruction.
-//!
-//! To prevent collisions, we partition the `u32` label ID space:
-//!
-//! - **Inline labels**: IDs `0` to `BLOCK_LABEL_BASE - 1` (allocated via [`CfgLower::new_label`])
-//! - **Block labels**: IDs `BLOCK_LABEL_BASE` to `u32::MAX` (computed via [`CfgLower::block_label`])
-//!
-//! See [`crate::vreg::BLOCK_LABEL_BASE`] for the constant definition.
-//!
-//! This gives each namespace ~2 billion IDs, which is more than sufficient for
-//! any realistic function. The separation is handled automatically by the
-//! respective methods.
 
 use ahash::AHashMap;
 use lasso::ThreadedRodeo;
@@ -39,7 +17,6 @@ use crate::frame_layout::{
     checked_aligned_cell_region_bytes, checked_cell_byte_offset, checked_cell_region_bytes,
     checked_displacement_bytes,
 };
-use crate::vreg::BLOCK_LABEL_BASE;
 
 /// Argument passing registers per System V AMD64 ABI. ABI arg slots beyond
 /// these are passed on the caller's stack (slot `k >= 6` at `[rbp+16+(k-6)*8]`
@@ -122,6 +99,34 @@ fn gp_result_index(pieces: rue_air::RegisterPieces) -> usize {
 /// return register — so the two directions name one register file.
 pub(super) const FP_RET_REGS: [Reg; 8] = FP_ARG_REGS;
 
+/// This target's answer to [`crate::call_plan::ScratchOverlap`], read off the
+/// rosters above rather than asserted: `rax` is `RET_REGS[0]` as well as the
+/// general-purpose reload scratch, and `xmm0` is `FP_RET_REGS[0]` as well as
+/// the floating-point one. A register return therefore writes its result
+/// registers in reverse, so a spilled later eightbyte's reload through a
+/// scratch register runs before that register receives its own result.
+pub(super) const RETURN_SCRATCH_OVERLAP: crate::call_plan::ScratchOverlap = {
+    let aliases = roster_contains(&RET_REGS, super::mir::SCRATCH_VALUE)
+        || roster_contains(&FP_RET_REGS, super::mir::SCRATCH_FP_VALUE);
+    if aliases {
+        crate::call_plan::ScratchOverlap::AliasesResultRegister
+    } else {
+        crate::call_plan::ScratchOverlap::Disjoint
+    }
+};
+
+/// Whether `roster` names `reg`.
+const fn roster_contains(roster: &[Reg], reg: Reg) -> bool {
+    let mut index = 0;
+    while index < roster.len() {
+        if roster[index] as u8 == reg as u8 {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
 // Call sequences and the prologue name these registers physically, and liveness
 // models neither those physical definitions nor their uses. So they must be off
 // limits to the allocator, not merely unlikely to collide (RUE-1146).
@@ -181,11 +186,6 @@ pub struct CfgLower<'a> {
     value_map: AHashMap<CfgValue, VReg>,
     /// Maps block parameters to vregs (block_id, param_index) -> vreg
     block_param_vregs: AHashMap<(BlockId, u32), VReg>,
-    /// Next inline label ID for generating unique labels.
-    ///
-    /// Inline labels (for overflow checks, bounds checks, etc.) use IDs from
-    /// the lower half of the `u32` space. See module docs for namespace details.
-    next_label: u32,
     /// Function name (needed to detect main function)
     fn_name: &'a str,
     /// Maps StructInit CFG values to their field vregs
@@ -395,7 +395,6 @@ impl<'a> CfgLower<'a> {
             mir: X86Mir::new(),
             value_map: AHashMap::with_capacity(num_values),
             block_param_vregs: AHashMap::with_capacity(estimated_block_params),
-            next_label: 0,
             fn_name: cfg.fn_name(),
             struct_slot_vregs: AHashMap::with_capacity(estimated_struct_inits),
             array_repeat_fills: AHashMap::new(),
@@ -583,87 +582,8 @@ impl<'a> CfgLower<'a> {
         });
     }
 
-    /// Recursively collect all scalar vregs from a struct value.
     fn ensure_by_ref_param_ptr(&mut self, param_slot: u32) -> VReg {
-        if let Some(ptr_vreg) = self.by_ref_param_ptrs.get(&param_slot).copied() {
-            return ptr_vreg;
-        }
-
-        // Load the pointer from the param's frame home. A register-only
-        // by-ref pointer (RUE-1170) never reaches this load: the entry
-        // preamble copies it out of its argument register into the cache
-        // before any block is lowered, so the memoized hit above serves it.
-        // Stack-passed pointers stay homed by the prologue, so this load is
-        // uniform regardless of param count.
-        let ptr_vreg = self.mir.alloc_vreg();
-        let slot = self.ctx.param_frame_slot(param_slot);
-        let offset = self.ctx.local_offset(slot);
-        self.mir.push(X86Inst::MovRM {
-            dst: Operand::Virtual(ptr_vreg),
-            base: Reg::Rbp,
-            offset,
-        });
-
-        // Cache it for future use
-        self.by_ref_param_ptrs.insert(param_slot, ptr_vreg);
-        ptr_vreg
-    }
-
-    /// Copy every register-only parameter (RUE-1170) out of its incoming
-    /// argument register into a virtual register, before CFG control flow
-    /// begins: the argument registers are caller-saved, so the copies must
-    /// precede every call and dominate every use (including loop back-edges
-    /// into the entry block). A register-only by-ref pointer seeds the
-    /// by-ref cache directly.
-    fn materialize_register_params(&mut self) {
-        for (param_slot, class, location) in self.ctx.param_entry_copies() {
-            let (vreg, copy) = match (class, location) {
-                (
-                    crate::abi_slot_class::AbiSlotClass::Gp,
-                    crate::call_plan::AbiSlotLocation::GpReg(class_index),
-                ) => {
-                    let vreg = self.mir.alloc_vreg();
-                    (
-                        vreg,
-                        X86Inst::MovRR {
-                            dst: Operand::Virtual(vreg),
-                            src: Operand::Physical(ARG_REGS[class_index]),
-                        },
-                    )
-                }
-                (
-                    crate::abi_slot_class::AbiSlotClass::Fp(width),
-                    crate::call_plan::AbiSlotLocation::FpReg(class_index),
-                ) => {
-                    let vreg = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
-                    (
-                        vreg,
-                        X86Inst::FloatMov {
-                            dst: Operand::Virtual(vreg),
-                            src: Operand::Physical(FP_ARG_REGS[class_index]),
-                            width,
-                        },
-                    )
-                }
-                _ => unreachable!("register-only parameter class and ABI bank must agree"),
-            };
-            self.mir.push(copy);
-            if self.ctx.cfg.is_param_by_ref(param_slot) {
-                self.by_ref_param_ptrs.insert(param_slot, vreg);
-            } else {
-                self.param_reg_vregs.insert(param_slot, vreg);
-            }
-        }
-    }
-
-    /// Materialize every by-reference parameter pointer before CFG control
-    /// flow begins, so the function-wide cache only contains definitions that
-    /// dominate every block which may reuse them.
-    fn preload_by_ref_param_ptrs(&mut self) {
-        self.materialize_register_params();
-        for param_slot in crate::value_plan::by_ref_param_slots(&self.ctx) {
-            self.ensure_by_ref_param_ptr(param_slot);
-        }
+        crate::cfg_lower::ensure_by_ref_param_ptr(self, param_slot)
     }
 
     fn emit_div_core(&mut self, is_64: bool, is_signed: bool, rhs_vreg: VReg) {
@@ -717,7 +637,7 @@ impl<'a> CfgLower<'a> {
         rhs_vreg: VReg,
         trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
-        let ok_label = self.new_label();
+        let ok_label = self.mir.alloc_label();
         if width.bits == 64 {
             // divisor == -1?
             self.mir.push(X86Inst::Cmp64RI {
@@ -782,32 +702,12 @@ impl<'a> CfgLower<'a> {
             IntegerExtension::Sign16 => X86Inst::Movsx16To64 { dst, src },
             IntegerExtension::Zero16 => X86Inst::Movzx16To64 { dst, src },
             IntegerExtension::Sign32 => X86Inst::Movsx32To64 { dst, src },
+            IntegerExtension::Zero32 => X86Inst::Movzx32To64 { dst, src },
         });
     }
 
-    /// Allocate a new inline label ID.
-    ///
-    /// These labels are used for control flow within instruction lowering
-    /// (overflow checks, bounds checks, etc.). IDs are allocated starting
-    /// from 0 and incrementing, staying within the lower half of the ID space.
-    ///
-    /// See the module documentation for details on label namespace separation.
-    fn new_label(&mut self) -> LabelId {
-        let label = LabelId::new(self.next_label);
-        self.next_label += 1;
-        label
-    }
-
-    /// Get the label for a CFG basic block.
-    ///
-    /// Block labels use IDs in the upper half of the `u32` space (starting at
-    /// [`BLOCK_LABEL_BASE`]) to avoid collisions with inline labels allocated by
-    /// [`Self::new_label`]. The mapping is deterministic: `block_id` maps to
-    /// `BLOCK_LABEL_BASE + block_id`.
-    ///
-    /// See the module documentation for details on label namespace separation.
     fn block_label(&self, block_id: BlockId) -> LabelId {
-        LabelId::new(BLOCK_LABEL_BASE + block_id.as_u32())
+        X86Mir::block_label(block_id.as_u32())
     }
 
     /// Get or compute the slot vregs for a multi-slot aggregate value.
@@ -1074,7 +974,7 @@ impl<'a> CfgLower<'a> {
                             src2: Operand::Virtual(src),
                         }
                     });
-                    let ok = self.new_label();
+                    let ok = self.mir.alloc_label();
                     self.mir.push(X86Inst::Jz { label: ok });
                     let _ = self.lower_runtime_call(overflow_call.clone());
                     self.mir.push(X86Inst::Label { id: ok });
@@ -1119,7 +1019,7 @@ impl<'a> CfgLower<'a> {
             }
             ArithmeticOperation::Div { lhs, rhs, width } => {
                 let vreg = self.mir.alloc_vreg();
-                let ok = self.new_label();
+                let ok = self.mir.alloc_label();
                 self.mir.push(if width.bits == 64 {
                     X86Inst::Test64RR {
                         src1: Operand::Virtual(rhs),
@@ -1150,7 +1050,7 @@ impl<'a> CfgLower<'a> {
             }
             ArithmeticOperation::Mod { lhs, rhs, width } => {
                 let vreg = self.mir.alloc_vreg();
-                let ok = self.new_label();
+                let ok = self.mir.alloc_label();
                 self.mir.push(if width.bits == 64 {
                     X86Inst::Test64RR {
                         src1: Operand::Virtual(rhs),
@@ -1208,21 +1108,7 @@ impl<'a> CfgLower<'a> {
         &mut self,
         actions: Vec<crate::value_plan::DropAction>,
     ) -> crate::value_plan::ValueResult {
-        for action in actions {
-            // One cleanup call at a time: building the plan emits the
-            // argument's marshaling, and a caller-owned indirect copy must stay
-            // live until the call it belongs to has returned.
-            let plan = crate::call_plan::CallPlan::from_inputs(
-                crate::call_plan::CallTarget::rue(action.symbol),
-                crate::call_plan::ReturnPlan::ZeroSized,
-                std::slice::from_ref(&action.argument),
-                std::slice::from_ref(&action.native),
-                self,
-            );
-            let _ = self.lower_call_plan(plan);
-        }
-
-        crate::value_plan::ValueResult::SideEffect
+        crate::cfg_lower::lower_drop_plan(self, actions)
     }
 
     fn lower_call_plan(
@@ -1462,6 +1348,11 @@ impl<'a> CfgLower<'a> {
     /// its register; otherwise the leaves are marshaled through the value's
     /// compact image first, and a floating-point piece then carries an image
     /// lane whose bits move whole.
+    ///
+    /// The moves run in the order
+    /// [`ReturnRegisters::write_order`](crate::call_plan::ReturnRegisters::write_order)
+    /// gives for this target's [`RETURN_SCRATCH_OVERLAP`], which is a
+    /// correctness property of a multi-eightbyte return, not a preference.
     fn write_return_registers(
         &mut self,
         registers: &crate::call_plan::ReturnRegisters,
@@ -1477,7 +1368,8 @@ impl<'a> CfgLower<'a> {
             eightbytes.len(),
             "a register return names a result register for every eightbyte"
         );
-        for (reg, value) in registers.regs.iter().zip(&eightbytes).rev() {
+        for position in registers.write_order(RETURN_SCRATCH_OVERLAP) {
+            let (reg, value) = (&registers.regs[position], &eightbytes[position]);
             match *reg {
                 crate::call_plan::ReturnSlotReg::Gp(index) => self.mir.push(X86Inst::MovRR {
                     dst: Operand::Physical(RET_REGS[index]),
@@ -1552,38 +1444,10 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Extend a foreign scalar return (in `vreg`) to its canonical 64-bit form
-    /// per the target-C classifier (ADR-0064 P2). The narrow value occupies the
-    /// low bits of the return register with unspecified high bits; this restores
-    /// the sign/zero extension Rue's scalar invariant relies on.
+    /// per the target-C classifier (ADR-0064 P2), through this backend's one
+    /// extension primitive.
     fn emit_c_return_extension(&mut self, vreg: VReg, ext: rue_air::ScalarAbiExtension) {
-        use rue_air::ScalarAbiExtension;
-        let dst = Operand::Virtual(vreg);
-        let src = Operand::Virtual(vreg);
-        match ext {
-            ScalarAbiExtension::None => {}
-            ScalarAbiExtension::Signed { from_bits: 8 } => {
-                self.mir.push(X86Inst::Movsx8To64 { dst, src })
-            }
-            ScalarAbiExtension::Signed { from_bits: 16 } => {
-                self.mir.push(X86Inst::Movsx16To64 { dst, src })
-            }
-            ScalarAbiExtension::Signed { from_bits: 32 } => {
-                self.mir.push(X86Inst::Movsx32To64 { dst, src })
-            }
-            ScalarAbiExtension::Unsigned { from_bits: 8 } => {
-                self.mir.push(X86Inst::Movzx8To64 { dst, src })
-            }
-            ScalarAbiExtension::Unsigned { from_bits: 16 } => {
-                self.mir.push(X86Inst::Movzx16To64 { dst, src })
-            }
-            ScalarAbiExtension::Unsigned { from_bits: 32 } => {
-                self.mir.push(X86Inst::Movzx32To64 { dst, src });
-            }
-            ScalarAbiExtension::Signed { from_bits }
-            | ScalarAbiExtension::Unsigned { from_bits } => {
-                panic!("unexpected target-C scalar extension width {from_bits}")
-            }
-        }
+        self.emit_extension(vreg, vreg, crate::cfg_lower::c_return_extension(ext));
     }
 
     /// Write the aggregate `value`'s leaves into the compact image at
@@ -2355,101 +2219,7 @@ impl<'a> CfgLower<'a> {
         ty: Type,
         policy: crate::value_plan::ValuePlan,
     ) -> (VReg, Vec<VReg>) {
-        // A slot's register class follows its LEAF, not the type wrapped around
-        // it (RUE-2001): a `struct Q { f: f64 }` and a bare `f64` hold the same
-        // thing in the same one slot, so reading the width off the parameter's
-        // own type would load a float-carrying wrapper with an integer load into
-        // a general-purpose register and hand it to a float-typed consumer.
-        let leaf_types = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty);
-        let float_width = crate::value_plan::primary_slot_float_width(&leaf_types);
-        let dst = self.mir.alloc_vreg_in(if float_width.is_some() {
-            crate::reg_class::RegClass::Fp
-        } else {
-            crate::reg_class::RegClass::Gp
-        });
-        let count = policy.shape.slot_count();
-        if count == 0 {
-            // No slot to load: `dst` stays the never-read placeholder.
-            return (dst, Vec::new());
-        }
-        if let crate::value_plan::StoragePolicy::ParameterSlot { by_ref: true, .. } = policy.storage
-        {
-            let ptr = self.ensure_by_ref_param_ptr(index);
-            if count > 1 {
-                let slots: Vec<_> = (0..count)
-                    .map(|slot| {
-                        let v = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::MovRMIndexed {
-                            dst: Operand::Virtual(v),
-                            base: ptr,
-                            offset: (slot * 8) as i32,
-                        });
-                        v
-                    })
-                    .collect();
-                return (slots[0], slots);
-            }
-            if let Some(width) = float_width {
-                <Self as crate::place_lower::PlaceLowerBackend>::emit_load_ptr_base(
-                    self,
-                    dst,
-                    ptr,
-                    Some(width),
-                );
-            } else {
-                self.mir.push(X86Inst::MovRMIndexed {
-                    dst: Operand::Virtual(dst),
-                    base: ptr,
-                    offset: 0,
-                });
-            }
-        } else if count > 1 {
-            let slots: Vec<_> = (0..count)
-                .map(|slot| {
-                    let width = crate::value_plan::float_width(leaf_types[slot as usize]);
-                    let v = self.mir.alloc_vreg_in(if width.is_some() {
-                        crate::reg_class::RegClass::Fp
-                    } else {
-                        crate::reg_class::RegClass::Gp
-                    });
-                    let frame_slot = self.ctx.param_value_low_slot(index, count) - slot;
-                    if let Some(width) = width {
-                        <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
-                            self, v, frame_slot, width,
-                        );
-                    } else {
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(v),
-                            base: Reg::Rbp,
-                            offset: self.ctx.local_offset(frame_slot),
-                        });
-                    }
-                    v
-                })
-                .collect();
-            return (slots[0], slots);
-        } else if let Some(&vreg) = self.param_reg_vregs.get(&index) {
-            // Register-only scalar (RUE-1170): the entry preamble copied the
-            // argument register into one read-only vreg shared by every read.
-            let _ = ty;
-            return (vreg, Vec::new());
-        } else if let Some(width) = float_width {
-            <Self as crate::place_lower::PlaceLowerBackend>::emit_float_load_slot(
-                self,
-                dst,
-                self.ctx.param_value_low_slot(index, 1),
-                width,
-            );
-        } else {
-            self.mir.push(X86Inst::MovRM {
-                dst: Operand::Virtual(dst),
-                base: Reg::Rbp,
-                offset: self
-                    .ctx
-                    .local_offset(self.ctx.param_value_low_slot(index, 1)),
-            });
-        }
-        (dst, Vec::new())
+        crate::cfg_lower::lower_param_value(self, index, ty, policy)
     }
 
     fn emit_masked_shift_count_vreg(&mut self, rhs: VReg, mask: u64) -> VReg {
@@ -2590,8 +2360,8 @@ impl<'a> CfgLower<'a> {
     /// bit folded into the new low bit (a sticky bit that keeps the single
     /// rounding correct), converted, and doubled exactly.
     fn lower_u64_to_float(&mut self, dst: VReg, src: VReg, width: FloatWidth) {
-        let non_negative = self.new_label();
-        let done = self.new_label();
+        let non_negative = self.mir.alloc_label();
+        let done = self.mir.alloc_label();
         self.mir.push(X86Inst::Cmp64RI {
             src: Operand::Virtual(src),
             imm: 0,
@@ -2654,8 +2424,8 @@ impl<'a> CfgLower<'a> {
     /// value is converted with `2^63` subtracted (exact, since both operands
     /// are at least `2^63`) and the bit put back on the integer side.
     fn lower_float_to_u64(&mut self, dst: VReg, src: VReg, width: FloatWidth) {
-        let small = self.new_label();
-        let done = self.new_label();
+        let small = self.mir.alloc_label();
+        let done = self.mir.alloc_label();
         let two63 = self.mir.alloc_vreg_in(crate::reg_class::RegClass::Fp);
         self.mir.push(X86Inst::FloatConst {
             dst: Operand::Virtual(two63),
@@ -2803,8 +2573,8 @@ impl<'a> CfgLower<'a> {
             bits: crate::value_plan::float_const_bits(width, 0.5),
             width,
         });
-        let not_up = self.new_label();
-        let done = self.new_label();
+        let not_up = self.mir.alloc_label();
+        let done = self.mir.alloc_label();
         // fraction >= 0.5 (ordered): round up.
         self.mir.push(X86Inst::FloatCmp {
             lhs: Operand::Virtual(fraction),
@@ -2915,7 +2685,7 @@ impl<'a> CfgLower<'a> {
         match plan {
             crate::value_plan::TrapPlan::Panic { call } => self.lower_runtime_call(call),
             crate::value_plan::TrapPlan::Assert { condition, call } => {
-                let pass = self.new_label();
+                let pass = self.mir.alloc_label();
                 self.mir.push(X86Inst::CmpRI {
                     src: Operand::Virtual(condition),
                     imm: 0,
@@ -3354,7 +3124,7 @@ impl<'a> CfgLower<'a> {
                         rhs: Operand::Virtual(bound),
                         width,
                     });
-                    let ok = self.new_label();
+                    let ok = self.mir.alloc_label();
                     self.mir.push(match guard.success {
                         crate::value_plan::FloatToIntGuardRelation::OrderedGreaterEqual => {
                             X86Inst::Jae { label: ok }
@@ -3490,7 +3260,7 @@ impl<'a> CfgLower<'a> {
             PostOpPolicy::OverflowFlags { .. } | PostOpPolicy::RangeCheck(_) => {}
         }
 
-        let ok_label = self.new_label();
+        let ok_label = self.mir.alloc_label();
         match policy {
             // The ALU op the plan's width selected already set the flags: CF for
             // an unsigned carry or borrow, OF for a signed overflow.
@@ -3585,7 +3355,7 @@ impl<'a> CfgLower<'a> {
             return;
         }
         let wide = from_width.bits > 32;
-        let ok_label = self.new_label();
+        let ok_label = self.mir.alloc_label();
 
         match check {
             IntCastCheckPlan::None => unreachable!("handled above"),
@@ -3603,7 +3373,7 @@ impl<'a> CfgLower<'a> {
                 let _ = self.lower_runtime_call(trap_call.clone());
                 self.mir.push(X86Inst::Label { id: ok_label });
 
-                let ok_label2 = self.new_label();
+                let ok_label2 = self.mir.alloc_label();
                 let max_vreg = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRI64 {
                     dst: Operand::Virtual(max_vreg),
@@ -3638,7 +3408,7 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(X86Inst::Label { id: ok_label });
 
                 if let Some(max) = then_max {
-                    let ok_label2 = self.new_label();
+                    let ok_label2 = self.mir.alloc_label();
                     let max_vreg = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::MovRI64 {
                         dst: Operand::Virtual(max_vreg),
@@ -3686,207 +3456,12 @@ impl<'a> CfgLower<'a> {
         });
     }
 
-    /// Emit a comparison instruction.
     fn emit_terminator_plan(&mut self, plan: crate::terminator_plan::TerminatorPlan) {
-        use crate::terminator_plan::{ReturnMode, ReturnValuePlan, TerminatorPlan};
-
-        match plan {
-            TerminatorPlan::Goto { edge } => {
-                self.emit_edge_moves(&edge);
-                if !edge.fallthrough {
-                    self.mir.push(X86Inst::Jmp {
-                        label: self.block_label(edge.target),
-                    });
-                }
-            }
-            TerminatorPlan::Branch {
-                condition,
-                then_edge,
-                else_edge,
-            } => {
-                self.mir.push(X86Inst::CmpRI {
-                    src: Operand::Virtual(condition),
-                    imm: 0,
-                });
-                if then_edge.fallthrough {
-                    let then_setup_label = self.new_label();
-                    self.mir.push(X86Inst::Jnz {
-                        label: then_setup_label,
-                    });
-                    self.emit_edge_moves(&else_edge);
-                    if !else_edge.fallthrough {
-                        self.mir.push(X86Inst::Jmp {
-                            label: self.block_label(else_edge.target),
-                        });
-                    }
-                    self.mir.push(X86Inst::Label {
-                        id: then_setup_label,
-                    });
-                    self.emit_edge_moves(&then_edge);
-                } else {
-                    let else_setup_label = self.new_label();
-                    self.mir.push(X86Inst::Jz {
-                        label: else_setup_label,
-                    });
-                    self.emit_edge_moves(&then_edge);
-                    if !then_edge.fallthrough {
-                        self.mir.push(X86Inst::Jmp {
-                            label: self.block_label(then_edge.target),
-                        });
-                    }
-                    self.mir.push(X86Inst::Label {
-                        id: else_setup_label,
-                    });
-                    self.emit_edge_moves(&else_edge);
-                    if !else_edge.fallthrough {
-                        self.mir.push(X86Inst::Jmp {
-                            label: self.block_label(else_edge.target),
-                        });
-                    }
-                }
-            }
-            TerminatorPlan::Switch {
-                scrutinee,
-                width,
-                cases,
-                default,
-            } => {
-                for case in cases {
-                    let case_vreg = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::MovRI64 {
-                        dst: Operand::Virtual(case_vreg),
-                        imm: case.value,
-                    });
-                    if width.bits == 64 {
-                        self.mir.push(X86Inst::Cmp64RR {
-                            src1: Operand::Virtual(scrutinee),
-                            src2: Operand::Virtual(case_vreg),
-                        });
-                    } else {
-                        self.mir.push(X86Inst::CmpRR {
-                            src1: Operand::Virtual(scrutinee),
-                            src2: Operand::Virtual(case_vreg),
-                        });
-                    }
-                    self.mir.push(X86Inst::Jz {
-                        label: self.block_label(case.target),
-                    });
-                }
-                self.mir.push(X86Inst::Jmp {
-                    label: self.block_label(default),
-                });
-            }
-            TerminatorPlan::Return { mode } => match mode {
-                ReturnMode::Exit { call } => {
-                    let _ = self.lower_runtime_call(call);
-                }
-                ReturnMode::Function { value } => match value {
-                    ReturnValuePlan::ZeroSized => self.mir.push(X86Inst::Ret),
-                    ReturnValuePlan::Scalar { value, float_width } => {
-                        self.mir.push(
-                            if self.mir.vreg_class(value) == crate::reg_class::RegClass::Fp {
-                                X86Inst::FloatMov {
-                                    dst: Operand::Physical(Reg::Xmm0),
-                                    src: Operand::Virtual(value),
-                                    width: float_width.expect("FP return width"),
-                                }
-                            } else {
-                                X86Inst::MovRR {
-                                    dst: Operand::Physical(Reg::Rax),
-                                    src: Operand::Virtual(value),
-                                }
-                            },
-                        );
-                        self.mir.push(X86Inst::Ret);
-                    }
-                    ReturnValuePlan::Aggregate {
-                        slots,
-                        return_plan,
-                        registers,
-                    } => {
-                        if let crate::call_plan::ReturnPlan::Sret { echoed, .. } = return_plan {
-                            let return_ty = self.ctx.cfg.return_type();
-                            match crate::types::aggregate_physical_slot_map(
-                                self.ctx.type_pool,
-                                return_ty,
-                            ) {
-                                Some(map) => {
-                                    // The sret image is written compact; its padding
-                                    // is zeroed first (ADR-0052 ruling 5).
-                                    let padding =
-                                        self.ctx.type_pool.compact_image_padding_ranges(return_ty);
-                                    crate::agg_slots::store_slots_to_sret_compact(
-                                        self, &slots, &map, &padding,
-                                    )
-                                }
-                                None => match crate::types::aggregate_dispatch_image(
-                                    self.ctx.type_pool,
-                                    return_ty,
-                                ) {
-                                    // Heterogeneous compact aggregate return (RUE-1037):
-                                    // write the sret image with a per-variant tag dispatch.
-                                    Some(image) => crate::agg_slots::store_dispatch_image_to_sret(
-                                        self, &slots, &image,
-                                    ),
-                                    None => crate::agg_slots::store_slots_to_sret(self, &slots),
-                                },
-                            }
-                            // SysV AMD64 requires the callee to leave the
-                            // indirect-result pointer in `rax` on return.
-                            if echoed {
-                                crate::agg_slots::SlotBackend::emit_sret_pointer_echo(self);
-                            }
-                        } else {
-                            match registers.as_ref() {
-                                Some(registers) => self.write_return_registers(registers, &slots),
-                                // A zero-sized aggregate names no result
-                                // register because it has no bytes to carry.
-                                None => assert!(
-                                    slots.is_empty(),
-                                    "only a zero-sized aggregate return names no \
-                                     result register"
-                                ),
-                            }
-                        }
-                        self.mir.push(X86Inst::Ret);
-                    }
-                },
-            },
-            TerminatorPlan::Unreachable => self.mir.push(X86Inst::Ud2),
-        }
+        crate::cfg_lower::emit_terminator_plan(self, plan)
     }
 
-    fn emit_edge_moves(&mut self, edge: &crate::terminator_plan::EdgePlan) {
-        for movement in &edge.moves {
-            self.mir.push(if let Some(width) = movement.float_width {
-                X86Inst::FloatMov {
-                    dst: Operand::Virtual(movement.destination),
-                    src: Operand::Virtual(movement.source),
-                    width,
-                }
-            } else {
-                X86Inst::MovRR {
-                    dst: Operand::Virtual(movement.destination),
-                    src: Operand::Virtual(movement.source),
-                }
-            });
-        }
-    }
-
-    /// Get the vreg for a CFG value.
     fn get_vreg(&mut self, value: CfgValue) -> VReg {
-        if let Some(&vreg) = self.value_map.get(&value) {
-            return vreg;
-        }
-
-        // Not yet lowered - lower it now
-        let ctx = self.ctx;
-        crate::value_plan::lower_value(&ctx, self, value);
-
-        self.value_map
-            .get(&value)
-            .copied()
-            .expect("value should have been lowered")
+        crate::cfg_lower::get_vreg(self, value)
     }
 }
 
@@ -3912,19 +3487,7 @@ impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
         value: CfgValue,
         plan: crate::value_plan::ValuePlan,
     ) -> crate::value_plan::MaterializedValue {
-        let primary = self.block_param_vregs[&(target, param_index)];
-        let slots = if plan.shape.requires_complete_slots() {
-            let slots = self
-                .struct_slot_vregs
-                .get(&value)
-                .cloned()
-                .expect("aggregate block parameter slots should be preallocated");
-            plan.assert_complete_slots(slots.len());
-            slots
-        } else {
-            Vec::new()
-        };
-        crate::value_plan::MaterializedValue { primary, slots }
+        crate::cfg_lower::materialize_block_param(self, target, param_index, value, plan)
     }
 
     fn emit_block_label(&mut self, block: BlockId) {
@@ -3940,39 +3503,11 @@ impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
 
 impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
     fn preload_by_ref_params(&mut self) {
-        self.preload_by_ref_param_ptrs();
-        // Read each by-value aggregate parameter whose leaves are not its
-        // eightbytes back out of the compact image the prologue laid down, so
-        // field projection and whole-value reads see the correct decomposition
-        // (ADR-0084).
-        for (base_slot, image_slot_offset, through_pointer, image) in
-            crate::value_plan::param_image_unmarshals(&self.ctx)
-        {
-            crate::agg_slots::unmarshal_param_image(
-                self,
-                base_slot,
-                image_slot_offset,
-                through_pointer,
-                &image,
-            );
-        }
+        crate::cfg_lower::preload_by_ref_params(self)
     }
 
     fn prepare_block_param(&mut self, block: BlockId, index: u32, value: CfgValue, ty: Type) {
-        let primary_ty = crate::types::aggregate_leaf_types(self.ctx.type_pool, ty)
-            .first()
-            .copied()
-            .unwrap_or(ty);
-        let vreg =
-            self.mir
-                .alloc_vreg_in(if crate::value_plan::float_width(primary_ty).is_some() {
-                    crate::reg_class::RegClass::Fp
-                } else {
-                    crate::reg_class::RegClass::Gp
-                });
-        self.block_param_vregs.insert((block, index), vreg);
-        self.value_map.insert(value, vreg);
-        crate::agg_slots::preallocate_block_param_slots(self, value, ty, vreg);
+        crate::cfg_lower::prepare_block_param(self, block, index, value, ty)
     }
 
     fn value_description(&self, value: CfgValue) -> String {
@@ -4467,6 +4002,148 @@ impl CfgLower<'_> {
     }
 }
 
+impl<'a> crate::cfg_lower::LoweringDriverBackend<'a> for CfgLower<'a> {
+    fn lowering_context(&self) -> crate::cfg_lower::CfgLowerContext<'a> {
+        self.ctx
+    }
+
+    fn value_map(&mut self) -> &mut AHashMap<CfgValue, VReg> {
+        &mut self.value_map
+    }
+
+    fn block_param_vregs(&mut self) -> &mut AHashMap<(BlockId, u32), VReg> {
+        &mut self.block_param_vregs
+    }
+
+    fn by_ref_param_ptrs(&mut self) -> &mut AHashMap<u32, VReg> {
+        &mut self.by_ref_param_ptrs
+    }
+
+    fn param_reg_vregs(&mut self) -> &mut AHashMap<u32, VReg> {
+        &mut self.param_reg_vregs
+    }
+
+    fn emit_float_reg_move(&mut self, dst: VReg, src: VReg, width: FloatWidth) {
+        self.mir.push(X86Inst::FloatMov {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(src),
+            width,
+        });
+    }
+
+    fn emit_gp_arg_register_copy(&mut self, dst: VReg, index: usize) {
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(dst),
+            src: Operand::Physical(ARG_REGS[index]),
+        });
+    }
+
+    fn emit_fp_arg_register_copy(&mut self, dst: VReg, index: usize, width: FloatWidth) {
+        self.mir.push(X86Inst::FloatMov {
+            dst: Operand::Virtual(dst),
+            src: Operand::Physical(FP_ARG_REGS[index]),
+            width,
+        });
+    }
+
+    fn lower_call_plan(
+        &mut self,
+        plan: crate::call_plan::CallPlan,
+    ) -> crate::value_plan::MaterializedValue {
+        CfgLower::lower_call_plan(self, plan)
+    }
+
+    fn emit_jump_to_block(&mut self, target: BlockId) {
+        let label = self.block_label(target);
+        self.mir.push(X86Inst::Jmp { label });
+    }
+
+    fn emit_branch_if_nonzero(&mut self, condition: VReg, label: LabelId) {
+        self.mir.push(X86Inst::CmpRI {
+            src: Operand::Virtual(condition),
+            imm: 0,
+        });
+        self.mir.push(X86Inst::Jnz { label });
+    }
+
+    fn emit_branch_if_zero(&mut self, condition: VReg, label: LabelId) {
+        self.mir.push(X86Inst::CmpRI {
+            src: Operand::Virtual(condition),
+            imm: 0,
+        });
+        self.mir.push(X86Inst::Jz { label });
+    }
+
+    fn emit_switch_case_compare(
+        &mut self,
+        scrutinee: VReg,
+        value: i64,
+        width: crate::value_plan::IntegerWidth,
+    ) {
+        let case_vreg = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(case_vreg),
+            imm: value,
+        });
+        if width.bits == 64 {
+            self.mir.push(X86Inst::Cmp64RR {
+                src1: Operand::Virtual(scrutinee),
+                src2: Operand::Virtual(case_vreg),
+            });
+        } else {
+            self.mir.push(X86Inst::CmpRR {
+                src1: Operand::Virtual(scrutinee),
+                src2: Operand::Virtual(case_vreg),
+            });
+        }
+    }
+
+    fn emit_branch_if_equal(&mut self, target: BlockId) {
+        let label = self.block_label(target);
+        self.mir.push(X86Inst::Jz { label });
+    }
+
+    fn emit_scalar_return_move(&mut self, value: VReg, float_width: Option<FloatWidth>) {
+        self.mir.push(
+            if self.mir.vreg_class(value) == crate::reg_class::RegClass::Fp {
+                X86Inst::FloatMov {
+                    dst: Operand::Physical(Reg::Xmm0),
+                    src: Operand::Virtual(value),
+                    width: float_width.expect("FP return width"),
+                }
+            } else {
+                X86Inst::MovRR {
+                    dst: Operand::Physical(Reg::Rax),
+                    src: Operand::Virtual(value),
+                }
+            },
+        );
+    }
+
+    fn emit_return(&mut self) {
+        self.mir.push(X86Inst::Ret);
+    }
+
+    fn emit_unreachable(&mut self) {
+        self.mir.push(X86Inst::Ud2);
+    }
+
+    fn write_return_registers(
+        &mut self,
+        registers: &crate::call_plan::ReturnRegisters,
+        slots: &[VReg],
+    ) {
+        CfgLower::write_return_registers(self, registers, slots)
+    }
+
+    fn lower_runtime_call(
+        &mut self,
+        plan: crate::runtime_call_plan::RuntimeCallPlan,
+    ) -> crate::value_plan::MaterializedValue {
+        CfgLower::lower_runtime_call(self, plan)
+    }
+}
+
 impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
@@ -4701,7 +4378,7 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         });
     }
     fn alloc_lowering_label(&mut self) -> LabelId {
-        self.new_label()
+        self.mir.alloc_label()
     }
     fn emit_marshal_branch_if_tag_ne(&mut self, tag: VReg, discriminant: u64, label: LabelId) {
         let discriminant = compact_tag_discriminant(discriminant);
@@ -4838,7 +4515,7 @@ impl crate::allocation::BoundsCheckBackend for CfgLower<'_> {
     }
 
     fn alloc_bounds_label(&mut self) -> LabelId {
-        self.new_label()
+        self.mir.alloc_label()
     }
 
     fn emit_bounds_branch(
@@ -4977,7 +4654,7 @@ impl crate::allocation::ScaleBackend for CfgLower<'_> {
                         dst: Operand::Virtual(dst),
                         src: Operand::Physical(Reg::Rax),
                     });
-                    let ok_label = self.new_label();
+                    let ok_label = self.mir.alloc_label();
                     self.mir.push(X86Inst::Jae { label: ok_label });
                     let _ = self.lower_runtime_call(
                         crate::runtime_call_plan::RuntimeCallPlan::no_args(
@@ -5119,16 +4796,21 @@ mod tests {
     #[test]
     fn zero32_consumers_use_canonical_move_not_shift_pair() {
         let source = include_str!("cfg_lower.rs");
-        let foreign = source
-            .split("ScalarAbiExtension::Unsigned { from_bits: 32 } => {")
+        // The canonical zero-extension is selected once, in this
+        // backend's single extension primitive; the foreign `unsigned int`
+        // return reaches it through `cfg_lower::c_return_extension`.
+        let widen = source
+            .split("IntegerExtension::Zero32 =>")
             .nth(1)
-            .expect("foreign u32 return extension must remain present")
-            .split("ScalarAbiExtension::Signed { from_bits }")
+            .expect("the canonical 32-bit zero-extension arm must remain present")
+            .split('\n')
             .next()
-            .expect("foreign extension match arm must have a following arm");
-        assert!(foreign.contains("X86Inst::Movzx32To64"));
-        assert!(!foreign.contains("X86Inst::ShlRI"));
-        assert!(!foreign.contains("X86Inst::ShrRI"));
+            .expect("an extension arm is one line");
+        assert!(widen.contains("X86Inst::Movzx32To64"));
+        assert!(!widen.contains("ShlRI"));
+        assert!(!widen.contains("ShrRI"));
+        assert!(!widen.contains("Lsl"));
+        assert!(!widen.contains("Lsr"));
         let bitcast = source
             .split("BitCastForm::Zero32 => {")
             .nth(1)
@@ -6977,6 +6659,154 @@ mod tests {
                 }
             )
         }));
+    }
+
+    /// A six-eightbyte register return whose slots outnumber the allocatable
+    /// general-purpose class, so register allocation must spill one of them.
+    fn six_eightbyte_return_under_register_pressure(
+        pool: &FrozenTypeInternPool,
+        interner: &ThreadedRodeo,
+        six_id: StructId,
+    ) -> ValidatedCfg {
+        let six_ty = Type::new_struct(six_id);
+        let mut fixture = FixtureCfg::new(
+            six_ty,
+            0,
+            "six",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            pool,
+            interner,
+        );
+        let base = fixture.konst(7, Type::I64);
+        let fields: Vec<_> = (1..=6)
+            .map(|value| {
+                let literal = fixture.konst(value, Type::I64);
+                fixture.value(CfgInstData::BitXor(base, literal), Type::I64)
+            })
+            .collect();
+        let value = fixture.struct_init(six_id, &fields, six_ty);
+        fixture.ret(Some(value));
+        fixture.cfg.finish(pool).expect("test CFG must verify")
+    }
+
+    #[test]
+    fn a_multi_eightbyte_return_writes_its_result_registers_in_reverse() {
+        // `rax` is `RET_REGS[0]` and the allocator's reload scratch at once, so
+        // this backend's `RETURN_SCRATCH_OVERLAP` orders the return's moves from
+        // the last eightbyte down to the first. The order is the shared
+        // decision in `call_plan::return_register_write_order`; only the
+        // predicate is this target's.
+        assert_eq!(
+            RETURN_SCRATCH_OVERLAP,
+            crate::call_plan::ScratchOverlap::AliasesResultRegister
+        );
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let six_id = register_struct(
+            &pool,
+            &interner,
+            "Six",
+            &[
+                ("a", Type::I64),
+                ("b", Type::I64),
+                ("c", Type::I64),
+                ("d", Type::I64),
+                ("e", Type::I64),
+                ("f", Type::I64),
+            ],
+        );
+        let pool = pool.freeze();
+        let cfg = six_eightbyte_return_under_register_pressure(&pool, &interner, six_id);
+        let mir = CfgLower::new(&cfg, &pool, &interner)
+            .lower()
+            .expect("six-eightbyte return must lower");
+        let written: Vec<_> = mir
+            .instructions()
+            .iter()
+            .filter_map(|inst| match inst {
+                X86Inst::MovRR {
+                    dst: Operand::Physical(dst),
+                    src: Operand::Virtual(_),
+                } if RET_REGS.contains(dst) => Some(*dst),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            written,
+            vec![Reg::R10, Reg::R9, Reg::R8, Reg::Rcx, Reg::Rdx, Reg::Rax]
+        );
+    }
+
+    #[test]
+    fn a_spill_reload_never_lands_on_an_already_written_result_register() {
+        // The reverse order exists for this: a spilled return slot is reloaded
+        // through `rax`, which is also `RET_REGS[0]`. Writing the result bank
+        // forward would put such a reload *after* `rax` already carried
+        // eightbyte 0, silently replacing the returned value's first eightbyte
+        // with a later slot's bits.
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let six_id = register_struct(
+            &pool,
+            &interner,
+            "Six",
+            &[
+                ("a", Type::I64),
+                ("b", Type::I64),
+                ("c", Type::I64),
+                ("d", Type::I64),
+                ("e", Type::I64),
+                ("f", Type::I64),
+            ],
+        );
+        let pool = pool.freeze();
+        let cfg = six_eightbyte_return_under_register_pressure(&pool, &interner, six_id);
+        let mir = CfgLower::new(&cfg, &pool, &interner)
+            .lower()
+            .expect("six-eightbyte return must lower");
+        let allocated = crate::x86_64::regalloc::RegAlloc::new(mir, 0)
+            .allocate()
+            .expect("six-eightbyte return must allocate");
+        let ret = allocated
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, X86Inst::Ret))
+            .expect("the function must return");
+        let body = &allocated.instructions()[..ret];
+        assert!(
+            body.iter().any(|inst| matches!(
+                inst,
+                X86Inst::MovRM {
+                    dst: Operand::Physical(dst),
+                    ..
+                } if RET_REGS.contains(dst)
+            )),
+            "the fixture must spill a return slot, or it proves nothing"
+        );
+        for reg in RET_REGS {
+            let Some(delivered) = body.iter().rposition(|inst| {
+                matches!(
+                    inst,
+                    X86Inst::MovRR {
+                        dst: Operand::Physical(dst),
+                        ..
+                    } if *dst == reg
+                )
+            }) else {
+                continue;
+            };
+            assert!(
+                !body[delivered + 1..].iter().any(|inst| matches!(
+                    inst,
+                    X86Inst::MovRM {
+                        dst: Operand::Physical(dst),
+                        ..
+                    } if *dst == reg
+                )),
+                "{reg:?} carried its eightbyte and was then reloaded over"
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -4,6 +4,28 @@
 //! - Maps closely to actual x86-64 instructions
 //! - Uses virtual registers (unlimited) that are later allocated to physical registers
 //! - Can be emitted to machine code or assembly text
+//!
+//! # Label Namespace Separation
+//!
+//! During lowering, we need to generate labels for two distinct purposes:
+//!
+//! 1. **Block labels** - Each CFG basic block gets a label for control flow
+//!    (jumps, branches, etc.). These are derived deterministically from block IDs.
+//!
+//! 2. **Inline labels** - Generated during instruction lowering for things like
+//!    overflow checks, bounds checks, division-by-zero checks, and conditional
+//!    branches within a single CFG instruction.
+//!
+//! To prevent collisions, we partition the `u32` label ID space:
+//!
+//! - **Inline labels**: IDs `0` to `BLOCK_LABEL_BASE - 1` (allocated via [`X86Mir::alloc_label`])
+//! - **Block labels**: IDs `BLOCK_LABEL_BASE` to `u32::MAX` (computed via [`X86Mir::block_label`])
+//!
+//! See [`crate::vreg::BLOCK_LABEL_BASE`] for the constant definition.
+//!
+//! This gives each namespace ~2 billion IDs, which is more than sufficient for
+//! any realistic function. The separation is handled automatically by the
+//! respective methods.
 
 use std::fmt;
 
@@ -20,7 +42,7 @@ const _: () = assert!(std::mem::size_of::<X86Inst>() <= 40);
 pub use crate::reg_class::{RegClass, VRegClasses};
 pub use crate::value_plan::FloatWidth;
 use crate::vreg::MirState;
-pub use crate::vreg::{LabelId, VReg};
+pub use crate::vreg::{BLOCK_LABEL_BASE, LabelId, VReg};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FloatBinOp {
@@ -1561,11 +1583,29 @@ impl X86Mir {
         self.state.vreg_class(vreg)
     }
 
-    /// Allocate a new label ID.
+    /// Allocate a new inline label ID.
+    ///
+    /// These labels are used for control flow within instruction lowering
+    /// (overflow checks, bounds checks, etc.). IDs are allocated starting
+    /// from 0 and incrementing, staying within the lower half of the ID space.
+    ///
+    /// See the module documentation for details on label namespace separation.
     pub fn alloc_label(&mut self) -> LabelId {
         let label = LabelId::new(self.next_label);
         self.next_label += 1;
         label
+    }
+
+    /// Get the label for a CFG basic block.
+    ///
+    /// Block labels use IDs in the upper half of the `u32` space (starting at
+    /// [`BLOCK_LABEL_BASE`]) to avoid collisions with inline labels allocated by
+    /// [`Self::alloc_label`]. The mapping is deterministic: `block_id` maps to
+    /// `BLOCK_LABEL_BASE + block_id`.
+    ///
+    /// See the module documentation for details on label namespace separation.
+    pub fn block_label(block_id: u32) -> LabelId {
+        LabelId::new(BLOCK_LABEL_BASE + block_id)
     }
 
     /// Get the number of virtual registers allocated.


### PR DESCRIPTION
## Summary

The target-independent lowering drivers were hand-mirrored between `x86_64/cfg_lower.rs` and `aarch64/cfg_lower.rs`. A driver written twice can differ twice, and one already had: a multi-eightbyte register return wrote its result registers in reverse on x86-64 and forward on AArch64, with the reason recorded only as a comment at an unrelated x86 call site.

- **The return-order invariant is stated.** `call_plan` owns the write order: `ScratchOverlap` (`Disjoint` / `AliasesResultRegister`), `return_register_write_order`, and `ReturnRegisters::write_order`. Each backend derives its own `RETURN_SCRATCH_OVERLAP` with a `const fn` over its rosters. SysV AMD64's `rax` is both `RET_REGS[0]` and the reload scratch (and `xmm0` likewise in the FP bank), so a spilled later eightbyte reloaded through it would land on an already-delivered result register unless the moves run backwards; AAPCS64's `x9`/`v16` sit outside `x0`-`x7`/`v0`-`v7`, so forward order stands. Both `write_return_registers` iterate the shared order; the hand-placed `.rev()` is gone. Tests pin both directions, including an x86-64 test that under real register pressure (six-eightbyte struct return) asserts a spill happened and no result register is reloaded over after it carries its eightbyte; with the predicate flipped it fails with `Rax carried its eightbyte and was then reloaded over`.
- **Drivers moved** into `crate::cfg_lower` behind a `LoweringDriverBackend` trait whose items are only instruction spellings and the lowerer's caches: `emit_terminator_plan`, `lower_param_value`, the entry preamble (`materialize_register_params`, `preload_by_ref_param_ptrs`, `preload_by_ref_params`, `ensure_by_ref_param_ptr`), the block-parameter helpers (`get_vreg`, `materialize_block_param`, `prepare_block_param`), `emit_edge_moves`, and `lower_drop_plan`. Three of them have no backend spelling left at all. The foreign narrow-return extension keeps its per-backend three-line spelling (the RUE-1982 guard requires exactly one `emit_extension` per backend) but reads its policy from one `c_return_extension` table, which needed `IntegerExtension::Zero32`.
- **Not moved, and why:** `lower_residual_value` and `lower_intrinsic_plan` differ in genuinely different sequences (x86 `emit_div_core` / float comparison / u64↔float; aarch64 overflow-check and wrap-narrow families; `@syscall`), and `lower_runtime_call` / `image_arg_eightbytes` are physical marshalling (x86 stages GP arguments through a `push`/`pop` pair with no AArch64 counterpart). Moving them needs a large new primitive surface with real byte-identity risk; left for a follow-up.
- **Labels:** x86-64 dropped its private `next_label` counter; both backends allocate through `Mir::alloc_label` and name blocks through `Mir::block_label`.
- **Slot bytes:** `frame_layout::slot_byte_offset` wraps `checked_cell_byte_offset`; both literal `(slot * 8)` sites and the nine unchecked `* SLOT_BYTES` sites in `agg_slots.rs` / `place_lower.rs` go through it.
- **Guard:** `api_inventory::target_independent_lowering_drivers_live_only_in_the_shared_cfg_lowering` asserts the moved drivers exist only in the shared module, each backend reaches them exactly once, neither keeps a second label counter, both name `RETURN_SCRATCH_OVERLAP` and spend result registers via `write_order`, and the order machinery lives in `call_plan.rs`.

`terminator_plan.rs` is untouched, so no planted-miscompile re-pin was needed. Line counts: x86-64 7730 → 7560, AArch64 7564 → 7386, shared `cfg_lower.rs` 593 → 1171.

## Byte identity

Every `examples/*.rue` and `examples/*/main.rue` root plus a 600-case sample of the CLI-test corpus, compiled for both targets before and after:

| target | executables compared | identical |
|---|---|---|
| x86-64-linux | 465 | 465 |
| aarch64-linux | 466 | 466 |

## Validation

`scripts/rue fmt`, `quick` (36/36), `unit codegen` (925), `cli abi aggregate_abi_matrix enum drop array_repeat struct float` (694), `ui` (437), `spec` (2889), and the planted-miscompile-isolation, codegen debug-assert, debug-assert-ledger and oracle-diff gates, all passing on the rebased tree. The agent's `premerge` on the pre-rebase tree passed except the two environmental CLI cases.

Closes RUE-1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_