### PR TITLE
RUE-2138: allocate narrow foreign stack store sources

### DIFF
--- a/crates/rue-c-abi-matrix/src/main.rs
+++ b/crates/rue-c-abi-matrix/src/main.rs
@@ -73,16 +73,20 @@ const RUN_TIMEOUT: Duration = Duration::from_secs(120);
 /// documents as its input.
 fn toolchain_available() -> bool {
     static AVAILABLE: OnceLock<bool> = OnceLock::new();
-    *AVAILABLE.get_or_init(|| ["cc", "ar"].iter().all(|tool| responds_to_version(tool)))
+    *AVAILABLE.get_or_init(|| ["cc", "ar"].iter().all(|tool| tool_is_invocable(tool)))
 }
 
-fn responds_to_version(tool: &str) -> bool {
+fn tool_is_invocable(tool: &str) -> bool {
     Command::new(tool)
         .arg("--version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
-        .is_ok_and(|status| status.success())
+        // Some native tools, including Apple's `ar`, reject GNU-only version
+        // flags even though they are fully invocable. Availability is about
+        // spawning the tool; real compile, archive, and link failures are
+        // reported by `run_step` below.
+        .is_ok()
 }
 
 /// The compiler path, made absolute: every subprocess below runs with the
@@ -284,6 +288,7 @@ mod tests {
         Bank, Direction, Leaf, PROBE_BYTES, Position, SHAPES, Shape, Ty, Value, generate,
         positions_for,
     };
+    use super::tool_is_invocable;
     use rue_air::{
         AggregateLeaves, ArgConvention, ArgLocation, CAbiLeaf, CAbiLeafKind, CAbiScalarKind,
         CAbiTypeFacts, PointerLocation, lower_c_signature,
@@ -292,6 +297,28 @@ mod tests {
 
     fn spec() -> CConventionSpec {
         CallingConvention::X86_64SysV.c_spec()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tool_probe_checks_invocability_not_version_exit_status() {
+        // Use a temporary executable that exits nonzero for every invocation,
+        // which models Apple's `ar --version` behavior without depending on a
+        // particular utility's exit status on the host.
+        let directory = tempfile::tempdir().expect("probe temp directory");
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = directory.path().join("nonzero-tool");
+        std::fs::write(&path, b"#!/bin/sh\nexit 1\n").expect("probe executable");
+        let mut permissions = std::fs::metadata(&path)
+            .expect("probe executable metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions).expect("probe executable permissions");
+        assert!(tool_is_invocable(
+            path.to_str().expect("probe path is UTF-8")
+        ));
+        assert!(!tool_is_invocable("__rue_missing_tool_for_probe__"));
     }
 
     /// Every C row the grid is generated for. The host runs one of them; the

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -1590,3 +1590,70 @@ fn main() -> i32 {
 args = ["--preview", "c_ffi", "--target", "aarch64-linux", "--emit", "asm", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== Assembly (aarch64-linux) ==="]
+
+# A narrow integer after eight register-width arguments exercises the physical
+# narrow-store rewrite on each C row. The x86-64 and AAPCS64 rows stage a whole
+# eight-byte slot, while Apple's row emits the natural one-byte store.
+
+[[case]]
+name = "x86_64_linux_stacked_u8_after_eight_u64"
+description = "A narrow integer tail after eight register-width arguments reaches the x86-64 assembly emitter."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_stack_u8(
+        a: u64, b: u64, c: u64, d: u64, e: u64,
+        f: u64, g: u64, h: u64, tail: u8,
+    ) -> u8;
+}
+
+fn main() -> i32 {
+    let value = checked { ffi_stack_u8(1, 2, 3, 4, 5, 6, 7, 8, 9) };
+    @dbg(value);
+    0
+}
+""" }]
+args = ["--preview", "c_ffi", "--target", "x86-64-linux", "--emit", "asm", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (x86-64-linux) ==="]
+
+[[case]]
+name = "aarch64_linux_stacked_u8_after_eight_u64"
+description = "A narrow integer tail after eight register-width arguments reaches the AAPCS64 assembly emitter."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_stack_u8(
+        a: u64, b: u64, c: u64, d: u64, e: u64,
+        f: u64, g: u64, h: u64, tail: u8,
+    ) -> u8;
+}
+
+fn main() -> i32 {
+    let value = checked { ffi_stack_u8(1, 2, 3, 4, 5, 6, 7, 8, 9) };
+    @dbg(value);
+    0
+}
+""" }]
+args = ["--preview", "c_ffi", "--target", "aarch64-linux", "--emit", "asm", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-linux) ==="]
+
+[[case]]
+name = "aarch64_macos_stacked_u8_after_eight_u64"
+description = "A narrow integer tail after eight register-width arguments reaches the Apple arm64 assembly emitter."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_stack_u8(
+        a: u64, b: u64, c: u64, d: u64, e: u64,
+        f: u64, g: u64, h: u64, tail: u8,
+    ) -> u8;
+}
+
+fn main() -> i32 {
+    let value = checked { ffi_stack_u8(1, 2, 3, 4, 5, 6, 7, 8, 9) };
+    @dbg(value);
+    0
+}
+""" }]
+args = ["--preview", "c_ffi", "--target", "aarch64-macos", "--emit", "asm", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-macos) ==="]

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -1327,9 +1327,9 @@ impl RegAlloc {
             Aarch64Inst::Ret => mir.push(Aarch64Inst::Ret),
             Aarch64Inst::Brk => mir.push(Aarch64Inst::Brk),
             Aarch64Inst::Svc { imm } => mir.push(Aarch64Inst::Svc { imm }),
-            // The physical-base narrow forms are produced by this pass from the
-            // indexed pseudos above with already-allocated operands; they never
-            // appear in the pre-allocation input, so pass them through unchanged.
+            // The physical-base narrow-load form is produced by this pass from
+            // the indexed pseudo above with already-allocated operands; it
+            // never appears in the pre-allocation input, so pass it through.
             Aarch64Inst::NarrowLoad {
                 dst,
                 base,
@@ -1348,12 +1348,15 @@ impl RegAlloc {
                 base,
                 offset,
                 width,
-            } => mir.push(Aarch64Inst::NarrowStore {
-                src,
-                base,
-                offset,
-                width,
-            }),
+            } => {
+                let src = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                mir.push(Aarch64Inst::NarrowStore {
+                    src,
+                    base,
+                    offset,
+                    width,
+                });
+            }
         }
         Ok(())
     }
@@ -1720,6 +1723,7 @@ impl RegAllocBackend for Aarch64Backend {
 
 #[cfg(test)]
 mod tests {
+    use super::super::Emitter;
     use super::Aarch64Backend;
     use super::liveness;
     use super::{
@@ -1762,6 +1766,138 @@ mod tests {
             error.to_string().contains("was not allocated"),
             "unexpected message: {error}"
         );
+
+        let mut buffer = RewriteBuffer::new();
+        let error = RegAlloc::rewrite_inst(
+            &context,
+            &mut buffer,
+            Aarch64Inst::NarrowStore {
+                src: Operand::Virtual(VReg::new(0)),
+                base: Reg::Sp,
+                offset: 0,
+                width: 1,
+            },
+        )
+        .expect_err("an unassigned narrow-store source must fail the rewrite");
+        assert_eq!(error.kind.code(), ErrorCode::INTERNAL_CODEGEN_ERROR);
+        assert!(
+            error.to_string().contains("was not allocated"),
+            "unexpected message: {error}"
+        );
+    }
+
+    #[test]
+    fn narrow_store_reloads_spilled_source_before_store() {
+        for (width, offset, spill_offset) in [(1, 0, -8), (2, 2, -16), (4, 4, -24)] {
+            let mut allocation: IndexMap<VReg, Option<Allocation<Reg>>> =
+                IndexMap::with_capacity(1);
+            allocation.resize(1, Some(Allocation::Spill(spill_offset)));
+            let coalesce_result = CoalesceResult::empty();
+            let context = AllocationContext::for_test(&allocation, &coalesce_result);
+            let mut buffer = RewriteBuffer::new();
+
+            RegAlloc::rewrite_inst(
+                &context,
+                &mut buffer,
+                Aarch64Inst::NarrowStore {
+                    src: Operand::Virtual(VReg::new(0)),
+                    base: Reg::Sp,
+                    offset,
+                    width,
+                },
+            )
+            .expect("spilled narrow-store source should rewrite");
+
+            let rewritten = buffer.drain_ordered_for_test();
+            assert_eq!(rewritten.len(), 2);
+            assert!(matches!(
+                rewritten[0],
+                Aarch64Inst::Ldr {
+                    dst: Operand::Physical(dst),
+                    base: Reg::Fp,
+                    offset: actual,
+                } if dst == SCRATCH_VALUE && actual == spill_offset
+            ));
+            assert!(matches!(
+                rewritten[1],
+                Aarch64Inst::NarrowStore {
+                    src: Operand::Physical(src),
+                    base: Reg::Sp,
+                    offset: actual,
+                    width: actual_width,
+                } if src == SCRATCH_VALUE && actual == offset && actual_width == width
+            ));
+
+            let mut emitted_mir = Aarch64Mir::new();
+            for inst in rewritten.iter().cloned() {
+                emitted_mir.push(inst);
+            }
+            let (code, _) = Emitter::new(&emitted_mir, 0, 0, 0, &[], &[])
+                .without_frame()
+                .emit()
+                .expect("spilled narrow-store rewrite should encode");
+            assert_eq!(
+                code.len(),
+                8,
+                "reload and narrow store should each encode once"
+            );
+        }
+    }
+
+    #[test]
+    fn narrow_store_preserves_allocated_and_physical_sources() {
+        let mut allocation: IndexMap<VReg, Option<Allocation<Reg>>> = IndexMap::with_capacity(1);
+        allocation.resize(1, Some(Allocation::Register(Reg::X13)));
+        let coalesce_result = CoalesceResult::empty();
+        let context = AllocationContext::for_test(&allocation, &coalesce_result);
+
+        let mut buffer = RewriteBuffer::new();
+        RegAlloc::rewrite_inst(
+            &context,
+            &mut buffer,
+            Aarch64Inst::NarrowStore {
+                src: Operand::Virtual(VReg::new(0)),
+                base: Reg::Sp,
+                offset: 6,
+                width: 2,
+            },
+        )
+        .expect("allocated narrow-store source should rewrite");
+        let rewritten = buffer.drain_ordered_for_test();
+        assert_eq!(rewritten.len(), 1);
+        assert!(matches!(
+            rewritten.as_slice(),
+            [Aarch64Inst::NarrowStore {
+                src: Operand::Physical(Reg::X13),
+                base: Reg::Sp,
+                offset: 6,
+                width: 2,
+            }]
+        ));
+
+        let mut physical_buffer = RewriteBuffer::new();
+        RegAlloc::rewrite_inst(
+            &context,
+            &mut physical_buffer,
+            Aarch64Inst::NarrowStore {
+                src: Operand::Physical(Reg::X14),
+                base: Reg::Sp,
+                offset: 8,
+                width: 4,
+            },
+        )
+        .expect("physical narrow-store source should rewrite");
+        let rewritten = physical_buffer.drain_ordered_for_test();
+        assert_eq!(rewritten.len(), 1);
+        assert!(matches!(
+            rewritten.as_slice(),
+            [Aarch64Inst::NarrowStore {
+                src: Operand::Physical(Reg::X14),
+                base: Reg::Sp,
+                offset: 8,
+                width: 4,
+            }]
+        ));
     }
 
     #[test]

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -1740,6 +1740,11 @@ impl<I> RewriteBuffer<I> {
             .chain(self.main.drain(..))
             .chain(self.after.drain(..))
     }
+
+    #[cfg(test)]
+    pub(crate) fn drain_ordered_for_test(&mut self) -> Vec<I> {
+        self.drain_ordered().collect()
+    }
 }
 
 /// Fail loudly if pre-allocation MIR names an allocatable register directly.


### PR DESCRIPTION
Foreign calls on Apple arm64 can now pass narrow integer arguments after exhausting the general-purpose argument registers. Register allocation resolves or reloads each narrow stack store's source before emission, preserving the assigned stack width and offset.

The native C ABI matrix also recognizes Apple's archiver as available even though it rejects `--version`. The existing narrow argument matrix can therefore execute on macOS; real compiler, archiver, and linker failures still fail the test.

Fixes RUE-2138.
Fixes RUE-2143.

Validation: allocation/emission regressions (6 tests), tool-probe regression (1), Darwin stack-placement regression (1), C FFI CLI cases (69), quick tier (36 targets), native C ABI matrix (4 passed, 0 ignored), oracle corpus audit, and formatting passed. The native matrix passed again on the integrated head in the full suite.

The complete local `scripts/rue test` run passed all 238 targets with no failures, timeouts, skips, or infrastructure errors. Required PR CI also passed on Linux x86-64, Linux ARM64, and macOS ARM64; all four native C ABI matrix tests executed on macOS.
