### PR TITLE
RUE-2163: classify a SIGSEGV by the address that faulted

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -589,6 +589,41 @@ driver_exit_code = 1
 compile_stdout_contains = ['"kind":"trap:div_by_zero"', '"message":"error: division by zero"']
 
 [[case]]
+name = "a_null_pointer_write_is_a_segfault_not_a_stack_overflow"
+description = """
+RUE-2163: the runtime reported every SIGSEGV as `stack overflow`, so a `checked`
+null write reached this taxonomy as `trap:stack_overflow`. The handler now reads
+the faulting address from `siginfo_t` and classifies it, and this runs a real
+null write through the real runtime so both the `trap:segfault` kind and the
+address its message carries are the runtime's own output rather than a retyped
+copy. No lowering stages a site beside a fault, so `location` stays the `test`
+declaration's header the way every other trap's does.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "writes through a null pointer" {
+    let zero: u64 = 0;
+    let p: ptr mut i64 = checked { @int_to_ptr(zero) };
+    checked { @ptr_write(p, 7) };
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "json"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    '"kind":"trap:segfault","location":{"column":1,"file":"tests.rue","line":1}',
+    '"message":"segmentation fault at 0x0"}',
+    '"verdict":"fail"',
+]
+
+[[case]]
 name = "an_early_exit_before_the_epilogue_is_incomplete"
 description = """
 ADR-0083 §3: a body calling `std.exit(0)` before its assertions must not report

--- a/crates/rue-cli-tests/cases/segfault.toml
+++ b/crates/rue-cli-tests/cases/segfault.toml
@@ -1,0 +1,66 @@
+# A SIGSEGV that is not a stack overflow reports its faulting address (RUE-2163).
+#
+# RUE-645 installed a SIGSEGV handler so a blown stack aborts cleanly instead of
+# dying by signal, and it reported *every* SIGSEGV as `stack overflow` on the
+# premise that safe Rue has no other way to raise one. `checked` blocks and raw
+# pointers (spec chapter 9) ended that premise, and a C FFI callee never obeyed
+# it: a null or wild `@ptr_write` faulted and the runtime blamed the stack.
+#
+# The handler is now installed with SA_SIGINFO on all three targets, reads the
+# faulting address out of the platform's `siginfo_t`, and reports
+# `segmentation fault at 0x<address>` for any address outside the window below
+# the stack base it captured at process entry. `stack_overflow.toml` holds the
+# other half of the contract — that unbounded recursion still says
+# `stack overflow` — because the two cases are only meaningful together.
+# See crates/rue-runtime/src/fault.rs for the window rule.
+#
+# Platform scope (`only_on` all three targets): the classification is per-target
+# work (three `siginfo_t` layouts, two ways to read `RLIMIT_STACK`, and Darwin's
+# caller-supplied signal trampoline), and each host's CI leg runs its own. A
+# regression is a wrong message, not a signal death, so these are ordinary
+# assertion failures rather than the FATAL shape `stack_overflow.toml` warns
+# about.
+
+[section]
+id = "cli.segfault"
+name = "Segmentation fault classification"
+description = "A SIGSEGV outside the stack window reports 'segmentation fault at 0x<address>' + exit 101 rather than 'stack overflow' (RUE-2163)."
+
+# The address is rendered in lowercase hex with no padding, so a null write is
+# `0x0` and not `0x0000000000000000`. Asserting the trailing newline pins that:
+# a padded address would not match.
+[[case]]
+name = "a_null_pointer_write_reports_a_zero_address"
+description = "Writing through `@int_to_ptr(0)` reports 'segmentation fault at 0x0' + exit 101, not 'stack overflow' (RUE-2163)."
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+files = [{ path = "prog.rue", source = """
+fn main() -> i32 {
+    let zero: u64 = 0;
+    let p: ptr mut i64 = checked { @int_to_ptr(zero) };
+    checked { @ptr_write(p, 7) };
+    0
+}
+""" }]
+stdout = ""
+exit_code = 101
+runtime_error_contains = ["segmentation fault at 0x0\n"]
+
+# An unmapped address far from both the null page and the stack. Every supported
+# target places the main stack gigabytes above 0xdead0000 — macOS aarch64 has the
+# lowest base, around 5.7 GiB — so this address is outside the overflow window on
+# all three, and the message must carry it verbatim.
+[[case]]
+name = "a_wild_pointer_write_reports_its_address"
+description = "Writing through `@int_to_ptr(0xdead0000)` names that address in the message (RUE-2163)."
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+files = [{ path = "prog.rue", source = """
+fn main() -> i32 {
+    let addr: u64 = 0xdead0000;
+    let p: ptr mut i64 = checked { @int_to_ptr(addr) };
+    checked { @ptr_write(p, 7) };
+    0
+}
+""" }]
+stdout = ""
+exit_code = 101
+runtime_error_contains = ["segmentation fault at 0xdead0000\n"]

--- a/crates/rue-cli-tests/cases/stack_overflow.toml
+++ b/crates/rue-cli-tests/cases/stack_overflow.toml
@@ -7,13 +7,17 @@
 # abort.
 #
 # The runtime now installs, in `_start`, an alternate signal stack (`sigaltstack`)
-# plus a SIGSEGV handler (`rt_sigaction`, `SA_ONSTACK`) that runs on that alt
-# stack even though the main stack is exhausted. The handler writes
+# plus a SIGSEGV handler (`rt_sigaction`, `SA_ONSTACK | SA_SIGINFO`) that runs on
+# that alt stack even though the main stack is exhausted. The handler writes
 # "stack overflow" to stderr and exits 101 — the same clean-abort code the other
 # runtime traps use (division by zero, overflow, bounds, @panic). This matches
-# how Rust and Go report a blown stack. Any SIGSEGV from safe Rue is treated as a
-# stack overflow: safe Rue has no other way to segfault (bounds-checked, no null
-# derefs, arithmetic traps). See crates/rue-runtime/src/entry.rs.
+# how Rust and Go report a blown stack. See crates/rue-runtime/src/entry.rs.
+#
+# Not every SIGSEGV is a stack overflow: the handler compares the faulting
+# address against the window below the stack base it captured at entry, and any
+# other fault reports `segmentation fault at 0x<address>` instead (RUE-2163).
+# This case is the "still a stack overflow" half of that contract; `segfault.toml`
+# is the other half, and the two are only meaningful together.
 #
 # Platform scope (`only_on` all three targets): the handler is implemented for
 # x86-64 Linux, aarch64 Linux, and aarch64 macOS (RUE-707). The macOS path uses
@@ -23,7 +27,7 @@
 # is verified by CI's macOS leg running this very case. If it regresses there,
 # this case fails loudly — a signal-death is a FATAL failure `known_bug` can't
 # absorb, which is why the scope stays `only_on`. See
-# crates/rue-runtime/src/aarch64_macos.rs::install_stack_overflow_handler.
+# crates/rue-runtime/src/aarch64_macos.rs::install_segv_handler.
 
 [section]
 id = "cli.stack_overflow"

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1557,16 +1557,18 @@ fn check_case_with_native_with_configuration(
     // Match the CLI runner: omitted `exit_code` means a successful process
     // exit, even when the case asserts on ordinary stderr text.
     let expected_exit = case.exit_code.unwrap_or(0);
-    // A stack-overflow trap (deep/unbounded recursion) is structurally
-    // un-modelable: reproducing it means actually exhausting the machine stack,
-    // which the in-process interpreter cannot do — its own recursion budget
-    // aborts first with a ResourceLimit. So a case expecting this trap is an
-    // oracle gap, not a case the harness can judge (RUE-645).
+    // The two SIGSEGV messages are structurally un-modelable. Reproducing a
+    // stack overflow means actually exhausting the machine stack, which the
+    // in-process interpreter cannot do — its own recursion budget aborts first
+    // with a ResourceLimit (RUE-645). Reproducing a segmentation fault means
+    // actually touching an address the process does not own, which the
+    // interpreter refuses by construction: it models a wild `@int_to_ptr` as an
+    // unsupported dereference rather than a memory access (RUE-2163). Either
+    // way the case is an oracle gap, not one the harness can judge.
     if expected_exit == rue_test_runner::RUNTIME_ERROR_EXIT_CODE
-        && case
-            .runtime_error_contains
-            .iter()
-            .any(|fragment| fragment == "stack overflow")
+        && case.runtime_error_contains.iter().any(|fragment| {
+            fragment == "stack overflow" || fragment.starts_with("segmentation fault at 0x")
+        })
     {
         return CaseOutcome::Ineligible(IneligibleReason::KnownOracleGap);
     }

--- a/crates/rue-runtime/src/aarch64_linux.rs
+++ b/crates/rue-runtime/src/aarch64_linux.rs
@@ -368,14 +368,16 @@ pub fn munmap(addr: *mut u8, size: usize) -> i64 {
 }
 
 // ============================================================================
-// Stack-overflow trapping (RUE-645)
+// SIGSEGV trapping (RUE-645, RUE-2163)
 // ============================================================================
 //
 // A stack overflow faults on the guard page and raises SIGSEGV. With no handler
 // the kernel kills the process (exit 139). To abort cleanly we register a small
 // alternate signal stack and a SIGSEGV handler that runs on it (SA_ONSTACK),
-// prints "stack overflow", and exits 101. See `entry::__rue_stack_overflow_handler`
-// for why any SIGSEGV from safe Rue is treated as a stack overflow.
+// which reports either a stack overflow or a segmentation fault at the faulting
+// address and exits 101. The handler is installed with SA_SIGINFO so it can read
+// that address out of `siginfo_t`; see `crate::fault` for the rule that decides
+// between the two.
 //
 // Unlike x86-64, aarch64 Linux needs no user-supplied signal-return trampoline:
 // the kernel installs the sigreturn trampoline from the vDSO automatically when
@@ -394,6 +396,10 @@ const SIGSEGV: u64 = 11;
 /// `SA_ONSTACK`: run the handler on the alternate signal stack.
 const SA_ONSTACK: u64 = 0x0800_0000;
 
+/// `SA_SIGINFO`: deliver the three-argument handler, whose second argument is
+/// the `siginfo_t` carrying the faulting address (RUE-2163).
+const SA_SIGINFO: u64 = 0x0000_0004;
+
 /// Kernel `struct sigaction` layout on aarch64 Linux (asm-generic ABI): handler,
 /// flags, restorer, then mask last.
 #[repr(C)]
@@ -410,6 +416,86 @@ struct StackT {
     ss_sp: *mut u8,
     ss_flags: i32,
     ss_size: usize,
+}
+
+/// The head of the kernel's `siginfo_t`, up to the field this runtime reads.
+///
+/// aarch64 takes the generic layout of `include/uapi/asm-generic/siginfo.h`
+/// unchanged: `si_signo`, `si_errno`, `si_code`, then the `_sifields` union,
+/// whose first member is a pointer and so starts at offset 16 on LP64.
+/// `_sigfault._addr` — the faulting address — is that union's first word. The
+/// kernel's buffer is 128 bytes, so reading these 24 is in bounds.
+#[repr(C)]
+struct SigInfo {
+    si_signo: i32,
+    si_errno: i32,
+    si_code: i32,
+    _pad: i32,
+    si_addr: usize,
+}
+
+/// The faulting address sits at offset 16; a stray field or padding change
+/// here would silently read the wrong word out of the kernel's buffer.
+const _: () = assert!(core::mem::offset_of!(SigInfo, si_addr) == 16);
+
+/// The address a SIGSEGV faulted on, read from the kernel's `siginfo_t`.
+///
+/// # Safety
+///
+/// `info` must be the `siginfo_t` pointer the kernel passed to a `SA_SIGINFO`
+/// signal handler.
+pub unsafe fn fault_address(info: *const u8) -> usize {
+    if info.is_null() {
+        return 0;
+    }
+    // SAFETY: the caller guarantees a kernel-supplied `siginfo_t`, which is at
+    // least 128 bytes and laid out as `SigInfo` describes.
+    unsafe { (*info.cast::<SigInfo>()).si_addr }
+}
+
+/// Linux aarch64 syscall number for prlimit64 (from asm-generic/unistd.h).
+///
+/// The asm-generic table has no `getrlimit`, so `prlimit64` is the only way to
+/// read `RLIMIT_STACK` here; x86-64 uses the same call for symmetry.
+const SYS_PRLIMIT64: u64 = 261;
+
+/// `RLIMIT_STACK` resource number (`include/uapi/asm-generic/resource.h`).
+const RLIMIT_STACK: u64 = 3;
+
+/// `struct rlimit64`: the soft limit, then the hard limit.
+#[repr(C)]
+struct Rlimit64 {
+    rlim_cur: u64,
+    rlim_max: u64,
+}
+
+/// The soft `RLIMIT_STACK`, or `None` when the kernel would not report it.
+///
+/// `RLIM64_INFINITY` (`~0`) is reported as `None`: an unlimited stack gives the
+/// classification no bound to work from, and `crate::fault` substitutes its own
+/// conservative window.
+pub fn stack_limit() -> Option<usize> {
+    let mut limit = Rlimit64 {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    let result: i64;
+    // SAFETY: prlimit64(pid=0 (self), resource, new_limit=NULL, old_limit) only
+    // writes through `old_limit`, which addresses the live local above.
+    unsafe {
+        asm!(
+            "svc #0",
+            in("x8") SYS_PRLIMIT64,
+            inlateout("x0") 0u64 => result, // pid: 0 = this process
+            in("x1") RLIMIT_STACK,
+            in("x2") 0u64,                  // new_limit: NULL
+            in("x3") &raw mut limit,
+        );
+    }
+    if result < 0 || limit.rlim_cur == u64::MAX {
+        return None;
+    }
+    usize::try_from(limit.rlim_cur).ok()
 }
 
 /// Register the alternate signal stack with `sigaltstack(2)`.
@@ -456,11 +542,11 @@ unsafe fn rt_sigaction(sig: u64, act: *const KernelSigaction) -> i64 {
     result
 }
 
-/// Install the stack-overflow SIGSEGV handler (see module comment above).
+/// Install the SIGSEGV handler (see module comment above).
 ///
 /// Best-effort: if the alt stack cannot be mapped or a syscall fails, we return
 /// without installing anything and keep the default SIGSEGV disposition.
-pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
+pub fn install_segv_handler(handler: crate::fault::SegvHandler) {
     /// Size of the alternate signal stack (16 KiB).
     const ALT_STACK_SIZE: usize = 16 * 1024;
 
@@ -482,7 +568,7 @@ pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
 
     let act = KernelSigaction {
         sa_handler: handler as usize,
-        sa_flags: SA_ONSTACK,
+        sa_flags: SA_ONSTACK | SA_SIGINFO,
         sa_restorer: 0,
         sa_mask: 0,
     };
@@ -653,13 +739,31 @@ mod tests {
     }
 
     #[test]
-    fn stack_overflow_handler_is_installable() {
+    fn segv_handler_is_installable() {
         // Reference the installer (and, transitively, its `sigaltstack` /
-        // `rt_sigaction` wrappers and structs) so the RUE-645 stack-overflow
-        // trap machinery is type-checked by the unit-test build. We only take
-        // its address: calling it would install a process-wide SIGSEGV handler,
-        // which must not happen inside the test harness.
-        let installer: fn(extern "C" fn(i32) -> !) = install_stack_overflow_handler;
+        // `rt_sigaction` wrappers and structs) so the SIGSEGV trap machinery is
+        // type-checked by the unit-test build. We only take its address:
+        // calling it would install a process-wide SIGSEGV handler, which must
+        // not happen inside the test harness.
+        let installer: fn(crate::fault::SegvHandler) = install_segv_handler;
         assert!(installer as usize != 0);
+    }
+
+    /// `fault_address` tolerates a null `siginfo_t` (a handler entered without
+    /// one) rather than dereferencing it. The populated path cannot be
+    /// exercised in-process — only the kernel produces a real `siginfo_t` — and
+    /// is covered by the `cli.segfault` cases.
+    #[test]
+    fn a_null_siginfo_reports_a_zero_fault_address() {
+        // SAFETY: the null case is exactly what this asks about.
+        assert_eq!(unsafe { fault_address(core::ptr::null()) }, 0);
+    }
+
+    /// The soft stack limit is a plausible finite size on any host running the
+    /// suite; `None` would mean the syscall shape is wrong.
+    #[test]
+    fn the_stack_limit_is_readable() {
+        let limit = stack_limit().expect("RLIMIT_STACK is set on Linux hosts");
+        assert!(limit >= 64 * 1024, "implausible stack limit: {limit}");
     }
 }

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -413,6 +413,21 @@ const SIGSEGV: u64 = 11;
 /// differs from Linux's (0x0800_0000).
 const SA_ONSTACK: i32 = 0x0001;
 
+/// Deliver the three-argument handler, whose second argument is the `siginfo_t`
+/// carrying the faulting address (RUE-2163). Darwin's value (0x0040) differs
+/// from Linux's (0x0004).
+const SA_SIGINFO: i32 = 0x0040;
+
+/// macOS syscall number for getrlimit (SYS_getrlimit).
+const SYS_GETRLIMIT: u64 = 194;
+
+/// `RLIMIT_STACK` resource number (XNU `bsd/sys/resource.h`), the same value
+/// Linux uses.
+const RLIMIT_STACK: u64 = 3;
+
+/// Darwin's `RLIM_INFINITY`, which is `(1 << 63) - 1` rather than Linux's `~0`.
+const RLIM_INFINITY: u64 = (1 << 63) - 1;
+
 // Darwin's `sigaction(2)` (SYS_sigaction = 46) takes a `struct __sigaction`
 // that, unlike Linux, carries a CALLER-SUPPLIED signal trampoline
 // (`sa_tramp`): on delivery the kernel jumps to `sa_tramp`, not the handler.
@@ -421,18 +436,24 @@ const SA_ONSTACK: i32 = 0x0001;
 // `sendsig` enters it with
 //   x0 = catcher (the registered handler), x1 = infostyle, x2 = sig,
 //   x3 = siginfo*, x4 = ucontext*.
-// Our catcher is `extern "C" fn(i32) -> !` and exits the process, so the
-// trampoline only needs to invoke it with the signal number in `x0`; it never
-// returns, so no `sigreturn` epilogue is required (the same reasoning as the
-// x86-64 Linux restorer, which also never runs because the handler exits).
+// Our catcher is the `SA_SIGINFO` three-argument handler
+// `extern "C" fn(i32, *const u8, *const u8) -> !`, so the trampoline shuffles
+// the kernel's registers into `(sig, siginfo, ucontext)` — the same shuffle
+// libplatform's own `_sigtramp` performs. The catcher exits the process, so it
+// never returns and no `sigreturn` epilogue is required (the same reasoning as
+// the x86-64 Linux restorer, which also never runs because the handler exits).
+// `infostyle` in x1 is what libc uses to pick a `sigreturn` flavor; a catcher
+// that never returns has no use for it.
 core::arch::global_asm!(
     ".private_extern _rue_darwin_sigtramp",
     ".globl _rue_darwin_sigtramp",
     ".p2align 2",
     "_rue_darwin_sigtramp:",
     "mov x9, x0", // x9 = catcher (the real handler)
-    "mov x0, x2", // x0 = sig (the handler's only argument)
-    "blr x9",     // catcher(sig) — never returns (it exits)
+    "mov x0, x2", // x0 = sig
+    "mov x1, x3", // x1 = siginfo*
+    "mov x2, x4", // x2 = ucontext*
+    "blr x9",     // catcher(sig, siginfo, ucontext) — never returns (it exits)
     "brk #0x1",   // trap if control ever returns here
 );
 
@@ -462,6 +483,83 @@ struct DarwinSigaction {
     sa_tramp: usize,
     sa_mask: u32,
     sa_flags: i32,
+}
+
+/// The head of Darwin's `siginfo_t`, up to the field this runtime reads.
+///
+/// XNU `bsd/sys/signal.h` declares `struct __siginfo` as `si_signo`,
+/// `si_errno`, `si_code`, `si_pid`, `si_uid`, `si_status` — six 32-bit fields —
+/// and then `void *si_addr`, so the faulting address sits at offset 24 rather
+/// than Linux's 16. The struct is 104 bytes, so reading these 32 is in bounds.
+#[repr(C)]
+struct DarwinSigInfo {
+    si_signo: i32,
+    si_errno: i32,
+    si_code: i32,
+    si_pid: i32,
+    si_uid: u32,
+    si_status: i32,
+    si_addr: usize,
+}
+
+/// The faulting address sits at offset 24; a stray field or padding change
+/// here would silently read the wrong word out of the kernel's buffer.
+const _: () = assert!(core::mem::offset_of!(DarwinSigInfo, si_addr) == 24);
+
+/// The address a SIGSEGV faulted on, read from the kernel's `siginfo_t`.
+///
+/// # Safety
+///
+/// `info` must be the `siginfo_t` pointer the kernel passed to a `SA_SIGINFO`
+/// signal handler (by way of `sa_tramp`).
+pub unsafe fn fault_address(info: *const u8) -> usize {
+    if info.is_null() {
+        return 0;
+    }
+    // SAFETY: the caller guarantees a kernel-supplied `siginfo_t`, which is 104
+    // bytes and laid out as `DarwinSigInfo` describes.
+    unsafe { (*info.cast::<DarwinSigInfo>()).si_addr }
+}
+
+/// Darwin `struct rlimit`: the soft limit, then the hard limit, both `rlim_t`
+/// (`__uint64_t`).
+#[repr(C)]
+struct DarwinRlimit {
+    rlim_cur: u64,
+    rlim_max: u64,
+}
+
+/// The soft `RLIMIT_STACK`, or `None` when the kernel would not report it.
+///
+/// `RLIM_INFINITY` is reported as `None`: an unlimited stack gives the
+/// classification no bound to work from, and `crate::fault` substitutes its own
+/// conservative window.
+pub fn stack_limit() -> Option<usize> {
+    let mut limit = DarwinRlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    let result: i64;
+    let err_flag: u64;
+    // SAFETY: getrlimit(which, rlp) writes only through `rlp`, which addresses
+    // the live local above; the carry flag signals an error as in every wrapper
+    // in this module.
+    unsafe {
+        asm!(
+            "svc #0x80",
+            "cset {err}, cs",
+            inlateout("x16") SYS_GETRLIMIT => _,
+            in("x0") RLIMIT_STACK,
+            in("x1") &raw mut limit,
+            lateout("x0") result,
+            err = out(reg) err_flag,
+            out("x17") _,
+        );
+    }
+    if err_flag != 0 || result < 0 || limit.rlim_cur >= RLIM_INFINITY {
+        return None;
+    }
+    usize::try_from(limit.rlim_cur).ok()
 }
 
 /// Register `nss` as the alternate signal stack (`sigaltstack(2)`).
@@ -514,13 +612,14 @@ unsafe fn sigaction_syscall(sig: u64, nsa: *const DarwinSigaction) -> i64 {
     if err_flag != 0 { -result } else { result }
 }
 
-/// Install the stack-overflow SIGSEGV handler (RUE-645 / RUE-707).
+/// Install the SIGSEGV handler (RUE-645 / RUE-707 / RUE-2163).
 ///
 /// Maps a 64 KiB alternate signal stack (comfortably above macOS
 /// `MINSIGSTKSZ`), registers it with `sigaltstack`, and installs a `SIGSEGV`
-/// handler via the raw `sigaction` syscall with `SA_ONSTACK` and our own
-/// `sa_tramp`. A stack overflow then aborts cleanly ("stack overflow", exit
-/// 101) instead of a raw SIGSEGV (exit 139), matching the Linux targets.
+/// handler via the raw `sigaction` syscall with `SA_ONSTACK | SA_SIGINFO` and
+/// our own `sa_tramp`. A fault then aborts cleanly ("stack overflow" or
+/// "segmentation fault at 0x…", exit 101) instead of a raw SIGSEGV (exit 139),
+/// matching the Linux targets.
 ///
 /// Every step is best-effort: any syscall failure leaves the default
 /// disposition in place, and a wrong trampoline only affects the (rare)
@@ -534,7 +633,7 @@ unsafe fn sigaction_syscall(sig: u64, nsa: *const DarwinSigaction) -> i64 {
 /// (LDR from the GOT slot -> ADD of the symbol address), so this reference
 /// links; behavioral verification is CI's macOS leg running the
 /// `stack_overflow.toml` CLI case.
-pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
+pub fn install_segv_handler(handler: crate::fault::SegvHandler) {
     const ALT_STACK_SIZE: usize = 64 * 1024;
 
     let stack = mmap(ALT_STACK_SIZE);
@@ -556,7 +655,7 @@ pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
         sa_handler: handler as usize,
         sa_tramp: rue_darwin_sigtramp as usize,
         sa_mask: 0,
-        sa_flags: SA_ONSTACK,
+        sa_flags: SA_ONSTACK | SA_SIGINFO,
     };
     // SAFETY: `act` is a valid `__sigaction` with a real trampoline; SIGSEGV
     // is a valid signal number.
@@ -633,9 +732,40 @@ mod tests {
         assert_eq!(SYS_WRITE, 4);
         assert_eq!(SYS_MMAP, 197);
         assert_eq!(SYS_MUNMAP, 73);
+        assert_eq!(SYS_GETRLIMIT, 194);
         assert_eq!(STDIN, 0);
         assert_eq!(STDOUT, 1);
         assert_eq!(STDERR, 2);
+    }
+
+    #[test]
+    fn segv_handler_is_installable() {
+        // Reference the installer (and, transitively, its `sigaltstack` /
+        // `sigaction` wrappers, structs, and the `sa_tramp` trampoline) so the
+        // SIGSEGV trap machinery is type-checked by the unit-test build. We
+        // only take its address: calling it would install a process-wide
+        // SIGSEGV handler, which must not happen inside the test harness.
+        let installer: fn(crate::fault::SegvHandler) = install_segv_handler;
+        assert!(installer as usize != 0);
+    }
+
+    /// `fault_address` tolerates a null `siginfo_t` (a trampoline entered
+    /// without one) rather than dereferencing it. The populated path cannot be
+    /// exercised in-process — only the kernel produces a real `siginfo_t` — and
+    /// is covered by the `cli.segfault` cases.
+    #[test]
+    fn a_null_siginfo_reports_a_zero_fault_address() {
+        // SAFETY: the null case is exactly what this asks about.
+        assert_eq!(unsafe { fault_address(core::ptr::null()) }, 0);
+    }
+
+    /// The soft stack limit is a plausible finite size on any macOS host
+    /// running the suite (the default is 8 MiB); `None` would mean the syscall
+    /// shape is wrong.
+    #[test]
+    fn the_stack_limit_is_readable() {
+        let limit = stack_limit().expect("RLIMIT_STACK is set on macOS hosts");
+        assert!(limit >= 64 * 1024, "implausible stack limit: {limit}");
     }
 
     #[test]
@@ -723,15 +853,5 @@ mod tests {
         // Zero-size mmap should fail (returns EINVAL on macOS)
         let ptr = mmap(0);
         assert!(ptr.is_null());
-    }
-
-    #[test]
-    fn stack_overflow_handler_is_installable() {
-        // Reference the installer so the unit-test build type-checks it.
-        // Taking its address keeps the signature in sync with the Linux
-        // backends without executing anything (installing a real SIGSEGV
-        // disposition inside the libtest harness would be hostile).
-        let installer: fn(extern "C" fn(i32) -> !) = install_stack_overflow_handler;
-        assert!(installer as usize != 0);
     }
 }

--- a/crates/rue-runtime/src/entry.rs
+++ b/crates/rue-runtime/src/entry.rs
@@ -32,8 +32,8 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     platform::exit(101)
 }
 
-/// SIGSEGV handler installed by `_start` to turn a stack overflow into a clean
-/// abort (RUE-645).
+/// SIGSEGV handler installed at process entry, which turns a fault into a clean
+/// abort (RUE-645) and says which kind of fault it was (RUE-2163).
 ///
 /// # Why this exists
 ///
@@ -41,28 +41,31 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 /// kernel guard page and raises `SIGSEGV`. With no handler the default
 /// disposition kills the process, and the shell reports the raw crash (exit code
 /// 139 = 128 + SIGSEGV). Rust and Go instead catch this and print a readable
-/// "stack overflow" message before exiting non-zero. This handler does the same:
-/// it writes `"stack overflow\n"` to stderr and exits with code 101 — the same
-/// abort code the other runtime traps use (division by zero, overflow, bounds).
+/// "stack overflow" message before exiting non-zero. This handler does the same,
+/// and exits with code 101 — the same abort code the other runtime traps use
+/// (division by zero, overflow, bounds).
 ///
 /// # Running on an exhausted stack
 ///
-/// The handler cannot run on the main stack, which is what overflowed. `_start`
-/// registers a small alternate signal stack via `sigaltstack` and installs this
-/// handler with `SA_ONSTACK`, so the kernel switches to that alt stack to deliver
-/// the signal. See each platform's `install_stack_overflow_handler`.
+/// The handler cannot run on the main stack, which is what overflowed. The entry
+/// code registers a small alternate signal stack via `sigaltstack` and installs
+/// this handler with `SA_ONSTACK`, so the kernel switches to that alt stack to
+/// deliver the signal. See each platform's `install_segv_handler`.
 ///
-/// # Treating any SIGSEGV as stack overflow
+/// # Classifying the fault
 ///
-/// We do not inspect `siginfo.si_addr` to confirm the fault is near the stack
-/// pointer. In safe Rue there is no other way to reach `SIGSEGV`: array accesses
-/// are bounds-checked, there are no null/raw-pointer dereferences, and arithmetic
-/// traps rather than corrupting memory. So any `SIGSEGV` a compiled Rue program
-/// can produce is a stack overflow, and reporting it as such is correct. This
-/// keeps the handler freestanding (no `SA_SIGINFO`, no `siginfo_t` layout).
+/// A blown stack is no longer the only `SIGSEGV` a Rue program can raise: a
+/// `checked` block can write through a null or wild raw pointer (spec chapter
+/// 9), and a C FFI callee can fault anywhere. The handler is therefore installed
+/// with `SA_SIGINFO` and reads the faulting address out of the `siginfo_t` the
+/// kernel supplies. An address inside the window below the captured stack base
+/// is a stack overflow and keeps the pinned `stack overflow` message; anything
+/// else reports `segmentation fault at 0x<address>`. [`crate::fault`] owns the
+/// window rule and the two messages.
 ///
-/// The signal-number argument is unused for the same reason: this handler is
-/// only ever registered for `SIGSEGV`.
+/// The signal-number argument is unused: this handler is only ever registered
+/// for `SIGSEGV`. The interrupted context is unused too — the handler exits
+/// rather than resuming.
 ///
 /// # Never returns
 ///
@@ -77,26 +80,35 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
         all(target_arch = "aarch64", target_os = "linux")
     )
 ))]
-pub(crate) extern "C" fn __rue_stack_overflow_handler(_sig: i32) -> ! {
-    // "stack overflow\n" built byte-by-byte to avoid the macOS byte-string
-    // linker bug (mirrors the message handlers in `error.rs`).
-    let mut msg = [0u8; 15];
-    msg[0] = b's';
-    msg[1] = b't';
-    msg[2] = b'a';
-    msg[3] = b'c';
-    msg[4] = b'k';
-    msg[5] = b' ';
-    msg[6] = b'o';
-    msg[7] = b'v';
-    msg[8] = b'e';
-    msg[9] = b'r';
-    msg[10] = b'f';
-    msg[11] = b'l';
-    msg[12] = b'o';
-    msg[13] = b'w';
-    msg[14] = b'\n';
-    platform::write_stderr(&msg);
+pub(crate) extern "C" fn __rue_segv_handler(_sig: i32, info: *const u8, _context: *const u8) -> ! {
+    // SAFETY: the kernel delivers this handler's `siginfo_t` in `info`, and the
+    // platform decoder tolerates a null pointer.
+    let address = unsafe { platform::fault_address(info) };
+
+    if crate::fault::is_stack_overflow(address) {
+        // "stack overflow\n" built byte-by-byte to avoid the macOS byte-string
+        // linker bug (mirrors the message handlers in `error.rs`).
+        let mut msg = [0u8; 15];
+        msg[0] = b's';
+        msg[1] = b't';
+        msg[2] = b'a';
+        msg[3] = b'c';
+        msg[4] = b'k';
+        msg[5] = b' ';
+        msg[6] = b'o';
+        msg[7] = b'v';
+        msg[8] = b'e';
+        msg[9] = b'r';
+        msg[10] = b'f';
+        msg[11] = b'l';
+        msg[12] = b'o';
+        msg[13] = b'w';
+        msg[14] = b'\n';
+        platform::write_stderr(&msg);
+    } else {
+        let mut buffer = [0u8; crate::fault::SEGFAULT_MESSAGE_MAX];
+        platform::write_stderr(crate::fault::segfault_message(address, &mut buffer));
+    }
     platform::exit(101)
 }
 
@@ -108,7 +120,28 @@ pub(crate) extern "C" fn __rue_stack_overflow_handler(_sig: i32) -> ! {
         all(target_arch = "aarch64", target_os = "linux")
     )
 ))]
-const _: extern "C" fn(i32) -> ! = __rue_stack_overflow_handler;
+const _: crate::fault::SegvHandler = __rue_segv_handler;
+
+/// Record the stack window and install the SIGSEGV handler before user code
+/// runs, so a fault aborts cleanly (RUE-645) instead of dying with a raw
+/// SIGSEGV (exit 139), and is classified against a real stack bound (RUE-2163).
+///
+/// `stack_top` is the stack pointer at process entry. Best-effort throughout:
+/// if the handler cannot be installed the program simply keeps the default
+/// SIGSEGV disposition, and if the platform cannot report `RLIMIT_STACK` the
+/// classification falls back to its own conservative window.
+#[cfg(all(
+    not(test),
+    any(
+        all(target_arch = "x86_64", target_os = "linux"),
+        all(target_arch = "aarch64", target_os = "macos"),
+        all(target_arch = "aarch64", target_os = "linux")
+    )
+))]
+fn arm_segv_handler(stack_top: usize) {
+    crate::fault::record_stack_window(stack_top, platform::stack_limit());
+    platform::install_segv_handler(__rue_segv_handler);
+}
 
 /// Normal SysV function called by the prologue-free x86-64 Linux entry shim.
 ///
@@ -126,11 +159,9 @@ pub(crate) fn __rue_x86_64_linux_start(stack: *const usize) -> ! {
     // SAFETY: `stack` is the initial process stack pointer from `_start`.
     unsafe { crate::process::capture_from_stack(stack) };
 
-    // Install the stack-overflow SIGSEGV handler before running user code so a
-    // deep-recursion overflow aborts cleanly (RUE-645) instead of dying with a
-    // raw SIGSEGV (exit 139). Best-effort: if setup fails the program simply
-    // keeps the default SIGSEGV disposition.
-    platform::install_stack_overflow_handler(__rue_stack_overflow_handler);
+    // The initial `%rsp` is the base of the main stack, which is what the
+    // SIGSEGV handler classifies a faulting address against (RUE-2163).
+    arm_segv_handler(stack as usize);
 
     // SAFETY: `main` is the linked Rue entry function and uses the C ABI.
     let exit_code = unsafe { main() };
@@ -165,10 +196,16 @@ pub(crate) unsafe fn _main(argc: i32, argv: *const *const u8, envp: *const *cons
     // SAFETY: `argv`/`envp` are the loader-supplied vectors for this process.
     unsafe { crate::process::capture(argc as u64, argv, envp) };
 
-    // Install the stack-overflow SIGSEGV handler before running user code.
-    // (A deliberate no-op on macOS; the Darwin trampoline is tracked by
-    // RUE-707.)
-    platform::install_stack_overflow_handler(__rue_stack_overflow_handler);
+    // dyld hands us argc/argv/envp rather than the raw entry stack, so the
+    // stack base the SIGSEGV handler classifies against is read from `sp` here
+    // (RUE-2163). This is a frame or two below the true base, which only widens
+    // the overflow window downward and so cannot lose a real overflow.
+    let stack_top: usize;
+    // SAFETY: reading the stack pointer has no side effects.
+    unsafe {
+        asm!("mov {}, sp", out(reg) stack_top, options(nomem, nostack, preserves_flags));
+    }
+    arm_segv_handler(stack_top);
 
     let exit_code: i32;
     // SAFETY: This is the program entry point called by the kernel.
@@ -216,11 +253,9 @@ pub(crate) fn __rue_aarch64_linux_start(stack: *const usize) -> ! {
     // SAFETY: `stack` is the initial process stack pointer from `_start`.
     unsafe { crate::process::capture_from_stack(stack) };
 
-    // Install the stack-overflow SIGSEGV handler before running user code so a
-    // deep-recursion overflow aborts cleanly (RUE-645) instead of dying with a
-    // raw SIGSEGV (exit 139). Best-effort: if setup fails the program simply
-    // keeps the default SIGSEGV disposition.
-    platform::install_stack_overflow_handler(__rue_stack_overflow_handler);
+    // The initial `sp` is the base of the main stack, which is what the SIGSEGV
+    // handler classifies a faulting address against (RUE-2163).
+    arm_segv_handler(stack as usize);
 
     let exit_code: i32;
     // SAFETY:

--- a/crates/rue-runtime/src/fault.rs
+++ b/crates/rue-runtime/src/fault.rs
@@ -1,0 +1,275 @@
+//! SIGSEGV classification: stack overflow, or an ordinary segmentation fault
+//! (RUE-2163).
+//!
+//! Before `checked` blocks and raw pointers (spec chapter 9) existed, a
+//! `SIGSEGV` in a compiled Rue program could only be a blown stack, so RUE-645's
+//! handler reported every one of them as `stack overflow`. That premise is gone:
+//! `checked { @ptr_write(@int_to_ptr(0), 7) }` faults on a null pointer, and a
+//! C FFI callee can fault anywhere at all. The handler now reads the faulting
+//! address out of the `siginfo_t` the kernel supplies and decides between the
+//! two, so a wild write is no longer reported as a stack overflow.
+//!
+//! # The decision rule
+//!
+//! A fault is a **stack overflow** exactly when its address lies in
+//!
+//! ```text
+//!   [ stack_top - (stack_window + GUARD_SLACK) , stack_top ]
+//! ```
+//!
+//! where
+//!
+//! - `stack_top` is the stack pointer the runtime captured at process entry,
+//!   before any user code ran. On the Linux targets that is the untouched
+//!   initial `rsp`/`sp` the kernel supplied (the same value `process.rs` reads
+//!   argc/argv/envp from); on macOS it is `sp` on entry to `_main`. Either is
+//!   within a few kilobytes below the true base of the main stack, and
+//!   *under*estimating the base only widens the window downward, which cannot
+//!   lose a real overflow.
+//! - `stack_window` is `RLIMIT_STACK`'s soft limit when the platform reports a
+//!   plausible finite one — greater than zero and at most [`MAX_STACK_WINDOW`]
+//!   — and [`FALLBACK_STACK_WINDOW`] otherwise. The clamp is what keeps
+//!   `ulimit -s unlimited` from turning the window into "every address below
+//!   the stack", which would classify every wild pointer as an overflow again.
+//! - [`GUARD_SLACK`] covers the kernel's guard region below the stack's lowest
+//!   addressable byte (Linux's default `stack_guard_gap` is 1 MiB), because a
+//!   frame larger than the remaining space can fault below the limit rather
+//!   than at it.
+//!
+//! Everything else is reported as a segmentation fault at its address.
+//!
+//! # Why this cannot confuse the two shapes we care about
+//!
+//! Unbounded recursion walks the stack pointer down one frame at a time and
+//! faults within one guard region of `stack_top - stack_window`, which is
+//! inside the window by construction. A null or wild pointer write faults at a
+//! small address — `0x0`, `0xdead0000` — while every supported target places
+//! the main stack gigabytes above that, and the window reaches at most
+//! `MAX_STACK_WINDOW + GUARD_SLACK` below its base. The two ranges cannot meet.
+//!
+//! A large *stride* — indexing an enormous offset off a stack object — is the
+//! shape the rule genuinely cannot name, and it is reported as a segmentation
+//! fault at the address it touched, which is the more useful of the two
+//! answers.
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+/// The `SA_SIGINFO` handler shape every platform installs: the signal number,
+/// the kernel's `siginfo_t`, and the interrupted context.
+///
+/// The `siginfo_t` is passed as an opaque pointer because its layout is
+/// per-platform; each platform module decodes it in its own `fault_address`.
+pub(crate) type SegvHandler = extern "C" fn(i32, *const u8, *const u8) -> !;
+
+/// Slack below the stack's lowest addressable byte that still counts as a
+/// stack overflow. Linux's default `stack_guard_gap` is 256 pages (1 MiB); the
+/// same allowance covers macOS, whose guard region is smaller.
+pub(crate) const GUARD_SLACK: usize = 1 << 20;
+
+/// The window used when the platform cannot report `RLIMIT_STACK`: the 8 MiB
+/// soft limit both Linux and macOS default to.
+pub(crate) const FALLBACK_STACK_WINDOW: usize = 8 << 20;
+
+/// The largest `RLIMIT_STACK` taken at face value. A larger (or infinite) limit
+/// falls back to [`FALLBACK_STACK_WINDOW`]: a window that reaches gigabytes
+/// below the stack would swallow the wild-pointer addresses this
+/// classification exists to distinguish.
+pub(crate) const MAX_STACK_WINDOW: usize = 1 << 30;
+
+/// The captured stack base. Zero until the entry code records the window.
+static STACK_TOP: AtomicUsize = AtomicUsize::new(0);
+
+/// The lowest address that still counts as a stack overflow.
+static STACK_LOW: AtomicUsize = AtomicUsize::new(0);
+
+/// Number of hex digits in a full address.
+const ADDRESS_DIGITS: usize = (usize::BITS / 4) as usize;
+
+/// Length of the `"segmentation fault at 0x"` prefix.
+const SEGFAULT_PREFIX_LEN: usize = 24;
+
+/// Buffer size the longest segmentation-fault message needs: the fixed prefix,
+/// a full-width address, and the newline.
+pub(crate) const SEGFAULT_MESSAGE_MAX: usize = SEGFAULT_PREFIX_LEN + ADDRESS_DIGITS + 1;
+
+/// The stack window `stack_top` and `stack_limit` imply, as
+/// `(highest, lowest)` addresses that count as a stack overflow.
+///
+/// Split out from [`record_stack_window`] so the rule itself is a pure
+/// function with unit tests; the statics only carry its answer to the handler.
+pub(crate) fn stack_window(stack_top: usize, stack_limit: Option<usize>) -> (usize, usize) {
+    let window = match stack_limit {
+        Some(limit) if limit > 0 && limit <= MAX_STACK_WINDOW => limit,
+        _ => FALLBACK_STACK_WINDOW,
+    };
+    let low = stack_top.saturating_sub(window).saturating_sub(GUARD_SLACK);
+    (stack_top, low)
+}
+
+/// Record the stack window the SIGSEGV handler classifies against.
+///
+/// Called from each platform's entry function before user code runs, so the
+/// handler itself makes no syscalls and reads only these two words. Rue has no
+/// threads, and the write happens-before any fault, so `Relaxed` suffices; the
+/// atomics exist to avoid `static mut`.
+pub(crate) fn record_stack_window(stack_top: usize, stack_limit: Option<usize>) {
+    let (top, low) = stack_window(stack_top, stack_limit);
+    STACK_TOP.store(top, Ordering::Relaxed);
+    STACK_LOW.store(low, Ordering::Relaxed);
+}
+
+/// Whether a fault at `address` is a stack overflow under the rule above.
+///
+/// A window of zero means the entry code never recorded one, which no
+/// supported entry path leaves possible; the defensive answer is RUE-645's
+/// original one, since a runtime that cannot locate its own stack has no
+/// grounds to contradict the handler's historical verdict.
+pub(crate) fn is_stack_overflow(address: usize) -> bool {
+    let top = STACK_TOP.load(Ordering::Relaxed);
+    if top == 0 {
+        return true;
+    }
+    address <= top && address >= STACK_LOW.load(Ordering::Relaxed)
+}
+
+/// Render `segmentation fault at 0x<address>\n` into `buffer`, returning the
+/// written bytes.
+///
+/// The address is lowercase hex with no padding, so a null write reports
+/// `0x0`. The prefix is assembled byte-by-byte rather than copied from a byte
+/// string, for the macOS linker reason the other pinned runtime messages
+/// document.
+pub(crate) fn segfault_message(address: usize, buffer: &mut [u8; SEGFAULT_MESSAGE_MAX]) -> &[u8] {
+    buffer[0] = b's';
+    buffer[1] = b'e';
+    buffer[2] = b'g';
+    buffer[3] = b'm';
+    buffer[4] = b'e';
+    buffer[5] = b'n';
+    buffer[6] = b't';
+    buffer[7] = b'a';
+    buffer[8] = b't';
+    buffer[9] = b'i';
+    buffer[10] = b'o';
+    buffer[11] = b'n';
+    buffer[12] = b' ';
+    buffer[13] = b'f';
+    buffer[14] = b'a';
+    buffer[15] = b'u';
+    buffer[16] = b'l';
+    buffer[17] = b't';
+    buffer[18] = b' ';
+    buffer[19] = b'a';
+    buffer[20] = b't';
+    buffer[21] = b' ';
+    buffer[22] = b'0';
+    buffer[23] = b'x';
+
+    let mut len = SEGFAULT_PREFIX_LEN;
+    let mut shift = usize::BITS - 4;
+    let mut started = false;
+    loop {
+        let digit = ((address >> shift) & 0xf) as u8;
+        if digit != 0 || started || shift == 0 {
+            started = true;
+            buffer[len] = if digit < 10 {
+                b'0' + digit
+            } else {
+                b'a' + (digit - 10)
+            };
+            len += 1;
+        }
+        if shift == 0 {
+            break;
+        }
+        shift -= 4;
+    }
+
+    buffer[len] = b'\n';
+    len += 1;
+    &buffer[..len]
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use std::string::String;
+
+    /// A plausible main-stack base on the supported targets.
+    const TOP: usize = 0x0000_7fff_ffff_e000;
+
+    fn render(address: usize) -> String {
+        let mut buffer = [0u8; SEGFAULT_MESSAGE_MAX];
+        String::from_utf8(segfault_message(address, &mut buffer).to_vec()).expect("ASCII")
+    }
+
+    #[test]
+    fn a_null_fault_renders_an_unpadded_zero() {
+        assert_eq!(render(0), "segmentation fault at 0x0\n");
+    }
+
+    #[test]
+    fn an_address_renders_in_lowercase_hex_without_padding() {
+        assert_eq!(render(0xdead_0000), "segmentation fault at 0xdead0000\n");
+        assert_eq!(render(0xabc), "segmentation fault at 0xabc\n");
+    }
+
+    #[test]
+    fn a_full_width_address_fits_the_buffer() {
+        assert_eq!(
+            render(usize::MAX),
+            "segmentation fault at 0xffffffffffffffff\n"
+        );
+    }
+
+    #[test]
+    fn the_window_is_the_reported_limit_plus_the_guard_slack() {
+        let (top, low) = stack_window(TOP, Some(8 << 20));
+        assert_eq!(top, TOP);
+        assert_eq!(low, TOP - (8 << 20) - GUARD_SLACK);
+    }
+
+    /// An absent, zero, or implausibly large limit (`ulimit -s unlimited`
+    /// reports `RLIM_INFINITY`) falls back to the 8 MiB default rather than
+    /// widening the window until it swallows wild pointers.
+    #[test]
+    fn an_unusable_limit_falls_back_to_the_default_window() {
+        let expected = TOP - FALLBACK_STACK_WINDOW - GUARD_SLACK;
+        assert_eq!(stack_window(TOP, None).1, expected);
+        assert_eq!(stack_window(TOP, Some(0)).1, expected);
+        assert_eq!(stack_window(TOP, Some(usize::MAX)).1, expected);
+        assert_eq!(stack_window(TOP, Some(MAX_STACK_WINDOW + 1)).1, expected);
+    }
+
+    /// A stack base near zero (no supported target has one) must not wrap.
+    #[test]
+    fn a_low_stack_base_saturates_instead_of_wrapping() {
+        assert_eq!(stack_window(4096, Some(8 << 20)).1, 0);
+    }
+
+    /// The two shapes the classification exists to separate, decided against a
+    /// recorded window. `record_stack_window` writes process-global statics, so
+    /// one test drives every case rather than racing parallel ones.
+    #[test]
+    fn overflow_addresses_classify_apart_from_wild_ones() {
+        record_stack_window(TOP, Some(8 << 20));
+
+        // Unbounded recursion: the fault lands just inside the limit, and a
+        // large frame can land inside the guard region just below it.
+        assert!(is_stack_overflow(TOP - (8 << 20) + 0x1000));
+        assert!(is_stack_overflow(TOP - (8 << 20) - 0x1000));
+        assert!(is_stack_overflow(TOP));
+
+        // A null or wild pointer write, and an address above the stack base.
+        assert!(!is_stack_overflow(0));
+        assert!(!is_stack_overflow(0xdead_0000));
+        assert!(!is_stack_overflow(TOP + 0x1000));
+
+        // A window that was never recorded keeps RUE-645's answer.
+        STACK_TOP.store(0, Ordering::Relaxed);
+        STACK_LOW.store(0, Ordering::Relaxed);
+        assert!(is_stack_overflow(0));
+    }
+}

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -156,6 +156,11 @@ pub mod random;
 pub mod string;
 pub mod test_channel;
 
+// Crate-internal: the SIGSEGV classification rule and its two pinned messages,
+// shared by the entry handler and the platform modules. Not part of the runtime
+// ABI.
+mod fault;
+
 // Crate-internal: Unicode's well-formed-UTF-8 table, shared by the string
 // decoders and the test channel's JSON escaper. Not part of the runtime ABI.
 mod utf8;

--- a/crates/rue-runtime/src/x86_64_linux.rs
+++ b/crates/rue-runtime/src/x86_64_linux.rs
@@ -425,14 +425,16 @@ pub fn munmap(addr: *mut u8, size: usize) -> i64 {
 }
 
 // ============================================================================
-// Stack-overflow trapping (RUE-645)
+// SIGSEGV trapping (RUE-645, RUE-2163)
 // ============================================================================
 //
 // A stack overflow faults on the guard page and raises SIGSEGV. With no handler
 // the kernel kills the process (exit 139). To abort cleanly we register a small
 // alternate signal stack and a SIGSEGV handler that runs on it (SA_ONSTACK),
-// prints "stack overflow", and exits 101. See `entry::__rue_stack_overflow_handler`
-// for why any SIGSEGV from safe Rue is treated as a stack overflow.
+// which reports either a stack overflow or a segmentation fault at the faulting
+// address and exits 101. The handler is installed with SA_SIGINFO so it can read
+// that address out of `siginfo_t`; see `crate::fault` for the rule that decides
+// between the two.
 
 /// Linux x86-64 syscall number for rt_sigaction (see `man 2 rt_sigaction`).
 const SYS_RT_SIGACTION: i64 = 13;
@@ -445,6 +447,10 @@ const SIGSEGV: i32 = 11;
 
 /// `SA_ONSTACK`: run the handler on the alternate signal stack.
 const SA_ONSTACK: u64 = 0x0800_0000;
+
+/// `SA_SIGINFO`: deliver the three-argument handler, whose second argument is
+/// the `siginfo_t` carrying the faulting address (RUE-2163).
+const SA_SIGINFO: u64 = 0x0000_0004;
 
 /// `SA_RESTORER`: the `sa_restorer` field is valid and should be used as the
 /// signal-return trampoline.
@@ -468,6 +474,92 @@ struct StackT {
     ss_sp: *mut u8,
     ss_flags: i32,
     ss_size: usize,
+}
+
+/// The head of the kernel's `siginfo_t`, up to the field this runtime reads.
+///
+/// `include/uapi/asm-generic/siginfo.h` lays the struct out as `si_signo`,
+/// `si_errno`, `si_code`, then the `_sifields` union. x86-64 supplies no
+/// preamble override, and the union's first member is a pointer, so on LP64 the
+/// union starts at offset 16 and `_sigfault._addr` — the faulting address — is
+/// its first word. The kernel's buffer is 128 bytes, so reading these 24 is in
+/// bounds for any signal.
+#[repr(C)]
+struct SigInfo {
+    si_signo: i32,
+    si_errno: i32,
+    si_code: i32,
+    _pad: i32,
+    si_addr: usize,
+}
+
+/// The faulting address sits at offset 16; a stray field or padding change
+/// here would silently read the wrong word out of the kernel's buffer.
+const _: () = assert!(core::mem::offset_of!(SigInfo, si_addr) == 16);
+
+/// The address a SIGSEGV faulted on, read from the kernel's `siginfo_t`.
+///
+/// # Safety
+///
+/// `info` must be the `siginfo_t` pointer the kernel passed to a `SA_SIGINFO`
+/// signal handler.
+pub unsafe fn fault_address(info: *const u8) -> usize {
+    if info.is_null() {
+        return 0;
+    }
+    // SAFETY: the caller guarantees a kernel-supplied `siginfo_t`, which is at
+    // least 128 bytes and laid out as `SigInfo` describes.
+    unsafe { (*info.cast::<SigInfo>()).si_addr }
+}
+
+/// Linux x86-64 syscall number for prlimit64 (see `man 2 prlimit`).
+///
+/// `getrlimit(2)` is the older interface; `prlimit64` is the one every current
+/// architecture provides (aarch64 has only this one), so both Linux targets use
+/// it and differ in nothing but the number.
+const SYS_PRLIMIT64: i64 = 302;
+
+/// `RLIMIT_STACK` resource number (`include/uapi/asm-generic/resource.h`).
+const RLIMIT_STACK: i64 = 3;
+
+/// `struct rlimit64`: the soft limit, then the hard limit.
+#[repr(C)]
+struct Rlimit64 {
+    rlim_cur: u64,
+    rlim_max: u64,
+}
+
+/// The soft `RLIMIT_STACK`, or `None` when the kernel would not report it.
+///
+/// `RLIM64_INFINITY` (`~0`) is reported as `None`: an unlimited stack gives the
+/// classification no bound to work from, and `crate::fault` substitutes its own
+/// conservative window.
+pub fn stack_limit() -> Option<usize> {
+    let mut limit = Rlimit64 {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    let result: i64;
+    // SAFETY: prlimit64(pid=0 (self), resource, new_limit=NULL, old_limit) only
+    // writes through `old_limit`, which addresses the live local above. rcx/r11
+    // are clobbered per the syscall ABI.
+    unsafe {
+        asm!(
+            "syscall",
+            in("rax") SYS_PRLIMIT64,
+            in("rdi") 0i64,               // pid: 0 = this process
+            in("rsi") RLIMIT_STACK,
+            in("rdx") 0i64,               // new_limit: NULL
+            in("r10") &raw mut limit,
+            lateout("rax") result,
+            out("rcx") _,
+            out("r11") _,
+        );
+    }
+    if result < 0 || limit.rlim_cur == u64::MAX {
+        return None;
+    }
+    usize::try_from(limit.rlim_cur).ok()
 }
 
 /// Register the alternate signal stack with `sigaltstack(2)`.
@@ -525,14 +617,14 @@ unsafe fn rt_sigaction(sig: i32, act: *const KernelSigaction) -> i64 {
     result
 }
 
-/// Install the stack-overflow SIGSEGV handler (see module comment above).
+/// Install the SIGSEGV handler (see module comment above).
 ///
 /// Best-effort: if the alt stack cannot be mapped or a syscall fails, we return
 /// without installing anything and the process keeps the default SIGSEGV
 /// disposition.
 ///
 /// `handler` never returns, so no `sa_restorer` is supplied.
-pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
+pub fn install_segv_handler(handler: crate::fault::SegvHandler) {
     /// Size of the alternate signal stack (16 KiB — ample for the tiny handler).
     const ALT_STACK_SIZE: usize = 16 * 1024;
 
@@ -554,7 +646,7 @@ pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
 
     let act = KernelSigaction {
         sa_handler: handler as usize,
-        sa_flags: SA_ONSTACK | SA_RESTORER,
+        sa_flags: SA_ONSTACK | SA_RESTORER | SA_SIGINFO,
         sa_restorer: crate::__rue_rt_sigreturn as usize,
         sa_mask: 0,
     };
@@ -763,14 +855,32 @@ mod tests {
     }
 
     #[test]
-    fn stack_overflow_handler_is_installable() {
+    fn segv_handler_is_installable() {
         // Reference the installer (and, transitively, its `sigaltstack` /
         // `rt_sigaction` wrappers, structs, and the `__rue_rt_sigreturn`
-        // trampoline) so the RUE-645 stack-overflow trap machinery is
-        // type-checked by the unit-test build. We only take its address:
-        // calling it would install a process-wide SIGSEGV handler, which must
-        // not happen inside the test harness.
-        let installer: fn(extern "C" fn(i32) -> !) = install_stack_overflow_handler;
+        // trampoline) so the SIGSEGV trap machinery is type-checked by the
+        // unit-test build. We only take its address: calling it would install a
+        // process-wide SIGSEGV handler, which must not happen inside the test
+        // harness.
+        let installer: fn(crate::fault::SegvHandler) = install_segv_handler;
         assert!(installer as usize != 0);
+    }
+
+    /// `fault_address` tolerates a null `siginfo_t` (a handler entered without
+    /// one) rather than dereferencing it. The populated path cannot be
+    /// exercised in-process — only the kernel produces a real `siginfo_t` — and
+    /// is covered by the `cli.segfault` cases.
+    #[test]
+    fn a_null_siginfo_reports_a_zero_fault_address() {
+        // SAFETY: the null case is exactly what this asks about.
+        assert_eq!(unsafe { fault_address(core::ptr::null()) }, 0);
+    }
+
+    /// The soft stack limit is a plausible finite size on any host running the
+    /// suite; `None` would mean the syscall shape is wrong.
+    #[test]
+    fn the_stack_limit_is_readable() {
+        let limit = stack_limit().expect("RLIMIT_STACK is set on Linux hosts");
+        assert!(limit >= 64 * 1024, "implausible stack limit: {limit}");
     }
 }

--- a/crates/rue/src/test_mode/verdict.rs
+++ b/crates/rue/src/test_mode/verdict.rs
@@ -31,7 +31,7 @@ use std::fmt;
 /// a bare `exit`.
 const TRAP_MESSAGES: &[(&str, &str)] = &[
     // `__rue_panic_no_msg`. The message-carrying `__rue_panic` writes
-    // `panic: <msg>`, which is matched by prefix below.
+    // `panic: <msg>`, which is one of the prefixes below.
     ("panic", "panic"),
     ("error: division by zero", "div_by_zero"),
     ("error: integer overflow", "overflow"),
@@ -41,11 +41,22 @@ const TRAP_MESSAGES: &[(&str, &str)] = &[
     ("stack overflow", "stack_overflow"),
 ];
 
+/// The traps whose pinned message carries a payload after a fixed prefix, and
+/// the `trap:<class>` name the event stream publishes for each.
+///
+/// A prefix is matched only at the start of the last stderr line, so these are
+/// as exact as the whole-line matches above: the runtime owns the prefix, and
+/// only the text after it varies.
+const TRAP_PREFIXES: &[(&str, &str)] = &[
+    // `__rue_panic`, ahead of the user's message text.
+    ("panic: ", "panic"),
+    // The SIGSEGV handler's non-overflow message, ahead of the faulting address
+    // in hex (RUE-2163).
+    ("segmentation fault at 0x", "segfault"),
+];
+
 /// `__rue_assert_failed`'s pinned message.
 const ASSERT_MESSAGE: &str = "assertion failed";
-
-/// `__rue_panic`'s prefix, ahead of the user's message text.
-const PANIC_PREFIX: &str = "panic: ";
 
 /// The `trap:` namespace a runtime trap's own failure frame reports under.
 const TRAP_PREFIX: &str = "trap:";
@@ -55,6 +66,7 @@ const TRAP_PREFIX: &str = "trap:";
 fn trap_class(name: &str) -> Option<&'static str> {
     TRAP_MESSAGES
         .iter()
+        .chain(TRAP_PREFIXES)
         .map(|(_, class)| *class)
         .find(|class| *class == name)
 }
@@ -502,7 +514,8 @@ pub(crate) fn classify(observation: Observation<'_>) -> Classification {
 /// that printed diagnostics of its own before tripping an assertion still
 /// trapped, and classifying it as a bare `exit` because it was chatty would
 /// lose the one piece of structure the abort-only runtime gives us. The match
-/// against that line is exact (or, for `@panic("msg")`, exact on the pinned
+/// against that line is exact (or, for the two messages that carry a payload —
+/// `@panic("msg")` and the segmentation fault's address — exact on the pinned
 /// prefix), so a reworded runtime message is a failed CLI case rather than a
 /// silent reclassification.
 fn classify_runtime_message(stderr: &[u8]) -> Option<FailureKind> {
@@ -512,8 +525,12 @@ fn classify_runtime_message(stderr: &[u8]) -> Option<FailureKind> {
     if last == ASSERT_MESSAGE {
         return Some(FailureKind::Assert);
     }
-    if last.starts_with(PANIC_PREFIX) {
-        return Some(FailureKind::Trap("panic"));
+    if let Some(class) = TRAP_PREFIXES
+        .iter()
+        .find(|(prefix, _)| last.starts_with(prefix))
+        .map(|(_, class)| *class)
+    {
+        return Some(FailureKind::Trap(class));
     }
     TRAP_MESSAGES
         .iter()
@@ -576,6 +593,8 @@ mod tests {
             ("error: index out of bounds\n", "bounds_check"),
             ("error: invalid UTF-8\n", "invalid_utf8"),
             ("stack overflow\n", "stack_overflow"),
+            ("segmentation fault at 0x0\n", "segfault"),
+            ("segmentation fault at 0xdead0000\n", "segfault"),
         ];
         for (stderr, class) in expected {
             assert_eq!(
@@ -584,6 +603,33 @@ mod tests {
                 "stderr {stderr:?}"
             );
         }
+    }
+
+    /// The two SIGSEGV outcomes are separate classes, not one (RUE-2163): a
+    /// wild pointer write used to reach `trap:stack_overflow` because the
+    /// runtime reported every fault as a blown stack.
+    #[test]
+    fn a_segmentation_fault_is_not_a_stack_overflow() {
+        assert_eq!(
+            observe(
+                Ok(101),
+                "segmentation fault at 0x0\n",
+                &ChannelFrames::default()
+            )
+            .verdict,
+            Verdict::Fail(FailureKind::Trap("segfault"))
+        );
+    }
+
+    /// A frame naming `trap:segfault` reaches the same kind the stderr match
+    /// produces, so one trap has one spelling however the runner learned of it.
+    #[test]
+    fn a_reported_segfault_frame_names_the_same_class() {
+        assert_eq!(
+            FailureKind::reported("trap:segfault"),
+            FailureKind::Trap("segfault")
+        );
+        assert_eq!(FailureKind::Trap("segfault").to_string(), "trap:segfault");
     }
 
     /// A test that printed before it trapped still trapped.

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -575,6 +575,7 @@ failure evidence.
 | `fail` | `assert_eq` | A `failure` frame from a failed `@assert_eq`, carrying `left` and `right`. |
 | `fail` | `assert_ne` | The same, from a failed `@assert_ne`. |
 | `fail` | `trap:<class>` | A `failure` frame with that kind — `@panic` and the bounds check write one — or the last stderr line being another pinned runtime message. |
+| `fail` | `trap:segfault` | The last stderr line being `segmentation fault at 0x<address>`: a `SIGSEGV` the runtime did not attribute to a blown stack (RUE-2163). The `message` is that whole line, address included. |
 | `fail` | `unhandled_error` | A `failure` frame with that kind — the test-body `?` failure arm. |
 | `fail` | *(verbatim)* | A `failure` frame with a kind the runner does not know (ADR-0083 §5.1). |
 | `fail` | `exit` | Any other nonzero exit. |
@@ -584,14 +585,32 @@ failure evidence.
 | `compile_error` | `compile_error` | The test's closure failed to analyze, so it was excluded from the image and no process ran. See below. |
 
 `trap:<class>` classes are `panic`, `div_by_zero`, `overflow`,
-`intcast_overflow`, `bounds_check`, `invalid_utf8`, and `stack_overflow`. The
-messages they match are the ones `crates/rue-runtime/src/error.rs` and `entry.rs`
-write before `exit(101)`; `crates/rue-cli-tests/cases/rue_test.toml` runs real
-programs down those paths, so a reworded runtime message fails a case rather than
-silently reclassifying a trap as a bare `exit`. A frame naming one of those
-classes reaches the same kind the stderr match produces, so one trap has one
-spelling however the runner learned of it; a `trap:` name outside the list is
-some other producer's and is published verbatim like any unknown kind.
+`intcast_overflow`, `bounds_check`, `invalid_utf8`, `stack_overflow`, and
+`segfault`. The messages they match are the ones
+`crates/rue-runtime/src/error.rs` and `entry.rs` write before `exit(101)`;
+`crates/rue-cli-tests/cases/rue_test.toml` runs real programs down those paths,
+so a reworded runtime message fails a case rather than silently reclassifying a
+trap as a bare `exit`. A frame naming one of those classes reaches the same kind
+the stderr match produces, so one trap has one spelling however the runner
+learned of it; a `trap:` name outside the list is some other producer's and is
+published verbatim like any unknown kind.
+
+Two of those messages carry a payload and are matched on their pinned prefix
+rather than whole: `@panic("msg")`'s `panic: <msg>`, and `segfault`'s
+`segmentation fault at 0x<address>`. The runtime owns the prefix and only the
+text after it varies, so the match is as exact as the whole-line ones. The
+address travels in the failure record's `message`, which for every trap is the
+stderr line the verdict was classified from; the `location` stays the `test`
+declaration's header, because no lowering stages a site beside a fault.
+
+`stack_overflow` and `segfault` are the two outcomes of one signal. The runtime
+catches `SIGSEGV`, reads the faulting address from `siginfo_t`, and reports a
+stack overflow only when that address falls in the window below the stack base
+it captured at process entry (`crates/rue-runtime/src/fault.rs`); every other
+fault — a null or wild raw-pointer write in a `checked` block, a C FFI callee
+touching bad memory — is a `segfault` naming its address. Before RUE-2163 the
+runtime reported every `SIGSEGV` as a blown stack, so both shapes arrived here
+as `trap:stack_overflow`.
 
 ### The `compile_error` verdict
 
@@ -666,7 +685,8 @@ Precedence, in order:
    message on the last non-empty line of stderr. The last line rather than the
    whole stream, so a test that printed diagnostics of its own before tripping an
    assertion is still classified by the trap it took; the comparison against that
-   line is exact.
+   line is exact, or exact on the pinned prefix for the two messages that carry a
+   payload (`panic: <msg>` and `segmentation fault at 0x<address>`).
 
 ### Reserved values
 
@@ -951,6 +971,12 @@ event of a run and in each `--list --format json` record.
   and optional, and `repro` still holds what it always did — the argv that
   reproduces this one test — in a spelling that resolves from more places than
   the old one, not a different kind of value.
+- The `trap:segfault` failure kind arrived the same way (RUE-2163). The version
+  stays `1.1`: `kind` has been an open field since v1.0 — a consumer already has
+  to publish a kind it does not recognize verbatim — and nothing a `1.1` consumer
+  already read changed. What changed is the runtime beneath it: a fault that used
+  to be reported as `trap:stack_overflow` is now reported as its own class, which
+  is a behavior fix rather than a schema change.
 - `run_started.cycle` and the `run_canceled` event arrived the same way
   (RUE-2023), as an optional field and a new event kind. The version stays
   `1.0`: nothing a `1.0` consumer already read changed, and a consumer that

--- a/docs/spec/src/08-runtime-behavior/05-signal-termination.md
+++ b/docs/spec/src/08-runtime-behavior/05-signal-termination.md
@@ -13,7 +13,7 @@ indexing) end a program *from inside* with the panic exit code 101. A program
 may also be ended *from outside* the language's control flow when the host
 operating system delivers a **signal** whose default disposition is to terminate
 the process. Rue installs one signal handler and no others: `SIGSEGV` is caught
-so that a stack overflow becomes a clean abort (8.5:6), and every other signal
+so that a memory fault becomes a clean abort (8.5:6), and every other signal
 keeps its platform-default behavior. This section describes the observable exit
 status in that case; because the trigger is external to the language, these
 paragraphs are informative rather than normative.
@@ -27,14 +27,27 @@ disposition would kill the process with the raw crash status `139`
 (`128 + SIGSEGV`, per 8.5:2) and no explanation. Before user code runs, the
 runtime instead
 installs a `SIGSEGV` handler on an alternate signal stack — so the handler can
-run even though the main stack is the thing that overflowed — which writes
-`stack overflow` to standard error and exits with the panic exit code `101`,
-the same code the traps of the preceding sections use. Any `SIGSEGV` is reported
-this way: in safe Rue a blown stack is the only way to raise one, because
-indexing is bounds-checked, there are no raw-pointer dereferences, and
-arithmetic traps rather than corrupting memory. A `SIGSEGV` raised from
-`checked` code (chapter 9), where those guarantees do not hold, is undefined
-behavior under B.3 and is reported the same way regardless of its cause.
+run even though the main stack is the thing that overflowed — which writes a
+one-line reason to standard error and exits with the panic exit code `101`, the
+same code the traps of the preceding sections use.
+
+The handler classifies the fault by the address that raised it, which the
+operating system supplies alongside the signal. A fault whose address lies in
+the region the runtime knows the main stack occupies — the stack base it
+captured at process entry, extended downward by the process's stack limit and
+the host's guard region — is reported as `stack overflow`. Any other fault is
+reported as `segmentation fault at 0x<address>`, with the faulting address in
+lowercase hexadecimal and no padding, so a null write reports
+`segmentation fault at 0x0`.
+
+In safe Rue only the first of those is reachable: indexing is bounds-checked,
+there are no raw-pointer dereferences, and arithmetic traps rather than
+corrupting memory. The second exists for `checked` code (chapter 9) and for
+foreign code called across the boundary of 9.3, where those guarantees do not
+hold. A `SIGSEGV` raised there is undefined behavior under B.3; reporting its
+address is a courtesy of this implementation and not a defined result, and no
+program may rely on which of the two messages a particular fault produces.
+
 Installing the handler is best-effort: on a host where the alternate stack or
 the handler registration is unavailable, the program keeps the default
 `SIGSEGV` disposition and exits with `139` as described above.


### PR DESCRIPTION
Fixes RUE-2163

## Problem

The runtime's SIGSEGV handler reported every fault as `stack overflow`, on the premise that safe Rue has no other way to raise one. `checked` blocks and raw pointers (chapter 9) and foreign callees (9.3) broke that premise: a write through a null pointer printed `stack overflow` and exited 101, and under `rue test` it was `trap:stack_overflow`, sending a reader to look for runaway recursion.

## Change

- The handler is installed with `SA_SIGINFO` on all three targets and reads the faulting address from the platform's `siginfo_t`: offset 24 on macOS (XNU `struct __siginfo`), offset 16 on both Linux targets (asm-generic `siginfo_t`). Each layout carries a compile-time `offset_of!` assertion. The Darwin trampoline gained the register shuffle libplatform's own `_sigtramp` performs.
- A fault is a stack overflow exactly when its address lies within `[stack_top - (stack_window + 1 MiB), stack_top]`: the stack pointer captured at process entry, the soft `RLIMIT_STACK` when finite and at most 1 GiB (8 MiB otherwise, so `ulimit -s unlimited` cannot swallow wild pointers), and one guard region of slack. Everything else prints `segmentation fault at 0x<addr>` in lowercase hex and exits 101 like every other trap. The rule and its two cases are documented in the new `crates/rue-runtime/src/fault.rs`.
- `rue test` classifies that message as kind `trap:segfault` with the address in the failure record; `kind` is an open field, so the schema stays 1.1, and the versioning note says so.
- Spec 8.5 now states which faults the handler classifies as an overflow and that other faults report their address as a courtesy of the implementation, not a defined result.
- The oracle-diff harness treats the segmentation-fault message as the same structural gap as `stack overflow`, since the interpreter refuses a wild dereference by construction.

## Verification

- macOS aarch64, live: unbounded recursion reports `stack overflow` at `ulimit -s` 1024, 8176, and 65520; a null write reports `segmentation fault at 0x0`; a wild write reports `segmentation fault at 0xdead0000`; a write one GiB below a stack address reports its address; `rue test` reports `trap:segfault` with the message and the header location.
- `scripts/rue unit runtime`: 114 passed. `scripts/rue cli segfault`: 4. `scripts/rue cli stack_overflow`: 4. `scripts/rue cli rue_test`: 114. `scripts/rue quick`: 946 passed.
- `scripts/rue premerge`: pass 220, fail 0.
- The Linux legs were compiled for both targets but not executed locally; the `siginfo_t` offsets and the `prlimit64` numbers rest on the kernel and glibc headers plus the compile-time assertions, and CI's Linux jobs running `cli.segfault` are the authority for them.
