### PR TITLE
RUE-2144: supply std to MCP Buck targets

### DIFF
--- a/crates/rue-mcp/BUCK
+++ b/crates/rue-mcp/BUCK
@@ -19,6 +19,7 @@ command_alias(
     exe = ":rue-mcp",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_STD_PATH": "$(location //std:std)",
         "RUE_SPEC_BINARY": "$(exe_target //crates/rue-spec:rue-spec)",
         "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
         "RUE_SPEC_DIR": "$(location //docs:spec-src)",
@@ -37,6 +38,7 @@ rue_sh_test(
     test = ":protocol-test-runner",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_STD_PATH": "$(location //std:std)",
         "RUE_MCP_BINARY": "$(exe_target :rue-mcp)",
         "RUE_SPEC_BINARY": "$(exe_target //crates/rue-spec:rue-spec)",
         "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",

--- a/crates/rue-mcp/protocol_test.py
+++ b/crates/rue-mcp/protocol_test.py
@@ -113,6 +113,8 @@ def tool_call(request_id, name, arguments):
 
 
 def protocol_and_real_producer_tests():
+    std_path = pathlib.Path(os.environ["RUE_STD_PATH"])
+    assert std_path.is_dir(), "Buck must provide the canonical standard library directory"
     process = server()
     send(process, request("discover", "server/discover"))
     discover = receive_id(process, "discover")["result"]
@@ -304,7 +306,11 @@ def protocol_and_real_producer_tests():
         bounded = assert_tool_views(receive_id(process, "bounded-check"))
         assert bounded["success"] is False and bounded["diagnostics"]
 
-        root.write_text("fn main() -> i32 { 0 }\n", encoding="utf-8")
+        root.write_text(
+            'const std = @import("std");\n'
+            'fn main() -> i32 { if std.ascii.is_digit(48) { 0 } else { 1 } }\n',
+            encoding="utf-8",
+        )
         executable = pathlib.Path(directory) / "program"
         send(process, tool_call("compile", "compile", {"root": str(root), "output": str(executable)}))
         compiled = assert_tool_views(receive_id(process, "compile"))

--- a/docs/process/mcp.md
+++ b/docs/process/mcp.md
@@ -6,12 +6,15 @@ runs the real filesystem driver with `--error-format json`, reads explanations
 and error metadata from `rue-error`, and runs the schema-v1 specification index
 producer. It does not host a daemon or add another compiler frontend.
 
-Run it through Buck so the canonical producer binaries and specification inputs
-are supplied explicitly:
+Run it through Buck so the canonical producer binaries, standard library, and
+specification inputs are supplied explicitly:
 
 ```console
 ./buck2 run //crates/rue-mcp:server
 ```
+
+The Buck target supplies the repository's `//std:std` directory as
+`RUE_STD_PATH`, so standard-library imports work without ambient configuration.
 
 Configure an MCP client with that command, the repository root as its working
 directory, and stdio transport. The server implements MCP revision


### PR DESCRIPTION
The MCP server and protocol-test Buck targets now supply the declared `//std:std` input through `RUE_STD_PATH`. Programs importing std work through the documented server command without user environment setup, and std lookup remains in the canonical driver.

The protocol regression compiles a real std-using program from a temporary root, and the setup documentation describes the supplied input.

Fixes RUE-2144.

Validation: the protocol target and documented server smoke passed with a bogus ambient `RUE_STD_PATH`; both Buck targets built; all 36 quick-tier targets, the MCP formatting check, and `git diff --check` passed.
