### PR TITLE
RUE-2101: answer a zero-sized parameter from its type, never from its slot

### DIFF
--- a/crates/rue-cli-tests/cases/zero_sized_parameter_slot_sharing.toml
+++ b/crates/rue-cli-tests/cases/zero_sized_parameter_slot_sharing.toml
@@ -1,0 +1,180 @@
+# The parameter half of the shared-slot hazard `cli.zero_sized_slot_sharing`
+# covers for locals.
+#
+# A by-value zero-sized argument occupies zero ABI slots, so the parameter
+# after it receives the index the zero-sized one is still named by. The
+# compiler is right about this at every optimization level; `rue-oracle` was
+# not. Its `CfgInstData::Param` read had always answered a zero-sized
+# parameter from its type, but the place-rooted paths and the `inout`
+# writeback still went to the slot, which holds the neighbour's value.
+#
+# Each case below was a red `oracle-diff` result before RUE-2101, for a
+# correctly compiled program, and so could not have been authored as a
+# `differential_opt` case at all — the same "the gate cannot see this class"
+# blind spot RUE-2095 closed for locals. The symptoms differ by what sits in
+# the shared slot:
+#
+#   - a scalar neighbour  -> ContractViolation(NonAggregateProjectionRead)
+#   - no neighbour at all -> ContractViolation(ParameterSlotOutOfBounds)
+#   - an address-taken zero-sized parameter -> the whole case was reclassified
+#     as an unmodeled `PointerWrite` gap, so oracle-diff silently stopped
+#     checking the program instead of failing on it
+#
+# `differential_opt` compiles and runs each at `-O0`/`-O1`/`-O2`/`-O3` and
+# requires one answer across all four.
+
+[section]
+id = "cli.zero_sized_parameter_slot_sharing"
+name = "Zero-sized parameters sharing an ABI slot"
+description = "A zero-sized parameter occupies no ABI slot, so its index names the next parameter's slot; nothing may read or write that slot on its behalf (RUE-2101)."
+
+[[case]]
+name = "zero_sized_parameter_field_read_does_not_read_its_neighbour"
+description = "RUE-2101: a field read on a zero-sized struct parameter must answer from the type, not from the sized parameter sharing its slot index."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn f(z: Empty, v: i64) -> i64 {
+    let _u: () = z.unit;
+    v
+}
+fn main() -> i32 {
+    @dbg(f(Empty { unit: () }, 5));
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+differential_opt = true
+
+# Slot indices only advance, so the collision is always with the parameter that
+# FOLLOWS the zero-sized one.
+[[case]]
+name = "zero_sized_parameter_between_two_sized_parameters"
+description = "RUE-2101: a zero-sized parameter between two sized ones shares the second one's slot, and both sized parameters must survive."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn f(a: i64, z: Empty, b: i64) -> i64 {
+    let _u: () = z.unit;
+    a * 10 + b
+}
+fn main() -> i32 {
+    @dbg(f(3, Empty { unit: () }, 4));
+    0
+}
+""" }]
+stdout = "34\n"
+exit_code = 0
+differential_opt = true
+
+# With nothing after it, the shared index is past the end of the parameter list
+# rather than another parameter's.
+[[case]]
+name = "trailing_zero_sized_parameter_owns_no_slot"
+description = "RUE-2101: a trailing zero-sized parameter names a slot that does not exist; reading it reported a parameter-slot bounds violation."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn f(v: i64, z: Empty) -> i64 {
+    let _u: () = z.unit;
+    v
+}
+fn main() -> i32 {
+    @dbg(f(7, Empty { unit: () }));
+    0
+}
+""" }]
+stdout = "7\n"
+exit_code = 0
+differential_opt = true
+
+# Two distinct zero-sized parameter types, one of them nested two projections
+# deep, all rooted at the sized parameter's index.
+[[case]]
+name = "two_zero_sized_parameters_share_one_slot_with_a_sized_one"
+description = "RUE-2101: distinct zero-sized parameter types sharing an index each answer from their own type, and neither disturbs the sized parameter."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+struct Nest { e: Empty }
+fn f(a: Empty, b: Nest, v: i64) -> i64 {
+    let _x: () = a.unit;
+    let _y: () = b.e.unit;
+    v
+}
+fn main() -> i32 {
+    @dbg(f(Empty { unit: () }, Nest { e: Empty { unit: () } }, 9));
+    0
+}
+""" }]
+stdout = "9\n"
+exit_code = 0
+differential_opt = true
+
+# The parameter table and the local table are separate storage; a function with
+# both a zero-sized parameter and a re-assigned zero-sized local needs both
+# RUE-2095's fix and this one.
+[[case]]
+name = "zero_sized_parameter_and_zero_sized_local_in_one_function"
+description = "RUE-2101/RUE-2095: a zero-sized parameter and a zero-sized local both share indices with sized storage in the same frame."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn f(z: Empty, v: i64) -> i64 {
+    let _u: () = z.unit;
+    let mut e: () = ();
+    let y: i64 = v + 1;
+    e = ();
+    let _w: () = e;
+    y
+}
+fn main() -> i32 {
+    @dbg(f(Empty { unit: () }, 5));
+    0
+}
+""" }]
+stdout = "6\n"
+exit_code = 0
+differential_opt = true
+
+# Address formation seeds a promoted allocation from the place's current value,
+# which for a zero-sized parameter meant reading the neighbour's slot.
+[[case]]
+name = "address_of_a_zero_sized_parameter_field_reads_no_slot"
+description = "RUE-2101: forming a zero-sized parameter's address must not read the sized parameter sharing its index."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn f(z: Empty, v: i64) -> i64 {
+    let _pointer: ptr const () = checked { @raw(z.unit) };
+    v
+}
+fn main() -> i32 {
+    @dbg(f(Empty { unit: () }, 5));
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+differential_opt = true
+
+# The `inout` copy-out at return walks the promoted table by parameter slot. A
+# promoted zero-sized parameter's entry names its `inout` neighbour's slot, so
+# the neighbour's final value was replaced by the zero-sized one.
+[[case]]
+name = "promoted_zero_sized_parameter_leaves_the_inout_neighbour_intact"
+description = "RUE-2101: an address-taken zero-sized parameter must not displace the copy-out value of the `inout` parameter sharing its slot index."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+struct Pair { a: i64, b: i64 }
+fn f(z: Empty, inout p: Pair) {
+    let _pointer: ptr const () = checked { @raw(z.unit) };
+    p.a = p.a + 10;
+    p.b = p.b + 20;
+}
+fn main() -> i32 {
+    let mut p: Pair = Pair { a: 1, b: 2 };
+    f(Empty { unit: () }, inout p);
+    @dbg(p.a);
+    @dbg(p.b);
+    0
+}
+""" }]
+stdout = "11\n22\n"
+exit_code = 0
+differential_opt = true

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1368,6 +1368,15 @@ struct Frame {
     /// occupies one pointer slot. The whole semantic value is kept at its base
     /// slot; extra by-value slots are `None` (they are only reached through the
     /// base via a projection, never directly).
+    ///
+    /// A zero-sized by-value parameter has **no entry at all**: it occupies
+    /// zero slots, so its `Param { index }` / `PlaceBase::Param(slot)` names
+    /// the slot the *next* parameter received. Reach parameter storage only
+    /// through [`Interp::zero_sized_param`], which decides that question from
+    /// the accessed type — the same "a slot index is not a storage name"
+    /// rule [`Frame::locals`] states as a `(slot, Type)` key (RUE-2095),
+    /// in the form the one table whose zero-sized rows do not exist can state
+    /// it (RUE-2101).
     params: Vec<Option<Value>>,
     /// Local storage keyed by `(slot, Type)`, never by the slot index alone.
     ///
@@ -3361,7 +3370,13 @@ impl<'a> Interp<'a> {
                     // address, its canonical bytes (rather than the copy-in
                     // snapshot) are authoritative for that writeback.
                     for (&key, &alloc) in &frame.promoted {
+                        // A zero-sized parameter's promoted allocation names
+                        // the slot its sized neighbour owns (RUE-2101), and
+                        // that slot's copy-out value is the neighbour's. Its
+                        // own value is fixed by its type, so there is nothing
+                        // to write back for it.
                         if let Some(slot) = key.param_slot()
+                            && !self.is_zero_sized(key.ty)
                             && let Some(value) = final_params.get_mut(slot)
                         {
                             *value = Some(self.promoted_slot_value(alloc)?);
@@ -3861,6 +3876,29 @@ impl<'a> Interp<'a> {
         }
     }
 
+    /// The value of a zero-sized parameter, whose storage `Frame::params`,
+    /// `Frame::param_places` and `Frame::promoted` never hold.
+    ///
+    /// `call_arg_slot_width` gives a by-value zero-sized argument a width of
+    /// zero, so `call_inner_with_places` never pushes it and its
+    /// `PlaceBase::Param(slot)` names the slot the NEXT parameter occupies.
+    /// Every slot-indexed parameter table therefore answers with the
+    /// neighbour's storage, which is a wrong value for a scalar neighbour and
+    /// a contract violation for an aggregate one (RUE-2101). Materialize the
+    /// unique value of the type instead, exactly as the `CfgInstData::Param`
+    /// read already does.
+    ///
+    /// A *by-reference* zero-sized parameter does own its one pointer slot, so
+    /// this is not the same "no storage" statement for it — but every value of
+    /// a zero-sized type is the same value, so answering from the type is
+    /// still exact, and the caller's copy-out observes an identical value.
+    /// Distinguishing the two modes would buy nothing and would need the
+    /// callee's `is_param_by_ref` at every access.
+    fn zero_sized_param(&self, base: PlaceBase, ty: Type) -> Option<Value> {
+        (matches!(base, PlaceBase::Param(_)) && self.is_zero_sized(ty))
+            .then(|| self.zero_sized_value(ty))
+    }
+
     fn eval_all(&mut self, cfg: &'a Cfg, frame: &mut Frame, vs: &[CfgValue]) -> Step<Vec<Value>> {
         vs.iter().map(|v| self.eval(cfg, frame, *v)).collect()
     }
@@ -3912,13 +3950,13 @@ impl<'a> Interp<'a> {
                 self.string_literal_value(text, ty)?
             }
             CfgInstData::Param { index } => {
-                if self.is_zero_sized(ty) {
-                    // A zero-sized parameter occupies NO slot (abi_slot_count
-                    // = 0), but the CFG still emits a Param read for it —
-                    // sharing its `index` with the NEXT parameter's slot. Do
-                    // not read the slot (that would grab the next parameter's
-                    // value); materialize the unique ZST value instead.
-                    self.zero_sized_value(ty)
+                // A zero-sized parameter occupies NO slot (abi_slot_count = 0),
+                // but the CFG still emits a Param read for it — sharing its
+                // `index` with the NEXT parameter's slot. Reading the slot
+                // would grab the next parameter's value, so this and every
+                // other parameter-storage path asks `zero_sized_param` first.
+                if let Some(value) = self.zero_sized_param(PlaceBase::Param(*index), ty) {
+                    value
                 } else if let Some(target) = frame.param_places.get(index).cloned() {
                     // Raw accessor execution redirects by-reference parameter
                     // slots to their caller places, matching canonical
@@ -4948,6 +4986,11 @@ impl<'a> Interp<'a> {
         path: &[(usize, Projection)],
     ) -> Step<Option<PtrTarget>> {
         let target = match base {
+            // A by-reference binding at a zero-sized parameter's index belongs
+            // to the parameter that actually owns the slot; leave the place
+            // unbound so the read materializes the zero-sized value instead
+            // (see `zero_sized_param`).
+            PlaceBase::Param(_) if self.is_zero_sized(base_type) => None,
             PlaceBase::Param(slot) => frame.param_places.get(&slot).cloned(),
             PlaceBase::Accessor(call) => match self.eval(cfg, frame, call)? {
                 Value::Ptr(target) => target,
@@ -5204,9 +5247,18 @@ impl<'a> Interp<'a> {
                 )
                 .map_err(Flow::from);
         }
+        // A zero-sized parameter owns no slot storage (see `zero_sized_param`),
+        // so neither its neighbour's promoted allocation nor its neighbour's
+        // `Frame::params` entry may receive the write. Route it into a scratch
+        // copy of the unique zero-sized value: every value of a zero-sized type
+        // is that value, so nothing observable is lost, while the projection
+        // walk below still reports an out-of-range or non-aggregate path.
+        let mut zero_sized_scratch = self.zero_sized_param(base, place.base_type);
         // A promoted base writes through the canonical byte allocation. The
         // unpromoted path can still mutate the frame's logical value directly.
-        if let Some(&a) = frame.promoted.get(&promotion_key(base, place.base_type)) {
+        if zero_sized_scratch.is_none()
+            && let Some(&a) = frame.promoted.get(&promotion_key(base, place.base_type))
+        {
             let (byte_offset, pointee) = self
                 .projection_offset(place.base_type, &path)
                 .ok_or_else(|| {
@@ -5235,11 +5287,15 @@ impl<'a> Interp<'a> {
                 .entry((slot, place.base_type))
                 .or_insert(Value::Unit),
             PlaceBase::Param(slot) => {
-                let slot = slot as usize;
-                if slot >= frame.params.len() {
-                    frame.params.resize(slot + 1, None);
+                if let Some(value) = zero_sized_scratch.as_mut() {
+                    value
+                } else {
+                    let slot = slot as usize;
+                    if slot >= frame.params.len() {
+                        frame.params.resize(slot + 1, None);
+                    }
+                    frame.params[slot].get_or_insert(Value::Unit)
                 }
-                frame.params[slot].get_or_insert(Value::Unit)
             }
             PlaceBase::Accessor(_) => {
                 return Err(unsupported(
@@ -5381,6 +5437,13 @@ impl<'a> Interp<'a> {
         }
     }
 
+    /// Store a callee-side `inout` parameter write into its slot.
+    ///
+    /// This is the one parameter-storage path that stays purely slot-indexed,
+    /// and deliberately: `ParamStore` names a writable by-reference parameter,
+    /// which occupies one pointer slot whatever its type, so a zero-sized
+    /// `inout` parameter really does own the slot it names and
+    /// `zero_sized_param`'s "no storage" rule does not apply to it (RUE-2101).
     fn set_param(frame: &mut Frame, slot: u32, val: Value) {
         let s = slot as usize;
         if s >= frame.params.len() {
@@ -5395,6 +5458,12 @@ impl<'a> Interp<'a> {
     /// (address-taken) slot's heap allocation so a pointer write is observed by
     /// a later direct read of the same slot.
     fn base_value_of(&self, frame: &Frame, base: PlaceBase, base_type: Type) -> Step<Value> {
+        // A zero-sized parameter has no slot of its own; answer from the type
+        // ahead of every slot-indexed table, which is the order the
+        // `CfgInstData::Param` read uses for the same reason.
+        if let Some(value) = self.zero_sized_param(base, base_type) {
+            return Ok(value);
+        }
         if let Some(&a) = frame.promoted.get(&promotion_key(base, base_type)) {
             return self.promoted_slot_value(a);
         }

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -1976,6 +1976,146 @@ fn zst_sharing_a_slot_with_an_address_taken_local_writes_through_the_pointer() {
     assert_eq!(run(src).stdout, "11\n");
 }
 
+// ---- zero-sized parameters sharing an ABI slot (RUE-2101) -----------------
+//
+// The parameter half of the same hazard. `call_arg_slot_width` gives a
+// by-value zero-sized argument a width of zero, so it is never laid into
+// `Frame::params` and its `Param { index }` / `PlaceBase::Param(slot)` names
+// the slot the NEXT parameter received. The `CfgInstData::Param` read has
+// always answered such a read from the type; the place-rooted paths
+// (`base_value_of`, `place_write`, `param_places`) and the `Return` inout
+// writeback did not, so a field read on a zero-sized parameter reached its
+// neighbour's storage.
+
+#[test]
+fn zst_parameter_field_read_does_not_read_the_slot_neighbour() {
+    // The issue's repro. `frame.params[0]` holds `v`'s `Int(5)`, so projecting
+    // a field of `z` there reported NonAggregateProjectionRead — an ORACLE
+    // FAILURE on a program the compiler gets right at every level.
+    let src = "struct Empty { unit: () }
+    fn f(z: Empty, v: i64) -> i64 {
+        let _u: () = z.unit;
+        v
+    }
+    fn main() -> i32 {
+        @dbg(f(Empty { unit: () }, 5));
+        0
+    }";
+    assert_eq!(run(src).stdout, "5\n");
+}
+
+#[test]
+fn zst_parameter_between_two_sized_parameters_collides_with_the_second() {
+    // Slot indices only advance, so the zero-sized parameter shares its index
+    // with the parameter that FOLLOWS it, not the one before.
+    let src = "struct Empty { unit: () }
+    fn f(a: i64, z: Empty, b: i64) -> i64 {
+        let _u: () = z.unit;
+        a * 10 + b
+    }
+    fn main() -> i32 {
+        @dbg(f(3, Empty { unit: () }, 4));
+        0
+    }";
+    assert_eq!(run(src).stdout, "34\n");
+}
+
+#[test]
+fn trailing_zst_parameter_owns_no_slot() {
+    // With no parameter after it, the shared index is past the end of the
+    // parameter list: reading the slot reported ParameterSlotOutOfBounds.
+    let src = "struct Empty { unit: () }
+    fn f(v: i64, z: Empty) -> i64 {
+        let _u: () = z.unit;
+        v
+    }
+    fn main() -> i32 {
+        @dbg(f(7, Empty { unit: () }));
+        0
+    }";
+    assert_eq!(run(src).stdout, "7\n");
+}
+
+#[test]
+fn two_zst_parameters_share_one_slot_with_the_sized_parameter() {
+    // Two distinct zero-sized parameter types, one of them nested, all naming
+    // the sized parameter's index.
+    let src = "struct Empty { unit: () }
+    struct Nest { e: Empty }
+    fn f(a: Empty, b: Nest, v: i64) -> i64 {
+        let _x: () = a.unit;
+        let _y: () = b.e.unit;
+        v
+    }
+    fn main() -> i32 {
+        @dbg(f(Empty { unit: () }, Nest { e: Empty { unit: () } }, 9));
+        0
+    }";
+    assert_eq!(run(src).stdout, "9\n");
+}
+
+#[test]
+fn zst_parameter_and_zst_local_keep_separate_storage() {
+    // The parameter table and the local table are separate fixes; a function
+    // with both a zero-sized parameter and a re-assigned zero-sized local
+    // needs each of them.
+    let src = "struct Empty { unit: () }
+    fn f(z: Empty, v: i64) -> i64 {
+        let _u: () = z.unit;
+        let mut e: () = ();
+        let y: i64 = v + 1;
+        e = ();
+        let _w: () = e;
+        y
+    }
+    fn main() -> i32 {
+        @dbg(f(Empty { unit: () }, 5));
+        0
+    }";
+    assert_eq!(run(src).stdout, "6\n");
+}
+
+#[test]
+fn address_taken_zst_parameter_does_not_promote_its_neighbours_slot() {
+    // Forming the zero-sized parameter's address read the neighbour's slot to
+    // seed the promoted allocation, so the read failed before any pointer
+    // existed.
+    let src = "struct Empty { unit: () }
+    fn f(z: Empty, v: i64) -> i64 {
+        let _pointer: ptr const () = checked { @raw(z.unit) };
+        v
+    }
+    fn main() -> i32 {
+        @dbg(f(Empty { unit: () }, 5));
+        0
+    }";
+    assert_eq!(run(src).stdout, "5\n");
+}
+
+#[test]
+fn promoted_zst_parameter_leaves_the_inout_neighbour_writeback_intact() {
+    // `Return`'s inout copy-out walks `Frame::promoted` and writes every
+    // parameter-keyed entry into its slot. A promoted zero-sized parameter's
+    // key names the slot its `inout` neighbour owns, so without the guard the
+    // neighbour's final value was replaced by the zero-sized one and the
+    // caller's copy-out wrote that back.
+    let src = "struct Empty { unit: () }
+    struct Pair { a: i64, b: i64 }
+    fn f(z: Empty, inout p: Pair) {
+        let _pointer: ptr const () = checked { @raw(z.unit) };
+        p.a = p.a + 10;
+        p.b = p.b + 20;
+    }
+    fn main() -> i32 {
+        let mut p: Pair = Pair { a: 1, b: 2 };
+        f(Empty { unit: () }, inout p);
+        @dbg(p.a);
+        @dbg(p.b);
+        0
+    }";
+    assert_eq!(run(src).stdout, "11\n22\n");
+}
+
 #[test]
 fn enum_parameter_width_comes_from_its_static_type() {
     let src = r#"enum Shape { Empty, One(i32), Pair(i32, i32) }


### PR DESCRIPTION
Fixes RUE-2101

## Problem

`call_arg_slot_width` gives a by-value zero-sized argument a width of zero, so the oracle never lays it into `Frame::params`, and its `Param { index }` / `PlaceBase::Param(slot)` names the slot the next parameter received. The `CfgInstData::Param` read already answered a zero-sized parameter from its type, but it was the only path that did: `base_value_of`, `place_write`'s parameter root, `external_place_target`'s `param_places` lookup, and `Return`'s inout copy-out all went to the slot. A field read on a zero-sized struct parameter beside a sized one was a red oracle failure for a program the compiler gets right at every optimization level, so oracle-diff could not gate the shape at all. This is the parameter half of the hazard RUE-2095 closed for locals.

## Change

- `Interp::zero_sized_param` decides from the accessed type whether a `PlaceBase::Param` names storage at all, and every parameter-storage path asks it first. A by-reference zero-sized parameter does own its pointer slot, but every value of a zero-sized type is the same value, so answering from the type is still exact and the caller's copy-out observes an identical value.
- `place_write` routes a write rooted at a zero-sized parameter into a scratch copy of the type's value so the projection walk still reports an out-of-range or non-aggregate path without touching the neighbour's slot or promoted allocation.
- `Return`'s promoted copy-out skips zero-sized keys, whose slot number is the neighbour's.
- `ParamStore` and `set_param` stay slot-indexed on purpose: they name a writable by-reference parameter, which occupies one slot whatever its type.

## Coverage

- Seven `rue-oracle` unit tests and a new CLI section `cli.zero_sized_parameter_slot_sharing` (seven `differential_opt` cases): a scalar neighbour, a zero-sized parameter between two sized ones, a trailing one, two distinct zero-sized types on one slot, a zero-sized parameter and a zero-sized local in one frame, an address-taken zero-sized parameter, and a promoted zero-sized parameter beside an `inout` aggregate.
- Each case was a red oracle result on trunk for a correctly compiled program.

## Verification

- `scripts/rue unit oracle zst`: 15 pass. `scripts/rue cli zero_sized_parameter`: 7 pass.
- `//crates/rue-oracle-diff:oracle-diff-test`: pass; no model-gap registry entry became stale.
- An additional 14-case probe set run through `rue-oracle-diff` against trunk and this branch removes four oracle failures and regresses nothing. The one remaining disagreement (whole-value equality of a zero-sized struct parameter) is identical on trunk and is filed separately.
