### PR TITLE
RUE-2174: make listing, presentation and the toolchain probe cancellable

### DIFF
--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -57,7 +57,11 @@ use import_discovery_owner::ImportDiscoveryOwner;
 pub use metrics::*;
 use program_artifacts::no_published_program;
 pub use rooted_artifacts::*;
-pub(crate) use rooted_projections::{TestClosureAnalysis, TestClosureAnalysisOutcome};
+#[cfg(test)]
+pub(crate) use rooted_projections::{RootedCancellationSite, set_rooted_cancellation_tripwire};
+pub(crate) use rooted_projections::{
+    TestClosureAnalysis, TestClosureAnalysisOutcome, TestInventoryOutcome,
+};
 #[cfg(test)]
 use rooted_projections::{stable_function_definition_root, stable_producer_definition_root};
 

--- a/crates/rue-compiler/src/session/import_discovery_owner/tests.rs
+++ b/crates/rue-compiler/src/session/import_discovery_owner/tests.rs
@@ -73,6 +73,7 @@ fn closed_continuation_for(
         RootedParkOutcome::Errors(errors) => {
             panic!("expected a trusted-toolchain park, got errors: {errors:?}")
         }
+        RootedParkOutcome::Canceled => panic!("an uncanceled probe cannot report cancellation"),
     }
     let token = session
         .closed_discovery_continuation()

--- a/crates/rue-compiler/src/session/rooted_artifacts.rs
+++ b/crates/rue-compiler/src/session/rooted_artifacts.rs
@@ -9,6 +9,11 @@ pub enum RootedParkOutcome {
     Ready,
     Errors(CompileErrors),
     Parked(Box<crate::ParkedToolchainModules>),
+    /// The caller's cancellation token was canceled while the probe ran. The
+    /// probe published nothing about the program: neither readiness nor a
+    /// park nor diagnostics, so the caller must not treat the request as
+    /// settled (RUE-2174).
+    Canceled,
 }
 
 #[derive(Clone)]

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -7,13 +7,58 @@ use super::{
     RootedCodegenOutput, RootedCodegenReadyOutput, RootedParkOutcome,
     RootedPreOptimizationCfgOutput, RootedPreOptimizationCfgUnit, SemanticRequestControl,
     StablePreviewFeatures, collect_rooted_exports, no_published_program, pipeline_abort_errors,
-    sort_rooted_warnings, unresolved_toolchain_park_errors,
+    pipeline_control_errors, sort_rooted_warnings, unresolved_toolchain_park_errors,
 };
 use crate::SemanticInputDescriptor;
 use ahash::AHashMap;
 use rue_air::Node;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+
+/// Where a rooted request can be canceled deterministically by a test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RootedCancellationSite {
+    /// Just before the body-closure request every semantic consumer issues:
+    /// the toolchain probe, a listing, a presentation, and a compile.
+    BodyClosure,
+    /// Just before the CFG batch — raw for a pre-optimization request,
+    /// optimized for every other CFG-side presentation or compile — once the
+    /// body closure has been analyzed.
+    CfgBatch,
+}
+
+/// Deterministic mid-request cancellation for tests (RUE-2174), mirroring
+/// `codegen_query::set_codegen_cancellation_tripwire`: reaching `site` cancels
+/// the armed token before the request at that site is issued, so the stale
+/// attempt must exit through the cancellation contract there rather than
+/// completing or settling anything.
+#[cfg(test)]
+static ROOTED_CANCELLATION_TRIPWIRE: std::sync::Mutex<
+    Option<(rue_query::CancellationToken, RootedCancellationSite)>,
+> = std::sync::Mutex::new(None);
+
+#[cfg(test)]
+pub(crate) fn set_rooted_cancellation_tripwire(
+    tripwire: Option<(rue_query::CancellationToken, RootedCancellationSite)>,
+) {
+    *ROOTED_CANCELLATION_TRIPWIRE.lock().unwrap() = tripwire;
+}
+
+/// One tripwire probe. Free of cost outside test builds.
+fn rooted_cancellation_probe(site: RootedCancellationSite) {
+    #[cfg(test)]
+    {
+        let mut slot = ROOTED_CANCELLATION_TRIPWIRE.lock().unwrap();
+        if let Some((token, armed)) = slot.as_ref()
+            && *armed == site
+        {
+            token.cancel();
+            *slot = None;
+        }
+    }
+    #[cfg(not(test))]
+    let _ = site;
+}
 
 impl CompilerSession {
     /// The call site that demanded `failing`, for a diagnostic raised inside a
@@ -272,6 +317,7 @@ impl CompilerSession {
         // runtime (RUE-1223).
         let _body_closure_collection_span =
             tracing::info_span!("body_closure_collection", phase = "semantic_analysis").entered();
+        rooted_cancellation_probe(RootedCancellationSite::BodyClosure);
         let request = self
             .queries
             .revisioned
@@ -705,22 +751,28 @@ impl CompilerSession {
         &mut self,
         options: &CompileOptions,
     ) -> Result<RootedCfgOutput, CompileErrors> {
+        self.rooted_cfg_request(options, rue_query::CancellationToken::new())
+            .map_err(|control| pipeline_control_errors("rooted CFG", control))
+    }
+
+    /// [`Self::rooted_cfg`] under a caller's cancellation token, keeping the
+    /// differential oracle's injected semantic fault on the same path so a
+    /// cancellable presentation observes exactly what the uncancellable one
+    /// does (RUE-2174).
+    pub(crate) fn rooted_cfg_request(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: rue_query::CancellationToken,
+    ) -> Result<RootedCfgOutput, PipelineRequestControl> {
         if self.oracle_fault == Some(crate::unstable::DifferentialOracleFault::Semantic) {
             self.oracle_fault.take();
-            return Err(CompileErrors::from(CompileError::without_span(
-                ErrorKind::InternalError("differential semantic fault".into()),
+            return Err(PipelineRequestControl::Compile(CompileErrors::from(
+                CompileError::without_span(ErrorKind::InternalError(
+                    "differential semantic fault".into(),
+                )),
             )));
         }
-        match self.rooted_cfg_with_cancellation(options, rue_query::CancellationToken::new()) {
-            Ok(output) => Ok(output),
-            Err(PipelineRequestControl::Compile(errors)) => Err(errors),
-            Err(PipelineRequestControl::Abort(abort)) => {
-                Err(pipeline_abort_errors("rooted CFG", abort))
-            }
-            Err(PipelineRequestControl::Parked(park)) => {
-                Err(unresolved_toolchain_park_errors(&park))
-            }
-        }
+        self.rooted_cfg_with_cancellation(options, cancellation)
     }
 
     /// The request's ordered test inventory, analyzed but not lowered, with the
@@ -738,29 +790,56 @@ impl CompilerSession {
         &mut self,
         options: &CompileOptions,
     ) -> Result<RootedTestInventory, CompileErrors> {
+        match self.cancellable_test_inventory(options, rue_query::CancellationToken::new()) {
+            TestInventoryOutcome::Listed(listing) => Ok(listing),
+            TestInventoryOutcome::Errors(errors) => Err(errors),
+            // The token this passed can never be canceled: nobody else holds it.
+            TestInventoryOutcome::Canceled => {
+                unreachable!("an uncancelled test inventory cannot report cancellation")
+            }
+        }
+    }
+
+    /// [`Self::rooted_test_inventory`] under a caller's cancellation token,
+    /// for a retained host whose listing request can be abandoned (RUE-2174).
+    ///
+    /// Cancellation is an outcome rather than an error for the same reason it
+    /// is one for the test-closure analysis: it says nothing about the program,
+    /// so neither a partial inventory nor diagnostics may be reported for it.
+    pub(crate) fn cancellable_test_inventory(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: rue_query::CancellationToken,
+    ) -> TestInventoryOutcome {
         // A listing reports declarations, so a test whose body does not analyze
         // is still listed: its declaration parsed, and the inventory is built
         // from the declaration projection rather than from the bodies
         // (ADR-0083 §3). Only a rejection that reaches no inventory at all —
         // one the request itself refused, before roots existed — stops it.
-        let (inventory, diagnostics) = match self
-            .rooted_body_graph_attempt(options, rue_query::CancellationToken::new())
-            .map_err(|control| semantic_control_errors("rooted test inventory", control))?
-        {
-            RootedBodyGraphAttempt::Graph(graph) => {
+        let (inventory, diagnostics) = match self.rooted_body_graph_attempt(options, cancellation) {
+            Ok(RootedBodyGraphAttempt::Graph(graph)) => {
                 (Arc::clone(&graph.test_inventory), CompileErrors::default())
             }
-            RootedBodyGraphAttempt::Rejected(rejection) => {
+            Ok(RootedBodyGraphAttempt::Rejected(rejection)) => {
                 if rejection.global {
-                    return Err(rejection.into_errors());
+                    return TestInventoryOutcome::Errors(rejection.into_errors());
                 }
                 (
                     Arc::clone(&rejection.test_inventory),
                     rejection.body_diagnostics(),
                 )
             }
+            Err(SemanticRequestControl::Abort(rue_query::QueryAbort::Canceled)) => {
+                return TestInventoryOutcome::Canceled;
+            }
+            Err(control) => {
+                return TestInventoryOutcome::Errors(semantic_control_errors(
+                    "rooted test inventory",
+                    control,
+                ));
+            }
         };
-        Ok(RootedTestInventory {
+        TestInventoryOutcome::Listed(RootedTestInventory {
             entries: inventory.iter().map(|test| test.entry.clone()).collect(),
             diagnostics,
         })
@@ -1213,6 +1292,9 @@ impl CompilerSession {
                 ),
             );
         }
+        // Both CFG batches — the raw one a pre-optimization request issues and
+        // the optimized one every other consumer issues — follow this point.
+        rooted_cancellation_probe(RootedCancellationSite::CfgBatch);
         if pre_optimization {
             let raw_requests = cfg_inputs
                 .iter()
@@ -1841,6 +1923,11 @@ impl CompilerSession {
         }))
     }
 
+    /// [`Self::rooted_codegen_with_cancellation`] under a token nobody can
+    /// cancel, for tests that want the plain artifact. Production consumers —
+    /// the presentation batch and the compile endpoints — carry their
+    /// request's token instead (RUE-2174).
+    #[cfg(test)]
     pub(crate) fn rooted_codegen(
         &mut self,
         options: &CompileOptions,
@@ -2418,17 +2505,45 @@ impl CompilerSession {
         self.queries.revisioned.query_evictions_for_test()
     }
 
+    /// [`Self::rooted_or_toolchain_park_with_cancellation`] under a token
+    /// nobody can cancel, for tests of the park itself. The production
+    /// acquisition loop always carries its request's token (RUE-2174).
+    #[cfg(test)]
     pub(crate) fn rooted_or_toolchain_park(
         &mut self,
         options: &CompileOptions,
     ) -> RootedParkOutcome {
-        match self.rooted_body_graph_with_cancellation(options, rue_query::CancellationToken::new())
-        {
+        match self.rooted_or_toolchain_park_with_cancellation(
+            options,
+            rue_query::CancellationToken::new(),
+        ) {
+            // The token this passed can never be canceled: nobody else holds it.
+            RootedParkOutcome::Canceled => {
+                unreachable!("an uncancelled toolchain probe cannot report cancellation")
+            }
+            outcome => outcome,
+        }
+    }
+
+    /// [`Self::rooted_or_toolchain_park`] under a caller's cancellation token
+    /// (RUE-2174): the host's acquisition loop hands the admitted request's
+    /// token to the semantic probe itself, so a canceled request stops inside
+    /// a long body-closure analysis rather than only between acquisition
+    /// rounds. A canceled probe attaches no park and settles nothing.
+    pub(crate) fn rooted_or_toolchain_park_with_cancellation(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: rue_query::CancellationToken,
+    ) -> RootedParkOutcome {
+        match self.rooted_body_graph_with_cancellation(options, cancellation) {
             Ok(_) => RootedParkOutcome::Ready,
             Err(SemanticRequestControl::Compile(errors)) => RootedParkOutcome::Errors(errors),
             Err(SemanticRequestControl::Parked(park)) => {
                 self.attach_toolchain_park(&park);
                 RootedParkOutcome::Parked(park)
+            }
+            Err(SemanticRequestControl::Abort(rue_query::QueryAbort::Canceled)) => {
+                RootedParkOutcome::Canceled
             }
             Err(SemanticRequestControl::Abort(abort)) => {
                 panic!("uncanceled rooted body-closure request aborted: {abort:?}")
@@ -3578,6 +3693,18 @@ pub(crate) struct TestClosureAnalysis {
     /// reach it. This is what stderr publishes; the copies attached to each
     /// failed test are the attribution convenience (ADR-0083 §3).
     pub(crate) diagnostics: CompileErrors,
+}
+
+/// What a cancellable test inventory answered (RUE-2174).
+pub(crate) enum TestInventoryOutcome {
+    Listed(RootedTestInventory),
+    /// The request was refused before any inventory existed; a per-body
+    /// failure is listed beside the inventory instead.
+    Errors(CompileErrors),
+    /// The caller abandoned the request. Nothing is reported: a partial
+    /// inventory or its diagnostics would describe a request nobody is
+    /// waiting for.
+    Canceled,
 }
 
 /// What a cancellable test-closure analysis answered (RUE-2023).

--- a/crates/rue-compiler/src/session/tests.rs
+++ b/crates/rue-compiler/src/session/tests.rs
@@ -982,6 +982,7 @@ fn absent_trusted_option_parks_the_rooted_attempt_with_exact_demand_and_anchor()
         RootedParkOutcome::Errors(errors) => {
             panic!("expected a trusted-toolchain park, got errors: {errors:?}")
         }
+        RootedParkOutcome::Canceled => panic!("an uncanceled probe cannot report cancellation"),
     };
 
     // Exact demand set: exactly the trusted std `Option` module.
@@ -1003,6 +1004,160 @@ fn absent_trusted_option_parks_the_rooted_attempt_with_exact_demand_and_anchor()
         !session.queries.revisioned.any_body_transaction_terminal(),
         "the park must precede any body transaction",
     );
+}
+
+/// RUE-2174: the toolchain probe runs under the request's own token. A
+/// request canceled before admission or during its body-closure work settles
+/// nothing — no terminal, no park, no diagnostics — and the next probe over
+/// the same session parks with the exact demand a fresh session would.
+#[test]
+fn canceled_toolchain_probe_settles_nothing_and_recovers() {
+    let source = snapshot(
+        &[(
+            1,
+            "/p/main.rue",
+            "main.rue",
+            "fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }",
+        )],
+        1,
+    );
+    let mut session = CompilerSession::new();
+    session.update(&source).into_result().unwrap();
+    let options = CompileOptions::default();
+
+    // Before admission.
+    let canceled = rue_query::CancellationToken::new();
+    canceled.cancel();
+    assert!(matches!(
+        session.rooted_or_toolchain_park_with_cancellation(&options, canceled),
+        RootedParkOutcome::Canceled
+    ));
+    assert!(!session.queries.revisioned.any_body_transaction_terminal());
+
+    // During the body-closure work every semantic consumer shares.
+    let token = rue_query::CancellationToken::new();
+    crate::session::set_rooted_cancellation_tripwire(Some((
+        token.clone(),
+        crate::session::RootedCancellationSite::BodyClosure,
+    )));
+    let outcome = session.rooted_or_toolchain_park_with_cancellation(&options, token.clone());
+    crate::session::set_rooted_cancellation_tripwire(None);
+    assert!(token.is_canceled(), "the tripwire must have fired");
+    assert!(matches!(outcome, RootedParkOutcome::Canceled));
+    assert!(!session.queries.revisioned.any_body_transaction_terminal());
+
+    // Recovery: a live request parks with exactly the demand a fresh session
+    // reports, so the canceled attempts left no park attached and no state
+    // behind.
+    let park = match session
+        .rooted_or_toolchain_park_with_cancellation(&options, rue_query::CancellationToken::new())
+    {
+        RootedParkOutcome::Parked(park) => park,
+        RootedParkOutcome::Ready => panic!("expected a trusted-toolchain park"),
+        RootedParkOutcome::Errors(errors) => panic!("expected a park, got errors: {errors:?}"),
+        RootedParkOutcome::Canceled => panic!("a live token cannot report cancellation"),
+    };
+    let demands: Vec<&str> = park
+        .demands()
+        .iter()
+        .map(crate::TrustedToolchainModuleDemand::logical_path)
+        .collect();
+    assert_eq!(demands, vec![crate::OPTION_MODULE_LOGICAL_PATH]);
+    assert_eq!(park.requesters().len(), 1);
+    assert_eq!(park.requesters()[0].name(), "main");
+}
+
+/// RUE-2174: a listing canceled before admission or during its closure
+/// analysis reports neither a partial inventory nor diagnostics, and the next
+/// listing over the same session is byte-for-byte the fresh one: every test
+/// listed, the broken one's diagnostics beside it.
+#[test]
+fn canceled_test_inventory_reports_nothing_and_recovers() {
+    let source = snapshot(
+        &[(
+            1,
+            "/p/main.rue",
+            "main.rue",
+            "fn main() -> i32 { 0 }\n\
+             test \"broken\" { let _bad: i32 = true; }\n\
+             test \"fine\" { }\n",
+        )],
+        1,
+    );
+    let options = test_declaration_options(crate::RootSelection::Tests);
+    let mut session = CompilerSession::new();
+    session.update(&source).into_result().unwrap();
+
+    let canceled = crate::unstable::CompilationCancellation::new();
+    canceled.cancel();
+    assert!(matches!(
+        crate::unstable::cancellable_test_inventory(&mut session, &options, canceled),
+        crate::unstable::CancellableTestListingOutcome::Canceled
+    ));
+
+    let cancellation = crate::unstable::CompilationCancellation::new();
+    let probe = rue_query::CancellationToken::new();
+    crate::session::set_rooted_cancellation_tripwire(Some((
+        probe.clone(),
+        crate::session::RootedCancellationSite::BodyClosure,
+    )));
+    // The tripwire cancels the query token; the host-facing handle observes it
+    // through the same shared state.
+    let outcome = crate::unstable::cancellable_test_inventory(
+        &mut session,
+        &options,
+        cancellation_from_token(&probe),
+    );
+    crate::session::set_rooted_cancellation_tripwire(None);
+    assert!(probe.is_canceled(), "the tripwire must have fired");
+    assert!(matches!(
+        outcome,
+        crate::unstable::CancellableTestListingOutcome::Canceled
+    ));
+    drop(cancellation);
+
+    let listed = match crate::unstable::cancellable_test_inventory(
+        &mut session,
+        &options,
+        crate::unstable::CompilationCancellation::new(),
+    ) {
+        crate::unstable::CancellableTestListingOutcome::Completed(listing) => listing,
+        crate::unstable::CancellableTestListingOutcome::Errors(errors) => {
+            panic!("a live listing analyzes: {errors:?}")
+        }
+        crate::unstable::CancellableTestListingOutcome::Canceled => {
+            panic!("a live token cannot report cancellation")
+        }
+    };
+    let mut fresh = CompilerSession::new();
+    fresh.update(&source).into_result().unwrap();
+    let expected = crate::unstable::test_inventory(&mut fresh, &options).unwrap();
+    assert_eq!(listed.inventory, expected.inventory);
+    assert_eq!(
+        listed.failure_diagnostics.as_slice(),
+        expected.failure_diagnostics.as_slice()
+    );
+    let ids = listed
+        .inventory
+        .entries
+        .iter()
+        .map(|entry| entry.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["main.rue::broken", "main.rue::fine"]);
+    assert!(
+        listed
+            .failure_diagnostics
+            .iter()
+            .any(|error| matches!(error.kind, rue_error::ErrorKind::TypeMismatch { .. }))
+    );
+}
+
+/// The host-facing cancellation handle over a query token a test already
+/// holds, so a tripwire armed on the token is observed by the request.
+fn cancellation_from_token(
+    token: &rue_query::CancellationToken,
+) -> crate::unstable::CompilationCancellation {
+    crate::unstable::CompilationCancellation::from_token_for_test(token.clone())
 }
 
 #[test]
@@ -1033,6 +1188,7 @@ fn already_reached_parks_batch_into_one_park_with_unioned_demands_and_anchors() 
         RootedParkOutcome::Errors(errors) => {
             panic!("expected a batched park, got errors: {errors:?}")
         }
+        RootedParkOutcome::Canceled => panic!("an uncanceled probe cannot report cancellation"),
     };
 
     // Union of absent modules across both already-reached bodies, sorted.

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -540,12 +540,17 @@ pub use crate::session::{
 };
 
 /// Run the production body-closure root without constructing a presentation
-/// artifact.
-pub fn rooted_or_toolchain_park(
+/// artifact, under the request's cancellation (RUE-2174): a host's
+/// acquisition loop hands its admitted request's token to the semantic probe
+/// itself, so an abandoned request stops inside a long body-closure analysis
+/// rather than only between acquisition rounds. A canceled probe reports
+/// [`RootedParkOutcome::Canceled`] and settles nothing.
+pub fn rooted_or_toolchain_park_with_cancellation(
     session: &mut crate::CompilerSession,
     options: &crate::CompileOptions,
+    cancellation: &CompilationCancellation,
 ) -> RootedParkOutcome {
-    session.rooted_or_toolchain_park(options)
+    session.rooted_or_toolchain_park_with_cancellation(options, cancellation.token.clone())
 }
 
 /// Discard protocol-only state from a superseded filesystem observation while
@@ -801,6 +806,45 @@ pub fn test_inventory(
     })
 }
 
+/// Host-facing outcome of a cancellable listing (RUE-2174).
+///
+/// The counterpart of [`CancellableTestImageOutcome`] for `rue test --list`:
+/// a retained host answers the listing under the request's token, and a
+/// request the client abandoned reports neither an inventory nor diagnostics.
+pub enum CancellableTestListingOutcome {
+    Completed(TestListing),
+    Errors(crate::CompileErrors),
+    Canceled,
+}
+
+/// [`test_inventory`] with cooperative cancellation (RUE-2174). The listing's
+/// semantics are unchanged: a broken test is still listed beside its
+/// diagnostics, and only a request refused before any inventory existed is
+/// an error.
+pub fn cancellable_test_inventory(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+    cancellation: CompilationCancellation,
+) -> CancellableTestListingOutcome {
+    if let Err(errors) = require_test_root_selection(options) {
+        return CancellableTestListingOutcome::Errors(errors);
+    }
+    match session.cancellable_test_inventory(options, cancellation.token) {
+        crate::session::TestInventoryOutcome::Listed(listing) => {
+            CancellableTestListingOutcome::Completed(TestListing {
+                inventory: TestInventory {
+                    entries: listing.entries,
+                },
+                failure_diagnostics: listing.diagnostics,
+            })
+        }
+        crate::session::TestInventoryOutcome::Errors(errors) => {
+            CancellableTestListingOutcome::Errors(errors)
+        }
+        crate::session::TestInventoryOutcome::Canceled => CancellableTestListingOutcome::Canceled,
+    }
+}
+
 /// One test excluded from a test image because its closure failed to analyze.
 ///
 /// The test keeps its `ordinal` — ordinals are the inventory's own indices, so
@@ -1017,6 +1061,13 @@ pub struct CompilationCancellation {
 impl CompilationCancellation {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Wrap a query token a test already holds, so a tripwire armed on that
+    /// token is the cancellation the host-facing request observes.
+    #[cfg(test)]
+    pub(crate) fn from_token_for_test(token: rue_query::CancellationToken) -> Self {
+        Self { token }
     }
 
     pub fn cancel(&self) {
@@ -1428,9 +1479,24 @@ impl crate::CompilerSession {
         &mut self,
         request: PresentationBatchRequest<'_>,
     ) -> Result<Vec<PresentationOutput>, crate::CompileErrors> {
+        self.present_many_with_cancellation(request, rue_query::CancellationToken::new())
+            .map_err(|control| crate::session::pipeline_control_errors("presentation", control))
+    }
+
+    /// [`Self::unstable_present_many`] under a caller's cancellation token
+    /// (RUE-2174). This is the one presentation implementation: the CFG-side
+    /// and backend families each run their rooted request under the token, so
+    /// an abandoned `--emit` request stops inside that work rather than after
+    /// it, and the uncancellable facade above is this with a token nobody can
+    /// cancel.
+    pub(crate) fn present_many_with_cancellation(
+        &mut self,
+        request: PresentationBatchRequest<'_>,
+        cancellation: rue_query::CancellationToken,
+    ) -> Result<Vec<PresentationOutput>, crate::session::PipelineRequestControl> {
         let invalid_input = |message: String| {
-            crate::CompileErrors::from(crate::CompileError::without_span(
-                crate::ErrorKind::InvalidCompilerInput(message),
+            crate::session::PipelineRequestControl::Compile(crate::CompileErrors::from(
+                crate::CompileError::without_span(crate::ErrorKind::InvalidCompilerInput(message)),
             ))
         };
         let program = self.published_owner().cloned().ok_or_else(|| {
@@ -1527,7 +1593,9 @@ impl crate::CompilerSession {
                     }
                 }
                 PresentationStage::Rir => {
-                    let rir = self.canonical_rir()?;
+                    let rir = self
+                        .canonical_rir()
+                        .map_err(crate::session::PipelineRequestControl::Compile)?;
                     let order = rir.presentation_order(request.file_order.iter().copied());
                     write!(
                         &mut text,
@@ -1547,7 +1615,11 @@ impl crate::CompilerSession {
                 | PresentationStage::RegAlloc
                 | PresentationStage::Asm => {
                     if codegen.is_none() {
-                        codegen = Some(self.rooted_codegen(request.options, backend_request)?);
+                        codegen = Some(self.rooted_codegen_with_cancellation(
+                            request.options,
+                            backend_request,
+                            cancellation.clone(),
+                        )?);
                     }
                     let rooted = codegen.as_ref().expect("computed above");
                     warnings = rooted.warnings.clone();
@@ -1560,7 +1632,8 @@ impl crate::CompilerSession {
                 | PresentationStage::StackFrame
                 | PresentationStage::Abi => {
                     if rooted_cfg.is_none() {
-                        rooted_cfg = Some(self.rooted_cfg(request.options)?);
+                        rooted_cfg =
+                            Some(self.rooted_cfg_request(request.options, cancellation.clone())?);
                     }
                     let rooted = rooted_cfg.as_ref().expect("computed above");
                     warnings = rooted.warnings.clone();
@@ -1581,6 +1654,32 @@ impl crate::CompilerSession {
             outputs.push(PresentationOutput { text, warnings });
         }
         Ok(outputs)
+    }
+}
+
+/// Host-facing outcome of a cancellable presentation batch (RUE-2174).
+pub enum CancellablePresentationOutcome {
+    Completed(Vec<PresentationOutput>),
+    Errors(crate::CompileErrors),
+    Canceled,
+}
+
+/// [`crate::CompilerSession::unstable_present_many`] with cooperative
+/// cancellation (RUE-2174), for a retained host whose analysis-only request
+/// can be abandoned while its CFG-side or backend family is being computed.
+pub fn cancellable_present_many(
+    session: &mut crate::CompilerSession,
+    request: PresentationBatchRequest<'_>,
+    cancellation: CompilationCancellation,
+) -> CancellablePresentationOutcome {
+    match session.present_many_with_cancellation(request, cancellation.token) {
+        Ok(outputs) => CancellablePresentationOutcome::Completed(outputs),
+        Err(crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)) => {
+            CancellablePresentationOutcome::Canceled
+        }
+        Err(control) => CancellablePresentationOutcome::Errors(
+            crate::session::pipeline_control_errors("presentation", control),
+        ),
     }
 }
 
@@ -1746,6 +1845,91 @@ mod codegen_unit_tests {
 
     fn borrow_accessor_options() -> crate::CompileOptions {
         crate::CompileOptions::default()
+    }
+
+    /// RUE-2174: a presentation canceled before admission, during its
+    /// body-closure work, during its CFG batch, or inside the backend kernel
+    /// reports nothing, and the next presentation over the same session equals
+    /// a fresh session's.
+    #[test]
+    fn canceled_presentation_reports_nothing_and_recovers() {
+        let snapshot = crate::SourceSnapshot::single(
+            "main.rue",
+            "fn add(x: i32) -> i32 { x + 1 } fn main() -> i32 { add(41) }",
+        )
+        .unwrap();
+        let options = crate::CompileOptions::default();
+        let order = snapshot
+            .files()
+            .map(|file| file.file_id)
+            .collect::<Vec<_>>();
+        let mut session = crate::CompilerSession::new();
+        crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
+        let request = |stages: &'static [PresentationStage]| PresentationBatchRequest {
+            stages,
+            options: &options,
+            file_order: &order,
+        };
+        const CFG_SIDE: &[PresentationStage] = &[PresentationStage::Air];
+        const BACKEND: &[PresentationStage] = &[PresentationStage::Asm];
+
+        let canceled = CompilationCancellation::new();
+        canceled.cancel();
+        assert!(matches!(
+            cancellable_present_many(&mut session, request(CFG_SIDE), canceled),
+            CancellablePresentationOutcome::Canceled
+        ));
+
+        for site in [
+            crate::session::RootedCancellationSite::BodyClosure,
+            crate::session::RootedCancellationSite::CfgBatch,
+        ] {
+            let token = rue_query::CancellationToken::new();
+            crate::session::set_rooted_cancellation_tripwire(Some((token.clone(), site)));
+            let outcome = cancellable_present_many(
+                &mut session,
+                request(CFG_SIDE),
+                CompilationCancellation::from_token_for_test(token.clone()),
+            );
+            crate::session::set_rooted_cancellation_tripwire(None);
+            assert!(token.is_canceled(), "the {site:?} tripwire must have fired");
+            assert!(
+                matches!(outcome, CancellablePresentationOutcome::Canceled),
+                "a request canceled at {site:?} reports cancellation"
+            );
+        }
+
+        let token = rue_query::CancellationToken::new();
+        crate::codegen_query::set_codegen_cancellation_tripwire(Some((token.clone(), 1)));
+        let outcome = cancellable_present_many(
+            &mut session,
+            request(BACKEND),
+            CompilationCancellation::from_token_for_test(token.clone()),
+        );
+        crate::codegen_query::set_codegen_cancellation_tripwire(None);
+        assert!(token.is_canceled(), "the backend tripwire must have fired");
+        assert!(matches!(outcome, CancellablePresentationOutcome::Canceled));
+
+        let mut fresh = crate::CompilerSession::new();
+        crate::publish_test_snapshot(&mut fresh, &snapshot).unwrap();
+        for stages in [CFG_SIDE, BACKEND] {
+            let recovered = match cancellable_present_many(
+                &mut session,
+                request(stages),
+                CompilationCancellation::new(),
+            ) {
+                CancellablePresentationOutcome::Completed(outputs) => outputs,
+                CancellablePresentationOutcome::Errors(errors) => {
+                    panic!("a live presentation renders: {errors:?}")
+                }
+                CancellablePresentationOutcome::Canceled => {
+                    panic!("a live token cannot report cancellation")
+                }
+            };
+            let expected = fresh.unstable_present_many(request(stages)).unwrap();
+            assert_eq!(recovered, expected);
+            assert!(!recovered[0].as_str().is_empty());
+        }
     }
 
     /// RUE-1728: the backend stages are projections of one code generation, so

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -3,12 +3,13 @@ use std::path::{Path, PathBuf};
 use rue_compiler::unstable::TestCandidateInventory;
 use rue_compiler::unstable::normalize_module_path;
 use rue_compiler::unstable::{
-    CancellableCompileOutcome, CancellableTestImageOutcome, CodegenReady, CompilationCancellation,
-    ObjectsReady, PresentationBatchRequest, PresentationOutput, PresentationRequest, TestImage,
-    TestListing, UnimportedTestFile, cancellable_executable_in_compile_scope,
-    cancellable_test_image_in_compile_scope, codegen_ready, executable_in_compile_scope,
-    objects_ready, runnable_ready, test_image_in_compile_scope, test_inventory,
-    unimported_test_files,
+    CancellableCompileOutcome, CancellablePresentationOutcome, CancellableTestImageOutcome,
+    CancellableTestListingOutcome, CodegenReady, CompilationCancellation, ObjectsReady,
+    PresentationBatchRequest, PresentationOutput, PresentationRequest, TestImage, TestListing,
+    UnimportedTestFile, cancellable_executable_in_compile_scope, cancellable_present_many,
+    cancellable_test_image_in_compile_scope, cancellable_test_inventory, codegen_ready,
+    executable_in_compile_scope, objects_ready, runnable_ready, test_image_in_compile_scope,
+    test_inventory, unimported_test_files,
 };
 use rue_compiler::{
     AcceptedReadManifest, CompileErrors, CompileOptions, CompileOutput, CompilerSessionConfig,
@@ -18,7 +19,7 @@ use rue_compiler::{
 
 use crate::source_loader::{
     AttemptedRead, ImportDiscoveryResult, SourceLoadError, SourceLoadRequest, WatchInput,
-    acquire_reached_toolchain_modules, acquire_reached_toolchain_modules_superseding, load,
+    acquire_reached_toolchain_modules, acquire_reached_toolchain_modules_cancellable, load,
     reload_from_filesystem,
 };
 
@@ -136,17 +137,18 @@ impl FilesystemCompilerHost {
     }
 
     /// Acquire like [`Self::acquire_reached_toolchain_modules`], aborting
-    /// promptly with [`SourceLoadError::Superseded`] once `supersession`
-    /// reports a newer source revision (RUE-1863). A superseded acquisition
-    /// never exposes partial state: a pre-commit abort keeps the prior state,
-    /// while a signal observed after publication may retain that one coherent
-    /// committed acquisition round.
-    pub fn acquire_reached_toolchain_modules_superseding(
+    /// promptly with [`SourceLoadError::Superseded`] once `cancellation` is
+    /// canceled (RUE-1863, RUE-2174): between rounds, inside a round's reads,
+    /// and inside the semantic probe that discovers each round's demands. A
+    /// canceled acquisition never exposes partial state: a pre-commit abort
+    /// keeps the prior state, while a cancellation observed after publication
+    /// may retain that one coherent committed acquisition round.
+    pub fn acquire_reached_toolchain_modules_cancellable(
         &mut self,
         options: &CompileOptions,
-        supersession: &dyn Fn() -> bool,
+        cancellation: &CompilationCancellation,
     ) -> Result<(), SourceLoadError> {
-        acquire_reached_toolchain_modules_superseding(&mut self.state, options, Some(supersession))
+        acquire_reached_toolchain_modules_cancellable(&mut self.state, options, cancellation)
     }
 
     pub fn source_snapshot(&self) -> &SourceSnapshot {
@@ -265,6 +267,17 @@ impl FilesystemCompilerHost {
         self.state.session.unstable_present_many(request)
     }
 
+    /// Produce the presentations like [`Self::present_many`], under a caller's
+    /// cancellation token (RUE-2174), so a retained host can abandon an
+    /// analysis-only request during its CFG-side or backend work.
+    pub fn cancellable_present_many(
+        &mut self,
+        request: PresentationBatchRequest<'_>,
+        cancellation: CompilationCancellation,
+    ) -> CancellablePresentationOutcome {
+        cancellable_present_many(&mut self.state.session, request, cancellation)
+    }
+
     /// Discovery's own diagnostics when this revision's import graph did not
     /// close valid, and nothing when it did.
     ///
@@ -320,6 +333,20 @@ impl FilesystemCompilerHost {
     pub fn test_inventory(&mut self, options: &CompileOptions) -> MultiErrorResult<TestListing> {
         self.closed_discovery()?;
         test_inventory(&mut self.state.session, options)
+    }
+
+    /// Answer the listing like [`Self::test_inventory`], under a caller's
+    /// cancellation token (RUE-2174), so a retained host can abandon a
+    /// `rue test --list` request whose client has gone away.
+    pub fn cancellable_test_inventory(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: CompilationCancellation,
+    ) -> CancellableTestListingOutcome {
+        if let Err(errors) = self.closed_discovery() {
+            return CancellableTestListingOutcome::Errors(errors);
+        }
+        cancellable_test_inventory(&mut self.state.session, options, cancellation)
     }
 
     /// Link the test image for the request's closure and publish the inventory

--- a/crates/rue/src/host_workflow_tests.rs
+++ b/crates/rue/src/host_workflow_tests.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rue_compiler::unstable::{
+    CancellablePresentationOutcome, CancellableTestListingOutcome, CompilationCancellation,
     EndpointWork, PresentationBatchRequest, PresentationOutput, PresentationStage,
     QueryRuntimeMetrics, TestImage, TestListing,
 };
@@ -13,7 +14,7 @@ use rue_compiler::{
 };
 use rue_error::ErrorKind;
 
-use crate::{FilesystemCompilerHost, HostOpenRequest, HostPathContext};
+use crate::{FilesystemCompilerHost, HostOpenRequest, HostPathContext, SourceLoadError};
 
 struct Project(PathBuf);
 
@@ -281,6 +282,100 @@ test \"fine\" { let _value = shared(6); }\n",
     );
     // Excluding broken from the runnable image must not change later roots.
     assert_listing_eq(&listing(&mut retained).unwrap(), &listed);
+}
+
+/// RUE-2174: acquisition, listing, and presentation each run under the
+/// request's cancellation. A canceled request reports nothing — no partial
+/// inventory, no diagnostics, no presentation — and the same retained host
+/// then answers a live request exactly as a fresh host does.
+#[test]
+fn canceled_requests_report_nothing_and_the_host_recovers() {
+    let project = Project::new();
+    project.write(
+        "\
+fn shared(x: i32) -> i32 { x + 1 }\n\
+fn main() -> i32 { shared(6) }\n\
+test \"broken\" { let _bad: i32 = true; }\n\
+test \"fine\" { let _value = shared(6); }\n",
+    );
+    let mut retained = project.open();
+    let test_options = options(RootSelection::Tests);
+    let executable_options = options(RootSelection::Executable);
+    let file_order = retained
+        .source_snapshot()
+        .files()
+        .map(|source| source.file_id)
+        .collect::<Vec<_>>();
+    const AIR: &[PresentationStage] = &[PresentationStage::Air];
+    fn air_request<'a>(
+        options: &'a CompileOptions,
+        file_order: &'a [rue_compiler::FileId],
+    ) -> PresentationBatchRequest<'a> {
+        PresentationBatchRequest {
+            stages: AIR,
+            options,
+            file_order,
+        }
+    }
+
+    let canceled = CompilationCancellation::new();
+    canceled.cancel();
+    assert!(matches!(
+        retained.acquire_reached_toolchain_modules_cancellable(&test_options, &canceled),
+        Err(SourceLoadError::Superseded)
+    ));
+    assert!(matches!(
+        retained.cancellable_test_inventory(&test_options, canceled.clone()),
+        CancellableTestListingOutcome::Canceled
+    ));
+    assert!(matches!(
+        retained.cancellable_present_many(
+            air_request(&executable_options, &file_order),
+            canceled.clone()
+        ),
+        CancellablePresentationOutcome::Canceled
+    ));
+
+    let live = CompilationCancellation::new();
+    retained
+        .acquire_reached_toolchain_modules_cancellable(&test_options, &live)
+        .expect("a live acquisition settles");
+    let listed = match retained.cancellable_test_inventory(&test_options, live.clone()) {
+        CancellableTestListingOutcome::Completed(listing) => listing,
+        CancellableTestListingOutcome::Errors(errors) => {
+            panic!("a live listing analyzes: {errors:?}")
+        }
+        CancellableTestListingOutcome::Canceled => {
+            panic!("a live token cannot report cancellation")
+        }
+    };
+    assert_listing_eq(&listed, &listing(&mut project.open()).unwrap());
+    assert_eq!(listed.inventory.entries.len(), 2);
+    assert_eq!(listed.inventory.entries[0].id, "main.rue::broken");
+    assert_eq!(listed.inventory.entries[1].id, "main.rue::fine");
+    assert_type_mismatch(&listed.failure_diagnostics);
+
+    retained
+        .acquire_reached_toolchain_modules_cancellable(&executable_options, &live)
+        .expect("a live acquisition settles");
+    let presented = match retained
+        .cancellable_present_many(air_request(&executable_options, &file_order), live)
+    {
+        CancellablePresentationOutcome::Completed(mut outputs) => outputs.pop().unwrap(),
+        CancellablePresentationOutcome::Errors(errors) => {
+            panic!("a live presentation renders: {errors:?}")
+        }
+        CancellablePresentationOutcome::Canceled => {
+            panic!("a live token cannot report cancellation")
+        }
+    };
+    assert_eq!(presented, air(&mut project.open()).unwrap());
+    // The broken test's diagnostics belong to the listing alone: the
+    // executable request over the same host neither sees them nor fails.
+    assert_output_eq(
+        &build(&mut retained).unwrap().output,
+        &build(&mut project.open()).unwrap().output,
+    );
 }
 
 #[test]

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -8,15 +8,16 @@ use std::time::{Duration, Instant, SystemTime};
 use ahash::{AHashMap, AHashSet};
 use rue_compiler::unstable::TestCandidateOutcome;
 use rue_compiler::unstable::{
-    AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
-    ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave, ImportInputRevision,
-    ImportObservation, ImportObservationStatus, RootedParkOutcome, TrustedSuccessorDelta,
-    abort_import_input_request, begin_import_input_request, begin_import_wave_with_accepted_reads,
-    close_import_discovery_successor, close_import_input_request, closed_discovery_continuation,
-    discovery_attempt, extend_import_wave, import_demand_frontier_for_roots,
-    import_observation_ledger, plan_delta_roots, plan_round_roots,
-    publish_import_observation_batch, publish_import_wave, publish_trusted_toolchain_successor,
-    rooted_or_toolchain_park, stage_import_discovery_successor, stage_import_input_request,
+    AcceptedImportSource, CompilationCancellation, DiscoverySourceAssembler, ImportDemandFrontier,
+    ImportDemandMode, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave,
+    ImportInputRevision, ImportObservation, ImportObservationStatus, RootedParkOutcome,
+    TrustedSuccessorDelta, abort_import_input_request, begin_import_input_request,
+    begin_import_wave_with_accepted_reads, close_import_discovery_successor,
+    close_import_input_request, closed_discovery_continuation, discovery_attempt,
+    extend_import_wave, import_demand_frontier_for_roots, import_observation_ledger,
+    plan_delta_roots, plan_round_roots, publish_import_observation_batch, publish_import_wave,
+    publish_trusted_toolchain_successor, rooted_or_toolchain_park_with_cancellation,
+    stage_import_discovery_successor, stage_import_input_request,
 };
 #[cfg(test)]
 use rue_compiler::unstable::{
@@ -1041,15 +1042,44 @@ pub enum SourceLoadError {
 #[derive(Clone, Copy, Default)]
 struct DiscoveryControl<'a> {
     supersession: Option<&'a dyn Fn() -> bool>,
+    /// The admitted request's cancellation, when the caller has one. Every
+    /// checkpoint observes it beside the supersession probe, and the semantic
+    /// probe inside toolchain acquisition runs under its token, so a canceled
+    /// request stops inside a long body-closure analysis rather than only
+    /// between acquisition rounds (RUE-2174).
+    cancellation: Option<&'a CompilationCancellation>,
 }
 
 impl<'a> DiscoveryControl<'a> {
     fn superseding(supersession: Option<&'a dyn Fn() -> bool>) -> Self {
-        Self { supersession }
+        Self {
+            supersession,
+            cancellation: None,
+        }
+    }
+
+    fn cancellable(cancellation: &'a CompilationCancellation) -> Self {
+        Self {
+            supersession: None,
+            cancellation: Some(cancellation),
+        }
     }
 
     fn checkpoint(self) -> Result<(), SourceLoadError> {
+        if self
+            .cancellation
+            .is_some_and(CompilationCancellation::is_canceled)
+        {
+            return Err(SourceLoadError::Superseded);
+        }
         check_supersession(self.supersession)
+    }
+
+    /// The token the semantic probe runs under: the request's own when the
+    /// caller supplied one, otherwise one nobody can cancel, which is exactly
+    /// the one-shot driver's uncancellable probe.
+    fn probe_cancellation(self) -> CompilationCancellation {
+        self.cancellation.cloned().unwrap_or_default()
     }
 }
 
@@ -2450,40 +2480,65 @@ pub(crate) fn acquire_reached_toolchain_modules(
     result: &mut ImportDiscoveryResult,
     options: &CompileOptions,
 ) -> Result<(), SourceLoadError> {
-    acquire_reached_toolchain_modules_superseding(result, options, None)
+    acquire_reached_toolchain_modules_inner(result, options, DiscoveryControl::default())
+        .map_err(prepare_source_load_error)
 }
 
-/// [`acquire_reached_toolchain_modules`] under a caller-owned edit-supersession
-/// probe (RUE-1863).
+/// [`acquire_reached_toolchain_modules`] under a caller-owned cancellation
+/// (RUE-1863, RUE-2174).
 ///
-/// Acquisition blocks on demand reads and on a multi-wave trusted re-close, so
-/// a watch cycle needs the same prompt supersession RUE-1830 gave
+/// Acquisition blocks on demand reads, on a multi-wave trusted re-close, and
+/// on the semantic probe that discovers each round's demands, so a watch cycle
+/// or a service request needs the same prompt abandonment RUE-1830 gave
 /// re-observation. Each round is a transaction: the demand reads land in a
 /// CLONE of the assembler, and the host's committed state — snapshot, manifest,
 /// revision, witness, assembler — is replaced only after the re-close returns.
 /// The compiler may provisionally stage that successor while the re-close runs,
-/// but a supersession before close aborts the import-input request, restores the
-/// session's committed selectors, and leaves every host field unchanged.
+/// but a cancellation before close aborts the import-input request, restores
+/// the session's committed selectors, and leaves every host field unchanged.
+/// The semantic probe itself runs under the request's token, so a cancellation
+/// during a long body-closure analysis stops there and settles nothing; it
+/// reports [`SourceLoadError::Superseded`] like every other checkpoint.
 ///
 /// A successful close is the commit boundary. The infallible host assignments
-/// then run to completion, so supersession observed afterward keeps the new
+/// then run to completion, so a cancellation observed afterward keeps the new
 /// session and host close coherent rather than rolling either half back.
-/// `None` keeps every check a no-op for the one-shot driver.
-pub(crate) fn acquire_reached_toolchain_modules_superseding(
+pub(crate) fn acquire_reached_toolchain_modules_cancellable(
     result: &mut ImportDiscoveryResult,
     options: &CompileOptions,
-    supersession: Option<&dyn Fn() -> bool>,
+    cancellation: &CompilationCancellation,
 ) -> Result<(), SourceLoadError> {
-    acquire_reached_toolchain_modules_superseding_inner(result, options, supersession)
-        .map_err(prepare_source_load_error)
+    acquire_reached_toolchain_modules_inner(
+        result,
+        options,
+        DiscoveryControl::cancellable(cancellation),
+    )
+    .map_err(prepare_source_load_error)
 }
 
-fn acquire_reached_toolchain_modules_superseding_inner(
+/// Acquisition under a bare supersession probe, for the loader's own tests of
+/// the round transaction: they trip the probe at counted checkpoints, which a
+/// token cannot express. Production callers hold a request token and use
+/// [`acquire_reached_toolchain_modules_cancellable`].
+#[cfg(test)]
+fn acquire_reached_toolchain_modules_superseding(
     result: &mut ImportDiscoveryResult,
     options: &CompileOptions,
     supersession: Option<&dyn Fn() -> bool>,
 ) -> Result<(), SourceLoadError> {
-    let control = DiscoveryControl::superseding(supersession);
+    acquire_reached_toolchain_modules_inner(
+        result,
+        options,
+        DiscoveryControl::superseding(supersession),
+    )
+    .map_err(prepare_source_load_error)
+}
+
+fn acquire_reached_toolchain_modules_inner(
+    result: &mut ImportDiscoveryResult,
+    options: &CompileOptions,
+    control: DiscoveryControl<'_>,
+) -> Result<(), SourceLoadError> {
     // A discovery that did not close valid (missing or ambiguous imports) has no
     // queryable program, so semantic analysis cannot run and there is nothing to
     // acquire. Leave it untouched: the driver surfaces the canonical import
@@ -2495,9 +2550,17 @@ fn acquire_reached_toolchain_modules_superseding_inner(
     }
     for _ in 0..MAX_TOOLCHAIN_ACQUISITION_ROUNDS {
         control.checkpoint()?;
-        match rooted_or_toolchain_park(&mut result.session, options) {
+        match rooted_or_toolchain_park_with_cancellation(
+            &mut result.session,
+            options,
+            &control.probe_cancellation(),
+        ) {
             // Analysis satisfied every reached-body demand (or there were none).
             RootedParkOutcome::Ready => return Ok(()),
+            // The request was abandoned inside the probe. Nothing was settled
+            // or attached, so this is the same report every other checkpoint
+            // makes; it is never a program diagnostic.
+            RootedParkOutcome::Canceled => return Err(SourceLoadError::Superseded),
             // Deterministic program diagnostics — the source itself, not the
             // toolchain, is at fault, and an erroneous body raises no toolchain
             // park, so there is nothing here to acquire. Reporting stays with
@@ -5523,6 +5586,36 @@ mod tests {
         .expect_err("a superseded acquisition must abort");
         assert!(matches!(error, SourceLoadError::Superseded), "{error:?}");
         assert_nothing_acquired(&mut result);
+    }
+
+    /// RUE-2174: the request token is the cancellation the production loop
+    /// observes. A token canceled before the first checkpoint aborts before
+    /// any demand read and commits nothing; a live token over the same result
+    /// then acquires the demanded module whole.
+    #[test]
+    fn canceled_acquisition_commits_no_partial_state_and_a_live_one_recovers() {
+        let (_project, _stdlib, main, std_root) = fallible_project("cancel-token");
+        let mut result =
+            discover_and_load_imports(main.to_str().unwrap(), None, Some(&std_root)).unwrap();
+        let canceled = CompilationCancellation::new();
+        canceled.cancel();
+        let error = acquire_reached_toolchain_modules_cancellable(
+            &mut result,
+            &CompileOptions::default(),
+            &canceled,
+        )
+        .expect_err("a canceled acquisition must abort");
+        assert!(matches!(error, SourceLoadError::Superseded), "{error:?}");
+        assert_nothing_acquired(&mut result);
+
+        acquire_reached_toolchain_modules_cancellable(
+            &mut result,
+            &CompileOptions::default(),
+            &CompilationCancellation::new(),
+        )
+        .expect("a live acquisition succeeds after a canceled one");
+        assert!(contains_trusted_option(&result.source_snapshot));
+        assert_eq!(result.source_snapshot.source_revision().modules().len(), 2);
     }
 
     /// Whether the demanded trusted module is visible in each of the three

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -399,7 +399,7 @@ pub(crate) fn run(request: WatchRequest) -> ! {
                 phase = ObservationPhase::Acquire;
                 test_acquire_delay();
                 observed = host
-                    .acquire_reached_toolchain_modules_superseding(&compile_options, &superseded);
+                    .acquire_reached_toolchain_modules_cancellable(&compile_options, &cancellation);
             }
             let monitor_changed = monitor.finish();
             let changed =


### PR DESCRIPTION
The cancellation boundary audit from RUE-2128 (ADR-0085 phase 2), as its own slice ahead of the service.

The executable and test-image adapters already ran under a request's `CompilationCancellation`, but three paths a daemon request will take still minted their own uncancelable token: the rooted test inventory behind `rue test --list`, the presentation batch behind `--emit air` (through `rooted_cfg` and `rooted_codegen`), and the semantic probe inside toolchain acquisition, which only checked its supersession probe between rounds, so a long body-closure analysis ran to completion after the caller had gone away.

**Compiler.** Cancellable forms go through the same computations rather than new ones: `cancellable_test_inventory` keeps the listing's partial-inventory semantics (a broken test is still listed beside its diagnostics) and reports `Canceled` instead of an inventory or diagnostics; `present_many_with_cancellation` is now the one presentation implementation, with the differential oracle's injected semantic fault kept on the same path, and `unstable_present_many` wraps it with a token nobody can cancel; `rooted_or_toolchain_park_with_cancellation` adds `RootedParkOutcome::Canceled`, which attaches no park and settles nothing. The plain `rooted_or_toolchain_park` and `rooted_codegen` session wrappers had only test callers left and are gated to tests, so production has one path each.

**Driver.** Toolchain acquisition takes the request's cancellation: every checkpoint observes it and the probe runs under its token, reporting `SourceLoadError::Superseded` like the other checkpoints (never a source diagnostic, never the uncanceled-path panic). Watch switches to that path, since its supersession probe already was the token. The host exposes `cancellable_test_inventory`, `cancellable_present_many`, and `acquire_reached_toolchain_modules_cancellable`. The loader's own round-transaction tests keep a test-only superseding wrapper because they trip at counted checkpoints.

**Coverage.** A test-only tripwire in the rooted projections cancels a request deterministically just before the shared body-closure request or before the CFG batch, mirroring the existing codegen tripwire. Compiler tests cancel the probe, the listing, and the presentation before admission, during body-closure work, during CFG work, and inside the backend kernel, then verify the next request over the same session equals a fresh session's. Driver tests do the same over a retained `FilesystemCompilerHost` and check that the listing's broken-test diagnostics never leak into the executable request; a loader test covers the token path's no-partial-commit and recovery.

Verified locally: full `rue-compiler` unit suite (1249 passed), both driver unit suites, `scripts/rue cli watch`, and the clippy/fmt gates for `rue-compiler` and `rue`.

Fixes RUE-2174