### PR TITLE
RUE-2095: key the oracle's local storage by (slot, Type)

### DIFF
--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -1016,8 +1016,8 @@ mod tests {
             Terminator::Return { value: Some(v) } if v == unit_load
         ));
     }
-    /// The other direction of the same aliasing, which no CLI case can cover:
-    /// the `()` is stored *last* and a sized load of the shared slot follows.
+    /// The other direction of the same aliasing: the `()` is stored *last* and
+    /// a sized load of the shared slot follows.
     ///
     /// Reaching this from source needs the zero-sized local to be re-assigned
     /// after the sized one is initialized (`let mut e: () = (); let y: i64 = 5;
@@ -1025,11 +1025,11 @@ mod tests {
     /// local's `Alloc` always comes first. That shape is miscompiled the other
     /// way round — the `()` reaches a sized consumer and makes its materialized
     /// slot count zero, so a store or an argument disappears rather than
-    /// appearing. It is pinned here rather than in `rue-cli-tests` because the
-    /// differential oracle mismodels the source shape itself: its own local
-    /// store is keyed by slot index too, so the re-assigned `()` overwrites the
-    /// sized neighbour and it reports the wrong answer for a correctly compiled
-    /// program.
+    /// appearing. The source form is covered by the `cli.zero_sized_slot_sharing`
+    /// re-assignment cases (it became oracle-gateable once RUE-2095 keyed the
+    /// reference interpreter's own local store by `(slot, Type)`); this test
+    /// drives the CFG shape directly, without depending on which consumer
+    /// happens to observe the ill-typed operand.
     #[test]
     fn test_block_local_declines_forwarding_a_zero_sized_store_to_a_sized_load() {
         let mut cfg = make_cfg(1);

--- a/crates/rue-cli-tests/cases/zero_sized_slot_sharing.toml
+++ b/crates/rue-cli-tests/cases/zero_sized_slot_sharing.toml
@@ -16,7 +16,8 @@
 # an unmodeled gap before executing anything, so oracle-diff can neither
 # confirm nor refute the bug through them.
 #
-# The cases here are the ones that pin the forwarder's type guard by itself.
+# The first three cases here are the ones that pin the forwarder's type guard
+# by itself.
 # None of them is a pointer operation, so the `@ptr_write` guard is provably
 # inert for all three and only the forwarder fix makes them pass. None forms a
 # zero-sized address either, so the oracle models them and runs them for real:
@@ -99,5 +100,98 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "303\n"
+exit_code = 0
+differential_opt = true
+
+# --- The re-assignment direction (RUE-2095) ---------------------------------
+#
+# Slot indices only ever advance, so a zero-sized local's `Alloc` always comes
+# first and the cases above forward the *sized* value into the `()` load. The
+# reverse — a `()` reaching a sized consumer, where a store or an argument
+# disappears instead of appearing — needs the zero-sized local to be re-assigned
+# after the sized one is initialized.
+#
+# RUE-2086 could not ship that shape as a CLI case: `rue-oracle` keyed its own
+# local store by slot index too, so the re-assigned `()` clobbered the sized
+# neighbour there and the oracle reported the wrong answer for a correctly
+# compiled program. Every case below would have been a permanent red
+# disagreement in `oracle-diff-test`. RUE-2095 keyed that store by
+# `(slot, Type)`, so the shape is modeled now and these cases are live
+# differential coverage for the one direction the corpus could not reach.
+[[case]]
+name = "zero_sized_reassignment_does_not_clobber_its_slot_neighbour"
+description = "RUE-2095: re-assigning a `()` must leave the sized local sharing its slot index untouched."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut e: () = ();
+    let y: i64 = 5;
+    e = ();
+    @dbg(y);
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "reassigned_zero_sized_argument_does_not_swallow_a_later_argument"
+description = "RUE-2086/RUE-2095: the reverse direction — a re-assigned `()` must not be forwarded into the sized load, which would give the `()` argument a slot and drop the sized one."
+files = [{ path = "main.rue", source = """
+fn take(u: (), v: i64) -> i64 { v }
+fn main() -> i32 {
+    let mut e: () = ();
+    let y: i64 = 5;
+    e = ();
+    let r: i64 = take(e, 9);
+    @dbg(r);
+    @dbg(y);
+    0
+}
+""" }]
+stdout = "9\n5\n"
+exit_code = 0
+differential_opt = true
+
+# Two zero-sized locals and a sized one all root at the same index; only the
+# type separates the three storage locations.
+[[case]]
+name = "two_zero_sized_types_share_one_slot_with_a_sized_local"
+description = "RUE-2095: distinct zero-sized types sharing a slot index each keep their own storage, and neither disturbs the sized local."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn main() -> i32 {
+    let mut a: () = ();
+    let mut b: Empty = Empty { unit: () };
+    let y: i64 = 7;
+    a = ();
+    b = Empty { unit: () };
+    @dbg(y);
+    0
+}
+""" }]
+stdout = "7\n"
+exit_code = 0
+differential_opt = true
+
+# A zero-sized local sharing its index with an aggregate: a slot-keyed store
+# replaces the aggregate root outright, so the next field projection has no
+# aggregate left to project.
+[[case]]
+name = "zero_sized_reassignment_leaves_an_aggregate_neighbour_projectable"
+description = "RUE-2095: re-assigning a `()` must not replace the aggregate that shares its slot index."
+files = [{ path = "main.rue", source = """
+struct Pair { a: i64, b: i64 }
+fn main() -> i32 {
+    let mut e: () = ();
+    let mut p: Pair = Pair { a: 3, b: 4 };
+    e = ();
+    p.b = p.a + p.b;
+    @dbg(p.a);
+    @dbg(p.b);
+    0
+}
+""" }]
+stdout = "3\n7\n"
 exit_code = 0
 differential_opt = true

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1332,14 +1332,25 @@ struct Frame {
     /// slot; extra by-value slots are `None` (they are only reached through the
     /// base via a projection, never directly).
     params: Vec<Option<Value>>,
-    locals: Vec<Option<Value>>,
+    /// Local storage keyed by `(slot, Type)`, never by the slot index alone.
+    ///
+    /// `reserve_frame_slots` advances the frame watermark by
+    /// `abi_slot_count(ty)`, so a zero-sized local reserves nothing and the
+    /// next local receives the same `$n` (RUE-2086). A slot index is therefore
+    /// not a unique name for a storage location, and a `()` write to the shared
+    /// index would otherwise clobber the sized neighbour's value. The type
+    /// discriminates them, which is the same key the CFG verifier's
+    /// `verify_raw_init_fact` and `verify_storage_fact` use for exactly this
+    /// convention (RUE-2095).
+    locals: HashMap<(u32, Type), Value>,
     cache: HashMap<u32, Value>,
     /// Slots whose address has been taken (`@raw`/`@raw_mut`/`@field_ptr`). The
     /// slot's storage is moved into the heap allocation named here; every
     /// subsequent `Load`/`Store`/`PlaceRead`/`PlaceWrite` of the slot aliases
     /// that allocation so a write through the pointer and a direct read agree.
-    /// Keyed by [`promotion_key`] over the slot's [`PlaceBase`].
-    promoted: HashMap<u64, usize>,
+    /// Keyed by [`promotion_key`], which carries the accessed type alongside
+    /// the [`PlaceBase`] for the same reason `locals` does.
+    promoted: HashMap<PromotionKey, usize>,
     /// Physical by-reference parameter slots bound to their caller locations.
     /// Ordinary calls retain copy-in/copy-out behavior and leave this empty;
     /// raw accessor execution uses it to preserve the yielded place identity.
@@ -3118,7 +3129,7 @@ impl<'a> Interp<'a> {
             .store(function, Ordering::Relaxed);
         let mut frame = Frame {
             params: param_slots,
-            locals: vec![None; cfg.num_locals() as usize],
+            locals: HashMap::new(),
             cache: HashMap::new(),
             promoted: HashMap::new(),
             param_places,
@@ -3200,11 +3211,10 @@ impl<'a> Interp<'a> {
                     // address, its canonical bytes (rather than the copy-in
                     // snapshot) are authoritative for that writeback.
                     for (&key, &alloc) in &frame.promoted {
-                        if key >> 32 == 1 {
-                            let slot = (key & u32::MAX as u64) as usize;
-                            if let Some(value) = final_params.get_mut(slot) {
-                                *value = Some(self.promoted_slot_value(alloc)?);
-                            }
+                        if let Some(slot) = key.param_slot()
+                            && let Some(value) = final_params.get_mut(slot)
+                        {
+                            *value = Some(self.promoted_slot_value(alloc)?);
                         }
                     }
                     return Ok((ret, final_params));
@@ -3770,8 +3780,9 @@ impl<'a> Interp<'a> {
                             ContractViolationKind::UnsplicedAccessor,
                         ),
                     )?
-                } else if let Some(&a) =
-                    frame.promoted.get(&promotion_key(PlaceBase::Param(*index)))
+                } else if let Some(&a) = frame
+                    .promoted
+                    .get(&promotion_key(PlaceBase::Param(*index), ty))
                 {
                     // The parameter's address was taken; read through its heap
                     // allocation so a `@ptr_write` is observed on re-read.
@@ -3880,14 +3891,18 @@ impl<'a> Interp<'a> {
             }
 
             CfgInstData::Alloc { slot, init } => {
+                // An `Alloc`'s own type is unit; the storage it names is keyed
+                // by the initializer's type, as in `verify_raw_init_fact`.
+                let init_ty = cfg.get_inst(*init).ty;
                 let val = self.eval(cfg, frame, *init)?;
-                self.store_local(frame, *slot, val)?;
+                self.store_local(frame, *slot, init_ty, val)?;
                 Value::Unit
             }
-            CfgInstData::Load { slot } => self.load_local(frame, *slot)?,
+            CfgInstData::Load { slot } => self.load_local(frame, *slot, ty)?,
             CfgInstData::Store { slot, value } => {
+                let stored_ty = cfg.get_inst(*value).ty;
                 let val = self.eval(cfg, frame, *value)?;
-                self.store_local(frame, *slot, val)?;
+                self.store_local(frame, *slot, stored_ty, val)?;
                 Value::Unit
             }
             CfgInstData::PlaceRead { place } => {
@@ -4669,25 +4684,20 @@ impl<'a> Interp<'a> {
         Ok(Value::Int(from_bits(r, bits, signed)))
     }
 
-    fn set_local(frame: &mut Frame, slot: u32, val: Value) {
-        let s = slot as usize;
-        if s >= frame.locals.len() {
-            frame.locals.resize(s + 1, None);
-        }
-        frame.locals[s] = Some(val);
+    fn set_local(frame: &mut Frame, slot: u32, ty: Type, val: Value) {
+        frame.locals.insert((slot, ty), val);
     }
 
-    fn get_local(frame: &Frame, slot: u32) -> Step<Value> {
-        frame
-            .locals
-            .get(slot as usize)
-            .and_then(|o| o.clone())
-            .ok_or_else(|| {
-                unsupported(
-                    UnsupportedKind::ContractViolation(ContractViolationKind::UninitializedLocal),
-                    format!("read of uninit local {slot}"),
-                )
-            })
+    fn get_local(frame: &Frame, slot: u32, ty: Type) -> Step<Value> {
+        frame.locals.get(&(slot, ty)).cloned().ok_or_else(|| {
+            unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::UninitializedLocal),
+                // The type is part of the storage name, so report it: a slot
+                // index alone cannot say which of the locals rooted there was
+                // read before it was written.
+                format!("read of uninit local {slot} ({ty:?})"),
+            )
+        })
     }
 
     // ---- aggregates & places ---------------------------------------------
@@ -4843,9 +4853,9 @@ impl<'a> Interp<'a> {
         self.promote_place(cfg, frame, place, cfg.get_inst(value).ty)
     }
 
-    fn base_value(frame: &Frame, base: PlaceBase) -> Step<Value> {
+    fn base_value(frame: &Frame, base: PlaceBase, base_type: Type) -> Step<Value> {
         match base {
-            PlaceBase::Local(slot) => Self::get_local(frame, slot),
+            PlaceBase::Local(slot) => Self::get_local(frame, slot, base_type),
             PlaceBase::Param(slot) => match frame.params.get(slot as usize) {
                 Some(Some(value)) => Ok(value.clone()),
                 Some(None) => Err(unsupported(
@@ -4898,7 +4908,7 @@ impl<'a> Interp<'a> {
                     unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrRead),
                 )?
             }
-            _ => self.base_value_of(frame, base)?,
+            _ => self.base_value_of(frame, base, place.base_type)?,
         };
         let mut current_ty = place.base_type;
         for (position, (idx, projection)) in path.iter().copied().enumerate() {
@@ -5046,7 +5056,7 @@ impl<'a> Interp<'a> {
         }
         // A promoted base writes through the canonical byte allocation. The
         // unpromoted path can still mutate the frame's logical value directly.
-        if let Some(&a) = frame.promoted.get(&promotion_key(base)) {
+        if let Some(&a) = frame.promoted.get(&promotion_key(base, place.base_type)) {
             let (byte_offset, pointee) = self
                 .projection_offset(place.base_type, &path)
                 .ok_or_else(|| {
@@ -5069,24 +5079,25 @@ impl<'a> Interp<'a> {
                 unsupported_intrinsic_kind_for_operation(rue_air::IntrinsicOperation::PtrWrite),
             );
         }
-        let root: &mut Value = {
-            let (store, slot) = match base {
-                PlaceBase::Local(slot) => (&mut frame.locals, slot as usize),
-                PlaceBase::Param(slot) => (&mut frame.params, slot as usize),
-                PlaceBase::Accessor(_) => {
-                    return Err(unsupported(
-                        UnsupportedKind::ContractViolation(
-                            ContractViolationKind::UnsplicedAccessor,
-                        ),
-                        "accessor place reached oracle write",
-                    ));
+        let root: &mut Value = match base {
+            PlaceBase::Local(slot) => frame
+                .locals
+                .entry((slot, place.base_type))
+                .or_insert(Value::Unit),
+            PlaceBase::Param(slot) => {
+                let slot = slot as usize;
+                if slot >= frame.params.len() {
+                    frame.params.resize(slot + 1, None);
                 }
-                PlaceBase::Indirect(_) => unreachable!("indirect places return above"),
-            };
-            if slot >= store.len() {
-                store.resize(slot + 1, None);
+                frame.params[slot].get_or_insert(Value::Unit)
             }
-            store[slot].get_or_insert(Value::Unit)
+            PlaceBase::Accessor(_) => {
+                return Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::UnsplicedAccessor),
+                    "accessor place reached oracle write",
+                ));
+            }
+            PlaceBase::Indirect(_) => unreachable!("indirect places return above"),
         };
         let mut cur = root;
         for (idx, _) in &path {
@@ -5233,11 +5244,11 @@ impl<'a> Interp<'a> {
     /// Current value of a place base, transparently reading through a promoted
     /// (address-taken) slot's heap allocation so a pointer write is observed by
     /// a later direct read of the same slot.
-    fn base_value_of(&self, frame: &Frame, base: PlaceBase) -> Step<Value> {
-        if let Some(&a) = frame.promoted.get(&promotion_key(base)) {
+    fn base_value_of(&self, frame: &Frame, base: PlaceBase, base_type: Type) -> Step<Value> {
+        if let Some(&a) = frame.promoted.get(&promotion_key(base, base_type)) {
             return self.promoted_slot_value(a);
         }
-        Self::base_value(frame, base)
+        Self::base_value(frame, base, base_type)
     }
 
     /// The logical value a promoted slot holds: the wrapped scalar unwrapped, or
@@ -5306,20 +5317,28 @@ impl<'a> Interp<'a> {
         Ok(())
     }
 
-    /// Read a local slot, honoring promotion.
-    fn load_local(&self, frame: &Frame, slot: u32) -> Step<Value> {
-        if let Some(&a) = frame.promoted.get(&promotion_key(PlaceBase::Local(slot))) {
+    /// Read a local slot, honoring promotion. `ty` is the accessed type, which
+    /// completes the storage key (see [`Frame::locals`]).
+    fn load_local(&self, frame: &Frame, slot: u32, ty: Type) -> Step<Value> {
+        if let Some(&a) = frame
+            .promoted
+            .get(&promotion_key(PlaceBase::Local(slot), ty))
+        {
             return self.promoted_slot_value(a);
         }
-        Self::get_local(frame, slot)
+        Self::get_local(frame, slot, ty)
     }
 
-    /// Write a local slot, honoring promotion.
-    fn store_local(&mut self, frame: &mut Frame, slot: u32, val: Value) -> Step<()> {
-        if let Some(&a) = frame.promoted.get(&promotion_key(PlaceBase::Local(slot))) {
+    /// Write a local slot, honoring promotion. `ty` is the stored value's type,
+    /// which completes the storage key (see [`Frame::locals`]).
+    fn store_local(&mut self, frame: &mut Frame, slot: u32, ty: Type, val: Value) -> Step<()> {
+        if let Some(&a) = frame
+            .promoted
+            .get(&promotion_key(PlaceBase::Local(slot), ty))
+        {
             self.set_promoted_slot(a, val)
         } else {
-            Self::set_local(frame, slot, val);
+            Self::set_local(frame, slot, ty, val);
             Ok(())
         }
     }
@@ -6421,14 +6440,14 @@ impl<'a> Interp<'a> {
         {
             return Ok(target);
         }
-        let key = promotion_key(base);
+        let key = promotion_key(base, place.base_type);
         // A pre-splice accessor can represent a borrowed receiver as the
         // canonical pointer value itself rather than in `param_places`. In
         // that form, a nested place such as `self.values` must stay rooted at
         // the pointer's allocation; promoting the base again would interpret
         // the pointer representation as the enclosing aggregate and lose the
         // receiver path.
-        if let Value::Ptr(Some(mut target)) = self.base_value_of(frame, base)? {
+        if let Value::Ptr(Some(mut target)) = self.base_value_of(frame, base, place.base_type)? {
             let (offset, view) =
                 self.projection_offset(place.base_type, &path)
                     .ok_or_else(|| {
@@ -6453,7 +6472,7 @@ impl<'a> Interp<'a> {
         let alloc = if let Some(&a) = frame.promoted.get(&key) {
             a
         } else {
-            let value = self.base_value_of(frame, base)?;
+            let value = self.base_value_of(frame, base, place.base_type)?;
             let a = self.heap_alloc_value(value, place.base_type, false)?;
             frame.promoted.insert(key, a);
             a
@@ -7449,8 +7468,26 @@ fn modeled_pointer_intrinsic(kind: UnsupportedIntrinsicKind) -> bool {
 }
 
 /// Stable map key for a promoted place base within a frame.
-fn promotion_key(base: PlaceBase) -> u64 {
-    match base {
+///
+/// `base` alone is not a unique storage name: a zero-sized local reserves no
+/// ABI slot, so its index is the index the next local receives (RUE-2086). The
+/// accessed type discriminates the two, matching how [`Frame::locals`] and the
+/// CFG verifier key the same convention (RUE-2095).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct PromotionKey {
+    base: u64,
+    ty: Type,
+}
+
+impl PromotionKey {
+    /// The parameter slot this key names, or `None` for any other base kind.
+    fn param_slot(self) -> Option<usize> {
+        (self.base >> 32 == 1).then_some((self.base & u32::MAX as u64) as usize)
+    }
+}
+
+fn promotion_key(base: PlaceBase, ty: Type) -> PromotionKey {
+    let base = match base {
         // Every payload is u32, so two high tag bits give the four base kinds
         // disjoint key spaces. In particular, an indirect value must never
         // alias an odd local's promoted allocation before the oracle reports
@@ -7459,7 +7496,8 @@ fn promotion_key(base: PlaceBase) -> u64 {
         PlaceBase::Param(slot) => (1u64 << 32) | slot as u64,
         PlaceBase::Accessor(value) => (2u64 << 32) | value.as_u32() as u64,
         PlaceBase::Indirect(value) => (3u64 << 32) | value.as_u32() as u64,
-    }
+    };
+    PromotionKey { base, ty }
 }
 
 /// Strictly decode the UTF-8 scalar starting at byte `offset`, returning

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -1826,6 +1826,97 @@ fn zst_param_forwarded_through_two_calls() {
     assert_eq!(exit(src), 42);
 }
 
+// ---- zero-sized locals sharing a frame slot (RUE-2095) ---------------------
+//
+// `reserve_frame_slots` advances the frame watermark by `abi_slot_count(ty)`,
+// so a zero-sized local reserves nothing and the next local receives the same
+// `$n`. Slot indices are therefore not unique storage names, and the oracle's
+// local store keys `(slot, Type)` so a `()` write cannot reach the sized
+// neighbour's value. RUE-2086 fixed the same hazard in the optimizer; the
+// oracle had it too, which made a *correct* compiler look like a miscompile and
+// left this whole shape class un-gateable by oracle-diff.
+
+#[test]
+fn zst_reassignment_does_not_clobber_the_local_sharing_its_slot() {
+    let src = "fn main() -> i32 {
+        let mut e: () = ();
+        let y: i64 = 5;
+        e = ();
+        @dbg(y);
+        0
+    }";
+    assert_eq!(run(src).stdout, "5\n");
+}
+
+#[test]
+fn two_zst_types_sharing_one_slot_keep_the_sized_value() {
+    // Each zero-sized local reserves nothing, so `()`, `Empty` and `i64` all
+    // root at the same index. Only the type separates the three.
+    let src = "struct Empty { unit: () }
+    fn main() -> i32 {
+        let mut a: () = ();
+        let mut b: Empty = Empty { unit: () };
+        let y: i64 = 7;
+        a = ();
+        b = Empty { unit: () };
+        @dbg(y);
+        0
+    }";
+    assert_eq!(run(src).stdout, "7\n");
+}
+
+#[test]
+fn zst_reassignment_in_a_loop_does_not_clobber_the_shared_slot() {
+    let src = "fn main() -> i32 {
+        let mut i: i64 = 0;
+        let mut e: () = ();
+        let mut acc: i64 = 0;
+        while i < 4 {
+            let y: i64 = i + 10;
+            e = ();
+            acc = acc + y;
+            i = i + 1;
+        }
+        @dbg(acc);
+        0
+    }";
+    assert_eq!(run(src).stdout, "46\n");
+}
+
+#[test]
+fn zst_sharing_a_slot_with_an_aggregate_keeps_the_aggregate_projectable() {
+    // A slot-keyed store replaced the aggregate with the unit value, so the
+    // next field projection reported NonAggregateProjectionRead rather than a
+    // wrong answer. Place bases are keyed by `place.base_type` for that reason.
+    let src = "struct Pair { a: i64, b: i64 }
+    fn main() -> i32 {
+        let mut e: () = ();
+        let mut p: Pair = Pair { a: 3, b: 4 };
+        e = ();
+        p.b = p.a + p.b;
+        @dbg(p.a);
+        @dbg(p.b);
+        0
+    }";
+    assert_eq!(run(src).stdout, "3\n7\n");
+}
+
+#[test]
+fn zst_sharing_a_slot_with_an_address_taken_local_writes_through_the_pointer() {
+    // The promotion table is keyed the same way: a `()` store to the shared
+    // index must not be redirected into the sized neighbour's heap allocation.
+    let src = "fn main() -> i32 {
+        let mut e: () = ();
+        let mut y: i64 = 5;
+        let p: ptr mut i64 = checked { @raw_mut(y) };
+        e = ();
+        checked { @ptr_write(p, 11) };
+        @dbg(y);
+        0
+    }";
+    assert_eq!(run(src).stdout, "11\n");
+}
+
 #[test]
 fn enum_parameter_width_comes_from_its_static_type() {
     let src = r#"enum Shape { Empty, One(i32), Pair(i32, i32) }

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -755,7 +755,7 @@ fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
         };
         let mut frame = Frame {
             params: Vec::new(),
-            locals: vec![None; cfg.num_locals() as usize],
+            locals: HashMap::new(),
             cache: HashMap::new(),
             promoted: HashMap::new(),
             param_places: HashMap::new(),
@@ -860,7 +860,7 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
         };
         let mut frame = Frame {
             params: Vec::new(),
-            locals: vec![None; cfg.num_locals() as usize],
+            locals: HashMap::new(),
             cache: HashMap::new(),
             promoted: HashMap::new(),
             param_places: HashMap::new(),
@@ -903,7 +903,7 @@ fn abort_intrinsics_require_exact_runtime_value_shapes() {
         };
         let mut frame = Frame {
             params: Vec::new(),
-            locals: vec![None; cfg.num_locals() as usize],
+            locals: HashMap::new(),
             cache: HashMap::new(),
             promoted: HashMap::new(),
             param_places: HashMap::new(),
@@ -935,7 +935,7 @@ fn abort_intrinsics_require_exact_runtime_value_shapes() {
     };
     let mut frame = Frame {
         params: Vec::new(),
-        locals: vec![None; cfg.num_locals() as usize],
+        locals: HashMap::new(),
         cache: HashMap::new(),
         promoted: HashMap::new(),
         param_places: HashMap::new(),
@@ -975,7 +975,7 @@ fn empty_slice_null_is_a_const_gap_and_user_int_to_ptr_stays_distinct() {
     assert!(interp.is_empty_slice_pointer(cfg, pointer));
     let mut frame = Frame {
         params: Vec::new(),
-        locals: vec![None; cfg.num_locals() as usize],
+        locals: HashMap::new(),
         cache: HashMap::new(),
         promoted: HashMap::new(),
         param_places: HashMap::new(),

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -30,20 +30,24 @@ fn flattened_parameter_padding_is_a_semantic_gap_but_oob_is_a_contract_failure()
             Some(Value::Aggregate(vec![Value::Int(1), Value::Int(2)])),
             None,
         ],
-        locals: Vec::new(),
+        locals: HashMap::new(),
         cache: HashMap::new(),
         promoted: HashMap::new(),
         param_places: HashMap::new(),
         place_return: false,
     };
 
-    let padding = expect_flow_unsupported(Interp::base_value(&frame, PlaceBase::Param(1)));
+    // The parameter's own type completes the storage key; for these two
+    // failure paths any type reaches the same parameter-slot diagnosis.
+    let padding =
+        expect_flow_unsupported(Interp::base_value(&frame, PlaceBase::Param(1), Type::I32));
     assert_eq!(
         padding.kind(),
         UnsupportedKind::SemanticGap(SemanticGapKind::FlattenedParameterSlot)
     );
 
-    let out_of_bounds = expect_flow_unsupported(Interp::base_value(&frame, PlaceBase::Param(2)));
+    let out_of_bounds =
+        expect_flow_unsupported(Interp::base_value(&frame, PlaceBase::Param(2), Type::I32));
     assert_eq!(
         out_of_bounds.kind(),
         UnsupportedKind::ContractViolation(ContractViolationKind::ParameterSlotOutOfBounds)
@@ -135,7 +139,7 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
         // metadata. A field projection of a non-aggregate must be a contract
         // violation, not a silently-read cell.
         params: vec![Some(Value::Ptr(None)), None],
-        locals: vec![None; cfg.num_locals() as usize],
+        locals: HashMap::new(),
         cache: HashMap::new(),
         promoted: HashMap::new(),
         param_places: HashMap::new(),
@@ -375,7 +379,7 @@ fn validated_cfg_rejects_invalid_owned_text_projection_metadata() {
     };
     let mut view_frame = Frame {
         params: Vec::new(),
-        locals: vec![None; view_cfg.num_locals() as usize],
+        locals: HashMap::new(),
         cache: HashMap::new(),
         promoted: HashMap::new(),
         param_places: HashMap::new(),
@@ -383,7 +387,9 @@ fn validated_cfg_rejects_invalid_owned_text_projection_metadata() {
     };
     // A non-aggregate value under str projection metadata: reading a field of
     // it must be a contract violation, not a silent success.
-    view_frame.locals[view_slot as usize] = Some(Value::Ptr(None));
+    view_frame
+        .locals
+        .insert((view_slot, view_place.base_type), Value::Ptr(None));
     let mut view_interp = Interp {
         state: &view_state,
         stdout_trace: Vec::new(),


### PR DESCRIPTION
`rue-oracle` (the reference interpreter oracle-diff differentially checks the compiler against) had the same ZST-slot-sharing hazard RUE-2086 fixed in the real compiler: a zero-sized local sharing a frame slot with a live non-ZST value could get the oracle's own slot-indexed local-store table clobbered, producing FALSE disagreements against a genuinely correct compiler. Since the oracle's local store was the reference, this meant the whole ZST-slot-sharing bug class could never be gated by oracle-diff at all — any case exercising it would either need a model-gap registration (silently disabling future checking of that shape) or would permanently redden `oracle-diff-test`.

Fix: re-key `Frame::locals` (`Vec<Option<Value>>` → `HashMap<(u32, Type), Value>`) and `Frame::promoted` (address-taken/promoted slots, via a new `PromotionKey`) by `(slot, Type)` instead of slot index alone — matching the convention the real compiler's verifier already uses (`verify_raw_init_fact`/`verify_storage_fact`). The `promoted` half matters independently: without it, a `()` store to a shared index still gets redirected into a sized neighbour's heap allocation.

Verified broadly: all six oracle-diff lanes (CLI + spec × O1/O2/O3) clean at both the original and rebased trunk point, 300 fuzz seeds / 1200 native lanes with zero disagreements, and a 10-shape generalization sweep where 8 shapes were wrong before the fix and all 10 are correct after — two of those manifested as `ORACLE FAILURES` rather than disagreements pre-fix, meaning the bug's blast radius included corrupting unrelated aggregate reads, not just producing a wrong scalar. Ships 4 new `differential_opt` CLI cases (`zero_sized_slot_sharing.toml`) plus 3 more added during adversarial review, each of which would have been a permanent red disagreement in `oracle-diff-test` before this fix — concrete proof the gate blind spot is closed.

A related but distinct gap in `Frame::params` (the same slot-indexing issue on the parameter path, not fully covered by the existing zero-sized-parameter special case) was found during review and filed separately as RUE-2101 — deliberately out of scope here to keep this fix minimal and reviewable.

Fixes RUE-2095