### PR TITLE
RUE-2007: pin IEEE NaN semantics for structural equality over float leaves

### DIFF
--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -817,16 +817,26 @@ params = [
   { variant = "inequality", a = "Value(1.5)", b = "Missing", op = "!=", exit_code = 1 },
 ]
 
-# RUE-2007 baseline. Structural equality is documented as a total equivalence
-# (4.3:3g), which `NaN` breaks: a float leaf compares under IEEE equality, so an
-# aggregate holding a `NaN` is not equal to itself even though both operands are
-# the same value with the same bits. This case records what the implementation
-# does today, at each depth the recursion reaches; deciding what the language
-# should say about it is RUE-2007's, not this case's.
+# =============================================================================
+# NaN and the reflexivity of structural equality (RUE-2007, decided)
+#
+# 4.3:3b compares every leaf by that leaf type's own equality, so a float leaf
+# uses the IEEE predicate of 3.12:27 and an aggregate reaching a `NaN` is not
+# equal to itself — even though both operands are the same value with the same
+# bits. That is the single place structural equality is not reflexive: 4.3:3g
+# states the resulting *partial* equivalence, and the `≈` note in
+# `docs/formal/01-core-calculus.md` §6.4 records that the exception enters
+# through a leaf type the core calculus does not model. The rejected
+# alternative was a bitwise/`@total_cmp` leaf rule that would have kept
+# equality total while making a field's equality disagree with that field's own
+# `==`. These cases pin the decision at each depth the recursion reaches, and
+# pin that nothing else lost reflexivity.
+# =============================================================================
+
 [[case]]
 name = "aggregate_holding_nan_is_not_equal_to_itself"
-spec = ["4.3:2", "4.3:3b", "4.3:3c", "4.3:3d"]
-description = "Observed NaN behaviour inside an aggregate, the measured baseline for RUE-2007's partial-equality decision."
+spec = ["4.3:2", "4.3:3b", "4.3:3c", "4.3:3d", "4.3:3g", "4.3:4c", "3.12:29"]
+description = "A struct field, an array element, and an enum payload each carry NaN's irreflexivity into the aggregate holding it."
 source = """
 struct Sample { wide: f64 }
 enum Reading { Value(f64), Missing }
@@ -846,3 +856,155 @@ fn main() -> i32 {
 }
 """
 exit_code = 15
+
+# Two separately built aggregates whose float leaves are both NaN are unequal
+# for the same reason a value is unequal to itself: no NaN comparison is equal.
+[[case]]
+name = "two_aggregates_holding_nan_are_unequal_to_each_other"
+spec = ["4.3:2", "4.3:3b", "4.3:3g", "4.3:4c", "3.12:29"]
+description = "`Sample { value: nan } == Sample { value: nan }` is false; `!=` is true."
+source = """
+struct Sample { value: f64 }
+
+fn id(v: f64) -> f64 { v }
+
+fn main() -> i32 {
+    let zero: f64 = id(0.0);
+    let nan = zero / zero;
+    let a = Sample { value: nan };
+    let b = Sample { value: nan };
+    if a == b { 0 } else if a != b { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+# A NaN-carrying aggregate against one that differs in an ordinary way is
+# unequal by the ordinary rule, not by anything NaN-specific: the answer is the
+# same `false` an all-integer aggregate would give, and `!=` is `true`.
+[[case]]
+name = "nan_aggregate_against_a_differing_aggregate_is_ordinary_inequality"
+spec = ["4.3:2", "4.3:3b", "4.3:3g", "4.3:4c", "3.12:29"]
+description = "Comparing a NaN-holding struct with a different non-NaN struct is plain inequality: `==` false, `!=` true."
+source = """
+struct Sample { tag: i32, value: f64 }
+
+fn id(v: f64) -> f64 { v }
+
+fn main() -> i32 {
+    let zero: f64 = id(0.0);
+    let nan = zero / zero;
+    let holds_nan = Sample { tag: 1, value: nan };
+    let differs = Sample { tag: 2, value: 1.5 };
+    if !(holds_nan == differs) && holds_nan != differs { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+# The recursion reaches the NaN through two aggregate levels and an array, so
+# the irreflexivity is not a property of a one-field wrapper's register shape.
+[[case]]
+name = "nested_aggregate_reaching_a_nan_at_depth_is_not_equal_to_itself"
+spec = ["4.3:2", "4.3:3b", "4.3:3c", "4.3:3d", "4.3:3g", "3.12:29"]
+description = "A NaN two aggregate levels down, and one inside an enum payload's struct, each defeat reflexivity."
+source = """
+struct Leaf { value: f64 }
+struct Middle { leaf: Leaf, count: i32 }
+struct Outer { middle: Middle, samples: [f64; 2] }
+enum Reading { Value(Leaf), Missing }
+
+fn id(v: f64) -> f64 { v }
+
+fn main() -> i32 {
+    let zero: f64 = id(0.0);
+    let nan = zero / zero;
+
+    let deep = Outer { middle: Middle { leaf: Leaf { value: nan }, count: 7 }, samples: [1.0, 2.0] };
+    let in_array = Outer { middle: Middle { leaf: Leaf { value: 1.0 }, count: 7 }, samples: [1.0, nan] };
+    let in_payload = Reading.Value(Leaf { value: nan });
+
+    let mut r: i32 = 0;
+    if deep != deep { r = r + 1; }
+    if in_array != in_array { r = r + 2; }
+    if in_payload != in_payload { r = r + 4; }
+    r
+}
+"""
+exit_code = 7
+
+# The carve-out is exactly the NaN. A float-carrying aggregate with no NaN in it
+# is still equal to itself at every depth, and so is every aggregate with no
+# float leaf at all — structural equality lost reflexivity nowhere else.
+[[case]]
+name = "aggregate_equality_stays_reflexive_without_a_nan"
+spec = ["4.3:2", "4.3:3b", "4.3:3c", "4.3:3d", "4.3:3g", "4.3:4c"]
+description = "Float-carrying aggregates with no NaN, and float-free aggregates, remain equal to themselves."
+source = """
+struct Leaf { value: f64 }
+struct Middle { leaf: Leaf, count: i32 }
+struct Outer { middle: Middle, samples: [f32; 2] }
+struct Plain { a: i32, b: bool }
+enum Reading { Value(Leaf), Missing }
+
+fn id(v: f64) -> f64 { v }
+
+fn main() -> i32 {
+    let zero: f64 = id(0.0);
+    let infinity = 1.0 / zero;
+
+    let finite = Outer { middle: Middle { leaf: Leaf { value: 1.5 }, count: 7 }, samples: [2.5, 3.5] };
+    let infinite = Outer { middle: Middle { leaf: Leaf { value: infinity }, count: 7 }, samples: [2.5, 3.5] };
+    let plain = Plain { a: 1, b: true };
+    let payload = Reading.Value(Leaf { value: -0.0 });
+    let missing = Reading.Missing;
+
+    let mut r: i32 = 0;
+    if finite == finite { r = r + 1; }
+    if infinite == infinite { r = r + 2; }
+    if plain == plain { r = r + 4; }
+    if payload == payload { r = r + 8; }
+    if missing == missing { r = r + 16; }
+    r
+}
+"""
+exit_code = 31
+
+# The same pin with the optimizer on. Constant folding compares constants as raw
+# stored bits, under which a NaN *is* equal to itself and `-0.0` is not equal to
+# `+0.0` — exactly backwards from 3.12:27 — so the aggregate walk has to keep
+# reaching a real float compare rather than a folded answer. `constfold.rs`
+# declines to fold a comparison with a float operand and has its own unit test
+# for that, but nothing pinned the *aggregate* path above -O0 until this case;
+# the scalar counterpart is `types.floats::nan_and_zero_comparisons_survive_
+# constant_folding`, which runs at -O1 for the same reason.
+[[case]]
+name = "aggregate_nan_equality_survives_constant_folding"
+spec = ["4.3:2", "4.3:3b", "4.3:3c", "4.3:3d", "4.3:3g", "3.12:29"]
+opt_level = 1
+description = "With the optimizer on and every leaf compile-time constant, a NaN-holding aggregate is still unequal to itself and a -0.0/+0.0 pair is still equal."
+source = """
+const NAN: f64 = 0.0 / 0.0;
+const NEG_ZERO: f64 = -0.0;
+const POS_ZERO: f64 = 0.0;
+
+struct Leaf { value: f64 }
+struct Outer { leaf: Leaf, samples: [f64; 2] }
+enum Reading { Value(f64), Missing }
+
+fn main() -> i32 {
+    let holds_nan = Outer { leaf: Leaf { value: NAN }, samples: [1.0, 2.0] };
+    let nan_in_array = Outer { leaf: Leaf { value: 1.0 }, samples: [1.0, NAN] };
+    let payload = Reading.Value(NAN);
+    let negative = Leaf { value: NEG_ZERO };
+    let positive = Leaf { value: POS_ZERO };
+    let finite = Outer { leaf: Leaf { value: 1.5 }, samples: [1.0, 2.0] };
+
+    let mut r: i32 = 0;
+    if holds_nan != holds_nan { r = r + 1; }
+    if nan_in_array != nan_in_array { r = r + 2; }
+    if payload != payload { r = r + 4; }
+    if negative == positive { r = r + 8; }
+    if finite == finite { r = r + 16; }
+    r
+}
+"""
+exit_code = 31

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -1850,14 +1850,57 @@ max_T` for a signed `T` (`Neg`).
 signedness (the value `n_T` already carries the sign). Only `==`/`!=` may reach an
 aggregate (ordering on aggregates is a §5 type error); there they compare
 **structurally** — a struct field-by-field, an array element-by-element, an enum
-same-tag-and-equal-payload, recursing into nested aggregates (RUE-285) — and a
-each canonical text rung (`str`, `Str(N)`, or `StrBuf`) by its byte content (`4.3:2`):
+same-tag-and-equal-payload, recursing into nested aggregates (RUE-285) — and
+compare a value of each canonical text rung (`str`, `Str(N)`, or `StrBuf`) by its
+byte content (`4.3:2`):
 
 ```
   v1 ≈ v2  ⟺  v1 and v2 are structurally equal      (scalars by value; aggregates componentwise; strings by content)
   ─────────────────────────────────────────────────────────────────────────────────── (D-Eq)
   v1 == v2 → (v1 ≈ v2)                v1 != v2 → ¬(v1 ≈ v2)
 ```
+
+**`≈` is a total equivalence on the core's types, and only on those (RUE-2007).**
+Every `T` of §2 bottoms out in an `int(w, s)`, `bool`, or `unit` leaf, each
+comparing by value, and the canonical text rungs added by §6.13.4 compare by
+byte content — every one of those leaf relations is itself reflexive, so `≈` as
+stated above is reflexive, symmetric, and transitive. Prose `4.3:3b`, which
+cites this rule, must not be read as claiming more than that. The surface
+language's **floating-point types** `f32`/`f64` (`3.12:1`) are deliberately
+**not** among §2's `T` and are not modeled here; a float leaf compares by the
+IEEE 754 predicate (`3.12:27`), under which a `NaN` is not equal to itself. So
+`≈` extended over float leaves stays symmetric and transitive but loses
+reflexivity at exactly one place: `¬(v ≈ v)` for any `v` reaching a `NaN`, at
+any depth (`3.12:29`). Extended `≈` is a *partial* equivalence — a partial
+equivalence *relation* in the usual sense, symmetric and transitive without being
+reflexive, not a partially **defined** one. It remains a **total predicate**:
+every pair of well-typed values is either related or not, so `(D-Eq)` still fires
+on every pair and progress is untouched. What `≈` loses is reflexivity, not
+definedness. The prose says the same (`4.3:3g`).
+
+The extension is **conservative for §7**. `≈` occurs in exactly two rule
+statements in this document — `(D-Eq)` here and the container equations of
+§6.13.4 — and neither appeals to reflexivity: `(D-Eq)` only forwards `≈`'s truth
+value into a `bool`, and `≟` neither moves nor drops its operands (§4.1, §6.3),
+so no ownership, drop, or progress obligation is stated in terms of `v ≈ v`. The
+two `a == a` remarks in §5.4 and §5.8 are claims about **loan consistency**, not
+about the value produced, and the meta-level `=` of `(D-Use-Shared-Read)` and of
+§7's preservation statement is identity on model values, which stays reflexive
+whatever IEEE says. Adding a float leaf whose equality is irreflexive therefore
+invalidates no §7 theorem; it changes which `bool` a compare produces and nothing
+else.
+
+Equality also reaches values through the container **searches** §6.13.3 leaves as
+compositions rather than writing out (`index_of`, `contains`): those evaluate `≟`
+and so inherit this answer without naming `≈`. A buffer holding a `NaN` does not
+report that it `contains` one, for the same reason the aggregate around a `NaN`
+is not equal to itself. That is a consequence of the rule, not an exception to
+it, and it is why prose `4.3:3g`'s pointer at `@total_cmp` is advice about
+comparison rather than about the current search methods. Giving `f32`/`f64`
+their own `T`, values, and arithmetic dynamics (including the trap-free division
+of `3.12:22`, which does *not* fit §6.4's `(D-Div-Zero)`) is a separate
+amendment; this note records the equality consequence rather than leaving the
+prose citation overclaiming.
 
 **Bitwise `& | ^ ~` and shifts `<< >>`** operate on the `w`-bit two's-complement
 representation and never trap (`bitop`/`shift`). Write `β_w(n)` for
@@ -2846,7 +2889,7 @@ witness of the dynamic semantics (RUE-50), cited inline in each §6 rule group.
 | §5.7 divergence + never-coercion; (Loop-Div)/(Loop-Break) loop typing, reachable back-edge invariance, and the break-edge join | 3.4:1/2/3/4/6/6a/8, 3.4:9, 4.8:21, 3.8:50/51/79/80 |
 | §6.2 evaluation order (contexts, left-to-right) | 4.0:3–9 |
 | §6.3 dynamic use: declared-linear destructure, copy vs. ordinary move; equality borrows | 3.8:5/7/22/33/60/68/74, 3.9:1/2/13/15/28/34, 4.3:3f |
-| §6.4 operator dynamics: arith/div/mod, compare, bitwise/shift | 4.2:1, 4.3:1/2, 4.3a:10, 3.1:6/13 |
+| §6.4 operator dynamics: arith/div/mod, compare, bitwise/shift; the `≈` totality note and its float-leaf exception | 4.2:1, 4.3:1/2, 4.3:3b, 4.3:3g, 4.3a:10, 3.1:6/13, 3.12:27, 3.12:29 |
 | §6.5 aggregate intro + projection (declared-linear selection and bounds) | 3.5:2, 3.6:16, 3.8:33/60/68, 3.9:34, 4.11:14, 4.12:9, 8.2 |
 | §6.6 enum intro + match dynamics | 6.3:17, 4.7:16 |
 | §6.7/§6.8 let/seq/scope-drop (σ registration + `endscope`), assignment overwrite-drop; α-renamed shadowing | 4.5:3, 3.8:12/13, 3.8:55/64, 3.9 |

--- a/docs/spec/src/03-types/12-floating-point-types.md
+++ b/docs/spec/src/03-types/12-floating-point-types.md
@@ -275,9 +275,10 @@ other, even though they are distinct values with distinct sign bits.
 {{ rule(id="3.12:29", cat="dynamic-semantics") }}
 
 Structural equality on an aggregate (4.3:3b) applies these rules at each
-floating-point leaf. An array or struct holding a NaN is therefore not equal to
-itself, and two aggregates whose corresponding leaves are `-0.0` and `+0.0` are
-equal. A NaN is the value that makes Rue's structural `==` a partial
+floating-point leaf, at any depth. A struct, an array, or an enum payload
+holding a NaN is therefore not equal to itself, and neither is any aggregate
+enclosing one; two aggregates whose corresponding leaves are `-0.0` and `+0.0`
+are equal. A NaN is the value that makes Rue's structural `==` a partial
 equivalence rather than a total one (4.3:3g).
 
 {{ rule(id="3.12:30", cat="example") }}

--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -50,6 +50,20 @@ recursively by this rule down to scalar leaves — are equal (core calculus
 rule `(D-Eq)`). Specifically, two struct values are equal if and only if they
 have the same struct type and all corresponding fields are equal.
 
+Every leaf the recursion reaches is compared by its own type's equality — never
+by a byte-wise comparison of the aggregate's storage. An integer, `bool`, or unit
+leaf compares by value; a string leaf by content (4.3:3); a raw-pointer leaf by
+address (4.3:3e); and a floating-point leaf by the IEEE comparison of 3.12:27, so
+`-0.0` and `+0.0` leaves are equal although their bits differ, and a NaN leaf is
+not equal to itself. For every leaf type 4.3:2 also admits as a whole operand,
+that leaf relation is the one a top-level comparison of the type would use, so a
+component's equality never disagrees with that component's own `==`. The raw
+pointer is the one leaf kind with no top-level comparison of its own — it is not
+among 4.3:2's operand types — which is why 4.3:3e defines it only in field
+position. A floating-point leaf is the only leaf whose equality is not reflexive:
+an aggregate that reaches a NaN at any depth is therefore not equal to itself
+(3.12:29, 4.3:3g).
+
 {{ rule(id="4.3:3c", cat="normative") }}
 
 Two array values are equal if and only if they have the same element type and
@@ -83,11 +97,25 @@ usable afterward.
 Equality is structural **by default**. Trait-based refinement of equality —
 opting a type out of comparison, or giving it a user-defined equality (a
 `PartialEq`-style mechanism) — is deferred until traits exist (RUE-246).
-Structural equality is a *partial* equivalence, not a total one: the
-floating-point types have a value unequal to itself, `NaN` (3.12:27), and an
-aggregate reaching one at any leaf inherits that (3.12:29). This is the concrete
-motivation for the eventual `PartialEq`/`Eq` split; until it lands,
-`@total_cmp` (3.12:32) is the total order available for sorting and hashing.
+
+Structural equality is symmetric and transitive everywhere, and reflexive
+everywhere *except* through a NaN: a NaN is the one value unequal to itself
+(3.12:27), and a value that reaches one at any leaf inherits that (3.12:29). It
+is therefore a *partial* equivalence rather than a total one — but the exception
+is exactly the NaN leaf. Equality is total on every type with no floating-point
+leaf, which is every type Rue had before `f32` and `f64`, and on every value of
+a float-carrying type that holds no NaN.
+
+That exception is deliberate. The alternative — comparing an aggregate's float
+leaves by their bits, or by `@total_cmp` (3.12:32), so that structural equality
+stayed a total equivalence — was rejected because it would make a field's
+equality disagree with that field's own `==`: `Sample { value: nan }` would be
+equal to itself while the `nan == nan` inside it stayed `false`. Applying IEEE
+at the leaf (4.3:3b) keeps the two the same operator, and matches what a
+derived structural equality does over IEEE floats in other languages. The
+partiality is the concrete motivation for the eventual `PartialEq`/`Eq` split;
+until that lands, `@total_cmp` is the total order available for sorting and
+hashing, and it is the tool to reach for when a container needs reflexivity.
 
 {{ rule(id="4.3:4") }}
 
@@ -126,6 +154,33 @@ fn main() -> i32 {
     let b = [1, 2, 3];
     let equal = a == b;      // borrows a and b
     if equal && a[0] == b[0] { 1 } else { 0 }
+}
+```
+
+{{ rule(id="4.3:4c", cat="example") }}
+
+A float leaf carries IEEE equality into the aggregate around it (4.3:3b). An
+aggregate holding a NaN is not equal to itself; every other aggregate is, so the
+only reflexivity failure is the one the NaN introduces.
+
+```rue
+struct Sample { value: f64 }
+
+fn id(v: f64) -> f64 { v }
+
+fn main() -> i32 {
+    let zero: f64 = id(0.0);
+    let nan = zero / zero;
+    let a = Sample { value: nan };
+    let b = Sample { value: nan };
+    let c = Sample { value: 1.5 };
+
+    @dbg(a == a);   // false: the NaN leaf is not equal to itself
+    @dbg(a == b);   // false: two NaN leaves are unordered, not equal
+    @dbg(a == c);   // false: ordinary inequality, no NaN rule needed
+    @dbg(a != c);   // true
+    @dbg(c == c);   // true: no NaN, so equality is reflexive here
+    0
 }
 ```
 


### PR DESCRIPTION
Fixes RUE-2007

## Decision

Structural equality applies IEEE 754 equality at every float leaf, at any depth. An aggregate that reaches a NaN is therefore not equal to itself, and `-0.0`/`+0.0` leaves compare equal. This is the decision ADR-0065 §2 already made and that the maintainer confirmed on the issue; the compiler and the oracle have implemented it all along, at every optimization level. Only the specification and the core-calculus note lagged.

The rejected alternative was a bitwise or `@total_cmp` leaf rule for aggregates, which would have kept structural equality a total equivalence while making a field's equality disagree with that field's own `==`. 4.3:3g now records both the decision and the reason.

## Changes

- **Spec 4.3:3b** states that every leaf compares by its own type's equality, never by a byte-wise comparison of the aggregate's storage, and that the float leaf is the only irreflexive one. The agrees-with-top-level guarantee is scoped to the leaf types 4.3:2 admits as whole operands, since a raw pointer has no top-level `==` and is defined only in field position by 4.3:3e.
- **Spec 4.3:3g** replaces the "partial equivalence" sentence with the full statement: symmetric and transitive everywhere, reflexive everywhere except through a NaN, with the rejected alternative and the `@total_cmp` advice.
- **Spec 4.3:4c** is a new example pinning the five cases a reader needs.
- **Spec 3.12:29** now says "at any depth" and names enum payloads.
- **Core calculus §6.4** gains a note on the `≈` relation: it is a total equivalence on the core's own types, and extending it over float leaves keeps it a total predicate (so `(D-Eq)` still fires and progress is untouched) while losing reflexivity at exactly the NaN. The note argues that this is conservative for every §7 theorem, records that container searches (`contains`, `index_of`) inherit the same answer, and names the real float amendment as separate work. A pre-existing typo in the same paragraph is fixed.
- **Spec cases** under `expressions/comparison.toml`: the existing baseline case is promoted to a normative pin and four cases are added, covering NaN in a struct field, an array element, an enum payload, two aggregate levels down, two separately built NaN aggregates, ordinary inequality against a NaN aggregate, and reflexivity everywhere a NaN is absent. One case runs at `-O1` so the aggregate path is pinned past constant folding, matching the scalar precedent in `types/floats.toml`.

## Verification

- `scripts/rue spec comparison`: 118 passed.
- `//:spec-traceability` and `//:compiler-spec-machine-index`: pass.
- Full `scripts/rue spec`, `scripts/rue cli`, `scripts/rue quick`, `scripts/rue premerge`, and the oracle-diff corpus target were run on the pre-rebase tree and were clean; the rebase onto trunk touched no overlapping file.
- Each new case's program was run by hand at `-O0` through `-O3` with identical exit codes.
