### PR TITLE
RUE-2161: a callable const alias names the same callee its target does

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -6,7 +6,9 @@
 //! loan, move, and representation coercion decisions delegate to
 //! `analysis::ownership`.
 
-use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
+use super::super::ordinary_engine::{
+    OrdinaryBodyAnalysisHost, OrdinaryBodyEngine, ResolvedCalleeName,
+};
 use super::*;
 use crate::sema::NamedConstDependencyTargetEvent;
 use crate::sema::context::DivergenceKind;
@@ -276,63 +278,45 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         let source_name = name;
-        let mut name = name;
-        let mut resolved_alias = false;
-        let const_info = self
-            .call_facts()
-            .call_resolve_const_info_in_file(name, span.file_id);
-        if let Some(const_info) = const_info
-            && let Some(callee) = const_info.value.as_function()
-        {
-            let alias_name = self.body_interner().resolve(&name).to_string();
-            self.check_item_visibility(
-                crate::PrivateItemKind::Const,
-                &alias_name,
-                const_info.span.file_id,
-                const_info.is_pub,
-                span,
-            )?;
-            self.record_body_named_dependency(NamedConstDependencyTargetEvent::ValueConst {
-                file: const_info.span.file_id.index(),
-                name: alias_name,
-            });
-            name = callee.spur();
-            resolved_alias = true;
-        }
-
-        let local_name = (!resolved_alias)
-            .then(|| {
-                self.call_facts()
-                    .call_resolve_function_name_local(name, span.file_id)
-            })
-            .flatten();
-        if let Some(local_name) = local_name {
-            name = local_name;
-        }
-
-        // `print(s)` / `println(s)` / `eprint(s)` / `eprintln(s)` are builtin
-        // free functions, not
-        // user-defined ones: intercept them here before the function lookup,
-        // but only when the program hasn't shadowed the name with its own
-        // `fn print`/`fn println`/`fn eprint`/`fn eprintln` (a user definition
-        // wins, keeping these names unreserved).
-        if !resolved_alias
-            && local_name.is_none()
-            && (source_name == self.known_symbols().print
+        // One resolution order for the callee name, shared with the staged
+        // inference pre-pass and comptime call admission (RUE-2161).
+        let Some(resolved) = self.resolve_callee_name(name, span.file_id) else {
+            // `print(s)` / `println(s)` / `eprint(s)` / `eprintln(s)` are
+            // builtin free functions, not user-defined ones: intercept them
+            // here, but only when the program hasn't shadowed the name with
+            // its own `fn print`/`fn println`/`fn eprint`/`fn eprintln` (a
+            // user definition wins, keeping these names unreserved).
+            if source_name == self.known_symbols().print
                 || source_name == self.known_symbols().println
                 || source_name == self.known_symbols().eprint
-                || source_name == self.known_symbols().eprintln)
-        {
-            return self.analyze_print_builtin(air, source_name, args_range, span, ctx);
-        }
-
-        if !resolved_alias && local_name.is_none() {
+                || source_name == self.known_symbols().eprintln
+            {
+                return self.analyze_print_builtin(air, source_name, args_range, span, ctx);
+            }
             let fn_name_str = self.body_interner().resolve(&source_name).to_string();
             return Err(CompileError::new(
                 ErrorKind::UndefinedFunction(fn_name_str),
                 span,
             ));
-        }
+        };
+        let name = match resolved {
+            ResolvedCalleeName::Local(local) => local,
+            ResolvedCalleeName::Alias { callee, alias } => {
+                let alias_name = self.body_interner().resolve(&source_name).to_string();
+                self.check_item_visibility(
+                    crate::PrivateItemKind::Const,
+                    &alias_name,
+                    alias.span.file_id,
+                    alias.is_pub,
+                    span,
+                )?;
+                self.record_body_named_dependency(NamedConstDependencyTargetEvent::ValueConst {
+                    file: alias.span.file_id.index(),
+                    name: alias_name,
+                });
+                callee
+            }
+        };
 
         // Look up the function
         let source_name = self.call_facts().call_source_function_name(name);

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -1406,6 +1406,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// passes `None`; receivers that name module bindings, including
     /// re-export chains, are resolved through the canonical file/module
     /// visibility walk.
+    ///
+    /// Both shapes resolve the callee name through
+    /// [`OrdinaryBodyEngine::resolve_callee_name_local`], so a call spelled
+    /// through a function-valued `const` alias is the same fact site as the
+    /// target's own spelling. When it was not, the alias spelling produced no
+    /// canonical comptime arguments, the receiver's type arrived only after
+    /// literal defaulting had already chosen `i32`, and an integer literal
+    /// stopped unifying with the method result (RUE-2161).
     fn generic_callee_key(
         &mut self,
         inst_data: &rue_rir::InstData,
@@ -1414,7 +1422,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> Option<Spur> {
         match inst_data {
             rue_rir::InstData::Call { name, .. } => Some(
-                self.resolve_function_name_local(*name, span.file_id)
+                self.resolve_callee_name_local(*name, span.file_id)
                     .unwrap_or(*name),
             ),
             rue_rir::InstData::MethodCall {
@@ -1423,7 +1431,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let module =
                     self.method_receiver_module(*receiver, span.file_id, resolved_types)?;
                 let module_file = self.module_def(module).file_id;
-                self.resolve_function_name_local(*method, module_file)
+                self.resolve_callee_name_local(*method, module_file)
             }
             _ => None,
         }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1351,16 +1351,39 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // function key here. Unqualified callers pass a source name, which
         // must be resolved by the current environment's defining file. Keep
         // those representations explicit so neither path can fall back to a
-        // graph-global source-name lookup.
-        let resolved = if name_is_resolved_key {
-            self.function_info(name).map(|info| (name, info))
+        // graph-global source-name lookup. An unqualified source name may be
+        // a function-valued `const` alias; it resolves to the same callee key
+        // the target's own spelling resolves to (RUE-2161).
+        let (resolved, alias) = if name_is_resolved_key {
+            (self.function_info(name).map(|info| (name, info)), None)
         } else {
-            self.resolve_function_name_local(name, file_id)
-                .and_then(|key| self.function_info(key).map(|info| (key, info)))
+            let resolved = self.resolve_callee_name(name, file_id);
+            let alias = match &resolved {
+                Some(super::ordinary_engine::ResolvedCalleeName::Alias { alias, .. }) => {
+                    Some(alias.clone())
+                }
+                _ => None,
+            };
+            (
+                resolved
+                    .map(super::ordinary_engine::ResolvedCalleeName::callee)
+                    .and_then(|key| self.function_info(key).map(|info| (key, info))),
+                alias,
+            )
         };
         let Some((name_key, fn_info)) = resolved else {
             return Ok(None);
         };
+        // A function-valued `const` alias is a second name for the callee, so
+        // the site depends on the alias as well as on the target (RUE-2161).
+        // Recording only the target would let an edit that repoints the alias
+        // leave this site's cached result standing.
+        if let Some(alias) = alias {
+            self.record_body_named_dependency(super::NamedConstDependencyTargetEvent::ValueConst {
+                file: alias.span.file_id.index(),
+                name: self.body_interner().resolve(&name).to_string(),
+            });
+        }
         let is_type_fn = self.function_returns_type(&fn_info);
         self.record_body_named_dependency(super::NamedConstDependencyTargetEvent::FreeFunction {
             file: fn_info.file_id.index(),

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -504,6 +504,27 @@ pub(crate) trait OrdinaryBodyAnalysisHost:
 {
 }
 
+/// How an unqualified call name reached its callee (RUE-2161).
+///
+/// The callee key is the same either way; the alias arm additionally carries
+/// the constant the name was bound by, because a site that reached its callee
+/// through an alias depends on that constant as well as on the target.
+#[derive(Debug, Clone)]
+pub(crate) enum ResolvedCalleeName {
+    /// A function declared in the naming file.
+    Local(Spur),
+    /// A `const F = <function>;` binding in the naming file.
+    Alias { callee: Spur, alias: ConstInfo },
+}
+
+impl ResolvedCalleeName {
+    pub(crate) fn callee(self) -> Spur {
+        match self {
+            Self::Local(callee) | Self::Alias { callee, .. } => callee,
+        }
+    }
+}
+
 /// Inherent-method receiver for the generic ordinary-body algorithm.
 ///
 /// The engine owns no analyzer representation or alternate semantic algorithm.
@@ -730,6 +751,48 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     }
     pub(crate) fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
         DeclarationFacts::resolve_function_name_local(self.storage, name, file)
+    }
+    /// The callee a function-valued `const` alias names, with the alias's own
+    /// constant, when `name` is bound in `file` by `const F = <function>;`.
+    ///
+    /// The callee symbol is the exact internal key the target's own spelling
+    /// resolves to, so an alias is a second name for one callee rather than a
+    /// second callee (RUE-2161).
+    pub(crate) fn const_function_alias(
+        &self,
+        file: FileId,
+        name: Spur,
+    ) -> Option<(Spur, ConstInfo)> {
+        let info = self.value_const(&(file, name))?;
+        let callee = info.value.as_function()?;
+        Some((callee.spur(), info))
+    }
+    /// How an unqualified source name reaches its callee in `file`.
+    ///
+    /// One resolution order for every consumer: a file-local function name,
+    /// and only when there is none, a function-valued `const` alias. Canonical
+    /// merge validation rejects a file that declares both, so the order is a
+    /// cost decision — an ordinary call pays no constant lookup — rather than
+    /// a precedence rule. Call analysis, the staged inference pre-pass, and
+    /// comptime call admission all read this, so a call spelled through an
+    /// alias reaches the same callee identity — and therefore the same
+    /// specialization, signature, and inference facts — as the target's own
+    /// spelling (RUE-2161).
+    pub(crate) fn resolve_callee_name(
+        &self,
+        name: Spur,
+        file: FileId,
+    ) -> Option<ResolvedCalleeName> {
+        if let Some(local) = self.resolve_function_name_local(name, file) {
+            return Some(ResolvedCalleeName::Local(local));
+        }
+        let (callee, alias) = self.const_function_alias(file, name)?;
+        Some(ResolvedCalleeName::Alias { callee, alias })
+    }
+    /// The internal callee key [`Self::resolve_callee_name`] selects.
+    pub(crate) fn resolve_callee_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
+        self.resolve_callee_name(name, file)
+            .map(ResolvedCalleeName::callee)
     }
     pub(crate) fn module_def(&self, module: ModuleId) -> ModuleDef {
         DeclarationFacts::module_def(self.storage, module)

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -4034,8 +4034,20 @@ where
                     .map(|definition| definition.file_id)
             })
             .unwrap_or_else(|| authority.file());
-        let Some(symbol) = self.function_for_file_symbol(file, name) else {
-            return Ok(None);
+        // A function-valued `const` alias names the same constructor the
+        // target's own spelling names, so `Alias(i64)` in type position
+        // resolves to one head and one specialization (RUE-2161).
+        let (symbol, alias) = match self.function_for_file_symbol(file, name) {
+            Some(symbol) => (symbol, None),
+            None => {
+                let Some(info) = self.const_info_for_symbol(file, name) else {
+                    return Ok(None);
+                };
+                let Some(callee) = info.value.as_function() else {
+                    return Ok(None);
+                };
+                (callee.spur(), Some(info))
+            }
         };
         let Some((_, definition)) = self.function_token_for_symbol(symbol) else {
             return Ok(None);
@@ -4043,10 +4055,19 @@ where
         let Some(signature) = DurableCallableSource::function(&self.source, &definition) else {
             return Ok(None);
         };
-        let site = self
-            .source
-            .definition_source(&definition)
-            .map_or(file, |locator| locator.file_id);
+        // Visibility follows the name that was written: a `pub` alias
+        // re-exports a private constructor and a private alias is rejected as
+        // the constant it is (10.4:22, ADR-0026), exactly as expression
+        // position already decides it.
+        let (site, is_public) = match &alias {
+            Some(info) => (info.span.file_id, info.is_pub),
+            None => (
+                self.source
+                    .definition_source(&definition)
+                    .map_or(file, |locator| locator.file_id),
+                signature.is_public,
+            ),
+        };
         let defining_file = self
             .source
             .source_path(site)
@@ -4068,7 +4089,7 @@ where
             site,
             parameters: parameters.into(),
             returns_type: self.callable_returns_type(&signature, signature.type_syntax.as_ref()),
-            is_public: signature.is_public,
+            is_public,
             defining_domain: crate::SemanticVisibilityDomain::from_file_path(Some(
                 defining_file.as_ref(),
             )),

--- a/crates/rue-cli-tests/cases/const_function_alias_type.toml
+++ b/crates/rue-cli-tests/cases/const_function_alias_type.toml
@@ -1,0 +1,109 @@
+# A callable const alias of a type constructor (`const P = lib.Pair;`, spec
+# 6.5:15) is usable wherever the target's own spelling is (spec 4.14:23):
+# member types, signatures, and another constant's initializer (RUE-2161).
+# RUE-603 taught those positions about a const *type* alias (`const P =
+# lib.Pair(i32);`); the callee behind an unapplied alias is resolved on the
+# same path, so both spellings reach one declaration. Driven through the real
+# binary with a two-file import so the cross-module resolution is exercised.
+
+[section]
+id = "cli.const_function_alias_type"
+name = "Callable const alias in type position"
+description = "`const P = lib.Pair;` heads a type-constructor application in member, signature, and constant-initializer position (RUE-2161)."
+
+[[case]]
+name = "alias_as_struct_field_and_enum_payload"
+description = "A callable alias of an imported generic is a valid struct-field AND enum-payload type."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "lib.rue", source = """
+pub fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+""" },
+  { path = "main.rue", source = """
+const lib = @import("lib.rue");
+const P = lib.Pair;
+struct Holder { p: P(i32) }
+enum Maybe { Has(P(i32)), No }
+fn main() -> i32 {
+    let h = Holder { p: P(i32) { a: 20, b: 1 } };
+    let extra = match Maybe.Has(P(i32) { a: 20, b: 1 }) {
+        Maybe.Has(q) => q.a + q.b,
+        Maybe.No => 0,
+    };
+    h.p.a + h.p.b + extra
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "alias_in_signature_and_constant_initializer"
+description = "A callable alias heads a parameter type, a return type, and another constant's initializer."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "lib.rue", source = """
+pub fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+""" },
+  { path = "main.rue", source = """
+const lib = @import("lib.rue");
+const P = lib.Pair;
+const PI = P(i32);
+fn make() -> P(i32) { PI { a: 20, b: 22 } }
+fn total(borrow p: PI) -> i32 { p.a + p.b }
+fn main() -> i32 {
+    let p = make();
+    total(borrow p)
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "alias_use_before_alias_declaration"
+description = "A signature naming `P(i32)` written above `const P = Pair` resolves (declaration order must not matter)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn get(borrow p: P(i32)) -> i32 { p.a + p.b }
+const P = Pair;
+fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+fn main() -> i32 {
+    let p = P(i32) { a: 20, b: 22 };
+    get(borrow p)
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "pub_alias_reexports_a_private_generic"
+description = "A `pub` alias re-exports the constructor behind it, in type position exactly as in expression position (10.4:22, ADR-0026)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "sub/lib.rue", source = """
+fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+pub const P = Pair;
+""" },
+  { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+fn total(borrow p: lib.P(i32)) -> i32 { p.a + p.b }
+fn main() -> i32 {
+    let p = lib.P(i32) { a: 20, b: 22 };
+    total(borrow p)
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "private_alias_across_directories_is_rejected_as_the_constant"
+description = "A private alias named from another directory reports the constant, not the constructor behind it."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "sub/lib.rue", source = """
+pub fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+const P = Pair;
+""" },
+  { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+fn total(borrow p: lib.P(i32)) -> i32 { p.a + p.b }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0706", "const `P` is private"]

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4352,7 +4352,7 @@ pub(super) use register_parse_import_parse;"#;
             (
                 "revisioned_database::tests::semantic_declaration".to_owned(),
                 "RevisionedQueryDatabase:call".to_owned(),
-                50
+                51
             ),
         ],
         "independent test databases have a separate exact construction inventory",

--- a/crates/rue-compiler/src/durable_comptime/host.rs
+++ b/crates/rue-compiler/src/durable_comptime/host.rs
@@ -120,6 +120,11 @@ impl<'a, A: DurableComptimeHostAuthority + ?Sized> DurableComptimeHost<'a, A> {
         self.services
             .durable_session_mut()
             .observe_dependency(start.dependency.clone());
+        if let Some(alias) = start.alias_dependency.clone() {
+            self.services
+                .durable_session_mut()
+                .observe_dependency(alias);
+        }
         let modes = argument_modes
             .iter()
             .map(|(mode, _)| match mode {
@@ -1517,6 +1522,11 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeStructuredTypes
         self.services
             .durable_session_mut()
             .observe_dependency(start.dependency.clone());
+        if let Some(alias) = start.alias_dependency.clone() {
+            self.services
+                .durable_session_mut()
+                .observe_dependency(alias);
+        }
         let admission = match self
             .services
             .finish_structured_comptime_call_admission(start, argument_count)

--- a/crates/rue-compiler/src/durable_comptime/lifecycle.rs
+++ b/crates/rue-compiler/src/durable_comptime/lifecycle.rs
@@ -1844,6 +1844,11 @@ pub(crate) struct DurableComptimeCallableAdmissionStart {
     pub(crate) configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
     pub(crate) name: Arc<str>,
     pub(crate) dependency: SemanticDeclarationDependency,
+    /// The function-valued `const` the call reached its callee through, when
+    /// the call was spelled with an alias (RUE-2161). The site depends on the
+    /// alias as well as on the target, so repointing `const F = g;` from `f`
+    /// to `g` invalidates every call that named `F`.
+    pub(crate) alias_dependency: Option<SemanticDeclarationDependency>,
 }
 
 /// The immutable, ordered facts admitted for one durable comptime callable.

--- a/crates/rue-compiler/src/durable_comptime/structured.rs
+++ b/crates/rue-compiler/src/durable_comptime/structured.rs
@@ -2660,6 +2660,7 @@ pub(super) mod structured_type_adapter_tests {
                         head.clone(),
                     ),
                 },
+                alias_dependency: None,
             })
         }
 
@@ -2928,6 +2929,9 @@ pub(super) mod structured_type_adapter_tests {
             let initial_active = session.active_calls_for_test();
             let initial_programs = session.program_count_for_test();
             session.observe_dependency(start.dependency.clone());
+            if let Some(alias) = start.alias_dependency.clone() {
+                session.observe_dependency(alias);
+            }
             let result = {
                 let services = DurableComptimeServices::new(&mut authority);
                 services.finish_structured_comptime_call_admission(start, 2)

--- a/crates/rue-compiler/src/revisioned_query_database/body/closure_nucleus.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/closure_nucleus.rs
@@ -242,6 +242,7 @@ pub(crate) fn semantic_nucleus_failure_is_internal_error(
     let kind = match failure {
         F::Diagnostic(kind)
         | F::DiagnosticAtParameter { kind, .. }
+        | F::DiagnosticAtSignatureType { kind, .. }
         | F::DiagnosticAtDeclaration { kind, .. }
         | F::DuplicateDeclaration { kind, .. }
         | F::DiagnosticAtProducerRange { kind, .. }

--- a/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
@@ -231,6 +231,65 @@ pub(in crate::revisioned_query_database) struct DurableComptimeRootAuthority<'db
 }
 
 impl<'db> DurableComptimeRootAuthority<'db> {
+    /// Admit a comptime call whose callee is named by a function-valued
+    /// `const` alias.
+    ///
+    /// A `const F = f;` alias is a second name for one callee, so the call is
+    /// admitted against the target's own declaration — the same admission the
+    /// target's own spelling produces — and additionally records a dependency
+    /// on the alias constant (RUE-2161).
+    fn begin_aliased_comptime_call_admission(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        module: &ModuleId,
+        name: &str,
+    ) -> Result<
+        crate::durable_comptime::DurableComptimeCallableAdmissionStart,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        type Failure = crate::semantic_query_nucleus::SemanticNucleusFailure;
+
+        let undefined = || {
+            rue_air::SemanticProviderError::Failure(Failure::Resolution(Arc::from(format!(
+                "undefined comptime function `{name}`"
+            ))))
+        };
+        let Some(alias) =
+            self.provider
+                .candidate_from(accessing_source, module, name, DefinitionKind::Const)?
+        else {
+            return Err(undefined());
+        };
+        let crate::semantic_query_nucleus::ConstResolutionProjection::Value { key, value, .. } =
+            self.provider.const_resolution(alias)?
+        else {
+            return Err(undefined());
+        };
+        let crate::durable_semantics::DurableConstValue::Function(target) = *value else {
+            return Err(undefined());
+        };
+        let mut start =
+            crate::durable_comptime::DurableComptimeSemanticAuthority::begin_comptime_call_admission_for_key(
+                self,
+                accessing_source,
+                &target,
+            )?;
+        start.alias_dependency = Some(
+            crate::semantic_query_nucleus::SemanticDeclarationDependency {
+                source: accessing_source.clone(),
+                kind: rue_air::DeclarationTypeDependencyKind::Body,
+                target:
+                    crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
+                        key,
+                    ),
+            },
+        );
+        Ok(start)
+    }
+
     pub(in crate::revisioned_query_database) fn finish_root(
         mut self,
     ) -> SemanticNucleusTypeProvider<'db> {
@@ -603,8 +662,6 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
             crate::semantic_query_nucleus::SemanticNucleusFailure,
         >,
     > {
-        type Failure = crate::semantic_query_nucleus::SemanticNucleusFailure;
-
         let candidate = self.provider.candidate_from(
             accessing_source,
             module,
@@ -612,9 +669,7 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
             DefinitionKind::Function,
         )?;
         let Some(candidate) = candidate else {
-            return Err(rue_air::SemanticProviderError::Failure(
-                Failure::Resolution(Arc::from(format!("undefined comptime function `{name}`"))),
-            ));
+            return self.begin_aliased_comptime_call_admission(accessing_source, module, name);
         };
         let identity = self.provider.identity(candidate.clone())?;
         Ok(crate::durable_comptime::DurableComptimeCallableAdmissionStart {
@@ -630,6 +685,7 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
                         identity.key,
                     ),
             },
+            alias_dependency: None,
         })
     }
 
@@ -677,6 +733,7 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
                         identity.key,
                     ),
             },
+            alias_dependency: None,
         })
     }
 
@@ -698,6 +755,7 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
             configuration,
             name,
             dependency: _,
+            alias_dependency: _,
         } = start;
         let signature = self.provider.signature(candidate.clone())?;
         let crate::semantic_query_nucleus::DeclarationSignatureProjection::Callable {

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -1253,6 +1253,77 @@ impl SemanticNucleusTypeProvider<'_> {
         Ok(())
     }
 
+    /// The declaration a comptime-call head names in `module`, and the
+    /// visibility the access is judged by.
+    ///
+    /// A `const F = <function>;` alias is a second name for one callee, not a
+    /// second callee: when `name` names no function it is resolved through the
+    /// constant's own value, and the head is then built from the target's
+    /// declaration exactly as the target's own spelling builds it (RUE-2161).
+    /// The alias constant joins this site's dependencies alongside the target,
+    /// so repointing the alias invalidates every signature that reached the
+    /// callee through it.
+    ///
+    /// Visibility follows the name that was written, not the declaration
+    /// behind it — the rule 10.4:22 states for a type alias and ADR-0026 for a
+    /// re-exported callable: a `pub` alias of a private constructor re-exports
+    /// it, and a private alias named from another directory is rejected as the
+    /// constant it is. That is what expression position already does, so both
+    /// positions accept the same programs.
+    fn constructor_candidate(
+        &mut self,
+        module: &ModuleId,
+        name: &str,
+    ) -> Result<
+        Option<ConstructorHeadSite>,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        if let Some(candidate) = self.candidate(module, name, DefinitionKind::Function)? {
+            return Ok(Some(ConstructorHeadSite {
+                candidate,
+                visibility: None,
+            }));
+        }
+        let Some(alias) = self.candidate(module, name, DefinitionKind::Const)? else {
+            return Ok(None);
+        };
+        let crate::semantic_query_nucleus::ConstResolutionProjection::Value {
+            key,
+            value,
+            dependencies,
+            ..
+        } = self.const_resolution(alias.clone())?
+        else {
+            return Ok(None);
+        };
+        let crate::durable_semantics::DurableConstValue::Function(target) = *value else {
+            return Ok(None);
+        };
+        self.dependencies.extend(dependencies.iter().cloned());
+        self.dependencies.insert(
+            crate::semantic_query_nucleus::SemanticDeclarationDependency {
+                source: self.dependency_source.clone(),
+                kind: self.dependency_kind,
+                target:
+                    crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
+                        key,
+                    ),
+            },
+        );
+        let visibility = self.identity(alias)?.is_public;
+        Ok(
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(&target).map(
+                |candidate| ConstructorHeadSite {
+                    candidate,
+                    visibility: Some(visibility),
+                },
+            ),
+        )
+    }
+
     fn constructor_fact(
         &mut self,
         module: &ModuleId,
@@ -1271,7 +1342,11 @@ impl SemanticNucleusTypeProvider<'_> {
         >,
     > {
         use crate::semantic_query_nucleus::DeclarationSignatureProjection;
-        let Some(candidate) = self.candidate(module, name, DefinitionKind::Function)? else {
+        let Some(ConstructorHeadSite {
+            candidate,
+            visibility,
+        }) = self.constructor_candidate(module, name)?
+        else {
             return Ok(None);
         };
         let identity = self.identity(candidate.clone())?;
@@ -1321,7 +1396,7 @@ impl SemanticNucleusTypeProvider<'_> {
             site: identity.key,
             parameters: parameters.into(),
             returns_type: result == crate::durable_semantics::DurableType::ComptimeType,
-            is_public: identity.is_public,
+            is_public: visibility.unwrap_or(identity.is_public),
             defining_domain: rue_air::SemanticVisibilityDomain::from_file_path(Some(
                 module.as_str(),
             )),
@@ -2139,6 +2214,15 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
     }
 }
 
+/// The declaration one comptime-call head resolves to, plus the visibility the
+/// written name carries when it is a callable `const` alias (RUE-2161).
+struct ConstructorHeadSite {
+    candidate: crate::declaration_candidate::DeclarationCandidateKey,
+    /// `Some` only for an alias: the constant's own `pub`-ness governs the
+    /// access, so a `pub` alias re-exports a private constructor.
+    visibility: Option<bool>,
+}
+
 pub(in crate::revisioned_query_database) enum ResolveSemanticSignatureError {
     Abort(QueryAbort),
     Failure(Box<crate::semantic_query_nucleus::SemanticNucleusFailure>),
@@ -2147,6 +2231,24 @@ pub(in crate::revisioned_query_database) enum ResolveSemanticSignatureError {
 impl ResolveSemanticSignatureError {
     fn failure(failure: crate::semantic_query_nucleus::SemanticNucleusFailure) -> Self {
         Self::Failure(Box::new(failure))
+    }
+
+    /// Re-anchor a plain signature diagnostic at the type that produced it.
+    ///
+    /// Type resolution runs once per written type, so the position is known
+    /// here and nowhere downstream; without it every unresolvable type in a
+    /// signature reported against the whole declaration (RUE-2161). Only a
+    /// bare diagnostic moves: a failure that already names its own site keeps
+    /// that site.
+    fn at_signature_type(self, anchor: crate::semantic_query_nucleus::SignatureTypeAnchor) -> Self {
+        use crate::semantic_query_nucleus::SemanticNucleusFailure as F;
+        match self {
+            Self::Failure(failure) => match *failure {
+                F::Diagnostic(kind) => Self::failure(F::DiagnosticAtSignatureType { kind, anchor }),
+                failure => Self::failure(failure),
+            },
+            abort => abort,
+        }
     }
 }
 
@@ -2538,13 +2640,21 @@ pub(in crate::revisioned_query_database) fn resolve_parsed_semantic_signature(
             }
             let parameters = parameters
                 .iter()
-                .map(|parameter| {
+                .enumerate()
+                .map(|(ordinal, parameter)| {
                     let ty = resolve(
                         provider,
                         syntax,
                         parameter.ty,
                         rue_air::DeclarationTypeDependencyKind::Signature,
-                    )?;
+                    )
+                    .map_err(|error| {
+                        error.at_signature_type(
+                            crate::semantic_query_nucleus::SignatureTypeAnchor::Parameter(
+                                ordinal as u32,
+                            ),
+                        )
+                    })?;
                     if parameter.is_comptime && !parsed.is_type_parameter_syntax(parameter.ty) {
                         provider
                             .deferred_value_parameters
@@ -2573,7 +2683,10 @@ pub(in crate::revisioned_query_database) fn resolve_parsed_semantic_signature(
                 syntax,
                 *result,
                 rue_air::DeclarationTypeDependencyKind::Signature,
-            )?;
+            )
+            .map_err(|error| {
+                error.at_signature_type(crate::semantic_query_nucleus::SignatureTypeAnchor::Result)
+            })?;
             if contains_slice(&result) {
                 return Err(diagnostic(rue_error::ErrorKind::SliceReturnNotAllowed));
             }

--- a/crates/rue-compiler/src/revisioned_query_database/tests.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests.rs
@@ -19,6 +19,7 @@ const EXPECTED_REVISIONED_QUERY_TESTS: &[&str] = &[
     "absent_declaration_shell_is_a_typed_position_free_failure_terminal",
     "absent_import_bindings_are_first_class_records_with_stamp_discipline",
     "alias_observed_after_publication_keeps_snapshot_manifest_and_view_in_agreement",
+    "aliased_type_constructor_signature_depends_on_the_alias_and_the_target",
     "anonymous_dependency_frontier_canonicalizes_aliases_before_deduplication",
     "anonymous_member_diagnostics_relocate_and_internal_trivia_invalidates",
     "anonymous_member_kind_mismatch_is_deterministic_not_cancellation",

--- a/crates/rue-compiler/src/revisioned_query_database/tests/semantic_declaration.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/semantic_declaration.rs
@@ -5495,3 +5495,88 @@ fn deferred_value_call_diagnostics_are_stable_and_keep_query_channels() {
         ResolveSemanticSignatureError::Abort(rue_query::QueryAbort::Canceled)
     ));
 }
+
+/// A signature that reaches a type constructor through a callable `const`
+/// alias must record BOTH declarations: the constant that names the callee and
+/// the callee itself (RUE-2161). Recording only the target would leave the
+/// signature standing when the alias is repointed; recording only the constant
+/// would leave it standing when the constructor's own body changes.
+#[test]
+fn aliased_type_constructor_signature_depends_on_the_alias_and_the_target() {
+    use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+    use crate::semantic_query_nucleus::{
+        SemanticDeclarationDependencyTarget as Target, SemanticNucleusKey as Key,
+        SemanticNucleusValue as Value,
+    };
+
+    let source = source_snapshot(
+        &[(
+            1,
+            "/main.rue",
+            "main.rue",
+            "fn Pair(comptime T: type) -> type { struct { a: T, b: T } } \
+             const P = Pair; \
+             fn direct(borrow p: Pair(i32)) -> i32 { p.a } \
+             fn aliased(borrow p: P(i32)) -> i32 { p.a } \
+             fn main() -> i32 { 0 }",
+        )],
+        1,
+    );
+    let module = ModuleId::from_logical_path("main.rue").unwrap();
+    let mut database = RevisionedQueryDatabase::default();
+    let revision =
+        database.source_revision(&crate::session::ExactSourceInput::new(&source), &source);
+    let stable_key = |kind, name| {
+        crate::StableDefinitionKey::from_stable_parts(
+            module.clone(),
+            crate::StableDefinitionNamespace::Value,
+            kind,
+            name,
+            None,
+        )
+    };
+    let constructor =
+        Target::TypeCallHead(stable_key(crate::StableDefinitionKind::Function, "Pair"));
+    let alias = Target::NamedValue(stable_key(crate::StableDefinitionKind::ValueConst, "P"));
+
+    let targets = |name: &str| {
+        let declaration =
+            declaration_candidate(&database, revision, &module, Category::Function, name);
+        let Value::Signature(signature) = request_semantic_nucleus(
+            &database,
+            revision,
+            Key::Signature(crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                declaration,
+                configuration: semantic_configuration(),
+            }),
+        ) else {
+            panic!("expected a signature projection for {name}");
+        };
+        signature
+            .dependencies
+            .iter()
+            .map(|dependency| dependency.target.clone())
+            .collect::<BTreeSet<_>>()
+    };
+
+    let direct = targets("direct");
+    assert!(
+        direct.contains(&constructor),
+        "the direct spelling must depend on the constructor: {direct:?}"
+    );
+    assert!(
+        !direct.contains(&alias),
+        "the direct spelling must not depend on the alias: {direct:?}"
+    );
+
+    let aliased = targets("aliased");
+    assert!(
+        aliased.contains(&constructor),
+        "the alias resolves to the same callee, so the same constructor dependency is \
+         recorded: {aliased:?}"
+    );
+    assert!(
+        aliased.contains(&alias),
+        "the alias constant is a second edge, not a substitute for the first: {aliased:?}"
+    );
+}

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -751,6 +751,15 @@ pub(crate) struct ForeignSignatureConflictFailure {
     pub(crate) right: ForeignSignatureSite,
 }
 
+/// Which type written in a declaration's signature a diagnostic belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SignatureTypeAnchor {
+    /// The type of the parameter at this zero-based position.
+    Parameter(u32),
+    /// The declaration's written result type.
+    Result,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SemanticNucleusFailure {
     Shell(Arc<str>),
@@ -760,6 +769,15 @@ pub(crate) enum SemanticNucleusFailure {
     DiagnosticAtParameter {
         kind: rue_error::ErrorKind,
         ordinal: u32,
+    },
+    /// A diagnostic about one type written in a signature, anchored at that
+    /// type rather than at the whole declaration (RUE-2161). The anchor is a
+    /// position in the parsed signature, not a span, so the stable failure
+    /// stays free of revision-local spans exactly as
+    /// [`Self::DiagnosticAtParameter`] does.
+    DiagnosticAtSignatureType {
+        kind: rue_error::ErrorKind,
+        anchor: SignatureTypeAnchor,
     },
     DiagnosticAtDeclaration {
         kind: rue_error::ErrorKind,
@@ -987,9 +1005,9 @@ impl RetainedCharge for SemanticNucleusFailure {
             Self::Shell(detail) | Self::Syntax(detail) | Self::Resolution(detail) => {
                 detail.retained_charge()
             }
-            Self::Diagnostic(kind) | Self::DiagnosticAtParameter { kind, .. } => {
-                kind.retained_charge()
-            }
+            Self::Diagnostic(kind)
+            | Self::DiagnosticAtParameter { kind, .. }
+            | Self::DiagnosticAtSignatureType { kind, .. } => kind.retained_charge(),
             Self::DiagnosticAtProducerRange { kind, producer, .. } => kind
                 .retained_charge()
                 .saturating_add(producer.retained_charge()),

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -2950,6 +2950,40 @@ fn executable_main_declaration(
     Ok(main_declaration.key.clone())
 }
 
+/// Where in a declaration's signature a query-owned failure belongs.
+///
+/// Two stable failure shapes reach this: a rule about the parameter itself
+/// (a duplicate name) anchors at the whole parameter, and a diagnostic about
+/// one written type anchors at that type (RUE-2161).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SignatureAnchor {
+    Parameter(u32),
+    ParameterType(u32),
+    ResultType,
+}
+
+/// The signature position a failure names, when it names one.
+fn signature_anchor(
+    failure: &crate::semantic_query_nucleus::SemanticNucleusFailure,
+) -> Option<(&rue_error::ErrorKind, SignatureAnchor)> {
+    use crate::semantic_query_nucleus::{
+        SemanticNucleusFailure as F, SignatureTypeAnchor as Written,
+    };
+    match failure {
+        F::DiagnosticAtParameter { kind, ordinal } => {
+            Some((kind, SignatureAnchor::Parameter(*ordinal)))
+        }
+        F::DiagnosticAtSignatureType { kind, anchor } => Some((
+            kind,
+            match anchor {
+                Written::Parameter(ordinal) => SignatureAnchor::ParameterType(*ordinal),
+                Written::Result => SignatureAnchor::ResultType,
+            },
+        )),
+        _ => None,
+    }
+}
+
 fn semantic_nucleus_failure_diagnostics(
     modules: &[Arc<crate::parsed_modules::ParsedModule>],
     declaration: Option<&crate::declaration_candidate::DeclarationCandidateKey>,
@@ -3024,33 +3058,46 @@ fn semantic_nucleus_failure_diagnostics(
             ),
         )));
     }
-    if let (Some(declaration), F::DiagnosticAtParameter { kind, ordinal }) = (declaration, failure)
+    if let Some((kind, anchor)) = signature_anchor(failure)
+        && let Some(declaration) = declaration
         && let Some(module) = modules
             .iter()
             .find(|module| module.module_id() == &declaration.module)
         && let Some(locator) = module.definitions().declaration_locator(declaration)
     {
-        let parameters = module.ast().items.iter().find_map(|item| match item {
+        // One AST lookup answers both anchors: the callable declared at this
+        // locator, whatever item shape carries it.
+        let signature = module.ast().items.iter().find_map(|item| match item {
             rue_parser::ast::Item::Function(function)
                 if function.span == locator.declaration_span =>
             {
-                Some(function.params.as_slice())
+                Some((function.params.as_slice(), function.return_type.as_ref()))
             }
             rue_parser::ast::Item::Struct(structure) => structure
                 .methods
                 .iter()
                 .find(|method| method.span == locator.declaration_span)
-                .map(|method| method.params.as_slice()),
+                .map(|method| (method.params.as_slice(), method.return_type.as_ref())),
             rue_parser::ast::Item::Extern(block) => block
                 .fns
                 .iter()
                 .find(|function| function.span == locator.declaration_span)
-                .map(|function| function.params.as_slice()),
+                .map(|function| (function.params.as_slice(), function.return_type.as_ref())),
             _ => None,
         });
-        if let Some(parameter) = parameters.and_then(|parameters| parameters.get(*ordinal as usize))
-        {
-            return CompileErrors::from(CompileError::new(kind.clone(), parameter.span));
+        if let Some((parameters, return_type)) = signature {
+            let span = match anchor {
+                SignatureAnchor::Parameter(ordinal) => parameters
+                    .get(ordinal as usize)
+                    .map(|parameter| parameter.span),
+                SignatureAnchor::ParameterType(ordinal) => parameters
+                    .get(ordinal as usize)
+                    .map(|parameter| parameter.ty.span()),
+                SignatureAnchor::ResultType => return_type.map(rue_parser::ast::TypeExpr::span),
+            };
+            if let Some(span) = span {
+                return CompileErrors::from(CompileError::new(kind.clone(), span));
+            }
         }
     }
     if let F::DiagnosticAtDeclaration { kind, declaration } = failure
@@ -3215,6 +3262,7 @@ fn semantic_nucleus_failure_diagnostics(
     let (kind, help, note) = match failure {
         F::Diagnostic(kind) => (kind.clone(), None, None),
         F::DiagnosticAtParameter { kind, .. } => (kind.clone(), None, None),
+        F::DiagnosticAtSignatureType { kind, .. } => (kind.clone(), None, None),
         F::DiagnosticAtDeclaration { kind, .. } => (kind.clone(), None, None),
         F::DuplicateDeclaration { kind, .. } => (kind.clone(), None, None),
         F::DuplicateDeclarations(_) => unreachable!("duplicate batches return above"),

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -1111,8 +1111,10 @@ fn provider_observation_counters_record_exact_production_work() {
         .expect("the program analyzes");
     let metrics = crate::unstable::provider_observation_metrics(&session);
     assert_eq!(
-        metrics.name_lookups, 5,
-        "the two distinct named primitive signatures each perform their canonical file-alias probe: {metrics:?}"
+        metrics.name_lookups, 4,
+        "the two distinct named primitive signatures each perform their canonical file-alias probe, \
+         and the unqualified call resolves on its file-local function probe — the function-valued \
+         `const` alias probe runs only when that one misses (RUE-2161): {metrics:?}"
     );
     assert_eq!(metrics.import_lookups, 0);
     assert_eq!(metrics.method_candidates, 0);
@@ -1175,8 +1177,11 @@ fn repeated_named_imports_register_their_identity_closure_once_per_body() {
 
     let metrics = crate::unstable::provider_observation_metrics(&session);
     assert_eq!(
-        metrics.name_lookups, 14,
-        "the first Item payload must serve type minting and endpoint installation without repeating candidate/destructor lookups; signature and struct-literal names also perform their canonical file-const alias probes: {metrics:?}"
+        metrics.name_lookups, 13,
+        "the first Item payload must serve type minting and endpoint installation without repeating \
+         candidate/destructor lookups; signature and struct-literal names also perform their \
+         canonical file-const alias probes, while the unqualified call resolves on its file-local \
+         function probe alone (RUE-2161): {metrics:?}"
     );
     assert_eq!(metrics.declaration_facts, 10, "{metrics:?}");
     assert_eq!(metrics.identity_facts, 5, "{metrics:?}");
@@ -6790,4 +6795,48 @@ fn dropped_compiler_sessions_end_their_query_worker_threads() {
         "{SESSIONS} dropped sessions created {births} worker threads and must \
          own none of them now"
     );
+}
+
+/// Repointing a callable `const` alias must re-analyze every site that named
+/// it (RUE-2161). A signature or body that reaches its callee through the
+/// alias records the constant alongside the target, so the warm session's
+/// artifacts after the edit match a session that never saw the old program.
+#[test]
+fn repointing_a_callable_alias_reanalyzes_every_site_that_named_it() {
+    let program = |target: &str| {
+        format!(
+            r#"
+            fn Wrap1(comptime T: type) -> type {{
+                struct {{ v: T, fn get(borrow self) -> T {{ self.v }} }}
+            }}
+            fn Wrap2(comptime T: type) -> type {{
+                struct {{ v: T, fn get(borrow self) -> T {{ self.v + 1 }} }}
+            }}
+            const W = {target};
+            fn read(borrow w: W(i32)) -> i32 {{ w.get() }}
+            fn main() -> i32 {{
+                let w = W(i32) {{ v: 41 }};
+                read(borrow w)
+            }}
+        "#
+        )
+    };
+    let before = program("Wrap1");
+    let after = program("Wrap2");
+    let original = snapshot(&[(91, "/p/main.rue", "main.rue", &before)], 91);
+    let edited = snapshot(&[(91, "/p/main.rue", "main.rue", &after)], 91);
+
+    let mut session = CompilerSession::new();
+    session.update(&original).into_result().unwrap();
+    session.rooted_cfg(&CompileOptions::default()).unwrap();
+    session.update(&edited).into_result().unwrap();
+    let actual = session.rooted_cfg(&CompileOptions::default()).unwrap();
+
+    let mut fresh_session = CompilerSession::new();
+    fresh_session.update(&edited).into_result().unwrap();
+    let fresh = fresh_session
+        .rooted_cfg(&CompileOptions::default())
+        .unwrap();
+    assert_body_artifact_parity(&actual, &fresh);
+    assert_diagnostic_parity(&session, &fresh_session);
 }

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -3676,3 +3676,288 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Type-constructor application through a callable const alias (RUE-2161)
+#
+# 6.5:15 makes `const P = Pair;` a callable alias with the same call behavior
+# as the aliased function, and 4.14:23 admits a type-constructor call wherever
+# a type is expected. Composing the two, the alias spelling must reduce to the
+# same type — and take the same inference facts — as the target's own spelling
+# in every position.
+# =============================================================================
+
+[[case]]
+name = "callable_alias_type_constructor_in_param_and_return_position"
+spec = ["4.14:23", "4.14:23b", "6.5:15"]
+description = "A callable const alias of a type constructor is usable in parameter and return type position."
+source = """
+fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+
+const P = Pair;
+
+fn make() -> P(i32) { P(i32) { a: 20, b: 22 } }
+
+fn total(borrow p: P(i32)) -> i32 { p.a + p.b }
+
+fn main() -> i32 {
+    let p = make();
+    total(borrow p)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "callable_alias_type_constructor_in_const_initializer"
+spec = ["4.14:23", "4.14:23b", "6.5:15", "10.4:21"]
+description = "A callable const alias may head a type-constructor application in another constant's initializer."
+source = """
+fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+
+const P = Pair;
+const PI = P(i32);
+
+fn total(borrow p: PI) -> i32 { p.a + p.b }
+
+fn main() -> i32 {
+    let p = PI { a: 20, b: 22 };
+    total(borrow p)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "callable_alias_receiver_result_unifies_integer_literal"
+spec = ["4.14:23", "4.14:23b", "6.5:15"]
+description = "A value built through a callable alias carries the same method result types as one built through the target's own spelling, so an integer literal unifies with them."
+source = """
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+
+        fn make(v: T) -> Self { Self { v: v } }
+        fn get(borrow self) -> T { self.v }
+        fn count(borrow self) -> u64 { 1 }
+    }
+}
+
+const B = Box;
+
+fn main() -> i32 {
+    let b = B(i64).make(7);
+    @assert_eq(b.get(), 7);
+    @assert_eq(b.count(), 1);
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "callable_alias_of_imported_type_constructor"
+spec = ["4.14:23", "4.14:23b", "6.5:15"]
+description = "A callable const alias of a generic reached through a module binding resolves in type position and in expression position alike."
+source = """
+const boxes = @import("boxes.rue");
+
+const B = boxes.Box;
+
+fn take(borrow b: B(i64)) -> i64 { b.get() }
+
+fn main() -> i32 {
+    let b = B(i64).make(7);
+    @assert_eq(take(borrow b), 7);
+    42
+}
+"""
+aux_files = { "boxes.rue" = """
+pub fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+
+        fn make(v: T) -> Self { Self { v: v } }
+        fn get(borrow self) -> T { self.v }
+    }
+}
+""" }
+exit_code = 42
+
+[[case]]
+name = "reexported_callable_alias_in_type_position"
+spec = ["4.14:23", "4.14:23b", "6.5:15"]
+description = "A re-exported callable alias (`pub const Box = lib.Box;`) heads a module-qualified type-constructor application in a signature."
+source = """
+const facade = @import("facade.rue");
+
+fn take(borrow b: facade.Box(i64)) -> i64 { b.get() }
+
+fn main() -> i32 {
+    let b = facade.Box(i64).make(7);
+    @assert_eq(take(borrow b), 7);
+    42
+}
+"""
+aux_files = { "boxes.rue" = """
+pub fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+
+        fn make(v: T) -> Self { Self { v: v } }
+        fn get(borrow self) -> T { self.v }
+    }
+}
+""", "facade.rue" = """
+const boxes = @import("boxes.rue");
+
+pub const Box = boxes.Box;
+""" }
+exit_code = 42
+
+[[case]]
+name = "callable_alias_of_std_generic_unifies_literals"
+spec = ["4.14:23", "4.14:23b", "6.5:15"]
+real_std = true
+description = "The `const ArrayBuf = std.arraybuf.ArrayBuf;` idiom works in a signature and leaves every method result unifiable with an integer literal."
+source = """
+const std = @import("std");
+
+const ArrayBuf = std.arraybuf.ArrayBuf;
+const Option = std.option.Option;
+
+fn count(borrow xs: ArrayBuf(i64)) -> u64 { xs.len() }
+
+fn first(borrow xs: ArrayBuf(i64)) -> Option(i64) {
+    let head = xs.get(0)?;
+    Option(i64).Some(head)
+}
+
+fn main() -> i32 {
+    let mut xs = ArrayBuf(i64).new();
+    xs.push(7);
+    @assert_eq(count(borrow xs), 1);
+    @assert_eq(first(borrow xs), Option(i64).Some(7));
+    @assert_eq(xs.get_or(0, 0), 7);
+    @assert_eq(xs.get(0), Option(i64).Some(7));
+    let picked = match xs.get(0) {
+        Option(i64).Some(v) => v,
+        Option(i64).None => 0,
+    };
+    @assert_eq(picked, 7);
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "callable_alias_as_a_comptime_type_argument"
+spec = ["4.14:23", "4.14:23b", "4.14:6", "6.5:15"]
+description = "An application of one callable alias is a compile-time-known type argument to another, exactly as the target's own spelling is."
+source = """
+fn Opt(comptime T: type) -> type { enum { Some(T), None } }
+
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+
+        fn make(v: T) -> Self { Self { v: v } }
+        fn count(borrow self) -> u64 { 1 }
+    }
+}
+
+const O = Opt;
+const B = Box;
+
+fn main() -> i32 {
+    let b = B(O(i64)).make(O(i64).Some(7));
+    @assert_eq(b.count(), 1);
+    let inner = match b.v {
+        O(i64).Some(n) => n,
+        O(i64).None => 0,
+    };
+    @assert_eq(inner, 7);
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "callable_alias_of_std_generic_as_a_comptime_type_argument"
+spec = ["4.14:23", "4.14:23b", "4.14:6", "6.5:15"]
+real_std = true
+description = "`ArrayBuf(Option(i64))` through two `const` aliases reduces exactly as the module-qualified spelling does."
+source = """
+const std = @import("std");
+
+const ArrayBuf = std.arraybuf.ArrayBuf;
+const Option = std.option.Option;
+
+fn main() -> i32 {
+    let mut xs = ArrayBuf(Option(i64)).new();
+    xs.push(Option(i64).Some(7));
+    @assert_eq(xs.len(), 1);
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "callable_alias_receiver_constant_index_borrow_accessor"
+spec = ["4.14:23", "4.14:23b", "6.5:15", "6.6:3"]
+real_std = true
+description = "A constant-index borrow accessor on a receiver built through a callable alias lowers exactly as it does through the module-qualified spelling."
+source = """
+const std = @import("std");
+
+const ArrayBuf = std.arraybuf.ArrayBuf;
+
+fn main() -> i32 {
+    let mut c = ArrayBuf(i64).new();
+    c.push(-1);
+    c.push(5);
+    @assert_eq(c.get_ref(0), -1);
+    @assert_eq(c.get_ref(1), 5);
+    @dbg(c.get_ref(0));
+    42
+}
+"""
+expected_stdout = "-1\n"
+exit_code = 42
+
+[[case]]
+name = "pub_callable_alias_reexports_its_constructor"
+spec = ["4.14:23", "4.14:23b", "6.5:15", "10.4:22"]
+description = "A `pub` callable alias re-exports the constructor it names, so a private generic is reachable through it from another directory."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn total(borrow p: lib.P(i32)) -> i32 { p.a + p.b }
+
+fn main() -> i32 {
+    let p = lib.P(i32) { a: 20, b: 22 };
+    total(borrow p)
+}
+"""
+aux_files = { "sub/lib.rue" = """
+fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+
+pub const P = Pair;
+""" }
+exit_code = 42
+
+[[case]]
+name = "private_callable_alias_is_rejected_as_the_constant"
+spec = ["4.14:23b", "6.5:15", "10.4:22"]
+description = "A private callable alias named from another directory reports the constant, not the public constructor behind it."
+source = """
+const lib = @import("sub/lib.rue");
+
+fn total(borrow p: lib.P(i32)) -> i32 { p.a + p.b }
+
+fn main() -> i32 { 0 }
+"""
+aux_files = { "sub/lib.rue" = """
+pub fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+
+const P = Pair;
+""" }
+compile_fail = true
+error_contains = ["E0706", "const `P` is private"]

--- a/crates/rue-ui-tests/cases/diagnostics/error-spans.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/error-spans.toml
@@ -90,3 +90,51 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["4:28", "field 'text' expects type str", "expected str, found i32"]
+
+# =============================================================================
+# Signature type errors
+# =============================================================================
+
+# A type written in a signature is resolved once, per written type, by the
+# declaration-level type machine. That resolver knows which parameter (or the
+# result) it is resolving, and it is the only place that knows; the stable
+# failure now carries that position, so the diagnostic lands on the type
+# instead of on the whole declaration (RUE-2161).
+
+[[case]]
+name = "unknown_parameter_type_points_at_the_type"
+source = """
+fn f(borrow p: Nope) -> i32 { 0 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["1:16", "unknown type 'Nope'"]
+
+[[case]]
+name = "unknown_parameter_type_constructor_points_at_the_application"
+source = """
+fn f(borrow p: Nope(i32)) -> i32 { 0 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["1:16", "unknown type 'Nope(...)'"]
+
+[[case]]
+name = "unknown_result_type_points_at_the_result_type"
+source = """
+fn f(p: i32) -> Nope(i32) { 0 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["1:17", "unknown type 'Nope(...)'"]
+
+[[case]]
+name = "unknown_method_parameter_type_points_at_the_type"
+source = """
+struct S {
+    fn m(borrow self, x: Nope(i32)) -> i32 { 0 }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["2:26", "unknown type 'Nope(...)'"]

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -602,6 +602,36 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="4.14:23b", cat="normative") }}
+
+A type constructor may also be reached through a callable alias — a constant
+bound to the constructor rather than to its application (`const P = Pair;`,
+`const ArrayBuf = std.arraybuf.ArrayBuf;`, rule 6.5:15) — in every position
+rules 4.14:22 and 4.14:23 admit: a type annotation, a parameter, return, field,
+array-element or pointer-pointee type, a comptime `type` argument, another
+constant's initializer, and a path head heading a struct literal, an
+associated-function or enum-variant call, or a match pattern. The alias names
+the same constructor its target names, so the call is evaluated exactly as if
+the target had been named at that point and reduces to the same type: the
+alias introduces no second constructor, no second specialization, and no new
+typing rule. Visibility is the constant's own, by rule 10.4:22: a `pub` alias
+re-exports the constructor it names, and a private alias reached from another
+directory is rejected as the constant it is.
+
+```rue
+fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+
+const P = Pair;             // callable alias, not an application
+const PI = P(i32);          // applied in another constant's initializer
+
+fn total(borrow p: P(i32)) -> i32 { p.a + p.b }   // parameter position
+
+fn main() -> i32 {
+    let p: PI = P(i32) { a: 20, b: 22 };          // annotation and path head
+    total(borrow p)
+}
+```
+
 {{ rule(id="4.14:24", cat="normative") }}
 
 The comptime parameters of a type constructor — both `type` parameters and


### PR DESCRIPTION
Fixes RUE-2161

## Problem

`const ArrayBuf = std.arraybuf.ArrayBuf;` binds a function-valued constant, and only the ordinary call analyzer could see through it. Every other place that turns a name into a callee looked for a function declaration and gave up, so the idiom every test file uses failed in four ways: `fn f(borrow xs: ArrayBuf(i64))` was E0204 "unknown type" with a span over the whole function; `const IntBuf = ArrayBuf(i64);` was E1200 "undefined comptime function"; a value built through the alias never became a generic fact site, so its method results arrived after literal defaulting and `@assert_eq(xs.len(), 1)` was E0702; and the alias as a comptime type argument (`ArrayBuf(Option(i64))`) was E1201. A constant-index borrow accessor through the alias ICEd in CFG verification, and an alias-built buffer handed to a helper with the qualified signature printed 4294967295 for -1, because the two spellings produced different instantiations.

## Change

Each existing resolver consults the constant when the function lookup misses, and resolves to the exact callee key the target's own spelling resolves to. No new path.

- `OrdinaryBodyEngine::resolve_callee_name` is the one body-level order, file-local function then function-valued const; `analyze_call`, `generic_callee_key`, and `admit_comptime_call` all read it, and the call analyzer's inline alias branch is folded into it. An ordinary call pays one fewer name lookup than before.
- The body type-annotation and signature constructors (`type_syntax_constructor`, `constructor_fact`, `module_constructor`) resolve a head through the constant, so a facade re-export `pub const Pair = lib.Pair;` works in a signature as it already did in an expression.
- Comptime call admission delegates an aliased head to admission against the target's own declaration.
- Visibility is the constant's own in every position, by 10.4:22: a `pub` alias re-exports the constructor, a private alias reached from another directory is rejected as the constant. Expression position already behaved this way; type position now agrees.
- An aliased site records the constant alongside the target as a declaration dependency, so watch and incremental rebuilds see an edit to either.
- E0204 in a signature now anchors to the parameter or result type syntax rather than the whole item.
- Spec: new normative paragraph 4.14:23b states that a type constructor may be reached through a callable alias in every position 4.14:22 and 4.14:23 admit, evaluating exactly as if the target had been named, with the constant's own visibility. Struct-field and enum-payload positions still report an unresolvable type against the whole item; that projection has no per-member position and is left for a follow-up.

The aliased and qualified spellings now produce identical AIR apart from the module-path instructions the qualified spelling spells.

## Coverage

- Eleven spec cases under `expressions.comptime` citing 4.14:23b: parameter and return position, const initializer, receiver-result literal unification (`len`, `get(0)?`, `get_or`, match arm, `Option(i64).Some(7)`), an imported user generic, a re-exported alias, the alias as a comptime type argument, the constant-index accessor, and the two visibility directions.
- Four UI cases pinning the E0204 anchor; a CLI section `const_function_alias_type` with five cases; two compiler unit tests for the dependency edges. Removing the alias resolution fails four spec cases; removing the dependency edge fails its unit test.

## Verification

- `scripts/rue spec`: 2933 passed. `scripts/rue ui`: 445 passed. `scripts/rue cli`: 2841 passed. `scripts/rue unit compiler`: 1244 passed; `rue-air`: 897 passed. `scripts/rue quick`: 36 targets.
- `//tests/std:std-tests`: 157 passed. `//examples:gazette-tests`: 35 passed. `//:spec-traceability`, `//:compiler-spec-machine-index`, `//:adr-registry-validation`: pass.
- `scripts/rue premerge` on macOS: 219 pass, 1 fail. The failure is `running_image::subprocess_identity_is_bound_to_the_running_image_not_its_path`, a layout-fragile `install_name_tool` fixture that flips on pristine trunk from a one-line inert addition and passes on trunk in a separate checkout; tracked as RUE-2169.
