### PR TITLE
RUE-2089: one cycle driver for the executable and the test image

### DIFF
--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -5,7 +5,9 @@ use rue_compiler::unstable::{
     CancellableCompileOutcome, CancellableTestImageOutcome, CompilationCancellation,
     OneShotMetrics, TestCompileFailure, TestImage, TestInventory,
 };
-use rue_compiler::{CompileOptions, CompileWarning, LinkerMode};
+use rue_compiler::{
+    CompileErrors, CompileOptions, CompileOutput, CompileWarning, LinkerMode, MultiErrorResult,
+};
 use rue_driver::{FilesystemCompilerHost, WatchInput};
 
 use crate::DiagnosticOutput;
@@ -78,20 +80,18 @@ impl PublishedExecutable {
     }
 }
 
-/// One compile cycle: destination preflight, compile, publish, warnings, and
-/// the success line.
+/// One executable cycle: discovery gate, destination preflight, compile,
+/// publish, warnings, and the success line.
 ///
 /// The batch driver runs it once and the watch loop runs it per revision, so
 /// there is one implementation of each of those steps rather than two that
-/// drift. What a watch cycle adds — the change monitor, cancellation,
-/// re-observation, and the cycle's own progress text — stays in `watch`, which
-/// reads the report this returns and decides what to say and whether to keep
-/// looping.
+/// drift (RUE-1969). What a watch cycle adds — the change monitor,
+/// cancellation, re-observation, and the cycle's own progress text — stays in
+/// `watch`, which reads the report this returns and decides what to say and
+/// whether to keep looping.
 ///
-/// The discovery gate is not a step here: the host's compile-scope entry
-/// points refuse an unclosed import graph and hand back discovery's own
-/// diagnostics, so a cycle reports the unresolved `@import` through the
-/// ordinary compile-failure path whichever driver runs it (RUE-1969).
+/// The steps themselves are [`drive`], shared with the test-image cycle; this
+/// request adds only what is the executable's alone, the success line.
 pub(crate) struct CycleRequest<'a, 'diagnostics> {
     pub(crate) host: &'a mut FilesystemCompilerHost,
     pub(crate) options: &'a CompileOptions,
@@ -147,11 +147,15 @@ pub(crate) enum Supersession {
 /// The outcome of a cycle. Every diagnostic it produced is already on the
 /// diagnostic stream; the report says what happened so the caller can pick an
 /// exit status or a progress line.
-pub(crate) enum CycleReport {
-    /// The executable reached the output path. Boxed because the one-shot
-    /// metrics it carries dwarf every other outcome, and a report is built
-    /// once per cycle.
-    Published(Box<PublishedExecutable>),
+///
+/// `Published` carries what the artifact's cycle promises once its bytes are
+/// at the output path: the executable's metrics, or the test image's
+/// inventory. The other three outcomes are the same for both.
+pub(crate) enum CycleReport<Published = PublishedExecutable> {
+    /// The artifact reached the output path. Boxed because the one-shot
+    /// metrics an executable carries dwarf every other outcome, and a report
+    /// is built once per cycle.
+    Published(Box<Published>),
     /// The program was rejected, or the destination or publication was
     /// refused.
     Failed,
@@ -172,7 +176,183 @@ pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
         observation,
         announcement,
     } = request;
+    let report = drive::<CompileOutput>(
+        host,
+        options,
+        diagnostics,
+        Path::new(output_path),
+        observation,
+    );
+    if let CycleReport::Published(_) = &report {
+        announce(announcement, source_path, output_path, options);
+    }
+    report
+}
 
+/// What one cycle compiles and publishes.
+///
+/// The executable cycle and the test-image cycle differ in exactly two places:
+/// what the host is asked to compile, and what rides beside the linked bytes
+/// from that compile to the report. Everything between — the discovery gate,
+/// the destination preflight, the supersession check, publication, the
+/// warnings, the publication outcome — is one sequence, [`drive`], written
+/// once over this trait rather than once per artifact (RUE-2089). A change to
+/// the order of those steps has one home.
+trait CycleArtifact: Sized {
+    /// What rides beside the linked output from the compile to the report.
+    type Companion;
+    /// What the report carries once the bytes are at the output path.
+    type Published;
+
+    fn compile(
+        host: &mut FilesystemCompilerHost,
+        options: &CompileOptions,
+    ) -> MultiErrorResult<Self>;
+
+    fn compile_cancellable(
+        host: &mut FilesystemCompilerHost,
+        options: &CompileOptions,
+        cancellation: CompilationCancellation,
+    ) -> Compiled<Self>;
+
+    /// Split the artifact into the output every cycle links and publishes and
+    /// the part that is this artifact's own.
+    fn into_parts(self) -> (CompileOutput, Self::Companion);
+
+    /// Diagnostics the companion carries, printed after the warnings and
+    /// before the publication outcome so a failed publication cannot discard
+    /// them. The executable has none.
+    fn print_companion_diagnostics(
+        _companion: &Self::Companion,
+        _diagnostics: &DiagnosticOutput<'_>,
+    ) {
+    }
+
+    fn published(companion: Self::Companion, executable: PublishedExecutable) -> Self::Published;
+}
+
+/// A cancellable compile's answer, in one spelling for every artifact.
+enum Compiled<Artifact> {
+    Completed(Artifact),
+    Errors(CompileErrors),
+    Canceled,
+}
+
+impl CycleArtifact for CompileOutput {
+    type Companion = ();
+    type Published = PublishedExecutable;
+
+    fn compile(
+        host: &mut FilesystemCompilerHost,
+        options: &CompileOptions,
+    ) -> MultiErrorResult<Self> {
+        host.executable_in_compile_scope(options)
+    }
+
+    fn compile_cancellable(
+        host: &mut FilesystemCompilerHost,
+        options: &CompileOptions,
+        cancellation: CompilationCancellation,
+    ) -> Compiled<Self> {
+        match host.cancellable_executable_in_compile_scope(options, cancellation) {
+            CancellableCompileOutcome::Completed(output) => Compiled::Completed(*output),
+            CancellableCompileOutcome::Errors(errors) => Compiled::Errors(errors),
+            CancellableCompileOutcome::Canceled => Compiled::Canceled,
+        }
+    }
+
+    fn into_parts(self) -> (CompileOutput, ()) {
+        (self, ())
+    }
+
+    fn published((): (), executable: PublishedExecutable) -> PublishedExecutable {
+        executable
+    }
+}
+
+/// What a test image carries beside its linked bytes (ADR-0083 §3).
+struct TestImageCompanion {
+    inventory: TestInventory,
+    compile_failures: Vec<TestCompileFailure>,
+    failure_diagnostics: CompileErrors,
+}
+
+impl CycleArtifact for TestImage {
+    type Companion = TestImageCompanion;
+    type Published = PublishedTestImage;
+
+    fn compile(
+        host: &mut FilesystemCompilerHost,
+        options: &CompileOptions,
+    ) -> MultiErrorResult<Self> {
+        host.test_image_in_compile_scope(options)
+    }
+
+    fn compile_cancellable(
+        host: &mut FilesystemCompilerHost,
+        options: &CompileOptions,
+        cancellation: CompilationCancellation,
+    ) -> Compiled<Self> {
+        match host.cancellable_test_image_in_compile_scope(options, cancellation) {
+            CancellableTestImageOutcome::Completed(image) => Compiled::Completed(*image),
+            CancellableTestImageOutcome::Errors(errors) => Compiled::Errors(errors),
+            CancellableTestImageOutcome::Canceled => Compiled::Canceled,
+        }
+    }
+
+    fn into_parts(self) -> (CompileOutput, TestImageCompanion) {
+        let TestImage {
+            output,
+            inventory,
+            compile_failures,
+            failure_diagnostics,
+        } = self;
+        (
+            output,
+            TestImageCompanion {
+                inventory,
+                compile_failures,
+                failure_diagnostics,
+            },
+        )
+    }
+
+    /// stderr is the authoritative diagnostic stream and carries the closure's
+    /// own analysis failures exactly as a whole-request failure would have:
+    /// once, in the run's own `--error-format`, before any event. The copies
+    /// inside the `compile_error` events are the attribution (ADR-0083 §3).
+    /// They are published here rather than by the run, and so whatever the
+    /// selection turns out to be, because the closure that produced them is
+    /// the WHOLE closure: a filter narrows the run set, never the analysis
+    /// root set, and a filtered run that silently swallowed a broken test file
+    /// would be the papercut the unimported-test-file warning exists to
+    /// prevent.
+    fn print_companion_diagnostics(
+        companion: &TestImageCompanion,
+        diagnostics: &DiagnosticOutput<'_>,
+    ) {
+        if !companion.failure_diagnostics.is_empty() {
+            diagnostics.print_errors(&companion.failure_diagnostics);
+        }
+    }
+
+    fn published(companion: TestImageCompanion, _: PublishedExecutable) -> PublishedTestImage {
+        PublishedTestImage {
+            inventory: companion.inventory,
+            compile_failures: companion.compile_failures,
+        }
+    }
+}
+
+/// The one cycle both artifacts run: discovery gate, destination preflight,
+/// compile, publish, warnings, publication outcome.
+fn drive<Artifact: CycleArtifact>(
+    host: &mut FilesystemCompilerHost,
+    options: &CompileOptions,
+    diagnostics: &DiagnosticOutput<'_>,
+    output_path: &Path,
+    observation: CycleObservation<'_>,
+) -> CycleReport<Artifact::Published> {
     // A revision whose import graph did not close valid is reported as that
     // and nothing else: the unresolved `@import` is the user's problem, and
     // the destination preflight's answer about the output path would only bury
@@ -188,7 +368,7 @@ pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
     // destination can be validated before any semantic, codegen, or link work
     // and the set retained for mandatory revalidation immediately before the
     // atomic publication.
-    let destination = match preflight(Path::new(output_path), host, &observation) {
+    let destination = match preflight(output_path, host, &observation) {
         Ok(destination) => destination,
         Err(error) => {
             diagnostics.print_error(&error.into_compile_error());
@@ -196,26 +376,20 @@ pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
         }
     };
 
-    let linked = match observation {
-        CycleObservation::OneShot => match host.executable_in_compile_scope(options) {
-            Ok(output) => linked_executable(
-                output,
-                options,
-                destination,
-                PublicationObservation::OneShot,
-            ),
+    let (artifact, observation) = match observation {
+        CycleObservation::OneShot => match Artifact::compile(host, options) {
+            Ok(artifact) => (artifact, PublicationObservation::OneShot),
             Err(errors) => {
                 diagnostics.print_errors(&errors);
                 return CycleReport::Failed;
             }
         },
         CycleObservation::Watch {
-            ref inputs,
-            ref cancellation,
+            inputs,
+            cancellation,
             superseded,
         } => {
-            let outcome =
-                host.cancellable_executable_in_compile_scope(options, cancellation.clone());
+            let outcome = Artifact::compile_cancellable(host, options, cancellation);
             // A superseded cycle describes bytes that no longer exist. Check
             // before reporting, so a transient error the user has already
             // fixed never reaches the terminal.
@@ -223,20 +397,17 @@ pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
                 return CycleReport::Superseded(Supersession::BeforePublication);
             }
             match outcome {
-                CancellableCompileOutcome::Completed(output) => linked_executable(
-                    *output,
-                    options,
-                    destination,
-                    PublicationObservation::Watch(inputs.clone()),
-                ),
-                CancellableCompileOutcome::Errors(errors) => {
+                Compiled::Completed(artifact) => (artifact, PublicationObservation::Watch(inputs)),
+                Compiled::Errors(errors) => {
                     diagnostics.print_errors(&errors);
                     return CycleReport::Failed;
                 }
-                CancellableCompileOutcome::Canceled => return CycleReport::Canceled,
+                Compiled::Canceled => return CycleReport::Canceled,
             }
         }
     };
+    let (output, companion) = artifact.into_parts();
+    let linked = linked_executable(output, options, destination, observation);
 
     // Publication runs after the compiler's timing root closes, so it is
     // measured as a driver phase: it breaks down process-minus-root overhead
@@ -245,13 +416,14 @@ pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
         let _span = tracing::info_span!("output_write", driver_phase = true).entered();
         linked.publish()
     };
-    // Warnings live outside the publication result so a failure cannot discard
-    // them; present them before inspecting the publication outcome.
+    // Warnings, and whatever diagnostics the artifact carries beside them,
+    // live outside the publication result so a failure cannot discard them;
+    // present them before inspecting the publication outcome.
     diagnostics.print_warnings(&publication.warnings);
+    Artifact::print_companion_diagnostics(&companion, diagnostics);
     match publication.result {
-        Ok(published) => {
-            announce(announcement, source_path, output_path, options);
-            CycleReport::Published(Box::new(published))
+        Ok(executable) => {
+            CycleReport::Published(Box::new(Artifact::published(companion, executable)))
         }
         Err(PublishError::InputsChanged) => CycleReport::Superseded(Supersession::AtPublication),
         Err(error) => {
@@ -333,13 +505,13 @@ pub(crate) struct PublishedTestImage {
 
 /// One test-image cycle, the test-mode twin of [`CycleRequest`].
 ///
-/// Same steps in the same order as [`drive_cycle`] — discovery gate,
-/// destination preflight, compile, publish, warnings — over the request's test
-/// root set instead of its executable one, so `rue test` and `rue test --watch`
-/// reach the image through one orchestration rather than two (RUE-2023). What
-/// a watch cycle adds around it stays in `watch`, exactly as it does for the
-/// executable cycle; what a test cycle adds *after* it — the run — is
-/// `test_mode`'s.
+/// The same [`drive`] as the executable cycle — discovery gate, destination
+/// preflight, compile, publish, warnings — over the request's test root set
+/// instead of its executable one, so `rue test` and `rue test --watch` reach
+/// the image through the one orchestration `rue build` and `rue build --watch`
+/// use (RUE-2023, RUE-2089). What a watch cycle adds around it stays in
+/// `watch`, exactly as it does for the executable cycle; what a test cycle
+/// adds *after* it — the run — is `test_mode`'s.
 pub(crate) struct TestCycleRequest<'a, 'diagnostics> {
     pub(crate) host: &'a mut FilesystemCompilerHost,
     pub(crate) options: &'a CompileOptions,
@@ -351,18 +523,9 @@ pub(crate) struct TestCycleRequest<'a, 'diagnostics> {
     pub(crate) observation: CycleObservation<'a>,
 }
 
-/// The outcome of a test-image cycle, on the same terms as [`CycleReport`].
-pub(crate) enum TestCycleReport {
-    /// The image reached the cycle's image path and can be run.
-    Published(Box<PublishedTestImage>),
-    /// The request was rejected outside every test closure, or the image could
-    /// not be staged. Diagnostics are already on the diagnostic stream.
-    Failed,
-    /// A newer source revision arrived before the image could be published.
-    Superseded(Supersession),
-    /// The image build was canceled without a newer revision being observed.
-    Canceled,
-}
+/// The outcome of a test-image cycle: [`CycleReport`] carrying the image's
+/// inventory instead of the executable's metrics.
+pub(crate) type TestCycleReport = CycleReport<PublishedTestImage>;
 
 pub(crate) fn drive_test_cycle(request: TestCycleRequest<'_, '_>) -> TestCycleReport {
     let TestCycleRequest {
@@ -372,105 +535,5 @@ pub(crate) fn drive_test_cycle(request: TestCycleRequest<'_, '_>) -> TestCycleRe
         image_path,
         observation,
     } = request;
-
-    // The same gate the executable cycle opens with, and for the same reason:
-    // an unresolved `@import` is the user's problem and is reported as itself
-    // rather than as whatever the staging preflight would have said (RUE-810).
-    if let Some(errors) = host.discovery_refusal() {
-        diagnostics.print_errors(&errors);
-        return TestCycleReport::Failed;
-    }
-
-    let destination = match preflight(image_path, host, &observation) {
-        Ok(destination) => destination,
-        Err(error) => {
-            diagnostics.print_error(&error.into_compile_error());
-            return TestCycleReport::Failed;
-        }
-    };
-
-    let image = match observation {
-        CycleObservation::OneShot => match host.test_image_in_compile_scope(options) {
-            Ok(image) => image,
-            Err(errors) => {
-                diagnostics.print_errors(&errors);
-                return TestCycleReport::Failed;
-            }
-        },
-        CycleObservation::Watch {
-            ref cancellation,
-            superseded,
-            ..
-        } => {
-            let outcome =
-                host.cancellable_test_image_in_compile_scope(options, cancellation.clone());
-            // A superseded cycle describes an image the user's source no longer
-            // asks for. Check before reporting, so a transient error already
-            // fixed on disk never reaches the terminal.
-            if superseded() {
-                return TestCycleReport::Superseded(Supersession::BeforePublication);
-            }
-            match outcome {
-                CancellableTestImageOutcome::Completed(image) => *image,
-                CancellableTestImageOutcome::Errors(errors) => {
-                    diagnostics.print_errors(&errors);
-                    return TestCycleReport::Failed;
-                }
-                CancellableTestImageOutcome::Canceled => return TestCycleReport::Canceled,
-            }
-        }
-    };
-
-    let TestImage {
-        output,
-        inventory,
-        compile_failures,
-        failure_diagnostics,
-    } = image;
-    let metrics = output.unstable_metrics();
-    let linked = LinkedExecutable {
-        target: options.target,
-        warnings: output.warnings,
-        metrics,
-        linked_bytes: output.elf,
-        destination,
-        observation: match observation {
-            CycleObservation::OneShot => PublicationObservation::OneShot,
-            CycleObservation::Watch { inputs, .. } => PublicationObservation::Watch(inputs),
-        },
-    };
-    let publication = {
-        let _span = tracing::info_span!("output_write", driver_phase = true).entered();
-        linked.publish()
-    };
-    // Warnings and the closure's own analysis failures live outside the
-    // publication result so a failed publication cannot discard them, exactly
-    // as the executable cycle treats its warnings.
-    //
-    // stderr is the authoritative diagnostic stream and carries the failures
-    // exactly as a whole-request failure would have: once, in the run's own
-    // `--error-format`, before any event. The copies inside the `compile_error`
-    // events are the attribution (ADR-0083 §3). They are published here rather
-    // than by the run, and so whatever the selection turns out to be, because
-    // the closure that produced them is the WHOLE closure: a filter narrows the
-    // run set, never the analysis root set, and a filtered run that silently
-    // swallowed a broken test file would be the papercut the
-    // unimported-test-file warning exists to prevent.
-    diagnostics.print_warnings(&publication.warnings);
-    if !failure_diagnostics.is_empty() {
-        diagnostics.print_errors(&failure_diagnostics);
-    }
-    match publication.result {
-        Ok(_) => TestCycleReport::Published(Box::new(PublishedTestImage {
-            inventory,
-            compile_failures,
-        })),
-        Err(PublishError::InputsChanged) => {
-            TestCycleReport::Superseded(Supersession::AtPublication)
-        }
-        Err(error) => {
-            diagnostics.print_error(&error.into_compile_error());
-            TestCycleReport::Failed
-        }
-    }
+    drive::<TestImage>(host, options, diagnostics, image_path, observation)
 }


### PR DESCRIPTION
Fixes [RUE-2089](https://linear.app/steve-klabnik/issue/RUE-2089).

## Problem

RUE-2023 gave `rue test --watch` its own cycle body, `drive_test_cycle`, which reused every piece `drive_cycle` had established but wrote the sequence of those pieces out a second time. Gate, preflight, compile, supersession check, publish, warnings, and the publication outcome lived in two hundred-line copies in `compile.rs`, differing only in which host method they called and in the test image's failure diagnostics printed beside the warnings. A change to the order had two homes.

## Change

The sequence is now one generic `drive`, parameterized over a private `CycleArtifact` trait with two implementations: the executable's `CompileOutput`, and `TestImage`. An artifact says:

- how the host compiles it, one-shot and cancellable, with the cancellable outcome flattened into one `Compiled` spelling;
- how it splits into the output every cycle links and the companion that rides beside it (nothing for the executable; inventory, compile failures, and failure diagnostics for the test image);
- what it prints after the warnings (the test image's failure diagnostics, with their existing rationale comment moved onto that method);
- what it reports once published.

`CycleReport` becomes generic over that published part, with the executable's as its default, and `TestCycleReport` is an alias of it rather than a second enum. `drive_cycle` is the executable's thin wrapper, adding the success line; `drive_test_cycle` is the test image's, adding nothing. Both callers (`main.rs`, `watch.rs`, `test_mode`) are unchanged.

The `CycleRequest` doc no longer claims the discovery gate is not a step here. It has been the first step since RUE-810.

No behavior change is intended. The diff is net positive in lines because the trait scaffolding is explicit, but the orchestration order now has exactly one home.

## Tests

Existing coverage only; no new cases, since the behavior is unchanged. Ran locally: `scripts/rue quick`, the whole `rue` crate unit suite, the `rue` and `rue-driver` clippy gates, and the `watch` and `rue_test` CLI sections. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEHdMtLGAdvXY8GsGyCTza

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEHdMtLGAdvXY8GsGyCTza)_