### PR TITLE
RUE-2171: the spec says f32 and f64 are Copy types

### DIFF
--- a/crates/rue-spec/cases/types/floats.toml
+++ b/crates/rue-spec/cases/types/floats.toml
@@ -37,6 +37,36 @@ expected_stdout = """
 exit_code = 0
 
 [[case]]
+name = "float_values_are_copied_on_use_never_moved"
+spec = ["3.12:2a", "3.8:2"]
+description = "A float binding is Copy: it is read repeatedly, passed by value twice, and still usable, with no destructor or linear obligation."
+source = """
+fn halve(x: f64) -> f64 { x / 2.0 }
+fn shrink(x: f32) -> f32 { x - 0.25 }
+
+fn main() -> i32 {
+    let wide: f64 = 5.0;
+    let narrow: f32 = 1.5;
+    @dbg(halve(wide));
+    @dbg(halve(wide));
+    @dbg(shrink(narrow));
+    @dbg(shrink(narrow));
+    @dbg(wide + wide);
+    @dbg(narrow);
+    0
+}
+"""
+expected_stdout = """
+2.5
+2.5
+1.25
+1.25
+10.0
+1.5
+"""
+exit_code = 0
+
+[[case]]
 name = "float_type_names_are_ordinary_identifiers"
 spec = ["3.12:2"]
 description = "f32/f64 name types in every type position and are usable as `type` values"

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -324,12 +324,10 @@ Assignment of the class:
              = Copy   when there are no payload components  -- discriminant-only ⇒ empty join ⇒ Copy (6.3:19, 3.8:2)
 ```
 
-`class(float(w)) = Copy` is **derived, not assumed**. Prose `3.8:2`'s list of
-Copy types predates the float types and does not name them, and `3.12` never
-says it in so many words — but `3.12:26` uses one `f64` binding five times in a
-single body, which only a `Copy` type admits, and `3.12` gives a float type
-neither a destructor (`3.9:31`) nor a `linear` attribute (`3.8:58`). The core
-takes `Copy` on that derivation and records the prose omission as §9 item 5.
+`class(float(w)) = Copy` is stated by the prose: `3.12:2a` classifies both
+float types as Copy and `3.8:2` lists them, so the core takes `Copy` directly
+(the derivation from `3.12:26`, `3.9:31`, and `3.8:58` that an earlier draft
+relied on now merely agrees with it).
 
 An enum has no `@copy`/`linear` attribute of its own: its class is exactly the
 join of its variants' payload classes (`6.3:19`). It is `Copy` iff every payload
@@ -3284,11 +3282,12 @@ locked:
    (matching `3.8:68/70`); dynamic-index moves are forbidden. Confirm this stays
    as the core rule (it is what keeps the ownership analysis decidable without
    dependent types).
-5. **Two float-side prose silences the RUE-2158 amendment could not close
-   itself (§2, §3, §6.4).** Giving `f32`/`f64` their own place in the core
-   forced two questions the prose does not answer. The core takes the
-   conservative reading in each rather than inventing one, and both are marked
-   here rather than left implicit:
+5. **One float-side prose silence the RUE-2158 amendment could not close
+   itself (§2, §6.4).** Giving `f32`/`f64` their own place in the core forced a
+   question the prose does not answer. The core takes the conservative reading
+   rather than inventing one, and it is marked here rather than left implicit
+   (the `Copy` classification, the other silence that amendment found, is now
+   stated by `3.12:2a` and closed):
    - **NaN payloads.** `3.12:32` defines `@total_cmp`'s zero case as the
      operands having "the same bit pattern", and ADR-0065 §8 orders NaNs "by
      sign and payload bit pattern" — but no paragraph says which payload an
@@ -3301,10 +3300,4 @@ locked:
      might not. Confirm that reading — or, if a payload is meant to be
      observable, `𝔽_w` needs a payload component and `3.12:44` needs a
      companion paragraph fixing which payload an operation yields.
-   - **The `Copy` classification of the float types.** `3.8:2`'s list of Copy
-     types predates floats and does not name them, and `3.12` never states it.
-     §3 derives `class(float(w)) = Copy` from `3.12:26`, which uses one `f64`
-     binding five times in one body, and from the absence of any destructor or
-     `linear` attribute on a float type. Confirm the derivation — and `3.8:2`'s
-     list wants the two names added, a prose edit this `docs/formal`-only
-     change deliberately does not make.
+

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -20,6 +20,7 @@ Types in Rue are categorized by how they behave when *used* (3.8:76):
 The following types are Copy types:
 - All integer types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`)
 - The boolean type (`bool`)
+- The floating-point types (`f32`, `f64`) (3.12:2a)
 - The unit type (`()`)
 - The first-class string types: `str` (3.7:44) and the fixed inline buffers
   `Str(N)` (3.7:50)

--- a/docs/spec/src/03-types/12-floating-point-types.md
+++ b/docs/spec/src/03-types/12-floating-point-types.md
@@ -23,6 +23,13 @@ parameters and results, `const` annotations, struct fields, array element
 types — and, like the integer type names, may be used as `type` values
 (`@size_of(f64)`).
 
+{{ rule(id="3.12:2a", cat="normative") }}
+
+`f32` and `f64` are Copy types (3.8:2). A floating-point value is duplicated
+by a use and never moved: a binding of either type may be read any number of
+times, passed by value without being consumed, and neither type has a
+destructor (3.9:31) or may be declared `linear` (3.8:58).
+
 {{ rule(id="3.12:3", cat="normative") }}
 
 `comptime_float` is the compile-time-only type of a float literal (ADR-0025),


### PR DESCRIPTION
Fixes RUE-2171

## Problem

Spec 3.8:2 enumerates the built-in Copy types from before floats existed and never names `f32` or `f64`, and chapter 3.12 does not state the classification anywhere. The compiler treats them as Copy, and the RUE-2158 calculus amendment had to derive that from an example, recording the omission as an open item.

## Change

- 3.8:2 lists the floating-point types.
- New normative paragraph 3.12:2a: `f32` and `f64` are Copy types; a floating-point value is duplicated by a use and never moved, may be read any number of times and passed by value without being consumed, and has neither a destructor nor a `linear` attribute.
- A spec case under `types.floats` cites both paragraphs: one `f64` and one `f32` binding each read repeatedly and passed by value twice.
- The core calculus takes Copy directly from the prose in §3, and its §9 item now records only the remaining silence, NaN payloads.

## Verification

- `scripts/rue spec types.floats`: 73 passed. `//:spec-traceability`, `//:compiler-spec-machine-index`: pass. `scripts/validate-doc-links.py`: valid.
