### PR TITLE
RUE-2157: spell the raw-pointer types in 4.3:3e the way Rue does

### DIFF
--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -78,7 +78,7 @@ equal field-by-field. Two values of different variants are never equal.
 
 {{ rule(id="4.3:3e", cat="normative") }}
 
-A raw-pointer leaf (a `*const T` or `*mut T` field or element reached while
+A raw-pointer leaf (a `ptr const T` or `ptr mut T` field or element reached while
 comparing an aggregate) compares by **address**: two raw pointers are equal if
 and only if they hold the same address. The pointees are not examined.
 


### PR DESCRIPTION
Fixes RUE-2157

Rule 4.3:3e named the raw-pointer leaf types as `*const T` and `*mut T`, a spelling Rue does not have. The pointer types are `ptr const T` and `ptr mut T` (spec 9.1), which is also how the compiler renders them in its own diagnostics. Prose only: the rule ID, its category, and its cases are unchanged. This was the only occurrence in `docs/spec` and `docs/formal`; the eleven ADRs that use the old spelling are historical records and are left as written.

Verification: `//:spec-traceability` and `//:compiler-spec-machine-index` pass.
