### PR TITLE
RUE-2068: preserve corpus cleanup across deadline races

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1474,6 +1474,7 @@ filegroup(
     srcs = [
         "scripts/corpus-action",
         "scripts/corpus-timeout.py",
+        "scripts/test-corpus-timeout.py",
         "scripts/corpus-stamp-check",
     ],
 )

--- a/scripts/corpus-timeout.py
+++ b/scripts/corpus-timeout.py
@@ -72,17 +72,27 @@ def terminate_group(process: subprocess.Popen, first_signal: int = signal.SIGTER
     signal_group(process_group, first_signal)
 
     deadline = time.monotonic() + TERM_GRACE_SECONDS
-    while time.monotonic() < deadline:
+    # Read the clock once for the sleep decision: a separate condition read
+    # can cross the deadline and turn the next sleep duration negative.
+    while True:
         if not group_exists(process_group):
             return
-        time.sleep(min(0.05, deadline - time.monotonic()))
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(0.05, remaining))
 
     # Do not stop at the leader: a harness can leave descendants running after
     # it handles TERM, so the forced cleanup always addresses the whole group.
     signal_group(process_group, signal.SIGKILL)
     deadline = time.monotonic() + KILL_GRACE_SECONDS
-    while time.monotonic() < deadline and group_exists(process_group):
-        time.sleep(min(0.05, deadline - time.monotonic()))
+    while True:
+        if not group_exists(process_group):
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(0.05, remaining))
 
 
 def shell_status(returncode: int) -> int:

--- a/scripts/test-corpus-action.sh
+++ b/scripts/test-corpus-action.sh
@@ -19,6 +19,7 @@ else
 fi
 CORPUS_ACTION="$SCRIPTS_DIR/corpus-action"
 TIMEOUT_RUNNER="$SCRIPTS_DIR/corpus-timeout.py"
+TIMEOUT_TEST="$SCRIPTS_DIR/test-corpus-timeout.py"
 
 failures=0
 tests=0
@@ -243,6 +244,15 @@ t_timeout() {
     rm -rf "$dir"
 }
 
+# The cleanup deadline has two monotonic-clock edges. Keep the sleep argument
+# non-negative when the clock crosses either edge between loop checks.
+t_timeout_cleanup_deadline_race() {
+    local status
+    PYTHONDONTWRITEBYTECODE=1 python3 "$TIMEOUT_TEST"
+    status=$?
+    check "timeout cleanup deadline race test passes" "0" "$status"
+}
+
 # An ordinary exit 124 is still an ordinary harness result, not a timeout.
 # The private marker keeps the focused timeout diagnostic specific.
 t_exit_124_is_not_timeout() {
@@ -361,17 +371,28 @@ t_usage() {
     check "no arguments is a usage error" "2" "$status"
 }
 
-t_success
-t_failure_writes_no_stamp
-t_absolutize
-t_absolutize_declared_output
-t_missing_absolutize_target_fails
-t_plumbing_is_hidden
-t_timeout
-t_exit_124_is_not_timeout
-t_timeout_kills_descendants
-t_wrapper_cancellation
-t_usage
+run_test() {
+    local test_name
+    test_name="$1"
+    echo "corpus-action: running $test_name" >&2
+    "$test_name"
+}
+
+for test_name in \
+    t_success \
+    t_failure_writes_no_stamp \
+    t_absolutize \
+    t_absolutize_declared_output \
+    t_missing_absolutize_target_fails \
+    t_plumbing_is_hidden \
+    t_timeout \
+    t_timeout_cleanup_deadline_race \
+    t_exit_124_is_not_timeout \
+    t_timeout_kills_descendants \
+    t_wrapper_cancellation \
+    t_usage; do
+    run_test "$test_name"
+done
 
 if [ "$failures" -ne 0 ]; then
     echo "corpus-action: $failures/$tests checks failed" >&2

--- a/scripts/test-corpus-timeout.py
+++ b/scripts/test-corpus-timeout.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Focused tests for corpus-timeout cleanup deadline races."""
+
+import importlib.util
+import signal
+import sys
+from pathlib import Path
+
+
+def load_timeout_module():
+    path = Path(__file__).with_name("corpus-timeout.py")
+    spec = importlib.util.spec_from_file_location("corpus_timeout", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load corpus-timeout.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeProcess:
+    pid = 99
+
+
+def run_cleanup(clock_values, group_values):
+    module = load_timeout_module()
+    clock = iter(clock_values)
+    groups = iter(group_values)
+    sleeps = []
+    signals = []
+    original_monotonic = module.time.monotonic
+    original_sleep = module.time.sleep
+    original_group_exists = module.group_exists
+    original_signal_group = module.signal_group
+    try:
+        module.time.monotonic = lambda: next(clock)
+
+        def sleep(seconds):
+            if seconds < 0:
+                raise AssertionError("cleanup requested a negative sleep")
+            sleeps.append(seconds)
+
+        module.time.sleep = sleep
+        module.group_exists = lambda _group: next(groups)
+        module.signal_group = lambda group, number: signals.append((group, number))
+        module.terminate_group(FakeProcess())
+    finally:
+        module.time.monotonic = original_monotonic
+        module.time.sleep = original_sleep
+        module.group_exists = original_group_exists
+        module.signal_group = original_signal_group
+    return signals, sleeps
+
+
+def test_term_deadline_crossing() -> None:
+    # The clock crosses TERM's deadline between the loop condition and the
+    # sleep calculation used by the old implementation.
+    signals, sleeps = run_cleanup((0.0, 0.5, 1.1, 2.0, 3.1), (True, True, True))
+    expected = [(99, signal.SIGTERM), (99, signal.SIGKILL)]
+    if signals != expected:
+        raise AssertionError("TERM-edge signals were {!r}, expected {!r}".format(signals, expected))
+    if not sleeps or any(seconds < 0 for seconds in sleeps):
+        raise AssertionError("TERM-edge cleanup slept {!r}".format(sleeps))
+
+
+def test_kill_deadline_crossing() -> None:
+    # Keep both calls in the TERM iteration positive, then cross KILL's
+    # deadline between its loop condition and sleep calculation.
+    signals, sleeps = run_cleanup(
+        (0.0, 0.5, 0.6, 1.1, 2.0, 2.5, 3.1),
+        (True, True, True, True, True),
+    )
+    expected = [(99, signal.SIGTERM), (99, signal.SIGKILL)]
+    if signals != expected:
+        raise AssertionError("KILL-edge signals were {!r}, expected {!r}".format(signals, expected))
+    if len(sleeps) < 2 or any(seconds < 0 for seconds in sleeps):
+        raise AssertionError("KILL-edge cleanup slept {!r}".format(sleeps))
+
+
+def test_group_exit_skips_forced_kill() -> None:
+    signals, sleeps = run_cleanup((0.0, 0.1), (False,))
+    expected = [(99, signal.SIGTERM)]
+    if signals != expected:
+        raise AssertionError("normal-exit signals were {!r}, expected {!r}".format(signals, expected))
+    if sleeps:
+        raise AssertionError("normal-exit cleanup slept {!r}".format(sleeps))
+
+
+if __name__ == "__main__":
+    try:
+        test_term_deadline_crossing()
+        test_kill_deadline_crossing()
+        test_group_exit_skips_forced_kill()
+    except (AssertionError, RuntimeError, StopIteration) as error:
+        print("FAIL: {}".format(error), file=sys.stderr)
+        sys.exit(1)
+    print("corpus-timeout: deadline-race checks passed")


### PR DESCRIPTION
Corpus timeout cleanup could read the clock before a grace deadline, read it again after the deadline, and pass a negative duration to `sleep`. The resulting exception could skip forced process-group cleanup and leave the corpus test waiting on an open output pipe.

Check one remaining duration before each sleep in both cleanup phases. Add separate regressions for the TERM and KILL boundary races and a normal-exit control, and print each corpus subtest before it runs. Both race tests fail on the original runner with a negative-sleep error. The archived macOS hang did not identify its exact cause; this fixes a confirmed current-source hang mechanism and makes future timeouts attributable.

Validation: `./buck2 test //:corpus-action-tests`; `scripts/rue quick` (36 targets); `scripts/rue fmt`; the regression helper under Python 3.9; Bash 3.2 baseline and shell pipefail validation; `git diff --check`.

Fixes RUE-2068.
