### PR TITLE
RUE-2139: compact the StrMap key pool under dead-byte pressure

### DIFF
--- a/std/strmap.rue
+++ b/std/strmap.rue
@@ -38,12 +38,19 @@
 // the hash before comparing bytes. This mirrors the pooled-bytes interner in
 // examples/ruelex/interner.rue.
 //
-// POOL COMPACTION — inserting over a tombstone (or growing) appends the new
-// key's bytes to `pool` and leaves the old key's bytes stranded in it. Those
-// dead bytes would accumulate forever, so `_grow_to` rebuilds `pool` from
-// scratch, copying only the bytes of OCCUPIED slots. A rehash therefore also
-// compacts the key pool, and the old pool (with its dead bytes) is freed when
-// it is overwritten.
+// POOL COMPACTION — removing a key (and inserting a fresh one over its
+// tombstone) leaves the old key's bytes stranded in `pool`. Those dead bytes
+// must not accumulate forever, so `_grow_to` rebuilds `pool` from scratch,
+// copying only the bytes of OCCUPIED slots: a rehash also compacts the key
+// pool, and the old pool (with its dead bytes) is freed when it is overwritten.
+// Growth alone is not enough of a trigger: a map whose live size stays small
+// while the same keys are inserted and removed never grows, so `dead` counts
+// the stranded bytes and `insert` rehashes at the SAME capacity once they
+// outnumber the live key bytes (past a small floor). Each compaction costs one
+// pass over the table plus the live bytes, and it only fires after at least
+// that many dead bytes were appended, so the work stays amortized O(1) per
+// key byte and `pool` stays within a constant factor of the live key bytes
+// (RUE-2139).
 
 const arraybuf = @import("arraybuf.rue");
 const option = @import("option.rue");
@@ -94,6 +101,9 @@ pub fn StrMap(comptime V: type) -> type {
         states: States,
         count: u64,
         cap: u64,
+        // Key bytes in `pool` that belong to removed (tombstoned) slots. Reset
+        // by every `_grow_to`, which drops them.
+        dead: u64,
         filler: V,
 
         // COPY-`V` ONLY: the gate is stated ahead of everything else so an
@@ -115,6 +125,7 @@ pub fn StrMap(comptime V: type) -> type {
                 states: sb.new(),
                 count: 0,
                 cap: 0,
+                dead: 0,
                 filler: filler,
             };
             m._grow_to(8);
@@ -210,6 +221,16 @@ pub fn StrMap(comptime V: type) -> type {
             self.vals = nv;
             self.states = ns;
             self.cap = new_cap;
+            self.dead = 0;
+        }
+
+        // Whether the stranded key bytes in `pool` have outgrown the live ones.
+        // The floor keeps tiny maps from rebuilding on every other churn;
+        // above it, compacting once dead bytes exceed live bytes bounds the
+        // pool at about twice the live key bytes.
+        fn _needs_compaction(borrow self) -> bool {
+            let live = self.pool.len() - self.dead;
+            self.dead >= 64 && self.dead > live
         }
 
         // Write `k -> v` into `target`, appending the key bytes to the pool.
@@ -241,6 +262,10 @@ pub fn StrMap(comptime V: type) -> type {
                     @panic("out of memory");
                 }
                 self._grow_to(self.cap * 2);
+            } else if self._needs_compaction() {
+                // Same capacity: this rehash exists only to rebuild the pool
+                // without the dead key bytes (it clears tombstones too).
+                self._grow_to(self.cap);
             }
             let khash = _fnv1a(borrow k);
             let klen = k.len();
@@ -305,8 +330,8 @@ pub fn StrMap(comptime V: type) -> type {
         }
 
         // Remove `k`; returns whether it was present. The slot becomes a
-        // tombstone; its key bytes stay in the pool until the next `_grow_to`
-        // compacts them away.
+        // tombstone; its key bytes stay in the pool, counted in `dead`, until
+        // the next `_grow_to` compacts them away.
         fn remove(inout self, borrow k: StrBuf) -> bool {
             let khash = _fnv1a(borrow k);
             let klen = k.len();
@@ -320,6 +345,7 @@ pub fn StrMap(comptime V: type) -> type {
                     if self._key_eq(idx, borrow k, khash, klen) {
                         self.states.set(idx, _TOMBSTONE());
                         self.count -= 1;
+                        self.dead += klen;
                         return true;
                     }
                 }

--- a/tests/std/maps_tests.rue
+++ b/tests/std/maps_tests.rue
@@ -141,3 +141,89 @@ test "StrMap survives tombstone churn" {
     m.insert(borrow k, 9);
     @assert_eq(m.get(borrow k), OptI.Some(9));
 }
+
+// Dead key bytes are released without the table ever growing: with a live
+// size that never leaves 0..2 the load threshold is never crossed, so only the
+// dead-byte trigger can bound the pool (RUE-2139). The pool is read directly
+// because retention is not observable through the lookup API.
+test "StrMap bounds its key pool under same-key churn at a fixed live size" {
+    let mut m = StrMap.new(0);
+    let key: StrBuf = "hello";
+    let mut i: i64 = 0;
+    while i < 2000 {
+        m.insert(borrow key, i);
+        @assert_eq(m.get(borrow key), OptI.Some(i));
+        @assert(m.remove(borrow key));
+        @assert_eq(m.get(borrow key), OptI.None);
+        i += 1;
+    }
+    @assert(m.is_empty());
+    // Every churn appended five bytes; unbounded retention would hold 10000.
+    @assert(m.pool.len() < 200);
+}
+
+test "StrMap bounds its key pool under varying-key churn beside a persistent entry" {
+    let mut m = StrMap.new(0);
+    let sentinel: StrBuf = "persistent-sentinel";
+    m.insert(borrow sentinel, -1);
+    let mut i: i64 = 0;
+    while i < 2000 {
+        let key = std.fmt.int_to_string(i64, 100000 + i);
+        m.insert(borrow key, i);
+        @assert_eq(m.len(), 2);
+        @assert_eq(m.get(borrow key), OptI.Some(i));
+        @assert_eq(m.get(borrow sentinel), OptI.Some(-1));
+        @assert(m.remove(borrow key));
+        @assert_eq(m.get(borrow key), OptI.None);
+        i += 1;
+    }
+    @assert_eq(m.len(), 1);
+    @assert_eq(m.get(borrow sentinel), OptI.Some(-1));
+    // Unbounded retention would hold 6 * 2000 dead bytes plus the sentinel.
+    @assert(m.pool.len() < 200);
+    let overwrite: StrBuf = "persistent-sentinel";
+    m.insert(borrow overwrite, 7);
+    @assert_eq(m.len(), 1);
+    @assert_eq(m.get(borrow sentinel), OptI.Some(7));
+}
+
+// Compaction at the same capacity must keep every live entry findable, and
+// growth compaction must still take over once the live size climbs.
+test "StrMap keeps live entries across same-capacity compaction and growth" {
+    let mut m = StrMap.new(0);
+    let a: StrBuf = "alpha";
+    let b: StrBuf = "beta";
+    let c: StrBuf = "gamma";
+    m.insert(borrow a, 1);
+    m.insert(borrow b, 2);
+    m.insert(borrow c, 3);
+    let mut i: i64 = 0;
+    while i < 500 {
+        let key = std.fmt.int_to_string(i64, 5000 + i);
+        m.insert(borrow key, i);
+        @assert(m.remove(borrow key));
+        i += 1;
+    }
+    @assert_eq(m.len(), 3);
+    @assert_eq(m.get(borrow a), OptI.Some(1));
+    @assert_eq(m.get(borrow b), OptI.Some(2));
+    @assert_eq(m.get(borrow c), OptI.Some(3));
+    @assert(m.remove(borrow b));
+    @assert_eq(m.get(borrow b), OptI.None);
+    let mut j: i64 = 0;
+    while j < 300 {
+        let key = std.fmt.int_to_string(i64, j);
+        m.insert(borrow key, j);
+        j += 1;
+    }
+    @assert_eq(m.len(), 302);
+    @assert_eq(m.get(borrow a), OptI.Some(1));
+    @assert_eq(m.get(borrow b), OptI.None);
+    @assert_eq(m.get(borrow c), OptI.Some(3));
+    let mut k: i64 = 0;
+    while k < 300 {
+        let key = std.fmt.int_to_string(i64, k);
+        @assert_eq(m.get(borrow key), OptI.Some(k));
+        k += 1;
+    }
+}


### PR DESCRIPTION
`StrMap` stores every key's bytes in one pooled `StrBuf` and only rebuilt that pool when the live count crossed the growth threshold. A map whose live size stayed small while keys were inserted and removed therefore never grew and appended dead key bytes forever: the issue's repro held 100 dead bytes after 20 same-key churns, and 10000 after 2000.

The map now tracks `dead`, the bytes of removed keys still in the pool, and `insert` rehashes at the same capacity once the dead bytes outnumber the live key bytes past a 64-byte floor. That reuses the existing `_grow_to` compaction path (which also clears tombstones) rather than adding a second one. Each compaction costs one pass over the table plus the live bytes and fires only after at least that many dead bytes were appended, so the pool stays within a constant factor of the live key bytes at amortized O(1) per key byte. Compaction is not immediate after each removal.

Coverage in `tests/std/maps_tests.rue`: same-key churn at live size 0..1, varying-key churn beside a persistent sentinel entry (with a final overwrite), and lookups preserved across same-capacity compaction followed by growth. The retention tests read `pool.len()` directly because retention is not observable through the lookup API.

Verified locally: the repro's pool drops from 10000 bytes to 55 after 2000 churns, and `//tests/std:std-tests` passes with the three new tests.

Fixes RUE-2139