### PR TITLE
RUE-2105: acknowledge every save to a module the watcher cannot read at all

### DIFF
--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -329,3 +329,169 @@ touch = true
 [[case.watch.edits]]
 path = "extra.rue"
 source = "pub fn spare() -> i32 { 41 }\npub fn broken() -> i32 { 2 }\n"
+
+[[case]]
+name = "an_edit_to_a_newly_imported_unreadable_module_is_acknowledged"
+description = """
+RUE-2105. The same failure as the case above, one step earlier in the read.
+`extra.rue` is present but cannot be turned into source at all — its bytes are
+not UTF-8 — so no attempt ever accepts any bytes for it and it appears in no
+accepted-read manifest. Keying the suppression only on what an attempt
+*accepted* therefore left this family with nothing to observe: the failure
+reported once and then went silent over every later save, on the retry timer,
+which is the identical bug the case above closes for a module that reads fine
+and merely fails to parse.
+
+Both reports below carry the same message at the same location, so only the
+record of the attempt's rejected read can have produced the second.
+"""
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+]
+
+[case.watch]
+kind = "read_failure_outside_closure"
+expected_exit_codes = [1, 2]
+stderr_occurrences = [
+    { text = "could not read import candidate", count = 2 },
+    { text = "stream did not contain valid UTF-8", count = 2 },
+    # One status line per report, not one per retry and not one per save: the
+    # save that changed no bytes added none.
+    { text = "keeping the last successful executable", count = 2 },
+]
+
+# Stage the unreadable module. Nothing imports it yet, so it is in no closure
+# and no watch input, and the watcher must not stir for it.
+[[case.watch.edits]]
+path = "extra.rue"
+undecodable_source = "pub fn broken() -> i32 { 1 }\n"
+
+# Wire it into the closure for the first time.
+[[case.watch.edits]]
+path = "helper.rue"
+source = "const extra = @import(\"extra.rue\");\npub fn answer() -> i32 { extra.broken() }\n"
+
+# Edit it. It is exactly as unreadable and the diagnostic does not move, but it
+# is a save the user made and it owes an answer.
+[[case.watch.edits]]
+path = "extra.rue"
+undecodable_source = "pub fn broken() -> i32 { 41 }\n"
+
+# Save it without changing a byte. The record is content-derived on both sides
+# of the read, so the new modification time is invisible here too.
+[[case.watch.edits]]
+path = "extra.rue"
+touch = true
+
+# Repair it into real source. The published program answers with it.
+[[case.watch.edits]]
+path = "extra.rue"
+source = "pub fn broken() -> i32 { 2 }\n"
+
+[[case]]
+name = "an_edit_beside_a_directory_in_a_modules_place_is_acknowledged"
+description = """
+RUE-2105, the other shape of the same read failure: a directory where a module
+belongs. There are no bytes to accept, so the record falls back to the identity
+and metadata of whatever is at the path — which is what makes a change under
+that directory a new revision and a save that changes nothing still silent.
+
+The repair replaces the directory with a real module, so the counted string is
+the directory diagnostic alone: it is reported exactly twice, once when the
+directory is wired in and once for the change beneath it.
+"""
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+]
+
+[case.watch]
+kind = "read_failure_outside_closure"
+expected_exit_codes = [1, 2]
+stderr_occurrences = [
+    { text = "which is not a regular source file", count = 2 },
+]
+
+# Put a directory where `extra.rue` belongs.
+[[case.watch.edits]]
+path = "extra.rue"
+directory = true
+
+# Wire it in.
+[[case.watch.edits]]
+path = "helper.rue"
+source = "const extra = @import(\"extra.rue\");\npub fn answer() -> i32 { extra.broken() }\n"
+
+# Change what is under it. Creating the entry restamps the directory itself,
+# atomically — nothing here ever leaves the path momentarily absent, which
+# would produce a different diagnostic rather than a repeat of this one.
+[[case.watch.edits]]
+path = "extra.rue/inner.rue"
+source = "pub fn inner() -> i32 { 1 }\n"
+
+# Save that file without changing it. The directory is untouched, so this is
+# not a revision of the module and owes no report.
+[[case.watch.edits]]
+path = "extra.rue/inner.rue"
+touch = true
+
+# Replace the directory with a real module.
+[[case.watch.edits]]
+path = "extra.rue"
+source = "pub fn broken() -> i32 { 2 }\n"
+
+[[case]]
+name = "an_edit_beside_a_named_pipe_in_a_modules_place_is_acknowledged"
+only_on = [
+    "x86-64-linux",
+    "aarch64-linux",
+    "x86-64-macos",
+    "aarch64-macos",
+]
+description = """
+RUE-2105, the read failure that must be classified without opening anything. A
+named pipe where a module belongs is not a regular source file, and opening it
+for reading blocks until a writer appears — which never happens. The loader has
+always decided this from metadata alone; the record of what an attempt could not
+read has to hold the same order, or the observation itself never returns and the
+watcher stops answering entirely rather than merely going quiet.
+
+So the assertion that matters here is that the watcher keeps reporting at all:
+the first report when the pipe is wired in, a second for the closure edit beside
+it, and a publication when the module is repaired into real source.
+"""
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+]
+
+[case.watch]
+kind = "read_failure_outside_closure"
+expected_exit_codes = [1, 2]
+stderr_occurrences = [
+    { text = "which is not a regular source file", count = 2 },
+]
+
+# Put a named pipe where `extra.rue` belongs. Nothing imports it yet.
+[[case.watch.edits]]
+path = "extra.rue"
+fifo = true
+
+# Wire it in. This is the report that never arrived while the probe reached for
+# the pipe's bytes.
+[[case.watch.edits]]
+path = "helper.rue"
+source = "const extra = @import(\"extra.rue\");\npub fn answer() -> i32 { extra.broken() }\n"
+
+# Edit the importing module beside it. The pipe is untouched and renders the
+# same diagnostic, so this report can only come from the changed closure read —
+# which the loop has to still be running to produce.
+[[case.watch.edits]]
+path = "helper.rue"
+source = "const extra = @import(\"extra.rue\");\n\npub fn answer() -> i32 { extra.broken() }\n"
+
+# Replace the pipe with a real module.
+[[case.watch.edits]]
+path = "extra.rue"
+source = "pub fn broken() -> i32 { 2 }\n"

--- a/crates/rue-cli-tests/cases/watch_test.toml
+++ b/crates/rue-cli-tests/cases/watch_test.toml
@@ -549,3 +549,83 @@ source = """
 pub fn spare() -> i32 { 41 }
 pub fn broken() -> i32 { 2 }
 """
+
+[[case]]
+name = "an_edit_to_a_newly_imported_unreadable_module_is_acknowledged"
+description = """
+RUE-2105, on the test watcher. The two watchers share one re-observation arm,
+so they share this gap too: a module that is present but cannot be turned into
+source at all — its bytes are not UTF-8 — is accepted by no attempt, so keying
+the suppression only on accepted reads left it with nothing to observe and
+every save after the first was silent.
+
+The first edit stages the unreadable module, the second wires it into the test
+closure, the third edits it, the fourth saves it without changing a byte, and
+the fifth repairs it. Both reports carry the same rendering, so only the record
+of the attempt's rejected read can have produced the second.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 { 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn double(x: i32) -> i32 { x * 2 }
+""" },
+    { path = "tests.rue", source = """
+const helper = @import("helper.rue");
+
+test "doubles through the helper" {
+    @assert(helper.double(2) == 4);
+}
+""" },
+]
+
+[case.watch_test]
+kind = "read_failure_outside_closure"
+expected_exit = 0
+stdout_contains = [
+    '"cycle":1,"event":"run_started"',
+    '"cycle":2,"event":"run_started"',
+    '"compile_error":0,"crash":0,"event":"run_finished","failed":0,"passed":1',
+]
+stdout_not_contains = [
+    # Neither failing revision published anything, and no cycle number was
+    # spent on one.
+    '"cycle":3',
+    '"event":"run_canceled"',
+]
+stderr_occurrences = [
+    # The same rendering twice: the first report, and the acknowledgement of
+    # the edit to the module it names.
+    { text = "could not read import candidate", count = 2 },
+    { text = "stream did not contain valid UTF-8", count = 2 },
+    { text = "no summary for this revision", count = 2 },
+]
+
+[[case.watch_test.edits]]
+path = "extra.rue"
+undecodable_source = "pub fn broken() -> i32 { 1 }\n"
+
+[[case.watch_test.edits]]
+path = "helper.rue"
+source = """
+const extra = @import("extra.rue");
+
+pub fn double(x: i32) -> i32 { x * 2 }
+"""
+
+[[case.watch_test.edits]]
+path = "extra.rue"
+undecodable_source = "pub fn broken() -> i32 { 41 }\n"
+
+[[case.watch_test.edits]]
+path = "extra.rue"
+touch = true
+
+[[case.watch_test.edits]]
+path = "extra.rue"
+source = """
+pub fn broken() -> i32 { 2 }
+"""

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -2749,6 +2749,45 @@ const SUPPRESSED_RETRIES: usize = 3;
 /// only an attempt that actually told the user something publishes
 /// `reobserve-error`. That split is what makes the assertion event-driven
 /// instead of a sleep long enough to "probably" cover a few ticks (RUE-2091).
+/// Drive the shared "a module that cannot be read at all was wired into the
+/// closure" sequence, which both watchers run identically (RUE-2105).
+///
+/// The expectations come from the edits rather than from fixed indices, so one
+/// arm covers both shapes of the failure — undecodable bytes and a directory in
+/// the module's place — even though they need different numbers of steps:
+///
+/// - `edits[0]` stages the unreadable module. Nothing imports it yet, so it is
+///   in no closure and no watch input, and the watcher must not stir.
+/// - `edits[1]` wires it in. That is the first report.
+/// - every edit up to the last owes one more report, because a save the user
+///   made is a revision and silence after one is indistinguishable from a
+///   watcher that never noticed it — unless the edit is a `touch`, which moves
+///   no byte and must therefore report nothing.
+/// - the last edit repairs the module; the caller waits for the publication.
+fn run_read_failure_outside_closure(
+    child: &mut std::process::Child,
+    protocol: &Path,
+    dir: &Path,
+    edits: &[WatchEdit],
+    deadline: Instant,
+) -> Result<(), String> {
+    let (repair, leading) = edits
+        .split_last()
+        .ok_or_else(|| "read-failure watch scenario has no edits".to_string())?;
+    write_watch_edit(dir, &leading[0])?;
+    write_watch_edit(dir, &leading[1])?;
+    let mut reports = 1;
+    assert_failure_reported_once(child, protocol, reports, deadline)?;
+    for edit in &leading[2..] {
+        write_watch_edit(dir, edit)?;
+        if !edit.touch {
+            reports += 1;
+        }
+        assert_failure_reported_once(child, protocol, reports, deadline)?;
+    }
+    write_watch_edit(dir, repair)
+}
+
 fn assert_failure_reported_once(
     child: &mut std::process::Child,
     protocol: &Path,
@@ -2886,24 +2925,109 @@ fn replace_watch_symlink(_path: &Path, _target: &str) -> Result<(), String> {
 
 fn write_watch_edit(dir: &Path, edit: &WatchEdit) -> Result<(), String> {
     let path = dir.join(&edit.path);
-    match (
+    let requested = [
         edit.delete,
         edit.touch,
-        edit.source.as_deref(),
-        edit.symlink_target.as_deref(),
-    ) {
-        (true, false, None, None) => std::fs::remove_file(&path)
-            .map_err(|error| format!("failed to delete watch fixture {}: {error}", edit.path)),
-        (false, true, None, None) => touch_watch_fixture(&path)
-            .map_err(|error| format!("failed to touch watch fixture {}: {error}", edit.path)),
-        (false, false, Some(source), None) => std::fs::write(&path, source)
-            .map_err(|error| format!("failed to update watch fixture {}: {error}", edit.path)),
-        (false, false, None, Some(target)) => replace_watch_symlink(&path, target),
-        _ => Err(format!(
-            "watch edit {} must specify exactly one of delete, touch, source, or symlink_target",
+        edit.directory,
+        edit.fifo,
+        edit.source.is_some(),
+        edit.undecodable_source.is_some(),
+        edit.symlink_target.is_some(),
+    ];
+    if requested.iter().filter(|set| **set).count() != 1 {
+        return Err(format!(
+            "watch edit {} must specify exactly one of delete, touch, directory, fifo, source, \
+             undecodable_source, or symlink_target",
             edit.path
-        )),
+        ));
     }
+    let failed =
+        |error: std::io::Error| format!("failed to write watch fixture {}: {error}", edit.path);
+    if edit.delete {
+        return std::fs::remove_file(&path).map_err(failed);
+    }
+    if edit.touch {
+        return touch_watch_fixture(&path).map_err(failed);
+    }
+    if edit.directory {
+        return stage_watch_directory(&path).map_err(failed);
+    }
+    if edit.fifo {
+        return stage_watch_fifo(&path);
+    }
+    if let Some(target) = edit.symlink_target.as_deref() {
+        return replace_watch_symlink(&path, target);
+    }
+    // A repair can land on a path a previous edit turned into something
+    // `fs::write` cannot open: a directory, or a named pipe, where the open
+    // would block until a reader appeared and hang the harness rather than
+    // fail it. Clear those first. Inert for every case that only ever writes
+    // files, and `metadata` follows symlinks, so a case whose fixture is a
+    // symlink to a real file still writes through it as before.
+    match std::fs::metadata(&path) {
+        Ok(existing) if existing.is_dir() => std::fs::remove_dir_all(&path).map_err(failed)?,
+        Ok(existing) if !existing.is_file() => std::fs::remove_file(&path).map_err(failed)?,
+        _ => {}
+    }
+    if let Some(source) = edit.source.as_deref() {
+        return std::fs::write(&path, source).map_err(failed);
+    }
+    let source = edit
+        .undecodable_source
+        .as_deref()
+        .expect("exactly one edit action was requested");
+    std::fs::write(&path, undecodable_bytes(source)).map_err(failed)
+}
+
+/// The text with an invalid UTF-8 sequence in front of it.
+///
+/// `0xff 0xfe` can begin no UTF-8 encoding, so the file is present, has a
+/// stable size and content hash, and is perfectly readable as bytes — it simply
+/// is not text. That is exactly the read failure RUE-2105 is about: the loader
+/// accepts no bytes for the module, so before this it had nothing to key on and
+/// every save after the first was silent. Keeping the rest of the line readable
+/// text keeps the case file legible.
+fn undecodable_bytes(source: &str) -> Vec<u8> {
+    let mut bytes = vec![0xff_u8, 0xfe];
+    bytes.extend_from_slice(source.as_bytes());
+    bytes
+}
+
+/// Put a directory where a module belongs, replacing whatever is there.
+fn stage_watch_directory(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(_) => std::fs::remove_dir_all(path)?,
+    }
+    std::fs::create_dir(path)
+}
+
+/// Put a named pipe where a module belongs, replacing whatever is there.
+///
+/// Built at a sibling path and renamed into place so the module's own path is
+/// never momentarily absent: a re-observation landing in that window renders a
+/// missing import rather than the unreadable one the case is counting.
+#[cfg(unix)]
+fn stage_watch_fifo(path: &Path) -> Result<(), String> {
+    // The staged name is deliberately not a `.rue` spelling, so nothing can
+    // import it and no candidate route ever reaches it.
+    let staging = path.with_extension("rue-fifo-staging");
+    // This harness has no libc dependency, and `mkfifo(1)` is the same call.
+    let staged = std::process::Command::new("mkfifo")
+        .arg(staging.as_os_str())
+        .status()
+        .map_err(|error| format!("failed to run mkfifo: {error}"))?;
+    if !staged.success() {
+        return Err(format!("mkfifo {} failed: {staged}", staging.display()));
+    }
+    std::fs::rename(&staging, path)
+        .map_err(|error| format!("failed to move watch fifo into place: {error}"))
+}
+
+#[cfg(not(unix))]
+fn stage_watch_fifo(_path: &Path) -> Result<(), String> {
+    Err("watch fifo fixtures are only supported on Unix".into())
 }
 
 /// Restamp a fixture's modification time without touching a byte of it.
@@ -3011,6 +3135,12 @@ fn run_watch_case(
     if scenario.kind == WatchScenarioKind::FailureOutsideClosure && scenario.edits.len() != 4 {
         return Err(TestFailure::assertion(
             "failure-outside-closure watch scenario requires a wiring edit, a content edit, a touch, and a repair",
+        ));
+    }
+    if scenario.kind == WatchScenarioKind::ReadFailureOutsideClosure && scenario.edits.len() < 4 {
+        return Err(TestFailure::assertion(
+            "read-failure-outside-closure watch scenario requires a staging edit, a wiring \
+             edit, at least one edit to the unreadable module, and a repair",
         ));
     }
     if scenario.kind == WatchScenarioKind::SymlinkRetarget && scenario.edits.len() != 1 {
@@ -3225,6 +3355,16 @@ fn run_watch_case(
                 write_watch_edit(dir, &scenario.edits[3])?;
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
             }
+            WatchScenarioKind::ReadFailureOutsideClosure => {
+                run_read_failure_outside_closure(
+                    &mut child,
+                    &protocol,
+                    dir,
+                    &scenario.edits,
+                    deadline,
+                )?;
+                wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
+            }
             WatchScenarioKind::RepeatedFailure => {
                 // Each step below kills one way the suppression could be
                 // written wrong, and the loop it exercises is shared, so
@@ -3397,6 +3537,9 @@ fn run_watch_test_case(
         WatchTestScenarioKind::CompileError => 2,
         WatchTestScenarioKind::RepeatedFailure => 3,
         WatchTestScenarioKind::FailureOutsideClosure => 4,
+        // Reads its expectations from the edits themselves, so the lower bound
+        // is all the arity there is to check; the arm validates the rest.
+        WatchTestScenarioKind::ReadFailureOutsideClosure => scenario.edits.len().max(4),
     };
     if scenario.edits.len() != required_edits {
         return Err(TestFailure::assertion(format!(
@@ -3526,6 +3669,19 @@ fn run_watch_test_case(
                 write_watch_edit(dir, &scenario.edits[2])?;
                 assert_failure_reported_once(&mut child, &protocol, 2, deadline)?;
                 write_watch_edit(dir, &scenario.edits[3])?;
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 2, deadline)?;
+            }
+            WatchTestScenarioKind::ReadFailureOutsideClosure => {
+                // The `--watch` case of the same name carries the reasoning;
+                // this pins that the two watchers really do share the arm.
+                wait_for_watch_event(&mut child, &protocol, "run-finished", 1, deadline)?;
+                run_read_failure_outside_closure(
+                    &mut child,
+                    &protocol,
+                    dir,
+                    &scenario.edits,
+                    deadline,
+                )?;
                 wait_for_watch_event(&mut child, &protocol, "run-finished", 2, deadline)?;
             }
             WatchTestScenarioKind::Cancel => {

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -240,6 +240,16 @@ pub enum WatchScenarioKind {
     /// they produce is byte-identical, because that file is the one the user is
     /// editing (RUE-2103).
     FailureOutsideClosure,
+    /// The same retry timer and the same outside-the-closure module, one step
+    /// earlier in the read: the module is present but cannot be turned into
+    /// source at all — undecodable bytes, or a directory in its place — so the
+    /// attempt never accepts any bytes for it and there is nothing in any
+    /// manifest to key on. Edits to it must still be acknowledged (RUE-2105).
+    ///
+    /// The arm reads its expectations from the edits: the first stages the
+    /// unreadable module, the second wires it in, every edit between that and
+    /// the last owes a report unless it is a `touch`, and the last repairs.
+    ReadFailureOutsideClosure,
 }
 
 /// A synchronized end-to-end `rue test --watch` scenario (RUE-2023).
@@ -301,6 +311,9 @@ pub enum WatchTestScenarioKind {
     /// watchers share the re-observation arm, so they shared the gap and are
     /// pinned together (RUE-2103).
     FailureOutsideClosure,
+    /// [`WatchScenarioKind::ReadFailureOutsideClosure`] on the test watcher,
+    /// pinned on both surfaces for the same reason (RUE-2105).
+    ReadFailureOutsideClosure,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -317,6 +330,23 @@ pub struct WatchEdit {
     /// key built from file metadata instead would report on it (RUE-2103).
     #[serde(default)]
     pub touch: bool,
+    /// Write this text preceded by an invalid UTF-8 byte sequence, producing a
+    /// file that is present and perfectly readable as bytes but is not text —
+    /// the shape an editor produces by saving a binary over a module. A case
+    /// changes the text to change the file without making it any more
+    /// readable, which is the edit RUE-2105 must acknowledge.
+    #[serde(default)]
+    pub undecodable_source: Option<String>,
+    /// Put a directory at this path, replacing whatever is there. The other
+    /// way a module can be present and unreadable (RUE-2105).
+    #[serde(default)]
+    pub directory: bool,
+    /// Put a named pipe at this path, replacing whatever is there. The read
+    /// failure that must be classified from metadata alone: opening a pipe
+    /// that has no writer never returns, so a probe that reaches for its bytes
+    /// wedges the watcher instead of reporting it (RUE-2105). Unix only.
+    #[serde(default)]
+    pub fifo: bool,
     #[serde(default)]
     pub symlink_target: Option<String>,
 }

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -202,46 +202,225 @@ pub fn watch_input_fingerprints(inputs: &[WatchInput]) -> Vec<Option<WatchFinger
         .collect()
 }
 
-/// One physical source read an observation attempt accepted: where it read,
-/// and what it read there.
+/// One physical read an observation attempt made: where it read, and what it
+/// found there — whether or not the read could be accepted as source.
 ///
 /// The committed closure ([`ImportDiscoveryResult::watch_inputs`]) describes
 /// the last attempt that *succeeded*. A failed attempt commits nothing, so a
 /// module it read but never closed over is in no closure at all — and that
 /// module is frequently the one the failure's diagnostic names and the one
 /// being edited, because wiring a pre-existing broken file into the graph for
-/// the first time is exactly how the failure arrives (RUE-2103). This is the
-/// attempt's own record of what it touched, kept whether or not it committed.
+/// the first time is exactly how the failure arrives (RUE-2103).
 ///
-/// The fingerprint is the accepted bytes' content hash, not file metadata, so
-/// re-reading identical content compares equal: a rewrite that changes nothing
-/// is not a new revision, and only a real edit is.
-#[derive(Clone, Debug, Eq, PartialEq)]
+/// A candidate the attempt could not read at all is recorded here too, under a
+/// separate outcome. It has no accepted bytes, but it is the same workflow one
+/// step earlier — the file is present and is being edited, it just is not
+/// source yet (invalid UTF-8, a directory in the module's place). Recording
+/// only accepted reads left that family with nothing for the debounce to
+/// observe, so every save after the first was silent (RUE-2105).
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct AttemptedRead {
     requested_path: Arc<str>,
-    canonical_path: Arc<str>,
-    content_fingerprint: u64,
+    outcome: AttemptedReadOutcome,
 }
 
-/// Project an attempt's accepted-read manifest into its observation record.
+/// What an attempt found at an [`AttemptedRead`]'s path.
 ///
-/// Ordered by path rather than by the manifest's module identity so the record
-/// of two attempts over the same files compares equal regardless of the order
-/// discovery happened to reach them.
-fn attempted_reads_of(manifest: &AcceptedReadManifest) -> Vec<AttemptedRead> {
+/// The two variants can never compare equal, so a path that failed to read is
+/// always distinguishable from the same path read successfully — the record
+/// keeps "I could not read this" and "I read exactly these bytes" apart even
+/// when the fingerprints coincide.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+enum AttemptedReadOutcome {
+    /// The attempt read this file and accepted its bytes as source. The
+    /// fingerprint is the accepted bytes' content hash, not file metadata, so
+    /// re-reading identical content compares equal: a rewrite that changes
+    /// nothing is not a new revision, and only a real edit is.
+    Accepted {
+        canonical_path: Arc<str>,
+        content_fingerprint: u64,
+    },
+    /// The attempt could not turn what is at this path into source. `reason`
+    /// is the failure's shape, so a candidate that starts failing differently
+    /// is a different record; `observed` is whatever the attempt could still
+    /// see there, which is what makes one save distinguishable from the next.
+    Failed { reason: Arc<str>, observed: u64 },
+}
+
+/// Domain separators, so a raw-byte hash and a metadata hash for the same path
+/// cannot coincide.
+const FAILED_READ_CONTENT_TAG: u64 = 0x5255_4532_3130_3501;
+const FAILED_READ_PLACE_TAG: u64 = 0x5255_4532_3130_3502;
+
+/// What an attempt can still observe about a candidate it failed to read.
+///
+/// A failed read has no accepted bytes to hash, so without this the record of
+/// "I tried to read this and could not" is byte-for-byte identical on the next
+/// 250ms retry and on the user's next save, and the watch debounce cannot tell
+/// them apart (RUE-2105).
+///
+/// Metadata decides first, bytes second, on exactly the order the loader's own
+/// routes use: a candidate is classified by `is_file()` and is never opened
+/// unless it is a regular file. That order is load-bearing rather than tidy —
+/// opening a named pipe for reading blocks until a writer appears, so a `mkfifo`
+/// in a module's place would otherwise wedge the probe, and with it the watch
+/// retry that called it, forever.
+///
+/// For a regular file the bytes are the fingerprint: the common shape is a file
+/// that is present and perfectly readable but not *decodable* — invalid UTF-8 —
+/// and hashing its bytes keeps the same content-not-metadata rule the accepted
+/// half uses, so a rewrite that changes nothing still compares equal. Anything
+/// else — a directory, a pipe, a socket, a device, a dangling symlink — and any
+/// regular file whose bytes are unreachable anyway, such as a permission denial,
+/// falls back to the identity and metadata of whatever *is* there, which is all
+/// a failed attempt can see. Nothing at all hashes to zero.
+///
+/// Called only after a read has already failed, so it never runs on the
+/// accepted path. The fallback deliberately never follows a symlink: the record
+/// is about what is literally at the requested spelling.
+fn failed_candidate_fingerprint(path: &Path) -> u64 {
+    if fs::metadata(path).is_ok_and(|metadata| metadata.is_file())
+        && let Ok(bytes) = fs::read(path)
+    {
+        return WatchFingerprint::from_bytes(&bytes).0 ^ FAILED_READ_CONTENT_TAG;
+    }
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return 0;
+    };
+    let identity = physical_file_identity(&metadata);
+    let fingerprint = file_metadata_fingerprint(&metadata);
+    let mut place = [0_u8; 40];
+    for (slot, value) in place.chunks_exact_mut(8).zip([
+        identity.volume(),
+        identity.file(),
+        fingerprint.length(),
+        fingerprint.modified(),
+        fingerprint.changed(),
+    ]) {
+        slot.copy_from_slice(&value.to_le_bytes());
+    }
+    WatchFingerprint::from_bytes(&place).0 ^ FAILED_READ_PLACE_TAG
+}
+
+/// The reads one observation attempt made and could not accept.
+///
+/// Accepted reads survive a failed attempt in the assembler's manifest;
+/// rejected ones survive nowhere, so the attempt collects them here as it goes
+/// and its caller projects them alongside the manifest.
+type FailedReads = Vec<AttemptedRead>;
+
+/// Record a rejected observation, if it is one. Accepted and absent
+/// observations are not failures: an accepted read is already in the
+/// assembler's manifest, and an absent candidate is already a committed
+/// `observed_absent_path`, which the watch closure covers.
+fn record_failed_read(failed: &mut FailedReads, observation: &ImportObservation) {
+    let requested = observation.request().requested_path();
+    let (reason, probe): (String, bool) = match observation.status() {
+        ImportObservationStatus::Absent | ImportObservationStatus::PresentReadable { .. } => return,
+        ImportObservationStatus::PresentUnreadable(reason) => {
+            (format!("unreadable: {reason}"), true)
+        }
+        ImportObservationStatus::InvalidPhysicalType { canonical_path } => (
+            format!("not a regular source file at '{canonical_path}'"),
+            true,
+        ),
+        ImportObservationStatus::UnstableRead(reason) => {
+            (format!("changed during its read: {reason}"), true)
+        }
+        // A lexically denied path must not be probed at all — declining the
+        // filesystem is the whole content of that denial — and a canonically
+        // denied one is a path the policy says this build may not read. Both
+        // are configuration facts about the manifest rather than about what is
+        // on disk, and the manifest is itself a watched input.
+        ImportObservationStatus::DeniedLexical => (
+            "denied by the source manifest read policy".to_owned(),
+            false,
+        ),
+        ImportObservationStatus::DeniedCanonical { canonical_path } => (
+            format!("denied by the source manifest after resolving to '{canonical_path}'"),
+            false,
+        ),
+        // An abandoned attempt is answered by its restart, never by this record.
+        ImportObservationStatus::Cancelled => return,
+    };
+    push_failed_read(failed, requested, reason, probe);
+}
+
+/// Record a demanded trusted toolchain module the host could not acquire.
+///
+/// The same rule as [`record_failed_read`]: a hermetic denial is a statement
+/// about the read policy and must not touch the filesystem, while every
+/// integrity failure is a statement about what is (or is not) under the
+/// standard-library root, and observing it is what lets the next save be told
+/// from the next retry.
+fn record_failed_toolchain_demand(
+    failed: &mut FailedReads,
+    path: &Path,
+    error: &ToolchainAcquisitionError,
+) {
+    let (reason, probe) = match error {
+        ToolchainAcquisitionError::Hermetic(_) => (
+            "denied by the source manifest read policy".to_owned(),
+            false,
+        ),
+        // The failure's class, not its rendered text: the rendered diagnostic
+        // is already the other half of the debounce key, and repeating it here
+        // would add nothing this record does not already distinguish.
+        ToolchainAcquisitionError::Toolchain(error) => (
+            match error {
+                ToolchainIntegrityError::StdRootUnavailable { .. } => {
+                    "no standard-library root is configured".to_owned()
+                }
+                ToolchainIntegrityError::Missing { .. } => "missing from the toolchain".to_owned(),
+                ToolchainIntegrityError::Unreadable { reason, .. } => {
+                    format!("unreadable: {reason}")
+                }
+                ToolchainIntegrityError::Malformed { .. } => "malformed".to_owned(),
+                ToolchainIntegrityError::UnsatisfiedAfterPublish { .. } => {
+                    "unsatisfied after publication".to_owned()
+                }
+            },
+            true,
+        ),
+    };
+    push_failed_read(failed, path.to_string_lossy().as_ref(), reason, probe);
+}
+
+fn push_failed_read(failed: &mut FailedReads, requested: &str, reason: String, probe: bool) {
+    failed.push(AttemptedRead {
+        requested_path: Arc::from(requested),
+        outcome: AttemptedReadOutcome::Failed {
+            reason: Arc::from(reason),
+            observed: if probe {
+                failed_candidate_fingerprint(Path::new(requested))
+            } else {
+                0
+            },
+        },
+    });
+}
+
+/// Project an attempt's accepted-read manifest and its rejected reads into one
+/// observation record.
+///
+/// Sorted and deduplicated over the whole record rather than ordered by the
+/// manifest's module identity, so the record of two attempts over the same
+/// files compares equal regardless of the order discovery happened to reach
+/// them or how many times a round re-probed the same candidate.
+fn attempted_reads_of(manifest: &AcceptedReadManifest, failed: &FailedReads) -> Vec<AttemptedRead> {
     let mut reads: Vec<AttemptedRead> = manifest
         .iter()
         .map(|entry| AttemptedRead {
             requested_path: Arc::from(entry.requested_path()),
-            canonical_path: Arc::from(entry.canonical_path()),
-            content_fingerprint: entry.content_fingerprint(),
+            outcome: AttemptedReadOutcome::Accepted {
+                canonical_path: Arc::from(entry.canonical_path()),
+                content_fingerprint: entry.content_fingerprint(),
+            },
         })
+        .chain(failed.iter().cloned())
         .collect();
-    reads.sort_by(|left, right| {
-        left.requested_path
-            .cmp(&right.requested_path)
-            .then_with(|| left.canonical_path.cmp(&right.canonical_path))
-    });
+    reads.sort();
+    reads.dedup();
     reads
 }
 
@@ -671,11 +850,18 @@ fn execute_import_request(
     request: ImportDiscoveryRequest,
     source_manifest: Option<&SourceManifest>,
     reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
+    failed_reads: &mut FailedReads,
     control: DiscoveryControl<'_>,
 ) -> Result<ImportObservation, SourceLoadError> {
     control.checkpoint()?;
     let observation =
         execute_import_request_uncancelled(request, source_manifest, reobserved_reads);
+    // Every filesystem answer this host gives a discovery frontier passes
+    // through here, so this is the one place a rejected read can be recorded
+    // for all of them: policy denial, a missing canonical route, a directory
+    // where a file belongs, an I/O error, undecodable bytes, or a route that
+    // moved mid-read (RUE-2105).
+    record_failed_read(failed_reads, &observation);
     control.checkpoint()?;
     Ok(observation)
 }
@@ -1475,6 +1661,7 @@ fn run_import_wave(
     frontier: &ImportDemandFrontier,
     source_manifest: Option<&SourceManifest>,
     reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
+    failed_reads: &mut FailedReads,
     control: DiscoveryControl<'_>,
 ) -> Result<(ImportInputRevision, ImportDemandFrontier), SourceLoadError> {
     for attempt in 0..=WAVE_STAMP_RETRIES {
@@ -1495,7 +1682,13 @@ fn run_import_wave(
                 .iter()
                 .cloned()
                 .map(|request| {
-                    execute_import_request(request, source_manifest, reobserved_reads, control)
+                    execute_import_request(
+                        request,
+                        source_manifest,
+                        reobserved_reads,
+                        failed_reads,
+                        control,
+                    )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             extend_import_wave(staging, &mut wave, observations)
@@ -1571,6 +1764,7 @@ fn drive_import_discovery_to_close(
     reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
     continuation: Option<ImportInputRevision>,
     reclose: Option<ReClose<'_>>,
+    failed_reads: &mut FailedReads,
     control: DiscoveryControl<'_>,
 ) -> Result<ClosedDiscovery, SourceLoadError> {
     control.checkpoint()?;
@@ -1754,7 +1948,13 @@ fn drive_import_discovery_to_close(
                     .iter()
                     .cloned()
                     .map(|request| {
-                        execute_import_request(request, source_manifest, reobserved_reads, control)
+                        execute_import_request(
+                            request,
+                            source_manifest,
+                            reobserved_reads,
+                            failed_reads,
+                            control,
+                        )
                     })
                     .collect::<Result<Vec<_>, _>>()?;
                 control.checkpoint()?;
@@ -1818,6 +2018,7 @@ fn drive_import_discovery_to_close(
                     &frontier,
                     source_manifest,
                     reobserved_reads,
+                    failed_reads,
                     control,
                 )?;
                 input_revision = revision;
@@ -2030,6 +2231,7 @@ fn discover_and_load_imports_with_configuration(
     // forces a std read. This close threads its assembler, read policy, std root,
     // and closure witness out so that loop can satisfy demands and re-close in the
     // same request generation.
+    let mut failed_reads = FailedReads::new();
     let close = drive_import_discovery_to_close(
         &mut assembler,
         &mut staging,
@@ -2038,6 +2240,7 @@ fn discover_and_load_imports_with_configuration(
         None,
         None,
         None,
+        &mut failed_reads,
         DiscoveryControl::default(),
     )?;
 
@@ -2049,7 +2252,7 @@ fn discover_and_load_imports_with_configuration(
             root_display_path: root_source.to_owned(),
             context,
         },
-        attempted_reads: attempted_reads_of(&read_manifest),
+        attempted_reads: attempted_reads_of(&read_manifest, &failed_reads),
         read_manifest,
         observed_absent_paths: close.observed_absent_paths,
         revision: close.closed,
@@ -2159,6 +2362,7 @@ fn reload_from_filesystem_inner(
     // for requests the new rooted frontier actually issues; making every old
     // read explicit would keep modules that are no longer reachable after an
     // import-set edit and grow the retained snapshot monotonically.
+    let mut failed_reads = FailedReads::new();
     let close = match drive_import_discovery_to_close(
         &mut assembler,
         &mut result.session,
@@ -2167,6 +2371,7 @@ fn reload_from_filesystem_inner(
         Some(&reobserved),
         None,
         None,
+        &mut failed_reads,
         control,
     ) {
         Err(SourceLoadError::Superseded) => {
@@ -2185,13 +2390,14 @@ fn reload_from_filesystem_inner(
         // excluded above: it was abandoned, not answered, and the restart
         // observes the newer bytes itself.
         Err(error) => {
-            result.attempted_reads = attempted_reads_of(&assembler.accepted_read_manifest());
+            result.attempted_reads =
+                attempted_reads_of(&assembler.accepted_read_manifest(), &failed_reads);
             return Err(error);
         }
         Ok(close) => close,
     };
     let read_manifest = assembler.accepted_read_manifest();
-    result.attempted_reads = attempted_reads_of(&read_manifest);
+    result.attempted_reads = attempted_reads_of(&read_manifest, &failed_reads);
     result.source_snapshot = close.snapshot;
     result.read_manifest = read_manifest;
     result.observed_absent_paths = close.observed_absent_paths;
@@ -2315,16 +2521,33 @@ fn acquire_reached_toolchain_modules_superseding_inner(
                 // it, rather than carrying a partial module set forward
                 // (RUE-1863).
                 let mut round_assembler = result.assembler.clone();
+                let mut failed_reads = FailedReads::new();
                 for demand in park.demands() {
                     control.checkpoint()?;
-                    satisfy_toolchain_module_demand(
+                    // A demanded toolchain module is read outside the import
+                    // frontier, so its rejections are recorded here rather than
+                    // in `execute_import_request`. Without it a std module that
+                    // is present but unreadable reports once and then goes
+                    // silent over every later save, exactly as a program module
+                    // did (RUE-2105).
+                    if let Err(error) = satisfy_toolchain_module_demand(
                         &mut round_assembler,
                         &result.resolution.context,
                         result.std_root.as_deref(),
                         result.source_manifest.as_ref(),
                         demand,
-                    )
-                    .map_err(SourceLoadError::from)?;
+                    ) {
+                        record_failed_toolchain_demand(
+                            &mut failed_reads,
+                            &toolchain_module_path(&result.resolution.context, demand),
+                            &error,
+                        );
+                        result.attempted_reads = attempted_reads_of(
+                            &round_assembler.accepted_read_manifest(),
+                            &failed_reads,
+                        );
+                        return Err(SourceLoadError::from(error));
+                    }
                 }
                 let successor = round_assembler
                     .snapshot()
@@ -2365,6 +2588,7 @@ fn acquire_reached_toolchain_modules_superseding_inner(
                     None,
                     Some(delta.revision()),
                     Some(ReClose { delta: &delta }),
+                    &mut failed_reads,
                     control,
                 ) {
                     Ok(reclosed) => reclosed,
@@ -2375,8 +2599,10 @@ fn acquire_reached_toolchain_modules_superseding_inner(
                         // toolchain module from the same one on the next retry
                         // (RUE-2103).
                         if !matches!(error, SourceLoadError::Superseded) {
-                            result.attempted_reads =
-                                attempted_reads_of(&round_assembler.accepted_read_manifest());
+                            result.attempted_reads = attempted_reads_of(
+                                &round_assembler.accepted_read_manifest(),
+                                &failed_reads,
+                            );
                         }
                         let error = reclassify_reclose_failure(
                             error,
@@ -2395,7 +2621,7 @@ fn acquire_reached_toolchain_modules_superseding_inner(
                 // Commit boundary: every assignment below is infallible, so the
                 // round is applied whole or not at all.
                 result.read_manifest = round_assembler.accepted_read_manifest();
-                result.attempted_reads = attempted_reads_of(&result.read_manifest);
+                result.attempted_reads = attempted_reads_of(&result.read_manifest, &failed_reads);
                 result.assembler = round_assembler;
                 result.source_snapshot = reclosed.snapshot;
                 result.revision = reclosed.closed;
@@ -3825,6 +4051,195 @@ mod tests {
             names(result.attempted_reads()),
             ["extra.rue", "helper.rue", "main.rue"]
         );
+    }
+
+    /// The same contract one step earlier in the read: a module that is
+    /// present but that no attempt can turn into source at all — undecodable
+    /// bytes, a directory in its place — has no accepted bytes to fingerprint,
+    /// so recording only accepted reads left it with nothing for the watcher to
+    /// observe and every save after the first was silent (RUE-2105).
+    #[test]
+    fn a_failed_reobservation_records_a_module_it_could_not_read_at_all() {
+        let dir = TestDir::new("failed-attempt-unreadable");
+        let main = dir.write(
+            "main.rue",
+            r#"const helper = @import("helper.rue"); fn main() -> i32 { helper.value() }"#,
+        );
+        let helper = dir.write("helper.rue", "pub fn value() -> i32 { 1 }");
+        let extra = dir.path.join("extra.rue");
+        // Present, readable as bytes, and not source: the shape an editor
+        // produces by saving a binary file over a module.
+        fs::write(&extra, b"pub fn broken() -> i32 { \xff\xfe 2 }\n").unwrap();
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let named = |reads: &[AttemptedRead], name: &str| {
+            reads
+                .iter()
+                .find(|read| read.requested_path.ends_with(name))
+                .cloned()
+        };
+        let names = |reads: &[AttemptedRead]| {
+            reads
+                .iter()
+                .map(|read| {
+                    Path::new(read.requested_path.as_ref())
+                        .file_name()
+                        .unwrap()
+                        .to_string_lossy()
+                        .into_owned()
+                })
+                .collect::<Vec<_>>()
+        };
+        assert!(named(result.attempted_reads(), "extra.rue").is_none());
+
+        // Wire it in. The read itself fails, so nothing about it reaches the
+        // accepted-read manifest — the attempt's own record is the only account.
+        fs::write(
+            &helper,
+            r#"const extra = @import("extra.rue"); pub fn value() -> i32 { extra.broken() }"#,
+        )
+        .unwrap();
+        assert!(reload_from_filesystem(&mut result, None).is_err());
+        assert!(
+            !result
+                .watch_inputs()
+                .iter()
+                .any(|input| input.requested_path().ends_with("extra.rue")),
+            "a failed attempt commits nothing, so the closure is still the last successful one"
+        );
+        assert_eq!(
+            names(result.attempted_reads()),
+            ["extra.rue", "helper.rue", "main.rue"]
+        );
+        let undecodable = named(result.attempted_reads(), "extra.rue").unwrap();
+        assert!(matches!(
+            undecodable.outcome,
+            AttemptedReadOutcome::Failed { .. }
+        ));
+
+        // A bare retry over the same bytes records the same thing, which is
+        // what makes a repeat recognizable as one.
+        let failed = result.attempted_reads().to_vec();
+        assert!(reload_from_filesystem(&mut result, None).is_err());
+        assert_eq!(result.attempted_reads(), failed);
+
+        // Editing it records something else, even though it is still exactly
+        // as unreadable and the failure renders identically.
+        fs::write(&extra, b"pub fn broken() -> i32 { \xff\xfe 41 }\n").unwrap();
+        assert!(reload_from_filesystem(&mut result, None).is_err());
+        assert_eq!(names(result.attempted_reads()), names(&failed));
+        assert_ne!(result.attempted_reads(), failed);
+
+        // Content-derived, on the same terms as the accepted half: a save that
+        // moves the modification time without moving a byte is not a revision
+        // anyone asked to hear about.
+        let edited = result.attempted_reads().to_vec();
+        let now = std::time::SystemTime::now();
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&extra)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_accessed(now).set_modified(now))
+            .unwrap();
+        assert!(reload_from_filesystem(&mut result, None).is_err());
+        assert_eq!(result.attempted_reads(), edited);
+
+        // A directory in the module's place is the other shape of the same
+        // failure, and it is a different record even though the path is the
+        // same and no bytes were read in either case.
+        fs::remove_file(&extra).unwrap();
+        fs::create_dir(&extra).unwrap();
+        assert!(reload_from_filesystem(&mut result, None).is_err());
+        assert_eq!(names(result.attempted_reads()), names(&failed));
+        let directory = named(result.attempted_reads(), "extra.rue").unwrap();
+        assert_ne!(directory, undecodable);
+        assert!(matches!(
+            directory.outcome,
+            AttemptedReadOutcome::Failed { .. }
+        ));
+
+        // And a repair puts it in the committed closure. The accepted record
+        // for the path can never be mistaken for either failed one, whatever
+        // the fingerprints happen to be.
+        fs::remove_dir(&extra).unwrap();
+        fs::write(&extra, "pub fn broken() -> i32 { 41 }").unwrap();
+        reload_from_filesystem(&mut result, None).unwrap();
+        assert!(
+            result
+                .watch_inputs()
+                .iter()
+                .any(|input| input.requested_path().ends_with("extra.rue"))
+        );
+        let accepted = named(result.attempted_reads(), "extra.rue").unwrap();
+        assert!(matches!(
+            accepted.outcome,
+            AttemptedReadOutcome::Accepted { .. }
+        ));
+        assert_ne!(accepted, undecodable);
+        assert_ne!(accepted, directory);
+    }
+
+    /// A named pipe where a module belongs is classified, never opened.
+    ///
+    /// Every loader route decides a candidate's fate from `is_file()` and
+    /// opens nothing that is not a regular file, which is what keeps a pipe,
+    /// socket, or device in a module's place from blocking the compiler. The
+    /// record of a read the attempt could *not* accept runs on exactly those
+    /// paths and has to hold the same order: `open` on a pipe with no writer
+    /// never returns, so reaching for its bytes wedges the observation and,
+    /// with it, the watch retry that asked for one (RUE-2105).
+    ///
+    /// The assertion that matters is therefore that the call comes back.
+    #[cfg(unix)]
+    #[test]
+    fn a_named_pipe_in_a_modules_place_is_recorded_without_opening_it() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::FileTypeExt;
+
+        let dir = TestDir::new("failed-attempt-named-pipe");
+        let main = dir.write(
+            "main.rue",
+            r#"const helper = @import("helper.rue"); fn main() -> i32 { helper.value() }"#,
+        );
+        let helper = dir.write("helper.rue", "pub fn value() -> i32 { 1 }");
+        let extra = dir.path.join("extra.rue");
+        let name = std::ffi::CString::new(extra.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(name.as_ptr(), 0o644) }, 0);
+        assert!(
+            fs::symlink_metadata(&extra).unwrap().file_type().is_fifo(),
+            "the fixture has to actually be a pipe for this to test anything"
+        );
+
+        // Bounded off-thread, because the failure this pins is a call that
+        // never returns rather than one that returns the wrong thing: an
+        // in-line version of this test hangs the whole suite instead of
+        // failing it.
+        let (report, answer) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+            // Wire the pipe into the closure for the first time.
+            fs::write(
+                &helper,
+                r#"const extra = @import("extra.rue"); pub fn value() -> i32 { extra.broken() }"#,
+            )
+            .unwrap();
+            let rejected = reload_from_filesystem(&mut result, None).is_err();
+            let recorded = result
+                .attempted_reads()
+                .iter()
+                .find(|read| read.requested_path.ends_with("extra.rue"))
+                .cloned();
+            report.send((rejected, recorded)).ok();
+        });
+        let (rejected, recorded) = answer
+            .recv_timeout(Duration::from_secs(30))
+            .expect("observing a module's place must never wait for a pipe's writer");
+
+        assert!(rejected, "a named pipe is not a regular source file");
+        let recorded = recorded.expect("the candidate it could not read is on the record");
+        assert!(matches!(
+            recorded.outcome,
+            AttemptedReadOutcome::Failed { .. }
+        ));
     }
 
     #[test]

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -162,10 +162,11 @@ and the stream carries one array per distinct failure rather than one per retry
 (RUE-2091). The array returns when the rendered diagnostic changes or when any
 source the attempt read does — the retained closure plus whatever that attempt
 itself pulled in, so a module wired into the graph for the first time counts
-even though no successful revision has closed over it yet (RUE-2103). An
-unchanged failure over unchanged bytes publishes nothing further, and
-"unchanged" means the bytes: a save that rewrites a file without editing it is
-not a new revision. Nothing about the array's shape, code, or framing
+even though no successful revision has closed over it yet (RUE-2103). A module
+the attempt could not read at all counts too, on whatever it could still
+observe there (RUE-2105). An unchanged failure over unchanged bytes publishes
+nothing further, and "unchanged" means the bytes: a save that rewrites a file
+without editing it is not a new revision. Nothing about the array's shape, code, or framing
 changes with it, so this is an emission cadence rather than a schema change.
 
 Driver failures can occur before the initial compilation snapshot exists, or

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -900,10 +900,12 @@ has no one revision — and keeps compile mode's own exclusions (`--emit`,
   bytes says nothing. The report returns when the rendered diagnostic changes or
   when any source the attempt read does — the retained closure and whatever
   that attempt itself pulled in, which is what a module wired into the graph
-  for the first time is — so a save that leaves the error standing still gets
-  one line back rather than silence, and a watcher left inside an untouched
-  syntax error stays quiet indefinitely. "Changed" means the bytes, not the
-  modification time: saving a file without editing it is not a new revision.
+  for the first time is, including one it could only *try* to read because the
+  file is present but is not source (RUE-2105) — so a save that leaves the
+  error standing still gets one line back rather than silence, and a watcher
+  left inside an untouched syntax error stays quiet indefinitely. "Changed"
+  means the bytes, not the modification time: saving a file without editing it
+  is not a new revision.
 - **The exit status is produced only on SIGINT or SIGTERM**, and is the last
   cycle that COMPLETED reporting itself on the ordinary
   [exit-code table](#exit-codes): `0` if it passed, `1` if it failed, `3` if it


### PR DESCRIPTION
Fixes RUE-2105

## Problem

RUE-2103 taught the watch-mode error debounce to observe the sources an attempt *accepted*, so a module wired into the closure for the first time and then edited gets a fresh report instead of silence. A module the attempt could not read at all (invalid UTF-8, a directory in its place, a permission denial) is accepted by nothing, appears in no manifest, and so had nothing for the debounce to observe: the failure reported once and then every later save was silent on the 250 ms retry timer. This is the same spam-then-silence bug RUE-2103 closed, one step earlier in the read.

## Change

- `AttemptedRead` gains a second outcome. `Accepted` carries the canonical path and content fingerprint as before; `Failed` carries the failure's class and whatever the attempt could still observe at the path. The two variants never compare equal, so a path that failed to read is always distinguishable from the same path read successfully.
- `failed_candidate_fingerprint` decides from metadata first, mirroring the loader's own routes, and only then reads bytes: a regular file that is present but undecodable is hashed by content, so a byte-identical rewrite or an mtime-only save stays suppressed; anything else (a directory, a named pipe, a dangling symlink, a permission denial) is keyed on the identity and metadata of what is literally at the path. A named pipe is never opened, so the retry loop keeps ticking where an unconditional read would block forever.
- `execute_import_request` is the one place every filesystem answer to a discovery frontier passes through, so every rejected observation is recorded there; the toolchain-demand path records its own rejections at its single call site. Policy denials record without probing, preserving the read policy's promise that an undeclared path never touches the filesystem.
- `attempted_reads_of` merges the accepted manifest with the rejected reads, sorted and deduplicated, so two attempts over the same filesystem compare equal regardless of discovery order.
- `docs/process/diagnostics.md` and `docs/process/test-events.md` say that a module the attempt could only try to read counts too.

## Coverage

- Unit: a module that is present but undecodable is recorded with a `Failed` outcome; a bare retry records the same thing, an edit records a different thing, an mtime-only restamp records the same thing, a directory in its place is a different record again, and the repaired module's `Accepted` record differs from both. A `#[cfg(unix)]` test puts a named pipe in the module's place and asserts the reload returns promptly with a `Failed` record.
- CLI, event-driven on the watch test protocol: the invalid-UTF-8 shape on both watchers (`watch.toml`, `watch_test.toml`), the directory shape, and the named-pipe shape on `--watch`, each pinning the identical rendering exactly twice so only the rejected-read record can have produced the second report. New corpus fields `undecodable_source`, `directory`, and `fifo` on `WatchEdit`, and a `read_failure_outside_closure` scenario kind on both watchers.

## Verification

- `scripts/rue unit rue-driver`: 89 passed. `scripts/rue cli watch`: 26 passed.
- `scripts/rue premerge`: pass 220, fail 0.
- By hand, a real `--watch` session on the invalid-UTF-8, directory, permission-denied, and named-pipe shapes: one report per real edit, a byte-identical rewrite and a bare touch stay silent, and 80 idle retries per shape produce no spurious report.
