### PR TITLE
RUE-2081: one well-formed-UTF-8 table for the runtime

### DIFF
--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -7435,6 +7435,14 @@ fn promotion_key(base: PlaceBase) -> u64 {
 /// Returns `None` when `offset` is out of range or the byte sequence at that
 /// offset is invalid UTF-8; callers translate that to the runtime's
 /// `invalid UTF-8` trap.
+///
+/// The Unicode Table 3-7 ranges below are spelled out here on purpose, even
+/// though `rue_runtime::utf8` states the same table once for the runtime
+/// (RUE-2081). This is the oracle: its job is to disagree with the runtime
+/// whenever the runtime is wrong, and a model that imported the runtime's
+/// table would be comparing that table against itself, making the UTF-8 half
+/// of the differential vacuous. Independent derivation is the point, so do not
+/// "deduplicate" these into the shared table — fix them in place if they drift.
 fn char_at(bytes: &[u8], offset: i128) -> Option<(u32, u64)> {
     if offset < 0 || offset as u128 >= bytes.len() as u128 {
         return None;
@@ -7471,6 +7479,14 @@ fn char_at(bytes: &[u8], offset: i128) -> Option<(u32, u64)> {
 /// Leniently decode the UTF-8 scalar starting at byte `offset`, replacing
 /// invalid UTF-8 with U+FFFD and advancing by the runtime's maximal-subpart
 /// width. Backs the oracle's model of the lossy character runtime primitives.
+///
+/// The Unicode Table 3-7 ranges below are spelled out here on purpose, even
+/// though `rue_runtime::utf8` states the same table once for the runtime
+/// (RUE-2081). This is the oracle: its job is to disagree with the runtime
+/// whenever the runtime is wrong, and a model that imported the runtime's
+/// table would be comparing that table against itself, making the UTF-8 half
+/// of the differential vacuous. Independent derivation is the point, so do not
+/// "deduplicate" these into the shared table — fix them in place if they drift.
 fn char_at_lossy(bytes: &[u8], offset: i128) -> (u32, u64) {
     const FFFD: u32 = 0xFFFD;
     if offset < 0 || offset as u128 >= bytes.len() as u128 {

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -156,6 +156,10 @@ pub mod random;
 pub mod string;
 pub mod test_channel;
 
+// Crate-internal: Unicode's well-formed-UTF-8 table, shared by the string
+// decoders and the test channel's JSON escaper. Not part of the runtime ABI.
+mod utf8;
+
 macro_rules! call_runtime_helper_implementation {
     (__rue_exit($($argument:expr),*)) => { crate::entry::__rue_exit($($argument),*) };
     (__rue_alloc($($argument:expr),*)) => { crate::string::__rue_alloc($($argument),*) };

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -333,45 +333,44 @@ unsafe fn __rue_decode_utf8_at(ptr: *const u8, len: u64, offset: u64) -> (u32, u
     if b0 < 0x80 {
         return (b0 as u32, 1);
     }
-    // Lead byte determines the sequence width, the minimum non-overlong code
-    // point, and the initial code-point bits. Leads 0xC0/0xC1 (always overlong)
-    // and 0x80..=0xBF (continuation) and 0xF5..=0xFF (> U+10FFFF) are invalid.
-    let width: usize;
-    let min: u32;
-    let mut cp: u32;
-    if (0xC2..=0xDF).contains(&b0) {
-        width = 2;
-        min = 0x80;
-        cp = (b0 as u32) & 0x1F;
-    } else if (0xE0..=0xEF).contains(&b0) {
-        width = 3;
-        min = 0x800;
-        cp = (b0 as u32) & 0x0F;
-    } else if (0xF0..=0xF4).contains(&b0) {
-        width = 4;
-        min = 0x10000;
-        cp = (b0 as u32) & 0x07;
-    } else {
+    // The lead byte's row in the shared table ([`crate::utf8`]) fixes the
+    // sequence width, the range its first continuation byte may take, and the
+    // scalar bits the lead itself contributes. A byte with no row can never
+    // begin a sequence: 0xC0/0xC1 (always overlong), 0x80..=0xBF (a
+    // continuation), and 0xF5..=0xFF (past U+10FFFF).
+    //
+    // Reading the table directly is what rejects an overlong encoding, a
+    // surrogate, and an out-of-range scalar here: those are precisely what the
+    // first-continuation range encodes, so this no longer decodes the scalar
+    // first and range-checks it afterwards against a second set of hand-written
+    // bounds.
+    let Some(lead) = crate::utf8::lead(b0) else {
+        crate::error::__rue_invalid_utf8();
+    };
+    if i + lead.width > len {
         crate::error::__rue_invalid_utf8();
     }
-    if i + width > len {
+    // SAFETY: `i + lead.width <= len` (checked above) and every row has
+    // `width >= 2`, so `i + 1` is in bounds.
+    let b1 = unsafe { *ptr.add(i + 1) };
+    if !lead.accepts_first_continuation(b1) {
         crate::error::__rue_invalid_utf8();
     }
-    let mut k = 1usize;
-    while k < width {
-        // SAFETY: `i + width <= len` (checked above), so `i + k` is in bounds.
+    let mut cp = (lead.scalar_prefix << 6) | ((b1 as u32) & 0x3F);
+    // The remaining bytes are unconstrained continuations; the lead's row
+    // already narrowed the only one that carries a well-formedness rule.
+    let mut k = 2usize;
+    while k < lead.width {
+        // SAFETY: `i + lead.width <= len` (checked above), so `i + k` is in
+        // bounds.
         let b = unsafe { *ptr.add(i + k) };
-        if b & 0xC0 != 0x80 {
+        if !crate::utf8::is_continuation(b) {
             crate::error::__rue_invalid_utf8();
         }
         cp = (cp << 6) | ((b as u32) & 0x3F);
         k += 1;
     }
-    // Reject overlong encodings, UTF-16 surrogates, and out-of-range scalars.
-    if cp < min || (0xD800..=0xDFFF).contains(&cp) || cp > 0x10FFFF {
-        crate::error::__rue_invalid_utf8();
-    }
-    (cp, width as u64)
+    (cp, lead.width as u64)
 }
 
 crate::define_runtime_implementation! {
@@ -430,36 +429,23 @@ unsafe fn __rue_decode_utf8_lossy_at(ptr: *const u8, len: u64, offset: u64) -> (
     if b0 < 0x80 {
         return (b0 as u32, 1);
     }
-    // The lead byte fixes the sequence width and the valid range of the FIRST
-    // continuation byte. That first-byte range is what enforces non-overlong
-    // (0xE0 needs >= 0xA0, 0xF0 needs >= 0x90), non-surrogate (0xED needs
-    // <= 0x9F), and in-range (0xF4 needs <= 0x8F) — so a full-width sequence
-    // that clears these checks is always a valid scalar. Leads 0x80..=0xC1 and
-    // 0xF5..=0xFF can never begin a sequence: substitute one U+FFFD, step 1.
-    let (width, second_lo, second_hi) = match b0 {
-        0xC2..=0xDF => (2usize, 0x80u8, 0xBFu8),
-        0xE0 => (3, 0xA0, 0xBF),
-        0xE1..=0xEC => (3, 0x80, 0xBF),
-        0xED => (3, 0x80, 0x9F),
-        0xEE..=0xEF => (3, 0x80, 0xBF),
-        0xF0 => (4, 0x90, 0xBF),
-        0xF1..=0xF3 => (4, 0x80, 0xBF),
-        0xF4 => (4, 0x80, 0x8F),
-        _ => return (FFFD, 1),
+    // The lead byte's row in the shared table ([`crate::utf8`]) fixes the
+    // sequence width and the valid range of the FIRST continuation byte. That
+    // first-byte range is what enforces non-overlong, non-surrogate, and
+    // in-range, so a full-width sequence that clears these checks is always a
+    // valid scalar. A byte with no row — 0x80..=0xC1 and 0xF5..=0xFF — can
+    // never begin a sequence: substitute one U+FFFD, step 1.
+    let Some(lead) = crate::utf8::lead(b0) else {
+        return (FFFD, 1);
     };
-    let mask = match width {
-        2 => 0x1F,
-        3 => 0x0F,
-        _ => 0x07,
-    };
-    let mut cp = (b0 as u32) & mask;
-    // First continuation: uses the width-specific range above.
+    let mut cp = lead.scalar_prefix;
+    // First continuation: uses the width-specific range from the row.
     if i + 1 >= len {
         return (FFFD, 1);
     }
     // SAFETY: `i + 1 < len`, in bounds.
     let b1 = unsafe { *ptr.add(i + 1) };
-    if b1 < second_lo || b1 > second_hi {
+    if !lead.accepts_first_continuation(b1) {
         return (FFFD, 1);
     }
     cp = (cp << 6) | ((b1 as u32) & 0x3F);
@@ -467,19 +453,19 @@ unsafe fn __rue_decode_utf8_lossy_at(ptr: *const u8, len: u64, offset: u64) -> (
     // 0x80..=0xBF range. On a break, the maximal subpart is everything
     // consumed so far.
     let mut consumed = 2usize;
-    while consumed < width {
+    while consumed < lead.width {
         if i + consumed >= len {
             return (FFFD, consumed as u64);
         }
         // SAFETY: `i + consumed < len`, in bounds.
         let b = unsafe { *ptr.add(i + consumed) };
-        if b & 0xC0 != 0x80 {
+        if !crate::utf8::is_continuation(b) {
             return (FFFD, consumed as u64);
         }
         cp = (cp << 6) | ((b as u32) & 0x3F);
         consumed += 1;
     }
-    (cp, width as u64)
+    (cp, lead.width as u64)
 }
 
 crate::define_runtime_implementation! {

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -266,42 +266,36 @@ impl<'a> FrameWriter<'a> {
     }
 }
 
-/// The width of the well-formed UTF-8 sequence `bytes` starts with, or `None`
-/// when it does not start with one.
+/// The width of the well-formed multi-byte UTF-8 sequence `bytes` starts with,
+/// or `None` when it does not start with one.
 ///
-/// The ranges are Unicode's own well-formed byte sequences (Table 3-7), which
-/// reject an overlong encoding, a surrogate, and a scalar above `U+10FFFF` as
-/// well as a truncated sequence — `serde_json` and every other reader applies
-/// the same table, so anything looser here would let a line through that a
-/// reader still rejects. Written out rather than delegated to
-/// `core::str::from_utf8` so the freestanding build's emitted code stays a
-/// handful of comparisons with no libcall in it.
+/// Well-formedness is [`crate::utf8`]'s table — Unicode's own Table 3-7, which
+/// rejects an overlong encoding, a surrogate, and a scalar above `U+10FFFF` as
+/// well as a truncated sequence. `serde_json` and every other reader applies
+/// that same table, so anything looser here would let a line through that a
+/// reader still rejects.
+///
+/// ASCII is not a case: `escaped` handles a byte below `0x80` on its own
+/// path and only consults this one for `byte >= 0x80`, so a lead the table has
+/// no row for — including an ASCII byte — is reported as `None` rather than as
+/// a one-byte sequence.
 fn utf8_sequence_width(bytes: &[u8]) -> Option<usize> {
-    let lead = *bytes.first()?;
-    let (width, first_continuation) = match lead {
-        0x00..=0x7f => return Some(1),
-        0xc2..=0xdf => (2, 0x80..=0xbf),
-        0xe0 => (3, 0xa0..=0xbf),
-        0xe1..=0xec | 0xee..=0xef => (3, 0x80..=0xbf),
-        0xed => (3, 0x80..=0x9f),
-        0xf0 => (4, 0x90..=0xbf),
-        0xf1..=0xf3 => (4, 0x80..=0xbf),
-        0xf4 => (4, 0x80..=0x8f),
-        _ => return None,
-    };
-    if bytes.len() < width || !first_continuation.contains(&bytes[1]) {
+    let lead = crate::utf8::lead(*bytes.first()?)?;
+    // `bytes[1]` is in bounds because the width check short-circuits first and
+    // every row is at least two bytes wide (`crate::utf8::Utf8Lead::width`).
+    if bytes.len() < lead.width || !lead.accepts_first_continuation(bytes[1]) {
         return None;
     }
-    // The lead byte's range already constrained the first continuation; the
-    // rest are unconstrained trail bytes.
+    // The lead byte's row already constrained the first continuation; the rest
+    // are unconstrained trail bytes.
     let mut index = 2;
-    while index < width {
-        if !(0x80..=0xbf).contains(&bytes[index]) {
+    while index < lead.width {
+        if !crate::utf8::is_continuation(bytes[index]) {
             return None;
         }
         index += 1;
     }
-    Some(width)
+    Some(lead.width)
 }
 
 /// Write the terminal completion frame.

--- a/crates/rue-runtime/src/utf8.rs
+++ b/crates/rue-runtime/src/utf8.rs
@@ -1,0 +1,206 @@
+//! Unicode's table of well-formed UTF-8 byte sequences.
+//!
+//! Table 3-7 of the Unicode standard is the whole of UTF-8 well-formedness. A
+//! lead byte fixes two things: how many bytes the sequence it begins occupies,
+//! and the range its *first* continuation byte may take. That first-byte range
+//! is what rejects an overlong encoding (`0xE0` needs `>= 0xA0`, `0xF0` needs
+//! `>= 0x90`), a surrogate (`0xED` needs `<= 0x9F`), and a scalar above
+//! `U+10FFFF` (`0xF4` needs `<= 0x8F`). Every later byte of the sequence is an
+//! unconstrained continuation, so a full-width sequence that clears the table
+//! is always a valid scalar, and nothing outside the table ever is.
+//!
+//! The table is spelled out here rather than delegated to
+//! `core::str::from_utf8` so the freestanding build's emitted code stays a
+//! handful of comparisons with no libcall in it. Spelling it out *once* is why
+//! this module exists: the JSON escaper in [`crate::test_channel`] and the
+//! lossy decoder in [`crate::string`] both need the same rows, and two
+//! hand-copied tables in one crate are two things to keep in step.
+
+/// One lead byte's row of the table.
+///
+/// A row describes a multi-byte sequence only; see [`lead`] for why ASCII has
+/// no row.
+pub(crate) struct Utf8Lead {
+    /// Total bytes in the sequence, counting the lead byte itself.
+    ///
+    /// **Always at least 2.** The table has no single-byte row (see [`lead`]),
+    /// and both consumers depend on that: they read the first continuation
+    /// byte without a separate emptiness check once they know the buffer holds
+    /// `width` bytes, and [`lead`] derives [`Self::scalar_prefix`] with a mask
+    /// that is only correct for widths 2, 3 and 4. Adding a width-1 row would
+    /// make an in-bounds read out of bounds and the prefix mask wrong; add an
+    /// ASCII path to the caller instead.
+    pub(crate) width: usize,
+    /// Inclusive lower bound on the first continuation byte.
+    pub(crate) first_continuation_min: u8,
+    /// Inclusive upper bound on the first continuation byte.
+    pub(crate) first_continuation_max: u8,
+    /// The scalar bits the lead byte itself contributes, already masked off:
+    /// the high bits of a decoded scalar, before any continuation byte shifts
+    /// in its own six.
+    ///
+    /// Only meaningful for a multi-byte row; see [`Self::width`].
+    pub(crate) scalar_prefix: u32,
+}
+
+/// The table row for `byte`, or `None` when `byte` cannot begin a multi-byte
+/// sequence: a continuation byte (`0x80..=0xBF`), an always-overlong lead
+/// (`0xC0`, `0xC1`), or a lead past the end of the Unicode range
+/// (`0xF5..=0xFF`).
+///
+/// ASCII has no row on purpose — `byte < 0x80` returns `None` as well. A
+/// single byte is not a sequence with a continuation range to check, and every
+/// caller takes an ASCII fast path before it reaches the table, so a row for
+/// ASCII would only be an arm no caller can reach. That every row is therefore
+/// at least two bytes wide is load-bearing rather than incidental; see
+/// [`Utf8Lead::width`] before adding one.
+#[inline]
+pub(crate) fn lead(byte: u8) -> Option<Utf8Lead> {
+    let (width, first_continuation_min, first_continuation_max) = match byte {
+        0xC2..=0xDF => (2usize, 0x80u8, 0xBFu8),
+        0xE0 => (3, 0xA0, 0xBF),
+        0xE1..=0xEC => (3, 0x80, 0xBF),
+        0xED => (3, 0x80, 0x9F),
+        0xEE..=0xEF => (3, 0x80, 0xBF),
+        0xF0 => (4, 0x90, 0xBF),
+        0xF1..=0xF3 => (4, 0x80, 0xBF),
+        0xF4 => (4, 0x80, 0x8F),
+        _ => return None,
+    };
+    // A width-`n` lead is `n` leading ones, a zero, then its payload bits:
+    // `110xxxxx`, `1110xxxx`, `11110xxx`. That leaves `7 - width` payload bits,
+    // which is exactly the mask `0x7F >> width`. This relies on every row above
+    // having `width >= 2` (see `Utf8Lead::width`): a width-1 row would mask
+    // with `0x3F` and drop two bits of an ASCII byte.
+    let scalar_prefix = (byte & (0x7F >> width)) as u32;
+    Some(Utf8Lead {
+        width,
+        first_continuation_min,
+        first_continuation_max,
+        scalar_prefix,
+    })
+}
+
+impl Utf8Lead {
+    /// Whether `byte` is an acceptable *first* continuation for this lead.
+    #[inline]
+    pub(crate) fn accepts_first_continuation(&self, byte: u8) -> bool {
+        (self.first_continuation_min..=self.first_continuation_max).contains(&byte)
+    }
+}
+
+/// Whether `byte` is a continuation byte, `0b10xxxxxx`.
+///
+/// This is the check for every byte of a sequence *after* the first
+/// continuation, whose range the lead byte narrows instead.
+#[inline]
+pub(crate) fn is_continuation(byte: u8) -> bool {
+    byte & 0xC0 == 0x80
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+
+    /// Assemble the shortest byte sequence that exercises lead `b0` with first
+    /// continuation `b1`, padding any remaining positions with a continuation
+    /// byte that the table always accepts.
+    fn candidate(b0: u8, b1: u8, width: usize) -> std::vec::Vec<u8> {
+        let mut bytes = std::vec![0x80u8; width];
+        bytes[0] = b0;
+        if width > 1 {
+            bytes[1] = b1;
+        }
+        bytes
+    }
+
+    /// The table is Unicode's, so it must agree with the standard library's
+    /// validator on the whole lead-by-first-continuation cross product — the
+    /// entire content of the rows. `core::str::from_utf8` is the oracle here
+    /// only; the freestanding build never calls it.
+    #[test]
+    fn the_table_agrees_with_the_standard_validator_on_every_lead_and_first_byte() {
+        for b0 in 0u8..=0xFF {
+            for b1 in 0u8..=0xFF {
+                let row = lead(b0);
+                let accepted = row
+                    .as_ref()
+                    .is_some_and(|row| row.accepts_first_continuation(b1));
+                // Width 4 is the widest row; a shorter row ignores the tail.
+                let width = row.as_ref().map_or(1, |row| row.width);
+                let bytes = candidate(b0, b1, width);
+                let valid = b0 >= 0x80 && core::str::from_utf8(&bytes).is_ok();
+                assert_eq!(
+                    accepted, valid,
+                    "lead {b0:#04x}, first continuation {b1:#04x}: table says \
+                     {accepted}, validator says {valid}"
+                );
+            }
+        }
+    }
+
+    /// The prefix a row reports has to be the payload bits of the lead byte,
+    /// so a decoder that shifts continuations into it lands on the scalar the
+    /// standard library decodes.
+    #[test]
+    fn a_rows_scalar_prefix_reconstructs_the_scalar() {
+        for b0 in 0u8..=0xFF {
+            let Some(row) = lead(b0) else { continue };
+            for b1 in row.first_continuation_min..=row.first_continuation_max {
+                let bytes = candidate(b0, b1, row.width);
+                let text = core::str::from_utf8(&bytes).expect("row accepts this sequence");
+                let expected = text.chars().next().expect("one scalar").len_utf8();
+                assert_eq!(expected, row.width, "{bytes:?}");
+
+                let mut scalar = row.scalar_prefix;
+                for byte in &bytes[1..] {
+                    assert!(is_continuation(*byte), "{bytes:?}");
+                    scalar = (scalar << 6) | (u32::from(*byte) & 0x3F);
+                }
+                assert_eq!(
+                    scalar,
+                    text.chars().next().expect("one scalar") as u32,
+                    "{bytes:?}"
+                );
+            }
+        }
+    }
+
+    /// The bytes that can never begin a sequence are exactly the ones with no
+    /// row: continuations, the two always-overlong leads, and everything past
+    /// the end of the Unicode range.
+    #[test]
+    fn only_the_bytes_that_can_begin_a_sequence_have_a_row() {
+        for byte in 0u8..=0xFF {
+            let expected = matches!(byte, 0xC2..=0xF4);
+            assert_eq!(lead(byte).is_some(), expected, "{byte:#04x}");
+        }
+    }
+
+    /// Every row is at least two bytes wide. Both consumers read the first
+    /// continuation byte off the strength of this, and `lead`'s prefix mask is
+    /// only correct above width 1, so pin it rather than leaving it to prose.
+    #[test]
+    fn every_row_is_at_least_two_bytes_wide() {
+        for byte in 0u8..=0xFF {
+            let Some(row) = lead(byte) else { continue };
+            assert!(row.width >= 2, "{byte:#04x} has width {}", row.width);
+            assert!(row.width <= 4, "{byte:#04x} has width {}", row.width);
+        }
+    }
+
+    /// A continuation byte is the low quarter of the high half, and nothing
+    /// else.
+    #[test]
+    fn continuation_bytes_are_exactly_0x80_through_0xbf() {
+        for byte in 0u8..=0xFF {
+            assert_eq!(
+                is_continuation(byte),
+                (0x80..=0xBF).contains(&byte),
+                "{byte:#04x}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Unicode's Table 3-7 well-formedness rule was stated three times inside
`rue-runtime`: the test channel's JSON escaper and the lossy decoder carried
byte-for-byte copies of the lead/first-continuation ranges, and the strict
decoder carried the equivalent decode-then-range-check with its own overlong
minimums, surrogate range, and `U+10FFFF` bound. All three were correct, so this
is duplication risk rather than a live bug — the kind a future validator change
would silently miss in one place.

This extracts the table into a crate-internal `utf8` module. A lead byte's row
carries the sequence width, the range its first continuation byte may take, and
the scalar bits the lead itself contributes; `is_continuation` covers the
generic trail bytes. All three consumers read that one table and keep their own
shapes: the escaper reports a width or nothing, the lossy decoder substitutes
`U+FFFD` and advances by the maximal subpart, the strict decoder traps.

Folding in the strict decoder matters most, because its agreement with the table
is the one claim no unit test can hold — `__rue_invalid_utf8` terminates the
process, so no in-process test can observe its accept set. Reading the table
directly also drops the `min` constants, the `0xD800..=0xDFFF` surrogate range,
and the `0x10FFFF` bound, three more hand-written statements of the same rule.

`utf8_sequence_width`'s `0x00..=0x7f => Some(1)` arm is gone; it was unreachable,
since `escaped` handles a byte below `0x80` on its own path. The shared table has
no ASCII row, and that every row is therefore at least two bytes wide is
load-bearing — both consumers read the first continuation byte on the strength of
it, and the prefix mask `0x7F >> width` is only correct above width 1. Documented
on the field and pinned by a test.

## Behavior

No observable change. Verified by differential sweeps carrying the pre-refactor
bodies verbatim beside the new ones:

- **Lossy decoder**: bit-identical `(scalar, width)` over 221M cases (all
  256x256 lead/first-continuation pairs x boundary-class tails, at every
  truncation length, at every offset), including every `U+FFFD` path and
  maximal-subpart length.
- **Strict decoder**: 0 divergences over 200M+ cases, plus exhaustively over all
  1-, 2- and 3-byte strings. Since every rejection reaches the same argument-less
  divergent trap, accept-set equality plus `(scalar, width)` on accept is full
  observational equality.
- **Escaper**: identical everywhere `bytes[0] >= 0x80` — the caller's
  precondition — with the only divergence anywhere being the dropped ASCII arm.

End-to-end through a compiled binary, every Table 3-7 boundary class behaves as
before: `ED 9F BF` (U+D7FF) and `F4 8F BF BF` (U+10FFFF) decode, while `ED A0 80`
and `F4 90 80 80` one past each still trap with exit 101.

## Code size

The table stays written out rather than delegated to `core::str::from_utf8` —
the freestanding `no_std` build must not grow a libcall. Undefined-symbol sets
are identical to trunk on all three staticlibs, and every archive is smaller:

| target | trunk | this branch | delta |
|---|---|---|---|
| x86-64-linux | 4,323,802 | 4,322,890 | **-912** |
| aarch64-macos | 3,250,616 | 3,250,152 | **-464** |
| aarch64-linux | 4,533,352 | 4,531,912 | **-1440** |

`__rue_decode_utf8_at` drops from 79 x86-64 instructions to 55; the lossy decoder
stays call-free; the escaper loses an out-of-line `RangeInclusive::contains`.

`rue-oracle`'s `char_at`/`char_at_lossy` keep their own independent copies on
purpose and now say so — the oracle exists to disagree with the runtime, and a
model reading the runtime's table would compare it against itself.

Fixes RUE-2081
