### PR TITLE
State the 32-bit register-image invariant once, beside the width extension

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1284,6 +1284,11 @@ impl<'a> CfgLower<'a> {
                     });
                 }
                 let dst = self.mir.alloc_vreg();
+                // `value` is the canonical 64-bit image and `MovImm` defines the
+                // whole X register from it, so a negative 32-bit constant lands
+                // sign-extended while a 32-bit ALU result is zero-high. That is
+                // the 32-bit register-image invariant documented on
+                // `value_plan::width_extension`.
                 self.mir.push(Aarch64Inst::MovImm {
                     dst: Operand::Virtual(dst),
                     imm: value as i64,
@@ -6783,6 +6788,103 @@ mod tests {
         fixture.ret(Some(sum));
         let mir = fixture.lower_host();
         assert!(!mir.instructions().is_empty());
+    }
+
+    /// The AArch64 half of the 32-bit register-image invariant, whose single
+    /// statement lives on `value_plan::width_extension` (RUE-1338).
+    ///
+    /// `fn main() -> i32 { -1 + 2 }`: `MovImm` defines the whole X register
+    /// from the constant's canonical 64-bit image, so the negative constant
+    /// lands sign-extended, while the W-register add leaves bits 32-63 clear —
+    /// one function holding both admissible images of one type.
+    #[test]
+    fn a_negative_i32_constant_is_sign_extended_and_a_32_bit_add_is_zero_high() {
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let mut fixture = FixtureCfg::new(
+            Type::I32,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let minus_one = fixture.konst(-1_i64 as u64, Type::I32);
+        let two = fixture.konst(2, Type::I32);
+        let sum = fixture.value(CfgInstData::Add(minus_one, two), Type::I32);
+        fixture.ret(Some(sum));
+        let mir = fixture.lower_host();
+        let instructions = mir.instructions();
+
+        assert!(
+            instructions
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::MovImm { imm: -1, .. })),
+            "a negative i32 constant must carry its full 64-bit sign-extended \
+             image: {instructions:?}"
+        );
+        assert!(
+            instructions
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::MovImm { imm: 2, .. })),
+            "a non-negative constant is materialized zero-high: {instructions:?}"
+        );
+        assert!(
+            instructions
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::AddsRR { .. })),
+            "32-bit arithmetic must use the W-register form, which zeroes bits \
+             32-63: {instructions:?}"
+        );
+        assert!(
+            !instructions
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::AddsRR64 { .. })),
+            "a 32-bit add must not run at 64-bit width: {instructions:?}"
+        );
+    }
+
+    /// `fn main() -> i64 { (-1 + 2) as i64 }`: a 64-bit consumer of a 32-bit
+    /// value applies the width extension before reading bits 32-63, which is
+    /// what makes both register images safe (RUE-1338).
+    #[test]
+    fn a_64_bit_consumer_of_an_i32_value_applies_the_width_extension_first() {
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let mut fixture = FixtureCfg::new(
+            Type::I64,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let minus_one = fixture.konst(-1_i64 as u64, Type::I32);
+        let two = fixture.konst(2, Type::I32);
+        let sum = fixture.value(CfgInstData::Add(minus_one, two), Type::I32);
+        let widened = fixture.cast(sum, Type::I32, Type::I64);
+        fixture.ret(Some(widened));
+        let mir = fixture.lower_host();
+        let instructions = mir.instructions();
+
+        let add = instructions
+            .iter()
+            .position(|inst| matches!(inst, Aarch64Inst::AddsRR { .. }))
+            .expect("the 32-bit add must be emitted");
+        let extend = instructions
+            .iter()
+            .position(|inst| matches!(inst, Aarch64Inst::Sxtw { .. }))
+            .expect(
+                "a widening i32 -> i64 cast must re-extend the zero-high 32-bit \
+                 result before it is read as 64 bits",
+            );
+        assert!(
+            add < extend,
+            "the width extension must follow the 32-bit result it repairs: \
+             {instructions:?}"
+        );
     }
 
     #[test]

--- a/crates/rue-codegen/src/allocation.rs
+++ b/crates/rue-codegen/src/allocation.rs
@@ -160,8 +160,15 @@ pub const fn checked_byte_size(count: u64, element_bytes: u64) -> Option<u64> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoundsCondition {
     /// The index is valid exactly when it is below the array length as an
-    /// unsigned 64-bit value. This also rejects negative signed indices after
-    /// their canonical extension to the index width.
+    /// unsigned 64-bit value. This also rejects a negative signed index, and it
+    /// does so without extending a narrow index first: both register images a
+    /// 32-bit value may arrive in read as at least 2^31 unsigned when the value
+    /// is negative, which is past the largest array a program can declare
+    /// (E0906 caps an object at 268_435_455 slots, one per array element), so
+    /// both trap. This is the one consumer that reads a 32-bit value's bits
+    /// 32-63 without applying the width extension; see the 32-bit
+    /// register-image invariant on
+    /// [`crate::value_plan::width_extension`].
     UnsignedIndexLessThanLength,
 }
 

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -404,8 +404,10 @@ pub fn post_op_policy(operation: ArithmeticOperation, wrap: bool) -> PostOpPolic
 ///
 /// Only 8- and 16-bit results differ from the machine form both backends
 /// compute sub-64-bit arithmetic at, so this is [`width_extension`] with the
-/// 32-bit case dropped: a 32-bit ALU result is already canonical, while a
-/// 32-bit signed VALUE reaching a 64-bit leaf still needs the extension.
+/// 32-bit case dropped: a 32-bit ALU result is already in an admissible
+/// register image, while a 32-bit signed VALUE reaching a 64-bit leaf still
+/// needs the extension. See the 32-bit register-image invariant on
+/// [`width_extension`].
 pub fn narrowing_extension(width: IntegerWidth) -> IntegerExtension {
     match width.bits {
         8 | 16 => width_extension(width),
@@ -501,6 +503,14 @@ pub enum DebugValuePlan {
     Other,
 }
 
+/// The renormalization a same-width `@bitCast` performs on the bits ABOVE the
+/// cast's shared width, which belong to the register image rather than to the
+/// value (RUE-952).
+///
+/// [`Self::Zero32`] is what puts a 32-bit `@bitCast` result in the zero-high
+/// image; that both 32-bit types accept it, and what a 64-bit consumer must
+/// then do, is the 32-bit register-image invariant documented on
+/// [`width_extension`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BitCastForm {
     Move,
@@ -910,6 +920,9 @@ impl From<IntegerType> for IntegerWidth {
 /// Normalized extension required when an integer value feeds a 64-bit pointer
 /// arithmetic leaf. The shared planner selects the language-level fact; each
 /// adapter supplies its target instruction for that fact.
+///
+/// Which extension a width needs, and why a 32-bit value needs one at all, is
+/// the 32-bit register-image invariant documented on [`width_extension`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IntegerExtension {
     None,
@@ -2678,6 +2691,61 @@ pub fn integer_extension(ty: Type) -> IntegerExtension {
 /// reach it. Every extension either backend emits is named here, so a width is
 /// described once whether it is reached through a [`Type`] or an
 /// [`IntegerWidth`] (RUE-1982).
+///
+/// # The 32-bit register-image invariant
+///
+/// This is the one statement of that invariant; everything else that depends on
+/// it points here (RUE-1338).
+///
+/// A 32-bit value has TWO admissible register images, and both occur in
+/// ordinary code. Bits 0-31 always carry the value; bits 32-63 are either its
+/// sign extension or zero, decided solely by which producer made it:
+///
+/// - **Sign-extended.** An integer constant is materialized from the canonical
+///   64-bit image the CFG carries ([`IntegerType::canonicalize_u64`]), so a
+///   NEGATIVE `i32` constant becomes a full 64-bit pattern: `MovRI64` on
+///   x86-64, `MovImm` (a `MOVN`-based sequence) on AArch64. A four-byte load
+///   of a signed narrow scalar sign-extends ([`crate::types::NarrowScalar`]),
+///   AArch64 re-narrows a wrapping 32-bit multiply with `SXTW`, and a foreign
+///   `int` return is normalized with [`IntegerExtension::Sign32`].
+/// - **Zero-high** (bits 32-63 clear). Every 32-bit ALU result: x86-64's 32-bit
+///   instruction forms zero the destination's upper half, and AArch64's
+///   W-register forms zero the upper half of the X register. A constant that
+///   fits 32 bits unsigned (`MovRI32`), a four-byte load of an unsigned narrow
+///   scalar, a same-width `@bitCast` ([`BitCastForm::Zero32`]), and a foreign
+///   `unsigned int` return ([`IntegerExtension::Zero32`]) land here too.
+///
+/// Nothing in between normalizes them: register moves, block-parameter edge
+/// moves, spills and reloads (whole eight-byte slots) all preserve whichever
+/// image they were handed, and a Rue call passes and returns the image its
+/// producer chose. A consumer therefore may not assume either one.
+///
+/// **The rule.** A consumer that reads bits 32-63 of a 32-bit value must apply
+/// this function's extension first. Consumers that read only bits 0-31 need
+/// nothing, which is why most need nothing: a scalar compare runs at
+/// [`comparison_integer_width`], a `switch` case compare at
+/// [`Type::switch_compare_width`], arithmetic at the operand width, an
+/// aggregate-equality leaf at its semantic leaf type, and a four-byte store
+/// truncates. The consumers that do widen name the extension explicitly: the
+/// widening `i32 -> i64` cast carries [`IntegerExtension::Sign32`] in its
+/// `widen` field, and a pointer offset, `@debug`, and the runtime-helper
+/// arguments go through [`integer_extension`].
+///
+/// One consumer reads bits 32-63 without extending, and does so deliberately:
+/// the array bounds check compares the index against the length as an unsigned
+/// 64-bit value ([`crate::allocation::BoundsCondition`]). A non-negative 32-bit
+/// index has those bits clear in both images, and a negative one reads as at
+/// least 2^31 either way — past the largest array a program can declare, since
+/// E0906 caps an object at 268_435_455 slots and an array spends one per
+/// element. Both images therefore trap, which is the required answer.
+///
+/// An unsigned 32-bit value is the degenerate case where the two images
+/// coincide, which is why this function answers [`IntegerExtension::None`] for
+/// it rather than a zero-extension: every producer above already leaves bits
+/// 32-63 clear for a `u32`. That is also why [`narrowing_extension`] has
+/// nothing to do at 32 bits — a 32-bit ALU result is already in an admissible
+/// image — while a 32-bit signed VALUE reaching a 64-bit leaf still needs
+/// `Sign32`.
 pub fn width_extension(width: IntegerWidth) -> IntegerExtension {
     match width.bits {
         8 if width.signed => IntegerExtension::Sign8,
@@ -3055,6 +3123,44 @@ mod integer_policy_tests {
             assert_eq!(integer_extension(ty), width_extension(width));
             assert_eq!(integer_width(ty), Some(width));
         }
+    }
+
+    /// The policy half of the 32-bit register-image invariant documented on
+    /// [`width_extension`] (RUE-1338). The instruction-shape half is pinned in
+    /// each backend's `cfg_lower` tests.
+    #[test]
+    fn the_two_admissible_32_bit_register_images_are_named_by_one_policy() {
+        let signed = IntegerWidth {
+            bits: 32,
+            signed: true,
+        };
+        let unsigned = IntegerWidth {
+            bits: 32,
+            signed: false,
+        };
+
+        // A signed 32-bit value may arrive sign-extended or zero-high, so a
+        // 64-bit consumer must re-extend it before reading bits 32-63.
+        assert_eq!(width_extension(signed), IntegerExtension::Sign32);
+        // An unsigned one has a single image — every producer already leaves
+        // bits 32-63 clear — so it is canonical with no instruction.
+        assert_eq!(width_extension(unsigned), IntegerExtension::None);
+
+        // A 32-bit ALU result is already in an admissible image: nothing
+        // follows the operation to re-narrow it.
+        assert_eq!(narrowing_extension(signed), IntegerExtension::None);
+        assert_eq!(narrowing_extension(unsigned), IntegerExtension::None);
+
+        // A same-width `@bitCast` into either 32-bit type produces the
+        // zero-high image.
+        assert_eq!(bit_cast_form(Type::I32), BitCastForm::Zero32);
+        assert_eq!(bit_cast_form(Type::U32), BitCastForm::Zero32);
+
+        // Consumers that read only bits 0-31 need no extension, which is why
+        // a scalar compare and a `switch` case compare run at 32 bits.
+        assert_eq!(comparison_integer_width(Type::I32), signed);
+        assert_eq!(comparison_integer_width(Type::U32), unsigned);
+        assert_eq!(switch_compare_width(Type::I32).bits, 32);
     }
 }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1536,6 +1536,12 @@ impl<'a> CfgLower<'a> {
                     });
                 }
                 let dst = self.mir.alloc_vreg();
+                // `value` is the canonical 64-bit image, so a negative 32-bit
+                // constant needs the full pattern while everything that fits 32
+                // bits unsigned rides `mov r32, imm32`, which zero-extends.
+                // That is what gives a 32-bit value its two admissible register
+                // images: see the 32-bit register-image invariant on
+                // `value_plan::width_extension`.
                 if value <= u32::MAX as u64 {
                     self.mir.push(X86Inst::MovRI32 {
                         dst: Operand::Virtual(dst),
@@ -6974,6 +6980,104 @@ mod tests {
         fixture.ret(Some(sum));
         let mir = fixture.lower().expect("test lowering should succeed");
         assert!(!mir.instructions().is_empty());
+    }
+
+    /// The x86-64 half of the 32-bit register-image invariant, whose single
+    /// statement lives on `value_plan::width_extension` (RUE-1338).
+    ///
+    /// `fn main() -> i32 { -1 + 2 }`: the negative constant is materialized as
+    /// a full 64-bit sign-extended pattern, the non-negative one through
+    /// `mov r32, imm32` (zero-high), and the add runs at 32 bits — so one
+    /// function holds both admissible images of one type.
+    #[test]
+    fn a_negative_i32_constant_is_sign_extended_and_a_32_bit_add_is_zero_high() {
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let mut fixture = FixtureCfg::new(
+            Type::I32,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let minus_one = fixture.konst(-1_i64 as u64, Type::I32);
+        let two = fixture.konst(2, Type::I32);
+        let sum = fixture.value(CfgInstData::Add(minus_one, two), Type::I32);
+        fixture.ret(Some(sum));
+        let mir = fixture.lower().expect("test lowering should succeed");
+        let instructions = mir.instructions();
+
+        assert!(
+            instructions
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::MovRI64 { imm: -1, .. })),
+            "a negative i32 constant must carry its full 64-bit sign-extended \
+             image: {instructions:?}"
+        );
+        assert!(
+            instructions
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::MovRI32 { imm: 2, .. })),
+            "a constant that fits 32 bits unsigned rides the zero-extending \
+             32-bit move: {instructions:?}"
+        );
+        assert!(
+            instructions
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::AddRR { .. })),
+            "32-bit arithmetic must use the 32-bit ALU form, which leaves bits \
+             32-63 clear: {instructions:?}"
+        );
+        assert!(
+            !instructions
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::AddRR64 { .. })),
+            "a 32-bit add must not run at 64-bit width: {instructions:?}"
+        );
+    }
+
+    /// `fn main() -> i64 { (-1 + 2) as i64 }`: a 64-bit consumer of a 32-bit
+    /// value applies the width extension before reading bits 32-63, which is
+    /// what makes both register images safe (RUE-1338).
+    #[test]
+    fn a_64_bit_consumer_of_an_i32_value_applies_the_width_extension_first() {
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let mut fixture = FixtureCfg::new(
+            Type::I64,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let minus_one = fixture.konst(-1_i64 as u64, Type::I32);
+        let two = fixture.konst(2, Type::I32);
+        let sum = fixture.value(CfgInstData::Add(minus_one, two), Type::I32);
+        let widened = fixture.cast(sum, Type::I32, Type::I64);
+        fixture.ret(Some(widened));
+        let mir = fixture.lower().expect("test lowering should succeed");
+        let instructions = mir.instructions();
+
+        let add = instructions
+            .iter()
+            .position(|inst| matches!(inst, X86Inst::AddRR { .. }))
+            .expect("the 32-bit add must be emitted");
+        let extend = instructions
+            .iter()
+            .position(|inst| matches!(inst, X86Inst::Movsx32To64 { .. }))
+            .expect(
+                "a widening i32 -> i64 cast must re-extend the zero-high 32-bit \
+                 result before it is read as 64 bits",
+            );
+        assert!(
+            add < extend,
+            "the width extension must follow the 32-bit result it repairs: \
+             {instructions:?}"
+        );
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,6 +93,13 @@ peephole optimization, scheduling, stack-frame construction, verification, and
 byte emission. Common code owns architecture-neutral concerns such as aggregate
 slots, by-reference arguments, and virtual-register bookkeeping.
 
+Value-materialization policy that both backends must agree on lives in
+`rue-codegen`'s `value_plan`, including the 32-bit register-image invariant:
+a 32-bit value reaches a consumer either sign-extended (a negative constant is
+materialized from its canonical 64-bit image) or with bits 32-63 clear (every
+32-bit ALU result), and a consumer that reads those bits must apply the width
+extension first. The invariant is stated once, on `value_plan::width_extension`.
+
 Which convention governs a call boundary is one value type,
 `rue_target::CallingConvention`, and every psABI rule the compiler needs from a
 C row is data on `CConventionSpec` beside it — roster sizes, where the hidden


### PR DESCRIPTION
## Summary

A 32-bit value lives in a 64-bit register under two admissible images: bits 32..63 are either its sign extension (a negative `i32` constant materialized as a 64-bit pattern, a signed 4-byte load, a signed AArch64 wrapping multiply, a foreign `int` return) or zero (32-bit ALU results, non-negative constants, comparison results, `@bitCast`, unsigned loads). Copies, edge moves, spills and reloads preserve whichever image they were handed, and every 64-bit consumer applies the width extension first. Nothing was broken, but the invariant was unwritten and RUE-952's `@bitCast` work had to rediscover it.

- **One statement.** A `# The 32-bit register-image invariant` section on `width_extension` in `crates/rue-codegen/src/value_plan.rs` (the shared owner since RUE-1982) states the two images, which producers yield which, that copies preserve them, the rule for 64-bit consumers, and why `u32` is degenerate (only the zero-high image exists).
- **Pointers, not copies:** `IntegerExtension`, `narrowing_extension`, `BitCastForm`, `allocation::BoundsCondition::UnsignedIndexLessThanLength`, the integer-constant lowering in both `x86_64/cfg_lower.rs` and `aarch64/cfg_lower.rs`, and one paragraph in `docs/architecture.md` under native backends.
- **One corrected comment.** The array bounds check compares the index as a 64-bit unsigned value with no extension; its doc claimed the index arrived "after canonical extension to the index width", which is false. It is still exact: a non-negative 32-bit index has bits 32..63 clear in both images, a negative one reads as at least 2^31 unsigned either way, and E0906 caps any object at 268,435,455 slots, so no array length can swallow that. The comment now states the real reason.

Verification table (producers vs consumers, both backends) is in the agent's report; no producer/consumer pair reads bits 32..63 of a 32-bit value without an extension, so nothing to escalate.

## Tests

- `value_plan::integer_policy_tests::the_two_admissible_32_bit_register_images_are_named_by_one_policy`: `width_extension` i32 → `Sign32`, u32 → none; `narrowing_extension` 32 → none; `bit_cast_form(I32|U32)` → `Zero32`; comparison and switch widths 32.
- Per backend, `a_negative_i32_constant_is_sign_extended_and_a_32_bit_add_is_zero_high` (`-1 + 2` emits `MovRI64{-1}` + `MovRI32{2}` + a 32-bit add and no 64-bit add; `MovImm` + `AddsRR` on AArch64) and `a_64_bit_consumer_of_an_i32_value_applies_the_width_extension_first` (`(-1 + 2) as i64` emits `Movsx32To64` / `Sxtw` after the add).

## Byte identity

Every added non-comment line is inside a `#[cfg(test)]` module; the four production-file edits are comments only. Empirically, all 26 single-file examples compiled for x86-64-linux and aarch64-linux before and after: 52 of 52 digests identical.

## Validation

`scripts/rue fmt`, `quick` (36/36), `unit codegen` (936), and the planted-miscompile-isolation, codegen debug-assert and doc-link gates on the rebased tree; the agent's `premerge` on the pre-rebase tree passed except the environmental cases.

Closes RUE-1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvBrScVxQNWmMNEeHXSbvp)_