### PR TITLE
RUE-2156: one representation for the unit value in the oracle

### DIFF
--- a/crates/rue-cli-tests/cases/zero_sized_equality.toml
+++ b/crates/rue-cli-tests/cases/zero_sized_equality.toml
@@ -1,0 +1,155 @@
+# Whole-value equality on zero-sized operands.
+#
+# A zero-sized type has exactly one value, so any two operands of it are equal
+# — the compiler answers that at every optimization level, from the type,
+# without loading anything. `rue-oracle` carried two representations of the
+# unit value instead: `zero_sized_value` materialized `Value::Unit` for a
+# parameter that owns no storage, while a `()` literal reached the interpreter
+# as a `Const(0)` and became `Value::Int(0)`. Structural equality recursed to
+# the unit leaf and fell back to a derived `==` on the two `Value`s, so a
+# zero-sized parameter compared against a zero-sized literal or local was
+# reported UNEQUAL — a red `differential_opt` result for a correctly compiled
+# program (RUE-2156).
+#
+# Two neighbouring shapes agreed only by accident and are pinned here too: a
+# bare `()` operand is not an aggregate, so it took the numeric comparison
+# where both representations flatten to zero; and two zero-sized parameters
+# both come from the type, so neither side carried the literal's shape.
+#
+# `differential_opt` compiles and runs each at `-O0`/`-O1`/`-O2`/`-O3` and
+# requires one answer across all four.
+
+[section]
+id = "cli.zero_sized_equality"
+name = "Equality on zero-sized values"
+description = "A zero-sized type has one value, so whole-value equality on it is decided by the type and never by how an operand was produced (RUE-2156)."
+
+[[case]]
+name = "zero_sized_struct_parameter_equals_its_literal"
+description = "RUE-2156: a zero-sized struct parameter compared against the literal of its own type must be equal."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn f(z: Empty) -> i64 {
+    if (z == Empty { unit: () }) { 5 } else { 0 }
+}
+fn main() -> i32 {
+    @dbg(f(Empty { unit: () }));
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+differential_opt = true
+
+# Both operands are materialized from the type, so this shape agreed before the
+# fix; it pins the two sides against drifting apart again.
+[[case]]
+name = "two_zero_sized_struct_parameters_are_equal"
+description = "RUE-2156: two zero-sized struct parameters of the same type are equal, whichever storage-less path produced them."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn f(a: Empty, b: Empty) -> i64 {
+    if (a == b) { 5 } else { 0 }
+}
+fn main() -> i32 {
+    @dbg(f(Empty { unit: () }, Empty { unit: () }));
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+differential_opt = true
+
+# `!=` routes the same comparison through the opposite decision, so a
+# one-valued type must answer `false`.
+[[case]]
+name = "zero_sized_struct_parameter_is_not_unequal_to_its_literal"
+description = "RUE-2156: `!=` on a zero-sized struct parameter and its literal is false."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn f(z: Empty) -> i64 {
+    if (z != Empty { unit: () }) { 5 } else { 0 }
+}
+fn main() -> i32 {
+    @dbg(f(Empty { unit: () }));
+    0
+}
+""" }]
+stdout = "0\n"
+exit_code = 0
+differential_opt = true
+
+# Nesting puts the unit leaf two struct levels below the compared root.
+[[case]]
+name = "nested_zero_sized_struct_parameter_equals_its_literal"
+description = "RUE-2156: whole-value equality on a nested zero-sized struct reaches the unit leaf through two levels of recursion."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+struct Nest { e: Empty }
+fn f(n: Nest) -> i64 {
+    if (n == Nest { e: Empty { unit: () } }) { 5 } else { 0 }
+}
+fn main() -> i32 {
+    @dbg(f(Nest { e: Empty { unit: () } }));
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+differential_opt = true
+
+# A zero-sized local is built from the same literal, so it carried the
+# literal's representation and not the parameter's.
+[[case]]
+name = "zero_sized_struct_parameter_equals_a_zero_sized_local"
+description = "RUE-2156: a zero-sized struct parameter equals a zero-sized local of the same type."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn f(z: Empty) -> i64 {
+    let local: Empty = Empty { unit: () };
+    if (z == local) { 5 } else { 0 }
+}
+fn main() -> i32 {
+    @dbg(f(Empty { unit: () }));
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+differential_opt = true
+
+# An array of unit elements takes the array arm of the same recursion.
+[[case]]
+name = "zero_sized_array_parameter_equals_its_literal"
+description = "RUE-2156: a `[(); 2]` parameter compared whole against its literal is equal, element by element."
+files = [{ path = "main.rue", source = """
+fn f(z: [(); 2]) -> i64 {
+    if (z == [(); 2]) { 5 } else { 0 }
+}
+fn main() -> i32 {
+    @dbg(f([(); 2]));
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+differential_opt = true
+
+# A bare `()` operand is not an aggregate, so it never reached the structural
+# comparison at all and agreed by accident. Pin it as a consequence of the one
+# representation instead.
+[[case]]
+name = "bare_unit_parameter_equals_the_unit_literal"
+description = "RUE-2156: a bare `()` parameter equals the `()` literal."
+files = [{ path = "main.rue", source = """
+fn f(z: ()) -> i64 {
+    if (z == ()) { 5 } else { 0 }
+}
+fn main() -> i32 {
+    @dbg(f(()));
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+differential_opt = true

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -525,60 +525,6 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::Reallocate),
         &[],
     ),
-    Entry::new(
-        "cli.zero_sized_place_address",
-        "all_zst_root_address_is_non_null",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.zero_sized_place_address",
-        "all_zst_root_projected_address",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.zero_sized_place_address",
-        "all_zst_root_write_moves_no_bytes",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.zero_sized_place_address",
-        "indexed_zero_sized_field_address_in_bounds",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.zero_sized_place_address",
-        "sized_write_through_shared_slot_still_stores",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.zero_sized_place_address",
-        "trailing_zero_sized_field_address_is_non_null_and_distinct",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.zero_sized_place_address",
-        "trailing_zero_sized_field_address_keeps_neighbour_intact",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.zero_sized_place_address",
-        "trailing_zero_sized_field_write_moves_no_bytes",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.zero_sized_place_address",
-        "zero_sized_read_through_shared_slot_stays_correct",
-        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
 ];
 
 pub(crate) fn audit(scope: InventoryScope) -> ModelGapAudit<CaseId> {

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -3922,11 +3922,25 @@ impl<'a> Interp<'a> {
                         "compiler-synthesized empty-slice null pointer",
                     ));
                 }
-                // The constant is stored as a 64-bit two's-complement bit
-                // pattern (e.g. i32::MIN is `18446744071562067968` =
-                // 0xFFFFFFFF80000000), so a signed type reinterprets it as
-                // signed; an unsigned type takes the u64 value directly.
-                if ty.is_signed() {
+                // A zero-sized type has exactly one value, and the interpreter
+                // spells it `Value::Unit` — nested in the aggregate shape for
+                // a zero-sized struct or array. `zero_sized_value` produces
+                // that form for a parameter that owns no storage,
+                // `decode_value` produces it for a unit-typed read, and
+                // `encode_value` accepts nothing else at a unit type. A `()`
+                // literal arrives here as `Const(0)`, so answering with the
+                // integer pattern would give a one-valued type a second
+                // representation, which structural equality then reports as
+                // unequal (RUE-2156).
+                //
+                // Otherwise the constant is stored as a 64-bit two's-
+                // complement bit pattern (e.g. i32::MIN is
+                // `18446744071562067968` = 0xFFFFFFFF80000000), so a signed
+                // type reinterprets it as signed; an unsigned type takes the
+                // u64 value directly.
+                if self.is_zero_sized(ty) {
+                    self.zero_sized_value(ty)
+                } else if ty.is_signed() {
                     Value::Int(*n as i64 as i128)
                 } else {
                     Value::Int(*n as i128)
@@ -4709,6 +4723,12 @@ impl<'a> Interp<'a> {
             return Ok(x.as_int() == y.as_int());
         }
         match ty.kind() {
+            // A unit type has exactly one value, so its equality is settled by
+            // the type alone. Deciding it here rather than at the fallback's
+            // derived `==` keeps the leaf answer type-driven, as it already is
+            // for the integer and float leaves above, whose representations
+            // `as_int` and `float_equal` normalize rather than compare.
+            TypeKind::Unit => Ok(true),
             TypeKind::Struct(sid) => {
                 let (Value::Aggregate(xs), Value::Aggregate(ys)) = (x, y) else {
                     return Ok(x == y);

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -2116,6 +2116,122 @@ fn promoted_zst_parameter_leaves_the_inout_neighbour_writeback_intact() {
     assert_eq!(run(src).stdout, "11\n22\n");
 }
 
+// ---- one representation for the unit value (RUE-2156) ---------------------
+//
+// A unit-typed value is `Value::Unit`, wherever it comes from: the memory
+// model encodes and decodes only that shape at a unit type, and
+// `zero_sized_value` materializes it for a parameter that owns no storage. A
+// `CfgInstData::Const` at a unit type used to answer `Value::Int(0)` instead,
+// so the `()` a literal writes and the `()` a parameter reads were two
+// different `Value`s of the same one-valued type. Structural equality then
+// bottomed out in a representation-sensitive `==` on the leaves and called
+// them unequal, while the compiler answers `true` at every level.
+
+#[test]
+fn zst_struct_parameter_equals_its_literal() {
+    // The issue's repro: the parameter's `()` field came from the type as
+    // `Value::Unit`, the literal's from `Const` as `Value::Int(0)`.
+    let src = "struct Empty { unit: () }
+    fn f(z: Empty) -> i64 {
+        if (z == Empty { unit: () }) { 5 } else { 0 }
+    }
+    fn main() -> i32 {
+        @dbg(f(Empty { unit: () }));
+        0
+    }";
+    assert_eq!(run(src).stdout, "5\n");
+}
+
+#[test]
+fn zst_struct_parameters_equal_each_other() {
+    // Both operands are materialized from the type, so this shape agreed even
+    // before the fix; pin it so the two sides cannot drift apart again.
+    let src = "struct Empty { unit: () }
+    fn f(a: Empty, b: Empty) -> i64 {
+        if (a == b) { 5 } else { 0 }
+    }
+    fn main() -> i32 {
+        @dbg(f(Empty { unit: () }, Empty { unit: () }));
+        0
+    }";
+    assert_eq!(run(src).stdout, "5\n");
+}
+
+#[test]
+fn zst_struct_parameter_is_not_unequal_to_its_literal() {
+    // `!=` takes the same comparison through the opposite `pick`, so the
+    // one-valued type must answer `false` here.
+    let src = "struct Empty { unit: () }
+    fn f(z: Empty) -> i64 {
+        if (z != Empty { unit: () }) { 5 } else { 0 }
+    }
+    fn main() -> i32 {
+        @dbg(f(Empty { unit: () }));
+        0
+    }";
+    assert_eq!(run(src).stdout, "0\n");
+}
+
+#[test]
+fn nested_zst_struct_parameter_equals_its_literal() {
+    // The recursion reaches the unit leaf two struct levels down.
+    let src = "struct Empty { unit: () }
+    struct Nest { e: Empty }
+    fn f(n: Nest) -> i64 {
+        if (n == Nest { e: Empty { unit: () } }) { 5 } else { 0 }
+    }
+    fn main() -> i32 {
+        @dbg(f(Nest { e: Empty { unit: () } }));
+        0
+    }";
+    assert_eq!(run(src).stdout, "5\n");
+}
+
+#[test]
+fn zst_struct_parameter_equals_a_zst_local() {
+    // A zero-sized local is built by `struct_init` over the same `Const`, so
+    // it carried the literal's representation rather than the parameter's.
+    let src = "struct Empty { unit: () }
+    fn f(z: Empty) -> i64 {
+        let local: Empty = Empty { unit: () };
+        if (z == local) { 5 } else { 0 }
+    }
+    fn main() -> i32 {
+        @dbg(f(Empty { unit: () }));
+        0
+    }";
+    assert_eq!(run(src).stdout, "5\n");
+}
+
+#[test]
+fn zst_array_parameter_equals_its_literal() {
+    // An array of unit elements takes the array arm of the same recursion.
+    let src = "fn f(z: [(); 2]) -> i64 {
+        if (z == [(); 2]) { 5 } else { 0 }
+    }
+    fn main() -> i32 {
+        @dbg(f([(); 2]));
+        0
+    }";
+    assert_eq!(run(src).stdout, "5\n");
+}
+
+#[test]
+fn bare_unit_parameter_equals_the_unit_literal() {
+    // A bare `()` parameter agreed by accident: neither operand is an
+    // aggregate, so `cmp` took the numeric path where `as_int` flattens
+    // `Value::Unit` and `Value::Int(0)` alike to zero. Pin it as a
+    // consequence of the one representation instead.
+    let src = "fn f(z: ()) -> i64 {
+        if (z == ()) { 5 } else { 0 }
+    }
+    fn main() -> i32 {
+        @dbg(f(()));
+        0
+    }";
+    assert_eq!(run(src).stdout, "5\n");
+}
+
 #[test]
 fn enum_parameter_width_comes_from_its_static_type() {
     let src = r#"enum Shape { Empty, One(i32), Pair(i32, i32) }


### PR DESCRIPTION
Fixes RUE-2156

## Problem

`rue-oracle` held two `Value`s for the single value of a unit type. A parameter that owns no storage was materialized from its type by `zero_sized_value` as `Value::Unit`, while the `()` a literal writes reached the interpreter as `CfgInstData::Const(0)` and became `Value::Int(0)`. Structural equality recursed to the unit leaf and fell back to a derived `==` on the two `Value`s, so a zero-sized struct or array parameter compared whole against a literal or a local of the same type was reported unequal. The compiler answers `true` from the type at every optimization level, so this was an oracle-diff disagreement on a correctly compiled program. Two neighbouring shapes agreed only by accident: a bare `()` operand takes `cmp`'s numeric path where `as_int` flattens both representations to zero, and two zero-sized parameters both come from the type.

## Change

- `Value::Unit` is the canonical form, and the rest of the interpreter already said so: `decode_value` produces it for a unit-typed read and `encode_value` accepts nothing else at a unit type. `CfgInstData::Const` at a zero-sized type now answers from `zero_sized_value`, the same materializer the parameter read uses, which removes the second representation at its source.
- `values_equal_typed` decides a unit leaf from the type, as it already does for the integer and float leaves whose representations it normalizes rather than compares.
- That also makes a pointer write of a zero-sized place encodable, so the nine `cli.zero_sized_place_address` PointerWrite model-gap entries became stale and are deleted; oracle-diff now checks that section instead of skipping it.

## Coverage

- Seven `rue-oracle` unit tests and a new CLI section `cli.zero_sized_equality` (seven `differential_opt` cases): a zero-sized struct parameter against a literal, against another parameter, `!=`, a nested zero-sized struct, a parameter against a local, a `[(); 2]` parameter, and the bare `()` parameter shape so the accidental agreement becomes a pinned one.

## Verification

- `scripts/rue unit oracle`: 181 passed. `scripts/rue cli zero_sized`: 37 passed.
- `//crates/rue-oracle-diff:oracle-diff-test`: pass after the stale-entry deletion.
- `scripts/rue premerge`: pass 220, fail 0.
- Two reviewer probe sets through `rue-oracle-diff` (unit in enum payloads, unit array element writes, unit call results, mixed unit/i64 structs, zero-sized values returned from calls, plus the RUE-2101 parameter set): every modeled case agrees, 0 disagreements, 0 oracle failures.
