### PR TITLE
RUE-1778: preserve deferred field and element types

### DIFF
--- a/crates/rue-air/src/inference/constraint.rs
+++ b/crates/rue-air/src/inference/constraint.rs
@@ -5,6 +5,7 @@
 //! - [`Substitution`] - Mapping from type variables to resolved types
 
 use super::types::{InferType, TypeVarId};
+use lasso::Spur;
 use rue_span::Span;
 use std::cell::RefCell;
 
@@ -28,6 +29,45 @@ pub enum Constraint {
     /// Unlike ordinary equality, this admits an integer *literal* in an f32/f64
     /// destination without making mixed integer/float operators coercive.
     ContextualEqual(InferType, InferType, Span),
+
+    /// A field projection whose base type was not concrete during constraint
+    /// generation. The semantic field lookup is deliberately deferred until
+    /// the base has been solved; this keeps joined values (if/match results)
+    /// from acquiring an unconstrained synthetic field type.
+    FieldGet {
+        base: InferType,
+        field: Spur,
+        result: InferType,
+        span: Span,
+    },
+
+    /// A field assignment whose base type was not concrete during constraint
+    /// generation. Uses the same contextual equality as ordinary field
+    /// initialization and assignment.
+    FieldSet {
+        base: InferType,
+        field: Spur,
+        value: InferType,
+        span: Span,
+    },
+
+    /// An array or slice projection whose element type was unavailable during
+    /// generation. This uses the same deferred projection pass as fields;
+    /// structural `InferType::Array` elements remain intact.
+    IndexGet {
+        base: InferType,
+        result: InferType,
+        span: Span,
+    },
+
+    /// An array or slice assignment whose element type was unavailable during
+    /// generation. Unlike a field assignment this follows the existing strict
+    /// equality rule for indexed stores.
+    IndexSet {
+        base: InferType,
+        value: InferType,
+        span: Span,
+    },
 
     /// Type must be a signed integer: τ ∈ {i8, i16, i32, i64}.
     ///
@@ -83,6 +123,10 @@ impl Constraint {
         match self {
             Constraint::Equal(_, _, span)
             | Constraint::ContextualEqual(_, _, span)
+            | Constraint::FieldGet { span, .. }
+            | Constraint::FieldSet { span, .. }
+            | Constraint::IndexGet { span, .. }
+            | Constraint::IndexSet { span, .. }
             | Constraint::IsSigned(_, span)
             | Constraint::IsInteger(_, span)
             | Constraint::IsNumeric(_, span)

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -828,28 +828,6 @@ impl<'a> ConstraintGenerator<'a> {
         arg_count == 0 && self.interner.resolve(&method) == "len"
     }
 
-    /// Whether an already-known operand is one of Rue's packed string types.
-    /// String indexing is lowered by semantic analysis to a byte read, so its
-    /// result is always `u8`, unlike an array index whose element type comes
-    /// from the array itself. String literals are admitted here too: their
-    /// contextual type is finalized later, but indexing one has the same
-    /// result type regardless of whether it becomes `str` or `StrBuf`.
-    fn is_string_indexable_type(&self, ty: &InferType) -> bool {
-        if self.is_string_concrete(ty) || self.is_string_literal_candidate(ty) {
-            return true;
-        }
-        let InferType::Concrete(t) = ty else {
-            return false;
-        };
-        let Some(id) = t.as_struct() else {
-            return false;
-        };
-        matches!(
-            self.type_pool.text_view_kind(id),
-            Some(crate::types::TextViewKind::Str | crate::types::TextViewKind::StrFixed(_))
-        )
-    }
-
     /// The pointee of a pointer operand whose type is *already* concrete at
     /// constraint-generation time — an annotated binding, a parameter, or a
     /// pointer-returning intrinsic whose result was published by this pass.
@@ -1004,20 +982,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// mixed-width AIR the operator-agreement check in `inst.rs` rejects
     /// (RUE-1636 family; the check found this producer).
     fn concrete_element_type(&self, ty: &InferType) -> Option<Type> {
-        let ty = ty.as_concrete()?;
-        if let Some(array_id) = ty.as_array() {
-            return Some(self.type_pool.array_def(array_id).0);
-        }
-        let id = ty.as_struct()?;
-        // `str`/`Str(N)` share the view representation but index as bytes;
-        // `is_string_indexable_type` answers those before this is consulted.
-        if self.type_pool.text_view_kind(id) != Some(crate::types::TextViewKind::Slice) {
-            return None;
-        }
-        match self.type_pool.struct_def(id).fields.first()?.ty.kind() {
-            TypeKind::PtrConst(ptr_id) => Some(self.type_pool.ptr_const_def(ptr_id)),
-            _ => None,
-        }
+        self.type_pool.index_element_type(ty.as_concrete()?)
     }
 
     /// Provide file-level constant types (name -> declared type) for `VarRef`
@@ -1459,6 +1424,22 @@ impl<'a> ConstraintGenerator<'a> {
             Constraint::Equal(lhs, rhs, _) | Constraint::ContextualEqual(lhs, rhs, _) => {
                 record_type(&mut self.fixed_string_types, self.type_pool, lhs);
                 record_type(&mut self.fixed_string_types, self.type_pool, rhs);
+            }
+            Constraint::FieldGet { base, result, .. } => {
+                record_type(&mut self.fixed_string_types, self.type_pool, base);
+                record_type(&mut self.fixed_string_types, self.type_pool, result);
+            }
+            Constraint::FieldSet { base, value, .. } => {
+                record_type(&mut self.fixed_string_types, self.type_pool, base);
+                record_type(&mut self.fixed_string_types, self.type_pool, value);
+            }
+            Constraint::IndexGet { base, result, .. } => {
+                record_type(&mut self.fixed_string_types, self.type_pool, base);
+                record_type(&mut self.fixed_string_types, self.type_pool, result);
+            }
+            Constraint::IndexSet { base, value, .. } => {
+                record_type(&mut self.fixed_string_types, self.type_pool, base);
+                record_type(&mut self.fixed_string_types, self.type_pool, value);
             }
             Constraint::IsInteger(ty, _)
             | Constraint::IsNumeric(ty, _)
@@ -3051,8 +3032,10 @@ impl<'a> ConstraintGenerator<'a> {
                 // constraints see the real type instead of a free variable.
                 // This prevents literal defaulting from overriding the field
                 // width and gives method calls the concrete receiver they
-                // require. When the base is still a variable, fall back to a
-                // fresh var; sema resolves and diagnoses later.
+                // require. When the base is still a variable, retain a field
+                // obligation for the solver to discharge after joined bases
+                // resolve. A fresh result variable remains the representation
+                // used by all downstream constraints.
                 // (RUE-89, RUE-126)
                 match self.known_field_type(&base_info.ty, *field) {
                     Some(field_ty) => self.type_to_infer(field_ty),
@@ -3110,7 +3093,18 @@ impl<'a> ConstraintGenerator<'a> {
                         };
                         match member_nominal_ty.or(member_const_ty).or(member_module_ty) {
                             Some(member_ty) => self.type_to_infer(member_ty),
-                            None => InferType::Var(self.fresh_var()),
+                            None => {
+                                let result = InferType::Var(self.fresh_var());
+                                if !matches!(base_info.ty, InferType::Concrete(_)) {
+                                    self.add_constraint(Constraint::FieldGet {
+                                        base: base_info.ty,
+                                        field: *field,
+                                        result: result.clone(),
+                                        span,
+                                    });
+                                }
+                                result
+                            }
                         }
                     }
                 }
@@ -3140,6 +3134,13 @@ impl<'a> ConstraintGenerator<'a> {
                             value_info.span,
                         ));
                     }
+                } else if !matches!(base_info.ty, InferType::Concrete(_)) && value_info.continues {
+                    self.add_constraint(Constraint::FieldSet {
+                        base: base_info.ty,
+                        field: *field,
+                        value: value_info.ty,
+                        span: value_info.span,
+                    });
                 }
                 InferType::Concrete(Type::UNIT)
             }
@@ -3244,7 +3245,7 @@ impl<'a> ConstraintGenerator<'a> {
                 // Extract element type from array type.
                 // If base is InferType::Array, we can get the element type directly.
                 // Otherwise, we need a fresh variable that will be resolved later.
-                if self.is_string_indexable_type(&base_info.ty) {
+                if self.is_string_literal_candidate(&base_info.ty) {
                     InferType::Concrete(Type::U8)
                 } else {
                     match &base_info.ty {
@@ -3257,9 +3258,15 @@ impl<'a> ConstraintGenerator<'a> {
                             Some(element_type) => self.type_to_infer(element_type),
                             None => {
                                 // Base might be a type variable that will resolve to an array.
-                                // Use a fresh variable for the element type.
-                                let result_var = self.fresh_var();
-                                InferType::Var(result_var)
+                                // Use a fresh variable and defer the structural
+                                // element projection until the base resolves.
+                                let result = InferType::Var(self.fresh_var());
+                                self.add_constraint(Constraint::IndexGet {
+                                    base: base_info.ty.clone(),
+                                    result: result.clone(),
+                                    span: index_info.span,
+                                });
+                                result
                             }
                         },
                     }
@@ -3300,6 +3307,12 @@ impl<'a> ConstraintGenerator<'a> {
                             value_info.span,
                         ));
                     }
+                } else if !matches!(base_info.ty, InferType::Concrete(_)) && value_info.continues {
+                    self.add_constraint(Constraint::IndexSet {
+                        base: base_info.ty.clone(),
+                        value: value_info.ty,
+                        span: value_info.span,
+                    });
                 }
 
                 InferType::Concrete(Type::UNIT)
@@ -5621,12 +5634,14 @@ mod tests {
 
         // Result is a type variable (element type unknown)
         assert!(info.ty.is_var());
-        // Should generate 1 constraint: index must be an integer (spec 7.1:7)
-        assert_eq!(cgen.constraints().len(), 1);
+        // The index must be an integer, and the unresolved base's element
+        // projection is discharged after the base type is known.
+        assert_eq!(cgen.constraints().len(), 2);
         match &cgen.constraints()[0] {
             Constraint::IsInteger(_, _) => {}
             _ => panic!("Expected IsInteger constraint for index"),
         }
+        assert!(matches!(cgen.constraints()[1], Constraint::IndexGet { .. }));
     }
 
     #[test]
@@ -5665,12 +5680,14 @@ mod tests {
 
         // Index assignment produces Unit
         assert_eq!(info.ty, InferType::Concrete(Type::UNIT));
-        // Should generate 1 constraint: index must be an integer (spec 7.1:7)
-        assert_eq!(cgen.constraints().len(), 1);
+        // The index must be an integer, and an unresolved base retains a
+        // deferred element-store obligation.
+        assert_eq!(cgen.constraints().len(), 2);
         match &cgen.constraints()[0] {
             Constraint::IsInteger(_, _) => {}
             _ => panic!("Expected IsInteger constraint for index"),
         }
+        assert!(matches!(cgen.constraints()[1], Constraint::IndexSet { .. }));
     }
 
     #[test]

--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -6,6 +6,7 @@
 //! - [`Unifier`] - The unification engine
 
 use ahash::AHashSet;
+use lasso::Spur;
 
 use super::constraint::{Constraint, Substitution};
 use super::types::{InferType, TypeVarId};
@@ -570,10 +571,59 @@ impl Unifier {
         }
     }
 
+    /// Apply contextual equality's narrow implicit literal rule. Keeping this
+    /// in one path is essential for deferred field assignments: a field's
+    /// declared type is learned only after its base resolves, but it must
+    /// admit exactly the same literal contexts as an eagerly known field.
+    fn unify_contextual(
+        &mut self,
+        lhs: &InferType,
+        rhs: &InferType,
+        concrete_types_equal: &dyn Fn(Type, Type) -> bool,
+    ) -> UnifyResult {
+        let lhs_applied = self.substitution.apply(lhs);
+        let rhs_applied = self.substitution.apply(rhs);
+        let integer_literal = match lhs_applied {
+            InferType::IntLiteral => true,
+            InferType::Var(rep) => {
+                self.int_literal_vars.contains(&rep)
+                    || matches!(lhs, InferType::Var(var) if self.int_literal_vars.contains(var))
+            }
+            InferType::Concrete(_) | InferType::Array { .. } => false,
+        };
+        let expected_float = matches!(rhs_applied, InferType::Concrete(Type::F32 | Type::F64));
+        if integer_literal && expected_float {
+            let InferType::Concrete(expected) = rhs_applied else {
+                unreachable!()
+            };
+            self.rebind_int_literal_to_concrete(lhs, &expected);
+            UnifyResult::Ok
+        } else {
+            self.unify_with(lhs, rhs, concrete_types_equal)
+        }
+    }
+
+    fn register_string_context_types(
+        &mut self,
+        ty: &InferType,
+        is_string_context_type: &dyn Fn(&InferType) -> bool,
+    ) {
+        match ty {
+            InferType::Concrete(concrete) if is_string_context_type(ty) => {
+                self.string_literal_types.insert(*concrete);
+            }
+            InferType::Array { element, .. } => {
+                self.register_string_context_types(element, is_string_context_type)
+            }
+            _ => {}
+        }
+    }
+
     /// Solve a list of constraints, collecting any errors.
     ///
-    /// This is the main entry point for Algorithm W. It processes each constraint
-    /// in order, updates the substitution, and collects errors for reporting.
+    /// This is the main entry point for Algorithm W. It solves equality and
+    /// projection relationships before validating predicates, updating the
+    /// substitution and collecting errors for reporting.
     ///
     /// On error, the unifier continues processing remaining constraints to catch
     /// as many errors as possible in one pass. Type variables involved in errors
@@ -590,10 +640,40 @@ impl Unifier {
         constraints: &[Constraint],
         concrete_types_equal: &dyn Fn(Type, Type) -> bool,
     ) -> Vec<UnificationError> {
+        self.solve_constraints_with_projections(
+            constraints,
+            concrete_types_equal,
+            &|_, _| None,
+            &|_| None,
+            &|_| false,
+        )
+    }
+
+    /// Solve constraints with deferred field obligations and demand-driven
+    /// semantic field lookup. Field projections whose base was unresolved
+    /// during generation are revisited after ordinary equalities have joined
+    /// their bases, then again until nested projections reach a fixed point.
+    pub(crate) fn solve_constraints_with_projections(
+        &mut self,
+        constraints: &[Constraint],
+        concrete_types_equal: &dyn Fn(Type, Type) -> bool,
+        field_type: &dyn Fn(&InferType, Spur) -> Option<InferType>,
+        index_element_type: &dyn Fn(&InferType) -> Option<InferType>,
+        is_string_context_type: &dyn Fn(&InferType) -> bool,
+    ) -> Vec<UnificationError> {
         let mut errors = Vec::new();
+        let mut projections = Vec::new();
+        let mut predicates = Vec::new();
 
         for constraint in constraints {
-            let result = match constraint {
+            match constraint {
+                Constraint::FieldGet { .. }
+                | Constraint::FieldSet { .. }
+                | Constraint::IndexGet { .. }
+                | Constraint::IndexSet { .. } => {
+                    projections.push(constraint);
+                    continue;
+                }
                 Constraint::Equal(lhs, rhs, span) => {
                     let result = self.unify_with(lhs, rhs, concrete_types_equal);
                     if !result.is_ok() {
@@ -615,81 +695,109 @@ impl Unifier {
                 // error instead, which is why no source construct may name
                 // `comptime_float` (spec 3.12:3).
                 Constraint::ContextualEqual(lhs, rhs, span) => {
-                    let lhs_applied = self.substitution.apply(lhs);
-                    let rhs_applied = self.substitution.apply(rhs);
-                    let integer_literal = match lhs_applied {
-                        // A terminal IntLiteral is itself contextualizable.
-                        InferType::IntLiteral => true,
-                        // A marked variable may cross the implicit boundary
-                        // only while its applied class remains unresolved.
-                        // Checking the applied representative prevents a
-                        // later float context from overwriting an earlier
-                        // concrete integer binding.
-                        InferType::Var(rep) => {
-                            self.int_literal_vars.contains(&rep)
-                                || matches!(lhs, InferType::Var(var) if self.int_literal_vars.contains(var))
-                        }
-                        // Established concrete types must go through ordinary
-                        // equality and therefore report a conflict.
-                        InferType::Concrete(_) | InferType::Array { .. } => false,
-                    };
-                    let expected_float =
-                        matches!(rhs_applied, InferType::Concrete(Type::F32 | Type::F64));
-                    let result = if integer_literal && expected_float {
-                        let InferType::Concrete(expected) = rhs_applied else {
-                            unreachable!()
-                        };
-                        self.rebind_int_literal_to_concrete(lhs, &expected);
-                        UnifyResult::Ok
-                    } else {
-                        self.unify_with(lhs, rhs, concrete_types_equal)
-                    };
+                    let result = self.unify_contextual(lhs, rhs, concrete_types_equal);
                     if !result.is_ok() {
                         self.recover_from_error(lhs, rhs);
                         errors.push(UnificationError::new(result, *span));
                     }
                     continue;
                 }
-                Constraint::IsSigned(ty, span) => {
-                    let result = self.check_signed(ty);
-                    (result, *span)
+                Constraint::IsSigned(..)
+                | Constraint::IsInteger(..)
+                | Constraint::IsNumeric(..)
+                | Constraint::IsUnsigned(..) => {
+                    predicates.push(constraint);
+                    continue;
                 }
-                Constraint::IsInteger(ty, span) => {
-                    let result = self.check_integer(ty);
-                    (result, *span)
+            }
+        }
+
+        // Resolve field obligations after all ordinary equalities have had a
+        // chance to settle their bases. A nested projection may make the base
+        // of another obligation concrete, so keep applying newly available
+        // obligations until no progress is possible.
+        let mut pending = projections;
+        loop {
+            let mut next = Vec::new();
+            let mut progress = false;
+            for constraint in pending {
+                let projected_type = match constraint {
+                    Constraint::FieldGet { base, field, .. }
+                    | Constraint::FieldSet { base, field, .. } => {
+                        field_type(&self.substitution.apply(base), *field)
+                    }
+                    Constraint::IndexGet { base, .. } | Constraint::IndexSet { base, .. } => {
+                        index_element_type(&self.substitution.apply(base))
+                    }
+                    _ => unreachable!(),
+                };
+                let Some(projected_type) = projected_type else {
+                    next.push(constraint);
+                    continue;
+                };
+                // A demanded field may first expose a generated Str(N),
+                // including one nested inside a structural array type.
+                self.register_string_context_types(&projected_type, is_string_context_type);
+                progress = true;
+                let (actual, expected) = match constraint {
+                    Constraint::FieldGet { result, .. } | Constraint::IndexGet { result, .. } => {
+                        // The declared projection is the actual type; a use
+                        // such as an annotation constrains the result type.
+                        (&projected_type, result)
+                    }
+                    Constraint::FieldSet { value, .. } | Constraint::IndexSet { value, .. } => {
+                        (value, &projected_type)
+                    }
+                    _ => unreachable!(),
+                };
+                let result = if matches!(constraint, Constraint::FieldSet { .. }) {
+                    self.unify_contextual(actual, expected, concrete_types_equal)
+                } else {
+                    self.unify_with(actual, expected, concrete_types_equal)
+                };
+                if !result.is_ok() {
+                    self.recover_from_error(actual, expected);
+                    errors.push(UnificationError::new(result, constraint.span()));
                 }
-                Constraint::IsNumeric(ty, span) => {
-                    let result = self.check_numeric(ty);
-                    (result, *span)
-                }
+            }
+            if !progress || next.is_empty() {
+                // Unavailable projections remain the semantic pass's concern:
+                // it diagnoses unknown fields and invalid bases using source
+                // names. Staged inference can also legitimately lack a base
+                // until canonical comptime selection supplies it.
+                break;
+            }
+            pending = next;
+        }
+
+        // Predicates are checked last so a field obligation can constrain a
+        // numeric/sign/unsigned variable before these checks inspect it.
+        for constraint in predicates {
+            let (result, span) = match constraint {
+                Constraint::IsSigned(ty, span) => (self.check_signed(ty), *span),
+                Constraint::IsInteger(ty, span) => (self.check_integer(ty), *span),
+                Constraint::IsNumeric(ty, span) => (self.check_numeric(ty), *span),
                 Constraint::IsUnsigned(ty, span) => {
-                    // Special handling: if the type is an unbound variable or IntLiteral,
-                    // bind it to u64. This handles integer literals used as array indices.
                     let applied = self.substitution.apply(ty);
-                    match &applied {
+                    match applied {
                         InferType::IntLiteral => {
-                            // IntLiteral bound through a chain - bind the variable to u64
                             if let InferType::Var(var) = ty {
                                 self.substitution
                                     .insert(*var, InferType::Concrete(Type::U64));
                             }
                         }
                         InferType::Var(var) => {
-                            // Unbound variable - bind it to u64
-                            // This happens for integer literal variables that haven't
-                            // been constrained yet.
                             self.substitution
-                                .insert(*var, InferType::Concrete(Type::U64));
+                                .insert(var, InferType::Concrete(Type::U64));
                         }
                         _ => {}
                     }
-                    let result = self.check_unsigned(ty);
-                    (result, *span)
+                    (self.check_unsigned(ty), *span)
                 }
+                _ => unreachable!(),
             };
-
-            if !result.0.is_ok() {
-                errors.push(UnificationError::new(result.0, result.1));
+            if !result.is_ok() {
+                errors.push(UnificationError::new(result, span));
             }
         }
 
@@ -1573,6 +1681,63 @@ mod tests {
             assert_eq!(
                 contextual_unifier.resolve(&InferType::Var(b)),
                 Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn deferred_field_obligations_follow_joined_and_nested_bases() {
+        let base = TypeVarId::new(0);
+        let first = TypeVarId::new(1);
+        let nested = TypeVarId::new(2);
+        let literal = TypeVarId::new(3);
+        let field = Spur::default();
+        let constraints = vec![
+            Constraint::FieldGet {
+                base: InferType::Var(base),
+                field,
+                result: InferType::Var(first),
+                span: Span::new(0, 1),
+            },
+            Constraint::FieldGet {
+                base: InferType::Var(first),
+                field,
+                result: InferType::Var(nested),
+                span: Span::new(2, 3),
+            },
+            Constraint::equal(
+                InferType::Var(base),
+                InferType::Concrete(Type::I32),
+                Span::new(4, 5),
+            ),
+            Constraint::equal(
+                InferType::Var(nested),
+                InferType::Var(literal),
+                Span::new(6, 7),
+            ),
+        ];
+        for reverse in [false, true] {
+            let mut unifier = Unifier::new();
+            unifier.mark_int_literal_vars(&[literal]);
+            let mut ordered = constraints.clone();
+            if reverse {
+                ordered.reverse();
+            }
+            let errors = unifier.solve_constraints_with_projections(
+                &ordered,
+                &|left, right| left == right,
+                &|base, _| {
+                    matches!(base, InferType::Concrete(Type::I32 | Type::U64))
+                        .then_some(InferType::Concrete(Type::U64))
+                },
+                &|_| None,
+                &|_| false,
+            );
+            assert!(errors.is_empty());
+            unifier.default_int_literal_vars(&[literal]);
+            assert_eq!(
+                unifier.substitution.apply(&InferType::Var(literal)),
+                InferType::Concrete(Type::U64)
             );
         }
     }

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -1778,25 +1778,11 @@ impl Air {
                 // unrelated to its operands: the result is always `bool`.
                 //
                 // Operand agreement is enforced here only when the operands
-                // are not both integers. Two producers still emit mixed-width
-                // integer comparisons, and both sit outside this change:
-                //
-                //   * the slice bounds check lowers `s[i]` to
-                //     `Lt(index, len)`, keeping the source index's own
-                //     integer type on the left and the fat pointer's `u64`
-                //     length on the right;
-                //   * an integer literal compared against a struct field
-                //     whose base type is still an inference variable (the
-                //     value came from an `if`/`match` join) defaults to `i32`
-                //     while the field read is the field's declared type —
-                //     the documented `known_field_type` fallback in
-                //     `inference::generate`.
-                //
-                // Both are only accidentally correct: codegen picks a
-                // comparison's width from its LEFT operand, so a narrow left
-                // operand silently truncates the right one. Tighten this to
-                // plain `operands_agree` once those two producers agree with
-                // the invariant (RUE-1654).
+                // are not both integers. A method call whose receiver becomes
+                // concrete only after inference can still leave a neighboring
+                // literal at i32 beside its declared u64 result (RUE-2172).
+                // Tighten this to plain `operands_agree` once that producer
+                // preserves the method signature through constraint solving.
                 AirInstData::Eq(a, b)
                 | AirInstData::Ne(a, b)
                 | AirInstData::Lt(a, b)

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -3546,6 +3546,29 @@ impl TypeInternPool {
         inner.struct_lang_items.get(&struct_id) == Some(&LangItem::StrBuf)
     }
 
+    /// The element type of an indexable concrete value. Inference asks the
+    /// same metadata question both before and after a base type is solved.
+    pub(crate) fn index_element_type(&self, ty: Type) -> Option<Type> {
+        if let Some(array_id) = ty.as_array() {
+            return Some(self.array_def(array_id).0);
+        }
+        let struct_id = ty.as_struct()?;
+        if self.is_strbuf(struct_id) {
+            return Some(Type::U8);
+        }
+        match self.text_view_kind(struct_id)? {
+            crate::types::TextViewKind::Str | crate::types::TextViewKind::StrFixed(_) => {
+                Some(Type::U8)
+            }
+            crate::types::TextViewKind::Slice => {
+                match self.struct_def(struct_id).fields.first()?.ty.kind() {
+                    TypeKind::PtrConst(ptr_id) => Some(self.ptr_const_def(ptr_id)),
+                    _ => None,
+                }
+            }
+        }
+    }
+
     /// Record that a struct carries the `@repr(c)` guarantee marker (ADR-0064
     /// Amendment 1). Set during type-name registration; read by the FFI
     /// predicates and extern-signature enforcement.

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -903,13 +903,43 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         string_literal_types.dedup();
         unifier.mark_string_literal_vars(&string_literal_vars, &string_literal_types);
         let equivalence_queries = std::cell::Cell::new(0usize);
-        let errors = unifier.solve_constraints_with(&constraints, &|left, right| {
-            if left == right {
-                return true;
-            }
-            equivalence_queries.set(equivalence_queries.get() + 1);
-            self.types_equivalent(left, right)
-        });
+        let errors = unifier.solve_constraints_with_projections(
+            &constraints,
+            &|left, right| {
+                if left == right {
+                    return true;
+                }
+                equivalence_queries.set(equivalence_queries.get() + 1);
+                self.types_equivalent(left, right)
+            },
+            &|base, field| {
+                let InferType::Concrete(base) = base else {
+                    return None;
+                };
+                let struct_id = base.as_struct()?;
+                let field_name = self.body_interner().resolve(&field);
+                let field_ty = self
+                    .body_type_pool()
+                    .struct_def(struct_id)
+                    .find_field(field_name)
+                    .map(|(_, field)| field.ty)?;
+                Some(self.type_to_infer_type(field_ty))
+            },
+            &|base| match base {
+                InferType::Array { element, .. } => Some((**element).clone()),
+                InferType::Concrete(ty) => self
+                    .body_type_pool()
+                    .index_element_type(*ty)
+                    .map(|ty| self.type_to_infer_type(ty)),
+                _ => None,
+            },
+            &|ty| {
+                let InferType::Concrete(ty) = ty else {
+                    return false;
+                };
+                self.is_strbuf(*ty) || self.is_str_like(*ty)
+            },
+        );
         self.body_analysis_work_mut()
             .semantic_type_equivalence_queries += equivalence_queries.get();
 

--- a/crates/rue-cli-tests/cases/field_type_inference.toml
+++ b/crates/rue-cli-tests/cases/field_type_inference.toml
@@ -91,3 +91,175 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 6
+
+[[case]]
+name = "joined_array_field_read_keeps_declared_width"
+description = "RUE-1778: an array element selected from an if join retains its struct field type before comparing the literal."
+files = [{ path = "main.rue", source = """
+struct T { aux: u64 }
+fn a() -> T { T { aux: 4294967297 } }
+fn b() -> T { T { aux: 2 } }
+fn main() -> i32 {
+    let arr = if true { [a()] } else { [b()] };
+    let n = arr[0];
+    if n.aux == 4294967297 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "joined_nested_field_comparison_does_not_truncate"
+description = "A match-selected array element keeps nested field widths in both comparison orders and uncontextualized cast operands."
+files = [{ path = "main.rue", source = """
+struct Inner { value: u64 }
+struct Outer { inner: Inner }
+fn make() -> Outer { Outer { inner: Inner { value: 4294967297 } } }
+fn check(c: bool) -> i32 {
+    let arr = match c { true => [make()], false => [make()] };
+    let n = arr[0];
+    if 1 == n.inner.value { return 1; }
+    if n.inner.value != 4294967297 { return 2; }
+    @intCast(n.inner.value - 4294967297)
+}
+fn main() -> i32 { check(true) + check(false) }
+""" }]
+exit_code = 0
+
+[[case]]
+name = "joined_field_and_index_assignments_keep_context"
+description = "Deferred field stores contextualize integer literals for floats; indexed stores retain the array element width."
+files = [{ path = "main.rue", source = """
+struct T { wide: u64, fraction: f64, data: [u64; 1] }
+fn make() -> T { T { wide: 0, fraction: 0.0, data: [0] } }
+fn check(c: bool) -> i32 {
+    let arr = if c { [make()] } else { [make()] };
+    let mut n = arr[0];
+    n.wide = 4294967297;
+    n.fraction = 3;
+    n.data[0] = 4294967297;
+    if n.wide == 4294967297 && n.fraction == 3.0 && n.data[0] == 4294967297 { 0 } else { 1 }
+}
+fn main() -> i32 { check(true) + check(false) }
+""" }]
+exit_code = 0
+
+[[case]]
+name = "joined_field_assignment_rejects_out_of_range_literal"
+files = [{ path = "main.rue", source = """
+struct T { value: u8 }
+fn make() -> T { T { value: 1 } }
+fn main() -> i32 {
+    let arr = if true { [make()] } else { [make()] };
+    let mut n = arr[0];
+    n.value = 300;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800", "300", "u8"]
+
+[[case]]
+name = "joined_field_annotation_preserves_expected_and_found"
+files = [{ path = "main.rue", source = """
+struct T { value: u64 }
+fn make() -> T { T { value: 1 } }
+fn main() -> i32 {
+    let arr = if true { [make()] } else { [make()] };
+    let result: i32 = arr[0].value;
+    result
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "expected i32, found u64"]
+
+[[case]]
+name = "joined_field_missing_member_preserves_diagnostic"
+files = [{ path = "main.rue", source = """
+struct T { value: u64 }
+fn make() -> T { T { value: 1 } }
+fn main() -> i32 {
+    let arr = if true { [make()] } else { [make()] };
+    arr[0].missing;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0401", "missing"]
+
+[[case]]
+name = "joined_field_numeric_predicate_sees_resolved_type"
+files = [{ path = "main.rue", source = """
+struct T { value: u64 }
+fn make() -> T { T { value: 1 } }
+fn main() -> i32 {
+    let arr = if true { [make()] } else { [make()] };
+    let invalid = -arr[0].value;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0801", "u64"]
+
+[[case]]
+name = "joined_fixed_string_fields_contextualize_literals"
+files = [{ path = "main.rue", source = """
+struct T { text: Str(8), items: [Str(8); 1] }
+fn make() -> T { T { text: "hello", items: ["a"] } }
+fn check(c: bool) -> i32 {
+    let arr = if c { [make()] } else { [make()] };
+    let mut n = arr[0];
+    n.text = "abc";
+    n.items = ["b"];
+    if n.text == "abc" && n.items[0] == "b" { 0 } else { 1 }
+}
+fn main() -> i32 { check(true) + check(false) }
+""" }]
+exit_code = 0
+
+[[case]]
+name = "joined_fixed_string_field_rejects_non_string"
+files = [{ path = "main.rue", source = """
+struct T { text: Str(8) }
+fn make() -> T { T { text: "hello" } }
+fn main() -> i32 {
+    let arr = if true { [make()] } else { [make()] };
+    let mut n = arr[0];
+    n.text = true;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "bool"]
+
+[[case]]
+name = "joined_string_buffer_index_keeps_byte_width"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn make() -> StrBuf { "A" }
+fn check(c: bool) -> i32 {
+    let arr = if c { [make()] } else { [make()] };
+    let text = arr[0];
+    if text[0] + 1 == 66 { 0 } else { 1 }
+}
+fn main() -> i32 { check(true) + check(false) }
+""" }]
+exit_code = 0
+
+[[case]]
+name = "joined_field_method_result_width"
+description = "Deferred method signatures remain a separate inference obligation after field and element projections resolve."
+known_bug = "RUE-2172"
+files = [{ path = "main.rue", source = """
+struct Inner { fn get(self) -> u64 { 4294967297 } }
+struct T { inner: Inner }
+fn make() -> T { T { inner: Inner {} } }
+fn check(c: bool) -> i32 {
+    let arr = if c { [make()] } else { [make()] };
+    let n = arr[0];
+    if 1 == n.inner.get() { 1 } else { 0 }
+}
+fn main() -> i32 { check(true) }
+""" }]
+exit_code = 0


### PR DESCRIPTION
An array selected by `if` or `match` could lose its element and field types during inference. Comparing `1` with a `u64` field containing `4294967297` then incorrectly reported equality on native AArch64 because the literal defaulted to `i32`.

Retain field and element read/write obligations until their bases resolve, and solve those obligations before literal defaulting and numeric predicate checks. Concrete indexing metadata is shared between constraint generation and deferred solving. Regression coverage checks nested projections, both comparison orders, assignment ranges, annotation diagnostics, floats, and fixed-size strings.

The integer comparison validation exception remains for a separately tracked unresolved method-result producer, covered by an executable known-bug case.

Validation passed: focused inference and CLI tests, `scripts/rue quick`, formatting, `./buck2 test //crates/rue-oracle-diff:oracle-diff-test`, and the full `scripts/rue test` suite (238 Buck targets, zero failures). Separate adversarial review and native AArch64 regression probes passed.

Fixes RUE-1778
