### PR TITLE
RUE-2148: escape hashes in generated source manifests

### DIFF
--- a/fixtures/rue-program/BUCK
+++ b/fixtures/rue-program/BUCK
@@ -76,8 +76,8 @@ rue_program_test(
 )
 
 # The rue_test proving ground. `runner/main.rue` imports `lib_tests.rue` and
-# nothing imports `orphan_tests.rue`; both files are in srcs, so both are in
-# the declared candidate inventory.
+# nothing imports `orphan_tests.rue` or `orphan#tests.rue`; all files are in
+# srcs, so all are in the declared candidate inventory.
 #
 # The pair is what pins the rule's one non-obvious behavior. `rue test` reports
 # the orphan as a warning and still exits 0, so a rule that only forwarded the
@@ -95,6 +95,6 @@ rue_test(
     root = "fixtures/rue-program/runner/main.rue",
     srcs = glob(["runner/**/*.rue"]),
     # Negative control: passes if and only if the run WOULD have failed the
-    # target, for exactly this path and for no other reason.
-    expect_unimported = ["orphan_tests.rue"],
+    # target, for exactly these paths and for no other reason.
+    expect_unimported = ["orphan_tests.rue", "orphan#tests.rue"],
 )

--- a/fixtures/rue-program/hello/hash#helper.rue
+++ b/fixtures/rue-program/hello/hash#helper.rue
@@ -1,0 +1,1 @@
+pub fn value() -> i32 { 0 }

--- a/fixtures/rue-program/hello/main.rue
+++ b/fixtures/rue-program/hello/main.rue
@@ -7,8 +7,9 @@
 // hermetic denial. The binding is deliberately unused: acquisition is
 // triggered by the fallible intrinsic itself.
 const types = @import("sub/types.rue");
+const hash = @import("hash#helper.rue");
 
 fn main() -> i32 {
     let _parsed = @parse_i32("2");
-    types.value()
+    types.value() + hash.value()
 }

--- a/fixtures/rue-program/runner/main.rue
+++ b/fixtures/rue-program/runner/main.rue
@@ -1,7 +1,8 @@
 // ADR-0083 fixture root (RUE-2004): the aggregator import is the whole point.
 // `lib_tests.rue` is reachable only because this file imports it, and
-// `orphan_tests.rue` is deliberately reachable from nothing — which is what
-// the two rue_test targets over this directory pin from both sides.
+// `orphan_tests.rue` and `orphan#tests.rue` are deliberately reachable from
+// nothing — which is what the two rue_test targets over this directory pin
+// from both sides.
 const tests = @import("lib_tests.rue");
 
 fn main() -> i32 {

--- a/fixtures/rue-program/runner/orphan#tests.rue
+++ b/fixtures/rue-program/runner/orphan#tests.rue
@@ -1,0 +1,5 @@
+// Declared in srcs, imported by nothing. The hash in this filename exercises
+// the test-candidate inventory's source-manifest line grammar.
+test "nothing imports this hash file" {
+    @assert(1 == 1);
+}

--- a/rue_rules.bzl
+++ b/rue_rules.bzl
@@ -208,7 +208,9 @@ def _test_candidate_list(ctx: AnalysisContext):
                 project_path,
                 root_dir,
             ))
-        candidates.append(project_path[len(prefix):])
+        # `rue test` uses the same line grammar as --source-manifest: hashes
+        # begin comments unless escaped at this final serialization boundary.
+        candidates.append(project_path[len(prefix):].replace("#", "\\#"))
     return ctx.actions.write("test-candidates.list", candidates)
 
 

--- a/scripts/rue-program-derive-manifest.py
+++ b/scripts/rue-program-derive-manifest.py
@@ -68,6 +68,11 @@ def normalize(path: str) -> str:
     return posixpath.normpath(path.replace(os.sep, "/"))
 
 
+def escape_manifest_entry(entry: str) -> str:
+    """Quote literal hashes for the source-manifest line grammar."""
+    return entry.replace("#", r"\#")
+
+
 def reanchor(abs_path: str, roots: list[tuple[str, str]]) -> "str | None":
     """Map an envelope-absolute path to a project-relative path.
 
@@ -196,7 +201,10 @@ def main() -> None:
     # Entries resolve against the manifest file's own directory, which keeps
     # them identical across checkout roots.
     manifest_dir = posixpath.dirname(normalize(args.out)) or "."
-    lines = sorted(posixpath.relpath(entry, manifest_dir) for entry in entries)
+    lines = [
+        escape_manifest_entry(posixpath.relpath(entry, manifest_dir))
+        for entry in sorted(entries)
+    ]
     with open(args.out, "w", encoding="utf-8") as handle:
         handle.write("\n".join(lines) + "\n")
 

--- a/scripts/test-rue-program-derive-manifest.py
+++ b/scripts/test-rue-program-derive-manifest.py
@@ -109,6 +109,34 @@ class DeriveManifestTest(unittest.TestCase):
         self.assertIn("../stdout-dir/std/option.rue", manifest)
         self.assertNotIn("/checkout", manifest)
 
+    def test_hashes_are_escaped_in_every_declared_union(self):
+        with open(os.path.join(self.cwd, "stdout-dir/std/has#std.rue"), "w") as handle:
+            handle.write("// std\n")
+        env = envelope(
+            "/checkout/prog",
+            "/checkout/stdroot",
+            accepted=["/checkout/prog/has#read.rue"],
+            absent=["/checkout/prog/has#missing.rue"],
+        )
+        result = self.run_derive(
+            env,
+            ["prog/main.rue", "prog/has#read.rue", "prog/has#orphan.rue"],
+            extra=["--include-srcs"],
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            set(self.read_out().splitlines()),
+            {
+                "../prog/has\\#missing.rue",
+                "../prog/has\\#orphan.rue",
+                "../prog/has\\#read.rue",
+                "../prog/main.rue",
+                "../stdout-dir/std/_std.rue",
+                "../stdout-dir/std/has\\#std.rue",
+                "../stdout-dir/std/option.rue",
+            },
+        )
+
     def test_out_of_srcs_read_fails_the_build(self):
         env = envelope(
             "/checkout/prog",
@@ -149,11 +177,18 @@ class DeriveManifestTest(unittest.TestCase):
             env = envelope(
                 fake_root + "/prog",
                 fake_root + "/stdlocation",
-                accepted=[fake_root + "/prog/main.rue"],
-                absent=[fake_root + "/prog/helper.rue"],
+                accepted=[
+                    fake_root + "/prog/main.rue",
+                    fake_root + "/prog/hash#helper.rue",
+                ],
+                absent=[fake_root + "/prog/helper#missing.rue"],
             )
             out = "out/manifest-" + fake_root.replace("/", "_")
-            result = self.run_derive(env, ["prog/main.rue"], out=out)
+            result = self.run_derive(
+                env,
+                ["prog/main.rue", "prog/hash#helper.rue"],
+                out=out,
+            )
             self.assertEqual(result.returncode, 0, result.stderr)
             manifests.append(self.read_out(out))
         self.assertEqual(manifests[0], manifests[1])


### PR DESCRIPTION
Generated source manifests now escape literal hashes after reanchoring each path. Declared sources such as `hash#helper.rue` remain readable during manifest-enforced compilation, and the test-candidate writer uses the same escaping grammar.

Regression coverage includes accepted reads, absent candidates, unconditional std files, include-srcs entries, and relocation. Real Buck fixtures import a hash-named module and verify a hash-named orphan alongside the existing undeclared-source boundary control.

Fixes RUE-2148.

Validation: all 10 derive tests, five end-to-end program/test/boundary fixtures, all 36 quick-tier targets, formatting, and `git diff --check` passed.
