### PR TITLE
RUE-2151: preserve float widths in body comptime comparisons

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -2364,7 +2364,7 @@ fn comptime_host_is_an_empty_umbrella_over_its_capabilities() {
             owner.push((rest.split('(').next().unwrap_or_default(), current));
         }
     }
-    assert_eq!(owner.len(), 68, "the host contract lost or gained a method");
+    assert_eq!(owner.len(), 69, "the host contract lost or gained a method");
     for (method, trait_name) in &owner {
         assert!(
             capabilities.contains(trait_name),

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -390,6 +390,24 @@ pub trait ComptimeTypeAlgebra: ComptimeDomain {
         >,
         inst_ref: InstRef,
     ) -> Option<Self::Type>;
+    /// Resolve the concrete float type of an operand expression. This is
+    /// separate from `const_expr_type` so comparisons inspect their operands
+    /// rather than their boolean result expression.
+    fn float_expr_type(
+        &self,
+        _program: &Self::ProgramKey,
+        _env: &ComptimeEnv<
+            '_,
+            Self::Value,
+            Self::Type,
+            Self::Name,
+            Self::File,
+            Self::CanonicalIdentity,
+        >,
+        _inst_ref: InstRef,
+    ) -> Option<Self::Type> {
+        None
+    }
     /// Select the integer type for a binary operation. The default preserves
     /// the existing resolved-type lookup; durable hosts can fall back to the
     /// typed metadata carried by the reduced operands without inspecting RIR.
@@ -1931,23 +1949,31 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         }
     }
 
-    /// The float type a compile-time float operation is evaluated at, with its
-    /// width: the frame's expected result when that is a float, else the
-    /// expression's inferred type, else a concrete width an operand already
-    /// carries, else the `f64` default of ADR-0065 §3. This is the width at
-    /// which the same expression would execute at run time, so a `const` and a
-    /// `let` of one expression agree bit for bit.
+    /// The float type a compile-time float operation is evaluated at. Arithmetic
+    /// uses the frame's expected result or expression type before operand
+    /// metadata; comparisons use only their operand types so an enclosing
+    /// boolean or float result cannot choose the comparison width. Both paths
+    /// fall back to the `f64` default of ADR-0065 §3.
     fn float_operation_type(
         &mut self,
         env: &ComptimeEnv<'_, H::Value, H::Type, H::Name, H::File, H::CanonicalIdentity>,
         inst_ref: InstRef,
+        operand_refs: (InstRef, InstRef),
         lhs: &H::Value,
         rhs: Option<&H::Value>,
+        comparison: bool,
     ) -> Option<(H::Type, ComptimeFloatWidth)> {
+        let (lhs_ref, rhs_ref) = operand_refs;
         let candidates = [
-            env.expected_result.clone(),
-            self.host
-                .const_expr_type(&self.program_key(), env, inst_ref),
+            (!comparison).then(|| env.expected_result.clone()).flatten(),
+            (!comparison)
+                .then(|| {
+                    self.host
+                        .const_expr_type(&self.program_key(), env, inst_ref)
+                })
+                .flatten(),
+            self.host.float_expr_type(&self.program_key(), env, lhs_ref),
+            self.host.float_expr_type(&self.program_key(), env, rhs_ref),
             lhs.as_float_type(),
             rhs.and_then(ComptimeValue::as_float_type),
         ];
@@ -1981,6 +2007,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         rhs: H::Value,
         env: &ComptimeEnv<'_, H::Value, H::Type, H::Name, H::File, H::CanonicalIdentity>,
         inst_ref: InstRef,
+        operand_refs: (InstRef, InstRef),
         span: Span,
     ) -> ComptimeOutcome<H::Value, H::Failure> {
         use ComptimeIntegerOperation as Op;
@@ -2003,7 +2030,15 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 &self.diagnostic_site(span),
             );
         }
-        let Some((ty, width)) = self.float_operation_type(env, inst_ref, &lhs, Some(&rhs)) else {
+        let comparison_operation = matches!(operation, Op::Lt | Op::Gt | Op::Le | Op::Ge);
+        let Some((ty, width)) = self.float_operation_type(
+            env,
+            inst_ref,
+            operand_refs,
+            &lhs,
+            Some(&rhs),
+            comparison_operation,
+        ) else {
             return ComptimeOutcome::RuntimeDependent;
         };
         // An operand that already has a concrete float width must agree with
@@ -2084,8 +2119,11 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         equal: bool,
         env: &ComptimeEnv<'_, H::Value, H::Type, H::Name, H::File, H::CanonicalIdentity>,
         inst_ref: InstRef,
+        operand_refs: (InstRef, InstRef),
     ) -> ComptimeOutcome<H::Value, H::Failure> {
-        let Some((_, width)) = self.float_operation_type(env, inst_ref, lhs, Some(rhs)) else {
+        let Some((_, width)) =
+            self.float_operation_type(env, inst_ref, operand_refs, lhs, Some(rhs), true)
+        else {
             return ComptimeOutcome::RuntimeDependent;
         };
         let (Some(l), Some(r)) = (
@@ -2515,6 +2553,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             r,
                             env,
                             inst_ref,
+                            (*lhs, *rhs),
                             span,
                         );
                     }
@@ -2552,6 +2591,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             r,
                             env,
                             inst_ref,
+                            (*lhs, *rhs),
                             span,
                         );
                     }
@@ -2589,6 +2629,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             r,
                             env,
                             inst_ref,
+                            (*lhs, *rhs),
                             span,
                         );
                     }
@@ -2623,7 +2664,15 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                     self.eval_arith_operands(operation, *lhs, *rhs, env, span)
                 ) {
                     ArithOperands::Float(l, r) => {
-                        return self.float_binary(operation, l, r, env, inst_ref, span);
+                        return self.float_binary(
+                            operation,
+                            l,
+                            r,
+                            env,
+                            inst_ref,
+                            (*lhs, *rhs),
+                            span,
+                        );
                     }
                     ArithOperands::Integer(l, r) => (l, r),
                 };
@@ -2678,6 +2727,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
 
             // Comparison operations
             InstData::Eq { lhs, rhs } => {
+                let (lhs_ref, rhs_ref) = (*lhs, *rhs);
                 let lhs = match self.eval(*lhs, env) {
                     ComptimeOutcome::Known(value) => value,
                     ComptimeOutcome::RuntimeDependent => {
@@ -2713,7 +2763,14 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                                 if self.host.float_value_text(&lhs).is_some()
                                     || self.host.float_value_text(&rhs).is_some()
                                 {
-                                    return self.float_equality(&lhs, &rhs, true, env, inst_ref);
+                                    return self.float_equality(
+                                        &lhs,
+                                        &rhs,
+                                        true,
+                                        env,
+                                        inst_ref,
+                                        (lhs_ref, rhs_ref),
+                                    );
                                 }
                                 let site = self.diagnostic_site(span);
                                 self.host.compare_comptime_values(&lhs, &rhs, true, &site)
@@ -2724,6 +2781,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 }
             }
             InstData::Ne { lhs, rhs } => {
+                let (lhs_ref, rhs_ref) = (*lhs, *rhs);
                 let lhs = match self.eval(*lhs, env) {
                     ComptimeOutcome::Known(value) => value,
                     ComptimeOutcome::RuntimeDependent => {
@@ -2759,7 +2817,14 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                                 if self.host.float_value_text(&lhs).is_some()
                                     || self.host.float_value_text(&rhs).is_some()
                                 {
-                                    return self.float_equality(&lhs, &rhs, false, env, inst_ref);
+                                    return self.float_equality(
+                                        &lhs,
+                                        &rhs,
+                                        false,
+                                        env,
+                                        inst_ref,
+                                        (lhs_ref, rhs_ref),
+                                    );
                                 }
                                 let site = self.diagnostic_site(span);
                                 self.host.compare_comptime_values(&lhs, &rhs, false, &site)
@@ -2784,6 +2849,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             r,
                             env,
                             inst_ref,
+                            (*lhs, *rhs),
                             span,
                         );
                     }
@@ -2814,6 +2880,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             r,
                             env,
                             inst_ref,
+                            (*lhs, *rhs),
                             span,
                         );
                     }
@@ -2844,6 +2911,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             r,
                             env,
                             inst_ref,
+                            (*lhs, *rhs),
                             span,
                         );
                     }
@@ -2874,6 +2942,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             r,
                             env,
                             inst_ref,
+                            (*lhs, *rhs),
                             span,
                         );
                     }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2545,6 +2545,17 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeTypeAlgebra for OrdinaryBodyEngine
     ) -> Option<Type> {
         OrdinaryBodyEngine::const_expr_type(self, env, inst_ref)
     }
+    fn float_expr_type(
+        &self,
+        _program: &Self::ProgramKey,
+        env: &ComptimeEnv<'_>,
+        inst_ref: InstRef,
+    ) -> Option<Type> {
+        env.resolved_types?
+            .get(&inst_ref)
+            .copied()
+            .filter(Type::is_float)
+    }
     fn resolve_named_type_value(
         &mut self,
         _program: &Self::ProgramKey,

--- a/crates/rue-spec/cases/types/floats.toml
+++ b/crates/rue-spec/cases/types/floats.toml
@@ -148,6 +148,79 @@ expected_error_code = "E0204"
 error_contains = ["comptime_float"]
 
 [[case]]
+name = "body_comptime_comparisons_preserve_f32_width"
+spec = ["3.12:7", "3.12:46", "3.12:47"]
+description = "A body comptime comparison uses the concrete width of its operands, including a named constant, both operand orders, and nested arithmetic."
+source = """
+const NARROW: f32 = 16777216.0;
+const DECLARED: bool = NARROW == 16777217.0;
+const NAN32: f32 = 0.0 / 0.0;
+const NEG_ZERO32: f32 = -0.0;
+const SELECTED: f64 = if NARROW < 16777217.0 { 1.0 } else { 0.0 };
+
+fn runtime() -> bool { NARROW == 16777217.0 }
+fn select() -> f64 {
+    if comptime { NARROW < 16777217.0 } { 1.0 } else { 0.0 }
+}
+
+fn main() -> i32 {
+    @dbg(DECLARED);
+    @dbg(runtime());
+    @dbg(SELECTED);
+    @dbg(select());
+    @dbg(comptime { NARROW == 16777217.0 });
+    @dbg(comptime { 16777217.0 == NARROW });
+    @dbg(comptime { NARROW != 16777217.0 });
+    @dbg(comptime { 16777217.0 != NARROW });
+    @dbg(comptime { NARROW <= 16777217.0 });
+    @dbg(comptime { 16777217.0 > NARROW });
+    @dbg(comptime { NARROW >= 16777217.0 });
+    @dbg(comptime { (NARROW + 1.0) - NARROW == 0.0 });
+    @dbg(comptime { -0.0 == 0.0 });
+    @dbg(comptime { NEG_ZERO32 == 0.0 });
+    @dbg(comptime { NAN32 == NAN32 });
+    @dbg(comptime { NAN32 != NAN32 });
+    0
+}
+"""
+expected_stdout = """
+true
+true
+0.0
+0.0
+true
+true
+false
+false
+true
+false
+true
+true
+true
+true
+false
+true
+"""
+exit_code = 0
+
+[[case]]
+name = "body_comptime_mixed_float_widths_are_rejected"
+spec = ["3.12:13", "3.12:46", "3.12:49"]
+description = "A body comptime operation with explicitly incompatible concrete float operands is rejected before evaluation."
+source = """
+const NARROW: f32 = 1.0;
+const WIDE: f64 = 2.0;
+
+fn main() -> i32 {
+    @dbg(comptime { NARROW < WIDE });
+    0
+}
+"""
+compile_fail = true
+expected_error_code = "E0206"
+error_contains = ["type mismatch"]
+
+[[case]]
 name = "comptime_float_is_not_nameable_in_a_{case_name}"
 spec = ["3.12:3"]
 description = "The name is rejected in every type position, including a comptime parameter, exactly as comptime_int is"


### PR DESCRIPTION
Body comptime comparisons could evaluate an inferred f32 operand at f64 width, so `NARROW == 16777217.0` disagreed with the same comparison at runtime. Resolve comparison width from the operands through the existing type map, and keep enclosing result types from choosing that width.

Regression coverage includes all comparison operators, both operand orders, intermediate f32 rounding, IEEE edge cases, and mixed-width rejection.

Validation: focused spec cases, AIR comptime tests, quick suite, independent adversarial probes, and formatting passed. Full-suite validation is in progress.

Fixes RUE-2151
