### PR TITLE
RUE-2134: parse array repeats in intrinsic value arguments

### DIFF
--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -1153,6 +1153,7 @@ mod tests {
             ("!", |t| matches!(t, TypeExpr::Never(_))),
             ("[i32; 4]", |t| matches!(t, TypeExpr::Array { .. })),
             ("[i32; N]", |t| matches!(t, TypeExpr::Array { .. })),
+            ("[(); 3]", |t| matches!(t, TypeExpr::Array { .. })),
             ("[i32]", |t| matches!(t, TypeExpr::Slice { .. })),
             ("[[u8; 2]; 3]", |t| matches!(t, TypeExpr::Array { .. })),
             ("ptr const i32", |t| {
@@ -1248,6 +1249,41 @@ mod tests {
         assert!(matches!(&args[3], IntrinsicArg::Type(TypeExpr::Unit(_))));
         assert!(matches!(&args[4], IntrinsicArg::Expr(Expr::ArrayLit(_))));
         assert!(matches!(&args[5], IntrinsicArg::Expr(Expr::Ident(_))));
+    }
+
+    #[test]
+    fn value_position_intrinsics_accept_array_repeat_expressions() {
+        let args = intrinsic_args("fn f(n: i32) -> i32 { @drop(([1; 3])) }");
+        assert!(matches!(
+            &args[0],
+            IntrinsicArg::Expr(Expr::Paren(paren))
+                if matches!(&*paren.inner, Expr::ArrayLit(array) if array.repeat.is_some())
+        ));
+
+        let args =
+            intrinsic_args("fn f(n: i32, count: i32) -> i32 { @probe([n; count], [[1; 2]; 3]) }");
+        assert!(matches!(
+            &args[0],
+            IntrinsicArg::Expr(Expr::ArrayLit(array)) if array.repeat.is_some()
+        ));
+        assert!(matches!(
+            &args[1],
+            IntrinsicArg::Expr(Expr::ArrayLit(array)) if array.repeat.is_some()
+        ));
+
+        let args = intrinsic_args("fn f() -> i32 { @probe([(); 3], [() == (); 3], [!false; 3]) }");
+        assert!(args.iter().all(|arg| matches!(
+            arg,
+            IntrinsicArg::Expr(Expr::ArrayLit(array)) if array.repeat.is_some()
+        )));
+    }
+
+    #[test]
+    fn value_position_intrinsics_preserve_unambiguous_array_types() {
+        let args = intrinsic_args(
+            "fn f() -> i32 { @probe([i32; 3], [[i32; 2]; 3], [ptr const i32; 3], [!; 3]) }",
+        );
+        assert!(args.iter().all(|arg| matches!(arg, IntrinsicArg::Type(_))));
     }
 
     #[test]

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -714,7 +714,40 @@ impl Parser {
         }
     }
 
+    /// Whether the bracketed argument starts with an unambiguous type form.
+    ///
+    /// Array literals and array types share `[value; count]` syntax. A
+    /// semicolon therefore cannot classify the whole bracketed argument by
+    /// itself: `[1; 3]` and `[i32; 3]` need to remain an expression and a type
+    /// respectively. This bounded token check peels nested leading brackets
+    /// and recognizes only type-only starts (primitive/pointer/never syntax),
+    /// while leaving identifier and unit-expression starts ambiguous so named
+    /// and unit values are never treated as types. The canonical `ty()` parser
+    /// still consumes the type once the start is known; this scan only
+    /// resolves the shared leading token.
     fn bracket_is_array_type(&self) -> bool {
+        let mut element_start = self.cursor + 1;
+        let type_start = loop {
+            let Some(token) = self.tokens.get(element_start) else {
+                return false;
+            };
+            match token.kind {
+                TokenKind::LBracket => element_start += 1,
+                kind if self.primitive_spur(kind).is_some() || kind == TokenKind::Ptr => {
+                    break true;
+                }
+                TokenKind::Bang => {
+                    break self.tokens.get(element_start + 1).is_some_and(|token| {
+                        matches!(token.kind, TokenKind::Semi | TokenKind::RBracket)
+                    });
+                }
+                _ => break false,
+            }
+        };
+        if !type_start {
+            return false;
+        }
+
         let mut depth = 0usize;
         for token in &self.tokens[self.cursor..] {
             match token.kind {

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -31,6 +31,17 @@ fn main() -> i32 {
 exit_code = 4
 
 [[case]]
+name = "intrinsic_array_repeat_value_argument"
+spec = ["4.13:2", "7.1:39"]
+source = """
+fn main() -> i32 {
+    @drop([1; 3]);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
 name = "unknown_intrinsic"
 spec = ["4.13:5"]
 source = """

--- a/crates/rue-ui-tests/cases/diagnostics/parser_messages.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/parser_messages.toml
@@ -153,3 +153,15 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["`@align_of` takes a type in this argument position"]
+
+[[case]]
+name = "value_intrinsic_array_type_is_rejected_semantically"
+description = "An array type in a value-intrinsic argument remains a type and reaches the intrinsic type diagnostic."
+source = """
+fn main() -> i32 {
+    @dbg([i32; 3]);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0702]", "found type"]


### PR DESCRIPTION
Value-position intrinsic arguments now accept direct array-repeat expressions such as `@drop([1; 3])`. Bracket classification recognizes type-only starts instead of treating every semicolon as proof of a type; identifiers, unit values, nested repeats, and boolean expressions use the expression grammar.

Explicit type positions continue to use the canonical type parser, and unambiguous array types in value positions retain their semantic diagnostic. The classifier handles nested leading brackets iteratively.

Fixes RUE-2134.

Validation: focused parser tests, 225 intrinsic spec cases (11 existing skips), 11 parser diagnostic cases, an executable repeat matrix, all 36 quick-tier targets, formatting, and `git diff --check` passed. The final oracle corpus check also passed.
