### PR TITLE
RUE-2149: keep Mach-O private-external and weak bindings through symbol ingestion

### DIFF
--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -1131,6 +1131,107 @@ execute_if_native = true
 stdout = "5\n4\n"
 exit_code = 0
 
+# --- Archive member bindings a C toolchain produces (RUE-2149) --------------
+# The synthesized archive carries a hidden (`visibility("hidden")`) helper in a
+# member AFTER the probe that calls it, and two members that each define the
+# same weak (`__attribute__((weak))`) symbol. Every host links all three
+# targets, which is where Mach-O symbol ingestion used to drop both bindings
+# (the hidden helper became an undefined `E1000`, the weak pair a duplicate);
+# the matching native host also executes the image.
+
+[[case]]
+name = "x86_64_linux_archive_hidden_and_weak_members_link"
+description = "A hidden helper in a later archive member and weak definitions in two pulled members link and run on x86-64 Linux."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_hidden_probe() -> i64;
+    fn ffi_weak_probe_a() -> i64;
+    fn ffi_weak_probe_b() -> i64;
+    fn ffi_weak_shared() -> i64;
+}
+
+fn main() -> i32 {
+    // Pulls the probe member; the hidden helper it calls lives in a later
+    // member and is reached only through the archive index.
+    @dbg(checked { ffi_hidden_probe() });
+    // Pulls both weak members; their two weak `ffi_weak_shared` definitions
+    // coalesce instead of colliding.
+    let a = checked { ffi_weak_probe_a() };
+    let b = checked { ffi_weak_probe_b() };
+    let shared = checked { ffi_weak_shared() };
+    @dbg(a + b + shared);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "42\n126\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_archive_hidden_and_weak_members_link"
+description = "A hidden helper in a later archive member and weak definitions in two pulled members link and run on AArch64 Linux."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_hidden_probe() -> i64;
+    fn ffi_weak_probe_a() -> i64;
+    fn ffi_weak_probe_b() -> i64;
+    fn ffi_weak_shared() -> i64;
+}
+
+fn main() -> i32 {
+    // Pulls the probe member; the hidden helper it calls lives in a later
+    // member and is reached only through the archive index.
+    @dbg(checked { ffi_hidden_probe() });
+    // Pulls both weak members; their two weak `ffi_weak_shared` definitions
+    // coalesce instead of colliding.
+    let a = checked { ffi_weak_probe_a() };
+    let b = checked { ffi_weak_probe_b() };
+    let shared = checked { ffi_weak_shared() };
+    @dbg(a + b + shared);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "42\n126\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_macos_archive_hidden_and_weak_members_link"
+description = "A hidden (N_PEXT) helper in a later archive member and N_WEAK_DEF definitions in two pulled members link into a Mach-O image and run on macOS."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_hidden_probe() -> i64;
+    fn ffi_weak_probe_a() -> i64;
+    fn ffi_weak_probe_b() -> i64;
+    fn ffi_weak_shared() -> i64;
+}
+
+fn main() -> i32 {
+    // Pulls the probe member; the hidden helper it calls lives in a later
+    // member and is reached only through the archive index.
+    @dbg(checked { ffi_hidden_probe() });
+    // Pulls both weak members; their two weak `ffi_weak_shared` definitions
+    // coalesce instead of colliding.
+    let a = checked { ffi_weak_probe_a() };
+    let b = checked { ffi_weak_probe_b() };
+    let shared = checked { ffi_weak_shared() };
+    @dbg(a + b + shared);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-macos", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-macos"
+execute_if_native = true
+stdout = "42\n126\n"
+exit_code = 0
+
 # --- P4 export diagnostics (compile-fail) -----------------------------------
 
 [[case]]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -271,6 +271,16 @@ mod sharding;
 ///   `StrBuf`<->`char*` interop proof: it counts bytes before the NUL terminator
 ///   of the pointer argument, so a `StrBuf` exported via `std.c.owned_c_string`
 ///   round-trips its length through a real foreign call.
+///
+/// Symbol-binding members (RUE-2149), carrying the bindings a C toolchain
+/// produces so archive extraction and strong/weak resolution are proven on
+/// every object format:
+/// - `ffi_hidden_probe() -> 42` calls `ffi_hidden_helper`, a hidden
+///   (`visibility("hidden")`) definition in a LATER member.
+/// - `ffi_weak_probe_a`/`ffi_weak_probe_b` each live in a member whose
+///   definitions are weak (`__attribute__((weak))`) and that also defines
+///   `ffi_weak_shared`; pulling both members must coalesce the two weak
+///   definitions. All three return 42.
 fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
     // A leaf function returning 42 (P1).
     let answer: Vec<u8> = match target.arch() {
@@ -342,7 +352,7 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
     objects.push((
         "answer.o".to_string(),
         rue_linker::ObjectBuilder::new(target, "answer")
-            .code(answer)
+            .code(answer.clone())
             .build(),
     ));
     for symbol in echo_symbols {
@@ -764,6 +774,64 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
         caller_objects.push((format!("{symbol}.o"), builder.build()));
     }
     objects.extend(caller_objects);
+
+    // --- Symbol bindings a C toolchain produces (RUE-2149) --------------------
+    //
+    // Two shapes clang archives commonly carry, both of which must survive
+    // symbol ingestion so archive extraction and strong/weak resolution see
+    // them:
+    //
+    // - `ffi_hidden_probe` calls `ffi_hidden_helper`, a hidden
+    //   (`visibility("hidden")`: ELF STV_HIDDEN, Mach-O N_PEXT) definition in
+    //   a LATER member. The probe member is pulled by the program and the
+    //   helper only transitively, so the archive index must count the hidden
+    //   definition as a provider.
+    // - `ffi_weak_probe_a` and `ffi_weak_probe_b` each live in a member that
+    //   also defines the weak `ffi_weak_shared` (`__attribute__((weak))`:
+    //   STB_WEAK, N_WEAK_DEF). A program calling both probes pulls both
+    //   members, so the two weak definitions must coalesce instead of being
+    //   rejected as duplicates.
+    //
+    // Every definition of a member shares its binding, so each weak member
+    // defines `ffi_weak_shared` and carries its probe as a (weak) alias; all
+    // three symbols return 42 through the same leaf code.
+    let hidden_probe: Vec<u8> = match target.arch() {
+        // push rax ; call ffi_hidden_helper ; pop rcx ; ret
+        Arch::X86_64 => vec![0x50, 0xE8, 0x00, 0x00, 0x00, 0x00, 0x59, 0xC3],
+        // stp x29,x30,[sp,#-16]! ; bl ffi_hidden_helper ; ldp x29,x30,[sp],#16 ; ret
+        Arch::Aarch64 => vec![
+            0xFD, 0x7B, 0xBF, 0xA9, 0x00, 0x00, 0x00, 0x94, 0xFD, 0x7B, 0xC1, 0xA8, 0xC0, 0x03,
+            0x5F, 0xD6,
+        ],
+    };
+    let hidden_call_offset: u64 = match target.arch() {
+        Arch::X86_64 => 2,
+        Arch::Aarch64 => 4,
+    };
+    objects.push((
+        "ffi_hidden_probe.o".to_string(),
+        rue_linker::ObjectBuilder::new(target, "ffi_hidden_probe")
+            .code(hidden_probe)
+            .relocation(plt(hidden_call_offset, "ffi_hidden_helper"))
+            .build(),
+    ));
+    objects.push((
+        "ffi_hidden_helper.o".to_string(),
+        rue_linker::ObjectBuilder::new(target, "ffi_hidden_helper")
+            .code(answer.clone())
+            .linkage(rue_linker::DefinitionLinkage::Hidden)
+            .build(),
+    ));
+    for probe in ["ffi_weak_probe_a", "ffi_weak_probe_b"] {
+        objects.push((
+            format!("{probe}.o"),
+            rue_linker::ObjectBuilder::new(target, "ffi_weak_shared")
+                .alias(probe)
+                .code(answer.clone())
+                .linkage(rue_linker::DefinitionLinkage::Weak)
+                .build(),
+        ));
+    }
 
     let members: Vec<(&str, &[u8])> = objects
         .iter()

--- a/crates/rue-linker/src/constants.rs
+++ b/crates/rue-linker/src/constants.rs
@@ -121,6 +121,12 @@ pub const STB_GLOBAL: u8 = 1;
 /// STB_WEAK: Weak symbol
 pub const STB_WEAK: u8 = 2;
 
+// ELF symbol visibility (the low bits of `st_other`)
+
+/// STV_HIDDEN: the symbol resolves across the objects of one link but is not
+/// exported from the linked image (the `st_other` form of Mach-O's N_PEXT).
+pub const STV_HIDDEN: u8 = 2;
+
 // Symbol types (lower 4 bits of st_info)
 
 /// STT_NOTYPE: Symbol type not specified
@@ -303,6 +309,15 @@ pub const N_SECT: u8 = 0x0E;
 pub const N_UNDF: u8 = 0x00;
 /// N_ABS: Absolute symbol
 pub const N_ABS: u8 = 0x02;
+
+// Mach-O symbol descriptors (`n_desc` bits).
+
+/// N_WEAK_REF: an undefined symbol that need not be resolved (the reference
+/// binds to address 0 when no definition is found).
+pub const N_WEAK_REF: u16 = 0x0040;
+/// N_WEAK_DEF: a weak (coalesced) definition; a strong definition overrides
+/// it and the first of several weak definitions wins.
+pub const N_WEAK_DEF: u16 = 0x0080;
 
 // ARM64 relocation types (Mach-O)
 

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -48,6 +48,8 @@ use crate::constants::{
     N_SECT,
     N_TYPE,
     N_UNDF,
+    N_WEAK_DEF,
+    N_WEAK_REF,
     R_AARCH64_ABS64,
     R_AARCH64_ADD_ABS_LO12_NC,
     R_AARCH64_ADR_PREL_PG_HI21,
@@ -563,6 +565,40 @@ pub enum SymbolBinding {
     Local,
     Global,
     Weak,
+}
+
+/// The binding of a Mach-O symbol from its `n_type` and `n_desc` fields.
+///
+/// This is the one place Mach-O binding bits become a [`SymbolBinding`], so
+/// symbol-only archive indexing and a full parse classify a symbol
+/// identically:
+///
+/// - Without `N_EXT` the symbol is object-local. That includes a bare
+///   `N_PEXT`, which is how `ld -r` marks a private external it has already
+///   turned into a local.
+/// - `N_EXT | N_PEXT` is a private external (`visibility("hidden")`): it is
+///   not exported from the linked image, but it still resolves references
+///   from the other objects of that image, so it binds as a global. Treating
+///   it as local left the definition invisible to archive extraction and to
+///   the cross-object symbol table (RUE-2149).
+/// - `N_WEAK_DEF` on a definition and `N_WEAK_REF` on an undefined symbol are
+///   the weak binding the downstream strong/weak policy expects: a strong
+///   definition overrides a weak one, the first of several weak definitions
+///   wins, and a weak undefined reference pulls no archive member.
+pub(crate) fn macho_symbol_binding(n_type: u8, n_desc: u16) -> SymbolBinding {
+    if n_type & N_EXT == 0 {
+        return SymbolBinding::Local;
+    }
+    let weak_bit = if n_type & N_TYPE == N_UNDF {
+        N_WEAK_REF
+    } else {
+        N_WEAK_DEF
+    };
+    if n_desc & weak_bit != 0 {
+        SymbolBinding::Weak
+    } else {
+        SymbolBinding::Global
+    }
 }
 
 /// Symbol type.
@@ -1097,6 +1133,7 @@ impl ObjectFile {
                 let n_strx = read_u32(data, sym_offset) as usize;
                 let n_type = data[sym_offset + 4];
                 let n_sect = data[sym_offset + 5];
+                let n_desc = read_u16(data, sym_offset + 6);
                 let n_value = read_u64(data, sym_offset + 8);
 
                 // Read symbol name from string table
@@ -1118,16 +1155,7 @@ impl ObjectFile {
                 // collapsed "_foo" and "__foo" onto the same "__foo" symbol.
                 name = crate::util::strip_macho_underscore(&name).to_string();
 
-                // Determine binding (external or local)
-                // N_PEXT (0x10) makes a symbol private even if N_EXT is set
-                // Private external symbols should be treated as local to avoid duplicate symbol errors
-                let binding = if n_type & N_EXT != 0 && n_type & 0x10 == 0 {
-                    // External but not private -> Global
-                    SymbolBinding::Global
-                } else {
-                    // Local or private external -> Local
-                    SymbolBinding::Local
-                };
+                let binding = macho_symbol_binding(n_type, n_desc);
 
                 // Determine if symbol is defined (has a section) or undefined
                 let sym_type_bits = n_type & N_TYPE;
@@ -2090,6 +2118,7 @@ mod tests {
         n_type: u8,
         /// 1-indexed section number (0 = NO_SECT).
         n_sect: u8,
+        n_desc: u16,
         n_value: u64,
     }
 
@@ -2211,7 +2240,7 @@ mod tests {
             buf.extend_from_slice(&(name_offsets[i] as u32).to_le_bytes());
             buf.push(sym.n_type);
             buf.push(sym.n_sect);
-            buf.extend_from_slice(&0_u16.to_le_bytes());
+            buf.extend_from_slice(&sym.n_desc.to_le_bytes());
             buf.extend_from_slice(&sym.n_value.to_le_bytes());
         }
         // String table
@@ -2238,6 +2267,7 @@ mod tests {
                 name: "_foo",
                 n_type: N_EXT | N_UNDF,
                 n_sect: 0,
+                n_desc: 0,
                 n_value: 0,
             }],
         );
@@ -2278,6 +2308,7 @@ mod tests {
                 name: "_foo",
                 n_type: N_EXT | N_UNDF,
                 n_sect: 0,
+                n_desc: 0,
                 n_value: 0,
             }],
         );
@@ -2289,6 +2320,101 @@ mod tests {
         assert_eq!(relocs[0].addend, 0x14);
         assert_eq!(relocs[1].rel_type, RelocationType::AdrpPage21);
         assert_eq!(relocs[1].addend, -8, "24-bit addend must be sign-extended");
+    }
+
+    /// RUE-2149: Mach-O binding bits reach the linker's symbol table intact.
+    /// A private external (`N_EXT | N_PEXT`) is a global for cross-object
+    /// resolution, `N_WEAK_DEF` and `N_WEAK_REF` are weak, and only a symbol
+    /// without `N_EXT` is local — through both a full parse and the
+    /// symbol-only parse the archive index uses.
+    #[test]
+    fn test_macho_symbol_binding_preserves_private_external_and_weak() {
+        use crate::constants::{N_PEXT, N_WEAK_DEF, N_WEAK_REF};
+        let obj_bytes = build_test_macho(
+            &[TestMachoSection {
+                sectname: "__text",
+                segname: "__TEXT",
+                addr: 0,
+                data: vec![0xC0, 0x03, 0x5F, 0xD6],
+                relocs: vec![],
+            }],
+            &[
+                TestMachoSymbol {
+                    name: "_hidden",
+                    n_type: N_EXT | N_PEXT | N_SECT,
+                    n_sect: 1,
+                    n_desc: 0,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_weak_def",
+                    n_type: N_EXT | N_SECT,
+                    n_sect: 1,
+                    n_desc: N_WEAK_DEF,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_strong",
+                    n_type: N_EXT | N_SECT,
+                    n_sect: 1,
+                    n_desc: 0,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_local",
+                    n_type: N_SECT,
+                    n_sect: 1,
+                    n_desc: 0,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_was_private_now_local",
+                    n_type: N_PEXT | N_SECT,
+                    n_sect: 1,
+                    n_desc: 0,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_weak_ref",
+                    n_type: N_EXT | N_UNDF,
+                    n_sect: 0,
+                    n_desc: N_WEAK_REF,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_strong_ref",
+                    n_type: N_EXT | N_UNDF,
+                    n_sect: 0,
+                    n_desc: 0,
+                    n_value: 0,
+                },
+            ],
+        );
+        let expected = [
+            ("hidden", SymbolBinding::Global, true),
+            ("weak_def", SymbolBinding::Weak, true),
+            ("strong", SymbolBinding::Global, true),
+            ("local", SymbolBinding::Local, true),
+            ("was_private_now_local", SymbolBinding::Local, true),
+            ("weak_ref", SymbolBinding::Weak, false),
+            ("strong_ref", SymbolBinding::Global, false),
+        ];
+
+        let full = ObjectFile::parse(&obj_bytes).expect("full parse");
+        let symbols_only = ObjectFile::parse_symbols_with_cancellation(&obj_bytes, || false)
+            .expect("symbol-only parse");
+        for symbols in [&full.symbols, &symbols_only.symbols] {
+            assert_eq!(symbols.len(), expected.len());
+            for (sym, (name, binding, defined)) in symbols.iter().zip(expected) {
+                assert_eq!(sym.name, name);
+                assert_eq!(sym.binding, binding, "binding of {name}");
+                assert_eq!(
+                    sym.section_index.is_some(),
+                    defined,
+                    "definedness of {name}"
+                );
+            }
+        }
     }
 
     /// RUE-131 item 5c: a non-extern relocation against a section with no
@@ -2324,6 +2450,7 @@ mod tests {
                 name: "_main",
                 n_type: N_EXT | N_SECT,
                 n_sect: 1,
+                n_desc: 0,
                 n_value: 0,
             }],
         );
@@ -2380,6 +2507,7 @@ mod tests {
                     name: "_main",
                     n_type: N_EXT | N_SECT,
                     n_sect: 1,
+                    n_desc: 0,
                     n_value: 0,
                 },
                 // A LOCAL symbol at offset 0 of __cstring (n_value is the
@@ -2388,6 +2516,7 @@ mod tests {
                     name: "l_str",
                     n_type: N_SECT,
                     n_sect: 2,
+                    n_desc: 0,
                     n_value: 0x10,
                 },
             ],
@@ -2436,12 +2565,14 @@ mod tests {
                     name: "_main",
                     n_type: N_EXT | N_SECT,
                     n_sect: 1,
+                    n_desc: 0,
                     n_value: 4, // 4 into __text (addr 0)
                 },
                 TestMachoSymbol {
                     name: "_str",
                     n_type: N_SECT, // local
                     n_sect: 2,
+                    n_desc: 0,
                     n_value: 0x10 + 5, // 5 into __cstring (addr 0x10)
                 },
             ],
@@ -2472,6 +2603,7 @@ mod tests {
                 name: "_bad",
                 n_type: N_EXT | N_SECT,
                 n_sect: 1,
+                n_desc: 0,
                 n_value: 0x0f,
             }],
         );

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -12,14 +12,14 @@ use crate::constants::{
     LC_DYSYMTAB, LC_SEGMENT_64, LC_SYMTAB, MACHO64_BUILD_VERSION_CMD_SIZE,
     MACHO64_DYSYMTAB_CMD_SIZE, MACHO64_HEADER_SIZE, MACHO64_NLIST_SIZE, MACHO64_RELOC_SIZE,
     MACHO64_SECTION_SIZE, MACHO64_SEGMENT_CMD_SIZE, MACHO64_SYMTAB_CMD_SIZE, MH_MAGIC_64,
-    MH_OBJECT, N_EXT, N_SECT, N_UNDF, PLATFORM_MACOS, R_AARCH64_ABS64, R_AARCH64_ADD_ABS_LO12_NC,
-    R_AARCH64_ADR_PREL_PG_HI21, R_AARCH64_CALL26, R_AARCH64_JUMP26, R_AARCH64_LDST8_ABS_LO12_NC,
-    R_AARCH64_LDST16_ABS_LO12_NC, R_AARCH64_LDST32_ABS_LO12_NC, R_AARCH64_LDST64_ABS_LO12_NC,
-    R_AARCH64_LDST128_ABS_LO12_NC, R_X86_64_32, R_X86_64_32S, R_X86_64_64, R_X86_64_GOTPCREL,
-    R_X86_64_GOTPCRELX, R_X86_64_PC32, R_X86_64_PLT32, R_X86_64_REX_GOTPCRELX,
-    S_ATTR_PURE_INSTRUCTIONS, S_ATTR_SOME_INSTRUCTIONS, SHF_ALLOC, SHF_EXECINSTR, SHF_INFO_LINK,
-    SHT_PROGBITS, SHT_RELA, SHT_STRTAB, SHT_SYMTAB, STB_GLOBAL, STB_LOCAL, STT_FUNC, STT_NOTYPE,
-    STT_SECTION, elf_st_info,
+    MH_OBJECT, N_EXT, N_PEXT, N_SECT, N_UNDF, N_WEAK_DEF, PLATFORM_MACOS, R_AARCH64_ABS64,
+    R_AARCH64_ADD_ABS_LO12_NC, R_AARCH64_ADR_PREL_PG_HI21, R_AARCH64_CALL26, R_AARCH64_JUMP26,
+    R_AARCH64_LDST8_ABS_LO12_NC, R_AARCH64_LDST16_ABS_LO12_NC, R_AARCH64_LDST32_ABS_LO12_NC,
+    R_AARCH64_LDST64_ABS_LO12_NC, R_AARCH64_LDST128_ABS_LO12_NC, R_X86_64_32, R_X86_64_32S,
+    R_X86_64_64, R_X86_64_GOTPCREL, R_X86_64_GOTPCRELX, R_X86_64_PC32, R_X86_64_PLT32,
+    R_X86_64_REX_GOTPCRELX, S_ATTR_PURE_INSTRUCTIONS, S_ATTR_SOME_INSTRUCTIONS, SHF_ALLOC,
+    SHF_EXECINSTR, SHF_INFO_LINK, SHT_PROGBITS, SHT_RELA, SHT_STRTAB, SHT_SYMTAB, STB_GLOBAL,
+    STB_LOCAL, STB_WEAK, STT_FUNC, STT_NOTYPE, STT_SECTION, STV_HIDDEN, elf_st_info,
 };
 
 /// ELF section layout with explicit indices.
@@ -113,6 +113,29 @@ pub struct ObjectBuilder {
     /// Additional global names for the same code, each defined at offset 0 of
     /// the code section alongside [`Self::name`].
     pub aliases: Vec<String>,
+    /// How [`Self::name`] and its aliases bind for cross-object resolution.
+    pub linkage: DefinitionLinkage,
+}
+
+/// How an object's own definitions bind when several objects are linked.
+///
+/// Compiler-emitted objects are always [`DefinitionLinkage::Global`]. The
+/// other forms exist so synthesized foreign members can carry the bindings a
+/// C toolchain produces — `__attribute__((weak))` and
+/// `__attribute__((visibility("hidden")))` — and prove the linker resolves
+/// them the way the native toolchain does (RUE-2149).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DefinitionLinkage {
+    /// A strong, exported definition.
+    #[default]
+    Global,
+    /// A weak definition: overridden by a strong one, and the first of
+    /// several weak definitions wins.
+    Weak,
+    /// A hidden definition (ELF `STV_HIDDEN`, Mach-O `N_PEXT`): it resolves
+    /// references from the other objects of the link but is not exported from
+    /// the linked image.
+    Hidden,
 }
 
 /// A relocation in generated code.
@@ -139,7 +162,16 @@ impl ObjectBuilder {
             relocations: Vec::new(),
             strings: Vec::new(),
             aliases: Vec::new(),
+            linkage: DefinitionLinkage::Global,
         }
+    }
+
+    /// Bind [`Self::name`] and its aliases with `linkage` instead of the
+    /// default strong global binding.
+    #[must_use]
+    pub fn linkage(mut self, linkage: DefinitionLinkage) -> Self {
+        self.linkage = linkage;
+        self
     }
 
     /// Define `name` as an additional global symbol at the start of this
@@ -322,11 +354,19 @@ impl ObjectBuilder {
         // First non-local symbol index (for sh_info)
         let first_global_sym = next_sym_idx;
 
+        // The function and its aliases share one binding: STB_WEAK for a weak
+        // definition, and STV_HIDDEN in st_other for a hidden one.
+        let (def_bind, def_other) = match self.linkage {
+            DefinitionLinkage::Global => (STB_GLOBAL, 0),
+            DefinitionLinkage::Weak => (STB_WEAK, 0),
+            DefinitionLinkage::Hidden => (STB_GLOBAL, STV_HIDDEN),
+        };
+
         // Function symbol (global)
         let func_sym_idx = next_sym_idx;
         symtab.extend_from_slice(&(strtab_name as u32).to_le_bytes()); // st_name
-        symtab.push(elf_st_info(STB_GLOBAL, STT_FUNC)); // st_info
-        symtab.push(0); // st_other
+        symtab.push(elf_st_info(def_bind, STT_FUNC)); // st_info
+        symtab.push(def_other); // st_other
         symtab.extend_from_slice(&ElfSectionLayout::TEXT.to_le_bytes()); // st_shndx: .text
         symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
         symtab.extend_from_slice(&(self.code.len() as u64).to_le_bytes()); // st_size
@@ -337,8 +377,8 @@ impl ObjectBuilder {
         // each carries the function symbol's section, value, and size.
         for &name_offset in &alias_name_offsets {
             symtab.extend_from_slice(&(name_offset as u32).to_le_bytes()); // st_name
-            symtab.push(elf_st_info(STB_GLOBAL, STT_FUNC)); // st_info
-            symtab.push(0); // st_other
+            symtab.push(elf_st_info(def_bind, STT_FUNC)); // st_info
+            symtab.push(def_other); // st_other
             symtab.extend_from_slice(&ElfSectionLayout::TEXT.to_le_bytes()); // st_shndx: .text
             symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
             symtab.extend_from_slice(&(self.code.len() as u64).to_le_bytes()); // st_size
@@ -1068,19 +1108,28 @@ impl ObjectBuilder {
         // IMPORTANT: Function must be at index 0 so that string symbols start at
         // index 1+. macOS linker rejects r_symbolnum=0 in relocations as invalid.
 
+        // The function and its aliases share one binding: N_WEAK_DEF in
+        // n_desc for a weak definition, and N_PEXT alongside N_EXT for a
+        // hidden (private external) one.
+        let (def_n_type, def_n_desc): (u8, u16) = match self.linkage {
+            DefinitionLinkage::Global => (N_EXT | N_SECT, 0),
+            DefinitionLinkage::Weak => (N_EXT | N_SECT, N_WEAK_DEF),
+            DefinitionLinkage::Hidden => (N_EXT | N_PEXT | N_SECT, 0),
+        };
+
         // Symbol 0: External symbol for the function itself
         macho.extend_from_slice(&(func_name_offset as u32).to_le_bytes()); // n_strx
-        macho.push(N_EXT | N_SECT); // n_type: external, defined in section
+        macho.push(def_n_type); // n_type: external, defined in section
         macho.push(1); // n_sect: section 1 (__text)
-        macho.extend_from_slice(&0_u16.to_le_bytes()); // n_desc
+        macho.extend_from_slice(&def_n_desc.to_le_bytes()); // n_desc
         macho.extend_from_slice(&0_u64.to_le_bytes()); // n_value (function start; __text is at addr 0)
 
         // Alias symbols: the same code start under another name.
         for &name_offset in &alias_name_offsets {
             macho.extend_from_slice(&(name_offset as u32).to_le_bytes()); // n_strx
-            macho.push(N_EXT | N_SECT); // n_type: external, defined in section
+            macho.push(def_n_type); // n_type: external, defined in section
             macho.push(1); // n_sect: section 1 (__text)
-            macho.extend_from_slice(&0_u16.to_le_bytes()); // n_desc
+            macho.extend_from_slice(&def_n_desc.to_le_bytes()); // n_desc
             macho.extend_from_slice(&0_u64.to_le_bytes()); // n_value (__text is at addr 0)
         }
 

--- a/crates/rue-linker/src/lib.rs
+++ b/crates/rue-linker/src/lib.rs
@@ -23,5 +23,5 @@ pub use elf::{
     ElfMachine, ObjectFile, ObjectFormat, ObjectSymbols, Relocation, RelocationType, Section,
     SectionFlags, StructuredObject, StructuredRelocation, Symbol, SymbolBinding, SymbolType,
 };
-pub use emit::{CodeRelocation, ObjectBuilder};
+pub use emit::{CodeRelocation, DefinitionLinkage, ObjectBuilder};
 pub use linker::{LinkError, Linker};

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -3981,6 +3981,156 @@ mod tests {
         );
     }
 
+    /// A GNU `ar` archive holding `members`, the way the CLI harness and a
+    /// C toolchain's `ar rcs` lay one out; only the fields the archive reader
+    /// consumes are populated.
+    fn ar_archive(members: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(b"!<arch>\n");
+        for (name, data) in members {
+            let mut header = [b' '; 60];
+            let header_name = format!("{name}/");
+            header[..header_name.len()].copy_from_slice(header_name.as_bytes());
+            header[16] = b'0'; // mtime
+            header[28] = b'0'; // uid
+            header[34] = b'0'; // gid
+            header[40..43].copy_from_slice(b"644"); // mode
+            let size = data.len().to_string();
+            header[48..48 + size.len()].copy_from_slice(size.as_bytes());
+            header[58] = b'`';
+            header[59] = b'\n';
+            out.extend_from_slice(&header);
+            out.extend_from_slice(data);
+            if data.len() % 2 == 1 {
+                out.push(b'\n');
+            }
+        }
+        out
+    }
+
+    /// A Mach-O `main` that tail-branches to `callee`, so the link needs
+    /// `callee` resolved through whatever archive supplies it.
+    fn macho_main_branching_to(callee: &str) -> Vec<u8> {
+        ObjectBuilder::new(MACHO_TARGET, "main")
+            .code(vec![0x00, 0x00, 0x00, 0x14]) // b callee
+            .relocation(CodeRelocation {
+                offset: 0,
+                symbol: callee.into(),
+                rel_type: RelocationType::Jump26,
+                addend: 0,
+            })
+            .build()
+    }
+
+    /// Link `main` against `archive` twice — once fully parsed, once indexed —
+    /// and hand back both outcomes, so a test proves the symbol-only index and
+    /// the full parse agree on which members a link needs.
+    fn link_macho_main_against_archive(
+        main: &[u8],
+        archive: &[u8],
+    ) -> [Result<Vec<u8>, LinkError>; 2] {
+        let parsed = {
+            let mut linker = Linker::new(MACHO_TARGET);
+            linker.add_object(ObjectFile::parse(main).unwrap()).unwrap();
+            linker
+                .add_archive(Archive::parse_strict_objects(archive).unwrap())
+                .and_then(|()| linker.link("_main"))
+        };
+        let indexed = {
+            let mut linker = Linker::new(MACHO_TARGET);
+            linker.add_object(ObjectFile::parse(main).unwrap()).unwrap();
+            let index = ArchiveIndex::parse_strict_objects(archive).unwrap();
+            linker
+                .add_archive_index_with_cancellation(&index, &mut || false)
+                .and_then(|()| linker.link("_main"))
+        };
+        [parsed, indexed]
+    }
+
+    /// RUE-2149 case 1: a hidden (`N_PEXT | N_EXT`) helper in a later archive
+    /// member satisfies a reference from an earlier member. Hidden linkage
+    /// keeps the symbol out of the image's exports, not out of the link, so
+    /// the archive index must count it as a provider; treating it as local
+    /// left `helper` undefined.
+    #[test]
+    fn test_macho_archive_hidden_helper_resolves_across_members() {
+        use crate::emit::DefinitionLinkage;
+        let probe = ObjectBuilder::new(MACHO_TARGET, "probe")
+            .code(vec![0x00, 0x00, 0x00, 0x14]) // b helper
+            .relocation(CodeRelocation {
+                offset: 0,
+                symbol: "helper".into(),
+                rel_type: RelocationType::Jump26,
+                addend: 0,
+            })
+            .build();
+        let helper = ObjectBuilder::new(MACHO_TARGET, "helper")
+            .code(vec![0xC0, 0x03, 0x5F, 0xD6]) // ret
+            .linkage(DefinitionLinkage::Hidden)
+            .build();
+        let archive = ar_archive(&[("probe.o", &probe), ("helper.o", &helper)]);
+        let main = macho_main_branching_to("probe");
+
+        for outcome in link_macho_main_against_archive(&main, &archive) {
+            outcome.expect("a hidden helper in a later member must resolve");
+        }
+
+        // Hidden, not local: the parsed member exposes it as a global
+        // definition while a plain `N_SECT` symbol stays local.
+        let parsed = ObjectFile::parse(&helper).unwrap();
+        let sym = parsed.find_symbol("helper").expect("helper is defined");
+        assert_eq!(sym.binding, SymbolBinding::Global);
+    }
+
+    /// RUE-2149 case 2: two required members each carry an `N_WEAK_DEF`
+    /// definition of the same symbol. They coalesce under the established
+    /// first-weak-wins policy instead of being rejected as duplicates, while
+    /// two strong definitions in required members are still a duplicate.
+    #[test]
+    fn test_macho_archive_weak_definitions_coalesce_and_strong_still_collide() {
+        use crate::emit::DefinitionLinkage;
+        // main branches to `probe_a`, whose member also references `probe_b`,
+        // so both members are pulled in.
+        let member = |probe: &str, next: Option<&str>, linkage: DefinitionLinkage| {
+            let mut builder = ObjectBuilder::new(MACHO_TARGET, "shared")
+                .alias(probe)
+                .code(vec![0x00, 0x00, 0x00, 0x14, 0xC0, 0x03, 0x5F, 0xD6])
+                .linkage(linkage);
+            if let Some(next) = next {
+                builder = builder.relocation(CodeRelocation {
+                    offset: 0,
+                    symbol: next.into(),
+                    rel_type: RelocationType::Jump26,
+                    addend: 0,
+                });
+            }
+            builder.build()
+        };
+        let main = macho_main_branching_to("probe_a");
+
+        let weak_a = member("probe_a", Some("probe_b"), DefinitionLinkage::Weak);
+        let weak_b = member("probe_b", None, DefinitionLinkage::Weak);
+        let weak_archive = ar_archive(&[("weak_a.o", &weak_a), ("weak_b.o", &weak_b)]);
+        for outcome in link_macho_main_against_archive(&main, &weak_archive) {
+            outcome.expect("weak definitions in two required members must coalesce");
+        }
+        let parsed = ObjectFile::parse(&weak_a).unwrap();
+        assert_eq!(
+            parsed.find_symbol("shared").unwrap().binding,
+            SymbolBinding::Weak
+        );
+
+        let strong_a = member("probe_a", Some("probe_b"), DefinitionLinkage::Global);
+        let strong_b = member("probe_b", None, DefinitionLinkage::Global);
+        let strong_archive = ar_archive(&[("strong_a.o", &strong_a), ("strong_b.o", &strong_b)]);
+        for outcome in link_macho_main_against_archive(&main, &strong_archive) {
+            assert!(
+                matches!(outcome, Err(LinkError::DuplicateSymbol(ref name)) if name == "shared"),
+                "two strong definitions must still collide"
+            );
+        }
+    }
+
     /// RUE-848: an earlier weak provider and a later strong provider. Archive
     /// extraction is order-driven — the first member satisfying the reference is
     /// pulled, regardless of binding — so the weak member wins and the strong


### PR DESCRIPTION
Mach-O parsing mapped `N_PEXT | N_EXT` to a local symbol and never read `n_desc`, so binding information was lost before the archive index and the strong/weak resolution policy saw it. A hidden (`visibility("hidden")`) helper in a later archive member was invisible to extraction and left the reference undefined (E1000), and two `N_WEAK_DEF` definitions in required members were rejected as duplicates.

**Fix.** `macho_symbol_binding` in `crates/rue-linker/src/elf.rs` is now the one place Mach-O binding bits become a `SymbolBinding`, used by the symbol loop both parse depths share: a symbol without `N_EXT` is local (including a bare `N_PEXT`, which is how `ld -r` marks a former private external), `N_EXT | N_PEXT` is a global for cross-object resolution, and `N_WEAK_DEF` on a definition or `N_WEAK_REF` on an undefined symbol bind weak. The existing strong/weak and archive-order policies downstream apply unchanged, so strong duplicates still collide and a strong definition still overrides a weak one.

**Coverage.** `ObjectBuilder` gains a `DefinitionLinkage` knob (`Global`, `Weak`, `Hidden`) so the harness's synthesized foreign archive can carry the bindings a C toolchain produces on every object format: `STB_WEAK`/`STV_HIDDEN` for ELF, `N_WEAK_DEF`/`N_PEXT` for Mach-O. The archive now has a hidden helper in a member after the probe that calls it, and two weak members that both define `ffi_weak_shared`. Three new `cli.c_ffi` cases link that program for x86-64 Linux, AArch64 Linux, and aarch64-macos on every host (the Mach-O link is where the bug lived, so Linux hosts exercise it too) and execute on the matching native host. Unit tests cover the classification through both the full parse and the symbol-only parse the archive index uses, and an end-to-end Mach-O archive link through both `Archive` and `ArchiveIndex` for the hidden-helper case, the weak-coalescing case, and the strong-duplicate rejection.

Verified locally: with the old classification restored, the aarch64-macos CLI case fails with `duplicate symbol: ffi_weak_shared` and the three new unit tests fail; with the fix, `scripts/rue unit linker`, `scripts/rue cli c_ffi`, `scripts/rue cli linker`, the linker and cli-tests clippy/fmt gates, and `//crates/rue-oracle-diff:oracle-diff-test` all pass.

Fixes RUE-2149