### PR TITLE
RUE-2083: a complete failure frame outranks a flooded stream

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -416,6 +416,48 @@ compile_stdout_contains = [
 compile_stdout_not_contains = ['output_overflow']
 
 [[case]]
+name = "a_panic_that_floods_stderr_keeps_its_class_and_notes_the_flood"
+description = """
+RUE-2083: the channel's message bound and the stream budgets are independent,
+so a `@panic` message past 1 MiB writes a complete, bounded frame and still
+floods stderr. The frame is the failure — `trap:panic`, exit 101, its own site —
+and the flood is published beside it as the record's `runner_note` rather than
+as a `kind` that disagrees with the frame it sits next to.
+"""
+contract = "heavyweight_long"
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+test "floods stderr with its own message" {
+    let mut message = std.strbuf.StrBuf.from_str(borrow "HEAD");
+    let mut i: u64 = 0;
+    while i < 1200000 {
+        message.push(120);
+        i = i + 1;
+    }
+    @panic(message);
+}
+""" },
+]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"failure":{"exit_code":101,"kind":"trap:panic","location":{"column":5,"file":"tests.rue","line":10},"message":"panic: HEADxxxxx',
+    '"runner_note":"stderr exceeded its 1048576-byte retention budget; the process group was killed"}',
+    '"verdict":"fail"',
+]
+compile_stdout_not_contains = ['output_overflow']
+
+[[case]]
 name = "a_panic_message_that_is_not_utf8_still_reports_its_class"
 description = """
 RUE-2064: a Rue string is an arbitrary byte sequence, so a `@panic` message can

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -25,8 +25,9 @@
 //! its verdict: the runner kills the process group and publishes
 //! `output_overflow` in place of the class and the exit status the record was
 //! carrying. Stderr, which has no such role, still prints the message whole
-//! within its own retention budget — a message large enough to exhaust that
-//! budget too still overflows there.
+//! within its own retention budget — and a message large enough to exhaust
+//! that budget too still keeps its verdict, because the bounded record outranks
+//! a stream's flood (RUE-2083).
 //!
 //! Records reserved by §5.1 and §5.2 — `promotion` payloads and per-case
 //! `sub_result` identities — are named by the schema and produced by nothing in

--- a/crates/rue/src/test_mode/events.rs
+++ b/crates/rue/src/test_mode/events.rs
@@ -166,7 +166,8 @@ pub(crate) struct FailureRecord {
     /// A comparison failure's two rendered operands and the diff between them
     /// (ADR-0083 Phase 2.5). **Absent** on every other failure.
     pub(crate) comparison: Option<Comparison>,
-    /// The runner's own explanation, when it could not trust what it read.
+    /// The runner's own explanation: it could not trust what it read, or it
+    /// killed the group for a flood that a failure frame outranked (RUE-2083).
     pub(crate) runner_note: Option<String>,
     /// The compiler diagnostics behind a `compile_error` verdict, as the same
     /// JSON objects `--error-format json` emits for them (ADR-0083 §3).

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -1067,11 +1067,7 @@ fn failure_message(
         FailureKind::Incomplete => {
             "the test exited 0 without the dispatcher's completion record".to_owned()
         }
-        FailureKind::OutputOverflow(overflow) => format!(
-            "{} exceeded its {}-byte retention budget; the process group was killed",
-            overflow.stream.name(),
-            overflow.budget
-        ),
+        FailureKind::OutputOverflow(overflow) => overflow.describe(),
         FailureKind::Assert
         | FailureKind::AssertEq
         | FailureKind::AssertNe

--- a/crates/rue/src/test_mode/verdict.rs
+++ b/crates/rue/src/test_mode/verdict.rs
@@ -330,6 +330,26 @@ pub(crate) struct Overflow {
     pub(crate) budget: usize,
 }
 
+impl Overflow {
+    /// The one sentence the runner publishes about a flood, whether as the
+    /// failure's message or as the note beside a frame that outranked it.
+    pub(crate) fn describe(self) -> String {
+        format!(
+            "{} exceeded its {}-byte retention budget; the process group was killed",
+            self.stream.name(),
+            self.budget
+        )
+    }
+
+    /// Whether a failure frame read from the channel can still be trusted
+    /// after this flood. A flooded stream says nothing about the channel; a
+    /// flooded channel was cut mid-record, so nothing read from it can vouch
+    /// for the test's own account of its failure.
+    fn leaves_channel_intact(self) -> bool {
+        self.stream != CaptureStream::Channel
+    }
+}
+
 /// How the runner's own supervision ended a test, before its exit status is
 /// consulted at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -370,6 +390,14 @@ pub(crate) struct Classification {
 /// pass or as a bare exit with no explanation. Only then is the process's own
 /// account of itself consulted — a failure frame ahead of the exit status,
 /// since the frame carries structure the status cannot.
+///
+/// One supervision outcome yields to that account: a flooded stdout or stderr
+/// beside a well-formed failure frame (RUE-2083). The frame already says why
+/// the test failed — a `@panic` whose message outgrew stderr's budget is
+/// still a `trap:panic` at a site with an exit status — and the flood is a
+/// fact about the capture, published as the record's `runner_note`, not a
+/// second classification of the same failure. A flooded channel gets no such
+/// deference: it was cut mid-record, so it cannot vouch for its own frames.
 pub(crate) fn classify(observation: Observation<'_>) -> Classification {
     let frames = observation.frames;
     match observation.supervision {
@@ -380,6 +408,14 @@ pub(crate) fn classify(observation: Observation<'_>) -> Classification {
             };
         }
         Supervision::OutputOverflow(overflow) => {
+            if overflow.leaves_channel_intact() && frames.malformed.is_none() {
+                if let Some(failure) = &frames.failure {
+                    return Classification {
+                        verdict: Verdict::Fail(FailureKind::reported(&failure.kind)),
+                        runner_note: Some(overflow.describe()),
+                    };
+                }
+            }
             return Classification {
                 verdict: Verdict::Fail(FailureKind::OutputOverflow(overflow)),
                 runner_note: None,
@@ -692,6 +728,89 @@ mod tests {
         assert_eq!(CaptureStream::Stdout.name(), "stdout");
         assert_eq!(CaptureStream::Stderr.name(), "stderr");
         assert_eq!(CaptureStream::Channel.name(), "the failure channel");
+    }
+
+    /// RUE-2083: a `@panic` whose message outgrows stderr's budget still wrote
+    /// a complete frame to the channel, and that frame is the failure. The
+    /// flood is published beside it as the runner's note rather than as a
+    /// second, disagreeing classification.
+    #[test]
+    fn a_flooded_stream_yields_to_a_complete_failure_frame() {
+        let overflow = Overflow {
+            stream: CaptureStream::Stderr,
+            budget: 1024 * 1024,
+        };
+        let frames = ChannelFrames {
+            failure: Some(FailureFrame {
+                kind: "trap:panic".to_owned(),
+                message: "panic: HEAD".to_owned(),
+                ..FailureFrame::default()
+            }),
+            ..ChannelFrames::default()
+        };
+        let classified = classify(Observation {
+            supervision: Supervision::OutputOverflow(overflow),
+            status: Ok(101),
+            stderr: b"panic: HEAD",
+            frames: &frames,
+        });
+        assert_eq!(
+            classified.verdict,
+            Verdict::Fail(FailureKind::Trap("panic"))
+        );
+        assert_eq!(
+            classified.runner_note.as_deref(),
+            Some("stderr exceeded its 1048576-byte retention budget; the process group was killed")
+        );
+    }
+
+    /// The deference is to a frame the runner can trust. A flooded channel was
+    /// cut mid-record, and a malformed channel could not be read at all, so
+    /// neither lets a frame outrank the overflow.
+    #[test]
+    fn a_flooded_or_unreadable_channel_still_reports_the_overflow() {
+        let frame = FailureFrame {
+            kind: "trap:panic".to_owned(),
+            ..FailureFrame::default()
+        };
+        let channel = Overflow {
+            stream: CaptureStream::Channel,
+            budget: 256 * 1024,
+        };
+        let flooded_channel = classify(Observation {
+            supervision: Supervision::OutputOverflow(channel),
+            status: Err(9),
+            stderr: b"",
+            frames: &ChannelFrames {
+                failure: Some(frame.clone()),
+                ..ChannelFrames::default()
+            },
+        });
+        assert_eq!(
+            flooded_channel.verdict,
+            Verdict::Fail(FailureKind::OutputOverflow(channel))
+        );
+        assert_eq!(flooded_channel.runner_note, None);
+
+        let stdout = Overflow {
+            stream: CaptureStream::Stdout,
+            budget: 1024 * 1024,
+        };
+        let malformed = classify(Observation {
+            supervision: Supervision::OutputOverflow(stdout),
+            status: Err(9),
+            stderr: b"",
+            frames: &ChannelFrames {
+                failure: Some(frame),
+                malformed: Some("not JSON".to_owned()),
+                ..ChannelFrames::default()
+            },
+        });
+        assert_eq!(
+            malformed.verdict,
+            Verdict::Fail(FailureKind::OutputOverflow(stdout))
+        );
+        assert_eq!(malformed.runner_note, None);
     }
 
     /// A channel the runner could not read is never silently ignored — least

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -131,9 +131,10 @@ answers an exhausted channel by killing the process group and publishing
 `output_overflow` — losing the class and the exit status the record was carrying
 (RUE-2064). Stderr has no such role and still prints the message whole within
 its own 1 MiB retention budget, so the two routes to a trap agree except on the
-tail of a message past the bound. The bound buys the verdict back only up to
-that budget: a message long enough to exhaust stderr's own retention still
-overflows there, and is still published as `output_overflow`.
+tail of a message past the bound. A message long enough to exhaust stderr's own
+retention still overflows there, but the bounded frame outranks that flood
+(RUE-2083): the verdict keeps its `trap:panic`, and the flood is the record's
+`runner_note`.
 
 **Every string field is JSON text.** A Rue string is an arbitrary byte sequence,
 so a `message`, a `payload`, or a rendered operand can carry bytes that are not
@@ -303,7 +304,7 @@ consumers already handle instead of adding one.
 | `right` | string | Its right operand, rendered. Present exactly when `left` is. |
 | `diff` | array | The runner's diff from `left` to `right`. Present exactly when `left` is. |
 | `diagnostics` | array | The compiler diagnostics behind a `compile_error`, each the object `--error-format json` publishes for it ([diagnostics.md](diagnostics.md)). **Absent** on every other failure. |
-| `runner_note` | string | The runner's own explanation. **Absent** unless the runner could not trust what it read. |
+| `runner_note` | string | The runner's own explanation. **Absent** unless the runner could not trust what it read, or killed the group for a stream flood that a failure frame outranked. |
 
 `line` and `column` are both 1-based, and `column` counts Unicode scalars rather
 than bytes — the same coordinate the compiler's own diagnostics print for the
@@ -425,6 +426,14 @@ mid-line would otherwise surface as an unreadable frame and a bare `exit`,
 describing the symptom rather than the flood. Reading continues past the budget
 so `bytes_total` is the true count.
 
+One flood is outranked. A test that floods stdout or stderr and also writes a
+well-formed `failure` frame — a `@panic` whose message outgrows stderr's budget
+is the ordinary way — keeps the frame's kind, exit status, and location, and the
+flood becomes the record's `runner_note` (RUE-2083): the frame already says why
+the test failed, and the flood is a fact about the capture rather than a second
+classification of the same failure. A flooded channel is never outranked; it was
+cut mid-record and cannot vouch for its own frames.
+
 That window is sized for a machine, so the human renderer bounds what it prints
 of it: at most 64 lines or 8 KiB per stream, as a 48-line head and a 16-line
 tail with one line naming the lines and bytes skipped between them. Lines are
@@ -537,7 +546,7 @@ it before the run began.
 | `fail` | `unhandled_error` | A `failure` frame with that kind — the test-body `?` failure arm. |
 | `fail` | *(verbatim)* | A `failure` frame with a kind the runner does not know (ADR-0083 §5.1). |
 | `fail` | `exit` | Any other nonzero exit. |
-| `fail` | `output_overflow` | A stream budget was exhausted; the group was killed. |
+| `fail` | `output_overflow` | A capture budget was exhausted and the group was killed, with no well-formed `failure` frame to outrank a stream's flood. |
 | `timeout` | `timeout` | The per-test budget expired; the group was killed. |
 | `crash` | `signal` | Killed by a signal, SIGPIPE included. The `signal` field carries the number. |
 | `compile_error` | `compile_error` | The test's closure failed to analyze, so it was excluded from the image and no process ran. See below. |
@@ -612,7 +621,9 @@ Precedence, in order:
 
 1. **The runner's own supervision** — a timeout or an output overflow — because
    the runner's kill is what produced the signal death that would otherwise read
-   as a crash.
+   as a crash. A flooded stdout or stderr beside a well-formed `failure` frame
+   is the one exception: the frame classifies the failure and the flood is its
+   `runner_note` (RUE-2083). A flooded channel stays `output_overflow`.
 2. **A malformed channel line.** An unreadable failure report is never silently
    ignored: the verdict is `fail` with kind `exit` and a `runner_note` saying so,
    even when the process otherwise looks like a pass.


### PR DESCRIPTION
Fixes [RUE-2083](https://linear.app/steve-klabnik/issue/RUE-2083).

## Problem

The channel's message bound (RUE-2064) and the stream budgets are independent, so a `@panic` whose message is past 1 MiB writes a complete, correctly bounded `trap:panic` frame to the channel and still floods stderr. The published record was then internally inconsistent: `kind` came from supervision (`output_overflow`), while the message, exit status, and location came from the frame sitting next to it.

## Change

The issue offered two designs and asked for a maintainer call. This PR takes option 1: a well-formed failure frame outranks a flooded stdout or stderr. The frame already says why the test failed; the flood is a fact about the capture, so it becomes the record's `runner_note`, in the same spelling the overflow message used (now built in one place, `Overflow::describe`). Reversing to option 2 would be a small change confined to `classify` if you prefer it.

Two things are deliberately not outranked:

- A flooded **channel** was cut mid-record and cannot vouch for its own frames, so it stays `output_overflow`.
- A **malformed** channel is still never outranked.

`docs/process/test-events.md` updates the precedence list, the budgets section, the `output_overflow` taxonomy row, and the `runner_note` row. The `rue-runtime` channel module comment that said a stderr flood still costs the verdict is corrected.

## Tests

- Two unit tests in `verdict.rs`: a stderr flood beside a complete frame keeps the frame's kind with an overflow note; a flooded or malformed channel still reports `output_overflow` with no note.
- A CLI case pins the issue's repro end to end: a 1.2 MB `@panic` message yields `trap:panic`, exit 101, the frame's location, and the stderr runner note, with no `output_overflow` anywhere in the stream.
- Ran locally: `scripts/rue quick`, `scripts/rue unit rue test_mode`, the new case plus the three neighbouring overflow and long-panic CLI cases, and the oracle-diff target. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEHdMtLGAdvXY8GsGyCTza

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEHdMtLGAdvXY8GsGyCTza)_