### PR TITLE
RUE-2166: the human test report says each thing once

### DIFF
--- a/crates/rue-cli-tests/cases/rue_test.toml
+++ b/crates/rue-cli-tests/cases/rue_test.toml
@@ -730,8 +730,12 @@ name = "a_flood_is_elided_in_the_human_rendering_so_the_repro_survives"
 description = """
 RUE-1958: the retained window is a megabyte, which is thirteen thousand lines
 in a terminal. The human renderer prints a head and a tail with one line saying
-what it skipped, so the `scratch:` and `repro:` lines below the capture are
+what it skipped, so the summary and the `repro:` line below the capture are
 still on screen. `--format json` remains the lossless copy.
+
+The run has one failure, so RUE-2166's trailer is that failure's complete argv
+rather than a template: one broken test is the common case, and its line should
+be paste-ready without an edit.
 """
 contract = "heavyweight_long"
 files = [
@@ -759,10 +763,69 @@ compile_stdout_contains = [
     "output_overflow",
     "omitted here; --format json carries the whole capture",
     "further bytes were not retained",
+    "0 passed, 1 failed",
     "repro: /",
     "/rue test /",
-    "/main.rue --filter",
-    "0 passed, 1 failed",
+    "/main.rue --filter 'tests.rue::floods its own stdout' --exact",
+]
+compile_stdout_not_contains = ["put a failing test's ID"]
+
+[[case]]
+name = "many_failures_share_one_repro_template_under_the_summary"
+description = """
+RUE-2166: every repro of a run is the same line but for the selector, so a
+report with more than one failure prints it once, under the summary, with the
+selector replaced by a placeholder — each failure's own header is the ID that
+goes in it. `--exact` stays on the template so a pasted ID that is a prefix of
+another still selects one test. No failure block carries a repro of its own.
+
+The blocks are ordered by source position rather than by the shuffle, so the
+seed still governs execution while the report reads the way the file does:
+`zzz` is declared first and reported first.
+"""
+files = [
+    { path = "main.rue", source = """
+const tests = @import("tests.rue");
+
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "tests.rue", source = """
+test "zzz fails late" {
+    @assert_eq(1, 2);
+}
+
+test "aaa fails early" {
+    @assert_eq(3, 4);
+}
+""" },
+]
+args = ["test", "main.rue", "--seed", "1", "-j1", "--format", "human"]
+driver_exit_code = 1
+compile_stdout_contains = [
+    # Declaration order, whatever order the shuffle ran them in. Neither block
+    # echoes the pinned `panic: assertion failed: left == right` its header
+    # already quotes.
+    """
+FAIL tests.rue::zzz fails late
+  assert_eq: assertion failed: left == right  (tests.rue:2:5)
+  left:  1
+  right: 2
+         ^
+FAIL tests.rue::aaa fails early
+  assert_eq: assertion failed: left == right  (tests.rue:6:5)
+  left:  3
+  right: 4
+         ^
+""",
+    "0 passed, 2 failed",
+    "--filter '<id>' --exact",
+    "put a failing test's ID from above in place of '<id>'",
+]
+compile_stdout_not_contains = [
+    "--filter 'tests.rue::zzz fails late'",
+    "--filter 'tests.rue::aaa fails early'",
 ]
 
 # ========================= listing and selection =========================
@@ -2084,6 +2147,11 @@ analyze yields one `compile_error` verdict per dependent test, not a whole-run
 failure. The independent test is untouched, and the diagnostic reaches stderr
 once for the run however many tests it excluded — the copies in the events are
 the attribution.
+
+RUE-2166: the human report says it once too. One broken helper is one thing to
+fix, so it is one block naming every test it excluded, rather than one block
+per test each repeating the same message. The `run_finished` counts and the
+per-test events are unchanged.
 """
 files = [
     { path = "main.rue", source = """
@@ -2122,11 +2190,16 @@ test "ccc reaches only the good one" {
 args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 1
 compile_stdout_contains = [
-    "COMPILE ERROR tests.rue::aaa reaches the broken helper",
-    "COMPILE ERROR tests.rue::bbb reaches it too",
+    """
+COMPILE ERROR 2 tests
+  compile_error: type mismatch: expected i32, found bool  (helpers.rue:2:5)
+  the diagnostic is on stderr; these tests were excluded from the image
+    tests.rue::aaa reaches the broken helper
+    tests.rue::bbb reaches it too
+""",
     "1 passed, 2 compile errors (",
 ]
-compile_stdout_not_contains = ["COMPILE ERROR tests.rue::ccc reaches only the good one"]
+compile_stdout_not_contains = ["ccc reaches only the good one"]
 compile_stderr_contains = ["helpers.rue:2:5"]
 
 [[case]]
@@ -2172,11 +2245,16 @@ test "ccc destroys nothing" {
 args = ["test", "main.rue", "--seed", "1", "-j1"]
 driver_exit_code = 1
 compile_stdout_contains = [
-    "COMPILE ERROR tests.rue::aaa destroys one",
-    "COMPILE ERROR tests.rue::bbb destroys one too",
+    """
+COMPILE ERROR 2 tests
+  compile_error: type mismatch: expected i32, found bool  (tests.rue:4:5)
+  the diagnostic is on stderr; these tests were excluded from the image
+    tests.rue::aaa destroys one
+    tests.rue::bbb destroys one too
+""",
     "1 passed, 2 compile errors (",
 ]
-compile_stdout_not_contains = ["COMPILE ERROR tests.rue::ccc destroys nothing"]
+compile_stdout_not_contains = ["ccc destroys nothing"]
 compile_stderr_contains = ["tests.rue:4:5"]
 
 [[case]]
@@ -2452,14 +2530,19 @@ compile_stdout_contains = ['"verdict":"xfail"', '"kind":"assert"', '"passed":1',
 
 [[case]]
 name = "known_bug_xpass_has_a_full_human_report"
-description = "An unexpected pass fails the run and retains output and reproduction information."
+description = """
+An unexpected pass fails the run and retains output and reproduction
+information. Its scratch directory is retained but empty — the test wrote to
+stdout, not to disk — so RUE-2166 names it by the run root rather than spending
+a per-failure line on a path the naming scheme already gives.
+"""
 files = [{ path = "main.rue", source = """
 @known_bug("RUE-2018")
 test "fixed" { println("evidence from the passing test"); }
 """ }]
 args = ["test", "main.rue", "-j1"]
 driver_exit_code = 1
-compile_stdout_contains = ["XPASS main.rue::fixed", "remove the known-bug marker", "evidence from the passing test", "scratch:", "repro:", "0 passed, 1 unexpected pass"]
+compile_stdout_contains = ["XPASS main.rue::fixed", "remove the known-bug marker", "evidence from the passing test", "scratch root:", "repro:", "0 passed, 1 unexpected pass"]
 
 [[case]]
 name = "known_bug_does_not_suppress_timeout"

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -176,7 +176,12 @@ struct Reporter {
     /// Presentation policy the runner's notices need and the event schema does
     /// not carry. See `render::Context`.
     context: render::Context,
-    stdout: Mutex<()>,
+    /// The stdout lock, and with it the human report the run's failures
+    /// accumulate into: a person is shown them once, at the end, in source
+    /// order (RUE-2166). One `Reporter` covers one cycle, so the report never
+    /// outlives the run it describes. Untouched under `--format json`, whose
+    /// every line is published as it happens.
+    stdout: Mutex<render::Report>,
 }
 
 impl Reporter {
@@ -184,12 +189,12 @@ impl Reporter {
         Self {
             format,
             context,
-            stdout: Mutex::new(()),
+            stdout: Mutex::new(render::Report::new()),
         }
     }
 
     fn emit(&self, event: &Event) {
-        let _guard = self
+        let mut report = self
             .stdout
             .lock()
             .unwrap_or_else(|error| error.into_inner());
@@ -199,7 +204,7 @@ impl Reporter {
                 let _ = writeln!(out, "{}", event.to_ndjson());
             }
             OutputFormat::Human => {
-                if let Some(text) = render::render(event) {
+                if let Some(text) = report.observe(event) {
                     let _ = writeln!(out, "{text}");
                 }
             }

--- a/crates/rue/src/test_mode/render.rs
+++ b/crates/rue/src/test_mode/render.rs
@@ -7,13 +7,24 @@
 //! person and a tool cannot be shown two different counts of the same run.
 //!
 //! Verbosity is asymmetric on purpose. A failure prints whole — structure,
-//! location, captured output, the retained scratch directory, and the argv that
-//! reproduces it alone — and a pass prints nothing at all. No wall of green.
+//! location, and captured output — and a pass prints nothing at all. No wall
+//! of green.
+//!
+//! What a failure does *not* print is anything the reader already has
+//! (RUE-2166). The reproduction argv is identical across a run but for the
+//! selector, so it appears once, as a template, under the summary; a captured
+//! stderr holding only the pinned runtime line the header already quoted is
+//! dropped; a scratch directory the test left empty is named by its root
+//! rather than per test; and one compile error shared by many tests is one
+//! block naming them all. The stream is unaffected: every one of those is a
+//! decision about what to show, made from event values the NDJSON writer
+//! serializes unchanged.
 
 use std::fmt::Write as _;
+use std::path::Path;
 
 use super::diff::{DiffOp, Hunk};
-use super::events::{CandidateSource, Capture, Comparison, Event, TestFinished};
+use super::events::{CandidateSource, Capture, Comparison, Event, Location, TestFinished};
 use super::verdict::{TestExpectation, Verdict};
 
 /// What the human renderer is told out of band.
@@ -33,56 +44,108 @@ pub(crate) struct Context {
     pub(crate) multi_module_closure: bool,
 }
 
-/// Render one event for a person, or `None` when a person is owed nothing by
-/// it.
+/// The human report of one run, assembled from the events it consumes.
 ///
-/// Every line it produces is run data. Presentation policy that is not — the
-/// missing-inventory notice — is [`notice`]'s, and goes to stderr.
-pub(crate) fn render(event: &Event) -> Option<String> {
-    match event {
-        Event::RunStarted { .. } | Event::TestStarted { .. } => None,
-        Event::Test { id, .. } => Some(id.clone()),
-        Event::TestFinished(finished) => match finished.expectation {
-            Some(TestExpectation::Xfail) => Some(render_failure(finished)),
-            Some(TestExpectation::Xpass) => Some(render_failure(finished)),
-            None if !finished.verdict.is_pass() => Some(render_failure(finished)),
-            None => None,
-        },
-        Event::RunFinished {
-            passed,
-            failed,
-            timeout,
-            crash,
-            compile_error,
-            xfail,
-            xpass,
-            wall_ms,
-            // The unimported-test-file warnings are the runner's own, and
-            // stderr carries them once in every format (test-events.md,
-            // "Streams"). Rendering them here too would print a second copy
-            // on stdout whenever a terminal joins the streams.
-            unimported_test_files: _,
-            // The missing-inventory notice is the runner's own too, and goes
-            // to stderr with them. See `notice`.
-            test_candidates: _,
-        } => Some(summary(Counts {
-            passed: *passed,
-            failed: *failed,
-            timeout: *timeout,
-            crash: *crash,
-            compile_error: *compile_error,
-            xfail: *xfail,
-            xpass: *xpass,
-            wall_ms: *wall_ms,
-        })),
-        Event::RunCanceled {
-            reported,
-            selected,
-            wall_ms,
-            // The cycle number is for a consumer grouping a tailed stream; a
-            // person reading a terminal is already inside the cycle.
-            cycle: _,
-        } => Some(canceled(*reported, *selected, *wall_ms)),
+/// A failure is held rather than printed the moment it lands, because the
+/// report it belongs to is ordered, grouped, and given one shared
+/// reproduction, and none of those can be decided while tests are still
+/// finishing. Buffering is presentation and nothing more: the NDJSON stream
+/// publishes each `test_finished` when it happens, from the same values.
+///
+/// One `Report` covers one run. A `--watch` cycle builds its own, so a cycle's
+/// report never carries the previous cycle's failures.
+pub(crate) struct Report {
+    /// The non-passing tests so far, in the order the run finished them.
+    failures: Vec<TestFinished>,
+}
+
+impl Report {
+    pub(crate) fn new() -> Self {
+        Self {
+            failures: Vec::new(),
+        }
+    }
+
+    /// Render one event for a person, or `None` when a person is owed nothing
+    /// by it yet.
+    ///
+    /// Every line it produces is run data. Presentation policy that is not —
+    /// the missing-inventory notice — is [`notice`]'s, and goes to stderr.
+    pub(crate) fn observe(&mut self, event: &Event) -> Option<String> {
+        match event {
+            Event::RunStarted { .. } | Event::TestStarted { .. } => None,
+            Event::Test { id, .. } => Some(id.clone()),
+            Event::TestFinished(finished) => {
+                if is_reported(finished) {
+                    self.failures.push((**finished).clone());
+                }
+                None
+            }
+            Event::RunFinished {
+                passed,
+                failed,
+                timeout,
+                crash,
+                compile_error,
+                xfail,
+                xpass,
+                wall_ms,
+                // The unimported-test-file warnings are the runner's own, and
+                // stderr carries them once in every format (test-events.md,
+                // "Streams"). Rendering them here too would print a second copy
+                // on stdout whenever a terminal joins the streams.
+                unimported_test_files: _,
+                // The missing-inventory notice is the runner's own too, and goes
+                // to stderr with them. See `notice`.
+                test_candidates: _,
+            } => Some(self.finish(summary(Counts {
+                passed: *passed,
+                failed: *failed,
+                timeout: *timeout,
+                crash: *crash,
+                compile_error: *compile_error,
+                xfail: *xfail,
+                xpass: *xpass,
+                wall_ms: *wall_ms,
+            }))),
+            Event::RunCanceled {
+                reported,
+                selected,
+                wall_ms,
+                // The cycle number is for a consumer grouping a tailed stream; a
+                // person reading a terminal is already inside the cycle.
+                cycle: _,
+            } => Some(self.finish(canceled(*reported, *selected, *wall_ms))),
+        }
+    }
+
+    /// The whole report: the failures in source order, the line the run ended
+    /// with, and the trailer they share.
+    ///
+    /// A canceled cycle gets the same shape as a finished one. The verdicts it
+    /// did publish are the only account of that cycle anyone will get, so they
+    /// are printed with their reproduction exactly as a finished run's are.
+    fn finish(&mut self, closing: String) -> String {
+        let failures = std::mem::take(&mut self.failures);
+        let mut out = String::new();
+        for block in blocks(&failures) {
+            out.push_str(&block.text);
+            out.push('\n');
+        }
+        out.push_str(&closing);
+        push_trailer(&mut out, &failures);
+        out
+    }
+}
+
+/// Whether a person is owed a report for this finished test.
+///
+/// An expected failure and an unexpected pass are both reported: one is
+/// evidence the marker is still earned, the other is the prompt to remove it.
+fn is_reported(finished: &TestFinished) -> bool {
+    match finished.expectation {
+        Some(TestExpectation::Xfail | TestExpectation::Xpass) => true,
+        None => !finished.verdict.is_pass(),
     }
 }
 
@@ -178,67 +241,136 @@ fn seconds(millis: u64) -> String {
     format!("{}.{}s", millis / 1000, (millis % 1000) / 100)
 }
 
-/// One non-passing test, whole.
-fn render_failure(finished: &TestFinished) -> String {
-    let TestFinished {
-        id,
-        verdict,
-        expectation,
-        failure,
-        stdout,
-        stderr,
-        scratch_dir,
-        repro,
-        repro_env,
-        ..
-    } = finished;
-    let banner = match expectation {
+/// One block of the report, and where a reader would go to look at it.
+struct Block {
+    /// `(file, line, column, id)` — the failure's site, so the report reads in
+    /// the order a person navigates the source.
+    at: (String, u32, u32, String),
+    text: String,
+}
+
+/// The report's blocks, grouped and ordered.
+///
+/// Ordering is by source position rather than by the order the run finished
+/// them: the seed governs *execution*, and a shuffled report is a list a reader
+/// has to sort by hand before they can work through a file. The JSON stream
+/// still reports in completion order, which is what a consumer tailing a live
+/// run needs.
+fn blocks(failures: &[TestFinished]) -> Vec<Block> {
+    let mut blocks: Vec<Block> = Vec::new();
+    // One block per distinct diagnostic, not per test it excluded: a broken
+    // helper reached by N tests is one thing that is wrong, and N copies of its
+    // message say so N times without adding anything (RUE-2166).
+    let mut groups: Vec<(DiagnosticKey, Vec<&TestFinished>)> = Vec::new();
+    for failure in failures {
+        if !matches!(failure.verdict, Verdict::CompileError) {
+            blocks.push(ordinary_block(failure));
+            continue;
+        }
+        let key = diagnostic_key(failure);
+        match groups.iter_mut().find(|(existing, _)| *existing == key) {
+            Some((_, members)) => members.push(failure),
+            None => groups.push((key, vec![failure])),
+        }
+    }
+    for (_, mut members) in groups {
+        members.sort_by(|left, right| left.id.cmp(&right.id));
+        blocks.push(compile_error_block(&members));
+    }
+    blocks.sort_by(|left, right| left.at.cmp(&right.at));
+    blocks
+}
+
+/// What makes two `compile_error` verdicts the same diagnostic: the code the
+/// payload leads with, the message, and the site — plus the banner, because an
+/// expected failure and an ordinary one are different reports of one message.
+type DiagnosticKey = (&'static str, String, String, String, String);
+
+fn diagnostic_key(finished: &TestFinished) -> DiagnosticKey {
+    let failure = finished.failure.as_ref();
+    (
+        banner(finished),
+        failure
+            .map(|failure| failure.kind.clone())
+            .unwrap_or_default(),
+        failure
+            .map(|failure| failure.message.clone())
+            .unwrap_or_default(),
+        failure
+            .and_then(|failure| failure.payload.clone())
+            .unwrap_or_default(),
+        failure
+            .and_then(|failure| failure.location.as_ref())
+            .map(site)
+            .unwrap_or_default(),
+    )
+}
+
+/// The banner a verdict reports under.
+fn banner(finished: &TestFinished) -> &'static str {
+    match finished.expectation {
         Some(TestExpectation::Xfail) => "XFAIL",
         Some(TestExpectation::Xpass) => "XPASS",
-        _ => match verdict {
+        None => match finished.verdict {
             Verdict::Pass => "PASS",
             Verdict::Fail(_) => "FAIL",
             Verdict::Timeout => "TIMEOUT",
             Verdict::Crash(_) => "CRASH",
             Verdict::CompileError => "COMPILE ERROR",
         },
-    };
-    // A test that never ran has no captured output, no scratch directory, and
-    // nothing the runner observed: its whole report is the first diagnostic and
-    // a pointer to the stream that carries them all (ADR-0083 §3).
-    if matches!(verdict, Verdict::CompileError) {
-        let mut out = format!("{banner} {id}");
-        if let Some(failure) = failure {
-            out.push_str("\n  ");
-            out.push_str(&failure.kind);
-            if !failure.message.is_empty() {
-                let _ = write!(out, ": {}", failure.message);
-            }
-            if let Some(location) = &failure.location {
-                let _ = write!(
-                    out,
-                    "  ({}:{}:{})",
-                    location.file, location.line, location.column
-                );
-            }
-            let count = failure
-                .diagnostics
-                .as_ref()
-                .map_or(0, |diagnostics| diagnostics.len());
-            let _ = write!(
-                out,
-                "\n  {} on stderr; the test was excluded from the image",
-                if count == 1 {
-                    "the diagnostic is".to_owned()
-                } else {
-                    format!("{count} diagnostics are")
-                }
-            );
-        }
-        let _ = write!(out, "\n  repro: {}", shell_command(repro_env, repro));
-        return out;
     }
-    let mut out = format!("{banner} {id}");
+}
+
+/// `file:line:column`.
+fn site(location: &Location) -> String {
+    format!("{}:{}:{}", location.file, location.line, location.column)
+}
+
+/// Where a failure sends its reader.
+///
+/// Every failure record carries a location — a frame's own site when it
+/// reported one, the test declaration's header otherwise — so a header-located
+/// failure orders by the declaration, which is exactly where a reader would go.
+/// An unexpected pass has no failure record at all, and orders by the module
+/// its ID names, ahead of that module's located failures.
+fn position(finished: &TestFinished) -> (String, u32, u32, String) {
+    match finished
+        .failure
+        .as_ref()
+        .and_then(|failure| failure.location.as_ref())
+    {
+        Some(location) => (
+            location.file.clone(),
+            location.line,
+            location.column,
+            finished.id.clone(),
+        ),
+        None => (
+            module_of(&finished.id).to_owned(),
+            0,
+            0,
+            finished.id.clone(),
+        ),
+    }
+}
+
+/// The module half of a stable ID.
+fn module_of(id: &str) -> &str {
+    id.split_once("::").map_or(id, |(module, _)| module)
+}
+
+/// One test that ran and did not pass, whole.
+fn ordinary_block(finished: &TestFinished) -> Block {
+    let TestFinished {
+        id,
+        expectation,
+        failure,
+        stdout,
+        stderr,
+        scratch_dir,
+        ..
+    } = finished;
+    let mut out = format!("{} {id}", banner(finished));
     if matches!(expectation, Some(TestExpectation::Xpass)) {
         out.push_str("\n  test passed unexpectedly; remove the known-bug marker");
     }
@@ -249,11 +381,7 @@ fn render_failure(finished: &TestFinished) -> String {
             let _ = write!(out, ": {}", failure.message);
         }
         if let Some(location) = &failure.location {
-            let _ = write!(
-                out,
-                "  ({}:{}:{})",
-                location.file, location.line, location.column
-            );
+            let _ = write!(out, "  ({})", site(location));
         }
         if let Some(payload) = &failure.payload {
             if !payload.is_empty() {
@@ -267,13 +395,114 @@ fn render_failure(finished: &TestFinished) -> String {
             let _ = write!(out, "\n  note: {note}");
         }
     }
+    // stdout is the test's own voice and is never suppressed. stderr is shared
+    // with the runtime's abort path, and the block is dropped when that is all
+    // it holds.
     push_capture(&mut out, "stdout", stdout);
-    push_capture(&mut out, "stderr", stderr);
-    if let Some(scratch) = scratch_dir {
+    let message = failure.as_ref().map_or("", |failure| &failure.message);
+    if !stderr_only_repeats(stderr, message) {
+        push_capture(&mut out, "stderr", stderr);
+    }
+    if let Some(scratch) = scratch_dir
+        && scratch_holds_evidence(scratch)
+    {
         let _ = write!(out, "\n  scratch: {scratch}");
     }
-    let _ = write!(out, "\n  repro: {}", shell_command(repro_env, repro));
-    out
+    Block {
+        at: position(finished),
+        text: out,
+    }
+}
+
+/// One diagnostic that excluded tests from the image, and every test it
+/// excluded.
+///
+/// A test that never ran has no captured output, no scratch directory, and
+/// nothing the runner observed: its whole report is the diagnostic and a
+/// pointer to the stream that carries them all (ADR-0083 §3).
+fn compile_error_block(members: &[&TestFinished]) -> Block {
+    let first = members[0];
+    let mut out = match members {
+        [only] => format!("{} {}", banner(only), only.id),
+        _ => format!("{} {} tests", banner(first), members.len()),
+    };
+    if let Some(failure) = &first.failure {
+        out.push_str("\n  ");
+        out.push_str(&failure.kind);
+        if !failure.message.is_empty() {
+            let _ = write!(out, ": {}", failure.message);
+        }
+        if let Some(location) = &failure.location {
+            let _ = write!(out, "  ({})", site(location));
+        }
+        let count = failure
+            .diagnostics
+            .as_ref()
+            .map_or(0, |diagnostics| diagnostics.len());
+        let _ = write!(
+            out,
+            "\n  {} on stderr; {} excluded from the image",
+            if count == 1 {
+                "the diagnostic is".to_owned()
+            } else {
+                format!("{count} diagnostics are")
+            },
+            if members.len() == 1 {
+                "the test was"
+            } else {
+                "these tests were"
+            }
+        );
+    }
+    if members.len() > 1 {
+        for member in members {
+            let _ = write!(out, "\n    {}", member.id);
+        }
+    }
+    Block {
+        at: position(first),
+        text: out,
+    }
+}
+
+/// Whether a captured stderr says only what this failure's header already said.
+///
+/// The abort-only runtime writes one pinned line and exits: `panic: <message>`
+/// for a failed `@assert`, an unhandled `?`, and `@panic`; the trap's own
+/// message for a trap; `segmentation fault at 0x…` for a segfault. The failure
+/// record's `message` is that line — with the `panic: ` prefix when the line
+/// *is* the message, without it when an assertion frame reported the message
+/// alone — so a stderr holding nothing else is the header printed twice.
+///
+/// Anything the test itself wrote keeps the whole block, and so does a stream
+/// that overflowed its budget: what was cut is exactly what a reader cannot
+/// reconstruct from the header. The rule is for a repeat, not for brevity, and
+/// it never applies to stdout, which is the test's alone.
+fn stderr_only_repeats(capture: &Capture, message: &str) -> bool {
+    if message.is_empty() || capture.bytes_total != capture.retained.len() as u64 {
+        return false;
+    }
+    let Ok(text) = std::str::from_utf8(&capture.retained) else {
+        return false;
+    };
+    let text = text.trim();
+    text == message || text.strip_prefix(PANIC_PREFIX) == Some(message)
+}
+
+/// The prefix `__rue_panic` writes ahead of a message, which an assertion's own
+/// failure frame reports without.
+const PANIC_PREFIX: &str = "panic: ";
+
+/// Whether a retained scratch directory holds anything worth a line.
+///
+/// The runner creates the directory, makes it the test's working directory, and
+/// writes nothing into it itself — so an empty one is evidence of nothing, and
+/// its path is a line per failure that says only what the run root and the
+/// naming scheme already say (test-events.md, "Scratch directories and
+/// isolation"). A directory that cannot be read is treated as empty: naming a
+/// path a reader cannot open is the same non-information.
+fn scratch_holds_evidence(directory: &str) -> bool {
+    std::fs::read_dir(directory).is_ok_and(|mut entries| entries.next().is_some())
 }
 
 /// The two operands of a comparison assertion, and where they differ.
@@ -446,6 +675,79 @@ fn shell_command(env: &[(String, String)], argv: &[String]) -> String {
         .join(" ")
 }
 
+/// What the template puts where a test's stable ID goes.
+const ID_PLACEHOLDER: &str = "<id>";
+
+/// The report's trailer: what every failure in it shares.
+///
+/// The reproduction argv is the same line for every test of a run but for the
+/// selector, so it is printed once here rather than once per failure — four
+/// hundred characters of absolute paths that a reader has already read. Each
+/// failure's ID is its own header, which is exactly what the placeholder wants,
+/// and `--exact` stays on the line so a pasted ID still selects one test.
+///
+/// A run with a single failure prints that failure's complete line instead: the
+/// common case is one broken test, and a line that is already paste-ready
+/// should not ask for an edit first.
+fn push_trailer(out: &mut String, failures: &[TestFinished]) {
+    let Some(first) = failures.first() else {
+        return;
+    };
+    if let Some(root) = unnamed_scratch_root(failures) {
+        let _ = write!(out, "\nscratch root: {root}");
+    }
+    match failures {
+        [only] => {
+            let _ = write!(
+                out,
+                "\nrepro: {}",
+                shell_command(&only.repro_env, &only.repro)
+            );
+        }
+        _ => {
+            let _ = write!(
+                out,
+                "\nrepro: {}",
+                shell_command(&first.repro_env, &id_template(&first.repro))
+            );
+            let _ = write!(
+                out,
+                "\n  put a failing test's ID from above in place of {}",
+                shell_word(ID_PLACEHOLDER)
+            );
+        }
+    }
+}
+
+/// One repro argv with its selector replaced by the placeholder.
+///
+/// The substitution is on the argv, before quoting, so `shell_command` remains
+/// the one authority on what a shell would argue about — including the angle
+/// brackets, which is why the placeholder comes back quoted.
+fn id_template(argv: &[String]) -> Vec<String> {
+    let mut argv = argv.to_vec();
+    if let Some(index) = argv.iter().position(|word| word == "--filter")
+        && let Some(selector) = argv.get_mut(index + 1)
+    {
+        *selector = ID_PLACEHOLDER.to_owned();
+    }
+    argv
+}
+
+/// The run directory holding the scratch directories no failure named, or
+/// `None` when every retained directory got its own line.
+///
+/// Per-test directories are named `rue-test-<seed>-<ordinal>` under it, so the
+/// root plus the naming scheme is the whole address of an empty one.
+fn unnamed_scratch_root(failures: &[TestFinished]) -> Option<String> {
+    failures
+        .iter()
+        .filter_map(|failure| failure.scratch_dir.as_deref())
+        .filter(|directory| !scratch_holds_evidence(directory))
+        .find_map(|directory| Path::new(directory).parent())
+        .map(|root| root.display().to_string())
+}
+
 /// One argument, quoted only when a shell would read it as more than itself.
 fn shell_word(argument: &str) -> String {
     let safe = argument.bytes().all(|byte| {
@@ -461,7 +763,7 @@ fn shell_word(argument: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_mode::events::{Comparison, FailureRecord, Location, UnimportedFile};
+    use crate::test_mode::events::{Comparison, FailureRecord, UnimportedFile};
     use crate::test_mode::verdict::FailureKind;
 
     /// The notice an ordinary multi-module program is owed: the closure-size
@@ -473,6 +775,35 @@ mod tests {
                 multi_module_closure: true,
             },
         )
+    }
+
+    /// What one event alone prints, through a report of its own.
+    fn rendered(event: &Event) -> Option<String> {
+        let mut report = Report::new();
+        report.observe(event)
+    }
+
+    /// The whole report a run of these events produces, joined the way the
+    /// reporter writes it.
+    fn report_of(events: &[Event]) -> String {
+        let mut report = Report::new();
+        events
+            .iter()
+            .filter_map(|event| report.observe(event))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The block one finished test contributes, without the run's trailer.
+    fn block_of(event: &Event) -> String {
+        let Event::TestFinished(finished) = event else {
+            unreachable!("only a finished test has a block");
+        };
+        super::blocks(std::slice::from_ref(finished.as_ref()))
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     fn finished(verdict: Verdict, failure: Option<FailureRecord>) -> Event {
@@ -491,23 +822,47 @@ mod tests {
                 "/work/app/main.rue".to_owned(),
                 "--filter".to_owned(),
                 "app/t.rue::parses a port".to_owned(),
+                "--exact".to_owned(),
             ],
             repro_env: vec![("RUE_STD_PATH".to_owned(), "/opt/rue/std".to_owned())],
         }))
     }
 
+    /// A second failing test, at a site of its own, so a report has an order to
+    /// get right.
+    fn finished_at(id: &str, file: &str, line: u32, column: u32) -> Event {
+        let Event::TestFinished(mut finished) = finished(
+            Verdict::Fail(FailureKind::Assert),
+            Some(FailureRecord {
+                kind: "assert".to_owned(),
+                message: "assertion failed".to_owned(),
+                location: Some(Location {
+                    file: file.to_owned(),
+                    line,
+                    column,
+                }),
+                ..FailureRecord::default()
+            }),
+        ) else {
+            unreachable!();
+        };
+        finished.id = id.to_owned();
+        finished.repro[4] = id.to_owned();
+        Event::TestFinished(finished)
+    }
+
     /// The `compile_error` shape: no captures, no scratch directory, and the
     /// diagnostics the compiler decided it with.
-    fn compile_error_finished(diagnostics: usize) -> Event {
+    fn compile_error_finished(id: &str, diagnostics: usize) -> Event {
         Event::TestFinished(Box::new(TestFinished {
-            id: "app/t.rue::parses a port".to_owned(),
+            id: id.to_owned(),
             verdict: Verdict::CompileError,
             expectation: None,
             duration_ms: 0,
             failure: Some(FailureRecord {
                 kind: "compile_error".to_owned(),
                 message: "type mismatch: expected i32, found bool".to_owned(),
-                location: Some(super::super::events::Location {
+                location: Some(Location {
                     file: "app/t.rue".to_owned(),
                     line: 4,
                     column: 5,
@@ -529,19 +884,17 @@ mod tests {
     }
 
     /// A test that never ran has nothing observed to print: its report is the
-    /// banner, the first diagnostic, a pointer to stderr, and the repro
-    /// (ADR-0083 §3). It keeps the asymmetric-verbosity shape every other
-    /// failure has.
+    /// banner, the diagnostic, and a pointer to stderr (ADR-0083 §3). It keeps
+    /// the asymmetric-verbosity shape every other failure has.
     #[test]
     fn a_compile_error_names_its_diagnostic_and_points_at_stderr() {
-        let rendered = super::render(&compile_error_finished(1)).expect("a failure renders");
+        let rendered = block_of(&compile_error_finished("app/t.rue::parses a port", 1));
         assert_eq!(
             rendered,
             concat!(
                 "COMPILE ERROR app/t.rue::parses a port\n",
                 "  compile_error: type mismatch: expected i32, found bool  (app/t.rue:4:5)\n",
-                "  the diagnostic is on stderr; the test was excluded from the image\n",
-                "  repro: /opt/rue/bin/rue test /work/app/main.rue",
+                "  the diagnostic is on stderr; the test was excluded from the image",
             )
         );
         assert!(
@@ -549,11 +902,74 @@ mod tests {
             "a test that never ran captured nothing: {rendered}"
         );
         assert!(
-            super::render(&compile_error_finished(3))
-                .expect("a failure renders")
+            block_of(&compile_error_finished("app/t.rue::parses a port", 3))
                 .contains("3 diagnostics are on stderr"),
             "the count is the reader's cue that stderr has more"
         );
+    }
+
+    /// RUE-2166: a broken helper reached by three tests is one thing that is
+    /// wrong. It gets one block, naming every test it excluded, rather than
+    /// three copies of one message. The `run_finished` counts are unchanged —
+    /// three tests did not compile, however many diagnostics say so.
+    #[test]
+    fn one_diagnostic_is_one_block_naming_every_test_it_excluded() {
+        let rendered = report_of(&[
+            compile_error_finished("app/t.rue::ccc", 1),
+            compile_error_finished("app/t.rue::aaa", 1),
+            compile_error_finished("app/t.rue::bbb", 1),
+            Event::RunFinished {
+                passed: 0,
+                failed: 0,
+                timeout: 0,
+                crash: 0,
+                compile_error: 3,
+                xfail: 0,
+                xpass: 0,
+                wall_ms: 100,
+                unimported_test_files: None,
+                test_candidates: CandidateSource::Declared,
+            },
+        ]);
+        assert!(
+            rendered.starts_with(concat!(
+                "COMPILE ERROR 3 tests\n",
+                "  compile_error: type mismatch: expected i32, found bool  (app/t.rue:4:5)\n",
+                "  the diagnostic is on stderr; these tests were excluded from the image\n",
+                "    app/t.rue::aaa\n",
+                "    app/t.rue::bbb\n",
+                "    app/t.rue::ccc\n",
+            )),
+            "{rendered}"
+        );
+        assert_eq!(rendered.matches("type mismatch").count(), 1, "{rendered}");
+        assert!(
+            rendered.contains("0 passed, 3 compile errors ("),
+            "{rendered}"
+        );
+    }
+
+    /// Two different diagnostics are two different things to fix, so grouping
+    /// stops at the message: same code, same message, same site, one block.
+    #[test]
+    fn two_distinct_diagnostics_stay_two_blocks() {
+        let Event::TestFinished(mut other) = compile_error_finished("app/t.rue::bbb", 1) else {
+            unreachable!();
+        };
+        if let Some(failure) = other.failure.as_mut() {
+            failure.message = "unknown type 'Nope'".to_owned();
+            failure.payload = Some("E0101: unknown type 'Nope'".to_owned());
+        }
+        let blocks = super::blocks(&[
+            {
+                let Event::TestFinished(first) = compile_error_finished("app/t.rue::aaa", 1) else {
+                    unreachable!();
+                };
+                *first
+            },
+            *other,
+        ]);
+        assert_eq!(blocks.len(), 2, "one block per distinct diagnostic");
     }
 
     /// `compile_error` is its own summary class: "did not compile" and "ran and
@@ -562,7 +978,7 @@ mod tests {
     #[test]
     fn the_summary_counts_compile_errors_separately() {
         let summarized = |compile_error| {
-            super::render(&Event::RunFinished {
+            rendered(&Event::RunFinished {
                 passed: 2,
                 failed: 1,
                 timeout: 0,
@@ -583,7 +999,7 @@ mod tests {
 
     #[test]
     fn the_summary_names_expected_failures_and_unexpected_passes() {
-        let rendered = super::render(&Event::RunFinished {
+        let rendered = rendered(&Event::RunFinished {
             passed: 2,
             failed: 0,
             timeout: 0,
@@ -617,10 +1033,15 @@ mod tests {
         }
     }
 
-    /// No wall of green: a pass prints nothing.
+    /// No wall of green: a pass prints nothing, and adds nothing to the report
+    /// its run ends with.
     #[test]
     fn a_pass_prints_nothing() {
-        assert!(super::render(&finished(Verdict::Pass, None)).is_none());
+        assert!(rendered(&finished(Verdict::Pass, None)).is_none());
+        assert_eq!(
+            report_of(&[finished(Verdict::Pass, None), run_finished(1, 0, 0, 0)]),
+            "1 passed (0.9s)"
+        );
     }
 
     #[test]
@@ -636,17 +1057,27 @@ mod tests {
             unreachable!();
         };
         xfail.expectation = Some(TestExpectation::Xfail);
-        assert!(
-            super::render(&Event::TestFinished(xfail))
-                .expect("xfail renders")
-                .starts_with("XFAIL ")
-        );
+        assert!(block_of(&Event::TestFinished(xfail)).starts_with("XFAIL "));
 
         let Event::TestFinished(mut xpass) = finished(Verdict::Pass, None) else {
             unreachable!();
         };
         xpass.expectation = Some(TestExpectation::Xpass);
-        let rendered = super::render(&Event::TestFinished(xpass)).expect("xpass renders");
+        let rendered = report_of(&[
+            Event::TestFinished(xpass),
+            Event::RunFinished {
+                passed: 0,
+                failed: 0,
+                timeout: 0,
+                crash: 0,
+                compile_error: 0,
+                xfail: 0,
+                xpass: 1,
+                wall_ms: 900,
+                unimported_test_files: None,
+                test_candidates: CandidateSource::Declared,
+            },
+        ]);
         assert!(rendered.starts_with("XPASS app/t.rue::parses a port\n"));
         assert!(rendered.contains("remove the known-bug marker"));
         assert!(rendered.contains("repro:"));
@@ -658,13 +1089,13 @@ mod tests {
     #[test]
     fn run_and_test_start_print_nothing() {
         assert!(
-            super::render(&Event::TestStarted {
+            rendered(&Event::TestStarted {
                 id: "app/t.rue::ok".to_owned()
             })
             .is_none()
         );
         assert!(
-            super::render(&Event::RunStarted {
+            rendered(&Event::RunStarted {
                 root: "m.rue".to_owned(),
                 target: "x86-64-linux".to_owned(),
                 opt_level: "0".to_owned(),
@@ -681,10 +1112,10 @@ mod tests {
 
     /// A canceled cycle is the one thing a watch consumer must not read as a
     /// silent end, so it prints in place of the summary it replaces
-    /// (RUE-2023).
+    /// (RUE-2023) — and with it, the failures the cycle did publish.
     #[test]
     fn a_canceled_cycle_reports_what_it_managed() {
-        let rendered = super::render(&Event::RunCanceled {
+        let rendered = rendered(&Event::RunCanceled {
             cycle: 2,
             reported: 3,
             selected: 9,
@@ -695,19 +1126,55 @@ mod tests {
             rendered,
             "canceled after 3 of 9 tests (0.4s); a newer source revision is available"
         );
-        let single = super::render(&Event::RunCanceled {
+        let single = rendered_canceled();
+        assert!(single.contains("0 of 1 test ("), "{single}");
+    }
+
+    fn rendered_canceled() -> String {
+        rendered(&Event::RunCanceled {
             cycle: 1,
             reported: 0,
             selected: 1,
             wall_ms: 0,
         })
-        .expect("a canceled cycle is never silent");
-        assert!(single.contains("0 of 1 test ("), "{single}");
+        .expect("a canceled cycle is never silent")
+    }
+
+    /// A cycle abandoned mid-run still reports the failures it published, with
+    /// their reproduction: those verdicts are the only account of that cycle
+    /// anyone will get.
+    #[test]
+    fn a_canceled_cycle_still_carries_its_failures() {
+        let rendered = report_of(&[
+            finished(
+                Verdict::Fail(FailureKind::Assert),
+                Some(FailureRecord {
+                    kind: "assert".to_owned(),
+                    message: "assertion failed".to_owned(),
+                    ..FailureRecord::default()
+                }),
+            ),
+            Event::RunCanceled {
+                cycle: 2,
+                reported: 1,
+                selected: 9,
+                wall_ms: 400,
+            },
+        ]);
+        assert!(
+            rendered.starts_with("FAIL app/t.rue::parses a port\n"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("\ncanceled after 1 of 9 tests"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("\nrepro: RUE_STD_PATH="), "{rendered}");
     }
 
     #[test]
-    fn a_failure_prints_structure_output_scratch_and_repro() {
-        let rendered = super::render(&finished(
+    fn a_failure_prints_structure_and_output() {
+        let rendered = block_of(&finished(
             Verdict::Fail(FailureKind::Assert),
             Some(FailureRecord {
                 kind: "assert".to_owned(),
@@ -720,8 +1187,7 @@ mod tests {
                 }),
                 ..FailureRecord::default()
             }),
-        ))
-        .expect("a failure renders");
+        ));
         assert!(
             rendered.starts_with("FAIL app/t.rue::parses a port"),
             "{rendered}"
@@ -731,19 +1197,193 @@ mod tests {
             "{rendered}"
         );
         assert!(rendered.contains("--- stdout (9 bytes) ---"), "{rendered}");
-        assert!(rendered.contains("--- stderr (17 bytes) ---"), "{rendered}");
+        // This fixture's stderr holds the pinned line and nothing else, so the
+        // block is the header a second time and is dropped; the two tests below
+        // pin that rule on its own.
+        assert!(!rendered.contains("--- stderr"), "{rendered}");
+        // The repro is the report's, once, not this block's (RUE-2166).
+        assert!(!rendered.contains("repro:"), "{rendered}");
+    }
+
+    /// A run with one failure is the common case, and its line is already
+    /// paste-ready: it gets the complete argv rather than a template to edit.
+    /// The environment leads and every path is absolute, so the line runs in a
+    /// clean shell from any directory (RUE-2020).
+    #[test]
+    fn a_single_failure_keeps_its_whole_repro_line() {
+        let rendered = report_of(&[
+            finished(
+                Verdict::Fail(FailureKind::Assert),
+                Some(FailureRecord {
+                    kind: "assert".to_owned(),
+                    message: "assertion failed".to_owned(),
+                    ..FailureRecord::default()
+                }),
+            ),
+            run_finished(0, 1, 0, 0),
+        ]);
         assert!(
-            rendered.contains("scratch: /tmp/rue-test-417-2"),
-            "{rendered}"
-        );
-        // The environment leads and every path is absolute, so the line runs
-        // in a clean shell from any directory (RUE-2020).
-        assert!(
-            rendered.contains(
-                "repro: RUE_STD_PATH=/opt/rue/std /opt/rue/bin/rue test /work/app/main.rue \
-                 --filter 'app/t.rue::parses a port'"
+            rendered.ends_with(
+                "\nrepro: RUE_STD_PATH=/opt/rue/std /opt/rue/bin/rue test /work/app/main.rue \
+                 --filter 'app/t.rue::parses a port' --exact"
             ),
             "{rendered}"
+        );
+        assert!(!rendered.contains("in place of"), "{rendered}");
+        assert_eq!(rendered.matches("repro:").count(), 1, "{rendered}");
+    }
+
+    /// RUE-2166: every repro of a run is the same four hundred characters but
+    /// for the selector, so the report carries one template and each failure's
+    /// header is the ID that goes in it. `--exact` stays on the line so a
+    /// pasted ID that is a prefix of another still selects one test.
+    #[test]
+    fn many_failures_share_one_repro_template() {
+        let rendered = report_of(&[
+            finished_at("app/t.rue::aaa", "app/t.rue", 3, 1),
+            finished_at("app/t.rue::bbb", "app/t.rue", 9, 1),
+            run_finished(0, 2, 0, 0),
+        ]);
+        assert!(
+            rendered.contains(
+                "\nrepro: RUE_STD_PATH=/opt/rue/std /opt/rue/bin/rue test /work/app/main.rue \
+                 --filter '<id>' --exact\n  put a failing test's ID from above in place of '<id>'"
+            ),
+            "{rendered}"
+        );
+        assert_eq!(rendered.matches("repro:").count(), 1, "{rendered}");
+        assert!(
+            !rendered.contains("--filter 'app/t.rue::aaa'"),
+            "{rendered}"
+        );
+    }
+
+    /// RUE-2166: the report reads in the order a person navigates the source,
+    /// not in the order the shuffle happened to finish the tests. The seed
+    /// still governs execution, and the JSON stream still reports in completion
+    /// order.
+    #[test]
+    fn failures_are_reported_in_source_order() {
+        let rendered = report_of(&[
+            finished_at("app/z.rue::early", "app/z.rue", 2, 1),
+            finished_at("app/t.rue::later", "app/t.rue", 40, 1),
+            finished_at("app/t.rue::earlier", "app/t.rue", 7, 9),
+            finished_at("app/t.rue::same line", "app/t.rue", 7, 2),
+            run_finished(0, 4, 0, 0),
+        ]);
+        let order: Vec<&str> = rendered
+            .lines()
+            .filter(|line| line.starts_with("FAIL "))
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                "FAIL app/t.rue::same line",
+                "FAIL app/t.rue::earlier",
+                "FAIL app/t.rue::later",
+                "FAIL app/z.rue::early",
+            ],
+            "{rendered}"
+        );
+    }
+
+    /// An unexpected pass has no failure record and so no site. It orders by
+    /// the module its ID names, ahead of that module's located failures.
+    #[test]
+    fn a_failure_without_a_site_orders_by_its_module() {
+        let Event::TestFinished(mut xpass) = finished(Verdict::Pass, None) else {
+            unreachable!();
+        };
+        xpass.expectation = Some(TestExpectation::Xpass);
+        xpass.id = "app/t.rue::fixed".to_owned();
+        let rendered = report_of(&[
+            finished_at("app/t.rue::broken", "app/t.rue", 7, 1),
+            Event::TestFinished(xpass),
+            run_finished(0, 1, 0, 0),
+        ]);
+        assert!(
+            rendered.starts_with("XPASS app/t.rue::fixed\n"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("\nFAIL app/t.rue::broken\n"),
+            "{rendered}"
+        );
+    }
+
+    /// RUE-2166: the runtime's abort path writes one pinned line, and the
+    /// header already quotes it. A stderr holding only that line is the header
+    /// printed twice, whether the line carries the `panic: ` prefix or the
+    /// failure frame reported the message without it.
+    #[test]
+    fn a_stderr_that_only_repeats_the_header_is_left_out() {
+        let repeated = |stderr: &[u8], message: &str| {
+            let Event::TestFinished(mut finished) = finished(
+                Verdict::Fail(FailureKind::Assert),
+                Some(FailureRecord {
+                    kind: "assert".to_owned(),
+                    message: message.to_owned(),
+                    ..FailureRecord::default()
+                }),
+            ) else {
+                unreachable!();
+            };
+            let total = stderr.len() as u64;
+            finished.stderr = Capture::new(stderr.to_vec(), total, false);
+            block_of(&Event::TestFinished(finished))
+        };
+        // `panic: <message>`: what `__rue_panic` writes for an assertion or a
+        // `?` whose frame reported the message alone.
+        assert!(
+            !repeated(b"panic: x should exceed five\n", "x should exceed five").contains("stderr"),
+        );
+        // The trap's own message, which the record carries verbatim.
+        assert!(
+            !repeated(b"error: division by zero\n", "error: division by zero").contains("stderr"),
+        );
+        assert!(
+            !repeated(
+                b"segmentation fault at 0xdead\n",
+                "segmentation fault at 0xdead"
+            )
+            .contains("stderr"),
+        );
+        // stdout is the test's own voice and is never dropped for repeating
+        // anything.
+        assert!(
+            repeated(b"panic: boom\n", "boom").contains("--- stdout (9 bytes) ---"),
+            "stdout survives the stderr rule"
+        );
+    }
+
+    /// Anything else on stderr is the test's, and the block is kept whole: a
+    /// line the reader cannot reconstruct from the header is the whole reason
+    /// the capture exists.
+    #[test]
+    fn a_stderr_with_more_than_the_header_is_kept_whole() {
+        let kept = |stderr: &[u8], total: u64, message: &str| {
+            let Event::TestFinished(mut finished) = finished(
+                Verdict::Fail(FailureKind::Assert),
+                Some(FailureRecord {
+                    kind: "assert".to_owned(),
+                    message: message.to_owned(),
+                    ..FailureRecord::default()
+                }),
+            ) else {
+                unreachable!();
+            };
+            finished.stderr = Capture::new(stderr.to_vec(), total, false);
+            block_of(&Event::TestFinished(finished))
+        };
+        let rendered = kept(b"connecting\npanic: boom\n", 23, "boom");
+        assert!(rendered.contains("--- stderr (23 bytes) ---"), "{rendered}");
+        assert!(rendered.contains("\n  connecting"), "{rendered}");
+        // A stream cut at its budget keeps its block too: what was dropped is
+        // exactly what the header cannot stand in for.
+        let truncated = kept(b"panic: boom", 4096, "boom");
+        assert!(
+            truncated.contains("--- stderr (4096 bytes) ---"),
+            "{truncated}"
         );
     }
 
@@ -753,7 +1393,7 @@ mod tests {
     /// disagree about where the difference is.
     #[test]
     fn a_single_line_comparison_prints_both_values_and_a_caret() {
-        let rendered = super::render(&finished(
+        let rendered = block_of(&finished(
             Verdict::Fail(FailureKind::AssertEq),
             Some(FailureRecord {
                 kind: "assert_eq".to_owned(),
@@ -762,8 +1402,7 @@ mod tests {
                 comparison: Some(Comparison::new("41".to_owned(), "42".to_owned())),
                 ..FailureRecord::default()
             }),
-        ))
-        .expect("a failure renders");
+        ));
         assert!(
             rendered.contains("\n  left:  41\n  right: 42\n          ^\n"),
             "{rendered}"
@@ -774,7 +1413,7 @@ mod tests {
     /// difference and no caret is drawn — the two values *are* the report.
     #[test]
     fn identical_values_print_no_caret() {
-        let rendered = super::render(&finished(
+        let rendered = block_of(&finished(
             Verdict::Fail(FailureKind::AssertNe),
             Some(FailureRecord {
                 kind: "assert_ne".to_owned(),
@@ -782,8 +1421,7 @@ mod tests {
                 comparison: Some(Comparison::new("41".to_owned(), "41".to_owned())),
                 ..FailureRecord::default()
             }),
-        ))
-        .expect("a failure renders");
+        ));
         assert!(
             rendered.contains("\n  left:  41\n  right: 41\n  --- stdout"),
             "{rendered}"
@@ -794,7 +1432,7 @@ mod tests {
     /// of text locates nothing.
     #[test]
     fn a_multi_line_comparison_prints_a_hunk_listing() {
-        let rendered = super::render(&finished(
+        let rendered = block_of(&finished(
             Verdict::Fail(FailureKind::AssertEq),
             Some(FailureRecord {
                 kind: "assert_eq".to_owned(),
@@ -805,8 +1443,7 @@ mod tests {
                 )),
                 ..FailureRecord::default()
             }),
-        ))
-        .expect("a failure renders");
+        ));
         assert!(
             rendered.contains(
                 "\n  left:\n    alpha\n    beta\n    gamma\
@@ -822,7 +1459,7 @@ mod tests {
     /// is the only account of a failure report the runner could not read.
     #[test]
     fn a_runner_note_is_printed_with_its_failure() {
-        let rendered = super::render(&finished(
+        let rendered = block_of(&finished(
             Verdict::Fail(FailureKind::Exit),
             Some(FailureRecord {
                 kind: "exit".to_owned(),
@@ -830,8 +1467,7 @@ mod tests {
                 runner_note: Some("the test failure channel could not be read".to_owned()),
                 ..FailureRecord::default()
             }),
-        ))
-        .expect("a failure renders");
+        ));
         assert!(
             rendered.contains("note: the test failure channel could not be read"),
             "{rendered}"
@@ -840,10 +1476,52 @@ mod tests {
 
     #[test]
     fn timeouts_and_crashes_carry_their_own_banners() {
-        let timeout = super::render(&finished(Verdict::Timeout, None)).expect("a timeout renders");
+        let timeout = block_of(&finished(Verdict::Timeout, None));
         assert!(timeout.starts_with("TIMEOUT "), "{timeout}");
-        let crash = super::render(&finished(Verdict::Crash(11), None)).expect("a crash renders");
+        let crash = block_of(&finished(Verdict::Crash(11), None));
         assert!(crash.starts_with("CRASH "), "{crash}");
+    }
+
+    /// RUE-2166: the runner writes nothing into a scratch directory itself, so
+    /// an empty one is evidence of nothing and its per-test name is derivable
+    /// from the run root. A directory the test left something in is named where
+    /// the reader is already looking.
+    #[test]
+    fn a_scratch_directory_is_named_only_when_it_holds_something() {
+        let root = std::env::temp_dir().join(format!("rue-render-2166-{}", std::process::id()));
+        let scratch = root.join("rue-test-417-2");
+        std::fs::create_dir_all(&scratch).expect("a scratch directory");
+        let with_scratch = |directory: &std::path::Path| {
+            let Event::TestFinished(mut finished) = finished(
+                Verdict::Fail(FailureKind::Assert),
+                Some(FailureRecord {
+                    kind: "assert".to_owned(),
+                    message: "assertion failed".to_owned(),
+                    ..FailureRecord::default()
+                }),
+            ) else {
+                unreachable!();
+            };
+            finished.scratch_dir = Some(directory.display().to_string());
+            Event::TestFinished(finished)
+        };
+
+        let empty = report_of(&[with_scratch(&scratch), run_finished(0, 1, 0, 0)]);
+        assert!(!empty.contains("\n  scratch: "), "{empty}");
+        assert!(
+            empty.contains(&format!("\nscratch root: {}", root.display())),
+            "{empty}"
+        );
+
+        std::fs::write(scratch.join("out.txt"), b"kept").expect("evidence");
+        let kept = report_of(&[with_scratch(&scratch), run_finished(0, 1, 0, 0)]);
+        assert!(
+            kept.contains(&format!("\n  scratch: {}", scratch.display())),
+            "{kept}"
+        );
+        assert!(!kept.contains("scratch root:"), "{kept}");
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// Every number a person reads comes from the event, so the two surfaces
@@ -851,17 +1529,17 @@ mod tests {
     #[test]
     fn the_summary_names_only_the_classes_that_occurred() {
         assert!(
-            super::render(&run_finished(2, 0, 0, 0))
+            rendered(&run_finished(2, 0, 0, 0))
                 .unwrap()
                 .starts_with("2 passed (0.9s)")
         );
         assert!(
-            super::render(&run_finished(2, 1, 0, 0))
+            rendered(&run_finished(2, 1, 0, 0))
                 .unwrap()
                 .starts_with("2 passed, 1 failed (0.9s)")
         );
         assert!(
-            super::render(&run_finished(2, 1, 1, 1))
+            rendered(&run_finished(2, 1, 1, 1))
                 .unwrap()
                 .starts_with("2 passed, 1 failed, 1 timed out, 1 crashed (0.9s)")
         );
@@ -887,7 +1565,7 @@ mod tests {
     /// found". It says so as a notice, so stdout carries the summary alone.
     #[test]
     fn a_multi_module_run_without_a_candidate_inventory_says_so() {
-        let rendered = super::render(&no_inventory()).expect("a summary renders");
+        let rendered = rendered(&no_inventory()).expect("a summary renders");
         assert_eq!(rendered, "0 passed (0.1s)");
         assert_eq!(
             notice_multi(&no_inventory()),
@@ -904,7 +1582,7 @@ mod tests {
         let context = Context {
             multi_module_closure: false,
         };
-        let rendered = super::render(&no_inventory()).expect("a summary renders");
+        let rendered = rendered(&no_inventory()).expect("a summary renders");
         assert_eq!(rendered, "0 passed (0.1s)");
         assert_eq!(super::notice(&no_inventory(), context), None);
     }
@@ -951,7 +1629,7 @@ mod tests {
             ]),
             test_candidates: CandidateSource::Declared,
         };
-        let rendered = super::render(&event).expect("a summary renders");
+        let rendered = rendered(&event).expect("a summary renders");
         assert_eq!(rendered, "1 passed (0.0s)");
         assert!(!rendered.contains("warning:"), "{rendered}");
         assert!(!rendered.contains("app/orphan.rue"), "{rendered}");
@@ -962,7 +1640,7 @@ mod tests {
     #[test]
     fn a_listing_entry_renders_as_its_bare_identity() {
         assert_eq!(
-            super::render(&Event::Test {
+            rendered(&Event::Test {
                 id: "app/t.rue::ok".to_owned(),
                 module: "app/t.rue".to_owned(),
                 name: "ok".to_owned(),
@@ -988,6 +1666,28 @@ mod tests {
         );
     }
 
+    /// The template substitutes on the argv, before quoting, so `shell_command`
+    /// stays the one authority on what a shell would argue about — which is why
+    /// the placeholder comes back quoted.
+    #[test]
+    fn the_template_replaces_only_the_selector() {
+        let argv = vec![
+            "rue".to_owned(),
+            "test".to_owned(),
+            "/work/main.rue".to_owned(),
+            "--filter".to_owned(),
+            "app/t.rue::ok".to_owned(),
+            "--exact".to_owned(),
+        ];
+        assert_eq!(
+            shell_command(&[], &id_template(&argv)),
+            "rue test /work/main.rue --filter '<id>' --exact"
+        );
+        // A listing repro carries no selector, and comes back untouched.
+        let bare = vec!["rue".to_owned(), "test".to_owned()];
+        assert_eq!(id_template(&bare), bare);
+    }
+
     /// An assignment quotes only its value: quoting the name half would stop
     /// the shell from reading the word as an assignment at all.
     #[test]
@@ -1011,8 +1711,7 @@ mod tests {
 
     /// The retention window is a megabyte; the display bound is a screenful.
     /// A flooding test's failure has to stay readable in a terminal, which
-    /// means its own `scratch:` and `repro:` lines must survive the capture
-    /// above them.
+    /// means the summary and repro below it must survive the capture above.
     #[test]
     fn a_long_capture_is_shown_as_a_head_a_tail_and_what_was_skipped() {
         let data: String = (0..20_000).map(|i| format!("line {i}\n")).collect();

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -465,6 +465,14 @@ never cut through, the `bytes_total` header is unchanged, and `--format json`
 still carries the retained window whole — the bound is a display bound, not a
 second retention limit.
 
+The human renderer also **omits a stderr block whose whole content is the pinned
+line the failure header already quotes** (RUE-2166) — `panic: <message>` for a
+failed `@assert`, an unhandled `?`, and `@panic`; the trap's own message for a
+trap; `segmentation fault at 0x…` for a segfault. A retained stderr holding
+anything else, or one cut short of `bytes_total`, is printed whole: the rule is
+for a repeat, not for brevity. It never applies to stdout, which is the test's
+alone. `--format json` carries both captures either way.
+
 ### `run_finished`
 
 | Key | Type | Meaning |
@@ -662,7 +670,11 @@ written there once for the run, before any event, in the run's own
 `--error-format` and byte-for-byte as a whole-run failure would have written
 them — so a helper several tests share is reported once, not once per dependent
 test. The `diagnostics` array in each event is the attribution: which test each
-diagnostic excluded. Divergence between the two is a runner bug. They are
+diagnostic excluded. Divergence between the two is a runner bug. The human
+report follows stderr here and prints **one `COMPILE ERROR` block per distinct
+diagnostic** — same code, message, and location — listing every test it excluded
+under it (RUE-2166); the `run_finished.compile_error` count still counts tests,
+and the events are still one per test. They are
 written whatever the selection is, because the analysis root set is the whole
 closure: `--filter` narrows the run set, never the analysis root set, so a
 filtered run's verdicts are unchanged — but a filtered run that silently
@@ -767,6 +779,15 @@ shuffle that surfaced a bug is re-runnable.
 `--list` applies `--filter` and `--shard` but **not** the shuffle: a listing is
 an inventory, and stable-ID order is what makes two listings comparable.
 
+The seed governs **execution** order, and the event stream reports in completion
+order, which is what a consumer tailing a live run needs. The human report is
+read after the run instead, so it orders its failure blocks by the failure
+location's `(file, line, column)` and then by ID (RUE-2166): a shuffled report
+is a list a reader has to sort by hand before they can work through a file. A
+failure located at its test's declaration therefore sorts by the declaration,
+and an xpass — which has no failure record and so no location — sorts by the
+module its ID names, ahead of that module's located failures.
+
 ## Reproduction as data
 
 Every `test_finished` carries the exact argv that reproduces that one test, and
@@ -833,15 +854,36 @@ came from, on the tree it came from, for as long as those artifacts are there.
 
 The argv array and the `repro_env` object are the authoritative forms. The
 human renderer's `repro:` line is the assignments followed by the argv, all
-shell-quoted for pasting —
+shell-quoted for pasting, and a consumer should re-execute the array under the
+object rather than parse the line. Each assignment quotes only its value: a
+shell stops reading a word as an assignment once the name half is quoted.
+
+The line is printed **once per report, under the summary**, never per failure
+(RUE-2166): every repro of a run is the same four hundred characters but for
+the selector, and a reader who has just read the failure blocks does not need
+the paths again beside each one. It takes two forms.
+
+A run with **exactly one failure** prints that failure's complete argv, because
+one broken test is the common case and its line should be paste-ready without
+an edit:
 
 ```text
 repro: RUE_STD_PATH=/opt/rue/std /opt/rue/bin/rue test /work/app/main.rue --filter 'app/t.rue::parses a port' --exact --seed 417 --target x86-64-linux -O0 --timeout-ms 10000
 ```
 
-— and a consumer should re-execute the array under the object rather than parse
-the line. Each assignment quotes only its value: a shell stops reading a word as
-an assignment once the name half is quoted.
+A run with **more than one** prints a template instead, with the selector
+replaced by a placeholder and a line saying what goes in it. Each failure's own
+header above is that ID, and `--exact` stays on the line so a pasted ID that is
+a prefix of another still selects one test:
+
+```text
+repro: RUE_STD_PATH=/opt/rue/std /opt/rue/bin/rue test /work/app/main.rue --filter '<id>' --exact --seed 417 --target x86-64-linux -O0 --timeout-ms 10000
+  put a failing test's ID from above in place of '<id>'
+```
+
+Both forms are presentation. `--format json` is unaffected: every
+`test_finished` carries its own complete `repro` array and `repro_env` object,
+whatever the run's failure count.
 
 ## Scratch directories and isolation
 
@@ -850,6 +892,13 @@ pass and retained on anything else**, with its path in the event. The abort-only
 runtime means destructors do not run on a failing path, so the retained
 directory plus process death is what teardown-on-failure amounts to
 (ADR-0083 §5.4).
+
+The runner creates the directory, makes it the test's working directory, and
+writes nothing into it itself, so a retained one can be empty. The human report
+prints a per-failure `scratch:` line only for a directory that holds something,
+and otherwise names the run directory once, as `scratch root:` beside the
+`repro:` line (RUE-2166): the per-test name is derivable from it. `scratch_dir`
+is on every non-passing `test_finished` either way.
 
 Directories live under a per-run directory named for the seed and the runner's
 process id, and are themselves named `rue-test-<seed>-<ordinal>`. The run


### PR DESCRIPTION
Fixes RUE-2166

## Problem

The human test report repeated itself. Every failing test printed a ~400-character `repro:` line identical to its neighbours except the `--filter` value, a `scratch:` path, and a `--- stderr ---` block that echoed the one panic line the header had already summarized; a compile error shared by N tests printed N identical blocks; and the blocks came out in the shuffled execution order. On a 20-test suite with 12 non-passing tests the report was 99 lines, of which roughly 15 carried information. An agent reads this format by default, so the rest was tokens spent on nothing every cycle.

## Change (human format only; the NDJSON stream is untouched)

- **Repro once.** One `repro:` line after the summary. With several failures it is a template with `'<id>'` in the selector position and a line saying to substitute a failing id; with exactly one failure it is that failure's complete, paste-ready line. `shell_command` stays the single quoting authority.
- **No stderr echo.** The stderr block is omitted only when the retained capture is complete and equals the failure record's own message (with or without the `panic: ` prefix). Anything more is printed whole. Stdout is always printed.
- **Scratch once.** A per-failure `scratch:` line appears only when that directory holds something; otherwise one `scratch root:` line at the end names the run's root, under which the per-test names are derivable.
- **Grouped compile errors.** One `COMPILE ERROR` block per distinct diagnostic, listing every excluded test under it, headed by the count.
- **Source order.** Blocks are ordered by the failure's location, then the declaration position, then id; the seed still governs execution and the JSON stream still reports completion order.

The renderer became a small stateful `Report` the reporter carries for the run, so the trailer can be computed once; a watch cycle already has its own reporter and never inherits a previous cycle's failures. `docs/process/test-events.md` describes each rule.

## Verification

- The same suite renders in 58 lines instead of 99. Reviewer runs on the branch: the multi-failure, single-failure, grouped-compile-error (six tests sharing one broken helper collapse to one block), and all-green shapes each read as intended.
- `scripts/rue unit rue test_mode`: 140 passed (eleven new renderer tests). `scripts/rue cli rue_test`: 115 passed (one new case pinning the template). `scripts/rue cli watch`: 26 passed.
- `scripts/rue premerge`: 219 pass, 1 fail, the fail being the layout-fragile macOS fixture that RUE-2169 has since fixed on trunk; this branch is rebased onto that trunk.
