### PR TITLE
RUE-1779: check exact allocation layouts in debug runtimes

### DIFF
--- a/crates/rue-allocator/src/lib.rs
+++ b/crates/rue-allocator/src/lib.rs
@@ -106,6 +106,29 @@ enum AllocationKind {
     Direct { mapping_size: usize },
 }
 
+#[cfg(debug_assertions)]
+const DEBUG_HEADER_MAGIC: usize = 0x5255_4541_4c4c_4f43;
+
+#[cfg(debug_assertions)]
+#[repr(C)]
+struct AllocationHeader {
+    magic: usize,
+    size: u64,
+    align: u64,
+    raw_pointer: *mut u8,
+    mapping_size: usize,
+    kind: usize,
+}
+
+#[cfg(debug_assertions)]
+const _: () = {
+    assert!(core::mem::size_of::<AllocationHeader>() == 48);
+    assert!(core::mem::align_of::<AllocationHeader>() == 8);
+};
+
+#[cfg(debug_assertions)]
+const DIRECT_KIND: usize = usize::MAX;
+
 /// A recycling arena allocator using mappings supplied by `M`.
 ///
 /// Small requests are rounded to power-of-two classes from 8 bytes through
@@ -160,47 +183,129 @@ impl<M: PageMapper> Allocator<M> {
         };
 
         match kind {
-            AllocationKind::Small(class) => self.allocate_small(class),
-            AllocationKind::Direct { mapping_size } => M::map(mapping_size),
+            AllocationKind::Small(class) => self.allocate_small(class, size, align),
+            AllocationKind::Direct { mapping_size } => {
+                #[cfg(debug_assertions)]
+                let payload_offset = checked_align_up(
+                    core::mem::size_of::<AllocationHeader>(),
+                    match usize::try_from(align) {
+                        Ok(align) => align,
+                        Err(_) => unreachable!(),
+                    },
+                );
+                #[cfg(debug_assertions)]
+                let Some(payload_offset) = payload_offset else {
+                    return ptr::null_mut();
+                };
+                #[cfg(debug_assertions)]
+                let physical_mapping_size = mapping_size
+                    .checked_add(payload_offset)
+                    .and_then(|size| size.checked_next_multiple_of(PAGE_SIZE));
+                #[cfg(debug_assertions)]
+                let Some(mapping_size_for_mapper) = physical_mapping_size else {
+                    return ptr::null_mut();
+                };
+                #[cfg(not(debug_assertions))]
+                let mapping_size_for_mapper = mapping_size;
+                let raw_pointer = M::map(mapping_size_for_mapper);
+                if raw_pointer.is_null() {
+                    return ptr::null_mut();
+                }
+                #[cfg(debug_assertions)]
+                {
+                    // SAFETY: the mapping is page-aligned and the checked
+                    // offset leaves the complete header and allocation in it.
+                    let pointer = unsafe { raw_pointer.add(payload_offset) };
+                    // SAFETY: pointer is in the fresh mapping; the padded
+                    // prefix keeps its header aligned and before the payload.
+                    unsafe {
+                        write_allocation_header(
+                            pointer,
+                            size,
+                            align,
+                            raw_pointer,
+                            mapping_size_for_mapper,
+                            DIRECT_KIND,
+                        );
+                    }
+                    pointer
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    raw_pointer
+                }
+            }
         }
     }
 
     /// Release an allocation described by its original layout.
     ///
-    /// A null pointer is always accepted and has no effect. Unsupported layouts
-    /// are ignored defensively, although supplying one for a non-null pointer
-    /// violates the caller contract.
+    /// A null pointer is always accepted and has no effect. In debug builds,
+    /// the exact layout recorded at allocation time is checked before the
+    /// block is classified or returned to a free list. A mismatch panics;
+    /// arbitrary pointers and double frees remain outside this contract.
     ///
     /// # Safety
     ///
     /// A non-null `pointer` must identify a live allocation returned by this
     /// allocator for exactly `size` and `align`. It must not be used afterward.
+    /// Debug builds validate the exact layout of a live allocation before
+    /// changing allocator state; pointer validity and ownership remain the
+    /// caller's responsibility.
     pub unsafe fn deallocate(&self, pointer: *mut u8, size: u64, align: u64) {
         if pointer.is_null() {
             return;
         }
 
-        let Some(kind) = classify(size, align) else {
-            return;
-        };
+        #[cfg(debug_assertions)]
+        {
+            let record = unsafe { validate_allocation_header(pointer, size, align) };
+            if record.kind == DIRECT_KIND {
+                // SAFETY: the checked header came from this allocator and
+                // records the complete mapping returned by M::map.
+                unsafe { M::unmap(record.raw_pointer, record.mapping_size) };
+                return;
+            }
+            // SAFETY: the caller owns this live block, and its header records
+            // the small class that allocated it.
+            unsafe { self.release_small(pointer, record.kind) };
+        }
 
-        match kind {
-            AllocationKind::Small(class) => {
-                let _guard = self.lock();
-                // SAFETY: the lock grants exclusive access to the allocator
-                // state, and the caller provided a live block in this class.
-                unsafe {
-                    let state = &mut *self.state.get();
-                    let block = pointer.cast::<FreeBlock>();
-                    (*block).next = state.free_lists[class.index];
-                    state.free_lists[class.index] = block;
+        #[cfg(not(debug_assertions))]
+        {
+            let Some(kind) = classify(size, align) else {
+                return;
+            };
+
+            match kind {
+                AllocationKind::Small(class) => {
+                    // SAFETY: the caller supplied this live block's exact layout.
+                    unsafe { self.release_small(pointer, class.index) };
+                }
+                AllocationKind::Direct { mapping_size } => {
+                    // SAFETY: direct allocations return the mapping base, and the
+                    // caller supplied the exact layout used to derive its size.
+                    unsafe { M::unmap(pointer, mapping_size) };
                 }
             }
-            AllocationKind::Direct { mapping_size } => {
-                // SAFETY: direct allocations return the mapping base, and the
-                // caller supplied the exact layout used to derive its size.
-                unsafe { M::unmap(pointer, mapping_size) };
-            }
+        }
+    }
+
+    /// Return a live small block to its class's free list.
+    ///
+    /// # Safety
+    ///
+    /// `pointer` must be a live block owned by this allocator in `class_index`.
+    /// The caller retires the allocation and must not access it afterward.
+    unsafe fn release_small(&self, pointer: *mut u8, class_index: usize) {
+        let _guard = self.lock();
+        // SAFETY: the lock grants exclusive access to the allocator state, and
+        // callers provide a live block in the recorded class.
+        unsafe {
+            let state = &mut *self.state.get();
+            let block = pointer.cast::<FreeBlock>();
+            (*block).next = state.free_lists[class_index];
+            state.free_lists[class_index] = block;
         }
     }
 
@@ -231,7 +336,12 @@ impl<M: PageMapper> Allocator<M> {
     ) -> bool {
         // A null block owns no storage and a zero new size describes no
         // allocation at all; neither can be satisfied in place.
-        if pointer.is_null() || new_size == 0 {
+        if pointer.is_null() {
+            return false;
+        }
+        #[cfg(debug_assertions)]
+        let record = unsafe { validate_allocation_header(pointer, old_size, align) };
+        if new_size == 0 {
             return false;
         }
         let (Some(old_kind), Some(new_kind)) =
@@ -239,7 +349,16 @@ impl<M: PageMapper> Allocator<M> {
         else {
             return false;
         };
-        old_kind == new_kind
+        #[cfg(debug_assertions)]
+        assert!(record.kind == allocation_kind_key(old_kind));
+        if old_kind == new_kind {
+            #[cfg(debug_assertions)]
+            unsafe {
+                update_allocation_size(pointer, new_size)
+            };
+            return true;
+        }
+        false
     }
 
     /// Resize an allocation while preserving its initialized prefix.
@@ -266,6 +385,8 @@ impl<M: PageMapper> Allocator<M> {
         if pointer.is_null() {
             return self.allocate(new_size, align);
         }
+        #[cfg(debug_assertions)]
+        let record = unsafe { validate_allocation_header(pointer, old_size, align) };
         if new_size == 0 {
             // SAFETY: inherited from this function's caller contract.
             unsafe { self.deallocate(pointer, old_size, align) };
@@ -279,7 +400,14 @@ impl<M: PageMapper> Allocator<M> {
             return ptr::null_mut();
         };
 
+        #[cfg(debug_assertions)]
+        assert!(record.kind == allocation_kind_key(old_kind));
+
         if old_kind == new_kind {
+            #[cfg(debug_assertions)]
+            unsafe {
+                update_allocation_size(pointer, new_size)
+            };
             return pointer;
         }
 
@@ -297,7 +425,7 @@ impl<M: PageMapper> Allocator<M> {
         replacement
     }
 
-    fn allocate_small(&self, class: SmallClass) -> *mut u8 {
+    fn allocate_small(&self, class: SmallClass, size: u64, align: u64) -> *mut u8 {
         let _guard = self.lock();
         // SAFETY: the lock grants exclusive access to the allocator state.
         let state = unsafe { &mut *self.state.get() };
@@ -308,6 +436,15 @@ impl<M: PageMapper> Allocator<M> {
             // block whose first word contains a FreeBlock link.
             unsafe {
                 state.free_lists[class.index] = (*free).next;
+                #[cfg(debug_assertions)]
+                write_allocation_header(
+                    free.cast::<u8>(),
+                    size,
+                    align,
+                    ptr::null_mut(),
+                    0,
+                    class.index,
+                );
             }
             return free.cast::<u8>();
         }
@@ -315,7 +452,9 @@ impl<M: PageMapper> Allocator<M> {
         loop {
             if !state.current_arena.is_null() {
                 // SAFETY: current_arena is a live mapping owned by this state.
-                if let Some(pointer) = unsafe { allocate_from_arena(state.current_arena, class) } {
+                if let Some(pointer) =
+                    unsafe { allocate_from_arena(state.current_arena, class, size, align) }
+                {
                     return pointer;
                 }
             }
@@ -391,18 +530,43 @@ fn classify(size: u64, align: u64) -> Option<AllocationKind> {
 ///
 /// The caller must hold the allocator lock and `arena` must point to the live
 /// current arena owned by that allocator.
-unsafe fn allocate_from_arena(arena: *mut ArenaHeader, class: SmallClass) -> Option<*mut u8> {
+unsafe fn allocate_from_arena(
+    arena: *mut ArenaHeader,
+    class: SmallClass,
+    size: u64,
+    align: u64,
+) -> Option<*mut u8> {
+    #[cfg(not(debug_assertions))]
+    let _ = (size, align);
     // SAFETY: guaranteed by the caller.
     let header = unsafe { &mut *arena };
-    let aligned_offset = checked_align_up(header.offset, class.block_align)?;
-    let new_offset = aligned_offset.checked_add(class.block_size)?;
+    #[cfg(debug_assertions)]
+    let pointer_offset = {
+        let pointer_offset = checked_align_up(
+            header
+                .offset
+                .checked_add(core::mem::size_of::<AllocationHeader>())?,
+            class.block_align,
+        )?;
+        pointer_offset
+    };
+    #[cfg(not(debug_assertions))]
+    let pointer_offset = checked_align_up(header.offset, class.block_align)?;
+    let new_offset = pointer_offset.checked_add(class.block_size)?;
     if new_offset > header.size {
         return None;
     }
 
     header.offset = new_offset;
     // SAFETY: the checked offsets place the complete block in the arena.
-    Some(unsafe { arena.cast::<u8>().add(aligned_offset) })
+    let pointer = unsafe { arena.cast::<u8>().add(pointer_offset) };
+    #[cfg(debug_assertions)]
+    unsafe {
+        // SAFETY: pointer_offset is within the arena, and the header is
+        // immediately before the returned pointer.
+        write_allocation_header(pointer, size, align, ptr::null_mut(), 0, class.index);
+    }
+    Some(pointer)
 }
 
 const fn checked_align_up(value: usize, align: usize) -> Option<usize> {
@@ -410,6 +574,69 @@ const fn checked_align_up(value: usize, align: usize) -> Option<usize> {
         return None;
     };
     Some(added & !(align - 1))
+}
+
+#[cfg(debug_assertions)]
+unsafe fn write_allocation_header(
+    pointer: *mut u8,
+    size: u64,
+    align: u64,
+    raw_pointer: *mut u8,
+    mapping_size: usize,
+    kind: usize,
+) {
+    let header = unsafe {
+        pointer
+            .sub(core::mem::size_of::<AllocationHeader>())
+            .cast::<AllocationHeader>()
+    };
+    // SAFETY: callers place the header immediately before a suitably aligned
+    // pointer in storage owned by this allocator.
+    unsafe {
+        header.write(AllocationHeader {
+            magic: DEBUG_HEADER_MAGIC,
+            size,
+            align,
+            raw_pointer,
+            mapping_size,
+            kind,
+        });
+    }
+}
+
+#[cfg(debug_assertions)]
+unsafe fn validate_allocation_header(pointer: *mut u8, size: u64, align: u64) -> AllocationHeader {
+    let header = unsafe {
+        pointer
+            .sub(core::mem::size_of::<AllocationHeader>())
+            .cast::<AllocationHeader>()
+    };
+    // SAFETY: the caller promises a pointer returned by this allocator; the
+    // header was written when that allocation was created.
+    let record = unsafe { header.read() };
+    assert!(record.magic == DEBUG_HEADER_MAGIC);
+    assert!(record.size == size);
+    assert!(record.align == align);
+    record
+}
+
+#[cfg(debug_assertions)]
+unsafe fn update_allocation_size(pointer: *mut u8, size: u64) {
+    let header = unsafe {
+        pointer
+            .sub(core::mem::size_of::<AllocationHeader>())
+            .cast::<AllocationHeader>()
+    };
+    // SAFETY: the header belongs to this live allocation and remains in place.
+    unsafe { (*header).size = size };
+}
+
+#[cfg(debug_assertions)]
+const fn allocation_kind_key(kind: AllocationKind) -> usize {
+    match kind {
+        AllocationKind::Small(class) => class.index,
+        AllocationKind::Direct { .. } => DIRECT_KIND,
+    }
 }
 
 #[cfg(test)]
@@ -470,7 +697,7 @@ mod tests {
     #[test]
     fn allocations_honor_every_supported_alignment() {
         let allocator = Allocator::<TestMapper>::new();
-        for align in [1u64, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 4096] {
+        for align in [1u64, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096] {
             let pointer = allocator.allocate(64, align);
             assert!(!pointer.is_null());
             assert_eq!(pointer as usize % align as usize, 0);
@@ -552,6 +779,8 @@ mod tests {
         let grown = unsafe { allocator.reallocate(pointer, 65, 120, 8) };
         assert_eq!(grown, pointer);
         assert_eq!(unsafe { grown.read() }, 0x5a);
+        // SAFETY: successful growth relabeled the allocation to this layout.
+        unsafe { allocator.deallocate(grown, 120, 8) };
     }
 
     #[test]
@@ -598,15 +827,18 @@ mod tests {
     fn realloc_within_one_direct_mapping_keeps_the_pointer() {
         let allocator = Allocator::<TestMapper>::new();
         let old_size = (MAX_SMALL_SIZE + 1) as u64;
-        let new_size = old_size + 1000;
+        let new_size = 5 * PAGE_SIZE as u64;
         let pointer = allocator.allocate(old_size, 8);
         assert!(!pointer.is_null());
         unsafe { pointer.write(0xa5) };
 
-        // Both layouts round up to the same number of pages.
+        // 16,385 and 20,480 bytes both use the same five-page mapping.
         let grown = unsafe { allocator.reallocate(pointer, old_size, new_size, 8) };
         assert_eq!(grown, pointer);
         assert_eq!(unsafe { grown.read() }, 0xa5);
+        // SAFETY: the complete relabeled payload fits after the debug header,
+        // including the last byte of the logical five-page capacity.
+        unsafe { grown.add(new_size as usize - 1).write(0x5a) };
 
         // SAFETY: grown is live with the new layout.
         unsafe { allocator.deallocate(grown, new_size, 8) };
@@ -654,6 +886,65 @@ mod tests {
         unsafe { allocator.deallocate(direct, size, 8) };
         assert_eq!(COUNTED_MAPS.load(Ordering::Relaxed), 2);
         assert_eq!(COUNTED_UNMAPS.load(Ordering::Relaxed), 1);
+    }
+
+    #[cfg(debug_assertions)]
+    struct UnmapTrapMapper;
+
+    #[cfg(debug_assertions)]
+    // SAFETY: mapping delegates to the test mapper; unmapping is deliberately
+    // unreachable when layout validation runs before deallocation.
+    unsafe impl PageMapper for UnmapTrapMapper {
+        fn map(size: usize) -> *mut u8 {
+            TestMapper::map(size)
+        }
+
+        unsafe fn unmap(_pointer: *mut u8, _size: usize) {
+            panic!("unmap reached before layout validation");
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "record.size == size")]
+    fn wrong_direct_layout_panics_before_unmapping() {
+        let allocator = Allocator::<UnmapTrapMapper>::new();
+        let size = (MAX_SMALL_SIZE + 1) as u64;
+        let pointer = allocator.allocate(size, 8);
+        assert!(!pointer.is_null());
+        unsafe { allocator.deallocate(pointer, size + 1, 8) };
+    }
+
+    static PERMITTED_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    struct PermittedCountingMapper;
+
+    // SAFETY: delegates mapping operations to TestMapper and only counts the
+    // allocation-permitted hook with an atomic counter.
+    unsafe impl PageMapper for PermittedCountingMapper {
+        fn allocation_permitted() -> bool {
+            PERMITTED_CALLS.fetch_add(1, Ordering::Relaxed);
+            true
+        }
+
+        fn map(size: usize) -> *mut u8 {
+            TestMapper::map(size)
+        }
+
+        unsafe fn unmap(pointer: *mut u8, size: usize) {
+            // SAFETY: inherited from PageMapper::unmap's contract.
+            unsafe { TestMapper::unmap(pointer, size) };
+        }
+    }
+
+    #[test]
+    fn allocation_permitted_is_called_once_per_public_allocation_attempt() {
+        PERMITTED_CALLS.store(0, Ordering::Relaxed);
+        let allocator = Allocator::<PermittedCountingMapper>::new();
+        let pointer = allocator.allocate(64, 8);
+        assert!(!pointer.is_null());
+        assert_eq!(PERMITTED_CALLS.load(Ordering::Relaxed), 1);
+        unsafe { allocator.deallocate(pointer, 64, 8) };
     }
 
     static THREADED_ALLOCATOR: Allocator<TestMapper> = Allocator::new();
@@ -718,5 +1009,58 @@ mod tests {
         assert_eq!(unsafe { pointer.read() }, 0xa5);
         // SAFETY: failed realloc left pointer live.
         unsafe { allocator.deallocate(pointer, old_size, 8) };
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn deallocate_rejects_a_wrong_same_class_layout() {
+        let allocator = Allocator::<TestMapper>::new();
+        let pointer = allocator.allocate(64, 8);
+        assert!(!pointer.is_null());
+        // 63 and 64 use the same logical class, but the caller's exact layout
+        // contract still requires the original size.
+        unsafe { allocator.deallocate(pointer, 63, 8) };
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn deallocate_rejects_a_wrong_direct_layout() {
+        let allocator = Allocator::<TestMapper>::new();
+        let pointer = allocator.allocate((MAX_SMALL_SIZE + 1) as u64, 8);
+        assert!(!pointer.is_null());
+        // Both requests would round to the same mapping size.
+        unsafe { allocator.deallocate(pointer, (MAX_SMALL_SIZE + 2) as u64, 8) };
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn deallocate_rejects_a_wrong_alignment_before_invalid_layout_classification() {
+        let allocator = Allocator::<TestMapper>::new();
+        let pointer = allocator.allocate(64, 8);
+        assert!(!pointer.is_null());
+        unsafe { allocator.deallocate(pointer, 64, 3) };
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn realloc_validates_before_copying() {
+        let allocator = Allocator::<TestMapper>::new();
+        let pointer = allocator.allocate(32, 8);
+        assert!(!pointer.is_null());
+        unsafe { allocator.reallocate(pointer, 31, 128, 8) };
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn resize_validates_an_invalid_old_layout_before_zero_size_return() {
+        let allocator = Allocator::<TestMapper>::new();
+        let pointer = allocator.allocate(32, 8);
+        assert!(!pointer.is_null());
+        unsafe { allocator.resize_in_place(pointer, 31, 0, 8) };
     }
 }

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -8,6 +8,38 @@ name = "Source-defined std.strbuf.StrBuf"
 description = "The named std.strbuf.StrBuf header has its source-defined methods, layout, and drop behavior."
 
 [[case]]
+name = "literal_storage_drop_free_and_promotion"
+description = "Literal-backed strings release no allocation; explicit free, reuse, and promotion preserve ownership (RUE-2173)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+differential_opt = true
+stdout = ""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn discard(value: S) {}
+
+fn main() -> i32 {
+    let literal: S = "literal";
+    if literal.len() != 7 || literal.capacity() != 0 { return 1; }
+    discard(literal);
+
+    let mut released: S = "release";
+    released.free();
+    released.free();
+    if released.len() != 0 || released.capacity() != 0 { return 2; }
+    released.push(b'x');
+    if released != "x" { return 3; }
+
+    let mut promoted: S = "grow";
+    promoted.push(b'!');
+    if promoted != "grow!" || promoted.capacity() == 0 { return 4; }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
 name = "qualified_nonallocating_surface"
 description = "Qualified construction and nonallocating methods operate on the source-defined type."
 env = { RUE_STD_PATH = "${REAL_STD}" }

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -708,6 +708,37 @@ mod tests {
         result.expect("execute linked Rue program")
     }
 
+    /// The embedded debug runtime carries the allocator's exact layout checks
+    /// even though the runtime itself is compiled with `-Copt-level=z`. A real
+    /// linked Rue program therefore traps before a wrong-size or
+    /// wrong-alignment free can corrupt allocator state.
+    #[cfg(all(unix, debug_assertions))]
+    #[test]
+    #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+    fn platform_native_allocator_layout_mismatch_traps_before_free() {
+        for (label, source) in [
+            (
+                "same-class-size",
+                "fn main() { checked { let p: ptr mut u8 = @alloc(63, 1); @free(p, 64, 1); } }",
+            ),
+            (
+                "wrong-class-size",
+                "fn main() { checked { let p: ptr mut u8 = @alloc(4004, 1); @free(p, 3, 1); } }",
+            ),
+            (
+                "invalid-alignment",
+                "fn main() { checked { let p: ptr mut u8 = @alloc(64, 8); @free(p, 64, 16); } }",
+            ),
+        ] {
+            let snapshot = SourceSnapshot::single("allocator-layout.rue", source)
+                .expect("allocator mismatch fixture snapshot");
+            let output = compile_snapshot(&snapshot, &CompileOptions::default())
+                .expect("allocator mismatch fixture links");
+            let execution = execute_compiled_output(&output, label);
+            assert_eq!(execution.status.code(), Some(101), "{label}: {execution:?}");
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]

--- a/crates/rue-runtime/runtime.bzl
+++ b/crates/rue-runtime/runtime.bzl
@@ -12,6 +12,16 @@ RUNTIME_COMMON_RUSTC_FLAGS = [
     "-Crelocation-model=static",
 ]
 
+# The embedded runtime is always size-optimized, which otherwise leaves the
+# allocator's debug-only layout checks disabled even in the compiler's default
+# build mode. Keep this separate from the shared runtime flags: those flags
+# also compile zmij, while only the allocator needs this instrumentation.
+RUNTIME_ALLOCATOR_RUSTC_FLAGS = select({
+    "root//constraints:release": ["-Cdebug-assertions=no"],
+    "root//constraints:debug": ["-Cdebug-assertions=yes"],
+    "DEFAULT": ["-Cdebug-assertions=yes"],
+})
+
 # AArch64's LSE atomics use a compiler-rt runtime-detection symbol that Rue
 # does not provide. These flags must not leak into the x86-64 build.
 RUNTIME_AARCH64_RUSTC_FLAGS = [
@@ -77,6 +87,7 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
         target_sysroot,
     )
     allocator_args.add(ctx.attrs.rustc_flags)
+    allocator_args.add(ctx.attrs.allocator_rustc_flags)
     # Generic allocator code is instantiated into the runtime static library,
     # including source locations used by panic paths. The exported source
     # artifact lives under checkout-specific buck-out roots, so give rustc a
@@ -174,6 +185,7 @@ _runtime_staticlib = rule(
     impl = _runtime_staticlib_impl,
     attrs = {
         "allocator_crate_root": attrs.source(),
+        "allocator_rustc_flags": attrs.list(attrs.arg()),
         "abi_crate_root": attrs.source(),
         "crate_root": attrs.source(),
         "srcs": attrs.list(attrs.source()),
@@ -201,6 +213,7 @@ def runtime_staticlib(name: str, target_triple: str, target_std: str, visibility
         target_std = target_std,
         target_triple = target_triple,
         rustc_flags = flags,
+        allocator_rustc_flags = RUNTIME_ALLOCATOR_RUSTC_FLAGS,
         zmij_crate_root = "//third-party:zmij-0.1.7-lib.rs",
         zmij_traits_source = "//third-party:zmij-0.1.7-traits.rs",
         visibility = visibility,

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,6 +33,14 @@ scripts/rue storage reset /exact/root # full Buck reset of one registered worktr
 scripts/rue cache install            # install the private BuildBuddy cache config
 ```
 
+Buck's default target platform is the debug build; use
+`--target-platforms //platforms:debug` to select it explicitly. The optimized
+compiler and embedded runtime are built with
+`--target-platforms //platforms:release`. The runtime allocator's debug layout
+checks follow this Buck build mode, independent of any Rue source `-O` option:
+default/debug embedded runtimes check exact allocation layouts, while release
+embedded runtimes omit that bookkeeping.
+
 For direct compiler invocations, resolve the binary through `scripts/rue-bin`:
 
 ```bash

--- a/std/rawbuf.rue
+++ b/std/rawbuf.rue
@@ -26,15 +26,14 @@
 // surface here means memory ownership — allocate/reallocate/free, and the
 // buffer's teardown — has one home for both containers.
 //
-//   * OWNING (`cap > 0`): `ptr` addresses `cap` live cells the value owns and
-//     frees at teardown.
-//   * EMPTY (`cap == 0`): `ptr` is null; no allocation is held. No `T` is ever
-//     read or written in this state (the wrapper's `len` is 0), so the null
-//     pointer is never dereferenced.
-//
-// A future non-owning literal-backed state (a `StrBuf` built from a static
-// string literal, §6.13.4) belongs here too, as a third case of the same
-// invariant, so both containers can share it; it is not modeled yet.
+//   * OWNING (`cap > 0`, nonzero-sized `T`): `buf` addresses storage for `cap`
+//     cells that this core frees at teardown.
+//   * NON-OWNING (`cap == 0`): no allocation is held. An empty core has a null
+//     pointer; a literal-backed StrBuf instead holds a borrowed static byte
+//     address. StrBuf bounds reads by its length and promotes to owned storage
+//     before mutation. Neither form returns a block to the allocator.
+//   * ZERO-SIZED ELEMENTS: capacity is recorded without allocating storage;
+//     the pointer remains null and teardown has no block to release.
 
 // The sole raw byte-copy implementation. Callers pass validated logical
 // ranges; this private function performs the shared byte-size, address,
@@ -152,7 +151,7 @@ pub fn RawBuf(comptime T: type) -> type {
         }
 
         // Release the allocation and reset to the empty state. Idempotent and
-        // safe on an empty buffer: `@free(null, 0, align)` is a no-op. Callers
+        // safe on an empty buffer: `release` skips non-owning storage. Callers
         // that have already moved/dropped the live cells use this for early
         // release; the destructor calls the same path at scope exit.
         fn free(inout self) {
@@ -164,10 +163,14 @@ pub fn RawBuf(comptime T: type) -> type {
 
         // Hand the block back to the allocator with exactly the `(size, align)`
         // it was allocated with — the sizeless-allocator ABI's requirement.
-        // A zero-sized `T` never reached the allocator, so `cap * 0` is 0 and
-        // the pointer is null: the call is the documented no-op.
+        // Zero capacity can carry a non-null static address for a literal-backed
+        // StrBuf. Neither that address nor zero-sized-element storage belongs
+        // to the allocator, so both are handled before the allocator call.
         fn release(borrow self) {
             let element_size: u64 = @intCast(@size_of(T));
+            if self.cap == 0 || element_size == 0 {
+                return;
+            }
             let align: u64 = @intCast(@align_of(T));
             checked {
                 let block: ptr mut u8 = @int_to_ptr(@ptr_to_int(self.buf));


### PR DESCRIPTION
Freeing a 4,004-byte allocation as 3 bytes previously put it on the tiny-block free list without any failure. Debug runtimes now record and check the exact allocation size and alignment before freeing, resizing, or copying; a mismatch terminates the Rue program with exit 101.

The debug header preserves the allocator's existing logical size classes and page capacities, including in-place growth. Embedded allocator checks follow the compiler's Buck debug/release build mode independently of Rue source optimization flags. Release builds omit the bookkeeping.

The checks exposed a caller violation in `RawBuf`: literal-backed strings passed borrowed static storage to `@free` with size zero. The shared release path now skips non-owning and zero-sized storage. A regression covers literal teardown, repeated explicit free, reuse, and promotion to owned storage.

Validation passed: the full `scripts/rue test` suite (238 targets, zero failures), debug and release allocator unit tests, allocator Clippy, the native layout-mismatch regression, embedded-runtime builds, the StrBuf lifecycle and zero-sized ArrayBuf cases, and independent review of both allocator and caller changes. All PR CI checks passed on the published revision.

Fixes RUE-1779

Fixes RUE-2173
