### PR TITLE
RUE-1811: give compiler sessions immutable resource configuration

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -13,7 +13,9 @@ use crate::digest::sha256_bytes as sha256;
 use rue_compiler::unstable::{
     EndpointQueryWork, EndpointWork, MetricsSnapshot, QueryRuntimeMetrics, QueryValidationMetrics,
 };
-use rue_compiler::{CompileErrors, CompileOptions, CompileOutput, CompileWarning, OptLevel};
+use rue_compiler::{
+    CompileErrors, CompileOptions, CompileOutput, CompileWarning, CompilerSessionConfig, OptLevel,
+};
 use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
 use rue_perf_schema::{
     DisplayIdentityWork, EDIT_REPORT_SCHEMA_VERSION, EditEndpoints, EditManifest, EditOutcome,
@@ -443,6 +445,7 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
                     &fixture.overlays,
                     options.std_root.as_deref(),
                     &compile_options,
+                    CompilerSessionConfig::default(),
                     Some(&fixture.edit(declaration.scenario)),
                     declaration.expected_outcome,
                 )
@@ -705,9 +708,12 @@ pub(crate) fn write_validated_report(
 
 pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObservation, String> {
     let total_started = Instant::now();
-    let resolved_workers = resolve_workers(request.worker_mode);
-    rue_compiler::configure_thread_pool(resolved_workers as usize);
-
+    let compiler_config = CompilerSessionConfig::with_workers(match request.worker_mode {
+        WorkerMode::One => 1,
+        WorkerMode::Automatic => 0,
+    })
+    .map_err(|error| error.to_string())?;
+    let resolved_workers = compiler_config.workers() as u32;
     let isolated = tempfile::tempdir()
         .map_err(|error| format!("could not create isolated fixture: {error}"))?;
     copy_tree(request.fixture_root, isolated.path())?;
@@ -718,7 +724,12 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
         .map(|path| isolated_path(isolated.path(), path))
         .transpose()?;
 
-    let mut warm = open_host(&root, manifest.as_deref(), request.std_root)?;
+    let mut warm = open_host(
+        &root,
+        manifest.as_deref(),
+        request.std_root,
+        compiler_config,
+    )?;
     warm.acquire_reached_toolchain_modules(request.options)
         .map_err(source_load_error)?;
     let baseline = run_success(&mut warm, request.options)
@@ -825,7 +836,12 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
     let fresh_identity = match request.fresh_oracle {
         Some(identity) => identity.clone(),
         None => {
-            let mut fresh = open_host(&root, manifest.as_deref(), request.std_root)?;
+            let mut fresh = open_host(
+                &root,
+                manifest.as_deref(),
+                request.std_root,
+                compiler_config,
+            )?;
             fresh
                 .acquire_reached_toolchain_modules(request.options)
                 .map_err(source_load_error)?;
@@ -1021,9 +1037,9 @@ fn collect_retention(
     let workload = &manifest.retention_workload;
     let fixture = fixtures.workload(&workload.id);
     let fixture_root = repo_root.join(&fixture.fixture_root);
-    let resolved_workers = resolve_workers(WorkerMode::Automatic);
-    rue_compiler::configure_thread_pool(resolved_workers as usize);
-
+    let compiler_config =
+        CompilerSessionConfig::with_workers(0).map_err(|error| error.to_string())?;
+    let resolved_workers = compiler_config.workers() as u32;
     let body = fixture.edit(EditScenario::ReachedBodyOnly);
     let error = fixture.edit(EditScenario::ErrorIntroduction);
     let reachability = fixture.edit(EditScenario::ReachabilityDeletion);
@@ -1060,6 +1076,7 @@ fn collect_retention(
         &fixture.overlays,
         std_root,
         options,
+        compiler_config,
         None,
         ExpectedEditOutcome::Success,
     )?;
@@ -1072,6 +1089,7 @@ fn collect_retention(
                 &fixture.overlays,
                 std_root,
                 options,
+                compiler_config,
                 Some(operation),
                 *expected,
             )?,
@@ -1084,7 +1102,7 @@ fn collect_retention(
     copy_tree(&fixture_root, isolated.path())?;
     apply_overlays(isolated.path(), &fixture.overlays)?;
     let root = isolated_path(isolated.path(), &fixture.root_source)?;
-    let mut warm = open_host(&root, None, std_root)?;
+    let mut warm = open_host(&root, None, std_root, compiler_config)?;
     warm.acquire_reached_toolchain_modules(options)
         .map_err(source_load_error)?;
     run_success(&mut warm, options)
@@ -1175,6 +1193,7 @@ fn fresh_fixture_identity(
     overlays: &[OverlayOperation],
     std_root: Option<&Path>,
     options: &CompileOptions,
+    compiler_config: CompilerSessionConfig,
     operation: Option<&EditOperation>,
     expected: ExpectedEditOutcome,
 ) -> Result<OutcomeIdentity, String> {
@@ -1186,7 +1205,7 @@ fn fresh_fixture_identity(
         apply_operation(isolated.path(), operation)?;
     }
     let root = isolated_path(isolated.path(), root_source)?;
-    let mut host = open_host(&root, None, std_root)?;
+    let mut host = open_host(&root, None, std_root, compiler_config)?;
     host.acquire_reached_toolchain_modules(options)
         .map_err(source_load_error)?;
     Ok(fresh_identity(&mut host, options, expected))
@@ -1196,6 +1215,7 @@ fn open_host(
     root: &Path,
     manifest: Option<&Path>,
     std_root: Option<&Path>,
+    compiler_config: CompilerSessionConfig,
 ) -> Result<FilesystemCompilerHost, String> {
     FilesystemCompilerHost::open(HostOpenRequest {
         root_source: root
@@ -1203,6 +1223,7 @@ fn open_host(
             .ok_or_else(|| format!("fixture root is not UTF-8: {}", root.display()))?,
         source_manifest_path: manifest.and_then(Path::to_str),
         std_root,
+        compiler_config,
     })
     .map_err(source_load_error)
 }
@@ -1544,15 +1565,6 @@ fn copy_tree(source: &Path, destination: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn resolve_workers(mode: WorkerMode) -> u32 {
-    match mode {
-        WorkerMode::One => 1,
-        WorkerMode::Automatic => std::thread::available_parallelism()
-            .map(std::num::NonZeroUsize::get)
-            .unwrap_or(1) as u32,
-    }
-}
-
 fn elapsed_ns(started: Instant) -> u64 {
     let elapsed = started.elapsed().as_nanos();
     elapsed.min(u128::from(u64::MAX)).max(1) as u64
@@ -1723,6 +1735,7 @@ mod tests {
             &[],
             None,
             &options,
+            CompilerSessionConfig::default(),
             Some(&operation),
             ExpectedEditOutcome::Success,
         )

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -2004,8 +2004,8 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
 ];
 
 // Construction and registration execution is sealed end to end:
-// `CompilerSession::new` enters its derived Default once, the sole frontend
-// field creates its private capability, the token-gated database constructor
+// `CompilerSession::new` and Default enter with_configuration once, the sole
+// frontend field creates its private capability, the token-gated constructor
 // enters the private canonical constructor and ordered composer, and one shared
 // forwarding authority reaches one manifested leaf. Tests retain a separately
 // cfg-gated Default adapter into the private canonical entry. Any control-flow
@@ -2013,26 +2013,28 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
 // identity even when constructor, caller, and macro token counts do not.
 const CONSTRUCTION_TOKEN_STRUCT_IDENTITY: (usize, u64) = (80, 5_227_448_979_315_228_973);
 const CONSTRUCTION_TOKEN_IMPL_IDENTITY: (usize, u64) = (108, 2_765_439_612_714_245_239);
-const COMPILER_CRATE_ROOT_IDENTITY: (usize, u64) = (10_841, 1_910_863_920_709_222_275);
+const COMPILER_CRATE_ROOT_IDENTITY: (usize, u64) = (9_554, 8_267_950_807_996_322_251);
 const COMPILER_CRATE_ROOT_NAMESPACE_IDENTITY: (usize, u64, usize, u64) = (
-    115,
-    16_786_415_244_923_993_326,
-    230,
-    6_981_227_682_883_627_572,
+    117,
+    3_245_059_453_758_104_938,
+    234,
+    11_858_083_321_453_235_076,
 );
-const COMPILER_SESSION_ROOT_IDENTITY: (usize, u64) = (4_104, 13_149_755_327_201_892_371);
-const COMPILER_SESSION_CONSTRUCTOR_IDENTITY: (usize, u64) = (82, 10_721_269_354_679_246_675);
-const FRONTEND_DATABASE_CONSTRUCTION_IDENTITY: (usize, u64) = (268, 967_740_565_057_515_587);
-const DATABASE_INHERENT_CONSTRUCTOR_IDENTITY: (usize, u64) = (148, 15_840_470_727_822_522_148);
-const DATABASE_CANONICAL_CONSTRUCTOR_IDENTITY: (usize, u64) = (224, 1_314_571_707_455_964_487);
-const TEST_DEFAULT_DATABASE_ADAPTER_IDENTITY: (usize, u64) = (120, 3_163_599_038_660_274_771);
-const REGISTRATION_DATABASE_IMPL_IDENTITY: (usize, u64) = (35_472, 4_725_960_964_094_195_289);
+const COMPILER_SESSION_ROOT_IDENTITY: (usize, u64) = (4_144, 8_851_562_517_716_222_536);
+const COMPILER_SESSION_CONSTRUCTOR_IDENTITY: (usize, u64) = (102, 5_219_454_448_646_406_172);
+const CONFIGURED_SESSION_CONSTRUCTOR_IDENTITY: (usize, u64) = (1_539, 17_319_142_551_454_732_417);
+
+const FRONTEND_DATABASE_CONSTRUCTION_IDENTITY: (usize, u64) = (337, 8_000_487_404_225_303_363);
+const DATABASE_INHERENT_CONSTRUCTOR_IDENTITY: (usize, u64) = (214, 15_710_556_809_665_731_176);
+const DATABASE_CANONICAL_CONSTRUCTOR_IDENTITY: (usize, u64) = (254, 7_623_037_796_286_753_949);
+const TEST_DEFAULT_DATABASE_ADAPTER_IDENTITY: (usize, u64) = (159, 833_377_014_346_120_505);
+const REGISTRATION_DATABASE_IMPL_IDENTITY: (usize, u64) = (35_841, 394_004_127_612_251_398);
 const SHARED_FAMILY_FORWARDING_IDENTITY: (usize, u64) = (2_609, 9_595_658_320_490_175_466);
-const ORDERED_REGISTRATION_COMPOSER_IDENTITY: (usize, u64) = (33_989, 17_677_990_640_358_315_577);
+const ORDERED_REGISTRATION_COMPOSER_IDENTITY: (usize, u64) = (34_103, 9_655_978_331_066_028_191);
 // Macro imports, definitions, re-exports, and lexical ordering participate in
 // macro resolution. Seal the complete registrations authority and each wrapper
 // aggregate in addition to the executable identities inside them.
-const REGISTRATION_AUTHORITY_MODULE_IDENTITY: (usize, u64) = (45_442, 8_995_470_390_836_206_189);
+const REGISTRATION_AUTHORITY_MODULE_IDENTITY: (usize, u64) = (45_850, 14_304_398_088_276_605_794);
 const REGISTRATION_WRAPPER_MODULE_IDENTITIES: [(usize, u64); 5] = [
     (842, 17_134_465_730_999_135_202),
     (1_146, 9_973_452_843_887_101_603),
@@ -2152,7 +2154,7 @@ fn revisioned_database_hub_and_registered_family_authority_are_structural() {
         ),
         "the token constructor must remain private and one-shot",
     );
-    let compiler_session_marker = "#[derive(Debug, Default)]\npub struct CompilerSession {";
+    let compiler_session_marker = "#[derive(Debug)]\npub struct CompilerSession {";
     let compiler_session_start = session_code
         .find(compiler_session_marker)
         .expect("canonical CompilerSession declaration");
@@ -2167,7 +2169,7 @@ fn revisioned_database_hub_and_registered_family_authority_are_structural() {
     assert_eq!(
         executable_source_shape_identity(compiler_session_root),
         COMPILER_SESSION_ROOT_IDENTITY,
-        "CompilerSession's complete derived-Default field shape changed",
+        "CompilerSession's complete field shape changed",
     );
     let compiler_session_tokens = rust_code_tokens(compiler_session_root);
     let compiler_session_open = compiler_session_tokens
@@ -2182,15 +2184,13 @@ fn revisioned_database_hub_and_registered_family_authority_are_structural() {
             "derive",
             "(",
             "Debug",
-            ",",
-            "Default",
             ")",
             "]",
             "pub",
             "struct",
-            "CompilerSession",
+            "CompilerSession"
         ],
-        "CompilerSession must derive exactly Debug and Default in that reviewed order",
+        "CompilerSession must derive exactly Debug",
     );
     assert_eq!(
         struct_fields_with_type_carrier(
@@ -2199,7 +2199,7 @@ fn revisioned_database_hub_and_registered_family_authority_are_structural() {
             "FrontendQueryDatabase",
         ),
         ["queries|cfg=false|FrontendQueryDatabase"],
-        "derived Default must construct exactly one non-cfg frontend database field named queries",
+        "the session must construct one frontend database",
     );
     let compiler_session_constructor_marker = "pub fn new() -> Self {";
     let compiler_session_constructor_start = session_code
@@ -2221,9 +2221,60 @@ fn revisioned_database_hub_and_registered_family_authority_are_structural() {
     );
     assert_eq!(
         rust_code_tokens(compiler_session_constructor),
-        rust_code_tokens("pub fn new() -> Self { <Self as ::core::default::Default>::default() }",),
-        "CompilerSession::new must return exactly one absolute derived-Default UFCS call",
+        rust_code_tokens(
+            "pub fn new() -> Self { Self::with_configuration(crate::CompilerSessionConfig::default()) }",
+        ),
+        "CompilerSession::new must delegate exactly once to the default configuration",
     );
+    let configured_constructor_marker =
+        "pub fn with_configuration(configuration: crate::CompilerSessionConfig) -> Self {";
+    let configured_constructor =
+        exact_balanced_code_item(session_source, configured_constructor_marker);
+    assert_eq!(
+        executable_source_shape_identity(configured_constructor),
+        CONFIGURED_SESSION_CONSTRUCTOR_IDENTITY,
+        "the configured session initializer must construct exactly one canonical frontend",
+    );
+    assert_eq!(
+        type_method_definitions(session_source, "CompilerSession", "with_configuration"),
+        ["public"],
+        "the session must own one explicit configuration constructor",
+    );
+    let session_default =
+        exact_balanced_code_item(session_source, "impl Default for CompilerSession {");
+    assert_eq!(
+        rust_code_tokens(session_default),
+        rust_code_tokens(
+            "impl Default for CompilerSession { fn default() -> Self { Self::new() } }"
+        ),
+        "Default must enter the same canonical session constructor exactly once",
+    );
+    assert_eq!(
+        type_trait_impl_count(session_source, "CompilerSession", "Default"),
+        1,
+    );
+    let frontend_initializer = "super::FrontendQueryDatabase::new(configuration)";
+    assert_eq!(
+        configured_constructor.matches(frontend_initializer).count(),
+        1
+    );
+    for repeated_initializer in [
+        "[(), ()].map(|()| super::FrontendQueryDatabase::new(configuration)).into_iter().next().unwrap()",
+        "{ let construct = || super::FrontendQueryDatabase::new(configuration); let first = construct(); let _peer = construct(); first }",
+    ] {
+        let repeated =
+            configured_constructor.replacen(frontend_initializer, repeated_initializer, 1);
+        assert_eq!(
+            code_identifier_count(&repeated, "FrontendQueryDatabase"),
+            code_identifier_count(configured_constructor, "FrontendQueryDatabase"),
+            "the fixture must preserve the weaker frontend identifier inventory",
+        );
+        assert_ne!(
+            executable_source_shape_identity(&repeated),
+            CONFIGURED_SESSION_CONSTRUCTOR_IDENTITY,
+            "the configured initializer must reject repeated frontend construction",
+        );
+    }
     assert_eq!(
         type_method_definitions(session_source, "CompilerSession", "new"),
         ["public"],
@@ -2231,14 +2282,14 @@ fn revisioned_database_hub_and_registered_family_authority_are_structural() {
     );
     assert!(
         type_method_definitions(session_source, "CompilerSession", "default").is_empty(),
-        "CompilerSession cannot own an inherent default method that shadows the derived trait",
+        "CompilerSession cannot own an inherent default method that shadows the trait",
     );
     let compiler_session_default_references =
         revisioned_database_default_references(compiler_session_constructor, true);
     assert_eq!(
         compiler_session_default_references,
-        ["Self:call"],
-        "CompilerSession::new must contain one absolute derived-Default reference",
+        Vec::<String>::new(),
+        "CompilerSession::new must not construct a peer database directly",
     );
     #[derive(Default)]
     struct InherentDefaultResolutionProbe {
@@ -2273,12 +2324,13 @@ impl CompilerSession {
         ["private"],
         "the inherent-default fixture must perturb the live method-owner inventory",
     );
-    let absolute_session_default = "<Self as ::core::default::Default>::default()";
+    let absolute_session_default =
+        "Self::with_configuration(crate::CompilerSessionConfig::default())";
     let repeated_session_default_fixtures = [
         (
             "eager map",
             r#"[(), ()]
-            .map(|()| <Self as ::core::default::Default>::default())
+            .map(|()| Self::with_configuration(crate::CompilerSessionConfig::default()))
             .into_iter()
             .next()
             .expect("the expected session is first")"#,
@@ -2289,7 +2341,7 @@ impl CompilerSession {
             let mut expected = None;
             let mut iterations = 0;
             loop {
-                let value = <Self as ::core::default::Default>::default();
+                let value = Self::with_configuration(crate::CompilerSessionConfig::default());
                 if expected.is_none() {
                     expected = Some(value);
                 }
@@ -2304,7 +2356,7 @@ impl CompilerSession {
         (
             "local closure called twice",
             r#"{
-            let construct = || <Self as ::core::default::Default>::default();
+            let construct = || Self::with_configuration(crate::CompilerSessionConfig::default());
             let expected = construct();
             let _peer = construct();
             expected
@@ -2336,6 +2388,7 @@ impl CompilerSession {
     }
     let _token_gated_constructor: fn(
         crate::session::RevisionedQueryDatabaseConstructionToken,
+        crate::CompilerSessionConfig,
     )
         -> crate::revisioned_query_database::RevisionedQueryDatabase =
         crate::revisioned_query_database::RevisionedQueryDatabase::new;
@@ -2453,25 +2506,28 @@ impl CompilerSession {
     );
     let expected_inherent_constructor = r#"pub(crate) fn new(
         _authority: crate::session::RevisionedQueryDatabaseConstructionToken,
+        configuration: crate::CompilerSessionConfig,
     ) -> Self {
-        Self::new_canonical()
+        Self::new_canonical(configuration)
     }"#;
     assert_eq!(
         rust_code_tokens(inherent_database_constructor),
         rust_code_tokens(expected_inherent_constructor),
         "the production constructor must consume the exact session capability and delegate once",
     );
-    let canonical_database_constructor =
-        exact_balanced_code_item(registration_database_impl, "fn new_canonical() -> Self {");
+    let canonical_database_constructor = exact_balanced_code_item(
+        registration_database_impl,
+        "fn new_canonical(configuration: crate::CompilerSessionConfig) -> Self {",
+    );
     assert_eq!(
         executable_source_shape_identity(canonical_database_constructor),
         DATABASE_CANONICAL_CONSTRUCTOR_IDENTITY,
         "the private canonical database constructor changed executable shape",
     );
-    let expected_canonical_constructor = r#"fn new_canonical() -> Self {
+    let expected_canonical_constructor = r#"fn new_canonical(configuration: crate::CompilerSessionConfig) -> Self {
         Self::with_declaration_memo_retention_and_concurrency(
             DECLARATION_QUERY_MEMO_RETENTION,
-            crate::query_concurrency(),
+            configuration,
             u32::MAX as usize,
         )
     }"#;
@@ -2515,7 +2571,7 @@ impl CompilerSession {
     }
     let frontend_queries = include_str!("session/frontend_queries.rs");
     let frontend_database_construction =
-        exact_balanced_code_item(frontend_queries, "impl Default for FrontendQueryDatabase {");
+        exact_balanced_code_item(frontend_queries, "impl FrontendQueryDatabase {");
     assert_eq!(
         executable_source_shape_identity(frontend_database_construction),
         FRONTEND_DATABASE_CONSTRUCTION_IDENTITY,
@@ -2612,14 +2668,14 @@ impl CompilerSession {
     // private-canonical-constructor identity rejects that multiplicity.
     let constructor_one_shot = r#"        Self::with_declaration_memo_retention_and_concurrency(
             DECLARATION_QUERY_MEMO_RETENTION,
-            crate::query_concurrency(),
+            configuration,
             u32::MAX as usize,
         )"#;
     let constructor_repeated = r#"        [(), ()]
             .map(|()| {
                 Self::with_declaration_memo_retention_and_concurrency(
                     DECLARATION_QUERY_MEMO_RETENTION,
-                    crate::query_concurrency(),
+                    configuration,
                     u32::MAX as usize,
                 )
             })
@@ -2635,8 +2691,10 @@ impl CompilerSession {
     );
     let adversarial_constructor =
         canonical_database_constructor.replacen(constructor_one_shot, constructor_repeated, 1);
-    let adversarial_constructor =
-        exact_balanced_code_item(&adversarial_constructor, "fn new_canonical() -> Self {");
+    let adversarial_constructor = exact_balanced_code_item(
+        &adversarial_constructor,
+        "fn new_canonical(configuration: crate::CompilerSessionConfig) -> Self {",
+    );
     assert_eq!(
         code_identifier_count(adversarial_constructor, composer_constructor),
         code_identifier_count(canonical_database_constructor, composer_constructor),
@@ -2658,11 +2716,13 @@ impl CompilerSession {
     // the inherent constructor so two complete runtime graphs cannot be made.
     let frontend_one_shot = r#"revisioned: crate::revisioned_query_database::RevisionedQueryDatabase::new(
                 RevisionedQueryDatabaseConstructionToken::new(),
+                configuration,
             ),"#;
     let frontend_repeated = r#"revisioned: [(), ()]
                 .map(|()| {
                     crate::revisioned_query_database::RevisionedQueryDatabase::new(
                         RevisionedQueryDatabaseConstructionToken::new(),
+                        configuration,
                     )
                 })
                 .into_iter()
@@ -2677,10 +2737,8 @@ impl CompilerSession {
     );
     let adversarial_frontend =
         frontend_database_construction.replacen(frontend_one_shot, frontend_repeated, 1);
-    let adversarial_frontend = exact_balanced_code_item(
-        &adversarial_frontend,
-        "impl Default for FrontendQueryDatabase {",
-    );
+    let adversarial_frontend =
+        exact_balanced_code_item(&adversarial_frontend, "impl FrontendQueryDatabase {");
     assert_eq!(
         revisioned_database_new_references(adversarial_frontend),
         revisioned_database_new_references(frontend_database_construction),
@@ -4021,11 +4079,11 @@ pub(super) use register_parse_import_parse;"#;
         ],
         "the capability type may appear only in its session declaration/private constructor, the frontend call, and the token-gated database signature",
     );
-    let expected_frontend_database_identifiers = [("session".to_owned(), 3)];
+    let expected_frontend_database_identifiers = [("session".to_owned(), 4)];
     assert_eq!(
         identifier_owner_inventory(&compiler_construction_sources, "FrontendQueryDatabase",),
         expected_frontend_database_identifiers,
-        "the frontend database type must have exactly its declaration, Default owner, and canonical CompilerSession field",
+        "the frontend database type must have exactly its declaration, constructor owner, canonical session field, and configured initializer",
     );
     assert_eq!(
         type_method_definition_owner_inventory(
@@ -4087,10 +4145,9 @@ pub(super) use register_parse_import_parse;"#;
         );
     }
 
-    // `CompilerSession` derives `Default`, so every one of its private fields
-    // is part of the runtime-construction authority. These valid-Rust models
-    // preserve the sole explicit token/database calls but make the derived
-    // constructor create a second frontend database. The exact root identity,
+    // Every frontend-bearing session field is part of runtime-construction
+    // authority. These source models add a second carrier without changing
+    // the sole explicit token/database call. The exact root identity,
     // semantic carrier-field check, and compiler-wide identifier/alias
     // inventories independently reject the change.
     let add_compiler_session_field = |field: &str| {
@@ -4122,7 +4179,7 @@ pub(super) use register_parse_import_parse;"#;
         ),
         (
             "local wrapper duplicate",
-            "#[derive(Default)]\nstruct PeerFrontendQueryDatabase(FrontendQueryDatabase);\n",
+            "struct PeerFrontendQueryDatabase(FrontendQueryDatabase);\n",
             "_peer_queries: PeerFrontendQueryDatabase,",
         ),
     ];
@@ -4144,7 +4201,7 @@ pub(super) use register_parse_import_parse;"#;
                 "FrontendQueryDatabase",
             ),
             ["queries|cfg=false|FrontendQueryDatabase"],
-            "the {label} must fail the semantic derived-Default field inventory",
+            "the {label} must fail the semantic frontend field inventory",
         );
         let adversarial_sources = compiler_construction_sources
             .iter()
@@ -4220,7 +4277,7 @@ pub(super) use register_parse_import_parse;"#;
             ),
             ("parsed_modules".to_owned(), "Default:call".to_owned(), 1),
             ("queries".to_owned(), "Default:call".to_owned(), 2),
-            ("session".to_owned(), "Self:call".to_owned(), 5),
+            ("session".to_owned(), "Self:call".to_owned(), 2),
             ("unstable".to_owned(), "Default:call".to_owned(), 10),
             ("unstable".to_owned(), "Self:call".to_owned(), 1),
         ],
@@ -4454,7 +4511,7 @@ pub(super) use register_parse_import_parse;"#;
     ));
     let nested_module_owners = module_owner_inventory(&compiler_module_sources);
     let nested_module_fingerprint = source_inventory_fingerprint(&nested_module_owners);
-    let expected_nested_module_identity = (160, 14_291_932_838_853_825_352);
+    let expected_nested_module_identity = (162, 1_322_855_505_068_179_203);
     assert_eq!(
         (nested_module_owners.len(), nested_module_fingerprint),
         expected_nested_module_identity,
@@ -4646,7 +4703,7 @@ pub(super) use register_parse_import_parse;"#;
     assert_eq!(
         std::str::from_utf8(&compact_registrations)
             .expect("whitespace removal preserves UTF-8")
-            .matches("CompilerQueryRuntime(QueryRuntime::new(query_concurrency))")
+            .matches("CompilerQueryRuntime(QueryRuntime::with_retention_budgets(configuration.workers(),configuration.retention_budgets(),))")
             .count(),
         1,
         "the sole production runtime construction must remain registrations-owned",
@@ -4880,7 +4937,7 @@ pub(super) use register_parse_import_parse;"#;
         });
     assert_eq!(
         (declarations.len(), fingerprint),
-        (214, 11_207_454_508_476_726_153),
+        (214, 9_985_723_480_452_794_499),
         "crate-visible declaration names, signatures, fields, or phase owners changed"
     );
 
@@ -5424,6 +5481,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("canonical_semantic", include_str!("canonical_semantic.rs")),
     ("cfg_query", include_str!("cfg_query.rs")),
     ("codegen_query", include_str!("codegen_query.rs")),
+    ("configuration", include_str!("configuration.rs")),
     ("content_digest", include_str!("content_digest.rs")),
     ("object_query", include_str!("object_query.rs")),
     (
@@ -6798,6 +6856,12 @@ fn root_export_metadata(owner: &str, symbol: &str) -> (&'static str, &'static st
             _ => panic!("unclassified import-graph facade export: {symbol}"),
         },
         "diagnostic_attempt_store" => ("diagnostic", "cli+embedders"),
+        "configuration" => match symbol {
+            "CompilerSessionConfig" | "CompilerConfigurationError" | "MAX_QUERY_WORKERS" => {
+                ("session-configuration", "embedders")
+            }
+            _ => panic!("unclassified compiler configuration export: {symbol}"),
+        },
         "rue_error" => match symbol {
             "CompileErrors" | "CompileWarning" | "MultiErrorResult" | "PreviewFeature"
             | "PreviewFeatures" | "VERSION" => ("diagnostic", "cli+embedders"),
@@ -6910,7 +6974,8 @@ fn session_method_metadata(
         }
     } else {
         match symbol {
-            "new" | "update" => "session-operation",
+            "new" | "with_configuration" | "update" => "session-operation",
+            "configuration" => "session-configuration",
             "published" | "committed_import_graph" | "import_diagnostics" | "rir" | "semantic" => {
                 "artifact-query"
             }
@@ -6945,15 +7010,6 @@ fn semantic_api_inventory(facade: &str, modules: &[(&str, &str)]) -> Vec<ApiInve
                 "unstable",
                 "debug-module",
                 "in-tree-tooling",
-                symbol,
-                signature,
-            ));
-        } else if symbol == "configure_thread_pool" {
-            entries.push(ApiInventoryEntry::new(
-                "stable",
-                "lib",
-                "runtime-config",
-                "cli+embedders",
                 symbol,
                 signature,
             ));
@@ -7450,15 +7506,17 @@ fn removed_parallel_entry_points_cannot_return() {
 #[test]
 fn compiler_parallelism_has_one_query_budget_and_no_peer_parallel_frontier() {
     let root = include_str!("lib.rs");
+    let configuration = include_str!("configuration.rs");
     let cfg = include_str!("queries.rs");
     let backend = include_str!("backend.rs");
     let database = REVISIONED_DATABASE_SOURCE;
     assert!(
-        root.contains("QUERY_CONCURRENCY")
-            && root.contains("configure_thread_pool")
-            && database.contains("crate::query_concurrency()")
-            && database.contains("QueryRuntime::new(query_concurrency)"),
-        "compiler runtime configuration must feed the canonical query database budget"
+        !root.contains("QUERY_CONCURRENCY")
+            && !root.contains("configure_thread_pool")
+            && configuration.contains("pub struct CompilerSessionConfig")
+            && database.contains("configuration.workers()")
+            && database.contains("QueryRuntime::with_retention_budgets"),
+        "compiler runtime configuration must be immutable and feed the canonical query database budget"
     );
     for (module, source) in [("queries", cfg), ("backend", backend)] {
         for forbidden in ["rayon", ".par_iter(", ".into_par_iter("] {

--- a/crates/rue-compiler/src/configuration.rs
+++ b/crates/rue-compiler/src/configuration.rs
@@ -1,0 +1,145 @@
+//! Immutable configuration for a compiler session.
+
+use std::fmt;
+
+use rue_query::{DEFAULT_DEPENDENCY_PIN_BUDGET, DEFAULT_RETAINED_BYTE_BUDGET, RetentionBudgets};
+
+/// The largest explicit query worker count accepted by the compiler.
+pub const MAX_QUERY_WORKERS: usize = 256;
+
+/// An invalid compiler session configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompilerConfigurationError {
+    /// An explicit worker count was outside the supported range.
+    WorkerCountOutOfRange { requested: usize, maximum: usize },
+}
+
+impl fmt::Display for CompilerConfigurationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WorkerCountOutOfRange { requested, maximum } => write!(
+                formatter,
+                "compiler worker count must be 0 (automatic) or 1..={maximum}, got {requested}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CompilerConfigurationError {}
+
+/// Validated, immutable resources owned by one [`crate::CompilerSession`].
+///
+/// A worker count of zero requests host-parallel automatic selection. The
+/// stored value is always resolved, so reporting the configuration is stable
+/// for the lifetime of the session and never consults process-global state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompilerSessionConfig {
+    workers: usize,
+    retained_byte_budget: u64,
+    dependency_pin_budget: u64,
+}
+
+impl Default for CompilerSessionConfig {
+    fn default() -> Self {
+        Self::with_workers_and_retention(
+            0,
+            DEFAULT_RETAINED_BYTE_BUDGET,
+            DEFAULT_DEPENDENCY_PIN_BUDGET,
+        )
+        .expect("default compiler configuration is valid")
+    }
+}
+
+impl CompilerSessionConfig {
+    /// Construct and validate a session configuration.
+    ///
+    /// Retention values are soft accounting targets and accept the full `u64`
+    /// range. Zero asks the runtime to retain no unprotected idle artifacts;
+    /// active work and protected results may still exceed either target.
+    pub fn with_workers_and_retention(
+        workers: usize,
+        retained_byte_budget: u64,
+        dependency_pin_budget: u64,
+    ) -> Result<Self, CompilerConfigurationError> {
+        if workers > MAX_QUERY_WORKERS {
+            return Err(CompilerConfigurationError::WorkerCountOutOfRange {
+                requested: workers,
+                maximum: MAX_QUERY_WORKERS,
+            });
+        }
+        let workers = if workers == 0 {
+            std::thread::available_parallelism()
+                .map(std::num::NonZeroUsize::get)
+                .unwrap_or(1)
+        } else {
+            workers
+        };
+        Ok(Self {
+            workers,
+            retained_byte_budget,
+            dependency_pin_budget,
+        })
+    }
+
+    /// Construct a configuration with the established retention defaults.
+    pub fn with_workers(workers: usize) -> Result<Self, CompilerConfigurationError> {
+        Self::with_workers_and_retention(
+            workers,
+            DEFAULT_RETAINED_BYTE_BUDGET,
+            DEFAULT_DEPENDENCY_PIN_BUDGET,
+        )
+    }
+
+    /// The resolved number of query workers owned by this configuration.
+    pub fn workers(&self) -> usize {
+        self.workers
+    }
+
+    /// The runtime-wide retained artifact byte budget.
+    pub fn retained_byte_budget(&self) -> u64 {
+        self.retained_byte_budget
+    }
+
+    /// The runtime-wide dependency and input observation budget.
+    pub fn dependency_pin_budget(&self) -> u64 {
+        self.dependency_pin_budget
+    }
+
+    pub(crate) fn retention_budgets(self) -> RetentionBudgets {
+        RetentionBudgets {
+            retained_bytes: self.retained_byte_budget,
+            dependency_pins: self.dependency_pin_budget,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_explicit_worker_counts_and_resolves_automatic() {
+        assert_eq!(
+            CompilerSessionConfig::with_workers(0).unwrap().workers(),
+            std::thread::available_parallelism()
+                .map(std::num::NonZeroUsize::get)
+                .unwrap_or(1)
+        );
+        assert!(matches!(
+            CompilerSessionConfig::with_workers(MAX_QUERY_WORKERS + 1),
+            Err(CompilerConfigurationError::WorkerCountOutOfRange { .. })
+        ));
+        assert!(matches!(
+            CompilerSessionConfig::with_workers(usize::MAX),
+            Err(CompilerConfigurationError::WorkerCountOutOfRange { .. })
+        ));
+    }
+
+    #[test]
+    fn accepts_soft_budget_extremes_without_allocating_them() {
+        let configuration =
+            CompilerSessionConfig::with_workers_and_retention(1, 0, u64::MAX).unwrap();
+        assert_eq!(configuration.retained_byte_budget(), 0);
+        assert_eq!(configuration.dependency_pin_budget(), u64::MAX);
+    }
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -44,6 +44,7 @@ mod canonical_merge;
 mod canonical_semantic;
 mod cfg_query;
 mod codegen_query;
+mod configuration;
 mod content_digest;
 mod declaration_candidate;
 mod definition_snapshot;
@@ -129,6 +130,7 @@ pub use import_discovery::{
 };
 // Host discovery-protocol records are published through `unstable` only; the
 // crate-local paths keep the session and its tests on one spelling.
+pub use configuration::{CompilerConfigurationError, CompilerSessionConfig, MAX_QUERY_WORKERS};
 #[cfg(test)]
 pub(crate) use import_discovery::AcceptedImportSource;
 pub(crate) use import_discovery::{
@@ -247,41 +249,3 @@ pub(crate) use rue_linker::{
     Archive, CodeRelocation, Linker, ObjectBuilder, ObjectFile, RelocationType,
 };
 pub(crate) use rue_parser::Parser;
-
-// Zero means no embedder/driver override has been installed yet. The first
-// session lazily snapshots host parallelism so constructing CompilerSession
-// directly retains the CLI's default behavior without a peer executor.
-static QUERY_CONCURRENCY: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
-/// Configure the compiler's shared structured-query concurrency budget.
-///
-/// Registered batch schedulers consume this one shared budget, keeping
-/// structured-query concurrency under a single authority.
-pub fn configure_thread_pool(jobs: usize) -> usize {
-    let jobs = if jobs == 0 {
-        std::thread::available_parallelism()
-            .map(std::num::NonZeroUsize::get)
-            .unwrap_or(1)
-    } else {
-        jobs
-    };
-    QUERY_CONCURRENCY.store(jobs, std::sync::atomic::Ordering::Release);
-    jobs
-}
-
-pub(crate) fn query_concurrency() -> usize {
-    let configured = QUERY_CONCURRENCY.load(std::sync::atomic::Ordering::Acquire);
-    if configured != 0 {
-        return configured;
-    }
-    let detected = std::thread::available_parallelism()
-        .map(std::num::NonZeroUsize::get)
-        .unwrap_or(1);
-    let _ = QUERY_CONCURRENCY.compare_exchange(
-        0,
-        detected,
-        std::sync::atomic::Ordering::AcqRel,
-        std::sync::atomic::Ordering::Acquire,
-    );
-    QUERY_CONCURRENCY.load(std::sync::atomic::Ordering::Acquire)
-}

--- a/crates/rue-compiler/src/revisioned_query_database/registrations.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations.rs
@@ -296,21 +296,22 @@ pub(crate) const REGISTRATION_MANIFEST: &[(&str, &str, &str, &str)] = &[
 #[cfg(test)]
 impl Default for RevisionedQueryDatabase {
     fn default() -> Self {
-        Self::new_canonical()
+        Self::new_canonical(crate::CompilerSessionConfig::default())
     }
 }
 
 impl RevisionedQueryDatabase {
     pub(crate) fn new(
         _authority: crate::session::RevisionedQueryDatabaseConstructionToken,
+        configuration: crate::CompilerSessionConfig,
     ) -> Self {
-        Self::new_canonical()
+        Self::new_canonical(configuration)
     }
 
-    fn new_canonical() -> Self {
+    fn new_canonical(configuration: crate::CompilerSessionConfig) -> Self {
         Self::with_declaration_memo_retention_and_concurrency(
             DECLARATION_QUERY_MEMO_RETENTION,
-            crate::query_concurrency(),
+            configuration,
             u32::MAX as usize,
         )
     }
@@ -322,7 +323,7 @@ impl RevisionedQueryDatabase {
     pub(crate) fn with_declaration_memo_retention(declaration_memo_retention: usize) -> Self {
         Self::with_declaration_memo_retention_and_concurrency(
             declaration_memo_retention,
-            1,
+            crate::CompilerSessionConfig::with_workers(1).unwrap(),
             rue_lexer::MAX_INTERNED_STRINGS,
         )
     }
@@ -331,7 +332,7 @@ impl RevisionedQueryDatabase {
     pub(crate) fn with_query_concurrency(query_concurrency: usize) -> Self {
         Self::with_declaration_memo_retention_and_concurrency(
             DECLARATION_QUERY_MEMO_RETENTION,
-            query_concurrency,
+            crate::CompilerSessionConfig::with_workers(query_concurrency).unwrap(),
             rue_lexer::MAX_INTERNED_STRINGS,
         )
     }
@@ -340,17 +341,20 @@ impl RevisionedQueryDatabase {
     pub(crate) fn with_interner_limit(max_entries: usize) -> Self {
         Self::with_declaration_memo_retention_and_concurrency(
             DECLARATION_QUERY_MEMO_RETENTION,
-            1,
+            crate::CompilerSessionConfig::with_workers(1).unwrap(),
             max_entries,
         )
     }
 
     fn with_declaration_memo_retention_and_concurrency(
         declaration_memo_retention: usize,
-        query_concurrency: usize,
+        configuration: crate::CompilerSessionConfig,
         max_interner_entries: usize,
     ) -> Self {
-        let runtime = CompilerQueryRuntime(QueryRuntime::new(query_concurrency));
+        let runtime = CompilerQueryRuntime(QueryRuntime::with_retention_budgets(
+            configuration.workers(),
+            configuration.retention_budgets(),
+        ));
         let body_reachability_meter = Arc::new(BodyReachabilityMeter::default());
         let identity_resolution =
             Arc::new(crate::source_snapshot::IdentityResolutionMeter::default());

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -262,9 +262,10 @@ impl CompilerSessionUpdate {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CompilerSession {
     identity: Arc<()>,
+    configuration: crate::CompilerSessionConfig,
     /// Test-only injection for the canonical compilation-owned symbol bound.
     /// Production leaves this unset and uses the published u32 ceiling.
     #[cfg(test)]
@@ -335,6 +336,12 @@ pub struct CompilerSession {
     definition_shard_baseline: Option<crate::DefinitionSnapshot>,
     metrics: CompilerSessionMetrics,
     diagnostics: DiagnosticAttemptStore,
+}
+
+impl Default for CompilerSession {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(Debug)]

--- a/crates/rue-compiler/src/session/frontend_queries.rs
+++ b/crates/rue-compiler/src/session/frontend_queries.rs
@@ -12,11 +12,12 @@ pub(super) struct FrontendQueryDatabase {
     pub(super) revisioned: crate::revisioned_query_database::RevisionedQueryDatabase,
 }
 
-impl Default for FrontendQueryDatabase {
-    fn default() -> Self {
+impl FrontendQueryDatabase {
+    pub(super) fn new(configuration: crate::CompilerSessionConfig) -> Self {
         Self {
             revisioned: crate::revisioned_query_database::RevisionedQueryDatabase::new(
                 RevisionedQueryDatabaseConstructionToken::new(),
+                configuration,
             ),
         }
     }

--- a/crates/rue-compiler/src/session/revision_lifecycle.rs
+++ b/crates/rue-compiler/src/session/revision_lifecycle.rs
@@ -68,12 +68,10 @@ impl CompilerSession {
 
     #[cfg(test)]
     pub(crate) fn with_query_concurrency(workers: usize) -> Self {
-        let mut session = Self::default();
-        session.queries.revisioned =
-            crate::revisioned_query_database::RevisionedQueryDatabase::with_query_concurrency(
-                workers,
-            );
-        session
+        Self::with_configuration(
+            crate::CompilerSessionConfig::with_workers(workers)
+                .expect("test query concurrency must be valid"),
+        )
     }
 
     /// Construct a canonical session with a bounded shared symbol space for
@@ -82,7 +80,10 @@ impl CompilerSession {
     /// canonical materialization.
     #[cfg(test)]
     pub(crate) fn with_interner_limit(max_entries: usize) -> Self {
-        let mut session = Self::default();
+        let mut session = Self::with_configuration(
+            crate::CompilerSessionConfig::with_workers(1)
+                .expect("test query concurrency must be valid"),
+        );
         session.interner_limit = Some(max_entries);
         session.queries.revisioned =
             crate::revisioned_query_database::RevisionedQueryDatabase::with_interner_limit(
@@ -280,8 +281,55 @@ impl CompilerSession {
         }
     }
 
+    /// The validated resources selected when this session was constructed.
+    pub fn configuration(&self) -> &crate::CompilerSessionConfig {
+        &self.configuration
+    }
+
     pub fn new() -> Self {
-        <Self as ::core::default::Default>::default()
+        Self::with_configuration(crate::CompilerSessionConfig::default())
+    }
+
+    /// Construct a session with validated, immutable resource configuration.
+    pub fn with_configuration(configuration: crate::CompilerSessionConfig) -> Self {
+        Self {
+            identity: Arc::new(()),
+            configuration,
+            #[cfg(test)]
+            interner_limit: None,
+            #[cfg(test)]
+            cfg_interner_limit: None,
+            #[cfg(test)]
+            cfg_accessor_failure: false,
+            oracle_fault: None,
+            excluded_test_roots: Arc::from([]),
+            imports: super::ImportDiscoveryOwner::default(),
+            parse_sources_materialized: 0,
+            parse_key_entries_compared: 0,
+            parse_modules_dispatched: 0,
+            parse_invalidation_entries_compared: 0,
+            queries: super::FrontendQueryDatabase::new(configuration),
+            #[cfg(test)]
+            rooted_cfg_executions: Vec::new(),
+            #[cfg(test)]
+            warning_reference_executions: Vec::new(),
+            #[cfg(test)]
+            codegen_executions: Vec::new(),
+            #[cfg(test)]
+            codegen_attempt_work: Vec::new(),
+            #[cfg(test)]
+            codegen_collections: 0,
+            #[cfg(test)]
+            object_projection_executions: Vec::new(),
+            #[cfg(test)]
+            object_projection_collections: 0,
+            published: None,
+            published_snapshot: None,
+            batch_diagnostic_order: None,
+            definition_shard_baseline: None,
+            metrics: super::CompilerSessionMetrics::default(),
+            diagnostics: super::DiagnosticAttemptStore::default(),
+        }
     }
 
     pub(super) fn resume_canceled_query(

--- a/crates/rue-compiler/src/supported_api_inventory.rs
+++ b/crates/rue-compiler/src/supported_api_inventory.rs
@@ -9,8 +9,10 @@ pub(crate) const APPROVED: &str = r#"stable|CompilerSession|artifact-query|embed
 stable|CompilerSession|artifact-query|embedders|import_diagnostics|pub fn import_diagnostics(&mut self)->Result<Arc<FrontendDiagnosticSnapshot>,CompileErrors>
 stable|CompilerSession|artifact-query|embedders|published|pub fn published(&self)->Option<crate::SyntaxView>
 stable|CompilerSession|artifact-query|embedders|rir|pub fn rir(&mut self)->Result<Arc<crate::RirView>,CompileErrors>
+stable|CompilerSession|session-configuration|embedders|configuration|pub fn configuration(&self)->&crate::CompilerSessionConfig
 stable|CompilerSession|session-operation|embedders|new|pub fn new()->Self
 stable|CompilerSession|session-operation|embedders|update|pub fn update(&mut self,snapshot:&SourceSnapshot)->CompilerSessionUpdate
+stable|CompilerSession|session-operation|embedders|with_configuration|pub fn with_configuration(configuration:crate::CompilerSessionConfig)->Self
 stable|CompilerSessionUpdate|artifact-result|embedders|diagnostics|pub fn diagnostics(&self)->&Arc<FrontendDiagnosticSnapshot>
 stable|CompilerSessionUpdate|artifact-result|embedders|into_result|pub fn into_result(self)->Result<crate::SyntaxView,CompileErrors>
 stable|CompilerSessionUpdate|artifact-result|embedders|result|pub fn result(&self)->Result<crate::SyntaxView,&CompileErrors>
@@ -25,6 +27,9 @@ stable|artifact_views|artifact-view|embedders+tooling|SyntaxModuleView|pub use a
 stable|artifact_views|artifact-view|embedders+tooling|SyntaxNodeView|pub use artifact_views::SyntaxNodeView
 stable|artifact_views|artifact-view|embedders+tooling|SyntaxView|pub use artifact_views::SyntaxView
 stable|artifact_views|artifact-view|embedders+tooling|TokenView|pub use artifact_views::TokenView
+stable|configuration|session-configuration|embedders|CompilerConfigurationError|pub use configuration::CompilerConfigurationError
+stable|configuration|session-configuration|embedders|CompilerSessionConfig|pub use configuration::CompilerSessionConfig
+stable|configuration|session-configuration|embedders|MAX_QUERY_WORKERS|pub use configuration::MAX_QUERY_WORKERS
 stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyEnvelope|pub use dependency_envelope::DependencyEnvelope
 stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyEnvelopeStatus|pub use dependency_envelope::DependencyEnvelopeStatus
 stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyResolutionOutcome|pub use dependency_envelope::DependencyResolutionOutcome
@@ -48,7 +53,6 @@ stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImport
 stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportResolution|pub use import_graph::CanonicalImportResolution
 stable|import_graph|dependency-artifact|source-loaders+embedders|ImportDirective|pub use import_graph::ImportDirective
 stable|import_graph|dependency-artifact|source-loaders+embedders|ImportDirectives|pub use import_graph::ImportDirectives
-stable|lib|runtime-config|cli+embedders|configure_thread_pool|pub fn configure_thread_pool(jobs:usize)->usize
 stable|queries|compilation-config|cli+embedders|CompileOptions|pub use queries::CompileOptions
 stable|queries|compilation-config|cli+embedders|LinkerMode|pub use queries::LinkerMode
 stable|queries|compilation-config|cli+embedders|RootSelection|pub use queries::RootSelection

--- a/crates/rue-compiler/tests/public_api.rs
+++ b/crates/rue-compiler/tests/public_api.rs
@@ -13,6 +13,77 @@ use rue_compiler::{
 };
 use rue_error::ErrorKind;
 
+#[test]
+fn independently_configured_sessions_preserve_artifacts_and_diagnostics() {
+    use rue_compiler::CompilerSessionConfig;
+    use rue_compiler::unstable::oracle_executable;
+    use std::sync::Barrier;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Observation {
+        Executable(Vec<u8>, String),
+        Diagnostics(String),
+    }
+
+    let configurations = [
+        CompilerSessionConfig::with_workers_and_retention(1, 0, 0).unwrap(),
+        CompilerSessionConfig::with_workers_and_retention(3, 8 * 1024 * 1024, 16_384).unwrap(),
+    ];
+    let start = Arc::new(Barrier::new(configurations.len()));
+    let runs = configurations.map(|configuration| {
+        let start = start.clone();
+        std::thread::spawn(move || {
+            let mut session = CompilerSession::with_configuration(configuration);
+            // Both sessions exist before either begins work. Revisions then
+            // exercise success, failure, recovery and a reverted body under
+            // different worker limits and retention pressure.
+            start.wait();
+            let observations = [
+                "fn helper(x: i32) -> i32 { x + 1 } fn main() -> i32 { helper(4) }",
+                "fn helper(x: i32) -> i32 { x + 2 } fn main() -> i32 { helper(4) }",
+                "fn helper(x: i32) -> i32 { true } fn main() -> i32 { helper(4) }",
+                "fn helper(x: i32) -> i32 { x + 1 } fn main() -> i32 { helper(4) }",
+            ]
+            .map(|source| {
+                let snapshot = SourceSnapshot::single("main.rue", source).unwrap();
+                session.update(&snapshot).into_result().unwrap();
+                let observation =
+                    match oracle_executable(&mut session, &snapshot, &CompileOptions::default()) {
+                        Ok(output) => {
+                            assert!(!output.elf.is_empty());
+                            Observation::Executable(output.elf, format!("{:?}", output.warnings))
+                        }
+                        Err(errors) => Observation::Diagnostics(format!("{errors:?}")),
+                    };
+                assert_eq!(session.configuration(), &configuration);
+                let metrics = session.unstable_metrics();
+                let retention = metrics.retention();
+                // These gauges come from the query runtime, so they detect a
+                // constructor that stores a policy but fails to install it.
+                assert_eq!(
+                    retention.retained_byte_budget as u64,
+                    configuration.retained_byte_budget(),
+                );
+                assert_eq!(
+                    retention.dependency_pin_budget as u64,
+                    configuration.dependency_pin_budget(),
+                );
+                assert!(
+                    metrics.query_runtime().peak_query_workers <= configuration.workers() as u64
+                );
+                observation
+            });
+            assert!(matches!(observations[0], Observation::Executable(..)));
+            assert!(matches!(observations[1], Observation::Executable(..)));
+            assert!(matches!(observations[2], Observation::Diagnostics(..)));
+            assert_eq!(observations[0], observations[3]);
+            observations
+        })
+    });
+    let [serial, parallel] = runs.map(|run| run.join().expect("configuration parity worker"));
+    assert_eq!(serial, parallel);
+}
+
 type PublicStructuredJob =
     ComptimeStructuredTypeJob<u8, u16, u32, u64, u128, u128, Arc<str>, Arc<str>, Arc<[Arc<str>]>>;
 type PublicStructuredAuthority =

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -23,9 +23,10 @@
 //! `test.sh`, and Buck test targets set from `scripts/rue-bin`.
 
 use crate::{generator, trap::native_runtime_trap_kind};
+use rue_compiler::CompilerSessionConfig;
 use rue_oracle::{
     MAX_STDERR_BYTES, MAX_STDOUT_BYTES, RunSourceError, TrapKind, Unsupported, UnsupportedKind,
-    run_source_cfg_differential,
+    run_source_with_cfg_differential_with_configuration,
 };
 use rue_test_runner::supervise::{
     Outcome as SupervisedOutcome, OverflowPolicy, SupervisionError, Supervisor,
@@ -282,7 +283,7 @@ fn find_rue_binary() -> Result<PathBuf, String> {
     )
 }
 
-pub fn run(args: &[String]) -> ExitCode {
+pub fn run(args: &[String], configuration: CompilerSessionConfig) -> ExitCode {
     let cfg = match parse_args(args) {
         Ok(c) => c,
         Err(e) => {
@@ -338,7 +339,11 @@ pub fn run(args: &[String]) -> ExitCode {
     for seed in cfg.start..seed_end {
         let source = generator::generate(seed);
 
-        let oracle = match run_source_cfg_differential(&source) {
+        let oracle = match run_source_with_cfg_differential_with_configuration(
+            &source,
+            &rue_error::PreviewFeatures::new(),
+            configuration,
+        ) {
             Err(error) => {
                 // Unlike corpus mode, generated mode has a strong input
                 // contract: every program must compile and remain within the

--- a/crates/rue-oracle-diff/src/generator.rs
+++ b/crates/rue-oracle-diff/src/generator.rs
@@ -1115,12 +1115,12 @@ impl Program {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rue_compiler::{CompileOptions, CompilerSession, SourceSnapshot};
+    use rue_compiler::{CompileOptions, CompilerSession, CompilerSessionConfig, SourceSnapshot};
 
     fn validate_semantics(source: &str) -> rue_compiler::MultiErrorResult<()> {
         let snapshot = SourceSnapshot::single("<generator>", source)
             .map_err(rue_compiler::CompileErrors::from)?;
-        let mut session = CompilerSession::new();
+        let mut session = CompilerSession::with_configuration(CompilerSessionConfig::default());
         session.update(&snapshot).into_result()?;
         rue_compiler::unstable::rooted_cfg(&mut session, &CompileOptions::default()).map(drop)
     }

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -61,12 +61,13 @@ use rue_compiler::unstable::{
     import_observation_ledger, publish_import_observation_batch, stage_import_input_request,
 };
 use rue_compiler::{
-    CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext, PhysicalFileIdentity,
+    CompilerSession, CompilerSessionConfig, FileMetadataFingerprint, ImportDiscoveryContext,
+    PhysicalFileIdentity,
 };
 use rue_error::{PreviewFeature, PreviewFeatures};
 use rue_oracle::{
     ModelGapKind, Outcome, RunSourceError, TrapKind, run_session_with_cfg_differential,
-    run_source_with_cfg_differential,
+    run_source_with_cfg_differential_with_configuration,
 };
 // The rue-cli-tests corpus schema is owned by `rue_test_runner::cli_corpus`.
 // The differential reads the same authored files as the CLI suite, so it reads
@@ -445,15 +446,6 @@ fn parse_oracle_jobs(raw: Option<&str>) -> Result<Option<usize>, String> {
     }
 }
 
-/// Apply the `RUE_ORACLE_JOBS` bound to the shared compiler query concurrency.
-fn apply_oracle_jobs() -> Result<(), String> {
-    let raw = std::env::var(ORACLE_JOBS_VAR).ok();
-    if let Some(jobs) = parse_oracle_jobs(raw.as_deref())? {
-        rue_compiler::configure_thread_pool(jobs);
-    }
-    Ok(())
-}
-
 fn main() -> ExitCode {
     // The oracle interpreter (`rue_oracle::run_source` -> `eval`) recurses per
     // expression, so a deeply-nested but valid corpus program (e.g. the depth-60
@@ -470,21 +462,34 @@ fn main() -> ExitCode {
 }
 
 fn run() -> ExitCode {
-    if let Err(message) = apply_oracle_jobs() {
-        eprintln!("rue-oracle-diff: {message}");
-        return ExitCode::FAILURE;
-    }
+    let oracle_workers = match parse_oracle_jobs(std::env::var(ORACLE_JOBS_VAR).ok().as_deref()) {
+        Ok(workers) => workers.unwrap_or(0),
+        Err(message) => {
+            eprintln!("rue-oracle-diff: {message}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let oracle_configuration = match CompilerSessionConfig::with_workers(oracle_workers) {
+        Ok(configuration) => configuration,
+        Err(error) => {
+            eprintln!("rue-oracle-diff: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    // The configuration is copied into each compiler session below. It is
+    // immutable session input, so concurrent corpus cases cannot race over a
+    // process-global scheduler setting.
     // Subcommand dispatch: `rue-oracle-diff fuzz [...]` runs the differential
     // *fuzzer* (generate valid programs, cross-check oracle vs compiled binary);
     // with no subcommand it runs the corpus differential (below).
     let raw: Vec<String> = std::env::args().skip(1).collect();
     if raw.first().map(String::as_str) == Some("fuzz") {
-        return fuzz::run(&raw[1..]);
+        return fuzz::run(&raw[1..], oracle_configuration);
     }
     // `spec [cases-dir ...]` runs the differential over the rue-spec corpus
     // (templated cases expanded via rue-test-runner) instead of rue-cli-tests.
     if raw.first().map(String::as_str) == Some("spec") {
-        return spec_mode(raw[1..].to_vec());
+        return spec_mode_with_configuration(raw[1..].to_vec(), oracle_configuration);
     }
     // `dump <seed>...` prints the generated program(s) — a debugging aid for
     // inspecting what a seed produces (and reducing a repro by hand).
@@ -501,13 +506,21 @@ fn run() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-    corpus_mode(raw)
+    corpus_mode_with_configuration(raw, oracle_configuration)
 }
 
 /// The original corpus differential: run each rue-cli-tests case through the
 /// oracle and check it agrees with the case's expected exit code / stdout /
 /// stderr.
+#[cfg(test)]
 fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
+    corpus_mode_with_configuration(raw_args, CompilerSessionConfig::default())
+}
+
+fn corpus_mode_with_configuration(
+    raw_args: Vec<String>,
+    compiler_configuration: CompilerSessionConfig,
+) -> ExitCode {
     let inventory_scope = if raw_args.is_empty() {
         model_gaps::InventoryScope::Authoritative
     } else {
@@ -569,7 +582,7 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
     for (path, file) in &loaded_files {
         for case in &file.cases {
             let identity = format!("{}::{}", file.section.id, case.name);
-            let outcome = check_case_with_native(
+            let outcome = check_case_with_native_with_configuration(
                 path,
                 case,
                 file.section.contract.as_deref(),
@@ -577,6 +590,7 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
                     .as_ref()
                     .zip(execution_timeouts)
                     .map(|(runner, timeouts)| (runner, identity.as_str(), timeouts)),
+                compiler_configuration,
             );
             gap_audit.observe(
                 model_gaps::cli::CaseId::new(&file.section.id, &case.name),
@@ -794,7 +808,10 @@ fn finish_report(report: &Report, corpus: &str) -> ExitCode {
 /// [`rue_test_runner::load_test_files`] — the exact code the spec suite uses —
 /// so template semantics can never drift from the real runner. We then filter
 /// to the shapes the single-source oracle can model (see [`check_spec_case`]).
-fn spec_mode(raw_args: Vec<String>) -> ExitCode {
+fn spec_mode_with_configuration(
+    raw_args: Vec<String>,
+    compiler_configuration: CompilerSessionConfig,
+) -> ExitCode {
     let inventory_scope = if raw_args.is_empty() {
         model_gaps::InventoryScope::Authoritative
     } else {
@@ -851,10 +868,11 @@ fn spec_mode(raw_args: Vec<String>) -> ExitCode {
         for (ident, file) in files {
             for case in &file.case {
                 let identity = format!("{}::{}", file.section.id, case.name);
-                let outcome = check_spec_case_with_native(
+                let outcome = check_spec_case_with_native_with_configuration(
                     &ident,
                     case,
                     native.as_ref().map(|runner| (runner, identity.as_str())),
+                    compiler_configuration,
                 );
                 gap_audit.observe(
                     model_gaps::spec::CaseId::new(&file.section.id, &case.name),
@@ -929,20 +947,40 @@ fn check_spec_case(ident: &str, case: &rue_test_runner::Case) -> CaseOutcome {
     check_spec_case_with_known_gap(ident, case, is_known_gap, None)
 }
 
-fn check_spec_case_with_native(
+fn check_spec_case_with_native_with_configuration(
     ident: &str,
     case: &rue_test_runner::Case,
     native: Option<(&NativeRunner, &str)>,
+    configuration: CompilerSessionConfig,
 ) -> CaseOutcome {
     let is_known_gap = KNOWN_ORACLE_GAPS
         .iter()
         .any(|(i, n, _)| *i == ident && *n == case.name);
-    check_spec_case_with_known_gap(ident, case, is_known_gap, native)
+    check_spec_case_with_known_gap_and_configuration(
+        ident,
+        case,
+        is_known_gap,
+        native,
+        configuration,
+    )
 }
 
+#[cfg(test)]
 fn run_source_with_real_std(
     source: &str,
     preview_features: &PreviewFeatures,
+) -> Result<Result<Outcome, RunSourceError>, String> {
+    run_source_with_real_std_with_configuration(
+        source,
+        preview_features,
+        CompilerSessionConfig::default(),
+    )
+}
+
+fn run_source_with_real_std_with_configuration(
+    source: &str,
+    preview_features: &PreviewFeatures,
+    configuration: CompilerSessionConfig,
 ) -> Result<Result<Outcome, RunSourceError>, String> {
     let std_root = std::env::var_os("RUE_ORACLE_DIFF_STD")
         .map(PathBuf::from)
@@ -969,7 +1007,7 @@ fn run_source_with_real_std(
         root_source,
     )
     .map_err(|error| error.to_string())?;
-    let mut session = CompilerSession::new();
+    let mut session = CompilerSession::with_configuration(configuration);
     let mut identities = BTreeMap::<PathBuf, PhysicalFileIdentity>::new();
     let initial = assembler.snapshot().map_err(|error| error.to_string())?;
     let mut revision = begin_import_input_request(
@@ -1051,11 +1089,28 @@ fn run_source_with_real_std(
     }
 }
 
+#[cfg(test)]
 fn check_spec_case_with_known_gap(
     ident: &str,
     case: &rue_test_runner::Case,
     is_known_gap: bool,
     native: Option<(&NativeRunner, &str)>,
+) -> CaseOutcome {
+    check_spec_case_with_known_gap_and_configuration(
+        ident,
+        case,
+        is_known_gap,
+        native,
+        CompilerSessionConfig::default(),
+    )
+}
+
+fn check_spec_case_with_known_gap_and_configuration(
+    ident: &str,
+    case: &rue_test_runner::Case,
+    is_known_gap: bool,
+    native: Option<(&NativeRunner, &str)>,
+    compiler_configuration: CompilerSessionConfig,
 ) -> CaseOutcome {
     // Mirror the real rue-spec wrapper before classifying case shapes. Preview
     // cases without `preview_should_pass` use xfail semantics there, so they do
@@ -1123,7 +1178,11 @@ fn check_spec_case_with_known_gap(
     );
 
     let oracle_result = if case.real_std {
-        match run_source_with_real_std(&case.source, &preview_features) {
+        match run_source_with_real_std_with_configuration(
+            &case.source,
+            &preview_features,
+            compiler_configuration,
+        ) {
             Ok(result) => result,
             Err(error) => {
                 return classify_frontend_failure(format!(
@@ -1133,7 +1192,11 @@ fn check_spec_case_with_known_gap(
             }
         }
     } else {
-        run_source_with_cfg_differential(&case.source, &preview_features)
+        run_source_with_cfg_differential_with_configuration(
+            &case.source,
+            &preview_features,
+            compiler_configuration,
+        )
     };
     match oracle_result {
         // Only Unsupported values carrying a registrable ModelGapKind count as
@@ -1416,11 +1479,28 @@ fn unsupported_corpus_field(case: &Case) -> Option<IneligibleReason> {
     None
 }
 
+#[cfg(test)]
 fn check_case_with_native(
     path: &Path,
     case: &Case,
     section_contract: Option<&str>,
     native: Option<(&NativeRunner, &str, CliExecutionTimeouts)>,
+) -> CaseOutcome {
+    check_case_with_native_with_configuration(
+        path,
+        case,
+        section_contract,
+        native,
+        CompilerSessionConfig::default(),
+    )
+}
+
+fn check_case_with_native_with_configuration(
+    path: &Path,
+    case: &Case,
+    section_contract: Option<&str>,
+    native: Option<(&NativeRunner, &str, CliExecutionTimeouts)>,
+    compiler_configuration: CompilerSessionConfig,
 ) -> CaseOutcome {
     // Mirror the real CLI runner's wrapper order: explicit and host-filtered
     // cases never reach invocation parsing or execution.
@@ -1519,7 +1599,11 @@ fn check_case_with_native(
     };
 
     let oracle_result = if real_std {
-        match run_source_with_real_std(source, &preview_features) {
+        match run_source_with_real_std_with_configuration(
+            source,
+            &preview_features,
+            compiler_configuration,
+        ) {
             Ok(result) => result,
             Err(error) => {
                 return classify_frontend_failure(format!(
@@ -1530,7 +1614,11 @@ fn check_case_with_native(
             }
         }
     } else {
-        run_source_with_cfg_differential(source, &preview_features)
+        run_source_with_cfg_differential_with_configuration(
+            source,
+            &preview_features,
+            compiler_configuration,
+        )
     };
     match oracle_result {
         Err(error) => {

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -72,7 +72,8 @@ use lasso::ThreadedRodeo;
 use rue_air::{FrozenTypeInternPool, LayoutKind, RuntimeCallKind, Type, TypeKind};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
 use rue_compiler::{
-    CompileErrors, CompileOptions, CompilerSession, PreviewFeatures, SourceSnapshot,
+    CompileErrors, CompileOptions, CompilerSession, CompilerSessionConfig, PreviewFeatures,
+    SourceSnapshot,
 };
 use rue_runtime_abi::RuntimeTarget;
 use std::borrow::Cow;
@@ -162,7 +163,7 @@ fn query_cfg_state_from_snapshot(
     snapshot: &SourceSnapshot,
     options: &CompileOptions,
 ) -> Result<CompileState, CompileErrors> {
-    let mut session = CompilerSession::new();
+    let mut session = CompilerSession::with_configuration(CompilerSessionConfig::default());
     session.update(snapshot).into_result()?;
     query_cfg_state_from_session(session, options)
 }
@@ -640,10 +641,24 @@ pub fn run_source_with_cfg_differential(
     source: &str,
     preview_features: &PreviewFeatures,
 ) -> Result<Outcome, RunSourceError> {
+    run_source_with_cfg_differential_with_configuration(
+        source,
+        preview_features,
+        rue_compiler::CompilerSessionConfig::default(),
+    )
+}
+
+/// Configuration-aware form used by the differential harness when it selects
+/// an explicit per-process worker budget.
+pub fn run_source_with_cfg_differential_with_configuration(
+    source: &str,
+    preview_features: &PreviewFeatures,
+    configuration: rue_compiler::CompilerSessionConfig,
+) -> Result<Outcome, RunSourceError> {
     let snapshot = SourceSnapshot::single("<oracle>", source)
         .map_err(CompileErrors::from)
         .map_err(RunSourceError::Compile)?;
-    let mut session = CompilerSession::new();
+    let mut session = CompilerSession::with_configuration(configuration);
     session
         .update(&snapshot)
         .into_result()

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -10,8 +10,9 @@ use rue_compiler::unstable::{
     unimported_test_files,
 };
 use rue_compiler::{
-    AcceptedReadManifest, CompileErrors, CompileOptions, CompileOutput, ImportDiscoveryContext,
-    ImportDiscoveryStatus, ImportDiscoveryView, MultiErrorResult, RirView, SourceSnapshot,
+    AcceptedReadManifest, CompileErrors, CompileOptions, CompileOutput, CompilerSessionConfig,
+    ImportDiscoveryContext, ImportDiscoveryStatus, ImportDiscoveryView, MultiErrorResult, RirView,
+    SourceSnapshot,
 };
 
 use crate::source_loader::{
@@ -25,6 +26,7 @@ pub struct HostOpenRequest<'a> {
     pub root_source: &'a str,
     pub source_manifest_path: Option<&'a str>,
     pub std_root: Option<&'a Path>,
+    pub compiler_config: CompilerSessionConfig,
 }
 
 /// One canonical filesystem observer and retained compiler session.
@@ -39,6 +41,7 @@ impl FilesystemCompilerHost {
             root_source: request.root_source,
             source_manifest_path: request.source_manifest_path,
             std_root: request.std_root,
+            compiler_config: request.compiler_config,
         })
         .map(|state| Self { state })
     }
@@ -85,6 +88,11 @@ impl FilesystemCompilerHost {
 
     pub fn source_snapshot(&self) -> &SourceSnapshot {
         &self.state.source_snapshot
+    }
+
+    /// The immutable compiler resources captured when this host was opened.
+    pub fn compiler_configuration(&self) -> &CompilerSessionConfig {
+        self.state.session.configuration()
     }
 
     pub fn discovery_revision(&self) -> &ImportDiscoveryView {
@@ -345,6 +353,7 @@ mod tests {
                 root_source: root.to_str().unwrap(),
                 source_manifest_path: None,
                 std_root: None,
+                compiler_config: CompilerSessionConfig::default(),
             })
             .unwrap()
         }
@@ -445,6 +454,7 @@ mod tests {
             root_source: main.to_str().unwrap(),
             source_manifest_path: Some(manifest.to_str().unwrap()),
             std_root: None,
+            compiler_config: CompilerSessionConfig::default(),
         })
         .unwrap();
 
@@ -476,6 +486,7 @@ mod tests {
             root_source: main.to_str().unwrap(),
             source_manifest_path: None,
             std_root: Some(&std_root),
+            compiler_config: CompilerSessionConfig::default(),
         })
         .unwrap();
 
@@ -624,6 +635,7 @@ mod test_candidate_acquisition_tests {
             root_source: root.to_str().unwrap(),
             source_manifest_path: Some(manifest.to_str().unwrap()),
             std_root: None,
+            compiler_config: CompilerSessionConfig::default(),
         })
         .unwrap();
         let inventory = host.acquire_test_candidates(&declared).unwrap();
@@ -670,6 +682,7 @@ mod test_candidate_acquisition_tests {
             root_source: root.to_str().unwrap(),
             source_manifest_path: None,
             std_root: None,
+            compiler_config: CompilerSessionConfig::default(),
         })
         .unwrap();
         let inventory = host

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -36,8 +36,8 @@ use rue_driver::{
 };
 
 use rue_compiler::{
-    CompileErrors, CompileOptions, CompileWarning, FileId, LinkerMode, OptLevel, PreviewFeature,
-    PreviewFeatures, configure_thread_pool,
+    CompileErrors, CompileOptions, CompileWarning, CompilerSessionConfig, FileId, LinkerMode,
+    MAX_QUERY_WORKERS, OptLevel, PreviewFeature, PreviewFeatures,
 };
 #[cfg(test)]
 use rue_compiler::{CompilerSession, SourceMetadata, SourceSnapshot};
@@ -255,7 +255,7 @@ const VERSION: &str = rue_compiler::VERSION;
 /// values like `-j 100000` before the compiler schedules an impractical number
 /// of workers, while still leaving ample room above current CI and
 /// workstation core counts.
-const MAX_EXPLICIT_JOBS: usize = 256;
+const MAX_EXPLICIT_JOBS: usize = MAX_QUERY_WORKERS;
 
 fn print_version() {
     println!("rue {}", VERSION);
@@ -2513,11 +2513,13 @@ fn main() {
         None => None,
     };
 
-    // Configure the compiler's shared structured-query budget before
-    // dispatching to either the `--emit` path or the normal compile path, so
-    // every compile-mode driver path honors `-j`/`--jobs` (RUE-352). In test
-    // mode `--jobs` bounds test processes instead, so the pool auto-detects.
-    let resolved_workers = configure_thread_pool(compile_pool_jobs(&options.mode, options.jobs));
+    // Build the immutable compiler resource configuration before opening the
+    // filesystem host. In test mode `--jobs` bounds test processes instead,
+    // so the compiler configuration keeps automatic worker selection.
+    let compiler_config =
+        CompilerSessionConfig::with_workers(compile_pool_jobs(&options.mode, options.jobs))
+            .expect("CLI job validation must agree with compiler configuration");
+    let resolved_workers = compiler_config.workers();
 
     // Discover and load @import-ed modules from disk, transitively. Sema
     // resolves imports only against already-loaded files, so without this
@@ -2543,6 +2545,7 @@ fn main() {
             root_source: &options.source_path,
             source_manifest_path: options.source_manifest_path.as_deref(),
             std_root: captured_std_root.as_deref(),
+            compiler_config,
         }) {
             Ok(result) => result,
             Err(error) => report_source_load_error(error, options.error_format, &options.mode),
@@ -3158,6 +3161,7 @@ mod tests {
                     root_source: root.to_string_lossy().as_ref(),
                     source_manifest_path: None,
                     std_root: Some(&std_root),
+                    compiler_config: CompilerSessionConfig::default(),
                 })
                 .unwrap();
                 host.acquire_reached_toolchain_modules(&CompileOptions::default())
@@ -3200,6 +3204,7 @@ mod tests {
                     root_source: &root_source,
                     source_manifest_path: None,
                     std_root: None,
+                    compiler_config: CompilerSessionConfig::default(),
                 })
                 .unwrap()
             };
@@ -3262,6 +3267,7 @@ mod tests {
             root_source: main.to_str().unwrap(),
             source_manifest_path: None,
             std_root: None,
+            compiler_config: CompilerSessionConfig::default(),
         })
         .unwrap();
         let options = CompileOptions::default();

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -33,10 +33,10 @@ use rue_compiler::unstable::{
 use rue_compiler::unstable::{frontend_query_invalidations, rooted_cfg};
 use rue_compiler::unstable::{normalize_module_path, requested_path_for_module};
 use rue_compiler::{
-    AcceptedReadManifest, CompileErrors, CompileOptions, CompilerSession, DependencyEnvelope,
-    FileId, FileMetadataFingerprint, ImportDiscoveryContext, ImportDiscoveryStatus,
-    ImportDiscoveryView, PhysicalFileIdentity, SourceMetadata, SourceSnapshot,
-    TrustedToolchainModuleDemand, trusted_logical_path_for_requested,
+    AcceptedReadManifest, CompileErrors, CompileOptions, CompilerSession, CompilerSessionConfig,
+    DependencyEnvelope, FileId, FileMetadataFingerprint, ImportDiscoveryContext,
+    ImportDiscoveryStatus, ImportDiscoveryView, PhysicalFileIdentity, SourceMetadata,
+    SourceSnapshot, TrustedToolchainModuleDemand, trusted_logical_path_for_requested,
 };
 
 /// The content fingerprint used by the long-lived filesystem observer.
@@ -805,6 +805,7 @@ pub(crate) struct SourceLoadRequest<'a> {
     pub(crate) root_source: &'a str,
     pub(crate) source_manifest_path: Option<&'a str>,
     pub(crate) std_root: Option<&'a Path>,
+    pub(crate) compiler_config: CompilerSessionConfig,
 }
 
 #[derive(Debug)]
@@ -937,7 +938,12 @@ pub(crate) fn load(
             .map_err(SourceLoadError::Message)?;
         manifest
     };
-    discover_and_load_imports(request.root_source, manifest, request.std_root)
+    discover_and_load_imports_with_configuration(
+        request.root_source,
+        manifest,
+        request.std_root,
+        request.compiler_config,
+    )
 }
 
 #[derive(Debug)]
@@ -1794,10 +1800,25 @@ fn drive_import_discovery_to_close(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn discover_and_load_imports(
     root_source: &str,
     source_manifest: Option<SourceManifest>,
     std_root: Option<&Path>,
+) -> Result<ImportDiscoveryResult, SourceLoadError> {
+    discover_and_load_imports_with_configuration(
+        root_source,
+        source_manifest,
+        std_root,
+        CompilerSessionConfig::default(),
+    )
+}
+
+fn discover_and_load_imports_with_configuration(
+    root_source: &str,
+    source_manifest: Option<SourceManifest>,
+    std_root: Option<&Path>,
+    compiler_config: CompilerSessionConfig,
 ) -> Result<ImportDiscoveryResult, SourceLoadError> {
     // Validate the root source's span representability before discovery aliases
     // physical identities. With a single positional source there are no
@@ -1897,7 +1918,7 @@ pub(crate) fn discover_and_load_imports(
     )
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
 
-    let mut staging = CompilerSession::new();
+    let mut staging = CompilerSession::with_configuration(compiler_config);
     // Reach the parser-owned import fixed point and close. Trusted
     // toolchain-module acquisition (the compiler-rooted std `Option`/`StrBuf` a
     // reached fallible intrinsic needs but no `@import` pulls) is NOT done here:
@@ -4206,10 +4227,15 @@ mod tests {
     #[test]
     fn wave_ledger_order_and_contents_are_independent_of_worker_count() {
         fn discover(dir: &TestDir, jobs: usize) -> (String, Vec<String>, u64) {
-            rue_compiler::configure_thread_pool(jobs);
-            let result =
-                discover_and_load_imports(dir.path.join("main.rue").to_str().unwrap(), None, None)
-                    .unwrap();
+            let configuration = rue_compiler::CompilerSessionConfig::with_workers(jobs)
+                .expect("worker determinism test must use a valid configuration");
+            let result = discover_and_load_imports_with_configuration(
+                dir.path.join("main.rue").to_str().unwrap(),
+                None,
+                None,
+                configuration,
+            )
+            .unwrap();
             let modules = result
                 .source_snapshot
                 .source_revision()
@@ -4250,7 +4276,6 @@ mod tests {
         let single = discover(&dir, 1);
         let repeat = discover(&dir, 1);
         let parallel = discover(&dir, 4);
-        rue_compiler::configure_thread_pool(0);
 
         assert_eq!(single, repeat, "discovery must be reproducible run to run");
         assert_eq!(

--- a/docs/designs/0061-supported-compiler-facade.md
+++ b/docs/designs/0061-supported-compiler-facade.md
@@ -119,11 +119,11 @@ follow-ups, but the supported concepts are:
 requests:
   SourceSnapshot, SourceMetadata, SourceView, FileId
   CompileOptions, LinkerMode, OptLevel, PreviewFeature(s), Target, Arch
+  CompilerSessionConfig, CompilerConfigurationError, MAX_QUERY_WORKERS
   accepted import-read/observation inputs and opaque source/module identities
 
 operations:
   CompilerSession, CompilerSessionUpdate, compile_snapshot
-  configure_thread_pool (process-wide, idempotent configuration)
 
 views/results:
   CompileOutput
@@ -138,6 +138,17 @@ views/results:
 diagnostics. `CompilerSession` returns owner-retaining immutable artifacts
 (normally an `Arc` to a private owner) whose public methods yield the views.
 Views borrow the owner or carry an `Arc`; they never outlive it.
+
+Session resource policy is an immutable `CompilerSessionConfig` supplied at
+construction. `CompilerSession::new()` selects the established defaults;
+`with_configuration` uses a validated explicit policy. The default worker count
+is host parallelism, with one worker if detection fails. Explicit counts are
+bounded by `MAX_QUERY_WORKERS` (256); zero requests automatic selection. The
+resolved count is stored once and reported by the session. Soft retention
+defaults remain 8 GiB of retained charge and four million dependency/input
+observations. Explicit byte and pin budgets may be zero and are accounting
+targets, not hard memory limits. Each session configures its own canonical query
+runtime; constructing one session cannot change another's policy (RUE-1811).
 
 The stable API may expose opaque, equality/hashable IDs such as `FileId`,
 `ModuleId`, `SourceId`, and `SourceRevision`. Their numeric components and
@@ -223,7 +234,8 @@ of the supported API.
 | Keep | `CompileOptions`, `LinkerMode`, `OptLevel`, `PreviewFeature`, `PreviewFeatures`, `Target`, `Arch` | Stable compile request values. Reexports are intentional because they occur in compiler requests. |
 | Keep | `SourceMetadata`, `SourceSnapshot`, `SourceView`, `MAX_SOURCE_BYTES`, `FileId` | Stable owned source request and read-only file view. `FileId` stays opaque. |
 | Keep | `ModuleId`, `ModuleRevision`, `SourceId`, `SourceIdVersion`, `SourceRevision` | Stable opaque identity values; hide representation and construction not required by request assembly. |
-| Keep | `CompilerSession`, `CompilerSessionUpdate`, `compile_snapshot`, `configure_thread_pool` | Stable operations; no other one-shot compiler entry point is allowed. |
+| Keep | `CompilerSession`, `CompilerSessionUpdate`, `compile_snapshot` | Stable operations; no other one-shot compiler entry point is allowed. |
+| Keep | `CompilerSessionConfig`, `CompilerConfigurationError`, `MAX_QUERY_WORKERS` | Validated immutable per-session resource policy and its explicit-worker limit. |
 | Keep | `AcceptedImportSource`, `AcceptedReadManifestEntry`, `FileMetadataFingerprint`, `ImportDiscoveryContext`, `ImportObservation`, `ImportObservationLedger`, `ImportObservationStatus`, `PhysicalFileIdentity` | Stable host-to-session import observation inputs. Constructors validate owned data; identities remain opaque. |
 | View-wrap | `ImportDiscoveryPlan`, `ImportDiscoveryRequest`, `ImportOccurrenceKey`, `ImportCandidateRole` | The host receives a read-only plan/request view and returns observations; it cannot construct query-owned request identity. |
 | Move internal/direct owner | `DiscoverySourceAssembler` | Source aggregation belongs to the post-RUE-861 loader, not the compiler facade. |

--- a/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
+++ b/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
@@ -350,12 +350,13 @@ the waiting worker to ready dependency work. It must make progress with a budget
 of one and under adversarial claim, join, and dependency schedules; cross-task
 cycle detection alone is not a progress guarantee.
 
-Rue's existing process-global Rayon configuration and the CFG, optimization,
-and backend `par_iter` paths are part of this migration. Before query-level
-parallelism is enabled, they must execute through the same structured budget or
-be serial inside a query. `configure_thread_pool` remains a supported facade
-operation under ADR-0061, but its implementation becomes configuration of this
-shared budget rather than authorization for an independent nested pool.
+`CompilerSessionConfig` supplies immutable worker and soft retention budgets to
+the session's canonical runtime (ADR-0061, RUE-1811). Automatic worker selection
+is resolved at configuration construction. CFG, optimization, backend, and
+query-level parallel work share that runtime's structured budget. There is no
+mutable process-global compiler concurrency setting. Co-resident sessions may
+have different policies; a daemon must additionally bound their aggregate
+resource use (ADR-0085).
 
 ### 5. Stable identity and canonical artifacts are the interchange format
 

--- a/docs/designs/0085-persistent-compiler-daemon.md
+++ b/docs/designs/0085-persistent-compiler-daemon.md
@@ -50,8 +50,9 @@ linking, and editor protocols are independent extensions.
 
 ### What already exists
 
-The following findings were checked against source and tests at
-`b90243c49` on 2026-09-07. Tests cited here were read as evidence of existing
+The initial findings were checked against source and tests at
+`b90243c49` on 2026-09-07; implementation updates are noted below. Tests cited
+here were read as evidence of existing
 coverage; this research did not run a daemon prototype or measure a speedup.
 
 | Current source | Implication for a daemon |
@@ -84,15 +85,16 @@ lose more to communication than they gain from reuse.
 
 Several relevant issues are present in current source:
 
-- `configure_thread_pool` writes a process-global worker setting that new
-  sessions snapshot. Each session has its own runtime budget. This is the
-  unresolved configuration work tracked by RUE-1811, not a daemon-wide resource
-  scheduler.
+- [`CompilerSessionConfig`](../../crates/rue-compiler/src/configuration.rs)
+  now gives each session immutable worker and retention settings (RUE-1811).
+  CLI, benchmark, and oracle callers pass their policy explicitly. This supplies
+  per-session control; daemon-wide resource admission remains to be built.
 - [`retention.rs`](../../crates/rue-query/src/retention.rs) defaults to 8 GiB
   of retained artifact charge and four million dependency/input observations
   **per runtime**. These are soft accounting limits; protected results can
-  exceed them. The filesystem host exposes metrics but no production budget
-  configuration or trim operation. Multiplying these defaults across roots
+  exceed them. The filesystem host accepts configuration at construction and
+  exposes metrics, but has no production trim operation. Multiplying the
+  established defaults across roots
   would be an unsuitable implicit daemon policy.
 - [`source_loader::reload_from_filesystem`](../../crates/rue/src/source_loader.rs)
   re-observes the accepted closure and drives import discovery to a coherent


### PR DESCRIPTION
Compiler sessions inherited worker policy from the most recent process-global configuration call and had no production API for selecting retention budgets. Give each session an immutable `CompilerSessionConfig`, validate explicit worker counts, and pass that configuration through the canonical runtime, filesystem hosts, CLI, retained benchmarks, and differential oracle/fuzzer.

This is the first implementation step for ADR-0085. Automatic worker selection, the explicit 256-worker maximum, and existing soft retention defaults are preserved. `rue test --jobs` continues to control test processes. Benchmark worker reporting comes from the exact configuration used by its session.

Concurrent-session coverage compares executable bytes and diagnostics across edits, an error, and a revert with different worker/retention settings, and checks the budgets actually installed in the query runtime. Constructor and public API inventories retain their single-authority checks.

Validation: `scripts/rue quick` (36 targets passed); focused concurrent-session parity regression; broad local macOS `scripts/rue test` (238 targets passed, no failures or timeouts); formatting, ADR registry, documentation links, and `git diff --check`. All PR and merge-group GitHub checks passed.

Closes RUE-1811
