### PR TITLE
RUE-2132: select exact stable IDs in test reproductions

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -837,6 +837,28 @@ compile_stdout_contains = ["tests.rue::parse_port accepts\ntests.rue::parse_port
 compile_stdout_not_contains = ["lexer"]
 
 [[case]]
+name = "list_exact_filter_excludes_overlapping_ids"
+description = "`--list` and execution share exact stable-ID membership."
+files = [
+    { path = "main.rue", source = """
+const tests = @import("x.rue");
+const prefixed = @import("prefix/x.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "x.rue", source = """
+test "alpha" { @assert(1 == 1); }
+test "alphabet" { @assert(1 == 1); }
+""" },
+    { path = "prefix/x.rue", source = """
+test "alpha" { @assert(1 == 1); }
+""" },
+]
+args = ["test", "main.rue", "--list", "--filter", "x.rue::alpha", "--exact"]
+driver_exit_code = 0
+compile_stdout_contains = ["x.rue::alpha\n"]
+compile_stdout_not_contains = ["x.rue::alphabet", "prefix/x.rue::alpha"]
+
+[[case]]
 name = "repeated_filters_union_rather_than_intersect"
 files = [
     { path = "main.rue", source = """
@@ -1041,7 +1063,7 @@ compile_stdout_contains = [
     # them: argv[0] and the root are absolute (they start at the root
     # directory), and everything after the root is the fixed repro tail.
     '"repro":["/',
-    '"--filter","tests.rue::fails on purpose","--seed","9",',
+    '"--filter","tests.rue::fails on purpose","--exact","--seed","9",',
     '"-O0","--timeout-ms","9000"]',
     '/main.rue","--filter"',
     '"stderr":{"bytes_total":17,"data":"assertion failed\n","encoding":"utf8"}',
@@ -1176,43 +1198,51 @@ compile_stdout_contains = [
 [[case]]
 name = "the_repro_argv_reproduces_the_same_verdict_alone"
 description = """
-The repro from the earlier case, run as its own invocation: the same one test,
-the same `assert` verdict, and no other test in the run. A repro that selected
-by the bare name would also re-run the passing homonym below it. The published
-repro spells the root absolutely; a case's argv has to be machine-independent,
-so this one spells it relative to the fixture directory the harness runs in —
-the selection is what the case is about.
+The emitted repro is replayed by the harness as its actual argv and environment:
+the same one test, the same `assert` verdict, and no other test in the run. The
+initial run includes two imported modules whose IDs overlap by path and two
+test names where one is a prefix of the other. A repro that selected by
+substring would run the extra tests too.
 """
 files = [
     { path = "main.rue", source = """
-const tests = @import("tests.rue");
+const tests = @import("x.rue");
+const prefixed = @import("prefix/x.rue");
 
 fn main() -> i32 {
     0
 }
 """ },
-    { path = "tests.rue", source = """
-test "fails on purpose" {
+    { path = "x.rue", source = """
+test "alpha" {
     @assert(1 == 2);
 }
+test "alphabet" {
+    @assert(1 == 1);
+}
 """ },
-    { path = "other.rue", source = """
-test "fails on purpose" {
+    { path = "prefix/x.rue", source = """
+test "alpha" {
     @assert(1 == 1);
 }
 """ },
 ]
 args = [
-    "test", "main.rue", "--filter", "tests.rue::fails on purpose", "--seed", "9",
-    "-O0", "--timeout-ms", "9000",
+    "test", "main.rue", "--seed", "9", "-O0", "--timeout-ms", "9000",
     "-j1", "--format", "json",
 ]
 driver_exit_code = 1
+replay_repro = "x.rue::alpha"
+# The repro invokes the native test image; keep this end-to-end assertion on
+# every native platform where the CLI runner can execute it.
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 compile_stdout_contains = [
-    '"plan":{"selected":1,"total":1}',
+    '"plan":{"selected":3,"total":3}',
     '"kind":"assert"',
-    '"id":"tests.rue::fails on purpose"',
-    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+    '"id":"x.rue::alpha"',
+    '"id":"x.rue::alphabet"',
+    '"id":"prefix/x.rue::alpha"',
+    '"crash":0,"event":"run_finished","failed":1,"passed":2',
 ]
 
 [[case]]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -88,6 +88,8 @@
 //! - `compile_only`: don't run the produced binary
 //! - `driver_exit_code`: exact exit status of a driver subcommand invocation
 //!   that produces no program to run, such as `rue test` (ADR-0083)
+//! - `replay_repro`: stable ID whose published `test_finished.repro` argv and
+//!   environment are replayed and checked for the same one-test selection
 //! - `executable_target`: validate the produced executable's bounded ELF or
 //!   Mach-O structure, architecture, load commands, entry point, and resolved
 //!   entry relocation against this Rue target
@@ -208,6 +210,7 @@ use rue_test_runner::{
     validate_unique_test_names,
 };
 use serde::Serialize;
+use serde_json::Value;
 
 use sharding::CliShardPlan;
 
@@ -2021,6 +2024,7 @@ fn case_runs_prebuilt_program(case: &Case) -> bool {
         name: _,
         description: _,
         contract: _,
+        replay_repro,
         known_bug: _,
         known_bug_on: _,
         only_on: _,
@@ -2076,6 +2080,7 @@ fn case_runs_prebuilt_program(case: &Case) -> bool {
     // `source_path` is the staging key, so it must be the repo-relative form
     // the rule declared rather than an absolute path.
     Path::new(root).is_relative()
+        && replay_repro.is_none()
         && error_contains.is_empty()
         && json_diagnostic_order.is_empty()
         && compile_stdout_contains.is_empty()
@@ -2359,6 +2364,10 @@ fn run_case(
         }
     }
 
+    if let Some(target) = case.replay_repro.as_deref() {
+        replay_published_repro(&compile_output, dir, contract, target)?;
+    }
+
     // A driver subcommand's own exit status, checked before the
     // build-and-run expectations that do not apply to it (ADR-0083 §2).
     if let Some(expected) = case.driver_exit_code {
@@ -2451,6 +2460,171 @@ fn run_case(
     }
 
     run_case_program(case, contract, dir, &program)
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TestEventSummary {
+    planned: Option<usize>,
+    started: Vec<String>,
+    finished: Vec<(String, String)>,
+}
+
+type PublishedRepros = HashMap<String, (Vec<String>, HashMap<String, String>)>;
+
+/// Read the run membership and verdicts from a JSON test event stream. The
+/// replay assertion compares these records rather than searching presentation
+/// text, so it proves the emitted argv selected the same IDs.
+fn summarize_test_events(stdout: &[u8]) -> Result<(TestEventSummary, PublishedRepros), String> {
+    let mut summary = TestEventSummary::default();
+    let mut repros = HashMap::new();
+    let text = std::str::from_utf8(stdout)
+        .map_err(|error| format!("event stream is not UTF-8: {error}"))?;
+    for (line_number, line) in text.lines().enumerate() {
+        let value: Value = serde_json::from_str(line)
+            .map_err(|error| format!("event line {} is not JSON: {error}", line_number + 1))?;
+        let object = value
+            .as_object()
+            .ok_or_else(|| format!("event line {} is not an object", line_number + 1))?;
+        match object.get("event").and_then(Value::as_str) {
+            Some("run_started") => {
+                summary.planned = object
+                    .get("plan")
+                    .and_then(Value::as_object)
+                    .and_then(|plan| plan.get("selected"))
+                    .and_then(Value::as_u64)
+                    .and_then(|selected| usize::try_from(selected).ok());
+            }
+            Some("test_started") => summary.started.push(
+                object
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        format!("event line {} has no test_started id", line_number + 1)
+                    })?
+                    .to_owned(),
+            ),
+            Some("test_finished") => {
+                let id = object
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        format!("event line {} has no test_finished id", line_number + 1)
+                    })?
+                    .to_owned();
+                let verdict = object
+                    .get("verdict")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        format!(
+                            "event line {} has no test_finished verdict",
+                            line_number + 1
+                        )
+                    })?
+                    .to_owned();
+                let argv = object
+                    .get("repro")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| format!("event line {} has no repro argv", line_number + 1))?
+                    .iter()
+                    .map(|argument| {
+                        argument.as_str().map(str::to_owned).ok_or_else(|| {
+                            format!(
+                                "event line {} has a non-string repro argument",
+                                line_number + 1
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let mut repro_env = HashMap::new();
+                if let Some(environment) = object.get("repro_env") {
+                    for (key, value) in environment.as_object().ok_or_else(|| {
+                        format!("event line {} has a non-object repro_env", line_number + 1)
+                    })? {
+                        repro_env.insert(
+                            key.clone(),
+                            value
+                                .as_str()
+                                .ok_or_else(|| {
+                                    format!(
+                                        "event line {} has a non-string repro_env value",
+                                        line_number + 1
+                                    )
+                                })?
+                                .to_owned(),
+                        );
+                    }
+                }
+                repros.insert(id.clone(), (argv, repro_env));
+                summary.finished.push((id, verdict));
+            }
+            _ => {}
+        }
+    }
+    if repros.is_empty() {
+        return Err("test event stream has no test_finished repro".to_owned());
+    }
+    if summary.planned != Some(summary.started.len()) {
+        return Err(format!(
+            "run_started selected {:?} tests, but test_started carried {} IDs",
+            summary.planned,
+            summary.started.len()
+        ));
+    }
+    Ok((summary, repros))
+}
+
+/// Execute the exact argv published by a test_finished event, adding only the
+/// JSON presentation needed to inspect the replay's event stream.
+fn replay_published_repro(
+    initial: &Output,
+    directory: &Path,
+    contract: &ExecutionContract,
+    target: &str,
+) -> Result<(), TestFailure> {
+    let (initial_summary, repros) = summarize_test_events(&initial.stdout)
+        .map_err(|error| TestFailure::assertion(format!("invalid emitted repro: {error}")))?;
+    let (argv, environment) = repros.get(target).ok_or_else(|| {
+        TestFailure::assertion(format!("initial run published no repro for {target:?}"))
+    })?;
+    let expected_verdict = initial_summary
+        .finished
+        .iter()
+        .find_map(|(id, verdict)| (id == target).then_some(verdict.clone()))
+        .ok_or_else(|| {
+            TestFailure::assertion(format!("initial run finished no target {target:?}"))
+        })?;
+    let (program, args) = argv
+        .split_first()
+        .ok_or_else(|| TestFailure::assertion("emitted repro argv is empty"))?;
+    let mut command = compiler_command(Path::new(program));
+    command
+        .args(args)
+        .arg("--format")
+        .arg("json")
+        .current_dir(directory);
+    for (key, value) in environment {
+        command.env(key, value);
+    }
+    let replay = run_phase_with_timeout(
+        command,
+        ProcessPhase::Compiler,
+        contract.compile_timeout(),
+        None,
+    )?;
+    let (actual, _) = summarize_test_events(&replay.stdout).map_err(|error| {
+        TestFailure::assertion(format!("replayed repro emitted invalid events: {error}"))
+    })?;
+    let expected = TestEventSummary {
+        planned: Some(1),
+        started: vec![target.to_owned()],
+        finished: vec![(target.to_owned(), expected_verdict)],
+    };
+    if actual != expected {
+        return Err(TestFailure::assertion(format!(
+            "emitted repro selected different tests:\n  initial: {expected:?}\n  replay:  {actual:?}"
+        )));
+    }
+    Ok(())
 }
 
 fn watch_events(path: &Path) -> Vec<String> {
@@ -3922,6 +4096,19 @@ fn driver_exit_code_conflicts_with_compile_fail(case: &Case) -> bool {
     case.driver_exit_code.is_some() && case.compile_fail
 }
 
+fn invalid_replay_repro(case: &Case) -> Option<&'static str> {
+    let target = case.replay_repro.as_deref()?;
+    if target.is_empty() {
+        return Some("`replay_repro` must name a non-empty stable test ID");
+    }
+    if case.compile_fail || case.compile_only || case.watch.is_some() || case.watch_test.is_some() {
+        return Some(
+            "`replay_repro` requires an ordinary one-shot `rue test` case that publishes test events",
+        );
+    }
+    None
+}
+
 /// Return produced-program fields that are meaningless when `compile_only` or
 /// `driver_exit_code` stops the case before a program runs. Keep this list
 /// aligned with the assertions and inputs consumed exclusively by
@@ -4060,6 +4247,14 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                 // load time so the doc comment's promise is enforced, not merely
                 // documented (RUE-132).
                 for case in &tf.cases {
+                    if let Some(error) = invalid_replay_repro(case) {
+                        eprintln!(
+                            "error: {}: case '{}' declares invalid replay_repro: {error}",
+                            path.display(),
+                            case.name,
+                        );
+                        std::process::exit(1);
+                    }
                     if driver_exit_code_conflicts_with_compile_fail(case) {
                         eprintln!(
                             "error: {}: case '{}' declares both `driver_exit_code` and `compile_fail` — the first asserts an exact status and the second only a nonzero one; keep one",

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1420,6 +1420,7 @@ fn unsupported_corpus_field(case: &Case) -> Option<IneligibleReason> {
         // ignoring them here narrows what this harness verifies without
         // changing what the program is expected to do.
         description: _,
+        replay_repro: _,
         output: _,
         error_contains: _,
         compile_stdout_contains: _,

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -356,6 +356,10 @@ pub struct Case {
     /// Compiler arguments, relative to the temp dir (default: first file + `-o prog`).
     #[serde(default)]
     pub args: Option<Vec<String>>,
+    /// Stable ID whose published `test_finished.repro` argv and environment
+    /// should be replayed, checking that it selects and reports the same test.
+    #[serde(default)]
+    pub replay_repro: Option<String>,
     /// Synthesize a tiny C-free static archive exporting `answer() -> 42` as
     /// pure machine code for the case's target, and substitute its path for the
     /// `${FFI_ARCHIVE}` token in `args` (ADR-0064 C FFI P1 proof program). The

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -285,6 +285,7 @@ Commands:
   --list               List the inventory; no codegen, no linking, no execution
   --filter <pattern>   Run only tests whose stable id contains <pattern>
                        Can be repeated; repeated filters union
+  --exact              Match --filter values against complete stable ids
   --format <fmt>       Report as human text or as the NDJSON event stream
                        Formats: human, json (default: human)
   --timeout-ms <N>     Per-test wall-clock budget (default: {default_timeout})
@@ -759,6 +760,10 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
                 test.filters.push((*pattern).to_string());
                 test_flags_given.push("--filter");
             }
+            "--exact" => {
+                test.exact = true;
+                test_flags_given.push("--exact");
+            }
             "--format" => {
                 let Some(format_str) = args_iter.next() else {
                     eprintln!("Error: --format requires a value");
@@ -1078,8 +1083,8 @@ fn compile_pool_jobs(mode: &DriverMode, jobs: usize) -> usize {
 /// preview set, per-test budget, and any build-system inputs travel with it.
 /// The target and opt level are emitted even when they were defaulted: a repro
 /// is run later, possibly elsewhere, and "whatever the host was" is not a
-/// reproduction. `--filter` and `--seed` are added by the runner, which owns
-/// the identity being reproduced.
+/// reproduction. `--filter`, `--exact`, and `--seed` are added by the runner,
+/// which owns the identity being reproduced.
 fn test_repro_flags(options: &Options, path_context: &HostPathContext) -> Vec<String> {
     let mut flags = vec![
         "--target".to_string(),
@@ -3504,6 +3509,7 @@ mod tests {
             "main.rue",
             "--filter",
             "parse",
+            "--exact",
             "--filter",
             "lex",
             "--format",
@@ -3518,6 +3524,7 @@ mod tests {
         ]));
         assert_eq!(options.mode, DriverMode::Test);
         assert_eq!(options.test.filters, vec!["parse", "lex"]);
+        assert!(options.test.exact);
         assert_eq!(options.test.format, test_mode::OutputFormat::Json);
         assert_eq!(options.test.seed, Some(417));
         assert_eq!(options.test.timeout_ms, 500);
@@ -3587,6 +3594,7 @@ mod tests {
         let options = unwrap_options(parse_args_from(&["test", "main.rue"]));
         assert!(!options.test.list);
         assert!(options.test.filters.is_empty());
+        assert!(!options.test.exact);
         assert_eq!(options.test.format, test_mode::OutputFormat::Human);
         assert_eq!(options.test.timeout_ms, test_mode::DEFAULT_TIMEOUT_MS);
         assert_eq!(options.test.shard, None);
@@ -3654,6 +3662,7 @@ mod tests {
         for flag in [
             vec!["--list"],
             vec!["--filter", "x"],
+            vec!["--exact"],
             vec!["--format", "json"],
             vec!["--timeout-ms", "10"],
             vec!["--shard", "1/2"],

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -107,6 +107,8 @@ impl std::str::FromStr for OutputFormat {
 pub(crate) struct TestOptions {
     pub(crate) list: bool,
     pub(crate) filters: Vec<String>,
+    /// Match filters against complete stable IDs rather than substrings.
+    pub(crate) exact: bool,
     pub(crate) format: OutputFormat,
     pub(crate) timeout_ms: u64,
     pub(crate) shard: Option<Shard>,
@@ -120,6 +122,7 @@ impl Default for TestOptions {
         Self {
             list: false,
             filters: Vec::new(),
+            exact: false,
             format: OutputFormat::default(),
             timeout_ms: DEFAULT_TIMEOUT_MS,
             shard: None,
@@ -399,6 +402,7 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
     let plan = selection::plan(
         &image.inventory.entries,
         &options.filters,
+        options.exact,
         options.shard,
         seed,
     );
@@ -776,7 +780,12 @@ fn complete_listing(
     if !failure_diagnostics.is_empty() {
         diagnostics.print_prepared_errors(&failure_diagnostics);
     }
-    let selected = selection::select(&inventory.entries, &options.filters, options.shard);
+    let selected = selection::select(
+        &inventory.entries,
+        &options.filters,
+        options.exact,
+        options.shard,
+    );
     if selected.is_empty() {
         eprintln!("{}", empty_selection_reason(inventory.entries.len()));
         return TestExitCode::EmptySelection;
@@ -1332,6 +1341,10 @@ impl Repro<'_> {
             self.root.to_owned(),
             "--filter".to_owned(),
             id.to_owned(),
+            // A stable ID can be a prefix of another stable ID. Keep the
+            // runner's exact selector mode on the published argv so this
+            // reproduction names precisely the failing test.
+            "--exact".to_owned(),
             "--seed".to_owned(),
             seed.to_string(),
         ];
@@ -1531,6 +1544,7 @@ mod tests {
                 "/work/app/main.rue",
                 "--filter",
                 "app/t.rue::parses a port",
+                "--exact",
                 "--seed",
                 "417",
                 "--target",

--- a/crates/rue/src/test_mode/selection.rs
+++ b/crates/rue/src/test_mode/selection.rs
@@ -118,8 +118,16 @@ impl std::fmt::Display for Shard {
 /// rather than glob or regex because the ID's own shape (`<module>::<name>`)
 /// already gives a user the two prefixes they reach for, and a filter language
 /// is a compatibility surface this ADR does not need.
-pub(crate) fn matches_filters(id: &str, filters: &[String]) -> bool {
-    filters.is_empty() || filters.iter().any(|filter| id.contains(filter.as_str()))
+/// With `exact`, each filter instead has to equal the complete stable ID.
+pub(crate) fn matches_filters(id: &str, filters: &[String], exact: bool) -> bool {
+    filters.is_empty()
+        || filters.iter().any(|filter| {
+            if exact {
+                id == filter
+            } else {
+                id.contains(filter.as_str())
+            }
+        })
 }
 
 /// Which tests an invocation acts on: filter, then shard, in inventory order.
@@ -131,11 +139,12 @@ pub(crate) fn matches_filters(id: &str, filters: &[String]) -> bool {
 pub(crate) fn select<'a>(
     entries: &'a [TestInventoryEntry],
     filters: &[String],
+    exact: bool,
     shard: Option<Shard>,
 ) -> Vec<&'a TestInventoryEntry> {
     entries
         .iter()
-        .filter(|entry| matches_filters(&entry.id, filters))
+        .filter(|entry| matches_filters(&entry.id, filters, exact))
         .filter(|entry| shard.is_none_or(|shard| shard.owns(&entry.id)))
         .collect()
 }
@@ -144,10 +153,11 @@ pub(crate) fn select<'a>(
 pub(crate) fn plan(
     entries: &[TestInventoryEntry],
     filters: &[String],
+    exact: bool,
     shard: Option<Shard>,
     seed: u64,
 ) -> Vec<TestInventoryEntry> {
-    let mut selected: Vec<TestInventoryEntry> = select(entries, filters, shard)
+    let mut selected: Vec<TestInventoryEntry> = select(entries, filters, exact, shard)
         .into_iter()
         .cloned()
         .collect();
@@ -206,20 +216,50 @@ mod tests {
 
     #[test]
     fn no_filter_selects_everything() {
-        assert!(matches_filters("app/m.rue::anything", &[]));
+        assert!(matches_filters("app/m.rue::anything", &[], false));
+        assert!(matches_filters("app/m.rue::anything", &[], true));
     }
 
     #[test]
     fn filters_match_substrings_of_the_stable_id_and_union() {
         let filters = vec!["parse_port".to_owned(), "lexer".to_owned()];
-        assert!(matches_filters("app/p.rue::parse_port accepts", &filters));
-        assert!(matches_filters("app/l.rue::lexer eats spaces", &filters));
-        assert!(!matches_filters("app/x.rue::something else", &filters));
+        assert!(matches_filters(
+            "app/p.rue::parse_port accepts",
+            &filters,
+            false
+        ));
+        assert!(matches_filters(
+            "app/l.rue::lexer eats spaces",
+            &filters,
+            false
+        ));
+        assert!(!matches_filters(
+            "app/x.rue::something else",
+            &filters,
+            false
+        ));
         // The module half of the ID is matchable too, which is how a whole
         // file's tests are selected without naming each one.
         assert!(matches_filters(
             "app/lexer_tests.rue::whatever",
-            &["app/lexer_tests.rue".to_owned()]
+            &["app/lexer_tests.rue".to_owned()],
+            false
+        ));
+    }
+
+    #[test]
+    fn exact_filters_match_one_stable_id_and_still_union() {
+        let filters = vec![
+            "app/tests.rue::alpha".to_owned(),
+            "app/other.rue::beta".to_owned(),
+        ];
+        assert!(matches_filters("app/tests.rue::alpha", &filters, true));
+        assert!(matches_filters("app/other.rue::beta", &filters, true));
+        assert!(!matches_filters("app/tests.rue::alphabet", &filters, true));
+        assert!(!matches_filters(
+            "prefix/app/tests.rue::alpha",
+            &filters,
+            true
         ));
     }
 
@@ -230,7 +270,7 @@ mod tests {
         let mut union: Vec<String> = Vec::new();
         for index in 1..=4 {
             let shard = Shard { index, count: 4 };
-            union.extend(ids(&plan(&entries, &[], Some(shard), 0)));
+            union.extend(ids(&plan(&entries, &[], false, Some(shard), 0)));
         }
         union.sort();
         let mut all = ids(&entries);
@@ -249,12 +289,13 @@ mod tests {
             union.extend(ids(&plan(
                 &entries,
                 &filters,
+                false,
                 Some(Shard { index, count: 2 }),
                 7,
             )));
         }
         union.sort();
-        let mut expected = ids(&plan(&entries, &filters, None, 7));
+        let mut expected = ids(&plan(&entries, &filters, false, None, 7));
         expected.sort();
         assert_eq!(union, expected);
         assert!(expected.len() < 40, "the filter must actually narrow");
@@ -264,12 +305,12 @@ mod tests {
     fn a_seed_reproduces_an_order_and_different_seeds_generally_differ() {
         let entries = inventory(24);
         assert_eq!(
-            ids(&plan(&entries, &[], None, 417)),
-            ids(&plan(&entries, &[], None, 417))
+            ids(&plan(&entries, &[], false, None, 417)),
+            ids(&plan(&entries, &[], false, None, 417))
         );
         assert_ne!(
-            ids(&plan(&entries, &[], None, 417)),
-            ids(&plan(&entries, &[], None, 418))
+            ids(&plan(&entries, &[], false, None, 417)),
+            ids(&plan(&entries, &[], false, None, 418))
         );
     }
 
@@ -277,7 +318,7 @@ mod tests {
     #[test]
     fn the_shuffle_is_a_permutation() {
         let entries = inventory(31);
-        let mut shuffled = ids(&plan(&entries, &[], None, 99));
+        let mut shuffled = ids(&plan(&entries, &[], false, None, 99));
         shuffled.sort();
         let mut all = ids(&entries);
         all.sort();
@@ -304,14 +345,14 @@ mod tests {
     #[test]
     fn a_selection_keeps_inventory_order_while_a_plan_shuffles_it() {
         let entries = inventory(24);
-        let selected: Vec<String> = select(&entries, &[], None)
+        let selected: Vec<String> = select(&entries, &[], false, None)
             .into_iter()
             .map(|entry| entry.id.clone())
             .collect();
         assert_eq!(selected, ids(&entries));
         assert_ne!(
             selected,
-            ids(&plan(&entries, &[], None, 417)),
+            ids(&plan(&entries, &[], false, None, 417)),
             "a run's order is shuffled; a listing's is not"
         );
     }
@@ -323,11 +364,11 @@ mod tests {
         let entries = inventory(40);
         let filters = vec!["test 1".to_owned()];
         let shard = Some(Shard { index: 2, count: 3 });
-        let mut selected: Vec<String> = select(&entries, &filters, shard)
+        let mut selected: Vec<String> = select(&entries, &filters, false, shard)
             .into_iter()
             .map(|entry| entry.id.clone())
             .collect();
-        let mut planned = ids(&plan(&entries, &filters, shard, 417));
+        let mut planned = ids(&plan(&entries, &filters, false, shard, 417));
         assert!(!selected.is_empty(), "the fixture must select something");
         selected.sort();
         planned.sort();
@@ -336,7 +377,7 @@ mod tests {
 
     #[test]
     fn an_empty_or_single_selection_shuffles_without_panicking() {
-        assert!(plan(&[], &[], None, 5).is_empty());
-        assert_eq!(plan(&inventory(1), &[], None, 5).len(), 1);
+        assert!(plan(&[], &[], false, None, 5).is_empty());
+        assert_eq!(plan(&inventory(1), &[], false, None, 5).len(), 1);
     }
 }

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -691,6 +691,14 @@ as a substring. `--filter` is repeatable and repeated filters **union**. Matchin
 is over the whole ID, so `--filter app/lexer_tests.rue` selects one file's tests
 and `--filter "parse_port"` selects by name fragment.
 
+### `--exact`
+
+`--exact` is a modifier for `--filter`. When present, each filter must equal the
+complete stable ID. Repeated filters still **union**, and an invocation with no
+filters still selects every test. This gives a repro a way to select one ID even
+when another ID begins with it, while leaving ordinary substring filtering
+unchanged.
+
 ### `--shard K/N`
 
 `K` is 1-based. A test belongs to shard `K` when
@@ -738,13 +746,15 @@ the environment it has to be run under:
 
 ```json
 "repro":["/opt/rue/bin/rue","test","/work/app/main.rue",
- "--filter","app/t.rue::parses a port","--seed","417",
+ "--filter","app/t.rue::parses a port","--exact","--seed","417",
  "--target","x86-64-linux","-O0","--timeout-ms","10000"],
 "repro_env":{"RUE_STD_PATH":"/opt/rue/std"}
 ```
 
 It selects by the **full stable ID, never the bare name** — two modules may
 declare tests with the same name, and a repro that re-runs both is not a repro.
+The runner adds `--exact` to every emitted repro, so a stable ID that is a
+prefix of another ID still selects only the failing test.
 The seed, target, optimization level, any enabled preview features, and the
 per-test budget travel with it so the same image is rebuilt, and `--source-manifest` and
 `--link-archive` are repeated when they were given. The target and optimization
@@ -798,7 +808,7 @@ human renderer's `repro:` line is the assignments followed by the argv, all
 shell-quoted for pasting —
 
 ```text
-repro: RUE_STD_PATH=/opt/rue/std /opt/rue/bin/rue test /work/app/main.rue --filter 'app/t.rue::parses a port' --seed 417 --target x86-64-linux -O0 --timeout-ms 10000
+repro: RUE_STD_PATH=/opt/rue/std /opt/rue/bin/rue test /work/app/main.rue --filter 'app/t.rue::parses a port' --exact --seed 417 --target x86-64-linux -O0 --timeout-ms 10000
 ```
 
 — and a consumer should re-execute the array under the object rather than parse


### PR DESCRIPTION
Generated test reproduction commands use `--exact` to select the complete stable ID. Reproducing `x.rue::alpha` now runs that test alone when `x.rue::alphabet` and `prefix/x.rue::alpha` are also present. Ordinary `--filter` retains substring matching and repeated-filter union; execution and `--list` share membership selection.

The CLI regression executes the published argv and environment, then checks the replayed selection and verdict. It fails against the baseline compiler because three tests run, and passes with this change because one test runs.

Fixes RUE-2132.

Validation: selector and test-mode unit tests, all 36 quick-tier targets, 105 CLI cases (3 existing skips), exact-list and emitted-command replay regressions, formatting, and `git diff --check` passed. The oracle corpus check also passed, and final formatting left the committed worktree clean.

After rebasing onto the owned compiler-result changes, quick, the full rue_test CLI filter, oracle, and formatting passed again on the published commit.
