### PR TITLE
RUE-1943: the error printer's parameter shape comes from the places that read it

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -140,9 +140,9 @@ pub use sema::{
     SemanticProducedAnonymousMethodSignature, SemanticProducedAnonymousMethodType,
     SemanticProducedAnonymousNominal, SemanticProducedAnonymousNominalShape, SourceParamAbi,
     analyze_provider_anonymous_body, analyze_provider_ordinary_body,
-    analyze_provider_specialized_body, body_parameter_types, by_reference_parameter_pointee_types,
-    comptime_call_cycle_reason, comptime_depth_exceeded_reason, comptime_depth_over_limit,
-    next_comptime_depth, occupying_body_parameter_types,
+    analyze_provider_specialized_body, body_parameter_types, comptime_call_cycle_reason,
+    comptime_depth_exceeded_reason, comptime_depth_over_limit, next_comptime_depth,
+    occupying_body_parameter_types, parameter_place_base_types,
 };
 pub use sema::{
     COMPTIME_MATCH_NO_SELECTED_ARM, ComptimeDiagnosticSite, ComptimeIntegerOperation,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -109,7 +109,7 @@ pub use output::{
     DeclarationTypeDependencyTargetKind, ImplicitDropDependencySourceEvent,
     ImplicitNamedDestructorDependencyEvent, NamedConstDependencyEvent,
     NamedConstDependencyTargetEvent, ParamSlotModes, SourceParamAbi, body_parameter_types,
-    by_reference_parameter_pointee_types, occupying_body_parameter_types,
+    occupying_body_parameter_types, parameter_place_base_types,
 };
 pub use provider::{
     BodyFactProvider, DropCopyMetadata, ImportResolution, MemberCandidate, MemberKind,

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -304,21 +304,27 @@ pub fn occupying_body_parameter_types(
     types
 }
 
-/// The pointee type of every `borrow` / `inout` parameter the body reaches,
-/// keyed by the parameter's ABI slot.
+/// The base type of every parameter the body reaches through a place, keyed
+/// by the parameter's ABI slot.
 ///
-/// A by-reference parameter has no `Param` instruction and no drop entry — its
-/// slot carries the caller's pointer, and every use goes through a place whose
-/// base is that slot — so [`body_parameter_types`] deliberately does not see
-/// it. The place's own [`AirPlace::base_type`](crate::AirPlace) is the pointee
-/// type, recorded because a physical slot index does not identify it.
+/// A place rooted at a parameter slot carries the logical type stored there
+/// as its own [`AirPlace::base_type`](crate::AirPlace), recorded because a
+/// physical slot index does not identify it. That names two kinds of parameter
+/// [`body_parameter_types`] deliberately does not see. A by-reference
+/// parameter has no `Param` instruction and no drop entry — its slot carries
+/// the caller's pointer and every use goes through a place — so the base type
+/// here is its pointee. And a by-value parameter a body reads only through
+/// places, never whole, has no `Param` instruction either: a parameter that
+/// is only ever forwarded, or the error value a synthesized error printer
+/// walks field by field without a drop schedule (RUE-1943). For those the
+/// base type is the parameter's own, and it is what groups the parameter's
+/// slots into one descriptor at CFG build.
 ///
-/// This is a *presentation* recovery, not an ABI input: a by-reference
-/// parameter crosses as one pointer whatever it points at, so nothing in
-/// classification, layout, or code generation consults this. `--emit abi` reads
-/// it to name the type beside a placement. A parameter the body never reads
-/// through a place has no entry, and the report says so.
-pub fn by_reference_parameter_pointee_types(air: &crate::Air) -> ahash::AHashMap<u32, crate::Type> {
+/// A by-reference entry is presentation only — the parameter crosses as one
+/// pointer whatever it points at, so nothing in classification, layout, or
+/// code generation consults it; `--emit abi` reads it to name the type beside
+/// a placement. A parameter the body never reads through a place has no entry.
+pub fn parameter_place_base_types(air: &crate::Air) -> ahash::AHashMap<u32, crate::Type> {
     let mut types: ahash::AHashMap<u32, crate::Type> = ahash::AHashMap::new();
     for place in air.places() {
         if let crate::AirPlaceBase::Param(slot) = place.base {

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -842,13 +842,15 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
 
     // Slot -> source type. A parameter's own extent is what groups the slots,
     // so every by-value parameter needs one: the drop schedule and the body's
-    // `Param` instructions name most of them, and a parameter the body only
-    // ever *forwards* — a `borrow` of it as a call argument, say — is named by
-    // the place that reads it. A zero-sized parameter occupies no slot, so it
-    // never claims the slot it shares with the parameter that follows it.
+    // `Param` instructions name most of them, and a parameter the body reads
+    // only through places — one it only ever *forwards*, a `borrow` of it as
+    // a call argument, say, or the error value a synthesized printer walks
+    // field by field with no drop schedule (RUE-1943) — is named by the place
+    // that reads it. A zero-sized parameter occupies no slot, so it never
+    // claims the slot it shares with the parameter that follows it.
     let occupies = |ty: Type| type_pool.abi_slot_count(ty) > 0;
     let mut ty_at: AHashMap<u32, Type> = rue_air::occupying_body_parameter_types(air, occupies);
-    for (slot, ty) in rue_air::by_reference_parameter_pointee_types(air) {
+    for (slot, ty) in rue_air::parameter_place_base_types(air) {
         if occupies(ty) {
             ty_at.entry(slot).or_insert(ty);
         }

--- a/crates/rue-codegen/src/abi_report.rs
+++ b/crates/rue-codegen/src/abi_report.rs
@@ -440,9 +440,10 @@ fn native_side(
     // Two recoveries, because a body records the two parameter kinds
     // differently: a by-value parameter through its drop entry or `Param`
     // instruction, a by-reference one only through the pointee type on the
-    // places that read it.
+    // places that read it. The second also names a by-value parameter read
+    // only through places, which the report treats exactly as the first.
     let value_types = rue_air::body_parameter_types(air);
-    let pointee_types = rue_air::by_reference_parameter_pointee_types(air);
+    let pointee_types = rue_air::parameter_place_base_types(air);
 
     let descriptors = parameter_descriptors(cfg);
     let modes: Vec<AbiParameterMode> = descriptors

--- a/crates/rue-compiler/src/error_printer.rs
+++ b/crates/rue-compiler/src/error_printer.rs
@@ -504,21 +504,20 @@ pub(crate) fn synthesize_error_printer(
     let owner_ty = semantic_type_from_instance(owner);
     let mut builder = Builder::default();
     let mut statements = builder.prologue();
-    // The error value is one parameter, not one per slot. Naming it whole here
-    // is what makes the CFG's parameter-area descriptor cover the value's full
-    // width; every read below then goes through a place rooted at that one
-    // parameter, so the address arithmetic is the compiler's own rather than a
-    // second copy of it. Reading raw parameter slots would need this body to
-    // restate the parameter area's slot order, which is exactly the knowledge
-    // place lowering already owns.
+    // The error value is one parameter, not one per slot, and every read
+    // below goes through a place rooted at that one parameter, so the address
+    // arithmetic is the compiler's own rather than a second copy of it.
+    // Reading raw parameter slots would need this body to restate the
+    // parameter area's slot order, which is exactly the knowledge place
+    // lowering already owns.
     //
-    // Declared, deliberately unreferenced: the descriptor is derived from the
-    // AIR's `Param` instructions, and this body's real reads are place reads.
-    // Evaluating a whole-value `Param` here would additionally *consume* an
-    // error type that owns anything, and the reads that follow would then be
-    // reads after a move. The parameter's drop schedule cannot supply the
-    // descriptor instead, because this body deliberately has none (6.7:16).
-    builder.add(Data::Param { index: 0 }, owner_ty.clone());
+    // Those places are also what tells CFG construction the parameter's
+    // shape: each carries the owner as its base type, and the parameter-area
+    // descriptor is grouped from that (RUE-1943). No whole-value `Param`
+    // instruction is declared for it. Evaluating one would *consume* an error
+    // type that owns anything, making the reads that follow reads after a
+    // move, and this body deliberately has no drop schedule to name the
+    // parameter instead (6.7:16).
 
     // One payload binding serves every byte-string payload, one variant at a
     // time; it is as wide as the widest such payload and absent when no variant


### PR DESCRIPTION
Fixes [RUE-1943](https://linear.app/steve-klabnik/issue/RUE-1943). The issue was in Backlog; I took it because the Todo pool is down to needs-decision items and work already In Progress elsewhere, and this one asks for no design call. No behavior change.

## Problem

The synthesized error printer declared a `Param { index: 0 }` instruction it never referenced, so that `derive_source_param_abi` would find a type for slot 0 and group the error value's slots into one descriptor. Evaluating the instruction would have consumed an owned error value ahead of the place reads that follow, and the printer has no drop schedule to name the parameter instead (6.7:16).

## Change

The descriptor never needed the instruction. CFG construction already recovers a parameter's type from the places rooted at its slot, each of which carries the owner as its base type, and the printer reads its subject, every leaf, and every byte view through exactly such places. So:

- **The unreferenced instruction is deleted** from `error_printer.rs`, and the comment there now says what supplies the parameter's shape.
- **The recovery is renamed** from `by_reference_parameter_pointee_types` to `parameter_place_base_types`. Its doc claimed it was presentation-only and consulted by nothing in layout or codegen, which was already untrue: the CFG builder has read it since a forwarded-only by-value parameter needed naming. The doc now says which two parameter kinds it names (a by-reference pointee, and a by-value parameter read only through places) and that the CFG builder groups slots from it. The `build.rs` and `abi_report.rs` comments at the two call sites say the same.

This is the "derive the parameter ABI from what the body declares" option from the issue, with the places as the declaration. Drop glue already takes the separate cleanup-owner path in `derive_source_param_abi`, so it is untouched.

## Tests

Existing coverage only, since nothing observable changes. Ran locally: the whole `rue-compiler`, `rue-air`, `rue-cfg`, and `rue-codegen` unit suites (the printer's tests live in `test_body_try_tests.rs` and `assert_comparison_tests.rs`; the ABI report's in `abi_report.rs`), the `rue_test_question`, `rue_test_assert`, and `abi` CLI sections, `scripts/rue quick`, and the four crates' clippy gates. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEHdMtLGAdvXY8GsGyCTza

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEHdMtLGAdvXY8GsGyCTza)_