### PR TITLE
RUE-2066: only a test image writes to the failure channel

### DIFF
--- a/crates/rue-cli-tests/BUCK
+++ b/crates/rue-cli-tests/BUCK
@@ -21,6 +21,7 @@ rue_binary(
         "//crates/rue-linker:rue-linker",
         "//crates/rue-target:rue-target",
         "//crates/rue-test-runner:rue-test-runner",
+        "//third-party:libc",
         "//third-party:libtest2-mimic",
         "//third-party:serde",
         "//third-party:serde_json",

--- a/crates/rue-cli-tests/cases/panic_assert.toml
+++ b/crates/rue-cli-tests/cases/panic_assert.toml
@@ -199,6 +199,80 @@ exit_code = 101
 stdout = ""
 runtime_error_contains = ["panic: one is not two"]
 
+# ── Descriptor 3 is not this program's (RUE-2066) ────────────────────────────
+
+# The assertion family lowers identically in a test image and in an ordinary
+# executable (ADR-0083 §5.1), and the failing arm reports on the structured
+# failure channel — descriptor 3. In an ordinary executable that descriptor
+# belongs to whoever opened it: `prog 3>file`, or a program that opened a third
+# file of its own. The runtime therefore arms the channel only from the test
+# dispatcher's prologue, so these programs write their pinned stderr line and
+# nothing at all to 3. Without the armed flag each of them wrote a JSON failure
+# frame into the file.
+[[case]]
+name = "assert_eq_writes_no_frame_to_an_inherited_descriptor_three"
+description = "A failing @assert_eq in an ordinary executable leaves descriptor 3 untouched."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 41;
+    @assert_eq(a, 42);
+    0
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: assertion failed: left == right"]
+capture_fd3 = true
+fd3_empty = true
+
+[[case]]
+name = "assert_writes_no_frame_to_an_inherited_descriptor_three"
+description = "A failing @assert in an ordinary executable leaves descriptor 3 untouched."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @assert(false);
+    0
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["assertion failed"]
+capture_fd3 = true
+fd3_empty = true
+
+# The trap helpers report on the same channel, so @panic is the third producer
+# an ordinary executable must keep off descriptor 3.
+[[case]]
+name = "panic_writes_no_frame_to_an_inherited_descriptor_three"
+description = "@panic in an ordinary executable leaves descriptor 3 untouched."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @panic("boom");
+    0
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: boom"]
+capture_fd3 = true
+fd3_empty = true
+
+# A program that succeeds never reaches the channel at all; the case pins that
+# the capture itself does not perturb an ordinary run.
+[[case]]
+name = "a_passing_program_leaves_descriptor_three_untouched"
+description = "An executable with descriptor 3 open and no failure writes nothing to it."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @assert(true);
+    7
+}
+""" }]
+exit_code = 7
+stdout = ""
+capture_fd3 = true
+fd3_empty = true
+
 # ── Operand contract rejection ───────────────────────────────────────────────
 
 # The frontend must reject a non-bool condition before backend lowering. It

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -84,6 +84,10 @@
 //!   the inherited environment. Distinct from `env` (the compiler's env)
 //!   (RUE-935)
 //! - `stdin`: piped to the compiled program when it runs
+//! - `capture_fd3` + `fd3_empty`: open a file on the compiled program's
+//!   descriptor 3 for its run and assert nothing reached it — descriptor 3 is
+//!   the `rue test` failure channel, and an ordinary executable does not own
+//!   it (RUE-2066). Unix only
 //! - `compile_fail` + `error_contains`: expect compilation failure
 //! - `compile_only`: don't run the produced binary
 //! - `driver_exit_code`: exact exit status of a driver subcommand invocation
@@ -2111,6 +2115,10 @@ fn case_runs_prebuilt_program(case: &Case) -> bool {
         stdout_contains: _,
         runtime_error_contains: _,
         exit_code: _,
+        // Descriptor 3 is attached by the shared run phase, so a staged
+        // executable inherits it on the same terms as its argv and stdin.
+        capture_fd3: _,
+        fd3_empty: _,
         // The subject: a case must name a checked-in root...
         source_path: Some(root),
         // ...and must leave the compile exactly as `rue <root> -o prog`.
@@ -3758,6 +3766,70 @@ fn wait_for_watch_exit(
     Err("timed out waiting for the interrupted watch-test process to exit".to_string())
 }
 
+/// Put a file on the produced program's descriptor 3 and return its path.
+///
+/// Descriptor 3 has a meaning only inside a `rue test` image, where the runner
+/// installs the structured failure channel's write end there (ADR-0083 §3).
+/// Everywhere else it belongs to whoever opened it, so a case that pins "an
+/// ordinary executable writes nothing there" needs the descriptor actually
+/// open during the run — an unopened 3 makes the write fail with `EBADF` for
+/// the wrong reason and proves nothing.
+///
+/// A regular file rather than a pipe: nothing drains this descriptor while the
+/// program runs, and a program that flooded a pipe nobody reads would block
+/// until the case's timeout instead of failing on its bytes.
+#[cfg(unix)]
+fn attach_descriptor_three(command: &mut Command, dir: &Path) -> TestResult<PathBuf> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::process::CommandExt;
+
+    let path = dir.join("fd3.capture");
+    let file = std::fs::File::create(&path).map_err(|error| {
+        TestFailure::fatal(format!(
+            "failed to create the descriptor 3 capture at {}: {error}",
+            path.display()
+        ))
+    })?;
+    // The closure owns the file, so it stays open across the fork and is
+    // closed when the command is dropped.
+    // SAFETY: the closure runs between fork and exec and calls only
+    // `dup2`/`fcntl`, both async-signal-safe, allocating nothing.
+    unsafe {
+        command.pre_exec(move || {
+            let raw = file.as_raw_fd();
+            if raw == 3 {
+                // `dup2(3, 3)` is a no-op that leaves close-on-exec set, so the
+                // descriptor would vanish at exec. Clear the flag instead.
+                if libc::fcntl(3, libc::F_SETFD, 0) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                return Ok(());
+            }
+            // `dup2` clears close-on-exec on the new descriptor, which is what
+            // lets 3 survive into the program.
+            if libc::dup2(raw, 3) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    Ok(path)
+}
+
+/// Non-unix hosts have no descriptor inheritance to pin, and the CLI corpus
+/// records the field as unix-only.
+#[cfg(not(unix))]
+fn attach_descriptor_three(_command: &mut Command, dir: &Path) -> TestResult<PathBuf> {
+    let path = dir.join("fd3.capture");
+    std::fs::write(&path, b"").map_err(|error| {
+        TestFailure::fatal(format!(
+            "failed to create the descriptor 3 capture at {}: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(path)
+}
+
 /// Run the case's program from its temp directory and check every runtime
 /// expectation.
 ///
@@ -3787,12 +3859,35 @@ fn run_case_program(
     for (key, value) in &case.program_env {
         run_cmd.env(key, value);
     }
+    // Descriptor 3 is the `rue test` failure channel, and an ordinary
+    // executable must leave it alone (RUE-2066). A case that pins that gets a
+    // file on 3 for the program's run and reads it back below.
+    let fd3_capture = if case.capture_fd3 {
+        Some(attach_descriptor_three(&mut run_cmd, dir)?)
+    } else {
+        None
+    };
     let run_output = run_phase_with_timeout(
         run_cmd,
         ProcessPhase::ProducedProgram,
         contract.runtime_timeout(),
         case.stdin.as_deref(),
     )?;
+    if let Some(path) = &fd3_capture {
+        let captured = std::fs::read(path).map_err(|error| {
+            TestFailure::fatal(format!(
+                "failed to read the descriptor 3 capture at {}: {error}",
+                path.display()
+            ))
+        })?;
+        if case.fd3_empty && !captured.is_empty() {
+            return Err(TestFailure::assertion(format!(
+                "program wrote {} byte(s) to descriptor 3, which it does not own:\n{}",
+                captured.len(),
+                display_bytes(&captured)
+            )));
+        }
+    }
 
     let run_stdout = String::from_utf8_lossy(&run_output.stdout).to_string();
     let run_stderr = String::from_utf8_lossy(&run_output.stderr).to_string();
@@ -4320,6 +4415,17 @@ fn driver_exit_code_conflicts_with_compile_fail(case: &Case) -> bool {
     case.driver_exit_code.is_some() && case.compile_fail
 }
 
+/// `capture_fd3` opens a descriptor; it asserts nothing on its own, and an
+/// `fd3_*` assertion with no descriptor open would pass for the wrong reason.
+/// Neither half is meaningful without the other, so say which is missing.
+fn invalid_fd3_capture(case: &Case) -> Option<&'static str> {
+    match (case.capture_fd3, case.fd3_empty) {
+        (true, false) => Some("`capture_fd3` pins nothing without an `fd3_*` assertion"),
+        (false, true) => Some("`fd3_empty` requires `capture_fd3` to open the descriptor"),
+        _ => None,
+    }
+}
+
 fn invalid_replay_repro(case: &Case) -> Option<&'static str> {
     let target = case.replay_repro.as_deref()?;
     if target.is_empty() {
@@ -4352,6 +4458,8 @@ fn compile_only_runtime_fields(case: &Case) -> Vec<&'static str> {
             !case.runtime_error_contains.is_empty(),
         ),
         ("exit_code", case.exit_code.is_some()),
+        ("capture_fd3", case.capture_fd3),
+        ("fd3_empty", case.fd3_empty),
     ]
     .into_iter()
     .filter_map(|(field, present)| present.then_some(field))
@@ -4471,6 +4579,14 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                 // load time so the doc comment's promise is enforced, not merely
                 // documented (RUE-132).
                 for case in &tf.cases {
+                    if let Some(error) = invalid_fd3_capture(case) {
+                        eprintln!(
+                            "error: {}: case '{}' declares an invalid descriptor 3 capture: {error}",
+                            path.display(),
+                            case.name,
+                        );
+                        std::process::exit(1);
+                    }
                     if let Some(error) = invalid_replay_repro(case) {
                         eprintln!(
                             "error: {}: case '{}' declares invalid replay_repro: {error}",
@@ -6631,6 +6747,37 @@ mod tests {
         assert!(compile_fail_has_exit_code(&case));
     }
 
+    /// Each half of the descriptor 3 capture is useless alone: an open
+    /// descriptor nobody asserts on, or an assertion about a descriptor nobody
+    /// opened (which would pass because the program could not write there at
+    /// all).
+    #[test]
+    fn fd3_capture_requires_both_halves() {
+        assert_eq!(
+            invalid_fd3_capture(&Case {
+                capture_fd3: true,
+                ..Default::default()
+            }),
+            Some("`capture_fd3` pins nothing without an `fd3_*` assertion")
+        );
+        assert_eq!(
+            invalid_fd3_capture(&Case {
+                fd3_empty: true,
+                ..Default::default()
+            }),
+            Some("`fd3_empty` requires `capture_fd3` to open the descriptor")
+        );
+        assert_eq!(
+            invalid_fd3_capture(&Case {
+                capture_fd3: true,
+                fd3_empty: true,
+                ..Default::default()
+            }),
+            None
+        );
+        assert_eq!(invalid_fd3_capture(&Case::default()), None);
+    }
+
     #[test]
     fn compile_only_rejects_each_produced_program_field() {
         let mut cases = Vec::new();
@@ -6642,6 +6789,8 @@ mod tests {
             "stdout_contains",
             "runtime_error_contains",
             "exit_code",
+            "capture_fd3",
+            "fd3_empty",
         ] {
             let mut case = Case {
                 name: field.to_string(),
@@ -6659,6 +6808,8 @@ mod tests {
                 "stdout_contains" => case.stdout_contains = vec!["output".to_string()],
                 "runtime_error_contains" => case.runtime_error_contains = vec!["panic".to_string()],
                 "exit_code" => case.exit_code = Some(0),
+                "capture_fd3" => case.capture_fd3 = true,
+                "fd3_empty" => case.fd3_empty = true,
                 _ => unreachable!(),
             }
             cases.push((field, case));

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -134,6 +134,7 @@ enum IneligibleReason {
     CompilerEnvironment,
     RuntimeArguments,
     RuntimeEnvironment,
+    InheritedDescriptor,
     NamedExecutionContract,
     ExternalSourcePath,
     NoInlineSource,
@@ -164,6 +165,7 @@ impl fmt::Display for IneligibleReason {
             Self::CompilerEnvironment => f.write_str("compiler environment"),
             Self::RuntimeArguments => f.write_str("runtime command-line arguments"),
             Self::RuntimeEnvironment => f.write_str("runtime environment"),
+            Self::InheritedDescriptor => f.write_str("inherited descriptor capture"),
             Self::NamedExecutionContract => f.write_str("named execution contract"),
             Self::ExternalSourcePath => f.write_str("external source path"),
             Self::NoInlineSource => f.write_str("no inline source"),
@@ -1447,7 +1449,17 @@ fn unsupported_corpus_field(case: &Case) -> Option<IneligibleReason> {
         execute_if_native,
         requires_system_linker,
         driver_exit_code,
+        capture_fd3,
+        fd3_empty,
     } = case;
+
+    // Descriptor 3's contents are a property of the *process* the CLI suite
+    // spawns (RUE-2066). The oracle evaluates source in this process and
+    // inherits no such descriptor, so it can neither attach the capture nor
+    // judge what reached it.
+    if *capture_fd3 || *fd3_empty {
+        return Some(IneligibleReason::InheritedDescriptor);
+    }
 
     // `driver_exit_code` declares a driver subcommand that never produces a
     // program: there is no execution for the oracle to agree with.

--- a/crates/rue-runtime/src/process.rs
+++ b/crates/rue-runtime/src/process.rs
@@ -166,9 +166,17 @@ pub fn __rue_env_len(index: u64) -> u64 {
 /// them — nothing is copied, nothing is freed — so this is a pure narrowing of
 /// what the accessors will report.
 ///
+/// It also arms the structured failure channel. The dispatcher's prologue is
+/// the only caller, so reaching this function is the runtime's one proof that
+/// it is running inside a test image — which is what descriptor 3 means
+/// (RUE-2066). Everywhere else the assertion family, `@panic`, and the trap
+/// helpers write no frame at all, because an ordinary executable's descriptor
+/// 3 belongs to whoever opened it.
+///
 /// The dispatcher calls this once, before the selected test body runs.
 pub fn __rue_test_normalize_process() {
     ARG_COUNT.store(1, Ordering::Relaxed);
+    crate::test_channel::arm_channel();
 }
 
 #[cfg(test)]
@@ -244,6 +252,9 @@ mod tests {
 
         __rue_test_normalize_process();
         assert_eq!(__rue_arg_count(), 1);
+        // Reaching normalization is the runtime's one proof that this is a
+        // test image, so it is also what arms the failure channel (RUE-2066).
+        assert!(crate::test_channel::channel_is_armed());
         assert_eq!(__rue_arg_len(0), 8);
         // SAFETY: index 0 is in range and addresses 8 readable bytes.
         unsafe {

--- a/crates/rue-runtime/src/test_channel.rs
+++ b/crates/rue-runtime/src/test_channel.rs
@@ -7,14 +7,21 @@
 //! security boundary — it exists so an accidental collision with a test's own
 //! stdout or stderr cannot forge or truncate a verdict.
 //!
-//! Two properties are load-bearing:
+//! Three properties are load-bearing:
 //!
-//! - **Writes are best-effort.** A test run by hand has no descriptor 3, so
-//!   `EBADF` is expected rather than exceptional; a runner that closed its read
-//!   end yields `EPIPE`. Both are discarded. (`SIGPIPE` keeps its default
-//!   disposition here exactly as it does for stdout, spec §8.5, so a closed
-//!   reader terminates the process before `write` returns at all. The runner
-//!   holds its read end open until the child exits precisely for this reason.)
+//! - **Only a test image writes.** The assertion family lowers identically
+//!   everywhere (§5.1), so the runtime, not the compiler, decides whether a
+//!   frame is written: the dispatcher's prologue arms the channel, and nothing
+//!   else does. An ordinary executable's descriptor 3 belongs to whoever opened
+//!   it — `prog 3>file`, or a program with a third file of its own — and it
+//!   receives nothing (RUE-2066).
+//! - **Writes are best-effort.** An armed image run by hand has no descriptor
+//!   3, so `EBADF` is expected rather than exceptional; a runner that closed
+//!   its read end yields `EPIPE`. Both are discarded. (`SIGPIPE` keeps its
+//!   default disposition here exactly as it does for stdout, spec §8.5, so a
+//!   closed reader terminates the process before `write` returns at all. The
+//!   runner holds its read end open until the child exits precisely for this
+//!   reason.)
 //! - **No allocation, and no staging buffer.** A record is emitted as runs
 //!   borrowed straight from the caller's own bytes, so no part of it is ever
 //!   assembled in memory first. The only fixed-size buffer is the six bytes one
@@ -33,12 +40,42 @@
 //! `sub_result` identities — are named by the schema and produced by nothing in
 //! this version.
 
-use core::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 
 use crate::platform;
 
 /// Inherited failure-channel descriptor, pinned by the §3 exec contract.
 pub const CHANNEL_FD: u64 = 3;
+
+/// Whether this process is a test image, and so owns descriptor 3.
+///
+/// Only a test image's dispatcher prologue calls
+/// [`crate::process::__rue_test_normalize_process`], which is the one place
+/// that sets this. An ordinary executable never does, so it never writes a
+/// frame — descriptor 3 there belongs to whoever opened it (`prog 3>file`, or
+/// a program with a third file of its own), and the assertion family must not
+/// scribble JSON into someone else's descriptor (RUE-2066).
+///
+/// `Relaxed` is sufficient: the prologue runs before any user code on the same
+/// thread, so no other ordering could observe the store out of turn.
+static CHANNEL_ARMED: AtomicBool = AtomicBool::new(false);
+
+/// Arm the failure channel: this process is a test image dispatched by the
+/// runner, so descriptor 3 is the channel's write end.
+///
+/// Called from the dispatcher prologue's process normalization and nowhere
+/// else, which is exactly what makes "armed" mean "is a test image".
+pub(crate) fn arm_channel() {
+    CHANNEL_ARMED.store(true, Ordering::Relaxed);
+}
+
+/// Whether [`arm_channel`] has run. Exists so `process.rs` can assert that
+/// normalizing the process is what arms the channel, under the serialization
+/// its own process-global test already keeps.
+#[cfg(test)]
+pub(crate) fn channel_is_armed() -> bool {
+    CHANNEL_ARMED.load(Ordering::Relaxed)
+}
 
 /// The failing source location staged by the most recent
 /// [`__rue_test_failure_site`] call.
@@ -531,12 +568,34 @@ pub(crate) fn report_bounds_check() {
     report_trap(&TRAP_BOUNDS_CHECK_KIND, &BOUNDS_CHECK_MESSAGE, &[]);
 }
 
-/// Best-effort write of already-framed bytes to the inherited channel.
+/// Best-effort write of already-framed bytes to the inherited channel, in a
+/// test image only.
 fn emit_to_channel(bytes: &[u8]) {
-    // Discarded deliberately: `EBADF` when the program was run by hand without
-    // a channel, `EPIPE` when the runner is gone. Neither is recoverable and
-    // neither should disturb the test's own result.
-    let _ = platform::write_all(CHANNEL_FD, bytes);
+    write_when_armed(CHANNEL_ARMED.load(Ordering::Relaxed), bytes, &mut |frame| {
+        // Discarded deliberately: `EBADF` when a test image is run by hand
+        // without a channel, `EPIPE` when the runner is gone. Neither is
+        // recoverable and neither should disturb the test's own result.
+        let _ = platform::write_all(CHANNEL_FD, frame);
+    });
+}
+
+/// The armed gate: a frame reaches the descriptor only in a test image.
+///
+/// This is what keeps the channel the runner's rather than the world's. The
+/// assertion family lowers identically everywhere (§5.1), so without the gate
+/// an ordinary executable run as `prog 3>file` — or one that simply opened a
+/// third file of its own — would receive a JSON failure frame on a descriptor
+/// it was never promised (RUE-2066). The passing path pays nothing and the
+/// failing path pays one relaxed load.
+///
+/// The flag arrives as a parameter, and the descriptor as a sink, so the rule
+/// is checked in-process without writing to whatever the *host's* descriptor 3
+/// happens to be.
+fn write_when_armed(armed: bool, bytes: &[u8], sink: &mut dyn FnMut(&[u8])) {
+    if !armed {
+        return;
+    }
+    sink(bytes);
 }
 
 /// Borrow `len` bytes at `ptr`, tolerating the null-with-zero-length form the
@@ -671,10 +730,10 @@ crate::define_runtime_implementation! {
     /// failed: left == right` on stderr and exit 101.
     ///
     /// Both halves matter in different builds. Inside a test image the frame is
-    /// what the runner reads; in an ordinary executable there is no descriptor
-    /// 3, the frame write fails with `EBADF` as designed, and the pinned stderr
-    /// message is the whole report. `@assert_eq` therefore lowers the same way
-    /// wherever it is written.
+    /// what the runner reads; in an ordinary executable the channel is unarmed,
+    /// no frame is written at all, and the pinned stderr message is the whole
+    /// report. `@assert_eq` therefore lowers the same way wherever it is
+    /// written, and descriptor 3 stays the property of whoever opened it.
     ///
     /// # ABI
     ///
@@ -739,10 +798,10 @@ crate::define_runtime_implementation! {
     /// `panic: ` — because the form is stated, not inferred from the length.
     ///
     /// Both halves matter in different builds. Inside a test image the frame is
-    /// what the runner reads; in an ordinary executable there is no descriptor
-    /// 3, the frame write fails with `EBADF` as designed, and the pinned stderr
-    /// message is the whole report. `@assert` therefore lowers the same way
-    /// wherever it is written.
+    /// what the runner reads; in an ordinary executable the channel is unarmed,
+    /// no frame is written at all, and the pinned stderr message is the whole
+    /// report. `@assert` therefore lowers the same way wherever it is written,
+    /// and descriptor 3 stays the property of whoever opened it.
     ///
     /// # ABI
     ///
@@ -1263,10 +1322,42 @@ mod tests {
         assert_eq!(&TRAP_BOUNDS_CHECK_KIND[..], b"trap:bounds_check");
     }
 
+    /// The RUE-2066 rule, in both directions. An unarmed process is an
+    /// ordinary executable, whose descriptor 3 belongs to whoever opened it, so
+    /// nothing at all is written; an armed one is a test image, and the frame
+    /// reaches the sink byte for byte.
+    #[test]
+    fn a_frame_reaches_the_descriptor_only_while_armed() {
+        let mut written = Vec::new();
+        write_when_armed(false, b"{}\n", &mut |frame| {
+            written.extend_from_slice(frame)
+        });
+        assert!(written.is_empty(), "{:?}", written);
+
+        write_when_armed(true, b"{}\n", &mut |frame| written.extend_from_slice(frame));
+        assert_eq!(&written[..], b"{}\n");
+    }
+
+    /// Arming is what [`emit_to_channel`] reads, so the two halves of the rule
+    /// meet here: `arm_channel` flips exactly the flag the gate consults. The
+    /// flag is never cleared and `process.rs` owns the assertion that the
+    /// dispatcher prologue is what calls this, so nothing here depends on how
+    /// the unit tests interleave.
+    #[test]
+    fn arming_the_channel_opens_the_gate() {
+        arm_channel();
+        assert!(channel_is_armed());
+        write_when_armed(
+            CHANNEL_ARMED.load(Ordering::Relaxed),
+            b"{}\n",
+            &mut |frame| assert_eq!(frame, b"{}\n"),
+        );
+    }
+
     #[test]
     fn writing_to_a_closed_descriptor_is_tolerated() {
-        // The channel is absent whenever a test image is run by hand, so an
-        // `EBADF` write must return rather than abort. A descriptor far above
+        // The channel is absent whenever an armed test image is run by hand, so
+        // an `EBADF` write must return rather than abort. A descriptor far above
         // anything the harness opens stands in for that.
         let _ = platform::write_all(1_000_000, b"{}\n");
     }

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -423,6 +423,21 @@ pub struct Case {
     /// Piped to the compiled program's stdin.
     #[serde(default)]
     pub stdin: Option<String>,
+    /// Attach a capture to the COMPILED PROGRAM's descriptor 3 for its run.
+    ///
+    /// Descriptor 3 is the `rue test` structured failure channel (ADR-0083
+    /// §5.1), and an ordinary executable must leave it alone: it belongs to
+    /// whoever opened it — `prog 3>file`, or a program with a third file of its
+    /// own — and an assertion failure there reports on stderr only (RUE-2066).
+    /// A case sets this to make that descriptor observable, and then asserts on
+    /// it. Unix only; on other hosts the field has no effect. Setup, not an
+    /// assertion, so it needs one of the `fd3_*` fields below to pin anything.
+    #[serde(default)]
+    pub capture_fd3: bool,
+    /// Assert the program wrote nothing to descriptor 3. Requires
+    /// `capture_fd3`.
+    #[serde(default)]
+    pub fd3_empty: bool,
     /// Expect compilation to fail.
     #[serde(default)]
     pub compile_fail: bool,

--- a/docs/designs/0083-rue-test-mvp.md
+++ b/docs/designs/0083-rue-test-mvp.md
@@ -576,6 +576,20 @@ expected value, target span, content hash of what it replaces), applied by
 a future `rue test --accept` — the runner applying promotions, never the
 test, is what keeps snapshot tests hermetic.
 
+**Amendment (2026-09-10, RUE-2066): only a test image writes to the
+channel.** Making the descriptor best-effort, with `EBADF` as designed, let
+the assertion family lower identically in a test image and in an ordinary
+executable — which is the property this section wants. What it also produced
+was an ordinary executable that happened to have descriptor 3 open (`prog
+3>file`, or a program that had opened a third file) receiving a JSON failure
+frame on it whenever an assertion, `@panic`, or any trap fired. The channel is
+the runner's descriptor, not the world's, so the runtime now arms it: the
+dispatcher's prologue calls `__rue_test_normalize_process` and nothing else
+does, so reaching that call is the proof that descriptor 3 is the channel.
+Unarmed, the record writer returns without writing. The lowering, the schema,
+and the exec contract are unchanged, and the cost is one relaxed atomic load on
+the failing path.
+
 #### 5.2 In-language frameworks are ordinary Rue code; comptime is the generator
 
 BDD vocabularies, table harnesses, and property-test case machinery are

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -86,7 +86,7 @@ that implement its channel half.
 | `envp` | exactly `["RUE_TEST=1"]` |
 | working directory | a fresh private scratch directory |
 | stdin | `/dev/null` (immediate EOF) |
-| descriptor 3 | the write end of the structured failure channel |
+| descriptor 3 | the write end of the structured failure channel; only a test image writes to it |
 | process group | its own; the runner kills the group on expiry and again after exit |
 
 These are pinned values, not conveniences. The loader lays the real `argv` and
@@ -179,9 +179,9 @@ empty string; a comparison is recognized by the fields' presence, not by parsing
 through the `__rue_test_fail_comparison` helper
 ([runtime-abi.md](../runtime-abi.md)). They are ordinary intrinsics, usable
 anywhere `@assert` is, and they lower the same way in a test image and in an
-ordinary executable — the only difference is that an ordinary process has no
-descriptor 3, so the frame write fails with `EBADF` as designed and the pinned
-stderr message is the whole report.
+ordinary executable — the only difference is that an ordinary process never
+arms the channel, so no frame is written at all and the pinned stderr message is
+the whole report.
 
 `@assert` reports through the same channel, with `__rue_test_fail_assert`, and
 under the same build-independent rule. Its record's `message` is the pinned
@@ -190,8 +190,14 @@ under the same build-independent rule. Its record's `message` is the pinned
 has to know which was written. Both stderr forms are unchanged: `assertion
 failed` and `panic: {msg}` respectively, with status 101 (spec 4.13:5d).
 
-Writes are best-effort by design: an image run by hand has no descriptor 3, and
-`EBADF` there is expected rather than exceptional. The channel is **not a
+**Only a test image writes to descriptor 3.** The assertion family, `@panic`,
+and the trap helpers lower identically wherever they are written, so the
+distinction is the runtime's: the dispatcher's prologue arms the channel, and
+nothing else does. An ordinary executable's descriptor 3 belongs to whoever
+opened it — `prog 3>file`, or a program that opened a third file of its own —
+and it receives nothing, however the program fails (RUE-2066). Within an armed
+image writes are best-effort by design: an image run by hand has no descriptor
+3, and `EBADF` there is expected rather than exceptional. The channel is **not a
 security boundary** — it prevents accidental collision with a test's own stdout,
 which is all its consumers are promised.
 

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -333,9 +333,11 @@ lowering plus, on the failing branch, the two rendering calls and this pair.
 condition whose only arm is `__rue_test_failure_site` and
 `__rue_test_fail_assert`; the message is materialized before the branch, so it
 is still evaluated when the condition holds. The lowering does not depend on
-whether the request is a test one: an ordinary process simply has no descriptor
-3, so the frame write fails with `EBADF` as designed and the pinned stderr
-message plus exit 101 is the whole report.
+whether the request is a test one; the *runtime* makes that distinction
+instead. `__rue_test_normalize_process` arms the channel, and only the
+synthesized dispatcher's prologue calls it, so in an ordinary process no frame
+is written at all and the pinned stderr message plus exit 101 is the whole
+report (RUE-2066).
 
 `@panic(msg)` and `@panic()` compile to `__rue_test_failure_site` followed by
 the panic helper, under the same adjacency rule and the same build-independent
@@ -373,7 +375,13 @@ record has to stay JSON text (RUE-2064).
 contract.
 
 The completion and failure records go to a dedicated inherited descriptor,
-number 3, one JSON object per line. Writes are best-effort: a test image run by
+number 3, one JSON object per line, **and only from a test image**. The channel
+is armed by `__rue_test_normalize_process`, which the synthesized dispatcher's
+prologue calls before the selected test body runs and nothing else calls, so
+reaching it is the runtime's proof that descriptor 3 is the runner's. An
+ordinary executable never arms it and writes nothing there, whatever its own
+descriptor 3 happens to be — `prog 3>file`, or a program that opened a third
+file of its own (RUE-2066). Within an armed image writes are still best-effort: an image run by
 hand has no such descriptor, so `EBADF` is expected rather than exceptional.
 The channel is not a security boundary — it prevents accidental collision with
 a test's own stdout, which is all its consumers are promised.


### PR DESCRIPTION
Fixes RUE-2066

## Problem

ADR-0083 §5.1 made the failure channel "descriptor 3, best-effort, EBADF as designed" so the assertion family lowers identically in test images and ordinary executables. The consequence: an ordinary executable that happens to have descriptor 3 open received a JSON failure frame on it whenever an assertion, `@panic`, or a trap fired. Verified on trunk: `./prog 3>frame.txt` for a failing `@assert_eq` leaves a 176-byte frame in the file, and a trap leaves 133 bytes. The maintainer ruled on 2026-09-10 to close it with the armed flag the issue recommended.

## Change

- `CHANNEL_ARMED`, an atomic in the runtime's test channel, is set by `__rue_test_normalize_process`, the dispatcher prologue that only a test image runs, and `emit_to_channel` returns without writing while it is unarmed. The lowering, the frame schema, and the exec contract are unchanged; the cost is one relaxed load on the failing path. `EBADF`-is-expected still holds for an armed image run by hand.
- The CLI harness can now attach descriptor 3 for a case (`capture_fd3`, a regular file so a flooding program cannot block) and assert it stayed empty (`fd3_empty`); the corpus schema documents both, and the oracle-diff harness classifies such cases as ineligible since it evaluates in-process.
- `docs/runtime-abi.md` and `docs/process/test-events.md` now say only a test image writes to descriptor 3; the module and helper doc comments say the same. ADR-0083 §5.1 keeps its ratified text and carries a dated amendment recording the ruling, following the in-section precedent of ADR-0043 and ADR-0047. The spec is silent on the channel and needed no change.

The runtime is shared Rust, so no backend work.

## Verification

- Before and after, by the reviewer on trunk and the branch: a failing assertion and a trap each leave a frame on fd 3 on trunk and nothing on the branch; `rue test --format json` on the branch still reports `assert_eq` with `left`/`right` and `trap:panic` with their sites.
- Disabling the gate makes the three new failing-program cases fail; restoring it makes them pass.
- `scripts/rue unit runtime`: 116 passed. `scripts/rue unit cli-tests`: 58. `scripts/rue cli panic_assert`: 19. `scripts/rue cli rue_test`: 115. `scripts/rue quick`: 36 targets.
- `//crates/rue-oracle-diff:oracle-diff-test`: pass (the new fd-3 cases are skipped as ineligible, not executed).
- `scripts/rue premerge`: pass 220, fail 0.
