### PR TITLE
RUE-1902: specify panic termination without unwinding

### DIFF
--- a/crates/rue-spec/cases/runtime/traps.toml
+++ b/crates/rue-spec/cases/runtime/traps.toml
@@ -81,3 +81,53 @@ fn main() -> i32 {
 # and cannot be registered as a model gap. The three modeled trap categories
 # above keep their `runtime_error` assertions.
 exit_code = 101
+
+[[case]]
+name = "panic_terminates_without_callee_caller_cleanup_or_later_code"
+spec = ["8.0:1", "8.0:2", "3.9:1", "3.9:28"]
+description = "A panic in a callee runs no callee or caller destructor and skips later user code"
+source = """
+struct Guard { value: i32 }
+
+drop fn Guard(self) {
+    @dbg(self.value);
+}
+
+fn stop(guard: Guard) -> i32 {
+    @panic("stop now");
+    @dbg(88);
+}
+
+fn main() -> i32 {
+    let caller_guard = Guard { value: 2 };
+    stop(Guard { value: 1 });
+    @dbg(99);
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "panic: stop now"
+expected_stdout = ""
+
+[[case]]
+name = "overflow_terminates_without_cleanup_or_later_code"
+spec = ["8.0:2", "8.1:2"]
+description = "An arithmetic trap skips a live destructor and all later user code"
+source = """
+struct Guard { value: i32 }
+
+drop fn Guard(self) {
+    @dbg(self.value);
+}
+
+fn main() -> i32 {
+    let guard = Guard { value: 7 };
+    let maximum: i32 = 2147483647;
+    maximum + 1;
+    @dbg(99);
+    0
+}
+"""
+exit_code = 101
+runtime_error = "integer overflow"
+expected_stdout = ""

--- a/docs/designs/0088-panic-termination.md
+++ b/docs/designs/0088-panic-termination.md
@@ -1,0 +1,76 @@
+---
+id: 0088
+title: Panic termination without unwinding or recovery
+status: accepted
+tags: [semantics, runtime, ownership, principle]
+feature-flag: null
+created: 2026-09-10
+accepted: 2026-09-10
+implemented:
+spec-sections: ["8.0:2"]
+superseded-by:
+relates: ["RUE-1902"]
+---
+
+# ADR-0088: Panic termination without unwinding or recovery
+
+## Status
+
+Accepted on 2026-09-10 by Steve.
+
+## Summary
+
+Rue panics are process-terminating control flow. A panic abandons the current
+evaluation immediately, runs no language-level cleanup, and cannot be observed,
+caught, unwound, recovered, or resumed by Rue code.
+
+## Context
+
+Rue already defines one termination discipline for `@panic`, failed
+assertions, arithmetic traps, bounds violations, and division or remainder by
+zero: the runtime reports the failure and exits with status 101. Destructors
+and `?` introduce two distinct concerns that must remain explicit. A panic
+must not turn into an implicit cleanup path, and recoverable failures need a
+typed representation rather than an implicit handler mechanism.
+
+## Decision
+
+Every Rue panic terminates the process immediately. The panicking callee, its
+callers, and surrounding scopes do not run destructors or other language-level
+cleanup, and no user code after the trap executes. Rue has no handler, catch,
+unwind, recovery, or resume construct for a panic; no language expression can
+consume a panic as a value.
+
+This principle covers explicit `@panic`, failed `@assert`, `@assert_eq`, and
+`@assert_ne`, integer overflow, array bounds violations, division by zero,
+remainder by zero, allocation failure, and other runtime traps defined by the
+specification. The runtime's status-101 and diagnostic details remain owned by
+the applicable runtime-behavior rules.
+
+Recoverable errors use typed values: `Result`, `Option`, or an application
+enum, propagated with `?` as specified by ADR-0038. A host that must continue
+after a panic isolates the work in a subprocess, following ADR-0083's test
+execution model.
+
+This ADR does not decide effect tracking (RUE-225) or broken-pipe policy
+(RUE-510); those concerns are separate from panic termination.
+
+## Consequences
+
+### Positive
+
+- Panic behavior is deterministic and cannot accidentally run user cleanup.
+- The language has no hidden in-process recovery surface to constrain codegen.
+- Recoverable failures remain visible in types and ordinary control flow.
+
+### Negative
+
+- A Rue process cannot recover from a panic in place.
+- Hosts that need fault isolation pay the cost of a subprocess boundary.
+
+## References
+
+- [ADR-0036: Behavior classification preference](0036-behavior-classification-preference.md)
+- [ADR-0038: Error handling: sum types, Result/Option, and must-check via linearity](0038-error-handling-sum-types-result-must-check.md)
+- [ADR-0083: `rue test` MVP](0083-rue-test-mvp.md)
+- [Runtime Behavior, §8](../spec/src/08-runtime-behavior/_index.md)

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -249,4 +249,5 @@ The table is generated from ADR frontmatter. Run
 | [0084](0084-native-calling-convention.md) | The native Rue calling convention: the target C convention plus a wider return bank | Accepted | abi, codegen, semantics |
 | [0085](0085-persistent-compiler-daemon.md) | Persistent compiler daemon | Accepted | architecture, compiler, incremental, tooling, performance |
 | [0086](0086-no-macros-metaprogramming-never-runs-on-syntax.md) | No macros: metaprogramming never runs on syntax and never introduces names | Accepted | language, syntax, semantics, comptime, tooling, principle |
+| [0088](0088-panic-termination.md) | Panic termination without unwinding or recovery | Accepted | semantics, runtime, ownership, principle |
 <!-- ADR-INDEX:END -->

--- a/docs/spec/src/08-runtime-behavior/_index.md
+++ b/docs/spec/src/08-runtime-behavior/_index.md
@@ -30,3 +30,16 @@ must state it rather than cite this paragraph as closed.
 Each is total, deterministic, and observable, so a conforming compiler reproduces
 the same trap on the same input. The following sections state each category
 normatively.
+
+{{ rule(id="8.0:2", cat="normative") }}
+
+A panic terminates the program immediately. No language-level destructor or
+other cleanup runs for the panicking callee, its callers, or any surrounding
+scope, and no user code after the trap executes. Rue provides no language
+construct that observes, catches, unwinds, recovers, or resumes a panic. This
+rule applies to `@panic`, failed `@assert`/`@assert_eq`/`@assert_ne`, integer
+overflow, bounds violations, division or remainder by zero, and every other
+runtime trap defined by this chapter. Recoverable failures are represented as
+typed values such as `Result`, `Option`, or an application enum and propagated
+with `?` (ADR-0038); a host that must survive a panic isolates the work in a
+separate process (ADR-0083).


### PR DESCRIPTION
Record the approved panic-termination principle in ADR-0088 and specification rule 8.0:2: a panic terminates without running destructors, unwinding, or offering recovery to Rue code. Recoverable failures remain typed values; hosts that must survive a panic use process isolation.

Regression cases assert empty stdout when a callee panics or arithmetic overflows with live destructors, proving that cleanup and later user code do not run. Focused tests, `scripts/rue quick`, spec traceability, both oracle corpus checks, and the integrated ADR/documentation gates passed.

Fixes RUE-1902
