### PR TITLE
RUE-2127: separate owned compiler results from client publication

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -16,7 +16,7 @@ use rue_compiler::unstable::{
 use rue_compiler::{
     CompileErrors, CompileOptions, CompileOutput, CompileWarning, CompilerSessionConfig, OptLevel,
 };
-use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
+use rue_driver::{FilesystemCompilerHost, HostOpenRequest, HostPathContext, SourceLoadError};
 use rue_perf_schema::{
     DisplayIdentityWork, EDIT_REPORT_SCHEMA_VERSION, EditEndpoints, EditManifest, EditOutcome,
     EditReport, EditReportIdentity, EditReportRegime, EditRow, EditSample, EditScenario,
@@ -1224,6 +1224,7 @@ fn open_host(
         source_manifest_path: manifest.and_then(Path::to_str),
         std_root,
         compiler_config,
+        path_context: &HostPathContext::capture().map_err(|error| error.to_string())?,
     })
     .map_err(source_load_error)
 }

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -3,18 +3,23 @@ use std::time::Instant;
 
 use rue_compiler::unstable::{
     CancellableCompileOutcome, CancellableTestImageOutcome, CompilationCancellation,
-    OneShotMetrics, TestCompileFailure, TestImage, TestInventory,
+    OneShotMetrics, TestCandidateInventory, TestCompileFailure, TestImage, TestInventory,
+    UnimportedTestFile,
 };
 use rue_compiler::{
-    CompileErrors, CompileOptions, CompileOutput, CompileWarning, LinkerMode, MultiErrorResult,
+    AcceptedReadManifest, CompileErrors, CompileOptions, CompileOutput, CompileWarning, LinkerMode,
+    MultiErrorResult, SourceSnapshot,
 };
-use rue_driver::{FilesystemCompilerHost, WatchInput};
+use rue_driver::{
+    AttemptedRead, FilesystemCompilerHost, WatchInput, with_import_migration_helps,
+    with_import_migration_helps_batches,
+};
 
-use crate::DiagnosticOutput;
 use crate::output::{
-    PublicationDestination, PublishError, PublishRequest, publish_executable,
-    publish_watch_executable,
+    PublicationDestination, PublishError, PublishRequest, preflight_destination_with_display,
+    preflight_watch_destination_with_display, publish_executable, publish_watch_executable,
 };
+use crate::{DiagnosticOutput, ErrorFormat};
 
 /// Linked bytes and everything publication needs, held between the compiler's
 /// timing root closing and the atomic write.
@@ -166,6 +171,45 @@ pub(crate) enum CycleReport<Published = PublishedExecutable> {
     Canceled,
 }
 
+/// The compiler-owned answer to one cycle. It contains no borrow of the
+/// retained host, so a caller may reobserve or release that host before it
+/// consumes the result for diagnostics, publication, or test execution.
+pub(crate) struct OwnedCycleResponse<Artifact> {
+    source_snapshot: SourceSnapshot,
+    accepted_reads: AcceptedReadManifest,
+    attempted_reads: Vec<AttemptedRead>,
+    watch_inputs: Vec<WatchInput>,
+    published_user_module_count: usize,
+    error_format: ErrorFormat,
+    options: CompileOptions,
+    source_path: Option<String>,
+    output_display_path: String,
+    unimported_test_files: Option<Result<Vec<UnimportedTestFile>, CompileErrors>>,
+    result: OwnedCycleResult<Artifact>,
+}
+
+/// Filesystem observations belonging to a compiler cycle, carried with the
+/// owned result so later host observations cannot be mistaken for its inputs.
+pub(crate) struct OwnedCycleObservations {
+    pub(crate) accepted_reads: AcceptedReadManifest,
+    pub(crate) attempted_reads: Vec<AttemptedRead>,
+    pub(crate) watch_inputs: Vec<WatchInput>,
+}
+
+enum OwnedCycleResult<Artifact> {
+    Ready {
+        artifact: Artifact,
+        destination: PublicationDestination,
+        observation: PublicationObservation,
+    },
+    Failed {
+        errors: Option<CompileErrors>,
+        publication: Option<PublishError>,
+    },
+    Superseded(Supersession),
+    Canceled,
+}
+
 pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
     let CycleRequest {
         host,
@@ -176,17 +220,15 @@ pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
         observation,
         announcement,
     } = request;
-    let report = drive::<CompileOutput>(
+    drive::<CompileOutput>(
         host,
         options,
         diagnostics,
+        source_path,
         Path::new(output_path),
         observation,
-    );
-    if let CycleReport::Published(_) = &report {
-        announce(announcement, source_path, output_path, options);
-    }
-    report
+        Some(announcement),
+    )
 }
 
 /// What one cycle compiles and publishes.
@@ -198,7 +240,7 @@ pub(crate) fn drive_cycle(request: CycleRequest<'_, '_>) -> CycleReport {
 /// warnings, the publication outcome — is one sequence, [`drive`], written
 /// once over this trait rather than once per artifact (RUE-2089). A change to
 /// the order of those steps has one home.
-trait CycleArtifact: Sized {
+pub(crate) trait CycleArtifact: Sized {
     /// What rides beside the linked output from the compile to the report.
     type Companion;
     /// What the report carries once the bytes are at the output path.
@@ -219,6 +261,12 @@ trait CycleArtifact: Sized {
     /// the part that is this artifact's own.
     fn into_parts(self) -> (CompileOutput, Self::Companion);
 
+    /// Freeze presentation-only diagnostic facts while the source tree that
+    /// produced this artifact is still the active filesystem revision.
+    fn prepare(self) -> Self {
+        self
+    }
+
     /// Diagnostics the companion carries, printed after the warnings and
     /// before the publication outcome so a failed publication cannot discard
     /// them. The executable has none.
@@ -228,14 +276,272 @@ trait CycleArtifact: Sized {
     ) {
     }
 
-    fn published(companion: Self::Companion, executable: PublishedExecutable) -> Self::Published;
+    fn published(
+        companion: Self::Companion,
+        executable: PublishedExecutable,
+        unimported_test_files: Option<Result<Vec<UnimportedTestFile>, CompileErrors>>,
+        _source_snapshot: SourceSnapshot,
+        _error_format: ErrorFormat,
+        _observations: OwnedCycleObservations,
+    ) -> Self::Published;
 }
 
 /// A cancellable compile's answer, in one spelling for every artifact.
-enum Compiled<Artifact> {
+pub(crate) enum Compiled<Artifact> {
     Completed(Artifact),
     Errors(CompileErrors),
     Canceled,
+}
+
+fn owned_response<Artifact>(
+    host: &FilesystemCompilerHost,
+    error_format: ErrorFormat,
+    options: &CompileOptions,
+    source_path: Option<&str>,
+    output_display_path: &str,
+    result: OwnedCycleResult<Artifact>,
+) -> OwnedCycleResponse<Artifact> {
+    OwnedCycleResponse {
+        source_snapshot: host.source_snapshot().clone(),
+        accepted_reads: host.accepted_reads().clone(),
+        attempted_reads: host.attempted_reads().to_vec(),
+        watch_inputs: host.watch_inputs(),
+        published_user_module_count: host.published_user_module_count(),
+        error_format,
+        options: options.clone(),
+        source_path: source_path.map(str::to_owned),
+        output_display_path: output_display_path.to_owned(),
+        unimported_test_files: None,
+        result,
+    }
+}
+
+/// Produce an owned cycle answer while the retained host is available. This
+/// function performs every compiler query but does no diagnostics, output
+/// publication, or test execution; those are client completion operations.
+fn produce<Artifact: CycleArtifact>(
+    host: &mut FilesystemCompilerHost,
+    options: &CompileOptions,
+    error_format: ErrorFormat,
+    source_path: Option<&str>,
+    output_path: &Path,
+    observation: CycleObservation<'_>,
+) -> OwnedCycleResponse<Artifact> {
+    let output_display_path = output_path.to_string_lossy().into_owned();
+    let output_path = host.anchor_path(output_path);
+    if let Some(errors) = host.discovery_refusal() {
+        return owned_response(
+            host,
+            error_format,
+            options,
+            source_path,
+            &output_display_path,
+            OwnedCycleResult::Failed {
+                errors: Some(with_import_migration_helps(&errors)),
+                publication: None,
+            },
+        );
+    }
+
+    let destination = match preflight(
+        &output_path,
+        Path::new(&output_display_path),
+        host,
+        &observation,
+    ) {
+        Ok(destination) => destination,
+        Err(error) => {
+            return owned_response(
+                host,
+                error_format,
+                options,
+                source_path,
+                &output_display_path,
+                OwnedCycleResult::Failed {
+                    errors: None,
+                    publication: Some(error),
+                },
+            );
+        }
+    };
+
+    let (artifact, publication_observation) = match observation {
+        CycleObservation::OneShot => match Artifact::compile(host, options) {
+            Ok(artifact) => (Artifact::prepare(artifact), PublicationObservation::OneShot),
+            Err(errors) => {
+                return owned_response(
+                    host,
+                    error_format,
+                    options,
+                    source_path,
+                    &output_display_path,
+                    OwnedCycleResult::Failed {
+                        errors: Some(with_import_migration_helps(&errors)),
+                        publication: None,
+                    },
+                );
+            }
+        },
+        CycleObservation::Watch {
+            inputs,
+            cancellation,
+            superseded,
+        } => {
+            let outcome = Artifact::compile_cancellable(host, options, cancellation);
+            if superseded() {
+                return owned_response(
+                    host,
+                    error_format,
+                    options,
+                    source_path,
+                    &output_display_path,
+                    OwnedCycleResult::Superseded(Supersession::BeforePublication),
+                );
+            }
+            match outcome {
+                Compiled::Completed(artifact) => (
+                    Artifact::prepare(artifact),
+                    PublicationObservation::Watch(inputs),
+                ),
+                Compiled::Errors(errors) => {
+                    return owned_response(
+                        host,
+                        error_format,
+                        options,
+                        source_path,
+                        &output_display_path,
+                        OwnedCycleResult::Failed {
+                            errors: Some(with_import_migration_helps(&errors)),
+                            publication: None,
+                        },
+                    );
+                }
+                Compiled::Canceled => {
+                    return owned_response(
+                        host,
+                        error_format,
+                        options,
+                        source_path,
+                        &output_display_path,
+                        OwnedCycleResult::Canceled,
+                    );
+                }
+            }
+        }
+    };
+    owned_response(
+        host,
+        error_format,
+        options,
+        source_path,
+        &output_display_path,
+        OwnedCycleResult::Ready {
+            artifact,
+            destination,
+            observation: publication_observation,
+        },
+    )
+}
+
+impl<Artifact: CycleArtifact> OwnedCycleResponse<Artifact> {
+    pub(crate) fn published_user_module_count(&self) -> usize {
+        self.published_user_module_count
+    }
+
+    fn attach_unimported_test_files(
+        &mut self,
+        report: Option<Result<Vec<UnimportedTestFile>, CompileErrors>>,
+    ) {
+        self.unimported_test_files = report;
+    }
+
+    pub(crate) fn complete(
+        self,
+        announcement: Option<Announcement>,
+    ) -> CycleReport<Artifact::Published> {
+        let OwnedCycleResponse {
+            source_snapshot,
+            published_user_module_count: _,
+            error_format,
+            options,
+            source_path,
+            output_display_path,
+            unimported_test_files,
+            result,
+            accepted_reads,
+            attempted_reads,
+            watch_inputs,
+        } = self;
+        let source_infos = source_snapshot
+            .files()
+            .map(|source| {
+                (
+                    source.file_id,
+                    rue_compiler::unstable::SourceInfo::new(source.source, source.path),
+                )
+            })
+            .collect();
+        let diagnostics = DiagnosticOutput::new(error_format, source_infos);
+        let (artifact, destination, observation) = match result {
+            OwnedCycleResult::Ready {
+                artifact,
+                destination,
+                observation,
+            } => (artifact, destination, observation),
+            OwnedCycleResult::Failed {
+                errors,
+                publication,
+            } => {
+                if let Some(errors) = errors {
+                    diagnostics.print_prepared_errors(&errors);
+                }
+                if let Some(error) = publication {
+                    diagnostics.print_error(&error.into_compile_error());
+                }
+                return CycleReport::Failed;
+            }
+            OwnedCycleResult::Superseded(boundary) => {
+                return CycleReport::Superseded(boundary);
+            }
+            OwnedCycleResult::Canceled => return CycleReport::Canceled,
+        };
+        let (output, companion) = artifact.into_parts();
+        let linked = linked_executable(output, &options, destination, observation);
+        let publication = {
+            let _span = tracing::info_span!("output_write", driver_phase = true).entered();
+            linked.publish()
+        };
+        diagnostics.print_warnings(&publication.warnings);
+        Artifact::print_companion_diagnostics(&companion, &diagnostics);
+        match publication.result {
+            Ok(executable) => {
+                if let Some(announcement) = announcement {
+                    if let Some(source_path) = source_path {
+                        announce(announcement, &source_path, &output_display_path, &options);
+                    }
+                }
+                CycleReport::Published(Box::new(Artifact::published(
+                    companion,
+                    executable,
+                    unimported_test_files,
+                    source_snapshot.clone(),
+                    error_format,
+                    OwnedCycleObservations {
+                        accepted_reads,
+                        attempted_reads,
+                        watch_inputs,
+                    },
+                )))
+            }
+            Err(PublishError::InputsChanged) => {
+                CycleReport::Superseded(Supersession::AtPublication)
+            }
+            Err(error) => {
+                diagnostics.print_error(&error.into_compile_error());
+                CycleReport::Failed
+            }
+        }
+    }
 }
 
 impl CycleArtifact for CompileOutput {
@@ -265,13 +571,21 @@ impl CycleArtifact for CompileOutput {
         (self, ())
     }
 
-    fn published((): (), executable: PublishedExecutable) -> PublishedExecutable {
+    fn published(
+        (): (),
+        executable: PublishedExecutable,
+        _: Option<Result<Vec<UnimportedTestFile>, CompileErrors>>,
+        _: SourceSnapshot,
+        _: ErrorFormat,
+        observations: OwnedCycleObservations,
+    ) -> PublishedExecutable {
+        consume_cycle_observations(observations);
         executable
     }
 }
 
 /// What a test image carries beside its linked bytes (ADR-0083 §3).
-struct TestImageCompanion {
+pub(crate) struct TestImageCompanion {
     inventory: TestInventory,
     compile_failures: Vec<TestCompileFailure>,
     failure_diagnostics: CompileErrors,
@@ -332,16 +646,56 @@ impl CycleArtifact for TestImage {
         diagnostics: &DiagnosticOutput<'_>,
     ) {
         if !companion.failure_diagnostics.is_empty() {
-            diagnostics.print_errors(&companion.failure_diagnostics);
+            diagnostics.print_prepared_errors(&companion.failure_diagnostics);
         }
     }
 
-    fn published(companion: TestImageCompanion, _: PublishedExecutable) -> PublishedTestImage {
+    fn prepare(mut self) -> Self {
+        let mut batches = vec![&self.failure_diagnostics];
+        batches.extend(self.compile_failures.iter().map(|failure| &failure.errors));
+        let mut prepared = with_import_migration_helps_batches(&batches).into_iter();
+        self.failure_diagnostics = prepared
+            .next()
+            .expect("aggregate failure diagnostics have one prepared batch");
+        for failure in &mut self.compile_failures {
+            failure.errors = prepared
+                .next()
+                .expect("every test failure has one prepared batch");
+        }
+        self
+    }
+
+    fn published(
+        companion: TestImageCompanion,
+        _: PublishedExecutable,
+        unimported_test_files: Option<Result<Vec<UnimportedTestFile>, CompileErrors>>,
+        source_snapshot: SourceSnapshot,
+        error_format: ErrorFormat,
+        observations: OwnedCycleObservations,
+    ) -> PublishedTestImage {
+        consume_cycle_observations(observations);
         PublishedTestImage {
             inventory: companion.inventory,
             compile_failures: companion.compile_failures,
+            unimported_test_files,
+            source_snapshot,
+            error_format,
         }
     }
+}
+
+fn consume_cycle_observations(
+    OwnedCycleObservations {
+        accepted_reads,
+        attempted_reads,
+        watch_inputs,
+    }: OwnedCycleObservations,
+) {
+    // The publication boundary owns these records even when the published
+    // artifact does not expose them. Destructuring here makes that ownership
+    // explicit and keeps the response from silently borrowing a later host
+    // observation.
+    drop((accepted_reads, attempted_reads, watch_inputs));
 }
 
 /// The one cycle both artifacts run: discovery gate, destination preflight,
@@ -350,101 +704,41 @@ fn drive<Artifact: CycleArtifact>(
     host: &mut FilesystemCompilerHost,
     options: &CompileOptions,
     diagnostics: &DiagnosticOutput<'_>,
+    source_path: &str,
     output_path: &Path,
     observation: CycleObservation<'_>,
+    announcement: Option<Announcement>,
 ) -> CycleReport<Artifact::Published> {
-    // A revision whose import graph did not close valid is reported as that
-    // and nothing else: the unresolved `@import` is the user's problem, and
-    // the destination preflight's answer about the output path would only bury
-    // it (RUE-810). The host refuses such a revision at every compile-scope
-    // entry point regardless, so a driver that forgot to ask still cannot
-    // reach the compiler with one; asking here only fixes the order.
-    if let Some(errors) = host.discovery_refusal() {
-        diagnostics.print_errors(&errors);
-        return CycleReport::Failed;
-    }
-
-    // Closed discovery fixes the complete source identity set, so the
-    // destination can be validated before any semantic, codegen, or link work
-    // and the set retained for mandatory revalidation immediately before the
-    // atomic publication.
-    let destination = match preflight(output_path, host, &observation) {
-        Ok(destination) => destination,
-        Err(error) => {
-            diagnostics.print_error(&error.into_compile_error());
-            return CycleReport::Failed;
-        }
-    };
-
-    let (artifact, observation) = match observation {
-        CycleObservation::OneShot => match Artifact::compile(host, options) {
-            Ok(artifact) => (artifact, PublicationObservation::OneShot),
-            Err(errors) => {
-                diagnostics.print_errors(&errors);
-                return CycleReport::Failed;
-            }
-        },
-        CycleObservation::Watch {
-            inputs,
-            cancellation,
-            superseded,
-        } => {
-            let outcome = Artifact::compile_cancellable(host, options, cancellation);
-            // A superseded cycle describes bytes that no longer exist. Check
-            // before reporting, so a transient error the user has already
-            // fixed never reaches the terminal.
-            if superseded() {
-                return CycleReport::Superseded(Supersession::BeforePublication);
-            }
-            match outcome {
-                Compiled::Completed(artifact) => (artifact, PublicationObservation::Watch(inputs)),
-                Compiled::Errors(errors) => {
-                    diagnostics.print_errors(&errors);
-                    return CycleReport::Failed;
-                }
-                Compiled::Canceled => return CycleReport::Canceled,
-            }
-        }
-    };
-    let (output, companion) = artifact.into_parts();
-    let linked = linked_executable(output, options, destination, observation);
-
-    // Publication runs after the compiler's timing root closes, so it is
-    // measured as a driver phase: it breaks down process-minus-root overhead
-    // without becoming a second timing root (RUE-786).
-    let publication = {
-        let _span = tracing::info_span!("output_write", driver_phase = true).entered();
-        linked.publish()
-    };
-    // Warnings, and whatever diagnostics the artifact carries beside them,
-    // live outside the publication result so a failure cannot discard them;
-    // present them before inspecting the publication outcome.
-    diagnostics.print_warnings(&publication.warnings);
-    Artifact::print_companion_diagnostics(&companion, diagnostics);
-    match publication.result {
-        Ok(executable) => {
-            CycleReport::Published(Box::new(Artifact::published(companion, executable)))
-        }
-        Err(PublishError::InputsChanged) => CycleReport::Superseded(Supersession::AtPublication),
-        Err(error) => {
-            diagnostics.print_error(&error.into_compile_error());
-            CycleReport::Failed
-        }
-    }
+    produce::<Artifact>(
+        host,
+        options,
+        diagnostics.format(),
+        Some(source_path),
+        output_path,
+        observation,
+    )
+    .complete(announcement)
 }
 
 fn preflight(
     path: &Path,
+    display_path: &Path,
     host: &FilesystemCompilerHost,
     observation: &CycleObservation<'_>,
 ) -> Result<PublicationDestination, PublishError> {
     match observation {
-        CycleObservation::OneShot => crate::output::preflight_destination(
+        CycleObservation::OneShot => preflight_destination_with_display(
             path,
-            host.source_snapshot().files().map(|source| source.path),
+            display_path,
+            // Snapshot paths also serve diagnostics and can retain relative
+            // display spellings. Only accepted filesystem observations name
+            // the source identities independently of the process cwd.
+            host.accepted_reads()
+                .iter()
+                .flat_map(|read| [read.requested_path(), read.canonical_path()]),
         ),
         CycleObservation::Watch { inputs, .. } => {
-            crate::output::preflight_watch_destination(path, inputs)
+            preflight_watch_destination_with_display(path, display_path, inputs)
         }
     }
 }
@@ -501,6 +795,9 @@ fn linker_name(linker: &LinkerMode) -> &str {
 pub(crate) struct PublishedTestImage {
     pub(crate) inventory: TestInventory,
     pub(crate) compile_failures: Vec<TestCompileFailure>,
+    pub(crate) unimported_test_files: Option<Result<Vec<UnimportedTestFile>, CompileErrors>>,
+    pub(crate) source_snapshot: SourceSnapshot,
+    pub(crate) error_format: ErrorFormat,
 }
 
 /// One test-image cycle, the test-mode twin of [`CycleRequest`].
@@ -512,10 +809,11 @@ pub(crate) struct PublishedTestImage {
 /// use (RUE-2023, RUE-2089). What a watch cycle adds around it stays in
 /// `watch`, exactly as it does for the executable cycle; what a test cycle
 /// adds *after* it — the run — is `test_mode`'s.
-pub(crate) struct TestCycleRequest<'a, 'diagnostics> {
+pub(crate) struct TestCycleRequest<'a> {
     pub(crate) host: &'a mut FilesystemCompilerHost,
     pub(crate) options: &'a CompileOptions,
-    pub(crate) diagnostics: &'a DiagnosticOutput<'diagnostics>,
+    pub(crate) error_format: ErrorFormat,
+    pub(crate) candidates: Option<&'a TestCandidateInventory>,
     /// Where the linked image is staged. Always inside the run's own private
     /// directory, never a path the user named: `rue test` refuses `-o` for
     /// exactly this reason, so no cycle here can publish over a user artifact.
@@ -527,13 +825,30 @@ pub(crate) struct TestCycleRequest<'a, 'diagnostics> {
 /// inventory instead of the executable's metrics.
 pub(crate) type TestCycleReport = CycleReport<PublishedTestImage>;
 
-pub(crate) fn drive_test_cycle(request: TestCycleRequest<'_, '_>) -> TestCycleReport {
+pub(crate) fn produce_test_cycle(request: TestCycleRequest<'_>) -> OwnedCycleResponse<TestImage> {
     let TestCycleRequest {
         host,
         options,
-        diagnostics,
+        error_format,
         image_path,
+        candidates,
         observation,
+        ..
     } = request;
-    drive::<TestImage>(host, options, diagnostics, image_path, observation)
+    let mut response =
+        produce::<TestImage>(host, options, error_format, None, image_path, observation);
+    let report = if matches!(response.result, OwnedCycleResult::Ready { .. }) {
+        candidates.map(|candidates| {
+            host.unimported_test_files(candidates)
+                .map_err(|errors| with_import_migration_helps(&errors))
+        })
+    } else {
+        None
+    };
+    response.attach_unimported_test_files(report);
+    response
 }
+
+#[cfg(test)]
+#[path = "compile_owned_tests.rs"]
+mod owned_tests;

--- a/crates/rue/src/compile_owned_tests.rs
+++ b/crates/rue/src/compile_owned_tests.rs
@@ -1,0 +1,296 @@
+use super::*;
+use rue_compiler::unstable::{MultiFileFormatter, SourceInfo};
+use rue_compiler::{CompilerSessionConfig, RootSelection};
+use rue_driver::{HostOpenRequest, HostPathContext};
+use std::fs;
+use std::path::Path;
+
+struct Project {
+    directory: tempfile::TempDir,
+}
+
+impl Project {
+    fn new(source: &str) -> Self {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("main.rue");
+        fs::write(&root, source).unwrap();
+        Self { directory }
+    }
+
+    fn host(&self) -> FilesystemCompilerHost {
+        let context = HostPathContext::from_working_directory(self.directory.path()).unwrap();
+        FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: "main.rue",
+            source_manifest_path: None,
+            std_root: None,
+            compiler_config: CompilerSessionConfig::with_workers(1).unwrap(),
+            path_context: &context,
+        })
+        .unwrap()
+    }
+
+    fn options(&self, root_selection: RootSelection) -> CompileOptions {
+        CompileOptions {
+            root_selection,
+            ..CompileOptions::default()
+        }
+    }
+}
+
+#[test]
+fn executable_and_test_image_complete_after_host_drop() {
+    let project = Project::new(
+        "fn main() -> i32 { 0 }\n\
+         test \"passes\" { let _value = 1; }\n",
+    );
+    let output = project.directory.path().join("out");
+    let image = project.directory.path().join("image");
+    let mut host = project.host();
+    let options = project.options(RootSelection::Executable);
+    let response = produce::<CompileOutput>(
+        &mut host,
+        &options,
+        ErrorFormat::Text,
+        Some("main.rue"),
+        Path::new("out"),
+        CycleObservation::OneShot,
+    );
+    assert!(
+        !output.exists(),
+        "production must defer publication until response completion"
+    );
+
+    fs::write(
+        project.directory.path().join("main.rue"),
+        "fn main() -> i32 { 1 }\n",
+    )
+    .unwrap();
+    host.reobserve().unwrap();
+    drop(host);
+    assert!(matches!(response.complete(None), CycleReport::Published(_)));
+    assert!(
+        output.is_file(),
+        "completion must publish using owned destination"
+    );
+
+    let fresh_output = project.directory.path().join("fresh-out");
+    let mut fresh_host = project.host();
+    let fresh_options = project.options(RootSelection::Executable);
+    let fresh_response = produce::<CompileOutput>(
+        &mut fresh_host,
+        &fresh_options,
+        ErrorFormat::Text,
+        Some("main.rue"),
+        Path::new("fresh-out"),
+        CycleObservation::OneShot,
+    );
+    assert!(matches!(
+        fresh_response.complete(None),
+        CycleReport::Published(_)
+    ));
+    assert_ne!(
+        fs::read(&output).unwrap(),
+        fs::read(fresh_output).unwrap(),
+        "the retained response must publish its original source revision"
+    );
+
+    let mut host = project.host();
+    let options = project.options(RootSelection::Tests);
+    let response = produce_test_cycle(TestCycleRequest {
+        host: &mut host,
+        options: &options,
+        error_format: ErrorFormat::Text,
+        candidates: None,
+        image_path: Path::new("image"),
+        observation: CycleObservation::OneShot,
+    });
+    assert!(!image.exists(), "test-image production must be deferred");
+    drop(host);
+    assert!(matches!(response.complete(None), CycleReport::Published(_)));
+    assert!(
+        image.is_file(),
+        "test-image completion must publish after handoff"
+    );
+}
+
+#[test]
+fn superseded_owned_cycle_is_silent_and_preserves_existing_output() {
+    let project = Project::new("fn main() -> i32 { 0 }\n");
+    let output = project.directory.path().join("out");
+    fs::write(&output, b"previous").unwrap();
+    let mut host = project.host();
+    let options = project.options(RootSelection::Executable);
+    let inputs = host.watch_inputs();
+    let cancellation = rue_compiler::unstable::CompilationCancellation::new();
+    let response = produce::<CompileOutput>(
+        &mut host,
+        &options,
+        ErrorFormat::Text,
+        Some("main.rue"),
+        Path::new("out"),
+        CycleObservation::Watch {
+            inputs,
+            cancellation,
+            superseded: &|| true,
+        },
+    );
+    drop(host);
+    assert!(matches!(
+        response.complete(Some(Announcement::Completed)),
+        CycleReport::Superseded(Supersession::BeforePublication)
+    ));
+    assert_eq!(fs::read(output).unwrap(), b"previous");
+}
+
+#[test]
+fn owned_preflight_refuses_source_clobber_before_compile() {
+    let project = Project::new("fn main() -> i32 { true }\n");
+    let mut host = project.host();
+    let options = project.options(RootSelection::Executable);
+    let before = host.unstable_metrics().query_runtime();
+    let response = produce::<CompileOutput>(
+        &mut host,
+        &options,
+        ErrorFormat::Text,
+        Some("main.rue"),
+        &project.directory.path().join("main.rue"),
+        CycleObservation::OneShot,
+    );
+    let after = host.unstable_metrics().query_runtime();
+    assert!(matches!(
+        response.result,
+        OwnedCycleResult::Failed {
+            errors: None,
+            publication: Some(PublishError::WouldClobberSource { .. }),
+        }
+    ));
+    assert_eq!(before, after, "preflight must run before compiler queries");
+    assert_eq!(
+        fs::read(project.directory.path().join("main.rue")).unwrap(),
+        b"fn main() -> i32 { true }\n",
+        "preflight must leave the source untouched"
+    );
+}
+
+#[test]
+fn prepared_test_failures_survive_response_handoff() {
+    let original_source = "test \"broken\" { let value: i32 = true; let _ = value; }\n\
+         test \"fine\" { let _value = 1; }\n\
+         fn main() -> i32 { 0 }\n";
+    let project = Project::new(original_source);
+    let mut host = project.host();
+    let options = project.options(RootSelection::Tests);
+    let original_snapshot = host.source_snapshot().clone();
+    let response = produce_test_cycle(TestCycleRequest {
+        host: &mut host,
+        options: &options,
+        error_format: ErrorFormat::Json,
+        candidates: None,
+        image_path: Path::new("image"),
+        observation: CycleObservation::OneShot,
+    });
+    fs::write(
+        project.directory.path().join("main.rue"),
+        "\n\n\n\n\n\
+         test \"broken\" { let value: i32 = false; let _ = value; }\n\
+         test \"fine\" { let _value = 2; }\n\
+         fn main() -> i32 { 0 }\n",
+    )
+    .unwrap();
+    host.reobserve().unwrap();
+    drop(host);
+    let CycleReport::Published(image) = response.complete(None) else {
+        panic!("a surviving test should publish an image");
+    };
+    assert_eq!(image.compile_failures.len(), 1);
+    assert_eq!(image.compile_failures[0].entry.name, "broken");
+    assert_eq!(image.inventory.entries.len(), 2);
+    assert!(
+        image
+            .inventory
+            .entries
+            .iter()
+            .any(|entry| entry.name == "fine"),
+        "a valid sibling must survive the failed test closure"
+    );
+    assert!(!image.compile_failures[0].errors.is_empty());
+    assert!(
+        image.compile_failures[0]
+            .errors
+            .iter()
+            .any(|error| { matches!(error.kind, rue_error::ErrorKind::TypeMismatch { .. }) })
+    );
+    let original_source = original_snapshot.files().next().unwrap();
+    let original_error = image.compile_failures[0]
+        .errors
+        .iter()
+        .find(|error| matches!(error.kind, rue_error::ErrorKind::TypeMismatch { .. }))
+        .unwrap();
+    let original_span = original_error.span().unwrap();
+    assert_eq!(
+        image
+            .source_snapshot
+            .files()
+            .find(|source| source.file_id == original_source.file_id)
+            .unwrap()
+            .source,
+        original_source.source
+    );
+    assert!(
+        image
+            .compile_failures
+            .iter()
+            .all(|failure| failure.entry.name != "fine")
+    );
+    let source_before_span = &original_source.source[..original_span.start as usize];
+    let expected_line = source_before_span.matches('\n').count() as u32 + 1;
+    let expected_column = source_before_span.rsplit('\n').next().unwrap().len() as u32 + 1;
+    let sources = image
+        .source_snapshot
+        .files()
+        .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+        .collect::<Vec<_>>();
+    let text = MultiFileFormatter::new(sources.iter().cloned())
+        .format_errors(&image.compile_failures[0].errors);
+    assert!(
+        text.contains("true"),
+        "retained diagnostics use old source: {text}"
+    );
+    assert!(
+        !text.contains("false"),
+        "diagnostics used successor source: {text}"
+    );
+    let output = DiagnosticOutput::new(ErrorFormat::Json, sources);
+    let json = output.render_prepared_errors(&image.compile_failures[0].errors);
+    assert!(
+        json.contains("type mismatch"),
+        "missing typed JSON diagnostic: {json}"
+    );
+    let diagnostics: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        output.json_prepared_diagnostic_batches(&[&image.compile_failures[0].errors]),
+        vec![diagnostics.clone()],
+        "stderr and test-event diagnostic projections must agree after handoff"
+    );
+    let primary = diagnostics[0]["spans"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|span| span["primary"] == serde_json::Value::Bool(true))
+        .unwrap();
+    assert_eq!(primary["file"], original_source.path);
+    assert_eq!(primary["start"], original_span.start);
+    assert_eq!(primary["end"], original_span.end);
+    assert_eq!(primary["line"], expected_line);
+    assert_eq!(primary["column"], expected_column);
+    assert!(
+        !image
+            .source_snapshot
+            .files()
+            .next()
+            .unwrap()
+            .source
+            .is_empty()
+    );
+    assert_eq!(image.error_format, ErrorFormat::Json);
+}

--- a/crates/rue/src/emit.rs
+++ b/crates/rue/src/emit.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 use rue_compiler::unstable::MetricsSnapshot;
+use rue_compiler::unstable::PresentationOutput;
 #[cfg(test)]
 use rue_compiler::unstable::update_for_presentation;
 #[cfg(test)]
@@ -7,12 +8,13 @@ use rue_compiler::unstable::{
     CanonicalRirPresentationMetrics, ParseMetrics, SemanticMetrics, rooted_cfg,
 };
 use rue_compiler::unstable::{PresentationBatchRequest, PresentationRequest, PresentationStage};
-#[cfg(test)]
-use rue_compiler::{CompileErrors, CompilerSession, RirView, SourceSnapshot};
 use rue_compiler::{
-    CompileOptions, DependencyEnvelope, DependencyEnvelopeStatus, ImportDiscoveryStatus,
+    AcceptedReadManifest, CompileErrors, CompileOptions, DependencyEnvelope,
+    DependencyEnvelopeStatus, ImportDiscoveryStatus, SourceSnapshot,
 };
-use rue_driver::FilesystemCompilerHost;
+#[cfg(test)]
+use rue_compiler::{CompilerSession, RirView};
+use rue_driver::{AttemptedRead, FilesystemCompilerHost, WatchInput};
 #[cfg(test)]
 use rue_error::{CompileError, ErrorKind};
 #[cfg(test)]
@@ -239,77 +241,128 @@ pub(crate) struct EmitRequest<'a, 'diagnostics> {
     pub(crate) diagnostics: &'a DiagnosticOutput<'diagnostics>,
 }
 
-pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
+struct OwnedEmitResponse {
+    source_snapshot: SourceSnapshot,
+    accepted_reads: AcceptedReadManifest,
+    attempted_reads: Vec<AttemptedRead>,
+    watch_inputs: Vec<WatchInput>,
+    error_format: crate::ErrorFormat,
+    target: rue_target::Target,
+    result: OwnedEmitResult,
+}
+
+enum OwnedEmitResult {
+    Dependencies {
+        json: String,
+        errors: Option<CompileErrors>,
+    },
+    Stages(Vec<OwnedEmitStage>),
+    Failed(CompileErrors),
+    InternalFailure(String),
+}
+
+struct OwnedEmitStage {
+    stage: EmitStage,
+    file: Option<String>,
+    output: PresentationOutput,
+}
+
+fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
     let EmitRequest {
         host,
         stages,
         compile_options,
         diagnostics,
     } = request;
-
     let source_snapshot = host.source_snapshot().clone();
+    let accepted_reads = host.accepted_reads().clone();
+    let attempted_reads = host.attempted_reads().to_vec();
+    let watch_inputs = host.watch_inputs();
+    let error_format = diagnostics.format();
+    let target = compile_options.target;
     let discovery_revision = host.discovery_revision().clone();
 
     if stages.contains(&EmitStage::Deps) {
-        // `validate_output_modes` already rejected `--emit deps` mixed with any
-        // other stage before this point, so only the sole-deps case reaches here.
-        debug_assert_eq!(
-            stages.len(),
-            1,
-            "validate_output_modes must reject --emit deps combined with other stages"
-        );
-        let dependency_envelope = DependencyEnvelope::from_closed_revision(&discovery_revision)
-            .expect("closed valid or resolution-incomplete discovery has dependency topology");
+        debug_assert_eq!(stages.len(), 1);
+        let dependency_envelope =
+            match DependencyEnvelope::from_closed_revision(&discovery_revision) {
+                Some(envelope) => envelope,
+                None => {
+                    return OwnedEmitResponse {
+                        source_snapshot,
+                        accepted_reads,
+                        attempted_reads,
+                        watch_inputs,
+                        error_format,
+                        target,
+                        result: OwnedEmitResult::Failed(rue_driver::with_import_migration_helps(
+                            discovery_revision.diagnostics(),
+                        )),
+                    };
+                }
+            };
         let incomplete = dependency_envelope.status == DependencyEnvelopeStatus::Incomplete;
-        match serde_json::to_string_pretty(&dependency_envelope) {
-            Ok(json) => println!("{json}"),
-            Err(error) => {
-                eprintln!("Error emitting dependency envelope: {error}");
-                return Err(());
-            }
-        }
-        if incomplete {
-            diagnostics.print_errors(discovery_revision.diagnostics());
-            return Err(());
-        }
-        return Ok(());
+        let result = match serde_json::to_string_pretty(&dependency_envelope) {
+            Ok(json) => OwnedEmitResult::Dependencies {
+                json,
+                errors: incomplete.then(|| {
+                    rue_driver::with_import_migration_helps(discovery_revision.diagnostics())
+                }),
+            },
+            Err(error) => OwnedEmitResult::InternalFailure(format!(
+                "Error emitting dependency envelope: {error}"
+            )),
+        };
+        return OwnedEmitResponse {
+            source_snapshot,
+            accepted_reads,
+            attempted_reads,
+            watch_inputs,
+            error_format,
+            target,
+            result,
+        };
     }
 
     if discovery_revision.status() != ImportDiscoveryStatus::ClosedValid {
-        diagnostics.print_errors(discovery_revision.diagnostics());
-        return Err(());
+        return OwnedEmitResponse {
+            source_snapshot,
+            accepted_reads,
+            attempted_reads,
+            watch_inputs,
+            error_format,
+            target,
+            result: OwnedEmitResult::Failed(rue_driver::with_import_migration_helps(
+                discovery_revision.diagnostics(),
+            )),
+        };
     }
-    let frontend_route = emit_frontend_route(stages);
-    match frontend_route {
-        EmitFrontendRoute::SessionQuery => {}
+
+    match emit_frontend_route(stages) {
+        EmitFrontendRoute::SessionQuery
+        | EmitFrontendRoute::AstOnlySyntax
+        | EmitFrontendRoute::None => {}
         EmitFrontendRoute::RirOnly => {
-            // RIR is a pre-semantic presentation: force the RIR terminal so its
-            // parse/lowering diagnostics are attributed canonically, but never run
-            // semantic body analysis. Because the trusted-toolchain park is raised
-            // only by reached-body semantic analysis, this performs no park and no
-            // std acquisition — an `--emit rir` run reads zero std modules even for
-            // a reached fallible intrinsic. Semantic-only diagnostics (e.g. an
-            // undefined variable) belong to a normal build or a later `--emit`
-            // stage, not to the untyped-IR presentation.
             if let Err(errors) = host.rir() {
-                diagnostics.print_errors(&errors);
-                return Err(());
+                return OwnedEmitResponse {
+                    source_snapshot,
+                    accepted_reads,
+                    attempted_reads,
+                    watch_inputs,
+                    error_format,
+                    target,
+                    result: OwnedEmitResult::Failed(rue_driver::with_import_migration_helps(
+                        &errors,
+                    )),
+                };
             }
         }
-        EmitFrontendRoute::AstOnlySyntax | EmitFrontendRoute::None => {}
     }
 
     let file_order = source_snapshot
         .files()
         .map(|source| source.file_id)
         .collect::<Vec<_>>();
-
-    // The whole-program stages (RIR and every backend and CFG-side stage) are
-    // presented together, so a run naming several backend stages pays for one
-    // code generation rather than one per stage — the repeated general-inlining
-    // batch a per-stage call incurred at O2/O3 (RUE-1728). Their outputs come
-    // back in the order named. The per-file stages (tokens, AST) keep their own
-    // per-file rendering and are presented as they are reached.
     let whole_program_stages: Vec<PresentationStage> = stages
         .iter()
         .filter_map(|stage| match stage {
@@ -326,23 +379,33 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
             EmitStage::Tokens | EmitStage::Ast | EmitStage::Deps => None,
         })
         .collect();
-    let mut whole_program_outputs = if whole_program_stages.is_empty() {
-        std::collections::VecDeque::new()
+    let whole_program_outputs = if whole_program_stages.is_empty() {
+        Vec::new()
     } else {
         match host.present_many(PresentationBatchRequest {
             stages: &whole_program_stages,
             options: &compile_options,
             file_order: &file_order,
         }) {
-            Ok(outputs) => std::collections::VecDeque::from(outputs),
+            Ok(outputs) => outputs,
             Err(errors) => {
-                diagnostics.print_errors(&errors);
-                return Err(());
+                return OwnedEmitResponse {
+                    source_snapshot,
+                    accepted_reads,
+                    attempted_reads,
+                    watch_inputs,
+                    error_format,
+                    target,
+                    result: OwnedEmitResult::Failed(rue_driver::with_import_migration_helps(
+                        &errors,
+                    )),
+                };
             }
         }
     };
 
-    let mut warnings_printed = false;
+    let mut whole_program_index = 0;
+    let mut outputs = Vec::new();
     for stage in stages {
         if matches!(stage, EmitStage::Tokens | EmitStage::Ast) {
             let unstable_stage = match stage {
@@ -350,25 +413,36 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
                 EmitStage::Ast => PresentationStage::Ast,
                 _ => unreachable!(),
             };
-            for source in source_snapshot.files() {
-                match stage {
-                    EmitStage::Tokens => println!("=== Tokens ({}) ===", source.path),
-                    EmitStage::Ast => println!("=== AST ({}) ===", source.path),
-                    _ => unreachable!(),
-                }
+            let files = source_snapshot
+                .files()
+                .map(|source| (source.file_id, source.path.to_owned()))
+                .collect::<Vec<_>>();
+            for (file_id, file_path) in files {
                 let output = match host.present(PresentationRequest {
                     stage: unstable_stage,
                     options: &compile_options,
-                    file_order: &[source.file_id],
+                    file_order: &[file_id],
                 }) {
                     Ok(output) => output,
                     Err(errors) => {
-                        diagnostics.print_errors(&errors);
-                        return Err(());
+                        return OwnedEmitResponse {
+                            source_snapshot,
+                            accepted_reads,
+                            attempted_reads,
+                            watch_inputs,
+                            error_format,
+                            target,
+                            result: OwnedEmitResult::Failed(
+                                rue_driver::with_import_migration_helps(&errors),
+                            ),
+                        };
                     }
                 };
-                print!("{}", output.as_str());
-                println!();
+                outputs.push(OwnedEmitStage {
+                    stage: *stage,
+                    file: Some(file_path),
+                    output,
+                });
             }
             continue;
         }
@@ -376,62 +450,148 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
             continue;
         }
         let output = whole_program_outputs
-            .pop_front()
-            .expect("one whole-program output per whole-program stage");
-        if !warnings_printed && emit_requires_semantic(&[*stage]) {
-            diagnostics.print_warnings(output.warnings());
-            warnings_printed = true;
+            .get(whole_program_index)
+            .expect("one whole-program output per whole-program stage")
+            .clone();
+        whole_program_index += 1;
+        outputs.push(OwnedEmitStage {
+            stage: *stage,
+            file: None,
+            output,
+        });
+    }
+    OwnedEmitResponse {
+        source_snapshot,
+        accepted_reads,
+        attempted_reads,
+        watch_inputs,
+        error_format,
+        target,
+        result: OwnedEmitResult::Stages(outputs),
+    }
+}
+
+fn complete(response: OwnedEmitResponse) -> Result<(), ()> {
+    let OwnedEmitResponse {
+        source_snapshot,
+        accepted_reads,
+        attempted_reads,
+        watch_inputs,
+        error_format,
+        target,
+        result,
+    } = response;
+    consume_emit_observations(accepted_reads, attempted_reads, watch_inputs);
+    let sources = source_snapshot
+        .files()
+        .map(|source| {
+            (
+                source.file_id,
+                rue_compiler::unstable::SourceInfo::new(source.source, source.path),
+            )
+        })
+        .collect();
+    let diagnostics = DiagnosticOutput::new(error_format, sources);
+    match result {
+        OwnedEmitResult::InternalFailure(message) => {
+            eprintln!("{message}");
+            Err(())
         }
-        match stage {
-            EmitStage::Tokens | EmitStage::Ast => unreachable!(),
-            EmitStage::Rir => {
-                println!("=== RIR ===");
-                println!("{}", output.as_str());
-                println!();
+        OwnedEmitResult::Failed(errors) => {
+            diagnostics.print_prepared_errors(&errors);
+            Err(())
+        }
+        OwnedEmitResult::Dependencies { json, errors } => {
+            println!("{json}");
+            if let Some(errors) = errors {
+                diagnostics.print_prepared_errors(&errors);
+                Err(())
+            } else {
+                Ok(())
             }
-            EmitStage::Air => {
-                println!("=== AIR ===");
-                print!("{}", output.as_str());
-                println!();
+        }
+        OwnedEmitResult::Stages(outputs) => {
+            let mut warnings_printed = false;
+            for owned in outputs {
+                let output = owned.output;
+                if let Some(file) = owned.file {
+                    match owned.stage {
+                        EmitStage::Tokens => println!("=== Tokens ({file}) ==="),
+                        EmitStage::Ast => println!("=== AST ({file}) ==="),
+                        _ => unreachable!(),
+                    }
+                    print!("{}", output.as_str());
+                    println!();
+                    continue;
+                }
+                if !warnings_printed && emit_requires_semantic(&[owned.stage]) {
+                    diagnostics.print_warnings(output.warnings());
+                    warnings_printed = true;
+                }
+                match owned.stage {
+                    EmitStage::Rir => {
+                        println!("=== RIR ===");
+                        println!("{}", output.as_str());
+                        println!();
+                    }
+                    EmitStage::Air => {
+                        println!("=== AIR ===");
+                        print!("{}", output.as_str());
+                        println!();
+                    }
+                    EmitStage::Cfg => {
+                        println!("=== CFG ===");
+                        print!("{}", output.as_str());
+                        println!();
+                    }
+                    EmitStage::Lowering => println!("{}", output.as_str()),
+                    EmitStage::Mir => {
+                        println!("=== MIR ({target}) ===");
+                        println!("{}", output.as_str());
+                    }
+                    EmitStage::Liveness => {
+                        println!("=== Liveness Analysis ({target}) ===");
+                        println!("{}", output.as_str());
+                    }
+                    EmitStage::RegAlloc => {
+                        println!("=== Register Allocation ({target}) ===");
+                        println!("{}", output.as_str());
+                    }
+                    EmitStage::Asm => {
+                        println!("=== Assembly ({target}) ===");
+                        println!("{}", output.as_str());
+                    }
+                    EmitStage::StackFrame => print!("{}", output.as_str()),
+                    EmitStage::Abi => {
+                        println!("=== ABI ({target}) ===");
+                        print!("{}", output.as_str());
+                    }
+                    EmitStage::Tokens | EmitStage::Ast | EmitStage::Deps => unreachable!(),
+                }
             }
-            EmitStage::Cfg => {
-                println!("=== CFG ===");
-                print!("{}", output.as_str());
-                println!();
-            }
-            EmitStage::Lowering => {
-                println!("{}", output.as_str());
-            }
-            EmitStage::Mir => {
-                println!("=== MIR ({}) ===", compile_options.target);
-                println!("{}", output.as_str());
-            }
-            EmitStage::Liveness => {
-                println!("=== Liveness Analysis ({}) ===", compile_options.target);
-                println!("{}", output.as_str());
-            }
-            EmitStage::RegAlloc => {
-                println!("=== Register Allocation ({}) ===", compile_options.target);
-                println!("{}", output.as_str());
-            }
-            EmitStage::Asm => {
-                println!("=== Assembly ({}) ===", compile_options.target);
-                println!("{}", output.as_str());
-            }
-            EmitStage::StackFrame => {
-                print!("{}", output.as_str());
-            }
-            EmitStage::Abi => {
-                println!("=== ABI ({}) ===", compile_options.target);
-                print!("{}", output.as_str());
-            }
-            // Dependency presentation returns before frontend planning above.
-            EmitStage::Deps => {}
+            Ok(())
         }
     }
-
-    Ok(())
 }
+
+fn consume_emit_observations(
+    accepted_reads: AcceptedReadManifest,
+    attempted_reads: Vec<AttemptedRead>,
+    watch_inputs: Vec<WatchInput>,
+) {
+    // The response owns the exact closure and last attempt even though emit's
+    // presentation surface has no event field for them. Consume them at the
+    // completion boundary rather than consulting a successor host state.
+    drop((accepted_reads, attempted_reads, watch_inputs));
+}
+
+pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
+    complete(produce(request))
+}
+
+#[cfg(test)]
+#[path = "emit_owned_tests.rs"]
+mod owned_tests;
 
 #[cfg(test)]
 mod output_mode_tests {

--- a/crates/rue/src/emit_owned_tests.rs
+++ b/crates/rue/src/emit_owned_tests.rs
@@ -1,0 +1,192 @@
+use super::*;
+use crate::ErrorFormat;
+use rue_compiler::{CompilerSessionConfig, OptLevel};
+use rue_driver::{HostOpenRequest, HostPathContext};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+struct Project {
+    directory: tempfile::TempDir,
+    path: PathBuf,
+}
+
+impl Project {
+    fn new(source: &str) -> Self {
+        let directory = tempfile::tempdir().unwrap();
+        let path = fs::canonicalize(directory.path()).unwrap();
+        fs::create_dir(path.join("app")).unwrap();
+        fs::write(path.join("app/main.rue"), source).unwrap();
+        Self { directory, path }
+    }
+
+    fn open(&self, std_root: Option<&Path>) -> FilesystemCompilerHost {
+        FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: "app/main.rue",
+            source_manifest_path: None,
+            std_root,
+            compiler_config: CompilerSessionConfig::with_workers(1).unwrap(),
+            path_context: &HostPathContext::from_working_directory(self.path.clone()).unwrap(),
+        })
+        .unwrap()
+    }
+
+    fn write(&self, source: &str) {
+        fs::write(self.path.join("app/main.rue"), source).unwrap();
+    }
+}
+
+fn response(host: &mut FilesystemCompilerHost, stages: &[EmitStage]) -> OwnedEmitResponse {
+    // A completion must use the response's sources, even when the thin
+    // caller's formatter has no source context of its own.
+    let diagnostics = DiagnosticOutput::new(ErrorFormat::Json, Vec::new());
+    produce(EmitRequest {
+        host,
+        stages,
+        compile_options: CompileOptions {
+            opt_level: OptLevel::O0,
+            ..CompileOptions::default()
+        },
+        diagnostics: &diagnostics,
+    })
+}
+
+fn stages(response: &OwnedEmitResponse) -> &Vec<OwnedEmitStage> {
+    let OwnedEmitResult::Stages(stages) = &response.result else {
+        panic!("the fixture must produce its requested presentation");
+    };
+    stages
+}
+
+fn errors(response: &OwnedEmitResponse) -> &CompileErrors {
+    match &response.result {
+        OwnedEmitResult::Failed(errors)
+        | OwnedEmitResult::Dependencies {
+            errors: Some(errors),
+            ..
+        } => errors,
+        _ => panic!("the fixture must carry its import diagnostic"),
+    }
+}
+
+fn render_errors(response: &OwnedEmitResponse, format: ErrorFormat) -> String {
+    let sources = response
+        .source_snapshot
+        .files()
+        .map(|source| {
+            (
+                source.file_id,
+                rue_compiler::unstable::SourceInfo::new(source.source, source.path),
+            )
+        })
+        .collect();
+    DiagnosticOutput::new(format, sources).render_prepared_errors(errors(response))
+}
+
+#[test]
+fn owned_air_remains_the_requested_revision_after_host_refresh_and_drop() {
+    let project = Project::new("fn main() -> i32 { 1 }\n");
+    let mut host = project.open(None);
+    let owned = response(&mut host, &[EmitStage::Air]);
+    assert_eq!(&owned.accepted_reads, host.accepted_reads());
+    assert_eq!(owned.attempted_reads, host.attempted_reads());
+    assert_eq!(owned.watch_inputs, host.watch_inputs());
+    let original = stages(&owned)[0].output.as_str().to_owned();
+    assert_eq!(stages(&owned)[0].stage, EmitStage::Air);
+
+    project.write("fn main() -> i32 { 2 }\n");
+    host.reobserve().unwrap();
+    let successor = response(&mut host, &[EmitStage::Air]);
+    assert_ne!(owned.accepted_reads, successor.accepted_reads);
+    assert_ne!(stages(&successor)[0].output.as_str(), original);
+    let fresh = response(&mut project.open(None), &[EmitStage::Air]);
+    assert_eq!(stages(&successor)[0].output, stages(&fresh)[0].output);
+    drop(host);
+    project.directory.close().unwrap();
+
+    assert_eq!(stages(&owned)[0].output.as_str(), original);
+    assert_eq!(
+        owned.source_snapshot.files().next().unwrap().source,
+        "fn main() -> i32 { 1 }\n"
+    );
+    assert!(complete(owned).is_ok());
+}
+
+#[test]
+fn owned_analysis_and_incomplete_dependencies_freeze_import_help_and_locations() {
+    let project = Project::new("const sibling = @import(\"sibling\");\nfn main() -> i32 { 0 }\n");
+    fs::write(
+        project.path.join("app/sibling.rue"),
+        "pub fn value() -> i32 { 1 }\n",
+    )
+    .unwrap();
+    let mut host = project.open(None);
+    let analysis = response(&mut host, &[EmitStage::Air]);
+    let dependencies = response(&mut host, &[EmitStage::Deps]);
+    assert!(errors(&analysis).iter().any(|error| {
+        matches!(&error.kind, rue_error::ErrorKind::ModuleNotFound { path, .. } if path == "sibling")
+    }));
+    let text = render_errors(&analysis, ErrorFormat::Text);
+    let json = render_errors(&analysis, ErrorFormat::Json);
+    assert!(text.contains("@import(\"sibling\")"), "{text}");
+    assert_eq!(text.matches("extensionless import names").count(), 1);
+    assert_eq!(json.matches("extensionless import names").count(), 1);
+    assert_eq!(render_errors(&dependencies, ErrorFormat::Json), json);
+    let OwnedEmitResult::Dependencies { json: envelope, .. } = &dependencies.result else {
+        panic!("incomplete discovery must retain its dependency envelope");
+    };
+    let envelope: serde_json::Value = serde_json::from_str(envelope).unwrap();
+    assert_eq!(envelope["status"], "incomplete");
+
+    fs::remove_file(project.path.join("app/sibling.rue")).unwrap();
+    project.write("fn main() -> i32 { 99 }\n");
+    host.reobserve().unwrap();
+    assert!(matches!(
+        response(&mut host, &[EmitStage::Air]).result,
+        OwnedEmitResult::Stages(_)
+    ));
+    drop(host);
+    project.directory.close().unwrap();
+
+    assert_eq!(render_errors(&analysis, ErrorFormat::Text), text);
+    assert_eq!(render_errors(&analysis, ErrorFormat::Json), json);
+    assert_eq!(render_errors(&dependencies, ErrorFormat::Json), json);
+    assert!(complete(analysis).is_err());
+    assert!(complete(dependencies).is_err());
+}
+
+#[test]
+fn owned_syntax_batch_keeps_stage_order_without_acquiring_missing_std() {
+    let project = Project::new("fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }\n");
+    let mut host = project.open(Some(Path::new("unavailable-std")));
+    let attempted = host.attempted_reads().to_vec();
+    let requested = [EmitStage::Ast, EmitStage::Rir, EmitStage::Tokens];
+    let owned = response(&mut host, &requested);
+    assert_eq!(
+        stages(&owned)
+            .iter()
+            .map(|stage| stage.stage)
+            .collect::<Vec<_>>(),
+        requested
+    );
+    assert!(
+        stages(&owned)[0]
+            .file
+            .as_ref()
+            .unwrap()
+            .ends_with("main.rue")
+    );
+    assert_eq!(stages(&owned)[1].file, None);
+    assert!(
+        stages(&owned)[2]
+            .file
+            .as_ref()
+            .unwrap()
+            .ends_with("main.rue")
+    );
+    assert_eq!(host.source_snapshot().len(), 1);
+    assert_eq!(host.accepted_reads().len(), 1);
+    assert_eq!(host.attempted_reads(), attempted.as_slice());
+    drop(host);
+    project.directory.close().unwrap();
+    assert!(complete(owned).is_ok());
+}

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -1,6 +1,7 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rue_compiler::unstable::TestCandidateInventory;
+use rue_compiler::unstable::normalize_module_path;
 use rue_compiler::unstable::{
     CancellableCompileOutcome, CancellableTestImageOutcome, CodegenReady, CompilationCancellation,
     ObjectsReady, PresentationBatchRequest, PresentationOutput, PresentationRequest, TestImage,
@@ -22,16 +23,74 @@ use crate::source_loader::{
 };
 
 /// Immutable filesystem configuration captured when a retained host opens.
+#[derive(Clone, Debug)]
+pub struct HostPathContext {
+    working_directory: PathBuf,
+}
+
+impl HostPathContext {
+    /// Capture the invocation directory once so retained hosts never resolve
+    /// relative inputs against a later ambient working directory.
+    pub fn capture() -> Result<Self, String> {
+        std::env::current_dir()
+            .map(|working_directory| Self { working_directory })
+            .map_err(|error| format!("could not capture invocation directory: {error}"))
+    }
+
+    /// Construct a context for an embedding caller that already owns its path
+    /// resolution boundary.
+    pub fn from_working_directory(working_directory: impl Into<PathBuf>) -> Result<Self, String> {
+        let working_directory = working_directory.into();
+        if !working_directory.is_absolute() {
+            return Err(format!(
+                "invocation directory must be absolute: {}",
+                working_directory.display()
+            ));
+        }
+        Ok(Self { working_directory })
+    }
+
+    pub fn working_directory(&self) -> &Path {
+        &self.working_directory
+    }
+
+    /// Resolve an invocation spelling without consulting the ambient process
+    /// directory. The context is captured once at the request boundary.
+    pub fn resolve(&self, path: &Path) -> PathBuf {
+        let anchored = if path.is_absolute() {
+            path.to_owned()
+        } else {
+            self.working_directory.join(path)
+        };
+        PathBuf::from(normalize_module_path(&anchored.to_string_lossy()))
+    }
+
+    /// Anchor a client filesystem spelling to the captured invocation
+    /// directory while preserving symlinks and `..` components. Compiler
+    /// module identities use [`Self::resolve`]'s lexical normalization; link
+    /// archives, output paths, and reproductions are ordinary filesystem
+    /// arguments and must retain their requested route.
+    pub fn anchor(&self, path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            path.to_owned()
+        } else {
+            self.working_directory.join(path)
+        }
+    }
+}
+
 pub struct HostOpenRequest<'a> {
     pub root_source: &'a str,
     pub source_manifest_path: Option<&'a str>,
     pub std_root: Option<&'a Path>,
     pub compiler_config: CompilerSessionConfig,
+    pub path_context: &'a HostPathContext,
 }
 
 /// One canonical filesystem observer and retained compiler session.
 pub struct FilesystemCompilerHost {
     state: ImportDiscoveryResult,
+    path_context: HostPathContext,
 }
 
 impl FilesystemCompilerHost {
@@ -42,8 +101,12 @@ impl FilesystemCompilerHost {
             source_manifest_path: request.source_manifest_path,
             std_root: request.std_root,
             compiler_config: request.compiler_config,
+            path_context: request.path_context,
         })
-        .map(|state| Self { state })
+        .map(|state| Self {
+            state,
+            path_context: request.path_context.clone(),
+        })
     }
 
     /// Re-observe the exact accepted-read closure and publish its successor.
@@ -126,6 +189,14 @@ impl FilesystemCompilerHost {
 
     pub fn root_path(&self) -> &Path {
         &self.state.resolution.root_path
+    }
+
+    pub fn resolve_path(&self, path: &Path) -> PathBuf {
+        self.path_context.resolve(path)
+    }
+
+    pub fn anchor_path(&self, path: &Path) -> PathBuf {
+        self.path_context.anchor(path)
     }
 
     pub fn discovery_context(&self) -> &ImportDiscoveryContext {
@@ -354,6 +425,7 @@ mod tests {
                 source_manifest_path: None,
                 std_root: None,
                 compiler_config: CompilerSessionConfig::default(),
+                path_context: &HostPathContext::capture().unwrap(),
             })
             .unwrap()
         }
@@ -363,6 +435,20 @@ mod tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[test]
+    fn path_context_requires_an_absolute_invocation_directory() {
+        assert!(HostPathContext::from_working_directory("relative").is_err());
+    }
+
+    #[test]
+    fn path_context_resolves_relative_paths_against_its_captured_directory() {
+        let context = HostPathContext::from_working_directory("/tmp/rue-context").unwrap();
+        assert_eq!(
+            context.resolve(Path::new("./out/../program")),
+            PathBuf::from("/tmp/rue-context/program")
+        );
     }
 
     fn run_to_runnable(host: &mut FilesystemCompilerHost) -> CompileOutput {
@@ -455,6 +541,7 @@ mod tests {
             source_manifest_path: Some(manifest.to_str().unwrap()),
             std_root: None,
             compiler_config: CompilerSessionConfig::default(),
+            path_context: &HostPathContext::capture().unwrap(),
         })
         .unwrap();
 
@@ -487,6 +574,7 @@ mod tests {
             source_manifest_path: None,
             std_root: Some(&std_root),
             compiler_config: CompilerSessionConfig::default(),
+            path_context: &HostPathContext::capture().unwrap(),
         })
         .unwrap();
 
@@ -636,6 +724,7 @@ mod test_candidate_acquisition_tests {
             source_manifest_path: Some(manifest.to_str().unwrap()),
             std_root: None,
             compiler_config: CompilerSessionConfig::default(),
+            path_context: &HostPathContext::capture().unwrap(),
         })
         .unwrap();
         let inventory = host.acquire_test_candidates(&declared).unwrap();
@@ -683,6 +772,7 @@ mod test_candidate_acquisition_tests {
             source_manifest_path: None,
             std_root: None,
             compiler_config: CompilerSessionConfig::default(),
+            path_context: &HostPathContext::capture().unwrap(),
         })
         .unwrap();
         let inventory = host

--- a/crates/rue/src/host_workflow_tests.rs
+++ b/crates/rue/src/host_workflow_tests.rs
@@ -1,0 +1,589 @@
+//! Retained hosts share root selections and keep invocation paths isolated.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rue_compiler::unstable::{
+    EndpointWork, PresentationBatchRequest, PresentationOutput, PresentationStage,
+    QueryRuntimeMetrics, TestImage, TestListing,
+};
+use rue_compiler::{
+    CompileErrors, CompileOptions, CompileOutput, CompilerSessionConfig, OptLevel, RootSelection,
+};
+use rue_error::ErrorKind;
+
+use crate::{FilesystemCompilerHost, HostOpenRequest, HostPathContext};
+
+struct Project(PathBuf);
+
+impl Project {
+    fn new() -> Self {
+        static NEXT: AtomicUsize = AtomicUsize::new(0);
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "rue-host-workflow-{}-{timestamp}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&path).unwrap();
+        Self(fs::canonicalize(path).unwrap())
+    }
+
+    fn write(&self, source: &str) {
+        fs::write(self.0.join("main.rue"), source).unwrap();
+    }
+
+    fn open(&self) -> FilesystemCompilerHost {
+        let path_context = HostPathContext::from_working_directory(self.0.clone()).unwrap();
+        FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: "main.rue",
+            source_manifest_path: None,
+            std_root: None,
+            compiler_config: CompilerSessionConfig::with_workers(1).unwrap(),
+            path_context: &path_context,
+        })
+        .unwrap()
+    }
+}
+
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn options(root_selection: RootSelection) -> CompileOptions {
+    CompileOptions {
+        opt_level: OptLevel::O0,
+        root_selection,
+        ..CompileOptions::default()
+    }
+}
+
+fn acquire(host: &mut FilesystemCompilerHost, options: &CompileOptions) {
+    host.acquire_reached_toolchain_modules(options)
+        .expect("the fixture's reached toolchain demands must be satisfied");
+}
+
+fn air(host: &mut FilesystemCompilerHost) -> Result<PresentationOutput, CompileErrors> {
+    let options = options(RootSelection::Executable);
+    acquire(host, &options);
+    let file_order = host
+        .source_snapshot()
+        .files()
+        .map(|source| source.file_id)
+        .collect::<Vec<_>>();
+    host.present_many(PresentationBatchRequest {
+        stages: &[PresentationStage::Air],
+        options: &options,
+        file_order: &file_order,
+    })
+    .map(|mut outputs| {
+        assert_eq!(outputs.len(), 1);
+        outputs.remove(0)
+    })
+}
+
+fn listing(host: &mut FilesystemCompilerHost) -> Result<TestListing, CompileErrors> {
+    let options = options(RootSelection::Tests);
+    acquire(host, &options);
+    host.test_inventory(&options)
+}
+
+fn image(host: &mut FilesystemCompilerHost) -> Result<TestImage, CompileErrors> {
+    let options = options(RootSelection::Tests);
+    acquire(host, &options);
+    host.test_image_in_compile_scope(&options)
+}
+
+struct Build {
+    output: CompileOutput,
+    work: EndpointWork,
+    queries: QueryRuntimeMetrics,
+}
+
+fn build(host: &mut FilesystemCompilerHost) -> Result<Build, CompileErrors> {
+    // Acquisition can itself analyze bodies, so include it in the measured
+    // request rather than counting only the final artifact lookup.
+    let before = host.unstable_metrics().query_runtime();
+    let options = options(RootSelection::Executable);
+    acquire(host, &options);
+    let codegen = host.codegen_ready(&options)?;
+    let objects = host.objects_ready(codegen)?;
+    let work = objects.unstable_work();
+    let output = host.runnable_ready(objects)?;
+    let queries = host
+        .unstable_metrics()
+        .query_runtime()
+        .saturating_sub(before);
+    Ok(Build {
+        output,
+        work,
+        queries,
+    })
+}
+
+fn assert_output_eq(actual: &CompileOutput, expected: &CompileOutput) {
+    assert_eq!(actual.elf, expected.elf);
+    assert_eq!(actual.warnings, expected.warnings);
+}
+
+fn assert_listing_eq(actual: &TestListing, expected: &TestListing) {
+    assert_eq!(actual.inventory, expected.inventory);
+    assert_eq!(
+        actual.failure_diagnostics.as_slice(),
+        expected.failure_diagnostics.as_slice()
+    );
+}
+
+fn assert_image_eq(actual: &TestImage, expected: &TestImage) {
+    assert_output_eq(&actual.output, &expected.output);
+    assert_eq!(actual.inventory, expected.inventory);
+    assert_eq!(
+        actual.failure_diagnostics.as_slice(),
+        expected.failure_diagnostics.as_slice()
+    );
+    assert_eq!(
+        actual.compile_failures.len(),
+        expected.compile_failures.len()
+    );
+    for (actual, expected) in actual
+        .compile_failures
+        .iter()
+        .zip(&expected.compile_failures)
+    {
+        assert_eq!(actual.entry, expected.entry);
+        assert_eq!(actual.errors.as_slice(), expected.errors.as_slice());
+    }
+}
+
+fn assert_type_mismatch(errors: &CompileErrors) {
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error.kind, ErrorKind::TypeMismatch { .. })),
+        "expected the fixture's type error, got {errors:?}"
+    );
+}
+
+const SHARED_PROGRAM: &str = "\
+fn shared(x: i32) -> i32 { x + 1 }\n\
+fn main() -> i32 { shared(6) }\n\
+test \"shared helper\" { let _value = shared(6); }\n";
+
+#[test]
+fn mixed_analysis_listing_image_build_reuses_shared_functions() {
+    let project = Project::new();
+    project.write(SHARED_PROGRAM);
+    let mut retained = project.open();
+
+    let first_air = air(&mut retained).unwrap();
+    assert_eq!(first_air, air(&mut project.open()).unwrap());
+    assert!(!first_air.as_str().contains("shared helper"));
+
+    let listed = listing(&mut retained).unwrap();
+    assert_listing_eq(&listed, &listing(&mut project.open()).unwrap());
+    assert_eq!(listed.inventory.entries.len(), 1);
+    assert_eq!(listed.inventory.entries[0].id, "main.rue::shared helper");
+    assert_eq!(listed.inventory.entries[0].ordinal, 0);
+
+    let test_image = image(&mut retained).unwrap();
+    assert_image_eq(&test_image, &image(&mut project.open()).unwrap());
+
+    let executable = build(&mut retained).unwrap();
+    let fresh = build(&mut project.open()).unwrap();
+    assert_output_eq(&executable.output, &fresh.output);
+    let mut direct = project.open();
+    let executable_options = options(RootSelection::Executable);
+    acquire(&mut direct, &executable_options);
+    assert_output_eq(
+        &executable.output,
+        &direct
+            .executable_in_compile_scope(&executable_options)
+            .unwrap(),
+    );
+    assert_eq!(air(&mut retained).unwrap(), first_air);
+
+    // AIR already prepared main/shared's semantic bodies and CFGs. The image
+    // then generated shared and the test, but never the source main. Of this
+    // executable's two functions, shared is therefore the reused backend
+    // unit and main is the newly computed one.
+    assert_eq!(executable.work.semantic.computed, 0);
+    assert_eq!(executable.work.semantic.reused, 2);
+    assert_eq!(executable.work.cfg.computed, 0);
+    assert_eq!(executable.work.cfg.reused, 2);
+    assert_eq!(executable.work.codegen.computed, 1);
+    assert_eq!(executable.work.codegen.reused, 1);
+    // Internal linking uses structured codegen units without serializing
+    // objects. The explicit object endpoint above is the first consumer of
+    // these projections, so neither was available for reuse yet.
+    assert_eq!(executable.work.object_projection.computed, 2);
+    assert_eq!(executable.work.object_projection.reused, 0);
+    assert!(executable.queries.reuses > 0);
+    assert!(
+        executable.queries.body_completions < fresh.queries.body_completions,
+        "the whole warm request must compute fewer query bodies than a fresh build"
+    );
+
+    assert_image_eq(&image(&mut retained).unwrap(), &test_image);
+    let rebuilt = build(&mut retained).unwrap();
+    assert_output_eq(&rebuilt.output, &executable.output);
+    assert_eq!(rebuilt.work.codegen.computed, 0);
+    assert_eq!(rebuilt.work.codegen.reused, 2);
+    assert_eq!(rebuilt.work.object_projection.computed, 0);
+    assert_eq!(rebuilt.work.object_projection.reused, 2);
+}
+
+#[test]
+fn mixed_requests_keep_broken_test_attribution_out_of_executables() {
+    let project = Project::new();
+    project.write(
+        "\
+fn shared(x: i32) -> i32 { x + 1 }\n\
+fn main() -> i32 { shared(6) }\n\
+test \"broken\" { let _bad: i32 = true; }\n\
+test \"fine\" { let _value = shared(6); }\n",
+    );
+    let mut retained = project.open();
+
+    assert_eq!(
+        air(&mut retained).unwrap(),
+        air(&mut project.open()).unwrap()
+    );
+    let listed = listing(&mut retained).unwrap();
+    assert_listing_eq(&listed, &listing(&mut project.open()).unwrap());
+    assert_eq!(listed.inventory.entries.len(), 2);
+    assert_type_mismatch(&listed.failure_diagnostics);
+
+    let test_image = image(&mut retained).unwrap();
+    assert_image_eq(&test_image, &image(&mut project.open()).unwrap());
+    assert_eq!(test_image.inventory, listed.inventory);
+    assert_eq!(test_image.compile_failures.len(), 1);
+    let failure = &test_image.compile_failures[0];
+    assert_eq!(failure.entry.id, "main.rue::broken");
+    assert_eq!(failure.entry.ordinal, 0);
+    assert_eq!(test_image.inventory.entries[1].id, "main.rue::fine");
+    assert_eq!(test_image.inventory.entries[1].ordinal, 1);
+    assert_type_mismatch(&failure.errors);
+    assert_eq!(test_image.failure_diagnostics.len(), 1);
+
+    assert_output_eq(
+        &build(&mut retained).unwrap().output,
+        &build(&mut project.open()).unwrap().output,
+    );
+    assert_eq!(
+        air(&mut retained).unwrap(),
+        air(&mut project.open()).unwrap()
+    );
+    // Excluding broken from the runnable image must not change later roots.
+    assert_listing_eq(&listing(&mut retained).unwrap(), &listed);
+}
+
+#[test]
+fn mixed_requests_keep_main_errors_out_of_tests_and_recover_after_edit() {
+    let project = Project::new();
+    project.write(
+        "\
+fn shared(x: i32) -> i32 { x + 1 }\n\
+fn main() -> i32 { true }\n\
+test \"shared helper\" { let _value = shared(6); }\n",
+    );
+    let mut retained = project.open();
+
+    let errors = air(&mut retained).unwrap_err();
+    assert_type_mismatch(&errors);
+    assert_eq!(
+        errors.as_slice(),
+        air(&mut project.open()).unwrap_err().as_slice()
+    );
+    let listed = listing(&mut retained).unwrap();
+    assert_listing_eq(&listed, &listing(&mut project.open()).unwrap());
+    assert!(listed.failure_diagnostics.is_empty());
+    let test_image = image(&mut retained).unwrap();
+    assert_image_eq(&test_image, &image(&mut project.open()).unwrap());
+    assert!(test_image.compile_failures.is_empty());
+    let errors = build(&mut retained).err().expect("main is still ill-typed");
+    assert_type_mismatch(&errors);
+    let fresh_errors = build(&mut project.open())
+        .err()
+        .expect("fresh main is ill-typed too");
+    assert_eq!(errors.as_slice(), fresh_errors.as_slice());
+    assert_listing_eq(&listing(&mut retained).unwrap(), &listed);
+
+    project.write(SHARED_PROGRAM);
+    retained.reobserve().unwrap();
+    assert_eq!(
+        air(&mut retained).unwrap(),
+        air(&mut project.open()).unwrap()
+    );
+    assert_listing_eq(
+        &listing(&mut retained).unwrap(),
+        &listing(&mut project.open()).unwrap(),
+    );
+    assert_image_eq(
+        &image(&mut retained).unwrap(),
+        &image(&mut project.open()).unwrap(),
+    );
+    assert_output_eq(
+        &build(&mut retained).unwrap().output,
+        &build(&mut project.open()).unwrap().output,
+    );
+}
+
+#[test]
+fn explicit_contexts_keep_relative_inputs_isolated_across_reobservation() {
+    let projects = [Project::new(), Project::new()];
+    for (index, project) in projects.iter().enumerate() {
+        for directory in ["app", "control", "library"] {
+            fs::create_dir(project.0.join(directory)).unwrap();
+        }
+        fs::write(
+            project.0.join("app/main.rue"),
+            "const helper = @import(\"helper.rue\");\n\
+             fn main() -> i32 { let _ = @parse_i64(\"1\"); helper.value() }\n",
+        )
+        .unwrap();
+        fs::write(
+            project.0.join("app/helper.rue"),
+            format!("pub fn value() -> i32 {{ {} }}\n", index + 1),
+        )
+        .unwrap();
+        fs::write(
+            project.0.join("app/orphan.rue"),
+            "test \"not imported\" { }\n",
+        )
+        .unwrap();
+        fs::write(
+            project.0.join("library/option.rue"),
+            "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }\n",
+        )
+        .unwrap();
+        fs::write(
+            project.0.join("control/sources.list"),
+            "../app/main.rue\n../app/helper.rue\n../app/orphan.rue\n../library/option.rue\n",
+        )
+        .unwrap();
+    }
+    let open = |project: &Project| {
+        let context = HostPathContext::from_working_directory(project.0.clone()).unwrap();
+        FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: "app/main.rue",
+            source_manifest_path: Some("control/sources.list"),
+            std_root: Some(Path::new("library")),
+            compiler_config: CompilerSessionConfig::with_workers(1).unwrap(),
+            path_context: &context,
+        })
+        .unwrap()
+    };
+    // Neither opening nor alternating the hosts changes the process cwd.
+    // Each relative manifest entry is relative to control/, while candidates
+    // are relative to app/, and the std root is relative to the invocation.
+    let mut first = open(&projects[0]);
+    let mut second = open(&projects[1]);
+    let first_output = build(&mut first).unwrap().output;
+    let second_output = build(&mut second).unwrap().output;
+    assert_ne!(first_output.elf, second_output.elf);
+    for (host, project) in [(&mut first, &projects[0]), (&mut second, &projects[1])] {
+        let expected_std = fs::canonicalize(project.0.join("library")).unwrap();
+        assert_eq!(host.discovery_context().std_root(), expected_std.to_str());
+        assert!(host.accepted_reads().iter().any(|read| {
+            read.requested_path() == expected_std.join("option.rue").to_str().unwrap()
+        }));
+        let candidates = host
+            .acquire_test_candidates(&["orphan.rue".to_owned()])
+            .unwrap();
+        let report = host.unimported_test_files(&candidates).unwrap();
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].path, "orphan.rue");
+        assert_eq!(report[0].tests, 1);
+        assert!(!report[0].parse_failed);
+    }
+
+    fs::write(
+        projects[0].0.join("app/helper.rue"),
+        "pub fn value() -> i32 { 3 }\n",
+    )
+    .unwrap();
+    first.reobserve().unwrap();
+    second.reobserve().unwrap();
+    let updated = build(&mut first).unwrap().output;
+    assert_ne!(updated.elf, first_output.elf);
+    assert_output_eq(&updated, &build(&mut open(&projects[0])).unwrap().output);
+    assert_output_eq(&build(&mut second).unwrap().output, &second_output);
+
+    // Refresh also resolves the manifest from the original invocation.
+    fs::write(
+        projects[0].0.join("control/sources.list"),
+        "../app/main.rue\n",
+    )
+    .unwrap();
+    let error = first.reobserve().unwrap_err();
+    let crate::SourceLoadError::Compiler { errors, .. } = error else {
+        panic!("a newly denied import must be a compiler policy error");
+    };
+    let rendered = errors.to_string();
+    assert!(rendered.contains("source manifest"), "{rendered}");
+    assert!(rendered.contains("helper.rue"), "{rendered}");
+    // A read failure preserves the user's manifest spelling, independently
+    // of the compiler's denied-import diagnostic above.
+    fs::remove_file(projects[0].0.join("control/sources.list")).unwrap();
+    let crate::SourceLoadError::Message(message) = first.reobserve().unwrap_err() else {
+        panic!("a missing manifest must report its read failure");
+    };
+    assert!(message.contains("control/sources.list"), "{message}");
+    second.reobserve().unwrap();
+    assert_output_eq(&build(&mut second).unwrap().output, &second_output);
+}
+
+#[test]
+fn explicit_context_preserves_empty_std_as_unconfigured() {
+    let project = Project::new();
+    project.write("fn main() -> i32 { 0 }\n");
+    let context = HostPathContext::from_working_directory(project.0.clone()).unwrap();
+    let mut host = FilesystemCompilerHost::open(HostOpenRequest {
+        root_source: "main.rue",
+        source_manifest_path: None,
+        std_root: Some(Path::new("")),
+        compiler_config: CompilerSessionConfig::with_workers(1).unwrap(),
+        path_context: &context,
+    })
+    .unwrap();
+    assert_eq!(host.discovery_context().std_root(), None);
+    let expected = build(&mut project.open()).unwrap().output;
+    assert_output_eq(&build(&mut host).unwrap().output, &expected);
+    host.reobserve().unwrap();
+    assert_eq!(host.discovery_context().std_root(), None);
+    assert_output_eq(&build(&mut host).unwrap().output, &expected);
+}
+
+#[cfg(unix)]
+#[test]
+fn explicit_context_retains_requested_root_symlink_route() {
+    let project = Project::new();
+    for directory in ["link", "real"] {
+        fs::create_dir(project.0.join(directory)).unwrap();
+    }
+    fs::write(
+        project.0.join("real/main.rue"),
+        "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.value() }\n",
+    )
+    .unwrap();
+    fs::write(
+        project.0.join("real/helper.rue"),
+        "pub fn value() -> i32 { 99 }\n",
+    )
+    .unwrap();
+    fs::write(
+        project.0.join("link/helper.rue"),
+        "pub fn value() -> i32 { 1 }\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink("../real/main.rue", project.0.join("link/main.rue")).unwrap();
+    let context = HostPathContext::from_working_directory(project.0.clone()).unwrap();
+    let open = |root_source| {
+        FilesystemCompilerHost::open(HostOpenRequest {
+            root_source,
+            source_manifest_path: None,
+            std_root: None,
+            compiler_config: CompilerSessionConfig::with_workers(1).unwrap(),
+            path_context: &context,
+        })
+        .unwrap()
+    };
+    let mut retained = open("link/main.rue");
+    assert_eq!(retained.root_path(), project.0.join("link/main.rue"));
+    let root_read = retained
+        .accepted_reads()
+        .iter()
+        .find(|read| read.requested_path().ends_with("link/main.rue"))
+        .expect("the requested root spelling remains part of the observation");
+    assert!(!root_read.symlink_route().is_empty());
+    assert_eq!(
+        root_read.canonical_path(),
+        fs::canonicalize(project.0.join("real/main.rue"))
+            .unwrap()
+            .to_str()
+            .unwrap()
+    );
+    let before = build(&mut retained).unwrap().output;
+    assert_ne!(
+        before.elf,
+        build(&mut open("real/main.rue")).unwrap().output.elf
+    );
+    fs::write(
+        project.0.join("link/helper.rue"),
+        "pub fn value() -> i32 { 2 }\n",
+    )
+    .unwrap();
+    retained.reobserve().unwrap();
+    let after = build(&mut retained).unwrap().output;
+    assert_ne!(after.elf, before.elf);
+    assert_output_eq(&after, &build(&mut open("link/main.rue")).unwrap().output);
+}
+
+#[cfg(unix)]
+#[test]
+fn manifest_and_std_capture_preserve_filesystem_symlink_parent_routes() {
+    let project = Project::new();
+    for directory in ["app", "physical/deep", "physical/toolchain"] {
+        fs::create_dir_all(project.0.join(directory)).unwrap();
+    }
+    std::os::unix::fs::symlink("physical/deep", project.0.join("route")).unwrap();
+    let main = project.0.join("app/main.rue");
+    let option = project.0.join("physical/toolchain/option.rue");
+    fs::write(&main, "fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }\n").unwrap();
+    fs::write(
+        &option,
+        "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }\n",
+    )
+    .unwrap();
+    let manifest = project.0.join("physical/inputs.list");
+    fs::write(
+        &manifest,
+        format!("{}\n{}\n", main.display(), option.display()),
+    )
+    .unwrap();
+    let context = HostPathContext::from_working_directory(project.0.clone()).unwrap();
+    let mut host = FilesystemCompilerHost::open(HostOpenRequest {
+        root_source: "app/main.rue",
+        source_manifest_path: Some("route/../inputs.list"),
+        std_root: Some(Path::new("route/../toolchain")),
+        compiler_config: CompilerSessionConfig::with_workers(1).unwrap(),
+        path_context: &context,
+    })
+    .unwrap();
+    let expected = build(&mut host).unwrap().output;
+    assert_eq!(
+        host.discovery_context().std_root(),
+        project.0.join("physical/toolchain").to_str()
+    );
+    let observations = host.watch_inputs();
+    assert!(!crate::watch_inputs_changed(&observations));
+    assert!(
+        observations
+            .iter()
+            .any(|input| { input.requested_path() == project.0.join("route/../inputs.list") })
+    );
+    fs::write(
+        &manifest,
+        format!(
+            "# edited policy\n{}\n{}\n",
+            main.display(),
+            option.display()
+        ),
+    )
+    .unwrap();
+    assert!(crate::watch_inputs_changed(&observations));
+    host.reobserve().unwrap();
+    assert!(!crate::watch_inputs_changed(&host.watch_inputs()));
+    assert_output_eq(&build(&mut host).unwrap().output, &expected);
+    fs::remove_file(manifest).unwrap();
+    let crate::SourceLoadError::Message(message) = host.reobserve().unwrap_err() else {
+        panic!("refresh must reread the manifest through the captured route");
+    };
+    assert!(message.contains("route/../inputs.list"), "{message}");
+}

--- a/crates/rue/src/lib.rs
+++ b/crates/rue/src/lib.rs
@@ -6,12 +6,17 @@
 //! compiler artifact across revisions.
 
 mod host;
+#[cfg(test)]
+mod host_workflow_tests;
 mod source_loader;
 mod test_candidates;
 
-pub use host::{FilesystemCompilerHost, HostOpenRequest};
+pub use host::{FilesystemCompilerHost, HostOpenRequest, HostPathContext};
 pub use source_loader::{
     AttemptedRead, HermeticDenialError, SourceLoadError, ToolchainIntegrityError, WatchFingerprint,
     WatchInput, watch_input_fingerprints, watch_inputs_changed, watch_inputs_changed_with_reader,
+    with_import_migration_helps, with_import_migration_helps_batches,
 };
-pub use test_candidates::load_declared_candidates;
+pub use test_candidates::{
+    load_declared_candidates, load_declared_candidates_at, load_declared_candidates_with_context,
+};

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -32,7 +32,8 @@ use rue_compiler::unstable::{
 #[cfg(test)]
 use rue_compiler::unstable::{Span, update_for_presentation};
 use rue_driver::{
-    FilesystemCompilerHost, HostOpenRequest, SourceLoadError, ToolchainIntegrityError,
+    FilesystemCompilerHost, HostOpenRequest, HostPathContext, SourceLoadError,
+    ToolchainIntegrityError, with_import_migration_helps,
 };
 
 use rue_compiler::{
@@ -157,7 +158,7 @@ impl LogFormat {
 
 /// Format for compiler diagnostics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-enum ErrorFormat {
+pub(crate) enum ErrorFormat {
     /// Human-readable diagnostics with source snippets.
     #[default]
     Text,
@@ -1079,7 +1080,7 @@ fn compile_pool_jobs(mode: &DriverMode, jobs: usize) -> usize {
 /// is run later, possibly elsewhere, and "whatever the host was" is not a
 /// reproduction. `--filter` and `--seed` are added by the runner, which owns
 /// the identity being reproduced.
-fn test_repro_flags(options: &Options) -> Vec<String> {
+fn test_repro_flags(options: &Options, path_context: &HostPathContext) -> Vec<String> {
     let mut flags = vec![
         "--target".to_string(),
         options.target.to_string(),
@@ -1098,11 +1099,17 @@ fn test_repro_flags(options: &Options) -> Vec<String> {
     // (RUE-2020).
     if let Some(manifest) = &options.source_manifest_path {
         flags.push("--source-manifest".to_string());
-        flags.push(test_mode::absolute_spelling(Path::new(manifest)));
+        flags.push(test_mode::absolute_spelling_at(
+            Path::new(manifest),
+            path_context.working_directory(),
+        ));
     }
     for archive in &options.link_archives {
         flags.push("--link-archive".to_string());
-        flags.push(test_mode::absolute_spelling(archive));
+        flags.push(test_mode::absolute_spelling_at(
+            archive,
+            path_context.working_directory(),
+        ));
     }
     flags
 }
@@ -1191,51 +1198,6 @@ fn validate_watch_modes(options: &Options) -> Result<(), &'static str> {
     }
 }
 
-/// ADR-0078 migration help. An extensionless import names the directory
-/// facade alone under policy v2; when it misses but the sibling file module
-/// `{P}.rue` exists on disk, append the extensioned spelling as a help. The
-/// probe is presentation-only: it runs after discovery has closed, feeds no
-/// observation ledger, and creates no dependency edge, so it can never affect
-/// resolution, closure, or reuse.
-///
-/// `DiagnosticOutput` is its only caller, so the help reaches the reader
-/// whatever produced the diagnostic and whichever renderer presents it — a
-/// batch compile, an `--emit`, a watch cycle, a `rue test` image, and the JSON
-/// copies a `compile_error` event carries. Applying it per entry point instead
-/// is what let `--emit` and `--watch` publish the same `ModuleNotFound`
-/// without it (RUE-1969).
-fn with_import_migration_helps(errors: &CompileErrors) -> CompileErrors {
-    let mut enriched = CompileErrors::new();
-    for error in errors.iter() {
-        let sibling = match &error.kind {
-            rue_error::ErrorKind::ModuleNotFound { path, candidates }
-                if !path.ends_with(".rue") =>
-            {
-                let basename = Path::new(path)
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or(path);
-                let facade_suffix = format!("/_{basename}.rue");
-                candidates.iter().find_map(|candidate: &String| {
-                    let sibling = format!("{}.rue", candidate.strip_suffix(&facade_suffix)?);
-                    Path::new(&sibling)
-                        .is_file()
-                        .then_some((path.clone(), sibling))
-                })
-            }
-            _ => None,
-        };
-        match sibling {
-            Some((path, sibling)) => enriched.push(error.clone().with_help(format!(
-                "an extensionless import names the directory facade; the file module \
-                 '{sibling}' is imported with its extension: @import(\"{path}.rue\")"
-            ))),
-            None => enriched.push(error.clone()),
-        }
-    }
-    enriched
-}
-
 struct DiagnosticOutput<'a> {
     format: ErrorFormat,
     /// The path each file is known by, used to put a batch of diagnostics into
@@ -1277,6 +1239,10 @@ impl<'a> DiagnosticOutput<'a> {
         }
     }
 
+    pub(crate) fn format(&self) -> ErrorFormat {
+        self.format
+    }
+
     /// The same JSON objects `--error-format json` publishes for each batch of
     /// diagnostics, in the same source order, whatever format this output was
     /// built for.
@@ -1289,12 +1255,14 @@ impl<'a> DiagnosticOutput<'a> {
     /// The objects come from the diagnostic formatter's own serializer rather
     /// than from a second rendering here, so an event's copy and the
     /// `--error-format json` line on stderr can never disagree about a field.
-    fn json_diagnostic_batches(&self, batches: &[&CompileErrors]) -> Vec<Vec<serde_json::Value>> {
+    pub(crate) fn json_prepared_diagnostic_batches(
+        &self,
+        batches: &[&CompileErrors],
+    ) -> Vec<Vec<serde_json::Value>> {
         let formatter = MultiFileJsonFormatter::new(self.sources.iter().cloned());
         batches
             .iter()
             .map(|errors| {
-                let errors = with_import_migration_helps(errors);
                 self.in_source_order(errors.as_slice())
                     .into_iter()
                     .map(|error| {
@@ -1379,6 +1347,10 @@ impl<'a> DiagnosticOutput<'a> {
 
     fn render_errors(&self, errors: &CompileErrors) -> String {
         let errors = with_import_migration_helps(errors);
+        self.render_prepared_errors(&errors)
+    }
+
+    pub(crate) fn render_prepared_errors(&self, errors: &CompileErrors) -> String {
         let errors = CompileErrors::from(
             self.in_source_order(errors.as_slice())
                 .into_iter()
@@ -1421,6 +1393,10 @@ impl<'a> DiagnosticOutput<'a> {
 
     fn print_errors(&self, errors: &CompileErrors) {
         eprintln!("{}", self.render_errors(errors));
+    }
+
+    pub(crate) fn print_prepared_errors(&self, errors: &CompileErrors) {
+        eprintln!("{}", self.render_prepared_errors(errors));
     }
 
     fn print_warnings(&self, warnings: &[CompileWarning]) {
@@ -2274,7 +2250,7 @@ pub(crate) fn render_source_load_error(
                     "source loader produced an empty compiler diagnostic batch",
                 )
             } else {
-                diagnostics.render_errors(&errors)
+                diagnostics.render_prepared_errors(&errors)
             }
         }
     }
@@ -2481,6 +2457,14 @@ fn main() {
         std::process::exit(driver_failure_exit_code(&options.mode));
     }
 
+    // Capture the invocation directory before any request-relative input is
+    // read. Retained and watch paths must keep referring to this request even
+    // if a client changes the process cwd later.
+    let path_context = HostPathContext::capture().unwrap_or_else(|error| {
+        eprintln!("Error: {error}");
+        std::process::exit(driver_failure_exit_code(&options.mode));
+    });
+
     // Initialize tracing based on CLI options
     // Returns timing data if --time-passes or --benchmark-json was specified
     let timing_data = init_tracing(
@@ -2496,20 +2480,22 @@ fn main() {
     // Reporting against the list is `rue test`'s job (ADR-0083 §1); an ordinary
     // build validates the input and carries it no further.
     let declared_test_candidates = match options.test_candidates_path.as_deref() {
-        Some(path) => match rue_driver::load_declared_candidates(path) {
-            Ok(candidates) => {
-                tracing::debug!(
-                    path,
-                    declared_candidates = candidates.len(),
-                    "test candidate inventory declared"
-                );
-                Some(candidates)
+        Some(path) => {
+            match rue_driver::load_declared_candidates_with_context(path, &path_context) {
+                Ok(candidates) => {
+                    tracing::debug!(
+                        path,
+                        declared_candidates = candidates.len(),
+                        "test candidate inventory declared"
+                    );
+                    Some(candidates)
+                }
+                Err(message) => {
+                    eprintln!("{message}");
+                    std::process::exit(driver_failure_exit_code(&options.mode));
+                }
             }
-            Err(message) => {
-                eprintln!("{message}");
-                std::process::exit(driver_failure_exit_code(&options.mode));
-            }
-        },
+        }
         None => None,
     };
 
@@ -2520,7 +2506,6 @@ fn main() {
         CompilerSessionConfig::with_workers(compile_pool_jobs(&options.mode, options.jobs))
             .expect("CLI job validation must agree with compiler configuration");
     let resolved_workers = compiler_config.workers();
-
     // Discover and load @import-ed modules from disk, transitively. Sema
     // resolves imports only against already-loaded files, so without this
     // step `const utils = @import("utils")` fails with E0704 unless the
@@ -2546,6 +2531,7 @@ fn main() {
             source_manifest_path: options.source_manifest_path.as_deref(),
             std_root: captured_std_root.as_deref(),
             compiler_config,
+            path_context: &path_context,
         }) {
             Ok(result) => result,
             Err(error) => report_source_load_error(error, options.error_format, &options.mode),
@@ -2557,7 +2543,11 @@ fn main() {
         linker: options.linker.clone(),
         opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
-        link_archives: options.link_archives.clone(),
+        link_archives: options
+            .link_archives
+            .iter()
+            .map(|path| path_context.anchor(path))
+            .collect(),
         // A test request roots every test item in the closure; an executable
         // request roots none of them (ADR-0083 §1). This is the only place the
         // two differ, so `rue test` is one root set away from an ordinary
@@ -2599,12 +2589,20 @@ fn main() {
         // exist, because the loop never returns.
         let mode = match options.mode {
             DriverMode::Test => watch::WatchMode::Test(Box::new(watch::TestWatch {
-                repro_flags: test_repro_flags(&options),
+                repro_flags: test_repro_flags(&options, &path_context),
+                repro_root: test_mode::absolute_spelling_at(
+                    Path::new(&options.source_path),
+                    path_context.working_directory(),
+                ),
                 repro_env: test_repro_env(captured_std_root.as_deref()),
                 jobs: test_mode_jobs(options.jobs),
                 target: options.target,
                 opt_level: options.opt_level,
-                test_candidates_path: options.test_candidates_path.clone(),
+                test_candidates_path: options
+                    .test_candidates_path
+                    .as_deref()
+                    .map(|path| path_context.anchor(Path::new(path)).display().to_string()),
+                test_candidates_display_path: options.test_candidates_path.clone(),
                 // Derived once for the process: consecutive cycles then
                 // shuffle the same way, and a difference between two of them
                 // is attributable to the edit rather than to the order.
@@ -2715,7 +2713,11 @@ fn main() {
                 options: options.test.clone(),
                 diagnostics: &diagnostics,
                 root: options.source_path.clone(),
-                repro_flags: test_repro_flags(&options),
+                repro_flags: test_repro_flags(&options, &path_context),
+                repro_root: test_mode::absolute_spelling_at(
+                    Path::new(&options.source_path),
+                    path_context.working_directory(),
+                ),
                 repro_env: test_repro_env(captured_std_root.as_deref()),
                 jobs: test_mode_jobs(options.jobs),
                 target: options.target,
@@ -2770,12 +2772,13 @@ fn main() {
     // compiler and runner hash the published file rather than the
     // pre-publication linker buffer.
     let benchmark_emitted_output = if options.benchmark_json {
-        match std::fs::read(&options.output_path) {
+        let published_output_path = path_context.anchor(Path::new(&options.output_path));
+        match std::fs::read(&published_output_path) {
             Ok(bytes) => Some(EmittedOutput::of(&bytes)),
             Err(error) => {
                 eprintln!(
                     "Error: could not verify published benchmark output '{}': {error}",
-                    options.output_path
+                    published_output_path.display()
                 );
                 std::process::exit(1);
             }
@@ -3162,6 +3165,7 @@ mod tests {
                     source_manifest_path: None,
                     std_root: Some(&std_root),
                     compiler_config: CompilerSessionConfig::default(),
+                    path_context: &HostPathContext::capture().unwrap(),
                 })
                 .unwrap();
                 host.acquire_reached_toolchain_modules(&CompileOptions::default())
@@ -3205,6 +3209,7 @@ mod tests {
                     source_manifest_path: None,
                     std_root: None,
                     compiler_config: CompilerSessionConfig::default(),
+                    path_context: &HostPathContext::capture().unwrap(),
                 })
                 .unwrap()
             };
@@ -3268,6 +3273,7 @@ mod tests {
             source_manifest_path: None,
             std_root: None,
             compiler_config: CompilerSessionConfig::default(),
+            path_context: &HostPathContext::capture().unwrap(),
         })
         .unwrap();
         let options = CompileOptions::default();
@@ -3735,11 +3741,15 @@ mod tests {
             "--source-manifest",
             "sources.manifest",
         ]));
-        let flags = test_repro_flags(&options);
+        let context = HostPathContext::capture().unwrap();
+        let flags = test_repro_flags(&options, &context);
         // The manifest is absolutized rather than repeated: the `rue_test`
         // rule spells it as a project-relative buck-out path, and a repro is
         // run from somewhere else (RUE-2020).
-        let manifest = test_mode::absolute_spelling(Path::new("sources.manifest"));
+        let manifest = test_mode::absolute_spelling_at(
+            Path::new("sources.manifest"),
+            context.working_directory(),
+        );
         assert!(Path::new(&manifest).is_absolute(), "{manifest}");
         assert!(manifest.ends_with("/sources.manifest"), "{manifest}");
         assert_eq!(

--- a/crates/rue/src/output.rs
+++ b/crates/rue/src/output.rs
@@ -19,6 +19,7 @@ pub(crate) struct PublishRequest<'a> {
 
 pub(crate) struct PublicationDestination {
     path: PathBuf,
+    display_path: PathBuf,
     source_paths: Vec<PathBuf>,
 }
 
@@ -49,6 +50,28 @@ impl PublishError {
             paths,
             error,
         }
+    }
+
+    /// Finalizers operate on anchored paths. Project their structured path
+    /// fields to the invocation spelling without changing tool stderr or the
+    /// underlying I/O error.
+    fn with_display_path(mut self, actual: &Path, display: &Path) -> Self {
+        match &mut self {
+            Self::WouldClobberSource { path } | Self::Signing { path, .. } => {
+                if path == actual {
+                    *path = display.to_owned();
+                }
+            }
+            Self::Io { paths, .. } => {
+                for path in paths {
+                    if path == actual {
+                        *path = display.to_owned();
+                    }
+                }
+            }
+            Self::InputsChanged => {}
+        }
+        self
     }
 
     pub(crate) fn into_compile_error(self) -> CompileError {
@@ -127,7 +150,7 @@ fn validate_destination(destination: &PublicationDestination) -> Result<(), Publ
         .any(|source| output_would_clobber(&output_key, output_metadata.as_ref(), source))
     {
         return Err(PublishError::WouldClobberSource {
-            path: destination.path.clone(),
+            path: destination.display_path.clone(),
         });
     }
     Ok(())
@@ -135,27 +158,51 @@ fn validate_destination(destination: &PublicationDestination) -> Result<(), Publ
 
 /// Validate source/output identity before compilation and retain the complete
 /// source set for mandatory revalidation immediately before publication.
+#[cfg(test)]
 pub(crate) fn preflight_destination<'a>(
     path: &Path,
     source_paths: impl IntoIterator<Item = &'a str>,
 ) -> Result<PublicationDestination, PublishError> {
-    preflight_destination_paths(path, source_paths.into_iter().map(PathBuf::from))
+    preflight_destination_with_display(path, path, source_paths)
 }
 
-fn preflight_destination_paths(
+pub(crate) fn preflight_destination_with_display<'a>(
     path: &Path,
+    display_path: &Path,
+    source_paths: impl IntoIterator<Item = &'a str>,
+) -> Result<PublicationDestination, PublishError> {
+    preflight_destination_paths_with_display(
+        path,
+        display_path,
+        source_paths.into_iter().map(PathBuf::from),
+    )
+}
+
+fn preflight_destination_paths_with_display(
+    path: &Path,
+    display_path: &Path,
     source_paths: impl IntoIterator<Item = PathBuf>,
 ) -> Result<PublicationDestination, PublishError> {
     let destination = PublicationDestination {
         path: path.to_owned(),
+        display_path: display_path.to_owned(),
         source_paths: source_paths.into_iter().collect(),
     };
     validate_destination(&destination)?;
     Ok(destination)
 }
 
+#[cfg(test)]
 pub(crate) fn preflight_watch_destination(
     path: &Path,
+    inputs: &[WatchInput],
+) -> Result<PublicationDestination, PublishError> {
+    preflight_watch_destination_with_display(path, path, inputs)
+}
+
+pub(crate) fn preflight_watch_destination_with_display(
+    path: &Path,
+    display_path: &Path,
     inputs: &[WatchInput],
 ) -> Result<PublicationDestination, PublishError> {
     let source_paths = inputs
@@ -163,40 +210,52 @@ pub(crate) fn preflight_watch_destination(
         .flat_map(|input| [input.requested_path(), input.canonical_path()])
         .map(Path::to_owned)
         .collect::<Vec<_>>();
-    preflight_destination_paths(path, source_paths)
+    preflight_destination_paths_with_display(path, display_path, source_paths)
 }
 
-struct PendingOutput(PathBuf);
+struct PendingOutput {
+    path: PathBuf,
+    display_path: PathBuf,
+}
 
 impl PendingOutput {
     fn publish(mut self) {
-        self.0 = PathBuf::new();
+        self.path = PathBuf::new();
     }
 }
 
 impl Drop for PendingOutput {
     fn drop(&mut self) {
-        if !self.0.as_os_str().is_empty() {
-            let _ = fs::remove_file(&self.0);
+        if !self.path.as_os_str().is_empty() {
+            let _ = fs::remove_file(&self.path);
         }
     }
 }
 
-fn create_pending_output(destination: &Path) -> Result<(PendingOutput, fs::File), PublishError> {
-    let directory = destination.parent().unwrap_or_else(|| Path::new("."));
+fn create_pending_output(
+    destination: &PublicationDestination,
+) -> Result<(PendingOutput, fs::File), PublishError> {
+    let directory = destination.path.parent().unwrap_or_else(|| Path::new("."));
+    let display_directory = destination
+        .display_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
     let name = destination
+        .path
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("rue-output");
     for attempt in 0..1000_u32 {
-        let path = directory.join(format!(".{name}.rue-tmp-{}-{attempt}", std::process::id()));
+        let filename = format!(".{name}.rue-tmp-{}-{attempt}", std::process::id());
+        let path = directory.join(&filename);
+        let display_path = display_directory.join(filename);
         match OpenOptions::new().write(true).create_new(true).open(&path) {
-            Ok(file) => return Ok((PendingOutput(path), file)),
+            Ok(file) => return Ok((PendingOutput { path, display_path }, file)),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(error) => {
                 return Err(PublishError::io(
                     "could not create temporary executable",
-                    vec![path],
+                    vec![display_path],
                     error,
                 ));
             }
@@ -204,7 +263,7 @@ fn create_pending_output(destination: &Path) -> Result<(PendingOutput, fs::File)
     }
     Err(PublishError::io(
         "could not allocate a temporary executable path",
-        vec![destination.to_owned()],
+        vec![destination.display_path.clone()],
         io::Error::new(
             io::ErrorKind::AlreadyExists,
             "all temporary output names already exist",
@@ -278,24 +337,25 @@ fn publish_executable_with_finalizer_and_observation(
 ) -> Result<(), PublishError> {
     validate_destination(&request.destination)?;
     let destination = &request.destination.path;
-    let (pending, mut file) = create_pending_output(destination)?;
+    let (pending, mut file) = create_pending_output(&request.destination)?;
     file.write_all(request.bytes).map_err(|error| {
         PublishError::io(
             "could not write temporary executable",
-            vec![pending.0.clone()],
+            vec![pending.display_path.clone()],
             error,
         )
     })?;
     file.flush().map_err(|error| {
         PublishError::io(
             "could not flush temporary executable",
-            vec![pending.0.clone()],
+            vec![pending.display_path.clone()],
             error,
         )
     })?;
     drop(file);
 
-    finalizer(&pending.0, request.target)?;
+    finalizer(&pending.path, request.target)
+        .map_err(|error| error.with_display_path(&pending.path, &pending.display_path))?;
 
     // The hook is used only by deterministic unit tests to mutate an input in
     // the narrow window this check protects: after finalization/signing and
@@ -313,10 +373,13 @@ fn publish_executable_with_finalizer_and_observation(
         return Err(PublishError::InputsChanged);
     }
 
-    replace_destination(&pending.0, destination).map_err(|error| {
+    replace_destination(&pending.path, destination).map_err(|error| {
         PublishError::io(
             "could not atomically install finished executable",
-            vec![pending.0.clone(), destination.to_owned()],
+            vec![
+                pending.display_path.clone(),
+                request.destination.display_path.clone(),
+            ],
             error,
         )
     })?;
@@ -346,6 +409,139 @@ fn replace_destination(source: &Path, destination: &Path) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn anchored_creation_errors_keep_the_requested_output_directory() {
+        let directory = temporary_directory("publish-display-create");
+        let display = Path::new("missing/program");
+        let destination = preflight_destination_with_display(
+            &directory.join(display),
+            display,
+            std::iter::empty::<&str>(),
+        )
+        .unwrap();
+        let error = publish_executable(PublishRequest {
+            destination,
+            bytes: b"new",
+            target: Target::X86_64Linux,
+        })
+        .unwrap_err();
+        let PublishError::Io {
+            operation, paths, ..
+        } = error
+        else {
+            panic!("a missing parent must report the creation failure");
+        };
+        assert_eq!(operation, "could not create temporary executable");
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].parent(), Some(Path::new("missing")));
+        assert!(
+            paths[0]
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with(".program.rue-tmp-")
+        );
+        assert_eq!(fs::read_dir(&directory).unwrap().count(), 0);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn anchored_rename_errors_keep_both_requested_path_spellings() {
+        let directory = temporary_directory("publish-display-rename");
+        fs::create_dir(directory.join("program")).unwrap();
+        let destination = preflight_destination_with_display(
+            &directory.join("program"),
+            Path::new("program"),
+            std::iter::empty::<&str>(),
+        )
+        .unwrap();
+        let error = publish_executable(PublishRequest {
+            destination,
+            bytes: b"new",
+            target: Target::X86_64Linux,
+        })
+        .unwrap_err();
+        let PublishError::Io {
+            operation, paths, ..
+        } = error
+        else {
+            panic!("replacing a directory must report the rename failure");
+        };
+        assert_eq!(
+            operation,
+            "could not atomically install finished executable"
+        );
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0].parent(), Some(Path::new("")));
+        assert_eq!(paths[1], Path::new("program"));
+        assert!(directory.join("program").is_dir());
+        assert_eq!(fs::read_dir(&directory).unwrap().count(), 1);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn anchored_finalizer_errors_project_paths_and_preserve_tool_errors() {
+        let directory = temporary_directory("publish-display-finalize");
+        let destination_path = directory.join("program");
+        fs::write(&destination_path, b"old").unwrap();
+        let tool_message = format!("opaque tool detail naming {}", directory.display());
+        for signing in [false, true] {
+            let destination = preflight_destination_with_display(
+                &destination_path,
+                Path::new("program"),
+                std::iter::empty::<&str>(),
+            )
+            .unwrap();
+            let error = publish_executable_with_finalizer(
+                PublishRequest {
+                    destination,
+                    bytes: b"new",
+                    target: Target::X86_64Linux,
+                },
+                |temporary, _target| {
+                    assert!(temporary.is_absolute());
+                    assert_eq!(fs::read(temporary).unwrap(), b"new");
+                    if signing {
+                        Err(PublishError::Signing {
+                            path: temporary.to_owned(),
+                            error: SigningError::Rejected(tool_message.clone()),
+                        })
+                    } else {
+                        Err(PublishError::io(
+                            "injected finalizer I/O failure",
+                            vec![temporary.to_owned()],
+                            io::Error::other(tool_message.clone()),
+                        ))
+                    }
+                },
+            )
+            .unwrap_err();
+            let display = match error {
+                PublishError::Signing {
+                    path,
+                    error: SigningError::Rejected(stderr),
+                } => {
+                    assert!(signing);
+                    assert_eq!(stderr, tool_message);
+                    path
+                }
+                PublishError::Io {
+                    mut paths, error, ..
+                } => {
+                    assert!(!signing);
+                    assert_eq!(error.to_string(), tool_message);
+                    assert_eq!(paths.len(), 1);
+                    paths.remove(0)
+                }
+                _ => panic!("the finalizer's typed error must survive publication"),
+            };
+            assert_eq!(display.parent(), Some(Path::new("")));
+            assert_eq!(fs::read(&destination_path).unwrap(), b"old");
+            assert_eq!(fs::read_dir(&directory).unwrap().count(), 1);
+        }
+        fs::remove_dir_all(directory).unwrap();
+    }
 
     fn temporary_directory(name: &str) -> PathBuf {
         let unique = std::time::SystemTime::now()

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -20,14 +20,15 @@ use rue_compiler::unstable::{
 };
 #[cfg(test)]
 use rue_compiler::unstable::{
-    accepted_read_identity_lookups, accepted_read_identity_visits, committed_import_discovery,
-    committed_successor_sharing, exact_import_groups_dispatched, handoff_observation_visits,
-    handoff_observations, import_close_records_reduced, import_frontier_roots_requested,
-    import_plan_groups_constructed, import_view_full_leaves_published,
-    import_view_ledger_entries_cloned, import_view_overlay_leaves_published,
-    import_view_read_entries_compared, import_view_source_entries_compared,
-    parse_invalidation_entries_compared, parse_key_entries_compared, parse_modules_dispatched,
-    parse_sources_materialized, snapshot_module_resolution_visits, snapshot_module_resolutions,
+    MultiFileFormatter, SourceInfo, accepted_read_identity_lookups, accepted_read_identity_visits,
+    committed_import_discovery, committed_successor_sharing, exact_import_groups_dispatched,
+    handoff_observation_visits, handoff_observations, import_close_records_reduced,
+    import_frontier_roots_requested, import_plan_groups_constructed,
+    import_view_full_leaves_published, import_view_ledger_entries_cloned,
+    import_view_overlay_leaves_published, import_view_read_entries_compared,
+    import_view_source_entries_compared, parse_invalidation_entries_compared,
+    parse_key_entries_compared, parse_modules_dispatched, parse_sources_materialized,
+    snapshot_module_resolution_visits, snapshot_module_resolutions,
 };
 #[cfg(test)]
 use rue_compiler::unstable::{frontend_query_invalidations, rooted_cfg};
@@ -38,6 +39,8 @@ use rue_compiler::{
     ImportDiscoveryStatus, ImportDiscoveryView, PhysicalFileIdentity, SourceMetadata,
     SourceSnapshot, TrustedToolchainModuleDemand, trusted_logical_path_for_requested,
 };
+
+use crate::host::HostPathContext;
 
 /// The content fingerprint used by the long-lived filesystem observer.
 ///
@@ -245,33 +248,31 @@ fn attempted_reads_of(manifest: &AcceptedReadManifest) -> Vec<AttemptedRead> {
 #[derive(Debug)]
 pub(crate) struct SourceManifest {
     path: PathBuf,
+    display_path: String,
+    working_directory: PathBuf,
     content_hash: WatchFingerprint,
     allowed: AHashSet<PathBuf>,
     declared_paths: AHashSet<PathBuf>,
 }
 
 impl SourceManifest {
+    #[cfg(test)]
     pub(crate) fn load(path: &str) -> Result<Self, String> {
+        let context = HostPathContext::capture()?;
+        Self::load_with_context(path, &context)
+    }
+
+    pub(crate) fn load_with_context(path: &str, context: &HostPathContext) -> Result<Self, String> {
         let manifest_path = Path::new(path);
-        let content = fs::read_to_string(manifest_path)
+        let anchored_manifest_path = context.anchor(manifest_path);
+        let resolved_manifest_path = normalize_lexical_path(&anchored_manifest_path);
+        let content = fs::read_to_string(&anchored_manifest_path)
             .map_err(|e| format!("Error reading source manifest '{}': {}", path, e))?;
-        let base_dir = manifest_path
+        let base_dir = resolved_manifest_path
             .parent()
             .filter(|parent| !parent.as_os_str().is_empty())
             .unwrap_or_else(|| Path::new("."));
-        let base_dir = if base_dir.is_absolute() {
-            normalize_lexical_path(base_dir)
-        } else {
-            normalize_lexical_path(
-                &env::current_dir().map_err(|error| {
-                    format!(
-                        "Error reading source manifest '{}': cannot resolve current directory: {}",
-                        path, error
-                    )
-                })?
-                .join(base_dir),
-            )
-        };
+        let base_dir = normalize_lexical_path(base_dir);
 
         let mut allowed = AHashSet::new();
         let mut declared_paths = AHashSet::new();
@@ -314,7 +315,9 @@ impl SourceManifest {
         }
 
         Ok(Self {
-            path: manifest_path.to_path_buf(),
+            path: anchored_manifest_path,
+            display_path: path.to_owned(),
+            working_directory: context.working_directory().to_owned(),
             content_hash: WatchFingerprint::from_bytes(content.as_bytes()),
             allowed,
             declared_paths,
@@ -330,7 +333,13 @@ impl SourceManifest {
     }
 
     fn display_path(&self) -> String {
-        self.path.display().to_string()
+        self.display_path.clone()
+    }
+
+    fn reload(&self) -> Result<Self, String> {
+        let context = HostPathContext::from_working_directory(self.working_directory.clone())
+            .expect("a captured invocation directory is absolute");
+        Self::load_with_context(&self.display_path, &context)
     }
 
     fn policy_revision(&self) -> String {
@@ -354,22 +363,27 @@ impl SourceManifest {
     }
 }
 
-/// Anchor a host-supplied spelling at the current directory and reduce it with
-/// the compiler's one path normalizer.
+/// Reduce an already anchored path with the compiler's one path normalizer.
 ///
-/// Anchoring is the driver's own step: a relative command line argument or
-/// manifest entry names a file relative to the process, and every identity the
-/// compiler mints is absolute. The reduction itself is not the driver's to
+/// The driver anchors relative spellings at the captured invocation directory
+/// or manifest base before calling this function. Every identity the compiler
+/// mints is absolute. The reduction itself is not the driver's to
 /// decide — a manifest key that collapsed `..` differently from the requested
 /// path discovery mints would deny a file the compiler considers declared
 /// (RUE-1979), so it delegates to `normalize_module_path`.
 fn normalize_lexical_path(path: &Path) -> PathBuf {
+    debug_assert!(
+        path.is_absolute(),
+        "path anchoring must happen at the invocation boundary"
+    );
+    PathBuf::from(normalize_module_path(&path.to_string_lossy()))
+}
+
+fn normalize_lexical_path_at(path: &Path, working_directory: &Path) -> PathBuf {
     let absolute = if path.is_absolute() {
         path.to_path_buf()
     } else {
-        env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join(path)
+        working_directory.join(path)
     };
     PathBuf::from(normalize_module_path(&absolute.to_string_lossy()))
 }
@@ -776,9 +790,10 @@ pub(crate) fn parse_source_manifest_entry(raw_line: &str) -> String {
     entry.trim().to_string()
 }
 
-pub(crate) fn validate_manifest_allows_source(
+fn validate_manifest_allows_source_with_display(
     manifest: Option<&SourceManifest>,
     source_path: &str,
+    display_path: &str,
     role: &str,
 ) -> Result<(), String> {
     let Some(manifest) = manifest else {
@@ -796,7 +811,7 @@ pub(crate) fn validate_manifest_allows_source(
 
     Err(format!(
         "Error: {role} source '{}' is not listed in source manifest '{}'\nManifest entries are allowed source reads, not extra semantic roots.",
-        source_path,
+        display_path,
         manifest.display_path()
     ))
 }
@@ -806,6 +821,7 @@ pub(crate) struct SourceLoadRequest<'a> {
     pub(crate) source_manifest_path: Option<&'a str>,
     pub(crate) std_root: Option<&'a Path>,
     pub(crate) compiler_config: CompilerSessionConfig,
+    pub(crate) path_context: &'a HostPathContext,
 }
 
 #[derive(Debug)]
@@ -918,6 +934,72 @@ pub(crate) fn source_load_internal_error(
     }
 }
 
+fn prepare_source_load_errors(errors: CompileErrors) -> CompileErrors {
+    with_import_migration_helps(&errors)
+}
+
+fn prepare_source_load_error(error: SourceLoadError) -> SourceLoadError {
+    match error {
+        SourceLoadError::Compiler { snapshot, errors } => SourceLoadError::Compiler {
+            snapshot,
+            errors: prepare_source_load_errors(errors),
+        },
+        error => error,
+    }
+}
+
+/// Add presentation-only migration help to module-not-found diagnostics.
+///
+/// This belongs to the driver library because source-load failures can cross
+/// the host boundary before the command-line renderer exists. All diagnostic
+/// batches for one request use the same sibling probe cache, so text and JSON
+/// renderings observe one frozen filesystem fact set.
+pub fn with_import_migration_helps(errors: &CompileErrors) -> CompileErrors {
+    with_import_migration_helps_batches(&[errors])
+        .pop()
+        .expect("one diagnostic batch produces one result")
+}
+
+pub fn with_import_migration_helps_batches(batches: &[&CompileErrors]) -> Vec<CompileErrors> {
+    let mut sibling_exists = AHashMap::<String, bool>::new();
+    batches
+        .iter()
+        .map(|errors| {
+            let mut enriched = CompileErrors::new();
+            for error in errors.iter() {
+                let sibling = match &error.kind {
+                    rue_error::ErrorKind::ModuleNotFound { path, candidates }
+                        if !path.ends_with(".rue") =>
+                    {
+                        let basename = Path::new(path)
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .unwrap_or(path);
+                        let facade_suffix = format!("/_{basename}.rue");
+                        candidates.iter().find_map(|candidate: &String| {
+                            let sibling =
+                                format!("{}.rue", candidate.strip_suffix(&facade_suffix)?);
+                            let exists = *sibling_exists
+                                .entry(sibling.clone())
+                                .or_insert_with(|| Path::new(&sibling).is_file());
+                            exists.then_some((path.clone(), sibling))
+                        })
+                    }
+                    _ => None,
+                };
+                match sibling {
+                    Some((path, sibling)) => enriched.push(error.clone().with_help(format!(
+                        "an extensionless import names the directory facade; the file module \
+                 '{sibling}' is imported with its extension: @import(\"{path}.rue\")"
+                    ))),
+                    None => enriched.push(error.clone()),
+                }
+            }
+            enriched
+        })
+        .collect()
+}
+
 pub(crate) fn load(
     request: SourceLoadRequest<'_>,
 ) -> Result<ImportDiscoveryResult, SourceLoadError> {
@@ -931,19 +1013,34 @@ pub(crate) fn load(
         let _span = tracing::info_span!("source_manifest").entered();
         let manifest = request
             .source_manifest_path
-            .map(SourceManifest::load)
+            .map(|path| SourceManifest::load_with_context(path, request.path_context))
             .transpose()
             .map_err(SourceLoadError::Message)?;
-        validate_manifest_allows_source(manifest.as_ref(), request.root_source, "root")
-            .map_err(SourceLoadError::Message)?;
+        let root_path = normalize_lexical_path_at(
+            Path::new(request.root_source),
+            request.path_context.working_directory(),
+        );
+        validate_manifest_allows_source_with_display(
+            manifest.as_ref(),
+            &root_path.to_string_lossy(),
+            request.root_source,
+            "root",
+        )
+        .map_err(SourceLoadError::Message)?;
         manifest
     };
+    let std_root = request
+        .std_root
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(|path| request.path_context.anchor(path));
     discover_and_load_imports_with_configuration(
         request.root_source,
         manifest,
-        request.std_root,
+        std_root.as_deref(),
         request.compiler_config,
+        request.path_context,
     )
+    .map_err(prepare_source_load_error)
 }
 
 #[derive(Debug)]
@@ -996,6 +1093,7 @@ pub(crate) struct ImportDiscoveryResult {
 #[derive(Debug, Clone)]
 pub(crate) struct SourceResolutionInputs {
     pub(crate) root_path: PathBuf,
+    pub(crate) root_display_path: String,
     pub(crate) context: ImportDiscoveryContext,
 }
 
@@ -1806,11 +1904,13 @@ pub(crate) fn discover_and_load_imports(
     source_manifest: Option<SourceManifest>,
     std_root: Option<&Path>,
 ) -> Result<ImportDiscoveryResult, SourceLoadError> {
+    let path_context = HostPathContext::capture().expect("test invocation directory exists");
     discover_and_load_imports_with_configuration(
         root_source,
         source_manifest,
         std_root,
         CompilerSessionConfig::default(),
+        &path_context,
     )
 }
 
@@ -1819,6 +1919,7 @@ fn discover_and_load_imports_with_configuration(
     source_manifest: Option<SourceManifest>,
     std_root: Option<&Path>,
     compiler_config: CompilerSessionConfig,
+    path_context: &HostPathContext,
 ) -> Result<ImportDiscoveryResult, SourceLoadError> {
     // Validate the root source's span representability before discovery aliases
     // physical identities. With a single positional source there are no
@@ -1835,7 +1936,8 @@ fn discover_and_load_imports_with_configuration(
         });
     }
 
-    let root_path = normalize_lexical_path(Path::new(root_source));
+    let root_path =
+        normalize_lexical_path_at(Path::new(root_source), path_context.working_directory());
     let root_dir = root_path
         .parent()
         .unwrap_or_else(|| Path::new("/"))
@@ -1844,9 +1946,10 @@ fn discover_and_load_imports_with_configuration(
     // configured. Preserve that established contract before canonicalization:
     // canonicalizing `""` would otherwise turn it into the current project
     // directory and make the physical overlap guard reject ordinary projects.
-    let std_root = std_root
+    let std_root: Option<PathBuf> = std_root
         .filter(|path| !path.as_os_str().is_empty())
-        .map(capture_std_root);
+        .map(|path| path_context.anchor(path))
+        .map(|path| capture_std_root(&path));
     let canonicalize_root = || {
         fs::canonicalize(&root_path).map_err(|error| {
             SourceLoadError::Message(format!("Error reading {}: {error}", root_path.display()))
@@ -1941,7 +2044,11 @@ fn discover_and_load_imports_with_configuration(
     let read_manifest = assembler.accepted_read_manifest();
     Ok(ImportDiscoveryResult {
         source_snapshot: close.snapshot,
-        resolution: SourceResolutionInputs { root_path, context },
+        resolution: SourceResolutionInputs {
+            root_path,
+            root_display_path: root_source.to_owned(),
+            context,
+        },
         attempted_reads: attempted_reads_of(&read_manifest),
         read_manifest,
         observed_absent_paths: close.observed_absent_paths,
@@ -1964,6 +2071,13 @@ pub(crate) fn reload_from_filesystem(
     result: &mut ImportDiscoveryResult,
     supersession: Option<&dyn Fn() -> bool>,
 ) -> Result<(), SourceLoadError> {
+    reload_from_filesystem_inner(result, supersession).map_err(prepare_source_load_error)
+}
+
+fn reload_from_filesystem_inner(
+    result: &mut ImportDiscoveryResult,
+    supersession: Option<&dyn Fn() -> bool>,
+) -> Result<(), SourceLoadError> {
     let control = DiscoveryControl::superseding(supersession);
     // This attempt's observation record starts empty and is filled in once the
     // assembler exists, so a failure before any read is described as having
@@ -1973,13 +2087,14 @@ pub(crate) fn reload_from_filesystem(
     let source_manifest = result
         .source_manifest
         .as_ref()
-        .map(|manifest| SourceManifest::load(manifest.path.to_string_lossy().as_ref()))
+        .map(SourceManifest::reload)
         .transpose()
         .map_err(SourceLoadError::Message)?;
     control.checkpoint()?;
-    validate_manifest_allows_source(
+    validate_manifest_allows_source_with_display(
         source_manifest.as_ref(),
         result.resolution.root_path.to_string_lossy().as_ref(),
+        &result.resolution.root_display_path,
         "root",
     )
     .map_err(SourceLoadError::Message)?;
@@ -2149,6 +2264,15 @@ pub(crate) fn acquire_reached_toolchain_modules(
 /// session and host close coherent rather than rolling either half back.
 /// `None` keeps every check a no-op for the one-shot driver.
 pub(crate) fn acquire_reached_toolchain_modules_superseding(
+    result: &mut ImportDiscoveryResult,
+    options: &CompileOptions,
+    supersession: Option<&dyn Fn() -> bool>,
+) -> Result<(), SourceLoadError> {
+    acquire_reached_toolchain_modules_superseding_inner(result, options, supersession)
+        .map_err(prepare_source_load_error)
+}
+
+fn acquire_reached_toolchain_modules_superseding_inner(
     result: &mut ImportDiscoveryResult,
     options: &CompileOptions,
     supersession: Option<&dyn Fn() -> bool>,
@@ -4234,6 +4358,7 @@ mod tests {
                 None,
                 None,
                 configuration,
+                &HostPathContext::capture().unwrap(),
             )
             .unwrap();
             let modules = result
@@ -4424,6 +4549,51 @@ mod tests {
             Err(other) => panic!("policy change escaped typed diagnostics: {other:?}"),
             Ok(()) => panic!("policy change reused a now-denied read"),
         }
+    }
+
+    #[test]
+    fn failed_reobserve_error_owns_attempted_snapshot_after_predecessor_mutation() {
+        let dir = TestDir::new("owned-failed-reobserve-snapshot");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let leaf = dir.write("leaf.rue", "pub fn value() -> i32 { 1 }");
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+
+        fs::write(&leaf, "pub fn value() -> i32 {").unwrap();
+        let error = reload_from_filesystem(&mut result, None)
+            .expect_err("the changed import closure must fail before commit");
+        let SourceLoadError::Compiler { snapshot, errors } = error else {
+            panic!("expected owned compiler diagnostics, got {error:?}");
+        };
+        let snapshot = snapshot.expect("failed closure must carry its attempted snapshot");
+        let attempted_source = snapshot
+            .files()
+            .find(|source| source.path.ends_with("leaf.rue"))
+            .expect("the attempted snapshot retains the failing source")
+            .source
+            .to_owned();
+
+        // The retained error is consumed after a later observation has repaired
+        // the host and the failing file has changed again. Rendering must still
+        // use the attempted snapshot captured with this error.
+        fs::write(&leaf, "pub fn value() -> i32 { 2 }").unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
+        fs::remove_file(&leaf).unwrap();
+        let sources = snapshot
+            .files()
+            .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+            .collect::<Vec<_>>();
+        let rendered = MultiFileFormatter::new(sources).format_errors(&errors);
+        assert_eq!(attempted_source, "pub fn value() -> i32 {");
+        assert!(rendered.contains("pub fn value() -> i32 {"), "{rendered}");
+        assert!(!rendered.contains("value() -> i32 { 2 }"), "{rendered}");
+        assert!(
+            errors.iter().any(|error| {
+                matches!(error.kind, rue_error::ErrorKind::UnexpectedToken { .. })
+            })
+        );
     }
 
     #[cfg(unix)]

--- a/crates/rue/src/test_candidates.rs
+++ b/crates/rue/src/test_candidates.rs
@@ -17,7 +17,9 @@
 //! a build rule can write either file the same way.
 
 use std::fs;
+use std::path::Path;
 
+use crate::host::HostPathContext;
 use crate::source_loader::parse_source_manifest_entry;
 
 /// Read the declared candidate paths from a `--test-candidates` file.
@@ -27,8 +29,35 @@ use crate::source_loader::parse_source_manifest_entry;
 /// treating an unreadable list as "no candidates declared" would turn a broken
 /// build rule into a warning that never fires.
 pub fn load_declared_candidates(path: &str) -> Result<Vec<String>, String> {
-    let content = fs::read_to_string(path)
-        .map_err(|error| format!("Error reading test candidates '{}': {}", path, error))?;
+    load_declared_candidates_from_path(Path::new(path), path)
+}
+
+/// Read a candidate list using a request's captured cwd. The display spelling
+/// remains in errors while the filesystem read cannot drift if the process cwd
+/// changes before a retained/watch request rereads it.
+pub fn load_declared_candidates_with_context(
+    path: &str,
+    context: &HostPathContext,
+) -> Result<Vec<String>, String> {
+    load_declared_candidates_from_path(&context.anchor(Path::new(path)), path)
+}
+
+/// Read an already anchored candidate-list path while retaining its original
+/// command-line spelling for errors.
+pub fn load_declared_candidates_at(path: &Path, display_path: &str) -> Result<Vec<String>, String> {
+    load_declared_candidates_from_path(path, display_path)
+}
+
+fn load_declared_candidates_from_path(
+    path: &Path,
+    display_path: &str,
+) -> Result<Vec<String>, String> {
+    let content = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "Error reading test candidates '{}': {}",
+            display_path, error
+        )
+    })?;
     let mut candidates = Vec::new();
     for raw_line in content.lines() {
         let entry = parse_source_manifest_entry(raw_line);
@@ -109,6 +138,17 @@ mod tests {
         assert!(
             error.starts_with("Error reading test candidates"),
             "{error}"
+        );
+    }
+
+    #[test]
+    fn captured_context_anchors_relative_candidate_list_reads() {
+        let dir = scratch("candidate-list-context");
+        fs::write(dir.join("candidates.list"), "app/main.rue\n").unwrap();
+        let context = HostPathContext::from_working_directory(&dir).unwrap();
+        assert_eq!(
+            load_declared_candidates_with_context("candidates.list", &context).unwrap(),
+            vec!["app/main.rue".to_owned()]
         );
     }
 }

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -30,9 +30,9 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
-use rue_compiler::unstable::{TestCandidateInventory, TestInventoryEntry};
-use rue_compiler::{CompileOptions, OptLevel};
-use rue_driver::FilesystemCompilerHost;
+use rue_compiler::unstable::{SourceInfo, TestCandidateInventory, TestInventoryEntry};
+use rue_compiler::{AcceptedReadManifest, CompileErrors, CompileOptions, OptLevel, SourceSnapshot};
+use rue_driver::{AttemptedRead, FilesystemCompilerHost, WatchInput};
 use rue_target::Target;
 
 use events::{
@@ -137,6 +137,8 @@ pub(crate) struct TestRequest<'a, 'diagnostics> {
     /// The root source exactly as the command line spelled it, which is what
     /// `run_started` publishes.
     pub(crate) root: String,
+    /// The root anchored at the invocation directory for repros.
+    pub(crate) repro_root: String,
     /// The compile-mode flags a repro argv repeats after the filter and seed.
     pub(crate) repro_flags: Vec<String>,
     /// The environment assignments a repro must be run under, sorted by name.
@@ -220,6 +222,7 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
         options,
         diagnostics,
         root,
+        repro_root,
         repro_flags,
         repro_env,
         jobs,
@@ -252,6 +255,7 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
         options: &options,
         diagnostics,
         root: &root,
+        repro_root: &repro_root,
         repro_flags: &repro_flags,
         repro_env: &repro_env,
         jobs,
@@ -285,6 +289,7 @@ pub(crate) struct CycleRequest<'a, 'diagnostics> {
     pub(crate) options: &'a TestOptions,
     pub(crate) diagnostics: &'a crate::DiagnosticOutput<'diagnostics>,
     pub(crate) root: &'a str,
+    pub(crate) repro_root: &'a str,
     pub(crate) repro_flags: &'a [String],
     pub(crate) repro_env: &'a [(String, String)],
     pub(crate) jobs: usize,
@@ -326,6 +331,7 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
         options,
         diagnostics,
         root,
+        repro_root,
         repro_flags,
         repro_env,
         jobs,
@@ -353,14 +359,17 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
     // exists, built from the tests that did analyze (ADR-0083 §3). The cycle
     // that decides all of that is `compile`'s, shared with the executable
     // build and with executable watch (RUE-1969, RUE-2023).
-    let image = match crate::compile::drive_test_cycle(crate::compile::TestCycleRequest {
+    let response = crate::compile::produce_test_cycle(crate::compile::TestCycleRequest {
         host: &mut *host,
         options: compile_options,
-        diagnostics,
+        error_format: diagnostics.format(),
+        candidates,
         image_path: &image_path,
         observation,
-    }) {
-        crate::compile::TestCycleReport::Published(image) => *image,
+    });
+    let multi_module_closure = response.published_user_module_count() > 1;
+    let image = match response.complete(None) {
+        crate::compile::CycleReport::Published(image) => *image,
         crate::compile::TestCycleReport::Failed => {
             discard_run_root(&image_path, &run_root);
             return CycleOutcome::Finished(TestExitCode::RunnerError);
@@ -380,10 +389,11 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
     let reporter = Reporter::new(
         options.format,
         render::Context {
-            multi_module_closure: host.published_user_module_count() > 1,
+            multi_module_closure,
         },
     );
-    let compile_errors = CompileErrorVerdicts::new(&image.compile_failures, diagnostics);
+    let diagnostics = diagnostics_for_snapshot(image.error_format, &image.source_snapshot);
+    let compile_errors = CompileErrorVerdicts::new(&image.compile_failures, &diagnostics);
 
     let total = image.inventory.entries.len();
     let plan = selection::plan(
@@ -409,9 +419,10 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
 
     if plan.is_empty() {
         discard_run_root(&image_path, &run_root);
-        let unimported = report_unimported(host, candidates, diagnostics);
-        let Ok(unimported) = unimported else {
-            return CycleOutcome::Finished(TestExitCode::RunnerError);
+        let unimported = match report_unimported(image.unimported_test_files.as_ref(), &diagnostics)
+        {
+            Ok(unimported) => unimported,
+            Err(_) => return CycleOutcome::Finished(TestExitCode::RunnerError),
         };
         // Said before the terminal event, so a reader of an interleaved
         // terminal sees the reason ahead of the vacuous "0 passed" summary.
@@ -436,8 +447,6 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
     // names the compiler and the root by absolute path rather than by whatever
     // spelling this invocation happened to use (RUE-2020).
     let repro_program = repro_program();
-    let repro_root = absolute_spelling(Path::new(root));
-
     let outcome = execute_plan(ExecutionRequest {
         plan: &plan,
         compile_errors: &compile_errors,
@@ -448,7 +457,7 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
         timeout: Duration::from_millis(options.timeout_ms),
         jobs,
         repro_program: &repro_program,
-        repro_root: &repro_root,
+        repro_root,
         repro_flags,
         repro_env,
         reporter: &reporter,
@@ -481,8 +490,9 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
         return CycleOutcome::Finished(TestExitCode::RunnerError);
     }
 
-    let Ok(unimported) = report_unimported(host, candidates, diagnostics) else {
-        return CycleOutcome::Finished(TestExitCode::RunnerError);
+    let unimported = match report_unimported(image.unimported_test_files.as_ref(), &diagnostics) {
+        Ok(unimported) => unimported,
+        Err(_) => return CycleOutcome::Finished(TestExitCode::RunnerError),
     };
     reporter.emit(&Event::RunFinished {
         passed: outcome.passed,
@@ -565,7 +575,7 @@ impl CompileErrorVerdicts {
             .iter()
             .map(|failure| &failure.errors)
             .collect::<Vec<_>>();
-        let rendered = diagnostics.json_diagnostic_batches(&batches);
+        let rendered = diagnostics.json_prepared_diagnostic_batches(&batches);
         Self {
             by_ordinal: failures
                 .iter()
@@ -695,17 +705,61 @@ fn candidate_source(candidates: Option<&TestCandidateInventory>) -> CandidateSou
 /// that could disagree with the run it previews is worse than no listing. For
 /// the same reason it prints the closure's analysis diagnostics on stderr as
 /// the run path does, while still listing every declaration and exiting `0`.
-fn list(
+struct OwnedListingResponse {
+    source_snapshot: SourceSnapshot,
+    accepted_reads: AcceptedReadManifest,
+    attempted_reads: Vec<AttemptedRead>,
+    watch_inputs: Vec<WatchInput>,
+    error_format: crate::ErrorFormat,
+    result: Result<rue_compiler::unstable::TestListing, CompileErrors>,
+}
+
+fn produce_listing(
     host: &mut FilesystemCompilerHost,
     compile_options: &CompileOptions,
+    error_format: crate::ErrorFormat,
+) -> OwnedListingResponse {
+    let source_snapshot = host.source_snapshot().clone();
+    let accepted_reads = host.accepted_reads().clone();
+    let attempted_reads = host.attempted_reads().to_vec();
+    let watch_inputs = host.watch_inputs();
+    let result = host
+        .test_inventory(compile_options)
+        .map_err(|errors| rue_driver::with_import_migration_helps(&errors))
+        .map(|mut listing| {
+            listing.failure_diagnostics =
+                rue_driver::with_import_migration_helps(&listing.failure_diagnostics);
+            listing
+        });
+    OwnedListingResponse {
+        source_snapshot,
+        accepted_reads,
+        attempted_reads,
+        watch_inputs,
+        error_format,
+        result,
+    }
+}
+
+fn complete_listing(
+    response: OwnedListingResponse,
     options: &TestOptions,
-    diagnostics: &crate::DiagnosticOutput<'_>,
     reporter: &Reporter,
 ) -> TestExitCode {
-    let listing = match host.test_inventory(compile_options) {
+    let OwnedListingResponse {
+        source_snapshot,
+        accepted_reads,
+        attempted_reads,
+        watch_inputs,
+        error_format,
+        result,
+    } = response;
+    drop((accepted_reads, attempted_reads, watch_inputs));
+    let diagnostics = diagnostics_for_snapshot(error_format, &source_snapshot);
+    let listing = match result {
         Ok(listing) => listing,
         Err(errors) => {
-            diagnostics.print_errors(&errors);
+            diagnostics.print_prepared_errors(&errors);
             return TestExitCode::RunnerError;
         }
     };
@@ -720,7 +774,7 @@ fn list(
     // a reader inspecting a suite would see nothing wrong with tests the run
     // will report as `compile_error`.
     if !failure_diagnostics.is_empty() {
-        diagnostics.print_errors(&failure_diagnostics);
+        diagnostics.print_prepared_errors(&failure_diagnostics);
     }
     let selected = selection::select(&inventory.entries, &options.filters, options.shard);
     if selected.is_empty() {
@@ -753,6 +807,17 @@ fn list(
         });
     }
     TestExitCode::AllPassed
+}
+
+fn list(
+    host: &mut FilesystemCompilerHost,
+    compile_options: &CompileOptions,
+    options: &TestOptions,
+    diagnostics: &crate::DiagnosticOutput<'_>,
+    reporter: &Reporter,
+) -> TestExitCode {
+    let response = produce_listing(host, compile_options, diagnostics.format());
+    complete_listing(response, options, reporter)
 }
 
 struct ExecutionRequest<'a> {
@@ -1312,6 +1377,16 @@ pub(crate) fn absolute_spelling(path: &Path) -> String {
     }
 }
 
+/// Anchor a project input at the request cwd without canonicalizing it.
+/// Symlink and `..` routes are part of a source repro's meaning.
+pub(crate) fn absolute_spelling_at(path: &Path, working_directory: &Path) -> String {
+    if path.is_absolute() {
+        path.display().to_string()
+    } else {
+        working_directory.join(path).display().to_string()
+    }
+}
+
 /// An installed artifact spelled by the identity the filesystem gives it.
 ///
 /// The counterpart to [`absolute_spelling`], for paths that are toolchain
@@ -1342,17 +1417,18 @@ pub(crate) fn std_root_spelling(path: &Path) -> String {
 /// Returns `Err(())` when the report itself failed; its diagnostics have
 /// already been presented.
 fn report_unimported(
-    host: &mut FilesystemCompilerHost,
-    candidates: Option<&TestCandidateInventory>,
+    report: Option<
+        &Result<Vec<rue_compiler::unstable::UnimportedTestFile>, rue_compiler::CompileErrors>,
+    >,
     diagnostics: &crate::DiagnosticOutput<'_>,
 ) -> Result<Option<Vec<UnimportedFile>>, ()> {
-    let Some(candidates) = candidates else {
+    let Some(report) = report else {
         return Ok(None);
     };
-    let files = match host.unimported_test_files(candidates) {
+    let files = match report {
         Ok(files) => files,
         Err(errors) => {
-            diagnostics.print_errors(&errors);
+            diagnostics.print_prepared_errors(errors);
             return Err(());
         }
     };
@@ -1377,14 +1453,25 @@ fn report_unimported(
     }
     Ok(Some(
         files
-            .into_iter()
+            .iter()
             .map(|file| UnimportedFile {
-                path: file.path,
+                path: file.path.clone(),
                 tests: file.tests,
                 parse_failed: file.parse_failed,
             })
             .collect(),
     ))
+}
+
+fn diagnostics_for_snapshot(
+    format: crate::ErrorFormat,
+    snapshot: &rue_compiler::SourceSnapshot,
+) -> crate::DiagnosticOutput<'_> {
+    let sources = snapshot
+        .files()
+        .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+        .collect();
+    crate::DiagnosticOutput::new(format, sources)
 }
 
 #[cfg(test)]
@@ -1684,5 +1771,48 @@ mod tests {
         });
         assert_eq!(classification.verdict, Verdict::Fail(FailureKind::Assert));
         assert!(!is_xfail_failure(&classification));
+    }
+
+    #[test]
+    fn owned_listing_survives_host_drop_with_partial_failures() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("main.rue");
+        std::fs::write(
+            &root,
+            "test \"broken\" { let value: i32 = true; let _ = value; }\n\
+             test \"fine\" { let _value = 1; }\n",
+        )
+        .unwrap();
+        let context =
+            rue_driver::HostPathContext::from_working_directory(directory.path()).unwrap();
+        let mut host = rue_driver::FilesystemCompilerHost::open(rue_driver::HostOpenRequest {
+            root_source: "main.rue",
+            source_manifest_path: None,
+            std_root: None,
+            compiler_config: rue_compiler::CompilerSessionConfig::with_workers(1).unwrap(),
+            path_context: &context,
+        })
+        .unwrap();
+        let response = produce_listing(
+            &mut host,
+            &CompileOptions {
+                root_selection: rue_compiler::RootSelection::Tests,
+                ..CompileOptions::default()
+            },
+            crate::ErrorFormat::Json,
+        );
+        let Ok(listing) = &response.result else {
+            panic!("listing should preserve surviving declarations");
+        };
+        assert_eq!(listing.inventory.entries.len(), 2);
+        assert!(!listing.failure_diagnostics.is_empty());
+        std::fs::write(&root, "test \"replacement\" { let _value = 2; }\n").unwrap();
+        host.reobserve().unwrap();
+        drop(host);
+        let reporter = Reporter::new(OutputFormat::Json, render::Context::default());
+        assert_eq!(
+            complete_listing(response, &TestOptions::default(), &reporter),
+            TestExitCode::AllPassed
+        );
     }
 }

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -194,6 +194,7 @@ pub(crate) enum WatchMode {
 pub(crate) struct TestWatch {
     pub(crate) options: test_mode::TestOptions,
     pub(crate) repro_flags: Vec<String>,
+    pub(crate) repro_root: String,
     pub(crate) repro_env: Vec<(String, String)>,
     pub(crate) jobs: usize,
     pub(crate) target: Target,
@@ -202,6 +203,7 @@ pub(crate) struct TestWatch {
     /// it names are both ordinary disk state, and a cycle reports what is on
     /// disk now.
     pub(crate) test_candidates_path: Option<String>,
+    pub(crate) test_candidates_display_path: Option<String>,
     /// Derived once for the whole process unless `--seed` was given, so
     /// consecutive cycles shuffle the same way and a difference between two of
     /// them is attributable to the edit rather than to the order.
@@ -718,21 +720,29 @@ fn test_watch_cycle(request: TestWatchCycle<'_, '_>) -> test_mode::CycleOutcome 
     // so a candidate added, removed, or newly broken since the last cycle is
     // reported by this one. The warning it produces is printed by the cycle
     // itself, once, in each cycle whose report is non-empty (RUE-2023).
-    let candidates = match &config.test_candidates_path {
-        Some(path) => match rue_driver::load_declared_candidates(path) {
-            Ok(declared) => match host.acquire_test_candidates(&declared) {
-                Ok(inventory) => Some(inventory),
-                Err(errors) => {
-                    diagnostics.print_errors(&errors);
+    let candidates = match (
+        &config.test_candidates_path,
+        &config.test_candidates_display_path,
+    ) {
+        (Some(path), Some(display_path)) => {
+            match rue_driver::load_declared_candidates_at(Path::new(path), display_path) {
+                Ok(declared) => match host.acquire_test_candidates(&declared) {
+                    Ok(inventory) => Some(inventory),
+                    Err(errors) => {
+                        diagnostics.print_errors(&errors);
+                        return test_mode::CycleOutcome::Finished(
+                            test_mode::TestExitCode::RunnerError,
+                        );
+                    }
+                },
+                Err(message) => {
+                    eprintln!("{message}");
                     return test_mode::CycleOutcome::Finished(test_mode::TestExitCode::RunnerError);
                 }
-            },
-            Err(message) => {
-                eprintln!("{message}");
-                return test_mode::CycleOutcome::Finished(test_mode::TestExitCode::RunnerError);
             }
-        },
-        None => None,
+        }
+        (None, None) => None,
+        _ => unreachable!("candidate path and display path are paired"),
     };
     test_mode::run_cycle(test_mode::CycleRequest {
         host,
@@ -740,6 +750,7 @@ fn test_watch_cycle(request: TestWatchCycle<'_, '_>) -> test_mode::CycleOutcome 
         options: &config.options,
         diagnostics,
         root: source_path,
+        repro_root: &config.repro_root,
         repro_flags: &config.repro_flags,
         repro_env: &config.repro_env,
         jobs: config.jobs,

--- a/docs/designs/0085-persistent-compiler-daemon.md
+++ b/docs/designs/0085-persistent-compiler-daemon.md
@@ -41,10 +41,12 @@ Start with an opt-in daemon for ordinary compilation, `rue test` (including
 listing), and analysis-only requests through the existing semantic `--emit air`
 surface. Internal linking is used when an executable or test image is needed.
 Make it automatic for that supported surface after correctness, latency, and
-resource behavior are demonstrated. Retain in-memory query results through
-object production, perform a fresh link for image requests, and let the client
-publish or execute the result. Disk-persistent query caches, incremental
-linking, and editor protocols are independent extensions.
+resource behavior are demonstrated. Retain in-memory syntax, semantic, CFG,
+and codegen results, plus object projections when requested. The internal
+linker consumes structured codegen units without serializing objects. Perform
+a fresh link for image requests, and let the client publish or execute the
+result. Disk-persistent query caches, incremental linking, and editor protocols
+are independent extensions.
 
 ## Context
 
@@ -75,6 +77,15 @@ unaffected caller is reused, and executable bytes and warnings agree with a
 fresh compile. That demonstrates useful locality, not a prediction of daemon
 latency on a large program.
 
+The mixed-root regressions in
+[`host_workflow_tests`](../../crates/rue/src/host_workflow_tests.rs) exercise
+analysis, test listing, a test image, and an executable through one host. A
+helper shared by `main` and a test reuses its semantic body, CFG, and codegen
+unit across the root change. Explicit object projections are initially cold
+after an internal-linker image, because that path did not request them; they
+are reused once requested. These tests establish warm/fresh artifact parity
+and query reuse, rather than a client-latency improvement.
+
 ### Remaining costs and current gaps
 
 The CLI process still starts on every command. A new daemon must perform its
@@ -101,10 +112,15 @@ Several relevant issues are present in current source:
   successor. A daemon must still do that work. RUE-1817 tracks reducing the
   warm observation/validation floor; its older measurements are context, not
   measurements of this checkout.
-- The driver has process-global tracing and panic formatting, successful
-  one-shot `process::exit` behavior, and ambient path handling. System linking
-  inherits cwd, environment, and temporary-directory selection. These must
-  not become the configuration of whichever client happened to start a daemon.
+- The driver now captures invocation paths in `HostPathContext` and returns
+  owned executable, test-image, listing, and presentation responses (RUE-2127).
+  Their snapshots and prepared diagnostic facts survive host refresh or drop;
+  publication and test execution remain client operations. This supplies the
+  in-process boundary, while transport and service lifetime remain to be built.
+- Process-global tracing and panic formatting and successful one-shot
+  `process::exit` behavior remain in the driver. System linking inherits cwd,
+  environment, and temporary-directory selection. These must not become the
+  configuration of whichever client happened to start a daemon.
 - [`RevisionedQueryDatabase::drop`](../../crates/rue-compiler/src/revisioned_query_database/shared.rs)
   now explicitly stops and joins runtime workers; the worker-teardown leak is
   historical and removed. Its current ownership comment still documents strong
@@ -220,7 +236,11 @@ symlink-route semantics; blindly canonicalizing every argument would erase
 observations the source loader currently validates. Pass absolute spellings
 and the necessary presentation context through explicit APIs. Reuse the
 compiler-owned `normalize_module_path` authority already used by the source
-loader after anchoring paths to the captured cwd.
+loader for source/module identities after anchoring paths to the captured cwd.
+Ordinary filesystem arguments retain their route: a symlink followed by `..`
+can resolve differently from lexical normalization. In particular, anchor
+manifest reads, standard-library capture, link archives, output destinations,
+and reproduction arguments without changing their existing filesystem semantics.
 
 Keep argument and declared-input validation in the shared invocation path,
 including `--test-candidates` list validation even for ordinary compilation.

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -102,7 +102,9 @@ ALLOWANCES = {
         1, "redundant RIR variable-width encoding check"
     ),
     "crates/rue/src/emit.rs": Allowance(1, "validated sole-dependency emit mode"),
-    "crates/rue/src/source_loader.rs": Allowance(1, "redundant source-plan revision check"),
+    "crates/rue/src/source_loader.rs": Allowance(
+        2, "redundant source-plan revision and captured absolute-path checks"
+    ),
 }
 
 


### PR DESCRIPTION
A retained compiler host needs to accept a later request while an earlier client renders diagnostics, publishes an executable, or runs tests. Build, test-image, listing, and emit operations now produce owned responses containing their matching source snapshot, prepared diagnostic facts, and filesystem observations. Direct and watch commands consume those responses through the existing compiler and publication paths.

Invocation paths are captured once. Source identities retain the compiler's normalization rules; manifest, standard-library, archive, candidate, output, and reproduction paths preserve their filesystem routes and display spellings. Publication guards use accepted filesystem identities, including when the invocation directory differs from the process directory.

The regression coverage exercises analysis/list/test/build reuse through one host, isolated request directories and symlink routes, responses surviving host refresh/drop and file edits, partial test failures, and publication ordering/cleanup. ADR-0085 records the resulting ownership boundary and the distinction between retained codegen units and optional object projections. This is the in-process foundation; service transport and process lifecycle follow separately.

Validation: 378 compiler-driver tests and 84 host tests pass on the final tree, as do both production/benchmark lint variants, the assertion-policy and formatting gates, and 90 affected CLI cases. ADR registry, documentation links, and diff checks pass. The full 238-target run completed with 234 passes; its four failed unit/lint/policy targets were corrected and all pass in the final focused rerun. The quick run's other 35 targets also passed.

Closes RUE-2127
