### PR TITLE
RUE-2102: verify preserved CFG call contracts

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -16,8 +16,8 @@ use std::rc::Rc;
 
 use crate::CfgOutput;
 use crate::inst::{
-    BlockId, Cfg, CfgArgMode, CfgCallArg, CfgEditError, CfgInst, CfgInstData, CfgValue, Place,
-    PlaceBase, Projection, Terminator,
+    BlockId, Cfg, CfgArgMode, CfgCallArg, CfgCallContract, CfgCallContractArg, CfgEditError,
+    CfgInst, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator,
 };
 use crate::payload::{
     CfgArrayElements, CfgCallArgs, CfgElseArgs, CfgEnumPayload, CfgGotoArgs, CfgIntrinsicArgs,
@@ -1697,6 +1697,7 @@ impl<'a> CfgBuilder<'a> {
                 name,
                 args,
             } => {
+                let call_contract = self.call_contract(args, ty);
                 if let Some(runtime) = runtime {
                     self.assert_valid_runtime_call_args(
                         *runtime,
@@ -1728,6 +1729,7 @@ impl<'a> CfgBuilder<'a> {
                     ty,
                     span,
                 );
+                self.cfg.set_call_contract(value, call_contract);
                 // A call to a `-> !` function never returns: end the block
                 // here and diverge, exactly like `return`. Handing back a
                 // NEVER-typed "result" would let an enclosing if/match join
@@ -1749,6 +1751,7 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::AccessorCall { name, args } => {
+                let call_contract = self.call_contract(args, ty);
                 let mut arg_vals = Vec::new();
                 for arg in self.air.get_call_args(args) {
                     let Some(value) = self.lower_value(arg.value) else {
@@ -1762,6 +1765,7 @@ impl<'a> CfgBuilder<'a> {
                 let args_result = self.cfg.push_call_args(arg_vals);
                 let args = self.payload_or(args_result, CfgCallArgs::EMPTY, span);
                 let value = self.emit(CfgInstData::AccessorCall { name: *name, args }, ty, span);
+                self.cfg.set_call_contract(value, call_contract);
                 self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),
@@ -3298,6 +3302,19 @@ impl<'a> CfgBuilder<'a> {
         }
     }
 
+    /// Preserve the effective, already-validated AIR call contract on the
+    /// CFG value. The verifier later compares optimized operands with this
+    /// snapshot instead of deriving a second signature from the call name.
+    fn call_contract(&self, args: &rue_air::AirCallArgs, result: Type) -> CfgCallContract {
+        CfgCallContract::new(
+            self.air.get_call_args(args).map(|arg| CfgCallContractArg {
+                ty: self.air.get(arg.value).ty,
+                mode: Self::convert_arg_mode(arg.mode),
+            }),
+            result,
+        )
+    }
+
     /// Emit drops for all live slots in all scopes (for return).
     /// Drops are emitted in reverse order (LIFO) across all scopes.
     /// Owned (pass-by-value) parameters are dropped after all locals, in
@@ -4299,7 +4316,7 @@ impl<'a> CfgBuilder<'a> {
                 mode: CfgArgMode::Normal,
             }));
             let args = self.payload_or(args_result, CfgCallArgs::EMPTY, span);
-            self.emit(
+            let value = self.emit(
                 CfgInstData::Call {
                     runtime: None,
                     name,
@@ -4307,6 +4324,16 @@ impl<'a> CfgBuilder<'a> {
                 },
                 Type::UNIT,
                 span,
+            );
+            self.cfg.set_call_contract(
+                value,
+                CfgCallContract::new(
+                    [CfgCallContractArg {
+                        ty,
+                        mode: CfgArgMode::Normal,
+                    }],
+                    Type::UNIT,
+                ),
             );
         }
 

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -741,11 +741,14 @@ pub fn splice_call_in_block_in_place(
         // Spans are copied verbatim so a future location-carrying trap
         // mechanism inherits the callee's real source position (ADR-0049 §7).
         let translated = splice.value(CfgValue::from_raw(index as u32));
-        dst.add_inst(CfgInst {
+        let translated_value = dst.add_inst(CfgInst {
             data,
             ty: source.ty,
             span: source.span,
         });
+        if let Some(contract) = callee.call_contract(CfgValue::from_raw(index as u32)) {
+            dst.set_call_contract(translated_value, contract.clone());
+        }
         // A callee may already be the result of an inline splice. Rebase its
         // per-value ownership facts through the same value map as its code;
         // otherwise a nested callee's protected transfer Load becomes an

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -12,7 +12,7 @@
 //! This design follows Rust MIR's proven approach and eliminates redundant
 //! Load instructions for nested access patterns like `arr[i].field`.
 
-use std::{fmt, sync::Arc};
+use std::{collections::BTreeMap, fmt, sync::Arc};
 
 #[cfg(test)]
 use std::cell::Cell;
@@ -337,7 +337,7 @@ impl fmt::Display for BlockId {
 }
 
 /// A reference to a value (instruction result) in the CFG.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CfgValue(u32);
 
 impl CfgValue {
@@ -406,6 +406,33 @@ pub struct CfgCallArg {
     pub value: CfgValue,
     /// The passing mode for this argument
     pub mode: CfgArgMode,
+}
+
+/// The effective AIR contract accepted during semantic analysis and carried
+/// through CFG transforms with a call value. CFG verification consumes this
+/// established contract instead of resolving or reconstructing a signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CfgCallContract {
+    pub(crate) arguments: Arc<[CfgCallContractArg]>,
+    pub(crate) result: Type,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CfgCallContractArg {
+    pub(crate) ty: Type,
+    pub(crate) mode: CfgArgMode,
+}
+
+impl CfgCallContract {
+    pub(crate) fn new(
+        arguments: impl IntoIterator<Item = CfgCallContractArg>,
+        result: Type,
+    ) -> Self {
+        Self {
+            arguments: arguments.into_iter().collect::<Vec<_>>().into(),
+            result,
+        }
+    }
 }
 
 impl CfgCallArg {
@@ -758,6 +785,11 @@ pub struct Cfg {
     /// Extra storage for call arguments (CfgCallArg).
     /// Call instructions store (start, len) indices into this array.
     call_args: payload::CallArgs,
+    /// Effective AIR contracts for call values, indexed by CfgValue. This
+    /// metadata is populated at CFG construction and copied by transforms so
+    /// verification can check calls without a second signature table. Ordering
+    /// by value keeps CFG debug projections deterministic across workers.
+    call_contracts: BTreeMap<CfgValue, CfgCallContract>,
     /// Extra storage for switch cases (value, target block pairs).
     /// Switch terminators store (start, len) indices into this array.
     switch_cases: payload::SwitchCases,
@@ -1105,6 +1137,7 @@ impl Clone for Cfg {
                 .collect(),
             extra: self.extra.clone(),
             call_args: self.call_args.clone(),
+            call_contracts: self.call_contracts.clone(),
             switch_cases: self.switch_cases.clone(),
             projections: self.projections.clone(),
             num_locals: self.num_locals,
@@ -1356,11 +1389,28 @@ impl Cfg {
                     local_ty: domain!(ty(*local_ty)),
                 },
             };
-            cfg.add_inst(CfgInst {
+            let contract = self.call_contract(CfgValue::from_raw(cfg.values.len() as u32));
+            let value = cfg.add_inst(CfgInst {
                 data,
                 ty: domain!(ty(source.ty)),
                 span: domain!(span(source.span)),
             });
+            if let Some(contract) = contract {
+                let arguments = contract
+                    .arguments
+                    .iter()
+                    .map(|argument| {
+                        Ok(CfgCallContractArg {
+                            ty: ty(argument.ty).map_err(CfgRemapError::Domain)?,
+                            mode: argument.mode,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, CfgRemapError<E>>>()?;
+                cfg.set_call_contract(
+                    value,
+                    CfgCallContract::new(arguments, domain!(ty(contract.result))),
+                );
+            }
         }
 
         for source in &self.blocks {
@@ -1433,6 +1483,7 @@ impl Cfg {
             values: Vec::new(),
             extra: payload::Values::new(),
             call_args: payload::CallArgs::new(),
+            call_contracts: BTreeMap::new(),
             switch_cases: payload::SwitchCases::new(),
             projections: payload::Projections::new(),
             num_locals,
@@ -1673,6 +1724,26 @@ impl Cfg {
         let value = CfgValue::from_raw(index);
         self.values.push(inst);
         value
+    }
+
+    pub(crate) fn set_call_contract(&mut self, value: CfgValue, contract: CfgCallContract) {
+        self.call_contracts.insert(value, contract);
+    }
+
+    pub(crate) fn call_contract(&self, value: CfgValue) -> Option<&CfgCallContract> {
+        self.call_contracts.get(&value)
+    }
+
+    /// Estimated retained-storage charge for the sparse call-contract map.
+    pub fn call_contracts_storage_charge(&self) -> usize {
+        self.call_contracts.iter().fold(
+            self.call_contracts.len() * std::mem::size_of::<(CfgValue, CfgCallContract)>(),
+            |charge, (_, contract)| {
+                charge.saturating_add(
+                    contract.arguments.len() * std::mem::size_of::<CfgCallContractArg>(),
+                )
+            },
+        )
     }
 
     /// Get an instruction by value reference.
@@ -2392,8 +2463,20 @@ impl Cfg {
         let staged = Self::stage_edit(OP, args)?;
         self.validate_value_refs(OP, staged.iter(), |arg| arg.value)?;
         self.preflight_append(OP, block)?;
+        // `append_call` is the typed constructor used by CFG fixtures and
+        // other direct CFG clients. Capture its declared argument contract at
+        // construction time, before any later edit can mutate the operands.
+        // Compiler lowering uses the AIR-backed builder path and installs the
+        // same metadata explicitly from its canonical call arguments.
+        let contract = CfgCallContract::new(
+            staged.iter().map(|arg| CfgCallContractArg {
+                ty: self.get_inst(arg.value).ty,
+                mode: arg.mode,
+            }),
+            ty,
+        );
         let args = payload::push_call_args(&mut self.call_args, staged)?;
-        Ok(self.add_inst_to_block(
+        let value = self.add_inst_to_block(
             block,
             CfgInst {
                 data: CfgInstData::Call {
@@ -2404,7 +2487,9 @@ impl Cfg {
                 ty,
                 span,
             },
-        ))
+        );
+        self.set_call_contract(value, contract);
+        Ok(value)
     }
 
     pub fn append_intrinsic_operation(
@@ -4133,6 +4218,11 @@ mod tests {
         assert!(rewritten.is_ownership_boundary_value(replacement));
         assert_eq!(remapped.get_inst(call).span, Span::new(107, 108));
         assert_eq!(
+            remapped.call_contract(call),
+            cfg.call_contract(call),
+            "domain remapping must preserve the established call contract"
+        );
+        assert_eq!(
             remapped.get_array_elements(&remapped.get_inst(array).data),
             [old, replacement]
         );
@@ -4376,5 +4466,49 @@ mod tests {
             .unwrap();
         assert_eq!(visits.get(), USES);
         assert_eq!(Cfg::test_clone_count(), 1);
+    }
+
+    #[test]
+    fn remapping_retypes_the_established_call_contract_before_verification() {
+        let mut cfg = Cfg::new(Type::I32, 0, 0, "remap_call_contract".into(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let argument = cfg.append_inst(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(7),
+                ty: Type::I32,
+                span: Span::default(),
+            },
+        );
+        let call = cfg
+            .append_call(
+                entry,
+                None,
+                Spur::default(),
+                [CfgCallArg {
+                    value: argument,
+                    mode: CfgArgMode::Normal,
+                }],
+                Type::I32,
+                Span::default(),
+            )
+            .unwrap();
+        cfg.set_terminator(entry, Terminator::Return { value: Some(call) });
+
+        let remapped = cfg
+            .try_remap_domains::<()>(
+                |ty| Ok(if ty == Type::I32 { Type::I64 } else { ty }),
+                Ok,
+                Ok,
+                Ok,
+                Ok,
+                Ok,
+            )
+            .unwrap();
+        let contract = remapped.call_contract(call).unwrap();
+        assert_eq!(contract.arguments[0].ty, Type::I64);
+        assert_eq!(contract.result, Type::I64);
+        remapped.verify_with_fixture_pool().unwrap();
     }
 }

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -11,6 +11,9 @@
 use super::CfgOptimizationError;
 use super::loops::{NaturalLoop, loops};
 use crate::dominators::DominatorTree;
+use crate::inst::CfgCallContract;
+#[cfg(test)]
+use crate::inst::CfgCallContractArg;
 use crate::{
     BlockId, Cfg, CfgCallArg, CfgEditError, CfgInst, CfgInstData, CfgValue, PlaceBase, Projection,
     Terminator, Type,
@@ -588,6 +591,7 @@ struct SourceInst {
     /// takes no read handle on the source graph at all.
     data: CfgInstData,
     operands: SourceOperands,
+    call_contract: Option<CfgCallContract>,
 }
 
 /// One loop-body block as it was before unrolling started, with its
@@ -656,6 +660,7 @@ impl LoopSource {
                         span: inst.span,
                         data: inst.data.duplicate_with_owner(),
                         operands: capture_operands(cfg, &inst.data),
+                        call_contract: cfg.call_contract(value).cloned(),
                     },
                 );
                 if cfg.is_ownership_boundary_value(value) {
@@ -1022,6 +1027,9 @@ fn unroll_one(
             let data = remap_data(&i.operands, cfg, &i.data, &map, Some((trip.slot, raw)))?;
             let nv = map[&v];
             cfg.get_inst_mut(nv).data = data;
+            if let Some(contract) = &i.call_contract {
+                cfg.set_call_contract(nv, contract.clone());
+            }
         }
         iterations.push(block_map);
         all_maps.push(map);
@@ -2419,7 +2427,7 @@ mod tests {
                 mode: crate::CfgArgMode::Normal,
             }])
             .unwrap();
-        cfg.append_inst(
+        let accessor = cfg.append_inst(
             body,
             CfgInst {
                 data: CfgInstData::AccessorCall { name, args },
@@ -2427,8 +2435,28 @@ mod tests {
                 span: Span::new(11, 12),
             },
         );
+        cfg.set_call_contract(
+            accessor,
+            CfgCallContract::new(
+                [CfgCallContractArg {
+                    ty: Type::I32,
+                    mode: crate::CfgArgMode::Normal,
+                }],
+                Type::I32,
+            ),
+        );
         cfg.get_block_mut(body).terminator = term;
         let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loops_unrolled, 1);
+        cfg.verify_with_fixture_pool().unwrap();
+        assert!(
+            cfg.blocks()
+                .iter()
+                .flat_map(|block| block.insts.iter())
+                .any(|value| {
+                    matches!(cfg.get_inst(*value).data, CfgInstData::AccessorCall { .. })
+                        && cfg.call_contract(*value).is_some()
+                })
+        );
     }
 }

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -1656,6 +1656,9 @@ impl<'a> Verifier<'a> {
             CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } => {
                 self.verify_place(block, value, place)?
             }
+            CfgInstData::Call { .. } | CfgInstData::AccessorCall { .. } => {
+                self.verify_call_contract(block, value, inst.ty)?
+            }
             CfgInstData::Intrinsic {
                 operation, args, ..
             } => self.verify_intrinsic_operands(block, value, *operation, inst.ty, args)?,
@@ -1669,6 +1672,64 @@ impl<'a> Verifier<'a> {
             }
         });
         operand_result
+    }
+
+    /// Re-prove an ordinary or accessor call against the effective AIR
+    /// contract captured when this CFG value was built. Optimizations may
+    /// substitute operands, modes, or result metadata, but they must not
+    /// change the callee contract.
+    fn verify_call_contract(
+        &self,
+        block: BlockId,
+        value: CfgValue,
+        result_ty: Type,
+    ) -> Result<(), CfgVerificationError> {
+        let Some(contract) = self.cfg.call_contract(value) else {
+            return Err(self.semantic_error(
+                CfgVerificationLocation::Instruction { block, value },
+                format_args!(
+                    "call instruction {} in block {} has no established AIR call contract",
+                    value, block
+                ),
+            ));
+        };
+        let args = match &self.cfg.get_inst(value).data {
+            CfgInstData::Call { args, .. } | CfgInstData::AccessorCall { args, .. } => {
+                self.cfg.call_args(args)
+            }
+            _ => unreachable!("call contract attached to a non-call instruction"),
+        };
+        if result_ty != contract.result {
+            return Err(self.semantic_error(
+                CfgVerificationLocation::Instruction { block, value },
+                format_args!(
+                    "call instruction {} in block {} no longer has its established result type {:?}; found {:?}",
+                    value, block, contract.result, result_ty
+                ),
+            ));
+        }
+        if args.len() != contract.arguments.len() {
+            return Err(self.semantic_error(
+                CfgVerificationLocation::Instruction { block, value },
+                format_args!(
+                    "call instruction {} in block {} no longer has its established argument count {}; found {}",
+                    value, block, contract.arguments.len(), args.len()
+                ),
+            ));
+        }
+        for (index, (arg, expected)) in args.iter().zip(contract.arguments.iter()).enumerate() {
+            let actual_ty = self.inst(arg.value, block, "call argument")?.ty;
+            if actual_ty != expected.ty || arg.mode != expected.mode {
+                return Err(self.semantic_error(
+                    CfgVerificationLocation::Instruction { block, value },
+                    format_args!(
+                        "call instruction {} in block {} argument {} no longer satisfies its established contract: expected {:?} with mode {:?}, found {:?} with mode {:?}",
+                        value, block, index, expected.ty, expected.mode, actual_ty, arg.mode
+                    ),
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Re-prove an intrinsic's operand and result types against the single
@@ -2334,7 +2395,8 @@ impl<'a> Verifier<'a> {
 mod tests {
     use super::Verifier;
     use crate::inst::{
-        BlockId, Cfg, CfgInst, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator,
+        BlockId, Cfg, CfgArgMode, CfgCallArg, CfgCallContract, CfgCallContractArg, CfgInst,
+        CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator,
     };
     use crate::{CfgVerificationLocation, OptLevel, opt};
     use lasso::ThreadedRodeo;
@@ -4964,6 +5026,199 @@ mod tests {
     fn verify_accepts_a_well_typed_intrinsic_operand() {
         let (cfg, pool) = ptr_write_cfg(Type::I64);
         cfg.verify_with_type_pool(&pool).unwrap();
+    }
+
+    fn ordinary_call_cfg(
+        argument_ty: Type,
+        argument_mode: CfgArgMode,
+    ) -> (Cfg, FrozenTypeInternPool, CfgValue, CfgValue) {
+        let pool = TypeInternPool::new().freeze();
+        let mut cfg = Cfg::new(Type::I64, 0, 0, "ordinary_call".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let argument = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(7),
+                ty: argument_ty,
+                span: Span::new(0, 0),
+            },
+        );
+        let args = cfg
+            .push_call_args([CfgCallArg {
+                value: argument,
+                mode: argument_mode,
+            }])
+            .unwrap();
+        let call = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Call {
+                    runtime: None,
+                    name: ThreadedRodeo::default().get_or_intern("callee"),
+                    args,
+                },
+                ty: Type::I64,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_call_contract(
+            call,
+            crate::inst::CfgCallContract::new(
+                [crate::inst::CfgCallContractArg {
+                    ty: Type::I64,
+                    mode: CfgArgMode::Normal,
+                }],
+                Type::I64,
+            ),
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(call) });
+        (cfg, pool, argument, call)
+    }
+
+    #[test]
+    #[should_panic(expected = "argument 0 no longer satisfies its established contract")]
+    fn verify_rejects_ordinary_call_operand_substitution() {
+        let (cfg, pool, _, _) = ordinary_call_cfg(Type::UNIT, CfgArgMode::Normal);
+        cfg.verify_with_type_pool(&pool).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "argument 0 no longer satisfies its established contract")]
+    fn verify_rejects_ordinary_call_mode_substitution() {
+        let (cfg, pool, _, _) = ordinary_call_cfg(Type::I64, CfgArgMode::Borrow);
+        cfg.verify_with_type_pool(&pool).unwrap();
+    }
+
+    #[test]
+    fn verify_rejects_ordinary_call_without_an_established_contract() {
+        let pool = TypeInternPool::new().freeze();
+        let interner = ThreadedRodeo::new();
+        let mut cfg = Cfg::new(Type::I64, 0, 0, "missing_contract".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let args = cfg.push_call_args([]).unwrap();
+        let call = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Call {
+                    runtime: None,
+                    name: interner.get_or_intern("callee"),
+                    args,
+                },
+                ty: Type::I64,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(call) });
+
+        let error = cfg.verify_with_type_pool(&pool).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("has no established AIR call contract")
+        );
+    }
+
+    #[test]
+    fn verify_rejects_ordinary_call_argument_count_substitution() {
+        let pool = TypeInternPool::new().freeze();
+        let interner = ThreadedRodeo::new();
+        let mut cfg = Cfg::new(Type::I64, 0, 0, "call_arity".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let args = cfg.push_call_args([]).unwrap();
+        let call = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Call {
+                    runtime: None,
+                    name: interner.get_or_intern("callee"),
+                    args,
+                },
+                ty: Type::I64,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_call_contract(
+            call,
+            CfgCallContract::new(
+                [CfgCallContractArg {
+                    ty: Type::I64,
+                    mode: CfgArgMode::Normal,
+                }],
+                Type::I64,
+            ),
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(call) });
+
+        let error = cfg.verify_with_type_pool(&pool).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("established argument count 1; found 0")
+        );
+    }
+
+    #[test]
+    fn verify_rejects_ordinary_call_result_substitution() {
+        let (mut cfg, pool, _, call) = ordinary_call_cfg(Type::I64, CfgArgMode::Normal);
+        cfg.replace_inst_type(call, Type::BOOL).unwrap();
+
+        let error = cfg.verify_with_type_pool(&pool).unwrap_err();
+        assert!(error.to_string().contains("established result type"));
+    }
+
+    #[test]
+    fn verify_rechecks_accessor_call_against_its_established_contract() {
+        let pool = TypeInternPool::new().freeze();
+        let interner = ThreadedRodeo::new();
+        let mut cfg = Cfg::new(Type::I64, 0, 0, "accessor_contract".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let argument = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(7),
+                ty: Type::I64,
+                span: Span::new(0, 0),
+            },
+        );
+        let args = cfg
+            .push_call_args([CfgCallArg {
+                value: argument,
+                mode: CfgArgMode::Borrow,
+            }])
+            .unwrap();
+        let call = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::AccessorCall {
+                    name: interner.get_or_intern("accessor"),
+                    args,
+                },
+                ty: Type::I64,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_call_contract(
+            call,
+            CfgCallContract::new(
+                [CfgCallContractArg {
+                    ty: Type::I64,
+                    mode: CfgArgMode::Normal,
+                }],
+                Type::I64,
+            ),
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(call) });
+
+        let error = cfg.verify_with_type_pool(&pool).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("argument 0 no longer satisfies its established contract")
+        );
     }
 
     /// `@raw_mut` lowers by taking its operand's ADDRESS, so the operand has

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -815,6 +815,7 @@ impl RetainedCharge for rue_cfg::ValidatedCfg {
             .saturating_add((self.value_count() * std::mem::size_of::<rue_cfg::CfgInst>()) as u64)
             .saturating_add(payload.value_store_logical_bytes as u64)
             .saturating_add(payload.call_store_logical_bytes as u64)
+            .saturating_add(self.call_contracts_storage_charge() as u64)
             .saturating_add(payload.switch_store_logical_bytes as u64)
             .saturating_add(payload.projection_store_logical_bytes as u64)
             .saturating_add(self.fn_name().len() as u64)

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -676,6 +676,9 @@ fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
     // Every source/target mode mismatch is one slot wide for this scalar, so
     // a total-width-only guard cannot distinguish it. The Pair probe instead
     // replaces a valid two-slot argument with the one-slot entropy value.
+    // The CFG publication boundary owns this defense: once the call's AIR
+    // contract is frozen, malformed edits must be rejected before the oracle
+    // interpreter sees the graph.
     for (callee_name, replacement_mode) in [
         ("normal", CfgArgMode::Borrow),
         ("normal", CfgArgMode::Inout),
@@ -731,41 +734,37 @@ fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
             )
         };
 
+        let callee_cfg = state
+            .functions
+            .iter()
+            .find(|function| function.is_source_named(callee_name))
+            .map(|function| &*function.cfg)
+            .unwrap_or_else(|| panic!("missing CFG for {callee_name}"));
+        let layout_error = expect_flow_unsupported(contract_interp(&state).preflight_call_layout(
+            callee_cfg,
+            callee_name,
+            [(Type::U32, replacement_mode)],
+        ));
+        assert_eq!(
+            layout_error.kind(),
+            UnsupportedKind::ContractViolation(ContractViolationKind::CallParameterLayout),
+            "{callee_name} must retain the direct callee-layout preflight"
+        );
+
         let type_pool = state.type_pool().clone();
         let cfg = &mut state.functions[main_index].cfg;
         let mut args = cfg.get_call_args(&cfg.get_inst(call).data).to_vec();
         assert_eq!(args.len(), 1, "{callee_name} probe arity");
         args[0].value = random;
         args[0].mode = replacement_mode;
-        cfg.try_edit(&type_pool, |editor| editor.replace_call_args(call, args))
-            .unwrap();
-
-        let cfg = &state.functions[main_index].cfg;
-        let mut interp = Interp {
-            state: &state,
-            stdout_trace: Vec::new(),
-            stdout_bytes: 0,
-            stdout_cap: MAX_STDOUT_BYTES,
-            stderr_cap: MAX_STDERR_BYTES,
-            budget: STEP_BUDGET,
-            depth: 0,
-            heap: Vec::new(),
-            small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
-            heap_metadata_bytes: 0,
-        };
-        let mut frame = Frame {
-            params: Vec::new(),
-            locals: HashMap::new(),
-            cache: HashMap::new(),
-            promoted: HashMap::new(),
-            param_places: HashMap::new(),
-            place_return: false,
-        };
-        let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, call));
-        assert_eq!(
-            unsupported.kind(),
-            UnsupportedKind::ContractViolation(ContractViolationKind::CallParameterLayout),
-            "{callee_name} with {replacement_mode:?} must reject malformed static layout before @random_u32"
+        let error = cfg
+            .try_edit(&type_pool, |editor| editor.replace_call_args(call, args))
+            .expect_err("malformed call edits must fail CFG publication");
+        assert!(
+            error
+                .to_string()
+                .contains("no longer satisfies its established contract"),
+            "{callee_name} with {replacement_mode:?} should fail at the CFG contract boundary: {error}"
         );
     }
 }
@@ -1092,9 +1091,9 @@ fn empty_slice_null_is_a_const_gap_and_user_int_to_ptr_stays_distinct() {
         .iter()
         .position(|function| function.is_source_named("main"))
         .unwrap();
-    let (pointer, init, consumer, mut args) = {
+    let (init, consumer, mut args) = {
         let cfg = &wrong_consumer.functions[main].cfg;
-        let (_, pointer, init) = find_empty_slice_pointer_in_function(&wrong_consumer, "main");
+        let (_, _, init) = find_empty_slice_pointer_in_function(&wrong_consumer, "main");
         let (consumer, args) = cfg
             .blocks()
             .iter()
@@ -1106,19 +1105,22 @@ fn empty_slice_null_is_a_const_gap_and_user_int_to_ptr_stays_distinct() {
                     .filter(|(_, args)| args.iter().any(|arg| arg.value == init))
             })
             .expect("slice call consumer");
-        (pointer, init, consumer, args)
+        (init, consumer, args)
     };
     args.iter_mut()
         .find(|arg| arg.value == init)
         .expect("slice argument")
         .mode = CfgArgMode::Borrow;
     let pool = wrong_consumer.functions[main].type_pool.clone();
-    wrong_consumer.functions[main]
+    let error = wrong_consumer.functions[main]
         .cfg
         .try_edit(&pool, |editor| editor.replace_call_args(consumer, args))
-        .unwrap();
-    let cfg = &wrong_consumer.functions[main].cfg;
-    assert!(!contract_interp(&wrong_consumer).is_empty_slice_pointer(cfg, pointer));
+        .expect_err("mutating a user-call mode must fail CFG publication");
+    assert!(
+        error
+            .to_string()
+            .contains("no longer satisfies its established contract")
+    );
 
     let mut wrong_init_type = query_cfg_state_with_preview_features(source, &preview)
         .expect("slice type probe must compile");
@@ -1127,14 +1129,17 @@ fn empty_slice_null_is_a_const_gap_and_user_int_to_ptr_stays_distinct() {
         .iter()
         .position(|function| function.is_source_named("main"))
         .unwrap();
-    let (_, pointer, init) = find_empty_slice_pointer_in_function(&wrong_init_type, "main");
+    let (_, _, init) = find_empty_slice_pointer_in_function(&wrong_init_type, "main");
     let pool = wrong_init_type.functions[main].type_pool.clone();
-    wrong_init_type.functions[main]
+    let error = wrong_init_type.functions[main]
         .cfg
         .try_edit(&pool, |editor| editor.replace_inst_type(init, Type::UNIT))
-        .unwrap();
-    let cfg = &wrong_init_type.functions[main].cfg;
-    assert!(!contract_interp(&wrong_init_type).is_empty_slice_pointer(cfg, pointer));
+        .expect_err("mutating a user-call operand type must fail CFG publication");
+    assert!(
+        error
+            .to_string()
+            .contains("no longer satisfies its established contract")
+    );
 }
 
 #[test]


### PR DESCRIPTION
CFG verification previously allowed an ordinary or accessor call to acquire a different argument type, passing mode, arity, or result type after semantic analysis. Preserve each call’s accepted AIR contract through CFG construction, cloning, type remapping, inlining, and unrolling, and reject edits that violate it or lose it. Store contracts only for calls and include their storage in retained-memory accounting.

Add negative verifier tests and preservation checks for domain remapping and unrolling. Update oracle corruption probes to expect rejection at the earlier CFG publication boundary. The existing zero-sized call regressions already pass on trunk; this change closes the remaining verification gap.

Fixes RUE-2102

Validation:
- `scripts/rue quick`: 36 targets passed on the final change.
- Focused CFG verifier, remapping, unrolling, and zero-sized call regressions passed.
- Broad `scripts/rue test`: 237 targets passed; one worker-projection determinism test exposed hash-map debug ordering. Replaced the sparse map with ordered storage; the dedicated native compiler target then passed all 47 tests, including the failing regression.
- `scripts/rue fmt` and `git diff --check` passed.
