### PR TITLE
RUE-2168: an indirect place is read at its element's compact width and offset

### DIFF
--- a/crates/rue-cli-tests/cases/subword_indirect_place_reads.toml
+++ b/crates/rue-cli-tests/cases/subword_indirect_place_reads.toml
@@ -1,0 +1,273 @@
+# A `borrow` accessor's result is an indirect place: the trusted `@place`
+# bridge hands code generation a raw pointer into the container's buffer, and
+# `PlaceRead`/`PlaceWrite` on that base name ordinary program memory.
+#
+# That memory is laid out compactly (ADR-0052 representation 3) — a narrow
+# scalar occupies one, two, or four bytes and a field sits at its layout byte
+# offset — while the frame keeps the slot-shaped internal decomposition, eight
+# bytes per leaf. Shared place lowering applied the frame's model to both, so an
+# indirect read of a sub-word element loaded a whole eight-byte word and a
+# projected field was read at `slot * 8` instead of its compact offset. The
+# visible results were silent wrong answers, not crashes: `ArrayBuf(u8)`
+# holding `[1, 0, 2]` compared `get_ref(0)` against `1` as `0x00020001`, and a
+# `{ i32, u8, bool }` element read its second field out of the following
+# element (RUE-2168).
+#
+# The oracle already modeled the indirect place at the element's own width, so
+# these cases are the gate: `differential_opt` compiles and runs each at
+# `-O0`/`-O1`/`-O2`/`-O3` and requires one answer, and the oracle-diff corpus
+# checks that answer against the reference interpreter.
+
+[section]
+id = "cli.subword_indirect_place_reads"
+name = "Sub-word reads through a borrow accessor's place"
+description = "An indirect place is read and written at its element's compact width and byte offset, not at the frame's slot width (RUE-2168)."
+
+# Neighbouring elements are deliberately non-zero: a whole-word load of
+# element 0 of `[1, 0, 2]` reads 0x00020001, which no correct comparison with
+# `1` can produce.
+[[case]]
+name = "unsigned_narrow_elements_compare_at_their_own_width"
+description = "RUE-2168: `u8` and `u16` elements read through `get_ref` compare as one and two bytes, not as the word their neighbours share."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let mut a = std.arraybuf.ArrayBuf(u8).new();
+    a.push(1); a.push(0); a.push(2);
+    @dbg(a.get_ref(0) == 1);
+    @dbg(a.get_ref(0) != 1);
+    @dbg(a.get_ref(0) < 2);
+    @dbg(a.get_ref(2) == 2);
+    let mut b = std.arraybuf.ArrayBuf(u16).new();
+    b.push(7); b.push(1); b.push(65535);
+    @dbg(b.get_ref(0) == 7);
+    @dbg(b.get_ref(2) == 65535);
+    @dbg(b.get_ref(0) < b.get_ref(2));
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "true\nfalse\ntrue\ntrue\ntrue\ntrue\ntrue\n"
+exit_code = 0
+differential_opt = true
+
+# A signed narrow load must sign-extend into the slot-shaped register image
+# (the invariant on `value_plan::width_extension`), or a negative element
+# compares as a large positive one.
+[[case]]
+name = "signed_narrow_elements_sign_extend"
+description = "RUE-2168: negative `i8` and `i16` elements read through `get_ref` sign-extend, so they stay negative."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let mut a = std.arraybuf.ArrayBuf(i8).new();
+    a.push(-5); a.push(-1); a.push(127);
+    @dbg(a.get_ref(0));
+    @dbg(a.get_ref(0) < 0);
+    @dbg(a.get_ref(0) == -5);
+    @dbg(a.get_ref(1));
+    @dbg(a.get_ref(2));
+    let mut b = std.arraybuf.ArrayBuf(i16).new();
+    b.push(-300); b.push(7); b.push(-32768);
+    @dbg(b.get_ref(0));
+    @dbg(b.get_ref(0) < 0);
+    @dbg(b.get_ref(2));
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "-5\ntrue\ntrue\n-1\n127\n-300\ntrue\n-32768\n"
+exit_code = 0
+differential_opt = true
+
+# `i32` occupies four of the eight bytes a slot has, so it read its neighbour
+# too; the whole-word value then overflowed the narrow add rather than
+# producing a wrong sum.
+[[case]]
+name = "i32_elements_read_four_bytes"
+description = "RUE-2168: an `i32` element read through `get_ref` reads four bytes and sign-extends, so a negative element neither trips the overflow check nor absorbs its neighbour."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let mut a = std.arraybuf.ArrayBuf(i32).new();
+    a.push(-70000); a.push(5); a.push(2147483647);
+    @dbg(a.get_ref(0));
+    @dbg(a.get_ref(0) < 0);
+    @dbg(a.get_ref(0) + 1);
+    @dbg(a.get_ref(1) == 5);
+    @dbg(a.get_ref(2));
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "-70000\ntrue\n-69999\ntrue\n2147483647\n"
+exit_code = 0
+differential_opt = true
+
+# Arithmetic is where the wrong width stopped being silent: `1 + 0` on the
+# whole-word image of `[1, 0, 2]` traps the `u8` overflow check.
+[[case]]
+name = "narrow_elements_are_operands_of_checked_arithmetic"
+description = "RUE-2168: a `u8`/`u16` element read through `get_ref` enters an arithmetic operator at its own width, so the result neither overflows nor carries a neighbour."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let mut a = std.arraybuf.ArrayBuf(u8).new();
+    a.push(1); a.push(0); a.push(2);
+    let v: u8 = a.get_ref(0) + 0;
+    @dbg(v);
+    let w: u8 = a.get_ref(0) + a.get_ref(2);
+    @dbg(w);
+    let mut b = std.arraybuf.ArrayBuf(u16).new();
+    b.push(7); b.push(1);
+    let x: u16 = b.get_ref(0) * 2;
+    @dbg(x);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "1\n3\n14\n"
+exit_code = 0
+differential_opt = true
+
+# `bool` is one byte with a 0/1 validity invariant (ADR-0052 ruling 1); a
+# whole-word load of a `false` element next to a `true` one produced neither.
+[[case]]
+name = "bool_elements_read_one_byte"
+description = "RUE-2168: a `bool` element read through `get_ref` loads one zero-extended byte, preserving its 0/1 validity."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let mut a = std.arraybuf.ArrayBuf(bool).new();
+    a.push(false); a.push(true); a.push(true);
+    @dbg(a.get_ref(0));
+    @dbg(a.get_ref(1));
+    if a.get_ref(0) { @dbg(1); } else { @dbg(2); }
+    @dbg(a.get_ref(1) == a.get_ref(2));
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "false\ntrue\n2\ntrue\n"
+exit_code = 0
+differential_opt = true
+
+# The accessor's `self` is itself a by-reference parameter, so reading an
+# element inside a helper that borrows the whole container puts the indirect
+# place one level further from the frame.
+[[case]]
+name = "a_narrow_element_is_read_through_a_borrowed_container"
+description = "RUE-2168: an accessor read inside a helper that borrows the container reads at the element's own width."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn first(borrow a: std.arraybuf.ArrayBuf(u8)) -> u8 { a.get_ref(0) + 0 }
+fn is_one(borrow a: std.arraybuf.ArrayBuf(u8)) -> bool { a.get_ref(0) == 1 }
+fn head(borrow b: std.arraybuf.ArrayBuf(i16)) -> i16 { b.get_ref(0) + 0 }
+fn main() -> i32 {
+    let mut a = std.arraybuf.ArrayBuf(u8).new();
+    a.push(1); a.push(0); a.push(2);
+    @dbg(first(borrow a));
+    @dbg(is_one(borrow a));
+    let mut b = std.arraybuf.ArrayBuf(i16).new();
+    b.push(-300); b.push(7);
+    @dbg(head(borrow b));
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "1\ntrue\n-300\n"
+exit_code = 0
+differential_opt = true
+
+# `Narrow { a: i32, b: u8, c: bool }` is 6 bytes: `a` at 0, `b` at 4, `c` at 5.
+# Its slot decomposition puts them at bytes 0, 8, and 16, so every projection
+# but the first reached another element.
+[[case]]
+name = "a_struct_element_projects_at_its_compact_field_offsets"
+description = "RUE-2168: a field projected off an accessor's place is read at its compact byte offset, not at its slot offset."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+@copy
+struct Narrow { a: i32, b: u8, c: bool }
+fn main() -> i32 {
+    let mut xs = std.arraybuf.ArrayBuf(Narrow).new();
+    xs.push(Narrow { a: -5, b: 200, c: true });
+    xs.push(Narrow { a: 7, b: 9, c: false });
+    @dbg(xs.get_ref(0).a);
+    @dbg(xs.get_ref(0).b);
+    @dbg(xs.get_ref(0).c);
+    @dbg(xs.get_ref(1).a);
+    @dbg(xs.get_ref(1).b);
+    @dbg(xs.get_ref(1).c);
+    @dbg(xs.get_ref(0).b == 200);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "-5\n200\ntrue\n7\n9\nfalse\ntrue\n"
+exit_code = 0
+differential_opt = true
+
+# A whole aggregate read out of an accessor's place decodes the same compact
+# image `@ptr_read` of that element decodes, including a nested one.
+[[case]]
+name = "a_whole_element_decodes_its_compact_image"
+description = "RUE-2168: a multi-slot value read through an accessor's place decodes the compact image its container stores."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+@copy
+struct Inner { x: i32, y: u8 }
+@copy
+struct Outer { inner: Inner, tail: u8 }
+fn main() -> i32 {
+    let mut xs = std.arraybuf.ArrayBuf(Outer).new();
+    xs.push(Outer { inner: Inner { x: -5, y: 3 }, tail: 200 });
+    xs.push(Outer { inner: Inner { x: 7, y: 4 }, tail: 9 });
+    let first: Inner = xs.get_ref(0).inner;
+    @dbg(first.x);
+    @dbg(first.y);
+    @dbg(xs.get_ref(1).inner.x);
+    @dbg(xs.get_ref(1).inner.y);
+    @dbg(xs.get_ref(0).tail);
+    @dbg(xs.get_ref(1).tail);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "-5\n3\n7\n4\n200\n9\n"
+exit_code = 0
+differential_opt = true
+
+# A payload enum's compact image narrows its tag and packs its payload, so an
+# element matched straight out of the accessor exercises the tag-dispatched
+# decode rather than the slot-shaped one.
+[[case]]
+name = "an_enum_element_decodes_its_narrow_tag_and_payload"
+description = "RUE-2168: an enum element read through an accessor's place decodes its compact tag and payload."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+enum Step { Stop, Go(i64), Small(u8) }
+fn main() -> i32 {
+    let mut xs = std.arraybuf.ArrayBuf(Step).new();
+    xs.push(Step.Small(200));
+    xs.push(Step.Go(-7));
+    xs.push(Step.Stop);
+    match xs.get_ref(0) { Step.Stop => { @dbg(0); }, Step.Go(v) => { @dbg(v); }, Step.Small(v) => { @dbg(v); } }
+    match xs.get_ref(1) { Step.Stop => { @dbg(0); }, Step.Go(v) => { @dbg(v); }, Step.Small(v) => { @dbg(v); } }
+    match xs.get_ref(2) { Step.Stop => { @dbg(1); }, Step.Go(v) => { @dbg(v); }, Step.Small(v) => { @dbg(v); } }
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "200\n-7\n1\n"
+exit_code = 0
+differential_opt = true

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1659,22 +1659,23 @@ impl<'a> CfgLower<'a> {
             }
             ResidualValuePlan::PlaceRead { place, leaf_types } => {
                 let count = plan.policy.shape.slot_count();
+                let vals =
+                    crate::place_lower::lower_place_read_slots_plan(self, &place, ty, &leaf_types);
                 if count > 1 {
-                    let addr = self.mir.alloc_vreg();
-                    crate::place_lower::lower_checked_place_addr_plan(self, addr, &place);
-                    slots = crate::agg_slots::load_slots_through_ptr_typed(self, addr, &leaf_types);
-                    let dst = slots[0];
-                    dst
-                } else {
-                    let dst =
-                        self.mir
-                            .alloc_vreg_in(if plan.policy.primary_float_width.is_some() {
-                                crate::reg_class::RegClass::Fp
-                            } else {
-                                crate::reg_class::RegClass::Gp
-                            });
-                    crate::place_lower::lower_place_read_plan(self, dst, &place, ty);
-                    dst
+                    slots = vals.clone();
+                }
+                match vals.first() {
+                    Some(first) => *first,
+                    // A zero-sized place loads nothing: its primary is the
+                    // never-read placeholder such a value carries, kept
+                    // allocated so register allocation sees an ordinary value.
+                    None => self
+                        .mir
+                        .alloc_vreg_in(if plan.policy.primary_float_width.is_some() {
+                            crate::reg_class::RegClass::Fp
+                        } else {
+                            crate::reg_class::RegClass::Gp
+                        }),
                 }
             }
             ResidualValuePlan::PlaceWrite {
@@ -1682,6 +1683,7 @@ impl<'a> CfgLower<'a> {
                 value,
                 value_shape,
                 float_width,
+                value_ty,
                 leaf_types,
             } => {
                 let vals = if matches!(
@@ -1700,6 +1702,7 @@ impl<'a> CfgLower<'a> {
                     &place,
                     &vals,
                     float_width,
+                    value_ty,
                     &leaf_types,
                 );
                 return ValueResult::SideEffect;

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -248,18 +248,33 @@ pub(crate) fn store_enum_slots_through_ptr<B: SlotBackend>(
     // byte, so the whole image is initialized regardless of prior memory contents.
     zero_padding_through_ptr(b, ptr, padding);
     for (val, slot) in vals.iter().zip(map.iter()) {
-        match (slot.float_width, slot.access) {
-            (Some(width), _) if slot.bit_carrier => {
-                let fp = b.alloc_float_vreg();
-                b.emit_bits_to_float(fp, *val, width);
-                b.emit_float_store_through_ptr(fp, ptr, slot.byte_offset, width);
-            }
-            (Some(width), _) => b.emit_float_store_through_ptr(*val, ptr, slot.byte_offset, width),
-            (None, None) => b.emit_store_through_ptr(*val, ptr, slot.byte_offset),
-            (None, Some(access)) => {
-                b.emit_narrow_store_through_ptr(*val, ptr, slot.byte_offset, access)
-            }
+        store_physical_slot(b, *val, ptr, slot);
+    }
+}
+
+/// Store one value slot into its physical byte position, truncating a narrow
+/// leaf to its compact width and moving a bit-carrier slot back into the float
+/// register class first.
+///
+/// This is the single physical-store leaf: the whole-aggregate image writers and
+/// the indirect-place writer ([`crate::place_lower`]) both go through it, so a
+/// compact image written through a pointer intrinsic and one written through a
+/// place cannot disagree about a byte.
+pub(crate) fn store_physical_slot<B: SlotBackend>(
+    b: &mut B,
+    val: VReg,
+    ptr: VReg,
+    slot: &crate::types::PhysicalEnumSlot,
+) {
+    match (slot.float_width, slot.access) {
+        (Some(width), _) if slot.bit_carrier => {
+            let fp = b.alloc_float_vreg();
+            b.emit_bits_to_float(fp, val, width);
+            b.emit_float_store_through_ptr(fp, ptr, slot.byte_offset, width);
         }
+        (Some(width), _) => b.emit_float_store_through_ptr(val, ptr, slot.byte_offset, width),
+        (None, None) => b.emit_store_through_ptr(val, ptr, slot.byte_offset),
+        (None, Some(access)) => b.emit_narrow_store_through_ptr(val, ptr, slot.byte_offset, access),
     }
 }
 
@@ -273,28 +288,53 @@ pub(crate) fn load_enum_slots_through_ptr<B: SlotBackend>(
     ptr: VReg,
     map: &[crate::types::PhysicalEnumSlot],
 ) -> Vec<VReg> {
-    let mut vregs = Vec::with_capacity(map.len());
-    for slot in map {
-        let dst = if slot.float_width.is_some() && !slot.bit_carrier {
-            b.alloc_float_vreg()
-        } else {
-            b.alloc_vreg()
-        };
-        match (slot.float_width, slot.access) {
-            (Some(width), _) if slot.bit_carrier => {
-                let fp = b.alloc_float_vreg();
-                b.emit_float_load_through_ptr(fp, ptr, slot.byte_offset, width);
-                b.emit_float_to_bits(dst, fp, width);
-            }
-            (Some(width), _) => b.emit_float_load_through_ptr(dst, ptr, slot.byte_offset, width),
-            (None, None) => b.emit_load_through_ptr(dst, ptr, slot.byte_offset),
-            (None, Some(access)) => {
-                b.emit_narrow_load_through_ptr(dst, ptr, slot.byte_offset, access)
-            }
-        }
-        vregs.push(dst);
+    map.iter()
+        .map(|slot| {
+            let dst = alloc_physical_slot_vreg(b, slot);
+            load_physical_slot(b, dst, ptr, slot);
+            dst
+        })
+        .collect()
+}
+
+/// Allocate a vreg of the register class one physical slot's value lives in: a
+/// float class for a float leaf read as a float, the general-purpose class for
+/// everything else including a bit-carrier union slot.
+pub(crate) fn alloc_physical_slot_vreg<B: SlotBackend>(
+    b: &mut B,
+    slot: &crate::types::PhysicalEnumSlot,
+) -> VReg {
+    if slot.float_width.is_some() && !slot.bit_carrier {
+        b.alloc_float_vreg()
+    } else {
+        b.alloc_vreg()
     }
-    vregs
+}
+
+/// Load one value slot from its physical byte position, extending a narrow leaf
+/// back into the slot-shaped register image (zero-extended unsigned, sign-extended
+/// signed — the invariant on [`crate::value_plan::width_extension`]) and moving a
+/// bit-carrier slot out of the float register class.
+///
+/// This is the single physical-load leaf, the counterpart of
+/// [`store_physical_slot`]: the whole-aggregate image readers and the
+/// indirect-place reader ([`crate::place_lower`]) both go through it.
+pub(crate) fn load_physical_slot<B: SlotBackend>(
+    b: &mut B,
+    dst: VReg,
+    ptr: VReg,
+    slot: &crate::types::PhysicalEnumSlot,
+) {
+    match (slot.float_width, slot.access) {
+        (Some(width), _) if slot.bit_carrier => {
+            let fp = b.alloc_float_vreg();
+            b.emit_float_load_through_ptr(fp, ptr, slot.byte_offset, width);
+            b.emit_float_to_bits(dst, fp, width);
+        }
+        (Some(width), _) => b.emit_float_load_through_ptr(dst, ptr, slot.byte_offset, width),
+        (None, None) => b.emit_load_through_ptr(dst, ptr, slot.byte_offset),
+        (None, Some(access)) => b.emit_narrow_load_through_ptr(dst, ptr, slot.byte_offset, access),
+    }
 }
 
 /// Read one by-value aggregate parameter's leaves back out of its compact image

--- a/crates/rue-codegen/src/allocation.rs
+++ b/crates/rue-codegen/src/allocation.rs
@@ -123,11 +123,13 @@ pub const fn scale_kind(bytes: u64) -> ScaleKind {
 /// addressing strides by the *slot* stride — `abi_slot_count(element) *
 /// SLOT_BYTES` — not the compact element size. Under the slot model the two are
 /// identical (every leaf is eight bytes); under the compact layout (ADR-0052)
-/// they diverge, and the slot stride is the physically correct one because
-/// `[]`-indexed arrays only ever address slot-based storage (a frame value or a
-/// by-reference pointer into the caller's slot-based frame). Heap element
-/// stepping uses `@ptr_offset` (`pointer_offset_scale_plan`), which strides by
-/// the compact element size against a compact heap image (RUE-1014).
+/// they diverge, and the slot stride is the physically correct one for the
+/// slot-based storage this plan addresses: a frame value or a by-reference
+/// pointer into the caller's slot-based frame. An indexed place rooted at a raw
+/// pointer names a compact image instead and uses
+/// [`compact_index_scale_plan`]. Heap element stepping uses `@ptr_offset`
+/// (`pointer_offset_scale_plan`), which strides by the compact element size
+/// against a compact heap image (RUE-1014).
 #[inline]
 pub fn index_scale_plan(type_pool: &FrozenTypeInternPool, array_type: Type) -> ScalePlan {
     let (element_type, _) =
@@ -135,6 +137,20 @@ pub fn index_scale_plan(type_pool: &FrozenTypeInternPool, array_type: Type) -> S
     let slot_stride = u64::from(types::type_slot_count(type_pool, element_type)) * SLOT_BYTES;
     ScalePlan {
         kind: scale_kind(slot_stride),
+        purpose: ScalePurpose::IndexOffset,
+        overflow: OverflowBehavior::Wrap,
+    }
+}
+
+/// Build the scaling plan used for an array `[]` projection of an *indirect*
+/// place, whose storage a raw pointer names and is therefore laid out compactly
+/// (ADR-0052 representation 3). It strides by the compact element stride — the
+/// same distance `@ptr_offset` steps over the same image — so an indexed place
+/// and the pointer intrinsics reach the same element (RUE-2168).
+#[inline]
+pub fn compact_index_scale_plan(type_pool: &FrozenTypeInternPool, array_type: Type) -> ScalePlan {
+    ScalePlan {
+        kind: scale_kind(types::array_element_byte_stride(type_pool, array_type)),
         purpose: ScalePurpose::IndexOffset,
         overflow: OverflowBehavior::Wrap,
     }

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -67,8 +67,8 @@ pub(crate) trait PlaceLowerBackend: SlotBackend {
     /// Load from the address in `ptr` with no encoded displacement.
     ///
     /// AArch64 has separate base-only and base-plus-zero MIR variants. Keeping
-    /// this leaf preserves the pre-extraction choice at simple and dynamically
-    /// addressed place reads.
+    /// this leaf preserves the pre-extraction choice at a by-reference
+    /// parameter's own pointer and at dynamically addressed frame places.
     fn emit_load_ptr_base(
         &mut self,
         dst: VReg,
@@ -79,12 +79,29 @@ pub(crate) trait PlaceLowerBackend: SlotBackend {
     fn emit_float_store_slot(&mut self, src: VReg, slot: u32, width: crate::value_plan::FloatWidth);
 }
 
+/// Whether `place` names storage a raw pointer reaches rather than the frame.
+///
+/// The pointer an `Indirect` base carries comes from the trusted `@place`
+/// bridge, so it names ordinary program memory, which is laid out compactly
+/// (ADR-0052 representation 3): a field sits at its layout byte offset, an array
+/// element strides by the compact element stride, and a narrow scalar occupies
+/// one, two, or four bytes. Frame storage — a local, a by-value parameter, or
+/// the by-reference pointer a caller formed from one — is the slot-shaped
+/// internal decomposition instead, eight bytes per leaf. The two models disagree
+/// for every type that is not slot-identical, so each place is addressed and
+/// accessed in the model its own base names (RUE-2168).
+fn place_is_indirect(place: &ResolvedPlace) -> bool {
+    matches!(place.base, crate::value_plan::PlaceBasePlan::Pointer(_))
+}
+
 fn resolved_offsets<B: PlaceLowerBackend + ?Sized>(
     b: &mut B,
     place: &ResolvedPlace,
     check_bounds: bool,
 ) -> ResolvedProjectionOffsets {
+    let indirect = place_is_indirect(place);
     let mut static_slot_offset = 0;
+    let mut static_byte_offset: i64 = 0;
     let mut index_levels = Vec::new();
     for projection in &place.projections {
         match *projection {
@@ -93,6 +110,11 @@ fn resolved_offsets<B: PlaceLowerBackend + ?Sized>(
                 field_index,
             } => {
                 static_slot_offset += b.ctx().struct_field_slot_offset(struct_id, field_index);
+                static_byte_offset += crate::types::struct_field_byte_offset(
+                    b.ctx().type_pool,
+                    struct_id,
+                    field_index,
+                ) as i64;
             }
             crate::value_plan::ProjectionPlan::Index { array_type, index } => {
                 if check_bounds {
@@ -103,13 +125,19 @@ fn resolved_offsets<B: PlaceLowerBackend + ?Sized>(
                 }
                 index_levels.push(ResolvedIndexLevel {
                     index,
-                    scale: allocation::index_scale_plan(b.ctx().type_pool, array_type),
+                    scale: if indirect {
+                        allocation::compact_index_scale_plan(b.ctx().type_pool, array_type)
+                    } else {
+                        allocation::index_scale_plan(b.ctx().type_pool, array_type)
+                    },
                 });
             }
         }
     }
     ResolvedProjectionOffsets {
         static_slot_offset,
+        static_byte_offset: i32::try_from(static_byte_offset)
+            .expect("a projected field's compact byte offset fits an addressing displacement"),
         index_levels,
     }
 }
@@ -207,7 +235,8 @@ fn resolved_access<B: PlaceLowerBackend + ?Sized>(
             )
         }
         crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
-            let byte_offset = slot_byte_offset(offsets.static_slot_offset as usize);
+            // Compact displacements, not slot ones: see `place_is_indirect`.
+            let byte_offset = offsets.static_byte_offset;
             if let Some(dynamic) = dynamic_offset {
                 let addr = b.alloc_vreg();
                 b.emit_reg_move(addr, ptr);
@@ -256,7 +285,198 @@ fn frame_access<B: PlaceLowerBackend + ?Sized>(
     }
 }
 
-pub(crate) fn lower_place_read_plan<B: PlaceLowerBackend>(
+/// Read the value of type `ty` out of `place`, returning one vreg per logical
+/// slot in slot order. A zero-sized place yields no vregs; the bounds checks its
+/// projections carry still run.
+///
+/// This is the one place-read entry point both backends use. It routes an
+/// indirect place through the same compact decode `@ptr_read` performs on the
+/// same image, and frame storage through the slot-shaped loads the frame model
+/// needs (see [`place_is_indirect`]).
+pub(crate) fn lower_place_read_slots_plan<B: PlaceLowerBackend>(
+    b: &mut B,
+    place: &ResolvedPlace,
+    ty: Type,
+    leaf_types: &[Type],
+) -> Vec<VReg> {
+    if b.ctx().type_slot_count(ty) == 0 {
+        resolved_offsets(b, place, true);
+        return Vec::new();
+    }
+    if leaf_types.len() > 1 {
+        if place_is_indirect(place) {
+            let (ptr, byte_offset) = indirect_place_address(b, place);
+            return load_pointee(b, ptr, byte_offset, ty, leaf_types);
+        }
+        let addr = b.alloc_vreg();
+        lower_checked_place_addr_plan(b, addr, place);
+        return agg_slots::load_slots_through_ptr_typed(b, addr, leaf_types);
+    }
+    let dst = if crate::value_plan::primary_slot_float_width(leaf_types).is_some() {
+        b.alloc_float_vreg()
+    } else {
+        b.alloc_vreg()
+    };
+    lower_place_read_plan(b, dst, place, ty);
+    vec![dst]
+}
+
+/// The address of an indirect place: the base pointer plus the compact
+/// displacement of its projection chain, with any dynamic index already folded
+/// into a materialized address.
+fn indirect_place_address<B: PlaceLowerBackend>(b: &mut B, place: &ResolvedPlace) -> (VReg, i32) {
+    let offsets = resolved_offsets(b, place, true);
+    match resolved_access(b, place, offsets) {
+        ProjectedAccess::PointerOffset { ptr, byte_offset } => (ptr, byte_offset),
+        ProjectedAccess::PointerAddr(addr) => (addr, 0),
+        ProjectedAccess::FrameSlot(_) => unreachable!("an indirect place has no frame slot"),
+    }
+}
+
+/// Read the multi-slot pointee of type `ty` at `ptr + byte_offset`.
+///
+/// This is the compact decode `@ptr_read` performs, reached from the other end:
+/// an indirect place and the pointer intrinsics name the same image, so they
+/// consult the same authorities — `pointer_image_slot_map` for an aggregate with
+/// a variant-independent image, `aggregate_dispatch_image` for a tag-dispatched
+/// one, and the slot-identical typed loads for an aggregate whose compact image
+/// already is its slot image.
+fn load_pointee<B: PlaceLowerBackend>(
+    b: &mut B,
+    ptr: VReg,
+    byte_offset: i32,
+    ty: Type,
+    leaf_types: &[Type],
+) -> Vec<VReg> {
+    if let Some(map) = crate::types::pointer_image_slot_map(b.ctx().type_pool, ty) {
+        let slots: Vec<_> = map
+            .iter()
+            .map(|slot| shift_physical_slot(slot, byte_offset))
+            .collect();
+        return slots
+            .iter()
+            .map(|slot| {
+                let dst = agg_slots::alloc_physical_slot_vreg(b, slot);
+                agg_slots::load_physical_slot(b, dst, ptr, slot);
+                dst
+            })
+            .collect();
+    }
+    let base = offset_pointer(b, ptr, byte_offset);
+    if let Some(image) = crate::types::aggregate_dispatch_image(b.ctx().type_pool, ty) {
+        return agg_slots::load_dispatch_image(b, base, &image);
+    }
+    agg_slots::load_slots_through_ptr_typed(b, base, leaf_types)
+}
+
+/// Read the one-slot pointee of type `ty` at `ptr + byte_offset` into `dst`.
+///
+/// The single-slot half of [`load_pointee`], kept dst-directed so a scalar read
+/// needs no register move: a sub-word leaf is loaded at `narrow_scalar_access`'s
+/// width and extended into the slot-shaped register image (RUE-1338) — the same
+/// access `@ptr_read` of that leaf emits.
+fn load_pointee_into<B: PlaceLowerBackend>(
+    b: &mut B,
+    dst: VReg,
+    ptr: VReg,
+    byte_offset: i32,
+    ty: Type,
+    leaf: Type,
+) {
+    if let Some(map) = crate::types::pointer_image_slot_map(b.ctx().type_pool, ty) {
+        let [slot] = map.as_slice() else {
+            unreachable!("a one-slot pointee has a one-slot compact image");
+        };
+        let slot = shift_physical_slot(slot, byte_offset);
+        agg_slots::load_physical_slot(b, dst, ptr, &slot);
+        return;
+    }
+    match (
+        crate::value_plan::float_width(leaf),
+        crate::types::narrow_scalar_access(b.ctx().type_pool, leaf),
+    ) {
+        (Some(width), _) => b.emit_float_load_through_ptr(dst, ptr, byte_offset, width),
+        (None, Some(access)) => b.emit_narrow_load_through_ptr(dst, ptr, byte_offset, access),
+        (None, None) => b.emit_load_through_ptr(dst, ptr, byte_offset),
+    }
+}
+
+/// Write `vals` — one vreg per logical slot of a value of type `ty` — into the
+/// pointee at `ptr + byte_offset`. The counterpart of [`load_pointee`] and
+/// [`load_pointee_into`], and the same compact encode `@ptr_write` performs.
+fn store_pointee<B: PlaceLowerBackend>(
+    b: &mut B,
+    vals: &[VReg],
+    ptr: VReg,
+    byte_offset: i32,
+    ty: Type,
+    leaf_types: &[Type],
+) {
+    if let Some(map) = crate::types::pointer_image_slot_map(b.ctx().type_pool, ty) {
+        // Deterministic zero on construction (ADR-0052 ruling 5): the padding of
+        // the value being written, at the position it is written to.
+        let padding = b.ctx().type_pool.compact_image_padding_ranges(ty);
+        if padding.is_empty() {
+            let slots: Vec<_> = map
+                .iter()
+                .map(|slot| shift_physical_slot(slot, byte_offset))
+                .collect();
+            for (val, slot) in vals.iter().zip(slots.iter()) {
+                agg_slots::store_physical_slot(b, *val, ptr, slot);
+            }
+        } else {
+            let base = offset_pointer(b, ptr, byte_offset);
+            agg_slots::store_enum_slots_through_ptr(b, vals, base, &map, &padding);
+        }
+        return;
+    }
+    if let Some(image) = crate::types::aggregate_dispatch_image(b.ctx().type_pool, ty) {
+        let base = offset_pointer(b, ptr, byte_offset);
+        agg_slots::store_dispatch_image(b, vals, base, &image);
+        return;
+    }
+    if leaf_types.len() > 1 {
+        agg_slots::store_slots_through_ptr_typed(b, vals, ptr, byte_offset, leaf_types);
+        return;
+    }
+    let leaf = leaf_types[0];
+    match (
+        crate::value_plan::float_width(leaf),
+        crate::types::narrow_scalar_access(b.ctx().type_pool, leaf),
+    ) {
+        (Some(width), _) => b.emit_float_store_through_ptr(vals[0], ptr, byte_offset, width),
+        (None, Some(access)) => b.emit_narrow_store_through_ptr(vals[0], ptr, byte_offset, access),
+        (None, None) => b.emit_store_through_ptr(vals[0], ptr, byte_offset),
+    }
+}
+
+/// The same physical slot displaced to a sub-object's position in an enclosing
+/// image, so a projected read needs no address arithmetic of its own.
+fn shift_physical_slot(
+    slot: &crate::types::PhysicalEnumSlot,
+    byte_offset: i32,
+) -> crate::types::PhysicalEnumSlot {
+    crate::types::PhysicalEnumSlot {
+        byte_offset: slot.byte_offset + byte_offset,
+        ..*slot
+    }
+}
+
+/// Materialize `ptr + byte_offset` when the displacement cannot travel with the
+/// access itself.
+fn offset_pointer<B: PlaceLowerBackend>(b: &mut B, ptr: VReg, byte_offset: i32) -> VReg {
+    if byte_offset == 0 {
+        return ptr;
+    }
+    let addr = b.alloc_vreg();
+    b.emit_reg_move(addr, ptr);
+    b.emit_addr_add_imm(addr, byte_offset);
+    addr
+}
+
+/// The one-slot half of [`lower_place_read_slots_plan`], for a place rooted in
+/// the frame or at a by-reference parameter's pointer.
+fn lower_place_read_plan<B: PlaceLowerBackend>(
     b: &mut B,
     dst: VReg,
     place: &ResolvedPlace,
@@ -277,6 +497,12 @@ pub(crate) fn lower_place_read_plan<B: PlaceLowerBackend>(
         resolved_offsets(b, place, true);
         return;
     }
+    if place_is_indirect(place) {
+        let leaf = crate::types::aggregate_leaf_types(b.ctx().type_pool, ty)[0];
+        let (ptr, byte_offset) = indirect_place_address(b, place);
+        load_pointee_into(b, dst, ptr, byte_offset, ty, leaf);
+        return;
+    }
     if place.projections.is_empty() {
         match place.base {
             crate::value_plan::PlaceBasePlan::Local(slot) => match float_width {
@@ -294,8 +520,8 @@ pub(crate) fn lower_place_read_plan<B: PlaceLowerBackend>(
                 Some(width) => b.emit_float_load_slot(dst, b.ctx().param_frame_slot(slot), width),
                 None => b.emit_load_slot(dst, b.ctx().param_frame_slot(slot)),
             },
-            crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
-                b.emit_load_ptr_base(dst, ptr, float_width)
+            crate::value_plan::PlaceBasePlan::Pointer(_) => {
+                unreachable!("an indirect place read is decoded compactly above")
             }
         }
         return;
@@ -333,10 +559,16 @@ pub(crate) fn lower_place_write_plan<B: PlaceLowerBackend>(
     place: &ResolvedPlace,
     vals: &[VReg],
     float_width: Option<crate::value_plan::FloatWidth>,
+    value_ty: Type,
     leaf_types: &[Type],
 ) {
     if vals.is_empty() {
         resolved_offsets(b, place, true);
+        return;
+    }
+    if place_is_indirect(place) {
+        let (ptr, byte_offset) = indirect_place_address(b, place);
+        store_pointee(b, vals, ptr, byte_offset, value_ty, leaf_types);
         return;
     }
     if place.projections.is_empty() {
@@ -371,14 +603,8 @@ pub(crate) fn lower_place_write_plan<B: PlaceLowerBackend>(
                 slot,
                 by_ref: false,
             } => agg_slots::store_slots_typed(b, vals, b.ctx().param_frame_slot(slot), leaf_types),
-            crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
-                if vals.len() == 1
-                    && let Some(width) = float_width
-                {
-                    b.emit_float_store_through_ptr(vals[0], ptr, 0, width)
-                } else {
-                    agg_slots::store_slots_through_ptr_typed(b, vals, ptr, 0, leaf_types)
-                }
+            crate::value_plan::PlaceBasePlan::Pointer(_) => {
+                unreachable!("an indirect place write is encoded compactly above")
             }
         }
         return;
@@ -462,7 +688,8 @@ fn lower_place_addr_plan_with_bounds<B: PlaceLowerBackend + ?Sized>(
         }
         crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
             b.emit_reg_move(dst, ptr);
-            let byte_offset = slot_byte_offset(offsets.static_slot_offset as usize);
+            // Compact displacements, not slot ones: see `place_is_indirect`.
+            let byte_offset = offsets.static_byte_offset;
             if byte_offset != 0 {
                 b.emit_addr_add_imm(dst, byte_offset);
             }
@@ -500,7 +727,12 @@ struct ResolvedIndexLevel {
 }
 
 struct ResolvedProjectionOffsets {
+    /// Offset of the projected sub-object in the slot-shaped internal
+    /// decomposition, for a place rooted in the frame.
     static_slot_offset: u32,
+    /// Byte offset of the same sub-object in the compact physical image, for a
+    /// place rooted at a raw pointer (see [`place_is_indirect`]).
+    static_byte_offset: i32,
     index_levels: Vec<ResolvedIndexLevel>,
 }
 
@@ -1524,6 +1756,102 @@ mod tests {
                 }
             )),
             "a zero-sized place must not form a frame address"
+        );
+    }
+
+    /// An indirect place names a compact image, so both its projection
+    /// displacement and its leaf access must be the physical ones (RUE-2168).
+    /// Before this, a projected field was read at its slot offset and a
+    /// sub-word leaf as a whole eight-byte word, so `ArrayBuf(u8).get_ref(0)`
+    /// compared three elements at once.
+    #[test]
+    fn indirect_place_reads_use_compact_offsets_and_widths_on_both_backends() {
+        // The CFG models the body a `borrow` accessor splice leaves behind:
+        //
+        //     fn read(p: ptr mut Narrow) -> i16 { @place(p).b }
+        //
+        // `struct Narrow { a: i32, b: i16 }` lays out compactly as `a` at byte
+        // 0 and `b` at byte 4; its slot decomposition puts `b` at slot 1, byte
+        // 8. Only the compact offset reaches the field.
+        let interner = ThreadedRodeo::new();
+        let pool = TypeInternPool::new();
+        let narrow_id = register_struct(
+            &pool,
+            &interner,
+            "Narrow",
+            &[("a", Type::I32), ("b", Type::I16)],
+        );
+        let narrow_ty = Type::new_struct(narrow_id);
+        let ptr_ty = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(narrow_ty));
+        let pool = pool.freeze();
+
+        let mut cfg = Cfg::new(Type::I16, 0, 1, "read".to_string(), vec![false]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let pointer = value(&mut cfg, entry, CfgInstData::Param { index: 0 }, ptr_ty);
+        let read = cfg
+            .append_place_read(
+                entry,
+                PlaceBase::Indirect(pointer),
+                narrow_ty,
+                [Projection::Field {
+                    struct_id: narrow_id,
+                    field_index: 1,
+                }],
+                Type::I16,
+                span(),
+            )
+            .unwrap();
+        cfg.set_return(entry, Some(read));
+
+        let x86 = X86CfgLower::new_unchecked(&cfg, &pool, &interner)
+            .lower()
+            .expect("x86 indirect place read should lower");
+        let arm = Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux)
+            .lower()
+            .expect("AArch64 indirect place read should lower");
+
+        let x86_narrow: Vec<(i32, u8, bool)> = x86
+            .instructions()
+            .iter()
+            .filter_map(|inst| match inst {
+                X86Inst::NarrowLoadIndexed {
+                    offset,
+                    width,
+                    signed,
+                    ..
+                } => Some((*offset, *width, *signed)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(x86_narrow, vec![(4, 2, true)]);
+        assert!(
+            !x86.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::MovRMIndexed { .. })),
+            "a sub-word indirect read must not load a whole word"
+        );
+
+        let arm_narrow: Vec<(i32, u8, bool)> = arm
+            .instructions()
+            .iter()
+            .filter_map(|inst| match inst {
+                Aarch64Inst::NarrowLoadIndexed {
+                    offset,
+                    width,
+                    signed,
+                    ..
+                } => Some((*offset, *width, *signed)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(arm_narrow, vec![(4, 2, true)]);
+        assert!(
+            !arm.instructions().iter().any(|inst| matches!(
+                inst,
+                Aarch64Inst::LdrIndexed { .. } | Aarch64Inst::LdrIndexedOffset { .. }
+            )),
+            "a sub-word indirect read must not load a whole word"
         );
     }
 

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -281,6 +281,33 @@ pub fn struct_field_slot_offset(
     type_pool.struct_field_slot_offset(struct_id, field_index)
 }
 
+/// Compact physical byte offset of a struct field (ADR-0052 representation 3).
+///
+/// The counterpart of [`struct_field_slot_offset`] for storage a raw pointer
+/// names rather than a frame slot: memory reached through a pointer is laid out
+/// compactly, so a field there sits at its layout byte offset, not at its slot
+/// offset times the slot width. Both offsets are read from the same layout
+/// authority, so they cannot disagree about a slot-identical type.
+pub(crate) fn struct_field_byte_offset(
+    type_pool: &FrozenTypeInternPool,
+    struct_id: StructId,
+    field_index: u32,
+) -> u64 {
+    let layout = type_pool.layout(Type::new_struct(struct_id));
+    let rue_air::layout::LayoutKind::Struct { field_offsets, .. } = &layout.kind else {
+        unreachable!("a struct type must have a struct layout");
+    };
+    field_offsets[field_index as usize]
+}
+
+/// Compact physical stride of one array element, the distance between adjacent
+/// elements in memory a pointer names. The slot-model counterpart is
+/// [`array_element_slot_count`] times the slot width.
+pub(crate) fn array_element_byte_stride(type_pool: &FrozenTypeInternPool, array_type: Type) -> u64 {
+    let (element, _) = array_type_def_from_type(type_pool, array_type).unwrap_or((array_type, 0));
+    type_pool.layout(element).stride
+}
+
 /// Whether `ty`'s compact physical layout (ADR-0052 `aggregate_layout`) is
 /// byte-for-byte identical to the flattened eight-byte slot layout.
 ///

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -214,6 +214,10 @@ pub enum ResidualValuePlan {
         value: MaterializedValue,
         value_shape: ValueShape,
         float_width: Option<FloatWidth>,
+        /// The stored value's own type. An indirect place writes a compact
+        /// image, whose shape is a fact about the whole type rather than about
+        /// its leaves alone.
+        value_ty: Type,
         /// One leaf type per logical slot of the stored value; see
         /// [`crate::place_lower::lower_place_write_plan`].
         leaf_types: Vec<Type>,
@@ -1846,6 +1850,7 @@ fn residual_plan<A: ValueLowerAdapter>(
                 value: operand(ctx, adapter, stored),
                 value_shape: ValuePlan::for_value(ctx, stored).shape,
                 float_width: primary_slot_float_width(&leaf_types),
+                value_ty: ctx.cfg.get_inst(stored).ty,
                 leaf_types,
             }
         }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1937,22 +1937,23 @@ impl<'a> CfgLower<'a> {
             }
             ResidualValuePlan::PlaceRead { place, leaf_types } => {
                 let count = plan.policy.shape.slot_count();
+                let vals =
+                    crate::place_lower::lower_place_read_slots_plan(self, &place, ty, &leaf_types);
                 if count > 1 {
-                    let addr = self.mir.alloc_vreg();
-                    crate::place_lower::lower_checked_place_addr_plan(self, addr, &place);
-                    slots = crate::agg_slots::load_slots_through_ptr_typed(self, addr, &leaf_types);
-                    let dst = slots[0];
-                    dst
-                } else {
-                    let dst =
-                        self.mir
-                            .alloc_vreg_in(if plan.policy.primary_float_width.is_some() {
-                                crate::reg_class::RegClass::Fp
-                            } else {
-                                crate::reg_class::RegClass::Gp
-                            });
-                    crate::place_lower::lower_place_read_plan(self, dst, &place, ty);
-                    dst
+                    slots = vals.clone();
+                }
+                match vals.first() {
+                    Some(first) => *first,
+                    // A zero-sized place loads nothing: its primary is the
+                    // never-read placeholder such a value carries, kept
+                    // allocated so register allocation sees an ordinary value.
+                    None => self
+                        .mir
+                        .alloc_vreg_in(if plan.policy.primary_float_width.is_some() {
+                            crate::reg_class::RegClass::Fp
+                        } else {
+                            crate::reg_class::RegClass::Gp
+                        }),
                 }
             }
             ResidualValuePlan::PlaceWrite {
@@ -1960,6 +1961,7 @@ impl<'a> CfgLower<'a> {
                 value,
                 value_shape,
                 float_width,
+                value_ty,
                 leaf_types,
             } => {
                 let vals = if matches!(
@@ -1978,6 +1980,7 @@ impl<'a> CfgLower<'a> {
                     &place,
                     &vals,
                     float_width,
+                    value_ty,
                     &leaf_types,
                 );
                 return ValueResult::SideEffect;

--- a/crates/rue-compiler/src/error_printer.rs
+++ b/crates/rue-compiler/src/error_printer.rs
@@ -1975,30 +1975,11 @@ impl Builder {
             LeafSource::Payload { .. } => {
                 unreachable!("a payload is staged into a local before it is read through")
             }
-            LeafSource::Element(element) => {
-                let pointer = self.element_pointer(element, owner_ty);
-                if element.prefix.is_empty() && projections.is_empty() {
-                    // A whole element is read through the pointer intrinsic
-                    // rather than an indirect place: an indirect place read of
-                    // a narrower-than-word scalar loads a whole word today —
-                    // `ArrayBuf(u8).get_ref(0)` has the same defect — and
-                    // `@ptr_read` is the path the standard library's own
-                    // element reads already take.
-                    return self.add(
-                        Data::Intrinsic {
-                            operation: IntrinsicOperation::PtrRead,
-                            name: Arc::from(IntrinsicOperation::PtrRead.expected_spelling()),
-                            args: Arc::new([argument(pointer)]),
-                        },
-                        ty,
-                    );
-                }
-                (
-                    PlaceRoot::Indirect(pointer),
-                    element.prefix.clone(),
-                    element_type(&element.view),
-                )
-            }
+            LeafSource::Element(element) => (
+                PlaceRoot::Indirect(self.element_pointer(element, owner_ty)),
+                element.prefix.clone(),
+                element_type(&element.view),
+            ),
         };
         let steps = prefix
             .iter()

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -2233,3 +2233,55 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0259", "after an exclusive use"]
+
+# The yielded place is the receiver's own storage (6.6:12), so reading it
+# observes exactly the value stored there — at the element's own width, not at
+# the width of the machine word the element shares with its neighbours
+# (RUE-2168).
+[[case]]
+name = "accessor_result_reads_a_subword_element_at_its_own_width"
+spec = ["6.6:8", "6.6:12"]
+description = "A sub-word element read out of an accessor result is the element, not the word it shares with its neighbours."
+real_std = true
+source = """
+const std = @import("std");
+fn main() -> i32 {
+    let mut bytes = std.arraybuf.ArrayBuf(u8).new();
+    bytes.push(1);
+    bytes.push(0);
+    bytes.push(2);
+    let mut signed = std.arraybuf.ArrayBuf(i16).new();
+    signed.push(-300);
+    signed.push(7);
+    if bytes.get_ref(0) == 1 && bytes.get_ref(2) == 2 && signed.get_ref(0) == -300 {
+        0
+    } else {
+        1
+    }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "accessor_result_projects_a_narrow_field_at_its_own_offset"
+spec = ["6.6:8", "6.6:12"]
+description = "A field projected from an accessor result names that field of the receiver's element, whatever the field's width."
+real_std = true
+source = """
+const std = @import("std");
+@copy
+struct Narrow { a: i32, b: u8, c: bool }
+fn main() -> i32 {
+    let mut xs = std.arraybuf.ArrayBuf(Narrow).new();
+    xs.push(Narrow { a: -5, b: 200, c: true });
+    xs.push(Narrow { a: 7, b: 9, c: false });
+    if xs.get_ref(0).a == -5 && xs.get_ref(0).b == 200 && xs.get_ref(0).c
+        && xs.get_ref(1).b == 9
+    {
+        0
+    } else {
+        1
+    }
+}
+"""
+exit_code = 0


### PR DESCRIPTION
Fixes RUE-2168

## Problem

An indirect place, the raw pointer a `borrow self` accessor hands back through the trusted place bridge, names compact memory: sub-word scalars occupy one, two, or four bytes and fields sit at layout byte offsets. Shared place lowering applied the frame model to it instead, eight bytes per leaf. So `a.get_ref(0) == 1` on an `ArrayBuf(u8)` holding `[1, 0, 2]` loaded `0x00020001` and was false, `get_ref(0) + 0` trapped with overflow, `u16` elements compared unequal to themselves, and a `{ i32, u8, bool }` element projected its `b` field at byte 8 (the next element) instead of byte 4. `@ptr_read` and `@ptr_write` were already correct, which is why by-value reads worked and accessor results did not.

## Change

The fix is entirely in shared codegen, so both backends run one implementation and no new MIR instruction was needed; both already lower the narrow leaves (`ldrb`/`ldrsb`/`ldrh`/`ldrsh`/`ldrsw`, `movzx`/`movsx`).

- `place_lower.rs`: projections off an indirect base accumulate a compact byte offset alongside the slot offset and use a compact element stride; a new single entry point reads a place's slots, and the pointer path decodes and encodes exactly as `@ptr_read`/`@ptr_write` do, through the same authorities. The dead pointer arms in the frame paths are now unreachable.
- `agg_slots.rs`: the per-slot physical access is factored out and shared by the whole-image readers and the place path, so an image reached through a pointer intrinsic and one reached through a place cannot disagree about a byte.
- Both backends' `PlaceRead` and `PlaceWrite` arms forward to the shared path, with identical diffs.
- Sub-word loads zero-extend unsigned and `bool` and sign-extend signed, per the register-image invariant. Verified in the asm for all three targets.
- The RUE-2165 printer no longer needs its `@ptr_read` workaround; elements are read through an indirect place again and the record rendering is unchanged.
- The oracle needed no change: it already read an indirect place at the projected view type.

Not fixed here, filed as RUE-2170: passing a narrow element onward by reference (`f(borrow xs.get_ref(0))`) hands the callee a compact cell it reads as a slot. That is an ABI decision.

## Coverage

- New CLI section `cli.subword_indirect_place_reads`, nine `differential_opt` cases with exact stdout: `u8`/`u16` in `==`, `!=`, `<`; `i8`/`i16` sign extension including `-32768`; four-byte `i32`; checked `+` and `*`; `bool`; a narrow read inside a helper that borrows the container; a `{ i32, u8, bool }` element projected at compact offsets; a whole nested-struct element; a payload-enum element's narrow tag.
- Two spec cases under 6.6 (borrow accessors); a codegen unit test asserting the narrow load's offset, width, and signedness on both backends and that no whole-word load remains.

## Verification

- `scripts/rue unit codegen`: 947 passed. `scripts/rue cli cli.subword`: 17. `scripts/rue cli zero_sized`: 37. `scripts/rue spec 6.6`: 108. `scripts/rue cli rue_test_assert`: 27. `//tests/std:std-tests`: 157. `scripts/rue quick`: 947.
- `//crates/rue-oracle-diff:oracle-diff-test`: pass; the new section reports 9 modeled cases agreeing.
- `scripts/rue premerge`: 218 pass, 2 fail, both unrelated and reproduced on the base commit: the layout-fragile macOS `running_image` fixture (RUE-2169, fix in flight) and a `cli-known-bug-marker-validation` load flake that passes alone.
- Reviewer probes at `-O0` through `-O3`: every original repro, plus projected narrow fields after a `set`, `Deque(u8)`, `u16` at 65535, `i8` ordering, and the RUE-2165 printer suite with the workaround removed.
