### PR TITLE
RUE-2149: preserve Mach-O external and weak symbol bindings

### DIFF
--- a/crates/rue-c-abi-matrix/src/linker_regressions.rs
+++ b/crates/rue-c-abi-matrix/src/linker_regressions.rs
@@ -1,0 +1,128 @@
+//! Native C archive regressions for Mach-O symbol binding.
+//!
+//! These cases intentionally compile separate archive members with the host C
+//! toolchain. The internal linker must use the Mach-O symbol metadata to pull
+//! a private-external provider and to resolve duplicate weak definitions.
+
+use std::process::Command;
+
+use libtest2_mimic::{RunContext, RunError, Trial};
+use rue_target::Target;
+use rue_test_runner::compiler_command;
+
+const C_FLAGS: &[&str] = &["-c", "-O0", "-fno-stack-protector"];
+
+struct Case {
+    name: &'static str,
+    members: &'static [(&'static str, &'static str)],
+    rue_source: &'static str,
+    archive: &'static str,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        name: "private_external_archive_member",
+        members: &[
+            (
+                "a.c",
+                "__attribute__((visibility(\"hidden\"))) int helper(void);\nint probe(void) { return helper(); }\n",
+            ),
+            (
+                "b.c",
+                "__attribute__((visibility(\"hidden\"))) int helper(void) { return 42; }\n",
+            ),
+        ],
+        rue_source: "extern \"C\" { fn probe() -> i32; }\nfn main() -> i32 { let result = checked { probe() }; if result == 42 { 0 } else { 1 } }\n",
+        archive: "libprivate.a",
+    },
+    Case {
+        name: "weak_definitions_across_archive_members",
+        members: &[
+            (
+                "a.c",
+                "__attribute__((weak)) int shared(void) { return 42; }\nint probe_a(void) { return shared(); }\n",
+            ),
+            (
+                "b.c",
+                "__attribute__((weak)) int shared(void) { return 42; }\nint probe_b(void) { return shared(); }\n",
+            ),
+        ],
+        rue_source: "extern \"C\" { fn probe_a() -> i32; fn probe_b() -> i32; }\nfn main() -> i32 { let a = checked { probe_a() }; let b = checked { probe_b() }; if a + b == 84 { 0 } else { 1 } }\n",
+        archive: "libweak.a",
+    },
+];
+
+pub(crate) fn trials() -> Vec<Trial> {
+    CASES
+        .iter()
+        .map(|case| {
+            Trial::test(
+                format!("macho_symbol_binding::{}", case.name),
+                move |context: RunContext<'_>| {
+                    if !super::toolchain_available() {
+                        return context.ignore_for("no system cc and ar toolchain on PATH");
+                    }
+                    let Some(target) = Target::host() else {
+                        return context.ignore_for("no native Rue target describes this host");
+                    };
+                    if !target.is_macho() {
+                        return context
+                            .ignore_for("Mach-O archive regression requires a macOS host");
+                    }
+                    run_case(case).map_err(RunError::fail)
+                },
+            )
+        })
+        .collect()
+}
+
+fn run_case(case: &Case) -> Result<(), String> {
+    let directory = tempfile::Builder::new()
+        .prefix("rue-macho-symbol-binding-")
+        .tempdir()
+        .map_err(|error| format!("could not create temporary directory: {error}"))?;
+
+    let mut object_names = Vec::with_capacity(case.members.len());
+    for (source_name, source) in case.members {
+        std::fs::write(directory.path().join(source_name), source)
+            .map_err(|error| format!("could not write {source_name}: {error}"))?;
+        let object_name = format!("{}.o", source_name);
+        let mut cc = Command::new("cc");
+        cc.current_dir(directory.path())
+            .args(C_FLAGS)
+            .arg(source_name)
+            .arg("-o")
+            .arg(&object_name);
+        super::run_step("cc", cc)?;
+        object_names.push(object_name);
+    }
+
+    let mut ar = Command::new("ar");
+    ar.current_dir(directory.path())
+        .arg("rcs")
+        .arg(case.archive);
+    ar.args(&object_names);
+    super::run_step("ar", ar)?;
+
+    std::fs::write(directory.path().join("main.rue"), case.rue_source)
+        .map_err(|error| format!("could not write main.rue: {error}"))?;
+    let rue = super::rue_binary()?;
+    let mut compile = compiler_command(&rue);
+    compile.current_dir(directory.path()).args([
+        "main.rue",
+        "--preview",
+        "c_ffi",
+        "--linker",
+        "internal",
+        "--link-archive",
+        case.archive,
+        "-o",
+        "prog",
+    ]);
+    super::run_step("rue", compile)?;
+
+    let mut run = Command::new(directory.path().join("prog"));
+    run.current_dir(directory.path());
+    super::run_step("program", run)?;
+    Ok(())
+}

--- a/crates/rue-c-abi-matrix/src/main.rs
+++ b/crates/rue-c-abi-matrix/src/main.rs
@@ -34,6 +34,7 @@
 //! `requires_system_linker` cases follow.
 
 mod grid;
+mod linker_regressions;
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -278,6 +279,7 @@ fn main() {
         trials.push(trial(Direction::Import, explicit));
         trials.push(trial(Direction::Export, explicit));
     }
+    trials.extend(linker_regressions::trials());
 
     Harness::with_env().discover(trials).main();
 }

--- a/crates/rue-linker/src/constants.rs
+++ b/crates/rue-linker/src/constants.rs
@@ -295,6 +295,10 @@ pub const PLATFORM_MACOS: u32 = 1;
 pub const N_EXT: u8 = 0x01;
 /// N_PEXT: Private external symbol (visible for linking but not exported)
 pub const N_PEXT: u8 = 0x10;
+/// N_WEAK_REF: Undefined symbol is a weak reference
+pub const N_WEAK_REF: u16 = 0x0040;
+/// N_WEAK_DEF: Defined symbol is a weak definition
+pub const N_WEAK_DEF: u16 = 0x0080;
 /// N_TYPE: Mask for the type bits in n_type
 pub const N_TYPE: u8 = 0x0E;
 /// N_SECT: Symbol defined in section (type, not flag)

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -48,6 +48,8 @@ use crate::constants::{
     N_SECT,
     N_TYPE,
     N_UNDF,
+    N_WEAK_DEF,
+    N_WEAK_REF,
     R_AARCH64_ABS64,
     R_AARCH64_ADD_ABS_LO12_NC,
     R_AARCH64_ADR_PREL_PG_HI21,
@@ -1097,6 +1099,7 @@ impl ObjectFile {
                 let n_strx = read_u32(data, sym_offset) as usize;
                 let n_type = data[sym_offset + 4];
                 let n_sect = data[sym_offset + 5];
+                let n_desc = read_u16(data, sym_offset + 6);
                 let n_value = read_u64(data, sym_offset + 8);
 
                 // Read symbol name from string table
@@ -1118,17 +1121,6 @@ impl ObjectFile {
                 // collapsed "_foo" and "__foo" onto the same "__foo" symbol.
                 name = crate::util::strip_macho_underscore(&name).to_string();
 
-                // Determine binding (external or local)
-                // N_PEXT (0x10) makes a symbol private even if N_EXT is set
-                // Private external symbols should be treated as local to avoid duplicate symbol errors
-                let binding = if n_type & N_EXT != 0 && n_type & 0x10 == 0 {
-                    // External but not private -> Global
-                    SymbolBinding::Global
-                } else {
-                    // Local or private external -> Local
-                    SymbolBinding::Local
-                };
-
                 // Determine if symbol is defined (has a section) or undefined
                 let sym_type_bits = n_type & N_TYPE;
                 let section_index = if sym_type_bits == N_SECT && n_sect > 0 {
@@ -1140,6 +1132,25 @@ impl ObjectFile {
                     None // Absolute symbol (no section)
                 } else {
                     None
+                };
+
+                // N_PEXT marks a private-external symbol, which remains
+                // visible while linking the object and its archive peers. It
+                // is still an external symbol for resolution; only symbols
+                // without N_EXT are object-local. Weakness uses different
+                // descriptor bits for definitions and references (Apple's
+                // nlist.h): N_WEAK_DEF applies to defined symbols and
+                // N_WEAK_REF applies to undefined symbols.
+                let binding = if n_type & N_EXT == 0 {
+                    SymbolBinding::Local
+                } else if (section_index.is_some() && n_desc & N_WEAK_DEF != 0)
+                    || (section_index.is_none()
+                        && sym_type_bits == N_UNDF
+                        && n_desc & N_WEAK_REF != 0)
+                {
+                    SymbolBinding::Weak
+                } else {
+                    SymbolBinding::Global
                 };
 
                 // Determine symbol type based on section flags
@@ -1839,6 +1850,8 @@ impl ObjectFile {
 
 #[cfg(test)]
 mod tests {
+    use crate::constants::N_PEXT;
+
     use super::*;
     use crate::constants::{EI_CLASS, EI_DATA, EI_VERSION, ELF64_SHDR_SIZE as TEST_SHDR_SIZE};
 
@@ -2090,6 +2103,8 @@ mod tests {
         n_type: u8,
         /// 1-indexed section number (0 = NO_SECT).
         n_sect: u8,
+        /// Symbol descriptor bits, including weak definition/reference flags.
+        n_desc: u16,
         n_value: u64,
     }
 
@@ -2211,7 +2226,7 @@ mod tests {
             buf.extend_from_slice(&(name_offsets[i] as u32).to_le_bytes());
             buf.push(sym.n_type);
             buf.push(sym.n_sect);
-            buf.extend_from_slice(&0_u16.to_le_bytes());
+            buf.extend_from_slice(&sym.n_desc.to_le_bytes());
             buf.extend_from_slice(&sym.n_value.to_le_bytes());
         }
         // String table
@@ -2238,6 +2253,7 @@ mod tests {
                 name: "_foo",
                 n_type: N_EXT | N_UNDF,
                 n_sect: 0,
+                n_desc: 0,
                 n_value: 0,
             }],
         );
@@ -2278,6 +2294,7 @@ mod tests {
                 name: "_foo",
                 n_type: N_EXT | N_UNDF,
                 n_sect: 0,
+                n_desc: 0,
                 n_value: 0,
             }],
         );
@@ -2324,6 +2341,7 @@ mod tests {
                 name: "_main",
                 n_type: N_EXT | N_SECT,
                 n_sect: 1,
+                n_desc: 0,
                 n_value: 0,
             }],
         );
@@ -2380,6 +2398,7 @@ mod tests {
                     name: "_main",
                     n_type: N_EXT | N_SECT,
                     n_sect: 1,
+                    n_desc: 0,
                     n_value: 0,
                 },
                 // A LOCAL symbol at offset 0 of __cstring (n_value is the
@@ -2388,6 +2407,7 @@ mod tests {
                     name: "l_str",
                     n_type: N_SECT,
                     n_sect: 2,
+                    n_desc: 0,
                     n_value: 0x10,
                 },
             ],
@@ -2436,12 +2456,14 @@ mod tests {
                     name: "_main",
                     n_type: N_EXT | N_SECT,
                     n_sect: 1,
+                    n_desc: 0,
                     n_value: 4, // 4 into __text (addr 0)
                 },
                 TestMachoSymbol {
                     name: "_str",
                     n_type: N_SECT, // local
                     n_sect: 2,
+                    n_desc: 0,
                     n_value: 0x10 + 5, // 5 into __cstring (addr 0x10)
                 },
             ],
@@ -2458,6 +2480,121 @@ mod tests {
         assert_eq!(s.binding, SymbolBinding::Local);
     }
 
+    /// Mach-O's external and weak visibility bits must survive both parser
+    /// depths because archive indexing uses the symbols-only path while the
+    /// selected member later goes through the full path.
+    #[test]
+    fn test_macho_symbol_bindings_match_at_both_parse_depths() {
+        let obj_bytes = build_test_macho(
+            &[TestMachoSection {
+                sectname: "__text",
+                segname: "__TEXT",
+                addr: 0,
+                data: vec![0u8; 16],
+                relocs: vec![],
+            }],
+            &[
+                TestMachoSymbol {
+                    name: "_global",
+                    n_type: N_EXT | N_SECT,
+                    n_sect: 1,
+                    n_desc: 0,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_private",
+                    n_type: N_EXT | N_PEXT | N_SECT,
+                    n_sect: 1,
+                    n_desc: 0,
+                    n_value: 4,
+                },
+                TestMachoSymbol {
+                    name: "local",
+                    n_type: N_SECT,
+                    n_sect: 1,
+                    n_desc: 0,
+                    n_value: 8,
+                },
+                TestMachoSymbol {
+                    name: "_weak_def",
+                    n_type: N_EXT | N_SECT,
+                    n_sect: 1,
+                    n_desc: N_WEAK_DEF,
+                    n_value: 12,
+                },
+                TestMachoSymbol {
+                    name: "_weak_ref",
+                    n_type: N_EXT | N_UNDF,
+                    n_sect: 0,
+                    n_desc: N_WEAK_REF,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_strong_ref",
+                    n_type: N_EXT | N_UNDF,
+                    n_sect: 0,
+                    n_desc: 0,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_weak_def_ref",
+                    n_type: N_EXT | N_UNDF,
+                    n_sect: 0,
+                    n_desc: N_WEAK_DEF,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_weak_ref_def",
+                    n_type: N_EXT | N_SECT,
+                    n_sect: 1,
+                    n_desc: N_WEAK_REF,
+                    n_value: 0,
+                },
+                TestMachoSymbol {
+                    name: "_local_weak",
+                    n_type: N_SECT,
+                    n_sect: 1,
+                    n_desc: N_WEAK_DEF,
+                    n_value: 4,
+                },
+                TestMachoSymbol {
+                    name: "_private_weak",
+                    n_type: N_EXT | N_PEXT | N_SECT,
+                    n_sect: 1,
+                    n_desc: N_WEAK_DEF,
+                    n_value: 8,
+                },
+            ],
+        );
+
+        let full = ObjectFile::parse(&obj_bytes).expect("full parse");
+        let symbols_only = ObjectFile::parse_symbols_with_cancellation(&obj_bytes, || false)
+            .expect("symbols-only parse");
+        assert_eq!(full.symbols.len(), symbols_only.symbols.len());
+        for (full, indexed) in full.symbols.iter().zip(symbols_only.symbols.iter()) {
+            assert_eq!(full.name, indexed.name);
+            assert_eq!(full.section_index, indexed.section_index);
+            assert_eq!(full.value, indexed.value);
+            assert_eq!(full.binding, indexed.binding);
+        }
+
+        let binding = |name: &str| {
+            full.find_symbol(name)
+                .unwrap_or_else(|| panic!("missing Mach-O symbol {name}"))
+                .binding
+        };
+        assert_eq!(binding("global"), SymbolBinding::Global);
+        assert_eq!(binding("private"), SymbolBinding::Global);
+        assert_eq!(binding("local"), SymbolBinding::Local);
+        assert_eq!(binding("weak_def"), SymbolBinding::Weak);
+        assert_eq!(binding("weak_ref"), SymbolBinding::Weak);
+        assert_eq!(binding("strong_ref"), SymbolBinding::Global);
+        assert_eq!(binding("weak_def_ref"), SymbolBinding::Global);
+        assert_eq!(binding("weak_ref_def"), SymbolBinding::Global);
+        assert_eq!(binding("local_weak"), SymbolBinding::Local);
+        assert_eq!(binding("private_weak"), SymbolBinding::Weak);
+    }
+
     #[test]
     fn test_macho_symbol_value_below_section_address_is_rejected() {
         let obj_bytes = build_test_macho(
@@ -2472,6 +2609,7 @@ mod tests {
                 name: "_bad",
                 n_type: N_EXT | N_SECT,
                 n_sect: 1,
+                n_desc: 0,
                 n_value: 0x0f,
             }],
         );


### PR DESCRIPTION
Mach-O static archives lost private-external and weak symbol bindings during parsing. A hidden helper in another archive member appeared undefined, and weak definitions in two required members appeared to be duplicate strong definitions. The shared full and symbol-only parser now preserves external linkage and decodes the descriptor bits for weak definitions and references.

Serialized parser tests cover both parse depths and descriptor roles. Two native C archive regressions compile separate members with the host toolchain and execute a Rue program linked through the internal linker. Existing local-symbol isolation and strong/weak precedence tests remain passing.

Validation verified on Darwin arm64: 191 linker tests, all 36 quick-suite targets, six native C ABI execution cases (including both regressions), and both changed crates' formatting and Clippy gates passed. The full local suite is still running; this PR remains draft pending its terminal result and final review.

Fixes RUE-2149.
