### PR TITLE
RUE-2103: key the watch failure debounce on what the attempt read

### DIFF
--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -272,3 +272,60 @@ source = "pub fn answer() -> i32 { 2 }\n"
 [[case.watch.edits]]
 path = "helper.rue"
 source = "pub fn answer() -> i32 { let ; }\n"
+
+# RUE-2103. The suppression RUE-2091 added keys on the rendered diagnostic and
+# on an observation of the source. The observation half was built from the last
+# COMMITTED closure, and a failed re-observation commits nothing — so a module
+# that has never been read successfully was in no key at all, and saving it
+# produced no output whatsoever, however substantive the edit. That module is
+# not an unrelated file: wiring a pre-existing broken helper into the graph for
+# the first time is the ordinary way this failure arrives, which makes the
+# silent file exactly the one the diagnostic names and the user is editing.
+#
+# `extra.rue` is broken on disk from the start and imported by nobody. The
+# first edit wires it in; the second edits it; the third saves it without
+# changing a byte; the fourth repairs it. The two reports below carry the SAME
+# rendering at the SAME location, so only the source half of the key can have
+# produced the second one.
+[[case]]
+name = "an_edit_to_a_newly_imported_broken_module_is_acknowledged"
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+    { path = "extra.rue", source = "pub fn spare() -> i32 { 1 }\npub fn broken() -> i32 { 2\n" },
+]
+
+[case.watch]
+kind = "failure_outside_closure"
+expected_exit_codes = [1, 2]
+stderr_occurrences = [
+    # Twice, byte for byte, at the same line and column: the first report, and
+    # the acknowledgement of the edit to the file it names. A key that saw only
+    # the committed closure printed this once and then went silent.
+    { text = "error: [E0102]: expected semicolon after expression", count = 2 },
+    { text = "--> extra.rue:2:26", count = 2 },
+    # One status line per report, not one per retry and not one per save: the
+    # save that changed no bytes added none.
+    { text = "keeping the last successful executable", count = 2 },
+]
+
+# Wire the pre-existing broken module into the closure for the first time.
+[[case.watch.edits]]
+path = "helper.rue"
+source = "const extra = @import(\"extra.rue\");\npub fn answer() -> i32 { extra.broken() }\n"
+
+# Edit that module. Line 2 is untouched, so the diagnostic does not move.
+[[case.watch.edits]]
+path = "extra.rue"
+source = "pub fn spare() -> i32 { 41 }\npub fn broken() -> i32 { 2\n"
+
+# Save it without changing it. Content, not the modification time, is what
+# makes a revision.
+[[case.watch.edits]]
+path = "extra.rue"
+touch = true
+
+# Repair it. The published program now answers with the repaired module.
+[[case.watch.edits]]
+path = "extra.rue"
+source = "pub fn spare() -> i32 { 41 }\npub fn broken() -> i32 { 2 }\n"

--- a/crates/rue-cli-tests/cases/watch_test.toml
+++ b/crates/rue-cli-tests/cases/watch_test.toml
@@ -409,3 +409,89 @@ path = "helper.rue"
 source = """
 pub fn double(x: i32) -> i32 { x * 2 }
 """
+
+[[case]]
+name = "an_edit_to_a_newly_imported_broken_module_is_acknowledged"
+description = """
+RUE-2103, on the test watcher. The two watchers share one re-observation arm,
+so they shared the gap: the suppression key's source half was an observation of
+the last COMMITTED closure, and a failed re-observation commits nothing, so a
+module that had never been read successfully was in no key at all. Saving it
+produced nothing — the exact "did the watcher even see me" silence the source
+trigger exists to prevent, on the file the diagnostic names.
+
+`extra.rue` is broken on disk from the start and imported by nobody. The first
+edit wires it into the test closure through `helper.rue`; the second edits it;
+the third saves it without changing a byte; the fourth repairs it. Both reports
+below carry the same message, so only the source half of the key can have
+produced the second.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 { 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn double(x: i32) -> i32 { x * 2 }
+""" },
+    { path = "tests.rue", source = """
+const helper = @import("helper.rue");
+
+test "doubles through the helper" {
+    @assert(helper.double(2) == 4);
+}
+""" },
+    { path = "extra.rue", source = """
+pub fn spare() -> i32 { 1 }
+pub fn broken() -> i32 { 2
+""" },
+]
+
+[case.watch_test]
+kind = "failure_outside_closure"
+expected_exit = 0
+stdout_contains = [
+    '"cycle":1,"event":"run_started"',
+    '"cycle":2,"event":"run_started"',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":1',
+]
+stdout_not_contains = [
+    # Neither failing revision published anything, and no cycle number was
+    # spent on one.
+    '"cycle":3',
+    '"event":"run_canceled"',
+]
+stderr_occurrences = [
+    # The same rendering twice: the first report, and the acknowledgement of
+    # the edit to the module it names.
+    { text = "error: [E0102]: expected semicolon after expression", count = 2 },
+    { text = "--> extra.rue:2:26", count = 2 },
+    { text = "no summary for this revision", count = 2 },
+]
+
+[[case.watch_test.edits]]
+path = "helper.rue"
+source = """
+const extra = @import("extra.rue");
+
+pub fn double(x: i32) -> i32 { x * 2 }
+"""
+
+[[case.watch_test.edits]]
+path = "extra.rue"
+source = """
+pub fn spare() -> i32 { 41 }
+pub fn broken() -> i32 { 2
+"""
+
+[[case.watch_test.edits]]
+path = "extra.rue"
+touch = true
+
+[[case.watch_test.edits]]
+path = "extra.rue"
+source = """
+pub fn spare() -> i32 { 41 }
+pub fn broken() -> i32 { 2 }
+"""

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -190,7 +190,7 @@ use std::io::{BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_target::{Arch, Target};
@@ -2589,19 +2589,39 @@ fn write_watch_edit(dir: &Path, edit: &WatchEdit) -> Result<(), String> {
     let path = dir.join(&edit.path);
     match (
         edit.delete,
+        edit.touch,
         edit.source.as_deref(),
         edit.symlink_target.as_deref(),
     ) {
-        (true, None, None) => std::fs::remove_file(&path)
+        (true, false, None, None) => std::fs::remove_file(&path)
             .map_err(|error| format!("failed to delete watch fixture {}: {error}", edit.path)),
-        (false, Some(source), None) => std::fs::write(&path, source)
+        (false, true, None, None) => touch_watch_fixture(&path)
+            .map_err(|error| format!("failed to touch watch fixture {}: {error}", edit.path)),
+        (false, false, Some(source), None) => std::fs::write(&path, source)
             .map_err(|error| format!("failed to update watch fixture {}: {error}", edit.path)),
-        (false, None, Some(target)) => replace_watch_symlink(&path, target),
+        (false, false, None, Some(target)) => replace_watch_symlink(&path, target),
         _ => Err(format!(
-            "watch edit {} must specify exactly one of delete, source, or symlink_target",
+            "watch edit {} must specify exactly one of delete, touch, source, or symlink_target",
             edit.path
         )),
     }
+}
+
+/// Restamp a fixture's modification time without touching a byte of it.
+///
+/// Deliberately not a rewrite of the same content: `fs::write` truncates
+/// before it writes, so a re-observation landing in that window would read an
+/// empty file and turn the failure this case is sitting inside into an
+/// ordinary successful cycle. Setting the timestamp alone is the same
+/// user-visible event — a save that changed nothing — with no such window.
+fn touch_watch_fixture(path: &Path) -> std::io::Result<()> {
+    let file = std::fs::OpenOptions::new().write(true).open(path)?;
+    let now = SystemTime::now();
+    file.set_times(
+        std::fs::FileTimes::new()
+            .set_accessed(now)
+            .set_modified(now),
+    )
 }
 
 fn assert_watch_program(
@@ -2687,6 +2707,11 @@ fn run_watch_case(
         return Err(TestFailure::assertion(
             "repeated-failure watch scenario requires two failing edits, an unrelated \
              closure edit, a repair, and a verbatim re-break",
+        ));
+    }
+    if scenario.kind == WatchScenarioKind::FailureOutsideClosure && scenario.edits.len() != 4 {
+        return Err(TestFailure::assertion(
+            "failure-outside-closure watch scenario requires a wiring edit, a content edit, a touch, and a repair",
         ));
     }
     if scenario.kind == WatchScenarioKind::SymlinkRetarget && scenario.edits.len() != 1 {
@@ -2878,6 +2903,29 @@ fn run_watch_case(
             WatchScenarioKind::SymlinkRetarget => {
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
             }
+            WatchScenarioKind::FailureOutsideClosure => {
+                // The opening edit wires a pre-existing broken module into the
+                // closure for the first time. No successful close ever
+                // contained it, so it is in no committed watch closure — and
+                // it is the file the diagnostic names.
+                assert_failure_reported_once(&mut child, &protocol, 1, deadline)?;
+                // Editing that file is a new revision, and the watcher owes it
+                // an answer even though the rendering does not move. Before
+                // RUE-2103 this produced nothing at all, which is exactly the
+                // "did the watcher even see my save" silence the second
+                // suppression trigger exists to prevent.
+                write_watch_edit(dir, &scenario.edits[1])?;
+                assert_failure_reported_once(&mut child, &protocol, 2, deadline)?;
+                // A save that leaves the bytes alone is not a new revision.
+                // The key is the content the attempt read, so the file's new
+                // modification time is invisible and the report stays at two.
+                write_watch_edit(dir, &scenario.edits[2])?;
+                assert_failure_reported_once(&mut child, &protocol, 2, deadline)?;
+                // And repairing that same outside-the-closure module still
+                // publishes promptly.
+                write_watch_edit(dir, &scenario.edits[3])?;
+                wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
+            }
             WatchScenarioKind::RepeatedFailure => {
                 // Each step below kills one way the suppression could be
                 // written wrong, and the loop it exercises is shared, so
@@ -3049,6 +3097,7 @@ fn run_watch_test_case(
         WatchTestScenarioKind::Edit | WatchTestScenarioKind::Cancel => 1,
         WatchTestScenarioKind::CompileError => 2,
         WatchTestScenarioKind::RepeatedFailure => 3,
+        WatchTestScenarioKind::FailureOutsideClosure => 4,
     };
     if scenario.edits.len() != required_edits {
         return Err(TestFailure::assertion(format!(
@@ -3165,6 +3214,19 @@ fn run_watch_test_case(
                 write_watch_edit(dir, &scenario.edits[1])?;
                 assert_failure_reported_once(&mut child, &protocol, 2, deadline)?;
                 write_watch_edit(dir, &scenario.edits[2])?;
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 2, deadline)?;
+            }
+            WatchTestScenarioKind::FailureOutsideClosure => {
+                // The `--watch` case of the same name carries the reasoning;
+                // this pins that the two watchers really do share the arm.
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 1, deadline)?;
+                write_watch_edit(dir, &scenario.edits[0])?;
+                assert_failure_reported_once(&mut child, &protocol, 1, deadline)?;
+                write_watch_edit(dir, &scenario.edits[1])?;
+                assert_failure_reported_once(&mut child, &protocol, 2, deadline)?;
+                write_watch_edit(dir, &scenario.edits[2])?;
+                assert_failure_reported_once(&mut child, &protocol, 2, deadline)?;
+                write_watch_edit(dir, &scenario.edits[3])?;
                 wait_for_watch_event(&mut child, &protocol, "run-finished", 2, deadline)?;
             }
             WatchTestScenarioKind::Cancel => {

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -234,6 +234,12 @@ pub enum WatchScenarioKind {
     /// closure file while the broken one holds still, repairs it, and finally
     /// restores the broken bytes verbatim (RUE-2091).
     RepeatedFailure,
+    /// The same retry timer, but the broken module is one no successful close
+    /// ever contained: a pre-existing file wired into the closure for the first
+    /// time. Edits to it must still be acknowledged even though the diagnostic
+    /// they produce is byte-identical, because that file is the one the user is
+    /// editing (RUE-2103).
+    FailureOutsideClosure,
 }
 
 /// A synchronized end-to-end `rue test --watch` scenario (RUE-2023).
@@ -291,6 +297,10 @@ pub enum WatchTestScenarioKind {
     /// watchers share one loop, so the suppression they share is pinned on
     /// both surfaces (RUE-2091).
     RepeatedFailure,
+    /// [`WatchScenarioKind::FailureOutsideClosure`] on the test watcher. Both
+    /// watchers share the re-observation arm, so they shared the gap and are
+    /// pinned together (RUE-2103).
+    FailureOutsideClosure,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -301,6 +311,12 @@ pub struct WatchEdit {
     pub source: Option<String>,
     #[serde(default)]
     pub delete: bool,
+    /// Restamp the file's modification time and leave its bytes alone — the
+    /// save an editor performs on a document nobody changed. The watcher keys
+    /// on content, so this must produce no new revision and no new report; a
+    /// key built from file metadata instead would report on it (RUE-2103).
+    #[serde(default)]
+    pub touch: bool,
     #[serde(default)]
     pub symlink_target: Option<String>,
 }

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -15,7 +15,7 @@ use rue_compiler::{
 };
 
 use crate::source_loader::{
-    ImportDiscoveryResult, SourceLoadError, SourceLoadRequest, WatchInput,
+    AttemptedRead, ImportDiscoveryResult, SourceLoadError, SourceLoadRequest, WatchInput,
     acquire_reached_toolchain_modules, acquire_reached_toolchain_modules_superseding, load,
     reload_from_filesystem,
 };
@@ -103,6 +103,17 @@ impl FilesystemCompilerHost {
     /// change which reads are allowed on the next observation.
     pub fn watch_inputs(&self) -> Vec<WatchInput> {
         self.state.watch_inputs()
+    }
+
+    /// What the most recent observation attempt read, whether or not it
+    /// committed.
+    ///
+    /// [`Self::watch_inputs`] answers "what is the accepted closure"; this
+    /// answers the weaker "what did the loader last look at", which is the only
+    /// account of a failed attempt's files, since a failure commits none of
+    /// them (RUE-2103).
+    pub fn attempted_reads(&self) -> &[AttemptedRead] {
+        self.state.attempted_reads()
     }
 
     pub fn root_path(&self) -> &Path {

--- a/crates/rue/src/lib.rs
+++ b/crates/rue/src/lib.rs
@@ -11,7 +11,7 @@ mod test_candidates;
 
 pub use host::{FilesystemCompilerHost, HostOpenRequest};
 pub use source_loader::{
-    HermeticDenialError, SourceLoadError, ToolchainIntegrityError, WatchFingerprint, WatchInput,
-    watch_input_fingerprints, watch_inputs_changed, watch_inputs_changed_with_reader,
+    AttemptedRead, HermeticDenialError, SourceLoadError, ToolchainIntegrityError, WatchFingerprint,
+    WatchInput, watch_input_fingerprints, watch_inputs_changed, watch_inputs_changed_with_reader,
 };
 pub use test_candidates::load_declared_candidates;

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -199,6 +199,49 @@ pub fn watch_input_fingerprints(inputs: &[WatchInput]) -> Vec<Option<WatchFinger
         .collect()
 }
 
+/// One physical source read an observation attempt accepted: where it read,
+/// and what it read there.
+///
+/// The committed closure ([`ImportDiscoveryResult::watch_inputs`]) describes
+/// the last attempt that *succeeded*. A failed attempt commits nothing, so a
+/// module it read but never closed over is in no closure at all — and that
+/// module is frequently the one the failure's diagnostic names and the one
+/// being edited, because wiring a pre-existing broken file into the graph for
+/// the first time is exactly how the failure arrives (RUE-2103). This is the
+/// attempt's own record of what it touched, kept whether or not it committed.
+///
+/// The fingerprint is the accepted bytes' content hash, not file metadata, so
+/// re-reading identical content compares equal: a rewrite that changes nothing
+/// is not a new revision, and only a real edit is.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AttemptedRead {
+    requested_path: Arc<str>,
+    canonical_path: Arc<str>,
+    content_fingerprint: u64,
+}
+
+/// Project an attempt's accepted-read manifest into its observation record.
+///
+/// Ordered by path rather than by the manifest's module identity so the record
+/// of two attempts over the same files compares equal regardless of the order
+/// discovery happened to reach them.
+fn attempted_reads_of(manifest: &AcceptedReadManifest) -> Vec<AttemptedRead> {
+    let mut reads: Vec<AttemptedRead> = manifest
+        .iter()
+        .map(|entry| AttemptedRead {
+            requested_path: Arc::from(entry.requested_path()),
+            canonical_path: Arc::from(entry.canonical_path()),
+            content_fingerprint: entry.content_fingerprint(),
+        })
+        .collect();
+    reads.sort_by(|left, right| {
+        left.requested_path
+            .cmp(&right.requested_path)
+            .then_with(|| left.canonical_path.cmp(&right.canonical_path))
+    });
+    reads
+}
+
 #[derive(Debug)]
 pub(crate) struct SourceManifest {
     path: PathBuf,
@@ -908,6 +951,16 @@ pub(crate) struct ImportDiscoveryResult {
     /// graph. These negative observations are load-bearing when a later
     /// candidate won resolution, because creating one changes that winner.
     observed_absent_paths: Vec<PathBuf>,
+    /// Every physical read the most recent observation attempt accepted,
+    /// whether or not that attempt went on to commit.
+    ///
+    /// This is deliberately not part of the committed closure: `watch_inputs`
+    /// stays the exact accepted-read closure a successful revision was built
+    /// from, which is what `--emit deps` and the cycle's change monitor mean.
+    /// This is the weaker, wider thing — what the loader looked at last — and
+    /// the watcher reads it to tell one failing revision from the next
+    /// (RUE-2103).
+    attempted_reads: Vec<AttemptedRead>,
     /// Canonical import topology and diagnostics published by the compiler.
     pub(crate) revision: Arc<ImportDiscoveryView>,
     #[cfg(test)]
@@ -979,6 +1032,11 @@ impl ImportDiscoveryResult {
                 },
             },
         }
+    }
+
+    /// What the most recent observation attempt read, successful or failed.
+    pub(crate) fn attempted_reads(&self) -> &[AttemptedRead] {
+        &self.attempted_reads
     }
 
     pub(crate) fn watch_inputs(&self) -> Vec<WatchInput> {
@@ -1859,10 +1917,12 @@ pub(crate) fn discover_and_load_imports(
         DiscoveryControl::default(),
     )?;
 
+    let read_manifest = assembler.accepted_read_manifest();
     Ok(ImportDiscoveryResult {
         source_snapshot: close.snapshot,
         resolution: SourceResolutionInputs { root_path, context },
-        read_manifest: assembler.accepted_read_manifest(),
+        attempted_reads: attempted_reads_of(&read_manifest),
+        read_manifest,
         observed_absent_paths: close.observed_absent_paths,
         revision: close.closed,
         #[cfg(test)]
@@ -1884,6 +1944,10 @@ pub(crate) fn reload_from_filesystem(
     supersession: Option<&dyn Fn() -> bool>,
 ) -> Result<(), SourceLoadError> {
     let control = DiscoveryControl::superseding(supersession);
+    // This attempt's observation record starts empty and is filled in once the
+    // assembler exists, so a failure before any read is described as having
+    // read nothing rather than inheriting the previous attempt's files.
+    result.attempted_reads.clear();
     control.checkpoint()?;
     let source_manifest = result
         .source_manifest
@@ -1978,10 +2042,22 @@ pub(crate) fn reload_from_filesystem(
             })?;
             return Err(SourceLoadError::Superseded);
         }
-        outcome => outcome?,
+        // A failed close commits nothing, so record what it managed to read
+        // before it failed. Without this the watcher has no observation of the
+        // module whose bytes made the attempt fail, and cannot tell the user's
+        // next edit to it from a bare retry (RUE-2103). A superseded attempt is
+        // excluded above: it was abandoned, not answered, and the restart
+        // observes the newer bytes itself.
+        Err(error) => {
+            result.attempted_reads = attempted_reads_of(&assembler.accepted_read_manifest());
+            return Err(error);
+        }
+        Ok(close) => close,
     };
+    let read_manifest = assembler.accepted_read_manifest();
+    result.attempted_reads = attempted_reads_of(&read_manifest);
     result.source_snapshot = close.snapshot;
-    result.read_manifest = assembler.accepted_read_manifest();
+    result.read_manifest = read_manifest;
     result.observed_absent_paths = close.observed_absent_paths;
     result.revision = close.closed;
     result.assembler = assembler;
@@ -2148,6 +2224,15 @@ pub(crate) fn acquire_reached_toolchain_modules_superseding(
                 ) {
                     Ok(reclosed) => reclosed,
                     Err(error) => {
+                        // Same as the re-observation failure above: the round
+                        // commits nothing, so its reads survive only here, and
+                        // the watcher needs them to tell a newly broken
+                        // toolchain module from the same one on the next retry
+                        // (RUE-2103).
+                        if !matches!(error, SourceLoadError::Superseded) {
+                            result.attempted_reads =
+                                attempted_reads_of(&round_assembler.accepted_read_manifest());
+                        }
                         let error = reclassify_reclose_failure(
                             error,
                             &result.resolution.context,
@@ -2165,6 +2250,7 @@ pub(crate) fn acquire_reached_toolchain_modules_superseding(
                 // Commit boundary: every assignment below is infallible, so the
                 // round is applied whole or not at all.
                 result.read_manifest = round_assembler.accepted_read_manifest();
+                result.attempted_reads = attempted_reads_of(&result.read_manifest);
                 result.assembler = round_assembler;
                 result.source_snapshot = reclosed.snapshot;
                 result.revision = reclosed.closed;
@@ -3504,6 +3590,96 @@ mod tests {
                 "every recorded read of the published revision verifies"
             );
         }
+    }
+
+    /// A re-observation that fails commits nothing, so the module whose bytes
+    /// made it fail joins no closure — and if that module was never in one, it
+    /// is in no watch input either. The attempt's own record of what it read
+    /// is the only account of it, and it is what lets a watcher tell the next
+    /// edit to that module from a bare retry (RUE-2103).
+    #[test]
+    fn a_failed_reobservation_records_the_module_it_could_not_close_over() {
+        let dir = TestDir::new("failed-attempt-reads");
+        let main = dir.write(
+            "main.rue",
+            r#"const helper = @import("helper.rue"); fn main() -> i32 { helper.value() }"#,
+        );
+        let helper = dir.write("helper.rue", "pub fn value() -> i32 { 1 }");
+        // Broken on disk from the start, and imported by nobody.
+        let extra = dir.write("extra.rue", "pub fn broken() -> i32 { 2");
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let names = |reads: &[AttemptedRead]| {
+            reads
+                .iter()
+                .map(|read| {
+                    Path::new(read.requested_path.as_ref())
+                        .file_name()
+                        .unwrap()
+                        .to_string_lossy()
+                        .into_owned()
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(names(result.attempted_reads()), ["helper.rue", "main.rue"]);
+
+        // Wire it in. Discovery reads it, fails to parse it, and commits none
+        // of the revision that read it.
+        fs::write(
+            &helper,
+            r#"const extra = @import("extra.rue"); pub fn value() -> i32 { extra.broken() }"#,
+        )
+        .unwrap();
+        assert!(reload_from_filesystem(&mut result, None).is_err());
+        assert!(
+            !result
+                .watch_inputs()
+                .iter()
+                .any(|input| input.requested_path().ends_with("extra.rue")),
+            "a failed attempt commits nothing, so the closure is still the last successful one"
+        );
+        let failed = result.attempted_reads().to_vec();
+        assert_eq!(names(&failed), ["extra.rue", "helper.rue", "main.rue"]);
+
+        // Retrying over the same bytes reads the same thing, which is what
+        // makes the repeat recognizable as one.
+        assert!(reload_from_filesystem(&mut result, None).is_err());
+        assert_eq!(result.attempted_reads(), failed);
+
+        // Editing the module records something else, even though the file set
+        // and every path in it is identical: the record is content-derived.
+        fs::write(&extra, "pub fn broken() -> i32 { 41").unwrap();
+        assert!(reload_from_filesystem(&mut result, None).is_err());
+        assert_eq!(names(result.attempted_reads()), names(&failed));
+        assert_ne!(result.attempted_reads(), failed);
+
+        // Content-derived and nothing else. That edit moved the length and the
+        // modification time along with the bytes, so it cannot tell a content
+        // key from a metadata one; restamping the file without writing a byte
+        // can, and must record exactly what the read before it did.
+        let edited = result.attempted_reads().to_vec();
+        let now = std::time::SystemTime::now();
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&extra)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_accessed(now).set_modified(now))
+            .unwrap();
+        assert!(reload_from_filesystem(&mut result, None).is_err());
+        assert_eq!(result.attempted_reads(), edited);
+
+        // And a repair puts it in the committed closure, where it belongs.
+        fs::write(&extra, "pub fn broken() -> i32 { 41 }").unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
+        assert!(
+            result
+                .watch_inputs()
+                .iter()
+                .any(|input| input.requested_path().ends_with("extra.rue"))
+        );
+        assert_eq!(
+            names(result.attempted_reads()),
+            ["extra.rue", "helper.rue", "main.rue"]
+        );
     }
 
     #[test]

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -12,7 +12,8 @@ use rue_compiler::{CompileOptions, OptLevel};
 #[cfg(test)]
 use rue_driver::watch_inputs_changed_with_reader;
 use rue_driver::{
-    FilesystemCompilerHost, SourceLoadError, WatchFingerprint, WatchInput, watch_inputs_changed,
+    AttemptedRead, FilesystemCompilerHost, SourceLoadError, WatchFingerprint, WatchInput,
+    watch_inputs_changed,
 };
 use rue_target::Target;
 
@@ -148,9 +149,15 @@ impl ObservationPhase {
 ///   rendering risks swallowing a message the previous one did not contain.
 /// - **The source changed.** A revision that still fails identically is worth
 ///   one line back, because silence after a save is ambiguous: it looks the
-///   same as a watcher that never noticed the file. `observation` is the
-///   physical state of the retained closure this attempt read, so an edit
-///   anywhere in it re-reports even when the compiler's answer is unchanged.
+///   same as a watcher that never noticed the file. Two halves answer that,
+///   because neither alone covers the source a failing attempt reads:
+///   `observation` is the physical state of the *committed* closure at the
+///   start of this attempt, and `attempted_reads` is what the attempt itself
+///   accepted, which is the only account of a module the last successful close
+///   never contained. The second half is what makes the ordinary "wire in the
+///   scratch file I was drafting" edit report: the newly imported file is not
+///   in any committed closure yet, and it is usually the exact file the
+///   diagnostic names and the user is editing (RUE-2103).
 ///
 /// A clock carries neither signal, so there is no time-based reprint: a
 /// stuck-and-unedited watcher stays quiet indefinitely, which is the whole
@@ -158,6 +165,7 @@ impl ObservationPhase {
 struct ReportedFailure {
     diagnostic: String,
     observation: Vec<WatchObservation>,
+    attempted_reads: Vec<AttemptedRead>,
 }
 
 pub(crate) struct WatchRequest {
@@ -425,9 +433,22 @@ pub(crate) fn run(request: WatchRequest) -> ! {
                 }
                 Err(error) => {
                     let diagnostic = render_source_load_error(error, error_format);
+                    // Content hashes of the bytes the attempt accepted, on
+                    // the same terms as the closure observation above: a save
+                    // that rewrites a file without changing it compares equal
+                    // and stays suppressed. Deliberately not the modification
+                    // time the accepted-read manifest also carries, which such
+                    // a save moves without producing a revision anyone asked
+                    // to hear about.
+                    //
+                    // Compared borrowed, and copied only by the branch that
+                    // keeps it: this runs four times a second for as long as a
+                    // failure stands, and the suppressed retry is the path
+                    // RUE-2091 exists to keep both quiet and cheap.
                     let repeat = reported_failure.as_ref().is_some_and(|reported| {
                         reported.diagnostic == diagnostic
                             && reported.observation == observation_baseline
+                            && reported.attempted_reads == host.attempted_reads()
                     });
                     if repeat {
                         test_event(phase.repeated_error_event());
@@ -447,6 +468,7 @@ pub(crate) fn run(request: WatchRequest) -> ! {
                         reported_failure = Some(ReportedFailure {
                             diagnostic,
                             observation: observation_baseline,
+                            attempted_reads: host.attempted_reads().to_vec(),
                         });
                     }
                     thread::sleep(FAILED_REOBSERVE_RETRY);

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -159,9 +159,13 @@ the cycle status is progress text, not an additional diagnostic.
 A `--watch` failure the loop cannot park on — a re-observation or acquisition
 error, which may name a file that does not exist yet — is retried on a timer,
 and the stream carries one array per distinct failure rather than one per retry
-(RUE-2091). The array returns when the rendered diagnostic changes or when a
-source in the watched closure does; an unchanged failure over unchanged bytes
-publishes nothing further. Nothing about the array's shape, code, or framing
+(RUE-2091). The array returns when the rendered diagnostic changes or when any
+source the attempt read does — the retained closure plus whatever that attempt
+itself pulled in, so a module wired into the graph for the first time counts
+even though no successful revision has closed over it yet (RUE-2103). An
+unchanged failure over unchanged bytes publishes nothing further, and
+"unchanged" means the bytes: a save that rewrites a file without editing it is
+not a new revision. Nothing about the array's shape, code, or framing
 changes with it, so this is an emission cadence rather than a schema change.
 
 Driver failures can occur before the initial compilation snapshot exists, or

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -863,9 +863,12 @@ has no one revision — and keeps compile mode's own exclusions (`--emit`,
   park on — a broken `@import` may name a file that does not exist yet — is
   retried on a timer, and a retry that finds the same failure over the same
   bytes says nothing. The report returns when the rendered diagnostic changes or
-  when a source in the closure does, so a save that leaves the error standing
-  still gets one line back rather than silence, and a watcher left inside an
-  untouched syntax error stays quiet indefinitely.
+  when any source the attempt read does — the retained closure and whatever
+  that attempt itself pulled in, which is what a module wired into the graph
+  for the first time is — so a save that leaves the error standing still gets
+  one line back rather than silence, and a watcher left inside an untouched
+  syntax error stays quiet indefinitely. "Changed" means the bytes, not the
+  modification time: saving a file without editing it is not a new revision.
 - **The exit status is produced only on SIGINT or SIGTERM**, and is the last
   cycle that COMPLETED reporting itself on the ordinary
   [exit-code table](#exit-codes): `0` if it passed, `1` if it failed, `3` if it


### PR DESCRIPTION
Fixes RUE-2103

RUE-2091 stopped a repeating watch-mode failure from reprinting four times a
second by keying the report on `(rendered diagnostic, an observation of the
source)`. The source half was built from `watch_inputs()` — the *last committed*
closure. A failed re-observation commits nothing, so a module that has never
been read successfully is in no closure and therefore in no part of the key.

That module is not an unrelated file. Wiring a pre-existing broken helper into
the graph for the first time is the ordinary way this failure arrives, which
makes the missing file exactly the one the diagnostic names and the one being
edited. From that point, editing it — substantively, repeatedly — produced zero
output for as long as the diagnostic happened to render identically: precisely
the "did the watcher even see my save" ambiguity the source trigger exists to
prevent.

## The fix

Each observation attempt now records the physical reads it accepted — path plus
a content hash of the bytes it read — whether or not it went on to commit, and
the watcher folds that record into the key alongside the committed closure's
observation. Nothing new is read from the filesystem: the record is what the
attempt itself already read, taken from the assembler that a failed close
throws away.

- `watch_inputs()` is textually unchanged. The committed closure stays exactly
  what `--emit deps` and the cycle's change monitor mean; the new record is the
  separate, weaker "what did the loader last look at".
- A superseded attempt records nothing on either path — it was abandoned rather
  than answered, and the restart observes the newer bytes itself.
- The key gained a conjunct, so it can only report more often, never less. The
  retry cadence, the debounce, and supersession are untouched.
- The record is content-derived, not metadata-derived, so a save that rewrites a
  file without changing it still compares equal and stays suppressed.

## Coverage

- A loader unit test pinning the contract directly: a failed attempt commits
  nothing to the closure, records the module it could not close over, records
  the *same* thing on a bare retry, records a *different* thing after an edit,
  and records the same thing again after a modification-time restamp that moves
  no bytes.
- Two event-driven CLI cases, one per watcher surface, driven on the existing
  milestone protocol with no sleeps. Their `stderr_occurrences` pin the same
  diagnostic *and* the same `--> extra.rue:2:26` location twice, so the
  diagnostic half of the key is provably constant across the two reports and
  only the source half can explain the second.
- New corpus surface: a `failure_outside_closure` scenario kind on both
  watchers, and `WatchEdit.touch`, which restamps the modification time rather
  than rewriting identical bytes — `fs::write` truncates first, and a
  re-observation landing in that window would read an empty file, publish, and
  reset the failure.
- `docs/process/test-events.md` and `docs/process/diagnostics.md` both said the
  report returns when "a source in the closure" changes. Both now say any source
  the attempt read, and that "changed" means the bytes.

## Not covered, pre-existing

A module that fails at *read* time rather than parse time (invalid UTF-8, a
directory in its place) is never an accepted read, so it is not in the record
and its edits are still silent. That reproduces identically before and after
this change — it is a pre-existing residual on the same arm, tracked separately,
and covering it is a design call rather than a drive-by.
