### PR TITLE
RUE-2072: a dropped session frees its query graph

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1966,7 +1966,7 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
     (9_466, 873_764_896_819_683_713),
     (7_490, 12_196_017_486_031_950_345),
     (1_701, 16_025_502_829_918_190_611),
-    (3_763, 1_124_858_669_055_323_594),
+    (3_795, 3_937_414_938_340_436_614),
     (6_997, 6_265_749_180_761_052_443),
     (18_210, 5_072_850_203_005_355_192),
     (4_522, 5_373_278_958_757_567_170),
@@ -1974,15 +1974,15 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
     (2_722, 5_872_377_445_300_688_460),
     (8_143, 86_253_652_908_143_842),
     (8_573, 4_124_823_810_140_583_654),
-    (753, 3_150_885_663_910_159_936),
+    (970, 16_733_311_749_340_788_625),
     (2_583, 15_262_418_539_020_264_161),
-    (11653, 15_769_724_788_918_086_723),
-    (108_305, 456_066_266_069_628_992),
+    (11_629, 16_221_983_252_924_349_648),
+    (108_199, 8_302_308_910_582_227_017),
     (3_254, 11_949_940_325_034_004_149),
     (5_552, 14_658_861_127_087_730_967),
     (872, 14_092_162_116_261_787_003),
-    (1_269, 5_659_334_597_769_566_021),
-    (937, 12_382_607_771_958_723_582),
+    (1_290, 1_207_936_899_910_382_674),
+    (836, 3_950_283_209_266_403_086),
     (1_118, 11_609_591_179_459_560_863),
     (654, 537_683_909_027_197_867),
     (853, 11_600_476_735_713_182_533),
@@ -2028,13 +2028,13 @@ const FRONTEND_DATABASE_CONSTRUCTION_IDENTITY: (usize, u64) = (337, 8_000_487_40
 const DATABASE_INHERENT_CONSTRUCTOR_IDENTITY: (usize, u64) = (214, 15_710_556_809_665_731_176);
 const DATABASE_CANONICAL_CONSTRUCTOR_IDENTITY: (usize, u64) = (254, 7_623_037_796_286_753_949);
 const TEST_DEFAULT_DATABASE_ADAPTER_IDENTITY: (usize, u64) = (159, 833_377_014_346_120_505);
-const REGISTRATION_DATABASE_IMPL_IDENTITY: (usize, u64) = (35_841, 394_004_127_612_251_398);
+const REGISTRATION_DATABASE_IMPL_IDENTITY: (usize, u64) = (36_475, 17_026_732_725_499_497_919);
 const SHARED_FAMILY_FORWARDING_IDENTITY: (usize, u64) = (2_609, 9_595_658_320_490_175_466);
-const ORDERED_REGISTRATION_COMPOSER_IDENTITY: (usize, u64) = (34_103, 9_655_978_331_066_028_191);
+const ORDERED_REGISTRATION_COMPOSER_IDENTITY: (usize, u64) = (34_737, 4_603_882_617_820_224_274);
 // Macro imports, definitions, re-exports, and lexical ordering participate in
 // macro resolution. Seal the complete registrations authority and each wrapper
 // aggregate in addition to the executable identities inside them.
-const REGISTRATION_AUTHORITY_MODULE_IDENTITY: (usize, u64) = (45_850, 14_304_398_088_276_605_794);
+const REGISTRATION_AUTHORITY_MODULE_IDENTITY: (usize, u64) = (46_484, 41_521_323_921_666_457);
 const REGISTRATION_WRAPPER_MODULE_IDENTITIES: [(usize, u64); 5] = [
     (842, 17_134_465_730_999_135_202),
     (1_146, 9_973_452_843_887_101_603),
@@ -4937,7 +4937,7 @@ pub(super) use register_parse_import_parse;"#;
         });
     assert_eq!(
         (declarations.len(), fingerprint),
-        (214, 9_985_723_480_452_794_499),
+        (215, 11_071_889_845_285_197_929),
         "crate-visible declaration names, signatures, fields, or phase owners changed"
     );
 
@@ -5278,6 +5278,7 @@ struct:BodyClosureRequest
 fn:execution_for
 fn:was_retained
 fn:accrue_reachability_work
+fn:absent_body_request
 fn:accrue_candidate_body_plan_work
 use:crate
 use:closure_nucleus

--- a/crates/rue-compiler/src/revisioned_query_database/registrations.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations.rs
@@ -460,9 +460,8 @@ impl RevisionedQueryDatabase {
             runtime
         );
         let index_for_import_lookup = module_indexes.clone();
-        let resolve_import_for_lookup = Arc::new(std::sync::OnceLock::<
-            QueryFamily<ResolveImportKey, ResolveImportValue>,
-        >::new());
+        let resolve_import_for_lookup =
+            runtime.late_bound::<QueryFamily<ResolveImportKey, ResolveImportValue>>();
         let resolve_import_for_lookup_evaluator = resolve_import_for_lookup.clone();
         #[cfg(test)]
         let lookup_import_eval_probe = lookup_import_eval_log.clone();
@@ -545,6 +544,13 @@ impl RevisionedQueryDatabase {
             Arc::new(Mutex::new(PublishedDeclarationSemanticsRoot::default()));
         let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
         let body_reachability_root = Arc::new(Mutex::new(PublishedBodyReachabilityRoot::default()));
+        // Each publication root is shared between this database and the
+        // evaluators that publish into it, and holds terminal pins which each
+        // own a family handle. That is the same cycle shape as a back-patched
+        // holder, so the runtime empties them at the same moment (RUE-2072).
+        runtime.release_at_teardown(&declaration_semantics_root);
+        runtime.release_at_teardown(&body_closure_root);
+        runtime.release_at_teardown(&body_reachability_root);
         let warning_body_references = register_body_warning_body_references!(
             call_heads_for_warning_references,
             classifications_for_warning_references,
@@ -570,8 +576,7 @@ impl RevisionedQueryDatabase {
             warning_body_references_for_batch
         );
         let shared_durable_payloads = Arc::new(SharedDurablePayloadCache::default());
-        let body_transaction_evaluator =
-            Arc::new(std::sync::OnceLock::<BodyTransactionEvaluator>::new());
+        let body_transaction_evaluator = runtime.late_bound::<BodyTransactionEvaluator>();
         let body_transaction_evaluator_for_family = body_transaction_evaluator.clone();
         let body_transactions =
             register_body_body_transactions!(body_transaction_evaluator_for_family, runtime);
@@ -579,8 +584,7 @@ impl RevisionedQueryDatabase {
         let body_toolchain_demands =
             register_body_body_toolchain_demands!(artifacts_for_toolchain_demands, runtime);
         let transactions_for_produced_anonymous = body_transactions.clone();
-        let semantic_nucleus_for_produced_anonymous =
-            Arc::new(std::sync::OnceLock::<SemanticNucleusFamily>::new());
+        let semantic_nucleus_for_produced_anonymous = runtime.late_bound::<SemanticNucleusFamily>();
         let semantic_nucleus_for_produced_anonymous_evaluator =
             semantic_nucleus_for_produced_anonymous.clone();
         let body_produced_anonymous = register_body_body_produced_anonymous!(
@@ -590,9 +594,10 @@ impl RevisionedQueryDatabase {
             transactions_for_produced_anonymous
         );
         let produced_anonymous_for_semantic_nucleus = body_produced_anonymous.clone();
-        let type_facts_family = Arc::new(std::sync::OnceLock::<
-            QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::TypeFactsValue>,
-        >::new());
+        let type_facts_family = runtime.late_bound::<QueryFamily<
+            crate::type_queries::TypeQueryKey,
+            crate::type_queries::TypeFactsValue,
+        >>();
         let type_facts_for_semantic_nucleus = type_facts_family.clone();
         let semantic_nucleus = register_semantic_semantic_nucleus!(
             artifacts_for_semantic_nucleus,
@@ -662,9 +667,10 @@ impl RevisionedQueryDatabase {
             type_facts_family.set(type_facts.clone()).is_ok(),
             "TypeFacts family is installed once"
         );
-        let layout_family = Arc::new(std::sync::OnceLock::<
-            QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::LayoutValue>,
-        >::new());
+        let layout_family = runtime.late_bound::<QueryFamily<
+            crate::type_queries::TypeQueryKey,
+            crate::type_queries::LayoutValue,
+        >>();
         let layout_family_for_evaluator = layout_family.clone();
         let type_shapes_for_layout = type_shapes.clone();
         let layouts = register_semantic_layouts!(
@@ -705,6 +711,9 @@ impl RevisionedQueryDatabase {
         let backend_root = Arc::new(Mutex::new(PublishedBackendRoot::default()));
         let cfg_collection_root = Arc::new(Mutex::new(PublishedCollectionRoot::default()));
         let codegen_collection_root = Arc::new(Mutex::new(PublishedCollectionRoot::default()));
+        runtime.release_at_teardown(&backend_root);
+        runtime.release_at_teardown(&cfg_collection_root);
+        runtime.release_at_teardown(&codegen_collection_root);
         let cfgs_for_raw_batch = cfgs.clone();
         let backend_root_for_raw_cfg_batch = backend_root.clone();
         let body_closure_root_for_raw_cfg_batch = body_closure_root.clone();
@@ -790,6 +799,7 @@ impl RevisionedQueryDatabase {
         );
         let provider_observation_meter = Arc::new(ProviderObservationCounters::default());
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
+        runtime.release_at_teardown(&lookup_root_lease);
         let object_projections_for_backend_publication = object_projections.clone();
         let codegen_units_for_backend_publication = codegen_units.clone();
         let backend_root_for_publication = backend_root.clone();

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_produced_anonymous.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_produced_anonymous.rs
@@ -116,9 +116,9 @@ $runtime
                     };
                     let semantic_nucleus = $semantic_nucleus_for_produced_anonymous_evaluator
                         .get()
-                        .expect("SemanticNucleus is installed before requests begin");
+                        .ok_or(QueryAbort::ForeignRuntime)?;
                     let signature = context.query_registered(
-                        semantic_nucleus,
+                        &semantic_nucleus,
                         crate::semantic_query_nucleus::SemanticNucleusKey::Signature(
                             producer.clone(),
                         ),
@@ -157,7 +157,7 @@ $runtime
                         ));
                     };
                     let projected = context.query_registered(
-                        semantic_nucleus,
+                        &semantic_nucleus,
                         crate::semantic_query_nucleus::SemanticNucleusKey::ComptimeCall(call),
                     )?;
                     let projected = match projected.outcome() {

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_transactions.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/body/body_transactions.rs
@@ -6,10 +6,13 @@ macro_rules! register_body_body_transactions {
                 BODY_QUERY_MEMO_RETENTION,
                 crate::body_query::transaction_equal,
                 move |context, _, key: &crate::body_query::BodyQueryKey| {
-                    $body_transaction_evaluator_for_family
+                    // `None` before installation is a registration defect and
+                    // after teardown is a request against a database that is
+                    // gone; neither may proceed on a released evaluator.
+                    let evaluator = $body_transaction_evaluator_for_family
                         .get()
-                        .expect("BodyTransaction evaluator is installed before requests begin")
-                        .evaluate(context, key)
+                        .ok_or(QueryAbort::ForeignRuntime)?;
+                    evaluator.evaluate(context, key)
                 },
             )
             .expect("the BodyTransaction family has one canonical name")

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/parse_import/lookup_imports.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/parse_import/lookup_imports.rs
@@ -34,10 +34,11 @@ macro_rules! register_parse_import_lookup_imports {
                     };
                     if let LookupImportValue(Ok(binding)) = &mut value {
                         let directive = directive.ok_or(QueryAbort::Canceled)?;
+                        let resolve_imports = $resolve_import_for_lookup_evaluator
+                            .get()
+                            .ok_or(QueryAbort::ForeignRuntime)?;
                         let resolved = context.query_registered(
-                            $resolve_import_for_lookup_evaluator
-                                .get()
-                                .expect("ResolveImport is installed before requests begin"),
+                            &resolve_imports,
                             ResolveImportKey {
                                 occurrence: crate::ImportOccurrenceKey::from_directive(directive),
                                 mode: ImportDemandMode::Rooted,

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/layouts.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/layouts.rs
@@ -7,14 +7,10 @@ macro_rules! register_semantic_layouts {
                 |left: &crate::type_queries::LayoutValue,
                  right: &crate::type_queries::LayoutValue| left == right,
                 move |context, _, key: &crate::type_queries::TypeQueryKey| {
-                    evaluate_layout(
-                        context,
-                        $layout_family_for_evaluator
-                            .get()
-                            .expect("Layout family is installed before requests"),
-                        &$type_shapes_for_layout,
-                        key,
-                    )
+                    let layouts = $layout_family_for_evaluator
+                        .get()
+                        .ok_or(QueryAbort::ForeignRuntime)?;
+                    evaluate_layout(context, &layouts, &$type_shapes_for_layout, key)
                 },
             )
             .expect("the Layout family has one canonical name")

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
@@ -480,6 +480,9 @@ $runtime
                                 &query.gate.ty,
                                 &query.producer.configuration,
                             )?;
+                            let type_facts = $type_facts_for_semantic_nucleus
+                                .get()
+                                .ok_or(QueryAbort::ForeignRuntime)?;
                             let result = match query.gate.kind {
                                 crate::semantic_query_nucleus::DeferredOwnershipGateKind::RequireDroppable => provider
                                     .type_carries_linear(&query.gate.ty)
@@ -489,12 +492,7 @@ $runtime
                                         }
                                     })),
                                 crate::semantic_query_nucleus::DeferredOwnershipGateKind::RequireTriviallyDroppable => provider
-                                    .type_has_drop_glue(
-                                        $type_facts_for_semantic_nucleus
-                                            .get()
-                                            .expect("TypeFacts family is installed before requests"),
-                                        &query.gate.ty,
-                                    )
+                                    .type_has_drop_glue(&type_facts, &query.gate.ty)
                                     .map(|rejected| rejected.then(|| {
                                         rue_error::ErrorKind::ContainerElementNotTriviallyDroppable {
                                             ty: gate_type_name.clone(),

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/type_facts.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/type_facts.rs
@@ -7,11 +7,12 @@ macro_rules! register_semantic_type_facts {
                 |left: &crate::type_queries::TypeFactsValue,
                  right: &crate::type_queries::TypeFactsValue| left == right,
                 move |context, _, key: &crate::type_queries::TypeQueryKey| {
+                    let type_facts = $type_facts_family_for_evaluator
+                        .get()
+                        .ok_or(QueryAbort::ForeignRuntime)?;
                     evaluate_type_facts(
                         context,
-                        $type_facts_family_for_evaluator
-                            .get()
-                            .expect("TypeFacts family is installed before requests"),
+                        &type_facts,
                         &$type_shapes_for_type_facts,
                         &$semantic_nucleus_for_type_facts,
                         &$lookup_names_for_type_facts,

--- a/crates/rue-compiler/src/revisioned_query_database/shared.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/shared.rs
@@ -805,35 +805,48 @@ pub(crate) struct RevisionedQueryDatabase {
     >,
 }
 
-/// The database owns the query runtime, so the database ends its worker
-/// threads.
+/// The database owns the query runtime, so the database tears it down.
 ///
-/// Worker threads cannot wait for the last reference to the runtime core.
 /// Registered families are built in one pass, and every edge that runs
-/// backwards in that order is closed by back-patching an `Arc<OnceLock<..>>`
-/// the earlier family's evaluator already captured — the body-transaction
-/// evaluator, the semantic nucleus, and the type-facts family in
-/// `registrations`. Each back-patched value holds strong `QueryFamily` handles,
-/// and the body-transaction evaluator holds a `QueryRuntime` outright, so the
-/// registered family graph contains reference cycles that no database field can
-/// break. Dropping the database releases only part of the reference count on
-/// the core; the core, and with it the executor, survives the session.
+/// backwards in that order is closed by back-patching a value the earlier
+/// family's evaluator already captured — the `ResolveImport` family read by
+/// import lookup, the body-transaction evaluator, the semantic nucleus read by
+/// anonymous production, and the self-referential `TypeFacts` and `Layout`
+/// families in `registrations`. Each back-patched value holds strong
+/// `QueryFamily` handles, and the body-transaction evaluator holds a
+/// `QueryRuntime` outright, so the registered family graph contains reference
+/// cycles that no database field can break. The session-held publication roots
+/// are a second such shape: an `Arc<Mutex<..>>` shared between this database
+/// and the evaluators that publish into it, retaining terminal pins which each
+/// own a family handle. Dropping the database releases only part of the
+/// reference count on the core; without teardown the core, its memo tables,
+/// and the executor all survive the session.
 ///
-/// A process that compiles one program per session — the oracle-diff harness
-/// compiles one per corpus case — would therefore accumulate a runtime's worth
-/// of 8 MiB threads per program until the host refused another one, which
-/// stopped 282 cases of a corpus run against `kern.num_taskthreads` (RUE-2043).
+/// Two costs follow. A process that compiles one program per session — the
+/// oracle-diff harness compiles one per corpus case — accumulates a runtime's
+/// worth of 8 MiB threads per program until the host refuses another one,
+/// which stopped 282 cases of a corpus run against `kern.num_taskthreads`
+/// (RUE-2043); and it accumulates every memo node, terminal, artifact, and
+/// interned type of every program it ever compiled, about 2.3 MB per program
+/// (RUE-2072).
 ///
-/// This database is the owner that can name the moment the threads are no
-/// longer needed: it is a plain value inside `CompilerSession`, reachable only
-/// through `&mut self` methods, so no request can be in flight when it is
-/// destroyed. Registration's own `CompilerQueryRuntime` cannot own that moment
-/// — it is a temporary the constructor drops before the database exists — and
-/// a batch dispatched onto a runtime whose owner has shut it down is refused
-/// with `rue_query::WorkerSpawnFailure` rather than served.
+/// This database is the owner that can name the moment neither is needed: it
+/// is a plain value inside `CompilerSession`, reachable only through
+/// `&mut self` methods, so no request can be in flight when it is destroyed.
+/// Registration's own `CompilerQueryRuntime` cannot own that moment — it is a
+/// temporary the constructor drops before the database exists. Teardown is
+/// therefore one call on the runtime, which ends the workers and empties every
+/// value registered with it: a batch dispatched afterwards is refused with
+/// `rue_query::WorkerSpawnFailure`, and a family whose evaluator reads a
+/// released holder aborts its request, rather than either being served.
+///
+/// The alternative — holding the backward edges as `WeakQueryFamily` — was
+/// rejected: it moves the failure from one owner-chosen teardown into every
+/// evaluator, which would have to define what a mid-request upgrade failure
+/// means for a compilation already in progress.
 impl Drop for RevisionedQueryDatabase {
     fn drop(&mut self) {
-        self.runtime.shutdown_workers();
+        self.runtime.shut_down();
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database/test_support.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/test_support.rs
@@ -932,6 +932,28 @@ pub(super) fn lookup_incarnation(
     .node_incarnation()
 }
 
+/// A family, revision, and key which together outlive `database`.
+///
+/// The key names a function that does not exist, so the request it belongs to
+/// can never be answered from the memo: it must enter the registered evaluator,
+/// which is the path a teardown-released holder has to refuse (RUE-2072).
+pub(crate) fn absent_body_request(
+    database: &mut RevisionedQueryDatabase,
+    snapshot: &SourceSnapshot,
+) -> (
+    QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::BodyTransaction>,
+    Revision,
+    crate::body_query::BodyQueryKey,
+) {
+    let revision = revision_for(database, snapshot);
+    let module = ModuleId::from_logical_path("main.rue").expect("a valid logical module path");
+    let key = crate::body_query::BodyQueryKey::new(
+        free_function_instance(&module, "no_such_function"),
+        semantic_configuration(),
+    );
+    (database.body_transactions.clone(), revision, key)
+}
+
 /// A handle on the query runtime `database` owns.
 ///
 /// Cloning the handle is how a test outlives the database and still asks what

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -6797,6 +6797,88 @@ fn dropped_compiler_sessions_end_their_query_worker_threads() {
     );
 }
 
+/// RUE-2072: dropping a `CompilerSession` frees the query graph it built, not
+/// merely the worker threads.
+///
+/// Every memo node holds a strong reference to the runtime core, so the core's
+/// reference count is a census of the retained graph: a compiled program left
+/// it in the thousands while the session that produced it was gone. What kept
+/// it alive were the reference cycles named at `RevisionedQueryDatabase`'s
+/// destructor, and the probe for them is a handle that cannot itself keep the
+/// core alive — after the drop there must be nothing left to upgrade to.
+#[test]
+fn dropping_a_compiler_session_frees_its_query_runtime() {
+    let source = parallel_batch_fixture();
+    let snapshot =
+        SourceSnapshot::single("<test>", &source).expect("the fixture is a valid snapshot");
+    let mut session = CompilerSession::with_query_concurrency(2);
+    let published = crate::test_support::publish_test_snapshot(&mut session, &snapshot)
+        .expect("the fixture publishes");
+    crate::queries::compile_with_session(&mut session, &published, &CompileOptions::default())
+        .expect("the fixture compiles");
+
+    let runtime =
+        crate::revisioned_query_database::test_support::query_runtime(&session.queries.revisioned);
+    let weak = runtime.downgrade();
+    let retained_terminals = runtime.metrics().retained_terminals;
+    // One reference is the handle above; the rest are the compiled program's.
+    let held_by_the_graph = weak.strong_count() - 1;
+    drop(runtime);
+    assert!(
+        retained_terminals > 0 && held_by_the_graph > 100,
+        "the fixture must leave a real memo graph behind, or freeing it proves \
+         nothing: {retained_terminals} retained terminals, {held_by_the_graph} \
+         references to the core"
+    );
+
+    drop(session);
+
+    assert_eq!(
+        weak.strong_count(),
+        0,
+        "{held_by_the_graph} references to the runtime core survived the session \
+         that created every one of them"
+    );
+    assert!(
+        weak.upgrade().is_none(),
+        "a freed core must not be reachable from a weak handle"
+    );
+}
+
+/// RUE-2072: a family handle can outlive the database that registered it, and a
+/// request on one must be refused rather than served from a released evaluator.
+///
+/// Teardown empties the back-patched holders the registered evaluators read.
+/// A caller still holding a family and the runtime therefore reaches an
+/// evaluator whose dependencies are gone, which is a defect in that caller —
+/// but it must arrive as a typed abort, never as a panic or as work done
+/// against a half-released graph.
+#[test]
+fn a_request_on_a_query_graph_outliving_its_session_is_refused() {
+    let source = parallel_batch_fixture();
+    let snapshot =
+        SourceSnapshot::single("<test>", &source).expect("the fixture is a valid snapshot");
+    let mut session = CompilerSession::with_query_concurrency(2);
+    let published = crate::test_support::publish_test_snapshot(&mut session, &snapshot)
+        .expect("the fixture publishes");
+    crate::queries::compile_with_session(&mut session, &published, &CompileOptions::default())
+        .expect("the fixture compiles");
+    let (family, revision, key) =
+        crate::revisioned_query_database::test_support::absent_body_request(
+            &mut session.queries.revisioned,
+            &published,
+        );
+    let runtime =
+        crate::revisioned_query_database::test_support::query_runtime(&session.queries.revisioned);
+    drop(session);
+
+    let abort = runtime
+        .request_registered(&family, revision, key, rue_query::CancellationToken::new())
+        .into_result()
+        .expect_err("a torn-down graph must refuse the request rather than serve it");
+    assert_eq!(abort, rue_query::QueryAbort::ForeignRuntime);
+}
+
 /// Repointing a callable `const` alias must re-analyze every site that named
 /// it (RUE-2161). A signature or body that reaches its callee through the
 /// alias records the constant alongside the target, so the warm session's

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -14,6 +14,7 @@ mod outcome;
 mod retention;
 mod revision;
 mod task;
+mod teardown;
 mod validation;
 
 pub use context::*;
@@ -28,6 +29,7 @@ pub use outcome::*;
 pub use retention::*;
 pub use revision::*;
 pub use task::*;
+pub use teardown::*;
 pub use validation::*;
 
 #[cfg(test)]

--- a/crates/rue-query/src/outcome.rs
+++ b/crates/rue-query/src/outcome.rs
@@ -323,7 +323,11 @@ pub enum QueryAbort {
     Canceled,
     /// Exact nodes participating in a true dependency cycle.
     Cycle(Arc<[NodeIdentity]>),
-    /// The family belongs to a different runtime.
+    /// The family cannot be served by a live runtime: it belongs to a
+    /// different one, or the runtime's owner has torn it down and released the
+    /// values its registered evaluators read (RUE-2072). Both are defects in
+    /// the caller, reported rather than panicked so a driver publishes them as
+    /// an internal error instead of taking the process down.
     ForeignRuntime,
     /// The requested immutable revision has not been published or was retired.
     UnpublishedRevision(Revision),

--- a/crates/rue-query/src/registered_batch_tests.rs
+++ b/crates/rue-query/src/registered_batch_tests.rs
@@ -215,7 +215,7 @@ fn shutting_down_a_runtime_joins_its_workers_while_its_core_is_retained() {
     // Stand in for the retained query graph: references that outlive the owner.
     let retained_core = runtime.core.clone();
     let retained_graph = (child, root, runtime.clone());
-    runtime.shutdown_workers();
+    runtime.shut_down();
     drop(runtime);
 
     assert_eq!(
@@ -259,7 +259,7 @@ fn a_batch_dispatched_after_shutdown_aborts_without_panicking() {
         })
         .unwrap();
 
-    runtime.shutdown_workers();
+    runtime.shut_down();
     let abort = runtime
         .request_registered(&root, revision(1), Key("root"), CancellationToken::new())
         .into_result()

--- a/crates/rue-query/src/revision.rs
+++ b/crates/rue-query/src/revision.rs
@@ -33,6 +33,13 @@ pub(crate) struct RuntimeCore {
     pub(crate) revisions: RwLock<RevisionStore>,
     pub(crate) nodes: RwLock<NodeRegistry>,
     retention_families: Mutex<BTreeMap<u64, Weak<dyn RetentionFamily>>>,
+    /// Values this runtime's owner asked it to empty at teardown: the
+    /// back-patched holders that close the registered evaluator graph's
+    /// backward edges, plus the caller-owned publication roots which retain
+    /// terminal pins. Each is one reference cycle through a family handle, so
+    /// releasing them is what makes dropping the owner free the core
+    /// (RUE-2072).
+    teardown: TeardownRegistry,
     retention_budgets: RetentionBudgets,
     /// Aggregate thresholds are consulted only after a family-local probe, not
     /// by every publication.
@@ -474,6 +481,7 @@ impl QueryRuntime {
                 }),
                 nodes: RwLock::new(NodeRegistry::default()),
                 retention_families: Mutex::new(BTreeMap::new()),
+                teardown: TeardownRegistry::default(),
                 retention_budgets,
                 next_retained_byte_sweep: AtomicU64::new(
                     retention_budgets.retained_bytes.saturating_add(1),
@@ -498,29 +506,72 @@ impl QueryRuntime {
         }
     }
 
-    /// Ends this runtime's physical worker threads.
+    /// Releases everything this runtime's owner gave it: its physical worker
+    /// threads, and the values registered through
+    /// [`late_bound`](Self::late_bound) and
+    /// [`release_at_teardown`](Self::release_at_teardown).
     ///
-    /// Thread creation is the one host resource a query runtime holds, and its
-    /// owner must be able to release it at a point it chooses, because dropping
-    /// the last reference to the core is not a moment that reliably arrives: an
+    /// Both resources need an owner to name the moment, because dropping the
+    /// last reference to the core is not a moment that reliably arrives: an
     /// evaluator graph is free to hold `QueryFamily` and `QueryRuntime` handles
-    /// in cycles. The full account is at the destructor of `rue-compiler`'s
-    /// `RevisionedQueryDatabase` (RUE-2043).
+    /// in cycles, and worker threads cannot wait for a reference count that
+    /// never reaches zero (RUE-2043). Releasing the registered values breaks
+    /// those cycles, so the memo tables and the core are freed with the owner
+    /// rather than surviving it (RUE-2072). The full account is at the
+    /// destructor of `rue-compiler`'s `RevisionedQueryDatabase`.
     ///
     /// Call this from the owner that can prove no request is in flight; for the
     /// compiler that is the destructor of the database holding the runtime. The
-    /// runtime stays a valid value afterwards but owns no workers, and a
-    /// registered batch dispatched onto it is refused with a
-    /// [`WorkerSpawnFailure`](crate::WorkerSpawnFailure) rather than served:
-    /// this is teardown by an owner that is finished, not a way to pause.
-    pub fn shutdown_workers(&self) {
+    /// runtime stays a valid value afterwards but owns no workers and no
+    /// released value: a registered batch dispatched onto it is refused with a
+    /// [`WorkerSpawnFailure`](crate::WorkerSpawnFailure), and a family whose
+    /// evaluator reads a released holder aborts its request, rather than either
+    /// being served. This is teardown by an owner that is finished, not a way
+    /// to pause. Calling it twice releases nothing the second time.
+    pub fn shut_down(&self) {
         self.core.batch_executor.shutdown();
+        self.core.teardown.release();
+    }
+
+    /// Mints a holder for a value a registered evaluator reads but which is
+    /// installed only after that evaluator exists, and registers it for release
+    /// at [`shut_down`](Self::shut_down).
+    pub fn late_bound<T: Send + Sync + 'static>(&self) -> Arc<LateBound<T>> {
+        let holder = Arc::new(LateBound::new());
+        self.core.teardown.register(crate::teardown::erase(&holder));
+        holder
+    }
+
+    /// Registers a caller-owned value for release at
+    /// [`shut_down`](Self::shut_down).
+    ///
+    /// Use it for state shared between the runtime's owner and its registered
+    /// evaluators which retains query terminals — a publication root holding a
+    /// pin set, say. The registry holds `value` weakly and never keeps it
+    /// alive.
+    pub fn release_at_teardown<T: ReleaseOnTeardown + 'static>(&self, value: &Arc<T>) {
+        self.core.teardown.register(crate::teardown::erase(value));
+    }
+
+    /// Values still registered for release at teardown.
+    ///
+    /// Zero after [`shut_down`](Self::shut_down): the registry is consumed
+    /// rather than replayed, which is what makes a second teardown a no-op.
+    pub fn registered_teardown_values(&self) -> usize {
+        self.core.teardown.registered()
+    }
+
+    /// A non-owning handle on this runtime.
+    pub fn downgrade(&self) -> WeakQueryRuntime {
+        WeakQueryRuntime {
+            core: Arc::downgrade(&self.core),
+        }
     }
 
     /// Physical worker threads this runtime owns right now.
     ///
     /// Zero before the first registered batch dispatches one, and zero again
-    /// after [`shutdown_workers`](Self::shutdown_workers) joins them. Paired
+    /// after [`shut_down`](Self::shut_down) joins them. Paired
     /// with [`RuntimeMetrics::batch_worker_thread_births`](crate::RuntimeMetrics)
     /// it is the per-runtime statement of the ownership invariant: the threads
     /// a runtime created are gone, not merely unreferenced.

--- a/crates/rue-query/src/teardown.rs
+++ b/crates/rue-query/src/teardown.rs
@@ -1,0 +1,328 @@
+//! Owner-driven teardown of one query runtime.
+//!
+//! A runtime's owner ends it at a point it chooses rather than waiting for the
+//! last reference to the core, because that moment does not reliably arrive:
+//! an evaluator graph is free to hold `QueryFamily` and `QueryRuntime` handles
+//! in cycles, and a family holds its runtime's core. Teardown releases the two
+//! resources an owner gave the runtime — its physical worker threads
+//! (RUE-2043) and the values registered here (RUE-2072) — so dropping the owner
+//! actually frees the memo tables and the core.
+
+use std::fmt;
+use std::sync::{Arc, RwLock, Weak};
+
+use crate::{read, write};
+
+/// A value the runtime empties when its owner tears the runtime down.
+///
+/// Implementors are registered with [`QueryRuntime::release_at_teardown`](
+/// crate::QueryRuntime::release_at_teardown) and held there weakly, so
+/// registration never itself keeps a value alive.
+pub trait ReleaseOnTeardown: Send + Sync {
+    /// Drops whatever this value holds. Called once, by the runtime's owner,
+    /// when no request can be in flight; it must leave the value usable and
+    /// observably empty rather than poisoned.
+    fn release_on_teardown(&self);
+}
+
+/// Emptying a mutex-guarded value replaces it with its default.
+///
+/// The compiler's session-held publication roots are exactly this shape: an
+/// `Arc<Mutex<..>>` shared between the database and the registered evaluators
+/// that publish into it, holding retained terminal pins which each own a
+/// family handle.
+impl<T: Default + Send> ReleaseOnTeardown for std::sync::Mutex<T> {
+    fn release_on_teardown(&self) {
+        let held = std::mem::take(&mut *crate::lock(self));
+        drop(held);
+    }
+}
+
+/// A value a registered evaluator reads which is installed only after that
+/// evaluator exists.
+///
+/// Registration builds families in one pass, so every edge that runs backwards
+/// in that order — a family whose evaluator reads a family constructed later,
+/// or reads itself — is closed by installing the value here once construction
+/// has reached it. Each installed value holds strong family handles and a
+/// family holds its runtime's core, so these holders are precisely the
+/// reference cycles no owner field can break. Emptying them at teardown is
+/// what lets a dropped session free its memo tables and its core.
+///
+/// A read after teardown returns `None`, so the evaluator refuses with a typed
+/// abort instead of touching a released value.
+pub struct LateBound<T: Send + Sync + 'static> {
+    slot: RwLock<Slot<T>>,
+}
+
+enum Slot<T> {
+    /// Construction has not reached the installation site yet.
+    Pending,
+    /// Behind an `Arc` so a reader clones one reference and lets the lock go.
+    /// The value is read from inside a running evaluator, which may recursively
+    /// enter the same family; holding a read guard across that work would be a
+    /// recursive read lock, and teardown is not worth that hazard.
+    Installed(Arc<T>),
+    /// The owner tore the runtime down. Distinguished from `Pending` so a
+    /// post-teardown installation is refused rather than resurrecting a cycle.
+    Released,
+}
+
+impl<T: Send + Sync + 'static> fmt::Debug for LateBound<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = match &*read(&self.slot) {
+            Slot::Pending => "pending",
+            Slot::Installed(_) => "installed",
+            Slot::Released => "released",
+        };
+        formatter
+            .debug_struct("LateBound")
+            .field("state", &state)
+            .finish()
+    }
+}
+
+impl<T: Send + Sync + 'static> LateBound<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            slot: RwLock::new(Slot::Pending),
+        }
+    }
+
+    /// Installs the back-patched value.
+    ///
+    /// Returns the value unchanged when one is already installed, or when the
+    /// runtime has been torn down. Mirrors `OnceLock::set`, so an installation
+    /// site keeps asserting that it ran exactly once.
+    pub fn set(&self, value: T) -> Result<(), T> {
+        let mut slot = write(&self.slot);
+        match &*slot {
+            Slot::Pending => {
+                *slot = Slot::Installed(Arc::new(value));
+                Ok(())
+            }
+            Slot::Installed(_) | Slot::Released => Err(value),
+        }
+    }
+
+    /// The installed value, or `None` once the owner released it.
+    ///
+    /// `None` before installation is a registration defect; `None` after
+    /// teardown is a request against a runtime whose owner is finished with
+    /// it. Both are refusals rather than panics: a caller which reached either
+    /// state must abort its request, never proceed on a released value.
+    pub fn get(&self) -> Option<Arc<T>> {
+        match &*read(&self.slot) {
+            Slot::Installed(value) => Some(value.clone()),
+            Slot::Pending | Slot::Released => None,
+        }
+    }
+}
+
+impl<T: Send + Sync + 'static> ReleaseOnTeardown for LateBound<T> {
+    fn release_on_teardown(&self) {
+        // Take the value out from under the lock and drop it afterwards: the
+        // released value owns family handles whose destructors run retention
+        // bookkeeping, and none of that work may run while this holder's lock
+        // is held.
+        let held = std::mem::replace(&mut *write(&self.slot), Slot::Released);
+        drop(held);
+    }
+}
+
+/// Values registered for release when the runtime's owner tears it down.
+///
+/// Weak, because every registered value is owned by the graph it is part of.
+/// A registry that owned them would be one more edge keeping the cycle alive.
+#[derive(Debug, Default)]
+pub(crate) struct TeardownRegistry {
+    entries: std::sync::Mutex<Vec<Weak<dyn ReleaseOnTeardown>>>,
+}
+
+impl TeardownRegistry {
+    pub(crate) fn register(&self, value: Weak<dyn ReleaseOnTeardown>) {
+        crate::lock(&self.entries).push(value);
+    }
+
+    /// Empties every still-live registered value, exactly once.
+    ///
+    /// The registry is drained first so a released value's destructor cannot
+    /// observe a registration that is about to be released again.
+    pub(crate) fn release(&self) {
+        let entries: Vec<_> = crate::lock(&self.entries).drain(..).collect();
+        for entry in entries {
+            if let Some(value) = entry.upgrade() {
+                value.release_on_teardown();
+            }
+        }
+    }
+
+    pub(crate) fn registered(&self) -> usize {
+        crate::lock(&self.entries).len()
+    }
+}
+
+/// A non-owning handle on a query runtime.
+///
+/// Upgrading answers whether anything still holds the runtime's core. That is
+/// the question a session-retention test asks: after the owning database is
+/// dropped, a runtime whose graph freed itself has no core left to upgrade to,
+/// while one still held by an evaluator cycle does (RUE-2072).
+#[derive(Debug, Clone)]
+pub struct WeakQueryRuntime {
+    pub(crate) core: Weak<crate::RuntimeCore>,
+}
+
+impl WeakQueryRuntime {
+    /// The runtime, while its core is still referenced.
+    pub fn upgrade(&self) -> Option<crate::QueryRuntime> {
+        Some(crate::QueryRuntime {
+            core: self.core.upgrade()?,
+        })
+    }
+
+    /// References to the core held right now, zero once it is freed.
+    ///
+    /// Exposed for retention accounting: a census of what still holds a core
+    /// is otherwise invisible to a test that must not itself hold one.
+    pub fn strong_count(&self) -> usize {
+        Weak::strong_count(&self.core)
+    }
+}
+
+/// Wraps `value` so the runtime empties it at teardown.
+pub(crate) fn erase<T: ReleaseOnTeardown + 'static>(value: &Arc<T>) -> Weak<dyn ReleaseOnTeardown> {
+    let erased: Arc<dyn ReleaseOnTeardown> = value.clone();
+    Arc::downgrade(&erased)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::QueryRuntime;
+
+    #[test]
+    fn late_bound_values_are_released_by_runtime_teardown() {
+        let runtime = QueryRuntime::new(1);
+        let holder = runtime.late_bound::<Arc<u32>>();
+        let value = Arc::new(7_u32);
+        assert!(holder.set(value.clone()).is_ok());
+        assert_eq!(Arc::strong_count(&value), 2);
+        assert_eq!(**holder.get().expect("the value is installed"), 7);
+
+        runtime.shut_down();
+
+        assert!(
+            holder.get().is_none(),
+            "a read after teardown must report the value as gone, not serve it"
+        );
+        assert_eq!(
+            Arc::strong_count(&value),
+            1,
+            "teardown must drop the held value, not merely hide it"
+        );
+        assert!(
+            holder.set(Arc::new(9)).is_err(),
+            "a released holder must not accept a fresh value and rebuild the cycle"
+        );
+    }
+
+    #[test]
+    fn a_mutex_registered_for_teardown_is_emptied_in_place() {
+        let runtime = QueryRuntime::new(1);
+        let root = Arc::new(std::sync::Mutex::new(vec![Arc::new(1_u8)]));
+        runtime.release_at_teardown(&root);
+        let held = crate::lock(&root)[0].clone();
+        assert_eq!(Arc::strong_count(&held), 2);
+
+        runtime.shut_down();
+
+        assert!(crate::lock(&root).is_empty());
+        assert_eq!(Arc::strong_count(&held), 1);
+    }
+
+    #[test]
+    fn teardown_releases_each_registration_once_and_drops_the_registry() {
+        let runtime = QueryRuntime::new(1);
+        let root = Arc::new(std::sync::Mutex::new(vec![1_u8]));
+        runtime.release_at_teardown(&root);
+        let dropped = runtime.late_bound::<u8>();
+        assert!(dropped.set(3).is_ok());
+        assert_eq!(runtime.registered_teardown_values(), 2);
+
+        runtime.shut_down();
+        assert_eq!(
+            runtime.registered_teardown_values(),
+            0,
+            "teardown consumes its registrations"
+        );
+        // A second teardown is a no-op rather than a double release.
+        crate::lock(&root).push(9);
+        runtime.shut_down();
+        assert_eq!(crate::lock(&root).as_slice(), [9]);
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, std::hash::Hash)]
+    struct Key(&'static str);
+
+    impl crate::QueryKey for Key {
+        fn stable_identity(&self) -> String {
+            self.0.to_owned()
+        }
+
+        fn stable_hash(&self, hasher: &mut crate::StableHasher) {
+            std::hash::Hash::hash(self.0, hasher);
+        }
+    }
+
+    #[test]
+    fn a_request_reading_a_released_holder_aborts_instead_of_serving() {
+        let runtime = QueryRuntime::new(1);
+        let holder = runtime.late_bound::<u64>();
+        assert!(holder.set(41).is_ok());
+        let installed = holder.clone();
+        let family = runtime
+            .family_with_evaluator("test.late-bound", 4, move |_, _, _: &Key| {
+                let value = installed.get().ok_or(crate::QueryAbort::ForeignRuntime)?;
+                Ok(crate::QueryOutput::success(*value + 1))
+            })
+            .expect("the family has one canonical name");
+        runtime
+            .publish_revision(crate::Revision::new(1, 1), [])
+            .expect("the revision publishes");
+        let served = runtime
+            .request_registered(
+                &family,
+                crate::Revision::new(1, 1),
+                Key("k"),
+                crate::CancellationToken::new(),
+            )
+            .into_result()
+            .expect("an installed holder serves the request");
+        assert_eq!(served.outcome(), &crate::QueryOutcome::Success(42));
+
+        runtime.shut_down();
+
+        let refused = runtime
+            .request_registered(
+                &family,
+                crate::Revision::new(1, 1),
+                Key("fresh"),
+                crate::CancellationToken::new(),
+            )
+            .into_result()
+            .expect_err("a released holder must refuse the request rather than serve it");
+        assert_eq!(refused, crate::QueryAbort::ForeignRuntime);
+    }
+
+    #[test]
+    fn a_runtime_with_no_families_is_freed_when_its_owner_drops_it() {
+        let runtime = QueryRuntime::new(1);
+        let weak = runtime.downgrade();
+        assert_eq!(weak.strong_count(), 1);
+        runtime.shut_down();
+        drop(runtime);
+        assert!(weak.upgrade().is_none());
+        assert_eq!(weak.strong_count(), 0);
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,6 +193,17 @@ computed. `CompilerSessionWork::retention` reports the current
 session-owned diagnostic entries, distinct source attempts and bytes, unique
 dependency manifests, and invalidation plans.
 
+Dropping a session ends its query graph rather than orphaning it. The
+registered family graph contains reference cycles — back-patched values that
+close its backward edges, and publication roots holding terminal pins — so the
+last reference to the query runtime's core is not a moment that arrives on its
+own. The database that owns the runtime is reachable only through `&mut self`,
+so its destructor is the one point where no request can be in flight: it tears
+the runtime down, which ends the worker threads and releases every registered
+value. A process that compiles one program per session therefore does not
+accumulate the memo nodes, artifacts, and interned types of every program it
+has ever compiled.
+
 Syntax output uses an explicit `ParsedAstPresentation` adapter. It walks the
 `SourceSnapshot` in caller-selected order so diagnostics and `--emit ast`
 retain presentation order without constructing a second parsed or merged


### PR DESCRIPTION
Fixes RUE-2072

## Problem

Dropping a `CompilerSession` released only a fraction of the references to the query runtime's core, so every memo node, terminal, AIR/CFG artifact, and interned type from every program a process compiled stayed resident. Measured on trunk with `rue-oracle-diff`, one process, `RUE_ORACLE_JOBS=1`: 300 compilations peaked at 563 MB, 760 at 1.63 GB, 1276 at 3.77 GB, about 2.9 MB retained per program. Steve asked for the claim to be re-verified before work started; it was, on `e11666d38`.

## What held the core

A reference census with an external `Weak<RuntimeCore>` found two cycle shapes crossing between the database and the evaluators it owns: the five back-patched holders that close the registration graph's backward edges (import lookup, the body-transaction evaluator, the semantic nucleus, and the self-referential type-facts and layout families), and the seven session-held publication roots whose retained pin sets each own a family. The roots were the larger half and were not named in the issue.

## Change

Release on drop, at the one point where no request can be in flight. `RevisionedQueryDatabase` is reachable only through `&mut self`, so its destructor, which already ends the worker threads (RUE-2043), now tears the runtime down: it empties every registered value, and the last strong reference to the core goes with the database.

- `rue-query` gains a teardown registry on the core: `LateBound<T>` replaces the back-patched `OnceLock`s (a reader clones the `Arc` and drops the lock rather than holding a guard across a re-entrant evaluation), `ReleaseOnTeardown` covers the publication roots, and `shut_down` joins the workers and drains the registry, so a second teardown is a no-op.
- The post-teardown refusal is kept and widened: a batch is still refused, and an evaluator reading a released holder returns the existing `ForeignRuntime` abort instead of panicking.
- `Weak` everywhere was rejected: it moves the failure into every evaluator, each needing a mid-request upgrade-failure semantics, where this design has none.
- Watch mode keeps one session across cycles and is unaffected.
- `docs/architecture.md` describes session teardown.

## Verification

- New tests: a session drop leaves zero strong references to the core and the external weak handle fails to upgrade; a request on a graph outliving its session is refused; five `rue-query` teardown tests including the released-holder abort.
- `rue-query`: 214 passed. `rue-compiler`: 1246 passed. `scripts/rue quick`: 36 targets. `scripts/rue cli watch`: 26. `scripts/rue cli rue_test`: 115. `//crates/rue-oracle-diff:oracle-diff-test`: pass on the rebased branch.
- `scripts/rue premerge`: pass 220, fail 0.
- RSS, one process: implementer measured 111 / 137 / 153 MB for 300 / 760 / 1300 compilations against 537 / 1552 / 3592 MB on trunk; the reviewer reproduced 51 MB for 255 and 79 MB for 1065 on the rebased branch. Marginal cost per compiled program fell from about 2.9 MB to tens of kilobytes.
