### PR TITLE
RUE-2164: a standard-library module is named the way a program writes it

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -4635,7 +4635,7 @@ fn private_access_has_one_decision_and_one_diagnostic() {
 #[test]
 fn module_diagnostics_have_one_display_name() {
     let registry = include_str!("module_registry.rs");
-    assert!(registry.contains("pub fn module_display_name(import_path: &str) -> &str"));
+    assert!(registry.contains("pub fn module_display_name(import_path: &str) -> Cow<\'_, str>"));
     for (module, source) in AIR_CRATE_SOURCES {
         if *module == "module_registry" {
             continue;

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -89,7 +89,10 @@ pub use lowered_signature::{
     MAX_LEAF_CLASSIFIED_BYTES, PointerLocation, RegisterPiece, RegisterPieces, StackedPlacement,
     lower_c_signature, lower_native_return, lower_native_signature,
 };
-pub use module_registry::{ModuleRegistry, module_display_name};
+pub use module_registry::{
+    ModuleRegistry, module_display_name, unknown_module_member, unknown_module_member_help,
+    unknown_module_member_kind,
+};
 pub use param_arena::{ParamArena, ParamRange, ParamRangeData};
 pub use path_norm::{mangle_symbol_component, normalize_module_path};
 pub use private_access::{

--- a/crates/rue-air/src/module_registry.rs
+++ b/crates/rue-air/src/module_registry.rs
@@ -4,24 +4,129 @@
 //! modules used during semantic analysis. A semantic epoch prepopulates the
 //! registry in canonical durable-ID order before analysis begins.
 //!
+use std::borrow::Cow;
 use std::sync::{PoisonError, RwLock};
 
 use crate::types::{ModuleDef, ModuleId};
 
+/// The logical-path namespace every trusted standard-library module carries.
+///
+/// `rue_compiler::source_identity::TRUSTED_STANDARD_LIBRARY_NAMESPACE` is the
+/// authority that mints these identities; AIR sits below that crate, so the
+/// spelling is repeated here (as it already is in [`crate::types`]) rather
+/// than depended upon. The leading NUL is what keeps the namespace disjoint
+/// from every expressible filesystem path — and is exactly why it must never
+/// reach a reader.
+const TRUSTED_STANDARD_LIBRARY_NAMESPACE: &str = "\0rue-std/";
+
+/// The file stem of the standard library's root module, which a program names
+/// as plain `std`.
+const STANDARD_LIBRARY_ROOT_STEM: &str = "_std";
+
 /// How a module is named in a diagnostic that talks about it.
 ///
-/// One rendering for every emitter: the import path the source wrote, so
-/// `module 'sub/lib.rue' has no member 'x'` says which file was consulted.
-/// Rendering only the file stem loses exactly the part that distinguishes
-/// same-named files in different directories, which is the case the reader
-/// most needs to see.
+/// One rendering for every emitter, and it is the name the *source* uses, not
+/// the identity the compiler keys on:
+///
+/// * A user module renders as the import path the source wrote, so
+///   ``module `sub/lib.rue` has no member `x` `` says which file was
+///   consulted. Rendering only the file stem loses exactly the part that
+///   distinguishes same-named files in different directories, which is the
+///   case the reader most needs to see.
+/// * A trusted standard-library module renders as the dotted path a program
+///   writes after `const std = @import("std")` — `std` for the root
+///   (`_std.rue`) and `std.arraybuf` for a submodule — which is how the
+///   specification and the standard library's own documentation spell them
+///   (spec 4.14, `std.arraybuf.ArrayBuf`). Its logical path is
+///   `\0rue-std/<name>.rue`, whose leading NUL is a provenance marker rather
+///   than anything a reader could type; leaking it produced RUE-2164's
+///   ``module `<NUL>rue-std/_std.rue` has no member `io` ``.
 ///
 /// The argument is the import path rather than a [`ModuleDef`] because the
-/// three emitters hold a module in three shapes — a registry definition, an
+/// emitters hold a module in several shapes — a registry definition, an
 /// aggregate module fact, and a durable module identity — and the import path
-/// is what they share. Pass [`ModuleDef::import_path`]; do not re-render it.
-pub fn module_display_name(import_path: &str) -> &str {
-    import_path
+/// is what they share. Pass [`ModuleDef::import_path`] (or a durable
+/// [`ModuleId`]'s logical path); do not re-render it.
+pub fn module_display_name(import_path: &str) -> Cow<'_, str> {
+    let Some(relative) = import_path.strip_prefix(TRUSTED_STANDARD_LIBRARY_NAMESPACE) else {
+        return Cow::Borrowed(import_path);
+    };
+    let stem = relative.strip_suffix(".rue").unwrap_or(relative);
+    if stem == STANDARD_LIBRARY_ROOT_STEM {
+        return Cow::Borrowed("std");
+    }
+    // A nested trusted module (`math/float.rue`) is reached through the same
+    // dotted bindings as a flat one, so the separator renders as a dot too.
+    Cow::Owned(format!("std.{}", stem.replace('/', ".")))
+}
+
+/// The prelude's text free functions (spec 3.7): callable by bare name in any
+/// program, with no import and no module path.
+const PRELUDE_TEXT_FUNCTIONS: &str = "`print`, `println`, `eprint`, and `eprintln`";
+
+/// The `help:` line E0707 carries when a missing `std` member is really one of
+/// the prelude's free functions written as though it lived in a module.
+///
+/// `std.io.println("x")` is the shape this exists for: there is no `std.io`,
+/// and the reader's next question is not "which members does `std` have" but
+/// "where is `println`". The answer — nowhere, it needs no path — is the same
+/// for the four functions themselves (`std.println`) and for the module a
+/// reader reaches for to find them (`std.io`).
+pub fn unknown_module_member_help(module_display: &str, member_name: &str) -> Option<String> {
+    if module_display != "std" || !reaches_for_prelude_text(member_name) {
+        return None;
+    }
+    Some(format!(
+        "{PRELUDE_TEXT_FUNCTIONS} are free functions in the prelude: \
+         call `println(x)` directly, with no module path"
+    ))
+}
+
+/// Is `member` reaching for one of the prelude's text free functions?
+///
+/// Exactly the four names, the module names a reader expects to find them
+/// under, and any near miss that still spells `print` (`printf`,
+/// `print_line`, `printLn`).
+fn reaches_for_prelude_text(member: &str) -> bool {
+    let folded: String = member
+        .chars()
+        .filter(|c| *c != '_')
+        .flat_map(char::to_lowercase)
+        .collect();
+    matches!(folded.as_str(), "io" | "stdio" | "console") || folded.contains("print")
+}
+
+/// Build E0707 for `member_name` missing from `module_display`, with the
+/// prelude `help:` line attached when it applies.
+///
+/// The one place the diagnostic is assembled, so no emitter can attach the
+/// advice in some positions and not others. `module_display` must already be
+/// the [`module_display_name`] rendering; callers that hold a raw import or
+/// logical path pass it through that function first.
+pub fn unknown_module_member(
+    module_display: &str,
+    member_name: &str,
+    span: rue_span::Span,
+) -> rue_error::CompileError {
+    let error = rue_error::CompileError::new(
+        unknown_module_member_kind(module_display, member_name),
+        span,
+    );
+    match unknown_module_member_help(module_display, member_name) {
+        Some(help) => error.with_help(help),
+        None => error,
+    }
+}
+
+/// E0707's payload, for the failure carriers that hold an [`ErrorKind`]
+/// without a span of their own and attach the help separately.
+///
+/// [`ErrorKind`]: rue_error::ErrorKind
+pub fn unknown_module_member_kind(module_display: &str, member_name: &str) -> rue_error::ErrorKind {
+    rue_error::ErrorKind::UnknownModuleMember {
+        module_name: module_display.to_owned(),
+        member_name: member_name.to_owned(),
+    }
 }
 
 /// Thread-safe registry for modules.
@@ -77,5 +182,66 @@ impl ModuleRegistry {
 impl Default for ModuleRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{module_display_name as display, unknown_module_member_help as help};
+
+    #[test]
+    fn a_user_module_renders_as_the_import_path_it_was_written_with() {
+        for path in ["lib.rue", "sub/lib.rue", "../shared/lib.rue", "std.rue"] {
+            assert_eq!(display(path), path);
+        }
+    }
+
+    #[test]
+    fn a_trusted_module_renders_as_the_dotted_name_a_program_writes() {
+        // The root module's file stem is an implementation detail; a program
+        // reaches it as plain `std`.
+        assert_eq!(display("\0rue-std/_std.rue"), "std");
+        assert_eq!(display("\0rue-std/arraybuf.rue"), "std.arraybuf");
+        assert_eq!(display("\0rue-std/binary_heap.rue"), "std.binary_heap");
+        // A nested trusted module is reached through the same dotted bindings.
+        assert_eq!(display("\0rue-std/math/float.rue"), "std.math.float");
+    }
+
+    /// The whole point (RUE-2164): the provenance marker is an identity, and
+    /// no rendering may carry it to a reader.
+    #[test]
+    fn no_trusted_rendering_carries_the_provenance_marker() {
+        for path in [
+            "\0rue-std/_std.rue",
+            "\0rue-std/arraybuf.rue",
+            "\0rue-std/math/float.rue",
+        ] {
+            let rendered = display(path);
+            assert!(
+                !rendered.contains('\0') && !rendered.contains("rue-std"),
+                "{path:?} rendered as {rendered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_prelude_help_belongs_to_std_and_to_the_text_functions() {
+        for member in ["io", "print", "println", "eprint", "eprintln"] {
+            let advice = help("std", member).expect("a prelude miss is advised");
+            assert!(advice.contains("`println`") && advice.contains("no module path"));
+        }
+        // Near misses reach for the same four functions.
+        for member in ["printf", "print_line", "printLn", "stdio", "console"] {
+            assert!(help("std", member).is_some(), "{member} is a near miss");
+        }
+        // An ordinary std miss is not about printing.
+        for member in ["arraybuf", "nope", "sqrt"] {
+            assert!(help("std", member).is_none(), "{member} is not a near miss");
+        }
+        // And the advice is keyed on the trusted module, not on the spelling
+        // of the binding: a user module named `std.rue` is not the prelude.
+        assert!(help("std.rue", "println").is_none());
+        assert!(help("io.rue", "println").is_none());
+        assert!(help("std.arraybuf", "println").is_none());
     }
 }

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -1442,11 +1442,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         // Member not found in the module
-        Err(CompileError::new(
-            ErrorKind::UnknownModuleMember {
-                module_name: crate::module_display_name(module_fact.import_path()).to_string(),
-                member_name: member_name_str,
-            },
+        Err(crate::unknown_module_member(
+            &crate::module_display_name(module_fact.import_path()),
+            &member_name_str,
             span,
         ))
     }

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -40,13 +40,7 @@ fn check_module_member_access(
     // re-export const in the facade, whose presence is the membership grant
     // (`pub const f = @import("x").f;`, ADR-0026, RUE-592).
     if !via_reexport && module_file_id != Some(member_file_id) {
-        return Err(CompileError::new(
-            ErrorKind::UnknownModuleMember {
-                module_name: module_name.to_string(),
-                member_name: fn_name_str.to_string(),
-            },
-            span,
-        ));
+        return Err(crate::unknown_module_member(module_name, fn_name_str, span));
     }
 
     Ok(())
@@ -1374,24 +1368,22 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         let function_key = function_key.ok_or_else(|| {
-            CompileError::new(
-                ErrorKind::UnknownModuleMember {
-                    module_name: crate::module_display_name(&module_def.import_path).to_string(),
-                    member_name: fn_name_str.clone(),
-                },
+            crate::unknown_module_member(
+                &crate::module_display_name(&module_def.import_path),
+                &fn_name_str,
                 span,
             )
         })?;
         let fn_info = self
             .call_facts()
             .call_function_info(function_key)
-            .ok_or_compile_error(
-                ErrorKind::UnknownModuleMember {
-                    module_name: crate::module_display_name(&module_def.import_path).to_string(),
-                    member_name: fn_name_str.clone(),
-                },
-                span,
-            )?;
+            .ok_or_else(|| {
+                crate::unknown_module_member(
+                    &crate::module_display_name(&module_def.import_path),
+                    &fn_name_str,
+                    span,
+                )
+            })?;
 
         // Track this function as referenced (for lazy analysis)
         ctx.referenced_functions.insert(function_key);
@@ -1400,7 +1392,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let param_types = param_data.types().to_vec();
         let param_modes = param_data.modes().to_vec();
         check_module_member_access(
-            crate::module_display_name(&module_def.import_path),
+            &crate::module_display_name(&module_def.import_path),
             module_file_id,
             fn_info.file_id,
             &fn_name_str,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -788,13 +788,7 @@ fn module_path_compile_error(
             CompileError::new(ErrorKind::UnknownType(name.to_string()), span)
         }
         crate::SemanticModulePathFailure::UnknownMember { module, member, .. } => {
-            CompileError::new(
-                ErrorKind::UnknownModuleMember {
-                    module_name: module.to_string(),
-                    member_name: member.to_string(),
-                },
-                span,
-            )
+            crate::unknown_module_member(&module, &member, span)
         }
         // A module binding is a `const` (spec 10.4:1), so crossing a private
         // one is the ordinary module-member privacy violation E0706 — the same
@@ -888,13 +882,9 @@ pub(super) fn semantic_type_syntax_compile_error(
             },
             span,
         ),
-        E::Semantic(F::UnknownModuleMember { module, member, .. }) => CompileError::new(
-            ErrorKind::UnknownModuleMember {
-                module_name: module.to_string(),
-                member_name: member.to_string(),
-            },
-            span,
-        ),
+        E::Semantic(F::UnknownModuleMember { module, member, .. }) => {
+            crate::unknown_module_member(&module, &member, span)
+        }
         E::Semantic(F::PrivateItem { kind, name, .. }) => CompileError::new(
             crate::private_member_access(crate::PrivateItemKind::from(kind), &name),
             span,

--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -484,3 +484,35 @@ json_diagnostic_order = [
   "error E0001 main.rue:1:60",
 ]
 compile_stderr_not_contains = ["unexpected character: '"]
+
+[[case]]
+name = "trusted_module_name_reaches_json_consumers_without_its_provenance_marker"
+description = """
+RUE-2164: the standard library's modules are keyed by the synthetic logical
+path `\\0rue-std/<name>.rue`, and E0707 used to put that key straight into
+`message` — a literal NUL, serialized as `\\u0000`, in the one field the schema
+calls human-readable. No schema field changed: the module name has only ever
+travelled inside `message`, so this pins the rendered text (`std`, not
+`\\u0000rue-std/_std.rue`) and the absence of that escape — and of the raw byte —
+anywhere in the stream. It also pins that the advice rides the existing `helps`
+array rather than being folded into the message.
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    std.io.println("hello");
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0707 main.rue:4:5"]
+compile_stderr_contains = [
+  '"code":"E0707"',
+  '"message":"module `std` has no member `io`"',
+  '"helps":["`print`, `println`, `eprint`, and `eprintln` are free functions in the prelude: call `println(x)` directly, with no module path"]',
+]
+compile_stderr_not_contains = ["\\u0000", "rue-std", "\u0000"]

--- a/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
@@ -881,11 +881,9 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
         })?
         else {
             return Err(rue_air::SemanticProviderError::Failure(
-                crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                    rue_error::ErrorKind::UnknownModuleMember {
-                        module_name: module.to_string(),
-                        member_name: member.to_owned(),
-                    },
+                super::provider_body::unknown_module_member_failure(
+                    &rue_air::module_display_name(module.as_str()),
+                    member,
                 ),
             ));
         };

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -6,6 +6,32 @@
 
 use super::super::*;
 
+/// Carry E0707 as a nucleus failure, with the prelude `help:` line attached
+/// when the miss is really a free function written as a module member.
+///
+/// The nucleus holds an [`ErrorKind`] rather than a `CompileError` — its span
+/// is stamped downstream — so the advice rides the `DiagnosticWithHelp`
+/// carrier instead of `CompileError::with_help`. Both halves come from
+/// `rue_air`, so this path and the body-analysis path cannot word the same
+/// diagnostic differently (RUE-2164).
+///
+/// `module_display` must already be `rue_air::module_display_name`'s
+/// rendering.
+pub(super) fn unknown_module_member_failure(
+    module_display: &str,
+    member: &str,
+) -> crate::semantic_query_nucleus::SemanticNucleusFailure {
+    use crate::semantic_query_nucleus::SemanticNucleusFailure as F;
+    let kind = rue_air::unknown_module_member_kind(module_display, member);
+    match rue_air::unknown_module_member_help(module_display, member) {
+        Some(help) => F::DiagnosticWithHelp {
+            kind,
+            help: Arc::from(help),
+        },
+        None => F::Diagnostic(kind),
+    }
+}
+
 fn collect_body_type_reference(
     ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
     references: &mut BTreeSet<crate::body_query::BodyReference>,
@@ -1596,7 +1622,7 @@ impl rue_air::SemanticModulePathProvider<ModuleId, ModuleId, StableDefinitionKey
     }
 
     fn module_display_name(&self, module: &ModuleId) -> Arc<str> {
-        Arc::from(module.as_str())
+        Arc::from(rue_air::module_display_name(module.as_str()))
     }
 
     fn accessing_domain(&self, scope: &ModuleId) -> rue_air::SemanticVisibilityDomain {
@@ -2278,14 +2304,9 @@ pub(in crate::revisioned_query_database) fn semantic_type_query_failure(
                     ),
                 ),
                 F::UnknownModuleMember { module, member, .. } => {
-                    ResolveSemanticSignatureError::failure(
-                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                            ErrorKind::UnknownModuleMember {
-                                module_name: module.to_string(),
-                                member_name: member.to_string(),
-                            },
-                        ),
-                    )
+                    ResolveSemanticSignatureError::failure(unknown_module_member_failure(
+                        &module, &member,
+                    ))
                 }
                 F::ValueWhereTypeExpected { parameter, .. } => {
                     ResolveSemanticSignatureError::failure(
@@ -2463,14 +2484,9 @@ pub(in crate::revisioned_query_database) fn semantic_type_query_failure(
                     }
                     rue_air::SemanticModulePathFailure::UnknownMember {
                         module, member, ..
-                    } => ResolveSemanticSignatureError::failure(
-                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                            ErrorKind::UnknownModuleMember {
-                                module_name: module.to_string(),
-                                member_name: member.to_string(),
-                            },
-                        ),
-                    ),
+                    } => ResolveSemanticSignatureError::failure(unknown_module_member_failure(
+                        &module, &member,
+                    )),
                     rue_air::SemanticModulePathFailure::PrivateMember { member, .. } => {
                         ResolveSemanticSignatureError::failure(
                             crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(

--- a/crates/rue-ui-tests/cases/diagnostics/private_member_access.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/private_member_access.toml
@@ -275,3 +275,111 @@ aux_files = { "sub/lib.rue" = "pub fn real() -> i32 { 1 }\n" }
 compile_fail = true
 expected_error_code = "E0707"
 error_contains = ["module `sub/lib.rue` has no member `Nope`"]
+
+# ---------------------------------------------------------------------------
+# A trusted standard-library module renders as the name a program writes.
+#
+# RUE-2164: the standard library's modules are keyed by the synthetic logical
+# path `\0rue-std/<name>.rue`, whose leading NUL marks toolchain provenance
+# and is disjoint from every expressible filesystem path. That key is an
+# identity, not a name, and it used to reach the reader verbatim:
+# `module `<NUL>rue-std/_std.rue` has no member `io``. It now renders the way
+# the specification and the standard library's own prose spell these modules —
+# `std` for the root and `std.<name>` for a submodule.
+#
+# Each case pins the WHOLE stderr stream with `expected_error`, so the
+# assertion is byte-exact: neither the NUL itself nor the `␀` glyph the text
+# renderer maps it to can hide anywhere in the output.
+
+[[case]]
+name = "std_root_member_miss_names_std_not_its_provenance_marker"
+description = "`std.io.x` is the shape that exposed the leak: no `std.io` exists, so E0707 names the root module — as `std`, byte-exactly, with no NUL and no `␀`. The help line answers the question the reader actually has."
+real_std = true
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    std.io.println("x");
+    0
+}
+"""
+compile_fail = true
+expected_error_code = "E0707"
+expected_error = """
+error: [E0707]: module `std` has no member `io`
+ --> test.rue:4:5
+  |
+4 |     std.io.println("x");
+  |     ^^^^^^
+  |
+  = help: `print`, `println`, `eprint`, and `eprintln` are free functions in the prelude: call `println(x)` directly, with no module path
+"""
+
+[[case]]
+name = "std_submodule_member_miss_names_the_dotted_path"
+description = "A submodule renders as the dotted path a program writes (`std.arraybuf`, spec 4.14), not `\\0rue-std/arraybuf.rue`. A miss that is not reaching for a prelude function carries no help line."
+real_std = true
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    std.arraybuf.nope();
+    0
+}
+"""
+compile_fail = true
+expected_error_code = "E0707"
+expected_error = """
+error: [E0707]: module `std.arraybuf` has no member `nope`
+ --> test.rue:4:5
+  |
+4 |     std.arraybuf.nope();
+  |     ^^^^^^^^^^^^^^^^^^^
+  |
+"""
+
+[[case]]
+name = "prelude_free_function_written_as_a_std_member_gets_the_help"
+description = "`std.println(...)` is the other half of the same misconception, and gets the same answer: the four text functions need no module path at all."
+real_std = true
+source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    std.println("x");
+    0
+}
+"""
+compile_fail = true
+expected_error_code = "E0707"
+expected_error = """
+error: [E0707]: module `std` has no member `println`
+ --> test.rue:4:5
+  |
+4 |     std.println("x");
+  |     ^^^^^^^^^^^^^^^^
+  |
+  = help: `print`, `println`, `eprint`, and `eprintln` are free functions in the prelude: call `println(x)` directly, with no module path
+"""
+
+[[case]]
+name = "a_user_module_miss_is_unchanged_however_it_is_spelled"
+description = "The rendering and the help are keyed on the trusted namespace, not on how the source spells the binding: a user module bound as `std` and missing `println` still renders as its import path and still carries no help."
+source = """
+const std = @import("io.rue");
+
+fn main() -> i32 {
+    std.println("x")
+}
+"""
+aux_files = { "io.rue" = "pub fn real() -> i32 { 1 }\n" }
+compile_fail = true
+expected_error_code = "E0707"
+expected_error = """
+error: [E0707]: module `io.rue` has no member `println`
+ --> test.rue:4:5
+  |
+4 |     std.println("x")
+  |     ^^^^^^^^^^^^^^^^
+  |
+"""

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -65,6 +65,15 @@ are serialized in alphabetical order; consumers must not depend on key order.
 | `notes` | array of strings | Contextual footnotes. |
 | `helps` | array of strings | Actionable advice footnotes. |
 
+No key carries a module's identity. A diagnostic that names a module — E0707,
+whose `message` reads ``module `std.arraybuf` has no member `nope` `` — spells
+it the way a program would: the import path for a user module, and the dotted
+`std` / `std.<name>` form for a trusted standard-library module. The compiler
+keys library modules on a synthetic logical path whose leading NUL byte marks
+toolchain provenance (`\0rue-std/_std.rue`); that identity is not part of this
+surface and appears in no field, `message` included (RUE-2164). A consumer that
+wants a file rather than a name reads `spans[].file`.
+
 ### Span object
 
 | Key | Type | Meaning |


### PR DESCRIPTION
Fixes RUE-2164

## Problem

A trusted standard-library module carries a synthetic import path prefixed with a NUL byte, the toolchain-provenance marker. That path leaked into diagnostics: `std.io.println("x")` reported the module as the raw prefixed path with a 0x00 byte inside the JSON `message` (the text renderer had been mapping the byte to a control glyph). Two emitters also bypassed the single rendering hook and printed the module path raw.

## Change

- `module_display_name` renders a trusted module the way a program writes it: `std` for the root, `std.arraybuf` for a module, `std.math.float` for a nested one, and every user path exactly as before. The spelling follows the spec's own references to std modules.
- Every emitter that names a module now goes through that hook, including two that did not: the provider hook in `provider_body.rs` and the comptime adapter's unknown-member failure. The nucleus carriers build their failure through one shared constructor.
- E0707 on `std` carries a `help` when the missing member is `io`, `stdio`, `console`, or anything that folds to a `print` spelling: the four prelude print functions are free functions and take no module path. A user module bound to the name `std` never gets it; the help is keyed on the trusted namespace.
- No `--error-format json` field changed; module names only ever travelled inside `message`, and the `helps` array was already present. `docs/process/diagnostics.md` says so.

## Coverage

- Four UI cases beside the existing E0707 display-name cases (`std.io.x`, `std.arraybuf.nope`, `std.println`, and a user module bound as `std`), each a byte-exact golden of the whole stderr stream, so neither the raw byte nor its glyph can hide in it.
- A `json_diagnostics` CLI case pinning `message`, `helps`, and `code`, and asserting that neither the JSON NUL escape, the raw byte, nor the provenance prefix appears.
- Four unit tests in `module_registry.rs`.

## Verification

- `scripts/rue unit air`: 901 passed. `scripts/rue ui diagnostics`: 365 passed. `scripts/rue cli diagnostic_json`: 23 passed. `scripts/rue quick`: 36 targets.
- `scripts/rue premerge`: pass 220, fail 0.
- Reviewer probes on the branch in text and JSON mode: `std.io`, `std.arraybuf.nope`, a std miss in type position, and a user-module miss; zero NUL bytes, zero NUL escapes, zero provenance prefixes in every stream.
