### PR TITLE
RUE-2018: add expected-failure markers to test declarations

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -755,7 +755,30 @@ test "alpha" {
 args = ["test", "main.rue", "--list", "--format", "json"]
 driver_exit_code = 0
 compile_stdout_contains = [
-    '{"column":1,"event":"test","file":"tests.rue","id":"tests.rue::alpha","line":1,"module":"tests.rue","name":"alpha","schema":"1.0"}',
+    '{"column":1,"event":"test","file":"tests.rue","id":"tests.rue::alpha","line":1,"module":"tests.rue","name":"alpha","schema":"1.1"}',
+]
+compile_stdout_not_contains = ["run_started", "run_finished", "test_finished"]
+
+[[case]]
+name = "list_json_exposes_known_bug_metadata"
+description = "The canonical test inventory carries expected-failure metadata into JSON listings."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "tests.rue", source = """
+@known_bug("RUE-2018")
+test "unscoped" { }
+@known_bug_on("aarch64-macos", "RUE-2018")
+test "scoped" { }
+""" },
+]
+args = ["test", "main.rue", "--list", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = [
+    '"known_bug":"RUE-2018"',
+    '"known_bug_on":[{"issue":"RUE-2018","platform":"aarch64-macos"}]',
 ]
 compile_stdout_not_contains = ["run_started", "run_finished", "test_finished"]
 
@@ -945,7 +968,7 @@ args = ["test", "main.rue", "--seed", "424242", "-j1", "--format", "json"]
 driver_exit_code = 0
 compile_stdout_contains = [
     '{"event":"run_started","jobs":1,"opt_level":"0",',
-    '"plan":{"selected":1,"total":1},"root":"main.rue","schema":"1.0","seed":424242,',
+    '"plan":{"selected":1,"total":1},"root":"main.rue","schema":"1.1","seed":424242,',
     '{"event":"test_started","id":"tests.rue::alpha"}',
     '{"capability_summary":{"status":"unavailable"},',
     '"stderr":{"bytes_total":0,"digest":"sha256:',
@@ -1896,6 +1919,74 @@ compile_stdout_not_contains = ['"scratch_dir"']
 compile_stderr_contains = ["type mismatch: expected i32, found bool"]
 
 [[case]]
+name = "a_marked_compile_error_is_an_expected_failure"
+description = "A marked test whose body does not analyze is an xfail and does not make the run fail."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "tests.rue", source = """
+@known_bug("RUE-2018")
+test "known compile error" {
+    let wrong: i32 = true;
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = [
+    '"verdict":"xfail"',
+    '"kind":"compile_error"',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":0',
+    '"xfail":1,"xpass":0',
+]
+compile_stderr_contains = ["type mismatch: expected i32, found bool"]
+
+[[case]]
+name = "marked_compile_error_and_ordinary_test_have_separate_counts"
+description = "A marked compile error and an ordinary passing sibling both contribute exactly once to the run."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "tests.rue", source = """
+@known_bug("RUE-2018")
+test "known compile error" { let wrong: i32 = true; }
+test "still runs" { @assert(2 + 2 == 4); }
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = [
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":1',
+    '"xfail":1,"xpass":0',
+]
+compile_stderr_contains = ["type mismatch: expected i32, found bool"]
+
+[[case]]
+name = "a_known_bug_pass_is_an_unexpected_pass"
+description = "A passing test with a matching marker is an xpass and makes the run fail."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "tests.rue", source = """
+@known_bug("RUE-2018")
+test "fixed bug" { }
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"verdict":"xpass"',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":0',
+    '"xfail":0,"xpass":1',
+]
+
+[[case]]
 name = "a_broken_helper_is_one_verdict_per_dependent_test"
 description = """
 Maintainer ruling (2026-09-04): a helper several tests share that fails to
@@ -2256,3 +2347,79 @@ args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
 driver_exit_code = 2
 compile_stdout_not_contains = ['"event":"run_started"', '"event":"run_finished"', '"verdict"']
 compile_stderr_contains = ["unknown type 'Nope'"]
+
+[[case]]
+name = "known_bug_runtime_failure_preserves_evidence"
+description = "A marked assertion failure publishes xfail with its original evidence beside an ordinary passing test."
+files = [{ path = "main.rue", source = """
+@known_bug("RUE-2018")
+test "expected" { @assert(false); }
+test "ordinary" { }
+""" }]
+args = ["test", "main.rue", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = ['"verdict":"xfail"', '"kind":"assert"', '"passed":1', '"xfail":1,"xpass":0', '"scratch_dir"', '"repro"']
+
+[[case]]
+name = "known_bug_xpass_has_a_full_human_report"
+description = "An unexpected pass fails the run and retains output and reproduction information."
+files = [{ path = "main.rue", source = """
+@known_bug("RUE-2018")
+test "fixed" { println("evidence from the passing test"); }
+""" }]
+args = ["test", "main.rue", "-j1"]
+driver_exit_code = 1
+compile_stdout_contains = ["XPASS main.rue::fixed", "remove the known-bug marker", "evidence from the passing test", "scratch:", "repro:", "0 passed, 1 unexpected pass"]
+
+[[case]]
+name = "known_bug_does_not_suppress_timeout"
+description = "A known-bug marker cannot absorb a hung process."
+files = [{ path = "main.rue", source = """
+@known_bug("RUE-2018")
+test "hangs" { while true { } }
+""" }]
+args = ["test", "main.rue", "--timeout-ms", "500", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = ['"verdict":"timeout"', '"timeout":1', '"xfail":0,"xpass":0']
+
+[[case]]
+name = "known_bug_platform_aarch64_macos"
+description = "Matching platform markers accept failures; nonmatching markers leave passing tests ordinary."
+only_on = ["aarch64-macos"]
+files = [{ path = "main.rue", source = """
+@known_bug_on("aarch64-macos", "RUE-2018")
+test "matching" { @assert(false); }
+@known_bug_on("x86-64-linux", "RUE-2018")
+test "nonmatching" { }
+""" }]
+args = ["test", "main.rue", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = ['"verdict":"xfail"', '"verdict":"pass"', '"passed":1', '"xfail":1,"xpass":0']
+
+[[case]]
+name = "known_bug_platform_x86_64_linux"
+description = "Matching platform markers accept failures; nonmatching markers leave passing tests ordinary."
+only_on = ["x86-64-linux"]
+files = [{ path = "main.rue", source = """
+@known_bug_on("x86-64-linux", "RUE-2018")
+test "matching" { @assert(false); }
+@known_bug_on("aarch64-macos", "RUE-2018")
+test "nonmatching" { }
+""" }]
+args = ["test", "main.rue", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = ['"verdict":"xfail"', '"verdict":"pass"', '"passed":1', '"xfail":1,"xpass":0']
+
+[[case]]
+name = "known_bug_platform_aarch64_linux"
+description = "Matching platform markers accept failures; nonmatching markers leave passing tests ordinary."
+only_on = ["aarch64-linux"]
+files = [{ path = "main.rue", source = """
+@known_bug_on("aarch64-linux", "RUE-2018")
+test "matching" { @assert(false); }
+@known_bug_on("aarch64-macos", "RUE-2018")
+test "nonmatching" { }
+""" }]
+args = ["test", "main.rue", "-j1", "--format", "json"]
+driver_exit_code = 0
+compile_stdout_contains = ['"verdict":"xfail"', '"verdict":"pass"', '"passed":1', '"xfail":1,"xpass":0']

--- a/crates/rue-cli-tests/cases/watch_test.toml
+++ b/crates/rue-cli-tests/cases/watch_test.toml
@@ -48,7 +48,7 @@ kind = "edit"
 expected_exit = 1
 stdout_contains = [
     # Cycle 1: the head event carries its number, and both tests pass.
-    '"cycle":1,"event":"run_started","jobs":1,"opt_level":"0","plan":{"selected":2,"total":2},"root":"main.rue","schema":"1.0","seed":1',
+    '"cycle":1,"event":"run_started","jobs":1,"opt_level":"0","plan":{"selected":2,"total":2},"root":"main.rue","schema":"1.1","seed":1',
     '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":2',
     # Cycle 2: a second pair, numbered, over the same two tests.
     '"cycle":2,"event":"run_started"',
@@ -324,6 +324,60 @@ source = """
 test "doubles" {
     @assert(2 * 2 == 5);
 }
+"""
+
+[[case]]
+name = "known_bug_adding_a_marker_refreshes_the_retained_run"
+description = "A marker-only edit refreshes verdicts on the retained compiler."
+files = [{ path = "main.rue", source = """
+test "marked" { @assert(false); }
+""" }]
+
+[case.watch_test]
+kind = "edit"
+expected_exit = 0
+stdout_contains = [
+    '"cycle":1,"event":"run_started"',
+    '"cycle":2,"event":"run_started"',
+    '"verdict":"fail"',
+    '"verdict":"xfail"',
+    '"xfail":1,"xpass":0',
+    '"xfail":0,"xpass":0',
+]
+stdout_not_contains = ['"cycle":3', '"verdict":"xpass"']
+
+[[case.watch_test.edits]]
+path = "main.rue"
+source = """
+@known_bug("RUE-2018")
+test "marked" { @assert(false); }
+"""
+
+[[case]]
+name = "known_bug_removing_a_marker_refreshes_the_retained_run"
+description = "A marker-only edit refreshes verdicts on the retained compiler."
+files = [{ path = "main.rue", source = """
+@known_bug("RUE-2018")
+test "marked" { @assert(false); }
+""" }]
+
+[case.watch_test]
+kind = "edit"
+expected_exit = 1
+stdout_contains = [
+    '"cycle":1,"event":"run_started"',
+    '"cycle":2,"event":"run_started"',
+    '"verdict":"fail"',
+    '"verdict":"xfail"',
+    '"xfail":1,"xpass":0',
+    '"xfail":0,"xpass":0',
+]
+stdout_not_contains = ['"cycle":3', '"verdict":"xpass"']
+
+[[case.watch_test.edits]]
+path = "main.rue"
+source = """
+test "marked" { @assert(false); }
 """
 
 [[case]]

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -5770,6 +5770,49 @@ fn test_inventory_orders_every_module_by_stable_id() {
     assert_eq!((alpha.line, alpha.column), (3, 1));
 }
 
+/// Metadata-only source revisions must refresh the canonical inventory even
+/// when test identities and executable bodies stay the same.
+#[test]
+fn test_inventory_refreshes_known_bug_metadata_in_a_retained_session() {
+    let mut session = CompilerSession::new();
+    let options = test_declaration_options(crate::RootSelection::Tests);
+    for (directive, expected) in [
+        ("", None),
+        ("@known_bug(\"RUE-1\")", Some(("RUE-1", None))),
+        ("@known_bug(\"RUE-2\")", Some(("RUE-2", None))),
+        (
+            "@known_bug_on(\"aarch64-macos\", \"RUE-2\")",
+            Some(("RUE-2", Some("aarch64-macos"))),
+        ),
+        (
+            "@known_bug_on(\"x86-64-linux\", \"RUE-2\")",
+            Some(("RUE-2", Some("x86-64-linux"))),
+        ),
+        ("", None),
+    ] {
+        let source =
+            SourceSnapshot::single("main.rue", format!("{directive}\ntest \"stable\" {{ }}"))
+                .unwrap();
+        session.update(&source).into_result().unwrap();
+        let listing = crate::unstable::test_inventory(&mut session, &options).unwrap();
+        assert!(listing.failure_diagnostics.is_empty());
+        let entries = listing.inventory.entries;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "main.rue::stable");
+        assert_eq!(entries[0].ordinal, 0);
+        let actual = entries[0]
+            .expected_failures
+            .iter()
+            .map(|marker| (marker.issue.as_str(), marker.platform.as_deref()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual,
+            expected.into_iter().collect::<Vec<_>>(),
+            "{directive}"
+        );
+    }
+}
+
 /// A listing analyzes the closure and stops (ADR-0083 §2): no codegen, no
 /// object projection.
 #[test]

--- a/crates/rue-compiler/src/test_inventory.rs
+++ b/crates/rue-compiler/src/test_inventory.rs
@@ -22,7 +22,7 @@
 use std::sync::Arc;
 
 use crate::parsed_modules::ParsedModule;
-use crate::unstable::TestInventoryEntry;
+use crate::unstable::{TestExpectedFailure, TestInventoryEntry};
 
 /// One inventoried test: what a consumer is shown, and what the image calls.
 ///
@@ -83,6 +83,9 @@ pub(crate) fn collect_test_inventory(
             }
             None => (String::new(), 0, 0),
         };
+        let expected_failures = module
+            .and_then(|module| test_expected_failures(module, &name))
+            .unwrap_or_default();
         entries.push(RootedTest {
             entry: TestInventoryEntry {
                 id: format!("{module_path}::{name}"),
@@ -92,6 +95,7 @@ pub(crate) fn collect_test_inventory(
                 line,
                 column,
                 ordinal: 0,
+                expected_failures,
             },
             identity: root.clone(),
         });
@@ -101,6 +105,55 @@ pub(crate) fn collect_test_inventory(
         test.entry.ordinal = u32::try_from(ordinal).unwrap_or(u32::MAX);
     }
     entries
+}
+
+/// Read validated test expectation directives from the declaration that owns
+/// this inventory entry. This stays inside the existing inventory computation,
+/// so marker metadata follows the parsed module revision and cache boundary
+/// already used for stable identity and source location.
+fn test_expected_failures(module: &ParsedModule, name: &str) -> Option<Vec<TestExpectedFailure>> {
+    let test = module.ast().items.iter().find_map(|item| match item {
+        rue_parser::ast::Item::Test(test)
+            if module.try_resolve_raw_symbol(test.name.value) == Some(name) =>
+        {
+            Some(test)
+        }
+        _ => None,
+    })?;
+    let mut markers = Vec::new();
+    for directive in &test.directives {
+        match directive.kind {
+            Some(rue_parser::DirectiveName::KnownBug) => {
+                if let Some(arg) = directive.args.first() {
+                    markers.push(TestExpectedFailure {
+                        issue: module
+                            .try_resolve_raw_symbol(arg.ident.name)
+                            .unwrap_or_default()
+                            .to_owned(),
+                        platform: None,
+                    });
+                }
+            }
+            Some(rue_parser::DirectiveName::KnownBugOn) => {
+                if directive.args.len() >= 2 {
+                    markers.push(TestExpectedFailure {
+                        platform: Some(
+                            module
+                                .try_resolve_raw_symbol(directive.args[0].ident.name)
+                                .unwrap_or_default()
+                                .to_owned(),
+                        ),
+                        issue: module
+                            .try_resolve_raw_symbol(directive.args[1].ident.name)
+                            .unwrap_or_default()
+                            .to_owned(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    Some(markers)
 }
 
 /// The module identity a consumer is shown.

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -745,6 +745,18 @@ pub struct TestInventoryEntry {
     /// 1-based column of that header, on the same terms as `line`.
     pub column: u32,
     pub ordinal: u32,
+    /// Test-only expected-failure markers that apply on this host-independent
+    /// inventory. The runner filters platform-scoped entries at execution
+    /// time, keeping listing and cached inventory metadata complete.
+    pub expected_failures: Vec<TestExpectedFailure>,
+}
+
+/// One `@known_bug` or `@known_bug_on` marker attached to a test declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestExpectedFailure {
+    pub issue: String,
+    /// `None` for an unscoped `@known_bug`; otherwise the canonical host name.
+    pub platform: Option<String>,
 }
 
 /// Every test in a request's closure, in stable-ID order.

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -92,7 +92,9 @@ impl Directive {
         }
         self.args.iter().find_map(|arg| match arg.value {
             DirectiveArgValue::Repr(repr) => Some(repr),
-            DirectiveArgValue::Warning(_) | DirectiveArgValue::Unrecognized => None,
+            DirectiveArgValue::Warning(_)
+            | DirectiveArgValue::KnownBugText
+            | DirectiveArgValue::Unrecognized => None,
         })
     }
 }
@@ -101,11 +103,14 @@ impl Directive {
 /// against the owning directive's argument vocabulary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectiveArg {
-    /// The identifier as written (e.g., `unused_variable` in
-    /// `@allow(unused_variable)`)
+    /// The argument text as written. Quoted directive arguments use the same
+    /// interned text carrier so directive consumers have one lookup path.
     pub ident: Ident,
     /// What the identifier denotes for the owning directive.
     pub value: DirectiveArgValue,
+    /// Whether the source spelling was a string literal rather than an
+    /// identifier. Test expectation directives require quoted arguments.
+    pub quoted: bool,
 }
 
 /// The first directive in `directives` with the given name.

--- a/crates/rue-parser/src/directives.rs
+++ b/crates/rue-parser/src/directives.rs
@@ -16,6 +16,8 @@
 
 use std::fmt;
 
+use rue_target::HostPlatform;
+
 /// Declares one closed vocabulary: the variants, their source spellings, the
 /// full list and the spelling lookup are generated from a single table, so no
 /// half of the mapping can drift from another.
@@ -75,6 +77,10 @@ vocabulary! {
         /// `@non_exhaustive` opts a public enum into the source compatibility
         /// contract for matches in importing modules.
         NonExhaustive = "non_exhaustive",
+        /// `@known_bug("RUE-NNN")` marks a test as an expected failure.
+        KnownBug = "known_bug",
+        /// `@known_bug_on("platform", "RUE-NNN")` scopes an expected failure.
+        KnownBugOn = "known_bug_on",
     }
 }
 
@@ -135,6 +141,8 @@ pub enum DirectiveArity {
     None,
     /// Exactly one argument drawn from the directive's argument vocabulary.
     ExactlyOne,
+    /// Exactly two arguments drawn from the directive's argument vocabulary.
+    ExactlyTwo,
     /// Any number of arguments, each drawn from the directive's vocabulary.
     Any,
 }
@@ -149,6 +157,8 @@ pub enum DirectiveArity {
 pub enum DirectiveArgValue {
     Warning(WarningName),
     Repr(ReprArg),
+    /// A quoted string accepted by a test expectation directive.
+    KnownBugText,
     Unrecognized,
 }
 
@@ -170,6 +180,7 @@ impl DirectiveName {
             // spec 2.5:34
             DirectiveName::Repr => &[DirectiveSite::Struct],
             DirectiveName::NonExhaustive => &[DirectiveSite::Enum],
+            DirectiveName::KnownBug | DirectiveName::KnownBugOn => &[DirectiveSite::Test],
         }
     }
 
@@ -183,6 +194,8 @@ impl DirectiveName {
             // spec 2.5:34: parameterized, exactly one representation argument.
             DirectiveName::Repr => DirectiveArity::ExactlyOne,
             DirectiveName::NonExhaustive => DirectiveArity::None,
+            DirectiveName::KnownBug => DirectiveArity::ExactlyOne,
+            DirectiveName::KnownBugOn => DirectiveArity::ExactlyTwo,
         }
     }
 
@@ -191,17 +204,38 @@ impl DirectiveName {
         self.allowed_sites().contains(&site)
     }
 
-    /// Classify one argument identifier against this directive's argument
-    /// vocabulary.
-    pub fn classify_arg(self, text: &str) -> DirectiveArgValue {
+    /// Classify one argument against this directive's argument vocabulary.
+    pub fn classify_arg(self, text: &str, quoted: bool) -> DirectiveArgValue {
         match self {
-            DirectiveName::Allow => WarningName::from_source(text)
+            DirectiveName::Allow if !quoted => WarningName::from_source(text)
                 .map_or(DirectiveArgValue::Unrecognized, DirectiveArgValue::Warning),
-            DirectiveName::Repr => ReprArg::from_source(text)
+            DirectiveName::Repr if !quoted => ReprArg::from_source(text)
                 .map_or(DirectiveArgValue::Unrecognized, DirectiveArgValue::Repr),
-            DirectiveName::Copy | DirectiveName::NonExhaustive => DirectiveArgValue::Unrecognized,
+            DirectiveName::Allow | DirectiveName::Repr => DirectiveArgValue::Unrecognized,
+            DirectiveName::KnownBug | DirectiveName::KnownBugOn if quoted => {
+                DirectiveArgValue::KnownBugText
+            }
+            DirectiveName::Copy
+            | DirectiveName::NonExhaustive
+            | DirectiveName::KnownBug
+            | DirectiveName::KnownBugOn => DirectiveArgValue::Unrecognized,
         }
     }
+}
+
+/// Whether a quoted marker names a canonical Linear issue.
+pub fn is_canonical_known_bug_marker(marker: &str) -> bool {
+    let Some(number) = marker.strip_prefix("RUE-") else {
+        return false;
+    };
+    !number.is_empty()
+        && number.as_bytes()[0] != b'0'
+        && number.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+/// Whether a marker's platform is one of the harness's canonical host names.
+pub fn is_known_bug_platform(platform: &str) -> bool {
+    HostPlatform::from_name(platform).is_some()
 }
 
 impl WarningName {
@@ -320,7 +354,7 @@ mod tests {
     fn diagnostic_lists_read_as_prose() {
         assert_eq!(
             directive_name_list(),
-            "@allow, @copy, @repr, and @non_exhaustive"
+            "@allow, @copy, @repr, @non_exhaustive, @known_bug, and @known_bug_on"
         );
         assert_eq!(
             warning_name_list(),
@@ -358,19 +392,19 @@ mod tests {
     #[test]
     fn argument_vocabularies_follow_the_directive() {
         assert_eq!(
-            DirectiveName::Allow.classify_arg("unreachable_code"),
+            DirectiveName::Allow.classify_arg("unreachable_code", false),
             DirectiveArgValue::Warning(WarningName::UnreachableCode)
         );
         assert_eq!(
-            DirectiveName::Repr.classify_arg("c"),
+            DirectiveName::Repr.classify_arg("c", false),
             DirectiveArgValue::Repr(ReprArg::C)
         );
         assert_eq!(
-            DirectiveName::Repr.classify_arg("unreachable_code"),
+            DirectiveName::Repr.classify_arg("unreachable_code", false),
             DirectiveArgValue::Unrecognized
         );
         assert_eq!(
-            DirectiveName::Copy.classify_arg("c"),
+            DirectiveName::Copy.classify_arg("c", false),
             DirectiveArgValue::Unrecognized
         );
     }

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -751,6 +751,61 @@ mod tests {
     }
 
     #[test]
+    fn test_expectation_directives_keep_quoted_arguments() {
+        let (ast, interner) = parse_source("@known_bug(\"RUE-123\") test \"marked\" { }").unwrap();
+        let Item::Test(test) = &ast.items[0] else {
+            panic!("expected a test declaration");
+        };
+        assert_eq!(test.directives.len(), 1);
+        assert!(test.directives[0].args[0].quoted);
+        assert_eq!(
+            interner.resolve(&test.directives[0].args[0].ident.name),
+            "RUE-123"
+        );
+        let (ast, _) =
+            parse_source("@known_bug_on(\"aarch64-macos\", \"RUE-124\") test \"scoped\" { }")
+                .unwrap();
+        let Item::Test(test) = &ast.items[0] else {
+            panic!("expected a test declaration");
+        };
+        assert!(test.directives[0].args.iter().all(|arg| arg.quoted));
+    }
+
+    #[test]
+    fn ordinary_directives_reject_quoted_arguments() {
+        for source in [
+            r#"@allow("unused_variable") fn f() {}"#,
+            r#"@repr("c") struct S {}"#,
+        ] {
+            assert!(
+                parse_source(source).is_err(),
+                "accepted invalid directive: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_expectation_directives_reject_invalid_or_conflicting_metadata() {
+        for source in [
+            r#"@known_bug test "bad" {}"#,
+            r#"@known_bug("RUE-01") test "bad" {}"#,
+            r#"@known_bug("RUE-0") test "bad" {}"#,
+            r#"@known_bug("rue-1") test "bad" {}"#,
+            r#"@known_bug("RUE-1") fn bad() {}"#,
+            r#"@known_bug_on("aarch64-macos") test "bad" {}"#,
+            r#"@known_bug_on("unknown", "RUE-1") test "bad" {}"#,
+            r#"@known_bug("RUE-1") @known_bug("RUE-2") test "bad" {}"#,
+            r#"@known_bug("RUE-1") @known_bug_on("aarch64-macos", "RUE-2") test "bad" {}"#,
+            r#"@known_bug_on("aarch64-macos", "RUE-1") @known_bug_on("aarch64-macos", "RUE-2") test "bad" {}"#,
+        ] {
+            assert!(parse_source(source).is_err(), "accepted {source}");
+        }
+        assert!(parse_source(
+            r#"@known_bug_on("aarch64-macos", "RUE-1") @known_bug_on("x86-64-linux", "RUE-2") test "distinct" {}"#,
+        ).is_ok());
+    }
+
+    #[test]
     fn contextual_test_keyword_stays_an_ordinary_identifier() {
         // `test` is a keyword only at item position followed by a string
         // (ADR-0083 §1). `fn test`, a local `let test`, and a `const test` all

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -16,11 +16,21 @@ impl Parser {
             let mut args = Vec::new();
             if self.eat(TokenKind::LParen) {
                 args = self.comma_separated(TokenKind::RParen, |parser| {
-                    let ident = parser.ident()?;
+                    let (ident, quoted) = match parser.kind() {
+                        TokenKind::String(value) => {
+                            let span = parser.bump().span;
+                            (Ident { name: value, span }, true)
+                        }
+                        _ => (parser.ident()?, false),
+                    };
                     let value = kind.map_or(DirectiveArgValue::Unrecognized, |kind| {
-                        kind.classify_arg(parser.interner.resolve(&ident.name))
+                        kind.classify_arg(parser.interner.resolve(&ident.name), quoted)
                     });
-                    Ok(DirectiveArg { ident, value })
+                    Ok(DirectiveArg {
+                        ident,
+                        value,
+                        quoted,
+                    })
                 })?;
                 self.expect(TokenKind::RParen)?;
             }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -20,11 +20,13 @@
 use crate::ast::{Ast, Directive, Expr, IntrinsicArg, Item, Method, Statement, TypeExpr};
 use crate::directives::{
     DirectiveArgValue, DirectiveArity, DirectiveName, DirectiveSite, ReprArg, directive_name_list,
-    repr_arg_list, site_list, warning_name_list,
+    is_canonical_known_bug_marker, is_known_bug_platform, repr_arg_list, site_list,
+    warning_name_list,
 };
 use crate::parser_policy::diagnostics::ParserDiagnostics;
 use lasso::ThreadedRodeo;
 use rue_error::{CompileError, ErrorKind};
+use std::collections::HashSet;
 
 /// Walk the AST and report directive-validation diagnostics through the same
 /// bounded per-file policy as grammar recovery.
@@ -46,6 +48,7 @@ struct Validator<'a> {
 
 impl Validator<'_> {
     fn check_directives(&mut self, directives: &[Directive], site: DirectiveSite) {
+        self.check_known_bug_combinations(directives, site);
         for directive in directives {
             let Some(kind) = directive.kind else {
                 self.errors.push(CompileError::new(
@@ -81,6 +84,44 @@ impl Validator<'_> {
         }
     }
 
+    fn check_known_bug_combinations(&mut self, directives: &[Directive], site: DirectiveSite) {
+        if site != DirectiveSite::Test {
+            return;
+        }
+        let mut has_unscoped = false;
+        let mut scoped_platforms = HashSet::new();
+        for directive in directives {
+            match directive.kind {
+                Some(DirectiveName::KnownBug) => {
+                    if has_unscoped || !scoped_platforms.is_empty() {
+                        self.errors.push(CompileError::new(
+                            ErrorKind::ParseError(
+                                "a test may have only one unscoped known-bug marker, and it cannot be combined with platform-scoped markers".to_owned(),
+                            ),
+                            directive.span,
+                        ));
+                    }
+                    has_unscoped = true;
+                }
+                Some(DirectiveName::KnownBugOn) => {
+                    let Some(platform) = directive.args.first() else {
+                        continue;
+                    };
+                    let platform = self.interner.resolve(&platform.ident.name);
+                    if has_unscoped || !scoped_platforms.insert(platform.to_owned()) {
+                        self.errors.push(CompileError::new(
+                            ErrorKind::ParseError(
+                                "a test may have at most one known-bug marker per platform, and scoped markers cannot be combined with an unscoped marker".to_owned(),
+                            ),
+                            directive.span,
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// Report a wrong argument count, and answer whether the count is right.
     /// A wrong count already names what the directive accepts, so the
     /// arguments themselves are not reported a second time.
@@ -104,7 +145,17 @@ impl Validator<'_> {
                 ));
                 false
             }
-            DirectiveArity::None | DirectiveArity::ExactlyOne | DirectiveArity::Any => true,
+            DirectiveArity::ExactlyTwo if directive.args.len() != 2 => {
+                self.errors.push(CompileError::new(
+                    ErrorKind::ParseError(format!("@{kind} takes exactly two quoted arguments")),
+                    directive.span,
+                ));
+                false
+            }
+            DirectiveArity::None
+            | DirectiveArity::ExactlyOne
+            | DirectiveArity::ExactlyTwo
+            | DirectiveArity::Any => true,
         }
     }
 
@@ -130,7 +181,9 @@ impl Validator<'_> {
                                 arg.ident.span,
                             ));
                         }
-                        DirectiveArgValue::Repr(_) | DirectiveArgValue::Unrecognized => {
+                        DirectiveArgValue::Repr(_)
+                        | DirectiveArgValue::KnownBugText
+                        | DirectiveArgValue::Unrecognized => {
                             self.errors.push(CompileError::new(
                                 ErrorKind::ParseError(format!(
                                     "unrecognized warning name '{}' in @allow; \
@@ -152,7 +205,9 @@ impl Validator<'_> {
                 for arg in &directive.args {
                     match arg.value {
                         DirectiveArgValue::Repr(ReprArg::C) => {}
-                        DirectiveArgValue::Warning(_) | DirectiveArgValue::Unrecognized => {
+                        DirectiveArgValue::Warning(_)
+                        | DirectiveArgValue::KnownBugText
+                        | DirectiveArgValue::Unrecognized => {
                             self.errors.push(CompileError::new(
                                 ErrorKind::ParseError(format!(
                                     "unknown @repr argument '{}'; accepted arguments are {}",
@@ -163,6 +218,38 @@ impl Validator<'_> {
                             ));
                         }
                     }
+                }
+            }
+            DirectiveName::KnownBug => {
+                let arg = &directive.args[0];
+                let marker = self.interner.resolve(&arg.ident.name);
+                if !arg.quoted || !is_canonical_known_bug_marker(marker) {
+                    self.errors.push(CompileError::new(
+                        ErrorKind::ParseError(format!(
+                            "@known_bug requires a quoted canonical issue marker like \"RUE-123\", found {marker:?}"
+                        )),
+                        arg.ident.span,
+                    ));
+                }
+            }
+            DirectiveName::KnownBugOn => {
+                let platform = self.interner.resolve(&directive.args[0].ident.name);
+                let marker = self.interner.resolve(&directive.args[1].ident.name);
+                if !directive.args[0].quoted || !is_known_bug_platform(platform) {
+                    self.errors.push(CompileError::new(
+                        ErrorKind::ParseError(format!(
+                            "@known_bug_on requires a known quoted host platform, found {platform:?}"
+                        )),
+                        directive.args[0].ident.span,
+                    ));
+                }
+                if !directive.args[1].quoted || !is_canonical_known_bug_marker(marker) {
+                    self.errors.push(CompileError::new(
+                        ErrorKind::ParseError(format!(
+                            "@known_bug_on requires a quoted canonical issue marker like \"RUE-123\", found {marker:?}"
+                        )),
+                        directive.args[1].ident.span,
+                    ));
                 }
             }
             // Arity already rejected any argument these carry.

--- a/crates/rue-spec/cases/items/tests.toml
+++ b/crates/rue-spec/cases/items/tests.toml
@@ -57,6 +57,33 @@ fn main() -> i32 { 0 }
 exit_code = 0
 
 [[case]]
+name = "test_declaration_accepts_known_bug_directives"
+spec = ["6.7:18", "2.5:9"]
+description = "Tests may carry canonical expected-failure metadata, including a platform-scoped marker."
+source = """
+@known_bug("RUE-2018")
+test "known bug" { }
+
+@known_bug_on("aarch64-macos", "RUE-2018")
+test "platform known bug" { }
+
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
+name = "known_bug_directives_reject_malformed_markers"
+spec = ["6.7:18", "2.5:9"]
+description = "Expected-failure metadata requires a canonical issue marker and supported platform."
+source = """
+@known_bug("RUE-0")
+test "bad issue" { }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0102", "canonical issue marker"]
+
+[[case]]
 name = "public_test_declaration_is_rejected"
 spec = ["6.7:5"]
 description = "`test` takes no visibility modifier: a test is not callable, so `pub` has no meaning for it."

--- a/crates/rue-ui-tests/cases/diagnostics/directives.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/directives.toml
@@ -24,7 +24,7 @@ source = """
 fn main() -> i32 { 42 }
 """
 compile_fail = true
-error_contains = ["unknown directive '@important'", "@allow, @copy, @repr, and @non_exhaustive"]
+error_contains = ["unknown directive '@important'", "@allow, @copy, @repr, @non_exhaustive, @known_bug, and @known_bug_on"]
 
 [[case]]
 name = "non_exhaustive_directive_private_enum_rejected"
@@ -298,7 +298,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = ["unknown directive '@handle'", "@allow, @copy, @repr, and @non_exhaustive"]
+error_contains = ["unknown directive '@handle'", "@allow, @copy, @repr, @non_exhaustive, @known_bug, and @known_bug_on"]
 
 [[case]]
 name = "ordinary_handle_method_still_works"

--- a/crates/rue/src/test_mode/events.rs
+++ b/crates/rue/src/test_mode/events.rs
@@ -1,4 +1,4 @@
-//! The `rue test` event stream (ADR-0083 §2), schema `1.0`.
+//! The `rue test` event stream (ADR-0083 §2), schema `1.1`.
 //!
 //! Events are produced as ordinary Rust values first and serialized second.
 //! That ordering is the point: the human renderer consumes the same values in
@@ -16,10 +16,10 @@
 use serde_json::{Map, Value};
 
 use super::diff;
-use super::verdict::Verdict;
+use super::verdict::{TestExpectation, Verdict};
 
 /// The event schema version, published in the stream's head event.
-pub(crate) const SCHEMA_VERSION: &str = "1.0";
+pub(crate) const SCHEMA_VERSION: &str = "1.1";
 
 /// The `capability_summary` every `test_finished` carries.
 ///
@@ -305,6 +305,10 @@ pub(crate) enum Event {
         crash: usize,
         /// Selected tests whose closures failed to analyze (ADR-0083 §3).
         compile_error: usize,
+        /// Tests marked with an applicable `@known_bug` that failed normally.
+        xfail: usize,
+        /// Tests marked with an applicable `@known_bug` that passed.
+        xpass: usize,
         wall_ms: u64,
         unimported_test_files: Option<Vec<UnimportedFile>>,
         test_candidates: CandidateSource,
@@ -336,6 +340,10 @@ pub(crate) enum Event {
         file: String,
         line: u32,
         column: u32,
+        /// The unscoped marker, when this test carries one.
+        known_bug: Option<String>,
+        /// Platform-scoped markers, retained for machine-readable listing.
+        known_bug_on: Vec<(String, String)>,
     },
 }
 
@@ -345,6 +353,9 @@ pub(crate) enum Event {
 pub(crate) struct TestFinished {
     pub(crate) id: String,
     pub(crate) verdict: Verdict,
+    /// The applicable known-bug classification, when one changed the
+    /// ordinary observed verdict into an xfail or xpass.
+    pub(crate) expectation: Option<TestExpectation>,
     pub(crate) duration_ms: u64,
     pub(crate) failure: Option<FailureRecord>,
     pub(crate) stdout: Capture,
@@ -408,6 +419,7 @@ impl Event {
                 let TestFinished {
                     id,
                     verdict,
+                    expectation,
                     duration_ms,
                     failure,
                     stdout,
@@ -423,7 +435,11 @@ impl Event {
                 object.insert("id".to_owned(), Value::String(id.clone()));
                 object.insert(
                     "verdict".to_owned(),
-                    Value::String(verdict.as_str().to_owned()),
+                    Value::String(
+                        expectation
+                            .map_or_else(|| verdict.as_str(), TestExpectation::as_str)
+                            .to_owned(),
+                    ),
                 );
                 object.insert("duration_ms".to_owned(), Value::from(*duration_ms));
                 let mut capability = Map::new();
@@ -464,6 +480,8 @@ impl Event {
                 timeout,
                 crash,
                 compile_error,
+                xfail,
+                xpass,
                 wall_ms,
                 unimported_test_files,
                 test_candidates,
@@ -474,6 +492,8 @@ impl Event {
                 object.insert("timeout".to_owned(), Value::from(*timeout));
                 object.insert("crash".to_owned(), Value::from(*crash));
                 object.insert("compile_error".to_owned(), Value::from(*compile_error));
+                object.insert("xfail".to_owned(), Value::from(*xfail));
+                object.insert("xpass".to_owned(), Value::from(*xpass));
                 object.insert("wall_ms".to_owned(), Value::from(*wall_ms));
                 if let Some(files) = unimported_test_files {
                     object.insert(
@@ -522,6 +542,8 @@ impl Event {
                 file,
                 line,
                 column,
+                known_bug,
+                known_bug_on,
             } => {
                 object.insert("event".to_owned(), Value::String("test".to_owned()));
                 object.insert(
@@ -534,6 +556,28 @@ impl Event {
                 object.insert("file".to_owned(), Value::String(file.clone()));
                 object.insert("line".to_owned(), Value::from(*line));
                 object.insert("column".to_owned(), Value::from(*column));
+                if let Some(issue) = known_bug {
+                    object.insert("known_bug".to_owned(), Value::String(issue.clone()));
+                }
+                if !known_bug_on.is_empty() {
+                    object.insert(
+                        "known_bug_on".to_owned(),
+                        Value::Array(
+                            known_bug_on
+                                .iter()
+                                .map(|(platform, issue)| {
+                                    let mut marker = Map::new();
+                                    marker.insert("issue".to_owned(), Value::String(issue.clone()));
+                                    marker.insert(
+                                        "platform".to_owned(),
+                                        Value::String(platform.clone()),
+                                    );
+                                    Value::Object(marker)
+                                })
+                                .collect(),
+                        ),
+                    );
+                }
             }
         }
         Value::Object(object)
@@ -565,7 +609,7 @@ mod tests {
             line,
             "{\"event\":\"run_started\",\"jobs\":4,\"opt_level\":\"0\",\
              \"plan\":{\"selected\":3,\"total\":8},\"root\":\"app/main.rue\",\
-             \"schema\":\"1.0\",\"seed\":417,\"shard\":\"1/2\",\"target\":\"aarch64-macos\"}"
+             \"schema\":\"1.1\",\"seed\":417,\"shard\":\"1/2\",\"target\":\"aarch64-macos\"}"
         );
     }
 
@@ -632,6 +676,7 @@ mod tests {
         let line = Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::ok".to_owned(),
             verdict: Verdict::Pass,
+            expectation: None,
             duration_ms: 2,
             failure: None,
             stdout: Capture::new(b"hi\n".to_vec(), 3, true),
@@ -656,6 +701,7 @@ mod tests {
         let line = Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::bad".to_owned(),
             verdict: Verdict::Fail(FailureKind::Assert),
+            expectation: None,
             duration_ms: 5,
             failure: Some(FailureRecord {
                 kind: "assert".to_owned(),
@@ -708,6 +754,7 @@ mod tests {
         let line = Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::bad".to_owned(),
             verdict: Verdict::Fail(FailureKind::Assert),
+            expectation: None,
             duration_ms: 1,
             failure: None,
             stdout: Capture::new(Vec::new(), 0, false),
@@ -728,6 +775,7 @@ mod tests {
         let line = Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::bad".to_owned(),
             verdict: Verdict::Fail(FailureKind::AssertEq),
+            expectation: None,
             duration_ms: 5,
             failure: Some(FailureRecord {
                 kind: "assert_eq".to_owned(),
@@ -763,6 +811,7 @@ mod tests {
         let line = Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::bad".to_owned(),
             verdict: Verdict::Fail(FailureKind::Assert),
+            expectation: None,
             duration_ms: 1,
             failure: Some(FailureRecord {
                 kind: "assert".to_owned(),
@@ -810,13 +859,15 @@ mod tests {
             file: "/w/app/t.rue".to_owned(),
             line: 1,
             column: 1,
+            known_bug: None,
+            known_bug_on: Vec::new(),
         }
         .to_ndjson();
         assert_eq!(
             line,
             "{\"column\":1,\"event\":\"test\",\"file\":\"/w/app/t.rue\",\
              \"id\":\"app/t.rue::ok\",\"line\":1,\"module\":\"app/t.rue\",\
-             \"name\":\"ok\",\"schema\":\"1.0\"}"
+             \"name\":\"ok\",\"schema\":\"1.1\"}"
         );
     }
 
@@ -829,6 +880,7 @@ mod tests {
         let line = Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::broken".to_owned(),
             verdict: Verdict::CompileError,
+            expectation: None,
             duration_ms: 0,
             failure: Some(FailureRecord {
                 kind: "compile_error".to_owned(),
@@ -875,6 +927,8 @@ mod tests {
             timeout: 0,
             crash: 0,
             compile_error: 2,
+            xfail: 0,
+            xpass: 0,
             wall_ms: 5,
             unimported_test_files: None,
             test_candidates: CandidateSource::None,
@@ -894,6 +948,8 @@ mod tests {
             timeout: 0,
             crash: 0,
             compile_error: 0,
+            xfail: 0,
+            xpass: 0,
             wall_ms: 12,
             unimported_test_files: Some(vec![UnimportedFile {
                 path: "app/orphan.rue".to_owned(),
@@ -920,6 +976,8 @@ mod tests {
             timeout: 0,
             crash: 0,
             compile_error: 0,
+            xfail: 0,
+            xpass: 0,
             wall_ms: 0,
             unimported_test_files: None,
             test_candidates: CandidateSource::None,

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -41,7 +41,7 @@ use events::{
 };
 use exec::{DEFAULT_STREAM_BUDGET, Dispatch};
 use selection::Shard;
-use verdict::{FailureKind, Verdict};
+use verdict::{FailureKind, TestExpectation, Verdict};
 
 // What the watch loop drives a test cycle with. Test mode owns the run; the
 // loop owns the process's lifetime, the change monitor, and the signals
@@ -422,6 +422,8 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
             timeout: 0,
             crash: 0,
             compile_error: 0,
+            xfail: 0,
+            xpass: 0,
             wall_ms: elapsed_ms(started),
             unimported_test_files: unimported,
             test_candidates: candidate_source(candidates),
@@ -439,6 +441,7 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
     let outcome = execute_plan(ExecutionRequest {
         plan: &plan,
         compile_errors: &compile_errors,
+        target,
         image: &image_path,
         run_root: &run_root,
         seed,
@@ -487,6 +490,8 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
         timeout: outcome.timeout,
         crash: outcome.crash,
         compile_error: outcome.compile_error,
+        xfail: outcome.xfail,
+        xpass: outcome.xpass,
         wall_ms: elapsed_ms(started),
         unimported_test_files: unimported,
         test_candidates: candidate_source(candidates),
@@ -497,7 +502,9 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
     // the other tests' verdicts, never the 2 that says nothing ran
     // (ADR-0083 §3).
     CycleOutcome::Finished(
-        if outcome.failed + outcome.timeout + outcome.crash + outcome.compile_error > 0 {
+        if outcome.failed + outcome.timeout + outcome.crash + outcome.compile_error + outcome.xpass
+            > 0
+        {
             TestExitCode::Failures
         } else {
             TestExitCode::AllPassed
@@ -537,6 +544,8 @@ struct CompileErrorVerdicts {
 }
 
 struct CompileErrorVerdict {
+    /// Preserve typed infrastructure/ICE classification before rendering.
+    xfail_eligible: bool,
     /// The diagnostics rendered for a person, as the failure record's payload.
     payload: String,
     /// The first diagnostic's message, which is the record's `message`.
@@ -566,6 +575,7 @@ impl CompileErrorVerdicts {
                     (
                         failure.entry.ordinal,
                         CompileErrorVerdict {
+                            xfail_eligible: compile_errors_allow_xfail(&failure.errors),
                             payload: diagnostic_payload(&json),
                             message: first
                                 .and_then(|diagnostic| diagnostic.get("message"))
@@ -584,6 +594,26 @@ impl CompileErrorVerdicts {
     fn get(&self, ordinal: u32) -> Option<&CompileErrorVerdict> {
         self.by_ordinal.get(&ordinal)
     }
+}
+
+fn compile_errors_allow_xfail(errors: &rue_error::CompileErrors) -> bool {
+    use rue_error::ErrorKind;
+    !errors.is_empty()
+        && errors.iter().all(|error| {
+            !matches!(
+                error.kind,
+                ErrorKind::InternalError(_)
+                    | ErrorKind::InternalCodegenError(_)
+                    | ErrorKind::CompilerProducerInvariant(_)
+                    | ErrorKind::CompilerResourceExhaustion(_)
+                    | ErrorKind::OutputPublication(_)
+                    | ErrorKind::InvalidCompilerInput(_)
+                    | ErrorKind::UnsatisfiedTrustedToolchainInput(_)
+                    | ErrorKind::StdLibNotFound
+                    | ErrorKind::LinkError(_)
+                    | ErrorKind::UnsupportedTarget(_)
+            )
+        })
 }
 
 /// The failure record's `payload` for a `compile_error`: one line per
@@ -705,6 +735,21 @@ fn list(
             file: entry.file.clone(),
             line: entry.line,
             column: entry.column,
+            known_bug: entry
+                .expected_failures
+                .iter()
+                .find(|marker| marker.platform.is_none())
+                .map(|marker| marker.issue.clone()),
+            known_bug_on: entry
+                .expected_failures
+                .iter()
+                .filter_map(|marker| {
+                    marker
+                        .platform
+                        .as_ref()
+                        .map(|platform| (platform.clone(), marker.issue.clone()))
+                })
+                .collect(),
         });
     }
     TestExitCode::AllPassed
@@ -712,6 +757,7 @@ fn list(
 
 struct ExecutionRequest<'a> {
     plan: &'a [TestInventoryEntry],
+    target: Target,
     /// The verdicts the compiler already decided, by ordinal. A plan entry
     /// found here is reported without spawning anything: it has no body in the
     /// image (ADR-0083 §3).
@@ -738,6 +784,8 @@ struct ExecutionOutcome {
     timeout: usize,
     crash: usize,
     compile_error: usize,
+    xfail: usize,
+    xpass: usize,
     runner_error: Option<String>,
     /// An edit landed while the plan was running, so the run stopped short of
     /// it (RUE-2023).
@@ -748,7 +796,13 @@ impl ExecutionOutcome {
     /// Verdicts this run actually published, which is what a canceled cycle
     /// reports in place of counts by class.
     fn reported(&self) -> usize {
-        self.passed + self.failed + self.timeout + self.crash + self.compile_error
+        self.passed
+            + self.failed
+            + self.timeout
+            + self.crash
+            + self.compile_error
+            + self.xfail
+            + self.xpass
     }
 }
 
@@ -765,6 +819,8 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
     let timed_out = AtomicUsize::new(0);
     let crashed = AtomicUsize::new(0);
     let uncompiled = AtomicUsize::new(0);
+    let xfailed = AtomicUsize::new(0);
+    let xpassed = AtomicUsize::new(0);
     let runner_error: Mutex<Option<String>> = Mutex::new(None);
 
     std::thread::scope(|scope| {
@@ -775,6 +831,8 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
             let timed_out = &timed_out;
             let crashed = &crashed;
             let uncompiled = &uncompiled;
+            let xfailed = &xfailed;
+            let xpassed = &xpassed;
             let runner_error = &runner_error;
             let request = &request;
             scope.spawn(move || {
@@ -802,10 +860,24 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
                     // pool, so a `compile_error` lands where the shuffle put it
                     // rather than in a block of its own before the run.
                     if let Some(verdict) = request.compile_errors.get(entry.ordinal) {
-                        uncompiled.fetch_add(1, Ordering::Relaxed);
+                        let expectation = classify_expected(
+                            entry,
+                            request.target,
+                            &verdict::Classification {
+                                verdict: Verdict::CompileError,
+                                runner_note: None,
+                            },
+                            !verdict.xfail_eligible,
+                        );
+                        if expectation == Some(TestExpectation::Xfail) {
+                            xfailed.fetch_add(1, Ordering::Relaxed);
+                        } else {
+                            uncompiled.fetch_add(1, Ordering::Relaxed);
+                        }
                         request.reporter.emit(&compile_error_event(
                             entry,
                             verdict,
+                            expectation,
                             &Repro {
                                 program: request.repro_program,
                                 root: request.repro_root,
@@ -860,20 +932,37 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
                             return;
                         }
                     };
-                    match &execution.classification.verdict {
-                        Verdict::Pass => passed.fetch_add(1, Ordering::Relaxed),
-                        Verdict::Fail(_) => failed.fetch_add(1, Ordering::Relaxed),
-                        Verdict::Timeout => timed_out.fetch_add(1, Ordering::Relaxed),
-                        Verdict::Crash(_) => crashed.fetch_add(1, Ordering::Relaxed),
-                        // Decided by the compiler and reported above, so no
-                        // process can classify as one.
-                        Verdict::CompileError => unreachable!(
-                            "a compile_error verdict never reaches a dispatched process"
-                        ),
+                    let expected = classify_expected(
+                        entry,
+                        request.target,
+                        &execution.classification,
+                        execution.signal.is_some(),
+                    );
+                    match expected {
+                        Some(TestExpectation::Xfail) => {
+                            xfailed.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Some(TestExpectation::Xpass) => {
+                            xpassed.fetch_add(1, Ordering::Relaxed);
+                        }
+                        None => {
+                            match &execution.classification.verdict {
+                                Verdict::Pass => passed.fetch_add(1, Ordering::Relaxed),
+                                Verdict::Fail(_) => failed.fetch_add(1, Ordering::Relaxed),
+                                Verdict::Timeout => timed_out.fetch_add(1, Ordering::Relaxed),
+                                Verdict::Crash(_) => crashed.fetch_add(1, Ordering::Relaxed),
+                                // Decided by the compiler and reported above, so no
+                                // process can classify as one.
+                                Verdict::CompileError => unreachable!(
+                                    "a compile_error verdict never reaches a dispatched process"
+                                ),
+                            };
+                        }
                     };
                     let event = finish_event(
                         entry,
                         execution,
+                        expected,
                         &Repro {
                             program: request.repro_program,
                             root: request.repro_root,
@@ -895,6 +984,8 @@ fn execute_plan(request: ExecutionRequest<'_>) -> ExecutionOutcome {
         timeout: timed_out.into_inner(),
         crash: crashed.into_inner(),
         compile_error: uncompiled.into_inner(),
+        xfail: xfailed.into_inner(),
+        xpass: xpassed.into_inner(),
         runner_error: runner_error
             .into_inner()
             .unwrap_or_else(|error| error.into_inner()),
@@ -907,6 +998,54 @@ fn canceled(cancellation: Option<&exec::RunCancellation>) -> bool {
     cancellation.is_some_and(exec::RunCancellation::is_canceled)
 }
 
+fn classify_expected(
+    entry: &TestInventoryEntry,
+    target: Target,
+    classification: &verdict::Classification,
+    fatal_failure: bool,
+) -> Option<TestExpectation> {
+    if fatal_failure || !entry_has_expected_failure(entry, target) {
+        return None;
+    }
+    if is_xfail_failure(classification) {
+        Some(TestExpectation::Xfail)
+    } else if classification.verdict.is_pass() {
+        Some(TestExpectation::Xpass)
+    } else {
+        None
+    }
+}
+
+/// Whether this test has an expected-failure marker for the target executing
+/// the image. The inventory retains all platform-scoped markers so listings
+/// remain host-independent; execution is the boundary where one applies.
+fn entry_has_expected_failure(entry: &TestInventoryEntry, target: Target) -> bool {
+    entry.expected_failures.iter().any(|marker| {
+        marker
+            .platform
+            .as_deref()
+            .is_none_or(|platform| platform == target.name())
+    })
+}
+
+/// Only ordinary test failures are suppressible by an expected-failure marker.
+/// Runner notes, incomplete dispatches, output overflow, timeouts, and crashes
+/// remain infrastructure failures and must still fail the run visibly.
+fn is_xfail_failure(classification: &verdict::Classification) -> bool {
+    classification.runner_note.is_none()
+        && matches!(
+            classification.verdict,
+            Verdict::Fail(FailureKind::Assert)
+                | Verdict::Fail(FailureKind::AssertEq)
+                | Verdict::Fail(FailureKind::AssertNe)
+                | Verdict::Fail(FailureKind::Trap(_))
+                | Verdict::Fail(FailureKind::UnhandledError)
+                | Verdict::Fail(FailureKind::Reported(_))
+                | Verdict::Fail(FailureKind::Exit)
+                | Verdict::CompileError
+        )
+}
+
 /// Turn one finished process into its `test_finished` event.
 ///
 /// The scratch directory is deleted on a pass and retained on anything else,
@@ -916,19 +1055,22 @@ fn canceled(cancellation: Option<&exec::RunCancellation>) -> bool {
 fn finish_event(
     entry: &TestInventoryEntry,
     execution: exec::Execution,
+    expectation: Option<TestExpectation>,
     repro: &Repro<'_>,
     seed: u64,
     timeout: Duration,
 ) -> Event {
     let verdict = execution.classification.verdict.clone();
-    let passed = verdict.is_pass();
+    let passed = verdict.is_pass() && expectation.is_none();
     if passed {
         let _ = std::fs::remove_dir_all(&execution.scratch_dir);
     }
-    let failure = (!passed).then(|| failure_record(entry, &verdict, &execution, timeout));
+    let failure =
+        (!verdict.is_pass()).then(|| failure_record(entry, &verdict, &execution, timeout));
     Event::TestFinished(Box::new(TestFinished {
         id: entry.id.clone(),
         verdict,
+        expectation,
         duration_ms: u64::try_from(execution.duration.as_millis()).unwrap_or(u64::MAX),
         failure,
         stdout: Capture::new(execution.stdout, execution.stdout_total, passed),
@@ -1006,12 +1148,14 @@ fn failure_record(
 fn compile_error_event(
     entry: &TestInventoryEntry,
     verdict: &CompileErrorVerdict,
+    expectation: Option<TestExpectation>,
     repro: &Repro<'_>,
     seed: u64,
 ) -> Event {
     Event::TestFinished(Box::new(TestFinished {
         id: entry.id.clone(),
         verdict: Verdict::CompileError,
+        expectation,
         duration_ms: 0,
         failure: Some(FailureRecord {
             kind: FailureKind::CompileError.to_string(),
@@ -1443,5 +1587,102 @@ mod tests {
     fn the_opt_level_field_is_the_bare_digit() {
         assert_eq!(opt_level_digit(OptLevel::O0), "0");
         assert_eq!(opt_level_digit(OptLevel::O3), "3");
+    }
+
+    #[test]
+    fn expected_failure_markers_apply_only_to_their_target() {
+        let entry = TestInventoryEntry {
+            id: "app/t.rue::marked".to_owned(),
+            module: "app/t.rue".to_owned(),
+            name: "marked".to_owned(),
+            file: "app/t.rue".to_owned(),
+            line: 1,
+            column: 1,
+            ordinal: 0,
+            expected_failures: vec![rue_compiler::unstable::TestExpectedFailure {
+                issue: "RUE-123".to_owned(),
+                platform: Some("aarch64-macos".to_owned()),
+            }],
+        };
+        assert!(entry_has_expected_failure(&entry, Target::Aarch64Macos));
+        assert!(!entry_has_expected_failure(&entry, Target::X86_64Linux));
+        let observed = verdict::Classification {
+            verdict: Verdict::Fail(FailureKind::Assert),
+            runner_note: None,
+        };
+        assert_eq!(
+            classify_expected(&entry, Target::Aarch64Macos, &observed, false),
+            Some(TestExpectation::Xfail)
+        );
+        // A failure frame can outrank a signal in the observation classifier;
+        // it must not make that signal eligible for expected-failure handling.
+        assert_eq!(
+            classify_expected(&entry, Target::Aarch64Macos, &observed, true),
+            None
+        );
+    }
+
+    #[test]
+    fn compile_error_markers_cannot_hide_internal_or_environmental_errors() {
+        use rue_error::{CompileError, CompileErrors, ErrorKind};
+        let ordinary = CompileError::without_span(ErrorKind::ParseError("bad body".into()));
+        assert!(compile_errors_allow_xfail(&CompileErrors::from(
+            ordinary.clone()
+        )));
+        for kind in [
+            ErrorKind::InternalError("ICE".into()),
+            ErrorKind::InternalCodegenError("ICE".into()),
+            ErrorKind::CompilerProducerInvariant("ICE".into()),
+            ErrorKind::CompilerResourceExhaustion("allocation".into()),
+            ErrorKind::OutputPublication("write".into()),
+            ErrorKind::InvalidCompilerInput("input".into()),
+            ErrorKind::UnsatisfiedTrustedToolchainInput("std".into()),
+            ErrorKind::StdLibNotFound,
+            ErrorKind::LinkError("link".into()),
+            ErrorKind::UnsupportedTarget("target".into()),
+        ] {
+            let mut errors = CompileErrors::from(ordinary.clone());
+            errors.push(CompileError::without_span(kind));
+            assert!(!compile_errors_allow_xfail(&errors), "{errors:?}");
+        }
+    }
+
+    #[test]
+    fn expected_failures_do_not_hide_runner_failures() {
+        let ordinary = verdict::Classification {
+            verdict: Verdict::Fail(FailureKind::Assert),
+            runner_note: None,
+        };
+        assert!(is_xfail_failure(&ordinary));
+        assert!(!is_xfail_failure(&verdict::Classification {
+            verdict: Verdict::Fail(FailureKind::Incomplete),
+            runner_note: None,
+        }));
+        assert!(!is_xfail_failure(&verdict::Classification {
+            verdict: Verdict::Fail(FailureKind::Exit),
+            runner_note: Some("malformed channel".to_owned()),
+        }));
+    }
+
+    #[test]
+    fn expected_failures_do_not_hide_overflow_beside_a_complete_frame() {
+        let frames = verdict::ChannelFrames {
+            failure: Some(verdict::FailureFrame {
+                kind: "assert".to_owned(),
+                ..verdict::FailureFrame::default()
+            }),
+            ..verdict::ChannelFrames::default()
+        };
+        let classification = verdict::classify(verdict::Observation {
+            supervision: verdict::Supervision::OutputOverflow(verdict::Overflow {
+                stream: verdict::CaptureStream::Stderr,
+                budget: 1024,
+            }),
+            status: Ok(101),
+            stderr: b"assertion failed",
+            frames: &frames,
+        });
+        assert_eq!(classification.verdict, Verdict::Fail(FailureKind::Assert));
+        assert!(!is_xfail_failure(&classification));
     }
 }

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -14,7 +14,7 @@ use std::fmt::Write as _;
 
 use super::diff::{DiffOp, Hunk};
 use super::events::{CandidateSource, Capture, Comparison, Event, TestFinished};
-use super::verdict::Verdict;
+use super::verdict::{TestExpectation, Verdict};
 
 /// What the human renderer is told out of band.
 ///
@@ -42,15 +42,20 @@ pub(crate) fn render(event: &Event) -> Option<String> {
     match event {
         Event::RunStarted { .. } | Event::TestStarted { .. } => None,
         Event::Test { id, .. } => Some(id.clone()),
-        Event::TestFinished(finished) => {
-            (!finished.verdict.is_pass()).then(|| render_failure(finished))
-        }
+        Event::TestFinished(finished) => match finished.expectation {
+            Some(TestExpectation::Xfail) => Some(render_failure(finished)),
+            Some(TestExpectation::Xpass) => Some(render_failure(finished)),
+            None if !finished.verdict.is_pass() => Some(render_failure(finished)),
+            None => None,
+        },
         Event::RunFinished {
             passed,
             failed,
             timeout,
             crash,
             compile_error,
+            xfail,
+            xpass,
             wall_ms,
             // The unimported-test-file warnings are the runner's own, and
             // stderr carries them once in every format (test-events.md,
@@ -66,6 +71,8 @@ pub(crate) fn render(event: &Event) -> Option<String> {
             timeout: *timeout,
             crash: *crash,
             compile_error: *compile_error,
+            xfail: *xfail,
+            xpass: *xpass,
             wall_ms: *wall_ms,
         })),
         Event::RunCanceled {
@@ -121,6 +128,8 @@ struct Counts {
     timeout: usize,
     crash: usize,
     compile_error: usize,
+    xfail: usize,
+    xpass: usize,
     wall_ms: u64,
 }
 
@@ -147,6 +156,20 @@ fn summary(counts: Counts) -> String {
             if counts.compile_error == 1 { "" } else { "s" }
         ));
     }
+    if counts.xfail > 0 {
+        parts.push(format!(
+            "{} expected failure{}",
+            counts.xfail,
+            if counts.xfail == 1 { "" } else { "s" }
+        ));
+    }
+    if counts.xpass > 0 {
+        parts.push(format!(
+            "{} unexpected pass{}",
+            counts.xpass,
+            if counts.xpass == 1 { "" } else { "es" }
+        ));
+    }
     format!("{} ({})", parts.join(", "), seconds(counts.wall_ms))
 }
 
@@ -160,6 +183,7 @@ fn render_failure(finished: &TestFinished) -> String {
     let TestFinished {
         id,
         verdict,
+        expectation,
         failure,
         stdout,
         stderr,
@@ -168,12 +192,16 @@ fn render_failure(finished: &TestFinished) -> String {
         repro_env,
         ..
     } = finished;
-    let banner = match verdict {
-        Verdict::Pass => "PASS",
-        Verdict::Fail(_) => "FAIL",
-        Verdict::Timeout => "TIMEOUT",
-        Verdict::Crash(_) => "CRASH",
-        Verdict::CompileError => "COMPILE ERROR",
+    let banner = match expectation {
+        Some(TestExpectation::Xfail) => "XFAIL",
+        Some(TestExpectation::Xpass) => "XPASS",
+        _ => match verdict {
+            Verdict::Pass => "PASS",
+            Verdict::Fail(_) => "FAIL",
+            Verdict::Timeout => "TIMEOUT",
+            Verdict::Crash(_) => "CRASH",
+            Verdict::CompileError => "COMPILE ERROR",
+        },
     };
     // A test that never ran has no captured output, no scratch directory, and
     // nothing the runner observed: its whole report is the first diagnostic and
@@ -211,6 +239,9 @@ fn render_failure(finished: &TestFinished) -> String {
         return out;
     }
     let mut out = format!("{banner} {id}");
+    if matches!(expectation, Some(TestExpectation::Xpass)) {
+        out.push_str("\n  test passed unexpectedly; remove the known-bug marker");
+    }
     if let Some(failure) = failure {
         out.push_str("\n  ");
         out.push_str(&failure.kind);
@@ -448,6 +479,7 @@ mod tests {
         Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::parses a port".to_owned(),
             verdict,
+            expectation: None,
             duration_ms: 3,
             failure,
             stdout: Capture::new(b"checking\n".to_vec(), 9, false),
@@ -470,6 +502,7 @@ mod tests {
         Event::TestFinished(Box::new(TestFinished {
             id: "app/t.rue::parses a port".to_owned(),
             verdict: Verdict::CompileError,
+            expectation: None,
             duration_ms: 0,
             failure: Some(FailureRecord {
                 kind: "compile_error".to_owned(),
@@ -535,6 +568,8 @@ mod tests {
                 timeout: 0,
                 crash: 0,
                 compile_error,
+                xfail: 0,
+                xpass: 0,
                 wall_ms: 900,
                 unimported_test_files: None,
                 test_candidates: CandidateSource::Declared,
@@ -546,6 +581,27 @@ mod tests {
         assert_eq!(summarized(4), "2 passed, 1 failed, 4 compile errors (0.9s)");
     }
 
+    #[test]
+    fn the_summary_names_expected_failures_and_unexpected_passes() {
+        let rendered = super::render(&Event::RunFinished {
+            passed: 2,
+            failed: 0,
+            timeout: 0,
+            crash: 0,
+            compile_error: 0,
+            xfail: 1,
+            xpass: 1,
+            wall_ms: 900,
+            unimported_test_files: None,
+            test_candidates: CandidateSource::Declared,
+        })
+        .expect("a summary renders");
+        assert_eq!(
+            rendered,
+            "2 passed, 1 expected failure, 1 unexpected pass (0.9s)"
+        );
+    }
+
     fn run_finished(passed: usize, failed: usize, timeout: usize, crash: usize) -> Event {
         Event::RunFinished {
             passed,
@@ -553,6 +609,8 @@ mod tests {
             timeout,
             crash,
             compile_error: 0,
+            xfail: 0,
+            xpass: 0,
             wall_ms: 900,
             unimported_test_files: Some(Vec::new()),
             test_candidates: CandidateSource::Declared,
@@ -563,6 +621,36 @@ mod tests {
     #[test]
     fn a_pass_prints_nothing() {
         assert!(super::render(&finished(Verdict::Pass, None)).is_none());
+    }
+
+    #[test]
+    fn expected_failure_classifications_are_visible_to_humans() {
+        let Event::TestFinished(mut xfail) = finished(
+            Verdict::Fail(FailureKind::Assert),
+            Some(FailureRecord {
+                kind: "assert".to_owned(),
+                message: "assertion failed".to_owned(),
+                ..FailureRecord::default()
+            }),
+        ) else {
+            unreachable!();
+        };
+        xfail.expectation = Some(TestExpectation::Xfail);
+        assert!(
+            super::render(&Event::TestFinished(xfail))
+                .expect("xfail renders")
+                .starts_with("XFAIL ")
+        );
+
+        let Event::TestFinished(mut xpass) = finished(Verdict::Pass, None) else {
+            unreachable!();
+        };
+        xpass.expectation = Some(TestExpectation::Xpass);
+        let rendered = super::render(&Event::TestFinished(xpass)).expect("xpass renders");
+        assert!(rendered.starts_with("XPASS app/t.rue::parses a port\n"));
+        assert!(rendered.contains("remove the known-bug marker"));
+        assert!(rendered.contains("repro:"));
+        assert!(rendered.contains("checking"));
     }
 
     /// The head events are machine bookkeeping; a person is shown failures and
@@ -786,6 +874,8 @@ mod tests {
             timeout: 0,
             crash: 0,
             compile_error: 0,
+            xfail: 0,
+            xpass: 0,
             wall_ms: 100,
             unimported_test_files: None,
             test_candidates: CandidateSource::None,
@@ -844,6 +934,8 @@ mod tests {
             timeout: 0,
             crash: 0,
             compile_error: 0,
+            xfail: 0,
+            xpass: 0,
             wall_ms: 0,
             unimported_test_files: Some(vec![
                 UnimportedFile {
@@ -877,6 +969,8 @@ mod tests {
                 file: "app/t.rue".to_owned(),
                 line: 1,
                 column: 1,
+                known_bug: None,
+                known_bug_on: Vec::new(),
             }),
             Some("app/t.rue::ok".to_owned())
         );

--- a/crates/rue/src/test_mode/selection.rs
+++ b/crates/rue/src/test_mode/selection.rs
@@ -181,6 +181,7 @@ mod tests {
             line: 1,
             column: 1,
             ordinal: 0,
+            expected_failures: Vec::new(),
         }
     }
 

--- a/crates/rue/src/test_mode/verdict.rs
+++ b/crates/rue/src/test_mode/verdict.rs
@@ -175,6 +175,23 @@ impl Verdict {
     }
 }
 
+/// An applicable known-bug marker changes the published outcome while the
+/// original verdict and failure evidence remain available to the runner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TestExpectation {
+    Xfail,
+    Xpass,
+}
+
+impl TestExpectation {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Xfail => "xfail",
+            Self::Xpass => "xpass",
+        }
+    }
+}
+
 /// One frame read from the failure channel.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct FailureFrame {

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -10,6 +10,10 @@ companion of [diagnostics.md](diagnostics.md), which owns the *other* machine
 surface: `--error-format json` compiler diagnostics on stderr. The two are
 orthogonal and stay on their own streams.
 
+The event and listing streams use schema `1.1`. This minor version adds
+expected-failure classification and known-bug metadata while preserving the
+existing event structure and failure payloads.
+
 ```bash
 rue test app/main.rue
 rue test app/main.rue --format json
@@ -40,14 +44,15 @@ for an ordinary build of the same closure.
   one test's closure a different thing: that test gets the `compile_error`
   verdict and every other test still runs. A selection whose tests are all
   `compile_error` still links its dispatcher, so it still emits `run_started`,
-  its `test_finished` events, and `run_finished`, and exits `1`.
+  its `test_finished` events, and `run_finished`; it exits `1` unless every
+  compile error is an applicable expected failure.
 
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
-| `0` | Every selected test passed. |
-| `1` | At least one selected test failed, timed out, crashed, or is a `compile_error`. |
+| `0` | Every selected test passed or was an expected failure. |
+| `1` | At least one selected test failed, timed out, crashed, is an ordinary `compile_error`, or is an unexpected pass. |
 | `2` | The run could not be performed: a compile failure outside every test closure, a failing image link, an ICE, a bad flag combination, an unreadable root or candidate inventory, or a runner error. |
 | `3` | The selection was empty. |
 
@@ -252,7 +257,7 @@ The head event, and the only one carrying the schema version for a run.
 | Key | Type | Meaning |
 |-----|------|---------|
 | `event` | `"run_started"` | |
-| `schema` | string | Schema version, `"1.0"`. |
+| `schema` | string | Schema version, `"1.1"`. |
 | `root` | string | The root source exactly as the command line spelled it. |
 | `target` | string | The Rue target the image was built for. |
 | `opt_level` | string | The optimization level's digit: `"0"`–`"3"`. |
@@ -275,15 +280,26 @@ The head event, and the only one carrying the schema version for a run.
 |-----|------|---------|
 | `event` | `"test_finished"` | |
 | `id` | string | The stable test ID. |
-| `verdict` | string | `"pass"`, `"fail"`, `"timeout"`, `"crash"`, or `"compile_error"`. |
+| `verdict` | string | `"pass"`, `"fail"`, `"timeout"`, `"crash"`, `"compile_error"`, `"xfail"`, or `"xpass"`. |
 | `duration_ms` | integer | Wall time from spawn to reap. |
 | `capability_summary` | object | `{"status":"unavailable"}` — see below. |
-| `failure` | object | The failure record. **Absent** on a pass. |
+| `failure` | object | The failure record. **Absent** for `pass` and `xpass`. |
 | `stdout` | object | Capture record. |
 | `stderr` | object | Capture record. |
 | `scratch_dir` | string | The retained scratch directory. **Absent** on a pass, whose directory is deleted. |
 | `repro` | array of strings | The argv that reproduces this one test, naming the compiler and the root by absolute path. Always present. |
 | `repro_env` | object | The environment assignments that argv must be run under, as `name` → `value`. **Absent** when the run owed the environment nothing. |
+
+The `verdict` is `xfail` or `xpass` when an applicable `@known_bug` marker
+classifies an ordinary failure or pass. The `failure` record remains present for
+an xfail, and preserves the underlying failure kind; a compile error therefore
+has `verdict: "xfail"` and `failure.kind: "compile_error"`. An xpass retains
+its captured output and scratch directory for the full human report, but has no
+failure record because the process passed. Both classifications are counted in
+`run_finished.xfail` or `run_finished.xpass`; xpass makes the run exit `1` so
+a fixed bug prompts removal of its marker. Timeouts, crashes, output
+overflow, incomplete dispatches, malformed failure channels, and runner errors
+are never xfail-suppressed.
 
 `capability_summary` is present from v1.0 with an explicit `unavailable` status
 rather than omitted. The MVP verifies no hermeticity claim for any test and says
@@ -401,7 +417,7 @@ locates nothing.
 |-----|------|---------|
 | `encoding` | `"utf8"` \| `"base64"` | How `data` is encoded. |
 | `bytes_total` | integer | Every byte the process wrote to this stream — not the size of what was kept. |
-| `data` | string | The retained prefix. Present on a **non-pass**. |
+| `data` | string | The retained prefix. Present on a **non-pass**, including `xfail` and `xpass`. |
 | `digest` | string | `sha256:<hex>` over the retained bytes. Present on a **pass**. |
 
 Rue strings are arbitrary byte sequences written raw, so capture is lossless
@@ -446,7 +462,9 @@ second retention limit.
 | Key | Type | Meaning |
 |-----|------|---------|
 | `event` | `"run_finished"` | |
-| `passed` / `failed` / `timeout` / `crash` / `compile_error` | integer | Counts by verdict. |
+| `passed` / `failed` / `timeout` / `crash` / `compile_error` | integer | Counts ordinary observed verdicts; xfail and xpass are counted separately. |
+| `xfail` | integer | Applicable marked tests that produced an ordinary failure, including a per-test `compile_error`. |
+| `xpass` | integer | Applicable marked tests that passed unexpectedly. These make the run exit `1`. |
 | `wall_ms` | integer | Wall time for the whole run. |
 | `unimported_test_files` | array | Declared test files outside the closure. **Absent** without `--test-candidates`. |
 | `test_candidates` | `"declared"` \| `"none"` | Whether an inventory was supplied. |
@@ -504,12 +522,14 @@ carry it, each record names the schema version itself.
 | Key | Type | Meaning |
 |-----|------|---------|
 | `event` | `"test"` | |
-| `schema` | string | `"1.0"`. |
+| `schema` | string | `"1.1"`. |
 | `id` | string | The stable test ID. |
 | `module` | string | The module half of the ID. |
 | `name` | string | The test's name, verbatim. |
 | `file` | string | The declaring file as the compiler observed it. |
 | `line` / `column` | integer | 1-indexed position of the `test "name"` header, or `0` when the declaration could not be located in its module's syntax tree. |
+| `known_bug` | string | The issue marker from an unscoped `@known_bug("RUE-NNN")`. **Absent** when none is present. |
+| `known_bug_on` | array | Platform-scoped markers from `@known_bug_on("platform", "RUE-NNN")`, each `{"issue","platform"}`. **Absent** when none is present. |
 
 `--list --format human` prints one ID per line.
 
@@ -533,11 +553,15 @@ One classifier decides every verdict from one observation of a finished process:
 the runner's own supervision outcome, the exit status, the last non-empty line
 of stderr, and the frames read from the failure channel. One verdict is decided
 without a process at all — `compile_error`, below — because the compiler decided
-it before the run began.
+it before the run began. The applicable known-bug marker then classifies an
+eligible failure as `xfail` or a pass as `xpass`, preserving the original
+failure evidence.
 
 | Verdict | Failure kind | Produced when |
 |---------|--------------|---------------|
 | `pass` | — | Exit `0` **and** a `complete` frame was read. |
+| `xfail` | Underlying failure kind | An applicable known-bug marker accompanies an ordinary test failure or per-test compile error. |
+| `xpass` | — | An applicable known-bug marker accompanies a passing process. |
 | `fail` | `incomplete` | Exit `0` with no `complete` frame. |
 | `fail` | `assert` | A `failure` frame from a failed `@assert`, carrying the intrinsic's own site and its message. Falls back to the last stderr line being exactly `assertion failed` — which is what a comptime-decidable `@assert_eq` still reports as, and what an older image writes. |
 | `fail` | `assert_eq` | A `failure` frame from a failed `@assert_eq`, carrying `left` and `right`. |
@@ -598,7 +622,8 @@ declaration failures to their dependents is tracked as follow-up work.
 current behaviour so the residual is executable rather than prose.
 
 The event is the ordinary `test_finished` shape, so a consumer branches on
-`verdict` and nothing else: `duration_ms` is `0` and the capture records are
+`verdict` and its failure record: an expected compile error has `verdict:
+"xfail"`, while `failure.kind` remains `"compile_error"`; `duration_ms` is `0` and the capture records are
 empty, because no process existed; `scratch_dir` is absent for the same reason;
 `repro` is present as always. Its failure record carries `kind`
 `"compile_error"`, the first diagnostic's `message` and primary span as
@@ -883,7 +908,7 @@ verdict cache (ADR-0083 §6), which is opt-in and knows what it is claiming.
 
 ## Versioning
 
-This schema follows ADR-0061 §6. The version is `1.0`, published in the head
+This schema follows ADR-0061 §6. The version is `1.1`, published in the head
 event of a run and in each `--list --format json` record.
 
 - **Additive changes are minors.** A new event kind, a new optional field, a new

--- a/docs/spec/src/02-lexical-structure/05-builtins.md
+++ b/docs/spec/src/02-lexical-structure/05-builtins.md
@@ -58,9 +58,9 @@ A directive is a builtin that modifies the behavior of the immediately following
 {{ rule(id="2.5:9", cat="normative") }}
 
 ```ebnf
-directive = "@" IDENT "(" [ directive_args ] ")" ;
-directive_args = directive_arg { "," directive_arg } ;
-directive_arg = IDENT ;
+directive = "@" IDENT [ "(" [ directive_args ] ")" ] ;
+directive_args = directive_arg { "," directive_arg } [ "," ] ;
+directive_arg = IDENT | STRING ;
 ```
 
 {{ rule(id="2.5:10", cat="legality-rule") }}

--- a/docs/spec/src/06-items/07-tests.md
+++ b/docs/spec/src/06-items/07-tests.md
@@ -112,6 +112,19 @@ it parses test declarations for the reference scan of 6.7:10. (The feature was
 introduced behind the `test_declarations` preview gate and stabilized by
 RUE-1955.)
 
+{{ rule(id="6.7:18", cat="legality-rule") }}
+
+A test declaration **MAY** carry `@known_bug("RUE-NNN")` or
+`@known_bug_on("platform", "RUE-NNN")` metadata. These directives are valid
+only on tests. The issue marker **MUST** use the canonical positive Rue issue
+spelling, and a platform name **MUST** name a supported host platform;
+malformed markers are rejected. A matching marker records an ordinary test
+failure as an expected failure. A matching marker on a passing test is an
+unexpected pass and **MUST** fail the test run. Timeouts, crashes, and runner
+failures remain failures even when a test has a matching marker. A test
+**MAY** have one unscoped marker or one marker for each distinct platform; an
+unscoped marker **MUST NOT** be combined with platform-scoped markers.
+
 {{ rule(id="6.7:12", cat="informative") }}
 
 This section specifies the declaration, and the one construct whose meaning a

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -48,7 +48,8 @@ item           = function | extern_block | extern_export | struct_def | enum_def
 (* Directives and intrinsics *)
 directives     = { directive } ;
 directive      = "@" IDENT [ "(" [ directive_args ] ")" ] ;
-directive_args = IDENT { "," IDENT } [ "," ] ;
+directive_args = directive_arg { "," directive_arg } [ "," ] ;
+directive_arg  = IDENT | STRING ;
 intrinsic      = "@" IDENT "(" [ intrinsic_args ] ")" ;
 intrinsic_args = intrinsic_arg { "," intrinsic_arg } [ "," ] ;
 intrinsic_arg  = type | expression ;

--- a/fixtures/rue-program/runner/lib_tests.rue
+++ b/fixtures/rue-program/runner/lib_tests.rue
@@ -6,3 +6,10 @@ test "the runner reaches an imported test module" {
 test "and runs every test it declares" {
     @assert_eq(2 + 2, 4);
 }
+
+// Deliberate failure: the build-rule fixture must accept an xfail while
+// preserving its independent check for unimported test files.
+@known_bug("RUE-2018")
+test "expected failures succeed through the build supervisor" {
+    @assert(false);
+}

--- a/scripts/rue-test-supervisor.py
+++ b/scripts/rue-test-supervisor.py
@@ -41,7 +41,7 @@ import sys
 
 # Exit codes of `rue test` (docs/process/test-events.md, "Exit codes").
 _EXIT_REASONS = {
-    1: "a selected test failed, timed out, crashed, or did not compile",
+    1: "a selected test failed, timed out, crashed, did not compile, or unexpectedly passed",
     2: (
         "the run could not be performed (a compile failure outside every test "
         "closure, ICE, or runner error)"
@@ -158,7 +158,8 @@ def report(command, result, reasons, run_finished, events):
     failed = [
         event
         for event in events
-        if event.get("event") == "test_finished" and event.get("verdict") != "pass"
+        if event.get("event") == "test_finished"
+        and event.get("verdict") not in ("pass", "xfail")
     ]
     if failed:
         print("--- non-passing tests ---", file=sys.stderr)
@@ -181,12 +182,14 @@ def report(command, result, reasons, run_finished, events):
         # broken test closures as four zeroes: a failure for no stated reason.
         print(
             "summary: {} passed, {} failed, {} timed out, {} crashed, "
-            "{} did not compile in {} ms".format(
+            "{} did not compile, {} expected failures, {} unexpected passes in {} ms".format(
                 run_finished.get("passed", 0),
                 run_finished.get("failed", 0),
                 run_finished.get("timeout", 0),
                 run_finished.get("crash", 0),
                 run_finished.get("compile_error", 0),
+                run_finished.get("xfail", 0),
+                run_finished.get("xpass", 0),
                 run_finished.get("wall_ms", 0),
             ),
             file=sys.stderr,
@@ -274,8 +277,9 @@ def main(argv):
         for line in describe_unimported(unimported):
             print(line)
     print(
-        "rue_test: {} passed in {} ms".format(
+        "rue_test: {} passed, {} expected failures in {} ms".format(
             run_finished.get("passed", 0),
+            run_finished.get("xfail", 0),
             run_finished.get("wall_ms", 0),
         )
     )


### PR DESCRIPTION
Add `@known_bug("RUE-NNN")` and platform-scoped `@known_bug_on("platform", "RUE-NNN")` to test declarations. Marked ordinary failures, including per-test compile errors, publish `xfail`; marked passes publish `xpass` and fail the run. Unexpected passes retain output, scratch directories, and reproduction commands.

The canonical test inventory carries validated markers into listing and execution. Schema 1.1 exposes the metadata and mutually exclusive verdict counts. Internal compiler errors, infrastructure failures, timeouts, and signal deaths remain failures. The specification, grammar, event contract, and Buck supervisor describe the same behavior.

Validation: quick suite (36 targets), test-runner CLI cases (103 passed), watch cases (9 passed), retained-session metadata regression, and adversarial review. Broad suite: 238 targets passed, including all oracle corpora; UI suite: 437 cases passed. Rebased onto current trunk and added an integration regression ensuring a complete failure frame beside stream overflow cannot become xfail.

Fixes RUE-2018.
