### PR TITLE
Prime the Zig runtime cache once per toolchain pin

### DIFF
--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -315,6 +315,55 @@ they're recorded here so a future config change doesn't silently regress:
    discards the debug sections of inputs under the Zig cache directories and
    nothing else. macOS is unchanged: the prelude's path clang tools plus
    `-ld_classic`.
+
+   **Primed Zig runtime cache** (RUE-1939): compiling that runtime is a
+   per-action cost, not a per-toolchain one, because each link action gets its
+   own empty Zig cache under `BUCK_SCRATCH_PATH`. One cold link spent about
+   15 s of wall time and 19 s of CPU on it, and every binary, test, and build
+   script paid it. `toolchains//zig:runtime-cache` now performs that work once:
+   `zig_runtime_cache` links a throwaway translation unit
+   (`toolchains/zig/runtime_cache_probe.c`) for the target triple in each shape
+   a Linux Rust build produces — plain, PIE, and `-lgcc_s` for libunwind — and
+   keeps the resulting global cache as a single `.tar` artifact. The linker
+   wrapper unpacks that archive into the action's scratch directory and points
+   `ZIG_GLOBAL_CACHE_DIR` at it: Zig needs a writable cache and an action must
+   not write to its inputs. It unpacks under the `zig-global-cache` name, which
+   is what leaves `runtime-debug-discard.ld`'s input patterns matching the
+   seeded objects. The same cold link is then 0.13 s, unpacking included, and
+   the seed action is an ordinary cacheable action, so the 15 s is paid once
+   per toolchain pin rather than once per link.
+
+   The artifact is an archive rather than the cache tree because it is an input
+   to every link action in the build, and the tree is 926 small files — the one
+   artifact shape this repository has had to keep out of the remote CAS
+   (`toolchains/distribution.bzl`, RUE-2003). Unpacking one blob costs a link
+   what copying the tree would have.
+
+   Three properties make that safe. The seeded objects are the ones Zig would
+   have compiled in the action anyway, so a link's output bytes do not change:
+   the compiler binary has the same sha256 with the seed as without it. The
+   seed's own bytes *are* checkout-dependent — those objects carry DWARF whose
+   `DW_AT_comp_dir` is the seed action's working directory — but the linker
+   script discards exactly those sections, so a seed built in one checkout and
+   a seed built in another produce byte-identical links, which is what keeps
+   `scripts/check-reproducible-compiler.sh` green. And a seed that does not
+   match degrades rather than breaks: Zig keys the libunwind entries on the
+   paths it sees relative to the action's working directory, so a cache
+   produced under a different `buck-out` layout still supplies the glibc start
+   files and compiler_rt and costs a link about 0.7 s to rebuild libunwind,
+   not the original 15 s.
+
+   Bumping the pin needs no separate step: `ZIG_VERSION` and `ZIG_LINUX_TARGET`
+   in `toolchains/zig/defs.bzl` are inputs to the seed action, so changing the
+   Zig release or the glibc floor re-keys it and the next link seeds from the
+   rebuilt cache. `ZIG_LINUX_TARGET` is shared with `toolchains//:zig-cxx-tools`
+   so the triple the cache is primed for cannot drift from the triple the links
+   name. A new kind of link — a static executable, say — is the one case that
+   needs an edit: add its flags to `_RUNTIME_CACHE_LINK_SHAPES`, or that link
+   shape compiles its own runtime. The three shapes there are each load-bearing
+   and between them exhaustive as of Zig 0.16.0 — dropping one leaves entries
+   no other shape builds, and a shared-object link, as a proc-macro crate or a
+   cdylib performs, needs nothing they do not already provide.
 7. **Rust action memory** (RUE-320): a cache-disabled cold graph exceeded
    BuildBuddy's default per-action memory estimate and the executor OOM-killed
    rustc. The remote platform requests 4 GB per action; this is an execution

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -21,6 +21,7 @@ load("@prelude//toolchains:cxx.bzl", "cxx_tools_info_toolchain")
 load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
 load("@prelude//tests:test_toolchain.bzl", "noop_test_toolchain")
+load("@toolchains//zig:defs.bzl", "ZIG_LINUX_TARGET")
 load(":cxx_tools.bzl", "exec_cxx_tools", "zig_cxx_tools")
 load(":rue.bzl", "rue_toolchain")
 load(":remote_test_execution.bzl", "noop_remote_test_execution_toolchain")
@@ -42,15 +43,14 @@ export_file(
 #
 # The glibc floor is `2.17`, the oldest glibc Rust's `*-unknown-linux-gnu`
 # targets support, and the same floor `third-party/reindeer_rules.bzl` uses for
-# the mimalloc archive that these links consume. The linker wrapper applies
+# the mimalloc archive that these links consume; ZIG_LINUX_TARGET carries it,
+# and toolchains//zig:runtime-cache reads the same constant so the cache it
+# primes is the one these links look for. The linker wrapper applies
 # toolchains//zig:runtime-debug-discard.ld so the runtime objects Zig compiles
 # from source during a link do not record the checkout path in debug sections.
 zig_cxx_tools(
     name = "zig-cxx-tools",
-    target = select({
-        "prelude//cpu:arm64": "aarch64-linux-gnu.2.17",
-        "prelude//cpu:x86_64": "x86_64-linux-gnu.2.17",
-    }),
+    target = ZIG_LINUX_TARGET,
     compatible_with = ["prelude//os:linux"],
 )
 

--- a/toolchains/cxx_tools.bzl
+++ b/toolchains/cxx_tools.bzl
@@ -11,7 +11,9 @@ two rules here exploit that:
   linker, its bundled lld, compiler_rt, libunwind, and the glibc it links
   against all come from the SHA-pinned Zig tree instead of whatever the host
   happens to install. That is what makes a Linux link identical between a
-  developer machine, the remote cache, and the remote-execution worker.
+  developer machine, the remote cache, and the remote-execution worker. The
+  linker additionally starts from `toolchains//zig:runtime-cache`, so it finds
+  that runtime already compiled instead of building it per action.
 - `exec_cxx_tools` forwards the `CxxToolsInfo` of a selectable dependency, so
   `toolchains//BUCK` can pick the Zig tools on Linux and keep the prelude's
   path-discovered clang tools on macOS from one exec-configured target.
@@ -20,7 +22,7 @@ two rules here exploit that:
 load("@prelude//cxx:cxx_toolchain_types.bzl", "LinkerType")
 load("@prelude//toolchains:cxx.bzl", "CxxToolsInfo")
 load("@prelude//utils:cmd_script.bzl", "cmd_script")
-load("@toolchains//zig:defs.bzl", "ZigToolchainInfo")
+load("@toolchains//zig:defs.bzl", "ZigToolchainInfo", "zig_with_primed_cache")
 
 def _zig_cxx_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     # `ZigToolchainInfo.zig` is the cache-directory wrapper around the Zig
@@ -28,10 +30,23 @@ def _zig_cxx_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     # one definition of where Zig may write (ZIG_LOCAL_CACHE_DIR and
     # ZIG_GLOBAL_CACHE_DIR under BUCK_SCRATCH_PATH) and makes the bundled
     # libc, compiler_rt, and libunwind sources part of every action key.
-    zig = ctx.attrs._zig[ZigToolchainInfo].zig
+    toolchain = ctx.attrs._zig[ZigToolchainInfo]
+    zig = toolchain.zig
+
+    # The same wrapper, with the action's global cache primed from
+    # toolchains//zig:runtime-cache. Building the glibc start files,
+    # libunwind, and compiler_rt from source is a link-time cost — about 15 s
+    # of wall time with an empty cache — and it is the linker, not the
+    # compiler or the archiver, that pays it, so only the linker takes the
+    # primed cache and only link actions carry the archive as an input
+    # (RUE-1939).
+    linking_zig = zig_with_primed_cache(
+        toolchain,
+        ctx.attrs._runtime_cache[DefaultInfo].default_outputs[0],
+    )
     target = ["-target", ctx.attrs.target]
 
-    def tool(name: str, args: list) -> cmd_args:
+    def tool(name: str, command, args: list) -> cmd_args:
         # The prelude passes each tool to rustc as a single `-Clinker=` path
         # and to its own C rules as one executable, so bundle the multi-word
         # Zig command into a script. `cmd_script` carries the command's hidden
@@ -39,7 +54,7 @@ def _zig_cxx_tools_impl(ctx: AnalysisContext) -> list[Provider]:
         return cmd_script(
             actions = ctx.actions,
             name = name,
-            cmd = cmd_args(zig, args),
+            cmd = cmd_args(command, args),
         )
 
     # The target triple is explicit on every compiler and linker invocation so
@@ -56,10 +71,10 @@ def _zig_cxx_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     # of the runtime objects Zig compiles from source during the link; the
     # script explains why those objects, and only those, would otherwise make
     # the link depend on the checkout path.
-    cc = tool("zig-cc", ["cc"] + target)
-    cxx = tool("zig-c++", ["c++"] + target)
-    ar = tool("zig-ar", ["ar"])
-    linker = tool("zig-link", ["cc"] + target + [
+    cc = tool("zig-cc", zig, ["cc"] + target)
+    cxx = tool("zig-c++", zig, ["c++"] + target)
+    ar = tool("zig-ar", zig, ["ar"])
+    linker = tool("zig-link", linking_zig, ["cc"] + target + [
         cmd_args("-Wl,-T,", ctx.attrs._runtime_debug_discard, delimiter = ""),
     ])
 
@@ -86,6 +101,7 @@ zig_cxx_tools = rule(
         # Zig target triple, including the glibc version to link against, e.g.
         # `x86_64-linux-gnu.2.17`. Selected on the execution platform's CPU.
         "target": attrs.string(),
+        "_runtime_cache": attrs.dep(default = "toolchains//zig:runtime-cache"),
         "_runtime_debug_discard": attrs.source(default = "toolchains//zig:runtime-debug-discard.ld"),
         "_zig": attrs.toolchain_dep(default = "toolchains//:zig"),
     },

--- a/toolchains/zig/BUCK
+++ b/toolchains/zig/BUCK
@@ -1,4 +1,12 @@
-load(":defs.bzl", "ZIG_VERSION", "hermetic_zig_toolchain", "zig_c_static_archive", "zig_host_archive")
+load(
+    ":defs.bzl",
+    "ZIG_LINUX_TARGET",
+    "ZIG_VERSION",
+    "hermetic_zig_toolchain",
+    "zig_c_static_archive",
+    "zig_host_archive",
+    "zig_runtime_cache",
+)
 load("@root//:test_defs.bzl", "rue_sh_test")
 
 zig_host_archive("linux-x86_64", "x86_64-linux")
@@ -68,6 +76,20 @@ export_file(
 export_file(
     name = "runtime-debug-discard.ld",
     src = "runtime-debug-discard.ld",
+    visibility = ["toolchains//:zig-cxx-tools"],
+)
+
+# The Zig runtime every Linux link needs, compiled once instead of once per
+# link action (RUE-1939). The linker wrapper in toolchains//:zig-cxx-tools
+# unpacks this archive into the action's scratch directory and points
+# ZIG_GLOBAL_CACHE_DIR at it. Reached only through that exec-configured
+# wrapper, so the CPU select resolves on the execution platform, exactly as
+# the wrapper's own target triple does — hence the shared ZIG_LINUX_TARGET.
+zig_runtime_cache(
+    name = "runtime-cache",
+    src = "runtime_cache_probe.c",
+    compatible_with = ["prelude//os:linux"],
+    target = ZIG_LINUX_TARGET,
     visibility = ["toolchains//:zig-cxx-tools"],
 )
 

--- a/toolchains/zig/defs.bzl
+++ b/toolchains/zig/defs.bzl
@@ -1,4 +1,4 @@
-"""Hermetic Zig toolchain and focused C archive rule.
+"""Hermetic Zig toolchain, primed runtime cache, and focused C archive rule.
 
 Zig is distributed as one relocatable tree.  The RunInfo keeps that complete
 tree as a hidden input so the compiler executable, bundled libc descriptions,
@@ -8,6 +8,18 @@ and archive implementation all participate in action keys and remote inputs.
 load("@toolchains//:distribution.bzl", "toolchain_distribution")
 
 ZIG_VERSION = "0.16.0"
+
+# The Linux triple every `zig cc` invocation names, chosen on the execution
+# platform's CPU. The glibc floor is `2.17`, the oldest glibc Rust's
+# `*-unknown-linux-gnu` targets support; `third-party/reindeer_rules.bzl` pins
+# the same floor for the mimalloc archive these links consume. The C tools
+# (toolchains//:zig-cxx-tools) and the primed runtime cache
+# (toolchains//zig:runtime-cache) must name the same triple or the cache would
+# hold objects no link asks for, so both read it from here.
+ZIG_LINUX_TARGET = select({
+    "prelude//cpu:arm64": "aarch64-linux-gnu.2.17",
+    "prelude//cpu:x86_64": "x86_64-linux-gnu.2.17",
+})
 
 ZIG_RELEASES = {
     "x86_64-linux": struct(
@@ -29,8 +41,13 @@ ZIG_RELEASES = {
 }
 
 ZigToolchainInfo = provider(fields = [
-    # RunInfo for the relocatable Zig distribution.
+    # RunInfo for the relocatable Zig distribution, run with an empty cache.
     "zig",
+    # The three pieces `zig` is assembled from, so a consumer can build the
+    # same command with a primed global cache. See zig_with_primed_cache.
+    "cache_wrapper",
+    "binary",
+    "distribution",
     # Execution-host identity, retained for structural assertions and consumers
     # which must choose an explicit cross-compilation target.
     "host_platform",
@@ -53,6 +70,19 @@ def zig_host_archive(name: str, platform: str):
         visibility = [],
     )
 
+# The cache wrapper's first argument when an action wants an empty global
+# cache; anything else is an archive to prime the cache from.
+_EMPTY_CACHE = "-"
+
+def _zig_command(cache_wrapper: Artifact, binary: Artifact, distribution: Artifact, cache) -> cmd_args:
+    """The one shape of a Zig command line: wrapper, cache seed, then Zig.
+
+    `cache` is a zig_runtime_cache archive to prime the action's global cache
+    from, or `_EMPTY_CACHE`. The whole distribution is hidden behind the
+    executable so it reaches the action as an input.
+    """
+    return cmd_args("/bin/sh", cache_wrapper, cache, binary, hidden = [distribution])
+
 def _hermetic_zig_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
     distribution = ctx.attrs.distribution[DefaultInfo].default_outputs[0]
     zig_binary = distribution.project("zig")
@@ -64,18 +94,33 @@ def _hermetic_zig_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
             "cache_root=\"${BUCK_SCRATCH_PATH:-${TMPDIR:-/tmp}/rue-zig-${PPID}}\"",
             "export ZIG_LOCAL_CACHE_DIR=\"${cache_root}/zig-local-cache\"",
             "export ZIG_GLOBAL_CACHE_DIR=\"${cache_root}/zig-global-cache\"",
-            "zig=$1",
-            "shift",
+            # $1 is a primed global cache (a zig_runtime_cache archive) or
+            # _EMPTY_CACHE; $2 is the Zig executable.
+            "seed=$1",
+            "zig=$2",
+            "shift 2",
+            # The primed cache is unpacked into the action's scratch rather
+            # than read where it lies: Zig needs a writable cache and an action
+            # must not write to its inputs. It unpacks under the
+            # `zig-global-cache` name, so the objects in it still match the
+            # input patterns in toolchains/zig/runtime-debug-discard.ld.
+            "if [ \"${seed}\" != \"" + _EMPTY_CACHE + "\" ] && [ ! -d \"${ZIG_GLOBAL_CACHE_DIR}\" ]; then",
+            "    mkdir -p \"${ZIG_GLOBAL_CACHE_DIR}\"",
+            "    tar -xf \"${seed}\" -C \"${ZIG_GLOBAL_CACHE_DIR}\"",
+            "fi",
             "exec \"${zig}\" \"$@\"",
         ],
         is_executable = True,
     )
-    zig = RunInfo(args = cmd_args("/bin/sh", cache_wrapper, zig_binary, hidden = [distribution]))
+    zig = RunInfo(args = _zig_command(cache_wrapper, zig_binary, distribution, _EMPTY_CACHE))
     return [
         DefaultInfo(default_output = zig_binary),
         RunInfo(args = zig),
         ZigToolchainInfo(
             zig = zig,
+            cache_wrapper = cache_wrapper,
+            binary = zig_binary,
+            distribution = distribution,
             host_platform = ctx.attrs.host_platform,
         ),
     ]
@@ -87,6 +132,116 @@ hermetic_zig_toolchain = rule(
         "host_platform": attrs.string(),
     },
     is_toolchain_rule = True,
+)
+
+def zig_with_primed_cache(toolchain: ZigToolchainInfo, cache: Artifact) -> cmd_args:
+    """The Zig command with the action's global cache primed from `cache`.
+
+    `cache` is a zig_runtime_cache archive. Same wrapper, same
+    scratch-directory caches, and same hidden distribution as
+    `ZigToolchainInfo.zig`; the wrapper unpacks the primed cache before handing
+    over to Zig.
+    """
+    return _zig_command(
+        toolchain.cache_wrapper,
+        toolchain.binary,
+        toolchain.distribution,
+        cache,
+    )
+
+# The link shapes a Linux Rust build produces, and with them every piece of Zig
+# runtime such a build can ask for. Zig compiles that runtime from source the
+# first time a global cache needs it, which costs a link about 15 s of wall
+# time against 0.13 s when it starts from a primed cache. Priming performs each
+# shape once, in an action that is itself cached, and every link action then
+# starts from the result. Each shape earns its place — dropping one leaves
+# entries no other shape builds — and there is no fourth to add: a shared
+# object, as a proc-macro crate or a cdylib links, needs nothing these three
+# already provide.
+_RUNTIME_CACHE_LINK_SHAPES = [
+    # A plain executable: the glibc start files, the non-shared stubs, and
+    # compiler_rt.
+    [],
+    # A position-independent executable, which starts at Scrt1.o rather than
+    # crt1.o and brings its own init and ABI-note objects.
+    ["-pie", "-fPIE"],
+    # Every Rust link passes `-lgcc_s`, which `zig cc` resolves to the bundled
+    # libunwind — compiled from source like the rest, and keyed differently
+    # from anything the other two shapes build.
+    ["-lgcc_s"],
+]
+
+def _zig_runtime_cache_impl(ctx: AnalysisContext) -> list[Provider]:
+    toolchain = ctx.attrs._zig_toolchain[ZigToolchainInfo]
+
+    # One archive rather than the cache tree itself. The tree is 926 files, and
+    # it would be an input to every link action in the build; a tree of small
+    # files is the one artifact shape Rue has had to keep out of the remote CAS
+    # (see toolchains/distribution.bzl and RUE-2003). Unpacking costs the same
+    # as copying the tree would.
+    cache = ctx.actions.declare_output("zig-runtime-cache.tar")
+
+    prime = [
+        "#!/bin/sh",
+        "set -eu",
+        "archive=$1",
+        "zig=$2",
+        "target=$3",
+        "source=$4",
+        "scratch=\"${BUCK_SCRATCH_PATH:-${TMPDIR:-/tmp}}\"",
+        # Building this global cache is the action's whole purpose, but it is
+        # still scratch: only its archived form is the output. The local cache
+        # holds nothing worth keeping.
+        "export ZIG_GLOBAL_CACHE_DIR=\"${scratch}/zig-global-cache\"",
+        "export ZIG_LOCAL_CACHE_DIR=\"${scratch}/zig-local-cache\"",
+        "mkdir -p \"${ZIG_GLOBAL_CACHE_DIR}\" \"${scratch}/links\"",
+    ]
+    for index, flags in enumerate(_RUNTIME_CACHE_LINK_SHAPES):
+        link = (
+            "\"${zig}\" cc -target \"${target}\" \"${source}\"" +
+            " -o \"${{scratch}}/links/{}\"".format(index)
+        )
+        prime.append(" ".join([link] + flags))
+
+    # Sorted names and zeroed metadata so the archive depends on the cache
+    # contents alone.
+    prime.append(
+        "tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner" +
+        " -cf \"${archive}\" -C \"${ZIG_GLOBAL_CACHE_DIR}\" .",
+    )
+    prime_script = ctx.actions.write(
+        "prime-zig-runtime-cache.sh",
+        prime,
+        is_executable = True,
+    )
+
+    ctx.actions.run(
+        cmd_args(
+            "/bin/sh",
+            prime_script,
+            cache.as_output(),
+            toolchain.binary,
+            ctx.attrs.target,
+            ctx.attrs.src,
+            hidden = [toolchain.distribution],
+        ),
+        category = "zig_runtime_cache",
+        identifier = ctx.label.name,
+    )
+
+    return [DefaultInfo(default_output = cache)]
+
+zig_runtime_cache = rule(
+    impl = _zig_runtime_cache_impl,
+    attrs = {
+        "src": attrs.source(
+            doc = "Throwaway translation unit to link; only its Zig cache is kept.",
+        ),
+        "target": attrs.string(
+            doc = "Zig target triple to build the runtime for, glibc pin included.",
+        ),
+        "_zig_toolchain": attrs.toolchain_dep(default = "toolchains//:zig"),
+    },
 )
 
 def _zig_c_static_archive_impl(ctx: AnalysisContext) -> list[Provider]:

--- a/toolchains/zig/runtime_cache_probe.c
+++ b/toolchains/zig/runtime_cache_probe.c
@@ -1,0 +1,11 @@
+/*
+ * The translation unit toolchains/zig:runtime-cache links, once per target
+ * triple, so that Zig compiles its runtime support (the glibc start files and
+ * non-shared stubs, libunwind, compiler_rt) into a global cache that every
+ * later link action starts from.  Only that cache is kept; the executable the
+ * link produces is thrown away, so the program's behaviour is irrelevant and
+ * it should stay small enough to add nothing measurable to the link.
+ */
+int main(void) {
+    return 0;
+}


### PR DESCRIPTION
## Summary

With `zig cc` as the Linux linker (RUE-1937), every link action got its own empty Zig cache under `BUCK_SCRATCH_PATH`, so Zig recompiled the glibc start files, libunwind and compiler_rt from source on every link: ~15 s wall / ~18.6 s CPU per cold link action, for binaries, tests and build scripts alike, recurring on every PR that touches the compiler.

- **Seed.** A new `zig_runtime_cache` rule in `toolchains/zig/defs.bzl` links `toolchains/zig/runtime_cache_probe.c` with `zig cc -target <triple>` once per link shape (`[]`, `-pie -fPIE`, `-lgcc_s`; measured: plain gives 31 cache entries, PIE adds 4, `-lgcc_s` adds the 11 libunwind entries, and `-shared -fPIC` added nothing so it is not a shape) into a global cache in the action's scratch, then tars it into one `zig-runtime-cache.tar` output. It is an ordinary cacheable `ctx.actions.run`, so the ~15 s is paid once per toolchain pin. A single tar blob rather than a 926-file directory artifact avoids the per-input CAS cost `toolchains/distribution.bzl` documents (RUE-2003); untarring costs the same as copying.
- **Consumption.** The cache wrapper takes a first argument (an archive to seed from, or `-`), untars it into `${BUCK_SCRATCH_PATH}/zig-global-cache` (Zig needs a writable cache, and the directory name keeps `runtime-debug-discard.ld`'s `*zig-global-cache/*` patterns matching). Only `zig-link` takes the seed; `zig cc`/`zig c++`/`zig ar` keep the empty cache so compile and archive actions do not carry the artifact. `ZigToolchainInfo` exposes the wrapper/binary/distribution so `zig_with_primed_cache()` and the C tools go through one `_zig_command` helper, and `ZIG_LINUX_TARGET` moved into `defs.bzl` so the tools and the seed cannot name different triples.
- **Relocatability.** Two seeds built in different checkout roots differ (DWARF `DW_AT_comp_dir` in the objects), but the linker script discards exactly those sections, so links through the wrapper are byte-identical to an unseeded cold link with no checkout-path strings. Zig keys libunwind entries on the path relative to the action cwd; Buck actions all run at the project root, so seeds hit fully, and a mismatched layout only rebuilds libunwind (~0.7 s), never the whole cache.
- **Docs.** `docs/process/build-cache.md` §6 explains the seed, the safety argument, the archive rationale, and how to bump it when the Zig pin changes.

## Measurements

| cold link action | wall | CPU |
|---|---|---|
| before (empty cache) | 14.9–15.2 s | ~18.6 s |
| after (seeded) | 0.10–0.13 s | ~0.12 s |

`scripts/check-reproducible-compiler.sh` passes (cold relocated rebuild, 408 local commands, the seed action running in the candidate tree), and the compiler sha256 is identical before and after: `7d3afaa574a609b67694b4d155710d16cfadbb250a7d44542220764821f3c585`.

## Validation

`./buck2 test toolchains//zig/... //:ci-gate-validation //:doc-link-validation //:adr-registry-validation` (6 pass, including `runtime-debug-discard-test`, `toolchain-policy-test`, `archive-smoke-test`), `scripts/rue fmt`, `quick` (36/36), `cli abi ffi linking` (174), `ui` (437) on the rebased tree; the agent's `premerge` on the pre-rebase tree passed except the environmental cases. AArch64 and macOS lanes are covered by CI only.

Closes RUE-1939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_