### PR TITLE
RUE-2165: standard containers and floats render their contents

### DIFF
--- a/crates/rue-air/src/intrinsic.rs
+++ b/crates/rue-air/src/intrinsic.rs
@@ -180,6 +180,11 @@ fn runtime_air_result_type_in_pool(pool: &TypeInternPool, ty: Type) -> Option<Ru
     {
         return Some(RuntimeAirType::StrBuf);
     }
+    if let TypeKind::Array(array) = ty.kind()
+        && is_runtime_text_words(pool.array_def(array))
+    {
+        return Some(RuntimeAirType::StrBuf);
+    }
     if let TypeKind::Enum(enum_id) = ty.kind() {
         let definition = pool.enum_def(enum_id);
         let payload = exact_option_payload(&definition)?;
@@ -197,6 +202,25 @@ fn runtime_air_result_type_in_pool(pool: &TypeInternPool, ty: Type) -> Option<Ru
         });
     }
     runtime_air_type_in_pool(pool, ty)
+}
+
+/// Whether `ty` is the raw machine-word spelling of the runtime's
+/// `StrBufResult` out-pointer shape.
+///
+/// A source `StrBuf` is the ordinary way to receive one of these, but a
+/// *compiler-synthesized* body may not name a standard-library declaration —
+/// the structural error printer is demanded by a `?` or an assertion, not by a
+/// call the request's closure walked, so anything it named would have to be
+/// scheduled into that closure after the fact. Such a body receives the
+/// helper's `{ptr, cap, len}` triple as the three machine words it already is.
+/// Every Rue target is 64-bit, so this array and that triple have one layout.
+pub fn is_runtime_text_words((element, len): (Type, u64)) -> bool {
+    element == Type::U64
+        && len
+            == rue_runtime_abi::AggregateShapeId::StrBufResult
+                .shape()
+                .slots
+                .len() as u64
 }
 
 /// Return the payload of the one accepted Option layout. Runtime return
@@ -297,6 +321,11 @@ impl RuntimeAirTypePool for FrozenTypeInternPool {
         }
         if let TypeKind::Struct(struct_id) = ty.kind()
             && self.is_strbuf(struct_id)
+        {
+            return Some(RuntimeAirType::StrBuf);
+        }
+        if let TypeKind::Array(array) = ty.kind()
+            && is_runtime_text_words(self.array_def(array))
         {
             return Some(RuntimeAirType::StrBuf);
         }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -199,9 +199,9 @@ pub use semantic_type_resolution::{
 pub use specialize::{comptime_call_cycle_diagnostic, comptime_depth_exceeded_diagnostic};
 pub use types::{
     ArrayLen, ArrayTypeId, EnumDef, EnumId, LangItem, ModuleDef, ModuleId, PtrConstTypeId,
-    PtrMutTypeId, StructDef, StructField, StructId, TextViewKind, Type, TypeKind, array_type_name,
-    fixed_string_capacity, fixed_string_name, is_slice_struct_name, is_string_view_struct_name,
-    slice_struct_name, text_view_name_kind,
+    PtrMutTypeId, StdContainer, StructDef, StructField, StructId, TextViewKind, Type, TypeKind,
+    array_type_name, fixed_string_capacity, fixed_string_name, is_slice_struct_name,
+    is_string_view_struct_name, slice_struct_name, text_view_name_kind,
 };
 
 /// Sentinel value used to encode parameter slots in AIR instructions.

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -515,6 +515,68 @@ impl LangItem {
     }
 }
 
+/// A canonical standard-library container the structural printer renders by
+/// its elements (6.7:15).
+///
+/// Every one of these is an *anonymous* struct minted by a `pub fn Name(comptime
+/// …) -> type` in one std module, so the identity that distinguishes it from a
+/// same-shaped user struct is the producing type function's module and name —
+/// the same relocation-stable provenance rule [`LangItem`] applies to a named
+/// nominal, one level up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StdContainer {
+    /// `std.arraybuf.ArrayBuf(T)`.
+    ArrayBuf,
+    /// `std.deque.Deque(T)`.
+    Deque,
+    /// `std.stack.Stack(T)`.
+    Stack,
+    /// `std.queue.Queue(T)`.
+    Queue,
+    /// `std.binary_heap.BinaryHeap(T)`.
+    BinaryHeap,
+    /// `std.grid.Grid2D(T)`.
+    Grid2D,
+    /// `std.strmap.StrMap(V)`.
+    StrMap,
+    /// `std.intmap.IntMap(V)`.
+    IntMap,
+}
+
+impl StdContainer {
+    /// Classify the type function that minted an anonymous nominal, only after
+    /// its module has crossed a trusted standard-library provenance boundary.
+    pub fn from_standard_library_type_function(module_path: &str, name: &str) -> Option<Self> {
+        let module = crate::path_norm::normalize_module_path(module_path);
+        Some(match (module.as_str(), name) {
+            ("\0rue-std/arraybuf.rue", "ArrayBuf") => Self::ArrayBuf,
+            ("\0rue-std/deque.rue", "Deque") => Self::Deque,
+            ("\0rue-std/stack.rue", "Stack") => Self::Stack,
+            ("\0rue-std/queue.rue", "Queue") => Self::Queue,
+            ("\0rue-std/binary_heap.rue", "BinaryHeap") => Self::BinaryHeap,
+            ("\0rue-std/grid.rue", "Grid2D") => Self::Grid2D,
+            ("\0rue-std/strmap.rue", "StrMap") => Self::StrMap,
+            ("\0rue-std/intmap.rue", "IntMap") => Self::IntMap,
+            _ => return None,
+        })
+    }
+
+    /// What one of this container's units is called in a measured rendering,
+    /// singular then plural: `StrMap(i64) <2 entries>` against
+    /// `ArrayBuf(Foo) <3 elements>`.
+    pub fn unit_noun(self) -> (&'static str, &'static str) {
+        match self {
+            Self::StrMap | Self::IntMap => ("entry", "entries"),
+            Self::ArrayBuf
+            | Self::Deque
+            | Self::Stack
+            | Self::Queue
+            | Self::BinaryHeap
+            | Self::Grid2D => ("element", "elements"),
+        }
+    }
+}
+
 /// Definition of a struct type.
 #[derive(Debug, Clone)]
 pub struct StructDef {

--- a/crates/rue-cli-tests/cases/rue_test_assert.toml
+++ b/crates/rue-cli-tests/cases/rue_test_assert.toml
@@ -172,6 +172,471 @@ compile_stdout_contains = [
 ]
 
 [[case]]
+name = "a_container_comparison_renders_its_elements"
+description = """
+RUE-2165, spec 6.7:15: a standard container renders by its elements, not by its
+own fields. Before this rule both sides of this comparison rendered
+`{ core: RawBuf(i64), len: 3 }` and the diff was a single `equal` hunk — a
+report that named neither the values compared nor where they parted. The whole
+record is pinned here, diff included: with a list rendering the runner's
+character diff lands on exactly the element that differs.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+test "compares two buffers" {
+    let A = std.arraybuf.ArrayBuf(i64);
+    let mut left = A.new();
+    left.push(1);
+    left.push(2);
+    left.push(3);
+    let mut right = A.new();
+    right.push(1);
+    right.push(2);
+    right.push(4);
+    @assert_eq(left, right);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"diff":[{"op":"equal","text":"[1, 2, "},{"op":"delete","text":"3"},{"op":"insert","text":"4"},{"op":"equal","text":"]"}],"exit_code":101,"kind":"assert_eq","left":"[1, 2, 3]"',
+    '"message":"assertion failed: left == right","right":"[1, 2, 4]"',
+    '"column":5,"file":"tests.rue"',
+    '"line":13}',
+    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+]
+
+[[case]]
+name = "a_container_rendering_shows_length_and_element_differences"
+description = """
+Spec 6.7:15: an empty container renders as `[]`, so an absent element is a
+visible difference rather than an identical rendering; a shorter container is
+the prefix of a longer one, and the diff is the tail. A byte string reached as
+an element is double-quoted with `\\` and `"` escaped, so an element that
+contains the list's own `, ` separator cannot be read as two. Containers nest:
+an `ArrayBuf(ArrayBuf(i64))` renders both levels.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+test "empty against one" {
+    let A = std.arraybuf.ArrayBuf(i64);
+    let mut left = A.new();
+    let mut right = A.new();
+    right.push(7);
+    @assert_eq(left, right);
+}
+
+test "lengths differ" {
+    let A = std.arraybuf.ArrayBuf(i64);
+    let mut left = A.new();
+    left.push(1);
+    left.push(2);
+    let mut right = A.new();
+    right.push(1);
+    @assert_eq(left, right);
+}
+
+test "strings are quoted" {
+    let A = std.arraybuf.ArrayBuf(StrBuf);
+    let mut left = A.new();
+    left.push(StrBuf.from_str(borrow "al\\"pha"));
+    left.push(StrBuf.from_str(borrow "b, c"));
+    let mut right = A.new();
+    right.push(StrBuf.from_str(borrow "alpha"));
+    @assert_eq(left, right);
+}
+
+test "containers nest" {
+    let I = std.arraybuf.ArrayBuf(i64);
+    let A = std.arraybuf.ArrayBuf(I);
+    let mut left = A.new();
+    let mut row = I.new();
+    row.push(1);
+    row.push(2);
+    left.push(row);
+    let mut right = A.new();
+    let mut other = I.new();
+    other.push(1);
+    right.push(other);
+    @assert_eq(left, right);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"assert_eq","left":"[]","location":{"column":5,"file":"tests.rue","line":9},"message":"assertion failed: left == right","right":"[7]"',
+    '"kind":"assert_eq","left":"[1, 2]","location":{"column":5,"file":"tests.rue","line":19},"message":"assertion failed: left == right","right":"[1]"',
+    '"left":"[\"al\\\"pha\", \"b, c\"]"',
+    '"right":"[\"alpha\"]"',
+    '"left":"[[1, 2]]"',
+    '"right":"[[1]]"',
+    '"crash":0,"event":"run_finished","failed":4,"passed":0',
+]
+
+[[case]]
+name = "each_standard_container_renders_in_its_own_order"
+description = """
+Spec 6.7:15 fixes the order each container renders in: bottom to top for a
+`Stack`, front to back for a `Queue` (whose front has already moved) and a
+`Deque` (a ring, rendered from its head), storage order rather than sorted
+order for a `BinaryHeap`, and row-major with a bracket per row for a `Grid2D`.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+test "a stack renders bottom to top" {
+    let S = std.stack.Stack(i64);
+    let mut left = S.new();
+    left.push(1);
+    left.push(2);
+    let mut right = S.new();
+    @assert_eq(left, right);
+}
+
+test "a queue renders front to back" {
+    let Q = std.queue.Queue(i64);
+    let mut left = Q.new();
+    left.enqueue(1);
+    left.enqueue(2);
+    left.enqueue(3);
+    let gone = left.dequeue();
+    let mut right = Q.new();
+    @assert_eq(left, right);
+}
+
+test "a deque renders front to back" {
+    let D = std.deque.Deque(i64);
+    let mut left = D.new(0);
+    left.push_back(1);
+    left.push_back(2);
+    left.push_front(0);
+    let mut right = D.new(0);
+    @assert_eq(left, right);
+}
+
+test "a heap renders in storage order" {
+    let H = std.binary_heap.BinaryHeap(i64);
+    let mut left = H.new();
+    left.push(3);
+    left.push(1);
+    left.push(2);
+    let mut right = H.new();
+    @assert_eq(left, right);
+}
+
+test "a grid renders by rows" {
+    let G = std.grid.Grid2D(i64);
+    let mut left = G.new(2, 3, 0);
+    left.set(0, 0, 1);
+    left.set(1, 2, 9);
+    let mut right = G.new(0, 0, 0);
+    @assert_eq(left, right);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"left":"[1, 2]","location":{"column":5,"file":"tests.rue","line":9}',
+    '"left":"[2, 3]","location":{"column":5,"file":"tests.rue","line":20}',
+    '"left":"[0, 1, 2]","location":{"column":5,"file":"tests.rue","line":30}',
+    '"left":"[1, 3, 2]","location":{"column":5,"file":"tests.rue","line":40}',
+    '"left":"[[1, 0, 0], [0, 0, 9]]","location":{"column":5,"file":"tests.rue","line":49}',
+    '"crash":0,"event":"run_finished","failed":5,"passed":0',
+]
+
+[[case]]
+name = "a_container_of_records_renders_each_record"
+description = """
+RUE-2165, spec 6.7:15: a container is transparent to the one-level rule, so an
+element that is a struct or an enum renders as one — a list of records is the
+commonest container in a test, and `ArrayBuf(Point) <2 elements>` would say
+nothing about which record differs. It is the *element's* own nested aggregates
+that fall to the type-name rule, not the element itself. Narrow fields are
+pinned here too: `i32`, `u8` and `bool` fields render their own values rather
+than the machine word around them.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+@copy struct Point { x: i64, y: bool }
+@copy struct Narrow { a: i32, b: u8, c: bool }
+
+test "struct elements render as records" {
+    let A = std.arraybuf.ArrayBuf(Point);
+    let mut left = A.new();
+    left.push(Point { x: 1, y: true });
+    left.push(Point { x: 2, y: false });
+    let mut right = A.new();
+    right.push(Point { x: 1, y: true });
+    @assert_eq(left, right);
+}
+
+test "narrow fields keep their own values" {
+    let A = std.arraybuf.ArrayBuf(Narrow);
+    let mut left = A.new();
+    left.push(Narrow { a: 0 - 5, b: 200, c: true });
+    let mut right = A.new();
+    @assert_eq(left, right);
+}
+
+test "enum elements render as variants" {
+    let A = std.arraybuf.ArrayBuf(std.option.Option(i64));
+    let O = std.option.Option(i64);
+    let mut left = A.new();
+    left.push(O.Some(3));
+    left.push(O.None);
+    let mut right = A.new();
+    @assert_eq(left, right);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"left":"[{ x: 1, y: true }, { x: 2, y: false }]"',
+    '"right":"[{ x: 1, y: true }]"',
+    '"left":"[{ a: -5, b: 200, c: true }]"',
+    '"left":"[Some(3), None]"',
+    '"crash":0,"event":"run_finished","failed":3,"passed":0',
+]
+
+[[case]]
+name = "a_container_the_printer_cannot_look_inside_renders_its_size"
+description = """
+Spec 6.7:15: rendering never claims an equality the comparison did not find, so
+a container these rules cannot look into reports the size it does know — with
+the singular spelling for one. A map reaches its live entries through a
+representation this rendering does not read, and a container nested inside more
+than four others is past where the descent stops. A container reached as a
+struct field still renders its elements: the one-level rule stops at a user
+aggregate, not at a standard container.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Batch { label: StrBuf, items: std.arraybuf.ArrayBuf(i64) }
+
+test "an int map renders its entry count" {
+    let M = std.intmap.IntMap(i64);
+    let mut left = M.new(0);
+    left.insert(1, 10);
+    left.insert(2, 20);
+    let mut right = M.new(0);
+    right.insert(5, 50);
+    @assert_eq(left, right);
+}
+
+test "a string map renders its entry count" {
+    let M = std.strmap.StrMap(i64);
+    let mut left = M.new(0);
+    let key = StrBuf.from_str(borrow "k");
+    left.insert(borrow key, 7);
+    let mut right = M.new(0);
+    @assert_eq(left, right);
+}
+
+test "the descent stops after four containers" {
+    let A1 = std.arraybuf.ArrayBuf(i64);
+    let A2 = std.arraybuf.ArrayBuf(A1);
+    let A3 = std.arraybuf.ArrayBuf(A2);
+    let A4 = std.arraybuf.ArrayBuf(A3);
+    let A5 = std.arraybuf.ArrayBuf(A4);
+    let mut one = A1.new();
+    one.push(7);
+    let mut two = A2.new();
+    two.push(one);
+    let mut three = A3.new();
+    three.push(two);
+    let mut four = A4.new();
+    four.push(three);
+    let mut left = A5.new();
+    left.push(four);
+    let mut right = A5.new();
+    @assert_eq(left, right);
+}
+
+test "a struct field renders its elements" {
+    let A = std.arraybuf.ArrayBuf(i64);
+    let mut one = A.new();
+    one.push(1);
+    let mut two = A.new();
+    two.push(2);
+    two.push(3);
+    let left = Batch { label: StrBuf.from_str(borrow "one"), items: one };
+    let right = Batch { label: StrBuf.from_str(borrow "two"), items: two };
+    @assert_eq(left, right);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"left":"IntMap(i64) <2 entries>"',
+    '"right":"IntMap(i64) <1 entry>"',
+    '"left":"StrMap(i64) <1 entry>"',
+    '"right":"StrMap(i64) <0 entries>"',
+    '"left":"[[[[ArrayBuf(i64) <1 element>]]]]"',
+    '"left":"{ label: one, items: [1] }"',
+    '"right":"{ label: two, items: [2, 3] }"',
+    '"crash":0,"event":"run_finished","failed":4,"passed":0',
+]
+
+[[case]]
+name = "a_float_operand_renders_its_digits"
+description = """
+RUE-2165, spec 6.7:15 and 3.12:40-3.12:42: floats were stabilized after the
+payload rules were written, so an `f64` operand used to render as the text
+`f64` on both sides. It now renders through the same shortest-round-trip
+formatter `@to_string` uses, at the leaf, as a struct field, and as a container
+element — and an `f32` prints the digits that identify it as an `f32`.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+struct Reading { value: f64, count: i64 }
+
+test "a float scalar renders its digits" {
+    let observed: f64 = 2.5;
+    @assert_eq(observed, 3.5);
+}
+
+test "an f32 renders at its own width" {
+    let observed: f32 = 1.25;
+    @assert_eq(observed, 2.5);
+}
+
+test "a float struct field renders its digits" {
+    let left = Reading { value: 0.5, count: 1 };
+    let right = Reading { value: 0.25, count: 2 };
+    @assert_eq(left, right);
+}
+
+test "float elements render their digits" {
+    let A = std.arraybuf.ArrayBuf(f64);
+    let mut left = A.new();
+    left.push(1.5);
+    left.push(0.0 - 2.25);
+    let mut right = A.new();
+    @assert_eq(left, right);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"left":"2.5"',
+    '"right":"3.5"',
+    '"left":"1.25"',
+    '"left":"{ value: 0.5, count: 1 }"',
+    '"right":"{ value: 0.25, count: 2 }"',
+    '"left":"[1.5, -2.25]"',
+    '"crash":0,"event":"run_finished","failed":4,"passed":0',
+]
+
+[[case]]
+name = "a_long_container_is_truncated_mid_list"
+description = """
+Spec 6.7:15: a rendering is bounded to 4096 bytes and a truncated one says so.
+A container long enough to exceed the bound is cut inside its element list —
+there is no closing bracket — and the marker follows, so a reader can never
+mistake the prefix for the whole container.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+test "a long buffer is truncated mid list" {
+    let A = std.arraybuf.ArrayBuf(i64);
+    let mut left = A.new();
+    let mut i: i64 = 0;
+    while i < 2000 {
+        left.push(i);
+        i += 1;
+    }
+    let mut right = A.new();
+    @assert_eq(left, right);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"left":"[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,',
+    ', 838, 839, 840,  …[truncated]","location"',
+    '"right":"[]"',
+    '"crash":0,"event":"run_finished","failed":1,"passed":0',
+]
+
+[[case]]
 name = "assert_ne_on_equal_values_reports_the_pair_it_rejected"
 description = """
 An `@assert_ne` failure has two identical renderings, so its diff is one `equal`

--- a/crates/rue-cli-tests/cases/rue_test_question.toml
+++ b/crates/rue-cli-tests/cases/rue_test_question.toml
@@ -248,3 +248,66 @@ compile_stdout_contains = [
     '"line":10}',
 ]
 compile_stdout_not_contains = ['"column":29,', '"column":9,']
+
+[[case]]
+name = "an_unhandled_container_error_renders_its_elements"
+description = """
+RUE-2165, spec 6.7:15: the container rule is the payload rule, because both
+sides go through the same synthesized printer. An `ArrayBuf(i64)` carried as an
+enum payload renders as its elements inside the variant's parentheses, and one
+that is the whole error renders as the list alone — where before the rule both
+were `{ core: RawBuf(i64), len: 2 }`.
+"""
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+const std = @import("std");
+
+enum Code {
+    Missing,
+    Batch(std.arraybuf.ArrayBuf(i64)),
+}
+
+fn batched() -> std.result.Result(i64, Code) {
+    let R = std.result.Result(i64, Code);
+    let A = std.arraybuf.ArrayBuf(i64);
+    let mut items = A.new();
+    items.push(4);
+    items.push(5);
+    R.Err(Code.Batch(items))
+}
+
+fn bare() -> std.result.Result(i64, std.arraybuf.ArrayBuf(i64)) {
+    let R = std.result.Result(i64, std.arraybuf.ArrayBuf(i64));
+    let A = std.arraybuf.ArrayBuf(i64);
+    let mut items = A.new();
+    items.push(7);
+    R.Err(items)
+}
+
+test "unwraps a batched failure" {
+    let value = batched()?;
+    @assert(value == 0);
+}
+
+test "unwraps a bare container failure" {
+    let value = bare()?;
+    @assert(value == 0);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"unhandled_error"',
+    '"payload":"Batch([4, 5])"',
+    '"payload":"[7]"',
+    '"crash":0,"event":"run_finished","failed":2,"passed":0',
+]

--- a/crates/rue-compiler/src/error_printer.rs
+++ b/crates/rue-compiler/src/error_printer.rs
@@ -30,6 +30,14 @@
 //! `StrBuf` result is a source type; literal runs are `str` constants of this
 //! body; and the buffer comes from the byte-shaped `@alloc` helper.
 //!
+//! The one exception is the float formatter: shortest-round-trip decimal is not
+//! something to reimplement here, so a float leaf calls the same runtime helper
+//! `@to_string` and `@dbg` share. A runtime helper is not a standard-library
+//! declaration — it is an ABI export, like the allocator this body already
+//! calls — but its result *would* be a `StrBuf`, which is a source type, so
+//! this body receives the helper's out-pointer triple as the three machine
+//! words it already is (see `float_text_type`).
+//!
 //! The one shape it must know about is a byte string's, since the payload rules
 //! render one verbatim. A core `str` is a compiler-owned builtin whose `{ptr,
 //! len}` fields this module may read directly. `StrBuf` is a source type, so its
@@ -37,6 +45,41 @@
 //! `u64` field, and the unique `ptr u8` reachable through its aggregate fields —
 //! rather than by field index or field name, and a `StrBuf` whose shape no
 //! longer matches renders as its type name instead of by a stale projection.
+//!
+//! # Standard containers
+//!
+//! One level of struct rendering says nothing about a collection: every
+//! `ArrayBuf(i64)` in a program renders as `{ core: RawBuf(i64), len: 3 }`, so
+//! two that differ produce the same text and the report claims an equality the
+//! comparison did not find. The container rule of 6.7:15 renders those types by
+//! their elements instead — `[1, 2, 3]` — and the count of a container whose
+//! elements these rules cannot render, so no rendering is ever content-free.
+//!
+//! A container is recognized by canonical standard-library identity, never by
+//! field shape: each of these types is an anonymous struct minted by a `pub fn
+//! Name(comptime …) -> type` in one std module, so the identity gated on is the
+//! producing type function's ([`rue_air::StdContainer`]), one level up from the
+//! nominal provenance rule [`LangItem`] applies. A user struct holding a buffer
+//! and a length is therefore not one.
+//!
+//! Once a container is recognized, its *parts* are located structurally, the
+//! same way a `StrBuf`'s byte view is: `ArrayBuf(T)`'s length is its unique
+//! `u64` field and its element base the unique raw pointer reachable through
+//! its aggregate field. Every other sequence container wraps one `ArrayBuf` and
+//! adds scalar bookkeeping, so it is "that `ArrayBuf`'s parts behind this
+//! field" plus the named `u64`s its canonical shape declares. A shape that no
+//! longer matches renders as its type name, exactly as a stale `StrBuf` does.
+//!
+//! Elements are read through `@ptr_offset` on that base — the pointee's stride
+//! is codegen's own, so this module needs no layout knowledge — inside a loop
+//! whose index and count are locals, one pair per nesting level.
+//!
+//! A container is also transparent to the one-level rule, so an element carries
+//! a whole plan rather than a leaf: a struct element renders as `{ x: 1 }` and
+//! an enum element as `Some(3)`, and it is *that* rendering's own aggregate
+//! fields and payloads which fall to the type-name rule. A struct element is
+//! copied into a local of its own first, one per nesting level, because a
+//! narrow field read through the element pointer would load a whole word.
 //!
 //! # Bounds
 //!
@@ -76,22 +119,89 @@ pub(crate) const TRUNCATION_MARKER: &str = rue_runtime_abi::RENDERING_TRUNCATION
 
 /// How one value renders once the walk has stopped descending.
 ///
-/// Every one of these is a leaf: the payload rules render aggregates one level
-/// deep, so a field that is itself an aggregate renders as its type name rather
-/// than recursively.
+/// Most of these are leaves: the payload rules render aggregates one level
+/// deep, so a *user* aggregate reached below the top level renders as its type
+/// name rather than recursively. A standard-library container is the exception
+/// the container rule of 6.7:15 carves out — it is nominal, its length is
+/// readable, and rendering it as its type name would give two unequal
+/// containers the same text.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum LeafRender {
-    /// Fixed text — a type name, or the rendering of a value with no readable
-    /// content (a raw pointer, a module, a unit).
+    /// Fixed text — the rendering of a value with no readable content
+    /// (a raw pointer, a module, a unit).
     Literal(Arc<str>),
+    /// The value's own type name, because these rules cannot look inside it.
+    ///
+    /// Rendered exactly like [`LeafRender::Literal`]; kept apart from it so a
+    /// container can tell "an element the printer can render" from "an element
+    /// it can only name", and fall back to a count for the latter.
+    Opaque(Arc<str>),
     /// Decimal, with a leading `-` for a negative value.
     Signed,
     /// Decimal.
     Unsigned,
     /// `true` or `false`.
     Bool,
+    /// The shortest round-trip decimal of an `f32`/`f64`, formatted by the one
+    /// runtime helper `@to_string` and `@dbg` already share.
+    Float,
     /// The value's own bytes, reached by these projections.
     Bytes(ByteView),
+    /// The value's own bytes, double-quoted with `\` and `"` escaped.
+    ///
+    /// A container element takes this form: a verbatim element could contain
+    /// the list's own `, ` separator and make two different lists render the
+    /// same, which is exactly what a rendering must never do.
+    QuotedBytes(ByteView),
+    /// A standard-library container, by its elements or by its count.
+    Container(Arc<ContainerRender>),
+}
+
+/// How a standard-library container renders (6.7:15).
+///
+/// Every path here is a chain of field projections from the container value.
+/// They are located from the container's *canonical std identity* — the type
+/// function that minted it — and then checked against the shape that identity
+/// implies, so a std container whose internals change renders by its count
+/// rather than through a projection that has gone stale.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ContainerRender {
+    /// The container's source-level spelling, for the measured form.
+    pub(crate) name: Arc<str>,
+    /// What one of its units is called in the measured form, singular then
+    /// plural.
+    pub(crate) noun: (Arc<str>, Arc<str>),
+    /// Projections to the pointer addressing the backing store. Empty for a
+    /// container that only ever renders its count.
+    pub(crate) base: Arc<[PrinterProjection]>,
+    /// Whether that pointer is `ptr mut T` rather than `ptr const T`.
+    pub(crate) base_is_mut: bool,
+    /// Projections to the backing store's own element count.
+    pub(crate) length: Arc<[PrinterProjection]>,
+    /// Projections to the index the first live element sits at.
+    pub(crate) start: Option<Arc<[PrinterProjection]>>,
+    /// Projections to the live element count, for a container that keeps one
+    /// rather than running to the end of its backing store.
+    pub(crate) count: Option<Arc<[PrinterProjection]>>,
+    /// Projections to the modulus live indices wrap at.
+    pub(crate) modulus: Option<Arc<[PrinterProjection]>>,
+    /// Projections to the width the rendering breaks rows at.
+    pub(crate) row: Option<Arc<[PrinterProjection]>>,
+    /// The element type and how one element renders, or `None` when the
+    /// printer renders the count instead of the elements.
+    pub(crate) element: Option<ContainerElement>,
+}
+
+/// One rendered container element.
+///
+/// The element carries a whole plan, not a leaf: a container is transparent to
+/// the one-level rule, so an element that is a struct or an enum renders as one
+/// — `[{ x: 1 }]`, `[Some(3), None]` — and it is *that* rendering's fields and
+/// payloads which fall to the type-name rule.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ContainerElement {
+    pub(crate) ty: crate::TypeInstanceKey,
+    pub(crate) plan: Arc<ErrorPrinterPlan>,
 }
 
 /// Where a byte string keeps its pointer and its length, as field projections
@@ -152,10 +262,16 @@ pub(crate) struct ErrorPrinterFacts {
 
 impl crate::retained_charge::RetainedCharge for ErrorPrinterFacts {
     fn retained_charge(&self) -> u64 {
-        match &self.plan {
-            ErrorPrinterPlan::Leaf(render) => render.retained_charge(),
-            ErrorPrinterPlan::Struct { fields } => fields.retained_charge(),
-            ErrorPrinterPlan::Enum { variants } => variants.retained_charge(),
+        self.plan.retained_charge()
+    }
+}
+
+impl crate::retained_charge::RetainedCharge for ErrorPrinterPlan {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Leaf(render) => render.retained_charge(),
+            Self::Struct { fields } => fields.retained_charge(),
+            Self::Enum { variants } => variants.retained_charge(),
         }
     }
 }
@@ -163,15 +279,42 @@ impl crate::retained_charge::RetainedCharge for ErrorPrinterFacts {
 impl crate::retained_charge::RetainedCharge for LeafRender {
     fn retained_charge(&self) -> u64 {
         match self {
-            Self::Literal(text) => text.retained_charge(),
-            Self::Signed | Self::Unsigned | Self::Bool => 0,
-            Self::Bytes(view) => {
+            Self::Literal(text) | Self::Opaque(text) => text.retained_charge(),
+            Self::Signed | Self::Unsigned | Self::Bool | Self::Float => 0,
+            Self::Bytes(view) | Self::QuotedBytes(view) => {
                 view.pointer
                     .len()
                     .saturating_add(view.length.len())
                     .saturating_mul(std::mem::size_of::<PrinterProjection>()) as u64
             }
+            Self::Container(container) => container.retained_charge(),
         }
+    }
+}
+
+impl crate::retained_charge::RetainedCharge for ContainerRender {
+    fn retained_charge(&self) -> u64 {
+        let path = |path: &Arc<[PrinterProjection]>| {
+            (path.len() * std::mem::size_of::<PrinterProjection>()) as u64
+        };
+        let optional =
+            |optional: &Option<Arc<[PrinterProjection]>>| optional.as_ref().map_or(0, path);
+        self.name
+            .retained_charge()
+            .saturating_add(self.noun.0.retained_charge())
+            .saturating_add(self.noun.1.retained_charge())
+            .saturating_add(path(&self.base))
+            .saturating_add(path(&self.length))
+            .saturating_add(optional(&self.start))
+            .saturating_add(optional(&self.count))
+            .saturating_add(optional(&self.modulus))
+            .saturating_add(optional(&self.row))
+            .saturating_add(self.element.as_ref().map_or(0, |element| {
+                element
+                    .ty
+                    .retained_charge()
+                    .saturating_add(element.plan.retained_charge())
+            }))
     }
 }
 
@@ -204,9 +347,23 @@ pub(crate) trait ErrorPrinterTypes {
     fn enum_variants(&self, ty: &crate::TypeInstanceKey) -> Option<Vec<(Arc<str>, Vec<Ty>)>>;
     /// The language item a nominal is, when it is one.
     fn lang_item(&self, ty: &crate::TypeInstanceKey) -> Option<LangItem>;
+    /// The standard-library container a nominal is an instance of, when it is
+    /// one. Keyed by the canonical std identity of the type function that
+    /// minted the nominal, never by field shape, so a user struct that happens
+    /// to hold a buffer and a length is not mistaken for one.
+    fn std_container(&self, ty: &crate::TypeInstanceKey) -> Option<rue_air::StdContainer>;
     /// The source-level spelling used when a value renders as its type name.
     fn type_name(&self, ty: &crate::TypeInstanceKey) -> Arc<str>;
 }
+
+/// How deep the printer follows one standard container into another before it
+/// renders a count instead of elements.
+///
+/// A container's element type is a strictly smaller type expression, so the
+/// recursion terminates on its own; this is the belt-and-braces bound that
+/// keeps a pathological nesting out of the rendering rather than the
+/// termination argument.
+const MAX_CONTAINER_DEPTH: u32 = 4;
 
 /// Build the rendering plan for one error type.
 ///
@@ -216,7 +373,29 @@ pub(crate) fn plan_error_printer(
     owner: &crate::TypeInstanceKey,
     types: &impl ErrorPrinterTypes,
 ) -> ErrorPrinterFacts {
-    if let Some(variants) = types.enum_variants(owner) {
+    // The top level always renders something: an error type these rules cannot
+    // look inside is not a failure, it is a value that renders as its own type
+    // name. Only an element inside a container treats that as "unrenderable"
+    // and falls back to a count.
+    let plan = value_plan(owner, types, 0)
+        .unwrap_or_else(|| ErrorPrinterPlan::Leaf(LeafRender::Opaque(types.type_name(owner))));
+    ErrorPrinterFacts { plan }
+}
+
+/// The rendering plan for one value, or `None` when these rules cannot look
+/// inside it at all.
+///
+/// `depth` is the number of standard containers already entered, which bounds
+/// the nesting and picks the loop slots the body will use.
+fn value_plan(
+    ty: &crate::TypeInstanceKey,
+    types: &impl ErrorPrinterTypes,
+    depth: u32,
+) -> Option<ErrorPrinterPlan> {
+    if depth > MAX_CONTAINER_DEPTH {
+        return None;
+    }
+    if let Some(variants) = types.enum_variants(ty) {
         let variants = variants
             .into_iter()
             .map(|(name, payloads)| PrinterVariant {
@@ -227,7 +406,7 @@ pub(crate) fn plan_error_printer(
                         let ty = crate::semantic_identity::type_instance_from_semantic(ty);
                         PrinterField {
                             name: Arc::from(""),
-                            render: leaf_render(&ty, types),
+                            render: leaf_render_at(&ty, types, depth),
                             ty,
                         }
                     })
@@ -235,58 +414,274 @@ pub(crate) fn plan_error_printer(
                     .into(),
             })
             .collect::<Vec<_>>();
-        return ErrorPrinterFacts {
-            plan: ErrorPrinterPlan::Enum {
-                variants: variants.into(),
-            },
-        };
+        return Some(ErrorPrinterPlan::Enum {
+            variants: variants.into(),
+        });
     }
     // A byte string is a struct, and rendering its bytes beats rendering its
     // fields, so the leaf classification is consulted before the struct walk.
-    if let Some(view) = byte_view(owner, types) {
-        return ErrorPrinterFacts {
-            plan: ErrorPrinterPlan::Leaf(LeafRender::Bytes(view)),
-        };
+    if let Some(view) = byte_view(ty, types) {
+        return Some(ErrorPrinterPlan::Leaf(LeafRender::Bytes(view)));
     }
-    if let Some(fields) = types.struct_fields(owner) {
+    // A standard container is a struct too, and its `{ core: RawBuf(T), len: 3 }`
+    // rendering says nothing about what it holds, so the container rule is
+    // consulted ahead of the struct walk for the same reason.
+    if let Some(render) = container_render(ty, types, depth) {
+        return Some(ErrorPrinterPlan::Leaf(render));
+    }
+    if let Some(fields) = types.struct_fields(ty) {
         let fields = fields
             .into_iter()
             .map(|(name, ty)| {
                 let ty = crate::semantic_identity::type_instance_from_semantic(&ty);
                 PrinterField {
                     name,
-                    render: leaf_render(&ty, types),
+                    render: leaf_render_at(&ty, types, depth),
                     ty,
                 }
             })
             .collect::<Vec<_>>();
-        return ErrorPrinterFacts {
-            plan: ErrorPrinterPlan::Struct {
-                fields: fields.into(),
-            },
-        };
+        return Some(ErrorPrinterPlan::Struct {
+            fields: fields.into(),
+        });
     }
-    ErrorPrinterFacts {
-        plan: ErrorPrinterPlan::Leaf(leaf_render(owner, types)),
+    match leaf_render_at(ty, types, depth) {
+        // A raw pointer, a module, an array: named, never read. Inside a
+        // container that is a list of identical names, so the container
+        // reports its count instead.
+        LeafRender::Opaque(_) => None,
+        render => Some(ErrorPrinterPlan::Leaf(render)),
     }
 }
 
-/// Classify one value that the walk will not descend into.
-fn leaf_render(ty: &crate::TypeInstanceKey, types: &impl ErrorPrinterTypes) -> LeafRender {
+/// Classify one value that the walk will not descend into, `depth` standard
+/// containers in.
+fn leaf_render_at(
+    ty: &crate::TypeInstanceKey,
+    types: &impl ErrorPrinterTypes,
+    depth: u32,
+) -> LeafRender {
     use crate::TypeInstanceKey as T;
     match ty {
         T::I8 | T::I16 | T::I32 | T::I64 => LeafRender::Signed,
         T::U8 | T::U16 | T::U32 | T::U64 => LeafRender::Unsigned,
         T::Bool => LeafRender::Bool,
+        T::F32 | T::F64 => LeafRender::Float,
         T::Unit => LeafRender::Literal(Arc::from("()")),
-        _ => match byte_view(ty, types) {
-            Some(view) => LeafRender::Bytes(view),
-            // One level deep, and no deeper: an aggregate reached here is a
+        _ => {
+            if let Some(view) = byte_view(ty, types) {
+                return LeafRender::Bytes(view);
+            }
+            if let Some(render) = container_render(ty, types, depth) {
+                return render;
+            }
+            // One level deep, and no deeper: a user aggregate reached here is a
             // field of the error type, and rendering its own fields would be
             // the second level the payload rules stop at.
-            None => LeafRender::Literal(types.type_name(ty)),
-        },
+            LeafRender::Opaque(types.type_name(ty))
+        }
     }
+}
+
+/// Plan the rendering of `ty` when it is a standard-library container.
+fn container_render(
+    ty: &crate::TypeInstanceKey,
+    types: &impl ErrorPrinterTypes,
+    depth: u32,
+) -> Option<LeafRender> {
+    let kind = types.std_container(ty)?;
+    let name = types.type_name(ty);
+    let (singular, plural) = kind.unit_noun();
+    let noun = (Arc::<str>::from(singular), Arc::<str>::from(plural));
+    let parts = container_parts(kind, ty, types)?;
+    let element = match parts.element {
+        // A map's entries live behind a private slot-state encoding this
+        // module deliberately does not know, so it renders its entry count.
+        None => None,
+        // A container is transparent to the one-level rule, so its element is
+        // planned as if it were the top level: a struct element renders as
+        // `{ x: 1 }`, and it is that struct's own aggregate fields that fall to
+        // the type-name rule. An element the rules cannot look into at all
+        // leaves `None`, and the container renders its size.
+        Some(element_ty) => value_plan(&element_ty, types, depth + 1)
+            .map(quote_byte_elements)
+            .map(|plan| ContainerElement {
+                ty: element_ty,
+                plan: Arc::new(plan),
+            }),
+    };
+    Some(LeafRender::Container(Arc::new(ContainerRender {
+        name,
+        noun,
+        base: parts.base.into(),
+        base_is_mut: parts.base_is_mut,
+        length: parts.length.into(),
+        start: parts.start.map(Into::into),
+        count: parts.count.map(Into::into),
+        modulus: parts.modulus.map(Into::into),
+        row: parts.row.map(Into::into),
+        element,
+    })))
+}
+
+/// A byte-string element renders quoted, never verbatim; see
+/// [`LeafRender::QuotedBytes`]. Only a whole element takes that form — a byte
+/// string reached inside an element struct is an ordinary field rendering.
+fn quote_byte_elements(plan: ErrorPrinterPlan) -> ErrorPrinterPlan {
+    match plan {
+        ErrorPrinterPlan::Leaf(LeafRender::Bytes(view)) => {
+            ErrorPrinterPlan::Leaf(LeafRender::QuotedBytes(view))
+        }
+        other => other,
+    }
+}
+
+/// The projection paths one standard container's rendering reads.
+struct ContainerParts {
+    base: Vec<PrinterProjection>,
+    base_is_mut: bool,
+    length: Vec<PrinterProjection>,
+    start: Option<Vec<PrinterProjection>>,
+    count: Option<Vec<PrinterProjection>>,
+    modulus: Option<Vec<PrinterProjection>>,
+    row: Option<Vec<PrinterProjection>>,
+    /// The element type, or `None` for a container that renders its count.
+    element: Option<crate::TypeInstanceKey>,
+}
+
+/// Locate the parts of one standard container.
+///
+/// `ArrayBuf` is the one that owns storage: its length is its unique `u64`
+/// field and its element base is the unique raw pointer reachable through its
+/// aggregate field, both located structurally exactly as a `StrBuf`'s byte view
+/// is. Every other sequence container wraps one `ArrayBuf` and adds scalar
+/// bookkeeping, so it is located as "that `ArrayBuf`'s parts, behind this
+/// field" plus the named `u64`s its own canonical shape declares. A lookup that
+/// does not find the shape its identity implies yields `None`, and the value
+/// falls back to the type-name rendering it has today.
+fn container_parts(
+    kind: rue_air::StdContainer,
+    ty: &crate::TypeInstanceKey,
+    types: &impl ErrorPrinterTypes,
+) -> Option<ContainerParts> {
+    use rue_air::StdContainer as C;
+    let fields = types.struct_fields(ty)?;
+    let nominal = type_nominal(ty)?;
+    match kind {
+        C::ArrayBuf => {
+            let length = vec![PrinterProjection {
+                nominal: nominal.clone(),
+                field_index: unique_field(&fields, |ty| matches!(ty, Ty::U64))?,
+            }];
+            let (base, base_is_mut, element) =
+                element_pointer_projections(ty, &nominal, &fields, types)?;
+            Some(ContainerParts {
+                base,
+                base_is_mut,
+                length,
+                start: None,
+                count: None,
+                modulus: None,
+                row: None,
+                element: Some(element),
+            })
+        }
+        // `StrMap`/`IntMap` are open-addressed tables whose live slots are
+        // marked by a private state byte, so the printer reports the entry
+        // count the table itself keeps rather than guessing at occupancy.
+        C::StrMap | C::IntMap => Some(ContainerParts {
+            base: Vec::new(),
+            base_is_mut: false,
+            length: vec![named_u64_field(&nominal, &fields, "count")?],
+            start: None,
+            count: None,
+            modulus: None,
+            row: None,
+            element: None,
+        }),
+        C::Stack | C::Queue | C::BinaryHeap | C::Grid2D | C::Deque => {
+            let storage = match kind {
+                C::BinaryHeap => "data",
+                C::Grid2D => "cells",
+                _ => "buf",
+            };
+            let index = field_index(&fields, storage)?;
+            let inner_ty =
+                crate::semantic_identity::type_instance_from_semantic(&fields[index as usize].1);
+            if types.std_container(&inner_ty)? != C::ArrayBuf {
+                return None;
+            }
+            let inner = container_parts(C::ArrayBuf, &inner_ty, types)?;
+            let step = PrinterProjection {
+                nominal: nominal.clone(),
+                field_index: index,
+            };
+            let behind = |path: Vec<PrinterProjection>| {
+                std::iter::once(step.clone())
+                    .chain(path)
+                    .collect::<Vec<_>>()
+            };
+            let (start, count, modulus, row) = match kind {
+                C::Stack | C::BinaryHeap => (None, None, None, None),
+                // A queue never moves its front: it renders the suffix of its
+                // backing buffer that begins at `head`.
+                C::Queue => (
+                    Some(vec![named_u64_field(&nominal, &fields, "head")?]),
+                    None,
+                    None,
+                    None,
+                ),
+                // A deque is a ring: `count` live elements from `head`, taken
+                // modulo the capacity its backing buffer was grown to.
+                C::Deque => (
+                    Some(vec![named_u64_field(&nominal, &fields, "head")?]),
+                    Some(vec![named_u64_field(&nominal, &fields, "count")?]),
+                    Some(vec![named_u64_field(&nominal, &fields, "cap")?]),
+                    None,
+                ),
+                // A grid stores its cells row-major, so its rendering breaks
+                // every `cols` elements.
+                C::Grid2D => (
+                    None,
+                    None,
+                    None,
+                    Some(vec![named_u64_field(&nominal, &fields, "cols")?]),
+                ),
+                C::ArrayBuf | C::StrMap | C::IntMap => unreachable!("handled above"),
+            };
+            Some(ContainerParts {
+                base: behind(inner.base),
+                base_is_mut: inner.base_is_mut,
+                length: behind(inner.length),
+                start,
+                count,
+                modulus,
+                row,
+                element: inner.element,
+            })
+        }
+    }
+}
+
+/// The index of the field spelled `name`.
+fn field_index(fields: &[(Arc<str>, Ty)], name: &str) -> Option<u32> {
+    let index = fields
+        .iter()
+        .position(|(field, _)| field.as_ref() == name)?;
+    u32::try_from(index).ok()
+}
+
+/// A projection to the `u64` field spelled `name`.
+fn named_u64_field(
+    nominal: &crate::NominalInstanceKey,
+    fields: &[(Arc<str>, Ty)],
+    name: &str,
+) -> Option<PrinterProjection> {
+    let index = field_index(fields, name)?;
+    matches!(fields[index as usize].1, Ty::U64).then(|| PrinterProjection {
+        nominal: nominal.clone(),
+        field_index: index,
+    })
 }
 
 /// Locate the `{pointer, length}` of a byte string, if `ty` is one.
@@ -350,13 +745,47 @@ fn byte_pointer_projections(
     fields: &[(Arc<str>, Ty)],
     types: &impl ErrorPrinterTypes,
 ) -> Option<(Vec<PrinterProjection>, bool)> {
-    if let Some(index) = unique_field(fields, is_byte_pointer) {
+    let (projections, pointer) = pointer_projections(ty, nominal, fields, types, is_byte_pointer)?;
+    Some((projections, is_mut_byte_pointer(&pointer)))
+}
+
+/// The unique element pointer of a standard container, and what it addresses.
+///
+/// `ArrayBuf(T)` keeps its allocation in the shared growable-buffer core, so
+/// this is the same one-field-inside-one-field walk a `StrBuf`'s byte view
+/// takes; the difference is only which pointees qualify.
+fn element_pointer_projections(
+    ty: &crate::TypeInstanceKey,
+    nominal: &crate::NominalInstanceKey,
+    fields: &[(Arc<str>, Ty)],
+    types: &impl ErrorPrinterTypes,
+) -> Option<(Vec<PrinterProjection>, bool, crate::TypeInstanceKey)> {
+    let (projections, pointer) = pointer_projections(ty, nominal, fields, types, is_any_pointer)?;
+    let (pointee, is_mut) = match &pointer {
+        Ty::PtrMut(pointee) => (pointee, true),
+        Ty::PtrConst(pointee) => (pointee, false),
+        _ => return None,
+    };
+    let element = crate::semantic_identity::type_instance_from_semantic(pointee);
+    Some((projections, is_mut, element))
+}
+
+/// The one field of `ty` matching `predicate`, or the one inside its one
+/// aggregate field, together with that field's type.
+fn pointer_projections(
+    ty: &crate::TypeInstanceKey,
+    nominal: &crate::NominalInstanceKey,
+    fields: &[(Arc<str>, Ty)],
+    types: &impl ErrorPrinterTypes,
+    predicate: fn(&Ty) -> bool,
+) -> Option<(Vec<PrinterProjection>, Ty)> {
+    if let Some(index) = unique_field(fields, predicate) {
         return Some((
             vec![PrinterProjection {
                 nominal: nominal.clone(),
                 field_index: index,
             }],
-            is_mut_byte_pointer(&fields[index as usize].1),
+            fields[index as usize].1.clone(),
         ));
     }
     let inner_index = unique_field(fields, |field| {
@@ -370,7 +799,7 @@ fn byte_pointer_projections(
     }
     let inner_nominal = type_nominal(&inner_ty)?;
     let inner_fields = types.struct_fields(&inner_ty)?;
-    let index = unique_field(&inner_fields, is_byte_pointer)?;
+    let index = unique_field(&inner_fields, predicate)?;
     Some((
         vec![
             PrinterProjection {
@@ -382,7 +811,7 @@ fn byte_pointer_projections(
                 field_index: index,
             },
         ],
-        is_mut_byte_pointer(&inner_fields[index as usize].1),
+        inner_fields[index as usize].1.clone(),
     ))
 }
 
@@ -392,6 +821,10 @@ fn is_mut_byte_pointer(ty: &Ty) -> bool {
 
 fn is_byte_pointer(ty: &Ty) -> bool {
     matches!(ty, Ty::PtrConst(pointee) | Ty::PtrMut(pointee) if matches!(**pointee, Ty::U8))
+}
+
+fn is_any_pointer(ty: &Ty) -> bool {
+    matches!(ty, Ty::PtrConst(_) | Ty::PtrMut(_))
 }
 
 /// The index of the one field matching `predicate`, or `None` when zero or
@@ -431,20 +864,132 @@ pub(crate) fn collect_printer_plan_types(
     owner: &crate::TypeInstanceKey,
     facts: &ErrorPrinterFacts,
 ) -> std::collections::BTreeSet<crate::TypeInstanceKey> {
-    let mut types = std::collections::BTreeSet::new();
-    types.insert(owner.clone());
-    match &facts.plan {
-        ErrorPrinterPlan::Leaf(_) => {}
-        ErrorPrinterPlan::Struct { fields } => {
-            types.extend(fields.iter().map(|field| field.ty.clone()));
-        }
-        ErrorPrinterPlan::Enum { variants } => {
-            for variant in variants.iter() {
-                types.extend(variant.fields.iter().map(|field| field.ty.clone()));
+    fn walk(
+        plan: &ErrorPrinterPlan,
+        types: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
+    ) {
+        let leaf =
+            |render: &LeafRender,
+             types: &mut std::collections::BTreeSet<crate::TypeInstanceKey>| {
+                if let LeafRender::Container(container) = render
+                    && let Some(element) = container.element.as_ref()
+                {
+                    types.insert(element.ty.clone());
+                    walk(&element.plan, types);
+                }
+            };
+        match plan {
+            ErrorPrinterPlan::Leaf(render) => leaf(render, types),
+            ErrorPrinterPlan::Struct { fields } => {
+                for field in fields.iter() {
+                    types.insert(field.ty.clone());
+                    leaf(&field.render, types);
+                }
+            }
+            ErrorPrinterPlan::Enum { variants } => {
+                for variant in variants.iter() {
+                    for field in variant.fields.iter() {
+                        types.insert(field.ty.clone());
+                        leaf(&field.render, types);
+                    }
+                }
             }
         }
     }
+    let mut types = std::collections::BTreeSet::new();
+    types.insert(owner.clone());
+    walk(&facts.plan, &mut types);
     types
+}
+
+/// How many standard containers this plan can be inside at once.
+///
+/// One rendering never enters two containers at the same nesting level, so this
+/// is the number of loop index/count pairs the body needs, not the number of
+/// containers it mentions.
+fn container_depth(plan: &ErrorPrinterPlan) -> u32 {
+    fn leaf(render: &LeafRender) -> u32 {
+        match render {
+            LeafRender::Container(container) => container
+                .element
+                .as_ref()
+                .map_or(0, |element| container_depth(&element.plan))
+                .saturating_add(1),
+            LeafRender::Literal(_)
+            | LeafRender::Opaque(_)
+            | LeafRender::Signed
+            | LeafRender::Unsigned
+            | LeafRender::Bool
+            | LeafRender::Float
+            | LeafRender::Bytes(_)
+            | LeafRender::QuotedBytes(_) => 0,
+        }
+    }
+    match plan {
+        ErrorPrinterPlan::Leaf(render) => Some(leaf(render)),
+        ErrorPrinterPlan::Struct { fields } => fields.iter().map(|field| leaf(&field.render)).max(),
+        ErrorPrinterPlan::Enum { variants } => variants
+            .iter()
+            .flat_map(|variant| variant.fields.iter())
+            .map(|field| leaf(&field.render))
+            .max(),
+    }
+    .unwrap_or(0)
+}
+
+/// The width of the local each nesting level stages a *struct* element in,
+/// indexed by the depth that element is rendered at.
+///
+/// A struct element's fields are read as ordinary storage rather than through
+/// the element pointer, so the element is copied into a local first; see
+/// [`Builder::stage_struct_source`]. Only struct elements need one, so most
+/// depths have a width of zero.
+fn element_staging_widths(
+    plan: &ErrorPrinterPlan,
+    depths: u32,
+    width: &dyn Fn(&crate::TypeInstanceKey) -> Result<u32, Arc<str>>,
+) -> Result<Vec<u32>, Arc<str>> {
+    fn walk(
+        plan: &ErrorPrinterPlan,
+        depth: u32,
+        widths: &mut [u32],
+        width: &dyn Fn(&crate::TypeInstanceKey) -> Result<u32, Arc<str>>,
+    ) -> Result<(), Arc<str>> {
+        let leaf = |render: &LeafRender, widths: &mut [u32]| -> Result<(), Arc<str>> {
+            let LeafRender::Container(container) = render else {
+                return Ok(());
+            };
+            let Some(element) = container.element.as_ref() else {
+                return Ok(());
+            };
+            let inner = depth.saturating_add(1);
+            if matches!(*element.plan, ErrorPrinterPlan::Struct { .. })
+                && let Some(slot) = widths.get_mut(inner as usize)
+            {
+                *slot = (*slot).max(width(&element.ty)?);
+            }
+            walk(&element.plan, inner, widths, width)
+        };
+        match plan {
+            ErrorPrinterPlan::Leaf(render) => leaf(render, widths)?,
+            ErrorPrinterPlan::Struct { fields } => {
+                for field in fields.iter() {
+                    leaf(&field.render, widths)?;
+                }
+            }
+            ErrorPrinterPlan::Enum { variants } => {
+                for variant in variants.iter() {
+                    for field in variant.fields.iter() {
+                        leaf(&field.render, widths)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+    let mut widths = vec![0; depths.saturating_add(1) as usize];
+    walk(plan, 0, &mut widths, width)?;
+    Ok(widths)
 }
 
 /// Local slots the printer body declares.
@@ -473,12 +1018,43 @@ mod slot {
     pub(super) const CURSOR: u32 = 10;
     /// The literal run currently being appended. A local occupies one slot per
     /// ABI word, and a `str` is two — `{ptr, len}` — so this one is last of the
-    /// fixed slots and the base reserves both.
+    /// single-word fixed slots and the base reserves both.
     pub(super) const TEXT: u32 = 11;
-    /// First slot of the payload binding: an enum payload is a value, and a
-    /// byte view needs a place, so a byte-string payload is bound here before
-    /// it is projected. Its width comes from the payload's own layout.
-    pub(super) const PAYLOAD: u32 = TEXT + 2;
+    /// Address of the byte string a quoted element is escaping, held as an
+    /// integer so one slot serves a `ptr const u8` and a `ptr mut u8` source.
+    pub(super) const QUOTED: u32 = TEXT + 2;
+    /// Position of the byte being escaped.
+    pub(super) const QUOTED_CURSOR: u32 = QUOTED + 1;
+    /// How many bytes that string has.
+    pub(super) const QUOTED_LEN: u32 = QUOTED + 2;
+    /// First slot of the container loops: two per nesting level, the index of
+    /// the element being rendered and the number of elements to render.
+    pub(super) const SEQUENCE: u32 = QUOTED + 3;
+    /// Slots one container-nesting level occupies.
+    pub(super) const SEQUENCE_STRIDE: u32 = 2;
+    /// Slots the float formatter's result occupies: the runtime writes a
+    /// `{ptr, cap, len}` triple through its out-pointer.
+    pub(super) const FLOAT_STRIDE: u32 = 3;
+
+    /// The index slot of the container loop at `depth`.
+    pub(super) const fn sequence_index(depth: u32) -> u32 {
+        SEQUENCE + depth * SEQUENCE_STRIDE
+    }
+
+    /// The element-count slot of the container loop at `depth`.
+    pub(super) const fn sequence_count(depth: u32) -> u32 {
+        sequence_index(depth) + 1
+    }
+
+    /// The text a float formatted to, as the runtime handed it back.
+    pub(super) const fn float(depths: u32) -> u32 {
+        SEQUENCE + depths * SEQUENCE_STRIDE
+    }
+
+    /// First slot of the region each nesting level stages a struct element in.
+    pub(super) const fn elements(depths: u32) -> u32 {
+        float(depths) + FLOAT_STRIDE
+    }
 }
 
 /// The largest number of decimal digits a `u64` needs.
@@ -502,7 +1078,25 @@ pub(crate) fn synthesize_error_printer(
     };
     let num_param_slots = width(owner)?;
     let owner_ty = semantic_type_from_instance(owner);
-    let mut builder = Builder::default();
+    // Every container loop the plan can enter at once gets its own index and
+    // count, so a nested rendering never reuses the level above it.
+    let depths = container_depth(&facts.plan);
+    // Each nesting level that renders a struct element copies it into a local
+    // of its own; the widths are known only here, where layout is.
+    let element_widths = element_staging_widths(&facts.plan, depths, &width)?;
+    let mut element_slots = Vec::with_capacity(element_widths.len());
+    let mut next = slot::elements(depths);
+    for element_width in element_widths {
+        element_slots.push((next, element_width));
+        next = next.saturating_add(element_width);
+    }
+    let builder_payload_slot = next;
+    let mut builder = Builder {
+        float_slot: slot::float(depths),
+        element_slots,
+        payload_slot: builder_payload_slot,
+        ..Builder::default()
+    };
     let mut statements = builder.prologue();
     // The error value is one parameter, not one per slot, and every read
     // below goes through a place rooted at that one parameter, so the address
@@ -526,94 +1120,24 @@ pub(crate) fn synthesize_error_printer(
     if let ErrorPrinterPlan::Enum { variants } = &facts.plan {
         for variant in variants.iter() {
             for field in variant.fields.iter() {
-                if matches!(field.render, LeafRender::Bytes(_)) {
+                if matches!(
+                    field.render,
+                    LeafRender::Bytes(_) | LeafRender::QuotedBytes(_) | LeafRender::Container(_)
+                ) {
                     payload_slots = payload_slots.max(width(&field.ty)?);
                 }
             }
         }
     }
 
-    match &facts.plan {
-        ErrorPrinterPlan::Leaf(render) => {
-            let source = LeafSource::Projected(Vec::new());
-            builder.render_leaf(&mut statements, render, &source, &owner_ty, &owner_ty);
-        }
-        ErrorPrinterPlan::Struct { fields } => {
-            let nominal = type_nominal(owner)
-                .ok_or_else(|| Arc::<str>::from("a struct error type names a nominal"))?;
-            builder.append_literal(&mut statements, "{");
-            for (index, field) in fields.iter().enumerate() {
-                builder.append_literal(&mut statements, if index == 0 { " " } else { ", " });
-                builder.append_literal(&mut statements, &format!("{}: ", field.name));
-                let source = LeafSource::Projected(vec![PrinterProjection {
-                    nominal: nominal.clone(),
-                    field_index: u32::try_from(index).unwrap_or(u32::MAX),
-                }]);
-                let field_ty = semantic_type_from_instance(&field.ty);
-                builder.render_leaf(
-                    &mut statements,
-                    &field.render,
-                    &source,
-                    &owner_ty,
-                    &field_ty,
-                );
-            }
-            builder.append_literal(&mut statements, if fields.is_empty() { "}" } else { " }" });
-        }
-        ErrorPrinterPlan::Enum { variants } => {
-            let nominal = type_nominal(owner)
-                .ok_or_else(|| Arc::<str>::from("an enum error type names a nominal"))?;
-            // Matching the value itself, rather than an integer read out of a
-            // parameter slot, leaves the discriminant's position and width to
-            // the same lowering an ordinary `match` uses.
-            let scrutinee = builder.subject(&owner_ty);
-            let mut arms = Vec::with_capacity(variants.len());
-            for (index, variant) in variants.iter().enumerate() {
-                let variant_index = u32::try_from(index).unwrap_or(u32::MAX);
-                let mut arm = Vec::new();
-                builder.append_literal(&mut arm, &variant.name);
-                if !variant.fields.is_empty() {
-                    builder.append_literal(&mut arm, "(");
-                    for (position, field) in variant.fields.iter().enumerate() {
-                        if position > 0 {
-                            builder.append_literal(&mut arm, ", ");
-                        }
-                        let source = LeafSource::Payload {
-                            base: scrutinee,
-                            enum_key: nominal.clone(),
-                            variant_index,
-                            field_index: u32::try_from(position).unwrap_or(u32::MAX),
-                        };
-                        let field_ty = semantic_type_from_instance(&field.ty);
-                        builder.render_leaf(&mut arm, &field.render, &source, &owner_ty, &field_ty);
-                    }
-                    builder.append_literal(&mut arm, ")");
-                }
-                let unit = builder.add(Data::UnitConst, Ty::Unit);
-                let body = builder.add(
-                    Data::Block {
-                        statements: arm.into(),
-                        value: unit,
-                    },
-                    Ty::Unit,
-                );
-                arms.push(SemanticBodyMatchArm {
-                    pattern: SemanticBodyPattern::EnumVariant {
-                        enum_key: nominal.clone(),
-                        variant_index,
-                    },
-                    body,
-                });
-            }
-            statements.push(builder.add(
-                Data::Match {
-                    scrutinee,
-                    arms: arms.into(),
-                },
-                Ty::Unit,
-            ));
-        }
-    }
+    builder.render_plan(
+        &mut statements,
+        &facts.plan,
+        owner,
+        &LeafSource::Projected(Vec::new()),
+        &owner_ty,
+        0,
+    )?;
 
     builder.epilogue(&mut statements);
     let view = builder.finish_view();
@@ -661,14 +1185,19 @@ pub(crate) fn synthesize_error_printer(
         // instruction, so there is nothing after this body for a destructor to
         // protect (ADR-0083 §1 accepts exactly this).
         param_drops: Arc::new([]),
-        // The payload binding aliases the parameter's own storage rather than
-        // taking ownership of it; see the byte-view rendering above.
-        borrow_slots: if payload_slots > 0 {
-            Arc::new([slot::PAYLOAD])
-        } else {
-            Arc::new([])
-        },
-        num_locals: slot::PAYLOAD.saturating_add(payload_slots),
+        // A payload binding aliases the parameter's own storage, and a staged
+        // element is a bitwise copy of storage the container still owns;
+        // neither takes ownership. This body has no drop schedule at all, so
+        // declaring them non-owning states that rather than establishing it.
+        borrow_slots: builder
+            .element_slots
+            .iter()
+            .filter(|(_, width)| *width > 0)
+            .map(|(slot, _)| *slot)
+            .chain((payload_slots > 0).then_some(builder_payload_slot))
+            .collect::<Vec<_>>()
+            .into(),
+        num_locals: builder_payload_slot.saturating_add(payload_slots),
         num_param_slots,
         cleanup_owner: None,
         param_by_ref: vec![false; num_param_slots as usize].into(),
@@ -697,22 +1226,80 @@ fn byte_pointer_type() -> Ty {
     Ty::PtrMut(Arc::new(Ty::U8))
 }
 
+/// The element type a container renders, as the place reads see it.
+fn element_type(view: &ContainerRender) -> Ty {
+    semantic_type_from_instance(
+        &view
+            .element
+            .as_ref()
+            .expect("an element source renders elements")
+            .ty,
+    )
+}
+
+/// The runtime's `{ptr, cap, len}` formatting result, as three machine words.
+///
+/// The helper writes that triple through an out-pointer whose shape the runtime
+/// ABI owns ([`rue_runtime_abi::AggregateShapeId::StrBufResult`]). Receiving it
+/// as `[u64; 3]` rather than as `StrBuf` is what keeps this body free of any
+/// standard-library declaration, which it must be: the printer is demanded by a
+/// `?` or an assertion, not by a call the request's closure walked.
+fn float_text_type() -> Ty {
+    Ty::Array {
+        element: Arc::new(Ty::U64),
+        len: FLOAT_TEXT_WORDS,
+    }
+}
+
+/// Words of [`float_text_type`], and the two this module reads.
+const FLOAT_TEXT_WORDS: u64 = 3;
+const FLOAT_TEXT_POINTER: u64 = 0;
+const FLOAT_TEXT_LEN: u64 = 2;
+
+/// The exact pointer type a byte view's pointer field has. A place read is
+/// typed by the field it lands on, so the two spellings are not interchangeable.
+fn byte_view_pointer_type(view: &ByteView) -> Ty {
+    if view.pointer_is_mut {
+        byte_pointer_type()
+    } else {
+        Ty::PtrConst(Arc::new(Ty::U8))
+    }
+}
+
 /// The base a printer place is rooted at.
 enum PlaceRoot {
-    /// The one parameter, optionally reached through a field prefix.
-    Param(Vec<PrinterProjection>),
+    /// The one parameter.
+    Param,
     /// A local the printer bound a payload to.
     Local(u32),
+    /// The value one pointer addresses. Used for a container element, whose
+    /// address is recomputed from the container and the loop index at each
+    /// use, so no value crosses a branch boundary.
+    Indirect(u32),
+}
+
+/// One element of a container being rendered.
+#[derive(Clone)]
+struct ElementSource {
+    /// How to reach the container the element belongs to.
+    container: Box<LeafSource>,
+    view: Arc<ContainerRender>,
+    /// The loop index slot naming which element is being rendered.
+    index_slot: u32,
+    /// Field steps taken from the element itself, for an element whose own
+    /// rendering is a struct.
+    prefix: Vec<PrinterProjection>,
 }
 
 /// Where one rendered leaf lives inside the printer's single parameter.
+#[derive(Clone)]
 enum LeafSource {
     /// Reached from the parameter by field projections: the parameter itself
     /// when the list is empty, one of its fields otherwise.
     Projected(Vec<PrinterProjection>),
     /// One payload of the variant an arm matched, projected out of the enum
     /// value `base`. A payload is a value rather than a place, so a byte view
-    /// binds it to [`slot::PAYLOAD`] first.
+    /// binds it to the payload slot first.
     ///
     /// `base` is the *one* read of the parameter this body performs. An error
     /// type that owns anything is moved by that read, so reading the parameter
@@ -725,6 +1312,50 @@ enum LeafSource {
         variant_index: u32,
         field_index: u32,
     },
+    /// One element of a standard container.
+    Element(Box<ElementSource>),
+    /// A local this body bound a value to, so that a rendering needing a place
+    /// has one, optionally reached through a field prefix.
+    Local {
+        slot: u32,
+        /// The type the local holds, which is what a place rooted there is
+        /// typed by — never the type of the leaf a projection ends on.
+        root_ty: Ty,
+        prefix: Vec<PrinterProjection>,
+    },
+}
+
+impl LeafSource {
+    /// The same value's field, one step further in.
+    fn with_field(&self, step: PrinterProjection) -> Self {
+        let extend = |prefix: &Vec<PrinterProjection>| {
+            let mut prefix = prefix.clone();
+            prefix.push(step.clone());
+            prefix
+        };
+        match self {
+            Self::Projected(prefix) => Self::Projected(extend(prefix)),
+            Self::Local {
+                slot,
+                root_ty,
+                prefix,
+            } => Self::Local {
+                slot: *slot,
+                root_ty: root_ty.clone(),
+                prefix: extend(prefix),
+            },
+            Self::Element(element) => {
+                let mut element = element.clone();
+                element.prefix = extend(&element.prefix);
+                Self::Element(element)
+            }
+            // A payload is a value, not a place; every caller that projects
+            // stages it into a local first.
+            Self::Payload { .. } => {
+                unreachable!("a payload is staged into a local before it is projected")
+            }
+        }
+    }
 }
 
 /// Instruction accumulator for the generated body.
@@ -736,6 +1367,13 @@ struct Builder {
     instructions: Vec<Inst>,
     places: Vec<Place>,
     strings: Vec<Arc<str>>,
+    /// First slot of the float formatter's result; see [`slot::float`].
+    float_slot: u32,
+    /// First slot of the local each nesting level stages a struct element in,
+    /// by depth; zero-width where that depth stages nothing.
+    element_slots: Vec<(u32, u32)>,
+    /// First slot of the payload binding; see [`slot::payload`].
+    payload_slot: u32,
 }
 
 impl Builder {
@@ -852,6 +1490,26 @@ impl Builder {
         let index = self.string("");
         let empty = self.add(Data::StringConst(index), str_type());
         statements.push(self.bind(slot::TEXT, empty, str_type()));
+        // Every container loop's index and count is declared here rather than
+        // where the loop is rendered: a nested container's loop sits inside its
+        // parent's body, and a slot introduced there would be introduced once
+        // per iteration.
+        for slot in slot::QUOTED..self.float_slot {
+            let zero = self.constant(0, Ty::U64);
+            statements.push(self.bind(slot, zero, Ty::U64));
+        }
+        let empty = (0..slot::FLOAT_STRIDE)
+            .map(|_| self.constant(0, Ty::U64))
+            .collect::<Vec<_>>();
+        let empty = self.add(
+            Data::ArrayInit {
+                elements: empty.into(),
+                shape: rue_air::ArrayInitShape::Elementwise,
+            },
+            float_text_type(),
+        );
+        let slot = self.float_slot;
+        statements.push(self.bind(slot, empty, float_text_type()));
         statements
     }
 
@@ -1034,6 +1692,116 @@ impl Builder {
         statements.push(self.store(slot::LEN, total));
     }
 
+    /// Emit the rendering of one whole value.
+    ///
+    /// The same three shapes serve the error type itself and every container
+    /// element, because a container is transparent to the one-level rule: an
+    /// element struct renders as `{ x: 1 }` at the level a top-level struct
+    /// would, and it is that struct's own aggregate fields that fall to the
+    /// type-name rule.
+    fn render_plan(
+        &mut self,
+        statements: &mut Vec<u32>,
+        plan: &ErrorPrinterPlan,
+        value_key: &crate::TypeInstanceKey,
+        source: &LeafSource,
+        owner_ty: &Ty,
+        depth: u32,
+    ) -> Result<(), Arc<str>> {
+        let value_ty = semantic_type_from_instance(value_key);
+        match plan {
+            ErrorPrinterPlan::Leaf(render) => {
+                self.render_leaf(statements, render, source, owner_ty, &value_ty, depth)?;
+            }
+            ErrorPrinterPlan::Struct { fields } => {
+                let nominal = type_nominal(value_key)
+                    .ok_or_else(|| Arc::<str>::from("a struct rendering names a nominal"))?;
+                let source =
+                    self.stage_struct_source(statements, source, owner_ty, &value_ty, depth);
+                self.append_literal(statements, "{");
+                for (index, field) in fields.iter().enumerate() {
+                    self.append_literal(statements, if index == 0 { " " } else { ", " });
+                    self.append_literal(statements, &format!("{}: ", field.name));
+                    let field_source = source.with_field(PrinterProjection {
+                        nominal: nominal.clone(),
+                        field_index: u32::try_from(index).unwrap_or(u32::MAX),
+                    });
+                    let field_ty = semantic_type_from_instance(&field.ty);
+                    self.render_leaf(
+                        statements,
+                        &field.render,
+                        &field_source,
+                        owner_ty,
+                        &field_ty,
+                        depth,
+                    )?;
+                }
+                self.append_literal(statements, if fields.is_empty() { "}" } else { " }" });
+            }
+            ErrorPrinterPlan::Enum { variants } => {
+                let nominal = type_nominal(value_key)
+                    .ok_or_else(|| Arc::<str>::from("an enum rendering names a nominal"))?;
+                // Matching the value itself, rather than an integer read out of
+                // a parameter slot, leaves the discriminant's position and
+                // width to the same lowering an ordinary `match` uses.
+                let scrutinee = self.read_leaf(source, owner_ty, &value_ty);
+                let mut arms = Vec::with_capacity(variants.len());
+                for (index, variant) in variants.iter().enumerate() {
+                    let variant_index = u32::try_from(index).unwrap_or(u32::MAX);
+                    let mut arm = Vec::new();
+                    self.append_literal(&mut arm, &variant.name);
+                    if !variant.fields.is_empty() {
+                        self.append_literal(&mut arm, "(");
+                        for (position, field) in variant.fields.iter().enumerate() {
+                            if position > 0 {
+                                self.append_literal(&mut arm, ", ");
+                            }
+                            let payload = LeafSource::Payload {
+                                base: scrutinee,
+                                enum_key: nominal.clone(),
+                                variant_index,
+                                field_index: u32::try_from(position).unwrap_or(u32::MAX),
+                            };
+                            let field_ty = semantic_type_from_instance(&field.ty);
+                            self.render_leaf(
+                                &mut arm,
+                                &field.render,
+                                &payload,
+                                owner_ty,
+                                &field_ty,
+                                depth,
+                            )?;
+                        }
+                        self.append_literal(&mut arm, ")");
+                    }
+                    let unit = self.add(Data::UnitConst, Ty::Unit);
+                    let body = self.add(
+                        Data::Block {
+                            statements: arm.into(),
+                            value: unit,
+                        },
+                        Ty::Unit,
+                    );
+                    arms.push(SemanticBodyMatchArm {
+                        pattern: SemanticBodyPattern::EnumVariant {
+                            enum_key: nominal.clone(),
+                            variant_index,
+                        },
+                        body,
+                    });
+                }
+                statements.push(self.add(
+                    Data::Match {
+                        scrutinee,
+                        arms: arms.into(),
+                    },
+                    Ty::Unit,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Emit the rendering of one leaf.
     fn render_leaf(
         &mut self,
@@ -1042,9 +1810,12 @@ impl Builder {
         source: &LeafSource,
         owner_ty: &Ty,
         leaf_ty: &Ty,
-    ) {
+        depth: u32,
+    ) -> Result<(), Arc<str>> {
         match render {
-            LeafRender::Literal(text) => self.append_literal(statements, text),
+            LeafRender::Literal(text) | LeafRender::Opaque(text) => {
+                self.append_literal(statements, text)
+            }
             LeafRender::Bool => {
                 let read = self.read_leaf(source, owner_ty, leaf_ty);
                 let mut taken = Vec::new();
@@ -1096,46 +1867,513 @@ impl Builder {
                 statements.push(branch);
                 self.append_decimal(statements);
             }
+            LeafRender::Float => {
+                self.append_float(statements, source, owner_ty, leaf_ty);
+            }
             LeafRender::Bytes(view) => {
-                // A byte view is two field reads from the same value, which
-                // needs a place. A projected leaf already is one; a payload is a
-                // value, so it is bound to the payload slot first. That binding
-                // is declared non-owning (`borrow_slots` below): the error value
-                // the payload came from is the parameter, which this body never
-                // destroys, so a second owner here would only add a destructor
-                // call to a path that traps before it could matter — and one
-                // this request never rooted.
-                let (base, base_type) = match source {
-                    LeafSource::Projected(projections) => {
-                        (PlaceRoot::Param(projections.clone()), owner_ty.clone())
-                    }
-                    LeafSource::Payload { .. } => {
-                        let value = self.read_leaf(source, owner_ty, leaf_ty);
-                        statements.push(self.bind(slot::PAYLOAD, value, leaf_ty.clone()));
-                        (PlaceRoot::Local(slot::PAYLOAD), leaf_ty.clone())
-                    }
-                };
-                let pointer_ty = if view.pointer_is_mut {
-                    byte_pointer_type()
-                } else {
-                    Ty::PtrConst(Arc::new(Ty::U8))
-                };
-                let length = self.rooted_read(&base, &base_type, &view.length, Ty::U64);
-                let pointer_projections = view.pointer.clone();
+                let source = self.stage_place_source(statements, source, owner_ty, leaf_ty);
+                let pointer_ty = byte_view_pointer_type(view);
+                let length = self.read_through(&source, owner_ty, &view.length.clone(), Ty::U64);
+                let view = view.clone();
+                let owner_ty = owner_ty.clone();
                 self.append_bytes(statements, length, move |builder| {
-                    builder.rooted_read(&base, &base_type, &pointer_projections, pointer_ty)
+                    builder.read_through(&source, &owner_ty, &view.pointer, pointer_ty)
                 });
+            }
+            LeafRender::QuotedBytes(view) => {
+                let source = self.stage_place_source(statements, source, owner_ty, leaf_ty);
+                self.append_quoted(statements, view, &source, owner_ty);
+            }
+            LeafRender::Container(container) => {
+                let source = self.stage_place_source(statements, source, owner_ty, leaf_ty);
+                self.render_container(statements, container, &source, owner_ty, depth)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Give `source` a place to be read through, when it is not one already.
+    ///
+    /// A projected leaf and a container element already name storage. An enum
+    /// payload is a value, so it is bound to the payload slot first. That
+    /// binding is declared non-owning (`borrow_slots`): the error value the
+    /// payload came from is the parameter, which this body never destroys, so a
+    /// second owner here would only add a destructor call to a path that traps
+    /// before it could matter — and one this request never rooted.
+    fn stage_place_source(
+        &mut self,
+        statements: &mut Vec<u32>,
+        source: &LeafSource,
+        owner_ty: &Ty,
+        leaf_ty: &Ty,
+    ) -> LeafSource {
+        match source {
+            LeafSource::Projected(_) | LeafSource::Element(_) | LeafSource::Local { .. } => {
+                source.clone()
+            }
+            LeafSource::Payload { .. } => {
+                let value = self.read_leaf(source, owner_ty, leaf_ty);
+                let slot = self.payload_slot;
+                statements.push(self.bind(slot, value, leaf_ty.clone()));
+                LeafSource::Local {
+                    slot,
+                    root_ty: leaf_ty.clone(),
+                    prefix: Vec::new(),
+                }
             }
         }
     }
 
-    /// The whole error value, read through its own parameter place.
-    fn subject(&mut self, owner_ty: &Ty) -> u32 {
-        self.rooted_read(
-            &PlaceRoot::Param(Vec::new()),
+    /// Stage `source` so a struct's fields can be read as ordinary storage.
+    ///
+    /// A container element is addressed through a raw pointer, and an indirect
+    /// place read of a narrower-than-word field loads a whole word today
+    /// (`ArrayBuf(u8).get_ref(0)` has the same defect), so an element whose
+    /// rendering is a struct is copied into a local of its own first and read
+    /// from there. One local per nesting level: a nested container rebinds its
+    /// own, leaving the level above it intact.
+    fn stage_struct_source(
+        &mut self,
+        statements: &mut Vec<u32>,
+        source: &LeafSource,
+        owner_ty: &Ty,
+        value_ty: &Ty,
+        depth: u32,
+    ) -> LeafSource {
+        let LeafSource::Element(_) = source else {
+            return self.stage_place_source(statements, source, owner_ty, value_ty);
+        };
+        let value = self.read_leaf(source, owner_ty, value_ty);
+        let (slot, _) = self.element_slots[depth as usize];
+        statements.push(self.bind(slot, value, value_ty.clone()));
+        LeafSource::Local {
+            slot,
+            root_ty: value_ty.clone(),
+            prefix: Vec::new(),
+        }
+    }
+
+    /// Read `projections` out of the value `source` names.
+    ///
+    /// The root is resolved afresh on every call, so a read emitted inside a
+    /// branch or a loop body carries its own address arithmetic instead of
+    /// naming a value computed outside it.
+    fn read_through(
+        &mut self,
+        source: &LeafSource,
+        owner_ty: &Ty,
+        projections: &[PrinterProjection],
+        ty: Ty,
+    ) -> u32 {
+        let (root, prefix, base_type) = match source {
+            LeafSource::Projected(prefix) => (PlaceRoot::Param, prefix.clone(), owner_ty.clone()),
+            LeafSource::Local {
+                slot,
+                root_ty,
+                prefix,
+            } => (PlaceRoot::Local(*slot), prefix.clone(), root_ty.clone()),
+            LeafSource::Payload { .. } => {
+                unreachable!("a payload is staged into a local before it is read through")
+            }
+            LeafSource::Element(element) => {
+                let pointer = self.element_pointer(element, owner_ty);
+                if element.prefix.is_empty() && projections.is_empty() {
+                    // A whole element is read through the pointer intrinsic
+                    // rather than an indirect place: an indirect place read of
+                    // a narrower-than-word scalar loads a whole word today —
+                    // `ArrayBuf(u8).get_ref(0)` has the same defect — and
+                    // `@ptr_read` is the path the standard library's own
+                    // element reads already take.
+                    return self.add(
+                        Data::Intrinsic {
+                            operation: IntrinsicOperation::PtrRead,
+                            name: Arc::from(IntrinsicOperation::PtrRead.expected_spelling()),
+                            args: Arc::new([argument(pointer)]),
+                        },
+                        ty,
+                    );
+                }
+                (
+                    PlaceRoot::Indirect(pointer),
+                    element.prefix.clone(),
+                    element_type(&element.view),
+                )
+            }
+        };
+        let steps = prefix
+            .iter()
+            .chain(projections)
+            .cloned()
+            .collect::<Vec<_>>();
+        self.rooted_read(&root, &base_type, &steps, ty)
+    }
+
+    /// The address of the container element `source` names.
+    fn element_pointer(&mut self, source: &ElementSource, owner_ty: &Ty) -> u32 {
+        let view = source.view.clone();
+        let element_ty = element_type(&view);
+        let pointer_ty = if view.base_is_mut {
+            Ty::PtrMut(Arc::new(element_ty))
+        } else {
+            Ty::PtrConst(Arc::new(element_ty))
+        };
+        let base = self.read_through(&source.container, owner_ty, &view.base, pointer_ty.clone());
+        let mut index = self.load(source.index_slot, Ty::U64);
+        if let Some(start) = view.start.as_ref() {
+            let start = self.read_through(&source.container, owner_ty, start, Ty::U64);
+            index = self.add(Data::WrappingAdd(start, index), Ty::U64);
+        }
+        if let Some(modulus) = view.modulus.as_ref() {
+            // A zero modulus would trap the division, so it is replaced by one
+            // rather than guarded: a ring with no capacity has no elements, and
+            // this loop does not run.
+            let read = self.read_through(&source.container, owner_ty, modulus, Ty::U64);
+            let zero = self.constant(0, Ty::U64);
+            let usable = self.add(Data::Ne(read, zero), Ty::Bool);
+            let read = self.read_through(&source.container, owner_ty, modulus, Ty::U64);
+            let one = self.constant(1, Ty::U64);
+            let modulus = self.add(
+                Data::Branch {
+                    cond: usable,
+                    then_value: read,
+                    else_value: Some(one),
+                },
+                Ty::U64,
+            );
+            index = self.add(Data::Mod(index, modulus), Ty::U64);
+        }
+        self.add(
+            Data::Intrinsic {
+                operation: IntrinsicOperation::PtrOffset,
+                name: Arc::from(IntrinsicOperation::PtrOffset.expected_spelling()),
+                args: Arc::new([argument(base), argument(index)]),
+            },
+            pointer_ty,
+        )
+    }
+
+    /// How many elements a container renders: the count it keeps, or what is
+    /// left of its backing store after its first live index.
+    fn element_count(&mut self, view: &ContainerRender, source: &LeafSource, owner_ty: &Ty) -> u32 {
+        if let Some(count) = view.count.as_ref() {
+            return self.read_through(source, owner_ty, count, Ty::U64);
+        }
+        let length = self.read_through(source, owner_ty, &view.length, Ty::U64);
+        let Some(start) = view.start.as_ref() else {
+            return length;
+        };
+        let begin = self.read_through(source, owner_ty, start, Ty::U64);
+        let live = self.add(Data::Ge(length, begin), Ty::Bool);
+        let length = self.read_through(source, owner_ty, &view.length, Ty::U64);
+        let begin = self.read_through(source, owner_ty, start, Ty::U64);
+        let span = self.add(Data::WrappingSub(length, begin), Ty::U64);
+        let empty = self.constant(0, Ty::U64);
+        self.add(
+            Data::Branch {
+                cond: live,
+                then_value: span,
+                else_value: Some(empty),
+            },
+            Ty::U64,
+        )
+    }
+
+    /// Render a standard container: `[a, b, c]`, `[[a, b], [c, d]]` for a
+    /// grid, or `Name <n units>` when its elements are values these rules
+    /// cannot look inside (6.7:15).
+    fn render_container(
+        &mut self,
+        statements: &mut Vec<u32>,
+        view: &Arc<ContainerRender>,
+        source: &LeafSource,
+        owner_ty: &Ty,
+        depth: u32,
+    ) -> Result<(), Arc<str>> {
+        let Some(element) = view.element.as_ref() else {
+            self.append_literal(statements, &format!("{} <", view.name));
+            let count = self.element_count(view, source, owner_ty);
+            statements.push(self.store(slot::VALUE, count));
+            // The decimal renderer reads the magnitude without consuming it,
+            // so the count is still there to pick the noun's number.
+            self.append_decimal(statements);
+            let rendered = self.load(slot::VALUE, Ty::U64);
+            let one = self.constant(1, Ty::U64);
+            let single = self.add(Data::Eq(rendered, one), Ty::Bool);
+            let mut singular = Vec::new();
+            self.append_literal(&mut singular, &format!(" {}>", view.noun.0));
+            let mut plural = Vec::new();
+            self.append_literal(&mut plural, &format!(" {}>", view.noun.1));
+            let branch = self.choose(single, singular, plural);
+            statements.push(branch);
+            return Ok(());
+        };
+        let index_slot = slot::sequence_index(depth);
+        let count_slot = slot::sequence_count(depth);
+        let zero = self.constant(0, Ty::U64);
+        statements.push(self.store(index_slot, zero));
+        let count = self.element_count(view, source, owner_ty);
+        statements.push(self.store(count_slot, count));
+        self.append_literal(statements, "[");
+
+        // The loop stops as soon as the budget is spent: a container with a
+        // million elements would otherwise keep iterating over appends that
+        // copy nothing.
+        let index = self.load(index_slot, Ty::U64);
+        let count = self.load(count_slot, Ty::U64);
+        let remaining = self.add(Data::Lt(index, count), Ty::Bool);
+        let overflowed = self.load(slot::OVERFLOWED, Ty::U64);
+        let zero = self.constant(0, Ty::U64);
+        let room = self.add(Data::Eq(overflowed, zero), Ty::Bool);
+        let condition = self.add(Data::And(remaining, room), Ty::Bool);
+
+        let mut body = Vec::new();
+        let index = self.load(index_slot, Ty::U64);
+        let zero = self.constant(0, Ty::U64);
+        let later = self.add(Data::Gt(index, zero), Ty::Bool);
+        let mut separator = Vec::new();
+        self.append_literal(&mut separator, ", ");
+        body.push(self.guard(later, separator));
+        if view.row.is_some() {
+            let starts = self.row_boundary(view, source, owner_ty, index_slot);
+            let mut open = Vec::new();
+            self.append_literal(&mut open, "[");
+            body.push(self.guard(starts, open));
+        }
+        let element_source = LeafSource::Element(Box::new(ElementSource {
+            container: Box::new(source.clone()),
+            view: view.clone(),
+            index_slot,
+            prefix: Vec::new(),
+        }));
+        self.render_plan(
+            &mut body,
+            &element.plan,
+            &element.ty,
+            &element_source,
             owner_ty,
-            &[],
-            owner_ty.clone(),
+            depth + 1,
+        )?;
+        let index = self.load(index_slot, Ty::U64);
+        let one = self.constant(1, Ty::U64);
+        let next = self.add(Data::Add(index, one), Ty::U64);
+        body.push(self.store(index_slot, next));
+        if view.row.is_some() {
+            let ends = self.row_boundary(view, source, owner_ty, index_slot);
+            let mut close = Vec::new();
+            self.append_literal(&mut close, "]");
+            body.push(self.guard(ends, close));
+        }
+        let body = self.block(body);
+        statements.push(self.add(
+            Data::Loop {
+                cond: condition,
+                body,
+            },
+            Ty::Unit,
+        ));
+        self.append_literal(statements, "]");
+        Ok(())
+    }
+
+    /// Whether the loop index sits on a row boundary — `index % cols == 0`.
+    fn row_boundary(
+        &mut self,
+        view: &ContainerRender,
+        source: &LeafSource,
+        owner_ty: &Ty,
+        index_slot: u32,
+    ) -> u32 {
+        let row = view.row.as_ref().expect("a row boundary needs a row width");
+        let read = self.read_through(source, owner_ty, row, Ty::U64);
+        let zero = self.constant(0, Ty::U64);
+        let usable = self.add(Data::Ne(read, zero), Ty::Bool);
+        let read = self.read_through(source, owner_ty, row, Ty::U64);
+        let one = self.constant(1, Ty::U64);
+        // A zero-width row would trap the division. A grid with no columns has
+        // no cells, so the loop this guards never runs; one keeps the
+        // arithmetic total either way.
+        let width = self.add(
+            Data::Branch {
+                cond: usable,
+                then_value: read,
+                else_value: Some(one),
+            },
+            Ty::U64,
+        );
+        let index = self.load(index_slot, Ty::U64);
+        let position = self.add(Data::Mod(index, width), Ty::U64);
+        let boundary = self.constant(0, Ty::U64);
+        self.add(Data::Eq(position, boundary), Ty::Bool)
+    }
+
+    /// Append a byte string double-quoted, with `\` and `"` escaped.
+    fn append_quoted(
+        &mut self,
+        statements: &mut Vec<u32>,
+        view: &ByteView,
+        source: &LeafSource,
+        owner_ty: &Ty,
+    ) {
+        let pointer_ty = byte_view_pointer_type(view);
+        let pointer = self.read_through(source, owner_ty, &view.pointer, pointer_ty);
+        let address = self.add(
+            Data::Intrinsic {
+                operation: IntrinsicOperation::PtrToInt,
+                name: Arc::from(IntrinsicOperation::PtrToInt.expected_spelling()),
+                args: Arc::new([argument(pointer)]),
+            },
+            Ty::U64,
+        );
+        statements.push(self.store(slot::QUOTED, address));
+        let length = self.read_through(source, owner_ty, &view.length, Ty::U64);
+        statements.push(self.store(slot::QUOTED_LEN, length));
+        let zero = self.constant(0, Ty::U64);
+        statements.push(self.store(slot::QUOTED_CURSOR, zero));
+        self.append_literal(statements, "\"");
+
+        let cursor = self.load(slot::QUOTED_CURSOR, Ty::U64);
+        let limit = self.load(slot::QUOTED_LEN, Ty::U64);
+        let remaining = self.add(Data::Lt(cursor, limit), Ty::Bool);
+        let overflowed = self.load(slot::OVERFLOWED, Ty::U64);
+        let zero = self.constant(0, Ty::U64);
+        let room = self.add(Data::Eq(overflowed, zero), Ty::Bool);
+        let condition = self.add(Data::And(remaining, room), Ty::Bool);
+
+        let mut body = Vec::new();
+        let byte = self.quoted_byte();
+        let quote = self.constant(u64::from(b'"'), Ty::U8);
+        let is_quote = self.add(Data::Eq(byte, quote), Ty::Bool);
+        let byte = self.quoted_byte();
+        let backslash = self.constant(u64::from(b'\\'), Ty::U8);
+        let is_backslash = self.add(Data::Eq(byte, backslash), Ty::Bool);
+        let escaped = self.add(Data::Or(is_quote, is_backslash), Ty::Bool);
+        let mut prefix = Vec::new();
+        self.append_literal(&mut prefix, "\\");
+        body.push(self.guard(escaped, prefix));
+        let one = self.constant(1, Ty::U64);
+        self.append_bytes(&mut body, one, |builder| builder.quoted_pointer());
+        let cursor = self.load(slot::QUOTED_CURSOR, Ty::U64);
+        let one = self.constant(1, Ty::U64);
+        let next = self.add(Data::Add(cursor, one), Ty::U64);
+        body.push(self.store(slot::QUOTED_CURSOR, next));
+        let body = self.block(body);
+        statements.push(self.add(
+            Data::Loop {
+                cond: condition,
+                body,
+            },
+            Ty::Unit,
+        ));
+        self.append_literal(statements, "\"");
+    }
+
+    /// Append the shortest round-trip decimal of an `f32`/`f64`.
+    ///
+    /// The formatting itself is the runtime's, through the one helper
+    /// `@to_string` and `@dbg` already share, so there is exactly one float
+    /// spelling in the language. The helper answers through an out-pointer with
+    /// the runtime ABI's own `{ptr, cap, len}` shape; this body receives it as
+    /// three machine words rather than as a `StrBuf`, which is a
+    /// standard-library type the printer may not name.
+    fn append_float(
+        &mut self,
+        statements: &mut Vec<u32>,
+        source: &LeafSource,
+        owner_ty: &Ty,
+        leaf_ty: &Ty,
+    ) {
+        let narrow = *leaf_ty == Ty::F32;
+        let read = self.read_leaf(source, owner_ty, leaf_ty);
+        let pattern_ty = if narrow { Ty::U32 } else { Ty::U64 };
+        let bits = self.add(
+            Data::Intrinsic {
+                operation: IntrinsicOperation::BitCast,
+                name: Arc::from(IntrinsicOperation::BitCast.expected_spelling()),
+                args: Arc::new([argument(read)]),
+            },
+            pattern_ty.clone(),
+        );
+        // An `f32` crosses the ABI zero-extended into the same `u64` the
+        // helper's width discriminator then interprets.
+        let bits = self.widen(bits, &pattern_ty, Ty::U64);
+        let width = self.constant(
+            u64::from(if narrow {
+                rue_runtime_abi::FLOAT_WIDTH_F32
+            } else {
+                rue_runtime_abi::FLOAT_WIDTH_F64
+            }),
+            Ty::U32,
+        );
+        let text = self.add(
+            Data::RuntimeCall {
+                runtime: RuntimeCallKind::ToStringFloat,
+                args: Arc::new([argument(bits), argument(width)]),
+            },
+            float_text_type(),
+        );
+        let slot = self.float_slot;
+        statements.push(self.store(slot, text));
+        let length = self.float_word(FLOAT_TEXT_LEN);
+        self.append_bytes(statements, length, |builder| {
+            let address = builder.float_word(FLOAT_TEXT_POINTER);
+            builder.add(
+                Data::Intrinsic {
+                    operation: IntrinsicOperation::IntToPtr,
+                    name: Arc::from(IntrinsicOperation::IntToPtr.expected_spelling()),
+                    args: Arc::new([argument(address)]),
+                },
+                byte_pointer_type(),
+            )
+        });
+    }
+
+    /// One word of the float formatter's result.
+    fn float_word(&mut self, index: u64) -> u32 {
+        let position = self.constant(index, Ty::U64);
+        let slot = self.float_slot;
+        let place = self.place(Place {
+            base: AirPlaceBase::Local(slot),
+            base_type: float_text_type(),
+            projections: Arc::new([Projection::Index {
+                array_type: float_text_type(),
+                index: position,
+            }]),
+        });
+        self.add(Data::PlaceRead { place }, Ty::U64)
+    }
+
+    /// The address of the byte a quoted rendering is at.
+    fn quoted_pointer(&mut self) -> u32 {
+        let address = self.load(slot::QUOTED, Ty::U64);
+        let base = self.add(
+            Data::Intrinsic {
+                operation: IntrinsicOperation::IntToPtr,
+                name: Arc::from(IntrinsicOperation::IntToPtr.expected_spelling()),
+                args: Arc::new([argument(address)]),
+            },
+            byte_pointer_type(),
+        );
+        let cursor = self.load(slot::QUOTED_CURSOR, Ty::U64);
+        self.add(
+            Data::Intrinsic {
+                operation: IntrinsicOperation::PtrOffset,
+                name: Arc::from(IntrinsicOperation::PtrOffset.expected_spelling()),
+                args: Arc::new([argument(base), argument(cursor)]),
+            },
+            byte_pointer_type(),
+        )
+    }
+
+    /// The byte a quoted rendering is at.
+    fn quoted_byte(&mut self) -> u32 {
+        let pointer = self.quoted_pointer();
+        self.add(
+            Data::Intrinsic {
+                operation: IntrinsicOperation::PtrRead,
+                name: Arc::from(IntrinsicOperation::PtrRead.expected_spelling()),
+                args: Arc::new([argument(pointer)]),
+            },
+            Ty::U8,
         )
     }
 
@@ -1146,12 +2384,9 @@ impl Builder {
     /// different branch arms.
     fn read_leaf(&mut self, source: &LeafSource, owner_ty: &Ty, leaf_ty: &Ty) -> u32 {
         match source {
-            LeafSource::Projected(projections) => self.rooted_read(
-                &PlaceRoot::Param(Vec::new()),
-                owner_ty,
-                projections,
-                leaf_ty.clone(),
-            ),
+            LeafSource::Projected(_) | LeafSource::Local { .. } | LeafSource::Element(_) => {
+                self.read_through(source, owner_ty, &[], leaf_ty.clone())
+            }
             LeafSource::Payload {
                 base,
                 enum_key,
@@ -1177,16 +2412,18 @@ impl Builder {
         projections: &[PrinterProjection],
         ty: Ty,
     ) -> u32 {
-        let (base, prefix) = match root {
-            PlaceRoot::Param(prefix) => (AirPlaceBase::Param(0), prefix.as_slice()),
-            PlaceRoot::Local(slot) => (AirPlaceBase::Local(*slot), [].as_slice()),
+        let base = match root {
+            PlaceRoot::Param => AirPlaceBase::Param(0),
+            PlaceRoot::Local(slot) => AirPlaceBase::Local(*slot),
+            PlaceRoot::Indirect(pointer) => {
+                AirPlaceBase::Indirect(rue_air::AirRef::from_raw(*pointer))
+            }
         };
         let place = self.place(Place {
             base,
             base_type: base_type.clone(),
-            projections: prefix
+            projections: projections
                 .iter()
-                .chain(projections)
                 .map(|step| Projection::Field {
                     struct_key: step.nominal.clone(),
                     field_index: step.field_index,

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -264,6 +264,29 @@ impl crate::error_printer::ErrorPrinterTypes for LocalFactSelectionIndex<'_> {
             .flatten()
     }
 
+    fn std_container(&self, ty: &crate::TypeInstanceKey) -> Option<rue_air::StdContainer> {
+        // A standard container is an anonymous struct minted by a std type
+        // function, so the identity to gate on is the *producer's*, reached
+        // through the same trusted-provenance boundary a language item uses.
+        let crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(key)) = ty else {
+            return None;
+        };
+        if key.kind != rue_air::AnonymousNominalKind::Struct {
+            return None;
+        }
+        let crate::StableProducerId::Function(function) = &key.producer else {
+            return None;
+        };
+        let definition = crate::semantic_identity::function_base_definition(function)?;
+        if !definition.module().is_trusted_standard_library() {
+            return None;
+        }
+        rue_air::StdContainer::from_standard_library_type_function(
+            definition.module().as_str(),
+            definition.name(),
+        )
+    }
+
     fn type_name(&self, ty: &crate::TypeInstanceKey) -> Arc<str> {
         Arc::from(crate::durable_comptime::durable_type_diagnostic_name(
             &crate::semantic_identity::semantic_type_from_instance(ty),

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -355,7 +355,19 @@ pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[
          `crates/rue-compiler/src/test_image_tests.rs::platform_native_the_reported_payload_is_the_rendered_error`, \
          which pins one shape per rule — `None`, a unit variant, a payload variant \
          carrying a negative integer and a byte string, and a struct — and by the \
-         session test that proves one printer serves every site on an error type.",
+         session test that proves one printer serves every site on an error type. \
+         The standard-container and float rules need the real standard library, \
+         so they are covered by the CLI cases in \
+         `crates/rue-cli-tests/cases/rue_test_assert.toml` \
+         (`a_container_comparison_renders_its_elements`, \
+         `a_container_rendering_shows_length_and_element_differences`, \
+         `each_standard_container_renders_in_its_own_order`, \
+         `a_container_of_records_renders_each_record`, \
+         `a_container_the_printer_cannot_look_inside_renders_its_size`, \
+         `a_long_container_is_truncated_mid_list`, \
+         `a_float_operand_renders_its_digits`) and \
+         `rue_test_question.toml::an_unhandled_container_error_renders_its_elements`, \
+         which drives the same printer from a `?` payload.",
     ),
     (
         "6.7:16",

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -399,6 +399,14 @@ exact longest-common-subsequence expensive is reported as one wholesale
 `delete` followed by one `insert` rather than refined — the invariants above
 hold either way.
 
+There is no element-aware granularity, and none is needed for the list a
+standard container renders as (spec 6.7:15): the common prefix and suffix a
+character diff strips are whole elements plus their separators, so
+`[1, 2, 3]` against `[1, 2, 4]` reports `equal "[1, 2, "`, `delete "3"`,
+`insert "4"`, `equal "]"` — the differing element, located. A container long
+enough to be truncated is cut inside its list and carries the marker, so the
+diff of a truncated pair is a diff of prefixes and says so.
+
 A rendering that is not valid UTF-8 never reaches the diff: `left` and
 `right` are JSON string fields, and a channel line that is not valid UTF-8 is
 rejected as malformed before it becomes a frame at all, yielding `fail` with

--- a/docs/spec/src/03-types/12-floating-point-types.md
+++ b/docs/spec/src/03-types/12-floating-point-types.md
@@ -371,8 +371,9 @@ fn main() -> i32 {
 
 {{ rule(id="3.12:39", cat="normative") }}
 
-`@dbg` (4.13:6) and `@to_string` (§3.7) accept a floating-point argument. The
-text they produce for it is defined by 3.12:40 through 3.12:42.
+`@dbg` (4.13:6) and `@to_string` (§3.7) accept a floating-point argument, and a
+reported failure payload (6.7:15) may contain one. The text produced for it is
+defined by 3.12:40 through 3.12:42, whichever of them asks for it.
 
 {{ rule(id="3.12:40", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -180,7 +180,9 @@ and terminates with status 101, exactly as `@assert` does.
 
 Inside a test image the same failure is additionally reported as structured
 data: a record naming the failing kind, the intrinsic's source location, and
-both operands rendered as `left` and `right`. A failed `@assert` (4.13:5d) is
+both operands rendered as `left` and `right` by the rules 6.7:15 states for a
+rendered payload — the same synthesized printer serves both. A failed
+`@assert` (4.13:5d) is
 reported the same way, naming the kind `assert`, the intrinsic's source
 location, and the message it wrote to standard error — the pinned
 `assertion failed`, or the supplied one. Ordinary builds are unaffected — the

--- a/docs/spec/src/06-items/07-tests.md
+++ b/docs/spec/src/06-items/07-tests.md
@@ -182,14 +182,42 @@ truncated to it and the marker ` …[truncated]` is appended.
   declaration order, parenthesized and comma-separated, when it has one:
   `Invalid(-7, bad)`.
 - An integer renders in decimal, with a leading `-` when it is negative. A
-  `bool` renders as `true` or `false`.
+  `bool` renders as `true` or `false`. An `f32` or `f64` renders exactly as
+  3.12:40 through 3.12:42 define, through the same formatter `@to_string` uses.
 - A byte string — a `str`, a fixed `Str(N)`, or a `StrBuf` — renders as its own
   bytes, verbatim.
 - A struct renders as `{ field: value, … }`: each field's name, then its
   rendered value, in declaration order.
-- Rendering descends one level. A value reached inside a rendered struct field
-  or enum payload that is itself an aggregate renders as the name of its type,
-  and so does any value these rules cannot otherwise render.
+- A *standard container* — one of the trusted standard library's collection
+  types `ArrayBuf(T)`, `Deque(T)`, `Stack(T)`, `Queue(T)`, `BinaryHeap(T)`,
+  `Grid2D(T)`, `StrMap(V)` and `IntMap(V)` — renders by what it holds, never by
+  its own fields. A container is recognized by that standard-library identity,
+  so a user type of the same shape, or of the same name, is not one.
+- A sequence container renders as `[`, then its elements separated by `, `,
+  then `]`: `[1, 2, 3]`, and `[]` when it is empty. Each element renders by
+  these same rules *as if it were the reported value itself*, because a
+  container is transparent to the one-level rule below: a struct element renders
+  as `{ x: 1 }` and an enum element as `Some(3)`, and it is that element's own
+  fields and payloads which fall to the type-name rule.
+  The order is the container's own — front to back for a `Deque(T)` and a
+  `Queue(T)`, bottom to top for a `Stack(T)`, and storage order rather than
+  sorted order for a `BinaryHeap(T)`. A `Grid2D(T)` is row-major and brackets
+  each row: a two-by-three grid renders as `[[1, 0, 0], [0, 0, 9]]`. A byte
+  string reached as an element renders double-quoted with `\` and `"` escaped,
+  rather than verbatim, so that no element can be mistaken for two.
+- A container whose elements these rules cannot render — because an element is a
+  value they can only *name*, such as a raw pointer, or because the container is
+  nested inside more than four enclosing containers — renders as its type name
+  followed by its size instead: `ArrayBuf(Foo) <3 elements>`, and `<1 element>`
+  for one.
+  `StrMap(V)` and `IntMap(V)` always take that form —
+  `StrMap(i64) <2 entries>` — because their live entries are reached through a
+  representation this rendering does not read.
+- Rendering descends one level, and through a standard container. A value
+  reached inside a rendered struct field or enum payload that is itself an
+  aggregate renders as the name of its type, and so does any value these rules
+  cannot otherwise render; but a standard container reached there renders by its
+  elements, and so does a standard container reached as another one's element.
 
 {{ rule(id="6.7:16", cat="normative") }}
 


### PR DESCRIPTION
Fixes RUE-2165

## Problem

`@assert_eq` on two standard containers rendered both sides as the container's own fields, `{ core: RawBuf(i64), len: 3 }`, and produced a diff with one `equal` op. The structural printer descends one level and never read a heap buffer, so every `ArrayBuf`, `Deque`, `Stack`, `Queue`, `BinaryHeap`, `Grid2D`, `StrMap`, and `IntMap` comparison looked identical on both sides whatever it held. Float leaves had never rendered at all: an `f64` operand reported `f64`.

## Change

- The compiler-synthesized structural printer recognizes the standard containers by the identity of the std type function that minted them, never by field shape, so a user struct of the same shape or name is not one. Once recognized, a container's length and element storage are located structurally, the way a `StrBuf`'s byte view already was, and a shape that stops matching degrades to the type-name rendering rather than reading a stale projection.
- Sequence containers render by their elements: `[1, 2, 3]`, `[]`, `[true, false]`, `["a", "b, c"]` with byte strings quoted and escaped so no element reads as two, `[{ x: 1, y: true }]` for records, `[Some(3), None]` for enums, and nested containers to a depth of four. Order is the container's own: front to back for `Deque` and `Queue`, bottom to top for `Stack`, storage order for `BinaryHeap`, row-major with one bracket per row for `Grid2D`.
- A container is transparent to the one-level rule: an element renders as if it were the reported value itself, and it is that element's aggregate fields that fall to the type-name rule. Elements the rules can only name, and nesting past the cap, render as `ArrayBuf(Foo) <3 elements>`. `StrMap` and `IntMap` render `<n entries>`, since their live entries sit behind a private occupancy marker in std that the compiler should not hardcode.
- `f32` and `f64` leaves render through the runtime's float-to-text helper, the one `@dbg` uses, at their own width: `2.5`, `1.25`, `[1.5, -2.25]`, `[NaN, inf]`.
- The existing 4096-byte bound and ` …[truncated]` marker are unchanged; the element loop stops as soon as the budget is spent.
- Elements are read with `@ptr_read` into a local of their own rather than through an indirect place projection, because that projection loads a sub-word scalar as a whole word (RUE-2168, filed separately); the comment at the read says so.
- Spec 6.7:15 gains the container and float rules; 3.12:39 names the reported payload as a consumer of the float text rules; `docs/process/test-events.md` shows the diff a list rendering produces.

The printer is synthesized AIR, so no backend work was needed; the record, float, and enum-element printers were compiled for all three targets.

## Verification

- `scripts/rue spec 6.7`: 15 passed. `scripts/rue spec 3.12`: 77 passed. `scripts/rue cli rue_test`: 113 passed (seven new assertion cases, one new `?` case).
- `//:spec-traceability`, `//:compiler-spec-machine-index`: pass. `//tests/std:std-tests`: 157 passed. `//examples:gazette-tests`: 35 passed. `scripts/rue quick`: 36 targets pass.
- `scripts/rue premerge`: pass 220, fail 0.
- Reviewer probes at `-O0` and `-O2`: `u8`, `bool`, `f64` (including NaN and inf), `StrBuf`, record, enum, and nested-record elements, a `Deque` after wraparound, a 5000-element buffer truncating mid-list, a `?` payload container, and an `assert_ne(a, a)` on `ArrayBuf(StrBuf)` that renders both sides without disturbing the container, which is possible because the printer body has no drop schedule.
