### PR TITLE
RUE-2167: an integer literal in @int_to_ptr's address takes u64

### DIFF
--- a/crates/rue-air/src/inference/intrinsic_signature.rs
+++ b/crates/rue-air/src/inference/intrinsic_signature.rs
@@ -334,8 +334,13 @@ pub(crate) const fn intrinsic_shape(name: IntrinsicName) -> IntrinsicShape {
             },
             Fixed(Unit),
         ),
-        // `@int_to_ptr` returns a pointer type inferred from context.
-        I::IntToPtr => IntrinsicSignature::new(Uniform(Free), Fresh),
+        // `@int_to_ptr(addr)` returns a pointer type inferred from context, but
+        // its address operand is the declared `u64` of spec 9.2:6c. An
+        // integer-literal operand sees that type here (RUE-2167), so
+        // `@int_to_ptr(0)` works without pre-binding the address to a `u64`.
+        // Only literals are constrained, as for `@syscall`: a wrongly typed
+        // non-literal keeps semantic analysis' targeted E0702.
+        I::IntToPtr => IntrinsicSignature::new(Uniform(EqualIntLiteral(U64)), Fresh),
         I::TargetArch => IntrinsicSignature::new(Ungenerated, BuiltinEnum("Arch")),
         I::TargetOs => IntrinsicSignature::new(Ungenerated, BuiltinEnum("Os")),
         I::TargetDataModel => IntrinsicSignature::new(Ungenerated, BuiltinEnum("DataModel")),

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -302,6 +302,27 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ParseI64),
         &[],
     ),
+    // RUE-2167: `@int_to_ptr` of a literal address. The oracle's heap is
+    // allocation-shaped, so it models exactly two address sources: a zero
+    // address, which is the null pointer, and an address carrying the
+    // provenance of the pointer `@ptr_to_int` produced it from. A bare numeric
+    // address names no allocation it knows, so the interpreter stops with the
+    // typed `IntToPointer` gap rather than inventing one. The sibling
+    // `int_to_ptr_zero_is_the_null_pointer` and `@ptr_to_int` round-trip cases
+    // in this section are fully modeled and diffed; only these literal
+    // addresses are debt.
+    Entry::new(
+        "runtime.pointers",
+        "int_to_ptr_literal_address_spans_the_u64_range",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "runtime.pointers",
+        "int_to_ptr_literal_address_takes_u64",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
     // ADR-0059 phase 5 (RUE-963): the typed-access width and unaligned round
     // trip cases anchor their pointers via @int_to_ptr, which the oracle does
     // not model.

--- a/crates/rue-spec/cases/runtime/pointers.toml
+++ b/crates/rue-spec/cases/runtime/pointers.toml
@@ -194,27 +194,90 @@ fn main() -> i32 {
 """
 exit_code = 57  # 12345 % 256 = 57
 
-# The null-pointer idiom (9.2:6c): `@int_to_ptr` takes exactly a `u64`, so null
-# is written over a `u64` binding rather than a bare `0` literal, and
-# `@ptr_to_int(p) == 0` is the null test. Round-tripping an address through the
-# pair addresses the same storage.
+# The null-pointer idiom (9.2:6c): `@int_to_ptr` takes exactly a `u64`, and a
+# bare `0` literal in that operand position is fixed to `u64` by the operand
+# type (3.1:15, 9.2:6d), so the idiom needs no `u64` binding. `@ptr_to_int(p)
+# == 0` is the null test, and round-tripping an address through the pair
+# addresses the same storage.
 [[case]]
 name = "int_to_ptr_zero_is_the_null_pointer"
 spec = ["9.2:6c", "9.2:6e"]
 source = """
 fn main() -> i32 {
     let mut x: i32 = 10;
-    let zero: u64 = 0;
     checked {
         let p: ptr mut i32 = @raw_mut(x);
         @ptr_write(p, 99);
         let back: ptr mut i32 = @int_to_ptr(@ptr_to_int(p));
-        let null: ptr mut u8 = @int_to_ptr(zero);
+        let null: ptr mut u8 = @int_to_ptr(0);
         if @ptr_to_int(null) == 0 { @ptr_read(back) } else { 0 }
     }
 }
 """
 exit_code = 99
+
+# RUE-2167: a bare integer literal in `@int_to_ptr`'s address position takes the
+# declared `u64` (3.1:15, 9.2:6d) instead of defaulting to `i32` and failing the
+# operand check. The address is only converted here, never dereferenced, so the
+# case is about the type the literal acquires.
+[[case]]
+name = "int_to_ptr_literal_address_takes_u64"
+spec = ["9.2:6c", "9.2:6d"]
+source = """
+fn main() -> i32 {
+    let p: ptr mut i64 = checked { @int_to_ptr(4096) };
+    let addr: u64 = checked { @ptr_to_int(p) };
+    @intCast(addr / 1024)
+}
+"""
+exit_code = 4
+
+# RUE-2167: the literal takes `u64`, not the widest signed type — an address
+# above `i64::MAX` round-trips unchanged.
+[[case]]
+name = "int_to_ptr_literal_address_spans_the_u64_range"
+spec = ["9.2:6c", "9.2:6d"]
+source = """
+fn main() -> i32 {
+    let p: ptr mut u8 = checked { @int_to_ptr(18446744073709551615) };
+    let addr: u64 = checked { @ptr_to_int(p) };
+    if addr == 18446744073709551615 { 7 } else { 1 }
+}
+"""
+exit_code = 7
+
+# RUE-2167 control: giving the literal the operand's `u64` does not widen what
+# a literal may denote. A value past the tokenization limit (2.1:4) is still
+# rejected here, exactly as it is in a `u64` annotation.
+[[case]]
+name = "int_to_ptr_literal_above_the_u64_range_is_rejected"
+spec = ["9.2:6d", "2.1:4"]
+source = """
+fn main() -> i32 {
+    let p: ptr mut u8 = checked { @int_to_ptr(18446744073709551616) };
+    let addr: u64 = checked { @ptr_to_int(p) };
+    @intCast(addr)
+}
+"""
+compile_fail = true
+expected_error_code = "E0002"
+
+# RUE-2167 control: only an integer literal takes the operand's `u64`. A
+# negated literal is not one, so it keeps the operand check's own diagnostic
+# rather than being laundered into a `u64` address — the same outcome
+# `@syscall` gives a negative argument.
+[[case]]
+name = "int_to_ptr_negative_literal_is_rejected"
+spec = ["9.2:6d"]
+source = """
+fn main() -> i32 {
+    let p: ptr mut u8 = checked { @int_to_ptr(-1) };
+    let addr: u64 = checked { @ptr_to_int(p) };
+    @intCast(addr)
+}
+"""
+compile_fail = true
+expected_error_code = "E0702"
 
 # @ptr_read/@ptr_write move exactly @size_of(T) physical bytes, never a
 # fixed-width slot (9.2:6b). At T = u8 that is one byte: writing through a

--- a/docs/designs/0059-byte-oriented-memory-intrinsics.md
+++ b/docs/designs/0059-byte-oriented-memory-intrinsics.md
@@ -278,6 +278,10 @@ let zero: u64 = 0;
 let null: ptr mut u8 = checked { @int_to_ptr(zero) };
 ```
 
+RUE-2167 removed the second half of that: an integer literal in the address
+position now takes the declared `u64`, so `checked { @int_to_ptr(0) }` compiles
+and the `u64` binding is optional (spec 9.2:6d).
+
 `std/fs.rue` and `std/mem.rue` use exactly this form. Names are chosen so a later strict/exposed
 provenance split does not force a rename of the common path.
 

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -125,21 +125,22 @@ null, and `@ptr_to_int(p) == 0` is the null test.
 evaluates to `u8`, while a byte write requires a `ptr mut u8` and a value of
 exactly `u8`. `@ptr_to_int` accepts a pointer of any pointee type and
 mutability and evaluates to `u64`. `@int_to_ptr` requires an operand of exactly
-`u64` — an untyped integer literal is not accepted, so the null idiom is
-written over a `u64` binding — and evaluates to a `ptr mut T` whose pointee
-type is inferred from context.
+`u64` — an untyped integer literal in that operand position is one of the uses
+that fixes its type (3.1:15), so `@int_to_ptr(0)` writes the null idiom
+directly and no `u64` binding is needed; a literal that takes `u64` here is
+range-checked against it like any other literal given that type (3.1:17) — and
+evaluates to a `ptr mut T` whose pointee type is inferred from context.
 
 {{ rule(id="9.2:6e", cat="example") }}
 
 ```rue
 fn main() -> i32 {
     let mut x: i32 = 10;
-    let zero: u64 = 0;
     checked {
         let p: ptr mut i32 = @raw_mut(x);
         @ptr_write(p, 99);                        // writes @size_of(i32) == 4 bytes
         let back: ptr mut i32 = @int_to_ptr(@ptr_to_int(p));
-        let null: ptr mut u8 = @int_to_ptr(zero); // the null-pointer idiom
+        let null: ptr mut u8 = @int_to_ptr(0);    // the null-pointer idiom
         if @ptr_to_int(null) == 0 { @ptr_read(back) } else { 0 }
     }
 }


### PR DESCRIPTION
Fixes RUE-2167

## Problem

`@int_to_ptr(0)` rejected a bare integer literal with E0702 "expects u64, found i32", so the null-pointer idiom had to be written over a `u64` binding. Spec 9.2:6d documented that as the rule.

## Change

- The intrinsic signature table (`crates/rue-air/src/inference/intrinsic_signature.rs`), which is where RUE-954 landed the same treatment for `@syscall`, now constrains `@int_to_ptr`'s operand with `EqualIntLiteral(U64)`: a literal takes `u64`, a non-literal keeps semantic analysis's targeted E0702 (`@int_to_ptr(x)` with `x: i32` and `@int_to_ptr(-1)` are still rejected as before), and the context-inferred result pointee is untouched.
- The whole intrinsic table was swept with a bare-literal probe against every fixed-integer operand. `@int_to_ptr` was the only broken row; the allocation, byte, argv/env, and syscall intrinsics already constrained theirs, and the contextual ones (`@ptr_offset`, the casts, `@to_string`) are contextual by design.
- Spec 9.2:6d now says the literal takes `u64` under 3.1:15 and is range-checked under 3.1:17; the 9.2:6e example writes `@int_to_ptr(0)`. ADR-0059 gets a note that this lifts the restriction it spelled out.
- The two new executing spec cases reach an address the oracle cannot model (its heap is allocation-shaped and maps only `0` and provenance-carrying addresses), so they are registered as `IntToPointer` model gaps in the spec registry, with the reason.

## Coverage

Five cases under `runtime.pointers`: `@int_to_ptr(4096)`, the full `u64` range round-tripping through `@ptr_to_int`, the null idiom in literal form, a literal above the `u64` range still rejected, and a negative literal still rejected.

## Verification

- `scripts/rue spec runtime.pointers`: 24 passed. `scripts/rue spec expressions.intrinsics`: 190 passed. `scripts/rue quick`: 947 unit tests.
- `//:spec-traceability`, `//:compiler-spec-machine-index`: pass. `//crates/rue-oracle-diff:oracle-diff-spec-test`: pass after the gap registration.
- `scripts/rue premerge`: pass 220, fail 0.
- Reviewer probes on the branch at `-O0` and `-O2`: a literal address round-trips; an `i32` variable and `-1` are rejected with the same E0702 as before.
