### PR TITLE
RUE-2094: re-prove every intrinsic's operand types after optimization

### DIFF
--- a/crates/rue-cfg/src/api_inventory.rs
+++ b/crates/rue-cfg/src/api_inventory.rs
@@ -300,6 +300,34 @@ fn validated_cfg_consuming_editor_conversion_does_not_copy_payloads() {
     assert!(!conversion.contains("clone("));
 }
 
+/// The post-optimization operand check consumes the same authority CFG
+/// construction does. A second, hand-rolled signature table in the verifier
+/// would drift from `IntrinsicOperation::validate_call` and quietly stop
+/// catching the substitution it exists for (RUE-2094).
+#[test]
+fn cfg_verification_rechecks_intrinsic_operands_through_the_shared_validator() {
+    let verify = include_str!("verify.rs");
+    let production = verify
+        .split("\n#[cfg(test)]\nmod ")
+        .next()
+        .expect("CFG verifier production prefix");
+    assert_eq!(
+        production.matches("operation.validate_call(").count(),
+        1,
+        "CFG verification must re-prove intrinsic call shapes through the one shared validator"
+    );
+    for forbidden in [
+        "IntrinsicOperation::PtrWrite =>",
+        "IntrinsicOperation::PtrRead =>",
+        "pointer_pointee(",
+    ] {
+        assert!(
+            !production.contains(forbidden),
+            "CFG verification grew its own intrinsic signature table: {forbidden}"
+        );
+    }
+}
+
 #[test]
 fn cfg_intrinsics_revalidate_and_preserve_the_semantic_operation() {
     let build = include_str!("build.rs");

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -20,8 +20,9 @@
 //! Every arena value has exactly one legal attachment, block parameters agree
 //! with their attachment metadata, and every operand is defined before use and
 //! dominated by its definition. Targets, variable-length storage slices,
-//! local/parameter slots, places, projections, edge arguments, conditions, and
-//! returns are validated before any getter or graph traversal can index them.
+//! local/parameter slots, places, projections, edge arguments, conditions,
+//! returns, and intrinsic call signatures are validated before any getter or
+//! graph traversal can index them.
 //! Once those structural preconditions hold, a forward dataflow pass verifies
 //! explicit storage lifetimes, explicit Drop consumption, and initialization
 //! of unannotated compiler-owned slots such as runtime drop flags.
@@ -41,7 +42,11 @@ use crate::dominators::DominatorTree;
 use crate::inst::{
     BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, ValidatedCfg,
 };
-use rue_air::{FrozenTypeInternPool, Type, TypeKind};
+use crate::payload::CfgIntrinsicArgs;
+use rue_air::{
+    AirArgMode, FrozenTypeInternPool, IntrinsicAirArgument, IntrinsicAirArgumentSource,
+    IntrinsicOperation, Type, TypeKind,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum OwnerRoot {
@@ -360,6 +365,23 @@ impl Cfg {
 enum Attachment {
     Param { block: BlockId },
     Inst { block: BlockId, position: usize },
+}
+
+/// Name an intrinsic operand's structural origin for a verification report.
+/// The address-taking intrinsics accept only a place-shaped operand, so the
+/// origin is as much a part of the diagnosis as the type is.
+fn describe_operand_source(source: IntrinsicAirArgumentSource) -> &'static str {
+    match source {
+        IntrinsicAirArgumentSource::Value => "a computed value",
+        IntrinsicAirArgumentSource::Load => "a local load",
+        IntrinsicAirArgumentSource::Param => "a parameter",
+        IntrinsicAirArgumentSource::PlaceRead {
+            terminal_field: true,
+        } => "a field place read",
+        IntrinsicAirArgumentSource::PlaceRead {
+            terminal_field: false,
+        } => "a place read",
+    }
 }
 
 struct Verifier<'a> {
@@ -1634,6 +1656,9 @@ impl<'a> Verifier<'a> {
             CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } => {
                 self.verify_place(block, value, place)?
             }
+            CfgInstData::Intrinsic {
+                operation, args, ..
+            } => self.verify_intrinsic_operands(block, value, *operation, inst.ty, args)?,
             CfgInstData::BlockParam { .. } => unreachable!(),
             _ => {}
         }
@@ -1644,6 +1669,114 @@ impl<'a> Verifier<'a> {
             }
         });
         operand_result
+    }
+
+    /// Re-prove an intrinsic's operand and result types against the single
+    /// authority that accepted them on AIR.
+    ///
+    /// CFG construction proves this contract once (`build.rs`), but both
+    /// backends derive an intrinsic operand's marshalled width from the
+    /// operand's *own* CFG type, so an optimization pass that substitutes a
+    /// differently typed value into an operand silently rewrites the lowered
+    /// call's ABI. That is the one channel RUE-2086's store-to-load hazard
+    /// flowed through, and it reached codegen only because nothing after
+    /// optimization re-checked operand types. Re-running
+    /// [`IntrinsicOperation::validate_call`] keeps AIR, CFG construction and
+    /// the optimized graph on one contract rather than a second, drifting
+    /// copy of the signature table (RUE-2094).
+    ///
+    /// The operand's structural origin is read back out of the CFG, so the
+    /// address-taking family (`@raw`/`@raw_mut`/`@field_ptr`) is held to the
+    /// same "still a place read" requirement codegen depends on when it takes
+    /// the operand's address (RUE-521).
+    fn verify_intrinsic_operands(
+        &self,
+        block: BlockId,
+        value: CfgValue,
+        operation: IntrinsicOperation,
+        result_ty: Type,
+        args: &CfgIntrinsicArgs,
+    ) -> Result<(), CfgVerificationError> {
+        let operands = self.cfg.intrinsic_args(args);
+        let mut arguments = Vec::with_capacity(operands.len());
+        for &operand in operands {
+            let inst = self.inst(operand, block, "intrinsic argument")?;
+            arguments.push(IntrinsicAirArgument {
+                ty: inst.ty,
+                mode: AirArgMode::Normal,
+                source: self.intrinsic_operand_source(operand),
+            });
+        }
+        // An error type is a diagnostic placeholder, not a claim about a
+        // value's ABI: a graph still carrying one is already reported and its
+        // signature relationships are not meaningful.
+        if result_ty == Type::ERROR || arguments.iter().any(|argument| argument.ty == Type::ERROR) {
+            return Ok(());
+        }
+        if operation.validate_call(self.type_pool, &arguments, result_ty) {
+            return Ok(());
+        }
+        let operand_summary = if operands.is_empty() {
+            "no operands".to_string()
+        } else {
+            operands
+                .iter()
+                .zip(&arguments)
+                .enumerate()
+                .map(|(index, (operand, argument))| {
+                    format!(
+                        "operand {} ({}) has type {:?} from {}",
+                        index,
+                        operand,
+                        argument.ty,
+                        describe_operand_source(argument.source)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        Err(self.semantic_error(
+            CfgVerificationLocation::Instruction { block, value },
+            format_args!(
+                "intrinsic {:?} instruction {} in block {} no longer satisfies its call signature: {}, result type is {:?}",
+                operation, value, block, operand_summary, result_ty
+            ),
+        ))
+    }
+
+    /// The structural origin of an intrinsic operand as the optimized CFG
+    /// presents it, in the vocabulary the shared AIR validator speaks.
+    ///
+    /// The three place-shaped instructions accepted here are exactly the three
+    /// `rue_codegen::value_plan::addressable_value_plan` can lower — it returns
+    /// `None` for everything else — so this classification is neither tighter
+    /// nor looser than code generation's own requirement for an operand whose
+    /// address is taken. A fourth place-shaped instruction has to be added in
+    /// both places, and in `rue_air::intrinsic_air_argument_with_place_lookup`,
+    /// which is the AIR-side original.
+    ///
+    /// Unlike every other verifier arm this reads an operand's *payload*, not
+    /// just its type, and it runs before `verify_use` has proved that operand
+    /// attached — post-optimization verification deliberately tolerates
+    /// detached dead values in the arena. So the projection slice is taken
+    /// through the checked accessor: a corrupt range degrades to `Value` and is
+    /// reported as an ill-typed operand, rather than panicking inside the
+    /// unchecked payload view.
+    fn intrinsic_operand_source(&self, operand: CfgValue) -> IntrinsicAirArgumentSource {
+        match &self.cfg.get_inst(operand).data {
+            CfgInstData::Load { .. } => IntrinsicAirArgumentSource::Load,
+            CfgInstData::Param { .. } => IntrinsicAirArgumentSource::Param,
+            CfgInstData::PlaceRead { place } => IntrinsicAirArgumentSource::PlaceRead {
+                terminal_field: matches!(
+                    self.cfg
+                        .checked_place_projections(place)
+                        .ok()
+                        .and_then(<[Projection]>::last),
+                    Some(Projection::Field { .. })
+                ),
+            },
+            _ => IntrinsicAirArgumentSource::Value,
+        }
     }
 
     fn check_local_slot(
@@ -2206,7 +2339,8 @@ mod tests {
     use crate::{CfgVerificationLocation, OptLevel, opt};
     use lasso::ThreadedRodeo;
     use rue_air::{
-        FrozenTypeInternPool, StructDef, StructField, StructId, Type, TypeInternPool, TypeKind,
+        FrozenTypeInternPool, IntrinsicOperation, StructDef, StructField, StructId, Type,
+        TypeInternPool, TypeKind,
     };
     use rue_span::Span;
 
@@ -4750,6 +4884,123 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify_with_type_pool(&pool).unwrap();
+    }
+
+    /// Build `@ptr_write(param0, operand)` where `param0` is a `*mut i64`,
+    /// returning the graph and the pool that defines the pointer type. The
+    /// caller chooses the written operand's type: `Type::I64` is the shape a
+    /// well-formed pipeline produces, and anything else is the ill-typed
+    /// substitution RUE-2086's store-to-load hazard fed to codegen.
+    fn ptr_write_cfg(written_ty: Type) -> (Cfg, FrozenTypeInternPool) {
+        let pool = TypeInternPool::new();
+        let ptr_ty = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::I64));
+        let pool = pool.freeze();
+        let mut cfg = Cfg::new(Type::UNIT, 0, 1, "ptr_write".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let pointer = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Param { index: 0 },
+                ty: ptr_ty,
+                span: Span::new(0, 0),
+            },
+        );
+        let written = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: written_ty,
+                span: Span::new(0, 0),
+            },
+        );
+        let args = cfg.push_intrinsic_args([pointer, written]).unwrap();
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Intrinsic {
+                    operation: IntrinsicOperation::PtrWrite,
+                    name: ThreadedRodeo::default().get_or_intern("ptr_write"),
+                    args,
+                },
+                ty: Type::UNIT,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: None });
+        (cfg, pool)
+    }
+
+    /// The channel RUE-2086 flowed through: codegen reads an intrinsic
+    /// operand's marshalled width off the operand's own type, so a pass that
+    /// substitutes a zero-sized value for a `*mut i64`'s pointee silently
+    /// drops the store instead of miscompiling it later (RUE-2094).
+    #[test]
+    #[should_panic(
+        expected = "intrinsic PtrWrite instruction v2 in block bb0 no longer satisfies its call signature"
+    )]
+    fn verify_rejects_intrinsic_operand_of_the_wrong_type() {
+        let (cfg, pool) = ptr_write_cfg(Type::UNIT);
+        cfg.verify_with_type_pool(&pool).unwrap();
+    }
+
+    /// The report names the offending operand, its type, and its origin, so a
+    /// compiler developer reads the substitution straight out of the message.
+    #[test]
+    fn intrinsic_operand_report_names_the_operand_and_its_type() {
+        let (cfg, pool) = ptr_write_cfg(Type::UNIT);
+        let message = cfg.verify_with_type_pool(&pool).unwrap_err().to_string();
+        assert!(
+            message.contains("operand 1 (v1) has type Type::UNIT"),
+            "{message}"
+        );
+        assert!(message.contains("result type is Type::UNIT"), "{message}");
+    }
+
+    /// The matching well-typed graph is accepted: the check re-proves the
+    /// construction-time contract, it does not tighten it.
+    #[test]
+    fn verify_accepts_a_well_typed_intrinsic_operand() {
+        let (cfg, pool) = ptr_write_cfg(Type::I64);
+        cfg.verify_with_type_pool(&pool).unwrap();
+    }
+
+    /// `@raw_mut` lowers by taking its operand's ADDRESS, so the operand has
+    /// to still be a place read after optimization. A constant-folded operand
+    /// is the RUE-521 shape, and it is a type-system violation the shared AIR
+    /// validator already knows how to reject.
+    #[test]
+    #[should_panic(expected = "from a computed value")]
+    fn verify_rejects_address_taking_intrinsic_operand_folded_to_a_constant() {
+        let pool = TypeInternPool::new();
+        let ptr_ty = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::I64));
+        let pool = pool.freeze();
+        let mut cfg = Cfg::new(Type::UNIT, 1, 0, "raw_mut".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let folded = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(7),
+                ty: Type::I64,
+                span: Span::new(0, 0),
+            },
+        );
+        let args = cfg.push_intrinsic_args([folded]).unwrap();
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Intrinsic {
+                    operation: IntrinsicOperation::RawMut,
+                    name: ThreadedRodeo::default().get_or_intern("raw_mut"),
+                    args,
+                },
+                ty: ptr_ty,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: None });
         cfg.verify_with_type_pool(&pool).unwrap();
     }
 

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2325,14 +2325,30 @@ impl<'a> CfgLower<'a> {
                 let ptr = plan.args[0].primary;
                 let value = &plan.args[1];
                 if plan.zero_sized_pointee_write || value.slot_count == 0 {
-                    // Nothing to store. The declared pointee's width is the
-                    // authority: a `ptr mut ()` write moves no bytes however
-                    // the value operand materialized, which is what keeps a
-                    // differently typed value forwarded into that operand from
-                    // becoming a store through the zero-sized sentinel address
-                    // (RUE-2086). The materialized slot count still answers for
-                    // a diverging operand, so the two only ever agree to store
-                    // nothing.
+                    // Nothing to store: a `ptr mut ()` write moves no bytes.
+                    //
+                    // The two halves cannot disagree on any graph this backend
+                    // can legally be handed. `CfgLower` takes a `ValidatedCfg`,
+                    // and verification proves an intrinsic operand's type
+                    // against the operation's signature after optimization
+                    // (RUE-2094) — for `@ptr_write` that forces the value
+                    // operand's type to BE the declared pointee, and both
+                    // halves are the same function of that one type.
+                    //
+                    // The disjunct is kept anyway, and must not be deleted on a
+                    // dead-code argument. It is what stands between an
+                    // ill-typed operand and memory corruption if a graph ever
+                    // reaches lowering without that proof: with RUE-2086's
+                    // forwarding fix absent and this test removed, the repro
+                    // stores eight bytes through a zero-sized type's sentinel
+                    // address and faults. Verification is the first line of
+                    // defence and is itself new code with a known hole (it does
+                    // not check user-call arguments); this is the second, and
+                    // the failure mode it converts is "no store" rather than
+                    // "wrong store". It is pinned by
+                    // `zero_sized_pointee_write_plan_stores_nothing_with_a_sized_operand`,
+                    // which has to build the plan directly because no verified
+                    // CFG can express the distinguishing shape.
                 } else if let Some(map) = &plan.physical_slots {
                     // A compact enum value: truncate each internal slot to its
                     // physical width at its compact byte offset (RUE-1000). The
@@ -5014,6 +5030,21 @@ mod tests {
 
     /// A CFG fixture under construction. Instructions append to `current`,
     /// which multi-block fixtures retarget as they go.
+    /// One intrinsic operand plan with the fields this backend's `@ptr_write`
+    /// arm reads: the vreg holding it, how many slots it materialized into, and
+    /// its type.
+    fn arg_plan(primary: VReg, slot_count: u32, ty: Type) -> crate::value_plan::IntrinsicArgPlan {
+        crate::value_plan::IntrinsicArgPlan {
+            primary,
+            slots: Vec::new(),
+            slot_count,
+            integer_extension: crate::value_plan::IntegerExtension::None,
+            place: None,
+            debug: crate::value_plan::DebugValuePlan::Other,
+            ty,
+        }
+    }
+
     struct FixtureCfg<'a> {
         cfg: Cfg,
         current: BlockId,
@@ -5178,6 +5209,26 @@ mod tests {
 
         fn ret(&mut self, result: Option<CfgValue>) {
             self.cfg.set_return(self.current, result);
+        }
+
+        /// Hand a hand-built `IntrinsicPlan` straight to the backend, below the
+        /// `ValidatedCfg` boundary.
+        ///
+        /// CFG verification proves an intrinsic operand's type against the
+        /// operation's signature after optimization (RUE-2094), so the one
+        /// shape that tells RUE-2086's two guard halves apart — a zero-sized
+        /// declared pointee with a *sized* value operand — can no longer be
+        /// expressed as a CFG at all. The plan is the last level at which it
+        /// still can, so the guard is pinned here rather than left untested.
+        fn lower_plan(
+            self,
+            build: impl FnOnce(&mut Aarch64Mir) -> crate::value_plan::IntrinsicPlan,
+        ) -> Aarch64Mir {
+            let cfg = self.cfg.finish(self.pool).expect("test CFG must verify");
+            let mut lower = CfgLower::new(&cfg, self.pool, self.interner, Target::Aarch64Linux);
+            let plan = build(&mut lower.mir);
+            lower.lower_intrinsic_plan(plan);
+            lower.mir
         }
 
         fn lower(self) -> rue_error::CompileResult<Aarch64Mir> {
@@ -7663,9 +7714,17 @@ mod tests {
     /// `$n`. Value forwarding once handed the pointer stored in that shared
     /// slot to the `()`-typed load of the other local, and this arm — reading
     /// the materialized operand's slot count — emitted a real eight-byte store
-    /// through the zero-sized sentinel address. The ill-typed operand is
-    /// reproduced verbatim here so the arm is pinned independently of the
-    /// optimizer that produced it.
+    /// through the zero-sized sentinel address.
+    ///
+    /// The graph that forged that ill-typed operand is no longer
+    /// constructible: CFG verification re-proves every intrinsic's operand
+    /// types after optimization, so a `@ptr_write` whose value operand does
+    /// not match the pointer's declared pointee is an ICE at verification
+    /// rather than a store (RUE-2094, pinned in `rue-cfg`'s
+    /// `verify_rejects_intrinsic_operand_of_the_wrong_type`). The pointee
+    /// then decides the same thing the operand's width does, so what this
+    /// case still pins is the observable contract: a write through
+    /// `ptr mut ()` moves no bytes.
     #[test]
     fn zero_sized_pointee_write_emits_no_store() {
         let interner = ThreadedRodeo::new();
@@ -7682,10 +7741,11 @@ mod tests {
             &interner,
         );
         let address = fixture.konst(1, unit_ptr_ty);
+        let written = fixture.konst(0, Type::UNIT);
         fixture.intrinsic(
             rue_air::IntrinsicOperation::PtrWrite,
             "ptr_write",
-            &[address, address],
+            &[address, written],
             Type::UNIT,
         );
         let zero = fixture.konst(0, Type::I32);
@@ -7699,6 +7759,72 @@ mod tests {
                     | Aarch64Inst::FloatStore { .. }
             )),
             "a zero-sized pointee write must store nothing: {:?}",
+            mir.instructions()
+        );
+    }
+
+    /// The one shape that tells RUE-2086's two guard halves apart, and the only
+    /// level at which it is still constructible.
+    ///
+    /// A zero-sized declared pointee with a *sized* value operand is exactly the
+    /// graph the RUE-2086 forwarding defect produced, and it is what
+    /// `plan.zero_sized_pointee_write` exists to refuse. CFG verification now
+    /// rejects it before code generation ever sees it (RUE-2094), so no fixture
+    /// built through `Cfg::finish` can reach this arm with the two halves
+    /// disagreeing — which would leave the disjunct with no coverage at all and
+    /// invite a future reader to delete it as dead. The plan is handed to the
+    /// backend directly so it stays pinned: without the disjunct this emits a
+    /// real store through a zero-sized type's sentinel address.
+    #[test]
+    fn zero_sized_pointee_write_plan_stores_nothing_with_a_sized_operand() {
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let unit_ptr_ty = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::UNIT));
+        let pool = pool.freeze();
+        let mut fixture = FixtureCfg::new(
+            Type::UNIT,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        // The carrier body only has to verify; the plan under test is handed to
+        // the backend directly, not lowered from this graph.
+        fixture.ret(None);
+        let mir = fixture.lower_plan(|mir| {
+            let pointer = mir.alloc_vreg();
+            let written = mir.alloc_vreg();
+            crate::value_plan::IntrinsicPlan {
+                operation: rue_air::IntrinsicOperation::PtrWrite,
+                runtime_call: None,
+                option_discriminants: None,
+                bit_cast_form: None,
+                args: vec![
+                    arg_plan(pointer, 1, unit_ptr_ty),
+                    // The ill-typed operand: a sized value behind a `ptr mut ()`.
+                    arg_plan(written, 1, Type::I64),
+                ],
+                result_ty: Type::UNIT,
+                result_slots: 0,
+                scale: None,
+                narrow_access: None,
+                physical_slots: None,
+                dispatch_image: None,
+                image_padding: Vec::new(),
+                zero_sized_pointee_write: true,
+            }
+        });
+        assert!(
+            !mir.instructions().iter().any(|inst| matches!(
+                inst,
+                Aarch64Inst::StrIndexed { .. }
+                    | Aarch64Inst::NarrowStoreIndexed { .. }
+                    | Aarch64Inst::FloatStore { .. }
+            )),
+            "a zero-sized declared pointee must store nothing even when the value \
+             operand materialized a slot: {:?}",
             mir.instructions()
         );
     }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -592,6 +592,13 @@ pub struct IntrinsicPlan {
     /// backends refuse the store when either this flag or the materialized
     /// slot count says there are no bytes, so the two answers only ever
     /// subtract stores, never add one.
+    ///
+    /// Since RUE-2094 the two answers cannot actually differ on a graph the
+    /// backends can be handed: CFG verification re-proves the operand's type
+    /// against the pointee after optimization, and both answers are the same
+    /// function of that one type. This stays as the second line of defence for
+    /// a graph that reaches lowering without that proof — see the guard's own
+    /// comment in each backend for why deleting it is the wrong call.
     pub zero_sized_pointee_write: bool,
 }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2889,14 +2889,30 @@ impl<'a> CfgLower<'a> {
                 let ptr = plan.args[0].primary;
                 let value = &plan.args[1];
                 if plan.zero_sized_pointee_write || value.slot_count == 0 {
-                    // Nothing to store. The declared pointee's width is the
-                    // authority: a `ptr mut ()` write moves no bytes however
-                    // the value operand materialized, which is what keeps a
-                    // differently typed value forwarded into that operand from
-                    // becoming a store through the zero-sized sentinel address
-                    // (RUE-2086). The materialized slot count still answers for
-                    // a diverging operand, so the two only ever agree to store
-                    // nothing.
+                    // Nothing to store: a `ptr mut ()` write moves no bytes.
+                    //
+                    // The two halves cannot disagree on any graph this backend
+                    // can legally be handed. `CfgLower` takes a `ValidatedCfg`,
+                    // and verification proves an intrinsic operand's type
+                    // against the operation's signature after optimization
+                    // (RUE-2094) — for `@ptr_write` that forces the value
+                    // operand's type to BE the declared pointee, and both
+                    // halves are the same function of that one type.
+                    //
+                    // The disjunct is kept anyway, and must not be deleted on a
+                    // dead-code argument. It is what stands between an
+                    // ill-typed operand and memory corruption if a graph ever
+                    // reaches lowering without that proof: with RUE-2086's
+                    // forwarding fix absent and this test removed, the repro
+                    // stores eight bytes through a zero-sized type's sentinel
+                    // address and faults. Verification is the first line of
+                    // defence and is itself new code with a known hole (it does
+                    // not check user-call arguments); this is the second, and
+                    // the failure mode it converts is "no store" rather than
+                    // "wrong store". It is pinned by
+                    // `zero_sized_pointee_write_plan_stores_nothing_with_a_sized_operand`,
+                    // which has to build the plan directly because no verified
+                    // CFG can express the distinguishing shape.
                 } else if let Some(map) = &plan.physical_slots {
                     // A compact enum value: truncate each internal slot to its
                     // physical width at its compact byte offset (RUE-1000). The
@@ -4985,6 +5001,21 @@ mod tests {
 
     /// A CFG fixture under construction. Instructions append to `current`,
     /// which multi-block fixtures retarget as they go.
+    /// One intrinsic operand plan with the fields this backend's `@ptr_write`
+    /// arm reads: the vreg holding it, how many slots it materialized into, and
+    /// its type.
+    fn arg_plan(primary: VReg, slot_count: u32, ty: Type) -> crate::value_plan::IntrinsicArgPlan {
+        crate::value_plan::IntrinsicArgPlan {
+            primary,
+            slots: Vec::new(),
+            slot_count,
+            integer_extension: crate::value_plan::IntegerExtension::None,
+            place: None,
+            debug: crate::value_plan::DebugValuePlan::Other,
+            ty,
+        }
+    }
+
     struct FixtureCfg<'a> {
         cfg: Cfg,
         current: BlockId,
@@ -5149,6 +5180,26 @@ mod tests {
 
         fn ret(&mut self, result: Option<CfgValue>) {
             self.cfg.set_return(self.current, result);
+        }
+
+        /// Hand a hand-built `IntrinsicPlan` straight to the backend, below the
+        /// `ValidatedCfg` boundary.
+        ///
+        /// CFG verification proves an intrinsic operand's type against the
+        /// operation's signature after optimization (RUE-2094), so the one
+        /// shape that tells RUE-2086's two guard halves apart — a zero-sized
+        /// declared pointee with a *sized* value operand — can no longer be
+        /// expressed as a CFG at all. The plan is the last level at which it
+        /// still can, so the guard is pinned here rather than left untested.
+        fn lower_plan(
+            self,
+            build: impl FnOnce(&mut X86Mir) -> crate::value_plan::IntrinsicPlan,
+        ) -> X86Mir {
+            let cfg = self.cfg.finish(self.pool).expect("test CFG must verify");
+            let mut lower = CfgLower::new(&cfg, self.pool, self.interner);
+            let plan = build(&mut lower.mir);
+            lower.lower_intrinsic_plan(plan);
+            lower.mir
         }
 
         fn lower(self) -> rue_error::CompileResult<X86Mir> {
@@ -7831,9 +7882,17 @@ mod tests {
     /// `$n`. Value forwarding once handed the pointer stored in that shared
     /// slot to the `()`-typed load of the other local, and this arm — reading
     /// the materialized operand's slot count — emitted a real eight-byte store
-    /// through the zero-sized sentinel address. The ill-typed operand is
-    /// reproduced verbatim here so the arm is pinned independently of the
-    /// optimizer that produced it.
+    /// through the zero-sized sentinel address.
+    ///
+    /// The graph that forged that ill-typed operand is no longer
+    /// constructible: CFG verification re-proves every intrinsic's operand
+    /// types after optimization, so a `@ptr_write` whose value operand does
+    /// not match the pointer's declared pointee is an ICE at verification
+    /// rather than a store (RUE-2094, pinned in `rue-cfg`'s
+    /// `verify_rejects_intrinsic_operand_of_the_wrong_type`). The pointee
+    /// then decides the same thing the operand's width does, so what this
+    /// case still pins is the observable contract: a write through
+    /// `ptr mut ()` moves no bytes.
     #[test]
     fn zero_sized_pointee_write_emits_no_store() {
         let interner = ThreadedRodeo::new();
@@ -7850,10 +7909,11 @@ mod tests {
             &interner,
         );
         let address = fixture.konst(1, unit_ptr_ty);
+        let written = fixture.konst(0, Type::UNIT);
         fixture.intrinsic(
             rue_air::IntrinsicOperation::PtrWrite,
             "ptr_write",
-            &[address, address],
+            &[address, written],
             Type::UNIT,
         );
         let zero = fixture.konst(0, Type::I32);
@@ -7867,6 +7927,72 @@ mod tests {
                     | X86Inst::FloatStore { .. }
             )),
             "a zero-sized pointee write must store nothing: {:?}",
+            mir.instructions()
+        );
+    }
+
+    /// The one shape that tells RUE-2086's two guard halves apart, and the only
+    /// level at which it is still constructible.
+    ///
+    /// A zero-sized declared pointee with a *sized* value operand is exactly the
+    /// graph the RUE-2086 forwarding defect produced, and it is what
+    /// `plan.zero_sized_pointee_write` exists to refuse. CFG verification now
+    /// rejects it before code generation ever sees it (RUE-2094), so no fixture
+    /// built through `Cfg::finish` can reach this arm with the two halves
+    /// disagreeing — which would leave the disjunct with no coverage at all and
+    /// invite a future reader to delete it as dead. The plan is handed to the
+    /// backend directly so it stays pinned: without the disjunct this emits a
+    /// real store through a zero-sized type's sentinel address.
+    #[test]
+    fn zero_sized_pointee_write_plan_stores_nothing_with_a_sized_operand() {
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let unit_ptr_ty = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::UNIT));
+        let pool = pool.freeze();
+        let mut fixture = FixtureCfg::new(
+            Type::UNIT,
+            0,
+            "main",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        // The carrier body only has to verify; the plan under test is handed to
+        // the backend directly, not lowered from this graph.
+        fixture.ret(None);
+        let mir = fixture.lower_plan(|mir| {
+            let pointer = mir.alloc_vreg();
+            let written = mir.alloc_vreg();
+            crate::value_plan::IntrinsicPlan {
+                operation: rue_air::IntrinsicOperation::PtrWrite,
+                runtime_call: None,
+                option_discriminants: None,
+                bit_cast_form: None,
+                args: vec![
+                    arg_plan(pointer, 1, unit_ptr_ty),
+                    // The ill-typed operand: a sized value behind a `ptr mut ()`.
+                    arg_plan(written, 1, Type::I64),
+                ],
+                result_ty: Type::UNIT,
+                result_slots: 0,
+                scale: None,
+                narrow_access: None,
+                physical_slots: None,
+                dispatch_image: None,
+                image_padding: Vec::new(),
+                zero_sized_pointee_write: true,
+            }
+        });
+        assert!(
+            !mir.instructions().iter().any(|inst| matches!(
+                inst,
+                X86Inst::MovMRIndexed { .. }
+                    | X86Inst::NarrowStoreIndexed { .. }
+                    | X86Inst::FloatStore { .. }
+            )),
+            "a zero-sized declared pointee must store nothing even when the value \
+             operand materialized a slot: {:?}",
             mir.instructions()
         );
     }

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -785,7 +785,7 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
     }"#;
 
     for probe in 0..5 {
-        let mut state = query_cfg_state(source).expect("abort-preflight probe must compile");
+        let state = query_cfg_state(source).expect("abort-preflight probe must compile");
         let main_index = state
             .functions
             .iter()
@@ -803,8 +803,6 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
             (random, panic, panic_args, assertion, assert_args)
         };
 
-        let type_pool = state.type_pool().clone();
-        let cfg = &mut state.functions[main_index].cfg;
         let (outer, replacement_args, replacement_ty, expected) = match probe {
             0 => (
                 panic,
@@ -838,14 +836,20 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
             ),
             _ => unreachable!(),
         };
-        cfg.try_edit(&type_pool, |editor| {
-            editor.replace_intrinsic_args(outer, replacement_args)?;
-            editor.replace_inst_type(outer, replacement_ty)?;
-            Ok::<_, rue_cfg::CfgEditError>(())
-        })
-        .unwrap();
-
-        let cfg = &state.functions[main_index].cfg;
+        // The compiler's own CFG verifier re-proves every intrinsic's call
+        // shape after optimization (RUE-2094), so a graph carrying one of
+        // these malformed intrinsics can no longer be published at all. The
+        // oracle's preflight is a trust boundary for precisely the graphs
+        // verification did not produce — an injected fault, a future
+        // optimizer defect — so the probe is interpreted straight off an
+        // unpublished editor rather than round-tripped through a publisher
+        // whose job is now to reject it.
+        let mut malformed = state.functions[main_index].cfg.clone().into_editor();
+        malformed
+            .replace_intrinsic_args(outer, replacement_args)
+            .unwrap();
+        malformed.replace_inst_type(outer, replacement_ty).unwrap();
+        let cfg = &malformed;
         let mut interp = Interp {
             state: &state,
             stdout_trace: Vec::new(),


### PR DESCRIPTION
Fixes RUE-2094

RUE-2086 was a store-to-load forwarding hazard that substituted a `()`-typed value into a `@ptr_write` value operand. It reached code generation because nothing between the optimizer and the backends re-checks an intrinsic operand's type, and both backends derive an operand's marshalled width from the operand's *own* CFG type — so an ill-typed substitution silently rewrites the lowered call's ABI.

The CFG verifier already re-proves block parameters, branch conditions, return values, edge arguments, place reads, and `(slot, Type)` storage facts after optimization. Intrinsic operands were the one channel it did not cover, and the one this whole bug class flows through.

## What this does

`Verifier::verify_inst` rebuilds each intrinsic's operand descriptors from the CFG and re-runs `IntrinsicOperation::validate_call` — the same authority AIR emission, CFG construction, and the oracle already consume. There is no second signature table, and an `api_inventory` test pins that there never will be.

The operand's structural origin is recovered from the CFG too, so `@raw`/`@raw_mut`/`@field_ptr` are held to the place-read shape code generation needs when it takes an operand's address. The three shapes accepted are exactly the three `addressable_value_plan` can lower, so the check is neither tighter nor looser than the backends' own requirement.

A report names the operation, instruction, block, every operand with its type and origin, and the result type:

```
CFG verification failed in `main`: intrinsic PtrWrite instruction v17 in block bb0
no longer satisfies its call signature: operand 0 (v13) has type Type::new_ptr_mut(PtrMutTypeId(5))
from a computed value, operand 1 (v1) has type Type::UNIT from a computed value,
result type is Type::UNIT
```

## Scope: intrinsics, not user calls

A `Cfg` is a per-function artifact and `CfgInstData::Call` carries only a name, so checking an argument against its declared parameter type needs a program-wide signature table threaded through every verification entry point. That is a separate change. **A pure user-call argument shift with no intrinsic consumer is therefore still not caught** — the `inline_shift` shape from RUE-2086's review still miscompiles silently. A follow-up issue should carry that repro.

Verified against a compiler with RUE-2086's forwarding fix reverted: `rev_write` (printed `1`, correct is `5`) and `call_shift` (printed `9 0`, correct is `9 5`) become clean ICEs naming the operand; `inline_shift` is unchanged and uncaught.

## RUE-2086's codegen disjunct

`plan.zero_sized_pointee_write` is now redundant for every graph the backends can be handed: `CfgLower` takes a `ValidatedCfg`, verification forces the value operand's type to be the declared pointee, and both halves of the guard are the same function of that one type.

It is kept, because redundant is not unnecessary. With RUE-2086's forwarding fix reverted but the disjunct intact the repro compiles correctly; remove the disjunct as well and RUE-2086's eight-byte store through a zero-sized type's sentinel address comes back. Verification is the first line of defence and is itself new code with a known hole. Both backends' comments and the `IntrinsicPlan` field doc now say precisely this, so it is not deleted later on a dead-code argument, and a new per-backend test hands the distinguishing plan to the lowerer directly — the only level at which that shape is still constructible.

## Testing

- `scripts/rue premerge` — 220 pass, 0 fail (on this rebased tree)
- `scripts/rue test` (full) — 238 pass, 0 fail
- All six oracle-diff corpora plus the planted-miscompile gate — pass
- 51 example roots x `-O0..-O3` — zero over-rejections
- 56/56 emitted binaries byte-identical to the base compiler, so this cannot alter codegen output
- Performance: below the noise floor — paired CPU time within +-1%, and +0.7% of the `cfg_and_optimization` phase, which is under +0.1% of a compile