### PR TITLE
RUE-2091: report a repeating watch re-observation failure once, not per retry

### DIFF
--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -206,38 +206,69 @@ source = "const util = @import(\"util.rue\");\nfn main() -> i32 { util.value() }
 # and its status line on every tick, roughly four identical reports a second
 # for as long as someone sat inside the error.
 #
-# The report now belongs to the failure rather than to the tick. The case
-# stays inside one error for several retries, replaces it with a different one,
-# and finally repairs it, so all three of the behaviors that matter are pinned
-# together: the repeat is silent, a changed failure is not, and the repair
-# still publishes promptly.
+# The report now belongs to the failure rather than to the tick, and it returns
+# on two triggers: the rendered diagnostic changing, or a source in the watched
+# closure changing. The case walks both, plus the memory a successful revision
+# clears, because each is separately mutation-survivable — a suite that pins
+# only the silence would stay green while a later change quietly undid either
+# trigger.
+#
+# `rue test --watch` shares this loop, so `cli.watch_test` pins that the
+# suppression reaches the other watcher rather than re-deriving these three
+# behaviors against it.
 [[case]]
 name = "an_unchanged_reobserve_failure_is_reported_once_not_per_retry"
 files = [
-    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nconst other = @import(\"other.rue\");\nfn main() -> i32 { helper.answer() + other.extra() }\n" },
     { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+    { path = "other.rue", source = "pub fn extra() -> i32 { 0 }\n" },
 ]
 
 [case.watch]
 kind = "repeated_failure"
-expected_exit_codes = [1, 2]
+# 1 + 0 to start; the repaired revision publishes 2 + 3, which is also the last
+# thing published — the verbatim re-break that follows it compiles nothing.
+expected_exit_codes = [1, 5]
 stderr_occurrences = [
-    # The first failure, held for several retries, reported once.
-    { text = "expected semicolon after expression", count = 1 },
-    # The second is a different message, so it is news and gets its own report.
-    { text = "expected 'mut' or identifier or '_', found ';'", count = 1 },
+    # The first failure, held for several retries, reported once. The code is
+    # part of the expectation: keeping the wording while moving the code would
+    # otherwise pass.
+    { text = "error: [E0102]: expected semicolon after expression", count = 1 },
+    # The second failure is reported three times over three revisions, and
+    # never twice for the same one: once when it replaces the first, once when
+    # an unrelated closure file is saved underneath it, and once when its exact
+    # bytes come back after a repair.
+    { text = "error: [E0100]: expected 'mut' or identifier or '_', found ';'", count = 3 },
     # One status line per report, not one per attempt.
-    { text = "keeping the last successful executable", count = 2 },
+    { text = "keeping the last successful executable", count = 4 },
 ]
 
+# Break the closure. Reported once, however many times it is retried.
 [[case.watch.edits]]
 path = "helper.rue"
 source = "pub fn answer() -> i32 { 1 \n"
 
+# A different failure, and so a different report.
 [[case.watch.edits]]
 path = "helper.rue"
 source = "pub fn answer() -> i32 { let ; }\n"
 
+# A save to another closure file. `helper.rue` is untouched and its rendering
+# is byte-identical, so the diagnostic half of the key cannot explain this
+# report; only the physical observation of the closure can.
+[[case.watch.edits]]
+path = "other.rue"
+source = "pub fn extra() -> i32 { 3 }\n"
+
+# The repair, which must still publish promptly.
 [[case.watch.edits]]
 path = "helper.rue"
 source = "pub fn answer() -> i32 { 2 }\n"
+
+# The previous failure's bytes, restored verbatim: same rendering, and the same
+# physical closure state the third report described, since `other.rue` has not
+# moved since. Only the reset on the intervening successful revision makes this
+# news again.
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { let ; }\n"

--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -197,3 +197,47 @@ expected_exit_codes = [7]
 [[case.watch.edits]]
 path = "main.rue"
 source = "const util = @import(\"util.rue\");\nfn main() -> i32 { util.value() }\n"
+
+# RUE-2091. A syntax error inside the closure fails import discovery, not
+# compilation, and a failed discovery cannot park on a change: the broken
+# `@import` may name a file that does not exist yet, which is outside the
+# retained closure and so outside anything there is to watch. The loop
+# therefore retries every 250ms — and it used to reprint the whole diagnostic
+# and its status line on every tick, roughly four identical reports a second
+# for as long as someone sat inside the error.
+#
+# The report now belongs to the failure rather than to the tick. The case
+# stays inside one error for several retries, replaces it with a different one,
+# and finally repairs it, so all three of the behaviors that matter are pinned
+# together: the repeat is silent, a changed failure is not, and the repair
+# still publishes promptly.
+[[case]]
+name = "an_unchanged_reobserve_failure_is_reported_once_not_per_retry"
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+]
+
+[case.watch]
+kind = "repeated_failure"
+expected_exit_codes = [1, 2]
+stderr_occurrences = [
+    # The first failure, held for several retries, reported once.
+    { text = "expected semicolon after expression", count = 1 },
+    # The second is a different message, so it is news and gets its own report.
+    { text = "expected 'mut' or identifier or '_', found ';'", count = 1 },
+    # One status line per report, not one per attempt.
+    { text = "keeping the last successful executable", count = 2 },
+]
+
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 1 \n"
+
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { let ; }\n"
+
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 2 }\n"

--- a/crates/rue-cli-tests/cases/watch_test.toml
+++ b/crates/rue-cli-tests/cases/watch_test.toml
@@ -325,3 +325,81 @@ test "doubles" {
     @assert(2 * 2 == 5);
 }
 """
+
+[[case]]
+name = "an_unchanged_reobserve_failure_is_reported_once_not_per_retry"
+description = """
+RUE-2091. A syntax error in a helper fails import discovery rather than
+compilation, and a failed discovery cannot park on a change — the broken
+`@import` may name a file that does not exist yet, outside the retained closure
+and so outside anything there is to watch. The loop retries every 250ms
+instead, and it used to reprint the whole diagnostic and its status line on
+every tick.
+
+`rue test --watch` shares the executable watcher's loop, so it shared the spam;
+it is also the surface where a person or an agent sits inside a syntax error
+most often, mid-edit on a test body or its helpers. The report now belongs to
+the failure: an unchanged one is reported once however many times it is
+retried, a different one is reported on its own, and the repair still runs the
+next cycle promptly.
+
+A discovery failure consumes no cycle number, unlike the image failure
+`a_broken_closure_fails_the_cycle_and_the_loop_keeps_watching` pins: it never
+reaches the cycle body that numbers a run. The repaired cycle is therefore 2,
+with no gap.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 { 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn double(x: i32) -> i32 { x * 2 }
+""" },
+    { path = "tests.rue", source = """
+const helper = @import("helper.rue");
+
+test "doubles through the helper" {
+    @assert(helper.double(2) == 4);
+}
+""" },
+]
+
+[case.watch_test]
+kind = "repeated_failure"
+expected_exit = 0
+stdout_contains = [
+    '"cycle":1,"event":"run_started"',
+    '"cycle":2,"event":"run_started"',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":1',
+]
+stdout_not_contains = [
+    # Neither failing revision published anything, and no cycle number was
+    # spent on one.
+    '"cycle":3',
+    '"event":"run_canceled"',
+]
+stderr_occurrences = [
+    { text = "expected semicolon after expression", count = 1 },
+    { text = "expected 'mut' or identifier or '_', found ';'", count = 1 },
+    { text = "no summary for this revision", count = 2 },
+]
+
+[[case.watch_test.edits]]
+path = "helper.rue"
+source = """
+pub fn double(x: i32) -> i32 { x * 2
+"""
+
+[[case.watch_test.edits]]
+path = "helper.rue"
+source = """
+pub fn double(x: i32) -> i32 { let ; }
+"""
+
+[[case.watch_test.edits]]
+path = "helper.rue"
+source = """
+pub fn double(x: i32) -> i32 { x * 2 }
+"""

--- a/crates/rue-cli-tests/cases/watch_test.toml
+++ b/crates/rue-cli-tests/cases/watch_test.toml
@@ -343,6 +343,12 @@ the failure: an unchanged one is reported once however many times it is
 retried, a different one is reported on its own, and the repair still runs the
 next cycle promptly.
 
+What this case owes is that the suppression reaches this watcher at all, and
+that a failed cycle still publishes nothing to the event stream. The triggers
+that bring the report back, and the memory a successful revision clears, are
+properties of the shared arm and are pinned once, in
+`cli.watch::an_unchanged_reobserve_failure_is_reported_once_not_per_retry`.
+
 A discovery failure consumes no cycle number, unlike the image failure
 `a_broken_closure_fails_the_cycle_and_the_loop_keeps_watching` pins: it never
 reaches the cycle body that numbers a run. The repaired cycle is therefore 2,
@@ -381,8 +387,8 @@ stdout_not_contains = [
     '"event":"run_canceled"',
 ]
 stderr_occurrences = [
-    { text = "expected semicolon after expression", count = 1 },
-    { text = "expected 'mut' or identifier or '_', found ';'", count = 1 },
+    { text = "error: [E0102]: expected semicolon after expression", count = 1 },
+    { text = "error: [E0100]: expected 'mut' or identifier or '_', found ';'", count = 1 },
     { text = "no summary for this revision", count = 2 },
 ]
 

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -196,9 +196,9 @@ use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_target::{Arch, Target};
 use rue_test_runner::cli_corpus::{
     AutomaticExampleContract, Case, CliCaseTier, ExecutionClass, ExecutionContractDeclaration,
-    HangTimeoutProfile, Section, TestFile, TimeoutProfile, WatchEdit, WatchScenario,
-    WatchScenarioKind, WatchTestScenario, WatchTestScenarioKind, unknown_known_bug_on_platforms,
-    unknown_only_on_platforms,
+    HangTimeoutProfile, Section, StderrOccurrence, TestFile, TimeoutProfile, WatchEdit,
+    WatchScenario, WatchScenarioKind, WatchTestScenario, WatchTestScenarioKind,
+    unknown_known_bug_on_platforms, unknown_only_on_platforms,
 };
 use rue_test_runner::{
     ExpectedFailureOutcome, KNOWN_TARGETS, PlatformCaseSelection, ShardSelector, TestFailure,
@@ -2411,6 +2411,70 @@ fn watch_event_count(path: &Path, event: &str) -> usize {
         .count()
 }
 
+/// Check the exact-count stderr expectations a scenario declared.
+///
+/// Occurrences are counted as non-overlapping substring matches, which is what
+/// "the watcher said this N times" means for a diagnostic: each report is a
+/// whole rendering, and they cannot overlap.
+fn assert_stderr_occurrences(
+    stderr: &str,
+    expectations: &[StderrOccurrence],
+) -> Result<(), String> {
+    for expected in expectations {
+        let actual = stderr.matches(expected.text.as_str()).count();
+        if actual != expected.count {
+            return Err(format!(
+                "watch stderr held {actual} occurrence(s) of {:?}, expected {}",
+                expected.text, expected.count
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// How many suppressed retries a repeated-failure case waits out before it
+/// decides the watcher is holding its tongue.
+///
+/// The retry timer is 250ms, so three ticks is a little under a second of a
+/// failure state the watcher used to reprint at 4 Hz. The case waits for the
+/// milestones rather than for the clock: what it needs is evidence that
+/// attempts happened, not that time passed.
+const SUPPRESSED_RETRIES: usize = 3;
+
+/// Sit inside an unchanged re-observation failure for several retries and
+/// require that the watcher reported it exactly `reports` times in total.
+///
+/// A broken import cannot be waited on — it may name a file that does not
+/// exist yet, and so lies outside the closure there is anything to watch — so
+/// the loop retries on a timer instead. Every attempt publishes a milestone;
+/// only an attempt that actually told the user something publishes
+/// `reobserve-error`. That split is what makes the assertion event-driven
+/// instead of a sleep long enough to "probably" cover a few ticks (RUE-2091).
+fn assert_failure_reported_once(
+    child: &mut std::process::Child,
+    protocol: &Path,
+    reports: usize,
+    deadline: Instant,
+) -> Result<(), String> {
+    let suppressed = watch_event_count(protocol, "reobserve-error-repeat");
+    wait_for_watch_event(child, protocol, "reobserve-error", reports, deadline)?;
+    wait_for_watch_event(
+        child,
+        protocol,
+        "reobserve-error-repeat",
+        suppressed + SUPPRESSED_RETRIES,
+        deadline,
+    )?;
+    let actual = watch_event_count(protocol, "reobserve-error");
+    if actual != reports {
+        return Err(format!(
+            "watch reported an unchanged re-observation failure {actual} times, expected {reports}: {:?}",
+            watch_events(protocol)
+        ));
+    }
+    Ok(())
+}
+
 fn assert_fresh_cycle_after_supersession(
     events: &[String],
     superseded: usize,
@@ -2619,6 +2683,11 @@ fn run_watch_case(
             "supersede-acquire watch scenario needs two edits and an acquisition delay",
         ));
     }
+    if scenario.kind == WatchScenarioKind::RepeatedFailure && scenario.edits.len() != 3 {
+        return Err(TestFailure::assertion(
+            "repeated-failure watch scenario requires two failing edits and a repair",
+        ));
+    }
     if scenario.kind == WatchScenarioKind::SymlinkRetarget && scenario.edits.len() != 1 {
         return Err(TestFailure::assertion(
             "symlink-retarget watch scenario requires exactly one edit",
@@ -2808,6 +2877,20 @@ fn run_watch_case(
             WatchScenarioKind::SymlinkRetarget => {
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
             }
+            WatchScenarioKind::RepeatedFailure => {
+                // A syntax error inside the closure fails import discovery, so
+                // the loop retries on its timer rather than parking on a
+                // change. The report belongs to the failure, not to the tick.
+                assert_failure_reported_once(&mut child, &protocol, 1, deadline)?;
+                // A different failure is different news, even though the loop
+                // never stopped failing in between.
+                write_watch_edit(dir, &scenario.edits[1])?;
+                assert_failure_reported_once(&mut child, &protocol, 2, deadline)?;
+                // And the repair still publishes promptly: suppression is
+                // about the repeats, not about the loop's responsiveness.
+                write_watch_edit(dir, &scenario.edits[2])?;
+                wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
+            }
             WatchScenarioKind::SupersedeAcquire => {
                 // The first edit wakes the settled loop. Re-observation
                 // completes, and the widened acquisition window then lets the
@@ -2907,6 +2990,7 @@ fn run_watch_case(
                 return Err(format!("watch stderr did not contain {expected:?}"));
             }
         }
+        assert_stderr_occurrences(&stderr, &scenario.stderr_occurrences)?;
         if scenario.error_format.as_deref() == Some("json") {
             let diagnostics = validate_json_diagnostic_stream(&stderr)
                 .map_err(|error| format!("watch JSON stderr validation failed: {error}"))?;
@@ -2942,6 +3026,7 @@ fn run_watch_test_case(
     let required_edits = match scenario.kind {
         WatchTestScenarioKind::Edit | WatchTestScenarioKind::Cancel => 1,
         WatchTestScenarioKind::CompileError => 2,
+        WatchTestScenarioKind::RepeatedFailure => 3,
     };
     if scenario.edits.len() != required_edits {
         return Err(TestFailure::assertion(format!(
@@ -3051,6 +3136,15 @@ fn run_watch_test_case(
                 write_watch_edit(dir, &scenario.edits[1])?;
                 wait_for_watch_event(&mut child, &protocol, "run-finished", 2, deadline)?;
             }
+            WatchTestScenarioKind::RepeatedFailure => {
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 1, deadline)?;
+                write_watch_edit(dir, &scenario.edits[0])?;
+                assert_failure_reported_once(&mut child, &protocol, 1, deadline)?;
+                write_watch_edit(dir, &scenario.edits[1])?;
+                assert_failure_reported_once(&mut child, &protocol, 2, deadline)?;
+                write_watch_edit(dir, &scenario.edits[2])?;
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 2, deadline)?;
+            }
             WatchTestScenarioKind::Cancel => {
                 // Wait for a test process to actually exist before editing:
                 // the point of the case is the kill landing on a live group.
@@ -3098,6 +3192,7 @@ fn run_watch_test_case(
                 return Err(format!("watch-test stderr did not contain {expected:?}"));
             }
         }
+        assert_stderr_occurrences(&err, &scenario.stderr_occurrences)?;
         Ok(())
     });
     result.map_err(|error| {

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -2683,9 +2683,10 @@ fn run_watch_case(
             "supersede-acquire watch scenario needs two edits and an acquisition delay",
         ));
     }
-    if scenario.kind == WatchScenarioKind::RepeatedFailure && scenario.edits.len() != 3 {
+    if scenario.kind == WatchScenarioKind::RepeatedFailure && scenario.edits.len() != 5 {
         return Err(TestFailure::assertion(
-            "repeated-failure watch scenario requires two failing edits and a repair",
+            "repeated-failure watch scenario requires two failing edits, an unrelated \
+             closure edit, a repair, and a verbatim re-break",
         ));
     }
     if scenario.kind == WatchScenarioKind::SymlinkRetarget && scenario.edits.len() != 1 {
@@ -2878,6 +2879,11 @@ fn run_watch_case(
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
             }
             WatchScenarioKind::RepeatedFailure => {
+                // Each step below kills one way the suppression could be
+                // written wrong, and the loop it exercises is shared, so
+                // pinning them on the executable watcher covers the test
+                // watcher's copy of the same arm too.
+                //
                 // A syntax error inside the closure fails import discovery, so
                 // the loop retries on its timer rather than parking on a
                 // change. The report belongs to the failure, not to the tick.
@@ -2886,10 +2892,26 @@ fn run_watch_case(
                 // never stopped failing in between.
                 write_watch_edit(dir, &scenario.edits[1])?;
                 assert_failure_reported_once(&mut child, &protocol, 2, deadline)?;
-                // And the repair still publishes promptly: suppression is
-                // about the repeats, not about the loop's responsiveness.
+                // An edit to a DIFFERENT closure file, leaving the broken one
+                // and therefore the whole rendering byte-identical. The report
+                // still comes back, because silence after a save is
+                // indistinguishable from a watcher that never noticed it. This
+                // is the only step that fails if the physical-observation half
+                // of the suppression key stops being compared.
                 write_watch_edit(dir, &scenario.edits[2])?;
+                assert_failure_reported_once(&mut child, &protocol, 3, deadline)?;
+                // The repair still publishes promptly: suppression is about
+                // the repeats, not about the loop's responsiveness.
+                write_watch_edit(dir, &scenario.edits[3])?;
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
+                // Restoring the broken bytes verbatim puts the closure back in
+                // the exact physical state the previous report described, so
+                // only the memory a successful revision clears distinguishes
+                // this failure from a retry. Fingerprints are content hashes
+                // and cannot tell them apart; without the reset this report is
+                // swallowed.
+                write_watch_edit(dir, &scenario.edits[4])?;
+                assert_failure_reported_once(&mut child, &protocol, 4, deadline)?;
             }
             WatchScenarioKind::SupersedeAcquire => {
                 // The first edit wakes the settled loop. Re-observation

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1906,6 +1906,7 @@ mod tests {
             acquire_delay_ms: None,
             edits: Vec::new(),
             stderr_contains: Vec::new(),
+            stderr_occurrences: Vec::new(),
             expected_exit_codes: Vec::new(),
         }
     }
@@ -1920,6 +1921,7 @@ mod tests {
             stdout_contains: Vec::new(),
             stdout_not_contains: Vec::new(),
             stderr_contains: Vec::new(),
+            stderr_occurrences: Vec::new(),
             expected_exit: 0,
         }
     }

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -228,9 +228,11 @@ pub enum WatchScenarioKind {
     /// which is exactly what a first-cycle failure cannot produce.
     InitialFailure,
     /// A parse error in a closure module, which fails re-observation rather
-    /// than compilation and so puts the loop on its retry timer. The case sits
-    /// inside the failure for several retries, replaces it with a different
-    /// one, and finally repairs it (RUE-2091).
+    /// than compilation and so puts the loop on its retry timer. The case
+    /// walks every trigger the report obeys: it sits inside one failure for
+    /// several retries, replaces it with a different one, edits an unrelated
+    /// closure file while the broken one holds still, repairs it, and finally
+    /// restores the broken bytes verbatim (RUE-2091).
     RepeatedFailure,
 }
 

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -154,6 +154,19 @@ pub struct HardLinkFixture {
     pub target: String,
 }
 
+/// An exact-count expectation over a watch process's stderr.
+///
+/// `stderr_contains` answers "was this said at all", which cannot distinguish
+/// one report from thirty. A watcher that repeats a diagnostic while nothing
+/// changed is the bug RUE-2091 fixed, so the assertion that pins it has to
+/// count.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StderrOccurrence {
+    pub text: String,
+    pub count: usize,
+}
+
 /// Imperative end-to-end watch scenario. These cases use the watch protocol
 /// seam in `rue` to synchronize edits and then terminate the watch process;
 /// ordinary CLI cases remain declarative and use the normal compile/run path.
@@ -191,6 +204,10 @@ pub struct WatchScenario {
     /// told the user when it got there.
     #[serde(default)]
     pub stderr_contains: Vec<String>,
+    /// Substrings whose number of occurrences in stderr is itself the
+    /// assertion.
+    #[serde(default)]
+    pub stderr_occurrences: Vec<StderrOccurrence>,
     /// The exit status the published program has at each publication the
     /// scenario waits for. An `initial_failure` scenario publishes only once,
     /// so it declares one; every other kind declares two.
@@ -210,6 +227,11 @@ pub enum WatchScenarioKind {
     /// edit repairs the program. Every other kind opens with a publication,
     /// which is exactly what a first-cycle failure cannot produce.
     InitialFailure,
+    /// A parse error in a closure module, which fails re-observation rather
+    /// than compilation and so puts the loop on its retry timer. The case sits
+    /// inside the failure for several retries, replaces it with a different
+    /// one, and finally repairs it (RUE-2091).
+    RepeatedFailure,
 }
 
 /// A synchronized end-to-end `rue test --watch` scenario (RUE-2023).
@@ -242,6 +264,10 @@ pub struct WatchTestScenario {
     pub stdout_not_contains: Vec<String>,
     #[serde(default)]
     pub stderr_contains: Vec<String>,
+    /// Substrings whose number of occurrences in stderr is itself the
+    /// assertion.
+    #[serde(default)]
+    pub stderr_occurrences: Vec<StderrOccurrence>,
     /// The status the watcher exits with when the case interrupts it: the last
     /// COMPLETED cycle's, which is the only exit status a watcher produces.
     pub expected_exit: i32,
@@ -259,6 +285,10 @@ pub enum WatchTestScenarioKind {
     /// Edit while a test is running: the cycle is abandoned with
     /// `run_canceled` and the next one completes.
     Cancel,
+    /// The `--watch` half of [`WatchScenarioKind::RepeatedFailure`]: the two
+    /// watchers share one loop, so the suppression they share is pinned on
+    /// both surfaces (RUE-2091).
+    RepeatedFailure,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -108,12 +108,56 @@ impl ObservationPhase {
         }
     }
 
+    /// The milestone for a failure this cycle actually reported to the user.
     fn error_event(self) -> &'static str {
         match self {
             ObservationPhase::Reobserve => "reobserve-error",
             ObservationPhase::Acquire => "acquire-error",
         }
     }
+
+    /// The milestone for a retry that hit the failure already on screen and
+    /// said nothing. The retry itself is not silent to the protocol — a
+    /// harness can still count attempts — but the user's terminal is
+    /// (RUE-2091).
+    fn repeated_error_event(self) -> &'static str {
+        match self {
+            ObservationPhase::Reobserve => "reobserve-error-repeat",
+            ObservationPhase::Acquire => "acquire-error-repeat",
+        }
+    }
+}
+
+/// The re-observation failure whose diagnostic is already on the user's
+/// terminal.
+///
+/// A failed re-observation cannot simply wait for an edit: the failure may be
+/// an import naming a file that does not exist yet, which is outside the
+/// retained closure and so outside anything there is to watch. The loop
+/// therefore retries on a timer, and before RUE-2091 each tick reprinted the
+/// whole diagnostic — roughly four identical reports per second for as long as
+/// a person sat inside a syntax error.
+///
+/// Two things make a failure worth reporting again, and a bare timer is
+/// neither of them:
+///
+/// - **The message changed.** Identity is the rendered diagnostic byte for
+///   byte, which is what the user reads. A different code, a different file, or
+///   the same error a line further down is a different report, because the
+///   thing it tells someone to look at moved. Anything less than the whole
+///   rendering risks swallowing a message the previous one did not contain.
+/// - **The source changed.** A revision that still fails identically is worth
+///   one line back, because silence after a save is ambiguous: it looks the
+///   same as a watcher that never noticed the file. `observation` is the
+///   physical state of the retained closure this attempt read, so an edit
+///   anywhere in it re-reports even when the compiler's answer is unchanged.
+///
+/// A clock carries neither signal, so there is no time-based reprint: a
+/// stuck-and-unedited watcher stays quiet indefinitely, which is the whole
+/// point.
+struct ReportedFailure {
+    diagnostic: String,
+    observation: Vec<WatchObservation>,
 }
 
 pub(crate) struct WatchRequest {
@@ -299,6 +343,7 @@ pub(crate) fn run(request: WatchRequest) -> ! {
     } = request;
     let mut needs_reobserve = false;
     let mut cycle: u64 = 0;
+    let mut reported_failure: Option<ReportedFailure> = None;
 
     if let WatchMode::Test(_) = &mode {
         // Once for the process, before anything can spawn: descriptor 3 is
@@ -366,22 +411,44 @@ pub(crate) fn run(request: WatchRequest) -> ! {
                 continue;
             }
             match observed {
-                Ok(()) => test_event("acquire-ok"),
+                Ok(()) => {
+                    test_event("acquire-ok");
+                    // A revision that loads again ends the failure state. The
+                    // next failure is news even if it renders exactly like the
+                    // last one did — reverting to previously broken bytes must
+                    // report, and the fingerprints alone cannot tell that
+                    // revert from a retry, because they are content hashes.
+                    reported_failure = None;
+                }
                 Err(SourceLoadError::Superseded) => {
                     unreachable!("supersession was handled before source errors")
                 }
                 Err(error) => {
-                    test_event(phase.error_event());
-                    print_source_load_error(error, error_format);
-                    print_cycle_status(
-                        &mode,
-                        error_format,
-                        format!(
-                            "Watch cycle failed after {} ms; {}",
-                            cycle_started.elapsed().as_millis(),
-                            failure_consequence(&mode)
-                        ),
-                    );
+                    let diagnostic = render_source_load_error(error, error_format);
+                    let repeat = reported_failure.as_ref().is_some_and(|reported| {
+                        reported.diagnostic == diagnostic
+                            && reported.observation == observation_baseline
+                    });
+                    if repeat {
+                        test_event(phase.repeated_error_event());
+                    } else {
+                        test_event(phase.error_event());
+                        // Diagnostics are stderr's in both formats.
+                        eprintln!("{diagnostic}");
+                        print_cycle_status(
+                            &mode,
+                            error_format,
+                            format!(
+                                "Watch cycle failed after {} ms; {}",
+                                cycle_started.elapsed().as_millis(),
+                                failure_consequence(&mode)
+                            ),
+                        );
+                        reported_failure = Some(ReportedFailure {
+                            diagnostic,
+                            observation: observation_baseline,
+                        });
+                    }
                     thread::sleep(FAILED_REOBSERVE_RETRY);
                     continue;
                 }
@@ -662,10 +729,6 @@ fn test_watch_cycle(request: TestWatchCycle<'_, '_>) -> test_mode::CycleOutcome 
         cancellation: Some(cancellation),
         observation,
     })
-}
-
-fn print_source_load_error(error: SourceLoadError, error_format: ErrorFormat) {
-    eprintln!("{}", render_source_load_error(error, error_format));
 }
 
 /// Watch-cycle status is not a diagnostic. In JSON mode it must not share

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -156,6 +156,14 @@ source-load or environmental message and exit with status `1`. In `--watch`, a
 failed cycle keeps the last successful executable and the watcher continues;
 the cycle status is progress text, not an additional diagnostic.
 
+A `--watch` failure the loop cannot park on — a re-observation or acquisition
+error, which may name a file that does not exist yet — is retried on a timer,
+and the stream carries one array per distinct failure rather than one per retry
+(RUE-2091). The array returns when the rendered diagnostic changes or when a
+source in the watched closure does; an unchanged failure over unchanged bytes
+publishes nothing further. Nothing about the array's shape, code, or framing
+changes with it, so this is an emission cadence rather than a schema change.
+
 Driver failures can occur before the initial compilation snapshot exists, or
 after a snapshot exists while a watch cycle reobserves inputs or acquires a
 reached trusted-toolchain module.

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -848,6 +848,13 @@ has no one revision — and keeps compile mode's own exclusions (`--emit`,
   for this revision`), and the previous cycle's verdicts are not reprinted. Every status line
   the loop writes goes to stderr in both formats — stdout belongs to the event
   stream — which is where the runner's other notices already go.
+- **A failure is reported once, not once per retry.** A failure the loop cannot
+  park on — a broken `@import` may name a file that does not exist yet — is
+  retried on a timer, and a retry that finds the same failure over the same
+  bytes says nothing. The report returns when the rendered diagnostic changes or
+  when a source in the closure does, so a save that leaves the error standing
+  still gets one line back rather than silence, and a watcher left inside an
+  untouched syntax error stays quiet indefinitely.
 - **The exit status is produced only on SIGINT or SIGTERM**, and is the last
   cycle that COMPLETED reporting itself on the ordinary
   [exit-code table](#exit-codes): `0` if it passed, `1` if it failed, `3` if it


### PR DESCRIPTION
A syntax error inside a watched closure file fails import discovery rather than
compilation, and a failed discovery cannot park on a change: the broken
`@import` may name a file that does not exist yet, which is outside the
retained closure and so outside anything there is to watch. The loop therefore
retries every 250 ms — and it reprinted the whole diagnostic and its status line
on every tick. Measured on the parent commit: **30 identical reports in 8
seconds**, in both `rue --watch` and `rue test --watch`, which share this loop.

The report now belongs to the failure rather than to the tick. The loop
remembers what is already on the terminal as the rendered diagnostic plus the
physical state of the closure the attempt read, and a retry matching both says
nothing. It speaks again on two triggers:

- **the message changed** — a different code, a different file, or the same
  error a line further down all point somewhere new;
- **a source in the closure changed** — silence after a save is
  indistinguishable from a watcher that never noticed the file, so a revision
  that still fails identically gets one line back.

A clock carries neither signal, so there is no timer-based reprint: a watcher
left inside an untouched error stays quiet indefinitely. A revision that loads
again clears the memory — fingerprints are content hashes, so without that reset
a revert to previously broken bytes would be mistaken for a retry.

Measured on this branch, same window: **1 report**, with all 30 retry attempts
still happening underneath. The first report is still on the first failing tick,
on the same streams, in the same order; only repeats are dropped.

## Coverage

Event-driven through the existing `RUE_WATCH_TEST_PROTOCOL` milestones. A
suppressed retry publishes `reobserve-error-repeat` / `acquire-error-repeat`, so
a case waits for real attempts instead of sleeping. The executable case walks
all three behaviors — suppress, report a different failure, report an unrelated
closure save, publish the repair, report the restored bytes — and a new
exact-count `stderr_occurrences` corpus field pins the user-visible half. Each
step is mutation-checked: removing the suppression, the observation half of the
key, or the reset each fails the suite.

## Verification

`scripts/rue quick`, `scripts/rue cli watch`, `scripts/rue cli rue_test`, and
the full `premerge` tier (219 results across 221 targets) are green, as are all
four `//:cli-tests` shards.

## Follow-up, tracked separately

When the file the diagnostic names is outside the retained closure — a
pre-existing broken module wired in for the first time — saving it produces no
output, because the closure key cannot see it. Filed as its own issue; the
change is a large net improvement over the 4 Hz spam either way.

Fixes RUE-2091