### PR TITLE
RUE-2140: stop std.env.var key matching at the first separator

### DIFF
--- a/crates/rue-cli-tests/cases/std_env.toml
+++ b/crates/rue-cli-tests/cases/std_env.toml
@@ -141,3 +141,36 @@ fn main() -> i32 {
 """ }]
 stdout = "absent\n"
 exit_code = 0
+
+# The key is everything before an entry's FIRST '='. The whole value is
+# returned even when it contains '=' itself, and a name that reads through the
+# separator into the value (`KEY=left` against `KEY=left=right`) is not a key
+# match (RUE-2140). A strict prefix of the key stays absent too.
+[[case]]
+name = "var_key_stops_at_first_equals"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+program_env = { RUE_CLI_ENV_EQ = "left=right" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const Opt = std.option.Option(StrBuf);
+
+fn show(borrow key: StrBuf) {
+    match std.env.var(borrow key) {
+        Opt.Some(v) => @dbg(v),
+        Opt.None => @dbg("absent"),
+    }
+}
+
+fn main() -> i32 {
+    let exact: StrBuf = "RUE_CLI_ENV_EQ";
+    let through: StrBuf = "RUE_CLI_ENV_EQ=left";
+    let prefix: StrBuf = "RUE_CLI_ENV";
+    show(borrow exact);
+    show(borrow through);
+    show(borrow prefix);
+    0
+}
+""" }]
+stdout = "left=right\nabsent\nabsent\n"
+exit_code = 0

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -439,6 +439,12 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.std_env",
+        "var_key_stops_at_first_equals",
+        external(ExternalDependencyKind::EnvCount),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_env",
         "var_present_returns_value",
         external(ExternalDependencyKind::EnvCount),
         &[],

--- a/std/env.rue
+++ b/std/env.rue
@@ -86,8 +86,11 @@ pub fn env_count() -> u64 {
 }
 
 // Whether environment entry `[ptr, len)` has key `name` — i.e. the first
-// `name_len` bytes equal `name` and byte `name_len` is `'='` (0x3D). Keys never
-// contain `'='`, so this is an exact key match.
+// `name_len` bytes equal `name` and byte `name_len` is `'='` (0x3D). An entry's
+// key is everything before its FIRST `'='`, so the comparison stops as soon as
+// the entry reaches a separator: a `name` that itself contains `'='` (such as
+// `KEY=left` against `KEY=left=right`) never matches, instead of reading
+// through the separator into the entry's value.
 fn key_matches(entry_ptr: ptr mut u8, len: u64, borrow name: StrBuf, name_len: u64) -> bool {
     // Need room for the key plus the '=' separator.
     if len < name_len + 1 {
@@ -96,6 +99,10 @@ fn key_matches(entry_ptr: ptr mut u8, len: u64, borrow name: StrBuf, name_len: u
     let mut i: u64 = 0;
     while i < name_len {
         let entry_byte: u8 = checked { @ptr_read(@ptr_offset(entry_ptr, i)) };
+        // The entry's key ended before `name` did.
+        if entry_byte == 61 {
+            return false;
+        }
         // `name` is a borrow, so read its bytes through the borrow-safe
         // accessor: the trapping `name[i]` index form is a by-copy read that
         // would move out of the borrowed `StrBuf` (E0429).


### PR DESCRIPTION
An environment entry's key is everything before its first `=`, but `key_matches` in `std/env.rue` compared the requested name against the raw entry prefix and only then checked for a separator. A name containing `=` (`KEY=left` against `KEY=left=right`) therefore matched through the separator and `var` returned the tail of the value (`right`) instead of `None`.

The comparison now stops as soon as the entry reaches its separator, so a name that reads past the key can never match. Names without `=` behave as before.

Coverage: one new `cli.std_env` case with `program_env = { RUE_CLI_ENV_EQ = "left=right" }` checks that the exact key returns the whole value including its `=`, that `RUE_CLI_ENV_EQ=left` is absent, and that the strict prefix `RUE_CLI_ENV` is absent. The case is registered with the oracle-diff model gaps as an `EnvCount` external dependency, like the existing std.env cases.

Verified locally: reproduced `right` before the change and `None` after; `scripts/rue cli std_env`, `//tests/std:std-tests`, and `//crates/rue-oracle-diff:oracle-diff-test` pass.

Fixes RUE-2140