### PR TITLE
free_c_string accepts a null pointer

### DIFF
--- a/crates/rue-cli-tests/cases/std_c_strings.toml
+++ b/crates/rue-cli-tests/cases/std_c_strings.toml
@@ -30,7 +30,7 @@
 [section]
 id = "cli.std_c_strings"
 name = "std.c C-string export contract"
-description = "owned_c_string/free_c_string round-trips, and the interior-NUL rejection that keeps the free size equal to the allocated size (RUE-1710)."
+description = "owned_c_string/free_c_string round-trips, the interior-NUL rejection that keeps the free size equal to the allocated size (RUE-1710), and free_c_string's null no-op (RUE-1781)."
 
 # The repro, in the form it can still be observed in: an interior NUL now aborts
 # at the export instead of producing a buffer that will be freed under the wrong
@@ -224,5 +224,79 @@ stdout = """
 strlen: 11
 roundtrip equal: true
 reimported len: 11
+"""
+exit_code = 0
+
+# Freeing a null pointer is a no-op, on both targets (RUE-1781).
+#
+# `free_c_string` recovers the size by scanning to the terminator, so a null
+# argument used to start that scan at address 0 and fault before reaching
+# `@free`. Null tolerance is now part of the function's contract, matching C's
+# `free(NULL)` and the `@free` intrinsic underneath it (spec 9.2:11), so a
+# caller freeing a conditionally exported string needs no null test of its own.
+# The program frees a null pointer twice, then exports and frees a real string,
+# proving the early return did not disturb the ordinary path. Compiled for each
+# supported Linux target and run where that target is the host.
+[[case]]
+name = "c_free_c_string_null_is_a_noop_x86_64"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let zero: u64 = 0;
+    let empty: ptr mut u8 = checked { @int_to_ptr(zero) };
+    std.c.free_c_string(empty);
+    std.c.free_c_string(empty);
+    println("null free returned");
+
+    let text = "still works";
+    let sb = std.strbuf.StrBuf.from_str(borrow text);
+    let cstr = std.c.owned_c_string(borrow sb);
+    println("strlen: " + @to_string(std.c.c_strlen(cstr)));
+    std.c.free_c_string(cstr);
+    println("owned free returned");
+    0
+}
+""" }]
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = """
+null free returned
+strlen: 11
+owned free returned
+"""
+exit_code = 0
+
+[[case]]
+name = "c_free_c_string_null_is_a_noop_aarch64"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let zero: u64 = 0;
+    let empty: ptr mut u8 = checked { @int_to_ptr(zero) };
+    std.c.free_c_string(empty);
+    std.c.free_c_string(empty);
+    println("null free returned");
+
+    let text = "still works";
+    let sb = std.strbuf.StrBuf.from_str(borrow text);
+    let cstr = std.c.owned_c_string(borrow sb);
+    println("strlen: " + @to_string(std.c.c_strlen(cstr)));
+    std.c.free_c_string(cstr);
+    println("owned free returned");
+    0
+}
+""" }]
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = """
+null free returned
+strlen: 11
+owned free returned
 """
 exit_code = 0

--- a/std/c.rue
+++ b/std/c.rue
@@ -300,7 +300,16 @@ pub fn strbuf_from_c_string(cstr: ptr mut u8) -> strbuf.StrBuf {
 /// the wrong class — silently, with no diagnostic. Passing any other pointer —
 /// a StrBuf's backing buffer, a C-owned string, one built with a different
 /// length, or an already-freed pointer — is a contract violation.
+///
+/// A NULL `cstr` is the one exception, and it is a PROMISE rather than an
+/// accident: `free_c_string(null)` returns without doing anything, the way C's
+/// `free(NULL)` and the `@free` allocator underneath this function do. The
+/// scan would otherwise start at address 0 and fault. Freeing a conditionally
+/// exported string therefore needs no null test at the call site.
 pub fn free_c_string(cstr: ptr mut u8) {
+    if checked { @ptr_to_int(cstr) } == 0 {
+        return;
+    }
     let mut len: u64 = 0;
     let nul: u8 = 0;
     while checked { @ptr_read(@ptr_offset(cstr, len)) } != nul {


### PR DESCRIPTION
## Summary

`std.c.free_c_string` recovers the string's length by scanning from the pointer it is given, so a null pointer scanned from address 0 and faulted (the runtime's SIGSEGV handler reports it as `stack overflow`, exit 101). It is a public function taking a raw pointer, and "free of null is a no-op" is the convention of C's `free`, of `@free` (spec 9.2:11), and of the runtime heap underneath, so a caller holding a pointer they zeroed after a previous free got a fault instead of a no-op.

- `std/c.rue`: `free_c_string` returns early when `@ptr_to_int(cstr) == 0`, and its doc comment now states null tolerance as a promise of the contract, next to the existing contract-violation list.
- No other docs mention `free_c_string` (`docs/` and `website/` have no hits); the spec covers the language rather than std APIs, and 9.2:11 already states the null rule for `@free`, so no spec paragraph was added.

## Tests

Two new CLI cases in `crates/rue-cli-tests/cases/std_c_strings.toml` (x86-64-linux and aarch64-linux, `execute_if_native`): free null twice, then export and free a real string and exit 0, so the early return is shown not to cost the ordinary path. Before the change the program exits 101 with `stack overflow` on stderr; after it prints and exits 0.

## Validation

`scripts/rue fmt`, `quick` (36/36), `cli std_c_strings c_ffi` (73), `//tests/std:std-tests`, `//crates/rue-oracle-diff:oracle-diff-test` and `//:spec-traceability` on the rebased tree; the agent's `premerge` (219) on the pre-rebase tree passed except the two environmental CLI cases.

Closes RUE-1781

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_