### PR TITLE
RUE-1494: the preview_feature shortcode links ADRs on GitHub

### DIFF
--- a/examples/gazette/templates/shortcodes/preview_feature.html
+++ b/examples/gazette/templates/shortcodes/preview_feature.html
@@ -1,5 +1,5 @@
 <div class="preview-notice">
     <strong>Preview Feature</strong>:
     This feature requires <code>--preview {{ feature }}</code> to use.
-    {% if adr %}See <a href="/designs/{{ adr | lower }}">{{ adr | upper }}</a> for the design.{% endif %}
+    {% if adr %}See <a href="https://github.com/rue-language/rue/blob/trunk/docs/designs/{{ doc }}">{{ adr | upper }}</a> for the design.{% endif %}
 </div>

--- a/performance/ports/hugo/layouts/_shortcodes/preview_feature.html
+++ b/performance/ports/hugo/layouts/_shortcodes/preview_feature.html
@@ -2,5 +2,5 @@
 <div class="preview-notice">
     <strong>Preview Feature</strong>:
     This feature requires <code>--preview {{ .Get "feature" }}</code> to use.
-    {{ with .Get "adr" }}See <a href="/designs/{{ . | lower }}">{{ . | upper }}</a> for the design.{{ end }}
+    {{ with .Get "adr" }}See <a href="https://github.com/rue-language/rue/blob/trunk/docs/designs/{{ $.Get "doc" }}">{{ . | upper }}</a> for the design.{{ end }}
 </div>

--- a/scripts/gazette-corpus-diff.py
+++ b/scripts/gazette-corpus-diff.py
@@ -146,7 +146,7 @@ import gazette_peer_ports as peer_ports  # noqa: E402
 # and a label that advanced anyway would tell a reader diffing two observations
 # that the port moved when it did not. What changed is the COMPOSITION of the
 # identities, which `PREPARER_REVISION` records.
-GAZETTE_PORT_REVISION = 2
+GAZETTE_PORT_REVISION = 3
 
 # The revision of the FIXTURE ASSEMBLY this script implements, which
 # `performance/runtime.toml` pins for the gazette workloads. It is not a port
@@ -288,9 +288,17 @@ def corpus_rules() -> peer_ports.CorpusRules:
 #   error pages. They are transient Zola input explicitly excluded from the
 #   committed Gazette corpus, so no port follows and neither port revision
 #   advances. The assembly change is recorded by PREPARER_REVISION.
+#
+#   RUE-1494. `shortcodes/preview_feature.html` moved: its ADR link was a
+#   root-relative `/designs/…` route the site never emits, and it now points
+#   at the design document on GitHub, named by a new `doc` argument. Both
+#   ports follow, because each is a byte-for-byte port of the shortcode and
+#   the rendering rule itself changed. GAZETTE_PORT_REVISION advances to 3
+#   and PEER_PORT_REVISION to 3 (argued beside it in `gazette_peer_ports.py`).
+#   The corpus's one call site passes no `adr`, so no rendered page moves.
 PRODUCTION_TEMPLATE_ROOT = "website/templates"
 PRODUCTION_TEMPLATE_DIGEST = (
-    "3ba142b2b596b823d952fb9d6c7339ffda9f008353c80deb3150aac00437437f"
+    "803f829ddf0a9ccd6cf5f5b8c1bdf9f0d1a5904062865a8be63e98f445c63647"
 )
 
 # Pages Zola emits no rendered body for, so `body` mode has nothing to compare

--- a/scripts/gazette-corpus-diff.py
+++ b/scripts/gazette-corpus-diff.py
@@ -1571,11 +1571,14 @@ def check_links(out: str, model: Model, scale: int) -> tuple[int, int, int, list
     the entry is stale.
 
     KNOWN LIMIT: only hrefs beginning with the site's base URL are resolved.
-    Root-relative ones are skipped, which today is right — the corpus's are
-    `/spec/` and the `preview_feature` shortcode's `/designs/…`, the latter
-    naming a route no tool emits — but a template that started emitting
+    Root-relative ones are skipped, which today is right — the corpus's only
+    root-relative links are `/spec/` — but a template that started emitting
     relative links would lose coverage silently rather than loudly. The
-    `checked` count printed alongside is what would show it.
+    `checked` count printed alongside is what would show it. The
+    `preview_feature` shortcode's ADR link once sat in this blind spot, as a
+    root-relative `/designs/…` route no tool emits (RUE-1494); it now points
+    at the design document on GitHub, off-site and so unchecked here like
+    every other external link.
     """
     emitted = set(walk_files(out))
     directories = {rel.rsplit("/", 1)[0] + "/" for rel in emitted if "/" in rel}

--- a/scripts/gazette_peer_ports.py
+++ b/scripts/gazette_peer_ports.py
@@ -73,7 +73,14 @@ CorpusRules = collections.namedtuple(
 # would tell a reader diffing two observations that a peer's output changed
 # when only a comment did. The digest is the authoritative half and it records
 # the edit either way.
-PEER_PORT_REVISION = 2
+#
+# It advances to 3 with RUE-1494. The Hugo port of `preview_feature` followed
+# the production shortcode: its ADR link moved from a root-relative
+# `/designs/…` route to the design document on GitHub, named by a new `doc`
+# argument. That is a change to what the port renders, not to a comment, even
+# though the corpus's one call site passes no `adr` and so no rendered page
+# moves.
+PEER_PORT_REVISION = 3
 
 # What the PEERS render, and nothing gazette reads. Inside the comparison
 # identity alone.

--- a/website/templates/shortcodes/preview_feature.html
+++ b/website/templates/shortcodes/preview_feature.html
@@ -1,5 +1,5 @@
 <div class="preview-notice">
     <strong>Preview Feature</strong>:
     This feature requires <code>--preview {{ feature }}</code> to use.
-    {% if adr %}See <a href="/designs/{{ adr | lower }}">{{ adr | upper }}</a> for the design.{% endif %}
+    {% if adr %}See <a href="https://github.com/rue-language/rue/blob/trunk/docs/designs/{{ doc }}">{{ adr | upper }}</a> for the design.{% endif %}
 </div>


### PR DESCRIPTION
The `preview_feature` shortcode rendered a root-relative `/designs/<adr>` link, but the site has no designs section, so every ADR link it produced was dead by construction. The ruling on the issue keeps design documents off the site and accepts GitHub links, so the shortcode now targets the document under `docs/designs` on GitHub.

Callers pass the file name in a `doc` argument beside the `adr` label. A caller that omits `doc` fails the render instead of emitting a dead link. No tracked content calls the shortcode today; the former spec call site was removed when borrow accessors stabilized.

The gazette corpus link checker's `KNOWN LIMIT` note named the `/designs/…` link as the root-relative case it was skipping; the note now records that the link moved off-site.

Fixes RUE-1494