### PR TITLE
RUE-2137: preserve floating-point semantics in peephole identities

### DIFF
--- a/crates/rue-cfg/src/opt/peephole.rs
+++ b/crates/rue-cfg/src/opt/peephole.rs
@@ -138,6 +138,13 @@ fn reduce_unsigned_div_mod(cfg: &mut Cfg, stats: &mut Stats) {
 /// If `value` is a can't-trap operation that returns one operand unchanged,
 /// return that operand.
 fn identity_target(cfg: &Cfg, value: CfgValue) -> Option<CfgValue> {
+    // `Const` stores floating-point operands as their IEEE bit patterns, so
+    // payloads 0 and 1 are +0.0 and the minimum subnormal, respectively, not
+    // the integer identity values. Floating-point addition also has signed
+    // zero behavior that an identity rewrite would change.
+    if cfg.get_inst(value).ty.is_float() {
+        return None;
+    }
     let is0 = |v: CfgValue| const_int(cfg, v) == Some(0);
     let is1 = |v: CfgValue| const_int(cfg, v) == Some(1);
     match cfg.get_inst(value).data {
@@ -377,6 +384,61 @@ mod tests {
             cfg.get_inst(mul).data,
             CfgInstData::WrappingMul(..)
         ));
+    }
+
+    fn assert_float_identity_matrix(ty: Type) {
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, ty);
+        let zero = push(&mut cfg, CfgInstData::Const(0), ty);
+        let minimum_subnormal = push(&mut cfg, CfgInstData::Const(1), ty);
+        let add_right = push(&mut cfg, CfgInstData::Add(x, zero), ty);
+        let add_left = push(&mut cfg, CfgInstData::Add(zero, x), ty);
+        let sub = push(&mut cfg, CfgInstData::Sub(x, zero), ty);
+        let mul_right = push(&mut cfg, CfgInstData::Mul(x, minimum_subnormal), ty);
+        let mul_left = push(&mut cfg, CfgInstData::Mul(minimum_subnormal, x), ty);
+        let div = push(&mut cfg, CfgInstData::Div(x, minimum_subnormal), ty);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(div) });
+
+        let stats = run(&mut cfg).unwrap();
+        assert_eq!(stats.identities_rewired, 0);
+        assert!(matches!(
+            cfg.get_inst(add_right).data,
+            CfgInstData::Add(a, b) if a == x && b == zero
+        ));
+        assert!(matches!(
+            cfg.get_inst(add_left).data,
+            CfgInstData::Add(a, b) if a == zero && b == x
+        ));
+        assert!(matches!(
+            cfg.get_inst(sub).data,
+            CfgInstData::Sub(a, b) if a == x && b == zero
+        ));
+        assert!(matches!(
+            cfg.get_inst(mul_right).data,
+            CfgInstData::Mul(a, b) if a == x && b == minimum_subnormal
+        ));
+        assert!(matches!(
+            cfg.get_inst(mul_left).data,
+            CfgInstData::Mul(a, b) if a == minimum_subnormal && b == x
+        ));
+        assert!(matches!(
+            cfg.get_inst(div).data,
+            CfgInstData::Div(a, b) if a == x && b == minimum_subnormal
+        ));
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == div
+        ));
+    }
+
+    #[test]
+    fn test_f32_identity_shapes_untouched() {
+        assert_float_identity_matrix(Type::F32);
+    }
+
+    #[test]
+    fn test_f64_identity_shapes_untouched() {
+        assert_float_identity_matrix(Type::F64);
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -690,6 +690,66 @@ stdout = """21
 """
 exit_code = 42
 
+# Floating-point arithmetic uses the same raw `Const` payload storage as
+# integers, but payload 1 is the minimum subnormal rather than the integer
+# multiplicative identity. Signed zero also makes adding +0.0 observable.
+# Dynamic helper parameters keep these operations out of the immediate
+# constant-folding path, while the exact result checks pin IEEE behavior from
+# spec 3.12:21 at every optimization level.
+[[case]]
+name = "f32_float_peepholes_preserve_ieee_values"
+differential_opt = true
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+files = [{ path = "main.rue", source = """
+fn check_f32(x: f32, tiny: f32, z: f32) -> i32 {
+    let min: f32 = 1e-45;
+    let product_right = x * min;
+    let product_left = min * x;
+    let quotient = tiny / min;
+    let sum_right = z + 0.0;
+    let sum_left = 0.0 + z;
+    if product_right != min { return 1; }
+    if product_left != min { return 2; }
+    if quotient != 1.0 { return 3; }
+    if 1.0 / sum_right <= 0.0 { return 4; }
+    if 1.0 / sum_left <= 0.0 { return 5; }
+    0
+}
+
+fn main() -> i32 {
+    check_f32(1.0, 1e-45, -0.0)
+}
+""" }]
+stdout = ""
+exit_code = 0
+
+[[case]]
+name = "f64_float_peepholes_preserve_ieee_values"
+differential_opt = true
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+files = [{ path = "main.rue", source = """
+fn check_f64(x: f64, tiny: f64, z: f64) -> i32 {
+    let min: f64 = 5e-324;
+    let product_right = x * min;
+    let product_left = min * x;
+    let quotient = tiny / min;
+    let sum_right = z + 0.0;
+    let sum_left = 0.0 + z;
+    if product_right != min { return 1; }
+    if product_left != min { return 2; }
+    if quotient != 1.0 { return 3; }
+    if 1.0 / sum_right <= 0.0 { return 4; }
+    if 1.0 / sum_left <= 0.0 { return 5; }
+    0
+}
+
+fn main() -> i32 {
+    check_f64(1.0, 5e-324, -0.0)
+}
+""" }]
+stdout = ""
+exit_code = 0
+
 # Dominator-scoped CSE (RUE-913, RUE-1874): a repeated pure subexpression's
 # shared operand is value-numbered once and reused, so the three separate `const 100`
 # materializations in `weighted` collapse to a single instruction at -O2. The


### PR DESCRIPTION
Optimized floating-point multiplication and division could treat the minimum subnormal's raw bit pattern as the integer constant `1`, and addition could discard observable signed-zero behavior. The peephole identity pass now excludes floating-point operations while preserving integer and boolean simplifications.

Regression coverage checks both float widths, operand orders, subnormal multiplication and division, and signed-zero addition. The CLI cases run at O0–O3 on the native platform CI targets; both cases pass at O0 and fail at O1–O3 with the compiler before this change.

Fixes RUE-2137.

Validation: 13 peephole unit tests, both native differential CLI cases, all 36 quick-suite targets, formatting, and the CLI oracle-diff corpus passed. The quick suite needed one retry after an artifact-cache transport error.
