### PR TITLE
A float element coerces to a slice when its stride agrees

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -4646,3 +4646,60 @@ fn module_diagnostics_have_one_display_name() {
         );
     }
 }
+
+/// The fixed-array-to-slice coercion and code generation's raw-pointer gate ask
+/// one layout question, so they consult one predicate (RUE-2097).
+///
+/// The two used to share `is_slot_identical_layout`, which folds an *access
+/// kind* into a layout answer: a float leaf is never moved as an opaque slot, so
+/// that predicate calls `f64` non-identical even though its eight bytes sit
+/// exactly where the slot model puts them. Splitting the positional question out
+/// as `compact_stride_matches_slot_stride` let `[f64]` coerce; keeping both
+/// derived from one walk is what stops the E0908 refusal and the backend gate
+/// from drifting apart, in either direction.
+///
+/// The codegen half of the pair is guarded in `rue-codegen`'s own inventory
+/// (`frame_raw_aggregate_pointer_gate_uses_the_shared_stride_predicate`), which
+/// can read that crate's sources.
+#[test]
+fn slice_coercion_and_layout_predicates_come_from_one_walk() {
+    let call_abi = include_str!("call_abi.rs");
+    for predicate in [
+        "pub fn is_slot_identical_layout",
+        "pub fn compact_stride_matches_slot_stride",
+    ] {
+        assert_eq!(
+            call_abi.matches(predicate).count(),
+            1,
+            "{predicate} must have exactly one definition"
+        );
+    }
+    // Both public predicates are thin wrappers over one walk, so the leaf table
+    // and the aggregate recursion cannot fork.
+    assert_eq!(
+        call_abi.matches("fn slot_layout_agrees").count(),
+        1,
+        "the shared walk has exactly one definition"
+    );
+    for wrapper in [
+        "slot_layout_agrees(type_pool, ty, FloatLeaves::NotSlotShaped)",
+        "slot_layout_agrees(type_pool, ty, FloatLeaves::FillTheirSlot)",
+    ] {
+        assert!(
+            call_abi.contains(wrapper),
+            "a public layout predicate stopped delegating to the shared walk: {wrapper}"
+        );
+    }
+
+    // The coercion's E0908 site asks the positional question and only that one.
+    let ownership = include_str!("sema/analysis/ownership.rs");
+    assert!(
+        ownership.contains("crate::compact_stride_matches_slot_stride(self.body_type_pool()"),
+        "the slice coercion must refuse on the shared stride predicate"
+    );
+    assert!(
+        !ownership.contains("is_slot_identical_layout"),
+        "the slice coercion must not re-derive the layout answer from the \
+         call-ABI predicate"
+    );
+}

--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -99,16 +99,77 @@ pub fn is_multislot_aggregate(ty: Type, slot_count: u32) -> bool {
 }
 
 /// Whether the compact physical layout of `ty` is byte-for-byte identical to
-/// the flattened eight-byte slot layout, so slot-shaped marshaling is exactly
-/// correct for it (ADR-0052).
+/// the flattened eight-byte slot layout **and** every leaf may be moved as an
+/// opaque eight-byte slot, so slot-shaped marshaling is exactly correct for it
+/// (ADR-0052).
 ///
 /// True for eight-byte leaves (`i64`/`u64`/pointers, the recovery scalar) and
 /// zero-sized / compile-time-only types, and for aggregates built entirely from
 /// slot-identical leaves. Narrow scalars (one/two/four bytes) and enums (narrow
-/// tag) are not slot-identical. This is the single authority code generation's
-/// narrow-access refusal (RUE-974) consults, so no two sites disagree about
-/// which types the compact layout leaves unchanged.
+/// tag) are not slot-identical, and neither is a float leaf: it is read and
+/// written by a floating-point access at its own width, never as an opaque
+/// slot, even where its footprint is eight bytes. This is the single authority
+/// code generation's narrow-access refusal (RUE-974) consults, so no two sites
+/// disagree about which types the compact layout leaves unchanged.
+///
+/// The purely positional half of that question — do the compact and slot models
+/// put the same bytes at the same offsets — is
+/// [`compact_stride_matches_slot_stride`], which admits `f64`.
 pub fn is_slot_identical_layout<P: crate::FfiTypePool + ?Sized>(type_pool: &P, ty: Type) -> bool {
+    slot_layout_agrees(type_pool, ty, FloatLeaves::NotSlotShaped)
+}
+
+/// Whether `ty`'s compact stride and interior byte offsets equal its slot-model
+/// stride and offsets, so a compact-strided walk over frame-resident storage of
+/// `ty` addresses exactly the bytes the slot model put there (ADR-0052).
+///
+/// This is the pure *position* question, and it is the one the
+/// fixed-array-to-slice coercion asks: a view strides by the element's compact
+/// size while a frame array stores one eight-byte slot per leaf, so the view is
+/// exact precisely when those two strides — and, for an aggregate element, the
+/// field and element offsets inside it — agree.
+///
+/// True for every leaf whose compact footprint already fills a slot —
+/// `i64`/`u64`/pointers, the recovery scalar, **and `f64`** — for zero-sized and
+/// compile-time-only types, and for structs and arrays built entirely from such
+/// leaves. False for a narrow scalar (`bool`/`i8`/`u8`/`i16`/`u16`/`i32`/`u32`,
+/// and `f32`, whose compact stride is four bytes against an eight-byte slot),
+/// for an enum (its tag is narrowed), and for any aggregate holding one.
+///
+/// It differs from [`is_slot_identical_layout`] in exactly one place, `f64`.
+/// That predicate additionally demands that a leaf be movable as an opaque
+/// slot, which a float never is; but an access kind moves no bytes. An `f64`
+/// sits at its slot's base and fills the whole slot, so a compact walk and a
+/// slot walk visit identical addresses. Keeping the two questions apart is what
+/// lets `[f64]` coerce (RUE-2097) while `[i32]` stays refused (RUE-2055).
+pub fn compact_stride_matches_slot_stride<P: crate::FfiTypePool + ?Sized>(
+    type_pool: &P,
+    ty: Type,
+) -> bool {
+    slot_layout_agrees(type_pool, ty, FloatLeaves::FillTheirSlot)
+}
+
+/// How the one layout walk below treats a float leaf: the only place the two
+/// public predicates above differ.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FloatLeaves {
+    /// A float leaf is not slot-shaped, whatever its footprint: it is accessed
+    /// by a floating-point instruction at its own width rather than moved as an
+    /// opaque slot ([`is_slot_identical_layout`]).
+    NotSlotShaped,
+    /// A float leaf counts as slot-shaped when its compact footprint is a full
+    /// eight bytes, because the two models then place the same bytes at the
+    /// same offsets ([`compact_stride_matches_slot_stride`]).
+    FillTheirSlot,
+}
+
+/// The one walk both predicates above are thin wrappers over, so the set of
+/// leaf shapes and the aggregate recursion have a single home.
+fn slot_layout_agrees<P: crate::FfiTypePool + ?Sized>(
+    type_pool: &P,
+    ty: Type,
+    floats: FloatLeaves,
+) -> bool {
     match ty.kind() {
         // Eight-byte leaves and the recovery scalar: identical in both models.
         TypeKind::I64
@@ -122,10 +183,12 @@ pub fn is_slot_identical_layout<P: crate::FfiTypePool + ?Sized>(type_pool: &P, t
         | TypeKind::ComptimeType
         | TypeKind::ComptimeFloat
         | TypeKind::Module(_) => true,
-        // A float leaf is read and written by a floating-point access at its
-        // own width, never as an opaque slot, so it is not slot-identical even
-        // where its footprint is eight bytes.
-        TypeKind::F32 | TypeKind::F64 => false,
+        // An `f64` occupies its whole eight-byte slot, so the two models agree
+        // about where its bytes are; only the access kind differs.
+        TypeKind::F64 => floats == FloatLeaves::FillTheirSlot,
+        // An `f32` strides by four bytes against an eight-byte slot, so the two
+        // models disagree positionally as well.
+        TypeKind::F32 => false,
         // Narrow scalars: one/two/four bytes under the compact layout.
         TypeKind::I8
         | TypeKind::U8
@@ -137,10 +200,10 @@ pub fn is_slot_identical_layout<P: crate::FfiTypePool + ?Sized>(type_pool: &P, t
         TypeKind::Struct(id) => type_pool
             .ffi_struct_field_types(id)
             .into_iter()
-            .all(|field_ty| is_slot_identical_layout(type_pool, field_ty)),
+            .all(|field_ty| slot_layout_agrees(type_pool, field_ty, floats)),
         TypeKind::Array(id) => {
             let element = type_pool.ffi_array_element(id);
-            is_slot_identical_layout(type_pool, element)
+            slot_layout_agrees(type_pool, element, floats)
         }
         // Enums narrow their tag (u8/u16/u32 vs an eight-byte slot).
         TypeKind::Enum(_) => false,

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -47,7 +47,8 @@ mod types;
 
 pub use call_abi::{
     ArgConvention, CAbiScalarKind, NativeCallAbi, ScalarAbiExtension, aggregate_leaves,
-    c_abi_type_facts, is_multislot_aggregate, is_slot_identical_layout,
+    c_abi_type_facts, compact_stride_matches_slot_stride, is_multislot_aggregate,
+    is_slot_identical_layout,
 };
 pub use exact_decimal::canonical_decimal_literal;
 pub use exact_decimal::finite_float_literal_bits;

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -7817,15 +7817,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(self.type_mismatch_error(slice_ty, arr_ty, span));
         }
 
-        // A non-slot-width element's compact memory image is not byte-identical
-        // to the full-slot representation used by frame arrays. For narrow
-        // scalars this makes the slice's compact element stride differ from the
-        // frame stride; aggregate elements can also differ in tags, fields, or
-        // padding. Keep the deliberate refusal, but report it at the source-level
-        // coercion boundary rather than letting the synthesized pointer reach the
-        // backend's raw-pointer safety gate (RUE-1595). Empty arrays remain valid:
-        // their null pointer is never dereferenced.
-        if arr_len != 0 && !crate::is_slot_identical_layout(self.body_type_pool(), arr_elem) {
+        // The view strides by the element's compact size while a frame array
+        // keeps one eight-byte slot per leaf, so the coercion is exact exactly
+        // when those two strides — and, inside an aggregate element, the field
+        // and element offsets — agree. `compact_stride_matches_slot_stride` is
+        // the one authority on that; code generation's raw-pointer gate consults
+        // the same predicate, so the two cannot drift (RUE-1595, RUE-2097). A
+        // narrow element (`i32`, `u8`, `bool`, `i16`, `f32`) and any aggregate
+        // holding one still disagree and are still refused here, at the
+        // source-level coercion boundary rather than at the backend's gate.
+        // Empty arrays remain valid: their null pointer is never dereferenced.
+        if arr_len != 0
+            && !crate::compact_stride_matches_slot_stride(self.body_type_pool(), arr_elem)
+        {
             return Err(CompileError::new(
                 ErrorKind::SliceFrameArrayNotSupported {
                     element_type: self.format_type_name(arr_elem),

--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -821,7 +821,7 @@ name = "slice_frame_array_not_supported_code_is_explained"
 files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
 args = ["explain", "E0908"]
 compile_only = true
-compile_stdout_contains = ["E0908: Slice frame array not supported", "transitional limit", "RUE-1595", "Borrow a narrow-element frame array as a slice:", "Coerce a slot-width element type:", "docs/spec/src/07-arrays/02-slices.md (spec rule 7.2:14)", "docs/spec/src/07-arrays/02-slices.md (spec rule 7.2:12)", "docs/spec/src/07-arrays/02-slices.md (spec rule 7.2:13)", "docs/designs/0043-collection-string-type-trio.md"]
+compile_stdout_contains = ["E0908: Slice frame array not supported", "transitional limit", "RUE-1595", "Borrow a narrow-element frame array as a slice:", "Coerce a slot-filling element type:", "docs/spec/src/07-arrays/02-slices.md (spec rule 7.2:14)", "docs/spec/src/07-arrays/02-slices.md (spec rule 7.2:12)", "docs/spec/src/07-arrays/02-slices.md (spec rule 7.2:13)", "docs/designs/0043-collection-string-type-trio.md"]
 compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 

--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -12,22 +12,27 @@
 # `inout [T]` write-slices, range slicing `x[a..b]`, ArrayBuf/Vec slices, and
 # returning/storing a slice (E0487-E0489 second-class enforcement).
 #
-# Under the default compact layout these cases view a slot-identical backing
-# element type (i64: one eight-byte slot per element). The view is materialized
-# as `{ptr: @raw(arr[0]), len: N}` and indexed by `@ptr_offset(ptr, i)`, which
-# strides by `size_of(T)`; for a slot-identical element that stride equals the
-# frame's slot stride, so a frame-array view is exact. A slice over a frame array
-# of a NON-slot-identical element (e.g. `[i32]`/`[u8]`, whose compact stride is
-# narrower than the 8-byte frame slot) would stride across mismatched storage and
-# is refused loudly (RUE-987 / RUE-1035 M2); `slice_param_narrow_frame_refused`
-# pins that. The slice runtime itself (len, bounds-checked indexing, forwarding,
-# methods) is element-width-independent and is exercised here on i64.
+# Under the default compact layout these cases view a backing element type whose
+# own stride equals the frame's slot stride (i64: one eight-byte slot per
+# element). The view is materialized as `{ptr: @raw(arr[0]), len: N}` and indexed
+# by `@ptr_offset(ptr, i)`, which strides by `size_of(T)`; where that stride
+# equals the frame's slot stride a frame-array view is exact. A slice over a
+# frame array whose element has a narrower-than-slot leaf (e.g. `[i32]`/`[u8]`,
+# whose compact stride is narrower than the 8-byte frame slot) would stride
+# across mismatched storage and is refused loudly (RUE-987 / RUE-1035 M2);
+# `slice_param_narrow_frame_refused` pins that. The slice runtime itself (len,
+# bounds-checked indexing, forwarding, methods) is element-width-independent and
+# is exercised here on i64.
 #
-# The element type does not have to be a scalar. A struct built from slot-width
-# fields is slot-identical too, so `[S]` and `[P]` views coerce and stride by
-# the element's whole size; the `struct_element_*` cases below cover that
+# The element type does not have to be a scalar, and does not have to be an
+# integer. A struct built from slot-filling fields strides by its own whole size,
+# so `[S]` and `[P]` views coerce; the `struct_element_*` cases below cover that
 # family, including the multi-slot stride and the aggregate form of the same
-# narrow-element refusal (RUE-1610).
+# narrow-element refusal (RUE-1610). An `f64` fills its slot too — a float is
+# reached by a floating-point access rather than an opaque slot move, and an
+# access kind relocates no byte — so `[f64]` and float-carrying element structs
+# coerce as well; the `float_element_*` cases below cover that family on both
+# backends (RUE-2097).
 
 [section]
 id = "cli.slices"
@@ -125,8 +130,9 @@ exit_code = 6
 # A narrow-element view over a frame array is refused at the source-level
 # coercion boundary: the compact element stride differs from the frame slot
 # stride. The stable diagnostic names the actual restriction and does not leak
-# the backend's raw-pointer implementation. A slot-identical element (see the
-# i64 cases above) is exact; a heap-backed narrow slice awaits compact frames
+# the backend's raw-pointer implementation. An element whose own stride is the
+# frame's slot stride (see the i64 cases above) is exact; a heap-backed narrow
+# slice awaits compact frames
 # (RUE-975) / a heap slice API.
 [[case]]
 name = "slice_param_narrow_frame_refused"
@@ -300,7 +306,7 @@ error_contains = ["type mismatch"]
 # --- Struct element types (RUE-1610) -----------------------------------------
 #
 # A slice element may be any type the coercion admits (7.2:2, 7.2:14), and a
-# struct built from slot-width fields qualifies. The failing shape was a callee
+# struct built from slot-filling fields qualifies. The failing shape was a callee
 # that measures the view without ever naming the element type: the element's
 # nominal reached the callee's CFG epoch only through the view's `ptr` field, a
 # route that carried no nominal at all, so the body failed to materialize with
@@ -364,8 +370,8 @@ fn main() -> i32 {
 args = ["main.rue", "-o", "prog"]
 exit_code = 101
 
-# A multi-slot element is the stride case: an element of two i64 fields is
-# slot-identical but sixteen bytes wide, so a view that strided by one slot
+# A multi-slot element is the stride case: an element of two i64 fields fills
+# both its slots but is sixteen bytes wide, so a view that strided by one slot
 # would read the wrong halves of the wrong elements. The discriminating value
 # depends on every element being read whole and in order.
 [[case]]
@@ -458,8 +464,8 @@ args = ["main.rue", "-o", "prog"]
 exit_code = 0
 
 # The layout restriction of `slice_param_narrow_frame_refused` applies to an
-# aggregate element too: a struct holding an i32 field is not slot-identical,
-# and the diagnostic names the struct.
+# aggregate element too: a struct holding an i32 field strides narrower than the
+# frame slot, and the diagnostic names the struct.
 [[case]]
 name = "struct_element_with_narrow_field_refused"
 description = "A struct element holding a narrow field is refused at the coercion boundary with E0908 naming the struct."
@@ -665,3 +671,218 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 101
+
+# --- float elements (RUE-2097) -----------------------------------------------
+#
+# `f64`'s compact size, alignment and stride are all eight, and a frame array
+# stores it one element per eight-byte slot, so a `[f64]` view's `@ptr_offset`
+# stride (8) is exactly the frame's slot stride (8). The coercion used to be
+# refused anyway, because the predicate it consulted folded in an access-kind
+# question — a float leaf is never *moved* as an opaque slot — that decides
+# nothing about where its bytes are. These cases run the whole slice runtime
+# over float elements on both backends: element reads reach the float register
+# class through `@ptr_read` on `ptr const f64`.
+
+[[case]]
+name = "float_element_slice_head_x86_64"
+description = "RUE-2097 repro: a `[f64]` view of a frame array reads element 0 through the float bank (x86-64)."
+files = [{ path = "main.rue", source = """
+fn head(borrow a: [f64]) -> f64 { a[0] }
+fn main() -> i32 { let a = [1.5, 2.5, 3.5]; if head(borrow a) == 1.5 { 0 } else { 1 } }
+""" }]
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+exit_code = 0
+compile_stderr_not_contains = ["E0908", "E9001", "internal codegen error"]
+
+[[case]]
+name = "float_element_slice_head_aarch64"
+description = "The same `[f64]` view on AArch64: both backends materialize and index the view."
+files = [{ path = "main.rue", source = """
+fn head(borrow a: [f64]) -> f64 { a[0] }
+fn main() -> i32 { let a = [1.5, 2.5, 3.5]; if head(borrow a) == 1.5 { 0 } else { 1 } }
+""" }]
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 0
+compile_stderr_not_contains = ["E0908", "E9001", "internal codegen error"]
+
+[[case]]
+name = "float_element_slice_sum_len_forward_x86_64"
+description = "Summing a `[f64]` view: every position is read in order, `len()` is the array length, and a forwarded view still describes the same storage (x86-64)."
+files = [{ path = "main.rue", source = """
+fn sum(borrow s: [f64]) -> f64 {
+    let mut t: f64 = 0.0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        t = t + s[i];
+        i = i + 1;
+    }
+    t
+}
+fn forward(borrow s: [f64]) -> f64 { sum(borrow s) }
+fn ln(borrow s: [f64]) -> u64 { s.len() }
+fn main() -> i32 {
+    let a: [f64; 4] = [1.5, 2.25, 3.0, 0.25];
+    @dbg(forward(borrow a));
+    @dbg(ln(borrow a));
+    @float_to_int(forward(borrow a) * 4.0)
+}
+""" }]
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = """
+7.0
+4
+"""
+exit_code = 28
+
+[[case]]
+name = "float_element_slice_sum_len_forward_aarch64"
+description = "The same `[f64]` sum, length and forwarding on AArch64."
+files = [{ path = "main.rue", source = """
+fn sum(borrow s: [f64]) -> f64 {
+    let mut t: f64 = 0.0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        t = t + s[i];
+        i = i + 1;
+    }
+    t
+}
+fn forward(borrow s: [f64]) -> f64 { sum(borrow s) }
+fn ln(borrow s: [f64]) -> u64 { s.len() }
+fn main() -> i32 {
+    let a: [f64; 4] = [1.5, 2.25, 3.0, 0.25];
+    @dbg(forward(borrow a));
+    @dbg(ln(borrow a));
+    @float_to_int(forward(borrow a) * 4.0)
+}
+""" }]
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = """
+7.0
+4
+"""
+exit_code = 28
+
+[[case]]
+name = "float_element_slice_index_out_of_bounds_traps"
+description = "The bounds check is element-type-independent: a `[f64]` view traps (exit 101) on an out-of-range index."
+files = [{ path = "main.rue", source = """
+fn get(borrow s: [f64], i: u64) -> i32 { @float_to_int(s[i]) }
+fn main() -> i32 {
+    let a: [f64; 3] = [1.0, 2.0, 3.0];
+    get(borrow a, 5)
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+runtime_error_contains = ["index out of bounds"]
+
+[[case]]
+name = "float_element_struct_slice_multi_slot_stride_x86_64"
+description = "A `{f64, i64}` element fills both its slots, so the view strides by the whole sixteen-byte element and each half lands in its own register bank (x86-64)."
+files = [{ path = "main.rue", source = """
+struct Q { x: f64, n: i64 }
+fn total(borrow s: [Q]) -> i32 {
+    let mut acc: i64 = 0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        let e = s[i];
+        acc = acc * 10 + e.n + @float_to_int(e.x);
+        i = i + 1;
+    }
+    @intCast(acc)
+}
+fn main() -> i32 {
+    let a: [Q; 3] = [Q { x: 1.5, n: 0 }, Q { x: 2.5, n: 1 }, Q { x: 0.5, n: 3 }];
+    total(borrow a)
+}
+""" }]
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+exit_code = 133
+
+[[case]]
+name = "float_element_struct_slice_multi_slot_stride_aarch64"
+description = "The same `{f64, i64}` element stride on AArch64."
+files = [{ path = "main.rue", source = """
+struct Q { x: f64, n: i64 }
+fn total(borrow s: [Q]) -> i32 {
+    let mut acc: i64 = 0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        let e = s[i];
+        acc = acc * 10 + e.n + @float_to_int(e.x);
+        i = i + 1;
+    }
+    @intCast(acc)
+}
+fn main() -> i32 {
+    let a: [Q; 3] = [Q { x: 1.5, n: 0 }, Q { x: 2.5, n: 1 }, Q { x: 0.5, n: 3 }];
+    total(borrow a)
+}
+""" }]
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 133
+
+# The admission is about stride, not about being a float: `f32` strides by four
+# bytes against an eight-byte frame slot, so it stays refused with the same
+# diagnostic the narrow integers get.
+[[case]]
+name = "float_element_slice_f32_narrow_frame_refused"
+description = "`f32`'s four-byte stride still disagrees with the frame slot, so `[f32]` stays refused at the coercion boundary."
+files = [{ path = "main.rue", source = """
+fn head(borrow a: [f32]) -> f32 { a[0] }
+fn main() -> i32 {
+    let a: [f32; 3] = [1.5, 2.5, 3.5];
+    if head(borrow a) == 1.5 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0908", "frame array", "non-slot-width", "coerce or borrow", "f32"]
+compile_stderr_not_contains = ["E9001", "@raw", "@ptr_offset", "@alloc", "heap"]
+
+# An element struct mixing a slot-filling float with a narrow integer is still
+# refused: the narrow field is what disagrees, and the diagnostic names the
+# struct.
+[[case]]
+name = "float_element_struct_with_narrow_field_refused"
+description = "A `{f64, i32}` element is refused because of its narrow field, and the diagnostic names the struct."
+files = [{ path = "main.rue", source = """
+struct M { x: f64, n: i32 }
+fn ln(borrow s: [M]) -> i32 { @intCast(s.len()) }
+fn main() -> i32 {
+    let a: [M; 2] = [M { x: 1.0, n: 1 }, M { x: 2.0, n: 2 }];
+    ln(borrow a)
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0908", "non-slot-width", "coerce or borrow", "M"]
+compile_stderr_not_contains = ["E9000", "internal compiler error"]
+
+# An empty float array coerces like any other empty array: the pointer word is a
+# conventional null that no read reaches.
+[[case]]
+name = "float_element_slice_empty_view"
+description = "`[f64; 0]` coerces and measures zero, like every other empty array."
+files = [{ path = "main.rue", source = """
+fn ln(borrow s: [f64]) -> i32 { @intCast(s.len()) }
+fn main() -> i32 {
+    let a: [f64; 0] = [];
+    ln(borrow a)
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 0

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -528,3 +528,45 @@ fn foreign_call_and_mir_state_have_one_shared_authority() {
         assert!(!mir.contains("next_vreg: u32"));
     }
 }
+
+/// The frame raw-pointer gate asks the same layout question the
+/// fixed-array-to-slice coercion's E0908 refusal asks, through the same
+/// canonical predicate (RUE-2097).
+///
+/// The coercion synthesizes `@raw(arr[0])` and hands the result to this gate,
+/// so a gate that judged element layout by its own rule would either reject
+/// what semantic analysis accepted — an internal error on a legal program — or
+/// pass what semantic analysis would have refused. `rue-air`'s inventory guards
+/// the other half (`slice_coercion_and_layout_predicates_come_from_one_walk`).
+#[test]
+fn frame_raw_aggregate_pointer_gate_uses_the_shared_stride_predicate() {
+    let types = include_str!("types.rs");
+    let gate = types
+        .split("fn frame_raw_aggregate_pointer_unsupported(")
+        .nth(1)
+        .and_then(|rest| rest.split("\n}\n").next())
+        .expect("the frame raw-pointer gate");
+    assert!(
+        gate.contains("compact_stride_matches_slot_stride(type_pool, ty)"),
+        "the frame raw-pointer gate must judge layout with the canonical \
+         stride predicate"
+    );
+    assert!(
+        !gate.contains("is_slot_identical_layout"),
+        "the frame raw-pointer gate must not fold the call-ABI access-kind \
+         question into its layout answer"
+    );
+    // The local name is a thin delegation to the one authority in `rue-air`,
+    // not a second judgment.
+    assert!(
+        types.contains("rue_air::compact_stride_matches_slot_stride(type_pool, ty)"),
+        "the codegen wrapper must delegate to the canonical layout authority"
+    );
+    assert_eq!(
+        types
+            .matches("pub(crate) fn compact_stride_matches_slot_stride")
+            .count(),
+        1,
+        "the codegen wrapper has exactly one definition"
+    );
+}

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -301,6 +301,26 @@ pub(crate) fn is_slot_identical_layout(type_pool: &FrozenTypeInternPool, ty: Typ
     rue_air::is_slot_identical_layout(type_pool, ty)
 }
 
+/// Whether `ty`'s compact stride and interior byte offsets equal its slot-model
+/// stride and offsets, so a compact-strided walk over frame-resident storage of
+/// `ty` visits exactly the bytes the slot model put there.
+///
+/// Delegates to the canonical layout authority
+/// `rue_air::compact_stride_matches_slot_stride` — the same predicate semantic
+/// analysis refuses the fixed-array-to-slice coercion with (E0908) — so the
+/// source-level refusal and the raw-pointer gate below cannot disagree about
+/// which element shapes a compact-strided view may address.
+///
+/// It admits everything [`is_slot_identical_layout`] admits plus `f64` leaves,
+/// whose eight-byte footprint fills a slot even though a float is accessed by a
+/// floating-point instruction rather than moved as an opaque slot.
+pub(crate) fn compact_stride_matches_slot_stride(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+) -> bool {
+    rue_air::compact_stride_matches_slot_stride(type_pool, ty)
+}
+
 /// Physical width (1/2/4 bytes) and extension of a narrow scalar accessed
 /// through a pointer under the compact layout (ADR-0052, RUE-989).
 ///
@@ -1129,9 +1149,8 @@ pub(crate) fn compact_physical_access_unsupported(
     None
 }
 
-/// An `@raw`/`@raw_mut`/`@field_ptr` pointer into a
-/// **frame** aggregate that would then be accessed as a whole non-slot-identical
-/// aggregate, or strided across a non-slot-identical array, is unsupported and
+/// An `@raw`/`@raw_mut`/`@field_ptr` pointer into a **frame** aggregate whose
+/// compact byte positions disagree with its slot positions is unsupported and
 /// must be refused loudly (RUE-1035 M2).
 ///
 /// `@raw`-family intrinsics take the address of a place, whose base is always a
@@ -1139,33 +1158,39 @@ pub(crate) fn compact_physical_access_unsupported(
 /// `Local`/`Param`). Frames stay slot-shaped (RUE-975): a struct/array/enum sits
 /// one eight-byte slot per leaf. But `@ptr_read`/`@ptr_write` address a whole
 /// aggregate by its packed *compact image*, and `@ptr_offset` strides by the
-/// compact element size. For a non-slot-identical aggregate the two disagree, so
-/// the raw pointer silently mixes representations. Exactly two shapes break:
+/// compact element size. Where the two models put bytes at different offsets the
+/// raw pointer silently mixes representations. Exactly two shapes break:
 ///
-/// - the pointer's **pointee is a non-slot-identical aggregate** (`@raw_mut(v)`
-///   of a whole struct/array): a whole-value round trip through it scrambles
-///   fields (M2a); and
-/// - the addressed place **indexes into a non-slot-identical array**
-///   (`@raw(arr[i])` of a frame array element): the resulting element pointer
-///   strides by the compact size while the frame array strides by the slot size
-///   (M2b).
+/// - the pointer's **pointee is an aggregate whose compact image sits at
+///   different offsets than its slot image** (`@raw_mut(v)` of a whole
+///   struct/array): a whole-value round trip through it scrambles fields (M2a);
+///   and
+/// - the addressed place **indexes into an array whose element's compact stride
+///   differs from its slot stride** (`@raw(arr[i])` of a frame array element):
+///   the resulting element pointer strides by the compact size while the frame
+///   array strides by the slot size (M2b). This is the gate the
+///   fixed-array-to-slice coercion passes through, and it consults the very
+///   predicate that coercion's E0908 refusal does
+///   ([`compact_stride_matches_slot_stride`]), so the two cannot drift.
 ///
 /// Everything else stays allowed and correct: a **narrow scalar field** pointer
 /// (`@field_ptr(p.b)` → `ptr i32`) addresses the field's slot and hits its low
 /// bytes (RUE-989); a **bare scalar local** (`@raw_mut(n)` on `i32`) is not an
-/// aggregate; a **slot-identical** array/struct strides and round-trips
-/// identically to the slot model. Heap provenance is untouched: `@alloc` never
-/// flows through `@raw`, so every heap `@ptr_read`/`@ptr_write` round trip keeps
-/// working. Returns the offending frame aggregate type, or `None`.
+/// aggregate; an aggregate built only from slot-filling leaves — `i64`/`u64`,
+/// pointers, and `f64`, whose eight bytes fill their slot however the load
+/// spells itself — strides and round-trips identically to the slot model. Heap
+/// provenance is untouched: `@alloc` never flows through `@raw`, so every heap
+/// `@ptr_read`/`@ptr_write` round trip keeps working. Returns the offending
+/// frame aggregate type, or `None`.
 fn frame_raw_aggregate_pointer_unsupported(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
 ) -> Option<Type> {
-    let non_slot_identical_aggregate = |ty: Type| -> bool {
+    let misplaced_aggregate = |ty: Type| -> bool {
         matches!(
             ty.kind(),
             TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_)
-        ) && !is_slot_identical_layout(type_pool, ty)
+        ) && !compact_stride_matches_slot_stride(type_pool, ty)
     };
 
     for raw in 0..cfg.value_count() {
@@ -1178,26 +1203,28 @@ fn frame_raw_aggregate_pointer_unsupported(
             continue;
         }
 
-        // (a) The pointer addresses a whole non-slot-identical aggregate: reading
-        // or writing it through the pointer marshals the compact image against
-        // slot-shaped frame storage (M2a). A narrow scalar field pointer has a
-        // scalar pointee and is not caught here (RUE-989 handles it).
+        // (a) The pointer addresses a whole aggregate whose compact image sits at
+        // different offsets than its slot image: reading or writing it through
+        // the pointer marshals one against the other (M2a). A narrow scalar field
+        // pointer has a scalar pointee and is not caught here (RUE-989 handles
+        // it).
         let pointee = pointee_or_self(type_pool, inst.ty);
-        if non_slot_identical_aggregate(pointee) {
+        if misplaced_aggregate(pointee) {
             return Some(pointee);
         }
 
-        // (b) The addressed place indexes into a non-slot-identical frame array:
-        // the element pointer would stride by the compact element size while the
-        // frame array strides by the slot size (M2b). A field projection into a
-        // struct is not an array stride and stays allowed.
+        // (b) The addressed place indexes into a frame array whose element's
+        // compact stride differs from its slot stride: the element pointer would
+        // stride by the compact element size while the frame array strides by the
+        // slot size (M2b). A field projection into a struct is not an array
+        // stride and stays allowed.
         let Some(&operand) = cfg.get_intrinsic_args(&inst.data).first() else {
             continue;
         };
         if let CfgInstData::PlaceRead { place } = &cfg.get_inst(operand).data {
             for projection in cfg.get_place_projections(place) {
                 if let rue_cfg::Projection::Index { array_type, .. } = projection
-                    && non_slot_identical_aggregate(*array_type)
+                    && misplaced_aggregate(*array_type)
                 {
                     return Some(*array_type);
                 }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -2104,18 +2104,19 @@ define_error_codes! {
             ErrorCodeReference { title: "Implementation limits are diagnosed", path: "docs/spec/src/appendices/C-implementation-limits.md", rule: Some("C.1:2") },
         ],
     };
-    /// A frame array with non-slot-width elements cannot yet be borrowed as a
-    /// slice because slice pointer semantics use the compact element image
-    /// while frames keep a full-slot representation (RUE-1595).
+    /// A frame array whose element's compact stride differs from its slot
+    /// stride cannot yet be borrowed as a slice, because slice pointer
+    /// semantics stride by the compact element size while frames keep a
+    /// full-slot representation (RUE-1595).
     SLICE_FRAME_ARRAY_NOT_SUPPORTED = 908 => {
-        explanation: "The fixed-array-to-slice coercion materializes a two-word view — the address of element `0` and the length — and hands it to a `borrow [T]` parameter (7.2:12). A view strides by the element type's own size, while a frame-resident array still keeps one full 8-byte slot per element, so for an element whose compact image is not slot-identical the two strides disagree and the view would read the wrong addresses. E0908 refuses that coercion at the argument and names the element type (7.2:14). Non-slot-identical means an element narrower than a slot, such as `i32` or `u8`, or an aggregate holding such a field; an element built only from slot-width fields is slot-identical and coerces however many fields it has. An empty array is exempt, because a zero-length view's pointer word is never dereferenced. This is a transitional limit of the current implementation tracked by RUE-1595, not a property of the slice type: it is lifted when arrays adopt the compact element representation. An operand that is not a whole array place, or whose element type merely converts to the slice's, is a different failure — a type mismatch under 7.2:13.",
-        likely_cause: "A local array of a narrow element type was passed to a `borrow [T]` parameter, as in `head(borrow xs)` for `xs: [i32; 3]`. Until the restriction is lifted, either widen the element type to a slot-width one — `[i64; N]` coerces, and so does an element struct whose every field is slot-width — or take the fixed array itself as a `borrow [T; N]` parameter, which passes one pointer and needs no view. An empty array of any element type still coerces.",
+        explanation: "The fixed-array-to-slice coercion materializes a two-word view — the address of element `0` and the length — and hands it to a `borrow [T]` parameter (7.2:12). A view strides by the element type's own compact size, while a frame-resident array still keeps one full 8-byte slot per leaf, so the view is exact exactly when the element's compact stride equals its slot stride — and, inside an aggregate element, its field and element offsets agree too. E0908 refuses the coercion at the argument when they differ, naming the element type (7.2:14). They differ for an element with a leaf narrower than a slot — `bool`, `i8`/`u8`, `i16`/`u16`, `i32`/`u32`, and `f32`, whose compact stride is four bytes against an eight-byte slot — for an enum, whose tag is narrowed, and for any struct or array holding one of those. They agree for every leaf that fills its slot: `i64`, `u64`, pointers, and `f64`. A float is loaded and stored by a floating-point instruction rather than moved as an opaque slot, but an access kind moves no byte, so `[f64]` coerces like `[i64]` does; so does a struct or array built only from slot-filling leaves, however many fields it has. An empty array is exempt, because a zero-length view's pointer word is never dereferenced. This is a transitional limit of the current implementation tracked by RUE-1595, not a property of the slice type: it is lifted when arrays adopt the compact element representation. An operand that is not a whole array place, or whose element type merely converts to the slice's, is a different failure — a type mismatch under 7.2:13.",
+        likely_cause: "A local array whose element has a narrower-than-slot leaf was passed to a `borrow [T]` parameter, as in `head(borrow xs)` for `xs: [i32; 3]`. Until the restriction is lifted, either widen the element so every leaf fills its slot — `[i64; N]` and `[f64; N]` both coerce, and so does an element struct whose every field is slot-filling — or take the fixed array itself as a `borrow [T; N]` parameter, which passes one pointer and needs no view. An empty array of any element type still coerces.",
         examples: [
             ErrorCodeExample { title: "Borrow a narrow-element frame array as a slice", source: "fn head(borrow s: [i32]) -> i32 { s[0] }\n\nfn main() -> i32 {\n    let xs: [i32; 3] = [42, 1, 2];\n    head(borrow xs)\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
-            ErrorCodeExample { title: "Coerce a slot-width element type", source: "fn head(borrow s: [i64]) -> i32 { @intCast(s[0]) }\n\nfn main() -> i32 {\n    let xs: [i64; 3] = [42, 1, 2];\n    head(borrow xs)\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+            ErrorCodeExample { title: "Coerce a slot-filling element type", source: "fn head(borrow s: [i64]) -> i32 { @intCast(s[0]) }\n\nfn wide(borrow s: [f64]) -> i32 { @float_to_int(s[0] * 2.0) }\n\nfn main() -> i32 {\n    let xs: [i64; 3] = [42, 1, 2];\n    let ys: [f64; 3] = [1.5, 2.5, 3.5];\n    head(borrow xs) - wide(borrow ys)\n}", outcome: ErrorCodeExampleOutcome::Compiles },
         ],
         references: [
-            ErrorCodeReference { title: "Non-slot-width elements do not coerce", path: "docs/spec/src/07-arrays/02-slices.md", rule: Some("7.2:14") },
+            ErrorCodeReference { title: "Which element layouts coerce", path: "docs/spec/src/07-arrays/02-slices.md", rule: Some("7.2:14") },
             ErrorCodeReference { title: "Fixed-array-to-slice coercion", path: "docs/spec/src/07-arrays/02-slices.md", rule: Some("7.2:12") },
             ErrorCodeReference { title: "Coercion operand legality", path: "docs/spec/src/07-arrays/02-slices.md", rule: Some("7.2:13") },
             ErrorCodeReference { title: "The fixed/slice/growable type trio", path: "docs/designs/0043-collection-string-type-trio.md", rule: None },
@@ -3792,10 +3793,11 @@ pub enum ErrorKind {
          ({max_bytes} bytes)"
     )]
     FunctionFrameTooLarge { max_bytes: u64 },
-    /// A frame-resident array whose element's compact memory image differs from
-    /// its full-slot frame representation cannot yet be coerced to a borrowed
-    /// slice. The source-level coercion is rejected before it synthesizes a
-    /// pointer that would mix those representations (RUE-1595).
+    /// A frame-resident array whose element's compact stride differs from its
+    /// full-slot frame stride cannot yet be coerced to a borrowed slice. The
+    /// source-level coercion is rejected before it synthesizes a pointer that
+    /// would mix those representations (RUE-1595). An element whose every leaf
+    /// fills its slot — `i64`/`u64`, pointers, `f64` — does coerce.
     #[error(
         "a frame array with non-slot-width elements cannot yet coerce or borrow as a slice `[T]` (element type `{element_type}`)"
     )]

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -74,12 +74,6 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::PointerWrite),
         &[],
     ),
-    Entry::new(
-        "cli.float_codegen",
-        "native_float_pointer_widths_preserve_neighbor_bytes",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
     // std.fs File IO v0 (RUE-712, ADR-0057): pure-Rue fs over @syscall. The
     // oracle models the StrBuf/ArrayBuf and raw-pointer representation setup;
     // these cases remain debt because the host syscall effect is external.
@@ -401,6 +395,12 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.slices",
         "struct_element_slice_empty_view",
+        intrinsic(UnsupportedIntrinsicKind::EmptySlicePointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "float_element_slice_empty_view",
         intrinsic(UnsupportedIntrinsicKind::EmptySlicePointer),
         &[],
     ),

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -5486,6 +5486,20 @@ impl<'a> Interp<'a> {
                     raw >>= 8;
                 }
             }
+            // A float value is carried as its IEEE-754 bit pattern in an `Int`
+            // (the same encoding `Const` produces and `eval_float_operation`
+            // consumes), so its representation is that pattern little-endian at
+            // the type's own width — four bytes for `f32`, eight for `f64`.
+            // Without this arm a float never reaches memory at all, which is
+            // what made a `[f64]` view's `@raw(arr[0])` unmodelable.
+            (TypeKind::F32 | TypeKind::F64, Value::Int(pattern)) => {
+                initialized.fill(true);
+                let mut raw = *pattern as u128;
+                for byte in &mut bytes {
+                    *byte = raw as u8;
+                    raw >>= 8;
+                }
+            }
             (TypeKind::PtrConst(_) | TypeKind::PtrMut(_), Value::Ptr(ptr)) => {
                 let address = ptr.as_ref().map_or(0, |target| self.ptr_address(target));
                 initialized.fill(true);
@@ -5842,6 +5856,25 @@ impl<'a> Interp<'a> {
                     raw |= (*byte as u128) << (index * 8);
                 }
                 Ok(Value::Int(from_bits(raw, bits, kind_signed(kind))))
+            }
+            // The mirror of the float arm in `encode_value`: the stored bit
+            // pattern comes back as the unsigned integer the interpreter carries
+            // a float in. Every bit pattern of the type's width is a value
+            // (NaNs included), so there is no validity check to make here.
+            TypeKind::F32 | TypeKind::F64 => {
+                if initialized[..size].iter().any(|ready| !ready) {
+                    return Err(unsupported(
+                        unsupported_intrinsic_kind_for_operation(
+                            rue_air::IntrinsicOperation::PtrRead,
+                        ),
+                        "read of uninitialized float representation",
+                    ));
+                }
+                let mut raw = 0u128;
+                for (index, byte) in bytes[..size].iter().enumerate() {
+                    raw |= (*byte as u128) << (index * 8);
+                }
+                Ok(Value::Int(raw as i128))
             }
             TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => {
                 if initialized[..size].iter().any(|ready| !ready) {

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -1025,6 +1025,31 @@ fn aggregate_float_equality_is_ieee() {
 }
 
 #[test]
+fn float_values_round_trip_through_representation_bytes() {
+    // A float leaf reaches memory as its IEEE-754 bit pattern at its own width.
+    // Without that encoding the interpreter could evaluate float arithmetic but
+    // never place a float behind a pointer, so a `[f64]` view — whose `ptr` word
+    // is `@raw(a[0])` and whose element reads are `@ptr_read` — was unmodelable.
+    let outcome = run_source(
+        r#"fn fold(borrow s: [f64]) -> f64 {
+            let mut acc: f64 = 0.0;
+            let mut i: u64 = 0;
+            while i < s.len() {
+                acc = acc * 10.0 + s[i];
+                i = i + 1;
+            }
+            acc
+        }
+        fn main() -> i32 {
+            let a: [f64; 3] = [1.0, 2.0, 3.5];
+            @float_to_int(fold(borrow a))
+        }"#,
+    )
+    .expect("a float view's representation bytes are modeled");
+    assert_eq!(outcome.exit_code, 123);
+}
+
+#[test]
 fn float_conversions_rounding_and_total_order_are_modeled() {
     let outcome = run_source(
         r#"fn main() -> i32 {

--- a/crates/rue-spec/cases/arrays/slices.toml
+++ b/crates/rue-spec/cases/arrays/slices.toml
@@ -7,8 +7,8 @@
 # what the compiler does today, not what ADR-0043 eventually wants:
 #   * the exclusive `inout [T]` view is unimplemented, so an `inout [T]` (or
 #     unmarked `[T]`) parameter is uncallable — 7.2:10;
-#   * a non-empty frame array of a non-slot-width element cannot coerce —
-#     7.2:14 (E0908, RUE-1595).
+#   * a non-empty frame array whose element's own stride differs from the
+#     frame's slot stride cannot coerce — 7.2:14 (E0908, RUE-1595).
 # When either restriction lifts, these cases fail loudly and the rule they cite
 # is what must be re-decided.
 
@@ -73,7 +73,7 @@ fn main() -> i32 {
 exit_code = 44
 
 # The element type `T` is any type whose layout admits the coercion (7.2:14),
-# not just a scalar: a struct built from slot-width fields is a valid element,
+# not just a scalar: a struct built from slot-filling fields is a valid element,
 # and a body that only measures the view never names the element type itself.
 # That shape used to fail to compile — the element's nominal was not carried
 # into the callee's analysis (RUE-1610).
@@ -434,8 +434,8 @@ fn main() -> i32 {
 """
 
 # The restriction is about layout, not about being a scalar: a struct holding a
-# narrow field is not slot-identical either, and the diagnostic names the struct
-# as the element type.
+# narrow field strides narrower than the frame slot too, and the diagnostic names
+# the struct as the element type.
 [[case]]
 name = "slice_coercion_struct_element_with_narrow_field_rejected"
 spec = ["7.2:14"]
@@ -452,8 +452,9 @@ fn main() -> i32 {
 }
 """
 
-# A struct of slot-width fields is slot-identical however many fields it has,
-# so a multi-slot element coerces and the view strides by the whole element.
+# A struct of slot-filling fields strides at the frame's slot stride however many
+# fields it has, so a multi-slot element coerces and the view strides by the
+# whole element.
 [[case]]
 name = "slice_coercion_multi_slot_struct_element_strides_by_the_element"
 spec = ["7.2:14", "7.2:20"]
@@ -469,6 +470,98 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# An `f64` fills its eight-byte slot, so its own stride and the frame's slot
+# stride agree and the view is exact. That a float is reached by a
+# floating-point access rather than an opaque slot move relocates none of its
+# bytes, so `[f64]` is admitted on the same footing as `[i64]`.
+[[case]]
+name = "slice_coercion_float_element_is_admitted"
+spec = ["7.2:14"]
+source = """
+fn head(borrow s: [f64]) -> f64 {
+    s[0]
+}
+fn main() -> i32 {
+    let a: [f64; 3] = [1.5, 2.5, 3.5];
+    @float_to_int(head(borrow a) * 28.0)
+}
+"""
+exit_code = 42
+
+# Every position of a float view is read in order, at the element's own stride.
+[[case]]
+name = "slice_coercion_float_element_strides_by_the_element"
+spec = ["7.2:14", "7.2:20"]
+source = """
+fn fold(borrow s: [f64]) -> i32 {
+    let mut acc: f64 = 0.0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        acc = acc * 10.0 + s[i];
+        i = i + 1;
+    }
+    @float_to_int(acc)
+}
+fn main() -> i32 {
+    let a: [f64; 3] = [1.0, 2.0, 3.5];
+    fold(borrow a)
+}
+"""
+exit_code = 123
+
+# An element struct mixing a float with an integer fills both its slots, so it
+# coerces and the view strides by the whole element.
+[[case]]
+name = "slice_coercion_float_carrying_struct_element_is_admitted"
+spec = ["7.2:14", "7.2:20"]
+source = """
+struct Q { x: f64, n: i64 }
+fn last(borrow s: [Q]) -> i32 {
+    let e = s[2];
+    @intCast(e.n * 10) + @float_to_int(e.x)
+}
+fn main() -> i32 {
+    let a: [Q; 3] = [Q { x: 0.5, n: 1 }, Q { x: 1.5, n: 2 }, Q { x: 2.5, n: 4 }];
+    last(borrow a)
+}
+"""
+exit_code = 42
+
+# The admission is about stride, not about being a float: `f32` strides by four
+# bytes against an eight-byte frame slot and stays refused.
+[[case]]
+name = "slice_coercion_narrow_element_f32_rejected"
+spec = ["7.2:14"]
+compile_fail = true
+error_contains = ["E0908", "non-slot-width", "f32"]
+source = """
+fn head(borrow s: [f32]) -> f32 {
+    s[0]
+}
+fn main() -> i32 {
+    let a: [f32; 3] = [1.5, 2.5, 3.5];
+    if head(borrow a) == 1.5 { 0 } else { 1 }
+}
+"""
+
+# A struct mixing a slot-filling float with a narrow field is refused for the
+# narrow field, and the diagnostic names the struct.
+[[case]]
+name = "slice_coercion_float_carrying_struct_with_narrow_field_rejected"
+spec = ["7.2:14"]
+compile_fail = true
+error_contains = ["E0908", "non-slot-width", "M"]
+source = """
+struct M { x: f64, n: i32 }
+fn ln(borrow s: [M]) -> i32 {
+    @intCast(s.len())
+}
+fn main() -> i32 {
+    let a: [M; 2] = [M { x: 1.0, n: 1 }, M { x: 2.0, n: 2 }];
+    ln(borrow a)
+}
+"""
 
 # An EMPTY array is exempt from the narrow-element restriction: its pointer
 # word is never dereferenced, because every read is guarded by `i < len` and

--- a/docs/notes/compact-layout-default.md
+++ b/docs/notes/compact-layout-default.md
@@ -100,14 +100,18 @@ and runs under the default layout.
 ## The one remaining refusal: raw pointers into frame aggregates
 
 One construct is refused rather than laid out. Taking a raw pointer with
-`@raw` / `@raw_mut` / `@field_ptr` into a **frame-resident** non-slot-identical
-aggregate — or indexing such a frame array through a place — is refused with a
-construct-level diagnostic. The stack frame stores an aggregate slot-shaped (one
-eight-byte slot per leaf, the unchanged value-decomposition model, RUE-975),
-while `@ptr_read` / `@ptr_write` / `@ptr_offset` address memory by its packed
-compact image, so a raw pointer into a frame aggregate would stride across
-mismatched field and element layouts. Allocate the aggregate on the heap with
-`@alloc`, whose storage *is* the compact image, to round-trip it through a raw
-pointer. That refusal is about the construct, not about any preview flag; a
-slot-identical aggregate (all eight-byte leaves) is unaffected because its frame
-and compact images coincide.
+`@raw` / `@raw_mut` / `@field_ptr` into a **frame-resident** aggregate whose
+compact image sits at different byte offsets than its slot image — or indexing
+such a frame array through a place — is refused with a construct-level
+diagnostic. The stack frame stores an aggregate slot-shaped (one eight-byte slot
+per leaf, the unchanged value-decomposition model, RUE-975), while `@ptr_read` /
+`@ptr_write` / `@ptr_offset` address memory by its packed compact image, so a raw
+pointer into such a frame aggregate would stride across mismatched field and
+element layouts. Allocate the aggregate on the heap with `@alloc`, whose storage
+*is* the compact image, to round-trip it through a raw pointer. That refusal is
+about the construct, not about any preview flag; an aggregate built only from
+slot-filling leaves is unaffected because its frame and compact images coincide.
+The leaves that fill a slot are `i64`, `u64`, pointers, and `f64` — a float is
+reached by a floating-point access rather than an opaque slot move, but an access
+kind relocates no byte, which is why `[f64]` views a frame array exactly
+(RUE-2097).

--- a/docs/process/tutorial.md
+++ b/docs/process/tutorial.md
@@ -122,6 +122,7 @@ future library ergonomics already exist.
 Recorded here so the next author does not rediscover them. Remove an entry
 when the limitation is lifted and update the chapter that mentions it.
 
-- `[T]` slice parameters accept only 64-bit element types (E0908, RUE-2055);
+- `[T]` slice parameters accept only elements whose every leaf is 64 bits wide
+  — `i64`, `u64`, `f64`, pointers, and aggregates of those (E0908, RUE-2055);
   the slice examples use `i64`.
 - `for` does not iterate `ArrayBuf`; the examples index over `len()`.

--- a/docs/spec/src/07-arrays/02-slices.md
+++ b/docs/spec/src/07-arrays/02-slices.md
@@ -149,18 +149,25 @@ element type is a compile-time type mismatch, not a coercion.
 
 {{ rule(id="7.2:14", cat="legality-rule") }}
 
-A non-empty fixed array whose element type is not slot-identical in layout —
-an element narrower than a stack slot, such as `i32` or `u8`, or an aggregate
-holding such a field, such as `struct N { v: i32 }` — **MUST NOT** coerce to a
-slice. A view strides by the element's own size, which for such an element
-differs from the stride of the frame array it would view, so the coercion is
-refused at the argument with a diagnostic naming the element type. An element
-built only from slot-width fields is slot-identical and does coerce, however
-many fields it has: `struct S { v: i64 }` and `struct P { a: i64, b: i64 }` are
-both admitted, and the view strides by the element's whole size. This is a
-restriction of the current implementation, not a property of the slice type. An
-**empty** array is exempt: `[T; 0]` coerces for every element type, because a
-zero-length view's pointer word is never dereferenced (7.2:22).
+A non-empty fixed array **MUST NOT** coerce to a slice when its element type's
+own *stride* — the byte distance between consecutive elements of that type —
+differs from the stride the frame array stores it at, which is one eight-byte
+stack slot per leaf. A view strides by the element's own stride, so where the
+two disagree the view would read the wrong addresses; the coercion is refused
+at the argument with a diagnostic naming the element type. The two disagree for
+an element with a leaf narrower than a slot — `bool`, `i8`, `u8`, `i16`, `u16`,
+`i32`, `u32`, and `f32` — for an enum, whose tag is narrower than a slot, and
+for any aggregate holding one of those, such as `struct N { v: i32 }`. They
+agree for every leaf that fills a slot — `i64`, `u64`, a pointer, and `f64` —
+and for an aggregate built only from such leaves, however many fields it has:
+`[f64]`, `struct S { v: i64 }`, `struct P { a: i64, b: i64 }` and
+`struct Q { x: f64, n: i64 }` are all admitted, and the view strides by the
+element's whole size. That an `f64` is read and written by a floating-point
+access rather than as an opaque slot does not move any of its bytes, so it is
+admitted on the same footing as `i64`. This is a restriction of the current
+implementation, not a property of the slice type. An **empty** array is exempt:
+`[T; 0]` coerces for every element type, because a zero-length view's pointer
+word is never dereferenced (7.2:22).
 
 {{ rule(id="7.2:15", cat="normative") }}
 

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -168,10 +168,11 @@ behavior (see ADR-0028).
 
 ```rue
 fn main() -> i32 {
-    // A slot-identical element type (i64: one eight-byte slot per element) so a
-    // raw pointer into the frame-resident array is supported; a non-slot-identical
-    // frame array (e.g. [i32; 3], which packs to four-byte strides while the frame
-    // stores eight-byte slots) is refused by the current implementation (ADR-0052).
+    // An element whose own stride is the frame's slot stride (i64: one
+    // eight-byte slot per element) so a raw pointer into the frame-resident
+    // array is supported; an element that packs narrower (e.g. [i32; 3], four
+    // bytes against an eight-byte slot) is refused by the current
+    // implementation (ADR-0052).
     let arr: [i64; 3] = [10, 20, 30];
     let v: i64 = checked {
         let base: ptr const i64 = @raw(arr[0]);

--- a/website/content/tutorial/09-arrays-slices-and-buffers.md
+++ b/website/content/tutorial/09-arrays-slices-and-buffers.md
@@ -204,9 +204,9 @@ fn main() -> i32 {
 ```
 
 Slices are the newest rung of the ladder, and today they only work for
-elements that are 64 bits wide, such as `i64`, `u64`, and `f64`. A `[i32]`
-parameter is rejected with a diagnostic that says so. That restriction is
-expected to lift.
+elements whose every part is 64 bits wide: `i64`, `u64`, `f64`, a pointer, and
+structs built from those. A `[i32]` parameter is rejected with a diagnostic
+that says so. That restriction is expected to lift.
 
 A slice is a *view*: it does not own its elements, and it is only ever a
 parameter. You cannot return one, store one in a struct, or bind one to a


### PR DESCRIPTION
## Summary

The fixed-array-to-slice coercion refused `[f64]` with E0908 even though `f64`'s compact stride and the frame's slot stride both are 8 bytes, so the slice's `@ptr_offset` view and the frame layout already agree. The refusal predicate, `is_slot_identical_layout`, excludes floats for an access-kind reason (a float leaf is never moved as an opaque slot), which is the right question for call-ABI marshalling but not for the positional question the coercion asks. Spec 7.2:14, the E0908 explanation and the tutorial all described the refused set as "narrower than a slot", which `f64` is not (and the tutorial claimed `f64` already worked).

- **One predicate.** `rue_air::compact_stride_matches_slot_stride` in `call_abi.rs`; it and `is_slot_identical_layout` are thin wrappers over one private walk that differ in exactly one arm (`F64`). Admits `i64`/`u64`, pointers, `f64`, zero-sized/comptime-only types, and structs/arrays whose leaves are all of those. Still refuses `bool`, `i8`/`u8`, `i16`/`u16`, `i32`/`u32`, `f32`, enums, and any aggregate holding one of those (RUE-2055's narrow-element case is blocked on the RUE-1052 layout ruling and is not lifted).
- **Both refusal sites** consume it: the E0908 site in `sema/analysis/ownership.rs` and `frame_raw_aggregate_pointer_unsupported` cases (a) and (b) in `rue-codegen/src/types.rs`, through a delegation to the `rue_air` authority. Guard tests in both crates pin that each site calls the shared predicate and not `is_slot_identical_layout`, and that both public predicates delegate to the one walk.
- **Oracle** learned the float arm of `encode_value`/`decode` (IEEE-754 bit pattern, little-endian at the type's width), so a `[f64]` view's `@raw`/`@ptr_read` is modelable; the `native_float_pointer_widths_preserve_neighbor_bytes` model-gap entry is removed and `float_element_slice_empty_view` is added (the same conventional-null gap the existing empty-view cases carry).
- **Spec and docs.** 7.2:14 rewritten in place (id kept) to state the real rule: refused iff the element's own stride differs from the frame's slot stride, listing both sides. E0908's explanation and likely-cause rewritten, second example extended with `[f64]`. `docs/spec/src/09-unchecked-code/02-intrinsics.md`, `docs/notes/compact-layout-default.md`, `docs/process/tutorial.md` and the website tutorial corrected. The one-line E0908 message is unchanged (every shape still refused does have a narrower-than-slot leaf).

## Tests

- `crates/rue-cli-tests/cases/slices_mvp.toml`: nine new cases: head read, sum/`len()`/forwarding, and a `{f64,i64}` element, each for x86-64-linux and aarch64-linux with `execute_if_native`; plus an out-of-bounds trap, the `[f32]` refusal, the `{f64,i32}` refusal, and `[f64; 0]`.
- `crates/rue-spec/cases/arrays/slices.toml`: five cases citing 7.2:14 (`f64` admitted, float view strides by the element, `{f64,i64}` admitted, `[f32]` refused, `{f64,i32}` refused).
- One golden moved: `cli_explain.toml`'s E0908 example title, "slot-width" → "slot-filling", because "slot-width" was the wording the issue identifies as wrong.

## Byte identity

Compilers built from the base commit and from this tree, each compiling all 43 `examples/*.rue` / `examples/*/main.rue` for both x86-64-linux and aarch64-linux: 86 of 86 executables identical, 0 compile failures. Programs that newly compile were E0908/E9001 rejections on the base.

## Validation

`scripts/rue fmt`, `quick` (36/36), `unit air` (895), `unit codegen` (931), `unit oracle` (159), `cli slices float_codegen cli_explain pointers` (115), `ui` (437), `spec` (2900), and the spec-traceability, error-explanation-examples, oracle-diff, planted-miscompile-isolation and codegen debug-assert gates, all passing on the rebased tree. The agent's `premerge` on the pre-rebase tree passed (219) except the two environmental CLI cases. AArch64 cases are compile-verified here and execute in CI.

Closes RUE-2097

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_