### PR TITLE
RUE-2088: a call the callee cannot return past does not make it a non-leaf

### DIFF
--- a/crates/rue-cfg/src/dominators.rs
+++ b/crates/rue-cfg/src/dominators.rs
@@ -59,7 +59,7 @@
 //! turns the tree into the block order codegen must lower in (RUE-1758) and is
 //! this module's one consumer of `idom`.
 
-use crate::{BlockId, Cfg, Terminator};
+use crate::{BlockId, Cfg};
 
 /// The immediate-dominator tree of a [`Cfg`].
 ///
@@ -419,7 +419,9 @@ impl Adjacency {
         // Most terminators leave one or two edges.
         let mut targets = Vec::with_capacity(n * 2);
         for index in 0..n {
-            push_successors(cfg, BlockId::from_raw(index as u32), &mut targets);
+            cfg.visit_successors(BlockId::from_raw(index as u32), |target| {
+                targets.push(target)
+            });
             offsets.push(targets.len() as u32);
         }
         Self { offsets, targets }
@@ -453,26 +455,6 @@ impl Adjacency {
             }
         }
         Self { offsets, targets }
-    }
-}
-
-/// Append the successor blocks of `block`, in control-flow order.
-fn push_successors(cfg: &Cfg, block: BlockId, out: &mut Vec<BlockId>) {
-    match &cfg.get_block(block).terminator {
-        Terminator::Goto { target, .. } => out.push(*target),
-        Terminator::Branch {
-            then_block,
-            else_block,
-            ..
-        } => {
-            out.push(*then_block);
-            out.push(*else_block);
-        }
-        Terminator::Switch { cases, default, .. } => {
-            out.extend(cfg.switch_cases(cases).iter().map(|(_, target)| *target));
-            out.push(*default);
-        }
-        Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
     }
 }
 
@@ -676,7 +658,7 @@ mod tests {
                 return true;
             }
             let mut successors = Vec::new();
-            push_successors(cfg, block, &mut successors);
+            cfg.visit_successors(block, |target| successors.push(target));
             for successor in successors {
                 if removed == Some(successor) {
                     continue;

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -3185,6 +3185,71 @@ impl Cfg {
         preds
     }
 
+    /// Visit the successor blocks of `block` in control-flow order: a goto's
+    /// target; a branch's then and else; a switch's cases in arena order and
+    /// then its default. A return, an unreachable, and an unset terminator
+    /// have none.
+    ///
+    /// This is the one decoder of a terminator's out-edges. The successor
+    /// adjacencies dominance and loop analysis build are read off it rather
+    /// than matching the terminator again in each.
+    pub fn visit_successors(&self, block: BlockId, mut visit: impl FnMut(BlockId)) {
+        match &self.get_block(block).terminator {
+            Terminator::Goto { target, .. } => visit(*target),
+            Terminator::Branch {
+                then_block,
+                else_block,
+                ..
+            } => {
+                visit(*then_block);
+                visit(*else_block);
+            }
+            Terminator::Switch { cases, default, .. } => {
+                for &(_, target) in self.switch_cases(cases) {
+                    visit(target);
+                }
+                visit(*default);
+            }
+            Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
+        }
+    }
+
+    /// Whether each block, indexed by id, can reach a `Return` terminator.
+    ///
+    /// A block that cannot is one control can only leave by aborting: it ends
+    /// in `Unreachable` behind a never-returning call or intrinsic, or every
+    /// successor does. That is the CFG-level shape of the diverging region
+    /// register allocation reasons about (RUE-2065), and the inliner's leaf
+    /// rule reads it so a call staged inside a `@panic` arm does not count
+    /// against the callee (RUE-2088).
+    ///
+    /// Computed on demand from the current terminators, like the predecessor
+    /// table it closes over, so it is always in sync with the CFG.
+    pub fn returning_blocks(&self) -> Vec<bool> {
+        let mut returning = vec![false; self.blocks.len()];
+        let predecessors = self.compute_predecessors();
+        let mut worklist: Vec<BlockId> = self
+            .blocks
+            .iter()
+            .filter(|block| matches!(block.terminator, Terminator::Return { .. }))
+            .map(|block| block.id)
+            .collect();
+        for block in &worklist {
+            returning[block.0 as usize] = true;
+        }
+        // Backward closure over the predecessor table: each block enters the
+        // worklist at most once, when it is first proven to reach a return.
+        while let Some(block) = worklist.pop() {
+            for &predecessor in &predecessors[block.0 as usize] {
+                if !returning[predecessor.0 as usize] {
+                    returning[predecessor.0 as usize] = true;
+                    worklist.push(predecessor);
+                }
+            }
+        }
+        returning
+    }
+
     /// Compute predecessor lists for all blocks, indexed by block id.
     ///
     /// Predecessors are computed on demand from the current terminators
@@ -3730,6 +3795,71 @@ mod tests {
             checked_owner_index(MAX_CFG_ENTITIES_PER_FUNCTION as usize),
             None
         );
+    }
+
+    /// A block reaches a return through any path that ends in one; a block
+    /// whose every path ends in `Unreachable` is one control leaves only by
+    /// aborting, and so is a block that merely feeds such blocks.
+    #[test]
+    fn returning_blocks_close_backward_over_the_returns() {
+        let mut cfg = Cfg::new(Type::I32, 0, 0, "f".into(), Vec::<bool>::new());
+        let entry = cfg.new_block();
+        let arm = cfg.new_block();
+        let pass = cfg.new_block();
+        let exit = cfg.new_block();
+        let dead_end = cfg.new_block();
+        let cond = cfg.add_block_param(entry, Type::BOOL);
+        cfg.set_terminator(
+            entry,
+            Terminator::Branch {
+                cond,
+                then_block: arm,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
+                else_block: pass,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
+            },
+        );
+        cfg.set_terminator(arm, Terminator::Unreachable);
+        cfg.set_terminator(
+            pass,
+            Terminator::Goto {
+                target: exit,
+                args: crate::payload::CfgGotoArgs::EMPTY,
+            },
+        );
+        cfg.set_terminator(exit, Terminator::Return { value: None });
+        // Feeds only the aborting arm, so it cannot return either.
+        cfg.set_terminator(
+            dead_end,
+            Terminator::Goto {
+                target: arm,
+                args: crate::payload::CfgGotoArgs::EMPTY,
+            },
+        );
+
+        let returning = cfg.returning_blocks();
+        assert_eq!(returning.len(), 5);
+        assert!(
+            returning[entry.0 as usize],
+            "a branch with one returning arm returns"
+        );
+        assert!(
+            !returning[arm.0 as usize],
+            "an unreachable-terminated block does not"
+        );
+        assert!(returning[pass.0 as usize]);
+        assert!(returning[exit.0 as usize]);
+        assert!(
+            !returning[dead_end.0 as usize],
+            "a block feeding only the arm does not"
+        );
+
+        let mut successors = Vec::new();
+        cfg.visit_successors(entry, |target| successors.push(target));
+        assert_eq!(successors, vec![arm, pass]);
+        successors.clear();
+        cfg.visit_successors(exit, |target| successors.push(target));
+        assert!(successors.is_empty());
     }
 
     #[test]

--- a/crates/rue-cfg/src/opt/loops.rs
+++ b/crates/rue-cfg/src/opt/loops.rs
@@ -747,7 +747,7 @@ impl Successors {
     fn build(cfg: &Cfg, block_count: usize) -> Self {
         let mut edge_count = 0usize;
         for raw in 0..block_count {
-            visit_successors(cfg, BlockId::from_raw(raw as u32), |_| {
+            cfg.visit_successors(BlockId::from_raw(raw as u32), |_| {
                 edge_count = edge_count
                     .checked_add(1)
                     .expect("CFG successor count exceeds addressable memory");
@@ -758,7 +758,7 @@ impl Successors {
         let mut targets = Vec::with_capacity(edge_count);
         offsets.push(0);
         for raw in 0..block_count {
-            visit_successors(cfg, BlockId::from_raw(raw as u32), |target| {
+            cfg.visit_successors(BlockId::from_raw(raw as u32), |target| {
                 targets.push(target);
             });
             offsets.push(targets.len());
@@ -772,38 +772,12 @@ impl Successors {
     }
 }
 
-/// Visit successor blocks of `block` in control-flow order.
-///
-/// This is the single terminator decoder used by both passes of
-/// [`Successors::build`]: goto target; branch then and else; switch cases in
-/// arena order and then its default.
-fn visit_successors(cfg: &Cfg, block: BlockId, mut visit: impl FnMut(BlockId)) {
-    match &cfg.get_block(block).terminator {
-        Terminator::Goto { target, .. } => visit(*target),
-        Terminator::Branch {
-            then_block,
-            else_block,
-            ..
-        } => {
-            visit(*then_block);
-            visit(*else_block);
-        }
-        Terminator::Switch { cases, default, .. } => {
-            for &(_, target) in cfg.switch_cases(cases) {
-                visit(target);
-            }
-            visit(*default);
-        }
-        Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
-    }
-}
-
 /// Test-only successor helper for preheader assertions, driven by the same
 /// decoder as the analysis adjacency.
 #[cfg(test)]
 fn successors_of(cfg: &Cfg, block: BlockId) -> Vec<BlockId> {
     let mut successors = Vec::new();
-    visit_successors(cfg, block, |target| successors.push(target));
+    cfg.visit_successors(block, |target| successors.push(target));
     successors
 }
 

--- a/crates/rue-cli-tests/cases/panic_guard_prologue.toml
+++ b/crates/rue-cli-tests/cases/panic_guard_prologue.toml
@@ -195,3 +195,77 @@ args = ["main.rue", "-O2", "-o", "prog"]
 stdout = "41\n77\n42\n"
 runtime_error_contains = ["panic: guard"]
 exit_code = 101
+
+# RUE-2088: the arm's staging call is not a call boundary. `open` contains one
+# `Call` — `__rue_test_failure_site`, inside the `@panic` arm — and O2's leaf
+# rule used to refuse every callee containing any call, so a small guarded
+# accessor stayed out of line for a call that can only run on its way to an
+# abort. The rule now counts only calls in blocks that can reach the callee's
+# return. The caller below carries a string of its own so the arm's constants
+# import into its type pool; without one, importability still keeps the guard
+# out of line, which is its own issue.
+[[case]]
+name = "a_panic_guard_is_inlined_at_o2"
+description = "The failure-site call inside a `@panic` arm no longer makes the guard a non-leaf: at -O2 no call to `open` survives in `main`, and the folded guard leaves no panic call behind at a constant site."
+files = [{ path = "main.rue", source = """
+fn open(port: u16) -> u16 {
+    if port == 0 {
+        @panic("no port");
+    }
+    port
+}
+
+fn main() -> i32 {
+    @dbg("guarded");
+    if open(7) == 7 { 0 } else { 1 }
+}
+""" }]
+args = ["--emit", "asm", "--target", "x86-64-linux", "-O2", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (x86-64-linux) ===", "main:", "call __rue_dbg_str"]
+compile_stdout_not_contains = ["call __rue_sem", "call __rue_panic"]
+
+[[case]]
+name = "a_panic_guard_stays_out_of_line_below_o2"
+description = "The same program at -O1 keeps the source call boundary: general inlining begins at -O2."
+files = [{ path = "main.rue", source = """
+fn open(port: u16) -> u16 {
+    if port == 0 {
+        @panic("no port");
+    }
+    port
+}
+
+fn main() -> i32 {
+    @dbg("guarded");
+    if open(7) == 7 { 0 } else { 1 }
+}
+""" }]
+args = ["--emit", "asm", "--target", "x86-64-linux", "-O1", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["call __rue_sem", "call __rue_panic"]
+
+[[case]]
+name = "an_inlined_panic_guard_still_aborts_at_its_site"
+description = "Inlining the guard changes nothing the program can observe: the passing call returns its value and the failing call aborts with the pinned message and exit 101."
+files = [{ path = "main.rue", source = """
+fn open(port: u16) -> u16 {
+    if port == 0 {
+        @panic("no port");
+    }
+    port
+}
+
+fn main() -> i32 {
+    @dbg("guarded");
+    let good: i32 = @intCast(open(7));
+    @dbg(good);
+    let bad: i32 = @intCast(open(0));
+    @dbg(bad);
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+stdout = "guarded\n7\n"
+runtime_error_contains = ["panic: no port"]
+exit_code = 101

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -2715,7 +2715,15 @@ pub(crate) fn apply_general_inlining(
             rue_cfg::BlockId,
         )>,
     > = ahash::AHashMap::new();
-    let mut has_calls: ahash::AHashMap<crate::FunctionInstanceKey, bool> = ahash::AHashMap::new();
+    // O2's leaf rule (ADR-0049 §6) counts the calls a callee can return
+    // past. A call in a block that cannot reach the callee's return sits
+    // where control can only leave by aborting — a `@panic` arm staging its
+    // failure site — and never executes on the inlined caller's returning
+    // path, so it is not the call boundary the rule keeps O2 away from
+    // (RUE-2088). Every call still contributes its edge to the call graph:
+    // recursion is about what can be reached, not what can return.
+    let mut has_returning_calls: ahash::AHashMap<crate::FunctionInstanceKey, bool> =
+        ahash::AHashMap::new();
     for (function, record) in &records {
         let mut calls = Vec::new();
         // Every edge found in this iteration belongs to `function`, so the
@@ -2724,15 +2732,17 @@ pub(crate) fn apply_general_inlining(
         // `BTreeMap` probe over a recursive identity plus a deep key clone,
         // for each of them.
         let mut function_edges: Vec<crate::FunctionInstanceKey> = Vec::new();
-        let mut any_call = false;
+        let mut any_returning_call = false;
+        let returning_blocks = record.cfg.returning_blocks();
         for block in record.cfg.blocks() {
+            let block_returns = returning_blocks[block.id.as_u32() as usize];
             for &value in &block.insts {
                 let rue_cfg::CfgInstData::Call { runtime, name, .. } =
                     record.cfg.get_inst(value).data
                 else {
                     continue;
                 };
-                any_call = true;
+                any_returning_call |= block_returns;
                 if runtime.is_some() {
                     continue;
                 }
@@ -2748,7 +2758,7 @@ pub(crate) fn apply_general_inlining(
         if !function_edges.is_empty() {
             edges.insert(function.clone(), function_edges);
         }
-        has_calls.insert(function.clone(), any_call);
+        has_returning_calls.insert(function.clone(), any_returning_call);
         callsites.insert(function.clone(), calls);
     }
 
@@ -2800,7 +2810,7 @@ pub(crate) fn apply_general_inlining(
         }
         let size_eligible = match batch_opt_level {
             rue_cfg::OptLevel::O2 => {
-                !has_calls.get(function).copied().unwrap_or(true)
+                !has_returning_calls.get(function).copied().unwrap_or(true)
                     && phase2_size_eligible(record.cfg.value_count())
             }
             rue_cfg::OptLevel::O3 => phase3_size_eligible(record.cfg.value_count()),

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -3963,6 +3963,78 @@ mod tests {
         assert_eq!(has_unit(&o3, "middle"), has_unit(&o3_again, "middle"));
     }
 
+    /// RUE-2088: the staging call in a `@panic` arm sits in a block that
+    /// cannot reach the callee's return, so it is not the call boundary O2's
+    /// leaf rule refuses. The caller carries a string constant of its own so
+    /// the arm's constants can be imported into its type pool; with that,
+    /// the guarded accessor is consumed at O2 and its body dropped.
+    #[test]
+    fn phase2_admits_a_callee_whose_only_call_diverges() {
+        let snapshot = SourceSnapshot::single(
+            "<phase2-diverging-call-inline>",
+            r#"fn open(port: u16) -> u16 { if port == 0 { @panic("no port"); } port }
+               fn main() -> i32 { @dbg("guarded"); if open(7) == 7 { 0 } else { 1 } }"#,
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+
+        let user_calls_in_main = |output: &RootedCfgOutput| {
+            output
+                .cfgs
+                .iter()
+                .find(|unit| unit.record.codegen.defined_symbol.ends_with("main"))
+                .map(|unit| {
+                    unit.record
+                        .cfg
+                        .blocks()
+                        .iter()
+                        .flat_map(|block| block.insts.iter())
+                        .filter(|value| {
+                            matches!(
+                                unit.record.cfg.get_inst(**value).data,
+                                rue_cfg::CfgInstData::Call { runtime: None, .. }
+                            )
+                        })
+                        .count()
+                })
+                .unwrap_or_default()
+        };
+        let has_unit = |output: &RootedCfgOutput, name: &str| {
+            output.cfgs.iter().any(|unit| {
+                matches!(
+                    &unit.function,
+                    FunctionInstanceKey::Definition(definition) if definition.name() == name
+                )
+            })
+        };
+
+        let o1 = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O1,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(user_calls_in_main(&o1), 1);
+        assert!(has_unit(&o1, "open"));
+
+        let o2 = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O2,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(
+            user_calls_in_main(&o2),
+            0,
+            "the guard's arm no longer blocks O2 inlining"
+        );
+        assert!(!has_unit(&o2, "open"));
+    }
+
     #[cfg(unix)]
     #[test]
     #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]

--- a/docs/designs/0049-function-inlining.md
+++ b/docs/designs/0049-function-inlining.md
@@ -431,8 +431,9 @@ answer different questions:
   `CfgInstData::Call` instructions naming a symbol across all caller CFGs. Body
   references are duplicate-free and cannot answer this, so ten calls to `f` and
   one call to `f` produce the same callable reference.
-- **Leafness** ("does this callee contain any call?"): scan the callee's
-  `values` for `CfgInstData::Call`. Body references also include type and
+- **Leafness** ("can this callee return past a call?"): scan the callee's
+  blocks for `CfgInstData::Call`, counting only the blocks that can reach a
+  `Return` (`Cfg::returning_blocks`). Body references also include type and
   drop-glue demands, so they cannot cleanly report "contains a call."
 - **Candidate lookup** ("what is the callee body for this call?"): the `Call`'s
   `name: Spur` is the symbol key into the `{symbol → Cfg}` map. This is
@@ -475,10 +476,15 @@ The current criteria are deliberately conservative:
   standalone body while retaining the large workload's short-function majority;
   128 would admit an additional long-tail band without a measurement-backed
   need.
-- **Leaf-ness** from a CFG scan (§5): a callee containing no `CfgInstData::Call`
-  is a leaf and the safest first target. O2 remains leaf-only under its small
-  cap; O3 admits non-leaf callees under the larger cap, while refusing every
-  recursive SCC. The batch expands only the deterministic original call-site
+- **Leaf-ness** from a CFG scan (§5): a callee with no `CfgInstData::Call` in
+  any block that can reach its return is a leaf and the safest first target.
+  A call in a block control can only leave by aborting — the failure-site
+  staging call inside a `@panic` arm — does not count (RUE-2088): it never
+  executes on the inlined caller's returning path, so it imposes none of the
+  call-boundary cost the rule exists to avoid, and register allocation already
+  keeps such a region's registers out of the caller's prologue (RUE-2065). O2
+  remains leaf-only under its small cap; O3 admits non-leaf callees under the
+  larger cap, while refusing every recursive SCC. The batch expands only the deterministic original call-site
   set once, so copied non-leaf calls cannot recursively trigger more inlining.
 - **Single-call-site** callees (call multiplicity 1, from the §5 call-site graph)
   are the highest-value case: inlining them removes a call with no code-size cost


### PR DESCRIPTION
Fixes [RUE-2088](https://linear.app/steve-klabnik/issue/RUE-2088). Files [RUE-2104](https://linear.app/steve-klabnik/issue/RUE-2104) for the second blocker found on the way.

## Problem

O2 inlines only leaf callees, and a leaf was a body with no `Call` at all. A `@panic` guard stages its failure site with `__rue_test_failure_site` inside the arm, so a small guarded accessor was permanently out of line for a call that can only execute on its way to an abort, even after RUE-2065 took that arm's registers out of the passing path's prologue.

## Change

The issue asked whether the diverging-region fact could cheaply extend to the inliner. It can, at block granularity:

- **`Cfg::returning_blocks`** is the fact: a backward closure from the `Return` terminators over the predecessor table. A block that ends in `Unreachable` behind a never-returning call or intrinsic, or that only feeds such blocks, is one control leaves by aborting.
- **The O2 leaf rule** in `apply_general_inlining` now counts only calls in blocks that can reach the callee's return. Every call still contributes its edge to the call graph, so recursion detection is unchanged.
- **`Cfg::visit_successors`** replaces three private terminator decoders (dominator adjacency, loop analysis, and its tests) with one.

ADR-0049 §5 and §6 say what now counts as a leaf and why.

## What this does and does not fix

With this change the guarded accessor from the issue inlines at O2 **when the caller's type pool already holds a string type**, and at a constant call site the guard then folds away entirely (the CLI case pins that no `__rue_panic` call survives).

The issue's exact repro, whose `main` names no string, still stays out of line, and it turns out to stay out of line at O3 too, where there is no leaf rule at all. The arm's file-name and message constants are str-typed, and the splice silently refuses a callee whose body-local types are absent from the caller's immutable pool (`MissingStableType`). That is a type-pool boundary decision, filed as [RUE-2104](https://linear.app/steve-klabnik/issue/RUE-2104) with the evidence table. This PR does not touch it; the tests here give the caller a string so the leaf rule is what they measure.

## Tests

- `returning_blocks_close_backward_over_the_returns` in `rue-cfg` pins the fact on a hand-built graph, including a block that only feeds the aborting arm.
- `phase2_admits_a_callee_whose_only_call_diverges` in the compiler pipeline tests pins that the guard is consumed at O2 and its unit dropped, and kept at O1.
- Three CLI cases in `panic_guard_prologue.toml`: the O2 assembly has no call to the accessor and no panic call; the O1 assembly keeps both; the inlined guard still aborts with the pinned message and exit 101 at runtime.

Ran locally: `scripts/rue quick`, the whole `rue-cfg` unit suite, the compiler inlining tests, the `rue-cfg` and `rue-compiler` clippy gates, the oracle-diff corpus, the spec suite (2900 passed), and the `panic_guard`, `differential_opt`, and `inlin` CLI sections. The full CLI suite was run as well; its only failures are two cases this container cannot satisfy, not this change: `remove_dir_all_permission_denied_is_not_partial_success` (the container runs as root, so a mode-zero directory does not refuse the open) and `tcp_ipv6_loopback_round_trip` (the container has no IPv6 stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEHdMtLGAdvXY8GsGyCTza