### PR TITLE
RUE-1894: record no overloading, implicit conversions, or mutable globals

### DIFF
--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -388,6 +388,24 @@ compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
 [[case]]
+name = "duplicate_function_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0436"]
+compile_only = true
+compile_stdout_contains = ["E0436: Duplicate function definition", "A different parameter type, parameter count, return type, or parameter mode does not create an overload.", "docs/spec/src/10-modules/05-program-composition.md (spec rule 10.5:1)", "docs/spec/src/06-items/01-functions.md (spec rule 6.1:44)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
+name = "duplicate_method_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0410"]
+compile_only = true
+compile_stdout_contains = ["E0410: Duplicate method", "changing parameter types, count, return type, or mode does not create an overload.", "docs/spec/src/06-items/04-impl-blocks.md (spec rule 6.4:16)", "docs/spec/src/06-items/01-functions.md (spec rule 6.1:44)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
 name = "fixed_string_capacity_code_is_explained"
 files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
 args = ["explain", "E0492"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -928,13 +928,16 @@ define_error_codes! {
     };
     // 408, 409 retired with the @handle directive (RUE-199).
     DUPLICATE_METHOD = 410 => {
-        explanation: "A struct definition declares more than one method or associated function with the same name. Both declaration forms share the struct's callable-member name space, so each callable member name must be unique within that struct.",
+        explanation: "A struct definition declares more than one method or associated function with the same name. Both declaration forms share the struct's callable-member name space, so each callable member name must be unique within that struct; changing parameter types, count, return type, or mode does not create an overload.",
         likely_cause: "A method or associated function was copied, renamed incompletely, or generated twice in one struct definition. Remove one declaration or give the callable members distinct names.",
         examples: [
             ErrorCodeExample { title: "Duplicate method declaration", source: "struct Point {\n    x: i32,\n\n    fn value(self) -> i32 { self.x }\n    fn value(self) -> i32 { self.x }\n}\nfn main() -> i32 { 0 }", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
             ErrorCodeExample { title: "Give each method a unique name", source: "struct Point {\n    x: i32,\n\n    fn value(self) -> i32 { self.x }\n    fn doubled(self) -> i32 { self.x * 2 }\n}\nfn main() -> i32 { 0 }", outcome: ErrorCodeExampleOutcome::Compiles },
         ],
-        references: [ErrorCodeReference { title: "Unique method names", path: "docs/spec/src/06-items/04-impl-blocks.md", rule: Some("6.4:16") }],
+        references: [
+            ErrorCodeReference { title: "Unique method names", path: "docs/spec/src/06-items/04-impl-blocks.md", rule: Some("6.4:16") },
+            ErrorCodeReference { title: "One name, one signature per scope", path: "docs/spec/src/06-items/01-functions.md", rule: Some("6.1:44") },
+        ],
     };
     UNDEFINED_METHOD = 411 => {
         explanation: "A method call names no method available for the receiver's type. Rue resolves user-defined methods on the receiver's struct and supported built-in receiver methods, including operations on strings and slices.",
@@ -1202,13 +1205,16 @@ define_error_codes! {
         references: [ErrorCodeReference { title: "Reserved function names", path: "docs/spec/src/06-items/_index.md", rule: Some("6.0:5") }],
     };
     DUPLICATE_FUNCTION_DEFINITION = 436 => {
-        explanation: "One source file defines the same top-level function name more than once, or reuses a top-level name across functions, constants, and user-defined types. E0436 covers both function/function duplicates and collisions between different top-level declaration kinds; the metadata name and code are shared intentionally.",
+        explanation: "One source file defines the same top-level function name more than once, or reuses a top-level name across functions, constants, and user-defined types. E0436 covers both function/function duplicates and collisions between different top-level declaration kinds; the metadata name and code are shared intentionally. A different parameter type, parameter count, return type, or parameter mode does not create an overload.",
         likely_cause: "A declaration was copied, renamed to an existing item, or generated twice in one module. Remove or rename one declaration. The same spelling may be used independently in another source file because top-level names are module-scoped.",
         examples: [
             ErrorCodeExample { title: "Define a function twice in one module", source: "fn answer() -> i32 { 40 }\nfn answer() -> i32 { 42 }\nfn main() -> i32 { 0 }", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
             ErrorCodeExample { title: "Give top-level functions distinct names", source: "fn base() -> i32 { 40 }\nfn answer() -> i32 { base() + 2 }\nfn main() -> i32 { answer() }", outcome: ErrorCodeExampleOutcome::Compiles },
         ],
-        references: [ErrorCodeReference { title: "Module-scoped top-level name uniqueness", path: "docs/spec/src/10-modules/05-program-composition.md", rule: Some("10.5:1") }],
+        references: [
+            ErrorCodeReference { title: "Module-scoped top-level name uniqueness", path: "docs/spec/src/10-modules/05-program-composition.md", rule: Some("10.5:1") },
+            ErrorCodeReference { title: "One name, one signature per scope", path: "docs/spec/src/06-items/01-functions.md", rule: Some("6.1:44") },
+        ],
     };
     MOVE_OUT_OF_INOUT = 437 => {
         explanation: "A function tries to move a non-Copy value, or a non-Copy part of one, out of an `inout` parameter. The callee has exclusive mutable access to caller-owned storage but does not own that storage's value, so moving it would leave the caller with an invalid or partially moved value.",

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -531,7 +531,7 @@ exit_code = 42
 
 [[case]]
 name = "generic_function_multiple_types"
-spec = ["4.14:5"]
+spec = ["4.14:5", "6.1:44"]
 description = "Generic function called with different types creates separate specializations"
 source = """
 fn identity(comptime T: type, x: T) -> T {

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -71,6 +71,37 @@ spec = ["6.1:2"]
 source = "fn main() -> i32 { 99 }"
 exit_code = 99
 
+# Rue has one callable name per module/type scope. A changed signature does not
+# turn a second same-named declaration into an overload (6.1:44).
+
+[[case]]
+name = "same_function_name_different_parameter_type_rejected"
+spec = ["6.1:44"]
+source = "fn convert(value: i32) -> i32 { value }\nfn convert(value: bool) -> i32 { if value { 1 } else { 0 } }\nfn main() -> i32 { 0 }"
+compile_fail = true
+error_contains = ["E0436", "convert"]
+
+[[case]]
+name = "same_function_name_different_arity_rejected"
+spec = ["6.1:44"]
+source = "fn choose(value: i32) -> i32 { value }\nfn choose(left: i32, right: i32) -> i32 { left + right }\nfn main() -> i32 { 0 }"
+compile_fail = true
+error_contains = ["E0436", "choose"]
+
+[[case]]
+name = "same_function_name_different_return_type_rejected"
+spec = ["6.1:44"]
+source = "fn result() -> i32 { 1 }\nfn result() -> bool { true }\nfn main() -> i32 { 0 }"
+compile_fail = true
+error_contains = ["E0436", "result"]
+
+[[case]]
+name = "same_function_name_different_parameter_mode_rejected"
+spec = ["6.1:44"]
+source = "fn update(value: i32) -> i32 { value }\nfn update(inout value: i32) -> i32 { value }\nfn main() -> i32 { 0 }"
+compile_fail = true
+error_contains = ["E0436", "update"]
+
 # =============================================================================
 # Function parameters
 # =============================================================================

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -298,7 +298,7 @@ error_contains = "method"
 
 [[case]]
 name = "duplicate_method_name_error"
-spec = ["6.4:16"]
+spec = ["6.4:16", "6.1:44"]
 source = """
 struct Point {
     x: i32,

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -6,7 +6,7 @@ description = "Module-scoped top-level names and extent of analysis (spec chapte
 
 [[case]]
 name = "same_named_functions_across_imported_files_ok"
-spec = ["10.5:2"]
+spec = ["10.5:2", "6.1:44"]
 description = "Two loaded files may define the same top-level function name when each is accessed through its own module"
 source = """
 fn main() -> i32 {

--- a/docs/designs/0087-no-function-overloading-one-name-one-signature.md
+++ b/docs/designs/0087-no-function-overloading-one-name-one-signature.md
@@ -1,0 +1,41 @@
+---
+id: 0087
+title: "No function overloading: one name, one signature per scope"
+status: accepted
+tags: [language, semantics, principle]
+feature-flag: null
+created: 2026-09-10
+accepted: 2026-09-10
+implemented:
+spec-sections: ["6.1:44"]
+superseded-by:
+relates: ["RUE-1894"]
+---
+
+# ADR-0087: No function overloading: one name, one signature per scope
+
+## Status
+
+Accepted on 2026-09-10 by Steve. This record formalizes the current duplicate
+callable-name behavior as a permanent language principle and does not add a
+preview feature or change the implementation.
+
+## Decision
+
+Each callable name denotes one signature within its module or type scope:
+functions, methods, and associated functions cannot be overloaded by parameter
+type, parameter count, return type, or parameter mode, so same-scope duplicate
+callable names are rejected regardless of how their signatures differ. This
+keeps name resolution and tooling from searching overload candidates; APIs
+that need different behavior use distinct names or explicit value/type
+dispatch. The same spelling remains valid in distinct module or type scopes.
+Comptime specialization creates instances of one generic declaration, and
+fixed numeric operator intrinsics are language primitives, not user-defined
+overloads. Future interface primitive tiers are a separate design direction,
+not a claim of shipped functionality.
+
+## References
+
+- [Specification rule 6.1:44](../spec/src/06-items/01-functions.md)
+- [ADR-0025: Compile-Time Execution (comptime)](0025-comptime.md)
+- [ADR-0066: Producer-nominal anonymous types and incremental locality](0066-producer-nominal-anonymous-types-and-incremental-locality.md)

--- a/docs/designs/0089-no-mutable-globals.md
+++ b/docs/designs/0089-no-mutable-globals.md
@@ -1,0 +1,37 @@
+---
+id: 0089
+title: "No mutable globals: immutable module-level values"
+status: accepted
+tags: [language, semantics, ownership, principle]
+feature-flag: null
+created: 2026-09-10
+accepted: 2026-09-10
+implemented:
+spec-sections: []
+superseded-by:
+relates: ["RUE-1896"]
+---
+
+# ADR-0089: No mutable globals: immutable module-level values
+
+## Status
+
+Accepted on 2026-09-10 by Steve. This record ratifies the current module-level
+value-binding policy and does not add a language feature or preview gate.
+
+## Decision
+
+Module-level value bindings are `const` only, so they are immutable
+compile-time values; Rue does not provide ordinary mutable globals or a
+mutable `static` item. Implicit access to mutable global state would hide
+aliases and effects from the call signatures through which ADR-0037's
+fully static exclusivity model expresses access. Future shared runtime state
+must instead use immutable bindings with an explicitly designed
+interior-mutability abstraction, following Rust's general approach. That
+abstraction remains undesigned; this decision introduces no runtime static
+item, interior-mutability API, or change to ADR-0037's enforcement model.
+
+## References
+
+- [Specification note: Module-level Value Bindings](../spec/src/06-items/_index.md#module-level-value-bindings)
+- [ADR-0037: Exclusivity model — access-point-based, statically enforced](0037-exclusivity-model-access-point-based.md)

--- a/docs/designs/0090-no-implicit-conversions.md
+++ b/docs/designs/0090-no-implicit-conversions.md
@@ -1,0 +1,40 @@
+---
+id: 0090
+title: "No implicit conversions: typed values cross boundaries explicitly"
+status: accepted
+tags: [language, types, semantics, principle]
+feature-flag: null
+created: 2026-09-10
+accepted: 2026-09-10
+implemented:
+spec-sections: ["3.11"]
+superseded-by:
+relates: ["RUE-1895"]
+---
+
+# ADR-0090: No implicit conversions: typed values cross boundaries explicitly
+
+## Status
+
+Accepted on 2026-09-10 by Steve. This record ratifies the existing type-boundary
+policy and adds no conversion behavior or preview feature.
+
+## Decision
+
+Rue does not implicitly convert an already-typed value between distinct concrete
+types: integer widths and signedness domains, floating-point widths, integer and
+floating-point domains, string representations, option wrapping, and
+user-defined types require an explicit conversion intrinsic or constructor. The
+never type remains the sole general inference coercion, while contextual typing
+of untyped literals is inference; explicit `borrow`/`inout` view materialization
+for strings and slices remains a parameter-mode operation under the rules cited
+in 3.11 and is not a first-class value conversion. This keeps typed boundaries
+self-describing and prevents hidden loss, allocation, ownership, or runtime
+work; comptime specialization and fixed numeric operator intrinsics do not
+change that rule.
+
+## References
+
+- [Type Inference](../spec/src/03-types/11-type-inference.md)
+- [ADR-0007: Hindley–Milner type inference](0007-hindley-milner-inference.md)
+- [ADR-0043: The collection/string type trio](0043-collection-string-type-trio.md)

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -252,4 +252,5 @@ The table is generated from ADR frontmatter. Run
 | [0087](0087-no-function-overloading-one-name-one-signature.md) | No function overloading: one name, one signature per scope | Accepted | language, semantics, principle |
 | [0088](0088-panic-termination.md) | Panic termination without unwinding or recovery | Accepted | semantics, runtime, ownership, principle |
 | [0089](0089-no-mutable-globals.md) | No mutable globals: immutable module-level values | Accepted | language, semantics, ownership, principle |
+| [0090](0090-no-implicit-conversions.md) | No implicit conversions: typed values cross boundaries explicitly | Accepted | language, types, semantics, principle |
 <!-- ADR-INDEX:END -->

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -251,4 +251,5 @@ The table is generated from ADR frontmatter. Run
 | [0086](0086-no-macros-metaprogramming-never-runs-on-syntax.md) | No macros: metaprogramming never runs on syntax and never introduces names | Accepted | language, syntax, semantics, comptime, tooling, principle |
 | [0087](0087-no-function-overloading-one-name-one-signature.md) | No function overloading: one name, one signature per scope | Accepted | language, semantics, principle |
 | [0088](0088-panic-termination.md) | Panic termination without unwinding or recovery | Accepted | semantics, runtime, ownership, principle |
+| [0089](0089-no-mutable-globals.md) | No mutable globals: immutable module-level values | Accepted | language, semantics, ownership, principle |
 <!-- ADR-INDEX:END -->

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -249,5 +249,6 @@ The table is generated from ADR frontmatter. Run
 | [0084](0084-native-calling-convention.md) | The native Rue calling convention: the target C convention plus a wider return bank | Accepted | abi, codegen, semantics |
 | [0085](0085-persistent-compiler-daemon.md) | Persistent compiler daemon | Accepted | architecture, compiler, incremental, tooling, performance |
 | [0086](0086-no-macros-metaprogramming-never-runs-on-syntax.md) | No macros: metaprogramming never runs on syntax and never introduces names | Accepted | language, syntax, semantics, comptime, tooling, principle |
+| [0087](0087-no-function-overloading-one-name-one-signature.md) | No function overloading: one name, one signature per scope | Accepted | language, semantics, principle |
 | [0088](0088-panic-termination.md) | Panic termination without unwinding or recovery | Accepted | semantics, runtime, ownership, principle |
 <!-- ADR-INDEX:END -->

--- a/docs/spec/src/03-types/11-type-inference.md
+++ b/docs/spec/src/03-types/11-type-inference.md
@@ -105,18 +105,29 @@ fn main() -> i32 {
 {{ rule(id="3.11:8", cat="legality-rule") }}
 
 When an expected type is imposed on an expression, the expression's inferred
-type **MUST** be compatible with it (1.1): the two types are equal, or the
-inferred type coerces to the expected type. There are no implicit conversions
-between distinct concrete integer types; an incompatible type is a compile-time
-error (E0206).
+type **MUST** be compatible with it (1.1): the two types are identical, or an
+explicit rule for that position admits the expression. An already-typed value
+never undergoes an implicit conversion between distinct concrete types. This
+includes integer widths or signedness domains, `f32` and `f64`, integers and
+floating-point values, `str` and `StrBuf`/`Str(N)`, option wrapping, and
+user-defined types; an incompatible value is a compile-time error.
+Explicit conversion intrinsics and constructors are required for such changes.
+Contextual typing of an untyped literal is inference, not conversion of a
+value that already has a type.
 
 {{ rule(id="3.11:9", cat="normative") }}
 
-The only coercion applied during inference is the never type coercing to any
-type (3.4): a diverging expression (type `!`) is accepted in any expected-type
-position. The resolution of an unannotated integer literal to a concrete integer
-type (3.1:14) is inference, not a coercion — the literal has no fixed type until
-it is solved.
+The only general type coercion applied during inference is the never type
+coercing to any type (3.4:3): a diverging expression (type `!`) is accepted in
+any expected-type position. The resolution of an unannotated integer or float
+literal to a concrete type (3.1:14, 3.12:7, 3.12:11) is inference, not a
+coercion — the literal has no fixed type until it is solved. A string literal
+likewise takes its string representation from context (3.7:3, 3.7:44), without
+converting an already-typed string value. The explicit
+argument-position view materializations defined by 3.7:55, 3.7:58, 3.7:60,
+4.10:4, and 7.2:12 are selected by `borrow` or `inout` and remain available;
+they are passing-mode operations, not first-class value conversions. No other
+type difference is accepted.
 
 {{ rule(id="3.11:10") }}
 

--- a/docs/spec/src/03-types/12-floating-point-types.md
+++ b/docs/spec/src/03-types/12-floating-point-types.md
@@ -154,11 +154,11 @@ compile-time error (`E0206`).
 {{ rule(id="3.12:15", cat="informative") }}
 
 Every width or domain change is therefore written explicitly, with one of the
-three conversion intrinsics of the next section. This is the same discipline
-Rue applies to integers, where `@intCast` is required between integer widths,
-and it leaves the never-type coercion of 3.4:3 the language's only coercion:
-giving a literal a type (3.12:7, 3.12:11) is literal typing performed during
-inference, not a conversion of a value that already has one.
+three conversion intrinsics of the next section. This is the general
+no-implicit-conversion discipline of 3.11:8–9; `@intCast` is required between
+integer widths, for example. Giving a literal a type (3.12:7, 3.12:11) is
+literal typing performed during inference, not a conversion of a value that
+already has one.
 
 ## Conversion Intrinsics
 

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -24,6 +24,17 @@ param = IDENT ":" type ;
 
 Parameters **MUST** have explicit type annotations.
 
+{{ rule(id="6.1:44", cat="legality-rule") }}
+
+Within a module or type scope, each user-defined function name denotes exactly
+one signature. Rue does not support overloading by parameter type, parameter
+count, return type, or parameter mode (`inout` or `borrow`); two functions or
+callable members with the same name in one scope are therefore rejected even
+when their signatures differ. A comptime specialization of one generic
+function and a fixed numeric operator intrinsic are not overloads. The same
+spelling **MAY** be used in distinct module or type scopes, where ordinary
+scope resolution selects the declaration.
+
 {{ rule(id="6.1:34", cat="legality-rule") }}
 
 The parameters in a single parameter list **MUST** have distinct names. It is a compile-time error for a function or method to declare two parameters with the same name (for example, `fn f(x: i32, x: i32)`); the diagnostic identifies the second occurrence. A method's `self` receiver is not a named parameter for the purpose of this rule.

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -40,6 +40,15 @@ inside the struct body (6.4), and a user-defined destructor for a named struct
 is a top-level `drop fn` item (3.9). There is no item form that groups
 implementations under a type the way an `impl` block does in other languages.
 
+## Module-level Value Bindings
+
+**Specification note.** Module-level value bindings are `const` only (6.5:1–2)
+and therefore immutable compile-time values. Rue has no module-level `let`,
+`let mut`, or mutable `static` item. ADR-0089 records this policy and the
+direction for future shared runtime state: immutable bindings with an
+explicitly designed interior-mutability abstraction. Such an abstraction
+remains undesigned.
+
 ## Type Name Uniqueness
 
 {{ rule(id="6.0:2", cat="legality-rule") }}


### PR DESCRIPTION
Records three accepted language principles in individual ADRs and their canonical specification sections:

- RUE-1894: one signature per callable name within a scope. Duplicate-function and duplicate-method explanations cite the rule; regression cases cover different signatures, independent scopes, and generic specializations.
- RUE-1895: typed values require explicit conversions. Contextual literal typing, the never type, and explicit borrowed views retain their existing behavior; the float chapter cites the shared inference rule.
- RUE-1896: module-level value bindings are immutable compile-time constants. Future shared runtime state requires a separately designed interior-mutability abstraction under the existing exclusivity model.

Validation: each change passed the 36-target quick suite. Focused no-overloading spec and CLI cases passed, along with the CLI oracle. The inference, string, float, and slice specification suites passed for the conversion rule. The combined tree passed ADR registry, document-link, specification traceability, and compiler-spec index checks after rebasing onto current trunk. No new conversion behavior or mutable-state API is introduced.

Fixes RUE-1894
Fixes RUE-1895
Fixes RUE-1896
